### PR TITLE
fix: resolve intrinsic string JSX aliases

### DIFF
--- a/.changeset/bright-buttons-resolve.md
+++ b/.changeset/bright-buttons-resolve.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Preserve intrinsic host-element diagnostics for exact local constant-string JSX aliases.

--- a/packages/fuzz/corpus/regressions/jsx-no-target-blank--lowercase-intrinsic-shadow.tsx
+++ b/packages/fuzz/corpus/regressions/jsx-no-target-blank--lowercase-intrinsic-shadow.tsx
@@ -1,0 +1,6 @@
+// rule: jsx-no-target-blank
+// weakness: binding-provenance
+// source: PR #1167 Bugbot review
+export const button = "a" as const;
+
+export const ExternalAction = () => <button target="_blank">Open</button>;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vite-plus/test";
+import ts from "typescript";
 import { runRule } from "../../test-utils/run-rule.js";
 import { runScanRule } from "../../test-utils/run-scan-rule.js";
 import { ruleRegistry } from "../rule-registry.js";
@@ -6,6 +7,123 @@ import { KNOWN_UNCOVERED } from "./known-uncovered.js";
 import { livenessFixtures } from "./liveness-fixtures.js";
 import type { LivenessFixture } from "./liveness-fixtures.js";
 import type { Rule } from "../utils/rule.js";
+
+const INTRINSIC_STRING_ALIAS_RULE_IDS: ReadonlyArray<string> = [
+  "anchor-ambiguous-text",
+  "anchor-has-content",
+  "anchor-is-valid",
+  "aria-activedescendant-has-tabindex",
+  "aria-role",
+  "aria-unsupported-elements",
+  "autocomplete-valid",
+  "button-has-type",
+  "checked-requires-onchange-or-readonly",
+  "click-events-have-key-events",
+  "design-no-vague-button-label",
+  "dialog-has-accessible-name",
+  "forbid-dom-props",
+  "forbid-elements",
+  "heading-has-content",
+  "html-has-lang",
+  "html-no-invalid-paragraph-child",
+  "html-no-invalid-table-nesting",
+  "html-no-nested-interactive",
+  "iframe-has-title",
+  "iframe-missing-sandbox",
+  "img-redundant-alt",
+  "interactive-supports-focus",
+  "jsx-no-script-url",
+  "jsx-no-target-blank",
+  "lang",
+  "media-has-caption",
+  "mouse-events-have-key-events",
+  "nextjs-no-a-element",
+  "nextjs-no-css-link",
+  "nextjs-no-font-link",
+  "nextjs-no-img-element",
+  "nextjs-no-polyfill-script",
+  "no-aria-hidden-on-focusable",
+  "no-disabled-zoom",
+  "no-distracting-elements",
+  "no-img-lazy-with-high-fetchpriority",
+  "no-indeterminate-attribute",
+  "no-interactive-element-to-noninteractive-role",
+  "no-noninteractive-element-interactions",
+  "no-noninteractive-element-to-interactive-role",
+  "no-noninteractive-tabindex",
+  "no-prevent-default",
+  "no-redundant-roles",
+  "no-static-element-interactions",
+  "no-string-false-on-boolean-attribute",
+  "no-uncontrolled-input",
+  "no-undeferred-third-party",
+  "no-unknown-property",
+  "preact-prefer-ondblclick",
+  "preact-prefer-oninput",
+  "prefer-html-dialog",
+  "prefer-tag-over-role",
+  "rendering-animate-svg-wrapper",
+  "role-has-required-aria-props",
+  "role-supports-aria-props",
+  "scope",
+  "style-prop-object",
+  "tanstack-start-no-anchor-element",
+  "void-dom-elements-no-children",
+];
+
+const transformFirstIntrinsicToConstantAlias = (code: string): string | null => {
+  const sourceFile = ts.createSourceFile(
+    "fixture.tsx",
+    code,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX,
+  );
+  let openingElement: ts.JsxOpeningLikeElement | undefined;
+  const visit = (node: ts.Node): void => {
+    if (openingElement) return;
+    if (
+      (ts.isJsxOpeningElement(node) || ts.isJsxSelfClosingElement(node)) &&
+      ts.isIdentifier(node.tagName) &&
+      /^[a-z]/.test(node.tagName.text)
+    ) {
+      openingElement = node;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  if (!openingElement || !ts.isIdentifier(openingElement.tagName)) return null;
+
+  const intrinsicName = openingElement.tagName.text;
+  const replacements = [
+    { start: openingElement.tagName.getStart(sourceFile), end: openingElement.tagName.getEnd() },
+  ];
+  if (ts.isJsxOpeningElement(openingElement) && ts.isJsxElement(openingElement.parent)) {
+    replacements.push({
+      start: openingElement.parent.closingElement.tagName.getStart(sourceFile),
+      end: openingElement.parent.closingElement.tagName.getEnd(),
+    });
+  }
+
+  let transformedCode = code;
+  for (const replacement of replacements.sort((left, right) => right.start - left.start)) {
+    transformedCode = `${transformedCode.slice(0, replacement.start)}MetamorphicIntrinsic${transformedCode.slice(replacement.end)}`;
+  }
+  return `const MetamorphicIntrinsic = ${JSON.stringify(intrinsicName)} as const;\n${transformedCode}`;
+};
+
+const diagnosticIdentity = (rule: Rule, fixture: LivenessFixture): ReadonlyArray<string> => {
+  const result = runRule(rule, fixture.code, {
+    ...(fixture.filePath !== undefined ? { filename: fixture.filePath } : {}),
+    ...(fixture.settings !== undefined ? { settings: fixture.settings } : {}),
+    forceJsx: fixture.forceJsx ?? true,
+  });
+  expect(result.parseErrors).toEqual([]);
+  return result.diagnostics
+    .map((diagnostic) => `${diagnostic.message}\0${diagnostic.nodeType}`)
+    .sort();
+};
 
 const countFindings = (rule: Rule, fixture: LivenessFixture): number => {
   if (typeof rule.scan === "function") {
@@ -46,6 +164,18 @@ describe("rule liveness", () => {
     );
     expect(redundantUncoveredIds).toEqual([]);
   });
+
+  for (const ruleId of INTRINSIC_STRING_ALIAS_RULE_IDS) {
+    it(`${ruleId} preserves diagnostics for an exact intrinsic string alias`, () => {
+      const rule = ruleRegistry[ruleId];
+      const fixture = livenessFixtures[ruleId];
+      const transformedCode = transformFirstIntrinsicToConstantAlias(fixture.code);
+      if (!transformedCode) throw new Error(`Expected an intrinsic JSX tag for ${ruleId}`);
+      expect(diagnosticIdentity(rule, { ...fixture, code: transformedCode })).toEqual(
+        diagnosticIdentity(rule, fixture),
+      );
+    });
+  }
 
   for (const [ruleId, rule] of Object.entries(ruleRegistry)) {
     const fixture = livenessFixtures[ruleId];

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/anchor-is-valid.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/anchor-is-valid.ts
@@ -110,13 +110,8 @@ export const anchorIsValid = defineRule({
     return {
       JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
         if (isTestlikeFile) return;
-        if (
-          !fileHasJsxA11ySettings &&
-          (!isNodeOfType(node.name, "JSXIdentifier") || node.name.name !== "a")
-        ) {
-          return;
-        }
         const tag = getElementType(node, context.settings);
+        if (!fileHasJsxA11ySettings && tag !== "a") return;
         if (tag !== "a") return;
         // First-found custom href alternative, falling back to "href".
         let hrefAttribute: ReturnType<typeof hasJsxPropIgnoreCase> | undefined;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/dialog-has-accessible-name.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/dialog-has-accessible-name.ts
@@ -4,6 +4,7 @@ import { hasJsxPropIgnoreCase } from "../../utils/has-jsx-prop-ignore-case.js";
 import { hasJsxSpreadAttribute } from "../../utils/has-jsx-spread-attribute.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isTestlikeFilename } from "../../utils/is-testlike-filename.js";
+import { resolveJsxElementType } from "../../utils/resolve-jsx-element-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import type { RuleVisitors } from "../../utils/rule-visitors.js";
 
@@ -29,7 +30,7 @@ export const dialogHasAccessibleName = defineRule({
     return {
       JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
         if (!isNodeOfType(node.name, "JSXIdentifier")) return;
-        const tagName = node.name.name;
+        const tagName = resolveJsxElementType(node);
         // Custom components (`<Modal>`) own their internal DOM — we can't verify
         // whether they wire up a name, so only intrinsic lowercase elements.
         if (tagName[0] !== tagName[0]?.toLowerCase()) return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/prefer-html-dialog.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/prefer-html-dialog.ts
@@ -10,6 +10,7 @@ import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isTestlikeFilename } from "../../utils/is-testlike-filename.js";
 import type { RuleVisitors } from "../../utils/rule-visitors.js";
 import { walkAst } from "../../utils/walk-ast.js";
+import { resolveJsxElementType } from "../../utils/resolve-jsx-element-type.js";
 
 const ROLE_DIALOG_VALUES = new Set(["dialog", "alertdialog"]);
 
@@ -278,7 +279,7 @@ export const preferHtmlDialog = defineRule({
       },
       JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
         if (!isNodeOfType(node.name, "JSXIdentifier")) return;
-        const tagName = node.name.name;
+        const tagName = resolveJsxElementType(node);
         // Native `<dialog>` is the destination, not the source — never flag.
         if (tagName === "dialog") return;
         // Capitalised names are user components: a custom `<Dialog>` is

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/bundle-size/no-undeferred-third-party.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/bundle-size/no-undeferred-third-party.ts
@@ -5,6 +5,7 @@ import { hasJsxAttribute } from "../../utils/has-jsx-attribute.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { resolveJsxElementType } from "../../utils/resolve-jsx-element-type.js";
 
 // Scheme-relative or absolute URLs load from another origin; anything
 // else (`/analytics.js`, `./setup.js`) is served by the app itself and is
@@ -19,7 +20,7 @@ export const noUndeferredThirdParty = defineRule({
   recommendation: 'Use `next/script` with `strategy="lazyOnload"`, or add the `defer` attribute.',
   create: (context: RuleContext) => ({
     JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
-      if (!isNodeOfType(node.name, "JSXIdentifier") || node.name.name !== "script") return;
+      if (resolveJsxElementType(node) !== "script") return;
       const attributes = node.attributes ?? [];
       const srcAttribute = findJsxAttribute(attributes, "src");
       if (!srcAttribute) return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/html-no-invalid-paragraph-child.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/html-no-invalid-paragraph-child.ts
@@ -2,6 +2,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { resolveJsxElementType } from "../../utils/resolve-jsx-element-type.js";
 
 // Lifted verbatim from `preact/debug/src/debug.js`'s
 // `ILLEGAL_PARAGRAPH_CHILD_ELEMENTS` regex. These are the block-level
@@ -48,8 +49,7 @@ const buildMessage = (childTagName: string): string =>
 const isParagraphElement = (candidate: EsTreeNode): boolean => {
   if (!isNodeOfType(candidate, "JSXElement")) return false;
   const opening = candidate.openingElement;
-  if (!isNodeOfType(opening.name, "JSXIdentifier")) return false;
-  return opening.name.name === "p";
+  return resolveJsxElementType(opening) === "p";
 };
 
 // `node.parent` of a JSXOpeningElement is the JSXElement that owns it
@@ -115,8 +115,7 @@ export const htmlNoInvalidParagraphChild = defineRule({
   recommendation: "Swap the `<p>` for a `<div>`, or move the child outside the paragraph.",
   create: (context) => ({
     JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
-      if (!isNodeOfType(node.name, "JSXIdentifier")) return;
-      const childTagName = node.name.name;
+      const childTagName = resolveJsxElementType(node);
       if (!BLOCK_LEVEL_ELEMENTS.has(childTagName)) return;
       const enclosingParagraph = findEnclosingParagraph(node);
       if (!enclosingParagraph) return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/html-no-invalid-table-nesting.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/html-no-invalid-table-nesting.ts
@@ -3,6 +3,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isTestlikeFilename } from "../../utils/is-testlike-filename.js";
+import { resolveJsxElementType } from "../../utils/resolve-jsx-element-type.js";
 import { TRANSPARENT_EXPRESSION_WRAPPER_TYPES } from "../../utils/strip-paren-expression.js";
 
 const TABLE_ELEMENTS = new Set(["table", "thead", "tbody", "tfoot", "tr", "td", "th"]);
@@ -19,7 +20,7 @@ const getHostTagName = (jsxElement: EsTreeNode): string | null => {
   if (!isNodeOfType(jsxElement, "JSXElement")) return null;
   const opening = jsxElement.openingElement;
   if (!isNodeOfType(opening.name, "JSXIdentifier")) return null;
-  const tagName = opening.name.name;
+  const tagName = resolveJsxElementType(opening);
   // Capitalised names are user components — opaque to static HTML
   // structural checks, so we can't tell whether `<MyTable>` ultimately
   // renders a `<table>`. Bail out as soon as one shows up in the
@@ -96,7 +97,7 @@ const findClosestHostAncestor = (
     if (isNodeOfType(ancestor, "JSXElement")) {
       const opening = ancestor.openingElement;
       if (isNodeOfType(opening.name, "JSXIdentifier")) {
-        const ancestorTag = opening.name.name;
+        const ancestorTag = resolveJsxElementType(opening);
         if (ancestorTag.length === 0) {
           previous = ancestor;
           ancestor = ancestor.parent ?? null;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/html-no-nested-interactive.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/html-no-nested-interactive.ts
@@ -2,6 +2,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { resolveJsxElementType } from "../../utils/resolve-jsx-element-type.js";
 
 const buildMessage = (tagName: string): string =>
   `Your users get broken clicks, focus & screen readers because you can't put a \`<${tagName}>\` inside another \`<${tagName}>\`, so the browser closes the outer one early. Move the inner one out.`;
@@ -12,8 +13,7 @@ const isJsxElementWithTagName = (
 ): candidate is EsTreeNodeOfType<"JSXElement"> => {
   if (!isNodeOfType(candidate, "JSXElement")) return false;
   const opening = candidate.openingElement;
-  if (!isNodeOfType(opening.name, "JSXIdentifier")) return false;
-  return opening.name.name === tagName;
+  return resolveJsxElementType(opening) === tagName;
 };
 
 // `node.parent` of a JSXOpeningElement is the JSXElement that owns it
@@ -71,8 +71,7 @@ export const htmlNoNestedInteractive = defineRule({
     "Move the inner `<a>` or `<button>` so it's a sibling, or change the outer one to a plain `<div>` or `<span>`.",
   create: (context) => ({
     JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
-      if (!isNodeOfType(node.name, "JSXIdentifier")) return;
-      const tagName = node.name.name;
+      const tagName = resolveJsxElementType(node);
       if (tagName !== "a" && tagName !== "button") return;
       const enclosingElement = findEnclosingSameTag(node, tagName);
       if (!enclosingElement) return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-indeterminate-attribute.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-indeterminate-attribute.ts
@@ -8,6 +8,7 @@ import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isReactApiCall, type ReactApiCallOptions } from "../../utils/is-react-api-call.js";
 import type { RuleVisitors } from "../../utils/rule-visitors.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import { resolveJsxElementType } from "../../utils/resolve-jsx-element-type.js";
 
 const MESSAGE =
   "The `indeterminate` HTML attribute does not set a checkbox's visual state. Assign the `HTMLInputElement.indeterminate` DOM property instead.";
@@ -179,7 +180,7 @@ export const noIndeterminateAttribute = defineRule({
 
     return {
       JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
-        if (!isNodeOfType(node.name, "JSXIdentifier") || node.name.name !== "input") return;
+        if (resolveJsxElementType(node) !== "input") return;
         let typeAttribute: EsTreeNodeOfType<"JSXAttribute"> | null = null;
         let typeAttributeIndex: number | null = null;
         let indeterminateAttribute: EsTreeNodeOfType<"JSXAttribute"> | null = null;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-prevent-default.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-prevent-default.ts
@@ -14,6 +14,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { resolveJsxElementType } from "../../utils/resolve-jsx-element-type.js";
 
 // HACK: <button> is intentionally omitted. <button type="submit"> (the
 // HTML default inside a form) has a real default action, so calling
@@ -301,7 +302,7 @@ export const noPreventDefault = defineRule({
       : FORM_MESSAGE_GENERIC;
     return {
       JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
-        const elementName = isNodeOfType(node.name, "JSXIdentifier") ? node.name.name : null;
+        const elementName = resolveJsxElementType(node);
         if (!elementName) return;
 
         const targetEventProps = PREVENT_DEFAULT_ELEMENTS.get(elementName);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-uncontrolled-input.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-uncontrolled-input.ts
@@ -9,6 +9,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { resolveJsxElementType } from "../../utils/resolve-jsx-element-type.js";
 
 const UNCONTROLLED_INPUT_TAGS = new Set(["input", "textarea", "select"]);
 
@@ -112,8 +113,7 @@ export const noUncontrolledInput = defineRule({
 
       walkAst(componentBody, (child: EsTreeNode) => {
         if (!isNodeOfType(child, "JSXOpeningElement")) return;
-        if (!isNodeOfType(child.name, "JSXIdentifier")) return;
-        const tagName = child.name.name;
+        const tagName = resolveJsxElementType(child);
         if (!UNCONTROLLED_INPUT_TAGS.has(tagName)) return;
 
         const attributes = child.attributes ?? [];

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-disabled-zoom.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-disabled-zoom.ts
@@ -3,6 +3,7 @@ import { findJsxAttribute } from "../../utils/find-jsx-attribute.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { resolveJsxElementType } from "../../utils/resolve-jsx-element-type.js";
 
 export const noDisabledZoom = defineRule({
   id: "no-disabled-zoom",
@@ -14,7 +15,7 @@ export const noDisabledZoom = defineRule({
     "Remove `user-scalable=no` and `maximum-scale` from the viewport meta tag. If the layout breaks at 200% zoom, fix the layout instead.",
   create: (context: RuleContext) => ({
     JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
-      if (!isNodeOfType(node.name, "JSXIdentifier") || node.name.name !== "meta") return;
+      if (resolveJsxElementType(node) !== "meta") return;
 
       const nameAttr = findJsxAttribute(node.attributes ?? [], "name");
       if (!nameAttr?.value) return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-no-a-element.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-no-a-element.ts
@@ -4,6 +4,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { resolveJsxElementType } from "../../utils/resolve-jsx-element-type.js";
 
 // HACK: `undefined` doubles as "not statically knowable" (dynamic
 // expression), which callers must treat differently from a literal
@@ -30,7 +31,7 @@ export const nextjsNoAElement = defineRule({
     "`import Link from 'next/link'` for client-side navigation, prefetching, and preserved scroll position",
   create: (context: RuleContext) => ({
     JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
-      if (!isNodeOfType(node.name, "JSXIdentifier") || node.name.name !== "a") return;
+      if (resolveJsxElementType(node) !== "a") return;
 
       const attributes = node.attributes ?? [];
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-no-css-link.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-no-css-link.ts
@@ -4,6 +4,7 @@ import { findJsxAttribute } from "../../utils/find-jsx-attribute.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { resolveJsxElementType } from "../../utils/resolve-jsx-element-type.js";
 
 export const nextjsNoCssLink = defineRule({
   id: "nextjs-no-css-link",
@@ -15,7 +16,7 @@ export const nextjsNoCssLink = defineRule({
     "Import CSS directly or use CSS Modules so Next.js can bundle, order, and optimize the stylesheet.",
   create: (context: RuleContext) => ({
     JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
-      if (!isNodeOfType(node.name, "JSXIdentifier") || node.name.name !== "link") return;
+      if (resolveJsxElementType(node) !== "link") return;
       const attributes = node.attributes ?? [];
 
       const relAttribute = findJsxAttribute(attributes, "rel");

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-no-font-link.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-no-font-link.ts
@@ -4,6 +4,7 @@ import { findJsxAttribute } from "../../utils/find-jsx-attribute.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { resolveJsxElementType } from "../../utils/resolve-jsx-element-type.js";
 
 export const nextjsNoFontLink = defineRule({
   id: "nextjs-no-font-link",
@@ -15,7 +16,7 @@ export const nextjsNoFontLink = defineRule({
     '`import { Inter } from "next/font/google"` for self-hosting, zero layout shift, and no render-blocking requests',
   create: (context: RuleContext) => ({
     JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
-      if (!isNodeOfType(node.name, "JSXIdentifier") || node.name.name !== "link") return;
+      if (resolveJsxElementType(node) !== "link") return;
       const attributes = node.attributes ?? [];
 
       const hrefAttribute = findJsxAttribute(attributes, "href");

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-no-img-element.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-no-img-element.ts
@@ -12,6 +12,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import type { RuleVisitors } from "../../utils/rule-visitors.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import { walkAst } from "../../utils/walk-ast.js";
+import { resolveJsxElementType } from "../../utils/resolve-jsx-element-type.js";
 
 const NON_OPTIMIZABLE_SRC_PREFIX_PATTERN = /^\s*(data:|blob:)/i;
 const GENERATED_URL_NAME_PATTERN = /(data|object|blob)_?url/i;
@@ -168,7 +169,7 @@ export const nextjsNoImgElement = defineRule({
 
     return {
       JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
-        if (!isNodeOfType(node.name, "JSXIdentifier") || node.name.name !== "img") return;
+        if (resolveJsxElementType(node) !== "img") return;
         if (isGeneratedImageRenderContext(context, node)) return;
 
         const programRoot = findProgramRoot(node);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-no-polyfill-script.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-no-polyfill-script.ts
@@ -4,6 +4,7 @@ import { findJsxAttribute } from "../../utils/find-jsx-attribute.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { resolveJsxElementType } from "../../utils/resolve-jsx-element-type.js";
 
 export const nextjsNoPolyfillScript = defineRule({
   id: "nextjs-no-polyfill-script",
@@ -15,8 +16,8 @@ export const nextjsNoPolyfillScript = defineRule({
     "Next.js includes polyfills for fetch, Promise, Object.assign, Array.from, and 50+ others automatically",
   create: (context: RuleContext) => ({
     JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
-      if (!isNodeOfType(node.name, "JSXIdentifier")) return;
-      if (node.name.name !== "script" && node.name.name !== "Script") return;
+      const elementName = resolveJsxElementType(node);
+      if (elementName !== "script" && elementName !== "Script") return;
 
       const srcAttribute = findJsxAttribute(node.attributes ?? [], "src");
       if (!srcAttribute?.value) return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-img-lazy-with-high-fetchpriority.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-img-lazy-with-high-fetchpriority.ts
@@ -1,8 +1,8 @@
 import { defineRule } from "../../utils/define-rule.js";
 import { getJsxPropStringValue } from "../../utils/get-jsx-prop-string-value.js";
 import { hasJsxPropIgnoreCase } from "../../utils/has-jsx-prop-ignore-case.js";
-import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { resolveJsxElementType } from "../../utils/resolve-jsx-element-type.js";
 
 const MESSAGE =
   '`<img loading="lazy">` defers the request while `fetchPriority="high"` asks the browser to rush it, so the two directives contradict each other. Drop one: keep `fetchPriority="high"` (and eager loading) for an LCP image, or `loading="lazy"` for a below-the-fold one.';
@@ -15,7 +15,7 @@ export const noImgLazyWithHighFetchpriority = defineRule({
     'Don\'t combine `loading="lazy"` with `fetchPriority="high"`. A high-priority image (usually the LCP) should load eagerly; a lazy image is by definition not high priority.',
   create: (context) => ({
     JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
-      if (!isNodeOfType(node.name, "JSXIdentifier") || node.name.name !== "img") return;
+      if (resolveJsxElementType(node) !== "img") return;
 
       const loadingAttribute = hasJsxPropIgnoreCase(node.attributes, "loading");
       if (!loadingAttribute || getJsxPropStringValue(loadingAttribute)?.toLowerCase() !== "lazy") {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/rendering-animate-svg-wrapper.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/rendering-animate-svg-wrapper.ts
@@ -4,6 +4,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { resolveJsxElementType } from "../../utils/resolve-jsx-element-type.js";
 
 export const renderingAnimateSvgWrapper = defineRule({
   id: "rendering-animate-svg-wrapper",
@@ -14,7 +15,7 @@ export const renderingAnimateSvgWrapper = defineRule({
     "Wrap the SVG in a motion element so animation props apply to a stable wrapper instead of the SVG node itself.",
   create: (context: RuleContext) => ({
     JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
-      if (!isNodeOfType(node.name, "JSXIdentifier") || node.name.name !== "svg") return;
+      if (resolveJsxElementType(node) !== "svg") return;
 
       const hasAnimationProp = node.attributes?.some(
         (attribute: EsTreeNode) =>

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/preact/preact-prefer-ondblclick.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/preact/preact-prefer-ondblclick.ts
@@ -2,6 +2,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { findJsxAttribute } from "../../utils/find-jsx-attribute.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { resolveJsxElementType } from "../../utils/resolve-jsx-element-type.js";
 
 const MESSAGE =
   "Your users get no response from `onDoubleClick` in Preact core, where it never fires, so use `onDblClick` instead, which matches the DOM event name.";
@@ -33,7 +34,7 @@ export const preactPreferOndblclick = defineRule({
   create: (context) => ({
     JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
       if (!isNodeOfType(node.name, "JSXIdentifier")) return;
-      const tagName = node.name.name;
+      const tagName = resolveJsxElementType(node);
       if (tagName.length === 0 || tagName[0] !== tagName[0].toLowerCase()) return;
       const onDoubleClickAttribute = findJsxAttribute(node.attributes, "onDoubleClick");
       if (!onDoubleClickAttribute) return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/preact/preact-prefer-oninput.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/preact/preact-prefer-oninput.ts
@@ -3,6 +3,7 @@ import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { findJsxAttribute } from "../../utils/find-jsx-attribute.js";
 import { getJsxPropStringValue } from "../../utils/get-jsx-prop-string-value.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { resolveJsxElementType } from "../../utils/resolve-jsx-element-type.js";
 
 const PREFER_ONINPUT_MESSAGE =
   "Your users see no live updates because `onChange` on text inputs in Preact core only fires on blur, so use `onInput` instead. `preact/compat` handles this for you.";
@@ -15,7 +16,7 @@ const COMPAT_EXEMPT_INPUT_TYPES = new Set(["checkbox", "radio", "file"]);
 
 const isTextLikeInput = (openingElement: EsTreeNodeOfType<"JSXOpeningElement">): boolean => {
   if (!isNodeOfType(openingElement.name, "JSXIdentifier")) return false;
-  const tagName = openingElement.name.name;
+  const tagName = resolveJsxElementType(openingElement);
   if (tagName === "textarea") return true;
   if (tagName !== "input") return false;
   const typeAttribute = findJsxAttribute(openingElement.attributes, "type");

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/button-has-type.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/button-has-type.regressions.test.ts
@@ -3,6 +3,21 @@ import { runRule } from "../../../test-utils/run-rule.js";
 import { buttonHasType } from "./button-has-type.js";
 
 describe("react-builtins/button-has-type — regressions", () => {
+  it("treats an exact const string JSX alias as a button", () => {
+    const invalidResult = runRule(
+      buttonHasType,
+      'const ButtonTag = "button" as const; const Save = () => <ButtonTag>Save</ButtonTag>;',
+    );
+    const validResult = runRule(
+      buttonHasType,
+      'const ButtonTag = "button" as const; const Save = () => <ButtonTag type="button">Save</ButtonTag>;',
+    );
+    expect(invalidResult.parseErrors).toEqual([]);
+    expect(invalidResult.diagnostics).toHaveLength(1);
+    expect(validResult.parseErrors).toEqual([]);
+    expect(validResult.diagnostics).toEqual([]);
+  });
+
   // Bugbot review: bare `<button type />` is shorthand for
   // `type={true}` — should be flagged as invalid type, not silently
   // accepted via `if (!value) return`.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/button-has-type.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/button-has-type.ts
@@ -11,6 +11,7 @@ import { isCreateElementCall } from "../../utils/is-create-element-call.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isNullishExpression } from "../../utils/is-nullish-expression.js";
 import { isTestlikeFilename } from "../../utils/is-testlike-filename.js";
+import { resolveJsxElementType } from "../../utils/resolve-jsx-element-type.js";
 import type { Rule } from "../../utils/rule.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 
@@ -479,7 +480,7 @@ export const buttonHasType = defineRule({
     return {
       JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
         if (isTestlikeFile) return;
-        if (!isNodeOfType(node.name, "JSXIdentifier") || node.name.name !== "button") return;
+        if (resolveJsxElementType(node) !== "button") return;
         const typeAttr = hasJsxPropIgnoreCase(node.attributes, "type");
         if (!typeAttr) {
           // A spread (`<button {...props} />`) can forward `type` at

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/checked-requires-onchange-or-readonly.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/checked-requires-onchange-or-readonly.ts
@@ -4,6 +4,7 @@ import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { getJsxAttributeName } from "../../utils/get-jsx-attribute-name.js";
 import { isCreateElementCall } from "../../utils/is-create-element-call.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { resolveJsxElementType } from "../../utils/resolve-jsx-element-type.js";
 
 const MISSING_MESSAGE = "Your users can't toggle this input because `checked` has no `onChange`.";
 const EXCLUSIVE_MESSAGE =
@@ -182,7 +183,7 @@ export const checkedRequiresOnchangeOrReadonly = defineRule({
 
     return {
       JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
-        if (!isNodeOfType(node.name, "JSXIdentifier") || node.name.name !== "input") return;
+        if (resolveJsxElementType(node) !== "input") return;
         reportFromPresence(collectFromJsxAttributes(node.attributes));
       },
       CallExpression(node: EsTreeNodeOfType<"CallExpression">) {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/forbid-dom-props.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/forbid-dom-props.ts
@@ -2,6 +2,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { isReactComponentName } from "../../utils/is-react-component-name.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { resolveJsxElementType } from "../../utils/resolve-jsx-element-type.js";
 
 interface ForbiddenPropDescriptor {
   propName: string;
@@ -66,7 +67,7 @@ export const forbidDomProps = defineRule({
       JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
         if (forbidMap.size === 0) return;
         if (!isNodeOfType(node.name, "JSXIdentifier")) return;
-        const elementName = node.name.name;
+        const elementName = resolveJsxElementType(node);
         if (isReactComponentName(elementName)) return; // PascalCase = component
         for (const attribute of node.attributes) {
           if (!isNodeOfType(attribute, "JSXAttribute")) continue;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/forbid-elements.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/forbid-elements.ts
@@ -1,9 +1,9 @@
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { flattenCalleeName } from "../../utils/flatten-callee-name.js";
-import { flattenJsxName } from "../../utils/flatten-jsx-name.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isReactFunctionCall } from "../../utils/is-react-function-call.js";
+import { resolveJsxElementType } from "../../utils/resolve-jsx-element-type.js";
 
 const buildMessage = (element: string, customHelp?: string): string =>
   customHelp
@@ -54,7 +54,7 @@ export const forbidElements = defineRule({
     return {
       JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
         if (forbidMap.size === 0) return;
-        const fullName = flattenJsxName(node.name);
+        const fullName = resolveJsxElementType(node);
         if (!fullName || !forbidMap.has(fullName)) return;
         context.report({
           node: node.name,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/iframe-missing-sandbox.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/iframe-missing-sandbox.ts
@@ -9,6 +9,7 @@ import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isNullishExpression } from "../../utils/is-nullish-expression.js";
 import type { Rule } from "../../utils/rule.js";
 import { skipNonProductionFiles } from "../../utils/skip-non-production-files.js";
+import { resolveJsxElementType } from "../../utils/resolve-jsx-element-type.js";
 
 const ALLOWED_SANDBOX_VALUES = new Set([
   "downloads-without-user-activation",
@@ -87,7 +88,7 @@ export const iframeMissingSandbox = defineRule({
   matchByOccurrence: true,
   create: skipNonProductionFiles((context) => ({
     JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
-      if (!isNodeOfType(node.name, "JSXIdentifier") || node.name.name !== "iframe") return;
+      if (resolveJsxElementType(node) !== "iframe") return;
       const sandboxAttr = hasJsxPropIgnoreCase(node.attributes, "sandbox");
       if (!sandboxAttr) {
         // A fully-opaque spread (`<iframe {...props} />`) can forward

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-no-script-url.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-no-script-url.ts
@@ -1,6 +1,7 @@
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { resolveJsxElementType } from "../../utils/resolve-jsx-element-type.js";
 
 const MESSAGE = "A `javascript:` URL is an XSS hole that runs injected input as code.";
 
@@ -26,11 +27,6 @@ const resolveSettings = (
   if (typeof reactDoctor !== "object" || reactDoctor === null) return {};
   const ruleSettings = (reactDoctor as { jsxNoScriptUrl?: JsxNoScriptUrlSettings }).jsxNoScriptUrl;
   return ruleSettings ?? {};
-};
-
-const getElementName = (node: EsTreeNodeOfType<"JSXOpeningElement">): string | null => {
-  if (isNodeOfType(node.name, "JSXIdentifier")) return node.name.name;
-  return null;
 };
 
 const isLinkPropForElement = (
@@ -64,7 +60,8 @@ export const jsxNoScriptUrl = defineRule({
     const options = resolveSettings(context.settings);
     return {
       JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
-        const elementName = getElementName(node);
+        if (!isNodeOfType(node.name, "JSXIdentifier")) return;
+        const elementName = resolveJsxElementType(node);
         if (!elementName) return;
         for (const attribute of node.attributes) {
           if (!isNodeOfType(attribute, "JSXAttribute")) continue;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-no-target-blank.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-no-target-blank.regressions.test.ts
@@ -8,6 +8,21 @@ import { jsxNoTargetBlank } from "./jsx-no-target-blank.js";
 // always-enabled. These pin the exact corpus shapes that went unreported
 // while the rule was missing.
 describe("react-builtins/jsx-no-target-blank — regressions", () => {
+  it("treats an exact const string JSX alias as an anchor", () => {
+    const invalidResult = runRule(
+      jsxNoTargetBlank,
+      'const AnchorTag = "a" as const; const Link = () => <AnchorTag href="https://example.com" target="_blank">open</AnchorTag>;',
+    );
+    const validResult = runRule(
+      jsxNoTargetBlank,
+      'const AnchorTag = "a" as const; const Link = () => <AnchorTag href="https://example.com" target="_blank" rel="noreferrer">open</AnchorTag>;',
+    );
+    expect(invalidResult.parseErrors).toEqual([]);
+    expect(invalidResult.diagnostics).toHaveLength(1);
+    expect(validResult.parseErrors).toEqual([]);
+    expect(validResult.diagnostics).toEqual([]);
+  });
+
   it("flags an external link with target=_blank and no rel (internxt AuthShell)", () => {
     const result = runRule(
       jsxNoTargetBlank,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-no-target-blank.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-no-target-blank.ts
@@ -2,6 +2,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { resolveJsxElementType } from "../../utils/resolve-jsx-element-type.js";
 
 const NOREFERRER_MESSAGE =
   '`target="_blank"` without `rel="noreferrer"` lets the linked page hijack your tab to a phishing site.';
@@ -238,12 +239,6 @@ const checkTarget = (attributeValue: EsTreeNode): BranchTuple => {
   return { combined: false, testName: "", consequent: false, alternate: false };
 };
 
-const getOpeningElementName = (node: EsTreeNodeOfType<"JSXOpeningElement">): string | null => {
-  const name = node.name as EsTreeNode;
-  if (isNodeOfType(name, "JSXIdentifier")) return name.name;
-  return null;
-};
-
 // Port of `oxc_linter::rules::react::jsx_no_target_blank`.
 export const jsxNoTargetBlank = defineRule({
   id: "jsx-no-target-blank",
@@ -265,7 +260,8 @@ export const jsxNoTargetBlank = defineRule({
     };
     return {
       JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
-        const tagName = getOpeningElementName(node);
+        if (!isNodeOfType(node.name, "JSXIdentifier")) return;
+        const tagName = resolveJsxElementType(node);
         if (!tagName) return;
         if (!isLink(tagName) && !isForm(tagName)) return;
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-string-false-on-boolean-attribute.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-string-false-on-boolean-attribute.ts
@@ -2,6 +2,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import { getJsxPropStringValue } from "../../utils/get-jsx-prop-string-value.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { resolveJsxElementType } from "../../utils/resolve-jsx-element-type.js";
 
 // True HTML boolean attributes: presence means "on", absence means "off".
 // Deliberately EXCLUDES enumerated attributes that legitimately take the
@@ -42,12 +43,13 @@ export const noStringFalseOnBooleanAttribute = defineRule({
       // ASCII letter (a-z). Custom components start uppercase and own their
       // prop semantics (`<Foo disabled="false">` may take a real string).
       if (!isNodeOfType(node.name, "JSXIdentifier")) return;
-      const firstCharacter = node.name.name.charCodeAt(0);
+      const elementName = resolveJsxElementType(node);
+      const firstCharacter = elementName.charCodeAt(0);
       if (firstCharacter < 97 || firstCharacter > 122) return;
       // Custom elements (hyphenated tag names) own their attribute
       // semantics — many web components read `checked="false"` as a real
       // boolean. Matches `no-unknown-property`'s custom-element skip.
-      if (node.name.name.includes("-")) return;
+      if (elementName.includes("-")) return;
 
       for (const attribute of node.attributes) {
         if (!isNodeOfType(attribute, "JSXAttribute")) continue;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-unknown-property.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-unknown-property.ts
@@ -13,6 +13,7 @@ import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { getJsxAttributeName } from "../../utils/get-jsx-attribute-name.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { fileImportsNonReactJsxDialect } from "../../utils/non-react-jsx-dialect.js";
+import { resolveJsxElementType } from "../../utils/resolve-jsx-element-type.js";
 
 interface NoUnknownPropertySettings {
   ignore?: ReadonlyArray<string>;
@@ -119,7 +120,7 @@ export const noUnknownProperty = defineRule({
         }
         if (fileIsNonReactJsx) return;
         if (!isNodeOfType(node.name, "JSXIdentifier")) return;
-        const elementType = node.name.name;
+        const elementType = resolveJsxElementType(node);
         const firstCharacter = elementType.charCodeAt(0);
         const isLowercaseStart = firstCharacter >= 97 && firstCharacter <= 122;
         if (!isLowercaseStart || elementType === "fbt" || elementType === "fbs") return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/style-prop-object.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/style-prop-object.ts
@@ -5,6 +5,7 @@ import { findVariableInitializer } from "../../utils/find-variable-initializer.j
 import { isCreateElementCall } from "../../utils/is-create-element-call.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import { resolveJsxElementType } from "../../utils/resolve-jsx-element-type.js";
 
 const MESSAGE =
   "Your styles don't render because you passed the `style` prop a string instead of an object.";
@@ -125,11 +126,6 @@ const isInvalidStyleExpression = (expression: EsTreeNode): boolean => {
   return false;
 };
 
-const getJsxOpeningElementName = (node: EsTreeNodeOfType<"JSXOpeningElement">): string | null => {
-  if (isNodeOfType(node.name, "JSXIdentifier")) return node.name.name;
-  return null;
-};
-
 // Port of `oxc_linter::rules::react::style_prop_object`. Reports `style`
 // prop values that are clearly not objects: `style="..."` (string),
 // `style={true}` / `style={42}` / `style={"x"}` etc. Also flags
@@ -148,7 +144,8 @@ export const stylePropObject = defineRule({
 
     return {
       JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
-        const elementName = getJsxOpeningElementName(node);
+        if (!isNodeOfType(node.name, "JSXIdentifier")) return;
+        const elementName = resolveJsxElementType(node);
         if (elementName && allowSet.has(elementName)) return;
         // Custom components define their own `style` prop type — many
         // libraries (Expo's `<StatusBar style="auto"/>`, React Native

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/void-dom-elements-no-children.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/void-dom-elements-no-children.ts
@@ -4,6 +4,7 @@ import { isCreateElementCall } from "../../utils/is-create-element-call.js";
 import { isMeaningfulJsxChild } from "../../utils/is-meaningful-jsx-child.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isNullishExpression } from "../../utils/is-nullish-expression.js";
+import { resolveJsxElementType } from "../../utils/resolve-jsx-element-type.js";
 
 const VOID_DOM_ELEMENTS = new Set([
   "area",
@@ -52,8 +53,7 @@ export const voidDomElementsNoChildren = defineRule({
   create: (context) => ({
     JSXElement(node: EsTreeNodeOfType<"JSXElement">) {
       const openingElement = node.openingElement;
-      if (!isNodeOfType(openingElement.name, "JSXIdentifier")) return;
-      const tagName = openingElement.name.name;
+      const tagName = resolveJsxElementType(openingElement);
       if (!VOID_DOM_ELEMENTS.has(tagName)) return;
       const hasChildrenContent = node.children.some(isMeaningfulJsxChild);
       const hasChildrenLikeProp = findChildrenLikePropName(openingElement.attributes);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-ui/utils/get-opening-element-tag-name.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-ui/utils/get-opening-element-tag-name.ts
@@ -1,12 +1,15 @@
 import type { EsTreeNode } from "../../../utils/es-tree-node.js";
 import { isNodeOfType } from "../../../utils/is-node-of-type.js";
+import { resolveJsxElementType } from "../../../utils/resolve-jsx-element-type.js";
 
 export const getOpeningElementTagName = (
   openingElement: EsTreeNode | null | undefined,
 ): string | null => {
   if (!openingElement) return null;
   if (!isNodeOfType(openingElement, "JSXOpeningElement")) return null;
-  if (isNodeOfType(openingElement.name, "JSXIdentifier")) return openingElement.name.name;
+  if (isNodeOfType(openingElement.name, "JSXIdentifier")) {
+    return resolveJsxElementType(openingElement);
+  }
   if (isNodeOfType(openingElement.name, "JSXMemberExpression")) {
     let cursor: EsTreeNode = openingElement.name;
     while (isNodeOfType(cursor, "JSXMemberExpression")) {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-anchor-element.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-start/tanstack-start-no-anchor-element.ts
@@ -6,6 +6,7 @@ import type { RuleVisitors } from "../../utils/rule-visitors.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { findJsxAttribute } from "../../utils/find-jsx-attribute.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { resolveJsxElementType } from "../../utils/resolve-jsx-element-type.js";
 
 const getAttributeStringValue = (attribute: EsTreeNode | undefined): string | null => {
   if (!attribute || !isNodeOfType(attribute, "JSXAttribute") || !attribute.value) return null;
@@ -34,7 +35,7 @@ export const tanstackStartNoAnchorElement = defineRule({
     if (!isInProjectDirectory(context, "routes")) return {};
     return {
       JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
-        if (!isNodeOfType(node.name, "JSXIdentifier") || node.name.name !== "a") return;
+        if (resolveJsxElementType(node) !== "a") return;
 
         const attributes = node.attributes ?? [];
         const hrefAttribute = findJsxAttribute(attributes, "href");

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-element-type.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-element-type.ts
@@ -1,8 +1,7 @@
-import type { EsTreeNode } from "./es-tree-node.js";
 import type { EsTreeNodeOfType } from "./es-tree-node-of-type.js";
 import { getJsxPropStringValue } from "./get-jsx-prop-string-value.js";
 import { hasJsxPropIgnoreCase } from "./has-jsx-prop-ignore-case.js";
-import { isNodeOfType } from "./is-node-of-type.js";
+import { resolveJsxElementType } from "./resolve-jsx-element-type.js";
 
 interface JsxA11ySettings {
   components?: Readonly<Record<string, string>>;
@@ -30,23 +29,11 @@ const readJsxA11ySettings = (
   return a11ySettings;
 };
 
-const flattenJsxName = (name: EsTreeNode): string => {
-  if (isNodeOfType(name, "JSXIdentifier")) return name.name;
-  if (isNodeOfType(name, "JSXMemberExpression")) {
-    const obj = flattenJsxName(name.object);
-    return `${obj}.${name.property.name}`;
-  }
-  if (isNodeOfType(name, "JSXNamespacedName")) {
-    return `${name.namespace.name}:${name.name.name}`;
-  }
-  return "";
-};
-
 const computeElementType = (
   openingElement: EsTreeNodeOfType<"JSXOpeningElement">,
   a11ySettings: JsxA11ySettings,
 ): string => {
-  const baseName = flattenJsxName(openingElement.name as EsTreeNode);
+  const baseName = resolveJsxElementType(openingElement);
 
   if (a11ySettings.polymorphicPropName) {
     const polymorphicAttribute = hasJsxPropIgnoreCase(

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-jsx-element-type.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-jsx-element-type.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vite-plus/test";
+import { attachParentReferences } from "../../test-utils/attach-parent-references.js";
+import { parseFixture } from "../../test-utils/parse-fixture.js";
+import type { EsTreeNodeOfType } from "./es-tree-node-of-type.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+import { resolveJsxElementType } from "./resolve-jsx-element-type.js";
+import { walkAst } from "./walk-ast.js";
+
+const resolveFirstOpeningElementName = (source: string): string => {
+  const parsed = parseFixture(source);
+  attachParentReferences(parsed.program);
+  let openingElement: EsTreeNodeOfType<"JSXOpeningElement"> | null = null;
+  walkAst(parsed.program, (node) => {
+    if (!openingElement && isNodeOfType(node, "JSXOpeningElement")) openingElement = node;
+  });
+  if (!openingElement) throw new Error("Expected a JSX opening element");
+  return resolveJsxElementType(openingElement);
+};
+
+describe("resolveJsxElementType", () => {
+  it("resolves exact local const string bindings through TypeScript wrappers", () => {
+    expect(
+      resolveFirstOpeningElementName(
+        'const ButtonTag = "button" as const; const rendered = <ButtonTag />;',
+      ),
+    ).toBe("button");
+    expect(
+      resolveFirstOpeningElementName(
+        'const AnchorTag = ("a" satisfies string); const rendered = <AnchorTag />;',
+      ),
+    ).toBe("a");
+  });
+
+  it("keeps dynamic and non-const bindings opaque", () => {
+    expect(
+      resolveFirstOpeningElementName(
+        'const DynamicTag = condition ? "button" : "a"; const rendered = <DynamicTag />;',
+      ),
+    ).toBe("DynamicTag");
+    expect(
+      resolveFirstOpeningElementName('let ButtonTag = "button"; const rendered = <ButtonTag />;'),
+    ).toBe("ButtonTag");
+  });
+
+  it("keeps imports, components, and member expressions opaque", () => {
+    expect(
+      resolveFirstOpeningElementName(
+        'import { ButtonTag } from "./button"; const rendered = <ButtonTag />;',
+      ),
+    ).toBe("ButtonTag");
+    expect(
+      resolveFirstOpeningElementName(
+        "const rendered = <ButtonTag />; const ButtonTag = () => <span />;",
+      ),
+    ).toBe("ButtonTag");
+    expect(resolveFirstOpeningElementName("const rendered = <Widgets.Button />;")).toBe(
+      "Widgets.Button",
+    );
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-jsx-element-type.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-jsx-element-type.test.ts
@@ -42,6 +42,14 @@ describe("resolveJsxElementType", () => {
     ).toBe("ButtonTag");
   });
 
+  it("keeps lowercase JSX identifiers intrinsic", () => {
+    expect(
+      resolveFirstOpeningElementName(
+        'const button = "a" as const; const rendered = <button href="/account" />;',
+      ),
+    ).toBe("button");
+  });
+
   it("keeps imports, components, and member expressions opaque", () => {
     expect(
       resolveFirstOpeningElementName(

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-jsx-element-type.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-jsx-element-type.ts
@@ -1,0 +1,44 @@
+import type { EsTreeNode } from "./es-tree-node.js";
+import type { EsTreeNodeOfType } from "./es-tree-node-of-type.js";
+import { findVariableInitializer } from "./find-variable-initializer.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+import { stripParenExpression } from "./strip-paren-expression.js";
+
+const resolveConstantStringBinding = (name: EsTreeNodeOfType<"JSXIdentifier">): string | null => {
+  const binding = findVariableInitializer(name, name.name);
+  if (!binding?.initializer) return null;
+
+  const declarator = binding.bindingIdentifier.parent;
+  if (!declarator || !isNodeOfType(declarator, "VariableDeclarator")) return null;
+  if (declarator.id !== binding.bindingIdentifier) return null;
+
+  const declaration = declarator.parent;
+  if (!declaration || !isNodeOfType(declaration, "VariableDeclaration")) return null;
+  if (declaration.kind !== "const") return null;
+
+  const initializer = stripParenExpression(binding.initializer);
+  return isNodeOfType(initializer, "Literal") && typeof initializer.value === "string"
+    ? initializer.value
+    : null;
+};
+
+const flattenJsxName = (name: EsTreeNode): string => {
+  if (isNodeOfType(name, "JSXIdentifier")) return name.name;
+  if (isNodeOfType(name, "JSXMemberExpression")) {
+    return `${flattenJsxName(name.object)}.${name.property.name}`;
+  }
+  if (isNodeOfType(name, "JSXNamespacedName")) {
+    return `${name.namespace.name}:${name.name.name}`;
+  }
+  return "";
+};
+
+export const resolveJsxElementType = (
+  openingElement: EsTreeNodeOfType<"JSXOpeningElement">,
+): string => {
+  const name = openingElement.name;
+  if (isNodeOfType(name, "JSXIdentifier")) {
+    return resolveConstantStringBinding(name) ?? name.name;
+  }
+  return flattenJsxName(name);
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-jsx-element-type.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-jsx-element-type.ts
@@ -2,6 +2,7 @@ import type { EsTreeNode } from "./es-tree-node.js";
 import type { EsTreeNodeOfType } from "./es-tree-node-of-type.js";
 import { findVariableInitializer } from "./find-variable-initializer.js";
 import { isNodeOfType } from "./is-node-of-type.js";
+import { isUppercaseName } from "./is-uppercase-name.js";
 import { stripParenExpression } from "./strip-paren-expression.js";
 
 const resolveConstantStringBinding = (name: EsTreeNodeOfType<"JSXIdentifier">): string | null => {
@@ -38,6 +39,7 @@ export const resolveJsxElementType = (
 ): string => {
   const name = openingElement.name;
   if (isNodeOfType(name, "JSXIdentifier")) {
+    if (!isUppercaseName(name.name)) return name.name;
     return resolveConstantStringBinding(name) ?? name.name;
   }
   return flattenJsxName(name);


### PR DESCRIPTION
## Summary

- resolve exact local constant-string JSX bindings to their runtime element type
- route all 60 affected host-element rules through the shared resolver
- add registry-wide diagnostic-identity parity plus focused button, anchor, and opaque-binding controls

## Before / after

Before, an exact alias such as a local constant bound to the string button made host-element rules treat the JSX identifier as an opaque component. After, direct host tags and exact constant-string aliases produce the same diagnostics, while dynamic unions, imports, mutable bindings, ordinary components, and member expressions remain opaque.

## Validation

- oxlint-plugin-react-doctor: 544 files, 12,165 passed, 148 skipped
- root typecheck: 15/15 tasks passed
- root lint passed with pre-existing warnings only
- root format check passed
- JSON report smoke passed, schemaVersion 3
- strict fuzz: button-has-type, 500 iterations passed
- strict fuzz: jsx-no-target-blank, 500 iterations passed
- React Doctor changed-scope self-scan selected website and found no changed website source, so it was not a meaningful plugin scan
- RDE local take-10 launched all repositories but produced no completion; it matched the existing harness stall and no corpus result is claimed

The repository-wide test command reached green plugin coverage but unrelated dead-code, performance-harness, and CLI tests timed out while the host was saturated by external benchmark jobs. The affected package suite was rerun independently after rebase and passed in full.

## Scope

This intentionally does not infer through arbitrary components, dynamic strings, imports, mutable bindings, or polymorphic props.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide change to how JSX tag names are resolved across many lint rules; scope is intentionally narrow (exact local const strings only), with strong parity tests, but any resolver bug could shift findings across a large rule surface.
> 
> **Overview**
> Host-element lint rules no longer miss JSX when the tag is a **local `const` string alias** (e.g. `const ButtonTag = "button" as const` then `<ButtonTag />`). A shared **`resolveJsxElementType`** maps lowercase intrinsics as-is, resolves uppercase identifiers only when bound to an exact `const` string literal, and leaves imports, `let`, unions, and member expressions opaque.
> 
> Roughly **60** rules that keyed off raw tag names now use that resolver (a11y, correctness, Next.js, Preact, security, etc.), and **`getElementType`** / **`getOpeningElementTagName`** delegate to it where relevant.
> 
> **Tests:** unit coverage for the resolver; regression cases for `button-has-type` and `jsx-no-target-blank`; a fuzz corpus case for lowercase intrinsic shadowing; and liveness metamorphic tests that assert **diagnostic parity** between direct intrinsics and aliased tags across the affected rule set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c8e7871d77863b456f732de0cfd08b5c02c3ffc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->