### PR TITLE
fix: scan non-JSX files in partial scopes

### DIFF
--- a/.changeset/fuzzy-files-scan.md
+++ b/.changeset/fuzzy-files-scan.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Scan supported non-JSX JavaScript and TypeScript modules in partial and explicit-path scans.

--- a/packages/core/src/editor-scan.ts
+++ b/packages/core/src/editor-scan.ts
@@ -161,7 +161,7 @@ export const runEditorScan = async (input: EditorScanInput): Promise<EditorScanR
     warnings,
     isCi: false,
     resolveLocalGithubViewerPermission: false,
-    skipJsxIncludeFilter: true,
+    skipExplicitIncludePathFilter: true,
     // `layerOtlp` is a no-op unless REACT_DOCTOR_OTLP_ENDPOINT +
     // REACT_DOCTOR_OTLP_AUTH_HEADER are set; when they are, every
     // `runInspect` / `Service.method` span from this scan is exported,

--- a/packages/core/src/explicit-lint-include-paths.ts
+++ b/packages/core/src/explicit-lint-include-paths.ts
@@ -1,17 +1,4 @@
-import { JSX_FILE_PATTERN } from "./constants.js";
-import type { ProjectInfo } from "./types/index.js";
+import { isLintableSourceFile } from "./utils/is-lintable-source-file.js";
 
-export const NEXT_ENTRY_FILE_PATTERN =
-  /^(?:\.\/)?(?:src\/)?(?:middleware|proxy)\.(?:tsx?|jsx?|mts|mjs)$/;
-
-export const shouldIncludeExplicitLintPath = (filePath: string, project?: ProjectInfo): boolean =>
-  JSX_FILE_PATTERN.test(filePath) ||
-  (project?.framework === "nextjs" && NEXT_ENTRY_FILE_PATTERN.test(filePath));
-
-export const computeExplicitLintIncludePaths = (
-  includePaths: string[],
-  project?: ProjectInfo,
-): string[] | undefined =>
-  includePaths.length > 0
-    ? includePaths.filter((filePath) => shouldIncludeExplicitLintPath(filePath, project))
-    : undefined;
+export const computeExplicitLintIncludePaths = (includePaths: string[]): string[] | undefined =>
+  includePaths.length > 0 ? includePaths.filter(isLintableSourceFile) : undefined;

--- a/packages/core/src/resolve-lint-include-paths.ts
+++ b/packages/core/src/resolve-lint-include-paths.ts
@@ -1,12 +1,11 @@
-import type { ProjectInfo, ReactDoctorConfig } from "./types/index.js";
-import { shouldIncludeExplicitLintPath } from "./explicit-lint-include-paths.js";
+import type { ReactDoctorConfig } from "./types/index.js";
 import { compileIgnoredFilePatterns, isFileIgnoredByPatterns } from "./is-ignored-file.js";
+import { isLintableSourceFile } from "./utils/is-lintable-source-file.js";
 import { listSourceFiles } from "./utils/list-source-files.js";
 
 export const resolveLintIncludePaths = (
   rootDirectory: string,
   userConfig: ReactDoctorConfig | null,
-  project?: ProjectInfo,
 ): string[] | undefined => {
   if (!Array.isArray(userConfig?.ignore?.files) || userConfig.ignore.files.length === 0) {
     return undefined;
@@ -15,7 +14,7 @@ export const resolveLintIncludePaths = (
   const ignoredPatterns = compileIgnoredFilePatterns(userConfig);
 
   const includedPaths = listSourceFiles(rootDirectory).filter((filePath) => {
-    if (!shouldIncludeExplicitLintPath(filePath, project)) {
+    if (!isLintableSourceFile(filePath)) {
       return false;
     }
 

--- a/packages/core/src/run-inspect.ts
+++ b/packages/core/src/run-inspect.ts
@@ -116,15 +116,11 @@ export interface InspectInput {
    */
   readonly suppressScanSummary?: boolean;
   /**
-   * When `true`, `includePaths` is linted verbatim instead of being
-   * narrowed to JSX (`.tsx` / `.jsx`) files. The CLI's diff / staged
-   * paths intentionally restrict to JSX so a changed-files scan stays
-   * React-focused, but an editor scanning the exact buffer the user is
-   * editing wants its diagnostics regardless of extension (custom
-   * hooks, server actions, and module-level rules all fire in plain
-   * `.ts`). Defaults to `false` to preserve the CLI contract.
+   * When `true`, `includePaths` is linted verbatim instead of being filtered
+   * to React Doctor's supported source-file set. Editor scans use this for the
+   * exact buffer supplied by the language server.
    */
-  readonly skipJsxIncludeFilter?: boolean;
+  readonly skipExplicitIncludePathFilter?: boolean;
   /**
    * Whether the scanned project's `package.json` is among the changed files
    * in a diff / staged scan. Dependency health is a whole-project property
@@ -459,14 +455,13 @@ export const runInspect = <HooksR = never>(
         : Effect.succeed(null as string | null),
     );
 
-    const explicitLintIncludePaths = input.skipJsxIncludeFilter
+    const explicitLintIncludePaths = input.skipExplicitIncludePathFilter
       ? input.includePaths.length > 0
         ? [...input.includePaths]
         : undefined
-      : computeExplicitLintIncludePaths([...input.includePaths], project);
+      : computeExplicitLintIncludePaths([...input.includePaths]);
     const lintIncludePaths =
-      explicitLintIncludePaths ??
-      resolveLintIncludePaths(scanDirectory, resolvedConfig.config, project);
+      explicitLintIncludePaths ?? resolveLintIncludePaths(scanDirectory, resolvedConfig.config);
 
     // Absolute paths of the exact file set the linter scans, captured ONLY
     // for the multi-project summary (the sole consumer), which signals via

--- a/packages/core/src/types/diagnose.ts
+++ b/packages/core/src/types/diagnose.ts
@@ -8,6 +8,7 @@ export interface DiagnoseOptions {
   /** See `ReactDoctorConfig.deadCode`. Ignored in diff mode. */
   deadCode?: boolean;
   verbose?: boolean;
+  /** Restrict linting to these supported JS/TS source files. */
   includePaths?: string[];
   /**
    * Per-call override for `ReactDoctorConfig.respectInlineDisables`.

--- a/packages/core/src/types/inspect.ts
+++ b/packages/core/src/types/inspect.ts
@@ -125,6 +125,7 @@ export interface InspectOptions {
    * precedence over per-project config on every scan, like `lint`/`deadCode`.
    */
   supplyChain?: boolean;
+  /** Restrict linting to these supported JS/TS source files. */
   includePaths?: string[];
   configOverride?: ReactDoctorConfig | null;
   /**
@@ -312,9 +313,9 @@ export interface JsonReportProjectEntry {
   skippedCheckReasons?: Record<string, string>;
   /**
    * Number of source files this scan's linter examined. In diff / changed
-   * mode it's the count of changed React-eligible files (`.tsx`/`.jsx` plus
-   * framework entry files); in a full scan it's the whole source tree. `0`
-   * in a diff scan means the changed files held nothing React Doctor lints —
+   * mode it's the count of changed supported JS/TS source files; in a full
+   * scan it's the whole source tree. `0` in a diff scan means the changed
+   * files held nothing React Doctor lints —
    * the GitHub Action reads that as "nothing to report" (skips the PR comment;
    * the commit status says "skipped"). Optional: absent on reports from
    * constructors that don't track it (e.g. `toJsonReport`).

--- a/packages/core/tests/resolve-lint-include-paths.test.ts
+++ b/packages/core/tests/resolve-lint-include-paths.test.ts
@@ -2,35 +2,9 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
-import type { ProjectInfo } from "../src/types/index.js";
 import { resolveLintIncludePaths } from "../src/resolve-lint-include-paths.js";
 
 let tempDirectory: string;
-
-const nextProject = (rootDirectory: string): ProjectInfo => ({
-  rootDirectory,
-  projectName: "next-app",
-  reactVersion: "19.0.0",
-  reactMajorVersion: 19,
-  tailwindVersion: null,
-  zodVersion: null,
-  zodMajorVersion: null,
-  framework: "nextjs",
-  hasTypeScript: true,
-  hasReactCompiler: false,
-  hasTanStackQuery: false,
-  nextjsVersion: "^16.0.0",
-  nextjsMajorVersion: 16,
-  hasReactNativeWorkspace: false,
-  expoVersion: null,
-  shopifyFlashListVersion: null,
-  shopifyFlashListMajorVersion: null,
-  hasReanimated: false,
-  isPreES2023Target: false,
-  preactVersion: null,
-  preactMajorVersion: null,
-  sourceFileCount: 0,
-});
 
 const writeFixtureFile = (relativePath: string): void => {
   const absolutePath = path.join(tempDirectory, relativePath);
@@ -47,7 +21,7 @@ describe("resolveLintIncludePaths", () => {
     fs.rmSync(tempDirectory, { recursive: true, force: true });
   });
 
-  it("keeps Next middleware and proxy entries when ignore.files materializes a lint list", () => {
+  it("keeps all supported source files when ignore.files materializes a lint list", () => {
     for (const relativePath of [
       "src/App.tsx",
       "src/ignored.tsx",
@@ -61,12 +35,16 @@ describe("resolveLintIncludePaths", () => {
       writeFixtureFile(relativePath);
     }
 
-    const includedPaths = resolveLintIncludePaths(
-      tempDirectory,
-      { ignore: { files: ["src/ignored.tsx"] } },
-      nextProject(tempDirectory),
-    );
+    const includedPaths = resolveLintIncludePaths(tempDirectory, {
+      ignore: { files: ["src/ignored.tsx"] },
+    });
 
-    expect(includedPaths?.toSorted()).toEqual(["middleware.ts", "src/App.tsx", "src/proxy.mjs"]);
+    expect(includedPaths?.toSorted()).toEqual([
+      "middleware.ts",
+      "nested/middleware.ts",
+      "src/App.tsx",
+      "src/proxy.mjs",
+      "src/server.ts",
+    ]);
   });
 });

--- a/packages/core/tests/run-inspect.test.ts
+++ b/packages/core/tests/run-inspect.test.ts
@@ -848,7 +848,7 @@ describe("runInspect — diff mode skips dead-code", () => {
     expect(output.didDeadCodeFail).toBe(false);
   });
 
-  it("passes Next middleware and proxy entries through to the linter", async () => {
+  it("passes every supported explicit source file through to the linter", async () => {
     const nextProject: ProjectInfo = {
       ...sampleProject,
       framework: "nextjs",
@@ -898,12 +898,14 @@ describe("runInspect — diff mode skips dead-code", () => {
       "/repo/middleware.ts",
       "/repo/src/App.tsx",
       "/repo/src/proxy.mjs",
+      "/repo/src/server.ts",
     ]);
     // The Reporter captures diagnostics as they stream through, before the
     // final sort — so it preserves the linter's arrival (includePaths) order.
     expect(result.captured.map((diagnostic) => diagnostic.filePath)).toEqual([
       "/repo/middleware.ts",
       "/repo/src/proxy.mjs",
+      "/repo/src/server.ts",
       "/repo/src/App.tsx",
     ]);
   });

--- a/packages/react-doctor/src/cli/index.ts
+++ b/packages/react-doctor/src/cli/index.ts
@@ -171,7 +171,7 @@ const program = new Command()
   )
   .option(
     "--scope <value>",
-    "how much to scan/report: full (default), files, changed (only new issues vs base), or lines (only changed lines)",
+    "how much supported JS/TS source to scan/report: full (default), files, changed (only new issues vs base), or lines (only changed lines)",
   )
   .option("--base <ref>", "base git ref for files/changed/lines scope (auto-detected when omitted)")
   .addOption(

--- a/packages/react-doctor/src/cli/utils/build-run-event.ts
+++ b/packages/react-doctor/src/cli/utils/build-run-event.ts
@@ -2,6 +2,7 @@ import {
   filterDiagnosticsForSurface,
   isReactDoctorError,
   isScanComplete,
+  JSX_FILE_PATTERN,
   resolveGithubActionsScoreMetadata,
   summarizeDiagnostics,
 } from "@react-doctor/core";
@@ -471,6 +472,9 @@ const buildScanAttributes = (input: RunEventInput): RunEventAttributes => {
     // Scan extent — how many files this run covered (the denominator for
     // `diag.affectedFiles`). Known only on the success path.
     fileCount: input.result?.scannedFileCount ?? null,
+    nonJsxFileCount:
+      input.result?.analyzedFiles?.filter((filePath) => !JSX_FILE_PATTERN.test(filePath)).length ??
+      null,
   });
 };
 

--- a/packages/react-doctor/tests/build-run-event.test.ts
+++ b/packages/react-doctor/tests/build-run-event.test.ts
@@ -576,6 +576,19 @@ describe("buildRunEventAttributes", () => {
     expect(attributes["timing.scanMs"]).toBeUndefined();
   });
 
+  it("counts analyzed non-JSX source files for partial-scan coverage telemetry", () => {
+    const attributes = buildRunEventAttributes(
+      baseInput({
+        scope: "changed",
+        result: buildResult({
+          analyzedFiles: ["src/App.tsx", "src/hooks.ts", "src/runtime.mjs", "src/View.jsx"],
+          scannedFileCount: 4,
+        }),
+      }),
+    );
+    expect(attributes["scan.nonJsxFileCount"]).toBe(2);
+  });
+
   it("records each scan phase's enabled state, including supply-chain", () => {
     const enabled = buildRunEventAttributes(baseInput());
     expect(enabled["scan.lint"]).toBe(true);

--- a/packages/react-doctor/tests/explicit-lint-include-paths.test.ts
+++ b/packages/react-doctor/tests/explicit-lint-include-paths.test.ts
@@ -6,13 +6,30 @@ describe("computeExplicitLintIncludePaths", () => {
     expect(computeExplicitLintIncludePaths([])).toBeUndefined();
   });
 
-  it("filters to ordinary component-bearing JSX/TSX files", () => {
-    const paths = ["src/app.tsx", "src/utils.ts", "src/Button.jsx", "src/config.js"];
+  it("keeps every supported JS and TS source extension", () => {
+    const paths = [
+      "src/app.tsx",
+      "src/utils.ts",
+      "src/Button.jsx",
+      "src/config.js",
+      "src/hooks.mts",
+      "src/runtime.mjs",
+      "src/legacy.cts",
+      "src/legacy.cjs",
+      "src/styles.css",
+    ];
     const result = computeExplicitLintIncludePaths(paths);
-    expect(result).toEqual(["src/app.tsx", "src/Button.jsx"]);
+    expect(result).toEqual([
+      "src/app.tsx",
+      "src/utils.ts",
+      "src/Button.jsx",
+      "src/config.js",
+      "src/hooks.mts",
+      "src/runtime.mjs",
+    ]);
   });
 
-  it("keeps Next middleware and proxy entry files in Next projects", () => {
+  it("keeps ordinary modules and framework entry files in every project", () => {
     const paths = [
       "middleware.ts",
       "middleware.mjs",
@@ -23,30 +40,7 @@ describe("computeExplicitLintIncludePaths", () => {
       "nested/middleware.ts",
     ];
 
-    const result = computeExplicitLintIncludePaths(paths, {
-      rootDirectory: "/repo",
-      projectName: "next-app",
-      reactVersion: "19.0.0",
-      reactMajorVersion: 19,
-      tailwindVersion: null,
-      zodVersion: null,
-      zodMajorVersion: null,
-      framework: "nextjs",
-      hasTypeScript: true,
-      hasReactCompiler: false,
-      hasTanStackQuery: false,
-      nextjsVersion: "^16.0.0",
-      nextjsMajorVersion: 16,
-      hasReactNativeWorkspace: false,
-      expoVersion: null,
-      shopifyFlashListVersion: null,
-      shopifyFlashListMajorVersion: null,
-      hasReanimated: false,
-      isPreES2023Target: false,
-      preactVersion: null,
-      preactMajorVersion: null,
-      sourceFileCount: 0,
-    });
+    const result = computeExplicitLintIncludePaths(paths);
 
     expect(result).toEqual([
       "middleware.ts",
@@ -54,41 +48,13 @@ describe("computeExplicitLintIncludePaths", () => {
       "src/proxy.ts",
       "src/proxy.mts",
       "src/app.tsx",
+      "src/server.ts",
+      "nested/middleware.ts",
     ]);
   });
 
-  it("does not keep Next entry filenames for non-Next projects", () => {
-    const paths = ["middleware.ts", "src/proxy.mjs", "src/App.tsx"];
-    const result = computeExplicitLintIncludePaths(paths, {
-      rootDirectory: "/repo",
-      projectName: "vite-app",
-      reactVersion: "19.0.0",
-      reactMajorVersion: 19,
-      tailwindVersion: null,
-      zodVersion: null,
-      zodMajorVersion: null,
-      framework: "vite",
-      hasTypeScript: true,
-      hasReactCompiler: false,
-      hasTanStackQuery: false,
-      nextjsVersion: null,
-      nextjsMajorVersion: null,
-      hasReactNativeWorkspace: false,
-      expoVersion: null,
-      shopifyFlashListVersion: null,
-      shopifyFlashListMajorVersion: null,
-      hasReanimated: false,
-      isPreES2023Target: false,
-      preactVersion: null,
-      preactMajorVersion: null,
-      sourceFileCount: 0,
-    });
-
-    expect(result).toEqual(["src/App.tsx"]);
-  });
-
   it("returns empty array when no explicitly lintable files exist", () => {
-    const paths = ["src/utils.ts", "src/config.js"];
+    const paths = ["src/styles.css", "src/data.json", "src/legacy.cjs"];
     const result = computeExplicitLintIncludePaths(paths);
     expect(result).toEqual([]);
   });

--- a/packages/react-doctor/tests/inspect.test.ts
+++ b/packages/react-doctor/tests/inspect.test.ts
@@ -58,6 +58,42 @@ describe("inspect", () => {
     }
   });
 
+  it("lints every supported source extension in an explicit-path scan", async () => {
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-explicit-sources-"));
+    try {
+      const projectDirectory = setupReactProject(projectRoot, "app");
+      const extensions = ["ts", "tsx", "js", "jsx", "mts", "mjs"];
+      const includePaths = extensions.map((extension) => `src/conditional-hook.${extension}`);
+      for (const relativePath of includePaths) {
+        writeFile(
+          path.join(projectDirectory, relativePath),
+          'import { useState } from "react";\nexport const useConditional = (enabled) => { if (enabled) useState(0); };\n',
+        );
+      }
+
+      const result = await inspect(projectDirectory, {
+        lint: true,
+        deadCode: false,
+        noScore: true,
+        silent: true,
+        includePaths,
+      });
+
+      expect(result.scannedFileCount).toBe(includePaths.length);
+      expect(result.analyzedFiles?.toSorted()).toEqual(includePaths.toSorted());
+      expect(
+        result.diagnostics
+          .filter((diagnostic) => diagnostic.rule === "rules-of-hooks")
+          .map((diagnostic) => path.extname(diagnostic.filePath))
+          .toSorted(),
+      ).toEqual(extensions.map((extension) => `.${extension}`).toSorted());
+    } finally {
+      consoleSpy.mockRestore();
+      fs.rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
   it("throws when React dependency is missing", async () => {
     const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     try {


### PR DESCRIPTION
## Summary
- lint every supported JavaScript and TypeScript extension in files, changed, lines, staged, and explicit `includePaths` scans
- reuse the canonical `isLintableSourceFile` predicate for both explicit paths and ignore-materialized file lists
- clarify the CLI/API contract and record `scan.nonJsxFileCount` on the existing wide event

## Product contract
Developers expect an explicitly selected supported source file to be analyzed. This removes the JSX-only partial-scan policy without adding a flag or changing the JSON schema. Success is observable as partial runs with `scan.nonJsxFileCount > 0`; revert if that cohort raises scan errors by more than one percentage point across two releases.

## Validation
- core tests: 1,283 passed
- react-doctor tests: 2,202 passed, 27 skipped
- focused final-tree tests: 41 core and 45 react-doctor passed
- `nr typecheck`
- `nr lint` (existing warnings only)
- `nr format`
- `nr build`
- `nr smoke:json-report` (schemaVersion 3)
- React Doctor self-scan selected the website package and found no changed website source, so it was not a meaningful regression signal

## Compatibility
- patch changeset for `react-doctor`
- no new CLI flag, config field, package API, JSON field, or schema-version bump

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands which files run through oxlint in diff/staged/explicit scans, which can change CI findings and scan time without touching auth or schema.
> 
> **Overview**
> **Partial and explicit-path scans now lint all supported JS/TS modules**, not only `.tsx`/`.jsx` (and Next-only entry filenames). Explicit `includePaths` and ignore-materialized file lists both go through **`isLintableSourceFile`** (`.ts`, `.js`, `.mts`, `.mjs`, etc., minus generated bundles), so changed/files/lines/staged runs can analyze hooks, server modules, and middleware-style paths in any framework.
> 
> The editor path still passes **`skipExplicitIncludePathFilter`** (renamed from `skipJsxIncludeFilter`) so the language server can lint the exact buffer without that filter. API/docs and `--scope` help text now describe “supported JS/TS source” instead of JSX-only partial scans.
> 
> Telemetry adds **`scan.nonJsxFileCount`** on the run wide event so partial runs that picked up plain `.ts`/`.mjs` files are observable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4317a91a20aa727a817209b060ffcc058f6fad9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->