### PR TITLE
fix(security): trace dangerous HTML provenance

### DIFF
--- a/.changeset/slow-pans-relax.md
+++ b/.changeset/slow-pans-relax.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Track dynamic HTML through local aliases and helper parameters, and exclude declaration files from executable security scans.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/dangerous-html-sink.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/dangerous-html-sink.regressions.test.ts
@@ -99,6 +99,75 @@ describe("security-scan/dangerous-html-sink — regressions", () => {
     expect(findings).toHaveLength(1);
   });
 
+  it("flags prop HTML routed through a const alias", () => {
+    const findings = runScanRule(dangerousHtmlSink, {
+      relativePath: "src/components/preview.tsx",
+      content: `export const Preview = ({ html }: { html: string }) => {
+  const payload = html;
+  return <div dangerouslySetInnerHTML={{ __html: payload }} />;
+};
+`,
+    });
+    expect(findings).toHaveLength(1);
+  });
+
+  it("flags prop HTML routed through a visible helper parameter", () => {
+    const findings = runScanRule(dangerousHtmlSink, {
+      relativePath: "src/components/preview.tsx",
+      content: `const inject = (element: HTMLElement, payload: string) => {
+  element.innerHTML = payload;
+};
+export const Preview = ({ html }: { html: string }) => {
+  const element = document.querySelector("#preview");
+  if (element) inject(element, html);
+};
+`,
+    });
+    expect(findings).toHaveLength(1);
+  });
+
+  it("flags prop HTML routed through a function-declaration helper", () => {
+    const findings = runScanRule(dangerousHtmlSink, {
+      relativePath: "src/components/preview.tsx",
+      content: `function inject(element: HTMLElement, payload: string) {
+  element.innerHTML = payload;
+}
+export const Preview = ({ html }: { html: string }) => {
+  const element = document.querySelector("#preview");
+  if (element) inject(element, html);
+};
+`,
+    });
+    expect(findings).toHaveLength(1);
+  });
+
+  it("stays silent when a visible helper receives only static or sanitized HTML", () => {
+    const findings = runScanRule(dangerousHtmlSink, {
+      relativePath: "src/components/preview.tsx",
+      content: `const inject = (element: HTMLElement, payload: string) => {
+  element.innerHTML = payload;
+};
+inject(staticElement, "<strong data-html='static'>Safe</strong>");
+inject(cleanElement, DOMPurify.sanitize(html));
+`,
+    });
+    expect(findings).toHaveLength(0);
+  });
+
+  it("stays silent on declaration files with sink-shaped member names", () => {
+    const findings = runScanRule(dangerousHtmlSink, {
+      relativePath: "lib/types/vimeo-preview-image.d.ts",
+      content: `export interface VimeoPreviewImage {
+  innerHTML: string;
+  html: string;
+}
+declare const preview: VimeoPreviewImage;
+preview.innerHTML = preview.html;
+`,
+    });
+    expect(findings).toHaveLength(0);
+  });
+
   it("flags innerHTML assigned from fetched data", () => {
     const findings = runScanRule(dangerousHtmlSink, {
       relativePath: "src/widgets/banner.ts",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/dangerous-html-sink.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/dangerous-html-sink.regressions.test.ts
@@ -111,6 +111,35 @@ describe("security-scan/dangerous-html-sink — regressions", () => {
     expect(findings).toHaveLength(1);
   });
 
+  it("flags prop HTML routed through an alias after an unrelated same-named binding", () => {
+    const findings = runScanRule(dangerousHtmlSink, {
+      relativePath: "src/components/preview.tsx",
+      content: `const payload = "<strong>static</strong>";
+export const Preview = ({ html }: { html: string }) => {
+  const payload = html;
+  return <div dangerouslySetInnerHTML={{ __html: payload }} />;
+};
+`,
+    });
+    expect(findings).toHaveLength(1);
+  });
+
+  it("ignores an out-of-scope same-named binding when tracing an alias", () => {
+    const findings = runScanRule(dangerousHtmlSink, {
+      relativePath: "src/components/preview.tsx",
+      content: `const payload = props.html;
+const StaticPreview = () => {
+  const payload = "<strong>static</strong>";
+  return payload;
+};
+export const Preview = () => (
+  <div dangerouslySetInnerHTML={{ __html: payload }} />
+);
+`,
+    });
+    expect(findings).toHaveLength(1);
+  });
+
   it("flags prop HTML routed through a visible helper parameter", () => {
     const findings = runScanRule(dangerousHtmlSink, {
       relativePath: "src/components/preview.tsx",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/dangerous-html-sink.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/dangerous-html-sink.ts
@@ -168,17 +168,14 @@ const getTemplateInterpolations = (valueTail: string): string | null => {
 // declaration (bounded window), or null when the file never declares it.
 const getIdentifierDeclarationInitializer = (
   identifier: string,
+  sinkIndex: number,
   fileContent: string,
 ): string | null => {
-  const declarationPattern = new RegExp(
-    `(?:const|let|var)\\s+${escapeRegExp(identifier)}\\s*(?::[^=\\n]{0,120})?=\\s*`,
-  );
-  const declarationMatch = declarationPattern.exec(fileContent);
-  if (declarationMatch === null) return null;
-  const initializerStartIndex = declarationMatch.index + declarationMatch[0].length;
+  const declaration = findVisibleIdentifierDeclaration(identifier, sinkIndex, fileContent);
+  if (declaration === null) return null;
   return fileContent.slice(
-    initializerStartIndex,
-    initializerStartIndex + STATIC_TEMPLATE_MAX_CHARS,
+    declaration.initializerStartIndex,
+    declaration.initializerStartIndex + STATIC_TEMPLATE_MAX_CHARS,
   );
 };
 
@@ -338,6 +335,89 @@ const findMatchingBraceIndex = (fileContent: string, openingBraceIndex: number):
   return fileContent.length;
 };
 
+const findContainingBlockEndIndex = (fileContent: string, targetIndex: number): number => {
+  const openingBraceIndexes: number[] = [];
+  let quote: string | null = null;
+  let isLineComment = false;
+  let isBlockComment = false;
+  for (let index = 0; index < targetIndex; index += 1) {
+    const character = fileContent[index];
+    const nextCharacter = fileContent[index + 1];
+    if (isLineComment) {
+      if (character === "\n") isLineComment = false;
+      continue;
+    }
+    if (isBlockComment) {
+      if (character === "*" && nextCharacter === "/") {
+        isBlockComment = false;
+        index += 1;
+      }
+      continue;
+    }
+    if (quote !== null) {
+      if (character === quote && fileContent[index - 1] !== "\\") quote = null;
+      continue;
+    }
+    if (character === "/" && nextCharacter === "/") {
+      isLineComment = true;
+      index += 1;
+      continue;
+    }
+    if (character === "/" && nextCharacter === "*") {
+      isBlockComment = true;
+      index += 1;
+      continue;
+    }
+    if (character === '"' || character === "'" || character === "`") {
+      quote = character;
+      continue;
+    }
+    if (character === "{") openingBraceIndexes.push(index);
+    if (character === "}") openingBraceIndexes.pop();
+  }
+  const openingBraceIndex = openingBraceIndexes.at(-1);
+  return openingBraceIndex === undefined
+    ? fileContent.length
+    : findMatchingBraceIndex(fileContent, openingBraceIndex);
+};
+
+interface VisibleIdentifierDeclaration {
+  readonly initializer: string;
+  readonly initializerStartIndex: number;
+}
+
+const findVisibleIdentifierDeclaration = (
+  identifier: string,
+  sinkIndex: number,
+  fileContent: string,
+): VisibleIdentifierDeclaration | null => {
+  const initializerPattern = new RegExp(
+    `(?:const|let|var)\\s+${escapeRegExp(identifier)}\\s*(?::[^=\\n]*)?=\\s*([^;\\n]+)`,
+    "g",
+  );
+  let nearestDeclaration: VisibleIdentifierDeclaration | null = null;
+  let nearestDeclarationIndex = -1;
+  for (const match of fileContent.matchAll(initializerPattern)) {
+    const declarationIndex = match.index;
+    if (
+      declarationIndex === undefined ||
+      declarationIndex >= sinkIndex ||
+      declarationIndex <= nearestDeclarationIndex ||
+      findContainingBlockEndIndex(fileContent, declarationIndex) < sinkIndex
+    ) {
+      continue;
+    }
+    nearestDeclarationIndex = declarationIndex;
+    const initializer = match[1];
+    if (initializer === undefined) continue;
+    nearestDeclaration = {
+      initializer,
+      initializerStartIndex: declarationIndex + match[0].length - initializer.length,
+    };
+  }
+  return nearestDeclaration;
+};
+
 interface FunctionParameterSource {
   readonly functionName: string;
   readonly parameterIndex: number;
@@ -419,13 +499,10 @@ const isHtmlTainted = (
   if (identifier === undefined || visitedIdentifiers.has(identifier)) return false;
   visitedIdentifiers.add(identifier);
 
-  const initializerPattern = new RegExp(
-    `(?:const|let|var)\\s+${escapeRegExp(identifier)}\\s*(?::[^=\\n]*)?=\\s*([^;\\n]+)`,
-  );
-  const initializer = initializerPattern.exec(fileContent)?.[1];
+  const declaration = findVisibleIdentifierDeclaration(identifier, sinkIndex, fileContent);
   if (
-    initializer !== undefined &&
-    isHtmlTainted(initializer, fileContent, sinkIndex, visitedIdentifiers)
+    declaration !== null &&
+    isHtmlTainted(declaration.initializer, fileContent, sinkIndex, visitedIdentifiers)
   ) {
     return true;
   }
@@ -489,6 +566,10 @@ export const dangerousHtmlSink = defineRule({
       const terminatorIndex = valueTail.search(/[;}]/);
       const valueExpression =
         terminatorIndex >= 0 ? valueTail.slice(0, terminatorIndex + 1) : valueTail;
+      const sinkIndex =
+        lines.slice(0, lineIndex).join("\n").length +
+        (lineIndex > 0 ? 1 : 0) +
+        line.search(DANGEROUS_HTML_PATTERN);
 
       if (STRING_LITERAL_VALUE_PATTERN.test(valueExpression)) continue;
       if (MODULE_CONSTANT_VALUE_PATTERN.test(valueExpression)) continue;
@@ -527,6 +608,7 @@ export const dangerousHtmlSink = defineRule({
       ) {
         const declarationInitializer = getIdentifierDeclarationInitializer(
           valueIdentifier,
+          sinkIndex,
           file.content,
         );
         if (declarationInitializer !== null) {
@@ -541,10 +623,6 @@ export const dangerousHtmlSink = defineRule({
       if (SANITIZER_PATTERN.test(judgedExpression)) continue;
       if (ENV_CONFIG_VALUE_PATTERN.test(judgedExpression)) continue;
       if (I18N_VALUE_PATTERN.test(judgedExpression)) continue;
-      const sinkIndex =
-        lines.slice(0, lineIndex).join("\n").length +
-        (lineIndex > 0 ? 1 : 0) +
-        line.search(DANGEROUS_HTML_PATTERN);
       if (!isHtmlTainted(judgedExpression, file.content, sinkIndex, new Set())) continue;
       if (ESCAPING_SERIALIZER_CALL_PATTERN.test(valueExpression)) continue;
       // Highlighter output: a `highlighted*` value is escaped, token-wrapped

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/dangerous-html-sink.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/dangerous-html-sink.ts
@@ -316,6 +316,138 @@ const isAllOperandsDomContentConcat = (valueExpression: string): boolean => {
   });
 };
 
+const findMatchingBraceIndex = (fileContent: string, openingBraceIndex: number): number => {
+  let depth = 0;
+  let quote: string | null = null;
+  for (let index = openingBraceIndex; index < fileContent.length; index += 1) {
+    const character = fileContent[index];
+    if (quote !== null) {
+      if (character === quote && fileContent[index - 1] !== "\\") quote = null;
+      continue;
+    }
+    if (character === '"' || character === "'" || character === "`") {
+      quote = character;
+      continue;
+    }
+    if (character === "{") depth += 1;
+    if (character === "}") {
+      depth -= 1;
+      if (depth === 0) return index;
+    }
+  }
+  return fileContent.length;
+};
+
+interface FunctionParameterSource {
+  readonly functionName: string;
+  readonly parameterIndex: number;
+}
+
+const findContainingFunctionParameterSource = (
+  identifier: string,
+  sinkIndex: number,
+  fileContent: string,
+): FunctionParameterSource | null => {
+  const patterns = [
+    /function\s+([\w$]+)\s*\(([^)]*)\)\s*\{/g,
+    /(?:const|let|var)\s+([\w$]+)\s*=\s*(?:async\s*)?\(([^)]*)\)\s*=>\s*\{/g,
+  ];
+  let closestSource: FunctionParameterSource | null = null;
+  let closestStartIndex = -1;
+  for (const pattern of patterns) {
+    for (const match of fileContent.matchAll(pattern)) {
+      const matchIndex = match.index;
+      if (matchIndex === undefined || matchIndex >= sinkIndex || matchIndex < closestStartIndex) {
+        continue;
+      }
+      const openingBraceIndex = matchIndex + match[0].lastIndexOf("{");
+      if (findMatchingBraceIndex(fileContent, openingBraceIndex) < sinkIndex) continue;
+      const parameterIndex = (match[2] ?? "")
+        .split(",")
+        .findIndex(
+          (parameter) => parameter.trim().match(/^(?:\.\.\.)?([\w$]+)/)?.[1] === identifier,
+        );
+      if (parameterIndex < 0) continue;
+      closestStartIndex = matchIndex;
+      closestSource = { functionName: match[1] ?? "", parameterIndex };
+    }
+  }
+  return closestSource;
+};
+
+const splitTopLevelArguments = (argumentText: string): string[] => {
+  const argumentsList: string[] = [];
+  let startIndex = 0;
+  let depth = 0;
+  let quote: string | null = null;
+  for (let index = 0; index < argumentText.length; index += 1) {
+    const character = argumentText[index];
+    if (quote !== null) {
+      if (character === quote && argumentText[index - 1] !== "\\") quote = null;
+      continue;
+    }
+    if (character === '"' || character === "'" || character === "`") {
+      quote = character;
+      continue;
+    }
+    if (character === "(" || character === "[" || character === "{") depth += 1;
+    if (character === ")" || character === "]" || character === "}") depth -= 1;
+    if (character === "," && depth === 0) {
+      argumentsList.push(argumentText.slice(startIndex, index).trim());
+      startIndex = index + 1;
+    }
+  }
+  argumentsList.push(argumentText.slice(startIndex).trim());
+  return argumentsList;
+};
+
+const isHtmlTainted = (
+  expression: string,
+  fileContent: string,
+  sinkIndex: number,
+  visitedIdentifiers: Set<string>,
+): boolean => {
+  const trimmedExpression = expression.trim();
+  if (STRING_LITERAL_VALUE_PATTERN.test(`${trimmedExpression};`)) return false;
+  if (MODULE_CONSTANT_VALUE_PATTERN.test(`${trimmedExpression};`)) return false;
+  if (SANITIZER_PATTERN.test(trimmedExpression)) return false;
+  if (ENV_CONFIG_VALUE_PATTERN.test(trimmedExpression)) return false;
+  if (I18N_VALUE_PATTERN.test(trimmedExpression)) return false;
+  if (ESCAPING_SERIALIZER_CALL_PATTERN.test(trimmedExpression)) return false;
+  if (HTML_TAINT_PATTERN.test(trimmedExpression)) return true;
+  const identifier = trimmedExpression.match(/^([\w$]+)\s*(?:[;,})\n]|$)/)?.[1];
+  if (identifier === undefined || visitedIdentifiers.has(identifier)) return false;
+  visitedIdentifiers.add(identifier);
+
+  const initializerPattern = new RegExp(
+    `(?:const|let|var)\\s+${escapeRegExp(identifier)}\\s*(?::[^=\\n]*)?=\\s*([^;\\n]+)`,
+  );
+  const initializer = initializerPattern.exec(fileContent)?.[1];
+  if (
+    initializer !== undefined &&
+    isHtmlTainted(initializer, fileContent, sinkIndex, visitedIdentifiers)
+  ) {
+    return true;
+  }
+
+  const parameterSource = findContainingFunctionParameterSource(identifier, sinkIndex, fileContent);
+  if (parameterSource === null || parameterSource.functionName.length === 0) return false;
+  const callPattern = new RegExp(
+    `\\b${escapeRegExp(parameterSource.functionName)}\\s*\\(([^)]*)\\)`,
+    "g",
+  );
+  for (const callMatch of fileContent.matchAll(callPattern)) {
+    const argument = splitTopLevelArguments(callMatch[1] ?? "")[parameterSource.parameterIndex];
+    if (
+      argument !== undefined &&
+      isHtmlTainted(argument, fileContent, sinkIndex, new Set(visitedIdentifiers))
+    ) {
+      return true;
+    }
+  }
+  return false;
+};
+
 export const dangerousHtmlSink = defineRule({
   id: "dangerous-html-sink",
   title: "HTML injection sink with dynamic content",
@@ -409,7 +541,11 @@ export const dangerousHtmlSink = defineRule({
       if (SANITIZER_PATTERN.test(judgedExpression)) continue;
       if (ENV_CONFIG_VALUE_PATTERN.test(judgedExpression)) continue;
       if (I18N_VALUE_PATTERN.test(judgedExpression)) continue;
-      if (!HTML_TAINT_PATTERN.test(judgedExpression)) continue;
+      const sinkIndex =
+        lines.slice(0, lineIndex).join("\n").length +
+        (lineIndex > 0 ? 1 : 0) +
+        line.search(DANGEROUS_HTML_PATTERN);
+      if (!isHtmlTainted(judgedExpression, file.content, sinkIndex, new Set())) continue;
       if (ESCAPING_SERIALIZER_CALL_PATTERN.test(valueExpression)) continue;
       // Highlighter output: a `highlighted*` value is escaped, token-wrapped
       // markup by naming convention (often passed as a prop or routed through

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/utils/is-production-source-path.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/utils/is-production-source-path.ts
@@ -2,5 +2,6 @@ import { SOURCE_FILE_PATTERN } from "../../../constants/security-scan.js";
 import { isProductionFilePath } from "./is-production-file-path.js";
 
 export const isProductionSourcePath = (relativePath: string): boolean => {
+  if (/\.d\.[cm]?[jt]s$/i.test(relativePath)) return false;
   return isProductionFilePath(relativePath, SOURCE_FILE_PATTERN);
 };


### PR DESCRIPTION
## Summary

- trace dangerous HTML values through const aliases and visible helper parameters
- preserve trusted static, sanitized, i18n, environment, and serializer sources
- exclude TypeScript declaration files from executable security scans
- add a patch changeset and focused regression coverage

## Validation

- full plugin suite: 543 files, 11,959 passed, 148 skipped
- `nr typecheck`
- `nr lint`
- `nr format:check`
- `nr build`
- strict fuzz: 500 iterations
- fuzz package: 37 tests

## RDE OSS comparison (50 projects)

| Revision | `dangerous-html-sink` diagnostics | Repos |
| --- | ---: | ---: |
| baseline (`0.7.5`) | 10 | 3 |
| candidate | 10 | 3 |

The sorted rule/repo/root/file/line/column/message identity sets are exactly equal.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes heuristics for a security lint rule; OSS comparison reports identical diagnostic sets, but regex-based data-flow tracing can still miss or misread unusual patterns.
> 
> **Overview**
> Improves **`dangerous-html-sink`** so dynamic HTML is traced beyond the sink expression itself, while keeping existing trusted-source exemptions.
> 
> **Taint tracing:** Replaces a single `HTML_TAINT_PATTERN` check with recursive **`isHtmlTainted`**, which follows **const/let/var aliases** (scope-aware via block boundaries) and **helper parameters** (arrow and function declarations), walking call sites to see whether arguments are tainted. Identifier declarations now resolve to the **in-scope** binding before the sink, not the first file-wide match.
> 
> **Scan scope:** **`isProductionSourcePath`** skips **`.d.ts`** (and `.d.mts` / `.d.cts`) so type-only files with sink-shaped names are not scanned as executable code.
> 
> Patch changeset and regression tests cover alias routing, shadowed names, helper indirection, static/sanitized helper args, and declaration-file silence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc2a7a5b5fbcf4f0a1e233a5ab99a9997c5b520a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->