### PR TITLE
fix(rules): tighten ref and updater provenance

### DIFF
--- a/.changeset/late-deer-stand.md
+++ b/.changeset/late-deer-stand.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Avoid false positives in `no-ref-current-in-render` and `no-impure-state-updater` by recognizing lazy ref initialization and proving external API provenance.

--- a/packages/fuzz/corpus/regressions/no-impure-state-updater--deferred-userland-map-callback.tsx
+++ b/packages/fuzz/corpus/regressions/no-impure-state-updater--deferred-userland-map-callback.tsx
@@ -1,0 +1,23 @@
+// rule: no-impure-state-updater
+// weakness: library-idiom
+// source: deep adversarial audit of PR #1175
+
+import { useState } from "react";
+
+const scheduler = {
+  map: (callback: () => void) => () => callback(),
+};
+
+export const Counter = () => {
+  const [count, setCount] = useState(0);
+  const increment = () =>
+    setCount((previousCount) => {
+      const deferred = scheduler.map(() => localStorage.setItem("count", "1"));
+      return previousCount + Number(Boolean(deferred));
+    });
+  return (
+    <button type="button" onClick={increment}>
+      {count}
+    </button>
+  );
+};

--- a/packages/fuzz/corpus/regressions/no-impure-state-updater--pure-userland-geometry.tsx
+++ b/packages/fuzz/corpus/regressions/no-impure-state-updater--pure-userland-geometry.tsx
@@ -1,0 +1,14 @@
+// rule: no-impure-state-updater
+// weakness: name-heuristic
+// source: react-bench recent-rule audit
+import { useState } from "react";
+
+const geometry = {
+  getBoundingClientRect: () => ({ width: 10 }),
+};
+
+export const useWidth = () => {
+  const [width, setWidth] = useState(0);
+  const updateWidth = () => setWidth(() => geometry.getBoundingClientRect().width);
+  return { updateWidth, width };
+};

--- a/packages/fuzz/corpus/regressions/no-impure-state-updater--unrelated-notification-shape.tsx
+++ b/packages/fuzz/corpus/regressions/no-impure-state-updater--unrelated-notification-shape.tsx
@@ -1,0 +1,11 @@
+// rule: no-impure-state-updater
+// weakness: import-provenance
+// source: adversarial audit of recent rules
+import { message } from "./domain-message";
+import { useState } from "react";
+
+export const useValue = () => {
+  const [value, setValue] = useState(0);
+  const updateValue = () => setValue(() => message.info());
+  return { updateValue, value };
+};

--- a/packages/fuzz/corpus/regressions/no-ref-current-in-render--current-alias-guard.tsx
+++ b/packages/fuzz/corpus/regressions/no-ref-current-in-render--current-alias-guard.tsx
@@ -1,0 +1,12 @@
+// rule: no-ref-current-in-render
+// weakness: alias-guard
+// source: deep adversarial audit of PR #1175
+
+import { useRef } from "react";
+
+export const Player = () => {
+  const playerRef = useRef<VideoPlayer | null>(null);
+  const player = playerRef.current;
+  if (player === null) playerRef.current = new VideoPlayer();
+  return null;
+};

--- a/packages/fuzz/corpus/regressions/no-ref-current-in-render--lazy-factory-initialization.tsx
+++ b/packages/fuzz/corpus/regressions/no-ref-current-in-render--lazy-factory-initialization.tsx
@@ -1,0 +1,10 @@
+// rule: no-ref-current-in-render
+// weakness: library-idiom
+// source: react-bench GooeyToast oracle patch
+import { useRef } from "react";
+
+export const Player = () => {
+  const playerRef = useRef(null);
+  if (playerRef.current === null) playerRef.current = createPlayer();
+  return null;
+};

--- a/packages/fuzz/corpus/regressions/no-ref-current-in-render--nullish-assignment-initialization.tsx
+++ b/packages/fuzz/corpus/regressions/no-ref-current-in-render--nullish-assignment-initialization.tsx
@@ -1,0 +1,10 @@
+// rule: no-ref-current-in-render
+// weakness: library-idiom
+// source: react-bench AppFlowy oracle patch
+import { useRef } from "react";
+
+export const Player = () => {
+  const playerRef = useRef(null);
+  playerRef.current ??= createPlayer();
+  return null;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-impure-state-updater.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-impure-state-updater.test.ts
@@ -42,6 +42,19 @@ describe("no-impure-state-updater", () => {
        };`,
     ],
     [
+      "a DOM measurement through a local alias",
+      `import { useRef, useState } from "react";
+       const Gallery = () => {
+         const containerRef = useRef(null);
+         const [width, setWidth] = useState(0);
+         const measure = () => setWidth(() => {
+           const container = containerRef.current;
+           return container.getBoundingClientRect().width;
+         });
+         return <div ref={containerRef} onClick={measure}>{width}</div>;
+       };`,
+    ],
+    [
       "a nested state update",
       `import { useState } from "react";
        const Form = () => {
@@ -154,6 +167,37 @@ describe("no-impure-state-updater", () => {
            setCount((previousCount) => previousCount + 1);
          };
          return <button onClick={increment}>{count}</button>;
+       };`,
+    ],
+    [
+      "a pure userland geometry method",
+      `import { useState } from "react";
+       const geometry = { getBoundingClientRect: () => ({ width: 10 }) };
+       const Panel = () => {
+         const [width, setWidth] = useState(0);
+         setWidth(() => geometry.getBoundingClientRect().width);
+         return width;
+       };`,
+    ],
+    [
+      "an unrelated imported message object",
+      `import { message } from "./domain-message";
+       import { useState } from "react";
+       const Panel = () => {
+         const [value, setValue] = useState(0);
+         setValue(() => message.info());
+         return value;
+       };`,
+    ],
+    [
+      "a local hook with a notification-shaped name",
+      `import { useState } from "react";
+       const useToast = () => ({ success: () => 1 });
+       const Panel = () => {
+         const toast = useToast();
+         const [value, setValue] = useState(0);
+         setValue(() => toast.success());
+         return value;
        };`,
     ],
   ])("stays silent for %s", (_name, code) => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-impure-state-updater.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-impure-state-updater.test.ts
@@ -105,6 +105,92 @@ describe("no-impure-state-updater", () => {
          return <button onClick={increment}>{count}</button>;
        };`,
     ],
+    [
+      "a named updater function",
+      `import { useState } from "react";
+       const Counter = () => {
+         const [count, setCount] = useState(0);
+         const updateCount = (previousCount) => {
+           localStorage.setItem("count", String(previousCount));
+           return previousCount + 1;
+         };
+         setCount(updateCount);
+         return count;
+       };`,
+    ],
+    [
+      "a deep captured assignment",
+      `import { useState } from "react";
+       const cache = { nested: { value: 0 } };
+       const Counter = () => {
+         const [count, setCount] = useState(0);
+         setCount((previousCount) => {
+           cache.nested.value = previousCount;
+           return previousCount;
+         });
+         return count;
+       };`,
+    ],
+    [
+      "a window timer",
+      `import { useState } from "react";
+       const Counter = () => {
+         const [count, setCount] = useState(0);
+         setCount((previousCount) => {
+           window.setTimeout(save, 0);
+           return previousCount;
+         });
+         return count;
+       };`,
+    ],
+    [
+      "globalThis storage mutation",
+      `import { useState } from "react";
+       const Counter = () => {
+         const [count, setCount] = useState(0);
+         setCount((previousCount) => {
+           globalThis.localStorage.setItem("count", String(previousCount));
+           return previousCount;
+         });
+         return count;
+       };`,
+    ],
+    [
+      "an aliased notification import",
+      `import { useState } from "react";
+       import { toast as notify } from "sonner";
+       const Counter = () => {
+         const [count, setCount] = useState(0);
+         setCount((previousCount) => {
+           notify.error("Try again");
+           return previousCount;
+         });
+         return count;
+       };`,
+    ],
+    [
+      "an aliased notification hook",
+      `import { useState } from "react";
+       import { useToast as useNotifier } from "@chakra-ui/react";
+       const Counter = () => {
+         const notifier = useNotifier();
+         const [count, setCount] = useState(0);
+         setCount((previousCount) => {
+           notifier.error("Try again");
+           return previousCount;
+         });
+         return count;
+       };`,
+    ],
+    [
+      "a document DOM measurement",
+      `import { useState } from "react";
+       const Counter = () => {
+         const [width, setWidth] = useState(0);
+         setWidth(() => document.body.getBoundingClientRect().width);
+         return width;
+       };`,
+    ],
   ])("reports %s", (_name, code) => {
     const result = run(code);
     expect(result.parseErrors).toEqual([]);
@@ -211,6 +297,29 @@ describe("no-impure-state-updater", () => {
          const [value, setValue] = useState(0);
          setValue(() => toast.success());
          return value;
+       };`,
+    ],
+    [
+      "a deferred callback passed to a userland map method",
+      `import { useState } from "react";
+       const scheduler = { map: (callback) => () => callback() };
+       const Counter = () => {
+         const [count, setCount] = useState(0);
+         setCount((previousCount) => {
+           const deferred = scheduler.map(() => localStorage.setItem("count", "1"));
+           return previousCount + Number(Boolean(deferred));
+         });
+         return count;
+       };`,
+    ],
+    [
+      "a shadowed window timer",
+      `import { useState } from "react";
+       const window = { setTimeout: () => 1 };
+       const Counter = () => {
+         const [count, setCount] = useState(0);
+         setCount((previousCount) => previousCount + window.setTimeout());
+         return count;
        };`,
     ],
   ])("stays silent for %s", (_name, code) => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-impure-state-updater.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-impure-state-updater.test.ts
@@ -32,6 +32,19 @@ describe("no-impure-state-updater", () => {
        };`,
     ],
     [
+      "a notification package subpath",
+      `import { useState } from "react";
+       import message from "antd/es/message";
+       const Counter = () => {
+         const [count, setCount] = useState(0);
+         const increment = () => setCount((previousCount) => {
+           message.error("Try again");
+           return previousCount + 1;
+         });
+         return <button onClick={increment}>{count}</button>;
+       };`,
+    ],
+    [
       "a DOM measurement",
       `import { useRef, useState } from "react";
        const Gallery = () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-impure-state-updater.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-impure-state-updater.ts
@@ -3,15 +3,16 @@ import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
-import { executesDuringRender } from "../../utils/executes-during-render.js";
-import { getImportSourceForName } from "../../utils/find-import-source-for-name.js";
+import { getImportBindingForName } from "../../utils/find-import-source-for-name.js";
+import { getRootIdentifier } from "../../utils/get-root-identifier.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isReactApiCall } from "../../utils/is-react-api-call.js";
 import { hasReactRefCurrentOrigin } from "../../utils/react-ref-origin.js";
+import { resolveConstIdentifierAlias } from "../../utils/resolve-const-identifier-alias.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import { walkAst } from "../../utils/walk-ast.js";
-import { getRef } from "./utils/effect/ast.js";
+import { getRef, resolveToFunction } from "./utils/effect/ast.js";
 import { getProgramAnalysis } from "./utils/effect/get-program-analysis.js";
 import { getUseStateDecl, isStateSetterCall } from "./utils/effect/react.js";
 
@@ -52,6 +53,19 @@ const NOTIFICATION_MODULE_SOURCES = new Set([
   "react-toastify",
   "sonner",
 ]);
+const SYNCHRONOUS_ARRAY_METHOD_NAMES = new Set([
+  "every",
+  "filter",
+  "find",
+  "findIndex",
+  "flatMap",
+  "forEach",
+  "map",
+  "reduce",
+  "reduceRight",
+  "some",
+  "sort",
+]);
 
 const isNotificationModuleSource = (source: string | null): boolean => {
   if (!source) return false;
@@ -73,18 +87,59 @@ const getMemberCall = (node: EsTreeNode): MemberCall | null => {
 
 const isNotificationReceiver = (receiver: EsTreeNode, scopes: ScopeAnalysis): boolean => {
   if (!isNodeOfType(receiver, "Identifier")) return false;
-  if (!NOTIFICATION_RECEIVER_NAMES.has(receiver.name)) return false;
-  const importSource = getImportSourceForName(receiver, receiver.name);
-  if (importSource) return isNotificationModuleSource(importSource);
+  const importBinding = getImportBindingForName(receiver, receiver.name);
+  if (importBinding) {
+    return (
+      isNotificationModuleSource(importBinding.source) &&
+      (importBinding.exportedName === "default" ||
+        (importBinding.exportedName !== null &&
+          NOTIFICATION_RECEIVER_NAMES.has(importBinding.exportedName)))
+    );
+  }
   const symbol = scopes.symbolFor(receiver);
   if (!isNodeOfType(symbol?.initializer, "CallExpression")) return false;
   const callee = symbol.initializer.callee;
+  if (!isNodeOfType(callee, "Identifier")) return false;
+  const hookImport = getImportBindingForName(callee, callee.name);
+  return Boolean(
+    hookImport &&
+    isNotificationModuleSource(hookImport.source) &&
+    hookImport.exportedName !== null &&
+    /^use(?:Message|Notification|Toast)$/.test(hookImport.exportedName),
+  );
+};
+
+const isKnownGlobalObject = (
+  node: EsTreeNode,
+  expectedName: string,
+  scopes: ScopeAnalysis,
+): boolean =>
+  isNodeOfType(node, "Identifier") && node.name === expectedName && scopes.isGlobalReference(node);
+
+const isGlobalMember = (
+  node: EsTreeNode,
+  expectedPropertyName: string,
+  scopes: ScopeAnalysis,
+): boolean =>
+  isNodeOfType(node, "MemberExpression") &&
+  !node.computed &&
+  isNodeOfType(node.property, "Identifier") &&
+  node.property.name === expectedPropertyName &&
+  (isKnownGlobalObject(node.object, "window", scopes) ||
+    isKnownGlobalObject(node.object, "globalThis", scopes));
+
+const isStorageReceiver = (node: EsTreeNode, scopes: ScopeAnalysis): boolean => {
   if (
-    !isNodeOfType(callee, "Identifier") ||
-    !/^use(?:Message|Notification|Toast)$/.test(callee.name)
-  )
-    return false;
-  return isNotificationModuleSource(getImportSourceForName(callee, callee.name));
+    isNodeOfType(node, "Identifier") &&
+    STORAGE_RECEIVER_NAMES.has(node.name) &&
+    scopes.isGlobalReference(node)
+  ) {
+    return true;
+  }
+  for (const receiverName of STORAGE_RECEIVER_NAMES) {
+    if (isGlobalMember(node, receiverName, scopes)) return true;
+  }
+  return false;
 };
 
 const getKnownImpureCall = (
@@ -99,26 +154,36 @@ const getKnownImpureCall = (
     return `${callExpression.callee.name}()`;
   }
 
+  if (
+    isNodeOfType(callExpression.callee, "MemberExpression") &&
+    !callExpression.callee.computed &&
+    isNodeOfType(callExpression.callee.property, "Identifier") &&
+    TIMER_FUNCTION_NAMES.has(callExpression.callee.property.name) &&
+    (isKnownGlobalObject(callExpression.callee.object, "window", scopes) ||
+      isKnownGlobalObject(callExpression.callee.object, "globalThis", scopes))
+  ) {
+    return `${callExpression.callee.property.name}()`;
+  }
+
   const memberCall = getMemberCall(callExpression);
   if (!memberCall) return null;
   const { methodName, receiver } = memberCall;
-  if (
-    STORAGE_MUTATION_METHOD_NAMES.has(methodName) &&
-    isNodeOfType(receiver, "Identifier") &&
-    STORAGE_RECEIVER_NAMES.has(receiver.name) &&
-    scopes.isGlobalReference(receiver)
-  ) {
-    return `${receiver.name}.${methodName}()`;
+  if (STORAGE_MUTATION_METHOD_NAMES.has(methodName) && isStorageReceiver(receiver, scopes)) {
+    return `${methodName}()`;
   }
   if (EXTERNAL_READ_METHOD_NAMES.has(methodName) && hasReactRefCurrentOrigin(receiver, scopes)) {
     return `.${methodName}()`;
   }
+  const receiverRoot = getRootIdentifier(receiver);
   if (
-    NOTIFICATION_METHOD_NAMES.has(methodName) &&
-    isNodeOfType(receiver, "Identifier") &&
-    isNotificationReceiver(receiver, scopes)
+    EXTERNAL_READ_METHOD_NAMES.has(methodName) &&
+    receiverRoot !== null &&
+    isKnownGlobalObject(receiverRoot, "document", scopes)
   ) {
-    return `${receiver.name}.${methodName}()`;
+    return `.${methodName}()`;
+  }
+  if (NOTIFICATION_METHOD_NAMES.has(methodName) && isNotificationReceiver(receiver, scopes)) {
+    return `${methodName}()`;
   }
   return null;
 };
@@ -128,15 +193,7 @@ const getExternalAssignmentDescription = (
   updater: EsTreeNode,
   scopes: ScopeAnalysis,
 ): string | null => {
-  let rootIdentifier: EsTreeNodeOfType<"Identifier"> | null = null;
-  if (isNodeOfType(assignmentTarget, "Identifier")) {
-    rootIdentifier = assignmentTarget;
-  } else if (
-    isNodeOfType(assignmentTarget, "MemberExpression") &&
-    isNodeOfType(assignmentTarget.object, "Identifier")
-  ) {
-    rootIdentifier = assignmentTarget.object;
-  }
+  const rootIdentifier = getRootIdentifier(assignmentTarget);
   if (!rootIdentifier) return null;
   const updaterScope = scopes.ownScopeFor(updater);
   if (!updaterScope) return null;
@@ -150,12 +207,57 @@ const getExternalAssignmentDescription = (
     : `the captured value "${rootIdentifier.name}"`;
 };
 
+const isArrayValue = (node: EsTreeNode, scopes: ScopeAnalysis): boolean => {
+  const expression = stripParenExpression(node);
+  if (isNodeOfType(expression, "ArrayExpression")) return true;
+  if (!isNodeOfType(expression, "Identifier")) return false;
+  return isNodeOfType(
+    resolveConstIdentifierAlias(expression, scopes)?.initializer,
+    "ArrayExpression",
+  );
+};
+
+const isDefinitelySynchronousCallback = (callback: EsTreeNode, scopes: ScopeAnalysis): boolean => {
+  const parent = callback.parent;
+  if (!parent) return false;
+  if (isNodeOfType(parent, "CallExpression") && parent.callee === callback) return true;
+  if (
+    !isNodeOfType(parent, "CallExpression") ||
+    !parent.arguments?.some((argument) => argument === callback)
+  ) {
+    return false;
+  }
+  if (
+    isNodeOfType(parent.callee, "MemberExpression") &&
+    !parent.callee.computed &&
+    isNodeOfType(parent.callee.property, "Identifier") &&
+    SYNCHRONOUS_ARRAY_METHOD_NAMES.has(parent.callee.property.name) &&
+    isArrayValue(parent.callee.object, scopes)
+  ) {
+    return true;
+  }
+  return (
+    isNodeOfType(parent.callee, "MemberExpression") &&
+    !parent.callee.computed &&
+    isNodeOfType(parent.callee.object, "Identifier") &&
+    parent.callee.object.name === "Array" &&
+    scopes.isGlobalReference(parent.callee.object) &&
+    isNodeOfType(parent.callee.property, "Identifier") &&
+    parent.callee.property.name === "from" &&
+    parent.arguments[1] === callback
+  );
+};
+
 const findImpureUpdaterOperation = (updater: EsTreeNode, scopes: ScopeAnalysis): string | null => {
   const analysis = getProgramAnalysis(updater);
   let operation: string | null = null;
   walkAst(updater, (child: EsTreeNode): boolean | void => {
     if (operation) return false;
-    if (child !== updater && isFunctionLike(child) && !executesDuringRender(child, scopes)) {
+    if (
+      child !== updater &&
+      isFunctionLike(child) &&
+      !isDefinitelySynchronousCallback(child, scopes)
+    ) {
       return false;
     }
     if (isNodeOfType(child, "CallExpression")) {
@@ -192,8 +294,8 @@ export const noImpureStateUpdater = defineRule({
     "Keep state updater callbacks pure and return only the next state. Move notifications, storage, timers, ref writes, and other external work into the event or effect that queues the update.",
   create: (context) => ({
     CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
-      const updater = node.arguments?.[0];
-      if (!updater || !isFunctionLike(updater)) return;
+      const updaterArgument = node.arguments?.[0];
+      if (!updaterArgument) return;
       const analysis = getProgramAnalysis(node);
       if (!analysis || !isNodeOfType(node.callee, "Identifier")) return;
       const calleeReference = getRef(analysis, node.callee);
@@ -208,10 +310,18 @@ export const noImpureStateUpdater = defineRule({
       ) {
         return;
       }
+      let updater: EsTreeNode | null = null;
+      if (isFunctionLike(updaterArgument)) {
+        updater = updaterArgument;
+      } else if (isNodeOfType(updaterArgument, "Identifier")) {
+        const updaterReference = getRef(analysis, updaterArgument);
+        if (updaterReference) updater = resolveToFunction(updaterReference);
+      }
+      if (!updater) return;
       const operation = findImpureUpdaterOperation(updater, context.scopes);
       if (!operation) return;
       context.report({
-        node: updater,
+        node: updaterArgument,
         message: `This state updater performs ${operation}. React may run updater functions more than once, so side effects here can repeat or observe inconsistent external state.`,
       });
     },

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-impure-state-updater.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-impure-state-updater.ts
@@ -4,9 +4,11 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { executesDuringRender } from "../../utils/executes-during-render.js";
+import { getImportSourceForName } from "../../utils/find-import-source-for-name.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isReactApiCall } from "../../utils/is-react-api-call.js";
+import { hasReactRefCurrentOrigin } from "../../utils/react-ref-origin.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import { walkAst } from "../../utils/walk-ast.js";
 import { getRef } from "./utils/effect/ast.js";
@@ -41,6 +43,22 @@ const NOTIFICATION_METHOD_NAMES = new Set([
   "success",
   "warning",
 ]);
+const NOTIFICATION_MODULE_SOURCES = new Set([
+  "@chakra-ui/react",
+  "@heroui/react",
+  "@mantine/notifications",
+  "antd",
+  "react-hot-toast",
+  "react-toastify",
+  "sonner",
+]);
+
+const isNotificationModuleSource = (source: string | null): boolean =>
+  Boolean(
+    source &&
+    (NOTIFICATION_MODULE_SOURCES.has(source) ||
+      /(?:^|[/_.-])(?:notification|toast)s?(?:$|[/_.-])/i.test(source)),
+  );
 
 const getMemberCall = (node: EsTreeNode): MemberCall | null => {
   if (!isNodeOfType(node, "CallExpression")) return null;
@@ -55,13 +73,17 @@ const getMemberCall = (node: EsTreeNode): MemberCall | null => {
 const isNotificationReceiver = (receiver: EsTreeNode, scopes: ScopeAnalysis): boolean => {
   if (!isNodeOfType(receiver, "Identifier")) return false;
   if (!NOTIFICATION_RECEIVER_NAMES.has(receiver.name)) return false;
+  const importSource = getImportSourceForName(receiver, receiver.name);
+  if (importSource) return isNotificationModuleSource(importSource);
   const symbol = scopes.symbolFor(receiver);
-  if (symbol?.kind === "import") return true;
   if (!isNodeOfType(symbol?.initializer, "CallExpression")) return false;
   const callee = symbol.initializer.callee;
-  return (
-    isNodeOfType(callee, "Identifier") && /^use(?:Message|Notification|Toast)$/.test(callee.name)
-  );
+  if (
+    !isNodeOfType(callee, "Identifier") ||
+    !/^use(?:Message|Notification|Toast)$/.test(callee.name)
+  )
+    return false;
+  return isNotificationModuleSource(getImportSourceForName(callee, callee.name));
 };
 
 const getKnownImpureCall = (
@@ -87,7 +109,9 @@ const getKnownImpureCall = (
   ) {
     return `${receiver.name}.${methodName}()`;
   }
-  if (EXTERNAL_READ_METHOD_NAMES.has(methodName)) return `.${methodName}()`;
+  if (EXTERNAL_READ_METHOD_NAMES.has(methodName) && hasReactRefCurrentOrigin(receiver, scopes)) {
+    return `.${methodName}()`;
+  }
   if (
     NOTIFICATION_METHOD_NAMES.has(methodName) &&
     isNodeOfType(receiver, "Identifier") &&

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-impure-state-updater.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-impure-state-updater.ts
@@ -53,12 +53,13 @@ const NOTIFICATION_MODULE_SOURCES = new Set([
   "sonner",
 ]);
 
-const isNotificationModuleSource = (source: string | null): boolean =>
-  Boolean(
-    source &&
-    (NOTIFICATION_MODULE_SOURCES.has(source) ||
-      /(?:^|[/_.-])(?:notification|toast)s?(?:$|[/_.-])/i.test(source)),
-  );
+const isNotificationModuleSource = (source: string | null): boolean => {
+  if (!source) return false;
+  for (const moduleSource of NOTIFICATION_MODULE_SOURCES) {
+    if (source === moduleSource || source.startsWith(`${moduleSource}/`)) return true;
+  }
+  return /(?:^|[/_.-])(?:notification|toast)s?(?:$|[/_.-])/i.test(source);
+};
 
 const getMemberCall = (node: EsTreeNode): MemberCall | null => {
   if (!isNodeOfType(node, "CallExpression")) return null;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-ref-current-in-render.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-ref-current-in-render.test.ts
@@ -123,6 +123,38 @@ describe("no-ref-current-in-render", () => {
          return latestValueRef;
        };`,
     ],
+    [
+      "a repeated write under a null guard",
+      `import { useRef } from "react";
+       const Panel = () => {
+         const valueRef = useRef(null);
+         if (valueRef.current === null) {
+           valueRef.current = firstValue();
+           valueRef.current = secondValue();
+         }
+         return null;
+       };`,
+    ],
+    [
+      "a write in a loop under a null guard",
+      `import { useRef } from "react";
+       const Panel = ({ values }) => {
+         const valueRef = useRef(null);
+         if (valueRef.current === null) {
+           for (const value of values) valueRef.current = value;
+         }
+         return null;
+       };`,
+    ],
+    [
+      "a statically computed current write",
+      `import { useRef } from "react";
+       const Panel = ({ value }) => {
+         const valueRef = useRef(null);
+         valueRef["current"] = value;
+         return null;
+       };`,
+    ],
   ])("reports %s", (_name, code) => {
     const result = run(code);
     expect(result.parseErrors).toEqual([]);
@@ -206,6 +238,37 @@ describe("no-ref-current-in-render", () => {
        const Video = () => {
          const playerRef = useRef(null);
          playerRef.current ??= createVideoPlayer();
+         return <video />;
+       };`,
+    ],
+    [
+      "lazy initialization with logical-or assignment",
+      `import { useRef } from "react";
+       const Video = () => {
+         const playerRef = useRef(null);
+         playerRef.current ||= createVideoPlayer();
+         return <video />;
+       };`,
+    ],
+    [
+      "lazy initialization through a const current alias",
+      `import { useRef } from "react";
+       const Video = () => {
+         const playerRef = useRef(null);
+         const player = playerRef.current;
+         if (player === null) playerRef.current = createVideoPlayer();
+         return <video />;
+       };`,
+    ],
+    [
+      "mutually exclusive lazy initialization writes",
+      `import { useRef } from "react";
+       const Video = ({ useHardware }) => {
+         const playerRef = useRef(null);
+         if (playerRef.current === null) {
+           if (useHardware) playerRef.current = createHardwarePlayer();
+           else playerRef.current = createSoftwarePlayer();
+         }
          return <video />;
        };`,
     ],

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-ref-current-in-render.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-ref-current-in-render.test.ts
@@ -166,6 +166,50 @@ describe("no-ref-current-in-render", () => {
        };`,
     ],
     [
+      "lazy initialization from a factory",
+      `import { useRef } from "react";
+       const Video = () => {
+         const playerRef = useRef(null);
+         if (playerRef.current === null) {
+           playerRef.current = createVideoPlayer();
+         }
+         return <video />;
+       };`,
+    ],
+    [
+      "lazy initialization with an undefined sentinel",
+      `import { useRef } from "react";
+       const Video = () => {
+         const playerRef = useRef();
+         if (playerRef.current === undefined) {
+           playerRef.current = createVideoPlayer();
+         }
+         return <video />;
+       };`,
+    ],
+    [
+      "lazy initialization in an inequality alternate",
+      `import { useRef } from "react";
+       const Video = () => {
+         const playerRef = useRef(null);
+         if (playerRef.current !== null) {
+           preparePlayer(playerRef.current);
+         } else {
+           playerRef.current = createVideoPlayer();
+         }
+         return <video />;
+       };`,
+    ],
+    [
+      "lazy initialization with nullish assignment",
+      `import { useRef } from "react";
+       const Video = () => {
+         const playerRef = useRef(null);
+         playerRef.current ??= createVideoPlayer();
+         return <video />;
+       };`,
+    ],
+    [
       "an event handler",
       `import { useRef } from "react";
        const Button = () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-ref-current-in-render.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-ref-current-in-render.ts
@@ -3,22 +3,29 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { findRenderPhaseComponentOrHook } from "../../utils/find-render-phase-component-or-hook.js";
+import { getRangeStart } from "../../utils/get-range-start.js";
+import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
+import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { resolveReactRefSymbol } from "../../utils/react-ref-origin.js";
 import { resolveConstIdentifierAlias } from "../../utils/resolve-const-identifier-alias.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import { walkAst } from "../../utils/walk-ast.js";
+
+const REPEATED_ANCESTOR_TYPES = new Set([
+  "DoWhileStatement",
+  "ForInStatement",
+  "ForOfStatement",
+  "ForStatement",
+  "WhileStatement",
+]);
 
 const isSameRefCurrentMember = (
   node: EsTreeNode,
   refSymbol: SymbolDescriptor,
   scopes: ScopeAnalysis,
 ): boolean => {
-  if (
-    !isNodeOfType(node, "MemberExpression") ||
-    node.computed ||
-    !isNodeOfType(node.property, "Identifier") ||
-    node.property.name !== "current"
-  ) {
+  if (!isNodeOfType(node, "MemberExpression") || getStaticPropertyName(node) !== "current") {
     return false;
   }
   const receiver = stripParenExpression(node.object);
@@ -28,12 +35,102 @@ const isSameRefCurrentMember = (
   );
 };
 
+const isSameRefCurrentAlias = (
+  node: EsTreeNode,
+  refSymbol: SymbolDescriptor,
+  scopes: ScopeAnalysis,
+): boolean => {
+  if (isSameRefCurrentMember(node, refSymbol, scopes)) return true;
+  if (!isNodeOfType(node, "Identifier")) return false;
+  const aliasSymbol = scopes.symbolFor(node);
+  return (
+    aliasSymbol?.kind === "const" &&
+    aliasSymbol.initializer !== null &&
+    isSameRefCurrentMember(stripParenExpression(aliasSymbol.initializer), refSymbol, scopes)
+  );
+};
+
+const isEmptySentinel = (node: EsTreeNode, scopes: ScopeAnalysis): boolean =>
+  (isNodeOfType(node, "Literal") && node.value === null) ||
+  (isNodeOfType(node, "Identifier") && node.name === "undefined" && scopes.isGlobalReference(node));
+
+const hasRepeatedExecutionAncestor = (node: EsTreeNode, stop: EsTreeNode): boolean => {
+  let ancestor = node.parent;
+  while (ancestor && ancestor !== stop) {
+    if (isFunctionLike(ancestor) || REPEATED_ANCESTOR_TYPES.has(ancestor.type)) return true;
+    ancestor = ancestor.parent;
+  }
+  return ancestor !== stop;
+};
+
+const getBranchConstraints = (
+  node: EsTreeNode,
+  branchRoot: EsTreeNode,
+): Map<EsTreeNode, boolean> => {
+  const constraints = new Map<EsTreeNode, boolean>();
+  let descendant = node;
+  let ancestor = descendant.parent;
+  while (ancestor && descendant !== branchRoot) {
+    if (isNodeOfType(ancestor, "IfStatement")) {
+      if (ancestor.consequent === descendant) constraints.set(ancestor, true);
+      if (ancestor.alternate === descendant) constraints.set(ancestor, false);
+    }
+    descendant = ancestor;
+    ancestor = ancestor.parent;
+  }
+  return constraints;
+};
+
+const canExecuteTogether = (
+  firstConstraints: Map<EsTreeNode, boolean>,
+  secondConstraints: Map<EsTreeNode, boolean>,
+): boolean => {
+  for (const [statement, branch] of firstConstraints) {
+    const otherBranch = secondConstraints.get(statement);
+    if (otherBranch !== undefined && otherBranch !== branch) return false;
+  }
+  return true;
+};
+
+const hasNoPriorCoExecutableWrite = (
+  assignmentExpression: EsTreeNodeOfType<"AssignmentExpression">,
+  branchRoot: EsTreeNode,
+  refSymbol: SymbolDescriptor,
+  scopes: ScopeAnalysis,
+): boolean => {
+  const assignmentConstraints = getBranchConstraints(assignmentExpression, branchRoot);
+  const assignmentStart = getRangeStart(assignmentExpression);
+  let hasCoExecutableWrite = false;
+  walkAst(branchRoot, (child: EsTreeNode): boolean | void => {
+    if (hasCoExecutableWrite) return false;
+    const childStart = getRangeStart(child);
+    if (
+      child === assignmentExpression ||
+      !isNodeOfType(child, "AssignmentExpression") ||
+      assignmentStart === null ||
+      childStart === null ||
+      childStart >= assignmentStart ||
+      resolveReactRefSymbol(child.left, scopes)?.id !== refSymbol.id ||
+      hasRepeatedExecutionAncestor(child, branchRoot)
+    ) {
+      return;
+    }
+    if (canExecuteTogether(assignmentConstraints, getBranchConstraints(child, branchRoot))) {
+      hasCoExecutableWrite = true;
+      return false;
+    }
+  });
+  return !hasCoExecutableWrite;
+};
+
 const isDocumentedLazyInitialization = (
   assignmentExpression: EsTreeNodeOfType<"AssignmentExpression">,
   refSymbol: SymbolDescriptor,
   scopes: ScopeAnalysis,
 ): boolean => {
-  if (assignmentExpression.operator === "??=") return true;
+  if (assignmentExpression.operator === "??=" || assignmentExpression.operator === "||=") {
+    return true;
+  }
   if (assignmentExpression.operator !== "=") return false;
   let descendant: EsTreeNode = assignmentExpression;
   let ancestor = descendant.parent;
@@ -45,21 +142,16 @@ const isDocumentedLazyInitialization = (
     ) {
       const { left, right } = ancestor.test;
       const comparesEmptySentinel =
-        (isSameRefCurrentMember(left, refSymbol, scopes) &&
-          ((isNodeOfType(right, "Literal") && right.value === null) ||
-            (isNodeOfType(right, "Identifier") &&
-              right.name === "undefined" &&
-              scopes.isGlobalReference(right)))) ||
-        (isSameRefCurrentMember(right, refSymbol, scopes) &&
-          ((isNodeOfType(left, "Literal") && left.value === null) ||
-            (isNodeOfType(left, "Identifier") &&
-              left.name === "undefined" &&
-              scopes.isGlobalReference(left))));
+        (isSameRefCurrentAlias(left, refSymbol, scopes) && isEmptySentinel(right, scopes)) ||
+        (isSameRefCurrentAlias(right, refSymbol, scopes) && isEmptySentinel(left, scopes));
       const isEquality = ancestor.test.operator === "===" || ancestor.test.operator === "==";
+      const guardedBranch = isEquality ? ancestor.consequent : ancestor.alternate;
       if (
         comparesEmptySentinel &&
-        ((isEquality && ancestor.consequent === descendant) ||
-          (!isEquality && ancestor.alternate === descendant))
+        guardedBranch === descendant &&
+        guardedBranch &&
+        !hasRepeatedExecutionAncestor(assignmentExpression, guardedBranch) &&
+        hasNoPriorCoExecutableWrite(assignmentExpression, guardedBranch, refSymbol, scopes)
       )
         return true;
     }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-ref-current-in-render.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-ref-current-in-render.ts
@@ -4,36 +4,9 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { findRenderPhaseComponentOrHook } from "../../utils/find-render-phase-component-or-hook.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
-import { isReactApiCall } from "../../utils/is-react-api-call.js";
+import { resolveReactRefSymbol } from "../../utils/react-ref-origin.js";
 import { resolveConstIdentifierAlias } from "../../utils/resolve-const-identifier-alias.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
-
-const resolveReactRefSymbol = (
-  memberExpression: EsTreeNode,
-  scopes: ScopeAnalysis,
-): SymbolDescriptor | null => {
-  const receiver = isNodeOfType(memberExpression, "MemberExpression")
-    ? stripParenExpression(memberExpression.object)
-    : null;
-  if (
-    !isNodeOfType(memberExpression, "MemberExpression") ||
-    memberExpression.computed ||
-    !isNodeOfType(memberExpression.property, "Identifier") ||
-    memberExpression.property.name !== "current" ||
-    !isNodeOfType(receiver, "Identifier")
-  ) {
-    return null;
-  }
-  const symbol = resolveConstIdentifierAlias(receiver, scopes);
-  if (!symbol?.initializer) return null;
-  const initializer = stripParenExpression(symbol.initializer);
-  if (!isNodeOfType(initializer, "CallExpression")) return null;
-  return isReactApiCall(initializer, "useRef", scopes, {
-    allowGlobalReactNamespace: true,
-  })
-    ? symbol
-    : null;
-};
 
 const isSameRefCurrentMember = (
   node: EsTreeNode,
@@ -60,32 +33,35 @@ const isDocumentedLazyInitialization = (
   refSymbol: SymbolDescriptor,
   scopes: ScopeAnalysis,
 ): boolean => {
-  if (
-    assignmentExpression.operator !== "=" ||
-    !isNodeOfType(assignmentExpression.right, "NewExpression")
-  ) {
-    return false;
-  }
+  if (assignmentExpression.operator === "??=") return true;
+  if (assignmentExpression.operator !== "=") return false;
   let descendant: EsTreeNode = assignmentExpression;
   let ancestor = descendant.parent;
   while (ancestor) {
     if (
       isNodeOfType(ancestor, "IfStatement") &&
-      ancestor.consequent === descendant &&
       isNodeOfType(ancestor.test, "BinaryExpression") &&
-      (ancestor.test.operator === "===" || ancestor.test.operator === "==")
+      ["===", "==", "!==", "!="].includes(ancestor.test.operator)
     ) {
       const { left, right } = ancestor.test;
-      if (
+      const comparesEmptySentinel =
         (isSameRefCurrentMember(left, refSymbol, scopes) &&
-          isNodeOfType(right, "Literal") &&
-          right.value === null) ||
+          ((isNodeOfType(right, "Literal") && right.value === null) ||
+            (isNodeOfType(right, "Identifier") &&
+              right.name === "undefined" &&
+              scopes.isGlobalReference(right)))) ||
         (isSameRefCurrentMember(right, refSymbol, scopes) &&
-          isNodeOfType(left, "Literal") &&
-          left.value === null)
-      ) {
+          ((isNodeOfType(left, "Literal") && left.value === null) ||
+            (isNodeOfType(left, "Identifier") &&
+              left.name === "undefined" &&
+              scopes.isGlobalReference(left))));
+      const isEquality = ancestor.test.operator === "===" || ancestor.test.operator === "==";
+      if (
+        comparesEmptySentinel &&
+        ((isEquality && ancestor.consequent === descendant) ||
+          (!isEquality && ancestor.alternate === descendant))
+      )
         return true;
-      }
     }
     descendant = ancestor;
     ancestor = descendant.parent;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-root-identifier-name.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-root-identifier-name.ts
@@ -1,6 +1,6 @@
 import type { EsTreeNode } from "./es-tree-node.js";
-import { isNodeOfType } from "./is-node-of-type.js";
-import { stripParenExpression } from "./strip-paren-expression.js";
+import { getRootIdentifier } from "./get-root-identifier.js";
+import type { RootIdentifierOptions } from "./get-root-identifier.js";
 
 // HACK: walk a MemberExpression chain (computed or not) down to the
 // underlying root identifier. `state.nested.items` -> "state",
@@ -18,24 +18,5 @@ import { stripParenExpression } from "./strip-paren-expression.js";
 // expression that produced the receiver.
 export const getRootIdentifierName = (
   node: EsTreeNode | undefined | null,
-  options?: { followCallChains?: boolean },
-): string | null => {
-  if (!node) return null;
-  const followCallChains = options?.followCallChains === true;
-  let cursor: EsTreeNode | undefined = node;
-  while (cursor) {
-    cursor = stripParenExpression(cursor);
-    if (isNodeOfType(cursor, "MemberExpression")) {
-      cursor = cursor.object;
-      continue;
-    }
-    if (followCallChains && isNodeOfType(cursor, "CallExpression")) {
-      const callee: EsTreeNode | null | undefined = cursor.callee;
-      if (!isNodeOfType(callee, "MemberExpression")) return null;
-      cursor = callee.object;
-      continue;
-    }
-    break;
-  }
-  return isNodeOfType(cursor, "Identifier") ? cursor.name : null;
-};
+  options?: RootIdentifierOptions,
+): string | null => getRootIdentifier(node, options)?.name ?? null;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-root-identifier.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-root-identifier.ts
@@ -1,0 +1,31 @@
+import type { EsTreeNode } from "./es-tree-node.js";
+import type { EsTreeNodeOfType } from "./es-tree-node-of-type.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+import { stripParenExpression } from "./strip-paren-expression.js";
+
+export interface RootIdentifierOptions {
+  followCallChains?: boolean;
+}
+
+export const getRootIdentifier = (
+  node: EsTreeNode | undefined | null,
+  options?: RootIdentifierOptions,
+): EsTreeNodeOfType<"Identifier"> | null => {
+  if (!node) return null;
+  const followCallChains = options?.followCallChains === true;
+  let cursor: EsTreeNode | undefined = node;
+  while (cursor) {
+    cursor = stripParenExpression(cursor);
+    if (isNodeOfType(cursor, "MemberExpression")) {
+      cursor = cursor.object;
+      continue;
+    }
+    if (followCallChains && isNodeOfType(cursor, "CallExpression")) {
+      if (!isNodeOfType(cursor.callee, "MemberExpression")) return null;
+      cursor = cursor.callee.object;
+      continue;
+    }
+    break;
+  }
+  return isNodeOfType(cursor, "Identifier") ? cursor : null;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/react-ref-origin.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/react-ref-origin.ts
@@ -1,0 +1,47 @@
+import type { ScopeAnalysis, SymbolDescriptor } from "../semantic/scope-analysis.js";
+import type { EsTreeNode } from "./es-tree-node.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+import { isReactApiCall } from "./is-react-api-call.js";
+import { resolveConstIdentifierAlias } from "./resolve-const-identifier-alias.js";
+import { stripParenExpression } from "./strip-paren-expression.js";
+
+export const resolveReactRefSymbol = (
+  memberExpression: EsTreeNode,
+  scopes: ScopeAnalysis,
+): SymbolDescriptor | null => {
+  const receiver = isNodeOfType(memberExpression, "MemberExpression")
+    ? stripParenExpression(memberExpression.object)
+    : null;
+  if (
+    !isNodeOfType(memberExpression, "MemberExpression") ||
+    memberExpression.computed ||
+    !isNodeOfType(memberExpression.property, "Identifier") ||
+    memberExpression.property.name !== "current" ||
+    !isNodeOfType(receiver, "Identifier")
+  ) {
+    return null;
+  }
+  const symbol = resolveConstIdentifierAlias(receiver, scopes);
+  if (!symbol?.initializer) return null;
+  const initializer = stripParenExpression(symbol.initializer);
+  if (!isNodeOfType(initializer, "CallExpression")) return null;
+  return isReactApiCall(initializer, "useRef", scopes, {
+    allowGlobalReactNamespace: true,
+  })
+    ? symbol
+    : null;
+};
+
+export const hasReactRefCurrentOrigin = (
+  node: EsTreeNode,
+  scopes: ScopeAnalysis,
+  visitedSymbolIds: Set<number> = new Set(),
+): boolean => {
+  const expression = stripParenExpression(node);
+  if (resolveReactRefSymbol(expression, scopes)) return true;
+  if (!isNodeOfType(expression, "Identifier")) return false;
+  const symbol = resolveConstIdentifierAlias(expression, scopes);
+  if (!symbol?.initializer || visitedSymbolIds.has(symbol.id)) return false;
+  visitedSymbolIds.add(symbol.id);
+  return hasReactRefCurrentOrigin(symbol.initializer, scopes, visitedSymbolIds);
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/react-ref-origin.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/react-ref-origin.ts
@@ -1,5 +1,6 @@
 import type { ScopeAnalysis, SymbolDescriptor } from "../semantic/scope-analysis.js";
 import type { EsTreeNode } from "./es-tree-node.js";
+import { getStaticPropertyName } from "./get-static-property-name.js";
 import { isNodeOfType } from "./is-node-of-type.js";
 import { isReactApiCall } from "./is-react-api-call.js";
 import { resolveConstIdentifierAlias } from "./resolve-const-identifier-alias.js";
@@ -14,9 +15,7 @@ export const resolveReactRefSymbol = (
     : null;
   if (
     !isNodeOfType(memberExpression, "MemberExpression") ||
-    memberExpression.computed ||
-    !isNodeOfType(memberExpression.property, "Identifier") ||
-    memberExpression.property.name !== "current" ||
+    getStaticPropertyName(memberExpression) !== "current" ||
     !isNodeOfType(receiver, "Identifier")
   ) {
     return null;


### PR DESCRIPTION
## Why

Avoids false positives in `no-ref-current-in-render` and `no-impure-state-updater`.

React permits predictable lazy ref initialization, but the ref rule only allowed a null guard whose right-hand side was a `new` expression. The updater rule also classified APIs by method or variable name without proving that the receiver was a React ref or notification library.

Before:

```tsx
if (containerHoveredRef.current === null) {
  containerHoveredRef.current = getContainerHovered();
}

setWidth(() => geometry.getBoundingClientRect().width);
```

After:

```tsx
if (containerHoveredRef.current === null) {
  containerHoveredRef.current = getContainerHovered();
}

const element = elementRef.current;
setWidth(() => element.getBoundingClientRect().width);
```

The lazy initialization and pure userland geometry remain quiet, while the proven React-ref measurement still reports.

## What changed

- Supports null/undefined-guarded factory initialization, inequality alternates, and `??=` lazy ref initialization.
- Extracts shared React-ref origin resolution and follows const aliases.
- Requires proven React-ref provenance before treating geometry methods as external reads.
- Requires notification-library import provenance instead of matching arbitrary `message`, `notification`, or `toast` objects.
- Adds four permanent fuzz regression seeds and focused valid/invalid tests.
- Adds a patch changeset for `oxlint-plugin-react-doctor`.

RDE was not run because the local harness was stalled by pre-existing worker processes. Validation instead used the 120-repository react-bench cache and reconstructed task solutions.

## Test plan

- `nr test -- src/plugin/rules/state-and-effects/no-ref-current-in-render.test.ts src/plugin/rules/state-and-effects/no-impure-state-updater.test.ts`
- `FUZZ_RULE=no-ref-current-in-render FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz`
- `FUZZ_RULE=no-impure-state-updater FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz`
- `nr typecheck` in `packages/oxlint-plugin-react-doctor`
- `nr lint`
- `nr format:check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes heuristic lint logic for two error rules, which can shift real-world signal/noise; scope is mitigated by broad unit/fuzz coverage but not zero risk for edge cases.
> 
> **Overview**
> Reduces false positives in **`no-ref-current-in-render`** and **`no-impure-state-updater`** by tightening when writes and side effects count as violations.
> 
> **`no-ref-current-in-render`** now treats more patterns as allowed lazy init: null/undefined guards with factory assignments (not only `new`), `??=` / `||=`, inequality alternates, `current` read through a const alias, and mutually exclusive branches—while still reporting repeated writes, loop bodies, and computed `["current"]` assignments under a guard.
> 
> **`no-impure-state-updater`** ties “impure” APIs to provenance: toast/message calls only from known notification modules or hooks; DOM geometry reads only from React `ref.current` (with alias following) or `document`; globals like `window`/`globalThis` for timers and storage; named updater references resolved to their function bodies; nested callbacks skipped only when they are definitely synchronous (e.g. array `.map` on a real array), not arbitrary userland deferrals.
> 
> Shared **`react-ref-origin`** / **`getRootIdentifier`** helpers replace duplicated ref-root logic. Fuzz regression seeds and expanded rule tests lock in the behavior; patch changeset for `oxlint-plugin-react-doctor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4306ad69aa05d379e722b91e1d66221bab194841. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->