### PR TITLE
fix: follow synchronous render return indirection

### DIFF
--- a/.changeset/curvy-badgers-dream.md
+++ b/.changeset/curvy-badgers-dream.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Preserve component and memo diagnostics through synchronous local render return indirection.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/rerender-memo-before-early-return.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/rerender-memo-before-early-return.ts
@@ -1,6 +1,7 @@
 import { areExpressionsStructurallyEqual } from "../../utils/are-expressions-structurally-equal.js";
 import { collectReferenceIdentifierNames } from "../../utils/collect-reference-identifier-names.js";
 import { defineRule } from "../../utils/define-rule.js";
+import { functionReturnsMatchingExpression } from "../../utils/function-returns-matching-expression.js";
 import { isComponentAssignment } from "../../utils/is-component-assignment.js";
 import { isHookCall } from "../../utils/is-hook-call.js";
 import { isJsxElementOrFragment } from "../../utils/is-jsx-element-or-fragment.js";
@@ -10,11 +11,12 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
 
 const isJsxExpression = (node: EsTreeNode | null | undefined): boolean =>
   Boolean(node && isJsxElementOrFragment(stripParenExpression(node)));
 
-const callbackReturnsJsx = (callback: EsTreeNode | undefined): boolean => {
+const callbackReturnsJsx = (callback: EsTreeNode | undefined, scopes: ScopeAnalysis): boolean => {
   if (!callback) return false;
   if (
     !isNodeOfType(callback, "ArrowFunctionExpression") &&
@@ -22,15 +24,7 @@ const callbackReturnsJsx = (callback: EsTreeNode | undefined): boolean => {
   ) {
     return false;
   }
-  const body = callback.body;
-  if (isJsxExpression(body)) return true;
-  if (!isNodeOfType(body, "BlockStatement")) return false;
-  for (const stmt of body.body ?? []) {
-    if (isNodeOfType(stmt, "ReturnStatement") && isJsxExpression(stmt.argument)) {
-      return true;
-    }
-  }
-  return false;
+  return functionReturnsMatchingExpression(callback, scopes, isJsxExpression);
 };
 
 const returnArgumentUsesAnyName = (
@@ -184,7 +178,7 @@ export const rerenderMemoBeforeEarlyReturn = defineRule({
             if (
               isNodeOfType(init, "CallExpression") &&
               isHookCall(init, "useMemo") &&
-              callbackReturnsJsx(init.arguments?.[0])
+              callbackReturnsJsx(init.arguments?.[0], context.scopes)
             ) {
               memoNode = declarator;
               callbackGuardTests = collectLeadingCallbackGuardTests(init.arguments?.[0]);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-unstable-nested-components.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-unstable-nested-components.ts
@@ -1,5 +1,6 @@
 import { compileGlob } from "../../utils/compile-glob.js";
 import { defineRule } from "../../utils/define-rule.js";
+import { functionReturnsMatchingExpression } from "../../utils/function-returns-matching-expression.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { isCreateElementCall } from "../../utils/is-create-element-call.js";
@@ -8,6 +9,7 @@ import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isReactComponentName } from "../../utils/is-react-component-name.js";
 import { walkAst } from "../../utils/walk-ast.js";
+import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
 
 const buildMessage = (parentName: string | null): string => {
   let message =
@@ -71,6 +73,13 @@ const expressionContainsJsxOrCreateElement = (root: EsTreeNode): boolean => {
   return found;
 };
 
+const functionContainsJsxOrCreateElement = (
+  functionNode: EsTreeNode,
+  scopes: ScopeAnalysis,
+): boolean =>
+  expressionContainsJsxOrCreateElement(functionNode) ||
+  functionReturnsMatchingExpression(functionNode, scopes, expressionContainsJsxOrCreateElement);
+
 // True iff `classNode` extends React.Component / PureComponent (or a
 // bare `Component` / `PureComponent` symbol — matches the import shape
 // most React class components actually use).
@@ -87,6 +96,7 @@ const isReactClassComponent = (classNode: EsTreeNode): boolean => {
 // Walk up to find the FIRST enclosing function/class component.
 const findEnclosingComponent = (
   node: EsTreeNode,
+  scopes: ScopeAnalysis,
 ): { component: EsTreeNode; name: string | null } | null => {
   let walker: EsTreeNode | null | undefined = node.parent;
   while (walker) {
@@ -95,14 +105,14 @@ const findEnclosingComponent = (
       if (
         componentName &&
         isReactComponentName(componentName) &&
-        expressionContainsJsxOrCreateElement(walker)
+        functionContainsJsxOrCreateElement(walker, scopes)
       ) {
         return { component: walker, name: componentName };
       }
       // Anonymous default-exported function returning JSX counts too.
       if (
         !componentName &&
-        expressionContainsJsxOrCreateElement(walker) &&
+        functionContainsJsxOrCreateElement(walker, scopes) &&
         walker.parent &&
         isNodeOfType(walker.parent, "ExportDefaultDeclaration")
       ) {
@@ -491,7 +501,7 @@ export const noUnstableNestedComponents = defineRule({
         if (renderPropRegex.test(propInfo.propName)) return;
         if (settings.allowAsProps) return;
       }
-      const enclosing = findEnclosingComponent(candidateNode);
+      const enclosing = findEnclosingComponent(candidateNode, context.scopes);
       if (!enclosing) return;
       // A prop / object-callback candidate is instantiated by its
       // consumer, so don't gate it on local instantiation.
@@ -510,7 +520,7 @@ export const noUnstableNestedComponents = defineRule({
         "FunctionDeclaration" | "FunctionExpression" | "ArrowFunctionExpression"
       >,
     ): void => {
-      if (!expressionContainsJsxOrCreateElement(node as EsTreeNode)) {
+      if (!functionContainsJsxOrCreateElement(node as EsTreeNode, context.scopes)) {
         return;
       }
       const inferredName = inferFunctionLikeName(node as EsTreeNode);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/synchronous-render-return-indirection.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/synchronous-render-return-indirection.regressions.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vite-plus/test";
+import { GIANT_COMPONENT_LINE_THRESHOLD } from "../constants/thresholds.js";
+import { runRule } from "../../test-utils/run-rule.js";
+import { noGiantComponent } from "./architecture/no-giant-component.js";
+import { rerenderMemoBeforeEarlyReturn } from "./performance/rerender-memo-before-early-return.js";
+import { noUnstableNestedComponents } from "./react-builtins/no-unstable-nested-components.js";
+
+describe("synchronous render return indirection regressions", () => {
+  it("preserves no-giant-component through a zero-argument render helper", () => {
+    const fillerLines = Array.from(
+      { length: GIANT_COMPONENT_LINE_THRESHOLD },
+      (_, index) => `const value${index} = ${index};`,
+    ).join("\n");
+    const result = runRule(
+      noGiantComponent,
+      `function GiantComponent() {
+        ${fillerLines}
+        const render = () => <main />;
+        return render();
+      }`,
+      { filename: "fixture.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("preserves no-unstable-nested-components through a zero-argument render helper", () => {
+    const result = runRule(
+      noUnstableNestedComponents,
+      `function ParentComponent() {
+        function UnstableChild() {
+          const render = () => <div />;
+          return render();
+        }
+        return <UnstableChild />;
+      }`,
+      { filename: "fixture.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("preserves rerender-memo-before-early-return through local render values", () => {
+    const fixtures = [
+      `function Component({ condition }) {
+        const content = useMemo(() => { const output = <Heavy />; return output; }, []);
+        if (condition) return null;
+        return <div>{content}</div>;
+      }`,
+      `function Component({ condition }) {
+        const content = useMemo(() => { const render = () => <Heavy />; return render(); }, []);
+        if (condition) return null;
+        return <div>{content}</div>;
+      }`,
+      `function Component({ condition }) {
+        const content = useMemo(() => {
+          const output = <Heavy />;
+          if (!output) return null;
+          return output;
+        }, []);
+        if (condition) return null;
+        return <div>{content}</div>;
+      }`,
+    ];
+    for (const fixture of fixtures) {
+      const result = runRule(rerenderMemoBeforeEarlyReturn, fixture, {
+        filename: "fixture.tsx",
+      });
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    }
+  });
+
+  it("keeps parameterized and deferred render helpers opaque", () => {
+    const nestedComponentResult = runRule(
+      noUnstableNestedComponents,
+      `function ParentComponent(value) {
+        function Child() {
+          const render = (input) => <div>{input}</div>;
+          return render(value);
+        }
+        return <Child />;
+      }`,
+      { filename: "fixture.tsx" },
+    );
+    const memoResult = runRule(
+      rerenderMemoBeforeEarlyReturn,
+      `function Component({ condition }) {
+        const content = useMemo(() => { const render = () => <Heavy />; return render; }, []);
+        if (condition) return null;
+        return <div>{String(content)}</div>;
+      }`,
+      { filename: "fixture.tsx" },
+    );
+    expect(nestedComponentResult.parseErrors).toEqual([]);
+    expect(nestedComponentResult.diagnostics).toEqual([]);
+    expect(memoResult.parseErrors).toEqual([]);
+    expect(memoResult.diagnostics).toEqual([]);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/function-contains-react-render-output.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/function-contains-react-render-output.ts
@@ -1,4 +1,5 @@
 import type { EsTreeNode } from "./es-tree-node.js";
+import { functionReturnsMatchingExpression } from "./function-returns-matching-expression.js";
 import { isNodeOfType } from "./is-node-of-type.js";
 import { isReactApiCall, type ReactApiCallOptions } from "./is-react-api-call.js";
 import { walkAst } from "./walk-ast.js";
@@ -34,16 +35,17 @@ const isCallArgumentFunctionExpression = (node: EsTreeNode): boolean => {
 const isNestedRenderEvidenceBoundary = (node: EsTreeNode): boolean =>
   NESTED_RENDER_EVIDENCE_BOUNDARY_TYPES.has(node.type) && !isCallArgumentFunctionExpression(node);
 
+const isRenderOutputExpression = (node: EsTreeNode, scopes: ScopeAnalysis): boolean =>
+  node.type === "JSXElement" ||
+  node.type === "JSXFragment" ||
+  isReactApiCall(node, "createElement", scopes, REACT_CREATE_ELEMENT_OPTIONS);
+
 const containsRenderOutput = (rootNode: EsTreeNode, scopes: ScopeAnalysis): boolean => {
   let hasRenderOutput = false;
   walkAst(rootNode, (node: EsTreeNode): boolean | void => {
     if (hasRenderOutput) return false;
     if (node !== rootNode && isNestedRenderEvidenceBoundary(node)) return false;
-    if (
-      node.type === "JSXElement" ||
-      node.type === "JSXFragment" ||
-      isReactApiCall(node, "createElement", scopes, REACT_CREATE_ELEMENT_OPTIONS)
-    ) {
+    if (isRenderOutputExpression(node, scopes)) {
       hasRenderOutput = true;
       return false;
     }
@@ -71,7 +73,11 @@ export const functionContainsReactRenderOutput = (
 ): boolean => {
   const cachedEntry = renderOutputCache.get(functionNode);
   if (cachedEntry && cachedEntry.scopes === scopes) return cachedEntry.hasRenderOutput;
-  const hasRenderOutput = containsRenderOutput(functionNode, scopes);
+  const hasRenderOutput =
+    containsRenderOutput(functionNode, scopes) ||
+    functionReturnsMatchingExpression(functionNode, scopes, (expression) =>
+      isRenderOutputExpression(expression, scopes),
+    );
   renderOutputCache.set(functionNode, { scopes, hasRenderOutput });
   return hasRenderOutput;
 };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/function-returns-matching-expression.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/function-returns-matching-expression.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vite-plus/test";
+import { analyzeScopes } from "../semantic/scope-analysis.js";
+import { attachParentReferences } from "../../test-utils/attach-parent-references.js";
+import { parseFixture } from "../../test-utils/parse-fixture.js";
+import type { EsTreeNode } from "./es-tree-node.js";
+import { functionReturnsMatchingExpression } from "./function-returns-matching-expression.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+import { walkAst } from "./walk-ast.js";
+
+const mainFunctionReturnsJsx = (code: string): boolean => {
+  const parsed = parseFixture(code);
+  expect(parsed.errors).toEqual([]);
+  attachParentReferences(parsed.program);
+  let mainFunction: EsTreeNode | null = null;
+  walkAst(parsed.program, (node) => {
+    if (isNodeOfType(node, "FunctionDeclaration") && node.id?.name === "Main" && !mainFunction) {
+      mainFunction = node;
+    }
+  });
+  if (!mainFunction) throw new Error("Expected a Main function");
+  return functionReturnsMatchingExpression(
+    mainFunction,
+    analyzeScopes(parsed.program),
+    (expression) =>
+      isNodeOfType(expression, "JSXElement") || isNodeOfType(expression, "JSXFragment"),
+  );
+};
+
+describe("functionReturnsMatchingExpression", () => {
+  it("follows returned const values and zero-argument helpers", () => {
+    expect(
+      mainFunctionReturnsJsx(`function Main() { const output = <main />; return output; }`),
+    ).toBe(true);
+    expect(
+      mainFunctionReturnsJsx(`function Main() { const render = () => <main />; return render(); }`),
+    ).toBe(true);
+    expect(
+      mainFunctionReturnsJsx(
+        `function Main() { const render = (() => <main />) as () => JSX.Element; return render(); }`,
+      ),
+    ).toBe(true);
+    expect(
+      mainFunctionReturnsJsx(
+        `function Main(condition) { const output = <main />; return condition ? output : null; }`,
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps deferred, mutable, parameterized, imported, and recursive values opaque", () => {
+    expect(
+      mainFunctionReturnsJsx(`function Main() { const render = () => <main />; return render; }`),
+    ).toBe(false);
+    expect(
+      mainFunctionReturnsJsx(`function Main() { let output = <main />; return output; }`),
+    ).toBe(false);
+    expect(
+      mainFunctionReturnsJsx(`function Main() { let render = () => <main />; return render(); }`),
+    ).toBe(false);
+    expect(
+      mainFunctionReturnsJsx(
+        `function Main() { const render = (value) => <main>{value}</main>; return render("x"); }`,
+      ),
+    ).toBe(false);
+    expect(
+      mainFunctionReturnsJsx(
+        `import { render } from "./render"; function Main() { return render(); }`,
+      ),
+    ).toBe(false);
+    expect(
+      mainFunctionReturnsJsx(`function Main() { const render = () => render(); return render(); }`),
+    ).toBe(false);
+    expect(
+      mainFunctionReturnsJsx(
+        `function Main() { const render = async () => <main />; return render(); }`,
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/function-returns-matching-expression.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/function-returns-matching-expression.ts
@@ -1,0 +1,95 @@
+import type { ScopeAnalysis } from "../semantic/scope-analysis.js";
+import type { EsTreeNode } from "./es-tree-node.js";
+import { isFunctionLike } from "./is-function-like.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+import { stripParenExpression } from "./strip-paren-expression.js";
+import { walkAst } from "./walk-ast.js";
+
+const collectReturnedExpressions = (functionNode: EsTreeNode): EsTreeNode[] => {
+  if (!isFunctionLike(functionNode)) return [];
+  const body = functionNode.body;
+  if (!body) return [];
+  if (!isNodeOfType(body, "BlockStatement")) return [body];
+  const returnedExpressions: EsTreeNode[] = [];
+  walkAst(body, (node) => {
+    if (
+      node !== body &&
+      (isFunctionLike(node) ||
+        isNodeOfType(node, "ClassDeclaration") ||
+        isNodeOfType(node, "ClassExpression"))
+    ) {
+      return false;
+    }
+    if (isNodeOfType(node, "ReturnStatement") && node.argument) {
+      returnedExpressions.push(node.argument);
+    }
+  });
+  return returnedExpressions;
+};
+
+export const functionReturnsMatchingExpression = (
+  functionNode: EsTreeNode,
+  scopes: ScopeAnalysis,
+  matchesExpression: (expression: EsTreeNode) => boolean,
+): boolean => {
+  const visitedExpressions = new Set<EsTreeNode>();
+  const visitedFunctions = new Set<EsTreeNode>();
+
+  const functionMatches = (candidateFunction: EsTreeNode): boolean => {
+    if (visitedFunctions.has(candidateFunction)) return false;
+    visitedFunctions.add(candidateFunction);
+    return collectReturnedExpressions(candidateFunction).some(expressionMatches);
+  };
+
+  const expressionMatches = (expression: EsTreeNode): boolean => {
+    const unwrappedExpression = stripParenExpression(expression);
+    if (visitedExpressions.has(unwrappedExpression)) return false;
+    visitedExpressions.add(unwrappedExpression);
+    if (matchesExpression(unwrappedExpression)) return true;
+
+    if (isNodeOfType(unwrappedExpression, "Identifier")) {
+      const symbol = scopes.symbolFor(unwrappedExpression);
+      if (!symbol || symbol.kind !== "const" || !symbol.initializer) return false;
+      const initializer = stripParenExpression(symbol.initializer);
+      if (isFunctionLike(initializer)) return false;
+      return expressionMatches(initializer);
+    }
+
+    if (isNodeOfType(unwrappedExpression, "CallExpression")) {
+      if (unwrappedExpression.arguments.length !== 0) return false;
+      if (!isNodeOfType(unwrappedExpression.callee, "Identifier")) return false;
+      const symbol = scopes.symbolFor(unwrappedExpression.callee);
+      if (!symbol || (symbol.kind !== "const" && symbol.kind !== "function")) return false;
+      const initializer = symbol.initializer ? stripParenExpression(symbol.initializer) : null;
+      const candidateFunction = isFunctionLike(initializer)
+        ? initializer
+        : isFunctionLike(symbol.declarationNode)
+          ? symbol.declarationNode
+          : null;
+      if (
+        !candidateFunction ||
+        candidateFunction.async ||
+        candidateFunction.generator ||
+        candidateFunction.params.length !== 0
+      ) {
+        return false;
+      }
+      return functionMatches(candidateFunction);
+    }
+
+    if (isNodeOfType(unwrappedExpression, "ConditionalExpression")) {
+      return (
+        expressionMatches(unwrappedExpression.consequent) ||
+        expressionMatches(unwrappedExpression.alternate)
+      );
+    }
+    if (isNodeOfType(unwrappedExpression, "LogicalExpression")) {
+      return (
+        expressionMatches(unwrappedExpression.left) || expressionMatches(unwrappedExpression.right)
+      );
+    }
+    return false;
+  };
+
+  return functionMatches(functionNode);
+};


### PR DESCRIPTION
## Summary
- follow returned `const` values and directly invoked zero-argument helpers when classifying React render output
- restore `no-giant-component`, `no-unstable-nested-components`, and `rerender-memo-before-early-return` through local return indirection
- keep mutable, imported, parameterized, async, recursive, and deferred function values opaque

## Validation
- full oxlint plugin: 545 files, 12,106 passed, 148 skipped
- focused final-tree suites: 4 files, 33 passed
- strict fuzz: 500 iterations each for all three affected rules
- root `nr typecheck`, `nr lint`, `nr format`, and `nr build`
- `nr smoke:json-report` (schemaVersion 3)
- built React Doctor scan: 14 pre-existing warnings in unrelated files, none in this change

## RDE
Local RDE was attempted with 10 repositories. The harness launched all ten but produced no repo completion or result entry; SIGTERM was ignored, so the exact harness process was terminated and its zero-byte cache removed. No RDE result is claimed.

## Release
- patch changeset for `oxlint-plugin-react-doctor`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-only heuristic changes in the oxlint plugin with targeted tests; no runtime app or security impact, though classification edge cases could shift diagnostic counts slightly.
> 
> **Overview**
> Adds **`functionReturnsMatchingExpression`**, which treats components and memo callbacks as producing JSX when output is reached via **local `const` indirection** or **synchronous zero-argument helpers** (`return output`, `return render()`), using scope analysis with deliberate limits.
> 
> **`functionContainsReactRenderOutput`** now uses that helper, so rules like **`no-giant-component`** still fire when JSX is only returned through those patterns. **`no-unstable-nested-components`** and **`rerender-memo-before-early-return`** call the same logic directly instead of only scanning immediate returns or inline JSX.
> 
> **Opaque cases stay opaque**: deferred function values, `let`, parameterized helpers, imports, async helpers, and recursion still do not count as render output. Regression and unit tests cover the restored diagnostics and the negative cases. Patch changeset for **`oxlint-plugin-react-doctor`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5eeac922f108d84fcd345452f3efa079794dedf5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->