### PR TITLE
fix(effects): recognize split lifecycle cleanup

### DIFF
--- a/.changeset/gentle-effects-release.md
+++ b/.changeset/gentle-effects-release.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Recognize bound subscription disposers and split timer cleanup that covers both effect reruns and unmount.

--- a/packages/fuzz/corpus/regressions/effect-needs-cleanup--bound-subscription-disposer.tsx
+++ b/packages/fuzz/corpus/regressions/effect-needs-cleanup--bound-subscription-disposer.tsx
@@ -1,0 +1,16 @@
+// rule: effect-needs-cleanup
+// weakness: cleanup-provenance
+// source: ISSUES_TO_FIX_ASAP.md cross-version cleanup matrix
+import { useEffect } from "react";
+
+export const SubscriptionFeed = ({
+  store,
+}: {
+  store: { subscribe: (callback: () => void) => { unsubscribe: () => void } };
+}) => {
+  useEffect(() => {
+    const subscription = store.subscribe(() => undefined);
+    return subscription.unsubscribe.bind(subscription);
+  }, [store]);
+  return null;
+};

--- a/packages/fuzz/corpus/regressions/effect-needs-cleanup--split-timer-cleanup.tsx
+++ b/packages/fuzz/corpus/regressions/effect-needs-cleanup--split-timer-cleanup.tsx
@@ -1,0 +1,19 @@
+// rule: effect-needs-cleanup
+// weakness: cleanup-provenance
+// source: ISSUES_TO_FIX_ASAP.md ReactTooltip split cleanup
+import { useEffect, useRef } from "react";
+
+export const DeferredPreview = ({ value }: { value: string }) => {
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    timeoutRef.current = setTimeout(() => console.log(value), 300);
+  }, [value]);
+  useEffect(
+    () => () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    },
+    [],
+  );
+  return null;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
@@ -910,6 +910,45 @@ export const Debounced = ({ value }) => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("rejects split cleanup when an early return skips the rerun release", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect, useRef } from "react";
+export const Debounced = ({ enabled, value }) => {
+  const timeoutRef = useRef(null);
+  useEffect(() => {
+    if (!enabled) return;
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    timeoutRef.current = setTimeout(() => commit(value), 300);
+  }, [enabled, value]);
+  useEffect(() => () => clearTimeout(timeoutRef.current), []);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("rejects split cleanup when an outer condition skips the rerun release", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect, useRef } from "react";
+export const Debounced = ({ enabled, value }) => {
+  const timeoutRef = useRef(null);
+  useEffect(() => {
+    if (enabled) {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      timeoutRef.current = setTimeout(() => commit(value), 300);
+    }
+  }, [enabled, value]);
+  useEffect(() => () => clearTimeout(timeoutRef.current), []);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("accepts helper-mediated rerun and unmount cleanup for the same timer", () => {
     const result = runRule(
       effectNeedsCleanup,
@@ -976,6 +1015,23 @@ export const Feed = ({ store }) => {
   useEffect(() => {
     const subscription = store.subscribe(update);
     return subscription.unsubscribe.bind(subscription);
+  }, [store]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("accepts an aliased release method bound to its subscription receiver", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+export const Feed = ({ store }) => {
+  useEffect(() => {
+    const subscription = store.subscribe(update);
+    const cleanup = subscription.unsubscribe.bind(subscription);
+    return cleanup;
   }, [store]);
   return null;
 };`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
@@ -874,6 +874,132 @@ export const Debounced = ({ value }) => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("accepts a timer released before replacement and by a stable unmount effect", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect, useRef } from "react";
+export const Debounced = ({ value }) => {
+  const timeoutRef = useRef(null);
+  useEffect(() => {
+    clearTimeout(timeoutRef.current);
+    timeoutRef.current = setTimeout(() => commit(value), 300);
+  }, [value]);
+  useEffect(() => () => clearTimeout(timeoutRef.current), []);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("accepts a handle-guarded release before timer replacement", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect, useRef } from "react";
+export const Debounced = ({ value }) => {
+  const timeoutRef = useRef(null);
+  useEffect(() => {
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    timeoutRef.current = setTimeout(() => commit(value), 300);
+  }, [value]);
+  useEffect(() => () => clearTimeout(timeoutRef.current), []);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("accepts helper-mediated rerun and unmount cleanup for the same timer", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect, useRef } from "react";
+export const Debounced = ({ value }) => {
+  const timeoutRef = useRef(null);
+  const clearTimer = () => clearTimeout(timeoutRef.current);
+  useEffect(() => {
+    clearTimer();
+    timeoutRef.current = setTimeout(() => commit(value), 300);
+  }, [value]);
+  useEffect(() => clearTimer, []);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("rejects split cleanup that releases a different timer", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect, useRef } from "react";
+export const Debounced = ({ value }) => {
+  const timeoutRef = useRef(null);
+  const otherTimeoutRef = useRef(null);
+  useEffect(() => {
+    clearTimeout(timeoutRef.current);
+    timeoutRef.current = setTimeout(() => commit(value), 300);
+  }, [value]);
+  useEffect(() => () => clearTimeout(otherTimeoutRef.current), []);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("rejects split cleanup that is not returned on every unmount-effect path", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect, useRef } from "react";
+export const Debounced = ({ enabled, value }) => {
+  const timeoutRef = useRef(null);
+  useEffect(() => {
+    clearTimeout(timeoutRef.current);
+    timeoutRef.current = setTimeout(() => commit(value), 300);
+  }, [value]);
+  useEffect(() => {
+    if (enabled) return () => clearTimeout(timeoutRef.current);
+  }, []);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("accepts a release method bound to its subscription receiver", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+export const Feed = ({ store }) => {
+  useEffect(() => {
+    const subscription = store.subscribe(update);
+    return subscription.unsubscribe.bind(subscription);
+  }, [store]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("rejects a release method bound to a different subscription receiver", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+export const Feed = ({ store, otherSubscription }) => {
+  useEffect(() => {
+    const subscription = store.subscribe(update);
+    return subscription.unsubscribe.bind(otherSubscription);
+  }, [store, otherSubscription]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("does not flag a nested-callback release — only statement-level releases neutralize", () => {
     // `socket.onclose = () => socket.close()` runs later, if ever — it must
     // NOT count as a synchronous release.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -790,6 +790,224 @@ const doesCleanupFunctionReleaseUsage = (
   return didCleanupFunctionMatch;
 };
 
+const doesBoundCleanupReleaseUsage = (
+  expression: EsTreeNode,
+  usage: SubscribeLikeUsage,
+  context: RuleContext,
+): boolean => {
+  const callExpression = stripParenExpression(expression);
+  if (!isNodeOfType(callExpression, "CallExpression")) return false;
+  const bindCallee = stripParenExpression(callExpression.callee);
+  if (
+    !isNodeOfType(bindCallee, "MemberExpression") ||
+    bindCallee.computed ||
+    !isNodeOfType(bindCallee.property, "Identifier") ||
+    bindCallee.property.name !== "bind"
+  ) {
+    return false;
+  }
+  const releaseMember = stripParenExpression(bindCallee.object);
+  if (
+    !isNodeOfType(releaseMember, "MemberExpression") ||
+    releaseMember.computed ||
+    !isNodeOfType(releaseMember.property, "Identifier")
+  ) {
+    return false;
+  }
+  const releaseReceiverKey = resolveExpressionKey(releaseMember.object, context);
+  if (
+    releaseReceiverKey === null ||
+    releaseReceiverKey !== resolveExpressionKey(callExpression.arguments?.[0], context)
+  ) {
+    return false;
+  }
+  const releaseVerbName = releaseMember.property.name;
+  if (usage.kind === "socket") {
+    return (
+      usage.handleKey === releaseReceiverKey &&
+      (SOCKET_RELEASE_VERB_NAMES.has(releaseVerbName) ||
+        UNIVERSAL_RELEASE_VERB_NAMES.has(releaseVerbName))
+    );
+  }
+  return (
+    usage.kind === "subscribe" &&
+    usage.handleKey === releaseReceiverKey &&
+    (releaseVerbName === "unsubscribe" ||
+      releaseVerbName === "unsub" ||
+      releaseVerbName === "close" ||
+      releaseVerbName === "unwatch" ||
+      releaseVerbName === "unlisten" ||
+      BOUND_RESOURCE_RELEASE_METHOD_NAMES.has(releaseVerbName))
+  );
+};
+
+const callbackReturnsCleanupForUsage = (
+  callback: EsTreeNode,
+  usage: SubscribeLikeUsage,
+  context: RuleContext,
+): boolean => {
+  if (
+    !isNodeOfType(callback, "ArrowFunctionExpression") &&
+    !isNodeOfType(callback, "FunctionExpression")
+  ) {
+    return false;
+  }
+  const doesReturnedValueReleaseUsage = (returnedValue: EsTreeNode): boolean => {
+    if (doesBoundCleanupReleaseUsage(returnedValue, usage, context)) return true;
+    const cleanupFunction = resolveStableValue(returnedValue, context);
+    return Boolean(
+      cleanupFunction &&
+      isFunctionLike(cleanupFunction) &&
+      doesCleanupFunctionReleaseUsage(cleanupFunction, usage, context),
+    );
+  };
+  if (!isNodeOfType(callback.body, "BlockStatement")) {
+    return doesReturnedValueReleaseUsage(stripParenExpression(callback.body));
+  }
+  const matchingCleanupReturns: EsTreeNode[] = [];
+  walkInsideStatementBlocks(callback.body, (child: EsTreeNode) => {
+    if (
+      isNodeOfType(child, "ReturnStatement") &&
+      child.argument &&
+      doesReturnedValueReleaseUsage(stripParenExpression(child.argument))
+    ) {
+      matchingCleanupReturns.push(child);
+    }
+  });
+  const functionCfg = context.cfg.cfgFor(callback);
+  if (!functionCfg || matchingCleanupReturns.length === 0) return false;
+  const matchingBlocks = new Set(
+    matchingCleanupReturns.flatMap((returnNode) => {
+      const block = functionCfg.blockOf(returnNode);
+      return block ? [block] : [];
+    }),
+  );
+  const visitedBlocks = new Set([functionCfg.entry]);
+  const pendingBlocks = [functionCfg.entry];
+  while (pendingBlocks.length > 0) {
+    const currentBlock = pendingBlocks.pop();
+    if (!currentBlock) break;
+    if (matchingBlocks.has(currentBlock)) continue;
+    for (const edge of currentBlock.successors) {
+      if (edge.to === functionCfg.exit) return false;
+      if (visitedBlocks.has(edge.to)) continue;
+      visitedBlocks.add(edge.to);
+      pendingBlocks.push(edge.to);
+    }
+  }
+  return true;
+};
+
+const hasRerunReleaseBeforeUsage = (
+  callback: EsTreeNode,
+  usage: SubscribeLikeUsage,
+  context: RuleContext,
+): boolean => {
+  if (
+    (!isNodeOfType(callback, "ArrowFunctionExpression") &&
+      !isNodeOfType(callback, "FunctionExpression")) ||
+    !isNodeOfType(callback.body, "BlockStatement")
+  ) {
+    return false;
+  }
+  const functionCfg = context.cfg.cfgFor(callback);
+  const usageBlock = functionCfg?.blockOf(usage.node);
+  const usageStart = getRangeStart(usage.node);
+  if (!functionCfg || !usageBlock || usageStart === null) return false;
+  const isReleaseGuardedByHandle = (releaseCall: EsTreeNode): boolean => {
+    if (usage.handleKey === null) return false;
+    let ancestor = releaseCall.parent;
+    while (ancestor && ancestor !== callback.body) {
+      if (isNodeOfType(ancestor, "IfStatement")) {
+        return (
+          ancestor.alternate === null &&
+          resolveExpressionKey(ancestor.test, context) === usage.handleKey &&
+          getRangeStart(ancestor) !== null &&
+          (getRangeStart(ancestor) ?? usageStart) < usageStart
+        );
+      }
+      ancestor = ancestor.parent;
+    }
+    return false;
+  };
+  let didFindRelease = false;
+  walkInsideStatementBlocks(callback.body, (child: EsTreeNode) => {
+    if (didFindRelease || !isNodeOfType(child, "CallExpression")) return;
+    const releaseStart = getRangeStart(child);
+    if (
+      releaseStart === null ||
+      releaseStart >= usageStart ||
+      (functionCfg.blockOf(child) !== usageBlock && !isReleaseGuardedByHandle(child))
+    ) {
+      return;
+    }
+    if (doesReleaseCallMatchUsage(child, usage, context)) {
+      didFindRelease = true;
+      return false;
+    }
+    const helperFunction = resolveStableValue(child.callee, context);
+    if (
+      helperFunction &&
+      isFunctionLike(helperFunction) &&
+      doesCleanupFunctionReleaseUsage(helperFunction, usage, context)
+    ) {
+      didFindRelease = true;
+      return false;
+    }
+  });
+  return didFindRelease;
+};
+
+const hasStableUnmountCleanupForUsage = (
+  callback: EsTreeNode,
+  usage: SubscribeLikeUsage,
+  context: RuleContext,
+): boolean => {
+  const componentFunction = findEnclosingFunction(callback);
+  if (
+    !componentFunction ||
+    (!isNodeOfType(componentFunction, "ArrowFunctionExpression") &&
+      !isNodeOfType(componentFunction, "FunctionExpression") &&
+      !isNodeOfType(componentFunction, "FunctionDeclaration"))
+  ) {
+    return false;
+  }
+  let didFindUnmountCleanup = false;
+  walkAst(componentFunction.body, (child: EsTreeNode) => {
+    if (didFindUnmountCleanup) return false;
+    if (
+      !isNodeOfType(child, "CallExpression") ||
+      findEnclosingFunction(child) !== componentFunction
+    ) {
+      return;
+    }
+    if (!isHookCall(child, CLEANUP_EFFECT_HOOK_NAMES)) return;
+    const dependencyList = child.arguments?.[1];
+    if (!isNodeOfType(dependencyList, "ArrayExpression") || dependencyList.elements.length > 0) {
+      return;
+    }
+    const cleanupCallback = getEffectCallback(child);
+    if (
+      cleanupCallback &&
+      cleanupCallback !== callback &&
+      callbackReturnsCleanupForUsage(cleanupCallback, usage, context)
+    ) {
+      didFindUnmountCleanup = true;
+      return false;
+    }
+  });
+  return didFindUnmountCleanup;
+};
+
+const hasSplitLifecycleCleanup = (
+  callback: EsTreeNode,
+  usage: SubscribeLikeUsage,
+  context: RuleContext,
+): boolean =>
+  usage.handleKey !== null &&
+  hasRerunReleaseBeforeUsage(callback, usage, context) &&
+  hasStableUnmountCleanupForUsage(callback, usage, context);
+
 const effectHasCleanupForUsage = (
   callback: EsTreeNode,
   usage: SubscribeLikeUsage,
@@ -822,6 +1040,10 @@ const effectHasCleanupForUsage = (
     if (returnStart !== null && usageStart !== null && returnStart < usageStart) return;
     const returnedValue = child.argument ? stripParenExpression(child.argument) : null;
     if (!returnedValue) return;
+    if (doesBoundCleanupReleaseUsage(returnedValue, usage, context)) {
+      matchingCleanupReturns.push(child);
+      return;
+    }
     if (
       usage.kind === "subscribe" &&
       (returnedValue === usage.node ||
@@ -870,7 +1092,10 @@ const findFirstUsageWithoutCleanup = (
   context: RuleContext,
 ): SubscribeLikeUsage | null => {
   for (const usage of usages) {
-    if (!effectHasCleanupForUsage(callback, usage, context)) {
+    if (
+      !effectHasCleanupForUsage(callback, usage, context) &&
+      !hasSplitLifecycleCleanup(callback, usage, context)
+    ) {
       return usage;
     }
   }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -908,28 +908,7 @@ const callbackReturnsCleanupForUsage = (
       matchingCleanupReturns.push(child);
     }
   });
-  const functionCfg = context.cfg.cfgFor(callback);
-  if (!functionCfg || matchingCleanupReturns.length === 0) return false;
-  const matchingBlocks = new Set(
-    matchingCleanupReturns.flatMap((returnNode) => {
-      const block = functionCfg.blockOf(returnNode);
-      return block ? [block] : [];
-    }),
-  );
-  const visitedBlocks = new Set([functionCfg.entry]);
-  const pendingBlocks = [functionCfg.entry];
-  while (pendingBlocks.length > 0) {
-    const currentBlock = pendingBlocks.pop();
-    if (!currentBlock) break;
-    if (matchingBlocks.has(currentBlock)) continue;
-    for (const edge of currentBlock.successors) {
-      if (edge.to === functionCfg.exit) return false;
-      if (visitedBlocks.has(edge.to)) continue;
-      visitedBlocks.add(edge.to);
-      pendingBlocks.push(edge.to);
-    }
-  }
-  return true;
+  return doMatchingNodesCoverEveryPathFromFunctionEntry(callback, matchingCleanupReturns, context);
 };
 
 const hasRerunReleaseBeforeUsage = (

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -339,6 +339,37 @@ const doMatchingNodesCoverEveryPathAfterUsage = (
   return matchingBlocks.size > 0;
 };
 
+const doMatchingNodesCoverEveryPathFromFunctionEntry = (
+  owner: EsTreeNode,
+  matchingNodes: ReadonlyArray<EsTreeNode>,
+  context: RuleContext,
+): boolean => {
+  const functionCfg = context.cfg.cfgFor(owner);
+  if (!functionCfg) return false;
+  const matchingBlocks = new Set(
+    matchingNodes.flatMap((matchingNode) => {
+      if (context.cfg.enclosingFunction(matchingNode) !== owner) return [];
+      const matchingBlock = functionCfg.blockOf(matchingNode);
+      return matchingBlock ? [matchingBlock] : [];
+    }),
+  );
+  if (matchingBlocks.size === 0) return false;
+  const visitedBlocks = new Set([functionCfg.entry]);
+  const pendingBlocks = [functionCfg.entry];
+  while (pendingBlocks.length > 0) {
+    const currentBlock = pendingBlocks.pop();
+    if (!currentBlock) break;
+    if (matchingBlocks.has(currentBlock)) continue;
+    for (const edge of currentBlock.successors) {
+      if (edge.to === functionCfg.exit) return false;
+      if (visitedBlocks.has(edge.to)) continue;
+      visitedBlocks.add(edge.to);
+      pendingBlocks.push(edge.to);
+    }
+  }
+  return true;
+};
+
 // A resource registered and then released SYNCHRONOUSLY later in the same
 // effect body (`const socket = new WebSocket(url); …; socket.close();`,
 // `observer.observe(el); measure(); observer.disconnect();`) never outlives
@@ -855,6 +886,9 @@ const callbackReturnsCleanupForUsage = (
   const doesReturnedValueReleaseUsage = (returnedValue: EsTreeNode): boolean => {
     if (doesBoundCleanupReleaseUsage(returnedValue, usage, context)) return true;
     const cleanupFunction = resolveStableValue(returnedValue, context);
+    if (cleanupFunction && doesBoundCleanupReleaseUsage(cleanupFunction, usage, context)) {
+      return true;
+    }
     return Boolean(
       cleanupFunction &&
       isFunctionLike(cleanupFunction) &&
@@ -914,36 +948,37 @@ const hasRerunReleaseBeforeUsage = (
   const usageBlock = functionCfg?.blockOf(usage.node);
   const usageStart = getRangeStart(usage.node);
   if (!functionCfg || !usageBlock || usageStart === null) return false;
-  const isReleaseGuardedByHandle = (releaseCall: EsTreeNode): boolean => {
-    if (usage.handleKey === null) return false;
+  const findHandleGuard = (releaseCall: EsTreeNode): EsTreeNode | null => {
+    if (usage.handleKey === null) return null;
     let ancestor = releaseCall.parent;
     while (ancestor && ancestor !== callback.body) {
       if (isNodeOfType(ancestor, "IfStatement")) {
-        return (
-          ancestor.alternate === null &&
+        return ancestor.alternate === null &&
           resolveExpressionKey(ancestor.test, context) === usage.handleKey &&
           getRangeStart(ancestor) !== null &&
           (getRangeStart(ancestor) ?? usageStart) < usageStart
-        );
+          ? ancestor
+          : null;
       }
       ancestor = ancestor.parent;
     }
-    return false;
+    return null;
   };
-  let didFindRelease = false;
+  const matchingReleaseAnchors: EsTreeNode[] = [];
   walkInsideStatementBlocks(callback.body, (child: EsTreeNode) => {
-    if (didFindRelease || !isNodeOfType(child, "CallExpression")) return;
+    if (!isNodeOfType(child, "CallExpression")) return;
     const releaseStart = getRangeStart(child);
+    const handleGuard = findHandleGuard(child);
     if (
       releaseStart === null ||
       releaseStart >= usageStart ||
-      (functionCfg.blockOf(child) !== usageBlock && !isReleaseGuardedByHandle(child))
+      (functionCfg.blockOf(child) !== usageBlock && !handleGuard)
     ) {
       return;
     }
     if (doesReleaseCallMatchUsage(child, usage, context)) {
-      didFindRelease = true;
-      return false;
+      matchingReleaseAnchors.push(handleGuard ?? child);
+      return;
     }
     const helperFunction = resolveStableValue(child.callee, context);
     if (
@@ -951,11 +986,10 @@ const hasRerunReleaseBeforeUsage = (
       isFunctionLike(helperFunction) &&
       doesCleanupFunctionReleaseUsage(helperFunction, usage, context)
     ) {
-      didFindRelease = true;
-      return false;
+      matchingReleaseAnchors.push(handleGuard ?? child);
     }
   });
-  return didFindRelease;
+  return doMatchingNodesCoverEveryPathFromFunctionEntry(callback, matchingReleaseAnchors, context);
 };
 
 const hasStableUnmountCleanupForUsage = (
@@ -1074,6 +1108,10 @@ const effectHasCleanupForUsage = (
       if (!returnedSymbol?.initializer) return;
     }
     const cleanupFunction = resolveStableValue(returnedValue, context);
+    if (cleanupFunction && doesBoundCleanupReleaseUsage(cleanupFunction, usage, context)) {
+      matchingCleanupReturns.push(child);
+      return;
+    }
     if (!cleanupFunction || !isFunctionLike(cleanupFunction)) return;
     if (doesCleanupFunctionReleaseUsage(cleanupFunction, usage, context)) {
       matchingCleanupReturns.push(child);


### PR DESCRIPTION
## Summary

- accept release methods bound to the same subscription/connection receiver
- recognize timer ownership split across an unconditional pre-replacement release and a stable empty-dependency unmount effect
- follow visible cleanup helpers while requiring exact resource identity and all-path unmount returns
- retain findings for missing cleanup, unrelated receivers/refs, conditional unmount returns, and cross-effect resources without rerun cleanup
- add adversarial regressions, two fuzz corpus fixtures, and a patch changeset

## Validation

- focused `effect-needs-cleanup` regressions — 130 passed
- full oxlint plugin suite — 543 files, 11,993 passed, 148 skipped
- fuzz regression corpus — 37 passed
- strict fuzz, 500 iterations
- `nr typecheck`
- `nr lint` — clean aside from existing warnings
- `nr format:check`
- post-change truffler deduplication search

## OSS validation

The local RDE checkout currently rejects schema-version-3 reports during harness decoding, so it cannot produce a trustworthy digest. The implementation is intentionally constrained to same-CFG-block rerun release, exact handle identity, empty dependency lists, and all-path cleanup returns.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Linter-only change with nuanced CFG/control-flow heuristics; false negatives are possible on edge cases, but scope is limited to cleanup provenance and heavily regression-tested.
> 
> **Overview**
> Extends **`effect-needs-cleanup`** so fewer legitimate patterns are flagged as missing cleanup.
> 
> **Bound subscription disposers** — Returning `subscription.unsubscribe.bind(subscription)` (or an alias) counts as cleanup when the bind receiver matches the subscription handle and the method is a known release verb; wrong receivers still fail.
> 
> **Split lifecycle timers** — A ref-backed timer can satisfy the rule when one effect clears/replaces it on every rerun path before `setTimeout`/`setInterval`, and a separate **`useEffect` with `[]`** returns matching unmount cleanup for the same ref. Conditional skips on rerun, a different ref, partial unmount returns, and cross-effect socket cleanup without rerun release stay rejected.
> 
> Implementation adds CFG **all-path-from-entry** coverage, bound-release detection in effect returns, and wires split cleanup into `findFirstUsageWithoutCleanup`. Regression tests and two fuzz corpus fixtures cover these shapes; patch changeset for `oxlint-plugin-react-doctor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d326d9ae96399f98505b940bafe489e2b4e7b647. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->