### PR TITLE
perf(core): cache per-file lint results in audit mode

### DIFF
--- a/.changeset/cache-audit-mode-lint.md
+++ b/.changeset/cache-audit-mode-lint.md
@@ -1,0 +1,5 @@
+---
+"@react-doctor/core": patch
+---
+
+Enable the per-file lint cache in audit mode (`--no-respect-inline-disables`). The neutralize pass already rewrites inline disable directives on disk before the per-file content hash is taken, so the cache key reflects exactly what oxlint linted; `respectInlineDisables` is now folded into the ruleset hash so audit and default runs occupy disjoint cache namespaces and never replay each other's entries. Warm audit-mode scans re-lint only changed files instead of the whole tree — the mode CI and pre-commit hooks run in.

--- a/packages/core/src/run-oxlint.ts
+++ b/packages/core/src/run-oxlint.ts
@@ -625,9 +625,8 @@ export const runOxlint = async (options: RunOxlintOptions): Promise<Diagnostic[]
     };
 
     // The cache is sound only when nothing rewrites file content out from
-    // under the content hash and every linted rule is one we can analyze:
-    //   - audit mode (`!respectInlineDisables`) mutates files in place, so the
-    //     hash wouldn't match what oxlint saw;
+    // under the content hash in a way the key can't see, and every linted rule
+    // is one we can analyze:
     //   - adopted `extends` and user plugins carry opaque rules that may read
     //     other files, which a content-of-self key can't invalidate;
     //   - React Compiler (`react-hooks-js`) can fail to LOAD at lint time
@@ -635,10 +634,14 @@ export const runOxlint = async (options: RunOxlintOptions): Promise<Diagnostic[]
     //     never spawns the cacheable pass, so that load failure would never
     //     trigger while stale React Compiler diagnostics keep replaying —
     //     breaking the byte-identical guarantee. Bypass entirely instead.
-    // Any of those falls back to the original single-config path.
+    // Any of those falls back to the original single-config path. Audit mode
+    // (`!respectInlineDisables`) is NOT a bypass: its neutralize pass rewrites
+    // disable directives on disk BEFORE the content is hashed (see the
+    // `restoreDisableDirectives` HACK above), so the key already reflects what
+    // oxlint saw, and `respectInlineDisables` is folded into the ruleset hash
+    // so audit and default runs never share a cache entry.
     const useFileLintCache =
       perFileLintCacheEnabled &&
-      respectInlineDisables &&
       !project.hasReactCompiler &&
       extendsPaths.length === 0 &&
       userPlugins.length === 0;
@@ -649,6 +652,7 @@ export const runOxlint = async (options: RunOxlintOptions): Promise<Diagnostic[]
         toolchainVersions: resolveOxlintToolchainVersions(nodeBinaryPath),
         ignorePatterns: combinedPatterns,
         tsconfigContent,
+        respectInlineDisables,
       });
       const cache = createFileLintCache(resolveReactDoctorCacheDir(rootDirectory), rulesetHash);
 
@@ -729,6 +733,7 @@ export const runOxlint = async (options: RunOxlintOptions): Promise<Diagnostic[]
               toolchainVersions: resolveOxlintToolchainVersions(nodeBinaryPath),
               ignorePatterns: combinedPatterns,
               tsconfigContent,
+              respectInlineDisables,
             }),
           )
         : null;

--- a/packages/core/src/runners/oxlint/compute-ruleset-hash.ts
+++ b/packages/core/src/runners/oxlint/compute-ruleset-hash.ts
@@ -15,6 +15,15 @@ interface RulesetHashInput {
    * parses / resolves a file, so a tsconfig edit must bust the cache even when
    * source content is unchanged. */
   readonly tsconfigContent: string | null;
+  /** Whether inline `// eslint-disable*` / `// oxlint-disable*` directives are
+   * respected. Audit mode (`false`) neutralizes those directives on disk BEFORE
+   * oxlint runs, so oxlint emits the very diagnostics they would have suppressed
+   * — a different RAW stream than default mode for the same source content. It
+   * therefore partitions the cache into disjoint audit / default namespaces so
+   * the two modes can never replay each other's entries. (This is the ONE
+   * inline-disable effect that is pre-cache; RD's own post-cache suppression of
+   * `react-doctor-disable-next-line` is deliberately NOT hashed — see below.) */
+  readonly respectInlineDisables: boolean;
 }
 
 const ROOT_DIRECTORY_PLACEHOLDER = "<root>";
@@ -50,4 +59,6 @@ export const computeRulesetHash = (input: RulesetHashInput): string =>
     .update([...input.ignorePatterns].join("\n"))
     .update("\u0000")
     .update(input.tsconfigContent ?? "")
+    .update("\u0000")
+    .update(input.respectInlineDisables ? "respect-inline-disables" : "audit-mode")
     .digest("hex");

--- a/packages/core/src/types/inspect.ts
+++ b/packages/core/src/types/inspect.ts
@@ -48,9 +48,9 @@ export interface InspectResult {
   scanElapsedMilliseconds?: number;
   /**
    * Per-file lint cache outcome: files served from cache, and total files
-   * considered. Both absent when the cache was off or bypassed (audit mode,
-   * adopted `extends`, user plugins). The CLI projects these onto the Sentry
-   * wide event as `lint.cacheHitRatio`.
+   * considered. Both absent when the cache was off or bypassed (adopted
+   * `extends`, user plugins, React Compiler). The CLI projects these onto the
+   * Sentry wide event as `lint.cacheHitRatio`.
    */
   lintCacheHitFileCount?: number | null;
   lintCacheTotalFileCount?: number | null;

--- a/packages/core/tests/compute-ruleset-hash.test.ts
+++ b/packages/core/tests/compute-ruleset-hash.test.ts
@@ -53,6 +53,7 @@ const hash = (
     toolchainVersions: TOOLCHAIN,
     ignorePatterns: [],
     tsconfigContent: null,
+    respectInlineDisables: true,
     ...input,
   });
 
@@ -99,6 +100,13 @@ describe("computeRulesetHash", () => {
     const withoutIgnore = hash({ config });
     const withIgnore = hash({ config, ignorePatterns: ["src/generated/**"] });
     expect(withIgnore).not.toBe(withoutIgnore);
+  });
+
+  it("partitions audit mode from default mode (neutralize changes the raw stream)", () => {
+    const config = cacheableConfig(makeProject("/repo/a"));
+    const defaultMode = hash({ config, respectInlineDisables: true });
+    const auditMode = hash({ config, respectInlineDisables: false });
+    expect(auditMode).not.toBe(defaultMode);
   });
 
   it("changes when tsconfig content changes (oxlint parses with it)", () => {

--- a/packages/react-doctor/tests/run-oxlint/file-lint-cache.test.ts
+++ b/packages/react-doctor/tests/run-oxlint/file-lint-cache.test.ts
@@ -196,20 +196,48 @@ export const App = () => <div><Button /></div>;
     expect(noBarrelHitsOnApp(afterDepChangeCacheOn)).toBe(0);
   });
 
-  it("bypasses the cache in audit mode (respectInlineDisables: false)", async () => {
-    const projectDir = setupFixture("audit-bypass", BARREL_INDEX);
-    let cacheStatsCalled = false;
-    const diagnostics = await scan(projectDir, {
+  it("uses the cache in audit mode, byte-identically (respectInlineDisables: false)", async () => {
+    // Audit mode neutralizes disable directives on disk BEFORE the content is
+    // hashed, so the per-file key reflects exactly what oxlint saw; the cache is
+    // used (not bypassed) and `respectInlineDisables` namespaces it away from
+    // default mode (see compute-ruleset-hash.test.ts). Cold populates with zero
+    // hits, a warm rescan replays every file, and both match a cache-off scan.
+    const projectDir = setupFixture("audit-cache", BARREL_INDEX);
+    let coldHits: number | null = null;
+    let coldTotal: number | null = null;
+    let warmHits: number | null = null;
+    let warmTotal: number | null = null;
+
+    const withCacheOff = await scan(projectDir, {
+      perFileLintCacheEnabled: false,
+      respectInlineDisables: false,
+    });
+    const cold = await scan(projectDir, {
       perFileLintCacheEnabled: true,
       respectInlineDisables: false,
-      onCacheStats: () => {
-        cacheStatsCalled = true;
+      onCacheStats: (hits, total) => {
+        coldHits = hits;
+        coldTotal = total;
       },
     });
-    // Audit mode mutates files in place, so the cache must be bypassed entirely
-    // (onCacheStats never fires) while diagnostics are still produced.
-    expect(cacheStatsCalled).toBe(false);
-    expect(diagnostics.some((diagnostic) => diagnostic.rule === "no-barrel-import")).toBe(true);
+    const warm = await scan(projectDir, {
+      perFileLintCacheEnabled: true,
+      respectInlineDisables: false,
+      onCacheStats: (hits, total) => {
+        warmHits = hits;
+        warmTotal = total;
+      },
+    });
+
+    // The cache runs (onCacheStats fires): cold is all misses, warm all hits.
+    expect(coldHits).toBe(0);
+    expect(coldTotal).toBeGreaterThan(0);
+    expect(warmHits).toBe(warmTotal);
+    expect(warmTotal).toBe(coldTotal);
+    // ...and the cached diagnostics are byte-identical to a from-scratch scan.
+    expect(serialize(cold)).toBe(serialize(withCacheOff));
+    expect(serialize(warm)).toBe(serialize(withCacheOff));
+    expect(withCacheOff.some((diagnostic) => diagnostic.rule === "no-barrel-import")).toBe(true);
   });
 
   it("dedupes the merged result when includePaths repeats a file (matches cache-off)", async () => {


### PR DESCRIPTION
## Why

The per-file lint cache (content-hash keyed; only changed files re-lint on a warm scan) is **bypassed whenever `respectInlineDisables` is `false`** — i.e. audit mode, `--no-respect-inline-disables`. The stated reason:

> audit mode (`!respectInlineDisables`) mutates files in place, so the hash wouldn't match what oxlint saw

But `neutralizeDisableDirectives` runs **before** the content is hashed — it's the `restoreDisableDirectives` HACK set up above the `try`, and the per-file `hashFileContents` loop is inside that `try` — so the key already reflects the exact bytes oxlint linted. The bypass is unnecessary.

This matters because audit mode is the mode that runs in **CI, pre-commit hooks, and offline graders** (any setup that must not honor inline `// eslint-disable*` suppressions). Those are precisely the repeated-scan, latency-sensitive contexts the cache exists for, and they were getting a full re-lint of the whole tree every run.

## What changed

- **`run-oxlint.ts`** — drop `respectInlineDisables` from the `useFileLintCache` gate. The other bypasses (React Compiler load-strip #833, adopted `extends`, user plugins) are unchanged.
- **`compute-ruleset-hash.ts`** — fold `respectInlineDisables` into the ruleset hash. Audit mode neutralizes disable directives, so oxlint emits a **different raw stream** for the same source content than default mode; partitioning the hash gives the two modes disjoint cache namespaces so they can never replay each other's entries. Both `computeRulesetHash` call sites (per-file + sidecar) pass it.

Soundness: for a file *with* a disable directive the two modes already produce different content hashes (neutralize changed the bytes) → distinct keys; for a file *without* one the content is identical *and* the raw stream is identical → safe to share. The ruleset-hash partition makes that reasoning unnecessary — the namespaces never intersect regardless.

## Test plan

- `pnpm --filter @react-doctor/core typecheck` — clean.
- `pnpm --filter @react-doctor/core test compute-ruleset-hash file-lint-cache sidecar-lint-cache` — 21/21; new test pins the audit-vs-default hash partition.
- Full core suite: 1278/1280. The 2 failures (`check-expo-project`, `check-security-scan` — both `.env.local` gitignore detection) reproduce identically on `origin/main` with this change stashed, i.e. pre-existing/environmental, unrelated to this diff.

## Downstream

Unblocks baking a warm `REACT_DOCTOR_CACHE_DIR` into offline audit-mode graders (react-bench verifier images) so verify-time scans re-lint only the agent's changed files — full-fidelity, no `--scope changed` file-set narrowing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes lint cache eligibility and keying; correctness relies on neutralize-before-hash ordering and separate audit/default namespaces, but behavior is covered by new and updated tests rather than live auth or data paths.
> 
> **Overview**
> **Audit mode** (`--no-respect-inline-disables`) no longer disables the per-file lint cache. The previous bypass assumed on-disk neutralization of disable directives would desync content hashes; the neutralize pass already runs **before** hashing, so keys still match what oxlint linted.
> 
> **`respectInlineDisables`** is now part of **`computeRulesetHash`** (per-file and sidecar caches), so default and audit runs use separate cache namespaces and cannot replay each other’s entries. Warm audit scans re-lint only changed files instead of the full tree.
> 
> Tests and type docs are updated: integration now expects cache hits in audit mode with byte-identical diagnostics; a unit test pins the audit vs default hash partition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a83f564c834ec23046738f9ffc46e0fb4e9c045. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->