### PR TITLE
fix: allow primitive display list keys

### DIFF
--- a/.changeset/pretty-bananas-kick.md
+++ b/.changeset/pretty-bananas-kick.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Allow stateless primitive display lists to use duplicate-disambiguating index keys.

--- a/packages/fuzz/corpus/regressions/no-array-index-as-key--primitive-display-list.tsx
+++ b/packages/fuzz/corpus/regressions/no-array-index-as-key--primitive-display-list.tsx
@@ -1,0 +1,15 @@
+// rule: no-array-index-as-key
+// weakness: control-flow
+// source: react-bench write-react-blueberrycongee-lumina-note-237
+
+interface LicenseFeaturesProps {
+  features: ReadonlyArray<string>;
+}
+
+export const LicenseFeatures = ({ features }: LicenseFeaturesProps) => (
+  <ul>
+    {features.map((feature, index) => (
+      <li key={`${feature}-${index}`}>{feature}</li>
+    ))}
+  </ul>
+);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-array-index-as-key.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-array-index-as-key.regressions.test.ts
@@ -706,6 +706,22 @@ const CodePanel = ({ tokens }) => (
       expect(result.diagnostics).toHaveLength(1);
     });
 
+    it("still flags opaque destructured siblings not represented in the key", () => {
+      const result = runRule(
+        noArrayIndexAsKey,
+        `const Rows = ({ rows }) => (
+  <ul>
+    {rows.map(({ label, content }, index) => (
+      <li key={\`\${label}-\${index}\`}>{content}</li>
+    ))}
+  </ul>
+);
+`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    });
+
     // glific InteractiveOptions: the map index is forwarded one hop into a
     // render helper whose FIRST parameter is the index.
     it("flags an index forwarded into a render helper's position-0 parameter", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-array-index-as-key.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-array-index-as-key.regressions.test.ts
@@ -722,6 +722,38 @@ const CodePanel = ({ tokens }) => (
       expect(result.diagnostics).toHaveLength(1);
     });
 
+    it("still flags primitive rows with DOM-managed stateful attributes", () => {
+      const result = runRule(
+        noArrayIndexAsKey,
+        `const EditableLabels = ({ labels }) => (
+  <ul>
+    {labels.map((label, index) => (
+      <li contentEditable key={\`\${label}-\${index}\`}>{label}</li>
+    ))}
+  </ul>
+);
+`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    });
+
+    it("stays silent when enumerated stateful attributes are statically false", () => {
+      const result = runRule(
+        noArrayIndexAsKey,
+        `const Labels = ({ labels }) => (
+  <ul>
+    {labels.map((label, index) => (
+      <li contentEditable={false} draggable="false" key={\`\${label}-\${index}\`}>{label}</li>
+    ))}
+  </ul>
+);
+`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
     // glific InteractiveOptions: the map index is forwarded one hop into a
     // render helper whose FIRST parameter is the index.
     it("flags an index forwarded into a render helper's position-0 parameter", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-array-index-as-key.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-array-index-as-key.regressions.test.ts
@@ -671,6 +671,41 @@ const CodePanel = ({ tokens }) => (
   });
 
   describe("fn-hunt corpus misses (2026-07) — must fire", () => {
+    it("stays silent on stateless primitive display rows with duplicate-disambiguating keys", () => {
+      const result = runRule(
+        noArrayIndexAsKey,
+        `const LicenseFeatures = ({ features }) => (
+  <ul>
+    {features.map((feature, index) => (
+      <li key={\`\${feature}-\${index}\`}>{feature}</li>
+    ))}
+  </ul>
+);
+`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it("still flags duplicate-disambiguating keys on editable rows", () => {
+      const result = runRule(
+        noArrayIndexAsKey,
+        `const EditableFeatures = ({ features, setFeature, removeFeature }) => (
+  <ul>
+    {features.map((feature, index) => (
+      <li key={\`\${feature}-\${index}\`}>
+        <input value={feature} onChange={(event) => setFeature(index, event.target.value)} />
+        <button onClick={() => removeFeature(index)}>Remove</button>
+      </li>
+    ))}
+  </ul>
+);
+`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    });
+
     // glific InteractiveOptions: the map index is forwarded one hop into a
     // render helper whose FIRST parameter is the index.
     it("flags an index forwarded into a render helper's position-0 parameter", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-array-index-as-key.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-array-index-as-key.ts
@@ -903,6 +903,17 @@ const templateHasOuterMemberIdentity = (
   return false;
 };
 
+const templateReferencesBareItem = (
+  template: EsTreeNodeOfType<"TemplateLiteral">,
+  itemNames: ReadonlySet<string>,
+): boolean =>
+  (template.expressions ?? []).some((expression) => {
+    const unwrappedExpression = stripParenExpression(expression);
+    return (
+      isNodeOfType(unwrappedExpression, "Identifier") && itemNames.has(unwrappedExpression.name)
+    );
+  });
+
 const forLoopTestReadsDataLength = (test: EsTreeNode): boolean => {
   let didFindLengthRead = false;
   walkAst(test, (child: EsTreeNode): boolean | void => {
@@ -1150,9 +1161,14 @@ export const noArrayIndexAsKey = defineRule({
             const jsxElement = openingElement.parent;
             if (jsxElement && isNodeOfType(jsxElement, "JSXElement")) {
               const isInlineTextRun = INLINE_TEXT_LEAF_TAGS.has(elementName.name);
+              const rendersPrimitiveItem = Boolean(
+                keyTemplate && templateReferencesBareItem(keyTemplate, itemNames),
+              );
               const isStateful = containsStatefulDescendant(jsxElement as EsTreeNode, {
                 memberRootNames: isInlineTextRun ? itemNames : EMPTY_NAME_SET,
-                bareIdentifierNames: derivedNames,
+                bareIdentifierNames: rendersPrimitiveItem
+                  ? new Set([...derivedNames, ...itemNames])
+                  : derivedNames,
               });
               if (!isStateful) return;
             }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-array-index-as-key.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-array-index-as-key.ts
@@ -903,16 +903,22 @@ const templateHasOuterMemberIdentity = (
   return false;
 };
 
-const templateReferencesBareItem = (
+const findBareItemNamesReferencedByTemplate = (
   template: EsTreeNodeOfType<"TemplateLiteral">,
   itemNames: ReadonlySet<string>,
-): boolean =>
-  (template.expressions ?? []).some((expression) => {
+): Set<string> => {
+  const referencedItemNames = new Set<string>();
+  for (const expression of template.expressions ?? []) {
     const unwrappedExpression = stripParenExpression(expression);
-    return (
-      isNodeOfType(unwrappedExpression, "Identifier") && itemNames.has(unwrappedExpression.name)
-    );
-  });
+    if (
+      isNodeOfType(unwrappedExpression, "Identifier") &&
+      itemNames.has(unwrappedExpression.name)
+    ) {
+      referencedItemNames.add(unwrappedExpression.name);
+    }
+  }
+  return referencedItemNames;
+};
 
 const forLoopTestReadsDataLength = (test: EsTreeNode): boolean => {
   let didFindLengthRead = false;
@@ -1161,14 +1167,15 @@ export const noArrayIndexAsKey = defineRule({
             const jsxElement = openingElement.parent;
             if (jsxElement && isNodeOfType(jsxElement, "JSXElement")) {
               const isInlineTextRun = INLINE_TEXT_LEAF_TAGS.has(elementName.name);
-              const rendersPrimitiveItem = Boolean(
-                keyTemplate && templateReferencesBareItem(keyTemplate, itemNames),
-              );
+              const primitiveItemNames = keyTemplate
+                ? findBareItemNamesReferencedByTemplate(keyTemplate, itemNames)
+                : EMPTY_NAME_SET;
               const isStateful = containsStatefulDescendant(jsxElement as EsTreeNode, {
                 memberRootNames: isInlineTextRun ? itemNames : EMPTY_NAME_SET,
-                bareIdentifierNames: rendersPrimitiveItem
-                  ? new Set([...derivedNames, ...itemNames])
-                  : derivedNames,
+                bareIdentifierNames:
+                  primitiveItemNames.size > 0
+                    ? new Set([...derivedNames, ...primitiveItemNames])
+                    : derivedNames,
               });
               if (!isStateful) return;
             }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/jsx-stateless-leaf.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/jsx-stateless-leaf.ts
@@ -143,6 +143,36 @@ const STATEFUL_HTML_DESCENDANT_TAGS: ReadonlySet<string> = new Set([
   "canvas",
 ]);
 
+const STATEFUL_HTML_ATTRIBUTE_NAMES: ReadonlySet<string> = new Set([
+  "autofocus",
+  "contenteditable",
+  "draggable",
+  "tabindex",
+]);
+
+const isStaticallyFalseAttributeValue = (attribute: EsTreeNode): boolean => {
+  if (!isNodeOfType(attribute, "JSXAttribute") || !attribute.value) return false;
+  const value = isNodeOfType(attribute.value, "JSXExpressionContainer")
+    ? attribute.value.expression
+    : attribute.value;
+  return isNodeOfType(value, "Literal") && (value.value === false || value.value === "false");
+};
+
+const hasStatefulHtmlAttribute = (openingElement: EsTreeNode): boolean => {
+  if (!isNodeOfType(openingElement, "JSXOpeningElement")) return false;
+  return openingElement.attributes.some((attribute) => {
+    if (
+      !isNodeOfType(attribute, "JSXAttribute") ||
+      !isNodeOfType(attribute.name, "JSXIdentifier")
+    ) {
+      return false;
+    }
+    const attributeName = attribute.name.name.toLowerCase();
+    if (!STATEFUL_HTML_ATTRIBUTE_NAMES.has(attributeName)) return false;
+    return attributeName === "tabindex" || !isStaticallyFalseAttributeValue(attribute);
+  });
+};
+
 const STATEFUL_DESCENDANT_SCAN_BUDGET = 200;
 
 interface RowContentScanOptions {
@@ -197,6 +227,7 @@ export const containsStatefulDescendant = (
       }
       // Member-expression JSX (e.g. `<Foo.Bar />`) — custom; stateful.
       if (name && isNodeOfType(name, "JSXMemberExpression")) return true;
+      if (hasStatefulHtmlAttribute(opening)) return true;
       const children = (node as { children?: ReadonlyArray<EsTreeNode> }).children ?? [];
       for (const child of children) stack.push(child);
       continue;


### PR DESCRIPTION
## Why

Avoid blocking immutable primitive display lists whose rows have no retained UI identity.

A read-only list such as:

```tsx
features.map((feature, index) => (
  <li key={`${feature}-${index}`}>{feature}</li>
))
```

uses the index only to disambiguate duplicate strings. Reconciliation cannot corrupt an input, child component state, animation, focus, or media load because the row is plain text.

## What changed

- Recognize a bare iterator item included in a composite key and rendered by a stateless HTML leaf.
- Keep diagnostics for controlled inputs, removal controls, custom components, animation elements, and other stateful descendants.
- Add positive and negative regressions plus a permanent fuzz-corpus seed.
- Add a patch changeset for `oxlint-plugin-react-doctor`.

## Eval results

| Check | Result |
| --- | --- |
| Repos scanned | 9 distinct repositories |
| RootDir scans | 50 |
| Target rule | `no-array-index-as-key` |
| Diagnostics | 133 across 6 repos; identical count to `main` |
| False positives found | 0 new hits |
| Output artifact | local RDE JSONL in disposable validation worktree |

## Test plan

- `nr test -- tests/no-array-index-as-key.regressions.test.ts` (full plugin suite: 538 files, 11,900 passed)
- `nr test` in `packages/fuzz` (37 passed)
- `FUZZ_RULE=no-array-index-as-key FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz`
- `nr build`
- `nr typecheck`
- `nr lint`
- `nr format:check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-rule precision tuning with broad regression coverage; no runtime app or security surface, only which patterns get diagnostics.
> 
> **Overview**
> **`no-array-index-as-key`** no longer warns on read-only primitive lists that use composite keys like `` `${feature}-${index}` `` when the iterator item appears in the key and the row is a stateless HTML leaf showing only that item (e.g. ``<li>{feature}</li>``).
> 
> The rule now detects bare map-item identifiers embedded in template keys and treats them as row content for the stateless-leaf exemption, alongside existing derived-local handling. **`containsStatefulDescendant`** treats DOM-managed attributes (`contentEditable`, `draggable`, `autofocus`, `tabindex`) as stateful unless they are statically `false`/`"false"`, so editable or draggable rows still warn. Destructured fields not reflected in the key, inputs, and other stateful descendants remain flagged.
> 
> Adds regression tests, a fuzz corpus seed, and a patch changeset for **`oxlint-plugin-react-doctor`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7d4ddf44dfae0c8bb81296940adeaba86f73294. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->