### PR TITLE
fix(security): distinguish product API key records

### DIFF
--- a/.changeset/lazy-fans-attack.md
+++ b/.changeset/lazy-fans-attack.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Avoid auth-token diagnostics for product-scoped API-key record collections while preserving authentication credential findings.

--- a/packages/fuzz/corpus/regressions/auth-token-in-web-storage--product-api-key-records.tsx
+++ b/packages/fuzz/corpus/regressions/auth-token-in-web-storage--product-api-key-records.tsx
@@ -1,0 +1,16 @@
+// rule: auth-token-in-web-storage
+// weakness: name-heuristic
+// source: react-bench fix-react-rdh-sofn-xyz-mailing-settings
+
+interface MailingApiKeyRecord {
+  id: string;
+  key: string;
+  status: string;
+  createdAt: string;
+}
+
+const STORAGE_KEY = "mailing.createdApiKeys";
+
+export const persistCreatedApiKeys = (records: MailingApiKeyRecord[]) => {
+  sessionStorage.setItem(STORAGE_KEY, JSON.stringify(records));
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/auth-token-in-web-storage.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/auth-token-in-web-storage.regressions.test.ts
@@ -53,6 +53,27 @@ describe("security/auth-token-in-web-storage — regressions", () => {
     expect(diagnostics.length).toBeGreaterThan(0);
   });
 
+  it("stays silent on product-scoped API-key table records", () => {
+    const { diagnostics } = runRule(
+      authTokenInWebStorage,
+      `const LOCAL_API_KEYS_STORAGE_KEY = "mailing.createdApiKeys";
+      sessionStorage.setItem(
+        LOCAL_API_KEYS_STORAGE_KEY,
+        JSON.stringify([{ id, key, status, createdAt }]),
+      );`,
+    );
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it("still flags authentication API keys and singular credentials", () => {
+    const { diagnostics } = runRule(
+      authTokenInWebStorage,
+      `sessionStorage.setItem("auth.apiKey", apiKey);
+      sessionStorage.setItem("mailing.createdApiKey", apiKey);`,
+    );
+    expect(diagnostics).toHaveLength(2);
+  });
+
   // Docs-validation FP wave: E2E scaffolding under `playwright/` seeds tokens
   // via page.evaluate to simulate login — test tooling, not production
   // exposure. `/playwright/` was missing from the testlike path segments.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/auth-token-in-web-storage.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/auth-token-in-web-storage.ts
@@ -29,9 +29,12 @@ const NON_AUTH_TOKEN_PATTERN =
   /csrf|xsrf|device|fcm|apns|push|design|tokeniz|syntax|css|theme|color/i;
 const STRONG_AUTH_KEY_PATTERN =
   /jwt|secret|password|passwd|credential|private[-_]?key|api[-_]?key|bearer|access[-_]?token|refresh[-_]?token|auth[-_]?token|id[-_]?token|session/i;
+const PRODUCT_API_KEY_RECORDS_PATTERN =
+  /(?:^|[._:-])(?:created|saved|integration|mailing)[-_]?api[-_]?keys$/i;
 const PRODUCT_API_KEY_COLLECTION_PATTERN = /[._:-](?:created|generated|saved)[-_]?api[-_]?keys$/i;
 
 const isAuthCredentialKey = (key: string): boolean => {
+  if (PRODUCT_API_KEY_RECORDS_PATTERN.test(key)) return false;
   if (!SENSITIVE_KEY_PATTERN.test(key)) return false;
   if (PRODUCT_API_KEY_COLLECTION_PATTERN.test(key)) return false;
   if (NON_AUTH_TOKEN_PATTERN.test(key) && !STRONG_AUTH_KEY_PATTERN.test(key)) return false;


### PR DESCRIPTION
## Summary

- keep `auth-token-in-web-storage` quiet for plural product API-key record collections such as `mailing.createdApiKeys`
- preserve findings for singular API keys and authentication-scoped API keys
- add regression, fuzz-corpus, and changeset coverage

## Validation

- full plugin suite: 543 files, 11,956 passed, 148 skipped
- `nr typecheck`
- `nr lint`
- `nr format:check`
- `nr build`
- strict fuzz: 500 iterations

## RDE OSS comparison (50 projects)

| Revision | `auth-token-in-web-storage` diagnostics | Repos |
| --- | ---: | ---: |
| baseline (`0.7.5`) | 0 | 0 |
| candidate | 0 | 0 |

The already-landed session-storage versioning exemption from #1137 remains unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches security-rule heuristics; behavior is constrained by new regression tests that assert real auth API keys still diagnose.
> 
> **Overview**
> Reduces false positives in **`auth-token-in-web-storage`** by treating plural, product-scoped storage keys (e.g. `mailing.createdApiKeys`) as non-credentials.
> 
> `isAuthCredentialKey` now short-circuits on a new **`PRODUCT_API_KEY_RECORDS_PATTERN`** (covers `created` / `saved` / `integration` / `mailing` … `apiKeys` at key start or after `.`, `_`, `:`, `-`) before the existing sensitive-key checks. Singular or auth-scoped keys such as `auth.apiKey` and `mailing.createdApiKey` still report.
> 
> Adds regression tests, a fuzz corpus case, and a patch changeset for `oxlint-plugin-react-doctor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68b75ba35a993f669e5270224ab51d695c837c14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->