### PR TITLE
fix(security): preserve HTML alias provenance

### DIFF
--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/dangerous-html-sink.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/dangerous-html-sink.regressions.test.ts
@@ -994,6 +994,68 @@ return <div dangerouslySetInnerHTML={{ __html: content }} />;
     expect(findings).toHaveLength(0);
   });
 
+  it("does not let a later trusted binding clear an earlier tainted alias", () => {
+    const content = [
+      "const source = props.userHtml;",
+      "const bodyHtml = source;",
+      "export const renderPreview = (element) => {",
+      '  const source = "<p>Static</p>";',
+      "  element.innerHTML = bodyHtml;",
+      "};",
+    ].join("\n");
+    const findings = runScanRule(dangerousHtmlSink, {
+      relativePath: "src/components/preview.ts",
+      content,
+    });
+    expect(findings).toHaveLength(1);
+  });
+
+  it("flags an externally called helper despite an outer trusted lookalike binding", () => {
+    const content = [
+      'const html = "<p>Static</p>";',
+      "export const renderPreview = (element, html) => {",
+      "  element.innerHTML = html;",
+      "};",
+    ].join("\n");
+    const findings = runScanRule(dangerousHtmlSink, {
+      relativePath: "src/components/preview.ts",
+      content,
+    });
+    expect(findings).toHaveLength(1);
+  });
+
+  it("ignores recursive calls when every external helper argument is trusted", () => {
+    const content = [
+      "function renderPreview(element, html, remaining) {",
+      "  element.innerHTML = html;",
+      "  if (remaining > 0) renderPreview(element, html, remaining - 1);",
+      "}",
+      'renderPreview(preview, "<p>Static</p>", 2);',
+    ].join("\n");
+    const findings = runScanRule(dangerousHtmlSink, {
+      relativePath: "src/components/preview.ts",
+      content,
+    });
+    expect(findings).toHaveLength(0);
+  });
+
+  it("prefers a nested tainted binding over a trusted helper parameter", () => {
+    const content = [
+      "const renderPreview = (element, html) => {",
+      "  if (element) {",
+      "    const html = props.userHtml;",
+      "    element.innerHTML = html;",
+      "  }",
+      "};",
+      'renderPreview(preview, "<p>Static</p>");',
+    ].join("\n");
+    const findings = runScanRule(dangerousHtmlSink, {
+      relativePath: "src/components/preview.ts",
+      content,
+    });
+    expect(findings).toHaveLength(1);
+  });
+
   it("still flags an identifier declared from a template with tainted interpolations", () => {
     const findings = runScanRule(dangerousHtmlSink, {
       relativePath: "src/widgets/card.ts",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/dangerous-html-sink.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/dangerous-html-sink.regressions.test.ts
@@ -1132,6 +1132,23 @@ return <div dangerouslySetInnerHTML={{ __html: content }} />;
     expect(findings).toHaveLength(0);
   });
 
+  it("flags a recursive call that reassigns a local parameter alias", () => {
+    const content = [
+      "function renderPreview(element, html, remaining) {",
+      "  element.innerHTML = html;",
+      "  let nextHtml = html;",
+      "  nextHtml = props.userHtml;",
+      "  if (remaining > 0) renderPreview(element, nextHtml, remaining - 1);",
+      "}",
+      'renderPreview(preview, "<p>Static</p>", 2);',
+    ].join("\n");
+    const findings = runScanRule(dangerousHtmlSink, {
+      relativePath: "src/components/preview.ts",
+      content,
+    });
+    expect(findings).toHaveLength(1);
+  });
+
   it("keeps a trusted helper argument containing parentheses intact", () => {
     const content = [
       "const renderPreview = (element, html) => {",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/dangerous-html-sink.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/dangerous-html-sink.regressions.test.ts
@@ -892,10 +892,7 @@ return <div dangerouslySetInnerHTML={{ __html: content }} />;
   it("stays silent on an identifier declared from an escapeHtml-escaped template (contact-print shape)", () => {
     const content = [
       "const html = `<html><body>",
-      "<header>${photoTag}",
       '<div><h1>${escapeHtml(name || "Contact")}</h1></div>',
-      "</header>",
-      '${rows.join("")}',
       "</body></html>`;",
       "printWindow.document.write(html);",
     ].join("\n");
@@ -1052,6 +1049,47 @@ return <div dangerouslySetInnerHTML={{ __html: content }} />;
     const findings = runScanRule(dangerousHtmlSink, {
       relativePath: "src/components/preview.ts",
       content,
+    });
+    expect(findings).toHaveLength(1);
+  });
+
+  it("stays silent when a highlighter result member is routed through an alias", () => {
+    const content = [
+      "const result = highlighter.codeToHtml(source);",
+      "const darkHtml = result.dark;",
+      "element.innerHTML = darkHtml;",
+    ].join("\n");
+    const findings = runScanRule(dangerousHtmlSink, {
+      relativePath: "src/components/preview.ts",
+      content,
+    });
+    expect(findings).toHaveLength(0);
+  });
+
+  it("flags a helper re-entry that replaces a trusted argument with tainted HTML", () => {
+    const content = [
+      "function renderPreview(element, html, nested) {",
+      "  element.innerHTML = html;",
+      "  if (nested) renderPreview(element, props.userHtml, false);",
+      "}",
+      'renderPreview(preview, "<p>Static</p>", true);',
+    ].join("\n");
+    const findings = runScanRule(dangerousHtmlSink, {
+      relativePath: "src/components/preview.ts",
+      content,
+    });
+    expect(findings).toHaveLength(1);
+  });
+
+  it.each([
+    "DOMPurify.sanitize(props.safeHtml) + props.userHtml",
+    "renderer.codeToHtml(source) + props.userHtml",
+    "process.env.STATIC_HTML + props.userHtml",
+    "`${DOMPurify.sanitize(props.safeHtml)}${props.userHtml}`",
+  ])("does not trust a partially sanitized compound value %#", (valueExpression) => {
+    const findings = runScanRule(dangerousHtmlSink, {
+      relativePath: "src/components/preview.ts",
+      content: `const bodyHtml = ${valueExpression};\nelement.innerHTML = bodyHtml;\n`,
     });
     expect(findings).toHaveLength(1);
   });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/dangerous-html-sink.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/dangerous-html-sink.regressions.test.ts
@@ -155,6 +155,47 @@ export const Preview = ({ html }: { html: string }) => {
     expect(findings).toHaveLength(1);
   });
 
+  it("flags a call-site alias declared after the helper sink", () => {
+    const findings = runScanRule(dangerousHtmlSink, {
+      relativePath: "src/components/preview.tsx",
+      content: `const inject = (element: HTMLElement, payload: string) => {
+  element.innerHTML = payload;
+};
+export const Preview = ({ html }: { html: string }) => {
+  const payload = html;
+  inject(document.body, payload);
+};
+`,
+    });
+    expect(findings).toHaveLength(1);
+  });
+
+  it("does not recurse forever through a self-calling helper", () => {
+    const findings = runScanRule(dangerousHtmlSink, {
+      relativePath: "src/components/preview.tsx",
+      content: `const inject = (element: HTMLElement, payload: string) => {
+  element.innerHTML = payload;
+  inject(element, payload);
+};
+inject(document.body, "<strong>static</strong>");
+`,
+    });
+    expect(findings).toHaveLength(0);
+  });
+
+  it("traces a helper parameter before an outer same-named binding", () => {
+    const findings = runScanRule(dangerousHtmlSink, {
+      relativePath: "src/components/preview.tsx",
+      content: `const payload = "<strong>static</strong>";
+const inject = (element: HTMLElement, payload: string) => {
+  element.innerHTML = payload;
+};
+inject(document.body, props.html);
+`,
+    });
+    expect(findings).toHaveLength(1);
+  });
+
   it("flags prop HTML routed through a function-declaration helper", () => {
     const findings = runScanRule(dangerousHtmlSink, {
       relativePath: "src/components/preview.tsx",
@@ -211,6 +252,49 @@ preview.innerHTML = preview.html;
       content: `const temporaryContainer = document.createElement("div");\ntemporaryContainer.innerHTML = toHtml(createGutterUtilityElement());\n`,
     });
     expect(findings).toHaveLength(0);
+  });
+
+  it("stays silent when trusted highlighter output is routed through an alias", () => {
+    const findings = runScanRule(dangerousHtmlSink, {
+      relativePath: "src/components/code-preview.tsx",
+      content: `const highlighted = highlighter.codeToHtml(code);
+const rendered = highlighted.dark;
+return <div dangerouslySetInnerHTML={{ __html: rendered }} />;
+`,
+    });
+    expect(findings).toHaveLength(0);
+  });
+
+  it("stays silent when escaping serializer output is routed through an alias", () => {
+    const findings = runScanRule(dangerousHtmlSink, {
+      relativePath: "src/components/code-preview.tsx",
+      content: `const escaped = renderToStaticMarkup(content);
+const rendered = escaped;
+return <div dangerouslySetInnerHTML={{ __html: rendered }} />;
+`,
+    });
+    expect(findings).toHaveLength(0);
+  });
+
+  it("flags a highlighter-named alias assigned from user HTML", () => {
+    const findings = runScanRule(dangerousHtmlSink, {
+      relativePath: "src/components/code-preview.tsx",
+      content: `const highlightedHtml = props.html;
+const rendered = highlightedHtml;
+return <div dangerouslySetInnerHTML={{ __html: rendered }} />;
+`,
+    });
+    expect(findings).toHaveLength(1);
+  });
+
+  it("flags a taint-named alias initialized by an opaque call", () => {
+    const findings = runScanRule(dangerousHtmlSink, {
+      relativePath: "src/components/preview.tsx",
+      content: `const content = loadPage();
+return <div dangerouslySetInnerHTML={{ __html: content }} />;
+`,
+    });
+    expect(findings).toHaveLength(1);
   });
 
   it("stays silent on KaTeX-rendered html identifiers", () => {
@@ -860,6 +944,54 @@ preview.innerHTML = preview.html;
       content: `const bodyHtml = props.body;\nreturn <div dangerouslySetInnerHTML={{ __html: bodyHtml || '' }} />;\n`,
     });
     expect(findings).toHaveLength(1);
+  });
+
+  it("still flags a taint-named property read from a helper parameter", () => {
+    const content = [
+      "const renderPreview = (element, data) => {",
+      "  element.innerHTML = data.html;",
+      "};",
+      "renderPreview(preview, loadPreview());",
+    ].join("\n");
+    const findings = runScanRule(dangerousHtmlSink, {
+      relativePath: "src/components/preview.ts",
+      content,
+    });
+    expect(findings).toHaveLength(1);
+  });
+
+  it("stays silent when every taint-named helper parameter receives explicitly trusted HTML", () => {
+    const content = [
+      "const renderPreview = (element, html) => {",
+      "  element.innerHTML = html;",
+      "};",
+      'renderPreview(firstPreview, "<p>Static preview</p>");',
+      "renderPreview(secondPreview, DOMPurify.sanitize(loadPreview()));",
+    ].join("\n");
+    const findings = runScanRule(dangerousHtmlSink, {
+      relativePath: "src/components/preview.ts",
+      content,
+    });
+    expect(findings).toHaveLength(0);
+  });
+
+  it("stays silent when trusted helper arguments pass through local aliases", () => {
+    const content = [
+      "const renderPreview = (element, html) => {",
+      "  element.innerHTML = html;",
+      "};",
+      'const staticPreview = "<p>Static preview</p>";',
+      "const sanitizedPreview = DOMPurify.sanitize(loadPreview());",
+      "const serializedPreview = highlighter.codeToHtml(source);",
+      "renderPreview(firstPreview, staticPreview);",
+      "renderPreview(secondPreview, sanitizedPreview);",
+      "renderPreview(thirdPreview, serializedPreview);",
+    ].join("\n");
+    const findings = runScanRule(dangerousHtmlSink, {
+      relativePath: "src/components/preview.ts",
+      content,
+    });
+    expect(findings).toHaveLength(0);
   });
 
   it("still flags an identifier declared from a template with tainted interpolations", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/dangerous-html-sink.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/dangerous-html-sink.regressions.test.ts
@@ -1094,6 +1094,66 @@ return <div dangerouslySetInnerHTML={{ __html: content }} />;
     expect(findings).toHaveLength(1);
   });
 
+  it.each(["safeHtml", "SANITIZED_HTML"])(
+    "does not trust a trusted-looking alias whose initializer is tainted: %s",
+    (trustedLookingName) => {
+      const findings = runScanRule(dangerousHtmlSink, {
+        relativePath: "src/components/preview.ts",
+        content: `const ${trustedLookingName} = props.userHtml;\nconst bodyHtml = ${trustedLookingName};\nelement.innerHTML = bodyHtml;\n`,
+      });
+      expect(findings).toHaveLength(1);
+    },
+  );
+
+  it.each([
+    "DOMPurify.sanitize(first) + DOMPurify.sanitize(second)",
+    "`${escapeHtml(first)}${escapeHtml(second)}`",
+  ])("stays silent when every compound value part is trusted %#", (valueExpression) => {
+    const findings = runScanRule(dangerousHtmlSink, {
+      relativePath: "src/components/preview.ts",
+      content: `const bodyHtml = ${valueExpression};\nelement.innerHTML = bodyHtml;\n`,
+    });
+    expect(findings).toHaveLength(0);
+  });
+
+  it("ignores a recursive call that re-passes the parameter through a local alias", () => {
+    const content = [
+      "function renderPreview(element, html, remaining) {",
+      "  element.innerHTML = html;",
+      "  const nextHtml = html;",
+      "  if (remaining > 0) renderPreview(element, nextHtml, remaining - 1);",
+      "}",
+      'renderPreview(preview, "<p>Static</p>", 2);',
+    ].join("\n");
+    const findings = runScanRule(dangerousHtmlSink, {
+      relativePath: "src/components/preview.ts",
+      content,
+    });
+    expect(findings).toHaveLength(0);
+  });
+
+  it("keeps a trusted helper argument containing parentheses intact", () => {
+    const content = [
+      "const renderPreview = (element, html) => {",
+      "  element.innerHTML = html;",
+      "};",
+      'renderPreview(preview, "<p>Static (preview)</p>");',
+    ].join("\n");
+    const findings = runScanRule(dangerousHtmlSink, {
+      relativePath: "src/components/preview.ts",
+      content,
+    });
+    expect(findings).toHaveLength(0);
+  });
+
+  it("does not trust a highlighter-named alias from a library-looking prop", () => {
+    const findings = runScanRule(dangerousHtmlSink, {
+      relativePath: "src/components/preview.ts",
+      content: "const highlightedHtml = props.shikiHtml;\nelement.innerHTML = highlightedHtml;\n",
+    });
+    expect(findings).toHaveLength(1);
+  });
+
   it("still flags an identifier declared from a template with tainted interpolations", () => {
     const findings = runScanRule(dangerousHtmlSink, {
       relativePath: "src/widgets/card.ts",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/dangerous-html-sink.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/dangerous-html-sink.ts
@@ -1,6 +1,7 @@
 import { defineRule } from "../../utils/define-rule.js";
 import type { ScanFinding } from "../../utils/file-scan.js";
 import { escapeRegExp } from "./utils/escape-reg-exp.js";
+import { findMatchingBracket } from "./utils/find-matching-bracket.js";
 import { isProductionSourcePath } from "./utils/is-production-source-path.js";
 
 // HTML-injection sinks: React's `dangerouslySetInnerHTML`, the DOM
@@ -338,28 +339,6 @@ const findMatchingBraceIndex = (fileContent: string, openingBraceIndex: number):
   return fileContent.length;
 };
 
-const findMatchingParenthesisIndex = (fileContent: string, openingIndex: number): number => {
-  let depth = 0;
-  let quote: string | null = null;
-  for (let index = openingIndex; index < fileContent.length; index += 1) {
-    const character = fileContent[index];
-    if (quote !== null) {
-      if (character === quote && fileContent[index - 1] !== "\\") quote = null;
-      continue;
-    }
-    if (character === '"' || character === "'" || character === "`") {
-      quote = character;
-      continue;
-    }
-    if (character === "(") depth += 1;
-    if (character === ")") {
-      depth -= 1;
-      if (depth === 0) return index;
-    }
-  }
-  return fileContent.length;
-};
-
 const findContainingBlockEndIndex = (fileContent: string, targetIndex: number): number => {
   const openingBraceIndexes: number[] = [];
   let quote: string | null = null;
@@ -410,6 +389,7 @@ interface VisibleIdentifierDeclaration {
   readonly declarationIndex: number;
   readonly initializer: string;
   readonly initializerStartIndex: number;
+  readonly isImmutable: boolean;
 }
 
 const findVisibleIdentifierDeclaration = (
@@ -418,7 +398,7 @@ const findVisibleIdentifierDeclaration = (
   fileContent: string,
 ): VisibleIdentifierDeclaration | null => {
   const initializerPattern = new RegExp(
-    `(?:const|let|var)\\s+${escapeRegExp(identifier)}\\s*(?::[^=\\n]*)?=\\s*([^;\\n]+)`,
+    `(const|let|var)\\s+${escapeRegExp(identifier)}\\s*(?::[^=\\n]*)?=\\s*([^;\\n]+)`,
     "g",
   );
   let nearestDeclaration: VisibleIdentifierDeclaration | null = null;
@@ -434,12 +414,13 @@ const findVisibleIdentifierDeclaration = (
       continue;
     }
     nearestDeclarationIndex = declarationIndex;
-    const initializer = match[1];
+    const initializer = match[2];
     if (initializer === undefined) continue;
     nearestDeclaration = {
       declarationIndex,
       initializer,
       initializerStartIndex: declarationIndex + match[0].length - initializer.length,
+      isImmutable: match[1] === "const",
     };
   }
   return nearestDeclaration;
@@ -523,7 +504,7 @@ const doesExpressionAliasIdentifier = (
   if (identifier === targetIdentifier) return true;
   if (visitedIdentifiers.has(identifier)) return false;
   const declaration = findVisibleIdentifierDeclaration(identifier, expressionIndex, fileContent);
-  if (!declaration) return false;
+  if (!declaration?.isImmutable) return false;
   const nextVisitedIdentifiers = new Set(visitedIdentifiers);
   nextVisitedIdentifiers.add(identifier);
   return doesExpressionAliasIdentifier(
@@ -659,10 +640,8 @@ const isHtmlTainted = (
         continue;
       }
       const openingParenthesisIndex = callMatch.index + callMatch[0].lastIndexOf("(");
-      const closingParenthesisIndex = findMatchingParenthesisIndex(
-        fileContent,
-        openingParenthesisIndex,
-      );
+      const closingParenthesisIndex = findMatchingBracket(fileContent, openingParenthesisIndex);
+      if (closingParenthesisIndex < 0) continue;
       const argument = splitTopLevelArguments(
         fileContent.slice(openingParenthesisIndex + 1, closingParenthesisIndex),
       )[parameterSource.parameterIndex];

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/dangerous-html-sink.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/dangerous-html-sink.ts
@@ -382,6 +382,7 @@ const findContainingBlockEndIndex = (fileContent: string, targetIndex: number): 
 };
 
 interface VisibleIdentifierDeclaration {
+  readonly declarationIndex: number;
   readonly initializer: string;
   readonly initializerStartIndex: number;
 }
@@ -411,6 +412,7 @@ const findVisibleIdentifierDeclaration = (
     const initializer = match[1];
     if (initializer === undefined) continue;
     nearestDeclaration = {
+      declarationIndex,
       initializer,
       initializerStartIndex: declarationIndex + match[0].length - initializer.length,
     };
@@ -469,6 +471,7 @@ const isExplicitlyTrustedHtmlValue = (
 };
 
 interface FunctionParameterSource {
+  readonly bodyEndIndex: number;
   readonly declarationNameIndex: number;
   readonly functionName: string;
   readonly parameterIndex: number;
@@ -492,7 +495,8 @@ const findContainingFunctionParameterSource = (
         continue;
       }
       const openingBraceIndex = matchIndex + match[0].lastIndexOf("{");
-      if (findMatchingBraceIndex(fileContent, openingBraceIndex) < sinkIndex) continue;
+      const bodyEndIndex = findMatchingBraceIndex(fileContent, openingBraceIndex);
+      if (bodyEndIndex < sinkIndex) continue;
       const parameterIndex = (match[2] ?? "")
         .split(",")
         .findIndex(
@@ -502,6 +506,7 @@ const findContainingFunctionParameterSource = (
       closestStartIndex = matchIndex;
       const functionName = match[1] ?? "";
       closestSource = {
+        bodyEndIndex,
         declarationNameIndex: matchIndex + match[0].indexOf(functionName),
         functionName,
         parameterIndex,
@@ -551,7 +556,32 @@ const isHtmlTainted = (
   if (visitedIdentifiers.has(identifier)) return false;
   visitedIdentifiers.add(identifier);
 
+  const declaration = findVisibleIdentifierDeclaration(identifier, sinkIndex, fileContent);
   const parameterSource = findContainingFunctionParameterSource(identifier, sinkIndex, fileContent);
+  const doesDeclarationShadowParameter =
+    declaration !== null &&
+    (parameterSource === null ||
+      declaration.declarationIndex > parameterSource.declarationNameIndex);
+  if (doesDeclarationShadowParameter) {
+    if (
+      isExplicitlyTrustedHtmlValue(
+        declaration.initializer,
+        fileContent,
+        declaration.initializerStartIndex,
+      )
+    ) {
+      return false;
+    }
+    return (
+      isHtmlTainted(
+        declaration.initializer,
+        fileContent,
+        declaration.initializerStartIndex,
+        visitedIdentifiers,
+        visitedCallSites,
+      ) || HTML_TAINT_PATTERN.test(trimmedExpression)
+    );
+  }
   if (parameterSource !== null && parameterSource.functionName.length > 0) {
     const callPattern = new RegExp(
       `\\b${escapeRegExp(parameterSource.functionName)}\\s*\\(([^)]*)\\)`,
@@ -562,6 +592,8 @@ const isHtmlTainted = (
     for (const callMatch of fileContent.matchAll(callPattern)) {
       if (
         callMatch.index === parameterSource.declarationNameIndex ||
+        (callMatch.index >= parameterSource.declarationNameIndex &&
+          callMatch.index <= parameterSource.bodyEndIndex) ||
         visitedCallSites.has(callMatch.index)
       ) {
         continue;
@@ -595,16 +627,24 @@ const isHtmlTainted = (
         !didInspectOnlyExplicitlyTrustedArguments && HTML_TAINT_PATTERN.test(trimmedExpression)
       );
     }
+    return HTML_TAINT_PATTERN.test(trimmedExpression);
   }
 
-  const declaration = findVisibleIdentifierDeclaration(identifier, sinkIndex, fileContent);
   if (declaration !== null) {
-    if (isExplicitlyTrustedHtmlValue(declaration.initializer, fileContent, sinkIndex)) return false;
+    if (
+      isExplicitlyTrustedHtmlValue(
+        declaration.initializer,
+        fileContent,
+        declaration.initializerStartIndex,
+      )
+    ) {
+      return false;
+    }
     return (
       isHtmlTainted(
         declaration.initializer,
         fileContent,
-        sinkIndex,
+        declaration.initializerStartIndex,
         visitedIdentifiers,
         visitedCallSites,
       ) || HTML_TAINT_PATTERN.test(trimmedExpression)

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/dangerous-html-sink.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/dangerous-html-sink.ts
@@ -445,18 +445,24 @@ const isExplicitlyTrustedHtmlValue = (
   visitedIdentifiers: Set<string> = new Set(),
 ): boolean => {
   const trimmedExpression = valueExpression.trim();
+  const isCompoundValue =
+    splitTopLevelByPlus(trimmedExpression).length > 1 ||
+    (trimmedExpression.match(/\$\{/g)?.length ?? 0) > 1;
   if (
-    STRING_LITERAL_VALUE_PATTERN.test(`${trimmedExpression};`) ||
-    MODULE_CONSTANT_VALUE_PATTERN.test(`${trimmedExpression};`) ||
-    SANITIZER_PATTERN.test(trimmedExpression) ||
-    ENV_CONFIG_VALUE_PATTERN.test(trimmedExpression) ||
-    I18N_VALUE_PATTERN.test(trimmedExpression) ||
-    ESCAPING_SERIALIZER_CALL_PATTERN.test(trimmedExpression) ||
-    isTrustedHighlighterValue(trimmedExpression, fileContent, sinkIndex)
+    !isCompoundValue &&
+    (STRING_LITERAL_VALUE_PATTERN.test(`${trimmedExpression};`) ||
+      MODULE_CONSTANT_VALUE_PATTERN.test(`${trimmedExpression};`) ||
+      SANITIZER_PATTERN.test(trimmedExpression) ||
+      ENV_CONFIG_VALUE_PATTERN.test(trimmedExpression) ||
+      I18N_VALUE_PATTERN.test(trimmedExpression) ||
+      ESCAPING_SERIALIZER_CALL_PATTERN.test(trimmedExpression) ||
+      isTrustedHighlighterValue(trimmedExpression, fileContent, sinkIndex))
   ) {
     return true;
   }
-  const identifier = trimmedExpression.match(/^([\w$]+)$/)?.[1];
+  const identifier = trimmedExpression.match(
+    /^([\w$]+)(?:(?:\??\.[\w$]+)|(?:\[\s*(?:"[^"\n]*"|'[^'\n]*'|\d+)\s*\]))*$/,
+  )?.[1];
   if (!identifier || visitedIdentifiers.has(identifier)) return false;
   const declaration = findVisibleIdentifierDeclaration(identifier, sinkIndex, fileContent);
   if (!declaration) return false;
@@ -592,14 +598,16 @@ const isHtmlTainted = (
     for (const callMatch of fileContent.matchAll(callPattern)) {
       if (
         callMatch.index === parameterSource.declarationNameIndex ||
-        (callMatch.index >= parameterSource.declarationNameIndex &&
-          callMatch.index <= parameterSource.bodyEndIndex) ||
         visitedCallSites.has(callMatch.index)
       ) {
         continue;
       }
       const argument = splitTopLevelArguments(callMatch[1] ?? "")[parameterSource.parameterIndex];
       if (argument === undefined) continue;
+      const isCallInsideFunctionBody =
+        callMatch.index >= parameterSource.declarationNameIndex &&
+        callMatch.index <= parameterSource.bodyEndIndex;
+      if (isCallInsideFunctionBody && argument.trim() === identifier) continue;
       didInspectCallArgument = true;
       didInspectOnlyExplicitlyTrustedArguments &&= isExplicitlyTrustedHtmlValue(
         argument,
@@ -630,26 +638,6 @@ const isHtmlTainted = (
     return HTML_TAINT_PATTERN.test(trimmedExpression);
   }
 
-  if (declaration !== null) {
-    if (
-      isExplicitlyTrustedHtmlValue(
-        declaration.initializer,
-        fileContent,
-        declaration.initializerStartIndex,
-      )
-    ) {
-      return false;
-    }
-    return (
-      isHtmlTainted(
-        declaration.initializer,
-        fileContent,
-        declaration.initializerStartIndex,
-        visitedIdentifiers,
-        visitedCallSites,
-      ) || HTML_TAINT_PATTERN.test(trimmedExpression)
-    );
-  }
   return HTML_TAINT_PATTERN.test(trimmedExpression);
 };
 
@@ -748,10 +736,15 @@ export const dangerousHtmlSink = defineRule({
 
       if (templateInterpolations === "") continue;
       const judgedExpression = templateInterpolations ?? valueExpression;
+      const doesJudgedExpressionCombineValues =
+        splitTopLevelByPlus(judgedExpression).length > 1 ||
+        (templateInterpolations?.match(/\$\{/g)?.length ?? 0) > 1;
 
-      if (SANITIZER_PATTERN.test(judgedExpression)) continue;
-      if (ENV_CONFIG_VALUE_PATTERN.test(judgedExpression)) continue;
-      if (I18N_VALUE_PATTERN.test(judgedExpression)) continue;
+      if (!doesJudgedExpressionCombineValues && SANITIZER_PATTERN.test(judgedExpression)) continue;
+      if (!doesJudgedExpressionCombineValues && ENV_CONFIG_VALUE_PATTERN.test(judgedExpression)) {
+        continue;
+      }
+      if (!doesJudgedExpressionCombineValues && I18N_VALUE_PATTERN.test(judgedExpression)) continue;
       if (!isHtmlTainted(judgedExpression, file.content, sinkIndex, new Set(), new Set())) continue;
       if (ESCAPING_SERIALIZER_CALL_PATTERN.test(valueExpression)) continue;
       // Highlighter output: a `highlighted*` value is escaped, token-wrapped
@@ -766,16 +759,40 @@ export const dangerousHtmlSink = defineRule({
       // provenance too (`{ html: hl.codeToHtml(code) }` routed through state).
       if (valueIdentifier !== undefined) {
         const escapedIdentifier = escapeRegExp(valueIdentifier);
-        const fromSerializer = new RegExp(
-          `\\b${escapedIdentifier}\\b\\s*${SERIALIZER_ASSIGNMENT_PATTERN.source}`,
-          "i",
+        const visibleDeclaration = findVisibleIdentifierDeclaration(
+          valueIdentifier,
+          sinkIndex,
+          file.content,
         );
-        if (fromSerializer.test(file.content)) continue;
-        const fromSanitizer = new RegExp(
-          `\\b${escapedIdentifier}\\b\\s*${SANITIZED_ASSIGNMENT_PATTERN.source}`,
-          "i",
-        );
-        if (fromSanitizer.test(file.content)) continue;
+        const visibleInitializer = visibleDeclaration?.initializer;
+        const isCompoundInitializer =
+          visibleInitializer !== undefined &&
+          (splitTopLevelByPlus(visibleInitializer).length > 1 ||
+            (visibleInitializer.match(/\$\{/g)?.length ?? 0) > 1);
+        if (!isCompoundInitializer) {
+          const fromSerializer = new RegExp(
+            `\\b${escapedIdentifier}\\b\\s*${SERIALIZER_ASSIGNMENT_PATTERN.source}`,
+            "i",
+          );
+          if (
+            visibleInitializer === undefined
+              ? fromSerializer.test(file.content)
+              : SERIALIZER_ASSIGNMENT_PATTERN.test(`=${visibleInitializer}`)
+          ) {
+            continue;
+          }
+          const fromSanitizer = new RegExp(
+            `\\b${escapedIdentifier}\\b\\s*${SANITIZED_ASSIGNMENT_PATTERN.source}`,
+            "i",
+          );
+          if (
+            visibleInitializer === undefined
+              ? fromSanitizer.test(file.content)
+              : SANITIZED_ASSIGNMENT_PATTERN.test(`=${visibleInitializer}`)
+          ) {
+            continue;
+          }
+        }
         const fromDomContent = new RegExp(
           `\\b${escapedIdentifier}\\b\\s*${DOM_CONTENT_ASSIGNMENT_PATTERN.source}`,
         );

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/dangerous-html-sink.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/dangerous-html-sink.ts
@@ -418,7 +418,58 @@ const findVisibleIdentifierDeclaration = (
   return nearestDeclaration;
 };
 
+const isTrustedHighlighterValue = (
+  valueExpression: string,
+  fileContent: string,
+  sinkIndex: number,
+): boolean => {
+  if (!/highlight/i.test(valueExpression)) return false;
+  const identifier = valueExpression.match(/^([\w$]+)/)?.[1];
+  if (identifier === undefined) return false;
+  const declaration = findVisibleIdentifierDeclaration(identifier, sinkIndex, fileContent);
+  if (declaration !== null) {
+    return (
+      ESCAPING_SERIALIZER_CALL_PATTERN.test(declaration.initializer) ||
+      SERIALIZER_ASSIGNMENT_PATTERN.test(`=${declaration.initializer}`)
+    );
+  }
+  return /highlighted/i.test(valueExpression) || HIGHLIGHTER_LIBRARY_PATTERN.test(fileContent);
+};
+
+const isExplicitlyTrustedHtmlValue = (
+  valueExpression: string,
+  fileContent: string,
+  sinkIndex: number,
+  visitedIdentifiers: Set<string> = new Set(),
+): boolean => {
+  const trimmedExpression = valueExpression.trim();
+  if (
+    STRING_LITERAL_VALUE_PATTERN.test(`${trimmedExpression};`) ||
+    MODULE_CONSTANT_VALUE_PATTERN.test(`${trimmedExpression};`) ||
+    SANITIZER_PATTERN.test(trimmedExpression) ||
+    ENV_CONFIG_VALUE_PATTERN.test(trimmedExpression) ||
+    I18N_VALUE_PATTERN.test(trimmedExpression) ||
+    ESCAPING_SERIALIZER_CALL_PATTERN.test(trimmedExpression) ||
+    isTrustedHighlighterValue(trimmedExpression, fileContent, sinkIndex)
+  ) {
+    return true;
+  }
+  const identifier = trimmedExpression.match(/^([\w$]+)$/)?.[1];
+  if (!identifier || visitedIdentifiers.has(identifier)) return false;
+  const declaration = findVisibleIdentifierDeclaration(identifier, sinkIndex, fileContent);
+  if (!declaration) return false;
+  const nextVisitedIdentifiers = new Set(visitedIdentifiers);
+  nextVisitedIdentifiers.add(identifier);
+  return isExplicitlyTrustedHtmlValue(
+    declaration.initializer,
+    fileContent,
+    declaration.initializerStartIndex,
+    nextVisitedIdentifiers,
+  );
+};
+
 interface FunctionParameterSource {
+  readonly declarationNameIndex: number;
   readonly functionName: string;
   readonly parameterIndex: number;
 }
@@ -449,7 +500,12 @@ const findContainingFunctionParameterSource = (
         );
       if (parameterIndex < 0) continue;
       closestStartIndex = matchIndex;
-      closestSource = { functionName: match[1] ?? "", parameterIndex };
+      const functionName = match[1] ?? "";
+      closestSource = {
+        declarationNameIndex: matchIndex + match[0].indexOf(functionName),
+        functionName,
+        parameterIndex,
+      };
     }
   }
   return closestSource;
@@ -486,43 +542,75 @@ const isHtmlTainted = (
   fileContent: string,
   sinkIndex: number,
   visitedIdentifiers: Set<string>,
+  visitedCallSites: Set<number>,
 ): boolean => {
   const trimmedExpression = expression.trim();
-  if (STRING_LITERAL_VALUE_PATTERN.test(`${trimmedExpression};`)) return false;
-  if (MODULE_CONSTANT_VALUE_PATTERN.test(`${trimmedExpression};`)) return false;
-  if (SANITIZER_PATTERN.test(trimmedExpression)) return false;
-  if (ENV_CONFIG_VALUE_PATTERN.test(trimmedExpression)) return false;
-  if (I18N_VALUE_PATTERN.test(trimmedExpression)) return false;
-  if (ESCAPING_SERIALIZER_CALL_PATTERN.test(trimmedExpression)) return false;
-  if (HTML_TAINT_PATTERN.test(trimmedExpression)) return true;
-  const identifier = trimmedExpression.match(/^([\w$]+)\s*(?:[;,})\n]|$)/)?.[1];
-  if (identifier === undefined || visitedIdentifiers.has(identifier)) return false;
+  if (isExplicitlyTrustedHtmlValue(trimmedExpression, fileContent, sinkIndex)) return false;
+  const identifier = trimmedExpression.match(/^([\w$]+)(?:\.|\s*(?:[;,})\n]|$))/)?.[1];
+  if (identifier === undefined) return HTML_TAINT_PATTERN.test(trimmedExpression);
+  if (visitedIdentifiers.has(identifier)) return false;
   visitedIdentifiers.add(identifier);
 
-  const declaration = findVisibleIdentifierDeclaration(identifier, sinkIndex, fileContent);
-  if (
-    declaration !== null &&
-    isHtmlTainted(declaration.initializer, fileContent, sinkIndex, visitedIdentifiers)
-  ) {
-    return true;
-  }
-
   const parameterSource = findContainingFunctionParameterSource(identifier, sinkIndex, fileContent);
-  if (parameterSource === null || parameterSource.functionName.length === 0) return false;
-  const callPattern = new RegExp(
-    `\\b${escapeRegExp(parameterSource.functionName)}\\s*\\(([^)]*)\\)`,
-    "g",
-  );
-  for (const callMatch of fileContent.matchAll(callPattern)) {
-    const argument = splitTopLevelArguments(callMatch[1] ?? "")[parameterSource.parameterIndex];
-    if (
-      argument !== undefined &&
-      isHtmlTainted(argument, fileContent, sinkIndex, new Set(visitedIdentifiers))
-    ) {
-      return true;
+  if (parameterSource !== null && parameterSource.functionName.length > 0) {
+    const callPattern = new RegExp(
+      `\\b${escapeRegExp(parameterSource.functionName)}\\s*\\(([^)]*)\\)`,
+      "g",
+    );
+    let didInspectCallArgument = false;
+    let didInspectOnlyExplicitlyTrustedArguments = true;
+    for (const callMatch of fileContent.matchAll(callPattern)) {
+      if (
+        callMatch.index === parameterSource.declarationNameIndex ||
+        visitedCallSites.has(callMatch.index)
+      ) {
+        continue;
+      }
+      const argument = splitTopLevelArguments(callMatch[1] ?? "")[parameterSource.parameterIndex];
+      if (argument === undefined) continue;
+      didInspectCallArgument = true;
+      didInspectOnlyExplicitlyTrustedArguments &&= isExplicitlyTrustedHtmlValue(
+        argument,
+        fileContent,
+        callMatch.index,
+      );
+      const callVisitedIdentifiers = new Set(visitedIdentifiers);
+      callVisitedIdentifiers.delete(identifier);
+      const nextVisitedCallSites = new Set(visitedCallSites);
+      nextVisitedCallSites.add(callMatch.index);
+      if (
+        isHtmlTainted(
+          argument,
+          fileContent,
+          callMatch.index,
+          callVisitedIdentifiers,
+          nextVisitedCallSites,
+        )
+      ) {
+        return true;
+      }
+    }
+    if (didInspectCallArgument) {
+      return (
+        !didInspectOnlyExplicitlyTrustedArguments && HTML_TAINT_PATTERN.test(trimmedExpression)
+      );
     }
   }
-  return false;
+
+  const declaration = findVisibleIdentifierDeclaration(identifier, sinkIndex, fileContent);
+  if (declaration !== null) {
+    if (isExplicitlyTrustedHtmlValue(declaration.initializer, fileContent, sinkIndex)) return false;
+    return (
+      isHtmlTainted(
+        declaration.initializer,
+        fileContent,
+        sinkIndex,
+        visitedIdentifiers,
+        visitedCallSites,
+      ) || HTML_TAINT_PATTERN.test(trimmedExpression)
+    );
+  }
+  return HTML_TAINT_PATTERN.test(trimmedExpression);
 };
 
 export const dangerousHtmlSink = defineRule({
@@ -604,7 +692,8 @@ export const dangerousHtmlSink = defineRule({
       if (
         templateInterpolations === null &&
         valueIdentifier !== undefined &&
-        BARE_IDENTIFIER_VALUE_PATTERN.test(valueExpression)
+        BARE_IDENTIFIER_VALUE_PATTERN.test(valueExpression) &&
+        findContainingFunctionParameterSource(valueIdentifier, sinkIndex, file.content) === null
       ) {
         const declarationInitializer = getIdentifierDeclarationInitializer(
           valueIdentifier,
@@ -623,17 +712,14 @@ export const dangerousHtmlSink = defineRule({
       if (SANITIZER_PATTERN.test(judgedExpression)) continue;
       if (ENV_CONFIG_VALUE_PATTERN.test(judgedExpression)) continue;
       if (I18N_VALUE_PATTERN.test(judgedExpression)) continue;
-      if (!isHtmlTainted(judgedExpression, file.content, sinkIndex, new Set())) continue;
+      if (!isHtmlTainted(judgedExpression, file.content, sinkIndex, new Set(), new Set())) continue;
       if (ESCAPING_SERIALIZER_CALL_PATTERN.test(valueExpression)) continue;
       // Highlighter output: a `highlighted*` value is escaped, token-wrapped
       // markup by naming convention (often passed as a prop or routed through
       // React state, so no direct serializer assignment is visible); a present-
       // tense `highlight*` value is trusted only when the file uses a highlighter
       // library. (`highlight*()` calls are handled by the serializer-call check.)
-      if (/highlighted/i.test(valueExpression)) continue;
-      if (/highlight/i.test(valueExpression) && HIGHLIGHTER_LIBRARY_PATTERN.test(file.content)) {
-        continue;
-      }
+      if (isTrustedHighlighterValue(valueExpression, file.content, sinkIndex)) continue;
       // Value is a bare identifier, member/index access, or identifier with a
       // literal fallback: exempt only when that identifier is assigned from a
       // serializer or a sanitizer in the file. `[:=]` accepts property-style

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/dangerous-html-sink.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/dangerous-html-sink.ts
@@ -95,6 +95,9 @@ const HIGHLIGHTER_LIBRARY_PATTERN =
 const SERIALIZER_ASSIGNMENT_PATTERN =
   /[:=]\s*[^\n;]*(?:\b(?:katex|shiki|hljs|prism|mermaid)\b|hast-util-to-html|renderHtmlFromRichText|(?:toHtml|render[A-Za-z]*(?:Html|HTML)|renderToString|renderToStaticMarkup|codeToHtml|codeToHast)\s*\()/i;
 
+const SERIALIZER_CALL_PROVENANCE_PATTERN =
+  /\b(?:(?:katex|shiki|hljs|prism|mermaid|highlighter)[\w$]*\.(?:render\w*|highlight\w*|codeTo(?:Html|Hast))|(?:toHtml|render(?:Html|HTML)[A-Za-z]*|render[A-Za-z]*(?:Html|HTML)|renderToString|renderToStaticMarkup|codeToHtml|codeToHast|highlight[A-Za-z]*))\s*\(/i;
+
 const BARE_IDENTIFIER_VALUE_PATTERN = /^[\w$]+\s*(?:[;,})\n]|$)/;
 
 // `lineHtml || " "` / `html ?? ""` — an identifier with a string-literal
@@ -335,6 +338,28 @@ const findMatchingBraceIndex = (fileContent: string, openingBraceIndex: number):
   return fileContent.length;
 };
 
+const findMatchingParenthesisIndex = (fileContent: string, openingIndex: number): number => {
+  let depth = 0;
+  let quote: string | null = null;
+  for (let index = openingIndex; index < fileContent.length; index += 1) {
+    const character = fileContent[index];
+    if (quote !== null) {
+      if (character === quote && fileContent[index - 1] !== "\\") quote = null;
+      continue;
+    }
+    if (character === '"' || character === "'" || character === "`") {
+      quote = character;
+      continue;
+    }
+    if (character === "(") depth += 1;
+    if (character === ")") {
+      depth -= 1;
+      if (depth === 0) return index;
+    }
+  }
+  return fileContent.length;
+};
+
 const findContainingBlockEndIndex = (fileContent: string, targetIndex: number): number => {
   const openingBraceIndexes: number[] = [];
   let quote: string | null = null;
@@ -430,10 +455,7 @@ const isTrustedHighlighterValue = (
   if (identifier === undefined) return false;
   const declaration = findVisibleIdentifierDeclaration(identifier, sinkIndex, fileContent);
   if (declaration !== null) {
-    return (
-      ESCAPING_SERIALIZER_CALL_PATTERN.test(declaration.initializer) ||
-      SERIALIZER_ASSIGNMENT_PATTERN.test(`=${declaration.initializer}`)
-    );
+    return SERIALIZER_CALL_PROVENANCE_PATTERN.test(declaration.initializer);
   }
   return /highlighted/i.test(valueExpression) || HIGHLIGHTER_LIBRARY_PATTERN.test(fileContent);
 };
@@ -445,33 +467,70 @@ const isExplicitlyTrustedHtmlValue = (
   visitedIdentifiers: Set<string> = new Set(),
 ): boolean => {
   const trimmedExpression = valueExpression.trim();
-  const isCompoundValue =
-    splitTopLevelByPlus(trimmedExpression).length > 1 ||
-    (trimmedExpression.match(/\$\{/g)?.length ?? 0) > 1;
-  if (
-    !isCompoundValue &&
-    (STRING_LITERAL_VALUE_PATTERN.test(`${trimmedExpression};`) ||
-      MODULE_CONSTANT_VALUE_PATTERN.test(`${trimmedExpression};`) ||
-      SANITIZER_PATTERN.test(trimmedExpression) ||
-      ENV_CONFIG_VALUE_PATTERN.test(trimmedExpression) ||
-      I18N_VALUE_PATTERN.test(trimmedExpression) ||
-      ESCAPING_SERIALIZER_CALL_PATTERN.test(trimmedExpression) ||
-      isTrustedHighlighterValue(trimmedExpression, fileContent, sinkIndex))
-  ) {
-    return true;
+  const concatenatedParts = splitTopLevelByPlus(trimmedExpression);
+  if (concatenatedParts.length > 1) {
+    return concatenatedParts.every((part) =>
+      isExplicitlyTrustedHtmlValue(part, fileContent, sinkIndex, visitedIdentifiers),
+    );
+  }
+  const interpolationParts = [...trimmedExpression.matchAll(/\$\{([^}]*)\}/g)].flatMap((match) =>
+    match[1] === undefined ? [] : [match[1]],
+  );
+  if (interpolationParts.length > 1) {
+    return interpolationParts.every((part) =>
+      isExplicitlyTrustedHtmlValue(part, fileContent, sinkIndex, visitedIdentifiers),
+    );
   }
   const identifier = trimmedExpression.match(
     /^([\w$]+)(?:(?:\??\.[\w$]+)|(?:\[\s*(?:"[^"\n]*"|'[^'\n]*'|\d+)\s*\]))*$/,
   )?.[1];
-  if (!identifier || visitedIdentifiers.has(identifier)) return false;
-  const declaration = findVisibleIdentifierDeclaration(identifier, sinkIndex, fileContent);
+  if (identifier && !visitedIdentifiers.has(identifier)) {
+    const declaration = findVisibleIdentifierDeclaration(identifier, sinkIndex, fileContent);
+    if (declaration) {
+      const nextVisitedIdentifiers = new Set(visitedIdentifiers);
+      nextVisitedIdentifiers.add(identifier);
+      return isExplicitlyTrustedHtmlValue(
+        declaration.initializer,
+        fileContent,
+        declaration.initializerStartIndex,
+        nextVisitedIdentifiers,
+      );
+    }
+  }
+  if (
+    STRING_LITERAL_VALUE_PATTERN.test(`${trimmedExpression};`) ||
+    MODULE_CONSTANT_VALUE_PATTERN.test(`${trimmedExpression};`) ||
+    SANITIZER_PATTERN.test(trimmedExpression) ||
+    ENV_CONFIG_VALUE_PATTERN.test(trimmedExpression) ||
+    I18N_VALUE_PATTERN.test(trimmedExpression) ||
+    ESCAPING_SERIALIZER_CALL_PATTERN.test(trimmedExpression) ||
+    isTrustedHighlighterValue(trimmedExpression, fileContent, sinkIndex)
+  ) {
+    return true;
+  }
+  return false;
+};
+
+const doesExpressionAliasIdentifier = (
+  expression: string,
+  targetIdentifier: string,
+  expressionIndex: number,
+  fileContent: string,
+  visitedIdentifiers: Set<string> = new Set(),
+): boolean => {
+  const identifier = expression.trim().match(/^([\w$]+)$/)?.[1];
+  if (!identifier) return false;
+  if (identifier === targetIdentifier) return true;
+  if (visitedIdentifiers.has(identifier)) return false;
+  const declaration = findVisibleIdentifierDeclaration(identifier, expressionIndex, fileContent);
   if (!declaration) return false;
   const nextVisitedIdentifiers = new Set(visitedIdentifiers);
   nextVisitedIdentifiers.add(identifier);
-  return isExplicitlyTrustedHtmlValue(
+  return doesExpressionAliasIdentifier(
     declaration.initializer,
-    fileContent,
+    targetIdentifier,
     declaration.initializerStartIndex,
+    fileContent,
     nextVisitedIdentifiers,
   );
 };
@@ -589,10 +648,7 @@ const isHtmlTainted = (
     );
   }
   if (parameterSource !== null && parameterSource.functionName.length > 0) {
-    const callPattern = new RegExp(
-      `\\b${escapeRegExp(parameterSource.functionName)}\\s*\\(([^)]*)\\)`,
-      "g",
-    );
+    const callPattern = new RegExp(`\\b${escapeRegExp(parameterSource.functionName)}\\s*\\(`, "g");
     let didInspectCallArgument = false;
     let didInspectOnlyExplicitlyTrustedArguments = true;
     for (const callMatch of fileContent.matchAll(callPattern)) {
@@ -602,12 +658,24 @@ const isHtmlTainted = (
       ) {
         continue;
       }
-      const argument = splitTopLevelArguments(callMatch[1] ?? "")[parameterSource.parameterIndex];
+      const openingParenthesisIndex = callMatch.index + callMatch[0].lastIndexOf("(");
+      const closingParenthesisIndex = findMatchingParenthesisIndex(
+        fileContent,
+        openingParenthesisIndex,
+      );
+      const argument = splitTopLevelArguments(
+        fileContent.slice(openingParenthesisIndex + 1, closingParenthesisIndex),
+      )[parameterSource.parameterIndex];
       if (argument === undefined) continue;
       const isCallInsideFunctionBody =
         callMatch.index >= parameterSource.declarationNameIndex &&
         callMatch.index <= parameterSource.bodyEndIndex;
-      if (isCallInsideFunctionBody && argument.trim() === identifier) continue;
+      if (
+        isCallInsideFunctionBody &&
+        doesExpressionAliasIdentifier(argument, identifier, callMatch.index, fileContent)
+      ) {
+        continue;
+      }
       didInspectCallArgument = true;
       didInspectOnlyExplicitlyTrustedArguments &&= isExplicitlyTrustedHtmlValue(
         argument,
@@ -777,7 +845,7 @@ export const dangerousHtmlSink = defineRule({
           if (
             visibleInitializer === undefined
               ? fromSerializer.test(file.content)
-              : SERIALIZER_ASSIGNMENT_PATTERN.test(`=${visibleInitializer}`)
+              : SERIALIZER_CALL_PROVENANCE_PATTERN.test(visibleInitializer)
           ) {
             continue;
           }


### PR DESCRIPTION
## Summary

- evaluate helper arguments at their actual call-site offsets so later aliases remain visible
- preserve highlighter and escaping-serializer trust through local aliases
- distinguish a helper declaration from real calls and keep taint-name fallback for externally called helpers

Follow-up to #1150 for the two valid post-merge Bugbot findings.

## Validation

- 543 plugin test files, 11,975 passing tests, 148 skipped
- full `nr typecheck`
- `FUZZ_RULE=dangerous-html-sink FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz`
- `nr format:check`
- local React Doctor changed-scope scan: no issues

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes security lint taint logic in a widely used rule; behavior shifts (more/ fewer warnings) but scope is limited to the oxlint plugin and is heavily regression-tested.
> 
> **Overview**
> Tightens the **`dangerous-html-sink`** static analysis so HTML trust and taint follow **local aliases** and **helper call sites** more accurately, addressing post-merge Bugbot findings from #1150.
> 
> **Provenance and trust:** Adds recursive **`isExplicitlyTrustedHtmlValue`** (including compound `+` / template parts) and **`isTrustedHighlighterValue`** so highlighter/serializer output stays trusted when routed through `const` aliases or member access. Compound expressions only skip the sink when **every** part is trusted; partially sanitized mixes still flag.
> 
> **Helper parameters:** **`isHtmlTainted`** now parses call arguments with **`findMatchingBracket`** (not a naive `[^)]*`), evaluates arguments at each **call-site offset**, skips the function **declaration** match and tracks **`visitedCallSites`** to avoid infinite recursion on self-calls. Recursive re-entry that swaps in tainted HTML still flags; re-passing the same trusted parameter through a `const` alias does not. **`doesExpressionAliasIdentifier`** ignores in-body recursive calls that only forward the parameter. Shadowing prefers inner **`const`** bindings over outer parameters; a later trusted binding does not clear an earlier tainted alias.
> 
> **Scan path:** Bare-identifier declaration shortcuts are skipped when the value is a **function parameter**; serializer/sanitizer exemptions consult the **visible initializer** when present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79931fb8948435e8ea89e4d48d69dbcc7eeda6d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->