### PR TITLE
fix(rule): follow query result const aliases

### DIFF
--- a/.changeset/quiet-query-aliases.md
+++ b/.changeset/quiet-query-aliases.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Track TanStack Query results through exact const alias chains before checking rest destructuring.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-query/query-no-rest-destructuring.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-query/query-no-rest-destructuring.regressions.test.ts
@@ -51,10 +51,70 @@ describe("tanstack-query/query-no-rest-destructuring — regressions", () => {
     expect(diagnostics.length).toBeGreaterThan(0);
   });
 
+  it("flags rest destructuring through multiple exact const aliases", () => {
+    const { diagnostics } = runRule(
+      queryNoRestDestructuring,
+      `import { useQuery } from "@tanstack/react-query";
+const queryResult = useQuery({ queryKey: ["todos"] });
+const exactResult = queryResult;
+const finalResult = exactResult;
+const { data, ...rest } = finalResult;`,
+    );
+    expect(diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("flags a namespace query result through multiple exact const aliases", () => {
+    const { diagnostics } = runRule(
+      queryNoRestDestructuring,
+      `import * as ReactQuery from "@tanstack/react-query";
+const queryResult = ReactQuery.useQuery({ queryKey: ["todos"] });
+const exactResult = queryResult;
+const { data, ...rest } = exactResult;`,
+    );
+    expect(diagnostics.length).toBeGreaterThan(0);
+  });
+
   it("stays silent on a two-step rest-destructure of a reassignable binding", () => {
     const { diagnostics } = runRule(
       queryNoRestDestructuring,
       `import { useQuery } from "@tanstack/react-query"; let queryResult = useQuery({ queryKey: ["todos"] }); queryResult = fallback; const { data, ...rest } = queryResult;`,
+    );
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it("stays silent when an alias chain reaches a reassignable binding", () => {
+    const { diagnostics } = runRule(
+      queryNoRestDestructuring,
+      `import { useQuery } from "@tanstack/react-query";
+let queryResult = useQuery({ queryKey: ["todos"] });
+queryResult = fallback;
+const exactResult = queryResult;
+const { data, ...rest } = exactResult;`,
+    );
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it("stays silent on conditional query-result aliases", () => {
+    const { diagnostics } = runRule(
+      queryNoRestDestructuring,
+      `import { useQuery } from "@tanstack/react-query";
+const queryResult = useQuery({ queryKey: ["todos"] });
+const selectedResult = condition ? queryResult : fallback;
+const { data, ...rest } = selectedResult;`,
+    );
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it("stays silent when a same-named local shadows an aliased query result", () => {
+    const { diagnostics } = runRule(
+      queryNoRestDestructuring,
+      `import { useQuery } from "@tanstack/react-query";
+const queryResult = useQuery({ queryKey: ["todos"] });
+const exactResult = queryResult;
+function read(exactResult) {
+  const { data, ...rest } = exactResult;
+  return rest;
+}`,
     );
     expect(diagnostics).toHaveLength(0);
   });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-query/query-no-rest-destructuring.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-query/query-no-rest-destructuring.ts
@@ -2,12 +2,12 @@ import { TANSTACK_QUERY_HOOKS } from "../../constants/tanstack.js";
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { RuleContext } from "../../utils/rule-context.js";
-import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
 import { getImportBindingForName } from "../../utils/find-import-source-for-name.js";
-import { isConstDeclaredBinding } from "../../utils/is-const-declared-binding.js";
 import { isTanstackQuerySource } from "../../utils/is-tanstack-query-source.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
+import { resolveConstIdentifierAlias } from "../../utils/resolve-const-identifier-alias.js";
 
 // Canonical TanStack hook name for a call expression, or null when the call
 // is not a TanStack Query hook. Resolves renamed imports
@@ -47,19 +47,21 @@ const resolveTanstackQueryHookName = (
   return null;
 };
 
-// Hook name behind a destructure initializer: a direct hook call, or a
-// `const` binding to one (`const result = useQuery(...); const { ...rest } =
-// result`). Reassignable bindings (`let`) stay exempt — the destructured
-// value may no longer be the query result.
-const resolveHookNameFromInitializer = (initializer: EsTreeNode): string | null => {
+// Hook name behind a destructure initializer: a direct hook call, or a chain
+// of exact `const` aliases rooted at one. Reassignable bindings (`let`) stay
+// exempt because the destructured value may no longer be the query result.
+const resolveHookNameFromInitializer = (
+  initializer: EsTreeNode,
+  scopes: ScopeAnalysis,
+): string | null => {
   if (isNodeOfType(initializer, "CallExpression")) {
     return resolveTanstackQueryHookName(initializer);
   }
   if (!isNodeOfType(initializer, "Identifier")) return null;
-  const binding = findVariableInitializer(initializer, initializer.name);
-  if (!binding?.initializer || !isConstDeclaredBinding(binding)) return null;
-  if (!isNodeOfType(binding.initializer, "CallExpression")) return null;
-  return resolveTanstackQueryHookName(binding.initializer);
+  const resolvedSymbol = resolveConstIdentifierAlias(initializer, scopes);
+  if (resolvedSymbol?.kind !== "const" || !resolvedSymbol.initializer) return null;
+  if (!isNodeOfType(resolvedSymbol.initializer, "CallExpression")) return null;
+  return resolveTanstackQueryHookName(resolvedSymbol.initializer);
 };
 
 export const queryNoRestDestructuring = defineRule({
@@ -80,7 +82,7 @@ export const queryNoRestDestructuring = defineRule({
       );
       if (!hasRestElement) return;
 
-      const hookName = resolveHookNameFromInitializer(node.init);
+      const hookName = resolveHookNameFromInitializer(node.init, context.scopes);
       if (!hookName) return;
 
       context.report({


### PR DESCRIPTION
## Why

query-no-rest-destructuring already catches a TanStack Query result stored in one const, but a second exact const alias erased the result provenance even though every alias still references the same query observer result. Rest destructuring therefore remained able to subscribe the component to every result field without a diagnostic.

Before:

    const result = useQuery({ queryKey: ["todos"] });
    const exactResult = result;
    const { data, ...rest } = exactResult; // missed

After, exact immutable alias chains are diagnosed. Reassignable, conditional, shadowed, and non-TanStack values remain clean.

## What changed

- reuse the existing scope-aware resolveConstIdentifierAlias utility to trace query results through exact const chains
- cover multi-hop named and namespace query calls
- retain conservative exits for let bindings, conditional values, and lexical shadows
- add a patch changeset

## Validation

- plugin suite: 548 files passed; 12,196 tests passed; 148 skipped
- plugin and monorepo typecheck passed
- monorepo build, format, lint, and JSON-report smoke passed
- full monorepo suite: one performance-harness timeout under parallel contention; serial React Doctor rerun passed all 205 files / 2,207 tests, and every other package passed in the original run
- fuzz harness: 37 passed; 400 skipped
- strict fuzz: 500 iterations with crash, slowness, and metamorphic invariance oracles over /Users/aidenybai/Developer/react-bench-5
- direct FP hunt: no query-no-rest-destructuring named-seed regression or hit in the 400-file corpus census; two unrelated pre-existing named regressions remained outside this PR
- local RDE launched ten rootDir scans, then the known harness failure stalled with only the parent process and a zero-byte cache; that process and only its generated empty cache were removed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow lint-rule change with conservative exits for non-const and ambiguous bindings; no runtime or security impact.
> 
> **Overview**
> **`query-no-rest-destructuring`** now follows **exact `const` alias chains** (via `resolveConstIdentifierAlias`) so rest destructuring on `const a = useQuery(...); const b = a; const { data, ...rest } = b` is flagged the same as a direct or one-hop binding.
> 
> **Unchanged behavior:** `let`/reassigned roots, conditional aliases, shadowed parameters, and non-TanStack `useQuery` still do not report. Regression tests cover multi-hop named and namespace imports; patch changeset for `oxlint-plugin-react-doctor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 315e436760ff1b8ece5bd90d5f274caacb76ad7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->