### PR TITLE
fix(rules): prove React effect hook bindings

### DIFF
--- a/.changeset/tidy-hooks-listen.md
+++ b/.changeset/tidy-hooks-listen.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Prove effect-hook calls resolve to React before applying effect callback semantics.

--- a/packages/fuzz/corpus/regressions/exhaustive-deps--shadowed-effect-binding.tsx
+++ b/packages/fuzz/corpus/regressions/exhaustive-deps--shadowed-effect-binding.tsx
@@ -1,0 +1,10 @@
+// rule: exhaustive-deps
+// weakness: name-heuristic
+// source: ISSUES_TO_FIX_ASAP.md semantic mutation matrix
+import { useEffect } from "react";
+
+export const EffectRunner = ({ value }: { value: string }) => {
+  const useEffect = (callback: () => void) => callback();
+  useEffect(() => consume(value), []);
+  return null;
+};

--- a/packages/fuzz/corpus/regressions/no-async-effect-callback--shadowed-effect-binding.tsx
+++ b/packages/fuzz/corpus/regressions/no-async-effect-callback--shadowed-effect-binding.tsx
@@ -1,0 +1,13 @@
+// rule: no-async-effect-callback
+// weakness: name-heuristic
+// source: ISSUES_TO_FIX_ASAP.md semantic mutation matrix
+export const AsyncRunner = ({
+  useEffect,
+}: {
+  useEffect: (callback: () => Promise<void>) => void;
+}) => {
+  useEffect(async () => {
+    await synchronize();
+  });
+  return null;
+};

--- a/packages/fuzz/corpus/regressions/no-fetch-in-effect--shadowed-effect-binding.tsx
+++ b/packages/fuzz/corpus/regressions/no-fetch-in-effect--shadowed-effect-binding.tsx
@@ -1,0 +1,13 @@
+// rule: no-fetch-in-effect
+// weakness: name-heuristic
+// source: ISSUES_TO_FIX_ASAP.md semantic mutation matrix
+export const RequestRunner = ({
+  engine,
+}: {
+  engine: { useEffect: (callback: () => void) => void };
+}) => {
+  engine.useEffect(() => {
+    fetch("/api/profile");
+  });
+  return null;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.regressions.test.ts
@@ -7,6 +7,33 @@ import { exhaustiveDeps } from "./exhaustive-deps.js";
 import { clearExhaustiveDepsSuppressionCache } from "./exhaustive-deps-suppression.js";
 
 describe("react-builtins/exhaustive-deps — regressions", () => {
+  it.each([
+    [
+      "a shadowing local",
+      `import { useEffect } from "react";
+      const C = ({ value }) => {
+        const useEffect = (callback) => callback();
+        useEffect(() => consume(value), []);
+      };`,
+    ],
+    [
+      "a function parameter",
+      `const C = ({ value, useEffect }) => {
+        useEffect(() => consume(value), []);
+      };`,
+    ],
+    [
+      "an arbitrary object method",
+      `const C = ({ value, engine }) => {
+        engine.useEffect(() => consume(value), []);
+      };`,
+    ],
+  ])("does not treat %s as a React effect", (_name, code) => {
+    const result = runRule(exhaustiveDeps, code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   // A module-scope constant used only as a parameter default is stable
   // across renders, so it must NOT be reported as a missing dependency.
   // Previously a manual (unfiltered) param-default walk added it

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.ts
@@ -11,6 +11,7 @@ import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { getStaticTemplateLiteralValue } from "../../utils/get-static-template-literal-value.js";
 import { isAstNode } from "../../utils/is-ast-node.js";
 import { isReactComponentOrHookName } from "../../utils/is-react-component-or-hook-name.js";
+import { isReactApiCall } from "../../utils/is-react-api-call.js";
 import { isReactHocCallbackArgument } from "../../utils/is-react-hoc-callback-argument.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { REACT_HOC_NAMES } from "../../constants/react.js";
@@ -1125,6 +1126,16 @@ If the missing value is recreated every render, move it inside the hook or stabi
       CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
         const hookName = getHookName(node.callee, context.scopes);
         if (!hookName || !isHookOfInterest(hookName, node.callee)) return;
+        if (
+          HOOKS_REQUIRING_DEPS_MATCH.has(hookName) &&
+          !isReactApiCall(node, HOOKS_REQUIRING_DEPS_MATCH, context.scopes, {
+            allowGlobalReactNamespace: true,
+            allowUnboundBareCalls: true,
+            resolveNamedAliases: true,
+          })
+        ) {
+          return;
+        }
 
         const callbackArgumentIndex = getCallbackArgumentIndex(hookName);
         const depsArgumentIndex = getDepsArgumentIndex(hookName);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-async-effect-callback.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-async-effect-callback.test.ts
@@ -89,4 +89,30 @@ describe("no-async-effect-callback", () => {
     const result = runRule(noAsyncEffectCallback, `subscribe(async () => { await handle(); });`);
     expect(result.diagnostics).toHaveLength(0);
   });
+
+  it.each([
+    [
+      "a shadowing local",
+      `import { useEffect } from "react";
+      const C = () => {
+        const useEffect = (callback) => callback();
+        useEffect(async () => { await sync(); });
+      };`,
+    ],
+    [
+      "a function parameter",
+      `const C = (useEffect) => {
+        useEffect(async () => { await sync(); });
+      };`,
+    ],
+    [
+      "an arbitrary object method",
+      `const C = ({ engine }) => {
+        engine.useEffect(async () => { await sync(); });
+      };`,
+    ],
+  ])("does not treat %s as a React effect", (_name, code) => {
+    const result = runRule(noAsyncEffectCallback, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-async-effect-callback.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-async-effect-callback.ts
@@ -1,7 +1,7 @@
 import { EFFECT_HOOK_NAMES } from "../../constants/react.js";
 import { defineRule } from "../../utils/define-rule.js";
 import { getEffectCallback } from "../../utils/get-effect-callback.js";
-import { isHookCall } from "../../utils/is-hook-call.js";
+import { isReactApiCall } from "../../utils/is-react-api-call.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
@@ -20,7 +20,15 @@ export const noAsyncEffectCallback = defineRule({
     "Don't make the effect callback `async`. Define an async function inside the effect and call it, then return a real cleanup function if you need one.",
   create: (context) => ({
     CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
-      if (!isHookCall(node, EFFECT_HOOK_NAMES)) return;
+      if (
+        !isReactApiCall(node, EFFECT_HOOK_NAMES, context.scopes, {
+          allowGlobalReactNamespace: true,
+          allowUnboundBareCalls: true,
+          resolveNamedAliases: true,
+        })
+      ) {
+        return;
+      }
       const callback = getEffectCallback(node);
       if (!callback) return;
       if (

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-fetch-in-effect.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-fetch-in-effect.regressions.test.ts
@@ -15,6 +15,31 @@ const expectPass = (code: string): void => {
 };
 
 describe("state-and-effects/no-fetch-in-effect — regressions", () => {
+  it.each([
+    [
+      "a shadowing local",
+      `import { useEffect } from "react";
+      const C = () => {
+        const useEffect = (callback) => callback();
+        useEffect(() => { fetch("/api/profile"); });
+      };`,
+    ],
+    [
+      "a function parameter",
+      `const C = (useEffect) => {
+        useEffect(() => { fetch("/api/profile"); });
+      };`,
+    ],
+    [
+      "an arbitrary object method",
+      `const C = ({ engine }) => {
+        engine.useEffect(() => { fetch("/api/profile"); });
+      };`,
+    ],
+  ])("does not treat %s as a React effect", (_name, code) => {
+    expectPass(code);
+  });
+
   it("does not flag a fetch cancelled via AbortController in the cleanup", () => {
     expectPass(`
       const useSubtitles = (subtitlesUrl) => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-fetch-in-effect.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-fetch-in-effect.ts
@@ -8,7 +8,7 @@ import { getEffectCallback } from "../../utils/get-effect-callback.js";
 import { getRangeStart } from "../../utils/get-range-start.js";
 import { getStaticPropertyKeyName } from "../../utils/get-static-property-key-name.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
-import { isHookCall } from "../../utils/is-hook-call.js";
+import { isReactApiCall } from "../../utils/is-react-api-call.js";
 import { isSetterCall } from "../../utils/is-setter-call.js";
 import { resolveExpressionKey } from "../../utils/resolve-expression-key.js";
 import { statementAlwaysExits } from "../../utils/statement-always-exits.js";
@@ -510,7 +510,15 @@ export const noFetchInEffect = defineRule({
     "Use a data-fetching layer or Server Component so fetches do not race, double-fire, or leak from `useEffect`.",
   create: (context: RuleContext) => ({
     CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
-      if (!isHookCall(node, EFFECT_HOOK_NAMES)) return;
+      if (
+        !isReactApiCall(node, EFFECT_HOOK_NAMES, context.scopes, {
+          allowGlobalReactNamespace: true,
+          allowUnboundBareCalls: true,
+          resolveNamedAliases: true,
+        })
+      ) {
+        return;
+      }
       const callback = getEffectCallback(node);
       if (!callback) return;
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-react-api-call.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-react-api-call.test.ts
@@ -46,6 +46,14 @@ describe("isReactApiCall", () => {
       expectedCount: 1,
     },
     {
+      name: "immutable named React API aliases",
+      code: `import { useEffect as runEffect } from "react";
+        const invokeEffect = runEffect as typeof runEffect;
+        invokeEffect(() => {});`,
+      options: { resolveNamedAliases: true },
+      expectedCount: 1,
+    },
+    {
       name: "default React receivers",
       code: 'import ReactClient from "react"; ReactClient.useEffect(() => {});',
       expectedCount: 1,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-react-api-call.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-react-api-call.ts
@@ -9,6 +9,7 @@ import { stripParenExpression } from "./strip-paren-expression.js";
 export interface ReactApiCallOptions {
   allowGlobalReactNamespace?: boolean;
   allowUnboundBareCalls?: boolean;
+  resolveNamedAliases?: boolean;
 }
 
 const includesApiName = (apiNames: string | ReadonlySet<string>, apiName: string): boolean =>
@@ -29,9 +30,12 @@ const isNamedReactApiImport = (
   identifier: EsTreeNode,
   apiNames: string | ReadonlySet<string>,
   scopes: ScopeAnalysis,
+  resolveAliases: boolean,
 ): boolean => {
   if (!isNodeOfType(identifier, "Identifier")) return false;
-  const symbol = scopes.symbolFor(identifier);
+  const symbol = resolveAliases
+    ? resolveConstIdentifierAlias(identifier, scopes)
+    : scopes.symbolFor(identifier);
   if (!symbol || !isImportedFromReact(symbol)) return false;
   const importedName = getImportedName(symbol.declarationNode);
   return Boolean(importedName && includesApiName(apiNames, importedName));
@@ -55,7 +59,9 @@ export const isReactApiCall = (
   if (!isNodeOfType(node, "CallExpression")) return false;
   const callee = stripParenExpression(node.callee);
   if (isNodeOfType(callee, "Identifier")) {
-    if (isNamedReactApiImport(callee, apiNames, scopes)) return true;
+    if (isNamedReactApiImport(callee, apiNames, scopes, Boolean(options.resolveNamedAliases))) {
+      return true;
+    }
     return Boolean(
       options.allowUnboundBareCalls &&
       includesApiName(apiNames, callee.name) &&


### PR DESCRIPTION
## Summary

- require React binding provenance before applying exhaustive deps, async-effect, or fetch-in-effect semantics
- preserve unbound/global React compatibility while rejecting shadowed locals, parameters, and arbitrary object methods
- resolve immutable named React hook aliases only for the three opted-in effect rules
- add three permanent fuzz corpus seeds and a patch changeset

## Validation

- 543 plugin test files, 11,982 passing tests, 148 skipped
- fuzz corpus tests: 37 passing
- full typecheck
- strict 500-iteration fuzz runs for all three affected rules
- format and deduplication checks
- changed-scope React Doctor scan: no issues
- local RDE: 50 OSS roots; no removals/additions attributable to the binding filter in the sampled corpus

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core detection for exhaustive-deps and two high-traffic effect rules; behavior shifts for non-React `useEffect` lookalikes while intended to preserve real React call sites via aliases and globals.
> 
> **Overview**
> Effect-related lint rules no longer treat every call named `useEffect` (or similar) as React: **`exhaustive-deps`**, **`no-async-effect-callback`**, and **`no-fetch-in-effect`** now gate on **`isReactApiCall`** with scope-aware provenance (React imports, namespace/default receivers, global `React`, unbound globals) instead of **`isHookCall`** name matching.
> 
> **`isReactApiCall`** gains optional **`resolveNamedAliases`** so immutable const aliases of renamed React hook imports still count; the three effect rules opt in. Shadowed locals, hook-named parameters, and **`engine.useEffect`**-style calls are ignored, cutting false positives from name heuristics.
> 
> Regression **`it.each`** cases and three fuzz corpus seeds document the shadowed-binding matrix; a patch changeset records the plugin fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c77df4b2ad978a608dc8f305538418a87f6a99bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->