### PR TITLE
fix: harden mutable HTML provenance

### DIFF
--- a/.changeset/calm-plums-trace.md
+++ b/.changeset/calm-plums-trace.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Harden dangerous HTML provenance across mutable trusted bindings and trusted helper aliases.

--- a/packages/fuzz/corpus/regressions/dangerous-html-sink--trusted-parameter-alias.tsx
+++ b/packages/fuzz/corpus/regressions/dangerous-html-sink--trusted-parameter-alias.tsx
@@ -1,0 +1,7 @@
+const renderPreview = (element, html) => {
+  const content = html;
+  element.innerHTML = content;
+};
+
+renderPreview(firstPreview, "<p>Static preview</p>");
+renderPreview(secondPreview, DOMPurify.sanitize(loadPreview()));

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/dangerous-html-sink.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/dangerous-html-sink.regressions.test.ts
@@ -1149,6 +1149,64 @@ return <div dangerouslySetInnerHTML={{ __html: content }} />;
     expect(findings).toHaveLength(1);
   });
 
+  it.each(["DOMPurify.sanitize(props.safeHtml)", "highlighter.codeToHtml(source)"])(
+    "does not trust a mutable binding initialized from trusted HTML: %s",
+    (initializer) => {
+      const content = [
+        `let renderedHtml = ${initializer};`,
+        "renderedHtml = props.userHtml;",
+        "element.innerHTML = renderedHtml;",
+      ].join("\n");
+      const findings = runScanRule(dangerousHtmlSink, {
+        relativePath: "src/components/preview.ts",
+        content,
+      });
+      expect(findings).toHaveLength(1);
+    },
+  );
+
+  it("keeps an unmodified mutable sanitized binding trusted", () => {
+    const content = [
+      "let renderedHtml = DOMPurify.sanitize(props.safeHtml);",
+      "other.renderedHtml = props.userHtml;",
+      "element.innerHTML = renderedHtml;",
+    ].join("\n");
+    const findings = runScanRule(dangerousHtmlSink, {
+      relativePath: "src/components/preview.ts",
+      content,
+    });
+    expect(findings).toHaveLength(0);
+  });
+
+  it("stays silent when a trusted helper parameter passes through a taint-named alias", () => {
+    const content = [
+      "const renderPreview = (element, html) => {",
+      "  const content = html;",
+      "  element.innerHTML = content;",
+      "};",
+      'renderPreview(firstPreview, "<p>Static preview</p>");',
+      "renderPreview(secondPreview, DOMPurify.sanitize(loadPreview()));",
+    ].join("\n");
+    const findings = runScanRule(dangerousHtmlSink, {
+      relativePath: "src/components/preview.ts",
+      content,
+    });
+    expect(findings).toHaveLength(0);
+  });
+
+  it("still flags a taint-named alias reached through an opaque local alias", () => {
+    const content = [
+      "const value = loadPage();",
+      "const content = value;",
+      "element.innerHTML = content;",
+    ].join("\n");
+    const findings = runScanRule(dangerousHtmlSink, {
+      relativePath: "src/components/preview.ts",
+      content,
+    });
+    expect(findings).toHaveLength(1);
+  });
+
   it("keeps a trusted helper argument containing parentheses intact", () => {
     const content = [
       "const renderPreview = (element, html) => {",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/dangerous-html-sink.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/dangerous-html-sink.ts
@@ -426,6 +426,21 @@ const findVisibleIdentifierDeclaration = (
   return nearestDeclaration;
 };
 
+const isDeclarationStable = (
+  identifier: string,
+  declaration: VisibleIdentifierDeclaration,
+  usageIndex: number,
+  fileContent: string,
+): boolean => {
+  if (declaration.isImmutable) return true;
+  const textAfterInitializer = fileContent.slice(
+    declaration.initializerStartIndex + declaration.initializer.length,
+    usageIndex,
+  );
+  const reassignmentPattern = new RegExp(`(?:^|[^\\w$.])${escapeRegExp(identifier)}\\s*=(?!=)`);
+  return !reassignmentPattern.test(textAfterInitializer);
+};
+
 const isTrustedHighlighterValue = (
   valueExpression: string,
   fileContent: string,
@@ -436,7 +451,10 @@ const isTrustedHighlighterValue = (
   if (identifier === undefined) return false;
   const declaration = findVisibleIdentifierDeclaration(identifier, sinkIndex, fileContent);
   if (declaration !== null) {
-    return SERIALIZER_CALL_PROVENANCE_PATTERN.test(declaration.initializer);
+    return (
+      isDeclarationStable(identifier, declaration, sinkIndex, fileContent) &&
+      SERIALIZER_CALL_PROVENANCE_PATTERN.test(declaration.initializer)
+    );
   }
   return /highlighted/i.test(valueExpression) || HIGHLIGHTER_LIBRARY_PATTERN.test(fileContent);
 };
@@ -467,7 +485,7 @@ const isExplicitlyTrustedHtmlValue = (
   )?.[1];
   if (identifier && !visitedIdentifiers.has(identifier)) {
     const declaration = findVisibleIdentifierDeclaration(identifier, sinkIndex, fileContent);
-    if (declaration) {
+    if (declaration && isDeclarationStable(identifier, declaration, sinkIndex, fileContent)) {
       const nextVisitedIdentifiers = new Set(visitedIdentifiers);
       nextVisitedIdentifiers.add(identifier);
       return isExplicitlyTrustedHtmlValue(
@@ -588,6 +606,31 @@ const splitTopLevelArguments = (argumentText: string): string[] => {
   return argumentsList;
 };
 
+const isBackedByFunctionParameter = (
+  expression: string,
+  expressionIndex: number,
+  fileContent: string,
+  visitedIdentifiers: Set<string> = new Set(),
+): boolean => {
+  const identifier = expression.trim().match(/^([\w$]+)$/)?.[1];
+  if (identifier === undefined || visitedIdentifiers.has(identifier)) return false;
+  if (findContainingFunctionParameterSource(identifier, expressionIndex, fileContent) !== null) {
+    return true;
+  }
+  const declaration = findVisibleIdentifierDeclaration(identifier, expressionIndex, fileContent);
+  if (!declaration || !isDeclarationStable(identifier, declaration, expressionIndex, fileContent)) {
+    return false;
+  }
+  const nextVisitedIdentifiers = new Set(visitedIdentifiers);
+  nextVisitedIdentifiers.add(identifier);
+  return isBackedByFunctionParameter(
+    declaration.initializer,
+    declaration.initializerStartIndex,
+    fileContent,
+    nextVisitedIdentifiers,
+  );
+};
+
 const isHtmlTainted = (
   expression: string,
   fileContent: string,
@@ -610,6 +653,7 @@ const isHtmlTainted = (
       declaration.declarationIndex > parameterSource.declarationNameIndex);
   if (doesDeclarationShadowParameter) {
     if (
+      isDeclarationStable(identifier, declaration, sinkIndex, fileContent) &&
       isExplicitlyTrustedHtmlValue(
         declaration.initializer,
         fileContent,
@@ -618,15 +662,25 @@ const isHtmlTainted = (
     ) {
       return false;
     }
-    return (
-      isHtmlTainted(
-        declaration.initializer,
-        fileContent,
-        declaration.initializerStartIndex,
-        visitedIdentifiers,
-        visitedCallSites,
-      ) || HTML_TAINT_PATTERN.test(trimmedExpression)
+    if (!isDeclarationStable(identifier, declaration, sinkIndex, fileContent)) return true;
+    const isInitializerTainted = isHtmlTainted(
+      declaration.initializer,
+      fileContent,
+      declaration.initializerStartIndex,
+      visitedIdentifiers,
+      visitedCallSites,
     );
+    if (isInitializerTainted) return true;
+    if (
+      isBackedByFunctionParameter(
+        declaration.initializer,
+        declaration.initializerStartIndex,
+        fileContent,
+      )
+    ) {
+      return false;
+    }
+    return HTML_TAINT_PATTERN.test(trimmedExpression);
   }
   if (parameterSource !== null && parameterSource.functionName.length > 0) {
     const callPattern = new RegExp(`\\b${escapeRegExp(parameterSource.functionName)}\\s*\\(`, "g");
@@ -824,7 +878,9 @@ export const dangerousHtmlSink = defineRule({
           if (
             visibleInitializer === undefined
               ? fromSerializer.test(file.content)
-              : SERIALIZER_CALL_PROVENANCE_PATTERN.test(visibleInitializer)
+              : visibleDeclaration !== null &&
+                isDeclarationStable(valueIdentifier, visibleDeclaration, sinkIndex, file.content) &&
+                SERIALIZER_CALL_PROVENANCE_PATTERN.test(visibleInitializer)
           ) {
             continue;
           }
@@ -835,7 +891,9 @@ export const dangerousHtmlSink = defineRule({
           if (
             visibleInitializer === undefined
               ? fromSanitizer.test(file.content)
-              : SANITIZED_ASSIGNMENT_PATTERN.test(`=${visibleInitializer}`)
+              : visibleDeclaration !== null &&
+                isDeclarationStable(valueIdentifier, visibleDeclaration, sinkIndex, file.content) &&
+                SANITIZED_ASSIGNMENT_PATTERN.test(`=${visibleInitializer}`)
           ) {
             continue;
           }


### PR DESCRIPTION
## Summary

- stop trusting sanitizer/highlighter initializers after the binding is reassigned before the sink
- keep stable mutable trusted bindings clean and avoid confusing same-named object properties with reassignment
- preserve trusted helper parameters through taint-named local aliases without laundering opaque local values
- add regression corpus coverage and a patch changeset

Follow-up to #1152 for the final Bugbot findings that landed at merge time.

## Validation

- oxlint plugin: 543 files, 12,075 passed, 148 skipped
- package typecheck
- format check
- strict targeted fuzz: `dangerous-html-sink`, 500 iterations
- post-change truffler deduplication search

RDE remains blocked by the eval harness rejecting schema-v3 reports.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes security-scan taint/provenance logic for HTML sinks; behavior shifts (more flags on reassigned sanitizers, fewer on trusted helper aliases) but is covered by targeted regressions and fuzz.
> 
> **Overview**
> Tightens the **`dangerous-html-sink`** oxlint rule so “trusted” HTML provenance cannot survive **`let`/`var` reassignment** or misleading **local aliases**.
> 
> **`isDeclarationStable`** requires that mutable bindings are not reassigned between their initializer and the sink before sanitizer/highlighter/serializer trust applies. Reassigning a variable that started as `DOMPurify.sanitize(...)` or `highlighter.codeToHtml(...)` is flagged again; unchanged `let` bindings and assignments on **other objects** (e.g. `other.renderedHtml = …`) stay trusted.
> 
> **`isBackedByFunctionParameter`** lets stable alias chains (`const content = html` inside a helper) inherit trust from a **function parameter** when all call sites pass explicitly trusted HTML, without treating opaque locals (`loadPage()` → `content`) as safe.
> 
> Regression tests and a fuzz corpus case cover trusted-helper + taint-named alias and mutable-binding edge cases. Patch changeset for `oxlint-plugin-react-doctor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07a833f4789997fd15b0f20cb656f609a15d0fc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->