### PR TITLE
fix: assign derived state diagnostics to one owner

### DIFF
--- a/.changeset/calm-effects-own.md
+++ b/.changeset/calm-effects-own.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Assign derived-state effect writes to one stable rule owner instead of emitting overlapping sibling diagnostics.

--- a/packages/core/src/utils/dedupe-diagnostics.ts
+++ b/packages/core/src/utils/dedupe-diagnostics.ts
@@ -1,5 +1,24 @@
 import type { Diagnostic } from "../types/index.js";
 
+const DERIVED_STATE_RULE_PRIORITY: ReadonlyMap<string, number> = new Map([
+  ["no-initialize-state", 0],
+  ["no-adjust-state-on-prop-change", 1],
+  ["no-derived-state", 2],
+  ["no-derived-state-effect", 3],
+]);
+
+const doDiagnosticSpansOverlap = (first: Diagnostic, second: Diagnostic): boolean => {
+  if (first.filePath !== second.filePath || first.plugin !== second.plugin) return false;
+  if (first.offset !== undefined && second.offset !== undefined) {
+    const firstEnd = first.offset + Math.max(first.length ?? 1, 1);
+    const secondEnd = second.offset + Math.max(second.length ?? 1, 1);
+    return first.offset < secondEnd && second.offset < firstEnd;
+  }
+  const firstEndLine = first.endLine ?? first.line;
+  const secondEndLine = second.endLine ?? second.line;
+  return first.line <= secondEndLine && second.line <= firstEndLine;
+};
+
 // HACK: oxlint plugin rules occasionally emit the same diagnostic
 // twice (e.g. when a rule's listener visits the same AST node through
 // two overlapping selectors). The duplicates have identical filePath,
@@ -19,6 +38,26 @@ export const dedupeDiagnostics = (diagnostics: Diagnostic[]): Diagnostic[] => {
     const key = `${diagnostic.filePath}\u0000${diagnostic.line}\u0000${diagnostic.column}\u0000${diagnostic.plugin}\u0000${diagnostic.rule}\u0000${diagnostic.severity}\u0000${diagnostic.message}`;
     if (seenKeys.has(key)) continue;
     seenKeys.add(key);
+    const priority = DERIVED_STATE_RULE_PRIORITY.get(diagnostic.rule);
+    if (priority !== undefined) {
+      const overlappingDiagnosticIndex = uniqueDiagnostics.findIndex(
+        (candidate) =>
+          candidate.rule !== diagnostic.rule &&
+          candidate.severity === diagnostic.severity &&
+          DERIVED_STATE_RULE_PRIORITY.has(candidate.rule) &&
+          doDiagnosticSpansOverlap(candidate, diagnostic),
+      );
+      if (overlappingDiagnosticIndex >= 0) {
+        const existingDiagnostic = uniqueDiagnostics[overlappingDiagnosticIndex];
+        const existingPriority = existingDiagnostic
+          ? DERIVED_STATE_RULE_PRIORITY.get(existingDiagnostic.rule)
+          : undefined;
+        if (existingPriority !== undefined && priority < existingPriority) {
+          uniqueDiagnostics[overlappingDiagnosticIndex] = diagnostic;
+        }
+        continue;
+      }
+    }
     uniqueDiagnostics.push(diagnostic);
   }
   return uniqueDiagnostics;

--- a/packages/core/tests/dedupe-diagnostics.test.ts
+++ b/packages/core/tests/dedupe-diagnostics.test.ts
@@ -51,6 +51,47 @@ describe("dedupeDiagnostics", () => {
     expect(dedupeDiagnostics([stateRule, mirrorRule])).toEqual([stateRule, mirrorRule]);
   });
 
+  it("keeps the most specific derived-state owner at one write", () => {
+    const generic = buildDiagnostic({ rule: "no-derived-state", offset: 100, length: 12 });
+    const effect = buildDiagnostic({
+      rule: "no-derived-state-effect",
+      offset: 80,
+      length: 60,
+    });
+    const propChange = buildDiagnostic({
+      rule: "no-adjust-state-on-prop-change",
+      offset: 100,
+      length: 12,
+    });
+    expect(dedupeDiagnostics([effect, generic, propChange])).toEqual([propChange]);
+  });
+
+  it("keeps mount initialization ahead of generic derived-state rules", () => {
+    const generic = buildDiagnostic({ rule: "no-derived-state", offset: 100, length: 12 });
+    const mount = buildDiagnostic({ rule: "no-initialize-state", offset: 100, length: 12 });
+    expect(dedupeDiagnostics([generic, mount])).toEqual([mount]);
+  });
+
+  it("preserves separate writes inside one overlapping effect diagnostic", () => {
+    const effect = buildDiagnostic({
+      rule: "no-derived-state-effect",
+      offset: 80,
+      length: 100,
+    });
+    const firstWrite = buildDiagnostic({
+      rule: "no-adjust-state-on-prop-change",
+      offset: 100,
+      length: 12,
+    });
+    const secondWrite = buildDiagnostic({
+      rule: "no-adjust-state-on-prop-change",
+      offset: 140,
+      length: 12,
+      column: 20,
+    });
+    expect(dedupeDiagnostics([effect, firstWrite, secondWrite])).toEqual([firstWrite, secondWrite]);
+  });
+
   it("preserves diagnostics with different messages at the same location and rule", () => {
     const useContextMessage = buildDiagnostic({
       rule: "no-react19-deprecated-apis",

--- a/packages/react-doctor/tests/namespace-hooks.test.ts
+++ b/packages/react-doctor/tests/namespace-hooks.test.ts
@@ -2,7 +2,7 @@ import * as path from "node:path";
 import { describe, expect, it } from "vite-plus/test";
 import type { Diagnostic } from "@react-doctor/core";
 import { runOxlint } from "@react-doctor/core";
-import { buildTestProject } from "./regressions/_helpers.js";
+import { buildIsolatedDerivedStateRuleConfig, buildTestProject } from "./regressions/_helpers.js";
 
 const FIXTURES_DIRECTORY = path.resolve(
   import.meta.dirname,
@@ -24,6 +24,7 @@ const findDiagnosticsInFile = (
   );
 
 let diagnostics: Diagnostic[];
+let isolatedDerivedStateEffectDiagnostics: Diagnostic[];
 
 describe("namespace hook detection (React.useEffect, React.useState, etc.)", () => {
   it("loads diagnostics from namespace-hooks fixture", async () => {
@@ -34,11 +35,25 @@ describe("namespace hook detection (React.useEffect, React.useState, etc.)", () 
         hasTanStackQuery: true,
       }),
     });
+    isolatedDerivedStateEffectDiagnostics = await runOxlint({
+      rootDirectory: BASIC_REACT_DIRECTORY,
+      project: buildTestProject({
+        rootDirectory: BASIC_REACT_DIRECTORY,
+        hasTanStackQuery: true,
+      }),
+      userConfig: {
+        rules: buildIsolatedDerivedStateRuleConfig("no-derived-state-effect"),
+      },
+    });
     expect(diagnostics.length).toBeGreaterThan(0);
   });
 
   it("detects no-derived-state-effect with React.useEffect", () => {
-    const issues = findDiagnosticsInFile(diagnostics, "no-derived-state-effect", "namespace-hooks");
+    const issues = findDiagnosticsInFile(
+      isolatedDerivedStateEffectDiagnostics,
+      "no-derived-state-effect",
+      "namespace-hooks",
+    );
     expect(issues.length).toBeGreaterThan(0);
     expect(issues[0].message).toContain("derive from other values");
   });
@@ -152,7 +167,9 @@ describe("namespace hook detection (React.useEffect, React.useState, etc.)", () 
     ];
 
     for (const rule of directImportRules) {
-      const stateIssues = findDiagnosticsInFile(diagnostics, rule, "state-issues");
+      const sourceDiagnostics =
+        rule === "no-derived-state-effect" ? isolatedDerivedStateEffectDiagnostics : diagnostics;
+      const stateIssues = findDiagnosticsInFile(sourceDiagnostics, rule, "state-issues");
       expect(
         stateIssues.length,
         `expected ${rule} to still fire on state-issues.tsx`,

--- a/packages/react-doctor/tests/regressions/_helpers.ts
+++ b/packages/react-doctor/tests/regressions/_helpers.ts
@@ -118,6 +118,13 @@ export interface CollectRuleHitsOptions {
   hasSsrDependency?: boolean;
 }
 
+const DERIVED_STATE_SIBLING_RULE_IDS = [
+  "no-adjust-state-on-prop-change",
+  "no-derived-state",
+  "no-derived-state-effect",
+  "no-initialize-state",
+];
+
 export interface BuildTestProjectOptions {
   rootDirectory: string;
   framework?: ProjectInfo["framework"];
@@ -199,13 +206,21 @@ export const collectRuleHits = async (
   options: CollectRuleHitsOptions = {},
 ): Promise<RuleHit[]> => {
   const project = buildTestProject({ rootDirectory: projectDir, ...options });
+  const isolatedSiblingRules = DERIVED_STATE_SIBLING_RULE_IDS.includes(ruleId)
+    ? Object.fromEntries(
+        DERIVED_STATE_SIBLING_RULE_IDS.map((siblingRuleId) => [
+          `react-doctor/${siblingRuleId}`,
+          siblingRuleId === ruleId ? "warn" : "off",
+        ]),
+      )
+    : { [`react-doctor/${ruleId}`]: "warn" };
   const diagnostics = await runOxlint({
     rootDirectory: projectDir,
     project,
     // Force-enable the rule under test so default-disabled rules
     // (`defaultEnabled: false`) still produce hits here. Severity is
     // irrelevant — callers assert on file path and message, not severity.
-    userConfig: { rules: { [`react-doctor/${ruleId}`]: "warn" } },
+    userConfig: { rules: isolatedSiblingRules },
   });
   return diagnostics
     .filter((diagnostic) => diagnostic.rule === ruleId)

--- a/packages/react-doctor/tests/regressions/_helpers.ts
+++ b/packages/react-doctor/tests/regressions/_helpers.ts
@@ -125,6 +125,16 @@ const DERIVED_STATE_SIBLING_RULE_IDS = [
   "no-initialize-state",
 ];
 
+export const buildIsolatedDerivedStateRuleConfig = (
+  ruleId: string,
+): Record<string, "off" | "warn"> =>
+  Object.fromEntries(
+    DERIVED_STATE_SIBLING_RULE_IDS.map((siblingRuleId) => [
+      `react-doctor/${siblingRuleId}`,
+      siblingRuleId === ruleId ? "warn" : "off",
+    ]),
+  );
+
 export interface BuildTestProjectOptions {
   rootDirectory: string;
   framework?: ProjectInfo["framework"];
@@ -207,12 +217,7 @@ export const collectRuleHits = async (
 ): Promise<RuleHit[]> => {
   const project = buildTestProject({ rootDirectory: projectDir, ...options });
   const isolatedSiblingRules = DERIVED_STATE_SIBLING_RULE_IDS.includes(ruleId)
-    ? Object.fromEntries(
-        DERIVED_STATE_SIBLING_RULE_IDS.map((siblingRuleId) => [
-          `react-doctor/${siblingRuleId}`,
-          siblingRuleId === ruleId ? "warn" : "off",
-        ]),
-      )
+    ? buildIsolatedDerivedStateRuleConfig(ruleId)
     : { [`react-doctor/${ruleId}`]: "warn" };
   const diagnostics = await runOxlint({
     rootDirectory: projectDir,

--- a/packages/react-doctor/tests/regressions/respect-lint-ignores.test.ts
+++ b/packages/react-doctor/tests/regressions/respect-lint-ignores.test.ts
@@ -17,7 +17,11 @@ import * as path from "node:path";
 import { afterAll, describe, expect, it } from "vite-plus/test";
 
 import { clearIgnorePatternsCache, collectIgnorePatterns, runOxlint } from "@react-doctor/core";
-import { buildTestProject, setupReactProject } from "./_helpers.js";
+import {
+  buildIsolatedDerivedStateRuleConfig,
+  buildTestProject,
+  setupReactProject,
+} from "./_helpers.js";
 
 const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "rd-respect-lint-ignores-"));
 
@@ -228,6 +232,9 @@ export const FullName = ({ first, last }: { first: string; last: string }) => {
       rootDirectory: projectDir,
       project: buildTestProject({ rootDirectory: projectDir }),
       respectInlineDisables: false,
+      userConfig: {
+        rules: buildIsolatedDerivedStateRuleConfig("no-derived-state-effect"),
+      },
     });
 
     expect(
@@ -259,6 +266,9 @@ export const FullName = ({ first, last }: { first: string; last: string }) => {
       rootDirectory: projectDir,
       project: buildTestProject({ rootDirectory: projectDir }),
       respectInlineDisables: false,
+      userConfig: {
+        rules: buildIsolatedDerivedStateRuleConfig("no-derived-state-effect"),
+      },
     });
 
     expect(diagnostics.some((d) => d.rule === "no-derived-state-effect")).toBe(true);

--- a/packages/react-doctor/tests/regressions/rule-messages.test.ts
+++ b/packages/react-doctor/tests/regressions/rule-messages.test.ts
@@ -19,7 +19,11 @@ import * as path from "node:path";
 import { afterAll, describe, expect, it } from "vite-plus/test";
 
 import { runOxlint } from "@react-doctor/core";
-import { buildTestProject, setupReactProject } from "./_helpers.js";
+import {
+  buildIsolatedDerivedStateRuleConfig,
+  buildTestProject,
+  setupReactProject,
+} from "./_helpers.js";
 
 const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "rd-rule-messages-"));
 
@@ -55,6 +59,9 @@ export const FullName = ({ firstName, lastName }: { firstName: string; lastName:
     const diagnostics = await runOxlint({
       rootDirectory: projectDir,
       project: buildTestProject({ rootDirectory: projectDir }),
+      userConfig: {
+        rules: buildIsolatedDerivedStateRuleConfig("no-derived-state-effect"),
+      },
     });
 
     const messages = diagnostics

--- a/packages/react-doctor/tests/run-oxlint/state-effects.test.ts
+++ b/packages/react-doctor/tests/run-oxlint/state-effects.test.ts
@@ -20,7 +20,7 @@ describe("runOxlint", () => {
   describeRules(
     "state & effects rules",
     {
-      "no-derived-state-effect": {
+      "no-adjust-state-on-prop-change": {
         fixture: "state-issues.tsx",
         ruleSource: "rules/state-and-effects.ts",
         severity: "warning",


### PR DESCRIPTION
## Summary

- collapse overlapping derived-state sibling findings to the most specific rule owner
- preserve distinct writes, same-rule findings, and diagnostics with different severities
- isolate sibling rules in regression helpers so each rule contract remains independently testable

## Validation

- core suite: 116 files / 1,282 tests
- state-rule regression suites: 4 files / 102 passed / 3 skipped
- `nr typecheck`
- `nr lint` (pre-existing warnings only)
- `nr format:check`
- post-change truffler dedup search

## RDE

The local RDE checkout currently rejects schema-v3 reports during decode, so corpus validation is blocked by the harness rather than this change. The behavior is covered at the core report boundary and by isolated rule-contract suites.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which rule users see at shared sites across the lint report pipeline; behavior is well-tested but affects diagnostic identity for a core rule family.
> 
> **Overview**
> **Overlapping derived-state diagnostics** from sibling rules (`no-initialize-state`, `no-adjust-state-on-prop-change`, `no-derived-state`, `no-derived-state-effect`) are collapsed in `dedupeDiagnostics` so users see a single finding per write site, with the **most specific** rule winning (mount init beats generic derived-state; prop-change beats broad effect rules).
> 
> Span overlap uses offsets when present, otherwise line ranges; distinct writes inside one large effect span stay separate, and exact-duplicate / different-severity behavior is unchanged.
> 
> Regression and integration tests use **`buildIsolatedDerivedStateRuleConfig`** to turn off sibling derived-state rules when asserting one rule’s contract; `state-effects` fixture coverage shifts to **`no-adjust-state-on-prop-change`** instead of the effect rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8602a1db3cc756939755400624821d1a07f29ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->