### PR TITLE
fix: preserve caller array lookup provenance

### DIFF
--- a/.changeset/orange-moons-cheat.md
+++ b/.changeset/orange-moons-cheat.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Keep js-set-map-lookups active when a caller-controlled array has a small destructuring fallback.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-set-map-lookups.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-set-map-lookups.regressions.test.ts
@@ -105,6 +105,26 @@ describe("js-performance/js-set-map-lookups — regressions", () => {
     );
   });
 
+  it.each([
+    `function f(rows, { weekendDays = [0, 6] }: { weekendDays?: number[] }) { for (const row of rows) { if (weekendDays.includes(row.day)) row.weekend = true; } }`,
+    `function f(rows, { weekendDays = [0, 6] }: { weekendDays?: readonly number[] }) { for (const row of rows) { if (weekendDays.includes(row.day)) row.weekend = true; } }`,
+    `function f(rows, weekendDays: number[] = [0, 6]) { for (const row of rows) { if (weekendDays.includes(row.day)) row.weekend = true; } }`,
+  ])("flags a caller-controlled array with a small fallback", (code) => {
+    expectFail(code);
+  });
+
+  it("flags a caller-controlled alias with a small fallback", () => {
+    expectFail(
+      `function f(rows, { weekendDays = [0, 6] }: { weekendDays?: number[] }) { const days = weekendDays; for (const row of rows) { if (days.includes(row.day)) row.weekend = true; } }`,
+    );
+  });
+
+  it("flags a caller-controlled nullish fallback", () => {
+    expectFail(
+      `function f(rows, options: { weekendDays?: number[] }) { const days = options.weekendDays ?? [0, 6]; for (const row of rows) { if (days.includes(row.day)) row.weekend = true; } }`,
+    );
+  });
+
   it("does not flag a SCREAMING_SNAKE_CASE constant receiver", () => {
     expectPass(
       `import { VALID_PAGE_TYPES } from "./types"; function f(entries){ for (const entry of entries){ if (VALID_PAGE_TYPES.includes(entry.pageType)) entry.ok = true; } }`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-set-map-lookups.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-set-map-lookups.ts
@@ -414,28 +414,32 @@ const isSmallFixedListMember = (receiver: EsTreeNode | null | undefined): boolea
   );
 };
 
+interface ResolvedInitializer {
+  readonly initializer: EsTreeNode;
+  readonly isDefault: boolean;
+}
+
 // Follow an identifier receiver to its declaration so `const ct =
 // flare.contentType; … ct.includes('json')` is recognized as the string
 // lookup it is, and `const KNOWN = ['a', 'b']; … KNOWN.includes(x)` as a
 // tiny fixed allowlist.
-const getResolvedInitializer = (receiver: EsTreeNode): EsTreeNode | null => {
+const getResolvedInitializer = (receiver: EsTreeNode): ResolvedInitializer | null => {
   if (!isNodeOfType(receiver, "Identifier")) return null;
   const binding = findVariableInitializer(receiver, receiver.name);
   const initializer = binding?.initializer ?? null;
+  if (!binding || !initializer) return null;
+  const isDefault = isNodeOfType(binding.bindingIdentifier.parent, "AssignmentPattern");
   // Follow one alias hop: `const supported = LOCALES;`.
-  if (initializer && isNodeOfType(initializer, "Identifier")) {
+  if (isNodeOfType(initializer, "Identifier")) {
     const aliased = findVariableInitializer(initializer, initializer.name);
-    return aliased?.initializer ?? initializer;
+    if (aliased?.initializer) {
+      return {
+        initializer: aliased.initializer,
+        isDefault: isDefault || isNodeOfType(aliased.bindingIdentifier.parent, "AssignmentPattern"),
+      };
+    }
   }
-  return initializer;
-};
-
-const getReceiverRootIdentifierName = (receiver: EsTreeNode): string | null => {
-  let current = stripParenExpression(receiver);
-  while (isNodeOfType(current, "MemberExpression")) {
-    current = stripParenExpression(current.object);
-  }
-  return isNodeOfType(current, "Identifier") ? current.name : null;
+  return { initializer, isDefault };
 };
 
 // `cookie.split(';')` produces string elements; a binding iterating over a
@@ -705,8 +709,10 @@ const isBoundedConstantCollection = (collection: EsTreeNode): boolean => {
   if (isScreamingSnakeCaseConstantReceiver(stripped)) return true;
   if (isSmallInlineLiteralArray(stripped)) return true;
   if (isNodeOfType(stripped, "Identifier")) {
-    const initializer = getResolvedInitializer(stripped);
-    if (initializer && isSmallInlineLiteralArray(initializer)) return true;
+    const resolved = getResolvedInitializer(stripped);
+    if (resolved && !resolved.isDefault && isSmallInlineLiteralArray(resolved.initializer)) {
+      return true;
+    }
   }
   return false;
 };
@@ -781,8 +787,13 @@ export const jsSetMapLookups = defineRule({
       }
       const resolvedInitializer = getResolvedInitializer(receiver);
       if (resolvedInitializer) {
-        if (isLikelyStringReceiver(resolvedInitializer)) return;
-        if (isSmallInlineLiteralArray(resolvedInitializer)) return;
+        if (isLikelyStringReceiver(resolvedInitializer.initializer)) return;
+        if (
+          !resolvedInitializer.isDefault &&
+          isSmallInlineLiteralArray(resolvedInitializer.initializer)
+        ) {
+          return;
+        }
       }
       if (isStringElementOfSplitIteration(receiver)) return;
       if (isReceiverDeclaredInNearestLoop(receiver, node)) return;


### PR DESCRIPTION
## Why

`js-set-map-lookups` treated a small destructuring default as proof that an array was always bounded. Callers can still supply an arbitrarily large array, so repeated `.includes()` calls inside a loop were missed.

Before:

```tsx
const groupEvents = (events, { weekendDays = [0, 6] }) =>
  events.map((event) => weekendDays.includes(event.day));
```

After this change, the lookup remains diagnosed because `weekendDays` is caller-controlled. Truly local small arrays and `Set.has()` remain clean.

## What changed

- retain whether a resolved initializer came from an `AssignmentPattern`
- refuse the small-array exemption for defaulted parameters and destructured inputs, including one local alias hop
- cover mutable, readonly, direct-default, destructured-default, alias, and nullish-fallback forms
- remove an unused receiver helper in the touched rule

## Eval results

A fresh local RDE run launched ten root scans but the existing eval harness stalled with zero completions, matching other 7–18 hour stuck local runs. I stopped only this run and removed its empty cache; no OSS result is claimed.

## Test plan

- `nr test src/plugin/rules/js-performance/js-set-map-lookups.regressions.test.ts` — 38 passed
- full plugin suite — 12,099 passed, 148 skipped
- `FUZZ_RULE=js-set-map-lookups FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz`
- `nr build`
- `nr typecheck`
- `nr lint` — existing warnings only
- `nr format:check`
- `nr smoke:json-report`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to one lint rule’s exemption logic and regression tests; behavior change is intentional (more diagnostics, fewer false negatives).
> 
> **Overview**
> Fixes a false negative in **`js-set-map-lookups`**: parameters or destructuring defaults like `weekendDays = [0, 6]` no longer count as “always small” arrays, so **`.includes()` / `.indexOf()` inside loops** is diagnosed when callers can pass a large array.
> 
> **`getResolvedInitializer`** now returns the initializer plus an **`isDefault`** flag (from `AssignmentPattern`, including one alias hop). The small-inline-array and bounded-constant-collection exemptions apply only when that binding is **not** a default—local small literals and module constants stay quiet.
> 
> Regression tests cover destructured defaults, direct defaults, aliases, and `?? [0, 6]` fallbacks. Unused **`getReceiverRootIdentifierName`** is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5355a1be70962fc2a37f19b3e699ccd439f88187. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->