### PR TITLE
fix(rules): resolve createContext bindings

### DIFF
--- a/.changeset/calm-contexts-resolve.md
+++ b/.changeset/calm-contexts-resolve.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Track createContext imports through aliases, namespace destructuring, and computed access while honoring lexical shadowing.

--- a/packages/fuzz/corpus/regressions/no-create-context-in-render--shadowed-react-api.tsx
+++ b/packages/fuzz/corpus/regressions/no-create-context-in-render--shadowed-react-api.tsx
@@ -1,0 +1,9 @@
+// rule: no-create-context-in-render
+// weakness: name-heuristic
+// source: ISSUES_TO_FIX_ASAP.md semantic mutation matrix
+import { createContext } from "react";
+
+export const ContextPreview = () => {
+  const createContext = (value: string) => ({ value });
+  return <pre>{createContext("preview").value}</pre>;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-create-context-in-render.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-create-context-in-render.test.ts
@@ -87,6 +87,36 @@ describe("no-create-context-in-render", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it.each([
+    [
+      "a namespace alias",
+      `import * as React from "react";
+      const R = React;
+      function App() { return R.createContext(null); }`,
+    ],
+    [
+      "a named API alias",
+      `import { createContext } from "react";
+      const makeContext = createContext;
+      function App() { return makeContext(null); }`,
+    ],
+    [
+      "namespace destructuring",
+      `import * as React from "react";
+      const { createContext: makeContext } = React;
+      function App() { return makeContext(null); }`,
+    ],
+    [
+      "static computed access",
+      `import * as React from "react";
+      function App() { return React["createContext"](null); }`,
+    ],
+  ])("flags createContext through %s", (_name, code) => {
+    const result = runRule(noCreateContextInRender, code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("does not flag createContext at module scope", () => {
     const result = runRule(
       noCreateContextInRender,
@@ -182,6 +212,18 @@ describe("no-create-context-in-render", () => {
     `,
     );
 
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not flag a local that shadows an imported createContext", () => {
+    const result = runRule(
+      noCreateContextInRender,
+      `import { createContext } from "react";
+      function App() {
+        const createContext = (value) => ({ value });
+        return createContext(null);
+      }`,
+    );
     expect(result.diagnostics).toEqual([]);
   });
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-create-context-in-render.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-create-context-in-render.ts
@@ -1,14 +1,15 @@
 import { defineRule } from "../../utils/define-rule.js";
 import { enclosingComponentOrHookName } from "../../utils/enclosing-component-or-hook-name.js";
+import type { ScopeAnalysis, SymbolDescriptor } from "../../semantic/scope-analysis.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
-import {
-  getImportBindingForName,
-  getImportSourceForName,
-} from "../../utils/find-import-source-for-name.js";
-import { isCanonicalReactNamespaceName } from "../../utils/is-canonical-react-namespace-name.js";
+import { getCallMethodName } from "../../utils/get-call-method-name.js";
+import { getImportedName } from "../../utils/get-imported-name.js";
+import { getStaticPropertyKeyName } from "../../utils/get-static-property-key-name.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { resolveConstIdentifierAlias } from "../../utils/resolve-const-identifier-alias.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 
 const MESSAGE =
   "createContext() builds a new context every render, so every consumer gets cut off & resets.";
@@ -19,34 +20,83 @@ const MESSAGE =
 // next render. Add new entries here as they appear in the ecosystem.
 const CONTEXT_MODULES: ReadonlyArray<string> = ["react", "use-context-selector", "react-tracked"];
 
-const isCreateContextCallee = (callee: EsTreeNode): boolean => {
+const getSupportedContextImportSource = (symbol: SymbolDescriptor | null): string | null => {
+  if (symbol?.kind !== "import") return null;
+  const importDeclaration = symbol.declarationNode.parent;
+  if (
+    !importDeclaration ||
+    !isNodeOfType(importDeclaration, "ImportDeclaration") ||
+    typeof importDeclaration.source.value !== "string" ||
+    !CONTEXT_MODULES.includes(importDeclaration.source.value)
+  ) {
+    return null;
+  }
+  return importDeclaration.source.value;
+};
+
+const isSupportedNamespaceSymbol = (symbol: SymbolDescriptor | null): boolean =>
+  getSupportedContextImportSource(symbol) !== null &&
+  Boolean(
+    symbol &&
+    (isNodeOfType(symbol.declarationNode, "ImportDefaultSpecifier") ||
+      isNodeOfType(symbol.declarationNode, "ImportNamespaceSpecifier")),
+  );
+
+const isDestructuredCreateContextBinding = (
+  identifier: EsTreeNode,
+  scopes: ScopeAnalysis,
+): boolean => {
+  if (!isNodeOfType(identifier, "Identifier")) return false;
+  const symbol = scopes.symbolFor(identifier);
+  if (
+    symbol?.kind !== "const" ||
+    !symbol.initializer ||
+    !isNodeOfType(symbol.declarationNode, "VariableDeclarator") ||
+    !isNodeOfType(symbol.declarationNode.id, "ObjectPattern")
+  ) {
+    return false;
+  }
+  const property = symbol.bindingIdentifier.parent;
+  if (
+    !property ||
+    !isNodeOfType(property, "Property") ||
+    getStaticPropertyKeyName(property, { allowComputedString: true }) !== "createContext"
+  ) {
+    return false;
+  }
+  const initializer = stripParenExpression(symbol.initializer);
+  return (
+    isNodeOfType(initializer, "Identifier") &&
+    isSupportedNamespaceSymbol(resolveConstIdentifierAlias(initializer, scopes))
+  );
+};
+
+const isCreateContextCall = (
+  node: EsTreeNodeOfType<"CallExpression">,
+  scopes: ScopeAnalysis,
+): boolean => {
+  const callee = stripParenExpression(node.callee);
   if (isNodeOfType(callee, "Identifier")) {
-    // Resolve through any renamed import — the binding carries the
-    // originally-exported symbol name, so we catch both
-    // `import { createContext } from "react"` and
-    // `import { createContext as makeCtx } from "react"`. We accept
-    // any module in `CONTEXT_MODULES`.
-    const binding = getImportBindingForName(callee, callee.name);
+    if (isDestructuredCreateContextBinding(callee, scopes)) return true;
+    const symbol = resolveConstIdentifierAlias(callee, scopes);
     return (
-      binding !== null &&
-      binding.exportedName === "createContext" &&
-      CONTEXT_MODULES.includes(binding.source)
+      getSupportedContextImportSource(symbol) !== null &&
+      Boolean(symbol && getImportedName(symbol.declarationNode) === "createContext")
     );
   }
-
-  if (isNodeOfType(callee, "MemberExpression") && !callee.computed) {
-    const namespaceIdentifier = callee.object;
-    const propertyIdentifier = callee.property;
-    if (!isNodeOfType(namespaceIdentifier, "Identifier")) return false;
-    if (!isNodeOfType(propertyIdentifier, "Identifier")) return false;
-    if (propertyIdentifier.name !== "createContext") return false;
-    const namespaceName = namespaceIdentifier.name;
-    if (isCanonicalReactNamespaceName(namespaceName)) return true;
-    const importSource = getImportSourceForName(namespaceIdentifier, namespaceName);
-    return importSource !== null && CONTEXT_MODULES.includes(importSource);
-  }
-
-  return false;
+  if (!isNodeOfType(callee, "MemberExpression")) return false;
+  const methodName =
+    getCallMethodName(callee) ??
+    (callee.computed &&
+    isNodeOfType(callee.property, "Literal") &&
+    typeof callee.property.value === "string"
+      ? callee.property.value
+      : null);
+  if (methodName !== "createContext") return false;
+  const receiver = stripParenExpression(callee.object);
+  if (!isNodeOfType(receiver, "Identifier")) return false;
+  if (receiver.name === "React" && scopes.isGlobalReference(receiver)) return true;
+  return isSupportedNamespaceSymbol(resolveConstIdentifierAlias(receiver, scopes));
 };
 
 // `createContext()` is identity-keyed: Provider/Consumer pairs match by
@@ -73,7 +123,7 @@ export const noCreateContextInRender = defineRule({
     "Move `createContext(...)` outside the component, to the top level of the file, so it stays the same on every render.",
   create: (context: RuleContext) => ({
     CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
-      if (!isCreateContextCallee(node.callee)) return;
+      if (!isCreateContextCall(node, context.scopes)) return;
       const componentOrHookName = enclosingComponentOrHookName(node);
       if (!componentOrHookName) return;
       context.report({


### PR DESCRIPTION
## Summary

- resolve `createContext` from supported React/context modules through named aliases, namespace aliases, destructuring, and static computed access
- require lexical symbol provenance so local functions and shadowed imports are not reported
- add adversarial rule tests, a fuzz regression seed, and a patch changeset

## Validation

- `cd packages/oxlint-plugin-react-doctor && nr test` — 543 files, 11,977 passed, 148 skipped
- `cd packages/fuzz && nr test` — 37 passed
- `nr typecheck`
- `FUZZ_RULE=no-create-context-in-render FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz`
- `nr lint` — clean aside from existing warnings
- `nr format:check`
- `nr build`
- `nr smoke:json-report`
- post-change truffler deduplication search

## OSS validation

A 50-root local RDE run was attempted. The current dirty eval-harness checkout rejected schema-version-3 CLI output while decoding results, before a trustworthy rule digest could be produced. Unit, corpus, and strict metamorphic fuzz coverage therefore carry this binding-only change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ESLint rule matching logic (more detections and different false-positive behavior on aliases/shadowing), which can affect CI signal on existing codebases without touching runtime app code.
> 
> **Overview**
> **`no-create-context-in-render`** no longer relies on simple import-name lookups; it uses **`context.scopes`** and **`resolveConstIdentifierAlias`** to decide whether a call is the real **`createContext`** from supported modules (`react`, `use-context-selector`, `react-tracked`).
> 
> The rule now reports in-render usage when the callee is reached via **namespace aliases** (`const R = React` → `R.createContext`), **named re-exports through const** (`makeContext = createContext`), **destructured namespace bindings** (`const { createContext: makeContext } = React`), or **static computed member access** (`React["createContext"]`). **Lexical shadowing** is respected: a local `createContext` that hides the import is not treated as React’s API.
> 
> Coverage adds parameterized rule tests for those patterns, a **no-flag** case for shadowed imports, a fuzz regression seed for shadowed React API, and a patch changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f7f6611d60afdbe9844a887c42cb5f7ae7d1a75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->