### PR TITLE
fix(rule): follow deferred hook result aliases

### DIFF
--- a/.changeset/tidy-hook-aliases.md
+++ b/.changeset/tidy-hook-aliases.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Follow exact hook-result aliases when classifying deferred reads.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/rerender-defer-reads-hook.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/rerender-defer-reads-hook.regressions.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { rerenderDeferReadsHook } from "./rerender-defer-reads-hook.js";
+
+const runDeferReadsRule = (componentBody: string) =>
+  runRule(
+    rerenderDeferReadsHook,
+    `function SearchButton() {
+${componentBody}
+}`,
+  );
+
+describe("state-and-effects/rerender-defer-reads-hook — exact aliases", () => {
+  it("flags a directly bound hook result read only inside an event handler", () => {
+    const result = runDeferReadsRule(`  const searchParams = useSearchParams();
+  const onClick = () => searchParams.get("query");
+  return <button onClick={onClick}>Search</button>;`);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a hook result through multiple exact const aliases", () => {
+    const result = runDeferReadsRule(`  const searchParams = useSearchParams();
+  const currentParams = searchParams;
+  const handlerParams = currentParams;
+  const onClick = () => handlerParams.get("query");
+  return <button onClick={onClick}>Search</button>;`);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a hook result extracted through an exact singleton array", () => {
+    const result = runDeferReadsRule(`  const searchParams = useSearchParams();
+  const [handlerParams] = [searchParams];
+  const onClick = () => handlerParams.get("query");
+  return <button onClick={onClick}>Search</button>;`);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a singleton-array alias through a TypeScript expression wrapper", () => {
+    const result = runDeferReadsRule(`  const searchParams = useSearchParams();
+  const [handlerParams] = [searchParams as SearchParams];
+  const onClick = () => handlerParams.get("query");
+  return <button onClick={onClick}>Search</button>;`);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays silent when an alias is read during render", () => {
+    const result = runDeferReadsRule(`  const searchParams = useSearchParams();
+  const currentParams = searchParams;
+  return <div>{currentParams.get("query")}</div>;`);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent when the hook result is unused", () => {
+    const result = runDeferReadsRule(`  const searchParams = useSearchParams();
+  return <button>Search</button>;`);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent across a mutable alias", () => {
+    const result = runDeferReadsRule(`  const searchParams = useSearchParams();
+  let currentParams = searchParams;
+  currentParams = getFallbackParams();
+  const onClick = () => currentParams.get("query");
+  return <button onClick={onClick}>Search</button>;`);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent across a conditional alias", () => {
+    const result = runDeferReadsRule(`  const searchParams = useSearchParams();
+  const currentParams = enabled ? searchParams : getFallbackParams();
+  const onClick = () => currentParams.get("query");
+  return <button onClick={onClick}>Search</button>;`);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("ignores a same-named binding inside a nested lexical scope", () => {
+    const result = runDeferReadsRule(`  const searchParams = useSearchParams();
+  const readFallback = (searchParams) => searchParams.get("query");
+  return <button onClick={() => readFallback(getFallbackParams())}>Search</button>;`);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/rerender-defer-reads-hook.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/rerender-defer-reads-hook.ts
@@ -1,20 +1,33 @@
 import { defineRule } from "../../utils/define-rule.js";
 import { isComponentAssignment } from "../../utils/is-component-assignment.js";
 import { isUppercaseName } from "../../utils/is-uppercase-name.js";
-import { walkAst } from "../../utils/walk-ast.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { collectHandlerBindingNames } from "./utils/collect-handler-binding-names.js";
 import { isInsideEventHandler } from "./utils/is-inside-event-handler.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import type { ScopeAnalysis, SymbolDescriptor } from "../../semantic/scope-analysis.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 
 const DEFERRABLE_HOOK_NAMES = new Set(["useSearchParams", "useParams", "usePathname"]);
 
+interface HookCallBinding {
+  valueSymbol: SymbolDescriptor;
+  hookName: string;
+  declarator: EsTreeNode;
+}
+
+interface ExactAliasSymbols {
+  symbols: SymbolDescriptor[];
+  aliasSourceIdentifiers: Set<EsTreeNode>;
+}
+
 const findHookCallBindings = (
   componentBody: EsTreeNode,
-): Array<{ valueName: string; hookName: string; declarator: EsTreeNode }> => {
-  const bindings: Array<{ valueName: string; hookName: string; declarator: EsTreeNode }> = [];
+  scopes: ScopeAnalysis,
+): HookCallBinding[] => {
+  const bindings: HookCallBinding[] = [];
   if (!isNodeOfType(componentBody, "BlockStatement")) return bindings;
 
   for (const statement of componentBody.body ?? []) {
@@ -25,14 +38,86 @@ const findHookCallBindings = (
       const callee = declarator.init.callee;
       if (!isNodeOfType(callee, "Identifier")) continue;
       if (!DEFERRABLE_HOOK_NAMES.has(callee.name)) continue;
+      const valueSymbol = scopes.symbolFor(declarator.id);
+      if (!valueSymbol) continue;
       bindings.push({
-        valueName: declarator.id.name,
+        valueSymbol,
         hookName: callee.name,
         declarator,
       });
     }
   }
   return bindings;
+};
+
+const collectExactAliasSymbols = (
+  componentBody: EsTreeNode,
+  sourceSymbol: SymbolDescriptor,
+  scopes: ScopeAnalysis,
+): ExactAliasSymbols => {
+  const symbols = [sourceSymbol];
+  const symbolIds = new Set([sourceSymbol.id]);
+  const aliasSourceIdentifiers = new Set<EsTreeNode>();
+  if (!isNodeOfType(componentBody, "BlockStatement")) {
+    return { symbols, aliasSourceIdentifiers };
+  }
+
+  let didFindAlias = true;
+  while (didFindAlias) {
+    didFindAlias = false;
+    for (const statement of componentBody.body ?? []) {
+      if (!isNodeOfType(statement, "VariableDeclaration") || statement.kind !== "const") continue;
+      for (const declarator of statement.declarations ?? []) {
+        let aliasIdentifier: EsTreeNode | null = null;
+        let sourceIdentifier: EsTreeNode | null = null;
+        const initializer = declarator.init ? stripParenExpression(declarator.init) : null;
+        const arrayBinding = isNodeOfType(declarator.id, "ArrayPattern")
+          ? declarator.id.elements[0]
+          : null;
+        const arrayValueNode = isNodeOfType(initializer, "ArrayExpression")
+          ? initializer.elements[0]
+          : null;
+        const arrayValue =
+          arrayValueNode && !isNodeOfType(arrayValueNode, "SpreadElement")
+            ? stripParenExpression(arrayValueNode)
+            : null;
+
+        if (isNodeOfType(declarator.id, "Identifier") && isNodeOfType(initializer, "Identifier")) {
+          aliasIdentifier = declarator.id;
+          sourceIdentifier = initializer;
+        } else if (
+          isNodeOfType(declarator.id, "ArrayPattern") &&
+          declarator.id.elements.length === 1 &&
+          isNodeOfType(arrayBinding, "Identifier") &&
+          isNodeOfType(initializer, "ArrayExpression") &&
+          initializer.elements.length === 1 &&
+          isNodeOfType(arrayValue, "Identifier")
+        ) {
+          aliasIdentifier = arrayBinding;
+          sourceIdentifier = arrayValue;
+        }
+
+        if (!aliasIdentifier || !sourceIdentifier) continue;
+        const referencedSymbol = scopes.symbolFor(sourceIdentifier);
+        const aliasSymbol = scopes.symbolFor(aliasIdentifier);
+        if (
+          !referencedSymbol ||
+          !symbolIds.has(referencedSymbol.id) ||
+          !aliasSymbol ||
+          aliasSymbol.kind !== "const" ||
+          symbolIds.has(aliasSymbol.id)
+        ) {
+          continue;
+        }
+        symbolIds.add(aliasSymbol.id);
+        symbols.push(aliasSymbol);
+        aliasSourceIdentifiers.add(sourceIdentifier);
+        didFindAlias = true;
+      }
+    }
+  }
+
+  return { symbols, aliasSourceIdentifiers };
 };
 
 // HACK: subscribing to `useSearchParams()` / `useParams()` /
@@ -59,22 +144,24 @@ export const rerenderDeferReadsHook = defineRule({
   create: (context: RuleContext) => {
     const checkComponent = (componentBody: EsTreeNode | null | undefined): void => {
       if (!componentBody || !isNodeOfType(componentBody, "BlockStatement")) return;
-      const bindings = findHookCallBindings(componentBody);
+      const bindings = findHookCallBindings(componentBody, context.scopes);
       if (bindings.length === 0) return;
       const handlerBindingNames = collectHandlerBindingNames(componentBody);
 
       for (const binding of bindings) {
+        const { symbols, aliasSourceIdentifiers } = collectExactAliasSymbols(
+          componentBody,
+          binding.valueSymbol,
+          context.scopes,
+        );
         const referenceLocations: EsTreeNode[] = [];
-        walkAst(componentBody, (child: EsTreeNode) => {
-          if (
-            isNodeOfType(binding.declarator, "VariableDeclarator") &&
-            child === binding.declarator.id
-          )
-            return;
-          if (isNodeOfType(child, "Identifier") && child.name === binding.valueName) {
-            referenceLocations.push(child);
+        for (const symbol of symbols) {
+          for (const reference of symbol.references) {
+            if (!aliasSourceIdentifiers.has(reference.identifier)) {
+              referenceLocations.push(reference.identifier);
+            }
           }
-        });
+        }
 
         if (referenceLocations.length === 0) continue;
 


### PR DESCRIPTION
## Summary

- resolve deferred URL-hook reads by semantic symbol instead of identifier spelling
- propagate hook-result identity through one or more exact const aliases and singleton-array extraction
- stop at mutable bindings, conditional merges, and lexical shadows

## Why

Exact aliases preserve the same subscribed hook result. When every meaningful read remains inside an event handler, the deferred-read guidance should not disappear merely because the result passed through another immutable binding.

## Validation

- focused regressions: 8 passed
- complete oxlint plugin suite: 12,204 passed, 148 skipped
- complete monorepo suite: 14 tasks passed; React Doctor 2,207 passed, 27 skipped
- build, format, lint, monorepo typecheck, and JSON report smoke pass
- React Doctor self-scan of the changed plugin package: clean
- strict fuzz: 500 iterations with crash, slowness, and metamorphic invariance oracles against /Users/aidenybai/Developer/react-bench-5

RDE could not evaluate this branch because the current local eval harness accepts report schema versions 1 and 2 while React Doctor now emits schema version 3. No eval-harness files were changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to one performance lint rule with explicit false-positive guards and regression tests; no runtime or auth impact.
> 
> **Overview**
> The **`rerender-defer-reads-hook`** rule now tracks **deferred URL hook reads** (`useSearchParams`, `useParams`, `usePathname`) via **scope symbols and references** instead of matching identifier names with `walkAst`.
> 
> It **extends** the same “only read in event handlers” warning to hook results reached through **immutable chains**: direct `const` aliases, **singleton-array** destructuring (including `as` wrappers via `stripParenExpression`), and **multi-hop** exact aliases. **Alias-definition sites** are excluded from “meaningful reads” so forwarding bindings do not hide handler-only usage.
> 
> The rule **does not** treat **mutable** (`let` reassignment), **conditional**, or **shadowed** bindings as the same subscribed value—those cases stay silent. A **regression test file** documents flag vs. silence behavior; the changeset bumps **`oxlint-plugin-react-doctor`** as a patch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e9e50d56c89cfee91e88f6a3a618e692ba4eb8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->