### PR TITLE
fix: resolve single rest-tuple parameters

### DIFF
--- a/.changeset/silly-tools-listen.md
+++ b/.changeset/silly-tools-listen.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Preserve component and callback diagnostics through single-binding rest-tuple parameters.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-many-boolean-props.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-many-boolean-props.ts
@@ -4,6 +4,7 @@ import { functionContainsReactRenderOutput } from "../../utils/function-contains
 import { isBooleanPrefixedPropName } from "../../utils/is-boolean-prefixed-prop-name.js";
 import { isComponentDeclaration } from "../../utils/is-component-declaration.js";
 import { isEventHandlerAttribute } from "../../utils/is-event-handler-attribute.js";
+import { resolveFirstArgumentBinding } from "../../utils/resolve-first-argument-binding.js";
 import { isUppercaseName } from "../../utils/is-uppercase-name.js";
 import { unwrapReactHocFunction } from "../../utils/unwrap-react-hoc-function.js";
 import { walkAst } from "../../utils/walk-ast.js";
@@ -147,15 +148,17 @@ export const noManyBooleanProps = defineRule({
       reportNode: EsTreeNode,
     ): void => {
       if (!param) return;
+      const propsBinding = resolveFirstArgumentBinding(param);
+      if (!propsBinding) return;
       // The component gates (uppercase name) also match non-component
       // factories like `function CreateValidator(options) { … }`, whose
       // `options.isStrict` accesses look like boolean props. Require
       // actual render output before treating the param as component props.
       if (!functionContainsReactRenderOutput(functionNode, context.scopes)) return;
-      if (isNodeOfType(param, "ObjectPattern")) {
+      if (isNodeOfType(propsBinding, "ObjectPattern")) {
         const callbackUsedNames = collectCallbackUsedNames(body, param, context.scopes);
         const booleanLikePropNames: string[] = [];
-        for (const property of param.properties ?? []) {
+        for (const property of propsBinding.properties ?? []) {
           if (!isNodeOfType(property, "Property")) continue;
           const keyName = isNodeOfType(property.key, "Identifier") ? property.key.name : null;
           if (!keyName) continue;
@@ -171,8 +174,8 @@ export const noManyBooleanProps = defineRule({
         reportIfMany(booleanLikePropNames, componentName, reportNode);
         return;
       }
-      if (isNodeOfType(param, "Identifier")) {
-        const accessed = collectBooleanLikePropsFromBody(body, param.name);
+      if (isNodeOfType(propsBinding, "Identifier")) {
+        const accessed = collectBooleanLikePropsFromBody(body, propsBinding.name);
         reportIfMany([...accessed], componentName, reportNode);
       }
     };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/prefer-explicit-variants.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/prefer-explicit-variants.ts
@@ -7,6 +7,7 @@ import { isComponentDeclaration } from "../../utils/is-component-declaration.js"
 import { isInlineFunctionExpression } from "../../utils/is-inline-function-expression.js";
 import { isJsxElementOrFragment } from "../../utils/is-jsx-element-or-fragment.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { resolveFirstArgumentBinding } from "../../utils/resolve-first-argument-binding.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import { walkAst } from "../../utils/walk-ast.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
@@ -81,8 +82,9 @@ const CROSS_CUTTING_STATE_BOOLEAN_NAMES = new Set<string>([
 // so the ternary-test lookup matches what the body actually references.
 const collectBooleanPropBindings = (param: EsTreeNode | undefined): Set<string> => {
   const bindings = new Set<string>();
-  if (!param || !isNodeOfType(param, "ObjectPattern")) return bindings;
-  for (const property of param.properties ?? []) {
+  const propsBinding = resolveFirstArgumentBinding(param);
+  if (!isNodeOfType(propsBinding, "ObjectPattern")) return bindings;
+  for (const property of propsBinding.properties ?? []) {
     if (!isNodeOfType(property, "Property")) continue;
     if (property.computed) continue;
     if (!isNodeOfType(property.key, "Identifier")) continue;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-index-maps.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-index-maps.ts
@@ -9,6 +9,7 @@ import { isInlineFunctionExpression } from "../../utils/is-inline-function-expre
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import { resolveFirstArgumentBinding } from "../../utils/resolve-first-argument-binding.js";
 import { walkAst } from "../../utils/walk-ast.js";
 
 // Only a predicate that tests a SINGLE equality on one field
@@ -32,7 +33,7 @@ const referencesParameter = (
 const isSingleFieldEqualityPredicate = (node: EsTreeNodeOfType<"CallExpression">): boolean => {
   const callback = node.arguments?.[0] as EsTreeNode | undefined;
   if (!isInlineFunctionExpression(callback)) return false;
-  const firstParameter = callback.params?.[0];
+  const firstParameter = resolveFirstArgumentBinding(callback.params?.[0]);
   if (!firstParameter || !isNodeOfType(firstParameter, "Identifier")) return false;
 
   let predicate: EsTreeNode | null = null;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/rerender-memo-with-default-value.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/rerender-memo-with-default-value.ts
@@ -12,6 +12,7 @@ import { isHookCall } from "../../utils/is-hook-call.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isUppercaseName } from "../../utils/is-uppercase-name.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import { resolveFirstArgumentBinding } from "../../utils/resolve-first-argument-binding.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import type { RuleContext } from "../../utils/rule-context.js";
@@ -68,10 +69,11 @@ const collectDefaultedEmptyBindings = (
 ): Map<string, DefaultedEmptyBinding> => {
   const bindings = new Map<string, DefaultedEmptyBinding>();
   const params = (functionNode as { params?: EsTreeNode[] }).params ?? [];
-  for (const param of params) {
-    collectFromObjectPattern(param, bindings);
+  for (const [parameterIndex, param] of params.entries()) {
+    const parameterBinding = parameterIndex === 0 ? resolveFirstArgumentBinding(param) : param;
+    if (parameterBinding) collectFromObjectPattern(parameterBinding, bindings);
   }
-  const propsParam = params[0];
+  const propsParam = resolveFirstArgumentBinding(params[0]);
   const body = (functionNode as { body?: EsTreeNode }).body;
   if (!propsParam || !isNodeOfType(propsParam, "Identifier") || !body) return bindings;
   if (!isNodeOfType(body, "BlockStatement")) return bindings;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/rest-tuple-parameters.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/rest-tuple-parameters.regressions.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../test-utils/run-rule.js";
+import { noManyBooleanProps } from "./architecture/no-many-boolean-props.js";
+import { preferExplicitVariants } from "./architecture/prefer-explicit-variants.js";
+import { jsIndexMaps } from "./js-performance/js-index-maps.js";
+import { rerenderMemoWithDefaultValue } from "./performance/rerender-memo-with-default-value.js";
+import { noPassDataToParent } from "./state-and-effects/no-pass-data-to-parent.js";
+import { noPassLiveStateToParent } from "./state-and-effects/no-pass-live-state-to-parent.js";
+
+describe("single rest-tuple parameter regressions", () => {
+  it("preserves no-many-boolean-props diagnostics", () => {
+    const result = runRule(
+      noManyBooleanProps,
+      `const Toggle = (...[{ isOpen, isLoading, hasIcon, canEdit }]: [Props]) => <div />;`,
+      { filename: "fixture.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("preserves prefer-explicit-variants diagnostics", () => {
+    const result = runRule(
+      preferExplicitVariants,
+      `const Composer = (...[{ isThread, isEditing }]: [Props]) => (
+        <div>
+          {isThread ? <ThreadHeader /> : <ChannelHeader />}
+          {isEditing ? <EditForm /> : <MessageContent />}
+        </div>
+      );`,
+      { filename: "fixture.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("preserves rerender-memo-with-default-value diagnostics", () => {
+    const result = runRule(
+      rerenderMemoWithDefaultValue,
+      `import { useMemo } from "react";
+const Chart = (...[{ places = [] }]: [Props]) => {
+  const placeByKey = useMemo(() => new Map(places.map((place) => [place.key, place])), [places]);
+  return <div>{placeByKey.size}</div>;
+};`,
+      { filename: "fixture.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("preserves no-pass-data-to-parent diagnostics", () => {
+    const result = runRule(
+      noPassDataToParent,
+      `const Child = (...[props]: [Props]) => {
+        const fetchedData = useSomeAPI();
+        useEffect(() => { props.onLoaded(fetchedData); }, [props, fetchedData]);
+        return null;
+      };`,
+      { filename: "fixture.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("preserves no-pass-live-state-to-parent diagnostics", () => {
+    const result = runRule(
+      noPassLiveStateToParent,
+      `const Child = (...[props]: [Props]) => {
+        const [results] = useState([]);
+        useEffect(() => { props.search(results); }, [props, results]);
+        return null;
+      };`,
+      { filename: "fixture.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("preserves js-index-maps diagnostics", () => {
+    const result = runRule(
+      jsIndexMaps,
+      `function findUsers(ids, users) {
+        for (const id of ids) users.find((...[user]: [User]) => user.id === id);
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("keeps multi-argument rest tuples opaque", () => {
+    const componentResult = runRule(
+      noManyBooleanProps,
+      `const Toggle = (...[{ isOpen, isLoading, hasIcon, canEdit }, mode]: [Props, string]) => <div>{mode}</div>;`,
+      { filename: "fixture.tsx" },
+    );
+    const callbackResult = runRule(
+      jsIndexMaps,
+      `function findUsers(ids, users) {
+        for (const id of ids) users.find((...[user, index]: [User, number]) => user.id === id);
+      }`,
+    );
+    expect(componentResult.parseErrors).toEqual([]);
+    expect(componentResult.diagnostics).toEqual([]);
+    expect(callbackResult.parseErrors).toEqual([]);
+    expect(callbackResult.diagnostics).toEqual([]);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/effect/react.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/effect/react.ts
@@ -3,6 +3,7 @@ import type { EsTreeNode } from "../../../../utils/es-tree-node.js";
 import { isAstNode } from "../../../../utils/is-ast-node.js";
 import { isFunctionLike } from "../../../../utils/is-function-like.js";
 import { isNodeOfType } from "../../../../utils/is-node-of-type.js";
+import { resolveFirstArgumentBinding } from "../../../../utils/resolve-first-argument-binding.js";
 import {
   TRANSPARENT_EXPRESSION_WRAPPER_TYPES,
   stripParenExpression,
@@ -350,6 +351,17 @@ export const isProp = (analysis: ProgramAnalysis, ref: Reference): boolean =>
     }),
   );
 
+const isWholePropsParameterBinding = (bindingNode: EsTreeNode): boolean => {
+  if (isFunctionLike(bindingNode.parent)) return true;
+  let declaringFunction: EsTreeNode | null | undefined = bindingNode.parent;
+  while (declaringFunction && !isFunctionLike(declaringFunction)) {
+    declaringFunction = declaringFunction.parent;
+  }
+  return Boolean(
+    declaringFunction && resolveFirstArgumentBinding(declaringFunction.params?.[0]) === bindingNode,
+  );
+};
+
 // True when the reference binds the WHOLE props object (`(props) =>`)
 // rather than a destructured prop value (`({ text }) =>`). Calling a
 // method directly on the props object (`props.search(results)`) calls
@@ -361,8 +373,7 @@ export const isWholePropsObjectReference = (analysis: ProgramAnalysis, ref: Refe
   Boolean(
     ref.resolved?.defs.some((def) => {
       if (def.type !== "Parameter") return false;
-      const bindingParent = (def.name as unknown as { parent?: EsTreeNode | null }).parent;
-      return isFunctionLike(bindingParent);
+      return isWholePropsParameterBinding(def.name as unknown as EsTreeNode);
     }),
   );
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-first-argument-binding.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-first-argument-binding.ts
@@ -1,0 +1,15 @@
+import type { EsTreeNode } from "./es-tree-node.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+
+export const resolveFirstArgumentBinding = (
+  firstParameter: EsTreeNode | null | undefined,
+): EsTreeNode | null => {
+  if (!firstParameter) return null;
+  if (!isNodeOfType(firstParameter, "RestElement")) return firstParameter;
+  if (!isNodeOfType(firstParameter.argument, "ArrayPattern")) return null;
+  const elements = firstParameter.argument.elements ?? [];
+  if (elements.length !== 1) return null;
+  const firstBinding = elements[0];
+  if (!firstBinding || isNodeOfType(firstBinding, "RestElement")) return null;
+  return firstBinding;
+};


### PR DESCRIPTION
## Summary
- normalize `(...[binding])` to the same first-argument binding consumed by direct component and callback parameters
- preserve findings for `no-many-boolean-props`, `prefer-explicit-variants`, `rerender-memo-with-default-value`, `no-pass-data-to-parent`, `no-pass-live-state-to-parent`, and `js-index-maps`
- keep multi-element rest tuples opaque so genuinely variadic callbacks are not broadened

## Validation
- full oxlint plugin: 544 files, 12,107 passed, 148 skipped
- focused shared regression suite: 7 passed
- strict fuzz: 500 iterations each for all six affected rules
- root `nr typecheck`, `nr lint`, `nr format`, and `nr build`
- `nr smoke:json-report` (schemaVersion 3)
- built React Doctor scan of the changed plugin package: no findings

## RDE
Local RDE was attempted with 10 repositories. The harness launched all ten but produced no repo completion or result entry; SIGINT/SIGTERM were ignored, so the exact harness process was terminated and its zero-byte cache removed. No RDE result is claimed.

## Release
- patch changeset for `oxlint-plugin-react-doctor`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted AST normalization in lint rules with regression tests; behavior only broadens for the narrow single-element rest-tuple case and deliberately skips multi-element tuples.
> 
> **Overview**
> Adds **`resolveFirstArgumentBinding`** so a lone `(...[binding]: [T])` rest-tuple parameter is treated like a normal first parameter (`binding` or `{ … }`), instead of being ignored by prop/callback analysis.
> 
> **Six rules** now use that helper for the first parameter (or callback arg): `no-many-boolean-props`, `prefer-explicit-variants`, `rerender-memo-with-default-value`, `js-index-maps`, and the parent-pass rules via **`isWholePropsObjectReference`** in effect utilities (`(...[props]: [Props])` counts as the whole props object). Multi-element rest tuples (`...[a, b]`) stay unresolved so variadic signatures are not widened.
> 
> Includes a **regression test suite** for single- and multi-tuple cases and a **patch changeset** for `oxlint-plugin-react-doctor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5a22d7ae19d584aaa9e62ba874c3f5eac3b2013. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->