### PR TITLE
fix(rules): resolve locale option aliases

### DIFF
--- a/.changeset/huge-sites-serve.md
+++ b/.changeset/huge-sites-serve.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Avoid false positives in no-locale-format-in-render when deterministic timezone options use a const alias.

--- a/packages/fuzz/corpus/regressions/no-locale-format-in-render--aliased-timezone-options.tsx
+++ b/packages/fuzz/corpus/regressions/no-locale-format-in-render--aliased-timezone-options.tsx
@@ -3,8 +3,8 @@
 // source: react-bench Webstudio oracle patch
 "use client";
 
-export const Timestamp = ({ value, locale, resolvedTimeZone }) => {
-  const options = { dateStyle: "medium", timeZone: resolvedTimeZone };
-  const formatter = new Intl.DateTimeFormat(locale, options);
-  return <time>{formatter.format(new Date(value))}</time>;
-};
+const locale = "en-US";
+const options = { dateStyle: "medium", timeZone: "UTC" };
+const formatter = new Intl.DateTimeFormat(locale, options);
+
+export const Timestamp = () => <time>{formatter.format(new Date(0))}</time>;

--- a/packages/fuzz/corpus/regressions/no-locale-format-in-render--aliased-timezone-options.tsx
+++ b/packages/fuzz/corpus/regressions/no-locale-format-in-render--aliased-timezone-options.tsx
@@ -1,0 +1,10 @@
+// rule: no-locale-format-in-render
+// weakness: alias-guard
+// source: react-bench Webstudio oracle patch
+"use client";
+
+export const Timestamp = ({ value, locale, resolvedTimeZone }) => {
+  const options = { dateStyle: "medium", timeZone: resolvedTimeZone };
+  const formatter = new Intl.DateTimeFormat(locale, options);
+  return <time>{formatter.format(new Date(value))}</time>;
+};

--- a/packages/fuzz/corpus/regressions/no-locale-format-in-render--const-options-alias.tsx
+++ b/packages/fuzz/corpus/regressions/no-locale-format-in-render--const-options-alias.tsx
@@ -1,0 +1,18 @@
+// rule: no-locale-format-in-render
+// weakness: alias-guard
+// source: react-bench oracle patch reported by user
+
+"use client";
+
+export const Timestamp = ({
+  value,
+  locale,
+  timeZone,
+}: {
+  value: string;
+  locale: string;
+  timeZone: string;
+}) => {
+  const options = { dateStyle: "medium", timeZone } as const;
+  return <time>{new Date(value).toLocaleString(locale, options)}</time>;
+};

--- a/packages/fuzz/corpus/regressions/no-locale-format-in-render--identity-alias-chain.tsx
+++ b/packages/fuzz/corpus/regressions/no-locale-format-in-render--identity-alias-chain.tsx
@@ -1,0 +1,13 @@
+// rule: no-locale-format-in-render
+// weakness: alias-guard
+// source: Cursor Bugbot review on PR 1176
+
+"use client";
+
+export const Timestamp = ({ value, locale }: { value: string; locale: string }) => {
+  const baseOptions = { timeZone: "UTC" };
+  const intermediateOptions = baseOptions;
+  const options = intermediateOptions;
+  const formatter = new Intl.DateTimeFormat(locale, options);
+  return <time>{formatter.format(new Date(value))}</time>;
+};

--- a/packages/fuzz/corpus/regressions/no-locale-format-in-render--read-only-destructure.tsx
+++ b/packages/fuzz/corpus/regressions/no-locale-format-in-render--read-only-destructure.tsx
@@ -1,0 +1,16 @@
+// rule: no-locale-format-in-render
+// weakness: alias-guard
+// source: Cursor Bugbot review on PR 1176
+
+"use client";
+
+export const Timestamp = ({ value, locale }: { value: string; locale: string }) => {
+  const options = { timeZone: "UTC" };
+  const { timeZone, ...remainingOptions } = options;
+  const formatter = new Intl.DateTimeFormat(locale, options);
+  return (
+    <time data-zone={timeZone} data-options={remainingOptions}>
+      {formatter.format(new Date(value))}
+    </time>
+  );
+};

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -290,11 +290,13 @@ export const JSX_LEAF_POOL = [
   `<iframe src={url} />`,
   `<time>{new Date(value).toLocaleString()}</time>`,
   `<span>{new Intl.DateTimeFormat().format(state)}</span>`,
+  `<time>{new Intl.DateTimeFormat("en-US", localeOptionsAlias).format(new Date(value))}</time>`,
 ] as const;
 
 // Rare-but-parseable weirdness kept from the original generator, plus
 // trace-mined oddities (unicode, globalThis gymnastics, labels).
 export const EDGE_CASE_STATEMENT_POOL = [
+  `const localeOptionsBase = { timeZone: "UTC" }; const localeOptionsAlias = localeOptionsBase; const { timeZone: localeTimeZone } = localeOptionsAlias;`,
   `const useState = () => [0, () => {}] as const;`,
   `const { useEffect: renamedEffect } = React;`,
   `const shadowed = (useMemo: () => void) => useMemo();`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-locale-format-in-render.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-locale-format-in-render.test.ts
@@ -323,6 +323,22 @@ export const Timestamp = ({ value }) => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("flags an options alias mutated by a helper in a formatter argument", () => {
+    const result = run(
+      `"use client";
+export const Timestamp = ({ value }) => {
+  const options = { timeZone: "UTC" };
+  const formatter = new Intl.DateTimeFormat((clearTimeZone(), "en-US"), options);
+  return <time>{formatter.format(new Date(value))}</time>;
+
+  function clearTimeZone() {
+    options.timeZone = undefined;
+  }
+};`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("keeps a spread snapshot deterministic when its source is mutated afterward", () => {
     const result = run(
       `"use client";
@@ -336,6 +352,44 @@ export const Timestamp = ({ value }) => {
 };`,
     );
     expect(result.diagnostics).toEqual([]);
+  });
+
+  it("keeps a spread snapshot deterministic when a later property calls a mutating helper", () => {
+    const result = run(
+      `"use client";
+export const Timestamp = ({ value }) => {
+  const options = { timeZone: "UTC" };
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    ...options,
+    marker: clearTimeZone(),
+  });
+  return <time>{formatter.format(new Date(value))}</time>;
+
+  function clearTimeZone() {
+    options.timeZone = undefined;
+  }
+};`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("flags a spread source mutated by an earlier property helper", () => {
+    const result = run(
+      `"use client";
+export const Timestamp = ({ value }) => {
+  const options = { timeZone: "UTC" };
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    marker: clearTimeZone(),
+    ...options,
+  });
+  return <time>{formatter.format(new Date(value))}</time>;
+
+  function clearTimeZone() {
+    options.timeZone = undefined;
+  }
+};`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
   });
 
   it("flags a mutation in a later-declared helper invoked before construction", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-locale-format-in-render.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-locale-format-in-render.test.ts
@@ -371,6 +371,61 @@ export const Timestamp = ({ value, locale }) => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("does not treat identity aliases on the formatter path as escapes", () => {
+    const result = run(
+      `"use client";
+export const Timestamp = ({ value, locale }) => {
+  const baseOptions = { timeZone: "UTC" };
+  const intermediateOptions = baseOptions;
+  const options = intermediateOptions;
+  const formatter = new Intl.DateTimeFormat(locale, options);
+  return <time>{formatter.format(new Date(value))}</time>;
+};`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still tracks mutations through aliases outside the formatter path", () => {
+    const result = run(
+      `"use client";
+export const Timestamp = ({ value, locale }) => {
+  const baseOptions = { timeZone: "UTC" };
+  const options = baseOptions;
+  const mutableAlias = baseOptions;
+  mutableAlias.timeZone = undefined;
+  const formatter = new Intl.DateTimeFormat(locale, options);
+  return <time>{formatter.format(new Date(value))}</time>;
+};`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not treat read-only destructuring as mutation", () => {
+    const result = run(
+      `"use client";
+export const Timestamp = ({ value, locale }) => {
+  const options = { timeZone: "UTC" };
+  const { timeZone, ...remainingOptions } = options;
+  const formatter = new Intl.DateTimeFormat(locale, options);
+  return <time data-zone={timeZone} data-options={remainingOptions}>{formatter.format(new Date(value))}</time>;
+};`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still tracks mutations inside destructuring defaults", () => {
+    const result = run(
+      `"use client";
+export const Timestamp = ({ value, locale }) => {
+  const options = { timeZone: "UTC" };
+  const { missing = (options.timeZone = undefined) } = {};
+  const formatter = new Intl.DateTimeFormat(locale, options);
+  return <time data-missing={missing}>{formatter.format(new Date(value))}</time>;
+};`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("flags a mutation evaluated in an earlier formatter argument", () => {
     const result = run(
       `"use client";

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-locale-format-in-render.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-locale-format-in-render.test.ts
@@ -296,6 +296,135 @@ export const Timestamp = ({ value, locale }) => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("flags a mutation evaluated in an earlier formatter argument", () => {
+    const result = run(
+      `"use client";
+export const Timestamp = ({ value }) => {
+  const options = { timeZone: "UTC" };
+  const formatter = new Intl.DateTimeFormat(
+    (options.timeZone = undefined, "en-US"),
+    options,
+  );
+  return <time>{formatter.format(new Date(value))}</time>;
+};`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a direct options alias mutated in a later formatter argument", () => {
+    const result = run(
+      `"use client";
+export const Timestamp = ({ value }) => {
+  const options = { timeZone: "UTC" };
+  const formatter = new Intl.DateTimeFormat("en-US", options, options.timeZone = undefined);
+  return <time>{formatter.format(new Date(value))}</time>;
+};`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("keeps a spread snapshot deterministic when its source is mutated afterward", () => {
+    const result = run(
+      `"use client";
+export const Timestamp = ({ value }) => {
+  const options = { timeZone: "UTC" };
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    ...options,
+    marker: (options.timeZone = undefined),
+  });
+  return <time>{formatter.format(new Date(value))}</time>;
+};`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("flags a mutation in a later-declared helper invoked before construction", () => {
+    const result = run(
+      `"use client";
+export const Timestamp = ({ value, locale }) => {
+  const options = { timeZone: "UTC" };
+  clearTimeZone();
+  const formatter = new Intl.DateTimeFormat(locale, options);
+  return <time>{formatter.format(new Date(value))}</time>;
+
+  function clearTimeZone() {
+    options.timeZone = undefined;
+  }
+};`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not treat a deferred callback mutation as render-time mutation", () => {
+    const result = run(
+      `"use client";
+export const Timestamp = ({ value, locale }) => {
+  const options = { timeZone: "UTC" };
+  useEffect(() => {
+    options.timeZone = undefined;
+  }, []);
+  const formatter = new Intl.DateTimeFormat(locale, options);
+  return <time>{formatter.format(new Date(value))}</time>;
+};`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not treat a named deferred helper as render-time mutation", () => {
+    const result = run(
+      `"use client";
+export const Timestamp = ({ value, locale }) => {
+  const options = { timeZone: "UTC" };
+  useEffect(clearTimeZone, []);
+  const formatter = new Intl.DateTimeFormat(locale, options);
+  return <time>{formatter.format(new Date(value))}</time>;
+
+  function clearTimeZone() {
+    options.timeZone = undefined;
+  }
+};`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not treat a helper invoked after construction as an earlier mutation", () => {
+    const result = run(
+      `"use client";
+export const Timestamp = ({ value, locale }) => {
+  const options = { timeZone: "UTC" };
+  const formatter = new Intl.DateTimeFormat(locale, options);
+  clearTimeZone();
+  return <time>{formatter.format(new Date(value))}</time>;
+
+  function clearTimeZone() {
+    options.timeZone = undefined;
+  }
+};`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("flags a mutation reached through a synchronous helper chain", () => {
+    const result = run(
+      `"use client";
+export const Timestamp = ({ value, locale }) => {
+  const options = { timeZone: "UTC" };
+  prepareOptions();
+  const formatter = new Intl.DateTimeFormat(locale, options);
+  return <time>{formatter.format(new Date(value))}</time>;
+
+  function prepareOptions() {
+    clearTimeZone();
+  }
+
+  function clearTimeZone() {
+    options.timeZone = undefined;
+  }
+};`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("flags a trailing spread whose timeZone is undefined", () => {
     const result = run(
       `"use client";

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-locale-format-in-render.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-locale-format-in-render.test.ts
@@ -251,6 +251,41 @@ export const Timestamp = ({ value, locale, useUtc }) => {
       `const options = { timeZone: "UTC" };
        inspect(options);`,
     ],
+    [
+      "an array destructuring write",
+      `const options = { timeZone: "UTC" };
+       [options.timeZone] = [undefined];`,
+    ],
+    [
+      "an object destructuring write",
+      `const options = { timeZone: "UTC" };
+       ({ timeZone: options.timeZone } = { timeZone: undefined });`,
+    ],
+    [
+      "a destructuring for-of write",
+      `const options = { timeZone: "UTC" };
+       for ([options.timeZone] of [[undefined]]) {}`,
+    ],
+    [
+      "a mutation through a secondary const alias",
+      `const options = { timeZone: "UTC" };
+       const alias = options;
+       delete alias.timeZone;`,
+    ],
+    [
+      "a mutation through an assigned alias",
+      `const options = { timeZone: "UTC" };
+       let alias;
+       alias = options;
+       alias.timeZone = undefined;`,
+    ],
+    [
+      "storage in a mutable member alias",
+      `const options = { timeZone: "UTC" };
+       const holder = {};
+       holder.options = options;
+       delete holder.options.timeZone;`,
+    ],
     ["an unknown trailing spread", `const options = { timeZone: "UTC", ...overrides };`],
     [
       "a final undefined duplicate property",
@@ -289,6 +324,21 @@ export const Timestamp = ({ value, locale }) => {
   consume(options.timeZone);
   options.timeZone.toLowerCase();
   options.hasOwnProperty("timeZone");
+  const formatter = new Intl.DateTimeFormat(locale, options);
+  return <time>{formatter.format(new Date(value))}</time>;
+};`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not treat a read-only secondary alias as mutation", () => {
+    const result = run(
+      `"use client";
+export const Timestamp = ({ value, locale }) => {
+  const options = { timeZone: "UTC" };
+  const alias = options;
+  alias.timeZone.toLowerCase();
+  alias.hasOwnProperty("timeZone");
   const formatter = new Intl.DateTimeFormat(locale, options);
   return <time>{formatter.format(new Date(value))}</time>;
 };`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-locale-format-in-render.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-locale-format-in-render.test.ts
@@ -389,6 +389,35 @@ export const Timestamp = ({ value }) => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("preserves the formatter boundary through an identity alias", () => {
+    const result = run(
+      `"use client";
+export const Timestamp = ({ value }) => {
+  const baseOptions = { timeZone: "UTC" };
+  const options = baseOptions;
+  const formatter = new Intl.DateTimeFormat(
+    (baseOptions.timeZone = undefined, "en-US"),
+    options,
+  );
+  return <time>{formatter.format(new Date(value))}</time>;
+};`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("preserves the formatter boundary while following a secondary alias", () => {
+    const result = run(
+      `"use client";
+export const Timestamp = ({ value }) => {
+  const options = { timeZone: "UTC" };
+  const alias = options;
+  const formatter = new Intl.DateTimeFormat("en-US", options, alias.timeZone = undefined);
+  return <time>{formatter.format(new Date(value))}</time>;
+};`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("keeps a spread snapshot deterministic when its source is mutated afterward", () => {
     const result = run(
       `"use client";
@@ -639,6 +668,34 @@ export const Timestamp = ({ value, locale }) => (
 );`,
     );
     expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a timeZone set through a const undefined alias", () => {
+    const result = run(
+      `"use client";
+export const Timestamp = ({ value, locale }) => {
+  const missingTimeZone = undefined;
+  const timeZone = missingTimeZone;
+  const options = { timeZone };
+  const formatter = new Intl.DateTimeFormat(locale, options);
+  return <time>{formatter.format(new Date(value))}</time>;
+};`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not confuse a shadowed undefined binding with undefined", () => {
+    const result = run(
+      `"use client";
+export const Timestamp = ({ value, locale }) => {
+  const undefined = "UTC";
+  const timeZone = undefined;
+  const options = { timeZone };
+  const formatter = new Intl.DateTimeFormat(locale, options);
+  return <time>{formatter.format(new Date(value))}</time>;
+};`,
+    );
+    expect(result.diagnostics).toEqual([]);
   });
 
   it("recognizes a shadowed undefined locale as explicit", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-locale-format-in-render.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-locale-format-in-render.test.ts
@@ -315,6 +315,31 @@ export const Timestamp = ({ value, locale, overrides }) => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("does not let nullish spreads override an explicit timeZone proof", () => {
+    const result = run(
+      `"use client";
+export const Timestamp = ({ value, locale }) => {
+  const missing = undefined;
+  const options = { timeZone: "UTC", ...null, ...missing };
+  const formatter = new Intl.DateTimeFormat(locale, options);
+  return <time>{formatter.format(new Date(value))}</time>;
+};`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not let primitive spreads override an explicit timeZone proof", () => {
+    const result = run(
+      `"use client";
+export const Timestamp = ({ value, locale }) => {
+  const options = { timeZone: "UTC", ...false, ...42, ..."text" };
+  const formatter = new Intl.DateTimeFormat(locale, options);
+  return <time>{formatter.format(new Date(value))}</time>;
+};`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("does not treat read-only option property uses as mutation", () => {
     const result = run(
       `"use client";

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-locale-format-in-render.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-locale-format-in-render.test.ts
@@ -182,6 +182,19 @@ export const Timestamp = ({ value, locale, resolvedTimeZone }) => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("does not trust mutable Intl option aliases", () => {
+    const result = run(
+      `"use client";
+export const Timestamp = ({ value, locale, resolvedTimeZone }) => {
+  let options = { dateStyle: "medium", timeZone: resolvedTimeZone };
+  options = getCurrentOptions(options);
+  const formatter = new Intl.DateTimeFormat(locale, options);
+  return <time>{formatter.format(new Date(value))}</time>;
+};`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("still flags an explicit locale WITHOUT a timeZone on a provable date", () => {
     const result = run(
       `"use client";

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-locale-format-in-render.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-locale-format-in-render.test.ts
@@ -425,6 +425,85 @@ export const Timestamp = ({ value, locale }) => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("flags a module-scope mutation before component rendering", () => {
+    const result = run(
+      `"use client";
+const options = { timeZone: "UTC" };
+
+export const Timestamp = ({ value, locale }) => {
+  const formatter = new Intl.DateTimeFormat(locale, options);
+  return <time>{formatter.format(new Date(value))}</time>;
+};
+
+options.timeZone = undefined;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("preserves a spread snapshot created before its source is mutated", () => {
+    const result = run(
+      `"use client";
+export const Timestamp = ({ value, locale }) => {
+  const baseOptions = { timeZone: "UTC" };
+  const options = { ...baseOptions };
+  baseOptions.timeZone = undefined;
+  const formatter = new Intl.DateTimeFormat(locale, options);
+  return <time>{formatter.format(new Date(value))}</time>;
+};`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("preserves a spread snapshot before a helper mutates its source", () => {
+    const result = run(
+      `"use client";
+export const Timestamp = ({ value, locale }) => {
+  const baseOptions = { timeZone: "UTC" };
+  const options = { ...baseOptions };
+  clearTimeZone();
+  const formatter = new Intl.DateTimeFormat(locale, options);
+  return <time>{formatter.format(new Date(value))}</time>;
+
+  function clearTimeZone() {
+    baseOptions.timeZone = undefined;
+  }
+};`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("flags a mutation in an IIFE invoked before construction", () => {
+    const result = run(
+      `"use client";
+export const Timestamp = ({ value, locale }) => {
+  const options = { timeZone: "UTC" };
+  (() => {
+    options.timeZone = undefined;
+  })();
+  const formatter = new Intl.DateTimeFormat(locale, options);
+  return <time>{formatter.format(new Date(value))}</time>;
+};`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not treat a deferred IIFE as a render-time mutation", () => {
+    const result = run(
+      `"use client";
+export const Timestamp = ({ value, locale }) => {
+  const options = { timeZone: "UTC" };
+  useEffect(() => {
+    (() => {
+      options.timeZone = undefined;
+    })();
+  }, []);
+  const formatter = new Intl.DateTimeFormat(locale, options);
+  return <time>{formatter.format(new Date(value))}</time>;
+};`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("flags a trailing spread whose timeZone is undefined", () => {
     const result = run(
       `"use client";

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-locale-format-in-render.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-locale-format-in-render.test.ts
@@ -195,6 +195,107 @@ export const Timestamp = ({ value, locale, resolvedTimeZone }) => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("does not flag frozen deterministic Intl options", () => {
+    const result = run(
+      `"use client";
+export const Timestamp = ({ value, locale }) => {
+  const options = Object.freeze({ dateStyle: "medium", timeZone: "UTC" });
+  const formatter = new Intl.DateTimeFormat(locale, options);
+  return <time>{formatter.format(new Date(value))}</time>;
+};`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not flag a conditional whose branches both set timeZone", () => {
+    const result = run(
+      `"use client";
+export const Timestamp = ({ value, locale, useUtc }) => {
+  const options = useUtc ? { timeZone: "UTC" } : { timeZone: "America/New_York" };
+  const formatter = new Intl.DateTimeFormat(locale, options);
+  return <time>{formatter.format(new Date(value))}</time>;
+};`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it.each([
+    [
+      "member mutation before construction",
+      `const options = { timeZone: "UTC" };
+       options.timeZone = undefined;`,
+    ],
+    [
+      "property deletion before construction",
+      `const options = { timeZone: "UTC" };
+       delete options.timeZone;`,
+    ],
+    [
+      "mutation through a nested const alias",
+      `const baseOptions = { timeZone: "UTC" };
+       const options = baseOptions;
+       options.timeZone = undefined;`,
+    ],
+    ["an unknown trailing spread", `const options = { timeZone: "UTC", ...overrides };`],
+    [
+      "a final undefined duplicate property",
+      `const options = { timeZone: "UTC", timeZone: undefined };`,
+    ],
+  ])("flags options invalidated by %s", (_name, optionSetup) => {
+    const result = run(
+      `"use client";
+export const Timestamp = ({ value, locale, overrides }) => {
+  ${optionSetup}
+  const formatter = new Intl.DateTimeFormat(locale, options);
+  return <time>{formatter.format(new Date(value))}</time>;
+};`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a trailing explicit timeZone after an unknown spread", () => {
+    const result = run(
+      `"use client";
+export const Timestamp = ({ value, locale, overrides }) => {
+  const options = { ...overrides, timeZone: "UTC" };
+  const formatter = new Intl.DateTimeFormat(locale, options);
+  return <time>{formatter.format(new Date(value))}</time>;
+};`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("flags an inline timeZone overridden by an unknown spread", () => {
+    const result = run(
+      `"use client";
+export const Timestamp = ({ value, locale, overrides }) => (
+  <time>{new Date(value).toLocaleString(locale, { timeZone: "UTC", ...overrides })}</time>
+);`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags an inline statically undefined timeZone", () => {
+    const result = run(
+      `"use client";
+export const Timestamp = ({ value, locale }) => (
+  <time>{new Date(value).toLocaleString(locale, { timeZone: void 0 })}</time>
+);`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("recognizes a shadowed undefined locale as explicit", () => {
+    const result = run(
+      `"use client";
+export const Timestamp = ({ value }) => {
+  const undefined = "en-US";
+  return <time>{new Date(value).toLocaleString(undefined, { timeZone: "UTC" })}</time>;
+};`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("still flags an explicit locale WITHOUT a timeZone on a provable date", () => {
     const result = run(
       `"use client";

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-locale-format-in-render.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-locale-format-in-render.test.ts
@@ -246,6 +246,11 @@ export const Timestamp = ({ value, locale, useUtc }) => {
       `const source = { timeZone: "UTC", options: { dateStyle: "medium" } };
        const { options } = source;`,
     ],
+    [
+      "passing the options object to an unknown function",
+      `const options = { timeZone: "UTC" };
+       inspect(options);`,
+    ],
     ["an unknown trailing spread", `const options = { timeZone: "UTC", ...overrides };`],
     [
       "a final undefined duplicate property",
@@ -268,6 +273,22 @@ export const Timestamp = ({ value, locale, overrides }) => {
       `"use client";
 export const Timestamp = ({ value, locale, overrides }) => {
   const options = { ...overrides, timeZone: "UTC" };
+  const formatter = new Intl.DateTimeFormat(locale, options);
+  return <time>{formatter.format(new Date(value))}</time>;
+};`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not treat read-only option property uses as mutation", () => {
+    const result = run(
+      `"use client";
+const consume = (value) => value;
+export const Timestamp = ({ value, locale }) => {
+  const options = { timeZone: "UTC" };
+  consume(options.timeZone);
+  options.timeZone.toLowerCase();
+  options.hasOwnProperty("timeZone");
   const formatter = new Intl.DateTimeFormat(locale, options);
   return <time>{formatter.format(new Date(value))}</time>;
 };`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-locale-format-in-render.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-locale-format-in-render.test.ts
@@ -558,6 +558,101 @@ export const Timestamp = ({ value, locale }) => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("flags a mutation in a synchronously invoked object method", () => {
+    const result = run(
+      `"use client";
+export const Timestamp = ({ value, locale }) => {
+  const options = { timeZone: "UTC" };
+  const helper = {
+    clearTimeZone() {
+      options.timeZone = undefined;
+    },
+  };
+  const alias = helper;
+  alias.clearTimeZone();
+  const formatter = new Intl.DateTimeFormat(locale, options);
+  return <time>{formatter.format(new Date(value))}</time>;
+};`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not treat a deferred object method call as render-time mutation", () => {
+    const result = run(
+      `"use client";
+export const Timestamp = ({ value, locale }) => {
+  const options = { timeZone: "UTC" };
+  const helper = {
+    clearTimeZone() {
+      options.timeZone = undefined;
+    },
+  };
+  useEffect(() => helper.clearTimeZone(), []);
+  const formatter = new Intl.DateTimeFormat(locale, options);
+  return <time>{formatter.format(new Date(value))}</time>;
+};`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not match a same-named method on an unrelated object", () => {
+    const result = run(
+      `"use client";
+export const Timestamp = ({ value, locale }) => {
+  const options = { timeZone: "UTC" };
+  const mutatingHelper = {
+    clearTimeZone() {
+      options.timeZone = undefined;
+    },
+  };
+  const readOnlyHelper = { clearTimeZone() {} };
+  readOnlyHelper.clearTimeZone();
+  const formatter = new Intl.DateTimeFormat(locale, options);
+  return <time>{formatter.format(new Date(value))}</time>;
+};`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("flags a mutation in a synchronously invoked class method", () => {
+    const result = run(
+      `"use client";
+export const Timestamp = ({ value, locale }) => {
+  const options = { timeZone: "UTC" };
+  class Helper {
+    clearTimeZone() {
+      options.timeZone = undefined;
+    }
+  }
+  const helper = new Helper();
+  const alias = helper;
+  alias.clearTimeZone();
+  const formatter = new Intl.DateTimeFormat(locale, options);
+  return <time>{formatter.format(new Date(value))}</time>;
+};`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a mutation in a synchronously invoked static method", () => {
+    const result = run(
+      `"use client";
+export const Timestamp = ({ value, locale }) => {
+  const options = { timeZone: "UTC" };
+  class Helper {
+    static clearTimeZone() {
+      options.timeZone = undefined;
+    }
+  }
+  const HelperAlias = Helper;
+  HelperAlias.clearTimeZone();
+  const formatter = new Intl.DateTimeFormat(locale, options);
+  return <time>{formatter.format(new Date(value))}</time>;
+};`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("flags a module-scope mutation before component rendering", () => {
     const result = run(
       `"use client";

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-locale-format-in-render.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-locale-format-in-render.test.ts
@@ -236,6 +236,16 @@ export const Timestamp = ({ value, locale, useUtc }) => {
        const options = baseOptions;
        options.timeZone = undefined;`,
     ],
+    [
+      "a mutation through a TypeScript wrapper",
+      `const options = { timeZone: "UTC" };
+       (options as Intl.DateTimeFormatOptions).timeZone = undefined;`,
+    ],
+    [
+      "a destructured const binding",
+      `const source = { timeZone: "UTC", options: { dateStyle: "medium" } };
+       const { options } = source;`,
+    ],
     ["an unknown trailing spread", `const options = { timeZone: "UTC", ...overrides };`],
     [
       "a final undefined duplicate property",
@@ -263,6 +273,19 @@ export const Timestamp = ({ value, locale, overrides }) => {
 };`,
     );
     expect(result.diagnostics).toEqual([]);
+  });
+
+  it("flags a trailing spread whose timeZone is undefined", () => {
+    const result = run(
+      `"use client";
+export const Timestamp = ({ value, locale }) => {
+  const overrides = { timeZone: undefined };
+  const options = { timeZone: "UTC", ...overrides };
+  const formatter = new Intl.DateTimeFormat(locale, options);
+  return <time>{formatter.format(new Date(value))}</time>;
+};`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
   });
 
   it("flags an inline timeZone overridden by an unknown spread", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-locale-format-in-render.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-locale-format-in-render.test.ts
@@ -170,6 +170,18 @@ export const Timestamp = ({ value }) => (
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("does not flag deterministic Intl options through a const alias", () => {
+    const result = run(
+      `"use client";
+export const Timestamp = ({ value, locale, resolvedTimeZone }) => {
+  const options = { dateStyle: "medium", timeZone: resolvedTimeZone };
+  const formatter = new Intl.DateTimeFormat(locale, options);
+  return <time>{formatter.format(new Date(value))}</time>;
+};`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("still flags an explicit locale WITHOUT a timeZone on a provable date", () => {
     const result = run(
       `"use client";

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-locale-format-in-render.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-locale-format-in-render.ts
@@ -1,4 +1,4 @@
-import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
+import type { ScopeAnalysis, SymbolDescriptor } from "../../semantic/scope-analysis.js";
 import { componentOrHookDisplayNameForFunction } from "../../utils/component-or-hook-display-name.js";
 import { defineRule } from "../../utils/define-rule.js";
 import { findEnclosingJsxOpeningElement } from "../../utils/find-enclosing-jsx-opening-element.js";
@@ -8,6 +8,8 @@ import { hasClientRenderEvidence } from "../../utils/has-client-render-evidence.
 import { hasDirective } from "../../utils/has-directive.js";
 import { hasEmailTemplateImport } from "../../utils/has-email-template-import.js";
 import { hasSuppressHydrationWarningAttribute } from "../../utils/has-suppress-hydration-warning-attribute.js";
+import { getRangeStart } from "../../utils/get-range-start.js";
+import { getStaticPropertyKeyName } from "../../utils/get-static-property-key-name.js";
 import { isAfterClientOnlyEarlyReturn } from "../../utils/is-after-client-only-early-return.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isGatedByFalsyInitialState } from "../../utils/is-gated-by-falsy-initial-state.js";
@@ -15,7 +17,6 @@ import { isGeneratedImageRenderContext } from "../../utils/is-generated-image-re
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { classifyReactNativeFileTarget } from "../../utils/is-react-native-file.js";
 import { isTestlikeFilename } from "../../utils/is-testlike-filename.js";
-import { resolveConstIdentifierAlias } from "../../utils/resolve-const-identifier-alias.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import { walkAst } from "../../utils/walk-ast.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
@@ -86,35 +87,178 @@ const receiverNameLooksDateFlavored = (expression: EsTreeNode | null | undefined
   return false;
 };
 
-const objectLiteralHasProperty = (
-  objectExpression: EsTreeNode | null | undefined,
-  propertyName: string,
-  scopes: ScopeAnalysis,
-): boolean => {
-  if (!objectExpression) return false;
-  const unwrapped = stripParenExpression(objectExpression);
-  if (isNodeOfType(unwrapped, "Identifier")) {
-    const symbol = resolveConstIdentifierAlias(unwrapped, scopes);
-    return Boolean(
-      symbol?.kind === "const" &&
-      symbol.initializer &&
-      objectLiteralHasProperty(symbol.initializer, propertyName, scopes),
-    );
-  }
-  if (!isNodeOfType(unwrapped, "ObjectExpression")) return false;
-  for (const property of unwrapped.properties ?? []) {
-    if (!isNodeOfType(property, "Property")) continue;
-    if (property.computed) continue;
-    if (isNodeOfType(property.key, "Identifier") && property.key.name === propertyName) return true;
-    if (isNodeOfType(property.key, "Literal") && property.key.value === propertyName) return true;
+const isStaticUndefined = (node: EsTreeNode, scopes: ScopeAnalysis): boolean => {
+  const expression = stripParenExpression(node);
+  return (
+    (isNodeOfType(expression, "Identifier") &&
+      expression.name === "undefined" &&
+      scopes.isGlobalReference(expression)) ||
+    (isNodeOfType(expression, "UnaryExpression") && expression.operator === "void")
+  );
+};
+
+const isWithinNode = (node: EsTreeNode, ancestor: EsTreeNode): boolean => {
+  let current: EsTreeNode | null | undefined = node;
+  while (current) {
+    if (current === ancestor) return true;
+    current = current.parent;
   }
   return false;
 };
 
-const hasExplicitLocaleArgument = (argument: EsTreeNode | null | undefined): boolean => {
+const isPotentialMutationReference = (identifier: EsTreeNode, usageNode: EsTreeNode): boolean => {
+  let expression: EsTreeNode = identifier;
+  let parent = expression.parent;
+  while (parent && isNodeOfType(parent, "MemberExpression") && parent.object === expression) {
+    expression = parent;
+    parent = expression.parent;
+  }
+  if (!parent || isWithinNode(identifier, usageNode)) return false;
+  if (isNodeOfType(parent, "AssignmentExpression") && parent.left === expression) return true;
+  if (isNodeOfType(parent, "UpdateExpression") && parent.argument === expression) return true;
+  if (
+    isNodeOfType(parent, "UnaryExpression") &&
+    parent.operator === "delete" &&
+    parent.argument === expression
+  ) {
+    return true;
+  }
+  if (isNodeOfType(parent, "CallExpression")) {
+    return (
+      parent.callee === expression || parent.arguments?.some((argument) => argument === expression)
+    );
+  }
+  if (isNodeOfType(parent, "NewExpression")) {
+    return parent.arguments?.some((argument) => argument === expression);
+  }
+  return false;
+};
+
+const wasMutatedBeforeUsage = (symbol: SymbolDescriptor, usageNode: EsTreeNode): boolean => {
+  const usageStart = getRangeStart(usageNode);
+  if (usageStart === null) return true;
+  return symbol.references.some((reference) => {
+    const referenceStart = getRangeStart(reference.identifier);
+    return (
+      referenceStart !== null &&
+      referenceStart < usageStart &&
+      isPotentialMutationReference(reference.identifier, usageNode)
+    );
+  });
+};
+
+const getObjectPropertyProof = (
+  objectExpression: EsTreeNode | null | undefined,
+  propertyName: string,
+  scopes: ScopeAnalysis,
+  usageNode: EsTreeNode,
+  visitedSymbolIds: Set<number> = new Set(),
+): boolean | null => {
+  if (!objectExpression) return false;
+  const unwrapped = stripParenExpression(objectExpression);
+  if (isNodeOfType(unwrapped, "Identifier")) {
+    const symbol = scopes.symbolFor(unwrapped);
+    if (
+      symbol?.kind !== "const" ||
+      !symbol.initializer ||
+      visitedSymbolIds.has(symbol.id) ||
+      wasMutatedBeforeUsage(symbol, usageNode)
+    ) {
+      return null;
+    }
+    visitedSymbolIds.add(symbol.id);
+    return getObjectPropertyProof(
+      symbol.initializer,
+      propertyName,
+      scopes,
+      usageNode,
+      visitedSymbolIds,
+    );
+  }
+  if (isNodeOfType(unwrapped, "ConditionalExpression")) {
+    const consequent = getObjectPropertyProof(
+      unwrapped.consequent,
+      propertyName,
+      scopes,
+      usageNode,
+      new Set(visitedSymbolIds),
+    );
+    const alternate = getObjectPropertyProof(
+      unwrapped.alternate,
+      propertyName,
+      scopes,
+      usageNode,
+      new Set(visitedSymbolIds),
+    );
+    return consequent === alternate ? consequent : null;
+  }
+  if (
+    isNodeOfType(unwrapped, "CallExpression") &&
+    isNodeOfType(unwrapped.callee, "MemberExpression") &&
+    !unwrapped.callee.computed &&
+    isNodeOfType(unwrapped.callee.object, "Identifier") &&
+    unwrapped.callee.object.name === "Object" &&
+    scopes.isGlobalReference(unwrapped.callee.object) &&
+    isNodeOfType(unwrapped.callee.property, "Identifier") &&
+    unwrapped.callee.property.name === "freeze"
+  ) {
+    return getObjectPropertyProof(
+      unwrapped.arguments?.[0],
+      propertyName,
+      scopes,
+      usageNode,
+      visitedSymbolIds,
+    );
+  }
+  if (!isNodeOfType(unwrapped, "ObjectExpression")) return null;
+  const properties = unwrapped.properties ?? [];
+  for (let propertyIndex = properties.length - 1; propertyIndex >= 0; propertyIndex -= 1) {
+    const property = properties[propertyIndex];
+    if (!property) continue;
+    if (isNodeOfType(property, "SpreadElement")) {
+      const spreadProof = getObjectPropertyProof(
+        property.argument,
+        propertyName,
+        scopes,
+        usageNode,
+        new Set(visitedSymbolIds),
+      );
+      if (spreadProof === true) return true;
+      if (spreadProof === null) return null;
+      continue;
+    }
+    if (
+      !isNodeOfType(property, "Property") ||
+      getStaticPropertyKeyName(property) !== propertyName
+    ) {
+      continue;
+    }
+    return !isStaticUndefined(property.value, scopes);
+  }
+  return false;
+};
+
+const objectHasExplicitProperty = (
+  objectExpression: EsTreeNode | null | undefined,
+  propertyName: string,
+  scopes: ScopeAnalysis,
+  usageNode: EsTreeNode,
+): boolean => getObjectPropertyProof(objectExpression, propertyName, scopes, usageNode) === true;
+
+const hasExplicitLocaleArgument = (
+  argument: EsTreeNode | null | undefined,
+  scopes: ScopeAnalysis,
+): boolean => {
   if (!argument) return false;
   const unwrapped = stripParenExpression(argument);
-  if (isNodeOfType(unwrapped, "Identifier") && unwrapped.name === "undefined") return false;
+  if (
+    (isNodeOfType(unwrapped, "Identifier") &&
+      unwrapped.name === "undefined" &&
+      scopes.isGlobalReference(unwrapped)) ||
+    (isNodeOfType(unwrapped, "UnaryExpression") && unwrapped.operator === "void")
+  ) {
+    return false;
+  }
   return true;
 };
 
@@ -129,9 +273,9 @@ const isDeterministicLocaleMethodCall = (
   scopes: ScopeAnalysis,
 ): boolean => {
   const localeArgument = call.arguments?.[0];
-  if (!hasExplicitLocaleArgument(localeArgument)) return false;
+  if (!hasExplicitLocaleArgument(localeArgument, scopes)) return false;
   const optionsArgument = call.arguments?.[1];
-  if (objectLiteralHasProperty(optionsArgument, "timeZone", scopes)) return true;
+  if (objectHasExplicitProperty(optionsArgument, "timeZone", scopes, call)) return true;
   // Explicit locale, no timeZone: still environment-dependent when the
   // receiver is a date. An unknown receiver could be a number (locale is
   // its only environment input), so stay quiet there.
@@ -184,9 +328,9 @@ const isDeterministicIntlConstruction = (
   ) {
     return false;
   }
-  if (!hasExplicitLocaleArgument(construction.arguments?.[0])) return false;
+  if (!hasExplicitLocaleArgument(construction.arguments?.[0], scopes)) return false;
   if (formatterName !== "DateTimeFormat") return true;
-  return objectLiteralHasProperty(construction.arguments?.[1], "timeZone", scopes);
+  return objectHasExplicitProperty(construction.arguments?.[1], "timeZone", scopes, construction);
 };
 
 // `Intl.DateTimeFormat().format(date)` — direct chain, or through a

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-locale-format-in-render.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-locale-format-in-render.ts
@@ -11,13 +11,17 @@ import { hasSuppressHydrationWarningAttribute } from "../../utils/has-suppress-h
 import { getRangeStart } from "../../utils/get-range-start.js";
 import { getStaticPropertyKeyName } from "../../utils/get-static-property-key-name.js";
 import { isAfterClientOnlyEarlyReturn } from "../../utils/is-after-client-only-early-return.js";
+import { isAstDescendant } from "../../utils/is-ast-descendant.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isGatedByFalsyInitialState } from "../../utils/is-gated-by-falsy-initial-state.js";
 import { isGeneratedImageRenderContext } from "../../utils/is-generated-image-render-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { classifyReactNativeFileTarget } from "../../utils/is-react-native-file.js";
 import { isTestlikeFilename } from "../../utils/is-testlike-filename.js";
-import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import {
+  stripParenExpression,
+  TRANSPARENT_EXPRESSION_WRAPPER_TYPES,
+} from "../../utils/strip-paren-expression.js";
 import { walkAst } from "../../utils/walk-ast.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
@@ -48,6 +52,15 @@ interface LocaleFormatMatch {
   readonly node: EsTreeNode;
   readonly display: string;
 }
+
+interface ObjectPropertyProof {
+  readonly status: "absent" | "present" | "undefined" | "unknown";
+}
+
+const ABSENT_PROPERTY_PROOF: ObjectPropertyProof = { status: "absent" };
+const PRESENT_PROPERTY_PROOF: ObjectPropertyProof = { status: "present" };
+const UNDEFINED_PROPERTY_PROOF: ObjectPropertyProof = { status: "undefined" };
+const UNKNOWN_PROPERTY_PROOF: ObjectPropertyProof = { status: "unknown" };
 
 const isProvableDateExpression = (expression: EsTreeNode | null | undefined): boolean => {
   if (!expression) return false;
@@ -97,23 +110,32 @@ const isStaticUndefined = (node: EsTreeNode, scopes: ScopeAnalysis): boolean => 
   );
 };
 
-const isWithinNode = (node: EsTreeNode, ancestor: EsTreeNode): boolean => {
-  let current: EsTreeNode | null | undefined = node;
-  while (current) {
-    if (current === ancestor) return true;
-    current = current.parent;
-  }
-  return false;
-};
-
 const isPotentialMutationReference = (identifier: EsTreeNode, usageNode: EsTreeNode): boolean => {
   let expression: EsTreeNode = identifier;
   let parent = expression.parent;
-  while (parent && isNodeOfType(parent, "MemberExpression") && parent.object === expression) {
+  while (
+    parent &&
+    TRANSPARENT_EXPRESSION_WRAPPER_TYPES.has(parent.type) &&
+    "expression" in parent &&
+    parent.expression === expression
+  ) {
     expression = parent;
     parent = expression.parent;
   }
-  if (!parent || isWithinNode(identifier, usageNode)) return false;
+  while (parent && isNodeOfType(parent, "MemberExpression") && parent.object === expression) {
+    expression = parent;
+    parent = expression.parent;
+    while (
+      parent &&
+      TRANSPARENT_EXPRESSION_WRAPPER_TYPES.has(parent.type) &&
+      "expression" in parent &&
+      parent.expression === expression
+    ) {
+      expression = parent;
+      parent = expression.parent;
+    }
+  }
+  if (!parent || isAstDescendant(identifier, usageNode)) return false;
   if (isNodeOfType(parent, "AssignmentExpression") && parent.left === expression) return true;
   if (isNodeOfType(parent, "UpdateExpression") && parent.argument === expression) return true;
   if (
@@ -153,18 +175,20 @@ const getObjectPropertyProof = (
   scopes: ScopeAnalysis,
   usageNode: EsTreeNode,
   visitedSymbolIds: Set<number> = new Set(),
-): boolean | null => {
-  if (!objectExpression) return false;
+): ObjectPropertyProof => {
+  if (!objectExpression) return ABSENT_PROPERTY_PROOF;
   const unwrapped = stripParenExpression(objectExpression);
   if (isNodeOfType(unwrapped, "Identifier")) {
     const symbol = scopes.symbolFor(unwrapped);
     if (
       symbol?.kind !== "const" ||
       !symbol.initializer ||
+      !isNodeOfType(symbol.declarationNode, "VariableDeclarator") ||
+      !isNodeOfType(symbol.declarationNode.id, "Identifier") ||
       visitedSymbolIds.has(symbol.id) ||
       wasMutatedBeforeUsage(symbol, usageNode)
     ) {
-      return null;
+      return UNKNOWN_PROPERTY_PROOF;
     }
     visitedSymbolIds.add(symbol.id);
     return getObjectPropertyProof(
@@ -190,7 +214,7 @@ const getObjectPropertyProof = (
       usageNode,
       new Set(visitedSymbolIds),
     );
-    return consequent === alternate ? consequent : null;
+    return consequent.status === alternate.status ? consequent : UNKNOWN_PROPERTY_PROOF;
   }
   if (
     isNodeOfType(unwrapped, "CallExpression") &&
@@ -210,7 +234,7 @@ const getObjectPropertyProof = (
       visitedSymbolIds,
     );
   }
-  if (!isNodeOfType(unwrapped, "ObjectExpression")) return null;
+  if (!isNodeOfType(unwrapped, "ObjectExpression")) return UNKNOWN_PROPERTY_PROOF;
   const properties = unwrapped.properties ?? [];
   for (let propertyIndex = properties.length - 1; propertyIndex >= 0; propertyIndex -= 1) {
     const property = properties[propertyIndex];
@@ -223,8 +247,7 @@ const getObjectPropertyProof = (
         usageNode,
         new Set(visitedSymbolIds),
       );
-      if (spreadProof === true) return true;
-      if (spreadProof === null) return null;
+      if (spreadProof.status !== "absent") return spreadProof;
       continue;
     }
     if (
@@ -233,9 +256,11 @@ const getObjectPropertyProof = (
     ) {
       continue;
     }
-    return !isStaticUndefined(property.value, scopes);
+    return isStaticUndefined(property.value, scopes)
+      ? UNDEFINED_PROPERTY_PROOF
+      : PRESENT_PROPERTY_PROOF;
   }
-  return false;
+  return ABSENT_PROPERTY_PROOF;
 };
 
 const objectHasExplicitProperty = (
@@ -243,7 +268,8 @@ const objectHasExplicitProperty = (
   propertyName: string,
   scopes: ScopeAnalysis,
   usageNode: EsTreeNode,
-): boolean => getObjectPropertyProof(objectExpression, propertyName, scopes, usageNode) === true;
+): boolean =>
+  getObjectPropertyProof(objectExpression, propertyName, scopes, usageNode).status === "present";
 
 const hasExplicitLocaleArgument = (
   argument: EsTreeNode | null | undefined,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-locale-format-in-render.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-locale-format-in-render.ts
@@ -116,14 +116,27 @@ const receiverNameLooksDateFlavored = (expression: EsTreeNode | null | undefined
   return false;
 };
 
-const isStaticUndefined = (node: EsTreeNode, scopes: ScopeAnalysis): boolean => {
+const isStaticUndefined = (
+  node: EsTreeNode,
+  scopes: ScopeAnalysis,
+  visitedSymbolIds: Set<number> = new Set(),
+): boolean => {
   const expression = stripParenExpression(node);
-  return (
-    (isNodeOfType(expression, "Identifier") &&
-      expression.name === "undefined" &&
-      scopes.isGlobalReference(expression)) ||
-    (isNodeOfType(expression, "UnaryExpression") && expression.operator === "void")
-  );
+  if (isNodeOfType(expression, "UnaryExpression") && expression.operator === "void") return true;
+  if (!isNodeOfType(expression, "Identifier")) return false;
+  if (expression.name === "undefined" && scopes.isGlobalReference(expression)) return true;
+  const symbol = scopes.symbolFor(expression);
+  if (
+    symbol?.kind !== "const" ||
+    !symbol.initializer ||
+    !isNodeOfType(symbol.declarationNode, "VariableDeclarator") ||
+    !isNodeOfType(symbol.declarationNode.id, "Identifier") ||
+    visitedSymbolIds.has(symbol.id)
+  ) {
+    return false;
+  }
+  visitedSymbolIds.add(symbol.id);
+  return isStaticUndefined(symbol.initializer, scopes, visitedSymbolIds);
 };
 
 const isNestedAssignmentTarget = (expression: EsTreeNode): boolean => {
@@ -311,15 +324,7 @@ const isFunctionInvokedBeforeUsage = (
   return wasInvokedBeforeUsage;
 };
 
-const wasMutatedBeforeUsage = (
-  symbol: SymbolDescriptor,
-  usageNode: EsTreeNode,
-  readNode: EsTreeNode,
-  scopes: ScopeAnalysis,
-  visitedMutationSymbolIds: Set<number> = new Set(),
-): boolean => {
-  if (visitedMutationSymbolIds.has(symbol.id)) return false;
-  visitedMutationSymbolIds.add(symbol.id);
+const getMutationUsageBoundary = (usageNode: EsTreeNode, readNode: EsTreeNode): number | null => {
   const readStart = getRangeStart(readNode);
   let readExpression = readNode;
   let readParent = readExpression.parent;
@@ -335,9 +340,25 @@ const wasMutatedBeforeUsage = (
   const isDirectUsageArgument =
     (isNodeOfType(usageNode, "CallExpression") || isNodeOfType(usageNode, "NewExpression")) &&
     usageNode.arguments?.some((argument) => argument === readExpression);
-  let usageBoundary = getRangeStart(usageNode);
-  if (isAstDescendant(readNode, usageNode)) usageBoundary = readStart;
-  if (isDirectUsageArgument) usageBoundary = usageNode.range?.[1] ?? null;
+  if (isDirectUsageArgument) return usageNode.range?.[1] ?? null;
+  if (isAstDescendant(readNode, usageNode)) return readStart;
+  return getRangeStart(usageNode);
+};
+
+const wasMutatedBeforeUsage = (
+  symbol: SymbolDescriptor,
+  usageNode: EsTreeNode,
+  readNode: EsTreeNode,
+  scopes: ScopeAnalysis,
+  visitedMutationSymbolIds: Set<number> = new Set(),
+  inheritedUsageBoundary?: number | null,
+): boolean => {
+  if (visitedMutationSymbolIds.has(symbol.id)) return false;
+  visitedMutationSymbolIds.add(symbol.id);
+  const usageBoundary =
+    inheritedUsageBoundary === undefined
+      ? getMutationUsageBoundary(usageNode, readNode)
+      : inheritedUsageBoundary;
   if (typeof usageBoundary !== "number") return true;
   const usageFunction = findEnclosingFunction(usageNode);
   return symbol.references.some((reference) => {
@@ -350,6 +371,7 @@ const wasMutatedBeforeUsage = (
         simpleAlias.readNode,
         scopes,
         new Set(visitedMutationSymbolIds),
+        usageBoundary,
       );
     }
     if (!isPotentialMutationReference(reference.identifier, readNode)) return false;
@@ -374,18 +396,23 @@ const getObjectPropertyProof = (
   scopes: ScopeAnalysis,
   usageNode: EsTreeNode,
   visitedSymbolIds: Set<number> = new Set(),
+  inheritedUsageBoundary?: number | null,
 ): ObjectPropertyProof => {
   if (!objectExpression) return ABSENT_PROPERTY_PROOF;
   const unwrapped = stripParenExpression(objectExpression);
   if (isNodeOfType(unwrapped, "Identifier")) {
     const symbol = scopes.symbolFor(unwrapped);
+    const usageBoundary =
+      inheritedUsageBoundary === undefined
+        ? getMutationUsageBoundary(usageNode, unwrapped)
+        : inheritedUsageBoundary;
     if (
       symbol?.kind !== "const" ||
       !symbol.initializer ||
       !isNodeOfType(symbol.declarationNode, "VariableDeclarator") ||
       !isNodeOfType(symbol.declarationNode.id, "Identifier") ||
       visitedSymbolIds.has(symbol.id) ||
-      wasMutatedBeforeUsage(symbol, usageNode, unwrapped, scopes)
+      wasMutatedBeforeUsage(symbol, usageNode, unwrapped, scopes, new Set(), usageBoundary)
     ) {
       return UNKNOWN_PROPERTY_PROOF;
     }
@@ -396,6 +423,7 @@ const getObjectPropertyProof = (
       scopes,
       usageNode,
       visitedSymbolIds,
+      usageBoundary,
     );
   }
   if (isNodeOfType(unwrapped, "ConditionalExpression")) {
@@ -405,6 +433,7 @@ const getObjectPropertyProof = (
       scopes,
       usageNode,
       new Set(visitedSymbolIds),
+      inheritedUsageBoundary,
     );
     const alternate = getObjectPropertyProof(
       unwrapped.alternate,
@@ -412,6 +441,7 @@ const getObjectPropertyProof = (
       scopes,
       usageNode,
       new Set(visitedSymbolIds),
+      inheritedUsageBoundary,
     );
     return consequent.status === alternate.status ? consequent : UNKNOWN_PROPERTY_PROOF;
   }
@@ -431,6 +461,7 @@ const getObjectPropertyProof = (
       scopes,
       usageNode,
       visitedSymbolIds,
+      inheritedUsageBoundary,
     );
   }
   if (!isNodeOfType(unwrapped, "ObjectExpression")) return UNKNOWN_PROPERTY_PROOF;
@@ -445,6 +476,7 @@ const getObjectPropertyProof = (
         scopes,
         unwrapped,
         new Set(visitedSymbolIds),
+        undefined,
       );
       if (spreadProof.status !== "absent") return spreadProof;
       continue;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-locale-format-in-render.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-locale-format-in-render.ts
@@ -10,6 +10,7 @@ import { hasEmailTemplateImport } from "../../utils/has-email-template-import.js
 import { hasSuppressHydrationWarningAttribute } from "../../utils/has-suppress-hydration-warning-attribute.js";
 import { getRangeStart } from "../../utils/get-range-start.js";
 import { getStaticPropertyKeyName } from "../../utils/get-static-property-key-name.js";
+import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
 import { isAfterClientOnlyEarlyReturn } from "../../utils/is-after-client-only-early-return.js";
 import { isAstDescendant } from "../../utils/is-ast-descendant.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
@@ -61,6 +62,14 @@ const ABSENT_PROPERTY_PROOF: ObjectPropertyProof = { status: "absent" };
 const PRESENT_PROPERTY_PROOF: ObjectPropertyProof = { status: "present" };
 const UNDEFINED_PROPERTY_PROOF: ObjectPropertyProof = { status: "undefined" };
 const UNKNOWN_PROPERTY_PROOF: ObjectPropertyProof = { status: "unknown" };
+const READ_ONLY_OBJECT_METHOD_NAMES = new Set([
+  "hasOwnProperty",
+  "isPrototypeOf",
+  "propertyIsEnumerable",
+  "toLocaleString",
+  "toString",
+  "valueOf",
+]);
 
 const isProvableDateExpression = (expression: EsTreeNode | null | undefined): boolean => {
   if (!expression) return false;
@@ -122,7 +131,10 @@ const isPotentialMutationReference = (identifier: EsTreeNode, usageNode: EsTreeN
     expression = parent;
     parent = expression.parent;
   }
+  const rootExpression = expression;
+  let memberDepth = 0;
   while (parent && isNodeOfType(parent, "MemberExpression") && parent.object === expression) {
+    memberDepth += 1;
     expression = parent;
     parent = expression.parent;
     while (
@@ -146,12 +158,19 @@ const isPotentialMutationReference = (identifier: EsTreeNode, usageNode: EsTreeN
     return true;
   }
   if (isNodeOfType(parent, "CallExpression")) {
-    return (
-      parent.callee === expression || parent.arguments?.some((argument) => argument === expression)
-    );
+    if (parent.callee === expression) {
+      if (memberDepth === 0) return true;
+      const memberExpression = stripParenExpression(expression);
+      return (
+        memberDepth === 1 &&
+        isNodeOfType(memberExpression, "MemberExpression") &&
+        !READ_ONLY_OBJECT_METHOD_NAMES.has(getStaticPropertyName(memberExpression) ?? "")
+      );
+    }
+    return memberDepth === 0 && parent.arguments?.some((argument) => argument === rootExpression);
   }
   if (isNodeOfType(parent, "NewExpression")) {
-    return parent.arguments?.some((argument) => argument === expression);
+    return memberDepth === 0 && parent.arguments?.some((argument) => argument === rootExpression);
   }
   return false;
 };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-locale-format-in-render.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-locale-format-in-render.ts
@@ -227,9 +227,6 @@ const isPotentialMutationReference = (identifier: EsTreeNode, readNode: EsTreeNo
   if (isNodeOfType(parent, "NewExpression")) {
     return memberDepth === 0 && parent.arguments?.some((argument) => argument === rootExpression);
   }
-  if (isNodeOfType(parent, "VariableDeclarator") && parent.init === rootExpression) {
-    return !isNodeOfType(parent.id, "Identifier");
-  }
   if (isNodeOfType(parent, "AssignmentExpression") && parent.right === rootExpression) {
     return true;
   }
@@ -497,6 +494,7 @@ const wasMutatedBeforeUsage = (
   scopes: ScopeAnalysis,
   visitedMutationSymbolIds: Set<number> = new Set(),
   inheritedUsageBoundary?: number | null,
+  readNodesBySymbolId: ReadonlyMap<number, EsTreeNode> = new Map(),
 ): boolean => {
   if (visitedMutationSymbolIds.has(symbol.id)) return false;
   visitedMutationSymbolIds.add(symbol.id);
@@ -513,10 +511,11 @@ const wasMutatedBeforeUsage = (
       return wasMutatedBeforeUsage(
         simpleAlias.symbol,
         usageNode,
-        simpleAlias.readNode,
+        readNodesBySymbolId.get(simpleAlias.symbol.id) ?? simpleAlias.readNode,
         scopes,
         new Set(visitedMutationSymbolIds),
         usageBoundary,
+        readNodesBySymbolId,
       );
     }
     if (!isPotentialMutationReference(reference.identifier, readNode)) return false;
@@ -542,6 +541,7 @@ const getObjectPropertyProof = (
   usageNode: EsTreeNode,
   visitedSymbolIds: Set<number> = new Set(),
   inheritedUsageBoundary?: number | null,
+  readNodesBySymbolId: ReadonlyMap<number, EsTreeNode> = new Map(),
 ): ObjectPropertyProof => {
   if (!objectExpression) return ABSENT_PROPERTY_PROOF;
   const unwrapped = stripParenExpression(objectExpression);
@@ -550,6 +550,8 @@ const getObjectPropertyProof = (
   }
   if (isNodeOfType(unwrapped, "Identifier")) {
     const symbol = scopes.symbolFor(unwrapped);
+    const nextReadNodesBySymbolId = new Map(readNodesBySymbolId);
+    if (symbol) nextReadNodesBySymbolId.set(symbol.id, unwrapped);
     const usageBoundary =
       inheritedUsageBoundary === undefined
         ? getMutationUsageBoundary(usageNode, unwrapped)
@@ -560,7 +562,15 @@ const getObjectPropertyProof = (
       !isNodeOfType(symbol.declarationNode, "VariableDeclarator") ||
       !isNodeOfType(symbol.declarationNode.id, "Identifier") ||
       visitedSymbolIds.has(symbol.id) ||
-      wasMutatedBeforeUsage(symbol, usageNode, unwrapped, scopes, new Set(), usageBoundary)
+      wasMutatedBeforeUsage(
+        symbol,
+        usageNode,
+        unwrapped,
+        scopes,
+        new Set(),
+        usageBoundary,
+        nextReadNodesBySymbolId,
+      )
     ) {
       return UNKNOWN_PROPERTY_PROOF;
     }
@@ -572,6 +582,7 @@ const getObjectPropertyProof = (
       usageNode,
       visitedSymbolIds,
       usageBoundary,
+      nextReadNodesBySymbolId,
     );
   }
   if (isNodeOfType(unwrapped, "ConditionalExpression")) {
@@ -582,6 +593,7 @@ const getObjectPropertyProof = (
       usageNode,
       new Set(visitedSymbolIds),
       inheritedUsageBoundary,
+      new Map(readNodesBySymbolId),
     );
     const alternate = getObjectPropertyProof(
       unwrapped.alternate,
@@ -590,6 +602,7 @@ const getObjectPropertyProof = (
       usageNode,
       new Set(visitedSymbolIds),
       inheritedUsageBoundary,
+      new Map(readNodesBySymbolId),
     );
     return consequent.status === alternate.status ? consequent : UNKNOWN_PROPERTY_PROOF;
   }
@@ -610,6 +623,7 @@ const getObjectPropertyProof = (
       usageNode,
       visitedSymbolIds,
       inheritedUsageBoundary,
+      readNodesBySymbolId,
     );
   }
   if (!isNodeOfType(unwrapped, "ObjectExpression")) return UNKNOWN_PROPERTY_PROOF;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-locale-format-in-render.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-locale-format-in-render.ts
@@ -60,6 +60,11 @@ interface ObjectPropertyProof {
   readonly status: "absent" | "present" | "undefined" | "unknown";
 }
 
+interface SimpleAlias {
+  readonly symbol: SymbolDescriptor;
+  readonly readNode: EsTreeNode;
+}
+
 const ABSENT_PROPERTY_PROOF: ObjectPropertyProof = { status: "absent" };
 const PRESENT_PROPERTY_PROOF: ObjectPropertyProof = { status: "present" };
 const UNDEFINED_PROPERTY_PROOF: ObjectPropertyProof = { status: "undefined" };
@@ -121,6 +126,33 @@ const isStaticUndefined = (node: EsTreeNode, scopes: ScopeAnalysis): boolean => 
   );
 };
 
+const isNestedAssignmentTarget = (expression: EsTreeNode): boolean => {
+  let target = expression;
+  let parent = target.parent;
+  while (parent) {
+    if (isNodeOfType(parent, "AssignmentExpression")) return parent.left === target;
+    if (isNodeOfType(parent, "ForInStatement") || isNodeOfType(parent, "ForOfStatement")) {
+      return parent.left === target;
+    }
+    if (isNodeOfType(parent, "AssignmentPattern")) {
+      if (parent.left !== target) return false;
+    } else if (isNodeOfType(parent, "RestElement")) {
+      if (parent.argument !== target) return false;
+    } else if (isNodeOfType(parent, "ArrayPattern")) {
+      if (!parent.elements?.some((element) => element === target)) return false;
+    } else if (isNodeOfType(parent, "Property")) {
+      if (parent.value !== target || !isNodeOfType(parent.parent, "ObjectPattern")) return false;
+    } else if (isNodeOfType(parent, "ObjectPattern")) {
+      if (!parent.properties?.some((property) => property === target)) return false;
+    } else {
+      return false;
+    }
+    target = parent;
+    parent = target.parent;
+  }
+  return false;
+};
+
 const isPotentialMutationReference = (identifier: EsTreeNode, readNode: EsTreeNode): boolean => {
   let expression: EsTreeNode = identifier;
   let parent = expression.parent;
@@ -150,6 +182,7 @@ const isPotentialMutationReference = (identifier: EsTreeNode, readNode: EsTreeNo
     }
   }
   if (!parent || isAstDescendant(identifier, readNode)) return false;
+  if (isNestedAssignmentTarget(expression)) return true;
   if (isNodeOfType(parent, "AssignmentExpression") && parent.left === expression) return true;
   if (isNodeOfType(parent, "UpdateExpression") && parent.argument === expression) return true;
   if (
@@ -174,7 +207,36 @@ const isPotentialMutationReference = (identifier: EsTreeNode, readNode: EsTreeNo
   if (isNodeOfType(parent, "NewExpression")) {
     return memberDepth === 0 && parent.arguments?.some((argument) => argument === rootExpression);
   }
+  if (isNodeOfType(parent, "VariableDeclarator") && parent.init === rootExpression) {
+    return !isNodeOfType(parent.id, "Identifier");
+  }
+  if (isNodeOfType(parent, "AssignmentExpression") && parent.right === rootExpression) {
+    return true;
+  }
   return false;
+};
+
+const getSimpleAlias = (identifier: EsTreeNode, scopes: ScopeAnalysis): SimpleAlias | null => {
+  let expression = identifier;
+  let parent = expression.parent;
+  while (
+    parent &&
+    TRANSPARENT_EXPRESSION_WRAPPER_TYPES.has(parent.type) &&
+    "expression" in parent &&
+    parent.expression === expression
+  ) {
+    expression = parent;
+    parent = expression.parent;
+  }
+  if (
+    !isNodeOfType(parent, "VariableDeclarator") ||
+    parent.init !== expression ||
+    !isNodeOfType(parent.id, "Identifier")
+  ) {
+    return null;
+  }
+  const symbol = scopes.symbolFor(parent.id);
+  return symbol ? { symbol, readNode: parent.id } : null;
 };
 
 const getDirectCallForExpression = (expression: EsTreeNode): EsTreeNode | null => {
@@ -254,7 +316,10 @@ const wasMutatedBeforeUsage = (
   usageNode: EsTreeNode,
   readNode: EsTreeNode,
   scopes: ScopeAnalysis,
+  visitedMutationSymbolIds: Set<number> = new Set(),
 ): boolean => {
+  if (visitedMutationSymbolIds.has(symbol.id)) return false;
+  visitedMutationSymbolIds.add(symbol.id);
   const readStart = getRangeStart(readNode);
   let readExpression = readNode;
   let readParent = readExpression.parent;
@@ -277,6 +342,16 @@ const wasMutatedBeforeUsage = (
   const usageFunction = findEnclosingFunction(usageNode);
   return symbol.references.some((reference) => {
     const referenceStart = getRangeStart(reference.identifier);
+    const simpleAlias = getSimpleAlias(reference.identifier, scopes);
+    if (simpleAlias) {
+      return wasMutatedBeforeUsage(
+        simpleAlias.symbol,
+        usageNode,
+        simpleAlias.readNode,
+        scopes,
+        new Set(visitedMutationSymbolIds),
+      );
+    }
     if (!isPotentialMutationReference(reference.identifier, readNode)) return false;
     if (referenceStart === null) return true;
     const mutationFunction = findEnclosingFunction(reference.identifier);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-locale-format-in-render.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-locale-format-in-render.ts
@@ -177,8 +177,8 @@ const isPotentialMutationReference = (identifier: EsTreeNode, readNode: EsTreeNo
   return false;
 };
 
-const getDirectCallForIdentifier = (identifier: EsTreeNode): EsTreeNode | null => {
-  let callee: EsTreeNode = identifier;
+const getDirectCallForExpression = (expression: EsTreeNode): EsTreeNode | null => {
+  let callee: EsTreeNode = expression;
   let parent = callee.parent;
   while (
     parent &&
@@ -198,6 +198,18 @@ const isFunctionInvokedBeforeUsage = (
   scopes: ScopeAnalysis,
   visitedSymbolIds: Set<number>,
 ): boolean => {
+  const immediateCall = getDirectCallForExpression(functionNode);
+  if (immediateCall) {
+    const immediateCallFunction = findEnclosingFunction(immediateCall);
+    const usageFunction = findEnclosingFunction(usageNode);
+    if (immediateCallFunction === usageFunction) {
+      const immediateCallStart = getRangeStart(immediateCall);
+      const usageStart = getRangeStart(usageNode);
+      return immediateCallStart === null || usageStart === null || immediateCallStart < usageStart;
+    }
+    if (!immediateCallFunction) return usageFunction !== null;
+    return isFunctionInvokedBeforeUsage(immediateCallFunction, usageNode, scopes, visitedSymbolIds);
+  }
   const bindingIdentifier = getFunctionBindingIdentifier(functionNode);
   if (!bindingIdentifier) return false;
   const symbol = scopes.symbolFor(bindingIdentifier);
@@ -210,7 +222,7 @@ const isFunctionInvokedBeforeUsage = (
   walkAst(scopes.rootScope.node, (child) => {
     if (wasInvokedBeforeUsage || !isNodeOfType(child, "Identifier")) return;
     if (scopes.symbolFor(child)?.declarationNode !== symbol.declarationNode) return;
-    const call = getDirectCallForIdentifier(child);
+    const call = getDirectCallForExpression(child);
     if (!call) return false;
     const callFunction = findEnclosingFunction(call);
     if (callFunction === usageFunction) {
@@ -264,10 +276,9 @@ const wasMutatedBeforeUsage = (
     if (referenceStart === null) return true;
     const mutationFunction = findEnclosingFunction(reference.identifier);
     if (mutationFunction === usageFunction) return referenceStart < usageBoundary;
-    return (
-      mutationFunction !== null &&
-      isFunctionInvokedBeforeUsage(mutationFunction, usageNode, scopes, new Set())
-    );
+    if (!mutationFunction) return usageFunction !== null;
+    if (usageFunction && isAstDescendant(usageFunction, mutationFunction)) return true;
+    return isFunctionInvokedBeforeUsage(mutationFunction, usageNode, scopes, new Set());
   });
 };
 
@@ -346,7 +357,7 @@ const getObjectPropertyProof = (
         property.argument,
         propertyName,
         scopes,
-        usageNode,
+        unwrapped,
         new Set(visitedSymbolIds),
       );
       if (spreadProof.status !== "absent") return spreadProof;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-locale-format-in-render.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-locale-format-in-render.ts
@@ -1,3 +1,4 @@
+import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
 import { componentOrHookDisplayNameForFunction } from "../../utils/component-or-hook-display-name.js";
 import { defineRule } from "../../utils/define-rule.js";
 import { findEnclosingJsxOpeningElement } from "../../utils/find-enclosing-jsx-opening-element.js";
@@ -14,6 +15,7 @@ import { isGeneratedImageRenderContext } from "../../utils/is-generated-image-re
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { classifyReactNativeFileTarget } from "../../utils/is-react-native-file.js";
 import { isTestlikeFilename } from "../../utils/is-testlike-filename.js";
+import { resolveConstIdentifierAlias } from "../../utils/resolve-const-identifier-alias.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import { walkAst } from "../../utils/walk-ast.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
@@ -87,9 +89,16 @@ const receiverNameLooksDateFlavored = (expression: EsTreeNode | null | undefined
 const objectLiteralHasProperty = (
   objectExpression: EsTreeNode | null | undefined,
   propertyName: string,
+  scopes: ScopeAnalysis,
 ): boolean => {
   if (!objectExpression) return false;
   const unwrapped = stripParenExpression(objectExpression);
+  if (isNodeOfType(unwrapped, "Identifier")) {
+    const symbol = resolveConstIdentifierAlias(unwrapped, scopes);
+    return Boolean(
+      symbol?.initializer && objectLiteralHasProperty(symbol.initializer, propertyName, scopes),
+    );
+  }
   if (!isNodeOfType(unwrapped, "ObjectExpression")) return false;
   for (const property of unwrapped.properties ?? []) {
     if (!isNodeOfType(property, "Property")) continue;
@@ -115,11 +124,12 @@ const isDeterministicLocaleMethodCall = (
   call: EsTreeNodeOfType<"CallExpression">,
   methodName: string,
   receiverIsProvablyDate: boolean,
+  scopes: ScopeAnalysis,
 ): boolean => {
   const localeArgument = call.arguments?.[0];
   if (!hasExplicitLocaleArgument(localeArgument)) return false;
   const optionsArgument = call.arguments?.[1];
-  if (objectLiteralHasProperty(optionsArgument, "timeZone")) return true;
+  if (objectLiteralHasProperty(optionsArgument, "timeZone", scopes)) return true;
   // Explicit locale, no timeZone: still environment-dependent when the
   // receiver is a date. An unknown receiver could be a number (locale is
   // its only environment input), so stay quiet there.
@@ -128,6 +138,7 @@ const isDeterministicLocaleMethodCall = (
 
 const matchLocaleMethodCall = (
   call: EsTreeNodeOfType<"CallExpression">,
+  scopes: ScopeAnalysis,
 ): LocaleFormatMatch | null => {
   const callee = call.callee;
   if (!isNodeOfType(callee, "MemberExpression") || callee.computed) return null;
@@ -142,7 +153,8 @@ const matchLocaleMethodCall = (
   ) {
     return null;
   }
-  if (isDeterministicLocaleMethodCall(call, methodName, receiverIsProvablyDate)) return null;
+  if (isDeterministicLocaleMethodCall(call, methodName, receiverIsProvablyDate, scopes))
+    return null;
   return { node: call, display: `${methodName}()` };
 };
 
@@ -162,6 +174,7 @@ const getIntlFormatterName = (expression: EsTreeNode | null | undefined): string
 const isDeterministicIntlConstruction = (
   construction: EsTreeNode,
   formatterName: string,
+  scopes: ScopeAnalysis,
 ): boolean => {
   if (
     !isNodeOfType(construction, "CallExpression") &&
@@ -171,7 +184,7 @@ const isDeterministicIntlConstruction = (
   }
   if (!hasExplicitLocaleArgument(construction.arguments?.[0])) return false;
   if (formatterName !== "DateTimeFormat") return true;
-  return objectLiteralHasProperty(construction.arguments?.[1], "timeZone");
+  return objectLiteralHasProperty(construction.arguments?.[1], "timeZone", scopes);
 };
 
 // `Intl.DateTimeFormat().format(date)` — direct chain, or through a
@@ -179,6 +192,7 @@ const isDeterministicIntlConstruction = (
 // formatter.format(date)`).
 const matchIntlFormatCall = (
   call: EsTreeNodeOfType<"CallExpression">,
+  scopes: ScopeAnalysis,
 ): LocaleFormatMatch | null => {
   const callee = call.callee;
   if (!isNodeOfType(callee, "MemberExpression") || callee.computed) return null;
@@ -193,7 +207,7 @@ const matchIntlFormatCall = (
   if (!construction) return null;
   const formatterName = getIntlFormatterName(construction);
   if (!formatterName) return null;
-  if (isDeterministicIntlConstruction(construction, formatterName)) return null;
+  if (isDeterministicIntlConstruction(construction, formatterName, scopes)) return null;
   return { node: call, display: `Intl.${formatterName}().${callee.property.name}()` };
 };
 
@@ -296,8 +310,8 @@ export const noLocaleFormatInRender = defineRule({
       },
       CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
         const match =
-          matchLocaleMethodCall(node) ??
-          matchIntlFormatCall(node) ??
+          matchLocaleMethodCall(node, context.scopes) ??
+          matchIntlFormatCall(node, context.scopes) ??
           matchDateDefaultStringification(node);
         if (match) reportIfRenderPhase(match);
       },
@@ -323,7 +337,9 @@ export const noLocaleFormatInRender = defineRule({
         walkAst(helperNode.body ?? helperNode, (child: EsTreeNode) => {
           if (isFunctionLike(child)) return false;
           if (!isNodeOfType(child, "CallExpression")) return;
-          const match = matchLocaleMethodCall(child) ?? matchIntlFormatCall(child);
+          const match =
+            matchLocaleMethodCall(child, context.scopes) ??
+            matchIntlFormatCall(child, context.scopes);
           if (!match || reportedNodes.has(match.node)) return;
           if (fileIsEmailTemplate) return;
           if (!hasClientRenderEvidence(componentOrHookNode, fileHasUseClientDirective)) return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-locale-format-in-render.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-locale-format-in-render.ts
@@ -1,14 +1,16 @@
 import type { ScopeAnalysis, SymbolDescriptor } from "../../semantic/scope-analysis.js";
 import { componentOrHookDisplayNameForFunction } from "../../utils/component-or-hook-display-name.js";
 import { defineRule } from "../../utils/define-rule.js";
+import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
 import { findEnclosingJsxOpeningElement } from "../../utils/find-enclosing-jsx-opening-element.js";
 import { findRenderPhaseComponentOrHook } from "../../utils/find-render-phase-component-or-hook.js";
 import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
+import { getFunctionBindingIdentifier } from "../../utils/get-function-binding-name.js";
+import { getRangeStart } from "../../utils/get-range-start.js";
 import { hasClientRenderEvidence } from "../../utils/has-client-render-evidence.js";
 import { hasDirective } from "../../utils/has-directive.js";
 import { hasEmailTemplateImport } from "../../utils/has-email-template-import.js";
 import { hasSuppressHydrationWarningAttribute } from "../../utils/has-suppress-hydration-warning-attribute.js";
-import { getRangeStart } from "../../utils/get-range-start.js";
 import { getStaticPropertyKeyName } from "../../utils/get-static-property-key-name.js";
 import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
 import { isAfterClientOnlyEarlyReturn } from "../../utils/is-after-client-only-early-return.js";
@@ -119,7 +121,7 @@ const isStaticUndefined = (node: EsTreeNode, scopes: ScopeAnalysis): boolean => 
   );
 };
 
-const isPotentialMutationReference = (identifier: EsTreeNode, usageNode: EsTreeNode): boolean => {
+const isPotentialMutationReference = (identifier: EsTreeNode, readNode: EsTreeNode): boolean => {
   let expression: EsTreeNode = identifier;
   let parent = expression.parent;
   while (
@@ -147,7 +149,7 @@ const isPotentialMutationReference = (identifier: EsTreeNode, usageNode: EsTreeN
       parent = expression.parent;
     }
   }
-  if (!parent || isAstDescendant(identifier, usageNode)) return false;
+  if (!parent || isAstDescendant(identifier, readNode)) return false;
   if (isNodeOfType(parent, "AssignmentExpression") && parent.left === expression) return true;
   if (isNodeOfType(parent, "UpdateExpression") && parent.argument === expression) return true;
   if (
@@ -175,15 +177,96 @@ const isPotentialMutationReference = (identifier: EsTreeNode, usageNode: EsTreeN
   return false;
 };
 
-const wasMutatedBeforeUsage = (symbol: SymbolDescriptor, usageNode: EsTreeNode): boolean => {
+const getDirectCallForIdentifier = (identifier: EsTreeNode): EsTreeNode | null => {
+  let callee: EsTreeNode = identifier;
+  let parent = callee.parent;
+  while (
+    parent &&
+    TRANSPARENT_EXPRESSION_WRAPPER_TYPES.has(parent.type) &&
+    "expression" in parent &&
+    parent.expression === callee
+  ) {
+    callee = parent;
+    parent = callee.parent;
+  }
+  return isNodeOfType(parent, "CallExpression") && parent.callee === callee ? parent : null;
+};
+
+const isFunctionInvokedBeforeUsage = (
+  functionNode: EsTreeNode,
+  usageNode: EsTreeNode,
+  scopes: ScopeAnalysis,
+  visitedSymbolIds: Set<number>,
+): boolean => {
+  const bindingIdentifier = getFunctionBindingIdentifier(functionNode);
+  if (!bindingIdentifier) return false;
+  const symbol = scopes.symbolFor(bindingIdentifier);
+  if (!symbol || visitedSymbolIds.has(symbol.id)) return false;
+  visitedSymbolIds.add(symbol.id);
+  const usageFunction = findEnclosingFunction(usageNode);
   const usageStart = getRangeStart(usageNode);
   if (usageStart === null) return true;
+  let wasInvokedBeforeUsage = false;
+  walkAst(scopes.rootScope.node, (child) => {
+    if (wasInvokedBeforeUsage || !isNodeOfType(child, "Identifier")) return;
+    if (scopes.symbolFor(child)?.declarationNode !== symbol.declarationNode) return;
+    const call = getDirectCallForIdentifier(child);
+    if (!call) return false;
+    const callFunction = findEnclosingFunction(call);
+    if (callFunction === usageFunction) {
+      const callStart = getRangeStart(call);
+      wasInvokedBeforeUsage = callStart === null || callStart < usageStart;
+      return;
+    }
+    if (!callFunction) {
+      wasInvokedBeforeUsage = usageFunction !== null;
+      return;
+    }
+    wasInvokedBeforeUsage = isFunctionInvokedBeforeUsage(
+      callFunction,
+      usageNode,
+      scopes,
+      new Set(visitedSymbolIds),
+    );
+  });
+  return wasInvokedBeforeUsage;
+};
+
+const wasMutatedBeforeUsage = (
+  symbol: SymbolDescriptor,
+  usageNode: EsTreeNode,
+  readNode: EsTreeNode,
+  scopes: ScopeAnalysis,
+): boolean => {
+  const readStart = getRangeStart(readNode);
+  let readExpression = readNode;
+  let readParent = readExpression.parent;
+  while (
+    readParent &&
+    TRANSPARENT_EXPRESSION_WRAPPER_TYPES.has(readParent.type) &&
+    "expression" in readParent &&
+    readParent.expression === readExpression
+  ) {
+    readExpression = readParent;
+    readParent = readExpression.parent;
+  }
+  const isDirectUsageArgument =
+    (isNodeOfType(usageNode, "CallExpression") || isNodeOfType(usageNode, "NewExpression")) &&
+    usageNode.arguments?.some((argument) => argument === readExpression);
+  let usageBoundary = getRangeStart(usageNode);
+  if (isAstDescendant(readNode, usageNode)) usageBoundary = readStart;
+  if (isDirectUsageArgument) usageBoundary = usageNode.range?.[1] ?? null;
+  if (typeof usageBoundary !== "number") return true;
+  const usageFunction = findEnclosingFunction(usageNode);
   return symbol.references.some((reference) => {
     const referenceStart = getRangeStart(reference.identifier);
+    if (!isPotentialMutationReference(reference.identifier, readNode)) return false;
+    if (referenceStart === null) return true;
+    const mutationFunction = findEnclosingFunction(reference.identifier);
+    if (mutationFunction === usageFunction) return referenceStart < usageBoundary;
     return (
-      referenceStart !== null &&
-      referenceStart < usageStart &&
-      isPotentialMutationReference(reference.identifier, usageNode)
+      mutationFunction !== null &&
+      isFunctionInvokedBeforeUsage(mutationFunction, usageNode, scopes, new Set())
     );
   });
 };
@@ -205,7 +288,7 @@ const getObjectPropertyProof = (
       !isNodeOfType(symbol.declarationNode, "VariableDeclarator") ||
       !isNodeOfType(symbol.declarationNode.id, "Identifier") ||
       visitedSymbolIds.has(symbol.id) ||
-      wasMutatedBeforeUsage(symbol, usageNode)
+      wasMutatedBeforeUsage(symbol, usageNode, unwrapped, scopes)
     ) {
       return UNKNOWN_PROPERTY_PROOF;
     }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-locale-format-in-render.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-locale-format-in-render.ts
@@ -195,6 +195,7 @@ const getDirectCallForExpression = (expression: EsTreeNode): EsTreeNode | null =
 const isFunctionInvokedBeforeUsage = (
   functionNode: EsTreeNode,
   usageNode: EsTreeNode,
+  usageBoundary: number,
   scopes: ScopeAnalysis,
   visitedSymbolIds: Set<number>,
 ): boolean => {
@@ -204,11 +205,16 @@ const isFunctionInvokedBeforeUsage = (
     const usageFunction = findEnclosingFunction(usageNode);
     if (immediateCallFunction === usageFunction) {
       const immediateCallStart = getRangeStart(immediateCall);
-      const usageStart = getRangeStart(usageNode);
-      return immediateCallStart === null || usageStart === null || immediateCallStart < usageStart;
+      return immediateCallStart === null || immediateCallStart < usageBoundary;
     }
     if (!immediateCallFunction) return usageFunction !== null;
-    return isFunctionInvokedBeforeUsage(immediateCallFunction, usageNode, scopes, visitedSymbolIds);
+    return isFunctionInvokedBeforeUsage(
+      immediateCallFunction,
+      usageNode,
+      usageBoundary,
+      scopes,
+      visitedSymbolIds,
+    );
   }
   const bindingIdentifier = getFunctionBindingIdentifier(functionNode);
   if (!bindingIdentifier) return false;
@@ -216,8 +222,6 @@ const isFunctionInvokedBeforeUsage = (
   if (!symbol || visitedSymbolIds.has(symbol.id)) return false;
   visitedSymbolIds.add(symbol.id);
   const usageFunction = findEnclosingFunction(usageNode);
-  const usageStart = getRangeStart(usageNode);
-  if (usageStart === null) return true;
   let wasInvokedBeforeUsage = false;
   walkAst(scopes.rootScope.node, (child) => {
     if (wasInvokedBeforeUsage || !isNodeOfType(child, "Identifier")) return;
@@ -227,7 +231,7 @@ const isFunctionInvokedBeforeUsage = (
     const callFunction = findEnclosingFunction(call);
     if (callFunction === usageFunction) {
       const callStart = getRangeStart(call);
-      wasInvokedBeforeUsage = callStart === null || callStart < usageStart;
+      wasInvokedBeforeUsage = callStart === null || callStart < usageBoundary;
       return;
     }
     if (!callFunction) {
@@ -237,6 +241,7 @@ const isFunctionInvokedBeforeUsage = (
     wasInvokedBeforeUsage = isFunctionInvokedBeforeUsage(
       callFunction,
       usageNode,
+      usageBoundary,
       scopes,
       new Set(visitedSymbolIds),
     );
@@ -278,7 +283,13 @@ const wasMutatedBeforeUsage = (
     if (mutationFunction === usageFunction) return referenceStart < usageBoundary;
     if (!mutationFunction) return usageFunction !== null;
     if (usageFunction && isAstDescendant(usageFunction, mutationFunction)) return true;
-    return isFunctionInvokedBeforeUsage(mutationFunction, usageNode, scopes, new Set());
+    return isFunctionInvokedBeforeUsage(
+      mutationFunction,
+      usageNode,
+      usageBoundary,
+      scopes,
+      new Set(),
+    );
   });
 };
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-locale-format-in-render.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-locale-format-in-render.ts
@@ -65,6 +65,13 @@ interface SimpleAlias {
   readonly readNode: EsTreeNode;
 }
 
+interface MethodOwner {
+  readonly methodName: string;
+  readonly ownerKind: "class" | "object";
+  readonly ownerSymbol: SymbolDescriptor;
+  readonly isStatic: boolean;
+}
+
 const ABSENT_PROPERTY_PROOF: ObjectPropertyProof = { status: "absent" };
 const PRESENT_PROPERTY_PROOF: ObjectPropertyProof = { status: "present" };
 const UNDEFINED_PROPERTY_PROOF: ObjectPropertyProof = { status: "undefined" };
@@ -267,17 +274,130 @@ const getDirectCallForExpression = (expression: EsTreeNode): EsTreeNode | null =
   return isNodeOfType(parent, "CallExpression") && parent.callee === callee ? parent : null;
 };
 
+const getMethodOwner = (functionNode: EsTreeNode, scopes: ScopeAnalysis): MethodOwner | null => {
+  const methodNode = functionNode.parent;
+  if (
+    isNodeOfType(methodNode, "Property") &&
+    methodNode.value === functionNode &&
+    isNodeOfType(methodNode.parent, "ObjectExpression")
+  ) {
+    const objectParent = methodNode.parent.parent;
+    if (
+      !isNodeOfType(objectParent, "VariableDeclarator") ||
+      objectParent.init !== methodNode.parent ||
+      !isNodeOfType(objectParent.id, "Identifier")
+    ) {
+      return null;
+    }
+    const ownerSymbol = scopes.symbolFor(objectParent.id);
+    const methodName = getStaticPropertyKeyName(methodNode, { allowComputedString: true });
+    return ownerSymbol && methodName
+      ? { methodName, ownerKind: "object", ownerSymbol, isStatic: false }
+      : null;
+  }
+  if (
+    !isNodeOfType(methodNode, "MethodDefinition") ||
+    methodNode.value !== functionNode ||
+    !isNodeOfType(methodNode.parent, "ClassBody")
+  ) {
+    return null;
+  }
+  const classNode = methodNode.parent.parent;
+  if (!isNodeOfType(classNode, "ClassDeclaration") && !isNodeOfType(classNode, "ClassExpression")) {
+    return null;
+  }
+  let bindingIdentifier = isNodeOfType(classNode.id, "Identifier") ? classNode.id : null;
+  if (!bindingIdentifier && isNodeOfType(classNode.parent, "VariableDeclarator")) {
+    bindingIdentifier = isNodeOfType(classNode.parent.id, "Identifier")
+      ? classNode.parent.id
+      : null;
+  }
+  if (!bindingIdentifier) return null;
+  const ownerSymbol = scopes.symbolFor(bindingIdentifier);
+  const methodName = getStaticPropertyKeyName(methodNode, { allowComputedString: true });
+  return ownerSymbol && methodName
+    ? {
+        methodName,
+        ownerKind: "class",
+        ownerSymbol,
+        isStatic: Boolean(methodNode.static),
+      }
+    : null;
+};
+
+const doesSymbolResolveToOwner = (
+  symbol: SymbolDescriptor | null,
+  ownerSymbol: SymbolDescriptor,
+  scopes: ScopeAnalysis,
+  visitedSymbolIds: Set<number> = new Set(),
+): boolean => {
+  if (!symbol) return false;
+  if (symbol.declarationNode === ownerSymbol.declarationNode) return true;
+  if (symbol.kind !== "const" || !symbol.initializer || visitedSymbolIds.has(symbol.id)) {
+    return false;
+  }
+  visitedSymbolIds.add(symbol.id);
+  const initializer = stripParenExpression(symbol.initializer);
+  return (
+    isNodeOfType(initializer, "Identifier") &&
+    doesSymbolResolveToOwner(scopes.symbolFor(initializer), ownerSymbol, scopes, visitedSymbolIds)
+  );
+};
+
+const isClassInstanceExpression = (
+  expression: EsTreeNode,
+  ownerSymbol: SymbolDescriptor,
+  scopes: ScopeAnalysis,
+  visitedSymbolIds: Set<number> = new Set(),
+): boolean => {
+  const candidate = stripParenExpression(expression);
+  if (isNodeOfType(candidate, "NewExpression") && isNodeOfType(candidate.callee, "Identifier")) {
+    return doesSymbolResolveToOwner(scopes.symbolFor(candidate.callee), ownerSymbol, scopes);
+  }
+  if (!isNodeOfType(candidate, "Identifier")) return false;
+  const symbol = scopes.symbolFor(candidate);
+  if (symbol?.kind !== "const" || !symbol.initializer || visitedSymbolIds.has(symbol.id)) {
+    return false;
+  }
+  visitedSymbolIds.add(symbol.id);
+  return isClassInstanceExpression(symbol.initializer, ownerSymbol, scopes, visitedSymbolIds);
+};
+
+const getMethodCalls = (functionNode: EsTreeNode, scopes: ScopeAnalysis): EsTreeNode[] => {
+  const owner = getMethodOwner(functionNode, scopes);
+  if (!owner) return [];
+  const calls: EsTreeNode[] = [];
+  walkAst(scopes.rootScope.node, (child) => {
+    if (!isNodeOfType(child, "MemberExpression")) return;
+    if (getStaticPropertyName(child) !== owner.methodName) return;
+    const receiver = stripParenExpression(child.object);
+    let doesReceiverMatch =
+      isNodeOfType(receiver, "Identifier") &&
+      doesSymbolResolveToOwner(scopes.symbolFor(receiver), owner.ownerSymbol, scopes);
+    if (owner.ownerKind === "class" && !owner.isStatic) {
+      doesReceiverMatch = isClassInstanceExpression(receiver, owner.ownerSymbol, scopes);
+    }
+    if (!doesReceiverMatch) return;
+    const call = getDirectCallForExpression(child);
+    if (call) calls.push(call);
+  });
+  return calls;
+};
+
 const isFunctionInvokedBeforeUsage = (
   functionNode: EsTreeNode,
   usageNode: EsTreeNode,
   usageBoundary: number,
   scopes: ScopeAnalysis,
   visitedSymbolIds: Set<number>,
+  visitedFunctionNodes: Set<EsTreeNode> = new Set(),
 ): boolean => {
+  if (visitedFunctionNodes.has(functionNode)) return false;
+  visitedFunctionNodes.add(functionNode);
+  const usageFunction = findEnclosingFunction(usageNode);
   const immediateCall = getDirectCallForExpression(functionNode);
   if (immediateCall) {
     const immediateCallFunction = findEnclosingFunction(immediateCall);
-    const usageFunction = findEnclosingFunction(usageNode);
     if (immediateCallFunction === usageFunction) {
       const immediateCallStart = getRangeStart(immediateCall);
       return immediateCallStart === null || immediateCallStart < usageBoundary;
@@ -289,14 +409,38 @@ const isFunctionInvokedBeforeUsage = (
       usageBoundary,
       scopes,
       visitedSymbolIds,
+      new Set(visitedFunctionNodes),
     );
+  }
+  for (const methodCall of getMethodCalls(functionNode, scopes)) {
+    const methodCallFunction = findEnclosingFunction(methodCall);
+    if (methodCallFunction === usageFunction) {
+      const methodCallStart = getRangeStart(methodCall);
+      if (methodCallStart === null || methodCallStart < usageBoundary) return true;
+      continue;
+    }
+    if (!methodCallFunction) {
+      if (usageFunction) return true;
+      continue;
+    }
+    if (
+      isFunctionInvokedBeforeUsage(
+        methodCallFunction,
+        usageNode,
+        usageBoundary,
+        scopes,
+        new Set(visitedSymbolIds),
+        new Set(visitedFunctionNodes),
+      )
+    ) {
+      return true;
+    }
   }
   const bindingIdentifier = getFunctionBindingIdentifier(functionNode);
   if (!bindingIdentifier) return false;
   const symbol = scopes.symbolFor(bindingIdentifier);
   if (!symbol || visitedSymbolIds.has(symbol.id)) return false;
   visitedSymbolIds.add(symbol.id);
-  const usageFunction = findEnclosingFunction(usageNode);
   let wasInvokedBeforeUsage = false;
   walkAst(scopes.rootScope.node, (child) => {
     if (wasInvokedBeforeUsage || !isNodeOfType(child, "Identifier")) return;
@@ -319,6 +463,7 @@ const isFunctionInvokedBeforeUsage = (
       usageBoundary,
       scopes,
       new Set(visitedSymbolIds),
+      new Set(visitedFunctionNodes),
     );
   });
   return wasInvokedBeforeUsage;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-locale-format-in-render.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-locale-format-in-render.ts
@@ -96,7 +96,9 @@ const objectLiteralHasProperty = (
   if (isNodeOfType(unwrapped, "Identifier")) {
     const symbol = resolveConstIdentifierAlias(unwrapped, scopes);
     return Boolean(
-      symbol?.initializer && objectLiteralHasProperty(symbol.initializer, propertyName, scopes),
+      symbol?.kind === "const" &&
+      symbol.initializer &&
+      objectLiteralHasProperty(symbol.initializer, propertyName, scopes),
     );
   }
   if (!isNodeOfType(unwrapped, "ObjectExpression")) return false;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-locale-format-in-render.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-locale-format-in-render.ts
@@ -545,6 +545,9 @@ const getObjectPropertyProof = (
 ): ObjectPropertyProof => {
   if (!objectExpression) return ABSENT_PROPERTY_PROOF;
   const unwrapped = stripParenExpression(objectExpression);
+  if (isNodeOfType(unwrapped, "Literal") || isStaticUndefined(unwrapped, scopes)) {
+    return ABSENT_PROPERTY_PROOF;
+  }
   if (isNodeOfType(unwrapped, "Identifier")) {
     const symbol = scopes.symbolFor(unwrapped);
     const usageBoundary =

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-static-property-key-name.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-static-property-key-name.test.ts
@@ -93,4 +93,26 @@ describe("getStaticPropertyKeyName", () => {
       expect(getStaticPropertyKeyName(requireProperty(properties, 4), testCase.options)).toBe(null);
     });
   }
+
+  it("reads class method keys", () => {
+    const parsed = parseFixture(`
+      class Helper {
+        clear() {}
+        ["computed"]() {}
+      }
+    `);
+    expect(parsed.errors).toEqual([]);
+    const methods: EsTreeNode[] = [];
+    walkAst(parsed.program, (node: EsTreeNode) => {
+      if (isNodeOfType(node, "MethodDefinition")) methods.push(node);
+    });
+    const clearMethod = methods[0];
+    const computedMethod = methods[1];
+    if (!clearMethod || !computedMethod) throw new Error("fixture class methods were not parsed");
+    expect(getStaticPropertyKeyName(clearMethod)).toBe("clear");
+    expect(getStaticPropertyKeyName(computedMethod)).toBe(null);
+    expect(getStaticPropertyKeyName(computedMethod, { allowComputedString: true })).toBe(
+      "computed",
+    );
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-static-property-key-name.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-static-property-key-name.ts
@@ -10,7 +10,7 @@ export const getStaticPropertyKeyName = (
   node: EsTreeNode,
   options: StaticPropertyKeyOptions = {},
 ): string | null => {
-  if (!isNodeOfType(node, "Property")) return null;
+  if (!isNodeOfType(node, "Property") && !isNodeOfType(node, "MethodDefinition")) return null;
   if (node.computed) {
     if (
       options.allowComputedString &&


### PR DESCRIPTION
## Why

Avoids a false positive in `no-locale-format-in-render` when deterministic timezone options are stored in a local const.

Before:

```tsx
const options = { dateStyle: "medium", timeZone: resolvedTimeZone };
const formatter = new Intl.DateTimeFormat(locale, options);
return <time>{formatter.format(date)}</time>;
```

After:

```tsx
const options = { dateStyle: "medium", timeZone: resolvedTimeZone };
const formatter = new Intl.DateTimeFormat(locale, options);
return <time>{formatter.format(date)}</time>;
```

The code is unchanged; the rule now resolves the const alias and recognizes the explicit `timeZone`.

## What changed

- Resolves const aliases when inspecting locale formatter option objects.
- Threads scope analysis through locale method and Intl formatter matching.
- Adds a focused regression test based on the Webstudio react-bench task.
- Adds a permanent fuzz regression seed.
- Adds a patch changeset for `oxlint-plugin-react-doctor`.

RDE was not run because the local harness was stalled by pre-existing worker processes. Validation instead used the 120-repository react-bench cache and reconstructed task solutions.

## Test plan

- `nr test -- src/plugin/rules/performance/no-locale-format-in-render.test.ts`
- `FUZZ_RULE=no-locale-format-in-render FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz`
- `nr typecheck` in `packages/oxlint-plugin-react-doctor`
- `nr lint`
- `nr format:check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Substantial new static analysis in a correctness rule could miss edge cases or change diagnostic behavior, though risk is limited to lint output rather than runtime.
> 
> **Overview**
> Fixes **false positives** in `no-locale-format-in-render` when `timeZone` (and locale options generally) live in a **`const` alias** or chained identity alias instead of an inline object literal—patterns like `const options = { timeZone }` passed to `Intl.DateTimeFormat` or `toLocaleString`.
> 
> The rule’s deterministic-path logic is replaced with **scope-aware property proofing**: it follows `const` bindings, treats read-only uses (destructure, property reads, identity aliases) as safe, and still flags **mutable** options (reassignment, mutation, unknown spreads, sync helper/method side effects before construction).
> 
> **Scope analysis** is threaded through locale/`Intl` matching; **`getStaticPropertyKeyName`** also reads **class method** keys for mutation-via-helper tracking. Adds a large regression test matrix, fuzz corpus seeds, and snippet-pool coverage for aliased timezone options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b28027a687ca796779c85c19e4b08fd2f6525c76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->