### PR TITLE
fix(rule): detect sealed server module state

### DIFF
--- a/.changeset/green-server-containers.md
+++ b/.changeset/green-server-containers.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Detect writes to existing properties of sealed server module state.

--- a/packages/fuzz/README.md
+++ b/packages/fuzz/README.md
@@ -56,6 +56,7 @@ FUZZ_INVARIANTS=1 pnpm fuzz                # warn on invariant violations
 FUZZ_STRICT=1 pnpm fuzz                    # fail on invariant violations too
 FUZZ_CORPUS_DIR=~/corpus-repos pnpm fuzz   # also fuzz real files + crossover
 FUZZ_PRINT_SILENT=1 pnpm fuzz              # list rules that never fired
+FUZZ_PRINT_STATS=1 pnpm fuzz               # print executed, fired, and parse-skip counts
 ```
 
 `scripts/measure-coverage.ts` and `scripts/measure-corpus-coverage.ts` (run

--- a/packages/fuzz/corpus/regressions/server-no-mutable-module-state--getter-only-sealed-property.tsx
+++ b/packages/fuzz/corpus/regressions/server-no-mutable-module-state--getter-only-sealed-property.tsx
@@ -1,0 +1,15 @@
+// rule: server-no-mutable-module-state
+// weakness: control-flow
+// source: PR #1180
+
+"use server";
+
+const state = Object.seal({
+  get count() {
+    return 0;
+  },
+});
+
+export const increment = async () => {
+  state.count++;
+};

--- a/packages/fuzz/corpus/regressions/server-no-mutable-module-state--module-initialization-write.tsx
+++ b/packages/fuzz/corpus/regressions/server-no-mutable-module-state--module-initialization-write.tsx
@@ -1,0 +1,10 @@
+// rule: server-no-mutable-module-state
+// weakness: control-flow
+// source: PR #1180
+
+"use server";
+
+const state = Object.seal({ count: 0 });
+state.count = 1;
+
+export const read = async () => state.count;

--- a/packages/fuzz/corpus/regressions/server-no-mutable-module-state--opaque-nested-mutator.tsx
+++ b/packages/fuzz/corpus/regressions/server-no-mutable-module-state--opaque-nested-mutator.tsx
@@ -1,0 +1,11 @@
+// rule: server-no-mutable-module-state
+// weakness: name-heuristic
+// source: PR #1180
+
+"use server";
+
+const state = Object.seal({ service: getService() });
+
+export const update = async () => {
+  state.service.set("status", "active");
+};

--- a/packages/fuzz/src/constants.ts
+++ b/packages/fuzz/src/constants.ts
@@ -1,5 +1,7 @@
 export const DEFAULT_FUZZ_ITERATIONS = 25;
 export const DEFAULT_FUZZ_SEED = 1;
+export const DEFAULT_FUZZ_TEST_TIMEOUT_MS = 60_000;
+export const FUZZ_ITERATION_TIMEOUT_BUDGET_MS = 30;
 export const SLOW_RULE_THRESHOLD_MS = 2_000;
 // A slow measurement is only a finding if the program stays slow across
 // this many re-runs of the same code (fastest time wins). Filters out
@@ -11,6 +13,7 @@ export const MAX_NOISE_MUTATIONS = 3;
 // One iteration in ~8 produces a pathological-shape program (deep JSX,
 // long chains) instead of a realistic one, probing recursive walkers.
 export const PATHOLOGICAL_PROGRAM_PROBABILITY = 0.12;
+export const SERVER_MODULE_PROGRAM_PROBABILITY = 0.12;
 export const DEEP_JSX_NESTING_DEPTH = 250;
 export const LONG_CHAIN_LINK_COUNT = 300;
 export const WIDE_SIBLING_COUNT = 400;

--- a/packages/fuzz/src/generate-fuzz-program.ts
+++ b/packages/fuzz/src/generate-fuzz-program.ts
@@ -1,4 +1,7 @@
-import { PATHOLOGICAL_PROGRAM_PROBABILITY } from "./constants.js";
+import {
+  PATHOLOGICAL_PROGRAM_PROBABILITY,
+  SERVER_MODULE_PROGRAM_PROBABILITY,
+} from "./constants.js";
 import { generatePathologicalProgram } from "./generate-pathological-program.js";
 import type { SeededRandom } from "./seeded-random.js";
 import {
@@ -12,6 +15,7 @@ import {
   JSX_LEAF_POOL,
   LIBRARY_SNIPPET_POOL,
   MODULE_SCOPE_SNIPPET_POOL,
+  SERVER_MODULE_PROGRAM_POOL,
   STATE_SNIPPET_POOL,
   TRIGGER_IDENTIFIER_POOL,
 } from "./snippet-pools.js";
@@ -246,6 +250,10 @@ const buildModuleNoise: SnippetBuilder = (random) =>
     : random.pick(MODULE_SCOPE_SNIPPET_POOL);
 
 export const generateStructuredFuzzProgram = (random: SeededRandom): GeneratedFuzzProgram => {
+  if (random.chance(SERVER_MODULE_PROGRAM_PROBABILITY)) {
+    const code = `${random.pick(SERVER_MODULE_PROGRAM_POOL)}\n`;
+    return { code, sections: [code] };
+  }
   if (random.chance(PATHOLOGICAL_PROGRAM_PROBABILITY)) {
     const code = generatePathologicalProgram(random);
     return { code, sections: [code] };

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -180,6 +180,72 @@ export const MODULE_SCOPE_SNIPPET_POOL = [
   `let sharedSnapshot = "idle"; const snapshotListeners = new Set(); function subscribeSnapshot(listener) { snapshotListeners.add(listener); return () => snapshotListeners.delete(listener); }`,
 ] as const;
 
+export const SERVER_MODULE_PROGRAM_POOL = [
+  `"use server";
+const state = Object.seal({ count: 0 });
+export const increment = async () => {
+  state.count++;
+};`,
+  `"use server";
+const state = Object.preventExtensions({ users: [] });
+export const addUser = async (user: unknown) => {
+  state.users.push(user);
+};`,
+  `"use server";
+const state = Object.seal({ cache: new Map<string, unknown>() });
+export const remember = async (key: string, value: unknown) => {
+  state.cache.set(key, value);
+};`,
+  `"use server";
+const state = Object.seal({ count: 0 });
+const incrementState = (target: { count: number }) => {
+  target.count++;
+};
+export const increment = async () => {
+  incrementState(state);
+};`,
+  `"use server";
+const state = Object.seal({ count: 0 });
+export const update = async (patch: { count?: number }) => {
+  Object.assign(state, patch);
+};`,
+  `"use server";
+const state = Object.preventExtensions({ count: 0 });
+export const removeCount = async () => {
+  delete state.count;
+};`,
+  `"use server";
+const state = Object.freeze({ count: 0 });
+export const increment = async () => {
+  state.count++;
+};`,
+  `"use server";
+const state = Object.seal({ get count() { return 0; } });
+export const increment = async () => {
+  state.count++;
+};`,
+  `"use server";
+const state = Object.preventExtensions({ count: 0 });
+state.count = 1;
+export const read = async () => state.count;`,
+  `"use server";
+const state = Object.seal({ service: getService() });
+export const update = async () => {
+  state.service.set("status", "active");
+};`,
+  `"use server";
+const state = Object.seal({ service: { set(value: string) { persist(value); } } });
+export const update = async () => {
+  state.service.set("active");
+};`,
+  `"use server";
+const Object = { seal: <Value,>(value: Value) => value };
+const state = Object.seal({ count: 0 });
+export const increment = async () => {
+  state.count++;
+};`,
+] as const;
+
 // Attributes that specifically trip a11y validity rules — misspelled aria
 // props, invalid roles, wrong-typed values, missing pairings.
 export const A11Y_TRIGGER_ATTRIBUTE_POOL = [

--- a/packages/fuzz/tests/fuzz-rules.test.ts
+++ b/packages/fuzz/tests/fuzz-rules.test.ts
@@ -7,11 +7,17 @@ import { fuzzRuleWithStats } from "../src/fuzz-rule.js";
 import type { FuzzFinding } from "../src/fuzz-rule.js";
 import { loadFuzzCorpus } from "../src/load-fuzz-corpus.js";
 import type { FuzzCorpusEntry } from "../src/load-fuzz-corpus.js";
-import { DEFAULT_FUZZ_ITERATIONS, DEFAULT_FUZZ_SEED } from "../src/constants.js";
+import {
+  DEFAULT_FUZZ_ITERATIONS,
+  DEFAULT_FUZZ_SEED,
+  DEFAULT_FUZZ_TEST_TIMEOUT_MS,
+  FUZZ_ITERATION_TIMEOUT_BUDGET_MS,
+} from "../src/constants.js";
 
 const isFuzzEnabled = process.env.REACT_DOCTOR_FUZZ === "1";
 const isStrict = process.env.FUZZ_STRICT === "1";
 const shouldCheckInvariants = isStrict || process.env.FUZZ_INVARIANTS === "1";
+const shouldPrintStats = process.env.FUZZ_PRINT_STATS === "1";
 const ruleFilter = process.env.FUZZ_RULE;
 
 // A malformed env value silently degrading to zero iterations would make
@@ -29,6 +35,10 @@ const readPositiveIntegerEnv = (name: string, defaultValue: number): number => {
 };
 const iterations = readPositiveIntegerEnv("FUZZ_ITERATIONS", DEFAULT_FUZZ_ITERATIONS);
 const seed = readPositiveIntegerEnv("FUZZ_SEED", DEFAULT_FUZZ_SEED);
+const fuzzTestTimeoutMs = Math.max(
+  DEFAULT_FUZZ_TEST_TIMEOUT_MS,
+  iterations * FUZZ_ITERATION_TIMEOUT_BUDGET_MS,
+);
 const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
 // The built-in regression corpus (confirmed historical false positives —
@@ -110,32 +120,42 @@ describe.skipIf(!isFuzzEnabled)("adversarial rule fuzzing", () => {
   }
 
   for (const entry of selectedRules) {
-    it(`survives fuzzing: ${entry.id}`, () => {
-      const { findings, stats } = fuzzRuleWithStats(entry.id, entry.rule, {
-        iterations,
-        seed,
-        checkInvariants: shouldCheckInvariants,
-        corpus,
-      });
-      // A rule with crash/slow findings was definitely exercised past its
-      // early bails, so it isn't "silent" even without a diagnostic.
-      const wasExercised = stats.firedProgramCount > 0 || findings.length > 0;
-      (wasExercised ? firedRuleIds : silentRuleIds).add(entry.id);
-      const blockingFindings = isStrict
-        ? findings
-        : findings.filter(
-            (finding) => finding.kind !== "invariant-violation" && finding.kind !== "verdict-drop",
+    it(
+      `survives fuzzing: ${entry.id}`,
+      () => {
+        const { findings, stats } = fuzzRuleWithStats(entry.id, entry.rule, {
+          iterations,
+          seed,
+          checkInvariants: shouldCheckInvariants,
+          corpus,
+        });
+        if (shouldPrintStats) {
+          console.info(
+            `fuzz stats: ${entry.id} executed=${stats.executedProgramCount} fired=${stats.firedProgramCount} skipped-parse=${stats.skippedParseErrorCount}`,
           );
-      const advisoryFindings = findings.filter((finding) => !blockingFindings.includes(finding));
-      for (const finding of advisoryFindings) {
-        console.warn(formatFinding(finding, writeReproducer(finding)));
-      }
-      if (blockingFindings.length > 0) {
-        const summary = blockingFindings
-          .map((finding) => formatFinding(finding, writeReproducer(finding)))
-          .join("\n\n");
-        expect.fail(`${blockingFindings.length} fuzz finding(s):\n\n${summary}`);
-      }
-    });
+        }
+        // A rule with crash/slow findings was definitely exercised past its
+        // early bails, so it isn't "silent" even without a diagnostic.
+        const wasExercised = stats.firedProgramCount > 0 || findings.length > 0;
+        (wasExercised ? firedRuleIds : silentRuleIds).add(entry.id);
+        const blockingFindings = isStrict
+          ? findings
+          : findings.filter(
+              (finding) =>
+                finding.kind !== "invariant-violation" && finding.kind !== "verdict-drop",
+            );
+        const advisoryFindings = findings.filter((finding) => !blockingFindings.includes(finding));
+        for (const finding of advisoryFindings) {
+          console.warn(formatFinding(finding, writeReproducer(finding)));
+        }
+        if (blockingFindings.length > 0) {
+          const summary = blockingFindings
+            .map((finding) => formatFinding(finding, writeReproducer(finding)))
+            .join("\n\n");
+          expect.fail(`${blockingFindings.length} fuzz finding(s):\n\n${summary}`);
+        }
+      },
+      fuzzTestTimeoutMs,
+    );
   }
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-async-client-component.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-async-client-component.regressions.test.ts
@@ -64,6 +64,16 @@ const Profile = (Object.freeze as typeof Object.freeze)(async () => <div />);`,
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("flags an async client component when the integrity receiver has a TypeScript wrapper", () => {
+    const result = runRule(
+      nextjsAsyncClientComponent,
+      `"use client";
+const Profile = (Object as any).freeze(async () => <div />);`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("stays silent for a wrapped synchronous client component", () => {
     const result = runRule(
       nextjsAsyncClientComponent,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-inline-prop-on-memo-component.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-inline-prop-on-memo-component.regressions.test.ts
@@ -109,6 +109,18 @@ function List() {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("flags fresh inline props when the integrity receiver has a TypeScript wrapper", () => {
+    const result = runRule(
+      noInlinePropOnMemoComponent,
+      `const Row = memo(Inner);
+function List() {
+  return <Row config={(Object as any).freeze({ mode: "compact" })} />;
+}`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("stays silent on a module-scoped frozen object", () => {
     const result = runRule(
       noInlinePropOnMemoComponent,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-cache-with-object-literal.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-cache-with-object-literal.regressions.test.ts
@@ -47,6 +47,17 @@ export const loadUser = async () => getUser(Object.freeze(Object.seal({ id: 1 })
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("flags a fresh cache key when the integrity receiver has a TypeScript wrapper", () => {
+    const result = runRule(
+      serverCacheWithObjectLiteral,
+      `import { cache } from "react";
+const getUser = cache(async (params) => db.user.find(params));
+export const loadUser = async () => getUser((Object as any).freeze({ id: 1 }));`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("stays silent for a stable module-scoped frozen cache key", () => {
     const result = runRule(
       serverCacheWithObjectLiteral,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-no-mutable-module-state.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-no-mutable-module-state.regressions.test.ts
@@ -244,6 +244,7 @@ export async function increment() {
       );
       expect(result.parseErrors).toEqual([]);
       expect(result.diagnostics).toHaveLength(1);
+      expect(result.diagnostics[0].message).toContain('"state = {}"');
     },
   );
 
@@ -528,5 +529,340 @@ export async function update() {
     );
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toEqual([]);
+  });
+
+  it.each(["const state = { count: 0 };", "const state = new Map();"])(
+    "stays silent on a shadowed Object.assign over a plain container (%s)",
+    (declaration) => {
+      const result = runRule(
+        serverNoMutableModuleState,
+        `"use server";
+${declaration}
+export async function update() {
+  const Object = { assign: () => null };
+  Object.assign(state, { count: 1 });
+}`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    },
+  );
+
+  it.each(["async () => { target.count++; }", "() => { target.count++; }"])(
+    "flags a module-scope factory call whose returned closure (%s) mutates the container",
+    (closureSource) => {
+      const result = runRule(
+        serverNoMutableModuleState,
+        `"use server";
+const state = { count: 0 };
+const makeIncrementer = (target) => ${closureSource};
+export const increment = makeIncrementer(state);`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    },
+  );
+
+  it("stays silent when a module-scope helper call only mutates its parameter at initialization", () => {
+    const result = runRule(
+      serverNoMutableModuleState,
+      `"use server";
+const state = { count: 0 };
+const seed = (target) => {
+  target.count = 1;
+};
+seed(state);
+export async function read() {
+  return state.count;
+}`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it.each([
+    ["new Map()", 'state.set("a", 1)'],
+    ["new Set()", 'state.add("a")'],
+    ["[0]", "state[0]++"],
+  ])("flags a mutated sealed non-object container (%s)", (containerSource, mutation) => {
+    const result = runRule(
+      serverNoMutableModuleState,
+      `"use server";
+const state = Object.seal(${containerSource});
+export async function update() {
+  ${mutation};
+}`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays silent when a sealed Map is only populated during module initialization", () => {
+    const result = runRule(
+      serverNoMutableModuleState,
+      `"use server";
+const state = Object.seal(new Map());
+state.set("a", 1);
+export async function read() {
+  return state.get("a");
+}`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it.each([
+    ["new Map()", 'state.set("a", 1)'],
+    ["[]", "state.push(1)"],
+  ])(
+    "stays silent when a const %s container is only populated during module initialization",
+    (containerSource, mutation) => {
+      const result = runRule(
+        serverNoMutableModuleState,
+        `"use server";
+const state = ${containerSource};
+${mutation};
+export async function read() {
+  return state;
+}`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    },
+  );
+
+  it.each(["const state = { count: 0 };", "const state = Object.seal({ count: 0 });"])(
+    "stays silent on a module-scope IIFE that writes during initialization",
+    (declaration) => {
+      const result = runRule(
+        serverNoMutableModuleState,
+        `"use server";
+${declaration}
+(() => {
+  state.count = 1;
+})();
+export async function read() {
+  return state.count;
+}`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    },
+  );
+
+  it("still flags a write inside an IIFE that runs per request", () => {
+    const result = runRule(
+      serverNoMutableModuleState,
+      `"use server";
+const state = Object.seal({ count: 0 });
+export async function update() {
+  (() => {
+    state.count = 1;
+  })();
+}`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a deferred callback registered inside a module-scope IIFE", () => {
+    const result = runRule(
+      serverNoMutableModuleState,
+      `"use server";
+const state = Object.seal({ count: 0 });
+(() => {
+  setInterval(() => {
+    state.count++;
+  }, 1000);
+})();`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags an all-spread Object.assign source over a sealed container", () => {
+    const result = runRule(
+      serverNoMutableModuleState,
+      `"use server";
+const state = Object.seal({ count: 0 });
+export async function update(patch) {
+  Object.assign(state, { ...patch });
+}`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays silent when a spread patch cannot update any getter-only sealed property", () => {
+    const result = runRule(
+      serverNoMutableModuleState,
+      `"use server";
+const state = Object.seal({ get count() { return 0; } });
+export async function update(patch) {
+  Object.assign(state, { ...patch });
+}`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("flags a defineProperties descriptor that updates an existing sealed property", () => {
+    const result = runRule(
+      serverNoMutableModuleState,
+      `"use server";
+const state = Object.seal({ count: 0 });
+export async function reset() {
+  Object.defineProperties(state, { count: { value: 1 } });
+}`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays silent when defineProperties only targets missing sealed properties", () => {
+    const result = runRule(
+      serverNoMutableModuleState,
+      `"use server";
+const state = Object.seal({ count: 0 });
+export async function label() {
+  Object.defineProperties(state, { label: { value: "active" } });
+}`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent when defineProperty targets a missing sealed property", () => {
+    const result = runRule(
+      serverNoMutableModuleState,
+      `"use server";
+const state = Object.seal({ count: 0 });
+export async function label() {
+  Object.defineProperty(state, "label", { value: "active" });
+}`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it.each([
+    ["users: []", "state.users.push(entry)"],
+    ["cache: new Map()", 'state.cache.set("id", entry)'],
+    ["tags: new Set()", "state.tags.add(entry)"],
+    ["registry: new WeakMap()", "state.registry.set(entry, 1)"],
+    ["seen: new WeakSet()", "state.seen.add(entry)"],
+    ["nested: { count: 0 }", "state.nested.count = 1"],
+  ])(
+    "flags an isolated nested mutation on a sealed { %s } property",
+    (propertySource, mutation) => {
+      const result = runRule(
+        serverNoMutableModuleState,
+        `"use server";
+const state = Object.seal({ ${propertySource} });
+export async function update(entry) {
+  ${mutation};
+}`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    },
+  );
+
+  it.each([
+    ["registry: new WeakMap()", "state.registry.clear()"],
+    ["seen: new WeakSet()", "state.seen.clear()"],
+  ])(
+    "stays silent on a nested method the sealed { %s } container does not support",
+    (propertySource, mutation) => {
+      const result = runRule(
+        serverNoMutableModuleState,
+        `"use server";
+const state = Object.seal({ ${propertySource} });
+export async function update() {
+  ${mutation};
+}`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    },
+  );
+
+  it("flags a mutation through a module-level alias of a sealed container", () => {
+    const result = runRule(
+      serverNoMutableModuleState,
+      `"use server";
+const state = Object.seal({ count: 0 });
+const alias = state;
+export async function increment() {
+  alias.count++;
+}`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a sealed-property write when the container receiver is wrapped in `as any`", () => {
+    const result = runRule(
+      serverNoMutableModuleState,
+      `"use server";
+const state = Object.seal({ count: 0 });
+export async function increment() {
+  (state as any).count++;
+}`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays silent on a delete under chained preventExtensions + seal wrappers", () => {
+    const result = runRule(
+      serverNoMutableModuleState,
+      `"use server";
+const state = Object.preventExtensions(Object.seal({ count: 0 }));
+export async function removeCount() {
+  delete state.count;
+}`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("flags an existing-property write under chained integrity wrappers", () => {
+    const result = runRule(
+      serverNoMutableModuleState,
+      `"use server";
+const state = Object.preventExtensions(Object.seal({ count: 0 }));
+export async function increment() {
+  state.count++;
+}`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays silent on Object.setPrototypeOf over a sealed container", () => {
+    const result = runRule(
+      serverNoMutableModuleState,
+      `"use server";
+const state = Object.seal({ count: 0 });
+export async function detach(proto) {
+  Object.setPrototypeOf(state, proto);
+}`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("flags Object.setPrototypeOf over a plain container", () => {
+    const result = runRule(
+      serverNoMutableModuleState,
+      `"use server";
+const state = { count: 0 };
+export async function detach(proto) {
+  Object.setPrototypeOf(state, proto);
+}`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
   });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-no-mutable-module-state.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-no-mutable-module-state.regressions.test.ts
@@ -247,6 +247,22 @@ export async function increment() {
     },
   );
 
+  it.each(["Object as any", "Object!"])(
+    "flags a write when the integrity call receiver is wrapped as %s",
+    (objectReceiver) => {
+      const result = runRule(
+        serverNoMutableModuleState,
+        `"use server";
+const state = (${objectReceiver}).seal({ count: 0 });
+export async function increment() {
+  state.count++;
+}`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    },
+  );
+
   it.each(["seal", "preventExtensions"])(
     "stays silent on a rejected new property write through Object.%s",
     (methodName) => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-no-mutable-module-state.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-no-mutable-module-state.regressions.test.ts
@@ -230,4 +230,287 @@ export async function track(userId) {
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toHaveLength(1);
   });
+
+  it.each(["seal", "preventExtensions"])(
+    "flags a write to an existing Object.%s property",
+    (methodName) => {
+      const result = runRule(
+        serverNoMutableModuleState,
+        `"use server";
+const state = Object.${methodName}({ count: 0 });
+export async function increment() {
+  state.count++;
+}`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    },
+  );
+
+  it.each(["seal", "preventExtensions"])(
+    "stays silent on a rejected new property write through Object.%s",
+    (methodName) => {
+      const result = runRule(
+        serverNoMutableModuleState,
+        `"use server";
+const state = Object.${methodName}({ count: 0 });
+export async function addLabel() {
+  state.label = "active";
+}`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    },
+  );
+
+  it("stays silent on a rejected delete from a sealed object", () => {
+    const result = runRule(
+      serverNoMutableModuleState,
+      `"use server";
+const state = Object.seal({ count: 0 });
+export async function removeCount() {
+  delete state.count;
+}`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("flags a permitted delete from a non-extensible object", () => {
+    const result = runRule(
+      serverNoMutableModuleState,
+      `"use server";
+const state = Object.preventExtensions({ count: 0 });
+export async function removeCount() {
+  delete state.count;
+}`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a descriptor update to an existing sealed property", () => {
+    const result = runRule(
+      serverNoMutableModuleState,
+      `"use server";
+const state = Object.seal({ count: 0 });
+export async function reset() {
+  Object.defineProperty(state, "count", { value: 1 });
+}`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays silent on a frozen object", () => {
+    const result = runRule(
+      serverNoMutableModuleState,
+      `"use server";
+const state = Object.freeze({ count: 0 });
+export async function increment() {
+  state.count++;
+}`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it.each(["seal", "preventExtensions"])(
+    "stays silent on a rejected write to a getter-only Object.%s property",
+    (methodName) => {
+      const result = runRule(
+        serverNoMutableModuleState,
+        `"use server";
+const state = Object.${methodName}({ get count() { return 0; } });
+export async function increment() {
+  state.count++;
+}`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    },
+  );
+
+  it("stays silent when a dynamic patch cannot update any non-extensible property", () => {
+    const result = runRule(
+      serverNoMutableModuleState,
+      `"use server";
+const state = Object.preventExtensions({ get count() { return 0; } });
+export async function update(patch) {
+  Object.assign(state, patch);
+}`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent when a sealed setter delegates without storing state", () => {
+    const result = runRule(
+      serverNoMutableModuleState,
+      `"use server";
+const state = Object.seal({ set count(value) { persist(value); } });
+export async function update() {
+  state.count = 1;
+}`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent on a mutator-shaped call below a scalar sealed property", () => {
+    const result = runRule(
+      serverNoMutableModuleState,
+      `"use server";
+const state = Object.seal({ count: 0 });
+export async function update() {
+  state.count.set(1);
+}`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent on an opaque nested method whose name resembles a mutator", () => {
+    const result = runRule(
+      serverNoMutableModuleState,
+      `"use server";
+const state = Object.seal({ service: getService() });
+export async function update() {
+  state.service.set("status", "active");
+}`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("flags nested writes through statically mutable sealed properties", () => {
+    const result = runRule(
+      serverNoMutableModuleState,
+      `"use server";
+const state = Object.seal({ users: [], nested: { count: 0 }, cache: new Map() });
+export async function update(user) {
+  state.users[0] = user;
+  state.nested.count++;
+  state.cache.set(user.id, user);
+}`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays silent on a custom mutator-shaped method in a nested object literal", () => {
+    const result = runRule(
+      serverNoMutableModuleState,
+      `"use server";
+const state = Object.seal({ service: { set(value) { persist(value); } } });
+export async function update() {
+  state.service.set("active");
+}`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent on a shadowed Object.seal implementation", () => {
+    const result = runRule(
+      serverNoMutableModuleState,
+      `"use server";
+const Object = { seal: () => sharedState };
+const state = Object.seal({ count: 0 });
+export async function increment() {
+  state.count++;
+}`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("flags a sealed object passed to a helper that mutates an existing property", () => {
+    const result = runRule(
+      serverNoMutableModuleState,
+      `"use server";
+const state = Object.seal({ count: 0 });
+const increment = (target) => { target.count++; };
+export async function update() {
+  increment(state);
+}`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays silent when a helper only attempts to add a sealed property", () => {
+    const result = runRule(
+      serverNoMutableModuleState,
+      `"use server";
+const state = Object.seal({ count: 0 });
+const addLabel = (target) => { target.label = "active"; };
+export async function update() {
+  addLabel(state);
+}`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("flags a dynamic Object.assign that may update existing sealed properties", () => {
+    const result = runRule(
+      serverNoMutableModuleState,
+      `"use server";
+const state = Object.seal({ count: 0 });
+export async function update(patch) {
+  Object.assign(state, patch);
+}`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it.each([
+    "const state = { count: 0 };",
+    "const state = Object.seal({ count: 0 });",
+    "const state = Object.preventExtensions({ count: 0 });",
+  ])(
+    "stays silent when a const container is only populated during module initialization",
+    (declaration) => {
+      const result = runRule(
+        serverNoMutableModuleState,
+        `"use server";
+${declaration}
+state.count = 1;
+export async function read() {
+  return state.count;
+}`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    },
+  );
+
+  it("still flags a mutation inside a module-initialized scheduled callback", () => {
+    const result = runRule(
+      serverNoMutableModuleState,
+      `"use server";
+const state = Object.seal({ count: 0 });
+setInterval(() => {
+  state.count++;
+}, 1000);`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays silent on a shadowed Object.assign lookalike", () => {
+    const result = runRule(
+      serverNoMutableModuleState,
+      `"use server";
+const state = Object.seal({ count: 0 });
+export async function update() {
+  const Object = { assign: () => null };
+  Object.assign(state, { count: 1 });
+}`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-no-mutable-module-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-no-mutable-module-state.ts
@@ -12,7 +12,7 @@ import {
 import type { ScopeAnalysis, SymbolDescriptor } from "../../semantic/scope-analysis.js";
 import { getStaticPropertyKeyName } from "../../utils/get-static-property-key-name.js";
 import { getObjectIntegrityMethodName } from "../../utils/unwrap-object-integrity-expression.js";
-import { isInsideFunctionScope } from "../../utils/is-inside-function-scope.js";
+import { isImmediatelyInvokedFunction } from "../../utils/is-immediately-invoked-function.js";
 
 const MUTABLE_CONTAINER_CONSTRUCTORS = new Set(["Map", "Set", "WeakMap", "WeakSet"]);
 const WRITABLE_INTEGRITY_METHOD_NAMES = new Set(["seal", "preventExtensions"]);
@@ -89,8 +89,10 @@ const getMutableConstInitializer = (
     initializer = stripParenExpression(wrappedInitializer);
   }
 
-  if (hasIntegrityWrapper) {
-    if (!isNodeOfType(initializer, "ObjectExpression")) return null;
+  // seal/preventExtensions only lock an object's property table — Map/Set
+  // internal slots and existing array indices stay writable, so a sealed
+  // non-object container falls through to the plain-container classification.
+  if (hasIntegrityWrapper && isNodeOfType(initializer, "ObjectExpression")) {
     const writablePropertyNames = new Set<string>();
     const nestedPropertyKinds = new Map<string, string>();
     for (const property of initializer.properties) {
@@ -259,20 +261,42 @@ const isKnownPropertyObjectMutation = (
     return writablePropertyNames.size > 0;
   }
   return propertyObject.properties.some((property) => {
+    if (isNodeOfType(property, "SpreadElement")) return writablePropertyNames.size > 0;
     const propertyName = getStaticPropertyKeyName(property, { allowComputedString: true });
     return propertyName !== null && writablePropertyNames.has(propertyName);
   });
+};
+
+// A write executes during module initialization when every enclosing function
+// up to `boundaryNode` (the module root when null) is immediately invoked —
+// an IIFE body runs once at import, exactly like a top-level statement. Any
+// non-invoked function ancestor defers the write to a later call, which on a
+// server module means potentially once per request.
+const runsAfterModuleInitialization = (
+  node: EsTreeNode,
+  boundaryNode: EsTreeNode | null = null,
+): boolean => {
+  let ancestor = node.parent;
+  while (ancestor && ancestor !== boundaryNode) {
+    if (isFunctionLike(ancestor) && !isImmediatelyInvokedFunction(ancestor)) return true;
+    ancestor = ancestor.parent ?? null;
+  }
+  return false;
 };
 
 // A bare reference passed as a call argument mutates the container when the
 // call is `Object.assign(X, …)`-shaped, or when the callee is a same-file
 // function whose matching parameter is mutated in its body (one hop only —
 // deeper escapes stay silent so read-only lookup helpers are never flagged).
+// The mutation only counts when it runs per request: the call site itself is
+// per-request, or the parameter escapes into a deferred function inside the
+// callee (a closure returned from a module-init factory call still leaks).
 const isMutatedThroughCallArgument = (
   referenceIdentifier: EsTreeNode,
   scopes: ScopeAnalysis,
   mayFollowCalleeHop: boolean,
-  initializer: MutableConstInitializer | null = null,
+  initializer: MutableConstInitializer | null,
+  callSiteRunsPerRequest: boolean,
 ): boolean => {
   const callExpression = referenceIdentifier.parent;
   if (!callExpression || !isNodeOfType(callExpression, "CallExpression")) return false;
@@ -287,6 +311,7 @@ const isMutatedThroughCallArgument = (
     const methodName = getMemberPropertyName(callee);
     const calleeReceiver = stripParenExpression(callee.object);
     return Boolean(
+      callSiteRunsPerRequest &&
       isNodeOfType(calleeReceiver, "Identifier") &&
       calleeReceiver.name === "Object" &&
       scopes.isGlobalReference(calleeReceiver) &&
@@ -311,11 +336,22 @@ const isMutatedThroughCallArgument = (
   if (!parameter || !isNodeOfType(parameter, "Identifier")) return false;
   const parameterSymbol = scopes.symbolFor(parameter);
   if (!parameterSymbol) return false;
-  return parameterSymbol.references.some(
-    (parameterReference) =>
-      isAllowedDirectMutation(parameterReference.identifier, initializer) ||
-      isMutatedThroughCallArgument(parameterReference.identifier, scopes, false, initializer),
-  );
+  return parameterSymbol.references.some((parameterReference) => {
+    const parameterRunsPerRequest =
+      callSiteRunsPerRequest ||
+      runsAfterModuleInitialization(parameterReference.identifier, calleeFunction);
+    return (
+      (parameterRunsPerRequest &&
+        isAllowedDirectMutation(parameterReference.identifier, initializer)) ||
+      isMutatedThroughCallArgument(
+        parameterReference.identifier,
+        scopes,
+        false,
+        initializer,
+        parameterRunsPerRequest,
+      )
+    );
+  });
 };
 
 const isAllowedDirectMutation = (
@@ -364,27 +400,35 @@ const collectAliasGroup = (
   return aliasGroup;
 };
 
-// True when the binding's contents are written from inside a function — i.e.
-// potentially per request; writes at module scope run once during module
-// initialization and never count. A write is a member assignment (`X.y = …`,
-// `X.a[i] = …` at any depth), `delete X.y`, a mutating method call
-// (`X.push(...)`, `X.users.push(...)`, `X["set"](...)`), `Object.assign(X, …)`,
-// or an escape into a same-file callee that mutates the parameter. Resolution
-// is scope-aware, so a shadowed local or parameter of the same name never
-// counts. A const container that is never mutated is an immutable lookup
-// table — sharing it across requests is correct, so it must NOT be flagged.
+// True when the binding's contents are written after module initialization —
+// i.e. potentially per request; writes that run once at import (top-level
+// statements and module-scope IIFEs) never count. A write is a member
+// assignment (`X.y = …`, `X.a[i] = …` at any depth), `delete X.y`, a mutating
+// method call (`X.push(...)`, `X.users.push(...)`, `X["set"](...)`),
+// `Object.assign(X, …)`, or an escape into a same-file callee that mutates
+// the parameter. Resolution is scope-aware, so a shadowed local or parameter
+// of the same name never counts. A const container that is never mutated is
+// an immutable lookup table — sharing it across requests is correct, so it
+// must NOT be flagged.
 const isContainerContentsMutated = (
   containerSymbol: SymbolDescriptor,
   scopes: ScopeAnalysis,
   initializer: MutableConstInitializer,
 ): boolean =>
   collectAliasGroup(containerSymbol, scopes).some((groupSymbol) =>
-    groupSymbol.references.some(
-      (reference) =>
-        isInsideFunctionScope(reference.identifier) &&
-        (isAllowedDirectMutation(reference.identifier, initializer) ||
-          isMutatedThroughCallArgument(reference.identifier, scopes, true, initializer)),
-    ),
+    groupSymbol.references.some((reference) => {
+      const referenceRunsPerRequest = runsAfterModuleInitialization(reference.identifier);
+      return (
+        (referenceRunsPerRequest && isAllowedDirectMutation(reference.identifier, initializer)) ||
+        isMutatedThroughCallArgument(
+          reference.identifier,
+          scopes,
+          true,
+          initializer,
+          referenceRunsPerRequest,
+        )
+      );
+    }),
   );
 
 // HACK: in `"use server"` files, mutable module-level state (let/var, OR

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-no-mutable-module-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-no-mutable-module-state.ts
@@ -24,29 +24,6 @@ interface MutableConstInitializer {
   allowsPropertyDeletion: boolean;
 }
 
-const MUTATING_METHODS = new Set([
-  "push",
-  "pop",
-  "shift",
-  "unshift",
-  "splice",
-  "sort",
-  "reverse",
-  "fill",
-  "copyWithin",
-  "set",
-  "add",
-  "delete",
-  "clear",
-]);
-
-const OBJECT_MUTATING_METHODS = new Set([
-  "assign",
-  "defineProperty",
-  "defineProperties",
-  "setPrototypeOf",
-]);
-
 const ARRAY_MUTATING_METHODS = new Set([
   "push",
   "pop",
@@ -59,8 +36,25 @@ const ARRAY_MUTATING_METHODS = new Set([
   "copyWithin",
 ]);
 
-const getNestedPropertyKind = (propertyValue: EsTreeNode): string | null => {
-  const value = stripParenExpression(propertyValue);
+const MUTATING_METHODS = new Set([...ARRAY_MUTATING_METHODS, "set", "add", "delete", "clear"]);
+
+const NESTED_MUTATING_METHODS: Record<string, ReadonlySet<string>> = {
+  Array: ARRAY_MUTATING_METHODS,
+  Map: new Set(["set", "delete", "clear"]),
+  WeakMap: new Set(["set", "delete"]),
+  Set: new Set(["add", "delete", "clear"]),
+  WeakSet: new Set(["add", "delete"]),
+};
+
+const OBJECT_MUTATING_METHODS = new Set([
+  "assign",
+  "defineProperty",
+  "defineProperties",
+  "setPrototypeOf",
+]);
+
+const getMutableContainerKind = (containerExpression: EsTreeNode): string | null => {
+  const value = stripParenExpression(containerExpression);
   if (isNodeOfType(value, "ArrayExpression")) return "Array";
   if (isNodeOfType(value, "ObjectExpression")) return "Object";
   if (
@@ -100,11 +94,11 @@ const getMutableConstInitializer = (
     const writablePropertyNames = new Set<string>();
     const nestedPropertyKinds = new Map<string, string>();
     for (const property of initializer.properties) {
-      if (isNodeOfType(property, "Property") && property.kind !== "init") continue;
+      if (!isNodeOfType(property, "Property") || property.kind !== "init") continue;
       const propertyName = getStaticPropertyKeyName(property, { allowComputedString: true });
-      if (propertyName === null || !isNodeOfType(property, "Property")) continue;
+      if (propertyName === null) continue;
       writablePropertyNames.add(propertyName);
-      const nestedPropertyKind = getNestedPropertyKind(property.value);
+      const nestedPropertyKind = getMutableContainerKind(property.value);
       if (nestedPropertyKind) nestedPropertyKinds.set(propertyName, nestedPropertyKind);
     }
     return {
@@ -115,35 +109,15 @@ const getMutableConstInitializer = (
     };
   }
 
-  if (isNodeOfType(initializer, "ArrayExpression")) {
-    return {
-      containerKind: "[]",
-      writablePropertyNames: null,
-      nestedPropertyKinds: null,
-      allowsPropertyDeletion: true,
-    };
-  }
-  if (isNodeOfType(initializer, "ObjectExpression")) {
-    return {
-      containerKind: "{}",
-      writablePropertyNames: null,
-      nestedPropertyKinds: null,
-      allowsPropertyDeletion: true,
-    };
-  }
-  if (
-    isNodeOfType(initializer, "NewExpression") &&
-    isNodeOfType(initializer.callee, "Identifier") &&
-    MUTABLE_CONTAINER_CONSTRUCTORS.has(initializer.callee.name)
-  ) {
-    return {
-      containerKind: `new ${initializer.callee.name}()`,
-      writablePropertyNames: null,
-      nestedPropertyKinds: null,
-      allowsPropertyDeletion: true,
-    };
-  }
-  return null;
+  const containerKindName = getMutableContainerKind(initializer);
+  if (!containerKindName) return null;
+  const containerKindLabels: Record<string, string> = { Array: "[]", Object: "{}" };
+  return {
+    containerKind: containerKindLabels[containerKindName] ?? `new ${containerKindName}()`,
+    writablePropertyNames: null,
+    nestedPropertyKinds: null,
+    allowsPropertyDeletion: true,
+  };
 };
 
 const getMemberPropertyName = (
@@ -260,38 +234,17 @@ const isSupportedNestedMethodMutation = (
   }
   const methodName = getMemberPropertyName(chainTip);
   if (!methodName) return false;
-  if (nestedPropertyKind === "Array") return ARRAY_MUTATING_METHODS.has(methodName);
-  if (nestedPropertyKind === "Map") {
-    return methodName === "set" || methodName === "delete" || methodName === "clear";
-  }
-  if (nestedPropertyKind === "WeakMap") return methodName === "set" || methodName === "delete";
-  if (nestedPropertyKind === "Set") {
-    return methodName === "add" || methodName === "delete" || methodName === "clear";
-  }
-  if (nestedPropertyKind === "WeakSet") return methodName === "add" || methodName === "delete";
-  return false;
+  return Boolean(NESTED_MUTATING_METHODS[nestedPropertyKind]?.has(methodName));
 };
 
+// The caller has already proven the call is `Object.<methodName>(container, …)`
+// with a global `Object` receiver and methodName in OBJECT_MUTATING_METHODS.
 const isKnownPropertyObjectMutation = (
-  referenceIdentifier: EsTreeNode,
+  callExpression: EsTreeNodeOfType<"CallExpression">,
+  methodName: string,
   writablePropertyNames: Set<string>,
-  scopes: ScopeAnalysis,
 ): boolean => {
-  const callExpression = referenceIdentifier.parent;
-  if (!callExpression || !isNodeOfType(callExpression, "CallExpression")) return false;
-  if (callExpression.arguments[0] !== referenceIdentifier) return false;
-  const callee = callExpression.callee;
-  if (!isNodeOfType(callee, "MemberExpression")) return false;
-  const receiver = stripParenExpression(callee.object);
-  if (
-    !isNodeOfType(receiver, "Identifier") ||
-    receiver.name !== "Object" ||
-    !scopes.isGlobalReference(receiver) ||
-    getMemberPropertyName(callee) === "setPrototypeOf"
-  ) {
-    return false;
-  }
-  const methodName = getMemberPropertyName(callee);
+  if (methodName === "setPrototypeOf") return false;
   if (methodName === "defineProperty") {
     const propertyNameNode = callExpression.arguments[1];
     return Boolean(
@@ -302,7 +255,6 @@ const isKnownPropertyObjectMutation = (
     );
   }
   const propertyObject = callExpression.arguments[1];
-  if (methodName !== "assign" && methodName !== "defineProperties") return false;
   if (!isNodeOfType(propertyObject, "ObjectExpression")) {
     return writablePropertyNames.size > 0;
   }
@@ -343,9 +295,9 @@ const isMutatedThroughCallArgument = (
       referenceArgumentIndex === 0 &&
       (!initializer?.writablePropertyNames ||
         isKnownPropertyObjectMutation(
-          referenceIdentifier,
+          callExpression,
+          methodName,
           initializer.writablePropertyNames,
-          scopes,
         )),
     );
   }
@@ -412,14 +364,15 @@ const collectAliasGroup = (
   return aliasGroup;
 };
 
-// True when the binding's contents are written anywhere in the module: a
-// member assignment (`X.y = …`, `X.a[i] = …` at any depth), `delete X.y`, a
-// mutating method call (`X.push(...)`, `X.users.push(...)`, `X["set"](...)`),
-// `Object.assign(X, …)`, or an escape into a same-file callee that mutates
-// the parameter. Resolution is scope-aware, so a shadowed local or parameter
-// of the same name never counts. A const container that is never mutated is
-// an immutable lookup table — sharing it across requests is correct, so it
-// must NOT be flagged.
+// True when the binding's contents are written from inside a function — i.e.
+// potentially per request; writes at module scope run once during module
+// initialization and never count. A write is a member assignment (`X.y = …`,
+// `X.a[i] = …` at any depth), `delete X.y`, a mutating method call
+// (`X.push(...)`, `X.users.push(...)`, `X["set"](...)`), `Object.assign(X, …)`,
+// or an escape into a same-file callee that mutates the parameter. Resolution
+// is scope-aware, so a shadowed local or parameter of the same name never
+// counts. A const container that is never mutated is an immutable lookup
+// table — sharing it across requests is correct, so it must NOT be flagged.
 const isContainerContentsMutated = (
   containerSymbol: SymbolDescriptor,
   scopes: ScopeAnalysis,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-no-mutable-module-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-no-mutable-module-state.ts
@@ -10,8 +10,19 @@ import {
   stripParenExpression,
 } from "../../utils/strip-paren-expression.js";
 import type { ScopeAnalysis, SymbolDescriptor } from "../../semantic/scope-analysis.js";
+import { getStaticPropertyKeyName } from "../../utils/get-static-property-key-name.js";
+import { getObjectIntegrityMethodName } from "../../utils/unwrap-object-integrity-expression.js";
+import { isInsideFunctionScope } from "../../utils/is-inside-function-scope.js";
 
 const MUTABLE_CONTAINER_CONSTRUCTORS = new Set(["Map", "Set", "WeakMap", "WeakSet"]);
+const WRITABLE_INTEGRITY_METHOD_NAMES = new Set(["seal", "preventExtensions"]);
+
+interface MutableConstInitializer {
+  containerKind: string;
+  writablePropertyNames: Set<string> | null;
+  nestedPropertyKinds: Map<string, string> | null;
+  allowsPropertyDeletion: boolean;
+}
 
 const MUTATING_METHODS = new Set([
   "push",
@@ -36,16 +47,101 @@ const OBJECT_MUTATING_METHODS = new Set([
   "setPrototypeOf",
 ]);
 
-const isMutableConstInitializer = (init: EsTreeNode | null | undefined): string | null => {
-  if (!init) return null;
-  if (isNodeOfType(init, "ArrayExpression")) return "[]";
-  if (isNodeOfType(init, "ObjectExpression")) return "{}";
+const ARRAY_MUTATING_METHODS = new Set([
+  "push",
+  "pop",
+  "shift",
+  "unshift",
+  "splice",
+  "sort",
+  "reverse",
+  "fill",
+  "copyWithin",
+]);
+
+const getNestedPropertyKind = (propertyValue: EsTreeNode): string | null => {
+  const value = stripParenExpression(propertyValue);
+  if (isNodeOfType(value, "ArrayExpression")) return "Array";
+  if (isNodeOfType(value, "ObjectExpression")) return "Object";
   if (
-    isNodeOfType(init, "NewExpression") &&
-    isNodeOfType(init.callee, "Identifier") &&
-    MUTABLE_CONTAINER_CONSTRUCTORS.has(init.callee.name)
+    isNodeOfType(value, "NewExpression") &&
+    isNodeOfType(value.callee, "Identifier") &&
+    MUTABLE_CONTAINER_CONSTRUCTORS.has(value.callee.name)
   ) {
-    return `new ${init.callee.name}()`;
+    return value.callee.name;
+  }
+  return null;
+};
+
+const getMutableConstInitializer = (
+  init: EsTreeNode | null | undefined,
+  scopes: ScopeAnalysis,
+): MutableConstInitializer | null => {
+  if (!init) return null;
+  let initializer = stripParenExpression(init);
+  let hasIntegrityWrapper = false;
+  let allowsPropertyDeletion = true;
+  while (isNodeOfType(initializer, "CallExpression")) {
+    const methodName = getObjectIntegrityMethodName(
+      initializer,
+      scopes,
+      WRITABLE_INTEGRITY_METHOD_NAMES,
+    );
+    if (!methodName) break;
+    const wrappedInitializer = initializer.arguments[0];
+    if (!wrappedInitializer || isNodeOfType(wrappedInitializer, "SpreadElement")) return null;
+    hasIntegrityWrapper = true;
+    if (methodName === "seal") allowsPropertyDeletion = false;
+    initializer = stripParenExpression(wrappedInitializer);
+  }
+
+  if (hasIntegrityWrapper) {
+    if (!isNodeOfType(initializer, "ObjectExpression")) return null;
+    const writablePropertyNames = new Set<string>();
+    const nestedPropertyKinds = new Map<string, string>();
+    for (const property of initializer.properties) {
+      if (isNodeOfType(property, "Property") && property.kind !== "init") continue;
+      const propertyName = getStaticPropertyKeyName(property, { allowComputedString: true });
+      if (propertyName === null || !isNodeOfType(property, "Property")) continue;
+      writablePropertyNames.add(propertyName);
+      const nestedPropertyKind = getNestedPropertyKind(property.value);
+      if (nestedPropertyKind) nestedPropertyKinds.set(propertyName, nestedPropertyKind);
+    }
+    return {
+      containerKind: "{}",
+      writablePropertyNames,
+      nestedPropertyKinds,
+      allowsPropertyDeletion,
+    };
+  }
+
+  if (isNodeOfType(initializer, "ArrayExpression")) {
+    return {
+      containerKind: "[]",
+      writablePropertyNames: null,
+      nestedPropertyKinds: null,
+      allowsPropertyDeletion: true,
+    };
+  }
+  if (isNodeOfType(initializer, "ObjectExpression")) {
+    return {
+      containerKind: "{}",
+      writablePropertyNames: null,
+      nestedPropertyKinds: null,
+      allowsPropertyDeletion: true,
+    };
+  }
+  if (
+    isNodeOfType(initializer, "NewExpression") &&
+    isNodeOfType(initializer.callee, "Identifier") &&
+    MUTABLE_CONTAINER_CONSTRUCTORS.has(initializer.callee.name)
+  ) {
+    return {
+      containerKind: `new ${initializer.callee.name}()`,
+      writablePropertyNames: null,
+      nestedPropertyKinds: null,
+      allowsPropertyDeletion: true,
+    };
   }
   return null;
 };
@@ -116,6 +212,106 @@ const isDirectContentsMutation = (referenceIdentifier: EsTreeNode): boolean => {
   return false;
 };
 
+const getRootPropertyName = (referenceIdentifier: EsTreeNode): string | null => {
+  let receiver: EsTreeNode = referenceIdentifier;
+  while (
+    receiver.parent &&
+    TRANSPARENT_EXPRESSION_WRAPPER_TYPES.has(receiver.parent.type) &&
+    "expression" in receiver.parent &&
+    receiver.parent.expression === receiver
+  ) {
+    receiver = receiver.parent;
+  }
+  if (!receiver.parent || !isNodeOfType(receiver.parent, "MemberExpression")) return null;
+  if (receiver.parent.object !== receiver) return null;
+  return getMemberPropertyName(receiver.parent);
+};
+
+const isDeleteContentsMutation = (referenceIdentifier: EsTreeNode): boolean => {
+  const chainTip = ascendMemberChain(referenceIdentifier);
+  const chainTipParent = chainTip.parent;
+  return Boolean(
+    chainTipParent &&
+    isNodeOfType(chainTipParent, "UnaryExpression") &&
+    chainTipParent.operator === "delete" &&
+    chainTipParent.argument === chainTip,
+  );
+};
+
+const isDirectRootPropertyMutation = (referenceIdentifier: EsTreeNode): boolean => {
+  const chainTip = ascendMemberChain(referenceIdentifier);
+  if (!isNodeOfType(chainTip, "MemberExpression")) return false;
+  return stripParenExpression(chainTip.object) === referenceIdentifier;
+};
+
+const isSupportedNestedMethodMutation = (
+  referenceIdentifier: EsTreeNode,
+  nestedPropertyKind: string,
+): boolean => {
+  const chainTip = ascendMemberChain(referenceIdentifier);
+  const chainTipParent = chainTip.parent;
+  if (
+    !isNodeOfType(chainTip, "MemberExpression") ||
+    !chainTipParent ||
+    !isNodeOfType(chainTipParent, "CallExpression") ||
+    chainTipParent.callee !== chainTip
+  ) {
+    return true;
+  }
+  const methodName = getMemberPropertyName(chainTip);
+  if (!methodName) return false;
+  if (nestedPropertyKind === "Array") return ARRAY_MUTATING_METHODS.has(methodName);
+  if (nestedPropertyKind === "Map") {
+    return methodName === "set" || methodName === "delete" || methodName === "clear";
+  }
+  if (nestedPropertyKind === "WeakMap") return methodName === "set" || methodName === "delete";
+  if (nestedPropertyKind === "Set") {
+    return methodName === "add" || methodName === "delete" || methodName === "clear";
+  }
+  if (nestedPropertyKind === "WeakSet") return methodName === "add" || methodName === "delete";
+  return false;
+};
+
+const isKnownPropertyObjectMutation = (
+  referenceIdentifier: EsTreeNode,
+  writablePropertyNames: Set<string>,
+  scopes: ScopeAnalysis,
+): boolean => {
+  const callExpression = referenceIdentifier.parent;
+  if (!callExpression || !isNodeOfType(callExpression, "CallExpression")) return false;
+  if (callExpression.arguments[0] !== referenceIdentifier) return false;
+  const callee = callExpression.callee;
+  if (!isNodeOfType(callee, "MemberExpression")) return false;
+  const receiver = stripParenExpression(callee.object);
+  if (
+    !isNodeOfType(receiver, "Identifier") ||
+    receiver.name !== "Object" ||
+    !scopes.isGlobalReference(receiver) ||
+    getMemberPropertyName(callee) === "setPrototypeOf"
+  ) {
+    return false;
+  }
+  const methodName = getMemberPropertyName(callee);
+  if (methodName === "defineProperty") {
+    const propertyNameNode = callExpression.arguments[1];
+    return Boolean(
+      propertyNameNode &&
+      isNodeOfType(propertyNameNode, "Literal") &&
+      typeof propertyNameNode.value === "string" &&
+      writablePropertyNames.has(propertyNameNode.value),
+    );
+  }
+  const propertyObject = callExpression.arguments[1];
+  if (methodName !== "assign" && methodName !== "defineProperties") return false;
+  if (!isNodeOfType(propertyObject, "ObjectExpression")) {
+    return writablePropertyNames.size > 0;
+  }
+  return propertyObject.properties.some((property) => {
+    const propertyName = getStaticPropertyKeyName(property, { allowComputedString: true });
+    return propertyName !== null && writablePropertyNames.has(propertyName);
+  });
+};
+
 // A bare reference passed as a call argument mutates the container when the
 // call is `Object.assign(X, …)`-shaped, or when the callee is a same-file
 // function whose matching parameter is mutated in its body (one hop only —
@@ -124,6 +320,7 @@ const isMutatedThroughCallArgument = (
   referenceIdentifier: EsTreeNode,
   scopes: ScopeAnalysis,
   mayFollowCalleeHop: boolean,
+  initializer: MutableConstInitializer | null = null,
 ): boolean => {
   const callExpression = referenceIdentifier.parent;
   if (!callExpression || !isNodeOfType(callExpression, "CallExpression")) return false;
@@ -140,9 +337,16 @@ const isMutatedThroughCallArgument = (
     return Boolean(
       isNodeOfType(calleeReceiver, "Identifier") &&
       calleeReceiver.name === "Object" &&
+      scopes.isGlobalReference(calleeReceiver) &&
       methodName !== null &&
       OBJECT_MUTATING_METHODS.has(methodName) &&
-      referenceArgumentIndex === 0,
+      referenceArgumentIndex === 0 &&
+      (!initializer?.writablePropertyNames ||
+        isKnownPropertyObjectMutation(
+          referenceIdentifier,
+          initializer.writablePropertyNames,
+          scopes,
+        )),
     );
   }
 
@@ -157,8 +361,25 @@ const isMutatedThroughCallArgument = (
   if (!parameterSymbol) return false;
   return parameterSymbol.references.some(
     (parameterReference) =>
-      isDirectContentsMutation(parameterReference.identifier) ||
-      isMutatedThroughCallArgument(parameterReference.identifier, scopes, false),
+      isAllowedDirectMutation(parameterReference.identifier, initializer) ||
+      isMutatedThroughCallArgument(parameterReference.identifier, scopes, false, initializer),
+  );
+};
+
+const isAllowedDirectMutation = (
+  referenceIdentifier: EsTreeNode,
+  initializer: MutableConstInitializer | null,
+): boolean => {
+  if (!isDirectContentsMutation(referenceIdentifier)) return false;
+  if (!initializer?.writablePropertyNames) return true;
+  const rootPropertyName = getRootPropertyName(referenceIdentifier);
+  if (!rootPropertyName || !initializer.writablePropertyNames.has(rootPropertyName)) return false;
+  if (isDirectRootPropertyMutation(referenceIdentifier)) {
+    return initializer.allowsPropertyDeletion || !isDeleteContentsMutation(referenceIdentifier);
+  }
+  const nestedPropertyKind = initializer.nestedPropertyKinds?.get(rootPropertyName);
+  return Boolean(
+    nestedPropertyKind && isSupportedNestedMethodMutation(referenceIdentifier, nestedPropertyKind),
   );
 };
 
@@ -202,12 +423,14 @@ const collectAliasGroup = (
 const isContainerContentsMutated = (
   containerSymbol: SymbolDescriptor,
   scopes: ScopeAnalysis,
+  initializer: MutableConstInitializer,
 ): boolean =>
   collectAliasGroup(containerSymbol, scopes).some((groupSymbol) =>
     groupSymbol.references.some(
       (reference) =>
-        isDirectContentsMutation(reference.identifier) ||
-        isMutatedThroughCallArgument(reference.identifier, scopes, true),
+        isInsideFunctionScope(reference.identifier) &&
+        (isAllowedDirectMutation(reference.identifier, initializer) ||
+          isMutatedThroughCallArgument(reference.identifier, scopes, true, initializer)),
     ),
   );
 
@@ -247,14 +470,14 @@ export const serverNoMutableModuleState = defineRule({
             continue;
           }
 
-          const containerKind = isMutableConstInitializer(declarator.init);
-          if (!containerKind || !isNodeOfType(declarator.id, "Identifier")) continue;
+          const initializer = getMutableConstInitializer(declarator.init, context.scopes);
+          if (!initializer || !isNodeOfType(declarator.id, "Identifier")) continue;
           const containerSymbol = context.scopes.symbolFor(declarator.id);
           if (!containerSymbol) continue;
-          if (isContainerContentsMutated(containerSymbol, context.scopes)) {
+          if (isContainerContentsMutated(containerSymbol, context.scopes, initializer)) {
             context.report({
               node: declarator,
-              message: `Module-scoped const "${variableName} = ${containerKind}" leaks state between your users, since every request shares it.`,
+              message: `Module-scoped const "${variableName} = ${initializer.containerKind}" leaks state between your users, since every request shares it.`,
             });
           }
         }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/unwrap-object-integrity-expression.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/unwrap-object-integrity-expression.ts
@@ -15,12 +15,15 @@ export const getObjectIntegrityMethodName = (
   const expression = stripParenExpression(node);
   if (!isNodeOfType(expression, "CallExpression")) return null;
   const callee = stripParenExpression(expression.callee);
+  const receiver = isNodeOfType(callee, "MemberExpression")
+    ? stripParenExpression(callee.object)
+    : callee;
   if (
     !isNodeOfType(callee, "MemberExpression") ||
     callee.computed ||
-    !isNodeOfType(callee.object, "Identifier") ||
-    callee.object.name !== "Object" ||
-    !scopes.isGlobalReference(callee.object) ||
+    !isNodeOfType(receiver, "Identifier") ||
+    receiver.name !== "Object" ||
+    !scopes.isGlobalReference(receiver) ||
     !isNodeOfType(callee.property, "Identifier") ||
     !methodNames.has(callee.property.name)
   ) {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/unwrap-object-integrity-expression.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/unwrap-object-integrity-expression.ts
@@ -7,6 +7,28 @@ export const OBJECT_INTEGRITY_METHOD_NAMES = new Set(["freeze", "seal", "prevent
 
 export const OBJECT_FREEZE_OR_SEAL_METHOD_NAMES = new Set(["freeze", "seal"]);
 
+export const getObjectIntegrityMethodName = (
+  node: EsTreeNode,
+  scopes: ScopeAnalysis,
+  methodNames = OBJECT_INTEGRITY_METHOD_NAMES,
+): string | null => {
+  const expression = stripParenExpression(node);
+  if (!isNodeOfType(expression, "CallExpression")) return null;
+  const callee = stripParenExpression(expression.callee);
+  if (
+    !isNodeOfType(callee, "MemberExpression") ||
+    callee.computed ||
+    !isNodeOfType(callee.object, "Identifier") ||
+    callee.object.name !== "Object" ||
+    !scopes.isGlobalReference(callee.object) ||
+    !isNodeOfType(callee.property, "Identifier") ||
+    !methodNames.has(callee.property.name)
+  ) {
+    return null;
+  }
+  return callee.property.name;
+};
+
 export const unwrapObjectIntegrityExpression = (
   node: EsTreeNode,
   scopes: ScopeAnalysis,
@@ -15,18 +37,7 @@ export const unwrapObjectIntegrityExpression = (
   let expression = stripParenExpression(node);
 
   while (isNodeOfType(expression, "CallExpression")) {
-    const callee = stripParenExpression(expression.callee);
-    if (
-      !isNodeOfType(callee, "MemberExpression") ||
-      callee.computed ||
-      !isNodeOfType(callee.object, "Identifier") ||
-      callee.object.name !== "Object" ||
-      !scopes.isGlobalReference(callee.object) ||
-      !isNodeOfType(callee.property, "Identifier") ||
-      !methodNames.has(callee.property.name)
-    ) {
-      break;
-    }
+    if (!getObjectIntegrityMethodName(expression, scopes, methodNames)) break;
 
     const wrappedExpression = expression.arguments[0];
     if (!wrappedExpression || isNodeOfType(wrappedExpression, "SpreadElement")) break;


### PR DESCRIPTION
## Summary

- preserve writable-object facts through global `Object.seal` and `Object.preventExtensions`
- report proven request-time writes to declared data properties while excluding module-initialization writes, rejected additions, sealed deletions, accessor-only properties, and speculative nested mutator-name calls
- preserve statically proven nested writes using declared Array/Object/Map/Set container kinds
- keep integrity-call recognition intact through transparent TypeScript wrappers on the global `Object` receiver
- add permanent false-positive corpus seeds and a dedicated server-module fuzz scenario pool

## Why

Sealing or preventing extensions does not make existing writable data properties immutable. A module-scoped server object can still leak state across requests when those properties or statically known nested containers change during an action or callback.

## Validation

- focused regressions: 44 passed
- complete oxlint plugin suite: 12,253 passed, 148 skipped
- complete workspace test matrix: 14/14 tasks passed; React Doctor CLI 2,207 passed and 27 skipped
- six independent strict 10,000-iteration campaigns: 60,000 unique seeded iterations across react-bench-5 and the preserved react-bench-4 job archive, with crash, verified-slowness, metamorphic-invariance, and verdict-preservation oracles
- measured bench-5 campaign: 6,180 parseable executions, 285 firing programs, 4,411 parse skips, 0 findings
- measured bench-4 campaign: 6,238 parseable executions, 262 firing programs, 4,311 parse skips, 0 findings
- corpus inputs per measured campaign: 400 external benchmark files plus 126 built-in regression seeds
- benchmark audit: the available react-bench checkouts contain no executable JavaScript/TypeScript `"use server"` module; external files therefore provide mutation/crossover pressure but not target liveness, which is supplied and measured through the new dedicated generator scenarios
- permanent FP corpus coverage: getter-only sealed properties, module-initialization-only writes, and opaque nested mutator-shaped calls
- adversarial rule coverage: delegating setters, zero-writable-property dynamic patches, scalar/custom nested mutator spellings, shadowed globals, rejected additions, sealed deletions, helper and alias writes, descriptor updates, and transparent TypeScript wrappers
- format, lint, monorepo typecheck, build, JSON report smoke, and changed-lines React Doctor self-scan pass
- whole-repo self-scan reports only five unrelated existing website/security warnings

RDE could not evaluate this branch because the current local eval harness accepts report schema versions 1 and 2 while React Doctor now emits schema version 3. No eval-harness files were changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The change is a large behavioral expansion of a server concurrency rule with nuanced control-flow and property-descriptor logic, so missed or extra diagnostics are possible despite broad regressions and fuzz coverage.
> 
> **Overview**
> **`server-no-mutable-module-state`** now treats module-scoped `const` bindings wrapped in global **`Object.seal`** / **`Object.preventExtensions`** as shared server state when **existing** declared properties (or known nested containers) are mutated **after** module initialization—e.g. in server actions, timers, or per-request IIFEs—not when writes run only at import time.
> 
> The rule models sealed object literals (writable property keys, nested `Array`/`Map`/`Set` kinds, seal vs delete rules), narrows **`Object.assign`** / **`defineProperty`** / helper-parameter escapes to properties that can actually change, and still ignores **`Object.freeze`**, rejected adds/deletes on sealed objects, getter/setter-only shapes, shadowed `Object`, and opaque nested “mutator” calls. Integrity peeling is centralized in **`getObjectIntegrityMethodName`** (used by **`unwrapObjectIntegrityExpression`**) so **`(Object as any).seal`**-style receivers stay recognized.
> 
> **Fuzzing** adds a **`"use server"`** program pool (~12% of generated iterations), regression corpus seeds for prior false positives, **`FUZZ_PRINT_STATS`**, and per-rule test timeouts scaled by iteration count. Other rules gain regressions that **`Object as any`** integrity wrappers still unwrap correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 455c1b7cdc8333b38f8355510634cb7e9aa2e51e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->