### PR TITLE
fix(rules): allow large text virtualization guards

### DIFF
--- a/.changeset/eighty-mugs-melt.md
+++ b/.changeset/eighty-mugs-melt.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Avoid no-polymorphic-children diagnostics for large-string virtualization guards while preserving small-string render-shape checks.

--- a/packages/fuzz/corpus/regressions/no-polymorphic-children--large-text-virtualization.tsx
+++ b/packages/fuzz/corpus/regressions/no-polymorphic-children--large-text-virtualization.tsx
@@ -1,0 +1,18 @@
+// rule: no-polymorphic-children
+// weakness: library-idiom
+// source: react-bench write-react-callstackincubator-rozenite-279
+
+import type { HTMLProps, ReactNode } from "react";
+
+interface CodeBlockProps extends HTMLProps<HTMLPreElement> {
+  children?: ReactNode;
+}
+
+const VirtualizedCode = ({ text }: { text: string }) => <code>{text.slice(0, 100)}</code>;
+
+export const CodeBlock = ({ children, ...preProps }: CodeBlockProps) => {
+  if (typeof children === "string" && children.length > 50_000) {
+    return <VirtualizedCode text={children} />;
+  }
+  return <pre {...preProps}>{children}</pre>;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/thresholds.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/thresholds.ts
@@ -57,3 +57,4 @@ export const TSCONFIG_EXTENDS_MAX_DEPTH = 8;
 // cap a deeply-branched reducer would blow up time + memory. Bailing is
 // safe — it can only cause missed diagnostics, never false positives.
 export const REDUCER_PATH_STATE_LIMIT = 1000;
+export const LARGE_TEXT_OPTIMIZATION_THRESHOLD_CHARS = 1000;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-polymorphic-children.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-polymorphic-children.regressions.test.ts
@@ -106,6 +106,38 @@ describe("correctness/no-polymorphic-children — regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("stays silent when a leading guard precedes large-string virtualization", () => {
+    const result = runRule(
+      noPolymorphicChildren,
+      `
+      const CodeBlock = ({ enabled, children }) => {
+        if (enabled && typeof children === 'string' && children.length > 50_000) {
+          return <VirtualizedCode text={children} />;
+        }
+        return <pre>{children}</pre>;
+      };
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent when the large-string length comparison is parenthesized", () => {
+    const result = runRule(
+      noPolymorphicChildren,
+      `
+      const CodeBlock = ({ children }) => {
+        if (typeof children === 'string' && (children.length > 50_000)) {
+          return <VirtualizedCode text={children} />;
+        }
+        return <pre>{children}</pre>;
+      };
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("still flags small-string branches that change layout semantics", () => {
     const result = runRule(
       noPolymorphicChildren,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-polymorphic-children.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-polymorphic-children.regressions.test.ts
@@ -90,6 +90,38 @@ describe("correctness/no-polymorphic-children — regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("stays silent when a backwards-compatible pre renderer virtualizes only large strings", () => {
+    const result = runRule(
+      noPolymorphicChildren,
+      `
+      const CodeBlock = ({ children, ...preProps }) => {
+        if (typeof children === 'string' && children.length > 50_000) {
+          return <VirtualizedCode text={children} />;
+        }
+        return <pre {...preProps}>{children}</pre>;
+      };
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still flags small-string branches that change layout semantics", () => {
+    const result = runRule(
+      noPolymorphicChildren,
+      `
+      const Button = ({ children }) => {
+        if (typeof children === 'string' && children.length > 3) {
+          return <button className="wide">{children}</button>;
+        }
+        return <div className="compact">{children}</div>;
+      };
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("still flags a ternary that renders different shapes", () => {
     const result = runRule(
       noPolymorphicChildren,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-polymorphic-children.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-polymorphic-children.ts
@@ -1,4 +1,5 @@
 import { defineRule } from "../../utils/define-rule.js";
+import { LARGE_TEXT_OPTIMIZATION_THRESHOLD_CHARS } from "../../constants/thresholds.js";
 import { isComponentParameterSymbol } from "../../utils/is-component-parameter-symbol.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { RuleContext } from "../../utils/rule-context.js";
@@ -155,6 +156,44 @@ const guardsRenderShape = (comparison: EsTreeNode): boolean => {
   return false;
 };
 
+const isPropsChildrenLength = (node: EsTreeNode, scopes: ScopeAnalysis): boolean => {
+  const unwrappedNode = stripParenExpression(node);
+  return (
+    isNodeOfType(unwrappedNode, "MemberExpression") &&
+    !unwrappedNode.computed &&
+    isNodeOfType(unwrappedNode.property, "Identifier") &&
+    unwrappedNode.property.name === "length" &&
+    resolvesToPropsChildren(stripParenExpression(unwrappedNode.object), scopes)
+  );
+};
+
+const isLargeTextLengthComparison = (node: EsTreeNode, scopes: ScopeAnalysis): boolean => {
+  if (!isNodeOfType(node, "BinaryExpression")) return false;
+  const leftIsLength = isPropsChildrenLength(node.left, scopes);
+  const rightIsLength = isPropsChildrenLength(node.right, scopes);
+  const thresholdNode = leftIsLength ? node.right : node.left;
+  if ((!leftIsLength && !rightIsLength) || !isNodeOfType(thresholdNode, "Literal")) return false;
+  if (
+    typeof thresholdNode.value !== "number" ||
+    thresholdNode.value < LARGE_TEXT_OPTIMIZATION_THRESHOLD_CHARS
+  ) {
+    return false;
+  }
+  return leftIsLength
+    ? node.operator === ">" || node.operator === ">="
+    : node.operator === "<" || node.operator === "<=";
+};
+
+const isLargeStringOptimizationGuard = (comparison: EsTreeNode, scopes: ScopeAnalysis): boolean => {
+  const comparisonRoot = findTransparentExpressionRoot(comparison);
+  const parent = comparisonRoot.parent;
+  if (!parent || !isNodeOfType(parent, "LogicalExpression") || parent.operator !== "&&") {
+    return false;
+  }
+  const otherOperand = parent.left === comparisonRoot ? parent.right : parent.left;
+  return isLargeTextLengthComparison(otherOperand, scopes);
+};
+
 // HACK: `typeof children === "string"` (or `=== 'object'`) is a
 // polymorphic-children smell — the component switches behavior based on
 // what the consumer happened to pass. Better to expose explicit
@@ -184,6 +223,7 @@ export const noPolymorphicChildren = defineRule({
       if (!isStringLiteral(node.left) && !isStringLiteral(node.right)) return;
 
       if (!guardsRenderShape(node)) return;
+      if (isLargeStringOptimizationGuard(node, context.scopes)) return;
 
       context.report({
         node,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-polymorphic-children.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-polymorphic-children.ts
@@ -168,10 +168,11 @@ const isPropsChildrenLength = (node: EsTreeNode, scopes: ScopeAnalysis): boolean
 };
 
 const isLargeTextLengthComparison = (node: EsTreeNode, scopes: ScopeAnalysis): boolean => {
-  if (!isNodeOfType(node, "BinaryExpression")) return false;
-  const leftIsLength = isPropsChildrenLength(node.left, scopes);
-  const rightIsLength = isPropsChildrenLength(node.right, scopes);
-  const thresholdNode = leftIsLength ? node.right : node.left;
+  const unwrappedNode = stripParenExpression(node);
+  if (!isNodeOfType(unwrappedNode, "BinaryExpression")) return false;
+  const leftIsLength = isPropsChildrenLength(unwrappedNode.left, scopes);
+  const rightIsLength = isPropsChildrenLength(unwrappedNode.right, scopes);
+  const thresholdNode = leftIsLength ? unwrappedNode.right : unwrappedNode.left;
   if ((!leftIsLength && !rightIsLength) || !isNodeOfType(thresholdNode, "Literal")) return false;
   if (
     typeof thresholdNode.value !== "number" ||
@@ -180,18 +181,20 @@ const isLargeTextLengthComparison = (node: EsTreeNode, scopes: ScopeAnalysis): b
     return false;
   }
   return leftIsLength
-    ? node.operator === ">" || node.operator === ">="
-    : node.operator === "<" || node.operator === "<=";
+    ? unwrappedNode.operator === ">" || unwrappedNode.operator === ">="
+    : unwrappedNode.operator === "<" || unwrappedNode.operator === "<=";
 };
 
 const isLargeStringOptimizationGuard = (comparison: EsTreeNode, scopes: ScopeAnalysis): boolean => {
-  const comparisonRoot = findTransparentExpressionRoot(comparison);
-  const parent = comparisonRoot.parent;
-  if (!parent || !isNodeOfType(parent, "LogicalExpression") || parent.operator !== "&&") {
-    return false;
+  let current = findTransparentExpressionRoot(comparison);
+  while (current.parent) {
+    const parent = current.parent;
+    if (!isNodeOfType(parent, "LogicalExpression") || parent.operator !== "&&") return false;
+    const otherOperand = parent.left === current ? parent.right : parent.left;
+    if (isLargeTextLengthComparison(otherOperand, scopes)) return true;
+    current = findTransparentExpressionRoot(parent);
   }
-  const otherOperand = parent.left === comparisonRoot ? parent.right : parent.left;
-  return isLargeTextLengthComparison(otherOperand, scopes);
+  return false;
 };
 
 // HACK: `typeof children === "string"` (or `=== 'object'`) is a


### PR DESCRIPTION
## Summary

- keep `no-polymorphic-children` quiet for backwards-compatible large-string virtualization guards
- retain diagnostics for small-string branches that change render semantics
- add regression and fuzz coverage plus a patch changeset

## Validation

- `nr test -- src/plugin/rules/correctness/no-polymorphic-children.regressions.test.ts` (full plugin suite: 543 files, 11,953 passed, 148 skipped)
- `nr typecheck`
- `nr lint`
- `nr format:check`
- strict fuzz: 500 iterations
- `nr build`

## RDE OSS comparison (50 projects)

| Revision | `no-polymorphic-children` diagnostics | Repos |
| --- | ---: | ---: |
| baseline (`0.7.5`) | 0 | 0 |
| candidate | 0 | 0 |

The candidate preserves the observed OSS diagnostic set while fixing the benchmark false positive.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-rule heuristic tweak with tests; may miss some polymorphic patterns that reuse large-length guards, but does not affect runtime behavior.
> 
> **Overview**
> **`no-polymorphic-children`** no longer warns when `typeof children === "string"` is paired with a **large-string length guard** (e.g. `children.length > 50_000`) in an `&&` chain that switches to virtualization, fixing false positives on backwards-compatible code-block patterns.
> 
> The rule still reports **small thresholds** that change render shape (e.g. length `> 3` with different JSX branches). Detection uses a new **`LARGE_TEXT_OPTIMIZATION_THRESHOLD_CHARS`** (1000) for the numeric literal in `children.length` comparisons, with support for parenthesized comparisons and leading guards.
> 
> Regression tests and a fuzz corpus case cover the virtualization idiom; patch changeset for `oxlint-plugin-react-doctor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33f799c1c48f1bf9ed2d0c56d5a8be75115fee18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->