### PR TITLE
fix(core): parse BOM-prefixed package manifests

### DIFF
--- a/.changeset/calm-manifests-read.md
+++ b/.changeset/calm-manifests-read.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Recognize React dependencies in UTF-8 BOM-prefixed package manifests.

--- a/packages/core/src/check-pnpm-hardening.ts
+++ b/packages/core/src/check-pnpm-hardening.ts
@@ -3,12 +3,12 @@ import * as path from "node:path";
 import { RECOMMENDED_PNPM_MINIMUM_RELEASE_AGE_MINUTES } from "./constants.js";
 import { isFile, findMonorepoRoot } from "./project-info/index.js";
 import type { Diagnostic } from "./types/index.js";
+import { stripUtf8Bom } from "./utils/strip-utf8-bom.js";
 
 const PNPM_WORKSPACE_FILE = "pnpm-workspace.yaml";
 const PNPM_LOCKFILE = "pnpm-lock.yaml";
 const PACKAGE_JSON_FILE = "package.json";
 const PNPM_HARDENING_RULE_KEY = "require-pnpm-hardening";
-const UTF8_BOM_CHAR = "\uFEFF";
 
 interface PnpmWorkspaceScalar {
   readonly value: string;
@@ -47,15 +47,12 @@ const stripInlineComment = (rawValue: string): string => {
 
 const unquote = (rawValue: string): string => rawValue.replace(/^["']|["']$/g, "");
 
-const stripBom = (rawContent: string): string =>
-  rawContent.startsWith(UTF8_BOM_CHAR) ? rawContent.slice(UTF8_BOM_CHAR.length) : rawContent;
-
 const parseHardeningSettings = (content: string): PnpmWorkspaceHardeningSettings => {
   let minimumReleaseAge: PnpmWorkspaceScalar | null = null;
   let blockExoticSubdeps: PnpmWorkspaceScalar | null = null;
   let trustPolicy: PnpmWorkspaceScalar | null = null;
 
-  const lines = stripBom(content).split(/\r?\n/);
+  const lines = stripUtf8Bom(content).split(/\r?\n/);
   for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
     const lineText = lines[lineIndex];
     if (lineText === undefined) continue;
@@ -86,7 +83,7 @@ const isPnpmManagedProject = (rootDirectory: string): boolean => {
   const packageJsonPath = path.join(rootDirectory, PACKAGE_JSON_FILE);
   if (!isFile(packageJsonPath)) return false;
   try {
-    const packageJsonRaw = fs.readFileSync(packageJsonPath, "utf-8");
+    const packageJsonRaw = stripUtf8Bom(fs.readFileSync(packageJsonPath, "utf-8"));
     const packageJson: unknown = JSON.parse(packageJsonRaw);
     if (
       packageJson !== null &&

--- a/packages/core/src/project-info/package-json.ts
+++ b/packages/core/src/project-info/package-json.ts
@@ -4,6 +4,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import type { PackageJson } from "../types/index.js";
 import { isErrnoException } from "../utils/is-errno-exception.js";
+import { stripUtf8Bom } from "../utils/strip-utf8-bom.js";
 
 const cachedPackageJsons = new Map<string, PackageJson>();
 
@@ -15,7 +16,7 @@ export const clearPackageJsonCache = (): void => {
 
 const readPackageJsonUncached = (packageJsonPath: string): PackageJson => {
   try {
-    return JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
+    return JSON.parse(stripUtf8Bom(fs.readFileSync(packageJsonPath, "utf-8")));
   } catch (error) {
     if (error instanceof SyntaxError) {
       return {};

--- a/packages/core/src/utils/strip-utf8-bom.ts
+++ b/packages/core/src/utils/strip-utf8-bom.ts
@@ -1,0 +1,4 @@
+const UTF8_BOM_CHARACTER = "\uFEFF";
+
+export const stripUtf8Bom = (content: string): string =>
+  content.startsWith(UTF8_BOM_CHARACTER) ? content.slice(UTF8_BOM_CHARACTER.length) : content;

--- a/packages/core/tests/check-pnpm-hardening.test.ts
+++ b/packages/core/tests/check-pnpm-hardening.test.ts
@@ -513,6 +513,23 @@ describe("checkPnpmHardening (monorepo sub-packages)", () => {
     expectMissingHardeningWarnings(diagnostics);
   });
 
+  it("detects packageManager in a UTF-8 BOM-prefixed package.json", () => {
+    const projectDirectory = path.join(temporaryRoot, "bom-prefixed-package-manager");
+    fs.mkdirSync(projectDirectory, { recursive: true });
+    fs.writeFileSync(
+      path.join(projectDirectory, "package.json"),
+      `\uFEFF${JSON.stringify({
+        name: "bom-prefixed-package-manager",
+        packageManager: "pnpm@9.0.0",
+        dependencies: { react: "^19.0.0" },
+      })}`,
+    );
+
+    const diagnostics = checkPnpmHardening(projectDirectory);
+
+    expectMissingHardeningWarnings(diagnostics);
+  });
+
   it("returns diagnostics for a standalone pnpm project with pnpm-lock.yaml only (no workspace)", () => {
     const standaloneWithLock = path.join(temporaryRoot, "standalone-lock");
     fs.mkdirSync(standaloneWithLock, { recursive: true });

--- a/packages/core/tests/discover-project.test.ts
+++ b/packages/core/tests/discover-project.test.ts
@@ -19,6 +19,22 @@ describe("discoverProject", () => {
     expect(projectInfo.reactVersion).toBe("^19.0.0");
   });
 
+  it("detects React from a UTF-8 BOM-prefixed package.json", () => {
+    const projectDirectory = path.join(tempDirectory, "bom-prefixed-package-json");
+    fs.mkdirSync(projectDirectory, { recursive: true });
+    fs.writeFileSync(
+      path.join(projectDirectory, "package.json"),
+      `\uFEFF${JSON.stringify({
+        name: "bom-prefixed-package-json",
+        dependencies: { react: "^18.3.1" },
+      })}`,
+    );
+
+    const projectInfo = discoverProject(projectDirectory);
+    expect(projectInfo.reactVersion).toBe("^18.3.1");
+    expect(projectInfo.reactMajorVersion).toBe(18);
+  });
+
   it("returns a valid framework", () => {
     const projectInfo = discoverProject(path.join(FIXTURES_DIRECTORY, "basic-react"));
     expect(VALID_FRAMEWORKS).toContain(projectInfo.framework);


### PR DESCRIPTION
## Summary

- strip one leading UTF-8 BOM before parsing `package.json`
- reuse the existing BOM behavior from pnpm workspace parsing through one shared utility
- apply the same decoder to pnpm `packageManager` detection
- add project-discovery and pnpm-hardening regressions plus a patch changeset

## Before

A package manifest accepted by Node and npm could begin with a UTF-8 BOM. React Doctor passed that marker to `JSON.parse`, treated the resulting syntax error as `{}`, lost the React dependency, and skipped every React-gated diagnostic.

## After

BOM-prefixed and ordinary UTF-8 manifests resolve the same React and package-manager capabilities. Existing fail-open behavior for genuinely malformed or unreadable manifests is unchanged by this narrowly scoped decoding fix.

## Validation

- focused core tests: 152 passed after rebase
- root build
- root lint (pre-existing warnings only)
- root typecheck
- JSON report smoke test
- full suite: timeout-only failures under host contention; all affected files passed serial isolated reruns (`16` core tests and `18` CLI tests)

Rule fuzzing and RDE are not applicable because this changes project metadata decoding, not an AST rule or diagnostic verdict implementation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow input-normalization change at read time; malformed JSON still fails open as before.
> 
> **Overview**
> Fixes **false “no React”** behavior when `package.json` starts with a UTF-8 BOM (valid for Node/npm) by stripping `\uFEFF` before `JSON.parse`.
> 
> Adds shared **`stripUtf8Bom`** and uses it in **`readPackageJson`** (project discovery / React version) and in **pnpm hardening** (workspace YAML parsing and `packageManager` detection on `package.json`). Replaces the local BOM helper in the hardening checker.
> 
> Adds regressions for BOM-prefixed manifests in discovery and pnpm detection; **patch changeset** for `react-doctor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb394d985c9a2cd436c75720b6c3a706959f980d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->