### PR TITLE
fix: resolve executable global bindings

### DIFF
--- a/.changeset/brave-globals-resolve.md
+++ b/.changeset/brave-globals-resolve.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Resolve executable browser globals by lexical binding and static property identity.

--- a/packages/fuzz/corpus/regressions/no-document-write--shadowed-global.ts
+++ b/packages/fuzz/corpus/regressions/no-document-write--shadowed-global.ts
@@ -1,0 +1,8 @@
+// rule: no-document-write
+// weakness: name-heuristic
+// source: ISSUES_TO_FIX_ASAP.md semantic mutation matrix
+const document = {
+  write: (value: string) => value,
+};
+
+export const writeToBuffer = (value: string) => document.write(value);

--- a/packages/fuzz/corpus/regressions/no-eval--globalthis-static-member.js
+++ b/packages/fuzz/corpus/regressions/no-eval--globalthis-static-member.js
@@ -1,0 +1,4 @@
+// rule: no-eval
+// weakness: static-computed-member
+// source: ISSUES_TO_FIX_ASAP.md semantic mutation matrix
+export const evaluatePayload = (payload) => globalThis["eval"](payload);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-document-write.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-document-write.test.ts
@@ -35,4 +35,27 @@ describe("no-document-write", () => {
     const result = runRule(noDocumentWrite, `document[method]("x");`);
     expect(result.diagnostics).toHaveLength(0);
   });
+
+  it.each([
+    `document["write"]("x");`,
+    'document[`writeln`]("x");',
+    `document?.write("x");`,
+    `document!.write("x");`,
+    `(document as Document)["write"]("x");`,
+    `(document satisfies Document).writeln("x");`,
+  ])("flags static global document write form %#", (source) => {
+    const result = runRule(noDocumentWrite, source);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it.each([
+    `const document = { write() {} }; document.write("x");`,
+    `const document = { write() {} }; document["write"]("x");`,
+    `const document = { writeln() {} }; document?.writeln("x");`,
+  ])("does not flag shadowed document form %#", (source) => {
+    const result = runRule(noDocumentWrite, source);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-document-write.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-document-write.ts
@@ -1,4 +1,5 @@
 import { defineRule } from "../../utils/define-rule.js";
+import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
@@ -9,8 +10,9 @@ const MESSAGE =
 
 const WRITE_METHODS = new Set(["write", "writeln"]);
 
-// `document.write(...)` / `document.writeln(...)` with a non-computed
-// `document` member callee.
+const isGlobalDocumentReference = (node: EsTreeNodeOfType<"Identifier">, context: RuleContext) =>
+  node.name === "document" && context.scopes.isGlobalReference(node);
+
 export const noDocumentWrite = defineRule({
   id: "no-document-write",
   title: "document.write/writeln",
@@ -19,16 +21,14 @@ export const noDocumentWrite = defineRule({
     "Don't use `document.write()`/`document.writeln()`. Append DOM nodes or set `innerHTML`/`textContent` on a specific element instead.",
   create: (context: RuleContext) => ({
     CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
-      const callee = node.callee;
-      if (!isNodeOfType(callee, "MemberExpression") || callee.computed) return;
+      const callee = stripParenExpression(node.callee);
+      if (!isNodeOfType(callee, "MemberExpression")) return;
       const receiver = stripParenExpression(callee.object);
-      if (!isNodeOfType(receiver, "Identifier") || receiver.name !== "document") return;
-      if (
-        !isNodeOfType(callee.property, "Identifier") ||
-        !WRITE_METHODS.has(callee.property.name)
-      ) {
+      if (!isNodeOfType(receiver, "Identifier") || !isGlobalDocumentReference(receiver, context)) {
         return;
       }
+      const methodName = getStaticPropertyName(callee);
+      if (methodName === null || !WRITE_METHODS.has(methodName)) return;
       context.report({ node, message: MESSAGE });
     },
   }),

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/no-eval.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/no-eval.regressions.test.ts
@@ -45,4 +45,30 @@ describe("security/no-eval — regressions", () => {
     });
     expect(result.diagnostics).toHaveLength(1);
   });
+
+  it.each([
+    `globalThis.eval(payload);`,
+    `globalThis["eval"](payload);`,
+    "globalThis[`eval`](payload);",
+    `(globalThis as typeof globalThis).eval(payload);`,
+    `globalThis?.eval(payload);`,
+    `globalThis.setTimeout("run()", 0);`,
+    `globalThis["setInterval"]("run()", 0);`,
+    `new globalThis.Function(payload);`,
+  ])("flags executable global form %#", (source) => {
+    const result = runRule(noEval, source, { filename: "src/run.ts" });
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it.each([
+    `const eval = (value: string) => value; eval(payload);`,
+    `const setTimeout = (value: string) => value; setTimeout("label");`,
+    `const setInterval = (value: string) => value; setInterval("label");`,
+    `class Function { constructor(value: unknown) {} } new Function(payload);`,
+  ])("does not flag shadowed executable lookalike %#", (source) => {
+    const result = runRule(noEval, source, { filename: "src/run.ts" });
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/no-eval.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/no-eval.ts
@@ -4,6 +4,9 @@ import { skipNonProductionFiles } from "../../utils/skip-non-production-files.js
 import type { RuleContext } from "../../utils/rule-context.js";
 import type { RuleVisitors } from "../../utils/rule-visitors.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 // A hyphen-delimited `sandbox` path segment (`lib/plugin-sandbox/runtime.tsx`,
@@ -13,6 +16,23 @@ import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 // Hyphen boundaries keep `CodeSandboxEmbed.tsx` / `codesandbox.ts` firing.
 const SANDBOX_SURFACE_PATH_PATTERN =
   /(?:^|[/-])sandbox(?:$|[/-])|(?:^|\/)[\w.]+-sandbox(?:\/|\.[cm]?[jt]sx?$)/i;
+
+const getExecutableGlobalName = (node: EsTreeNode, context: RuleContext): string | null => {
+  const expression = stripParenExpression(node);
+  if (isNodeOfType(expression, "Identifier")) {
+    return context.scopes.isGlobalReference(expression) ? expression.name : null;
+  }
+  if (!isNodeOfType(expression, "MemberExpression")) return null;
+  const receiver = stripParenExpression(expression.object);
+  if (
+    !isNodeOfType(receiver, "Identifier") ||
+    receiver.name !== "globalThis" ||
+    !context.scopes.isGlobalReference(receiver)
+  ) {
+    return null;
+  }
+  return getStaticPropertyName(expression);
+};
 
 export const noEval = defineRule({
   id: "no-eval",
@@ -24,7 +44,8 @@ export const noEval = defineRule({
     if (SANDBOX_SURFACE_PATH_PATTERN.test(normalizeFilename(context.filename ?? ""))) return {};
     return {
       CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
-        if (isNodeOfType(node.callee, "Identifier") && node.callee.name === "eval") {
+        const executableGlobalName = getExecutableGlobalName(node.callee, context);
+        if (executableGlobalName === "eval") {
           context.report({
             node,
             message: "eval() is a code-injection vulnerability: it runs any string as code.",
@@ -33,19 +54,18 @@ export const noEval = defineRule({
         }
 
         if (
-          isNodeOfType(node.callee, "Identifier") &&
-          (node.callee.name === "setTimeout" || node.callee.name === "setInterval") &&
+          (executableGlobalName === "setTimeout" || executableGlobalName === "setInterval") &&
           isNodeOfType(node.arguments?.[0], "Literal") &&
           typeof node.arguments[0].value === "string"
         ) {
           context.report({
             node,
-            message: `Passing a string to ${node.callee.name}() is a code-injection vulnerability, since it runs that string as code.`,
+            message: `Passing a string to ${executableGlobalName}() is a code-injection vulnerability, since it runs that string as code.`,
           });
         }
       },
       NewExpression(node: EsTreeNodeOfType<"NewExpression">) {
-        if (isNodeOfType(node.callee, "Identifier") && node.callee.name === "Function") {
+        if (getExecutableGlobalName(node.callee, context) === "Function") {
           // `new Function("return this")` is the ubiquitous globalThis polyfill
           // (webpack runtime, core-js): a constant body with no injectable input.
           const onlyArgument = node.arguments.length === 1 ? node.arguments[0] : undefined;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/zod/utils/zod-ast.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/zod/utils/zod-ast.ts
@@ -1,6 +1,7 @@
 import type { EsTreeNode } from "../../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../../utils/es-tree-node-of-type.js";
 import { findVariableInitializer } from "../../../utils/find-variable-initializer.js";
+import { getStaticPropertyName } from "../../../utils/get-static-property-name.js";
 import { isNodeOfType } from "../../../utils/is-node-of-type.js";
 import { stripParenExpression } from "../../../utils/strip-paren-expression.js";
 
@@ -22,16 +23,7 @@ interface MethodCall {
   receiver: EsTreeNode;
 }
 
-export const getStaticPropertyName = (
-  member: EsTreeNodeOfType<"MemberExpression">,
-): string | null => {
-  const property = member.property as EsTreeNode;
-  if (!member.computed && isNodeOfType(property, "Identifier")) return property.name;
-  if (member.computed && isNodeOfType(property, "Literal") && typeof property.value === "string") {
-    return property.value;
-  }
-  return null;
-};
+export { getStaticPropertyName } from "../../../utils/get-static-property-name.js";
 
 // The classification is a pure function of the identifier node within its
 // (immutable) file, and every zod rule re-queries the same identifiers —

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-static-property-name.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-static-property-name.ts
@@ -1,0 +1,21 @@
+import type { EsTreeNode } from "./es-tree-node.js";
+import type { EsTreeNodeOfType } from "./es-tree-node-of-type.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+
+export const getStaticPropertyName = (
+  memberExpression: EsTreeNodeOfType<"MemberExpression">,
+): string | null => {
+  const property = memberExpression.property as EsTreeNode;
+  if (!memberExpression.computed && isNodeOfType(property, "Identifier")) return property.name;
+  if (memberExpression.computed && isNodeOfType(property, "Literal")) {
+    return typeof property.value === "string" ? property.value : null;
+  }
+  if (
+    memberExpression.computed &&
+    isNodeOfType(property, "TemplateLiteral") &&
+    property.expressions.length === 0
+  ) {
+    return property.quasis[0]?.value.cooked ?? property.quasis[0]?.value.raw ?? null;
+  }
+  return null;
+};


### PR DESCRIPTION
## Summary

- prove `eval`, string timers, `Function`, and `document` are true global references before reporting
- recognize `globalThis` and static-computed member forms through transparent TypeScript wrappers
- promote the existing Zod static-property resolver into a shared utility and keep Zod on the shared implementation
- add regression corpus seeds for both confirmed semantic gaps

## Validation

- focused rule/Zod suites: 4 files / 56 tests
- full plugin suite: 543 files / 12,029 passed / 148 skipped
- fuzz corpus: 37 passed
- strict targeted fuzz: 500 iterations per changed rule
- `nr typecheck`
- `nr lint` (pre-existing warnings only)
- `nr format:check`
- truffler pre/post dedup search

## RDE

The local RDE checkout currently rejects schema-v3 reports during decode, so corpus validation is blocked by the harness rather than this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes detection logic for security rules (eval, timers, Function, document.write); mis-scoping could miss vulnerabilities or add false positives, though behavior is heavily regression-tested.
> 
> **Overview**
> Tightens **no-eval** and **no-document-write** so they only fire on real browser globals, not locals that share the same names.
> 
> **no-eval** now resolves callees through `getExecutableGlobalName`: identifiers must pass `context.scopes.isGlobalReference`, and `globalThis.eval` / `globalThis["setTimeout"]` / `new globalThis.Function(...)` are treated like bare `eval`, string timers, and `Function` when the property name is statically known (including bracket and no-substitution template literals). Shadowed `eval`, `setTimeout`, `setInterval`, or a local `Function` class no longer report.
> 
> **no-document-write** requires a global `document` binding and uses the shared static property helper, so forms like `document["write"]`, optional chaining, and TS casts still flag, while shadowed `document` objects do not. Dynamic `document[method]()` stays ignored.
> 
> `getStaticPropertyName` moves from Zod-only code into `plugin/utils` (with template-literal support); Zod rules re-export it unchanged. Fuzz regression seeds cover shadowed `document` and `globalThis["eval"]`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e35beb0c2188ce43d441f4ffdd4485f12ee3d20b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->