### PR TITLE
fix(a11y): inspect static JSX event spreads

### DIFF
--- a/.changeset/bright-spreads-listen.md
+++ b/.changeset/bright-spreads-listen.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Detect click handlers in statically known JSX object spreads when no keyboard handler is present.

--- a/packages/fuzz/corpus/regressions/click-events-have-key-events--static-object-spread.tsx
+++ b/packages/fuzz/corpus/regressions/click-events-have-key-events--static-object-spread.tsx
@@ -1,0 +1,6 @@
+// rule: click-events-have-key-events
+// weakness: transparent-spread
+// source: ISSUES_TO_FIX_ASAP.md semantic mutation matrix
+export const PreviewCard = ({ open }: { open: () => void }) => (
+  <div {...{ onClick: open }}>Preview</div>
+);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/click-events-have-key-events.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/click-events-have-key-events.regressions.test.ts
@@ -106,6 +106,87 @@ describe("a11y/click-events-have-key-events regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it.each([
+    ["an inline object", `export const Card = ({ open }) => <div {...{ onClick: open }} />;`],
+    [
+      "a local object",
+      `export const Card = ({ open }) => {
+        const cardProps = { className: "card", onClick: open };
+        return <div {...cardProps} />;
+      };`,
+    ],
+    [
+      "a static computed key",
+      `export const Card = ({ open }) => <div {...{ ["onClick"]: open }} />;`,
+    ],
+  ])("flags a noninteractive element whose click handler comes from %s", (_name, code) => {
+    const result = runRule(clickEventsHaveKeyEvents, code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a transparent spread that includes a keyboard handler", () => {
+    const result = runRule(
+      clickEventsHaveKeyEvents,
+      `export const Card = ({ open, openFromKeyboard }) => (
+        <div {...{ onClick: open, onKeyDown: openFromKeyboard }} />
+      );`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("flags repeated transparent spreads of the same click props object", () => {
+    const result = runRule(
+      clickEventsHaveKeyEvents,
+      `export const Card = ({ open }) => {
+        const cardProps = { onClick: open };
+        return <div {...cardProps} {...cardProps} />;
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag an inline focus-forwarding handler inside a transparent spread", () => {
+    const result = runRule(
+      clickEventsHaveKeyEvents,
+      `export const Field = ({ inputRef }) => (
+        <div {...{ onClick: () => inputRef.current?.focus() }} />
+      );`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not flag a named backdrop handler inside a transparent spread", () => {
+    const result = runRule(
+      clickEventsHaveKeyEvents,
+      `export const Modal = ({ close }) => {
+        const dismissBackdrop = (event) => {
+          if (event.target === event.currentTarget) close();
+        };
+        return <div {...{ onClick: dismissBackdrop }} />;
+      };`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not flag a native button whose click handler comes from a transparent spread", () => {
+    const result = runRule(
+      clickEventsHaveKeyEvents,
+      `export const Card = ({ open }) => <button {...{ onClick: open }} />;`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("keeps a spread role conservative when it can change accessibility semantics", () => {
+    const result = runRule(
+      clickEventsHaveKeyEvents,
+      `export const Option = ({ select }) => (
+        <div {...{ role: "option", onClick: select }} />
+      );`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("does not flag a role=option item of a listbox composite", () => {
     const result = runRule(
       clickEventsHaveKeyEvents,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/click-events-have-key-events.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/click-events-have-key-events.ts
@@ -1,17 +1,20 @@
 import { defineRule } from "../../utils/define-rule.js";
+import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
 import { flattenJsxName } from "../../utils/flatten-jsx-name.js";
 import { getElementType } from "../../utils/get-element-type.js";
+import { getStaticPropertyKeyName } from "../../utils/get-static-property-key-name.js";
 import { hasJsxPropIgnoreCase } from "../../utils/has-jsx-prop-ignore-case.js";
-import { hasJsxSpreadAttribute } from "../../utils/has-jsx-spread-attribute.js";
 import { isHiddenFromScreenReader } from "../../utils/is-hidden-from-screen-reader.js";
 import { isInteractiveElement } from "../../utils/is-interactive-element.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isPresentationRole } from "../../utils/is-presentation-role.js";
 import { isPureEventBlockerHandler } from "../../utils/is-pure-event-blocker-handler.js";
 import { isTestlikeFilename } from "../../utils/is-testlike-filename.js";
+import { resolveConstIdentifierAlias } from "../../utils/resolve-const-identifier-alias.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import { HTML_TAGS } from "../../constants/html-tags.js";
 
 const MESSAGE =
@@ -25,6 +28,98 @@ const KEY_HANDLERS = [
   "onKeyDownCapture",
   "onKeyPressCapture",
 ] as const;
+
+const CLICK_HANDLERS = ["onClick", "onClickCapture"] as const;
+const TRANSPARENT_SPREAD_EVENT_NAMES: ReadonlySet<string> = new Set(
+  [...CLICK_HANDLERS, ...KEY_HANDLERS].map((eventName) => eventName.toLowerCase()),
+);
+const CONSERVATIVE_SPREAD_PROP_NAMES: ReadonlySet<string> = new Set([
+  "aria-hidden",
+  "onmouseenter",
+  "onmouseover",
+  "role",
+]);
+
+const resolveSpreadObjectExpression = (
+  expression: EsTreeNode,
+  scopes: ScopeAnalysis,
+): EsTreeNodeOfType<"ObjectExpression"> | null => {
+  const innerExpression = stripParenExpression(expression);
+  if (isNodeOfType(innerExpression, "ObjectExpression")) return innerExpression;
+  if (!isNodeOfType(innerExpression, "Identifier")) return null;
+  const symbol = resolveConstIdentifierAlias(innerExpression, scopes);
+  if (symbol?.kind !== "const" || !symbol.initializer) return null;
+  const initializer = stripParenExpression(symbol.initializer);
+  return isNodeOfType(initializer, "ObjectExpression") ? initializer : null;
+};
+
+const collectTransparentSpreadEventNames = (
+  expression: EsTreeNode,
+  scopes: ScopeAnalysis,
+  eventValues: Map<string, EsTreeNode>,
+  visitedObjectExpressions: Set<EsTreeNode>,
+): boolean => {
+  const objectExpression = resolveSpreadObjectExpression(expression, scopes);
+  if (!objectExpression || visitedObjectExpressions.has(objectExpression)) return false;
+  visitedObjectExpressions.add(objectExpression);
+  let isTransparent = true;
+  for (const property of objectExpression.properties) {
+    if (isNodeOfType(property, "SpreadElement")) {
+      if (
+        !collectTransparentSpreadEventNames(
+          property.argument as EsTreeNode,
+          scopes,
+          eventValues,
+          visitedObjectExpressions,
+        )
+      ) {
+        isTransparent = false;
+        break;
+      }
+      continue;
+    }
+    if (!isNodeOfType(property, "Property")) {
+      isTransparent = false;
+      break;
+    }
+    const propertyName = getStaticPropertyKeyName(property, { allowComputedString: true });
+    if (!propertyName) {
+      isTransparent = false;
+      break;
+    }
+    const normalizedPropertyName = propertyName.toLowerCase();
+    if (CONSERVATIVE_SPREAD_PROP_NAMES.has(normalizedPropertyName)) {
+      isTransparent = false;
+      break;
+    }
+    if (TRANSPARENT_SPREAD_EVENT_NAMES.has(normalizedPropertyName)) {
+      eventValues.set(normalizedPropertyName, property.value as EsTreeNode);
+    }
+  }
+  visitedObjectExpressions.delete(objectExpression);
+  return isTransparent;
+};
+
+const getTransparentSpreadEventValues = (
+  attributes: EsTreeNode[],
+  scopes: ScopeAnalysis,
+): Map<string, EsTreeNode> | null => {
+  const eventValues = new Map<string, EsTreeNode>();
+  for (const attribute of attributes) {
+    if (!isNodeOfType(attribute, "JSXSpreadAttribute")) continue;
+    if (
+      !collectTransparentSpreadEventNames(
+        attribute.argument as EsTreeNode,
+        scopes,
+        eventValues,
+        new Set(),
+      )
+    ) {
+      return null;
+    }
+  }
+  return eventValues;
+};
 
 // OXC's `is_interactive_element` treats these as interactive, but none
 // of them takes focus or has native activation semantics — a
@@ -89,7 +184,11 @@ const isFocusForwardingFunctionBody = (body: EsTreeNode | null | undefined): boo
 
 const resolveHandlerFunction = (attribute: EsTreeNodeOfType<"JSXAttribute">): EsTreeNode | null => {
   if (!attribute.value || !isNodeOfType(attribute.value, "JSXExpressionContainer")) return null;
-  let expression = attribute.value.expression as EsTreeNode;
+  return resolveHandlerFunctionExpression(attribute.value.expression as EsTreeNode);
+};
+
+const resolveHandlerFunctionExpression = (handlerExpression: EsTreeNode): EsTreeNode | null => {
+  let expression = handlerExpression;
   if (isNodeOfType(expression, "Identifier")) {
     const binding = findVariableInitializer(expression, expression.name);
     if (!binding?.initializer) return null;
@@ -263,26 +362,45 @@ export const clickEventsHaveKeyEvents = defineRule({
         if (!FOCUSLESS_CONTAINER_TAGS.has(tag) && isInteractiveElement(tag, node)) return;
         // `onClickCapture` is the same click affordance on the capture
         // phase — equally unreachable from the keyboard.
+        const spreadEventValues = getTransparentSpreadEventValues(node.attributes, context.scopes);
+        if (!spreadEventValues) return;
         const onClick =
           hasJsxPropIgnoreCase(node.attributes, "onClick") ??
           hasJsxPropIgnoreCase(node.attributes, "onClickCapture");
-        if (!onClick) return;
-        if (isPureEventBlockerHandler(onClick)) return;
-        if (isFocusForwardingHandler(onClick)) return;
-        // A spread can carry keyboard handlers the static check can't
-        // see (react-aria's `{...buttonProps}` from useCalendarCell,
-        // `{...rest}` on design-system options).
-        if (hasJsxSpreadAttribute(node.attributes)) return;
+        const spreadOnClickExpression = CLICK_HANDLERS.map((name) =>
+          spreadEventValues.get(name.toLowerCase()),
+        ).find((expression) => expression !== undefined);
+        if (!onClick && !spreadOnClickExpression) {
+          return;
+        }
+        if (onClick && isPureEventBlockerHandler(onClick)) return;
+        if (onClick && isFocusForwardingHandler(onClick)) return;
+        const spreadHandlerFunction = spreadOnClickExpression
+          ? resolveHandlerFunctionExpression(spreadOnClickExpression)
+          : null;
+        if (
+          spreadHandlerFunction &&
+          (isFocusForwardingFunctionBody(
+            (spreadHandlerFunction as { body?: EsTreeNode }).body ?? null,
+          ) ||
+            containsBackdropDismissComparison(
+              (spreadHandlerFunction as { body?: EsTreeNode }).body ?? null,
+            ))
+        ) {
+          return;
+        }
         if (hasCompositeItemRole(node)) return;
         if (isHoverSelectionListItem(tag, node)) return;
-        if (isBackdropDismissHandler(onClick)) return;
+        if (onClick && isBackdropDismissHandler(onClick)) return;
         if (containsKeyboardActivatableDescendant(node.parent)) return;
 
         if (isHiddenFromScreenReader(node, context.settings)) return;
         // Presentational role (presentation / none) → not perceivable by AT.
         if (isPresentationRole(node)) return;
-        const hasKeyHandler = KEY_HANDLERS.some((handler) =>
-          hasJsxPropIgnoreCase(node.attributes, handler),
+        const hasKeyHandler = KEY_HANDLERS.some(
+          (handler) =>
+            hasJsxPropIgnoreCase(node.attributes, handler) ||
+            spreadEventValues.has(handler.toLowerCase()),
         );
         if (hasKeyHandler) return;
 


### PR DESCRIPTION
## Summary

- resolve inline and same-file const object spreads for click and keyboard event props
- support statically computed event keys and nested transparent object spreads
- keep opaque spreads and spreads that can change accessibility semantics conservative
- add focused regressions, a fuzz corpus seed, and a patch changeset

## Validation

- focused `click-events-have-key-events` regressions — 27 passed
- full oxlint plugin suite — 543 files, 11,987 passed, 148 skipped
- fuzz regression corpus — 37 passed
- strict fuzz, 500 iterations
- `nr typecheck`
- `nr lint` — clean aside from existing warnings
- `nr format:check`
- post-change truffler deduplication search

## OSS validation

The local RDE checkout currently rejects schema-version-3 reports during harness decoding, so it cannot produce a trustworthy digest. This change remains deliberately conservative for opaque and semantics-bearing spreads; rule, corpus, and metamorphic coverage validate the targeted static forms.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Narrows a broad spread bypass in an a11y rule, which can surface new warnings on static spread patterns; conservative fallbacks limit false positives on dynamic props.
> 
> **Overview**
> The **`click-events-have-key-events`** rule no longer skips every JSX spread. It now resolves **statically known** spread objects (inline literals, same-file `const` objects, nested transparent spreads, and computed string keys like `["onClick"]`) and treats click/keyboard handlers found there like explicit JSX props.
> 
> **Opaque or semantics-changing spreads stay conservative:** unknown identifiers, props such as `role` / `aria-hidden` / hover handlers in the spread object, or spreads that cannot be fully analyzed still suppress the rule (same as before for `{...buttonProps}`). Keyboard handlers in a transparent spread satisfy the rule; spread-sourced click handlers get the same focus-forwarding and backdrop-dismiss exemptions as direct `onClick`.
> 
> Adds regression tests and a fuzz corpus seed for `<div {...{ onClick: open }} />`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42eaf0951f3ad6fb957eea4bfb0e55c6527c39bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->