### PR TITLE
fix(rule): resolve NaN dependency bindings

### DIFF
--- a/.changeset/lucky-nan-bindings.md
+++ b/.changeset/lucky-nan-bindings.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Resolve global NaN dependencies through exact immutable bindings.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/hooks-no-nan-in-deps.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/hooks-no-nan-in-deps.test.ts
@@ -248,6 +248,107 @@ const Comp = () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("stays silent when a spread precedes the matched index in an array-destructure initializer", () => {
+    const result = runRule(
+      hooksNoNanInDeps,
+      `import { useEffect } from "react";
+const others = [1, 2];
+const [firstValue, secondValue] = [...others, Number.NaN];
+const Comp = () => {
+  useEffect(() => {}, [secondValue]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still flags an array-destructured NaN when a spread follows the matched index", () => {
+    const result = runRule(
+      hooksNoNanInDeps,
+      `import { useEffect } from "react";
+const others = [1, 2];
+const [firstValue] = [Number.NaN, ...others];
+const Comp = () => {
+  useEffect(() => {}, [firstValue]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags the array-destructured binding at a non-zero NaN initializer index", () => {
+    const result = runRule(
+      hooksNoNanInDeps,
+      `import { useEffect } from "react";
+const [, secondValue] = [0, Number.NaN];
+const Comp = () => {
+  useEffect(() => {}, [secondValue]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag an array-destructured binding whose initializer index holds a finite value", () => {
+    const result = runRule(
+      hooksNoNanInDeps,
+      `import { useEffect } from "react";
+const [firstValue] = [0, Number.NaN];
+const Comp = () => {
+  useEffect(() => {}, [firstValue]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent (and does not crash) on a self-referential const alias", () => {
+    const result = runRule(
+      hooksNoNanInDeps,
+      `import { useEffect } from "react";
+const selfValue = selfValue;
+const Comp = () => {
+  useEffect(() => {}, [selfValue]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("flags a computed string-key destructure of global Number.NaN", () => {
+    const result = runRule(
+      hooksNoNanInDeps,
+      `import { useEffect } from "react";
+const { ["NaN"]: computedValue } = Number;
+const Comp = () => {
+  useEffect(() => {}, [computedValue]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays silent on a NaN-keyed destructure off a non-global receiver", () => {
+    const result = runRule(
+      hooksNoNanInDeps,
+      `import { useEffect } from "react";
+const localNumber = { NaN: 2 };
+const { NaN: aliasValue } = localNumber;
+const Comp = () => {
+  useEffect(() => {}, [aliasValue]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("flags Number.NaN aliases through transparent TypeScript wrappers", () => {
     const result = runRule(
       hooksNoNanInDeps,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/hooks-no-nan-in-deps.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/hooks-no-nan-in-deps.test.ts
@@ -188,4 +188,79 @@ describe("hooks-no-nan-in-deps", () => {
 
     expect(result.diagnostics).toHaveLength(3);
   });
+
+  it("stays silent on shadowed finite NaN and Number.NaN bindings", () => {
+    const result = runRule(
+      hooksNoNanInDeps,
+      `import { useEffect } from "react";
+const NaN = 1;
+const Number = { NaN: 2 };
+const Comp = () => {
+  useEffect(() => {}, [NaN, Number.NaN]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("flags exact immutable aliases of the global NaN values", () => {
+    const result = runRule(
+      hooksNoNanInDeps,
+      `import { useEffect } from "react";
+const firstValue = Number.NaN;
+const secondValue = firstValue;
+const Comp = () => {
+  useEffect(() => {}, [secondValue]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags an exact destructured alias of global Number.NaN", () => {
+    const result = runRule(
+      hooksNoNanInDeps,
+      `import { useEffect } from "react";
+const { NaN: invalidValue } = Number;
+const Comp = () => {
+  useEffect(() => {}, [invalidValue]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays silent across a mutable NaN alias", () => {
+    const result = runRule(
+      hooksNoNanInDeps,
+      `import { useEffect } from "react";
+let invalidValue = Number.NaN;
+invalidValue = 0;
+const Comp = () => {
+  useEffect(() => {}, [invalidValue]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("flags Number.NaN aliases through transparent TypeScript wrappers", () => {
+    const result = runRule(
+      hooksNoNanInDeps,
+      `import { useEffect } from "react";
+const directValue = (Number as typeof Number).NaN;
+const { NaN: destructuredValue } = Number as typeof Number;
+const [arrayValue] = [Number.NaN as number] as const;
+const Comp = () => {
+  useEffect(() => {}, [directValue, destructuredValue, arrayValue]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(3);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/hooks-no-nan-in-deps.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/hooks-no-nan-in-deps.ts
@@ -1,9 +1,9 @@
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { getCalleeName } from "../../utils/get-callee-name.js";
 import { isHookCall } from "../../utils/is-hook-call.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { isGlobalNanValue } from "../../utils/is-global-nan-value.js";
 
 // Hooks whose tail (or trailing) argument is an explicit dependency array.
 // Notably excludes `@preact/signals`'s `useSignalEffect(callback)` — it
@@ -22,21 +22,6 @@ const HOOKS_WITH_DEP_ARRAY = new Set([
 
 const NAN_MESSAGE =
   "`NaN` in a dependency array never compares as changed with `Object.is`, so normalize the value before passing it as a dependency.";
-
-const isNanLiteral = (node: EsTreeNode): boolean => {
-  if (isNodeOfType(node, "Identifier") && node.name === "NaN") return true;
-  if (
-    isNodeOfType(node, "MemberExpression") &&
-    !node.computed &&
-    isNodeOfType(node.object, "Identifier") &&
-    node.object.name === "Number" &&
-    isNodeOfType(node.property, "Identifier") &&
-    node.property.name === "NaN"
-  ) {
-    return true;
-  }
-  return false;
-};
 
 // Mirrors the runtime check in `preact/debug/src/debug.js`:
 //   if (isNaN(arg)) {
@@ -72,7 +57,7 @@ export const hooksNoNanInDeps = defineRule({
       if (!depsArgument || !isNodeOfType(depsArgument, "ArrayExpression")) return;
       for (const element of depsArgument.elements) {
         if (!element) continue;
-        if (isNanLiteral(element)) {
+        if (!isNodeOfType(element, "SpreadElement") && isGlobalNanValue(element, context.scopes)) {
           context.report({ node: element, message: NAN_MESSAGE });
         }
       }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/hooks-no-nan-in-deps.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/hooks-no-nan-in-deps.ts
@@ -57,7 +57,7 @@ export const hooksNoNanInDeps = defineRule({
       if (!depsArgument || !isNodeOfType(depsArgument, "ArrayExpression")) return;
       for (const element of depsArgument.elements) {
         if (!element) continue;
-        if (!isNodeOfType(element, "SpreadElement") && isGlobalNanValue(element, context.scopes)) {
+        if (isGlobalNanValue(element, context.scopes)) {
           context.report({ node: element, message: NAN_MESSAGE });
         }
       }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-global-nan-value.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-global-nan-value.ts
@@ -40,7 +40,15 @@ export const isGlobalNanValue = (node: EsTreeNode, scopes: ScopeAnalysis): boole
         const bindingIndex = declaration.id.elements.findIndex(
           (element) => element === symbol.bindingIdentifier,
         );
-        const arrayValue = bindingIndex >= 0 ? declarationInitializer.elements[bindingIndex] : null;
+        if (bindingIndex < 0) return false;
+        const hasSpreadBeforeBinding = declarationInitializer.elements
+          .slice(0, bindingIndex)
+          .some(
+            (initializerElement) =>
+              initializerElement !== null && isNodeOfType(initializerElement, "SpreadElement"),
+          );
+        if (hasSpreadBeforeBinding) return false;
+        const arrayValue = declarationInitializer.elements[bindingIndex];
         return Boolean(
           arrayValue && !isNodeOfType(arrayValue, "SpreadElement") && visit(arrayValue),
         );

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-global-nan-value.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-global-nan-value.ts
@@ -1,0 +1,63 @@
+import type { ScopeAnalysis } from "../semantic/scope-analysis.js";
+import type { EsTreeNode } from "./es-tree-node.js";
+import { getStaticPropertyKeyName } from "./get-static-property-key-name.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+import { stripParenExpression } from "./strip-paren-expression.js";
+
+export const isGlobalNanValue = (node: EsTreeNode, scopes: ScopeAnalysis): boolean => {
+  const visitedSymbolIds = new Set<number>();
+
+  const visit = (candidate: EsTreeNode): boolean => {
+    const expression = stripParenExpression(candidate);
+    if (isNodeOfType(expression, "Identifier")) {
+      if (expression.name === "NaN" && scopes.isGlobalReference(expression)) return true;
+      const symbol = scopes.symbolFor(expression);
+      if (!symbol || symbol.kind !== "const" || visitedSymbolIds.has(symbol.id)) return false;
+      visitedSymbolIds.add(symbol.id);
+      const declaration = symbol.declarationNode;
+      if (!isNodeOfType(declaration, "VariableDeclarator") || !declaration.init) return false;
+      if (declaration.id === symbol.bindingIdentifier) return visit(declaration.init);
+      const declarationInitializer = stripParenExpression(declaration.init);
+
+      if (
+        isNodeOfType(declaration.id, "ObjectPattern") &&
+        isNodeOfType(declarationInitializer, "Identifier") &&
+        declarationInitializer.name === "Number" &&
+        scopes.isGlobalReference(declarationInitializer)
+      ) {
+        return declaration.id.properties.some(
+          (property) =>
+            isNodeOfType(property, "Property") &&
+            property.value === symbol.bindingIdentifier &&
+            getStaticPropertyKeyName(property, { allowComputedString: true }) === "NaN",
+        );
+      }
+
+      if (
+        isNodeOfType(declaration.id, "ArrayPattern") &&
+        isNodeOfType(declarationInitializer, "ArrayExpression")
+      ) {
+        const bindingIndex = declaration.id.elements.findIndex(
+          (element) => element === symbol.bindingIdentifier,
+        );
+        const arrayValue = bindingIndex >= 0 ? declarationInitializer.elements[bindingIndex] : null;
+        return Boolean(
+          arrayValue && !isNodeOfType(arrayValue, "SpreadElement") && visit(arrayValue),
+        );
+      }
+      return false;
+    }
+
+    if (!isNodeOfType(expression, "MemberExpression") || expression.computed) return false;
+    const receiver = stripParenExpression(expression.object);
+    return Boolean(
+      isNodeOfType(receiver, "Identifier") &&
+      receiver.name === "Number" &&
+      scopes.isGlobalReference(receiver) &&
+      isNodeOfType(expression.property, "Identifier") &&
+      expression.property.name === "NaN",
+    );
+  };
+
+  return visit(node);
+};


### PR DESCRIPTION
## Summary

- resolve only unshadowed global `NaN` and `Number.NaN` values in hook dependency arrays
- follow exact immutable const aliases, including supported object/array destructuring and transparent TypeScript wrappers
- keep shadowed globals and mutable aliases clean

## Validation

- focused rule tests: 17 passed
- full plugin suite: 549 files, 12,231 passed, 148 skipped
- plugin and workspace typecheck: passed
- workspace build: passed
- JSON smoke test and built CLI self-scan: passed
- strict all-oracle fuzz: 500 iterations against `/Users/aidenybai/Developer/react-bench-5`
- full root rerun: 205 passed, 2 skipped
- Bugbot wrapper finding fixed with direct, object-destructured, and array-destructured TypeScript-wrapper regressions

## RDE

The local RDE checkout currently accepts report schema versions 1/2 while this branch emits schema version 3, so RDE cannot consume current reports without changing the separate dirty eval checkout.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-only refinement in one rule with broad regression tests; no runtime or security impact.
> 
> **Overview**
> **`hooks-no-nan-in-deps`** no longer flags only literal `NaN` / `Number.NaN` tokens. It now uses scope-aware **`isGlobalNanValue`**, which still reports unshadowed globals but also follows **immutable `const` aliases** (including object/array destructuring from global `Number`, computed `"NaN"` keys, and parenthesis/TS assertion wrappers).
> 
> **False positives are reduced** for shadowed `NaN`/`Number`, `let` reassignment, array destructuring when a spread precedes the binding index, non-global destructuring receivers, and self-referential `const` initializers.
> 
> The rule implementation drops local `isNanLiteral` in favor of the shared helper; tests cover the new binding-resolution behavior. Patch changeset for `oxlint-plugin-react-doctor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e8b6820e36b4a840907cb5788f6a692c301c9b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->