### PR TITLE
fix: allow external subscription notifications

### DIFF
--- a/.changeset/tidy-media-notify.md
+++ b/.changeset/tidy-media-notify.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Allow effects to notify parents about externally subscribed browser state.

--- a/packages/fuzz/corpus/regressions/no-pass-data-to-parent--external-media-query.tsx
+++ b/packages/fuzz/corpus/regressions/no-pass-data-to-parent--external-media-query.tsx
@@ -1,0 +1,14 @@
+// rule: no-pass-data-to-parent
+// weakness: external-state-origin
+// source: ISSUES_TO_FIX_ASAP.md React Pro Sidebar report
+import { useEffect } from "react";
+
+export const SidebarStatus = ({ onBreakPoint }: { onBreakPoint: (broken: boolean) => void }) => {
+  const broken = useMediaQuery("(max-width: 768px)");
+
+  useEffect(() => {
+    onBreakPoint(broken);
+  }, [broken, onBreakPoint]);
+
+  return null;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.regressions.test.ts
@@ -35,7 +35,8 @@ describe("no-pass-data-to-parent — regressions", () => {
             return () => query.removeEventListener("change", update);
           }, []);
           useEffect(() => {
-            onBreakPoint(broken);
+            const currentBroken = broken;
+            onBreakPoint(currentBroken);
           }, [broken, onBreakPoint]);
           return null;
         };`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.regressions.test.ts
@@ -3,6 +3,63 @@ import { runRule } from "../../../test-utils/run-rule.js";
 import { noPassDataToParent } from "./no-pass-data-to-parent.js";
 
 describe("no-pass-data-to-parent — regressions", () => {
+  describe("external subscription notifications", () => {
+    it("stays silent when notifying a parent of a media-query hook transition", () => {
+      const result = runRule(
+        noPassDataToParent,
+        `const Sidebar = ({ onBreakPoint }) => {
+          const broken = useMediaQuery("(max-width: 768px)");
+          const previousBroken = useRef(broken);
+          useEffect(() => {
+            if (previousBroken.current !== broken) {
+              previousBroken.current = broken;
+              onBreakPoint(broken);
+            }
+          }, [broken, onBreakPoint]);
+          return null;
+        };`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it("stays silent when notifying a parent of state driven only by matchMedia", () => {
+      const result = runRule(
+        noPassDataToParent,
+        `const Sidebar = ({ onBreakPoint }) => {
+          const [broken, setBroken] = useState(false);
+          useEffect(() => {
+            const query = window.matchMedia("(max-width: 768px)");
+            const update = (event) => setBroken(event.matches);
+            query.addEventListener("change", update);
+            return () => query.removeEventListener("change", update);
+          }, []);
+          useEffect(() => {
+            onBreakPoint(broken);
+          }, [broken, onBreakPoint]);
+          return null;
+        };`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it("still flags ordinary child-owned form state passed to a parent", () => {
+      const result = runRule(
+        noPassDataToParent,
+        `const Form = ({ onChange }) => {
+          const value = useFormValue();
+          useEffect(() => {
+            onChange(value);
+          }, [value, onChange]);
+          return <input value={value} />;
+        };`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    });
+  });
+
   describe("router / namespaced API receivers", () => {
     it("stays silent on a destructured router prop redirecting in a useEffect (ant-design .dumi/pages/404 shape)", () => {
       const result = runRule(

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.ts
@@ -39,6 +39,7 @@ import {
 } from "./utils/effect/react.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import { isExternallyDrivenState } from "./utils/effect/external-state.js";
 import { getStaticMemberPropertyName } from "./utils/static-member-property-name.js";
 
 // 1:1 port of upstream `src/rules/no-pass-data-to-parent.js`, narrowed to
@@ -576,6 +577,15 @@ const getFunctionalUpdaterDataRefs = (
 
 const HOOK_NAME_PATTERN = /^use[A-Z0-9]/;
 
+const EXTERNAL_SUBSCRIPTION_HOOK_NAMES: ReadonlySet<string> = new Set([
+  "useIntersectionObserver",
+  "useMatchMedia",
+  "useMediaQuery",
+  "useResizeObserver",
+  "useVisibility",
+  "useWindowSize",
+]);
+
 // A value produced by a custom hook that is itself WIRED TO the component's
 // props (`useMarqueeSelection({ containerRef, onSelectionChange, ... })`)
 // is hook-owned interaction state the component merely bridges up — the
@@ -633,6 +643,26 @@ const isParentWiredHookCalleeRef = (analysis: ProgramAnalysis, ref: Reference): 
     getDownstreamRefs(analysis, hookArgument as EsTreeNode).some((downstreamRef) =>
       isProp(analysis, downstreamRef),
     ),
+  );
+};
+
+const isExternalSubscriptionHookRef = (ref: Reference): boolean => {
+  const identifier = ref.identifier as unknown as EsTreeNode;
+  if (!isNodeOfType(identifier, "Identifier")) return false;
+  if (EXTERNAL_SUBSCRIPTION_HOOK_NAMES.has(identifier.name) && isCalleePosition(identifier)) {
+    return true;
+  }
+  return Boolean(
+    ref.resolved?.defs.some((def) => {
+      const node = def.node as unknown as EsTreeNode;
+      if (!isNodeOfType(node, "VariableDeclarator") || !node.init) return false;
+      const initializer = stripParenExpression(node.init as EsTreeNode);
+      if (!isNodeOfType(initializer, "CallExpression")) return false;
+      const callee = stripParenExpression(initializer.callee as EsTreeNode);
+      return (
+        isNodeOfType(callee, "Identifier") && EXTERNAL_SUBSCRIPTION_HOOK_NAMES.has(callee.name)
+      );
+    }),
   );
 };
 
@@ -792,6 +822,8 @@ export const noPassDataToParent = defineRule({
 
           const isSomeArgsData = argsUpstreamRefs.some((argRef) => {
             if (isUseStateIdentifier(argRef.identifier as unknown as EsTreeNode)) return false;
+            if (isExternallyDrivenState(analysis, argRef)) return false;
+            if (isExternalSubscriptionHookRef(argRef)) return false;
             if (isProp(analysis, argRef)) return false;
             if (isUseRefIdentifier(argRef.identifier as unknown as EsTreeNode)) return false;
             if (isRefCurrent(argRef)) return false;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.ts
@@ -811,7 +811,11 @@ export const noPassDataToParent = defineRule({
               }
               return getDownstreamRefs(analysis, argument as EsTreeNode);
             })
-            .flatMap((argumentRef) => getUpstreamRefs(analysis, argumentRef))
+            .flatMap((argumentRef) =>
+              isExternallyDrivenState(analysis, argumentRef)
+                ? []
+                : getUpstreamRefs(analysis, argumentRef),
+            )
             .filter(isLeafRef);
           // A wrapper-hook callee hides the hand-off in its wrapped body, so
           // its data refs live on the eventual call chain, not the direct
@@ -822,7 +826,6 @@ export const noPassDataToParent = defineRule({
 
           const isSomeArgsData = argsUpstreamRefs.some((argRef) => {
             if (isUseStateIdentifier(argRef.identifier as unknown as EsTreeNode)) return false;
-            if (isExternallyDrivenState(analysis, argRef)) return false;
             if (isExternalSubscriptionHookRef(argRef)) return false;
             if (isProp(analysis, argRef)) return false;
             if (isUseRefIdentifier(argRef.identifier as unknown as EsTreeNode)) return false;


### PR DESCRIPTION
## Summary

- suppress `no-pass-data-to-parent` when callback data comes from known browser-subscription hooks
- reuse shared external-state provenance for local state driven exclusively by listeners, observers, timers, or subscriptions
- retain diagnostics for ordinary child-owned form data passed upward
- add a fuzz regression from the React Pro Sidebar report

## Validation

- focused regressions: 53 tests
- full plugin suite: 543 files / 12,011 passed / 148 skipped
- fuzz corpus: 37 passed
- strict targeted fuzz: 500 iterations
- package typecheck
- root lint (pre-existing warnings only)
- root format check
- truffler pre/post dedup search

## RDE

The local RDE checkout currently rejects schema-v3 reports during decode, so corpus validation is blocked by the harness rather than this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-rule heuristic change with targeted regressions; no runtime app or security impact.
> 
> **Overview**
> **`no-pass-data-to-parent`** no longer reports when a `useEffect` notifies a parent with values that come from **browser subscriptions** rather than child-owned UI state.
> 
> Argument tracing now skips refs classified by **`isExternallyDrivenState`** (e.g. `useState` updated only from `matchMedia` listeners), and treats known subscription hooks (`useMediaQuery`, `useMatchMedia`, `useResizeObserver`, etc.) as non–child-produced data via **`isExternalSubscriptionHookRef`**. Ordinary upward form/value callbacks (e.g. `onChange` with hook form state) still diagnose.
> 
> Adds regression tests and a fuzz corpus case for the React Pro Sidebar media-query pattern; patch changeset for **`oxlint-plugin-react-doctor`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37c3580916ca8aaa74e44d691d29b71ec6568482. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->