### PR TITLE
fix(rules): resolve React Fragment binding provenance

### DIFF
--- a/.changeset/fresh-fragments-bind.md
+++ b/.changeset/fresh-fragments-bind.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Resolve React Fragment imports and immutable aliases without matching unrelated local components.

--- a/packages/fuzz/corpus/regressions/jsx-fragments--local-fragment-lookalike.tsx
+++ b/packages/fuzz/corpus/regressions/jsx-fragments--local-fragment-lookalike.tsx
@@ -1,0 +1,10 @@
+// rule: jsx-fragments
+// weakness: binding-provenance
+// source: ISSUES_TO_FIX_ASAP.md Fragment lookalike report
+const Fragment = ({ children }: { children: React.ReactNode }) => <section>{children}</section>;
+
+export const Preview = () => (
+  <Fragment>
+    <span />
+  </Fragment>
+);

--- a/packages/fuzz/corpus/regressions/jsx-no-useless-fragment--local-fragment-lookalike.tsx
+++ b/packages/fuzz/corpus/regressions/jsx-no-useless-fragment--local-fragment-lookalike.tsx
@@ -1,0 +1,10 @@
+// rule: jsx-no-useless-fragment
+// weakness: binding-provenance
+// source: ISSUES_TO_FIX_ASAP.md Fragment lookalike report
+const Fragment = ({ children }: { children: React.ReactNode }) => <section>{children}</section>;
+
+export const Preview = () => (
+  <Fragment>
+    <span />
+  </Fragment>
+);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/fragment-binding-provenance.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/fragment-binding-provenance.regressions.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import type { Rule } from "../../utils/rule.js";
+import { jsxFragments } from "./jsx-fragments.js";
+import { jsxNoUselessFragment } from "./jsx-no-useless-fragment.js";
+
+const fragmentRules: ReadonlyArray<Rule> = [jsxFragments, jsxNoUselessFragment];
+
+const expectDiagnosticCount = (code: string, expectedCount: number): void => {
+  for (const rule of fragmentRules) {
+    const result = runRule(rule, code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(expectedCount);
+  }
+};
+
+describe("React Fragment binding provenance", () => {
+  it("recognizes named imports and immutable aliases", () => {
+    expectDiagnosticCount(
+      `import { Fragment } from "react";
+       const Wrapper = Fragment;
+       const View = () => <Wrapper><span /></Wrapper>;`,
+      1,
+    );
+  });
+
+  it("recognizes renamed, default, and namespace React imports", () => {
+    expectDiagnosticCount(
+      `import ReactDefault, { Fragment as ReactFragment } from "react";
+       import * as ReactNamespace from "react";
+       const NamespaceAlias = ReactNamespace;
+       const View = () => (
+         <main>
+           <ReactFragment><span /></ReactFragment>
+           <ReactDefault.Fragment><span /></ReactDefault.Fragment>
+           <NamespaceAlias.Fragment><span /></NamespaceAlias.Fragment>
+         </main>
+       );`,
+      3,
+    );
+  });
+
+  it("ignores an unrelated local component named Fragment", () => {
+    expectDiagnosticCount(
+      `const Fragment = ({ children }) => <section>{children}</section>;
+       const View = () => <Fragment><span /></Fragment>;`,
+      0,
+    );
+  });
+
+  it("honors lexical shadows of a real Fragment import", () => {
+    expectDiagnosticCount(
+      `import { Fragment } from "react";
+       const View = () => {
+         const Fragment = ({ children }) => <section>{children}</section>;
+         return <Fragment><span /></Fragment>;
+       };`,
+      0,
+    );
+  });
+
+  it("ignores same-shaped bindings from unrelated modules and objects", () => {
+    expectDiagnosticCount(
+      `import { Fragment as LibraryFragment } from "./ui";
+       const React = { Fragment: LibraryFragment };
+       const View = () => (
+         <main>
+           <LibraryFragment><span /></LibraryFragment>
+           <React.Fragment><span /></React.Fragment>
+         </main>
+       );`,
+      0,
+    );
+  });
+
+  it("keeps keyed real Fragments exempt", () => {
+    expectDiagnosticCount(
+      `import { Fragment } from "react";
+       const View = () => <Fragment key="stable"><span /></Fragment>;`,
+      0,
+    );
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-fragments.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-fragments.ts
@@ -47,7 +47,7 @@ export const jsxFragments = defineRule({
         // guard.
         if (!node.closingElement) return;
         const openingElement = node.openingElement;
-        if (!isJsxFragmentElement(openingElement as EsTreeNode)) return;
+        if (!isJsxFragmentElement(openingElement as EsTreeNode, context.scopes)) return;
         if (openingElement.attributes.length > 0) return;
         context.report({ node: openingElement, message: SYNTAX_MESSAGE });
       },

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-no-useless-fragment.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-no-useless-fragment.ts
@@ -132,7 +132,7 @@ export const jsxNoUselessFragment = defineRule({
     return {
       JSXElement(node: EsTreeNodeOfType<"JSXElement">) {
         const openingElement = node.openingElement;
-        if (!isJsxFragmentElement(openingElement as EsTreeNode)) return;
+        if (!isJsxFragmentElement(openingElement as EsTreeNode, context.scopes)) return;
         if (hasJsxKeyAttribute(openingElement)) return;
         const didReport = checkChildren(node, openingElement, node.children);
         if (didReport) return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-jsx-fragment-element.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-jsx-fragment-element.ts
@@ -1,20 +1,33 @@
+import type { ScopeAnalysis } from "../semantic/scope-analysis.js";
 import type { EsTreeNode } from "./es-tree-node.js";
+import { getImportedName } from "./get-imported-name.js";
+import { isImportedFromReact, isReactNamespaceImport } from "./is-react-api-call.js";
 import { isNodeOfType } from "./is-node-of-type.js";
+import { resolveConstIdentifierAlias } from "./resolve-const-identifier-alias.js";
 
 // Port of `oxc_linter::utils::react::is_jsx_fragment`. Returns true when a
 // JSXOpeningElement is `<Fragment>` or `<React.Fragment>`. The shorthand
 // `<>...</>` syntax is a separate AST node (`JSXFragment`) and is not
 // covered here.
-export const isJsxFragmentElement = (node: EsTreeNode): boolean => {
+export const isJsxFragmentElement = (node: EsTreeNode, scopes?: ScopeAnalysis): boolean => {
   if (!isNodeOfType(node, "JSXOpeningElement")) return false;
   const elementName = node.name;
 
-  if (isNodeOfType(elementName, "JSXIdentifier")) return elementName.name === "Fragment";
+  if (isNodeOfType(elementName, "JSXIdentifier")) {
+    if (!scopes) return elementName.name === "Fragment";
+    const symbol = resolveConstIdentifierAlias(elementName, scopes);
+    if (!symbol) {
+      return elementName.name === "Fragment" && scopes.isGlobalReference(elementName);
+    }
+    return isImportedFromReact(symbol) && getImportedName(symbol.declarationNode) === "Fragment";
+  }
 
   if (isNodeOfType(elementName, "JSXMemberExpression")) {
     if (!isNodeOfType(elementName.object, "JSXIdentifier")) return false;
-    if (elementName.object.name !== "React") return false;
-    return elementName.property.name === "Fragment";
+    if (elementName.property.name !== "Fragment") return false;
+    if (!scopes) return elementName.object.name === "React";
+    if (isReactNamespaceImport(elementName.object, scopes)) return true;
+    return elementName.object.name === "React" && scopes.isGlobalReference(elementName.object);
   }
 
   return false;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-const-identifier-alias.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-const-identifier-alias.ts
@@ -7,7 +7,9 @@ export const resolveConstIdentifierAlias = (
   identifier: EsTreeNode,
   scopes: ScopeAnalysis,
 ): SymbolDescriptor | null => {
-  if (!isNodeOfType(identifier, "Identifier")) return null;
+  if (!isNodeOfType(identifier, "Identifier") && !isNodeOfType(identifier, "JSXIdentifier")) {
+    return null;
+  }
   const visitedSymbolIds = new Set<number>();
   let symbol = scopes.symbolFor(identifier);
   while (symbol?.kind === "const") {


### PR DESCRIPTION
## Summary

- resolve named, renamed, default, and namespace React Fragment bindings in `jsx-fragments` and `jsx-no-useless-fragment`
- follow exact immutable aliases while honoring lexical shadows
- stop treating unrelated local `Fragment` components and same-shaped non-React bindings as React Fragments
- add focused regressions, fuzz corpus cases, and a patch changeset

## Before

```tsx
const Fragment = ({ children }) => <section>{children}</section>;
<Fragment><span /></Fragment>; // wrongly reported by both rules
```

```tsx
import { Fragment } from "react";
const Wrapper = Fragment;
<Wrapper><span /></Wrapper>; // missed by both rules
```

## After

Both rules use binding provenance: exact React Fragment imports and immutable aliases are diagnosed consistently, unrelated lookalikes stay clean, lexical shadows are respected, and keyed real Fragments remain exempt.

## Validation

- focused Fragment rule tests: 52 passed after rebase
- full oxlint plugin suite: 548 files, 12,184 passed, 148 skipped
- oxlint plugin typecheck
- root lint, typecheck, format check, and JSON-report smoke test
- strict fuzz: 500 cases each for `jsx-fragments` and `jsx-no-useless-fragment`
- React Doctor self-scan: exit 0; only five pre-existing findings
- full root test run: nine known timeout-only failures under host contention; every affected test passed in isolated `--maxWorkers=1` reruns

Local RDE `--take 10` launched all repositories but stalled without producing results on this host. The hung runner was terminated and its zero-byte generated cache was removed; no RDE result is claimed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted false-positive/negative fix in optional default-off JSX style rules, with focused regression and fuzz coverage; no auth or data-path changes.
> 
> **Overview**
> **`jsx-fragments`** and **`jsx-no-useless-fragment`** now pass **`context.scopes`** into **`isJsxFragmentElement`**, so they only target JSX that actually refers to React’s **`Fragment`** (named/renamed imports, default/namespace **`.Fragment`**, and immutable **`const` aliases**), not every tag named **`Fragment`**.
> 
> **`isJsxFragmentElement`** resolves **`JSXIdentifier`** bindings via **`resolveConstIdentifierAlias`** (now supports **`JSXIdentifier`**) and **`isImportedFromReact`**, treats namespace React imports correctly, and falls back to global **`Fragment`** / **`React`** only when scope info is missing. Lexical shadows and non-React lookalikes (local components, imports from other modules) are ignored; keyed real Fragments stay exempt in **`jsx-no-useless-fragment`**.
> 
> Adds **`fragment-binding-provenance.regressions.test.ts`**, fuzz corpus cases for local Fragment lookalikes, and a patch changeset for **`oxlint-plugin-react-doctor`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 051d3e9e0a18514fd427be9c55a72893924b5d52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->