### PR TITLE
fix: normalize discarded expression wrappers

### DIFF
--- a/.changeset/tidy-otters-unwind.md
+++ b/.changeset/tidy-otters-unwind.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Preserve direct-statement diagnostics through discarded unary and sequence wrappers.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-batch-dom-css.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-batch-dom-css.regressions.test.ts
@@ -3,6 +3,26 @@ import { runRule } from "../../../test-utils/run-rule.js";
 import { jsBatchDomCss } from "./js-batch-dom-css.js";
 
 describe("js-performance/js-batch-dom-css — regressions", () => {
+  it.each(["$", "($)", "void ($)", "(0, $)"])(
+    "flags layout-affecting writes through discarded wrapper %s",
+    (wrapper) => {
+      const heightWrite = wrapper.replace("$", "row.style.height = `${height}px`");
+      const widthWrite = wrapper.replace("$", 'row.style.width = "100%"');
+      const result = runRule(
+        jsBatchDomCss,
+        `function resizeRows(rows) {
+          for (const row of rows) {
+            const height = row.offsetHeight;
+            ${heightWrite};
+            ${widthWrite};
+          }
+        }`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    },
+  );
+
   it("stays silent when the styled element is created detached and appended after the writes", () => {
     const result = runRule(
       jsBatchDomCss,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-batch-dom-css.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-batch-dom-css.regressions.test.ts
@@ -6,8 +6,8 @@ describe("js-performance/js-batch-dom-css — regressions", () => {
   it.each(["$", "($)", "void ($)", "(0, $)"])(
     "flags layout-affecting writes through discarded wrapper %s",
     (wrapper) => {
-      const heightWrite = wrapper.replace("$", "row.style.height = `${height}px`");
-      const widthWrite = wrapper.replace("$", 'row.style.width = "100%"');
+      const heightWrite = wrapper.replaceAll("$", "row.style.height = `${height}px`");
+      const widthWrite = wrapper.replaceAll("$", 'row.style.width = "100%"');
       const result = runRule(
         jsBatchDomCss,
         `function resizeRows(rows) {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-batch-dom-css.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-batch-dom-css.ts
@@ -6,6 +6,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import { unwrapDiscardedExpression } from "../../utils/unwrap-discarded-expression.js";
 import { walkAst } from "../../utils/walk-ast.js";
 
 const ITERATOR_METHOD_NAMES: ReadonlySet<string> = new Set([
@@ -311,21 +312,31 @@ const hasAttachmentBefore = (
   return foundAttachment;
 };
 
+const getStyleAssignment = (node: EsTreeNode): EsTreeNodeOfType<"AssignmentExpression"> | null => {
+  if (!isNodeOfType(node, "ExpressionStatement")) return null;
+  const expression = unwrapDiscardedExpression(node);
+  if (!isNodeOfType(expression, "AssignmentExpression")) return null;
+  if (!isNodeOfType(expression.left, "MemberExpression")) return null;
+  if (!isNodeOfType(expression.left.object, "MemberExpression")) return null;
+  if (!isNodeOfType(expression.left.object.property, "Identifier")) return null;
+  return expression.left.object.property.name === "style" ? expression : null;
+};
+
 // Style writes on an element that is not in the document dirty nothing —
 // no live layout exists to recalculate. When the receiver resolves to a
 // same-file `createElement` / `cloneNode` / etc. binding and no
 // attachment call (`appendChild(el)`, `parent.replaceChild(el, …)`, …)
 // precedes the write, the write is provably reflow-free.
 const isProvablyDetachedAtWrite = (styleWriteStatement: EsTreeNode): boolean => {
+  const assignment = getStyleAssignment(styleWriteStatement);
   if (
-    !isNodeOfType(styleWriteStatement, "ExpressionStatement") ||
-    !isNodeOfType(styleWriteStatement.expression, "AssignmentExpression") ||
-    !isNodeOfType(styleWriteStatement.expression.left, "MemberExpression") ||
-    !isNodeOfType(styleWriteStatement.expression.left.object, "MemberExpression")
+    !assignment ||
+    !isNodeOfType(assignment.left, "MemberExpression") ||
+    !isNodeOfType(assignment.left.object, "MemberExpression")
   ) {
     return false;
   }
-  const elementExpression = styleWriteStatement.expression.left.object.object;
+  const elementExpression = assignment.left.object.object;
   const creationRoot = resolveDetachedCreationRoot(elementExpression as EsTreeNode, 0);
   if (!creationRoot) return false;
   return !hasAttachmentBefore(
@@ -343,20 +354,15 @@ export const jsBatchDomCss = defineRule({
   recommendation:
     "Do all your reads first, then all your writes. Mixing them inside a loop makes the browser recalculate the layout again and again, which is slow",
   create: (context: RuleContext) => {
-    const isStyleAssignment = (node: EsTreeNode): boolean =>
-      isNodeOfType(node, "ExpressionStatement") &&
-      isNodeOfType(node.expression, "AssignmentExpression") &&
-      isNodeOfType(node.expression.left, "MemberExpression") &&
-      isNodeOfType(node.expression.left.object, "MemberExpression") &&
-      isNodeOfType(node.expression.left.object.property, "Identifier") &&
-      node.expression.left.object.property.name === "style";
-
-    const writesLayoutAffectingProperty = (node: EsTreeNode): boolean =>
-      isNodeOfType(node, "ExpressionStatement") &&
-      isNodeOfType(node.expression, "AssignmentExpression") &&
-      isNodeOfType(node.expression.left, "MemberExpression") &&
-      isNodeOfType(node.expression.left.property, "Identifier") &&
-      !LAYOUT_NEUTRAL_STYLE_PROPERTY_NAMES.has(node.expression.left.property.name);
+    const writesLayoutAffectingProperty = (node: EsTreeNode): boolean => {
+      const assignment = getStyleAssignment(node);
+      return (
+        assignment !== null &&
+        isNodeOfType(assignment.left, "MemberExpression") &&
+        isNodeOfType(assignment.left.property, "Identifier") &&
+        !LAYOUT_NEUTRAL_STYLE_PROPERTY_NAMES.has(assignment.left.property.name)
+      );
+    };
 
     return {
       BlockStatement(node: EsTreeNodeOfType<"BlockStatement">) {
@@ -366,8 +372,8 @@ export const jsBatchDomCss = defineRule({
         let layoutReads: PerIterationLayoutReads | null = null;
         for (let statementIndex = 1; statementIndex < statements.length; statementIndex++) {
           if (
-            !isStyleAssignment(statements[statementIndex]) ||
-            !isStyleAssignment(statements[statementIndex - 1])
+            getStyleAssignment(statements[statementIndex]) === null ||
+            getStyleAssignment(statements[statementIndex - 1]) === null
           ) {
             continue;
           }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-animation-reaction-as-derived.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-animation-reaction-as-derived.regressions.test.ts
@@ -6,7 +6,7 @@ describe("react-native/rn-animation-reaction-as-derived — regressions", () => 
   it.each(["$", "($)", "void ($)", "(0, $)"])(
     "flags a shared-value copy through discarded wrapper %s",
     (wrapper) => {
-      const assignment = wrapper.replace("$", "target.value = current");
+      const assignment = wrapper.replaceAll("$", "target.value = current");
       const result = runRule(
         rnAnimationReactionAsDerived,
         `import { useAnimatedReaction } from "react-native-reanimated";

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-animation-reaction-as-derived.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-animation-reaction-as-derived.regressions.test.ts
@@ -3,6 +3,22 @@ import { runRule } from "../../../test-utils/run-rule.js";
 import { rnAnimationReactionAsDerived } from "./rn-animation-reaction-as-derived.js";
 
 describe("react-native/rn-animation-reaction-as-derived — regressions", () => {
+  it.each(["$", "($)", "void ($)", "(0, $)"])(
+    "flags a shared-value copy through discarded wrapper %s",
+    (wrapper) => {
+      const assignment = wrapper.replace("$", "target.value = current");
+      const result = runRule(
+        rnAnimationReactionAsDerived,
+        `import { useAnimatedReaction } from "react-native-reanimated";
+        const C = () => {
+          useAnimatedReaction(() => source.value, (current) => { ${assignment}; });
+        };`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    },
+  );
+
   it("stays silent on a locally-defined useAnimatedReaction", () => {
     const result = runRule(
       rnAnimationReactionAsDerived,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-animation-reaction-as-derived.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-animation-reaction-as-derived.ts
@@ -5,6 +5,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isNoOpStatement } from "../../utils/is-no-op-statement.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { unwrapDiscardedExpression } from "../../utils/unwrap-discarded-expression.js";
 
 const REANIMATED_MODULE_SOURCE = "react-native-reanimated";
 
@@ -55,10 +56,10 @@ export const rnAnimationReactionAsDerived = defineRule({
         if (statements.length !== 1) return;
         const onlyStatement = statements[0];
         if (!isNodeOfType(onlyStatement, "ExpressionStatement")) return;
-        singleAssignment = onlyStatement.expression;
+        singleAssignment = unwrapDiscardedExpression(onlyStatement);
       } else if (body) {
         // Concise arrow body like `(cur) => sv.value = cur`.
-        singleAssignment = body;
+        singleAssignment = unwrapDiscardedExpression(body);
       }
       if (!singleAssignment) return;
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.regressions.test.ts
@@ -3,6 +3,29 @@ import { runRule } from "../../../test-utils/run-rule.js";
 import { noEffectChain } from "./no-effect-chain.js";
 
 describe("no-effect-chain — regressions", () => {
+  it.each(["$", "($)", "void ($)", "(0, $)"])(
+    "flags a cross-effect chain through discarded wrapper %s",
+    (wrapper) => {
+      const upstreamEffect = wrapper.replace("$", "useEffect(() => { setFirst(1); }, [])");
+      const downstreamEffect = wrapper.replace(
+        "$",
+        "useEffect(() => { setSecond(first + 1); }, [first])",
+      );
+      const result = runRule(
+        noEffectChain,
+        `function C() {
+          const [first, setFirst] = useState(0);
+          const [second, setSecond] = useState(0);
+          ${upstreamEffect};
+          ${downstreamEffect};
+          return second;
+        }`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    },
+  );
+
   it("still flags the canonical cross-effect state chain", () => {
     const result = runRule(
       noEffectChain,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.regressions.test.ts
@@ -6,8 +6,8 @@ describe("no-effect-chain — regressions", () => {
   it.each(["$", "($)", "void ($)", "(0, $)"])(
     "flags a cross-effect chain through discarded wrapper %s",
     (wrapper) => {
-      const upstreamEffect = wrapper.replace("$", "useEffect(() => { setFirst(1); }, [])");
-      const downstreamEffect = wrapper.replace(
+      const upstreamEffect = wrapper.replaceAll("$", "useEffect(() => { setFirst(1); }, [])");
+      const downstreamEffect = wrapper.replaceAll(
         "$",
         "useEffect(() => { setSecond(first + 1); }, [first])",
       );

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.ts
@@ -21,6 +21,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { collectUseStateBindings } from "./utils/collect-use-state-bindings.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { unwrapDiscardedExpression } from "../../utils/unwrap-discarded-expression.js";
 
 // HACK: §7 of "You Might Not Need an Effect" — chains of computations:
 //
@@ -58,7 +59,7 @@ const findTopLevelEffectCalls = (componentBody: EsTreeNode): EsTreeNode[] => {
   if (!isNodeOfType(componentBody, "BlockStatement")) return effectCalls;
   for (const statement of componentBody.body ?? []) {
     if (!isNodeOfType(statement, "ExpressionStatement")) continue;
-    const expression = statement.expression;
+    const expression = unwrapDiscardedExpression(statement);
     if (!isNodeOfType(expression, "CallExpression")) continue;
     if (!isHookCall(expression, EFFECT_HOOK_NAMES)) continue;
     effectCalls.push(expression);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-mirror-prop-effect.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-mirror-prop-effect.regressions.test.ts
@@ -3,6 +3,23 @@ import { runRule } from "../../../test-utils/run-rule.js";
 import { noMirrorPropEffect } from "./no-mirror-prop-effect.js";
 
 describe("no-mirror-prop-effect — regressions", () => {
+  it.each(["$", "($)", "void ($)", "(0, $)"])(
+    "flags a prop mirror through discarded wrapper %s",
+    (wrapper) => {
+      const effect = wrapper.replace("$", "useEffect(() => { setDraft(value); }, [value])");
+      const result = runRule(
+        noMirrorPropEffect,
+        `function Form({ value }) {
+          const [draft, setDraft] = useState(value);
+          ${effect};
+          return <span>{draft}</span>;
+        }`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    },
+  );
+
   it("stays silent on an initial-only prop re-seed that is also user-editable", () => {
     const result = runRule(
       noMirrorPropEffect,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-mirror-prop-effect.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-mirror-prop-effect.regressions.test.ts
@@ -6,7 +6,7 @@ describe("no-mirror-prop-effect — regressions", () => {
   it.each(["$", "($)", "void ($)", "(0, $)"])(
     "flags a prop mirror through discarded wrapper %s",
     (wrapper) => {
-      const effect = wrapper.replace("$", "useEffect(() => { setDraft(value); }, [value])");
+      const effect = wrapper.replaceAll("$", "useEffect(() => { setDraft(value); }, [value])");
       const result = runRule(
         noMirrorPropEffect,
         `function Form({ value }) {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-mirror-prop-effect.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-mirror-prop-effect.ts
@@ -10,6 +10,7 @@ import { isInitialOnlyPropName } from "../../utils/is-initial-only-prop-name.js"
 import { isSetterIdentifier } from "../../utils/is-setter-identifier.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { unwrapDiscardedExpression } from "../../utils/unwrap-discarded-expression.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 // HACK: §1 of "You Might Not Need an Effect" — mirroring a prop into
@@ -128,7 +129,7 @@ export const noMirrorPropEffect = defineRule({
       // anyway.
       for (const statement of componentBody.body ?? []) {
         if (!isNodeOfType(statement, "ExpressionStatement")) continue;
-        const effectCall = statement.expression;
+        const effectCall = unwrapDiscardedExpression(statement);
         if (!isNodeOfType(effectCall, "CallExpression")) continue;
         if (!isHookCall(effectCall, EFFECT_HOOK_NAMES)) continue;
         if ((effectCall.arguments?.length ?? 0) < 2) continue;
@@ -146,9 +147,7 @@ export const noMirrorPropEffect = defineRule({
         const bodyStatements = getCallbackStatements(callback);
         if (bodyStatements.length !== 1) continue;
         const onlyStatement = bodyStatements[0];
-        const expression = isNodeOfType(onlyStatement, "ExpressionStatement")
-          ? onlyStatement.expression
-          : onlyStatement;
+        const expression = unwrapDiscardedExpression(onlyStatement);
         if (!isNodeOfType(expression, "CallExpression")) continue;
         if (!isNodeOfType(expression.callee, "Identifier")) continue;
         if (!isSetterIdentifier(expression.callee.name)) continue;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-self-updating-effect.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-self-updating-effect.regressions.test.ts
@@ -135,7 +135,7 @@ describe("no-self-updating-effect — diverging updaters keep firing", () => {
   it.each(["$", "($)", "void ($)", "(0, $)"])(
     "flags a self-updating effect through discarded wrapper %s",
     (wrapper) => {
-      const effect = wrapper.replace(
+      const effect = wrapper.replaceAll(
         "$",
         "useEffect(() => { setCount((value) => value + 1); }, [count])",
       );

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-self-updating-effect.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-self-updating-effect.regressions.test.ts
@@ -132,6 +132,26 @@ describe("no-self-updating-effect — accepted converging updaters stay quiet", 
 });
 
 describe("no-self-updating-effect — diverging updaters keep firing", () => {
+  it.each(["$", "($)", "void ($)", "(0, $)"])(
+    "flags a self-updating effect through discarded wrapper %s",
+    (wrapper) => {
+      const effect = wrapper.replace(
+        "$",
+        "useEffect(() => { setCount((value) => value + 1); }, [count])",
+      );
+      const result = runRule(
+        noSelfUpdatingEffect,
+        `function Counter() {
+          const [count, setCount] = useState(0);
+          ${effect};
+          return count;
+        }`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    },
+  );
+
   it("still flags an increment updater whose only guard is a nullish equality the write never establishes", () => {
     const result = runRule(
       noSelfUpdatingEffect,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-self-updating-effect.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-self-updating-effect.ts
@@ -12,6 +12,7 @@ import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { unwrapDiscardedExpression } from "../../utils/unwrap-discarded-expression.js";
 import { collectUseStateBindings } from "./utils/collect-use-state-bindings.js";
 
 // Every literal builds a value-equal result except a regex literal,
@@ -104,9 +105,7 @@ const getUnconditionalSetterCall = (
   // arrow body (`() => setCount(...)`) and the `ExpressionStatement` for a
   // block body (`() => { setCount(...); }`). Both are unconditional
   // synchronous writes, so unwrap the statement form and treat them alike.
-  const expression = stripParenExpression(
-    isNodeOfType(statement, "ExpressionStatement") ? statement.expression : statement,
-  );
+  const expression = unwrapDiscardedExpression(statement);
   if (!isNodeOfType(expression, "CallExpression")) return null;
   if (!isNodeOfType(expression.callee, "Identifier")) return null;
   if (!setterNames.has(expression.callee.name)) return null;
@@ -798,7 +797,7 @@ export const noSelfUpdatingEffect = defineRule({
 
       for (const statement of functionBody.body ?? []) {
         if (!isNodeOfType(statement, "ExpressionStatement")) continue;
-        const effectCall = statement.expression;
+        const effectCall = unwrapDiscardedExpression(statement);
         if (!isNodeOfType(effectCall, "CallExpression")) continue;
         if (!isHookCall(effectCall, EFFECT_HOOK_NAMES)) continue;
         if ((effectCall.arguments?.length ?? 0) < 2) continue;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/unwrap-discarded-expression.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/unwrap-discarded-expression.ts
@@ -1,0 +1,30 @@
+import type { EsTreeNode } from "./es-tree-node.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+import { stripParenExpression } from "./strip-paren-expression.js";
+
+export const unwrapDiscardedExpression = (node: EsTreeNode): EsTreeNode => {
+  let expression: EsTreeNode = isNodeOfType(node, "ExpressionStatement") ? node.expression : node;
+  for (;;) {
+    expression = stripParenExpression(expression);
+    if (isNodeOfType(expression, "UnaryExpression") && expression.operator === "void") {
+      expression = expression.argument;
+      continue;
+    }
+    if (isNodeOfType(expression, "SequenceExpression")) {
+      const expressions = expression.expressions ?? [];
+      const finalExpression = expressions.at(-1);
+      const prefixExpressions = expressions.slice(0, -1);
+      if (
+        finalExpression &&
+        prefixExpressions.length > 0 &&
+        prefixExpressions.every((prefixExpression) =>
+          isNodeOfType(stripParenExpression(prefixExpression), "Literal"),
+        )
+      ) {
+        expression = finalExpression;
+        continue;
+      }
+    }
+    return expression;
+  }
+};


### PR DESCRIPTION
## Summary

- add a shared discarded-expression normalizer for transparent wrappers, unary `void`, and literal-only sequence prefixes
- apply it to effect-chain, prop-mirror, self-updating-effect, DOM layout-write, and Reanimated shared-value-copy detection
- add direct, parenthesized, unary-void, and `(0, expression)` parity regressions for all five rules
- include a patch changeset

## Validation

- oxlint plugin: 543 files, 12,095 passed, 148 skipped
- package typecheck
- root build
- root lint (existing warnings only)
- root format check
- strict targeted fuzz: 500 iterations for each of the five rules
- post-change truffler deduplication search

## RDE

The current dirty local eval harness accepted schema-v3 setup but stalled for more than two minutes with 0/50 roots written and no child scans. Several pre-existing RDE processes in that checkout have been stuck for 6–18 hours. I terminated only this run; no RDE result is claimed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted lint AST normalization with conservative sequence handling and broad regression coverage; no runtime app behavior changes.
> 
> **Overview**
> Adds **`unwrapDiscardedExpression`**, which walks through transparent wrappers—parentheses, unary **`void`**, and comma sequences whose only leading operands are literals (e.g. **`(0, useEffect(...))`**)—so the inner expression is what rules inspect.
> 
> That helper is wired into five existing diagnostics: **effect chains**, **prop-mirror effects**, **self-updating effects**, **batched DOM style writes**, and **Reanimated reaction-as-derived** detection. **`js-batch-dom-css`** centralizes style-assignment parsing on the same path so wrapped **`el.style = …`** assignments are still recognized.
> 
> Regression tests assert each rule still fires when the relevant statement is bare or wrapped in **`($)`**, **`void ($)`**, or **`(0, $)`**. Patch changeset for **`oxlint-plugin-react-doctor`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37b3d49798d69f9750d84931ae756f5e4ab7bfed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->