### PR TITLE
fix: content-address scan caches

### DIFF
--- a/.changeset/fresh-caches-hash.md
+++ b/.changeset/fresh-caches-hash.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Prevent CLI and editor caches from replaying diagnostics after equal-metadata content changes.

--- a/packages/language-server/src/constants.ts
+++ b/packages/language-server/src/constants.ts
@@ -59,7 +59,7 @@ export const WORKSPACE_SCAN_CHUNK_SIZE = 100;
  * On-disk lint-cache schema version. Bump to invalidate every persisted
  * cache after a format change.
  */
-export const LINT_CACHE_VERSION = 1;
+export const LINT_CACHE_VERSION = 2;
 
 /**
  * Debounce before the in-memory lint cache is written to disk. A whole

--- a/packages/language-server/src/core/lint-cache.ts
+++ b/packages/language-server/src/core/lint-cache.ts
@@ -10,13 +10,11 @@ import {
 } from "../constants.js";
 import { SILENT_LOGGER, type Logger } from "../types.js";
 
-/** The file metadata the lint cache keys on (a stable content proxy). */
-export interface FileStat {
-  readonly mtimeMs: number;
-  readonly size: number;
+export interface FileIdentity {
+  readonly contentHash: string;
 }
 
-interface LintCacheEntry extends FileStat {
+interface LintCacheEntry extends FileIdentity {
   readonly diagnostics: CoreDiagnostic[];
 }
 
@@ -28,16 +26,16 @@ interface PersistedCache {
 
 /**
  * Per-project, content-aware lint result cache. Keyed by absolute file
- * path + (mtime, size) so an unchanged file skips the oxlint subprocess
+ * path + content hash so an unchanged file skips the oxlint subprocess
  * entirely on re-scan. Namespaced by a config fingerprint so a config /
  * dependency change starts fresh. Persisted to disk so a re-opened editor
  * gets near-instant diagnostics for everything it hasn't edited.
  */
 export interface LintCache {
-  /** Cached diagnostics for `fsPath` if its `FileStat` matches, else `null`. */
-  readonly lookup: (fsPath: string, stat: FileStat) => CoreDiagnostic[] | null;
+  /** Cached diagnostics for `fsPath` if its identity matches, else `null`. */
+  readonly lookup: (fsPath: string, identity: FileIdentity) => CoreDiagnostic[] | null;
   /** Record the diagnostics for a freshly-scanned file (empty = clean). */
-  readonly store: (fsPath: string, stat: FileStat, diagnostics: CoreDiagnostic[]) => void;
+  readonly store: (fsPath: string, identity: FileIdentity, diagnostics: CoreDiagnostic[]) => void;
   /** Debounced write-back to disk. */
   readonly schedulePersist: () => void;
   /** Write to disk now (cancels any pending debounce). */
@@ -106,15 +104,15 @@ export const createLintCache = (input: {
   };
 
   return {
-    lookup: (fsPath, stat) => {
+    lookup: (fsPath, identity) => {
       const entry = entries.get(fsPath);
-      if (entry !== undefined && entry.mtimeMs === stat.mtimeMs && entry.size === stat.size) {
+      if (entry !== undefined && entry.contentHash === identity.contentHash) {
         return entry.diagnostics;
       }
       return null;
     },
-    store: (fsPath, stat, diagnostics) => {
-      entries.set(fsPath, { ...stat, diagnostics });
+    store: (fsPath, identity, diagnostics) => {
+      entries.set(fsPath, { ...identity, diagnostics });
       dirty = true;
     },
     schedulePersist: () => {

--- a/packages/language-server/src/core/scan-runner.ts
+++ b/packages/language-server/src/core/scan-runner.ts
@@ -1,7 +1,7 @@
-import fs from "node:fs";
 import path from "node:path";
 import {
   computeConfigFingerprint,
+  hashFileContents,
   runEditorScan,
   type Diagnostic as CoreDiagnostic,
 } from "@react-doctor/core";
@@ -16,7 +16,7 @@ import {
 } from "../types.js";
 import { normalizeFsPath } from "../text/uri.js";
 import { toProjectRelative } from "../utils/to-project-relative.js";
-import { createLintCache, type FileStat, type LintCache } from "./lint-cache.js";
+import { createLintCache, type FileIdentity, type LintCache } from "./lint-cache.js";
 import { materializeOverlay, type OverlaySnapshot } from "./overlay.js";
 
 export interface ScanRunnerOptions {
@@ -73,13 +73,9 @@ const resolveDiagnosticFsPath = (
   return normalizeFsPath(absolute);
 };
 
-const statSafe = (fsPath: string): FileStat | null => {
-  try {
-    const stat = fs.statSync(fsPath);
-    return { mtimeMs: stat.mtimeMs, size: stat.size };
-  } catch {
-    return null;
-  }
+const readFileIdentity = (fsPath: string): FileIdentity | null => {
+  const contentHash = hashFileContents(fsPath);
+  return contentHash === null ? null : { contentHash };
 };
 
 /**
@@ -111,7 +107,7 @@ const outcomeWithoutScan = (
  * overlay tree (unsaved buffers) or disk, groups diagnostics by canonical
  * absolute path, and reports stale-detection metadata.
  *
- * A persistent per-file lint cache (keyed by mtime + size, namespaced by a
+ * A persistent per-file lint cache (keyed by content, namespaced by a
  * config fingerprint) short-circuits unchanged files so a re-opened editor
  * or repeated workspace scan skips the oxlint subprocess for everything it
  * hasn't edited. The cache applies only to disk-based, lint-only, per-file
@@ -157,15 +153,15 @@ export const createScanRunner = (options: ScanRunnerOptions): ScanRunner => {
     // Partition into cache hits (skip oxlint) and files that need scanning.
     // Fresh results are merged into `byFile` after the scan below.
     const byFile = new Map<string, CoreDiagnostic[]>();
-    const statByPath = new Map<string, FileStat>();
+    const identityByPath = new Map<string, FileIdentity>();
     let filesToScan = requestedPaths;
     if (cache) {
       const uncached: string[] = [];
       for (const fsPath of requestedPaths) {
-        const stat = statSafe(fsPath);
-        if (stat) {
-          statByPath.set(fsPath, stat);
-          const hit = cache.lookup(fsPath, stat);
+        const identity = readFileIdentity(fsPath);
+        if (identity) {
+          identityByPath.set(fsPath, identity);
+          const hit = cache.lookup(fsPath, identity);
           if (hit !== null) {
             if (hit.length > 0) byFile.set(fsPath, hit);
             continue;
@@ -247,9 +243,9 @@ export const createScanRunner = (options: ScanRunnerOptions): ScanRunner => {
         result.lintPartialFailures.length === 0
       ) {
         for (const fsPath of filesToScan) {
-          const stat = statByPath.get(fsPath);
-          if (!stat) continue;
-          cache.store(fsPath, stat, byFile.get(fsPath) ?? []);
+          const identity = identityByPath.get(fsPath);
+          if (!identity) continue;
+          cache.store(fsPath, identity, byFile.get(fsPath) ?? []);
         }
         cache.schedulePersist();
       }

--- a/packages/language-server/tests/unit/lint-cache.test.ts
+++ b/packages/language-server/tests/unit/lint-cache.test.ts
@@ -30,43 +30,45 @@ const diagnostic = (rule: string): CoreDiagnostic => ({
   category: "Correctness",
 });
 
+const fileIdentity = (contentHash: string) => ({ contentHash });
+
 describe("createLintCache", () => {
-  it("returns a hit only when path + mtime + size all match", () => {
+  it("returns a hit only when path and content hash match", () => {
     const cache = createLintCache({ projectDirectory: projectDir, fingerprint: "fp1" });
     const diagnostics = [diagnostic("no-array-index-key")];
-    cache.store("/p/a.tsx", { mtimeMs: 1000, size: 50 }, diagnostics);
+    cache.store("/p/a.tsx", fileIdentity("hash-a"), diagnostics);
 
-    expect(cache.lookup("/p/a.tsx", { mtimeMs: 1000, size: 50 })).toEqual(diagnostics);
-    expect(cache.lookup("/p/a.tsx", { mtimeMs: 1001, size: 50 })).toBeNull(); // mtime changed
-    expect(cache.lookup("/p/a.tsx", { mtimeMs: 1000, size: 51 })).toBeNull(); // size changed
-    expect(cache.lookup("/p/unknown.tsx", { mtimeMs: 1000, size: 50 })).toBeNull();
+    expect(cache.lookup("/p/a.tsx", fileIdentity("hash-a"))).toEqual(diagnostics);
+    expect(cache.lookup("/p/a.tsx", fileIdentity("hash-b"))).toBeNull();
+    expect(cache.lookup("/p/unknown.tsx", fileIdentity("hash-a"))).toBeNull();
   });
 
   it("distinguishes a cached-clean file ([]) from a miss (null)", () => {
     const cache = createLintCache({ projectDirectory: projectDir, fingerprint: "fp1" });
-    cache.store("/p/clean.tsx", { mtimeMs: 1, size: 1 }, []);
-    expect(cache.lookup("/p/clean.tsx", { mtimeMs: 1, size: 1 })).toEqual([]);
-    expect(cache.lookup("/p/never.tsx", { mtimeMs: 1, size: 1 })).toBeNull();
+    const identity = fileIdentity("clean");
+    cache.store("/p/clean.tsx", identity, []);
+    expect(cache.lookup("/p/clean.tsx", identity)).toEqual([]);
+    expect(cache.lookup("/p/never.tsx", identity)).toBeNull();
   });
 
   it("persists to disk and reloads under the same fingerprint", () => {
     const first = createLintCache({ projectDirectory: projectDir, fingerprint: "fp1" });
-    first.store("/p/a.tsx", { mtimeMs: 7, size: 8 }, [diagnostic("rule-a")]);
-    first.store("/p/clean.tsx", { mtimeMs: 9, size: 10 }, []);
+    first.store("/p/a.tsx", fileIdentity("hash-a"), [diagnostic("rule-a")]);
+    first.store("/p/clean.tsx", fileIdentity("clean"), []);
     first.flush();
 
     const reloaded = createLintCache({ projectDirectory: projectDir, fingerprint: "fp1" });
-    expect(reloaded.lookup("/p/a.tsx", { mtimeMs: 7, size: 8 })).toEqual([diagnostic("rule-a")]);
-    expect(reloaded.lookup("/p/clean.tsx", { mtimeMs: 9, size: 10 })).toEqual([]);
+    expect(reloaded.lookup("/p/a.tsx", fileIdentity("hash-a"))).toEqual([diagnostic("rule-a")]);
+    expect(reloaded.lookup("/p/clean.tsx", fileIdentity("clean"))).toEqual([]);
   });
 
   it("discards a persisted cache when the fingerprint changes", () => {
     const first = createLintCache({ projectDirectory: projectDir, fingerprint: "fp1" });
-    first.store("/p/a.tsx", { mtimeMs: 7, size: 8 }, [diagnostic("rule-a")]);
+    first.store("/p/a.tsx", fileIdentity("hash-a"), [diagnostic("rule-a")]);
     first.flush();
 
     const reloaded = createLintCache({ projectDirectory: projectDir, fingerprint: "fp2" });
-    expect(reloaded.lookup("/p/a.tsx", { mtimeMs: 7, size: 8 })).toBeNull();
+    expect(reloaded.lookup("/p/a.tsx", fileIdentity("hash-a"))).toBeNull();
   });
 });
 

--- a/packages/language-server/tests/unit/scan-runner.test.ts
+++ b/packages/language-server/tests/unit/scan-runner.test.ts
@@ -1,13 +1,88 @@
+import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vite-plus/test";
 import { createScanRunner } from "../../src/core/scan-runner.js";
-import type { ScanRequest } from "../../src/types.js";
+import type { ScanOutcome, ScanRequest } from "../../src/types.js";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const FIXTURE_DIR = path.join(here, "..", "fixtures", "simple-app");
 
 describe("scan-runner", () => {
+  it.each([
+    {
+      firstSource: 'export const App = () => <img src="x" />;\n',
+      secondSource: 'export const App = () => <img alt="x" />;\n',
+      firstHasAltText: true,
+      secondHasAltText: false,
+    },
+    {
+      firstSource: 'export const App = () => <img alt="x" />;\n',
+      secondSource: 'export const App = () => <img src="x" />;\n',
+      firstHasAltText: false,
+      secondHasAltText: true,
+    },
+  ])(
+    "does not replay equal-stat diagnostics after content changes %#",
+    async ({ firstSource, secondSource, firstHasAltText, secondHasAltText }) => {
+      expect(firstSource.length).toBe(secondSource.length);
+      const projectDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "rd-scan-runner-cache-"));
+      const sourceDirectory = path.join(projectDirectory, "src");
+      const sourcePath = path.join(sourceDirectory, "App.tsx");
+      fs.mkdirSync(path.join(projectDirectory, "node_modules"), { recursive: true });
+      fs.mkdirSync(sourceDirectory, { recursive: true });
+      fs.writeFileSync(
+        path.join(projectDirectory, "package.json"),
+        JSON.stringify({ dependencies: { react: "^19.0.0" } }),
+      );
+      fs.writeFileSync(sourcePath, firstSource);
+      const originalStat = fs.statSync(sourcePath);
+      const request: ScanRequest = {
+        id: 1,
+        priority: "save",
+        projectDirectory,
+        files: [sourcePath],
+        runDeadCode: false,
+        useOverlay: false,
+        reason: "test",
+      };
+      const hasAltTextDiagnostic = (outcome: ScanOutcome | null) =>
+        outcome?.byFile
+          .get(sourcePath)
+          ?.some((diagnostic) => diagnostic.rule.endsWith("alt-text")) ?? false;
+      const firstRunner = createScanRunner({
+        nodeBinaryPath: null,
+        readText: () => null,
+        version: "test",
+      });
+      let secondRunner: ReturnType<typeof createScanRunner> | null = null;
+
+      try {
+        const firstOutcome = await firstRunner.performScan(request, { isCancelled: false });
+        expect(hasAltTextDiagnostic(firstOutcome)).toBe(firstHasAltText);
+        firstRunner.dispose();
+
+        fs.writeFileSync(sourcePath, secondSource);
+        fs.utimesSync(sourcePath, originalStat.atime, originalStat.mtime);
+        secondRunner = createScanRunner({
+          nodeBinaryPath: null,
+          readText: () => null,
+          version: "test",
+        });
+        const secondOutcome = await secondRunner.performScan(
+          { ...request, id: 2 },
+          { isCancelled: false },
+        );
+        expect(hasAltTextDiagnostic(secondOutcome)).toBe(secondHasAltText);
+      } finally {
+        firstRunner.dispose();
+        secondRunner?.dispose();
+        fs.rmSync(projectDirectory, { recursive: true, force: true });
+      }
+    },
+  );
+
   // Regression: a per-file request whose paths all resolve outside the
   // project must NOT fall through to a whole-project lint (an empty
   // include list is otherwise treated as "scan everything").

--- a/packages/language-server/tests/unit/scan-runner.test.ts
+++ b/packages/language-server/tests/unit/scan-runner.test.ts
@@ -48,9 +48,10 @@ describe("scan-runner", () => {
         reason: "test",
       };
       const hasAltTextDiagnostic = (outcome: ScanOutcome | null) =>
-        outcome?.byFile
-          .get(sourcePath)
-          ?.some((diagnostic) => diagnostic.rule.endsWith("alt-text")) ?? false;
+        outcome !== null &&
+        Array.from(outcome.byFile.values()).some((diagnostics) =>
+          diagnostics.some((diagnostic) => diagnostic.rule.endsWith("alt-text")),
+        );
       const firstRunner = createScanRunner({
         nodeBinaryPath: null,
         readText: () => null,

--- a/packages/react-doctor/src/cli/utils/scan-result-cache.ts
+++ b/packages/react-doctor/src/cli/utils/scan-result-cache.ts
@@ -220,7 +220,7 @@ const buildDirtyPathContentFingerprint = (
   // serving a stale payload for an unfingerprintable state.
   if (!stats.isFile()) return null;
   if (stats.size > SCAN_RESULT_CACHE_MAX_HASHED_FILE_SIZE_BYTES) {
-    return `stat:${stats.mtimeMs}:${stats.size}`;
+    return null;
   }
   return hashFileContents(absolutePath);
 };

--- a/packages/react-doctor/tests/scan-result-cache.test.ts
+++ b/packages/react-doctor/tests/scan-result-cache.test.ts
@@ -11,7 +11,10 @@ import {
   shouldStoreScanPayload,
   type CachedScanPayload,
 } from "../src/cli/utils/scan-result-cache.js";
-import { SCAN_RESULT_CACHE_MAX_DIRTY_STATUS_ENTRY_COUNT } from "../src/cli/utils/constants.js";
+import {
+  SCAN_RESULT_CACHE_MAX_DIRTY_STATUS_ENTRY_COUNT,
+  SCAN_RESULT_CACHE_MAX_HASHED_FILE_SIZE_BYTES,
+} from "../src/cli/utils/constants.js";
 import { runGit } from "../src/cli/utils/git-hook-shared.js";
 import { VERSION } from "../src/cli/utils/version.js";
 import { commitAll, initGitRepo, setupReactProject } from "./regressions/_helpers.js";
@@ -502,6 +505,19 @@ describe("scan result cache", () => {
       ) {
         fs.writeFileSync(path.join(scratchDirectory, `file-${fileIndex}.txt`), String(fileIndex));
       }
+      expect(cacheKey(projectDirectory, baseOptions())).toBeNull();
+    });
+
+    it("disables caching when an oversized dirty file cannot be content-hashed", () => {
+      const projectDirectory = setupCleanProject("oversized-file");
+      const pluginPath = path.join(projectDirectory, "custom-rule.cjs");
+      const fileSize = SCAN_RESULT_CACHE_MAX_HASHED_FILE_SIZE_BYTES + 1;
+      fs.writeFileSync(pluginPath, "a".repeat(fileSize));
+      const originalStat = fs.statSync(pluginPath);
+      expect(cacheKey(projectDirectory, baseOptions())).toBeNull();
+
+      fs.writeFileSync(pluginPath, "b".repeat(fileSize));
+      fs.utimesSync(pluginPath, originalStat.atime, originalStat.mtime);
       expect(cacheKey(projectDirectory, baseOptions())).toBeNull();
     });
 


### PR DESCRIPTION
## Summary
- key persisted editor lint results by file content instead of mtime and size
- disable whole-scan cache reuse when a dirty oversized file cannot be content-hashed safely
- cover clean-to-diagnostic and diagnostic-to-clean equal-metadata edits, including persisted editor cache reloads

## Validation
- `nr test tests/unit/lint-cache.test.ts tests/unit/scan-runner.test.ts` (language server: 8 passed)
- `nr test tests/scan-result-cache.test.ts` (CLI: 24 passed)
- full language-server suite (63 passed)
- `nr typecheck`
- `nr lint` (existing warnings only)
- `nr format:check`
- `nr smoke:json-report`

## Full-suite note
`nr test` exercised the changed suites successfully but the concurrent local run exceeded existing timeouts in unrelated dead-code workers, performance harness cases, terminal stdin cases, and CLI output cases. The affected cache suites passed both in that run and in isolated post-rebase reruns.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cache invalidation for editor and CLI scan paths; incorrect hashing would miss or replay diagnostics, but behavior is conservative when hashing fails (cache off or miss).
> 
> **Overview**
> Fixes **stale diagnostics** when file bytes change but **mtime and size stay the same** (e.g. same-length edits). Editor **persisted lint cache** now keys entries by **content hash** (`FileIdentity`) instead of `mtime`/`size`, with **`LINT_CACHE_VERSION` bumped to 2** so old on-disk entries are dropped.
> 
> The language server **scan runner** fingerprints files via `hashFileContents` for cache lookup and store. The CLI **whole-scan cache** no longer falls back to a **stat fingerprint** for dirty files above the max hash size—those cases return **no cache key** so results are not reused unsafely.
> 
> Regression coverage includes **equal-metadata content swaps** (clean ↔ diagnostic) across persisted editor cache reloads, plus **oversized dirty files** that cannot be content-hashed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97fc3c93e26b12dd361beef74beb4cdb3b32d1e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->