### PR TITLE
fix(rule): allow safely validated localStorage payloads

### DIFF
--- a/.changeset/fair-storage-validation.md
+++ b/.changeset/fair-storage-validation.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Allow unversioned localStorage payloads whose reads validate parsed fields and safely fall back.

--- a/packages/fuzz/corpus/regressions/client-localstorage-no-version--validated-payload.tsx
+++ b/packages/fuzz/corpus/regressions/client-localstorage-no-version--validated-payload.tsx
@@ -1,0 +1,31 @@
+// rule: client-localstorage-no-version
+// weakness: control-flow
+// source: react-bench-internal RASMUS_TASKS.md
+
+const STORAGE_KEY = "keybindings";
+const DEFAULT_KEY_BINDINGS = { next: "j", previous: "k" };
+
+const isValidKeybindings = (value: unknown): value is typeof DEFAULT_KEY_BINDINGS => {
+  if (typeof value !== "object" || value === null) return false;
+  return (
+    "next" in value &&
+    typeof value.next === "string" &&
+    "previous" in value &&
+    typeof value.previous === "string"
+  );
+};
+
+const getStoredKeybindings = (): typeof DEFAULT_KEY_BINDINGS => {
+  try {
+    const rawValue = localStorage.getItem(STORAGE_KEY);
+    if (!rawValue) return DEFAULT_KEY_BINDINGS;
+    const parsedValue: unknown = JSON.parse(rawValue);
+    return isValidKeybindings(parsedValue) ? parsedValue : DEFAULT_KEY_BINDINGS;
+  } catch {
+    return DEFAULT_KEY_BINDINGS;
+  }
+};
+
+export const saveKeybindings = (keybindings = getStoredKeybindings()): void => {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(keybindings));
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/client/client-localstorage-no-version.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/client/client-localstorage-no-version.regressions.test.ts
@@ -21,6 +21,107 @@ describe("client/client-localstorage-no-version — regressions", () => {
     expect(result.diagnostics.length).toBeGreaterThan(0);
   });
 
+  it("stays silent when every read validates the parsed payload and falls back safely", () => {
+    const result = runRule(
+      clientLocalstorageNoVersion,
+      `const STORAGE_KEY = "keybindings";
+      const DEFAULT_KEY_BINDINGS = { next: "j", previous: "k" };
+      const isValidKeybindings = (value) => {
+        if (typeof value !== "object" || value === null) return false;
+        const keybindings = value as Record<string, unknown>;
+        return typeof keybindings.next === "string" &&
+          typeof keybindings.previous === "string";
+      };
+      const getStoredKeybindings = () => {
+        try {
+          const rawValue = localStorage.getItem(STORAGE_KEY);
+          if (!rawValue) return DEFAULT_KEY_BINDINGS;
+          const parsedValue = JSON.parse(rawValue);
+          return isValidKeybindings(parsedValue) ? parsedValue : DEFAULT_KEY_BINDINGS;
+        } catch {
+          return DEFAULT_KEY_BINDINGS;
+        }
+      };
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(keybindings));`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still flags readers that parse without validating the payload", () => {
+    const result = runRule(
+      clientLocalstorageNoVersion,
+      `const STORAGE_KEY = "preferences";
+      const getStoredPreferences = () => {
+        try {
+          const rawValue = localStorage.getItem(STORAGE_KEY);
+          return rawValue ? JSON.parse(rawValue) : {};
+        } catch {
+          return {};
+        }
+      };
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(preferences));`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags validation without a parse-error fallback", () => {
+    const result = runRule(
+      clientLocalstorageNoVersion,
+      `const STORAGE_KEY = "preferences";
+      const isValidPreferences = (value) => typeof value.name === "string";
+      const rawValue = localStorage.getItem(STORAGE_KEY);
+      const parsedValue = JSON.parse(rawValue);
+      const preferences = isValidPreferences(parsedValue) ? parsedValue : {};
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(preferences));`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags when validation does not guard the returned payload", () => {
+    const result = runRule(
+      clientLocalstorageNoVersion,
+      `const STORAGE_KEY = "preferences";
+      const isValidPreferences = (value) => typeof value.name === "string";
+      const getStoredPreferences = () => {
+        try {
+          const rawValue = localStorage.getItem(STORAGE_KEY);
+          const parsedValue = JSON.parse(rawValue);
+          isValidPreferences(parsedValue) ? parsedValue : {};
+          return parsedValue;
+        } catch {
+          return {};
+        }
+      };
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(preferences));`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags when another reader of the same key skips validation", () => {
+    const result = runRule(
+      clientLocalstorageNoVersion,
+      `const STORAGE_KEY = "preferences";
+      const isValidPreferences = (value) => typeof value.name === "string";
+      const getSafePreferences = () => {
+        try {
+          const rawValue = localStorage.getItem(STORAGE_KEY);
+          const parsedValue = JSON.parse(rawValue);
+          return isValidPreferences(parsedValue) ? parsedValue : {};
+        } catch {
+          return {};
+        }
+      };
+      const getUncheckedPreferences = () => JSON.parse(localStorage.getItem(STORAGE_KEY));
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(preferences));`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   // Mined miss (glific orgEvalAccessCache): the key was a same-file string
   // constant, not an inline literal, so the Literal-only gate skipped it.
   it("flags a key held in a same-file const string (glific shape)", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/client/client-localstorage-no-version.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/client/client-localstorage-no-version.regressions.test.ts
@@ -101,6 +101,29 @@ describe("client/client-localstorage-no-version — regressions", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("still flags when only a nested helper returns the validated payload", () => {
+    const result = runRule(
+      clientLocalstorageNoVersion,
+      `const STORAGE_KEY = "preferences";
+      const isValidPreferences = (value) => typeof value.name === "string";
+      const getStoredPreferences = () => {
+        try {
+          const rawValue = localStorage.getItem(STORAGE_KEY);
+          const parsedValue = JSON.parse(rawValue);
+          const getValidatedValue = () =>
+            isValidPreferences(parsedValue) ? parsedValue : {};
+          getValidatedValue();
+          return parsedValue;
+        } catch {
+          return {};
+        }
+      };
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(preferences));`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("still flags when another reader of the same key skips validation", () => {
     const result = runRule(
       clientLocalstorageNoVersion,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/client/client-localstorage-no-version.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/client/client-localstorage-no-version.ts
@@ -5,6 +5,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { collectSafelyValidatedLocalStorageKeys } from "../../utils/collect-safely-validated-local-storage-keys.js";
 
 const VERSIONED_KEY_PATTERN = /(?:[._:-]v\d+|@\d+|\bv\d+\b)/i;
 
@@ -56,29 +57,40 @@ export const clientLocalstorageNoVersion = defineRule({
   category: "Correctness",
   recommendation:
     'Put a version in the storage key (e.g. "myKey:v1"). If you change the data shape later, old saved data can be ignored instead of crashing the app.',
-  create: (context: RuleContext) => ({
-    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
-      if (!isNodeOfType(node.callee, "MemberExpression")) return;
-      const receiver = stripParenExpression(node.callee.object);
-      if (!isNodeOfType(receiver, "Identifier")) return;
-      if (receiver.name !== "localStorage") return;
-      if (!isNodeOfType(node.callee.property, "Identifier")) return;
-      if (node.callee.property.name !== "setItem") return;
+  create: (context: RuleContext) => {
+    let safelyValidatedStorageKeys: ReadonlySet<string> = new Set();
+    return {
+      Program(node: EsTreeNodeOfType<"Program">) {
+        safelyValidatedStorageKeys = collectSafelyValidatedLocalStorageKeys({
+          programNode: node,
+          scopes: context.scopes,
+          resolveKey: (keyNode) => resolveStringKey(keyNode, context),
+        });
+      },
+      CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+        if (!isNodeOfType(node.callee, "MemberExpression")) return;
+        const receiver = stripParenExpression(node.callee.object);
+        if (!isNodeOfType(receiver, "Identifier")) return;
+        if (receiver.name !== "localStorage") return;
+        if (!isNodeOfType(node.callee.property, "Identifier")) return;
+        if (node.callee.property.name !== "setItem") return;
 
-      const keyArg = node.arguments?.[0];
-      if (!keyArg) return;
-      const keyValue = resolveStringKey(keyArg, context);
-      if (keyValue === null) return;
-      if (isVersionedKey(keyValue)) return;
+        const keyArg = node.arguments?.[0];
+        if (!keyArg) return;
+        const keyValue = resolveStringKey(keyArg, context);
+        if (keyValue === null) return;
+        if (isVersionedKey(keyValue)) return;
+        if (safelyValidatedStorageKeys.has(keyValue)) return;
 
-      const valueArg = node.arguments?.[1];
-      if (!valueArg) return;
-      if (!isJsonStringifyCall(valueArg)) return;
+        const valueArg = node.arguments?.[1];
+        if (!valueArg) return;
+        if (!isJsonStringifyCall(valueArg)) return;
 
-      context.report({
-        node: keyArg,
-        message: `${receiver.name}.setItem("${keyValue}", JSON.stringify(...)) has no version, so changing the data shape later crashes your users' saved sessions. Add one to the key (e.g. "${keyValue}:v1").`,
-      });
-    },
-  }),
+        context.report({
+          node: keyArg,
+          message: `${receiver.name}.setItem("${keyValue}", JSON.stringify(...)) has no version, so changing the data shape later crashes your users' saved sessions. Add one to the key (e.g. "${keyValue}:v1").`,
+        });
+      },
+    };
+  },
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/collect-safely-validated-local-storage-keys.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/collect-safely-validated-local-storage-keys.ts
@@ -1,0 +1,190 @@
+import type { ScopeAnalysis } from "../semantic/scope-analysis.js";
+import type { EsTreeNode } from "./es-tree-node.js";
+import type { EsTreeNodeOfType } from "./es-tree-node-of-type.js";
+import { isFunctionLike } from "./is-function-like.js";
+import { isGlobalMethodCall } from "./is-global-method-call.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+import { stripParenExpression } from "./strip-paren-expression.js";
+import { walkAst } from "./walk-ast.js";
+
+interface ValidatedLocalStorageAnalysisInput {
+  readonly programNode: EsTreeNode;
+  readonly scopes: ScopeAnalysis;
+  readonly resolveKey: (keyNode: EsTreeNode) => string | null;
+}
+
+const isLocalStorageCall = (node: EsTreeNode, methodName: string): boolean => {
+  if (!isNodeOfType(node, "CallExpression")) return false;
+  const callee = stripParenExpression(node.callee);
+  if (!isNodeOfType(callee, "MemberExpression")) return false;
+  const receiver = stripParenExpression(callee.object);
+  return (
+    isNodeOfType(receiver, "Identifier") &&
+    receiver.name === "localStorage" &&
+    isNodeOfType(callee.property, "Identifier") &&
+    callee.property.name === methodName
+  );
+};
+
+const catchReturnsFallback = (tryStatement: EsTreeNodeOfType<"TryStatement">): boolean => {
+  const handler = tryStatement.handler;
+  if (!handler) return false;
+  let hasReturn = false;
+  let hasThrow = false;
+  walkAst(handler.body, (child) => {
+    if (isFunctionLike(child)) return false;
+    if (isNodeOfType(child, "ReturnStatement")) hasReturn = true;
+    if (isNodeOfType(child, "ThrowStatement")) hasThrow = true;
+  });
+  return hasReturn && !hasThrow;
+};
+
+const resolveValidatorFunction = (callee: EsTreeNode, scopes: ScopeAnalysis): EsTreeNode | null => {
+  const unwrappedCallee = stripParenExpression(callee);
+  if (!isNodeOfType(unwrappedCallee, "Identifier")) return null;
+  const symbol = scopes.symbolFor(unwrappedCallee);
+  if (!symbol) return null;
+  const candidate = symbol.kind === "function" ? symbol.declarationNode : symbol.initializer;
+  return isFunctionLike(candidate) ? candidate : null;
+};
+
+const validatorChecksPayloadProperties = (
+  validatorFunction: EsTreeNode,
+  scopes: ScopeAnalysis,
+): boolean => {
+  if (!isFunctionLike(validatorFunction)) return false;
+  const firstParameter = validatorFunction.params?.[0];
+  if (!firstParameter || !isNodeOfType(firstParameter, "Identifier")) return false;
+  const parameterSymbol = scopes.symbolFor(firstParameter);
+  if (!parameterSymbol) return false;
+  const payloadSymbolIds = new Set([parameterSymbol.id]);
+  let hasPropertyTypeCheck = false;
+  walkAst(validatorFunction.body, (child) => {
+    if (isFunctionLike(child)) return false;
+    if (
+      isNodeOfType(child, "VariableDeclarator") &&
+      isNodeOfType(child.id, "Identifier") &&
+      child.init
+    ) {
+      const initializer = stripParenExpression(child.init);
+      if (isNodeOfType(initializer, "Identifier")) {
+        const initializerSymbol = scopes.symbolFor(initializer);
+        if (initializerSymbol && payloadSymbolIds.has(initializerSymbol.id)) {
+          const aliasSymbol = scopes.symbolFor(child.id);
+          if (aliasSymbol) payloadSymbolIds.add(aliasSymbol.id);
+        }
+      }
+    }
+    if (!isNodeOfType(child, "UnaryExpression") || child.operator !== "typeof") return;
+    const checkedValue = stripParenExpression(child.argument);
+    if (!isNodeOfType(checkedValue, "MemberExpression")) return;
+    const receiver = stripParenExpression(checkedValue.object);
+    if (!isNodeOfType(receiver, "Identifier")) return;
+    const receiverSymbol = scopes.symbolFor(receiver);
+    if (receiverSymbol && payloadSymbolIds.has(receiverSymbol.id)) hasPropertyTypeCheck = true;
+  });
+  return hasPropertyTypeCheck;
+};
+
+const incrementCount = (counts: Map<string, number>, keyValue: string): void => {
+  counts.set(keyValue, (counts.get(keyValue) ?? 0) + 1);
+};
+
+const isReturnedExpression = (expression: EsTreeNode): boolean => {
+  const parent = expression.parent;
+  return Boolean(
+    parent && isNodeOfType(parent, "ReturnStatement") && parent.argument === expression,
+  );
+};
+
+export const collectSafelyValidatedLocalStorageKeys = ({
+  programNode,
+  scopes,
+  resolveKey,
+}: ValidatedLocalStorageAnalysisInput): ReadonlySet<string> => {
+  const readCountsByKey = new Map<string, number>();
+  const safeReadCountsByKey = new Map<string, number>();
+  const safeReadSymbolIds = new Set<number>();
+  walkAst(programNode, (child) => {
+    if (!isNodeOfType(child, "CallExpression") || !isLocalStorageCall(child, "getItem")) {
+      return;
+    }
+    const keyArgument = child.arguments?.[0];
+    if (!keyArgument) return;
+    const keyValue = resolveKey(keyArgument);
+    if (keyValue !== null) incrementCount(readCountsByKey, keyValue);
+  });
+  walkAst(programNode, (child) => {
+    if (!isNodeOfType(child, "TryStatement") || !catchReturnsFallback(child)) return;
+    const rawValueKeys = new Map<number, string>();
+    const parsedValueSources = new Map<number, number>();
+    walkAst(child.block, (tryChild) => {
+      if (
+        isNodeOfType(tryChild, "VariableDeclarator") &&
+        isNodeOfType(tryChild.id, "Identifier") &&
+        tryChild.init
+      ) {
+        const initializer = stripParenExpression(tryChild.init);
+        if (
+          isNodeOfType(initializer, "CallExpression") &&
+          isLocalStorageCall(initializer, "getItem")
+        ) {
+          const keyArgument = initializer.arguments?.[0];
+          const bindingSymbol = scopes.symbolFor(tryChild.id);
+          if (keyArgument && bindingSymbol) {
+            const keyValue = resolveKey(keyArgument);
+            if (keyValue !== null) rawValueKeys.set(bindingSymbol.id, keyValue);
+          }
+        }
+        if (
+          isNodeOfType(initializer, "CallExpression") &&
+          isGlobalMethodCall(initializer, "JSON", "parse")
+        ) {
+          const rawValueArgument = initializer.arguments?.[0];
+          const parsedValueSymbol = scopes.symbolFor(tryChild.id);
+          if (
+            rawValueArgument &&
+            isNodeOfType(rawValueArgument, "Identifier") &&
+            parsedValueSymbol
+          ) {
+            const rawValueSymbol = scopes.symbolFor(rawValueArgument);
+            if (rawValueSymbol && rawValueKeys.has(rawValueSymbol.id)) {
+              parsedValueSources.set(parsedValueSymbol.id, rawValueSymbol.id);
+            }
+          }
+        }
+      }
+      if (!isNodeOfType(tryChild, "ConditionalExpression") || !isReturnedExpression(tryChild)) {
+        return;
+      }
+      const test = stripParenExpression(tryChild.test);
+      if (!isNodeOfType(test, "CallExpression")) return;
+      const testedValue = test.arguments?.[0];
+      if (!testedValue || !isNodeOfType(testedValue, "Identifier")) return;
+      const parsedValueSymbol = scopes.symbolFor(testedValue);
+      if (!parsedValueSymbol) return;
+      const rawValueSymbolId = parsedValueSources.get(parsedValueSymbol.id);
+      if (rawValueSymbolId === undefined) return;
+      const returnedValue = stripParenExpression(tryChild.consequent);
+      if (
+        !isNodeOfType(returnedValue, "Identifier") ||
+        scopes.symbolFor(returnedValue)?.id !== parsedValueSymbol.id
+      ) {
+        return;
+      }
+      const validatorFunction = resolveValidatorFunction(test.callee, scopes);
+      if (!validatorFunction || !validatorChecksPayloadProperties(validatorFunction, scopes)) {
+        return;
+      }
+      const keyValue = rawValueKeys.get(rawValueSymbolId);
+      if (keyValue === undefined || safeReadSymbolIds.has(rawValueSymbolId)) return;
+      safeReadSymbolIds.add(rawValueSymbolId);
+      incrementCount(safeReadCountsByKey, keyValue);
+    });
+  });
+  const safeKeys = new Set<string>();
+  for (const [keyValue, readCount] of readCountsByKey) {
+    if (safeReadCountsByKey.get(keyValue) === readCount) safeKeys.add(keyValue);
+  }
+  return safeKeys;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/collect-safely-validated-local-storage-keys.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/collect-safely-validated-local-storage-keys.ts
@@ -119,6 +119,7 @@ export const collectSafelyValidatedLocalStorageKeys = ({
     const rawValueKeys = new Map<number, string>();
     const parsedValueSources = new Map<number, number>();
     walkAst(child.block, (tryChild) => {
+      if (isFunctionLike(tryChild)) return false;
       if (
         isNodeOfType(tryChild, "VariableDeclarator") &&
         isNodeOfType(tryChild.id, "Identifier") &&


### PR DESCRIPTION
## Summary

- suppress client-localstorage-no-version only when every static reader for the key parses inside try/catch, validates payload properties, and returns the parsed payload only from the valid branch
- retain diagnostics for parse-only, uncaught, unguarded-return, and mixed safe/unsafe reader shapes
- add the react-bench-internal regression to the evolving fuzz corpus and a patch changeset

## Before

A reader that safely validated every parsed field and fell back on invalid or corrupt data still caused the unversioned writer to be reported.

## After

That validated-reader shape is clean. The rule remains conservative: every statically known reader for the key must satisfy the proof, and standalone validation does not suppress an unsafe return.

## Validation

- plugin suite: 548 files passed; 12,190 tests passed; 148 skipped
- plugin typecheck passed
- root build, lint, typecheck, and JSON report smoke passed
- full root suite had nine host-contention timeout-only failures; every affected test passed when rerun serially, including 29 CLI/integration tests, 22 performance tests, and the core parity test
- fuzz package tests: 37 passed; 400 skipped
- strict rule fuzz: 500 iterations with crash, slowness, and metamorphic invariance oracles over /Users/aidenybai/Developer/react-bench-5
- direct false-positive hunt kept this named regression clean; two unrelated existing named regressions and 55 cross-rule candidates were recorded outside this PR
- local RDE launched ten repositories but the harness stalled before producing results; its zero-byte generated cache was removed and the eval checkout was left untouched

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New AST heuristic could miss unsafe reads or over-suppress warnings if validation patterns are incomplete; behavior is constrained by extensive regression tests.
> 
> **Overview**
> **`client-localstorage-no-version`** no longer warns on unversioned `localStorage.setItem(..., JSON.stringify(...))` when static analysis proves **every** `getItem` for that key is handled safely.
> 
> The rule now runs a **`Program`** pass via **`collectSafelyValidatedLocalStorageKeys`**, which looks for reads inside **`try`/`catch`** (catch returns a fallback, no rethrow), **`JSON.parse`** of the raw value, a validator call with **`typeof`** checks on payload properties, and a **`return`** that only uses the parsed value on the valid branch. Keys where all counted readers match that pattern are skipped at **`setItem`** time.
> 
> Unsafe shapes still report: parse-only reads, missing try/catch fallback, returning unvalidated parsed data, validation only in a nested helper, or mixed safe and unsafe readers for the same key.
> 
> Adds regression coverage in the plugin tests, a fuzz corpus sample for the validated-payload case, and a patch changeset for **`oxlint-plugin-react-doctor`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d68a9dae3b020254b07b2c969f16bd7c174e5f14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->