### PR TITLE
fix(rule): preserve facts through integrity wrappers

### DIFF
--- a/.changeset/curly-memo-references.md
+++ b/.changeset/curly-memo-references.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Preserve allocation and async-function facts through Object integrity wrappers.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-async-client-component.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-async-client-component.regressions.test.ts
@@ -27,4 +27,70 @@ export default async function Profile() {
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toEqual([]);
   });
+
+  it.each(["freeze", "seal"])(
+    "flags an async client component wrapped with Object.%s",
+    (methodName) => {
+      const result = runRule(
+        nextjsAsyncClientComponent,
+        `"use client";
+const Profile = Object.${methodName}(async () => {
+  const data = await loadProfile();
+  return <div>{data.name}</div>;
+});`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    },
+  );
+
+  it("flags an async client component through nested integrity wrappers", () => {
+    const result = runRule(
+      nextjsAsyncClientComponent,
+      `"use client";
+const Profile = Object.freeze(Object.seal(async () => <div />));`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags an async client component when the integrity callee has a TypeScript wrapper", () => {
+    const result = runRule(
+      nextjsAsyncClientComponent,
+      `"use client";
+const Profile = (Object.freeze as typeof Object.freeze)(async () => <div />);`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays silent for a wrapped synchronous client component", () => {
+    const result = runRule(
+      nextjsAsyncClientComponent,
+      `"use client";
+const Profile = Object.freeze(() => <div />);`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent for a wrapped async server component", () => {
+    const result = runRule(
+      nextjsAsyncClientComponent,
+      `const Profile = Object.freeze(async () => <div />);`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent for a shadowed Object.freeze implementation", () => {
+    const result = runRule(
+      nextjsAsyncClientComponent,
+      `"use client";
+const Object = { freeze: () => SharedProfile };
+const Profile = Object.freeze(async () => <div />);`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-async-client-component.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-async-client-component.ts
@@ -1,11 +1,14 @@
 import { defineRule } from "../../utils/define-rule.js";
 import { hasDirective } from "../../utils/has-directive.js";
-import { isComponentAssignment } from "../../utils/is-component-assignment.js";
 import { isInlineFunctionExpression } from "../../utils/is-inline-function-expression.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isUppercaseName } from "../../utils/is-uppercase-name.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import {
+  OBJECT_FREEZE_OR_SEAL_METHOD_NAMES,
+  unwrapObjectIntegrityExpression,
+} from "../../utils/unwrap-object-integrity-expression.js";
 
 export const nextjsAsyncClientComponent = defineRule({
   id: "nextjs-async-client-component",
@@ -32,10 +35,14 @@ export const nextjsAsyncClientComponent = defineRule({
       },
       VariableDeclarator(node: EsTreeNodeOfType<"VariableDeclarator">) {
         if (!fileHasUseClient) return;
-        if (!isComponentAssignment(node)) return;
-        if (!isInlineFunctionExpression(node.init)) return;
-        if (!node.init.async) return;
         if (!isNodeOfType(node.id, "Identifier")) return;
+        if (!isUppercaseName(node.id.name) || !node.init) return;
+        const componentFunction = unwrapObjectIntegrityExpression(
+          node.init,
+          context.scopes,
+          OBJECT_FREEZE_OR_SEAL_METHOD_NAMES,
+        );
+        if (!isInlineFunctionExpression(componentFunction) || !componentFunction.async) return;
         context.report({
           node,
           message: `Async client component "${node.id.name}" fails to render because client components can't be async.`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-inline-prop-on-memo-component.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-inline-prop-on-memo-component.regressions.test.ts
@@ -69,4 +69,85 @@ export function List() { return <Inner onClick={() => doThing()} />; }`,
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toEqual([]);
   });
+
+  it.each(["freeze", "seal", "preventExtensions"])(
+    "flags a fresh inline object wrapped with Object.%s",
+    (methodName) => {
+      const result = runRule(
+        noInlinePropOnMemoComponent,
+        `const Row = memo(Inner);
+function List() {
+  return <Row config={Object.${methodName}({ mode: "compact" })} />;
+}`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    },
+  );
+
+  it("flags fresh inline arrays through nested object integrity wrappers", () => {
+    const result = runRule(
+      noInlinePropOnMemoComponent,
+      `const Row = memo(Inner);
+function List() {
+  return <Row values={Object.freeze(Object.seal([1, 2, 3]))} />;
+}`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags fresh inline props when the integrity callee has a TypeScript wrapper", () => {
+    const result = runRule(
+      noInlinePropOnMemoComponent,
+      `const Row = memo(Inner);
+function List() {
+  return <Row config={(Object.freeze as typeof Object.freeze)({ mode: "compact" })} />;
+}`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays silent on a module-scoped frozen object", () => {
+    const result = runRule(
+      noInlinePropOnMemoComponent,
+      `const Row = memo(Inner);
+const config = Object.freeze({ mode: "compact" });
+function List() { return <Row config={config} />; }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent when the integrity wrapper receives an existing reference", () => {
+    const result = runRule(
+      noInlinePropOnMemoComponent,
+      `const Row = memo(Inner);
+function List({ config }) { return <Row config={Object.freeze(config)} />; }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent on a shadowed Object.freeze implementation", () => {
+    const result = runRule(
+      noInlinePropOnMemoComponent,
+      `const Row = memo(Inner);
+const Object = { freeze: () => sharedConfig };
+function List() { return <Row config={Object.freeze({ mode: "compact" })} />; }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent on an unknown integrity-like wrapper", () => {
+    const result = runRule(
+      noInlinePropOnMemoComponent,
+      `const Row = memo(Inner);
+function List() { return <Row config={freeze({ mode: "compact" })} />; }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-inline-prop-on-memo-component.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-inline-prop-on-memo-component.ts
@@ -3,6 +3,8 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
+import { unwrapObjectIntegrityExpression } from "../../utils/unwrap-object-integrity-expression.js";
 
 const isMemoCall = (node: EsTreeNode): boolean => {
   if (!isNodeOfType(node, "CallExpression")) return false;
@@ -35,20 +37,23 @@ const hasCustomComparator = (node: EsTreeNode): boolean =>
   (node.arguments?.length ?? 0) >= 2 &&
   !isDefaultEquivalentComparator(node.arguments?.[1]);
 
-const isInlineReference = (node: EsTreeNode): string | null => {
+const isInlineReference = (node: EsTreeNode, scopes: ScopeAnalysis): string | null => {
+  const referenceNode = unwrapObjectIntegrityExpression(node, scopes);
+
   if (
-    isNodeOfType(node, "ArrowFunctionExpression") ||
-    isNodeOfType(node, "FunctionExpression") ||
-    (isNodeOfType(node, "CallExpression") &&
-      isNodeOfType(node.callee, "MemberExpression") &&
-      isNodeOfType(node.callee.property, "Identifier") &&
-      node.callee.property.name === "bind")
+    isNodeOfType(referenceNode, "ArrowFunctionExpression") ||
+    isNodeOfType(referenceNode, "FunctionExpression") ||
+    (isNodeOfType(referenceNode, "CallExpression") &&
+      isNodeOfType(referenceNode.callee, "MemberExpression") &&
+      isNodeOfType(referenceNode.callee.property, "Identifier") &&
+      referenceNode.callee.property.name === "bind")
   )
     return "functions";
 
-  if (isNodeOfType(node, "ObjectExpression")) return "objects";
-  if (isNodeOfType(node, "ArrayExpression")) return "Arrays";
-  if (isNodeOfType(node, "JSXElement") || isNodeOfType(node, "JSXFragment")) return "JSX";
+  if (isNodeOfType(referenceNode, "ObjectExpression")) return "objects";
+  if (isNodeOfType(referenceNode, "ArrayExpression")) return "Arrays";
+  if (isNodeOfType(referenceNode, "JSXElement") || isNodeOfType(referenceNode, "JSXFragment"))
+    return "JSX";
 
   return null;
 };
@@ -104,7 +109,7 @@ export const noInlinePropOnMemoComponent = defineRule({
         }
         if (!elementName || !memoizedComponentNames.has(elementName)) return;
 
-        const propType = isInlineReference(node.value.expression);
+        const propType = isInlineReference(node.value.expression, context.scopes);
         if (propType) {
           context.report({
             node: node.value.expression,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-cache-with-object-literal.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-cache-with-object-literal.regressions.test.ts
@@ -24,4 +24,50 @@ export const loadUser = async () => getUser(1);`,
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toEqual([]);
   });
+
+  it.each(["freeze", "seal"])("flags a fresh cache key wrapped with Object.%s", (methodName) => {
+    const result = runRule(
+      serverCacheWithObjectLiteral,
+      `import { cache } from "react";
+const getUser = cache(async (params) => db.user.find(params));
+export const loadUser = async () => getUser(Object.${methodName}({ id: 1 }));`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a fresh cache key through nested integrity wrappers", () => {
+    const result = runRule(
+      serverCacheWithObjectLiteral,
+      `import { cache } from "react";
+const getUser = cache(async (params) => db.user.find(params));
+export const loadUser = async () => getUser(Object.freeze(Object.seal({ id: 1 })));`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays silent for a stable module-scoped frozen cache key", () => {
+    const result = runRule(
+      serverCacheWithObjectLiteral,
+      `import { cache } from "react";
+const getUser = cache(async (params) => db.user.find(params));
+const params = Object.freeze({ id: 1 });
+export const loadUser = async () => getUser(params);`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent for a shadowed Object.freeze implementation", () => {
+    const result = runRule(
+      serverCacheWithObjectLiteral,
+      `import { cache } from "react";
+const getUser = cache(async (params) => db.user.find(params));
+const Object = { freeze: () => stableParams };
+export const loadUser = async () => getUser(Object.freeze({ id: 1 }));`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-cache-with-object-literal.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-cache-with-object-literal.ts
@@ -2,6 +2,10 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import {
+  OBJECT_FREEZE_OR_SEAL_METHOD_NAMES,
+  unwrapObjectIntegrityExpression,
+} from "../../utils/unwrap-object-integrity-expression.js";
 
 // HACK: `cache(fn)` from React keys deduplication on REFERENCE equality
 // of the function arguments. Calling the cached function with object
@@ -40,7 +44,13 @@ export const serverCacheWithObjectLiteral = defineRule({
         if (!isNodeOfType(node.callee, "Identifier")) return;
         if (!cachedFunctionNames.has(node.callee.name)) return;
         const firstArg = node.arguments?.[0];
-        if (!isNodeOfType(firstArg, "ObjectExpression")) return;
+        if (!firstArg || isNodeOfType(firstArg, "SpreadElement")) return;
+        const cacheKey = unwrapObjectIntegrityExpression(
+          firstArg,
+          context.scopes,
+          OBJECT_FREEZE_OR_SEAL_METHOD_NAMES,
+        );
+        if (!isNodeOfType(cacheKey, "ObjectExpression")) return;
 
         context.report({
           node,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/unwrap-object-integrity-expression.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/unwrap-object-integrity-expression.ts
@@ -1,0 +1,37 @@
+import type { ScopeAnalysis } from "../semantic/scope-analysis.js";
+import type { EsTreeNode } from "./es-tree-node.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+import { stripParenExpression } from "./strip-paren-expression.js";
+
+export const OBJECT_INTEGRITY_METHOD_NAMES = new Set(["freeze", "seal", "preventExtensions"]);
+
+export const OBJECT_FREEZE_OR_SEAL_METHOD_NAMES = new Set(["freeze", "seal"]);
+
+export const unwrapObjectIntegrityExpression = (
+  node: EsTreeNode,
+  scopes: ScopeAnalysis,
+  methodNames = OBJECT_INTEGRITY_METHOD_NAMES,
+): EsTreeNode => {
+  let expression = stripParenExpression(node);
+
+  while (isNodeOfType(expression, "CallExpression")) {
+    const callee = stripParenExpression(expression.callee);
+    if (
+      !isNodeOfType(callee, "MemberExpression") ||
+      callee.computed ||
+      !isNodeOfType(callee.object, "Identifier") ||
+      callee.object.name !== "Object" ||
+      !scopes.isGlobalReference(callee.object) ||
+      !isNodeOfType(callee.property, "Identifier") ||
+      !methodNames.has(callee.property.name)
+    ) {
+      break;
+    }
+
+    const wrappedExpression = expression.arguments[0];
+    if (!wrappedExpression || isNodeOfType(wrappedExpression, "SpreadElement")) break;
+    expression = stripParenExpression(wrappedExpression);
+  }
+
+  return expression;
+};


### PR DESCRIPTION
## Summary

- add one binding-aware normalizer for identity-preserving Object integrity calls
- preserve fresh-allocation facts for memo props and React.cache object keys
- preserve async-function facts for wrapped Next.js client components
- reject shadowed Object lookalikes and keep stable values, primitives, synchronous functions, and server components clean

## Why

Object.freeze and Object.seal return the same value they receive. Object.preventExtensions does the same for the memo-prop case. These wrappers change integrity, but they do not stabilize a fresh allocation or turn an async function synchronous.

## Validation

- focused wrapper regressions: 32 passed
- complete oxlint plugin suite: 12,217 passed, 148 skipped
- serial React Doctor suite: 2,207 passed, 27 skipped, including the performance harness
- build, format, lint, monorepo typecheck, and JSON report smoke pass
- strict fuzz for no-inline-prop-on-memo-component: 500 iterations, all oracles, react-bench-5 corpus
- strict fuzz for server-cache-with-object-literal: 500 iterations, all oracles, react-bench-5 corpus
- strict fuzz for nextjs-async-client-component: 500 iterations, all oracles, react-bench-5 corpus
- direct corpus hunt: no target-rule finding in the 400-file census

RDE could not evaluate this branch because the current local eval harness accepts report schema versions 1 and 2 while React Doctor now emits schema version 3. No eval-harness files were changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static-analysis-only changes in oxlint rules with scope-aware global Object checks and broad regression coverage; no runtime or security impact.
> 
> **Overview**
> Adds **`unwrapObjectIntegrityExpression`**, which walks through nested global **`Object.freeze`**, **`Object.seal`**, and **`Object.preventExtensions`** (plus parenthesized/TS-cast callees) and returns the inner expression, while ignoring shadowed `Object` and wrappers around existing references.
> 
> **`no-inline-prop-on-memo-component`** now treats freshly allocated inline objects/arrays/functions inside those wrappers like unwrapped literals, so **`memo()`** bypasses are still reported.
> 
> **`nextjs-async-client-component`** applies the same peeling for **`freeze`/`seal`** around inline async component assignments in **`"use client"`** files.
> 
> **`server-cache-with-object-literal`** flags **`React.cache()`** calls whose first argument is still a fresh object literal after unwrapping.
> 
> Regression tests cover nested wrappers, TypeScript callee casts, module-scoped stable values, and shadowed **`Object`** implementations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe7a67131cb51b778b638cd177bc5c3b769797ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->