### PR TITLE
fix(cli): retain multiline diagnostics in line scope

### DIFF
--- a/.changeset/tiny-spans-touch.md
+++ b/.changeset/tiny-spans-touch.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Keep diagnostics whose multiline source spans intersect changed lines in line-scoped scans.

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -750,3 +750,5 @@ export const SUPPLY_CHAIN_ALERT_NOTE_MAX_CHARS = 160;
 // Next rule family — so a low Socket score would be redundant noise rather
 // than an actionable, distinct supply-chain signal.
 export const SUPPLY_CHAIN_IGNORED_PACKAGES: ReadonlySet<string> = new Set(["next"]);
+
+export const LINE_FEED_UTF8_BYTE = 10;

--- a/packages/core/src/runners/oxlint/parse-output.ts
+++ b/packages/core/src/runners/oxlint/parse-output.ts
@@ -1,3 +1,4 @@
+import * as fs from "node:fs";
 import * as path from "node:path";
 import reactDoctorPlugin from "oxlint-plugin-react-doctor";
 import type {
@@ -8,8 +9,10 @@ import type {
   ProjectInfo,
 } from "../../types/index.js";
 import { ERROR_PREVIEW_LENGTH_CHARS, OCCURRENCE_MATCHED_CATEGORIES } from "../../constants.js";
+import { findJsxOpenerSpan } from "../../find-jsx-opener-span.js";
 import { isLintableSourceFile } from "../../utils/is-lintable-source-file.js";
 import { isMinifiedSource } from "../../utils/is-minified-source.js";
+import { lineOfUtf8Offset } from "../../utils/line-of-utf8-offset.js";
 import { OxlintOutputUnparseable, ReactDoctorError } from "../../errors.js";
 import { getCapabilities } from "../../project-info/capabilities.js";
 import { appendReanimatedSharedValueHint } from "../../utils/append-reanimated-shared-value-hint.js";
@@ -311,10 +314,34 @@ export const parseOxlintOutput = (
   // bypassing whole-tree discovery) or when they're too small for the
   // discovery-time size gate. Cached so each file is read at most once.
   const minifiedFileCache = new Map<string, boolean>();
+  const sourceBufferCache = new Map<string, Buffer | null>();
+  const sourceLinesCache = new Map<string, string[] | null>();
+  const resolveAbsolutePath = (filename: string): string =>
+    path.isAbsolute(filename) ? filename : path.resolve(rootDirectory || ".", filename);
+  const readSourceBuffer = (filename: string): Buffer | null => {
+    const absolutePath = resolveAbsolutePath(filename);
+    const cached = sourceBufferCache.get(absolutePath);
+    if (cached !== undefined) return cached;
+    let sourceBuffer: Buffer | null;
+    try {
+      sourceBuffer = fs.readFileSync(absolutePath);
+    } catch {
+      sourceBuffer = null;
+    }
+    sourceBufferCache.set(absolutePath, sourceBuffer);
+    return sourceBuffer;
+  };
+  const readSourceLines = (filename: string): string[] | null => {
+    const absolutePath = resolveAbsolutePath(filename);
+    const cached = sourceLinesCache.get(absolutePath);
+    if (cached !== undefined) return cached;
+    const sourceBuffer = readSourceBuffer(filename);
+    const sourceLines = sourceBuffer ? sourceBuffer.toString("utf8").split("\n") : null;
+    sourceLinesCache.set(absolutePath, sourceLines);
+    return sourceLines;
+  };
   const isMinifiedDiagnosticFile = (filename: string): boolean => {
-    const absolutePath = path.isAbsolute(filename)
-      ? filename
-      : path.resolve(rootDirectory || ".", filename);
+    const absolutePath = resolveAbsolutePath(filename);
     const cached = minifiedFileCache.get(absolutePath);
     if (cached !== undefined) return cached;
     const minified = isMinifiedSource(absolutePath);
@@ -347,8 +374,29 @@ export const parseOxlintOutput = (
       // in-memory document. `line` / `column` stay the source of truth
       // for everything else; offset / length are additive.
       const primarySpan = primaryLabel?.span;
+      const sourceBuffer = primarySpan ? readSourceBuffer(diagnostic.filename) : null;
       const relatedLocations = buildRelatedLocations(diagnostic.labels, normalizedFilePath);
       const category = resolveDiagnosticCategory(plugin, rule);
+      const matchByOccurrence = resolveMatchByOccurrence(rule, category);
+      const sourceLines = primarySpan ? readSourceLines(diagnostic.filename) : null;
+      const primaryLineIndex = primarySpan ? primarySpan.line - 1 : -1;
+      const primaryLine = sourceLines?.[primaryLineIndex];
+      const primaryColumnIndex = primarySpan ? primarySpan.column - 1 : -1;
+      const isJsxTagLabel =
+        primaryLine !== undefined &&
+        primaryColumnIndex >= 0 &&
+        (primaryLine[primaryColumnIndex] === "<" || primaryLine[primaryColumnIndex - 1] === "<");
+      const jsxOpenerEndLineIndex =
+        sourceLines && isJsxTagLabel ? findJsxOpenerSpan(sourceLines, primaryLineIndex) : null;
+      const primarySpanEndLine =
+        jsxOpenerEndLineIndex !== null
+          ? jsxOpenerEndLineIndex + 1
+          : primarySpan && sourceBuffer
+            ? lineOfUtf8Offset(
+                sourceBuffer,
+                primarySpan.offset + Math.max(primarySpan.length - 1, 0),
+              )
+            : undefined;
       return {
         filePath: normalizedFilePath,
         plugin,
@@ -360,9 +408,15 @@ export const parseOxlintOutput = (
         url: diagnostic.url,
         line: primarySpan?.line ?? 0,
         column: primarySpan?.column ?? 0,
-        ...(primarySpan ? { offset: primarySpan.offset, length: primarySpan.length } : {}),
+        ...(primarySpan
+          ? {
+              offset: primarySpan.offset,
+              length: primarySpan.length,
+              ...(primarySpanEndLine !== undefined ? { endLine: primarySpanEndLine } : {}),
+            }
+          : {}),
         category,
-        ...(resolveMatchByOccurrence(rule, category) ? { matchByOccurrence: true } : {}),
+        ...(matchByOccurrence ? { matchByOccurrence: true } : {}),
         ...(relatedLocations.length > 0 ? { relatedLocations } : {}),
       };
     });

--- a/packages/core/src/runners/oxlint/suppress-memoization-in-bailed-out-functions.ts
+++ b/packages/core/src/runners/oxlint/suppress-memoization-in-bailed-out-functions.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import ts from "typescript";
 import type { Diagnostic } from "../../types/index.js";
+import { lineOfUtf8Offset } from "../../utils/line-of-utf8-offset.js";
 
 const MANUAL_MEMOIZATION_PLUGIN = "react-doctor";
 const MANUAL_MEMOIZATION_RULE = "react-compiler-no-manual-memoization";
@@ -49,17 +50,6 @@ const findOutermostEnclosingFunctionRange = (
   };
   visit(sourceFile);
   return foundRange;
-};
-
-const NEWLINE_BYTE = 10;
-
-const lineOfUtf8Offset = (sourceBuffer: Buffer, utf8Offset: number): number => {
-  let lineNumber = 1;
-  const scanEnd = Math.min(utf8Offset, sourceBuffer.length);
-  for (let byteIndex = 0; byteIndex < scanEnd; byteIndex++) {
-    if (sourceBuffer[byteIndex] === NEWLINE_BYTE) lineNumber++;
-  }
-  return lineNumber;
 };
 
 /**

--- a/packages/core/src/types/inspect.ts
+++ b/packages/core/src/types/inspect.ts
@@ -156,8 +156,8 @@ export interface InspectOptions {
    */
   baseline?: { ref: string };
   /**
-   * Restrict reported diagnostics to those landing on the lines the change
-   * touched (`--scope lines`). Each entry is one changed file with the
+   * Restrict reported diagnostics to those whose source spans intersect the
+   * lines the change touched (`--scope lines`). Each entry is one changed file with the
    * inclusive 1-based `[start, end]` line ranges the diff added/modified,
    * keyed by a path relative to the scanned directory (forward slashes).
    * Applied at the same post-lint seam as `baseline` — the score is still

--- a/packages/core/src/utils/line-of-utf8-offset.ts
+++ b/packages/core/src/utils/line-of-utf8-offset.ts
@@ -1,0 +1,10 @@
+import { LINE_FEED_UTF8_BYTE } from "../constants.js";
+
+export const lineOfUtf8Offset = (sourceBuffer: Buffer, utf8Offset: number): number => {
+  let lineNumber = 1;
+  const scanEnd = Math.min(utf8Offset, sourceBuffer.length);
+  for (let byteIndex = 0; byteIndex < scanEnd; byteIndex++) {
+    if (sourceBuffer[byteIndex] === LINE_FEED_UTF8_BYTE) lineNumber++;
+  }
+  return lineNumber;
+};

--- a/packages/core/tests/oxlint-diagnostic-span.test.ts
+++ b/packages/core/tests/oxlint-diagnostic-span.test.ts
@@ -1,0 +1,68 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import { parseOxlintOutput } from "../src/runners/oxlint/parse-output.js";
+import { buildProject } from "./helpers/oxlint-parse-harness.js";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const temporaryDirectory of temporaryDirectories.splice(0)) {
+    fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+  }
+});
+
+describe("parseOxlintOutput primary spans", () => {
+  it("derives the inclusive end line from an oxlint UTF-8 byte span", () => {
+    const temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-span-"));
+    temporaryDirectories.push(temporaryDirectory);
+    const filename = path.join(temporaryDirectory, "App.tsx");
+    const source = [
+      "export const App = () => (",
+      "  <button",
+      '    className="primary"',
+      "    disabled",
+      "  >Save</button>",
+      ");",
+    ].join("\n");
+    fs.writeFileSync(filename, source);
+    const spanStart = Buffer.byteLength(source.slice(0, source.indexOf("<button")));
+    const spanEnd = Buffer.byteLength(source.slice(0, source.indexOf(">Save") + 1));
+    const stdout = JSON.stringify({
+      diagnostics: [
+        {
+          message: "Button is missing an explicit type",
+          code: "react-doctor(button-has-type)",
+          severity: "error",
+          causes: [],
+          url: "",
+          help: "",
+          filename,
+          labels: [
+            {
+              label: "",
+              span: {
+                offset: spanStart,
+                length: spanEnd - spanStart,
+                line: 2,
+                column: 3,
+              },
+            },
+          ],
+          related: [],
+        },
+      ],
+      number_of_files: 1,
+      number_of_rules: 1,
+    });
+
+    const [diagnostic] = parseOxlintOutput(
+      stdout,
+      buildProject({ rootDirectory: temporaryDirectory }),
+      temporaryDirectory,
+    );
+
+    expect(diagnostic).toMatchObject({ line: 2, endLine: 5, offset: spanStart });
+  });
+});

--- a/packages/react-doctor/src/cli/index.ts
+++ b/packages/react-doctor/src/cli/index.ts
@@ -171,7 +171,7 @@ const program = new Command()
   )
   .option(
     "--scope <value>",
-    "how much supported JS/TS source to scan/report: full (default), files, changed (only new issues vs base), or lines (only changed lines)",
+    "how much supported JS/TS source to scan/report: full (default), files, changed (only new issues vs base), or lines (issues whose source spans touch changed lines)",
   )
   .option("--base <ref>", "base git ref for files/changed/lines scope (auto-detected when omitted)")
   .addOption(

--- a/packages/react-doctor/src/cli/utils/build-run-event.ts
+++ b/packages/react-doctor/src/cli/utils/build-run-event.ts
@@ -475,6 +475,10 @@ const buildScanAttributes = (input: RunEventInput): RunEventAttributes => {
     nonJsxFileCount:
       input.result?.analyzedFiles?.filter((filePath) => !JSX_FILE_PATTERN.test(filePath)).length ??
       null,
+    multilineDiagnosticCount:
+      input.result?.diagnostics.filter(
+        (diagnostic) => (diagnostic.endLine ?? diagnostic.line) > diagnostic.line,
+      ).length ?? null,
   });
 };
 

--- a/packages/react-doctor/src/cli/utils/ci/ci-provider.ts
+++ b/packages/react-doctor/src/cli/utils/ci/ci-provider.ts
@@ -144,7 +144,7 @@ const BLOCKING_SUMMARY: Record<BlockingLevel, string> = {
 const SCOPE_SUMMARY: Record<ScopeValue, string> = {
   full: "Scan the whole project on every run",
   files: "Report every issue in changed files",
-  lines: "Report issues on changed lines",
+  lines: "Report issues whose source spans touch changed lines",
   changed: "Report only the issues a change introduces",
 };
 

--- a/packages/react-doctor/src/cli/utils/diagnostic-intersects-line-ranges.ts
+++ b/packages/react-doctor/src/cli/utils/diagnostic-intersects-line-ranges.ts
@@ -1,0 +1,12 @@
+import type { Diagnostic } from "@react-doctor/core";
+
+export const diagnosticIntersectsLineRanges = (
+  diagnostic: Diagnostic,
+  lineRanges: ReadonlyArray<readonly [number, number]>,
+): boolean => {
+  const diagnosticEndLine = Math.max(diagnostic.line, diagnostic.endLine ?? diagnostic.line);
+  return lineRanges.some(
+    ([rangeStartLine, rangeEndLine]) =>
+      diagnostic.line <= rangeEndLine && diagnosticEndLine >= rangeStartLine,
+  );
+};

--- a/packages/react-doctor/src/inspect.ts
+++ b/packages/react-doctor/src/inspect.ts
@@ -43,6 +43,7 @@ import type {
   ScoreResult,
 } from "@react-doctor/core";
 import { toForwardSlashes } from "./cli/utils/path-format.js";
+import { diagnosticIntersectsLineRanges } from "./cli/utils/diagnostic-intersects-line-ranges.js";
 import { makeNoopConsole } from "./cli/utils/noop-console.js";
 import { materializeBaselineFiles } from "./cli/utils/materialize-baseline-files.js";
 import { createSourceLineReader } from "./cli/utils/read-source-line.js";
@@ -114,8 +115,8 @@ const recordOnboardingCompletion = (options: ResolvedInspectOptions): void => {
 const formatCategorySelection = (categoryFilters: ReadonlySet<string>): string =>
   [...categoryFilters].join(", ");
 
-// Builds the `--scope lines` predicate: a diagnostic survives when its line
-// falls in a changed range of its file. `changedLineRanges` is keyed by paths
+// Builds the `--scope lines` predicate: a diagnostic survives when its source
+// span intersects a changed range of its file. `changedLineRanges` is keyed by paths
 // relative to `directory`; diagnostic paths are normalized the same way so
 // absolute and relative forms both match.
 const buildChangedLineMatcher = (
@@ -134,7 +135,7 @@ const buildChangedLineMatcher = (
     );
     const ranges = rangesByFile.get(relativePath);
     if (ranges === undefined) return false;
-    return ranges.some(([start, end]) => diagnostic.line >= start && diagnostic.line <= end);
+    return diagnosticIntersectsLineRanges(diagnostic, ranges);
   };
 };
 
@@ -741,7 +742,7 @@ const runInspectWithRuntime = async (
       baselineDelta = comparison.baselineDelta;
     }
   } else if (options.changedLineRanges !== null && isDiffMode) {
-    // `--scope lines`: keep only diagnostics on the lines the change touched.
+    // `--scope lines`: keep diagnostics whose source spans touch the change.
     // Runs at the same post-lint seam as baseline (the score is already
     // computed on the full head set), so the gate, summary, and inline
     // comments all narrow together.

--- a/packages/react-doctor/tests/build-run-event.test.ts
+++ b/packages/react-doctor/tests/build-run-event.test.ts
@@ -110,6 +110,22 @@ describe("buildRunEventAttributes", () => {
     }
   });
 
+  it("records how many surfaced diagnostics span multiple lines", () => {
+    const attributes = buildRunEventAttributes(
+      baseInput({
+        result: buildResult({
+          diagnostics: [
+            buildDiagnostic({ line: 2, endLine: 5 }),
+            buildDiagnostic({ line: 8, endLine: 8 }),
+            buildDiagnostic({ line: 10 }),
+          ],
+        }),
+      }),
+    );
+
+    expect(attributes["scan.multilineDiagnosticCount"]).toBe(1);
+  });
+
   it("records whether the dead-code pass overlapped lint, and drops it on the failure path", () => {
     expect(
       buildRunEventAttributes(baseInput({ result: buildResult(), deadCodeOverlapped: true }))[

--- a/packages/react-doctor/tests/diagnostic-intersects-line-ranges.test.ts
+++ b/packages/react-doctor/tests/diagnostic-intersects-line-ranges.test.ts
@@ -1,0 +1,42 @@
+import type { Diagnostic } from "@react-doctor/core";
+import { describe, expect, it } from "vite-plus/test";
+import { diagnosticIntersectsLineRanges } from "../src/cli/utils/diagnostic-intersects-line-ranges.js";
+
+const buildDiagnostic = (overrides: Partial<Diagnostic> = {}): Diagnostic => ({
+  filePath: "src/App.tsx",
+  plugin: "react-doctor",
+  rule: "button-has-type",
+  severity: "error",
+  message: "Button is missing an explicit type",
+  help: 'Add type="button"',
+  line: 2,
+  column: 3,
+  category: "Accessibility",
+  ...overrides,
+});
+
+describe("diagnosticIntersectsLineRanges", () => {
+  it("keeps a multiline diagnostic when a changed continuation line intersects its span", () => {
+    const diagnostic = buildDiagnostic({ line: 2, endLine: 5 });
+
+    expect(diagnosticIntersectsLineRanges(diagnostic, [[4, 4]])).toBe(true);
+  });
+
+  it("keeps anchor-line behavior when no end line is available", () => {
+    const diagnostic = buildDiagnostic({ line: 2 });
+
+    expect(diagnosticIntersectsLineRanges(diagnostic, [[2, 2]])).toBe(true);
+    expect(diagnosticIntersectsLineRanges(diagnostic, [[3, 3]])).toBe(false);
+  });
+
+  it("drops a diagnostic whose complete span misses every changed range", () => {
+    const diagnostic = buildDiagnostic({ line: 2, endLine: 5 });
+
+    expect(
+      diagnosticIntersectsLineRanges(diagnostic, [
+        [1, 1],
+        [6, 8],
+      ]),
+    ).toBe(false);
+  });
+});

--- a/packages/react-doctor/tests/regressions/line-scope-multiline-span.test.ts
+++ b/packages/react-doctor/tests/regressions/line-scope-multiline-span.test.ts
@@ -1,0 +1,45 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { runOxlint } from "@react-doctor/core";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import { buildTestProject, setupReactProject } from "./_helpers.js";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const temporaryDirectory of temporaryDirectories.splice(0)) {
+    fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+  }
+});
+
+describe("line-scoped multiline diagnostics", () => {
+  it("carries the complete multiline button span into the parsed diagnostic", async () => {
+    const temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-line-scope-"));
+    temporaryDirectories.push(temporaryDirectory);
+    const projectDirectory = setupReactProject(temporaryDirectory, "multiline-button", {
+      files: {
+        "src/App.tsx": [
+          "export const App = () => (",
+          "  <button",
+          '    className="primary"',
+          "    disabled",
+          "  >",
+          "    Save",
+          "  </button>",
+          ");",
+        ].join("\n"),
+      },
+    });
+    const diagnostics = await runOxlint({
+      rootDirectory: projectDirectory,
+      project: buildTestProject({ rootDirectory: projectDirectory }),
+      userConfig: { rules: { "react-doctor/button-has-type": "error" } },
+    });
+
+    expect(diagnostics.find((diagnostic) => diagnostic.rule === "button-has-type")).toMatchObject({
+      line: 2,
+      endLine: 5,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- derive inclusive diagnostic end lines from oxlint UTF-8 spans
- expand tag-name diagnostics to the end of their JSX opening element using the existing opener scanner
- keep a diagnostic in `--scope lines` whenever its source span intersects a changed hunk
- expose `scan.multilineDiagnosticCount` on the run wide event and clarify the CLI/CI scope wording

## Before / after

```tsx
<button
  className="primary" // changed line
  disabled
>
  Save
</button>
```

Before, `button-has-type` was anchored to the `<button` line and line scope dropped it when only `className` changed. After, the parsed diagnostic carries the opening element through its closing `>`, so interval overlap retains the finding. Diagnostics without a derivable end span keep the prior anchor-line behavior.

## Validation

- focused core span/opener tests: 16 passing
- focused line-scope, real-rule, and telemetry tests: 34 passing
- plugin suite: 545 files, 12,173 passing, 148 skipped
- full workspace suite completed with nine host-contention timeouts; every affected file passed in isolated single-worker reruns (including the performance/profile harness)
- `nr lint`
- `nr typecheck`
- `nr format:check`
- `nr build`
- `nr smoke:json-report`
- React Doctor self-scan exited 0 with five pre-existing findings
- post-rebase focused tests and typechecks pass
- truffler pre/post dedup checks found only the new shared helpers

RDE and rule fuzzing are not applicable: this changes diagnostic span transport and CLI filtering, not a detector's verdict.

## Product guardrail

The user job is to surface findings caused by a changed hunk even when the rule anchors the opening line. `scan.multilineDiagnosticCount` measures adoption. Revert or narrow the expansion if line-scoped blocked-run/noise reports rise by more than 1 percentage point for two consecutive releases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PR/CI line-scoped reporting and diagnostic span shape; behavior widens slightly for multiline findings but is covered by focused tests and falls back to anchor-line when `endLine` is missing.
> 
> **Overview**
> **`--scope lines`** now keeps a finding when its **source span intersects** any changed hunk, not only when the anchor `line` sits on a touched line. That fixes cases like `button-has-type` on a multiline `<button>` where only a later attribute line changed.
> 
> During oxlint parsing, diagnostics gain an inclusive **`endLine`**: from the UTF-8 byte span when possible, and for JSX tag labels the span is extended through the opening element via **`findJsxOpenerSpan`**. **`lineOfUtf8Offset`** is shared (replacing a local copy in memoization suppression).
> 
> CLI/CI copy and **`InspectOptions`** docs describe span intersection. Telemetry adds **`scan.multilineDiagnosticCount`** on the run wide event.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35ac75d15dd5a8053a2c3972363a552a47c6ac49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->