### PR TITLE
fix(effects): preserve deterministic value provenance

### DIFF
--- a/.changeset/fresh-values-flow.md
+++ b/.changeset/fresh-values-flow.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Preserve render-value ownership through binding-safe deterministic standard-library transforms.

--- a/packages/fuzz/corpus/regressions/no-derived-state--deterministic-transform.tsx
+++ b/packages/fuzz/corpus/regressions/no-derived-state--deterministic-transform.tsx
@@ -1,0 +1,12 @@
+// rule: no-derived-state
+// weakness: value-provenance
+// source: ISSUES_TO_FIX_ASAP.md cross-version transform matrix
+import { useEffect, useState } from "react";
+
+export const SortedPreview = ({ values }: { values: string[] }) => {
+  const [sortedValues, setSortedValues] = useState<string[]>([]);
+  useEffect(() => {
+    setSortedValues(Array.from(values).toSorted());
+  }, [values]);
+  return <output>{sortedValues.join(", ")}</output>;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-state-write-contracts.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-state-write-contracts.test.ts
@@ -435,6 +435,58 @@ describe("derived-state family contracts", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it.each([
+    ["structuredClone", "structuredClone(value)"],
+    ["Object.assign", "Object.assign({}, value)"],
+    ["Array.from", "Array.from(value)"],
+    ["Date construction", "new Date(value)"],
+    ["Set construction", "new Set(value)"],
+    ["slice", "value.slice()"],
+    ["replace", 'value.replace("a", "b")'],
+    ["reduce", "value.reduce((total, item) => total + item, 0)"],
+    ["flatMap", "value.flatMap((item) => [item])"],
+    ["toSorted", "value.toSorted()"],
+    ["encodeURIComponent", "encodeURIComponent(value)"],
+  ])("preserves render ownership through %s", (_name, expression) => {
+    const transformCode = `function Example({ value }) {
+      const [mirror, setMirror] = useState(null);
+      useEffect(() => {
+        setMirror(${expression});
+      }, [value]);
+      return <div>{String(mirror)}</div>;
+    }`;
+    for (const rule of [noDerivedState, noDerivedStateEffect, noAdjustStateOnPropChange]) {
+      const result = runRule(rule, transformCode, { forceJsx: true });
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    }
+  });
+
+  it("does not trust shadowed deterministic global transforms", () => {
+    const transformCode = `function Example({ Array, Date, Object, Set, encodeURIComponent, structuredClone, value }) {
+      const [first, setFirst] = useState(null);
+      const [second, setSecond] = useState(null);
+      const [third, setThird] = useState(null);
+      const [fourth, setFourth] = useState(null);
+      const [fifth, setFifth] = useState(null);
+      const [sixth, setSixth] = useState(null);
+      useEffect(() => {
+        setFirst(structuredClone(value));
+        setSecond(Object.assign({}, value));
+        setThird(Array.from(value));
+        setFourth(new Date(value));
+        setFifth(new Set(value));
+        setSixth(encodeURIComponent(value));
+      }, [Array, Date, Object, Set, encodeURIComponent, structuredClone, value]);
+      return <>{first}{second}{third}{fourth}{fifth}{sixth}</>;
+    }`;
+    for (const rule of [noDerivedState, noDerivedStateEffect, noAdjustStateOnPropChange]) {
+      const result = runRule(rule, transformCode, { forceJsx: true });
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    }
+  });
+
   it("stays silent for a debounced copy of render state", () => {
     const debouncedCode = `function useDebouncedState(value, delay) {
       const [state, setState] = useState(value);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/collect-effect-state-write-facts.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/collect-effect-state-write-facts.ts
@@ -108,16 +108,19 @@ const PURE_GLOBAL_CALLEE_NAMES: ReadonlySet<string> = new Set([
   "Array",
   "BigInt",
   "Boolean",
+  "encodeURIComponent",
   "Number",
   "Object",
   "String",
   "parseFloat",
   "parseInt",
+  "structuredClone",
 ]);
 
-const PURE_GLOBAL_NAMESPACE_NAMES: ReadonlySet<string> = new Set(["JSON", "Math"]);
+const PURE_GLOBAL_CONSTRUCTOR_NAMES: ReadonlySet<string> = new Set(["Date", "Set"]);
 
 const PURE_HELPER_NAMESPACE_MEMBER_NAMES: ReadonlyMap<string, ReadonlySet<string>> = new Map([
+  ["Array", new Set(["from"])],
   ["JSON", new Set(["isRawJSON", "parse", "rawJSON", "stringify"])],
   [
     "Math",
@@ -157,16 +160,22 @@ const PURE_HELPER_NAMESPACE_MEMBER_NAMES: ReadonlyMap<string, ReadonlySet<string
       "trunc",
     ]),
   ],
+  ["Object", new Set(["assign"])],
 ]);
 
 const PURE_MEMBER_TRANSFORM_NAMES: ReadonlySet<string> = new Set([
   "concat",
   "filter",
+  "flatMap",
   "join",
   "map",
+  "reduce",
+  "replace",
+  "slice",
   "split",
   "toLowerCase",
   "toString",
+  "toSorted",
   "toUpperCase",
   "trim",
 ]);
@@ -842,6 +851,21 @@ const analyzeHelperExpression = (
     );
     return callbackSummary.isValid && !callbackSummary.canContinue;
   }
+  if (isNodeOfType(node, "NewExpression")) {
+    const callee = stripParenExpression(node.callee);
+    if (
+      !isNodeOfType(callee, "Identifier") ||
+      !PURE_GLOBAL_CONSTRUCTOR_NAMES.has(callee.name) ||
+      environment.parameterIndices.has(callee.name) ||
+      environment.recursiveNames.has(callee.name) ||
+      environment.shadowedGlobalNames.has(callee.name)
+    ) {
+      return false;
+    }
+    return (node.arguments ?? []).every((argument) =>
+      analyzeHelperExpression(argument as EsTreeNode, environment, usedParameterIndices),
+    );
+  }
   if (isNodeOfType(node, "CallExpression")) {
     const callee = stripParenExpression(node.callee);
     const calleeRoot = getMemberRoot(callee);
@@ -1259,9 +1283,12 @@ const collectValueEvidence = (
       (isNodeOfType(callee, "Identifier") &&
         PURE_GLOBAL_CALLEE_NAMES.has(callee.name) &&
         getIdentifierBindingIdentity(analysis, callee) === null) ||
-      (isNodeOfType(calleeRoot, "Identifier") &&
-        PURE_GLOBAL_NAMESPACE_NAMES.has(calleeRoot.name) &&
-        getIdentifierBindingIdentity(analysis, calleeRoot) === null);
+      (isNodeOfType(callee, "MemberExpression") &&
+        isNodeOfType(calleeRoot, "Identifier") &&
+        getIdentifierBindingIdentity(analysis, calleeRoot) === null &&
+        PURE_HELPER_NAMESPACE_MEMBER_NAMES.get(calleeRoot.name)?.has(
+          getStaticMemberName(callee) ?? "",
+        ) === true);
     const isPureMemberTransform =
       isNodeOfType(callee, "MemberExpression") &&
       PURE_MEMBER_TRANSFORM_NAMES.has(getStaticMemberName(callee) ?? "");
@@ -1358,6 +1385,31 @@ const collectValueEvidence = (
           argument,
           frame,
           remainingCallFrames - 1,
+          new Set(visitedBindings),
+        ),
+      );
+    }
+    return evidence;
+  }
+
+  if (isNodeOfType(node, "NewExpression")) {
+    const callee = stripParenExpression(node.callee);
+    if (
+      !isNodeOfType(callee, "Identifier") ||
+      !PURE_GLOBAL_CONSTRUCTOR_NAMES.has(callee.name) ||
+      getIdentifierBindingIdentity(analysis, callee) !== null
+    ) {
+      evidence.hasUnknownSource = true;
+      return evidence;
+    }
+    for (const argument of node.arguments ?? []) {
+      mergeEvidence(
+        evidence,
+        collectValueEvidence(
+          analysis,
+          argument as EsTreeNode,
+          frame,
+          remainingCallFrames,
           new Set(visitedBindings),
         ),
       );


### PR DESCRIPTION
## Summary

- preserve render-source ownership through `structuredClone`, `encodeURIComponent`, `Object.assign`, `Array.from`, `new Date`, `new Set`, and deterministic member transforms
- require unshadowed global/namespace/constructor bindings and keep opaque helpers/external reads unknown
- share the corrected evidence across `no-derived-state`, `no-derived-state-effect`, and `no-adjust-state-on-prop-change`
- add a cross-rule transform matrix, shadowing negatives, fuzz corpus coverage, and a patch changeset

## Validation

- focused shared effect-write contracts — 38 passed
- full oxlint plugin suite — 543 files, 11,999 passed, 148 skipped
- fuzz regression corpus — 37 passed
- strict fuzz — 500 iterations, 2 oracle cases passed
- `nr typecheck`
- `nr lint` — clean aside from existing warnings
- `nr format:check`
- post-change truffler deduplication search

## OSS validation

The local RDE checkout currently rejects schema-version-3 reports during harness decoding, so it cannot produce a trustworthy digest. The change is constrained to explicit deterministic allowlists with lexical binding checks and includes shadowed-global negative controls.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes static-analysis heuristics for effect state writes; false positives/negatives are possible if allowlists or shadowing checks are wrong, though scope is limited to explicit transforms with negative tests.
> 
> **Overview**
> Effect state-write analysis now treats **binding-safe, deterministic standard-library transforms** of props/render values as still “render-known,” so syncing them in an effect is reported by the derived-state family instead of being missed.
> 
> **`collect-effect-state-write-facts`** widens pure-transform allowlists (`structuredClone`, `encodeURIComponent`, `Object.assign` / `Array.from`, `new Date` / `new Set`, and members like `slice`, `replace`, `reduce`, `flatMap`, `toSorted`) in both helper summarization and `collectValueEvidence`. Namespace purity is narrowed to explicit members (e.g. `Object.assign`, `Array.from`) with **unshadowed** global roots via binding identity, replacing a coarser “whole namespace is pure” check. **`NewExpression`** paths mirror the same constructor allowlist and argument provenance rules.
> 
> **`no-derived-state`**, **`no-derived-state-effect`**, and **`no-adjust-state-on-prop-change`** pick up the behavior through shared facts (`isRenderKnownCopy`). Tests add a cross-rule transform matrix plus shadowed-global negatives; fuzz adds a `Array.from(…).toSorted()` regression. Patch changeset for `oxlint-plugin-react-doctor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 433a3c81bf2640a3a6f7632f7799ab029134da21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->