### PR TITLE
fix(rule): resolve exact effect callback bindings

### DIFF
--- a/.changeset/tidy-effect-callbacks.md
+++ b/.changeset/tidy-effect-callbacks.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Resolve exact local function bindings passed as effect callbacks.

--- a/packages/fuzz/corpus/regressions/no-effect-chain--async-iife-state-write.tsx
+++ b/packages/fuzz/corpus/regressions/no-effect-chain--async-iife-state-write.tsx
@@ -1,0 +1,24 @@
+// rule: no-effect-chain
+// weakness: control-flow
+// source: PR #1182 React Bench AppFlowy-Web delta audit
+
+import { useEffect, useState } from "react";
+
+export const RelationItems = ({ loadView }) => {
+  const [viewId, setViewId] = useState<string | null>(null);
+  const [rows, setRows] = useState<unknown[]>([]);
+
+  function loadViewId() {
+    void (async () => {
+      const view = await loadView();
+      setViewId(view.id);
+    })();
+  }
+
+  useEffect(loadViewId, [loadView]);
+  useEffect(() => {
+    if (viewId) setRows([]);
+  }, [viewId]);
+
+  return rows.length;
+};

--- a/packages/fuzz/corpus/regressions/no-effect-chain--block-context-setter-sync.tsx
+++ b/packages/fuzz/corpus/regressions/no-effect-chain--block-context-setter-sync.tsx
@@ -1,0 +1,19 @@
+// rule: no-effect-chain
+// weakness: library-idiom
+// source: PR #1182 Bugbot review
+
+import { useEffect, useState } from "react";
+
+export const Slideshow = ({ disabled, setAutoPlaying }) => {
+  const [playing, setPlaying] = useState(false);
+
+  useEffect(() => {
+    if (disabled) setPlaying(false);
+  }, [disabled]);
+
+  useEffect(() => {
+    setAutoPlaying(playing);
+  }, [playing, setAutoPlaying]);
+
+  return null;
+};

--- a/packages/fuzz/corpus/regressions/no-effect-chain--context-setter-sync.tsx
+++ b/packages/fuzz/corpus/regressions/no-effect-chain--context-setter-sync.tsx
@@ -1,0 +1,17 @@
+// rule: no-effect-chain
+// weakness: library-idiom
+// source: PR #1182 benchmark audit
+
+import { useEffect, useState } from "react";
+
+export const Slideshow = ({ disabled, setAutoPlaying }) => {
+  const [playing, setPlaying] = useState(false);
+
+  useEffect(() => {
+    if (disabled) setPlaying(false);
+  }, [disabled]);
+
+  useEffect(() => setAutoPlaying(playing), [playing, setAutoPlaying]);
+
+  return null;
+};

--- a/packages/fuzz/src/ast-equivalent-fuzz-variants.ts
+++ b/packages/fuzz/src/ast-equivalent-fuzz-variants.ts
@@ -1,6 +1,7 @@
 import { parseFixture } from "../../oxlint-plugin-react-doctor/src/test-utils/parse-fixture.js";
 import type { EsTreeNode } from "../../oxlint-plugin-react-doctor/src/plugin/utils/es-tree-node.js";
 import { isFunctionLike } from "../../oxlint-plugin-react-doctor/src/plugin/utils/is-function-like.js";
+import { isHookCall } from "../../oxlint-plugin-react-doctor/src/plugin/utils/is-hook-call.js";
 import { isNodeOfType } from "../../oxlint-plugin-react-doctor/src/plugin/utils/is-node-of-type.js";
 import { stripParenExpression } from "../../oxlint-plugin-react-doctor/src/plugin/utils/strip-paren-expression.js";
 import { walkAst } from "../../oxlint-plugin-react-doctor/src/plugin/utils/walk-ast.js";
@@ -26,30 +27,6 @@ const hasSpan = (node: EsTreeNode | null | undefined): node is EsTreeNode & Requ
 const EFFECT_HOOK_NAMES = new Set(["useEffect", "useInsertionEffect", "useLayoutEffect"]);
 const EFFECT_CALLBACK_ALIAS_PREFIX = "__reactDoctorFuzzEffectCallback";
 
-const applySpanReplacements = (
-  code: string,
-  replacements: ReadonlyArray<SpanReplacement>,
-): string => {
-  let result = code;
-  const orderedReplacements = [...replacements].sort((left, right) => right.start - left.start);
-  for (const replacement of orderedReplacements) {
-    result = result.slice(0, replacement.start) + replacement.text + result.slice(replacement.end);
-  }
-  return result;
-};
-
-const getEffectHookName = (callee: EsTreeNode): string | null => {
-  if (isNodeOfType(callee, "Identifier")) return callee.name;
-  if (
-    isNodeOfType(callee, "MemberExpression") &&
-    !callee.computed &&
-    isNodeOfType(callee.property, "Identifier")
-  ) {
-    return callee.property.name;
-  }
-  return null;
-};
-
 const buildEffectCallbackAliasVariant = (
   code: string,
   program: EsTreeNode,
@@ -60,9 +37,7 @@ const buildEffectCallbackAliasVariant = (
   walkAst(program, (statement) => {
     if (!isNodeOfType(statement, "ExpressionStatement") || !hasSpan(statement)) return;
     const node = statement.expression;
-    if (!isNodeOfType(node, "CallExpression")) return;
-    const hookName = getEffectHookName(node.callee);
-    if (!hookName || !EFFECT_HOOK_NAMES.has(hookName)) return;
+    if (!isNodeOfType(node, "CallExpression") || !isHookCall(node, EFFECT_HOOK_NAMES)) return;
     const callback = node.arguments[0];
     if (!callback || isNodeOfType(callback, "SpreadElement") || !hasSpan(callback)) return;
     if (!isFunctionLike(stripParenExpression(callback))) return;
@@ -81,9 +56,17 @@ const buildEffectCallbackAliasVariant = (
     );
   });
   if (replacements.length === 0) return null;
+  replacements.sort((left, right) => right.start - left.start);
+  let variantCode = code;
+  for (const replacement of replacements) {
+    variantCode =
+      variantCode.slice(0, replacement.start) +
+      replacement.text +
+      variantCode.slice(replacement.end);
+  }
   return {
     label: "inline effect callbacks extracted to const bindings",
-    code: applySpanReplacements(code, replacements),
+    code: variantCode,
   };
 };
 

--- a/packages/fuzz/src/ast-equivalent-fuzz-variants.ts
+++ b/packages/fuzz/src/ast-equivalent-fuzz-variants.ts
@@ -1,4 +1,9 @@
 import { parseFixture } from "../../oxlint-plugin-react-doctor/src/test-utils/parse-fixture.js";
+import type { EsTreeNode } from "../../oxlint-plugin-react-doctor/src/plugin/utils/es-tree-node.js";
+import { isFunctionLike } from "../../oxlint-plugin-react-doctor/src/plugin/utils/is-function-like.js";
+import { isNodeOfType } from "../../oxlint-plugin-react-doctor/src/plugin/utils/is-node-of-type.js";
+import { stripParenExpression } from "../../oxlint-plugin-react-doctor/src/plugin/utils/strip-paren-expression.js";
+import { walkAst } from "../../oxlint-plugin-react-doctor/src/plugin/utils/walk-ast.js";
 import type { EquivalentVariant } from "./equivalent-fuzz-variants.js";
 
 interface SpannedNode {
@@ -7,23 +12,98 @@ interface SpannedNode {
   type?: string;
 }
 
-const getTopLevelStatementSpans = (
+interface SpanReplacement {
+  start: number;
+  end: number;
+  text: string;
+}
+
+const hasSpan = (node: EsTreeNode | null | undefined): node is EsTreeNode & Required<SpannedNode> =>
+  Boolean(node) &&
+  typeof (node as unknown as SpannedNode).start === "number" &&
+  typeof (node as unknown as SpannedNode).end === "number";
+
+const EFFECT_HOOK_NAMES = new Set(["useEffect", "useInsertionEffect", "useLayoutEffect"]);
+const EFFECT_CALLBACK_ALIAS_PREFIX = "__reactDoctorFuzzEffectCallback";
+
+const applySpanReplacements = (
   code: string,
-  filename: string,
-): Array<{ start: number; end: number }> => {
+  replacements: ReadonlyArray<SpanReplacement>,
+): string => {
+  let result = code;
+  const orderedReplacements = [...replacements].sort((left, right) => right.start - left.start);
+  for (const replacement of orderedReplacements) {
+    result = result.slice(0, replacement.start) + replacement.text + result.slice(replacement.end);
+  }
+  return result;
+};
+
+const getEffectHookName = (callee: EsTreeNode): string | null => {
+  if (isNodeOfType(callee, "Identifier")) return callee.name;
+  if (
+    isNodeOfType(callee, "MemberExpression") &&
+    !callee.computed &&
+    isNodeOfType(callee.property, "Identifier")
+  ) {
+    return callee.property.name;
+  }
+  return null;
+};
+
+const buildEffectCallbackAliasVariant = (
+  code: string,
+  program: EsTreeNode,
+): EquivalentVariant | null => {
+  if (code.includes(EFFECT_CALLBACK_ALIAS_PREFIX)) return null;
+  const replacements: SpanReplacement[] = [];
+  let callbackIndex = 0;
+  walkAst(program, (statement) => {
+    if (!isNodeOfType(statement, "ExpressionStatement") || !hasSpan(statement)) return;
+    const node = statement.expression;
+    if (!isNodeOfType(node, "CallExpression")) return;
+    const hookName = getEffectHookName(node.callee);
+    if (!hookName || !EFFECT_HOOK_NAMES.has(hookName)) return;
+    const callback = node.arguments[0];
+    if (!callback || isNodeOfType(callback, "SpreadElement") || !hasSpan(callback)) return;
+    if (!isFunctionLike(stripParenExpression(callback))) return;
+    const lineStart = code.lastIndexOf("\n", statement.start - 1) + 1;
+    const indentation = code.slice(lineStart, statement.start);
+    if (!/^[\t ]*$/.test(indentation)) return;
+    const callbackName = `${EFFECT_CALLBACK_ALIAS_PREFIX}${callbackIndex}`;
+    callbackIndex += 1;
+    replacements.push(
+      {
+        start: lineStart,
+        end: lineStart,
+        text: `${indentation}const ${callbackName} = ${code.slice(callback.start, callback.end)};\n`,
+      },
+      { start: callback.start, end: callback.end, text: callbackName },
+    );
+  });
+  if (replacements.length === 0) return null;
+  return {
+    label: "inline effect callbacks extracted to const bindings",
+    code: applySpanReplacements(code, replacements),
+  };
+};
+
+const parseProgram = (code: string, filename: string): EsTreeNode | null => {
   try {
     const { program, errors } = parseFixture(code, { filename, forceJsx: true });
-    if (errors.length > 0) return [];
-    const body = (program as unknown as { body?: SpannedNode[] }).body ?? [];
-    const spans: Array<{ start: number; end: number }> = [];
-    for (const statement of body) {
-      if (typeof statement.start !== "number" || typeof statement.end !== "number") return [];
-      spans.push({ start: statement.start, end: statement.end });
-    }
-    return spans;
+    return errors.length > 0 ? null : program;
   } catch {
-    return [];
+    return null;
   }
+};
+
+const getTopLevelStatementSpans = (program: EsTreeNode): Array<{ start: number; end: number }> => {
+  const body = (program as unknown as { body?: SpannedNode[] }).body ?? [];
+  const spans: Array<{ start: number; end: number }> = [];
+  for (const statement of body) {
+    if (typeof statement.start !== "number" || typeof statement.end !== "number") return [];
+    spans.push({ start: statement.start, end: statement.end });
+  }
+  return spans;
 };
 
 const spliceBetweenStatements = (
@@ -55,15 +135,18 @@ const isCrlfSafe = (code: string): boolean => !code.includes("`") && !code.inclu
 export const buildAstEquivalentFuzzVariants = (
   code: string,
   filename: string,
+  shouldExtractEffectCallbacks = false,
 ): EquivalentVariant[] => {
   const variants: EquivalentVariant[] = [];
+  const program = parseProgram(code, filename);
+  if (!program) return variants;
   if (isCrlfSafe(code) && code.includes("\n")) {
     variants.push({
       label: "CRLF line endings",
       code: code.replace(/\r?\n/g, "\r\n"),
     });
   }
-  const spans = getTopLevelStatementSpans(code, filename);
+  const spans = getTopLevelStatementSpans(program);
   if (spans.length > 1) {
     const doAllGapsContainNewline = spans.every(
       (span, index) =>
@@ -85,6 +168,10 @@ export const buildAstEquivalentFuzzVariants = (
         code: spliceBetweenStatements(code, spans, "\n\n\n"),
       },
     );
+  }
+  if (shouldExtractEffectCallbacks) {
+    const effectCallbackAliasVariant = buildEffectCallbackAliasVariant(code, program);
+    if (effectCallbackAliasVariant) variants.push(effectCallbackAliasVariant);
   }
   return variants;
 };

--- a/packages/fuzz/src/fuzz-rule.ts
+++ b/packages/fuzz/src/fuzz-rule.ts
@@ -20,6 +20,12 @@ import { crossoverFuzzPrograms, mutateFuzzProgram } from "./mutate-fuzz-program.
 import { createSeededRandom } from "./seeded-random.js";
 import { FUZZ_FILENAME_POOL } from "./snippet-pools.js";
 
+const EFFECT_CALLBACK_ALIAS_RULE_IDS = new Set([
+  "no-cascading-set-state",
+  "no-effect-chain",
+  "no-fetch-in-effect",
+]);
+
 export type FuzzFindingKind = "crash" | "slow" | "invariant-violation" | "verdict-drop";
 
 export interface FuzzFinding {
@@ -260,7 +266,7 @@ export const fuzzRuleWithStats = (
 
     for (const variant of [
       ...buildEquivalentFuzzVariants(code, sections),
-      ...buildAstEquivalentFuzzVariants(code, filename),
+      ...buildAstEquivalentFuzzVariants(code, filename, EFFECT_CALLBACK_ALIAS_RULE_IDS.has(ruleId)),
     ]) {
       if (hasParseErrors(variant.code, filename)) continue;
       const variantOutcome = runRuleOnCode(rule, variant.code, filename);

--- a/packages/fuzz/src/generate-fuzz-program.ts
+++ b/packages/fuzz/src/generate-fuzz-program.ts
@@ -148,6 +148,13 @@ const SCENARIO_POOL: ReadonlyArray<SnippetBuilder> = [
       .join("\n    ")
       .replace(/^/, `const load = async () => {\n    `)
       .concat(`\n  };`),
+  () =>
+    [
+      `const [fuzzChainSource, setFuzzChainSource] = useState(0);`,
+      `const [fuzzChainTarget, setFuzzChainTarget] = useState(0);`,
+      `useEffect(() => { setFuzzChainSource(1); }, []);`,
+      `useEffect(() => { setFuzzChainTarget(fuzzChainSource + 1); }, [fuzzChainSource]);`,
+    ].join("\n  "),
 ];
 
 const buildComponent: SnippetBuilder = (random) => {

--- a/packages/fuzz/tests/fuzz-harness-smoke.test.ts
+++ b/packages/fuzz/tests/fuzz-harness-smoke.test.ts
@@ -5,6 +5,7 @@ import { fuzzRule } from "../src/fuzz-rule.js";
 import { generateStructuredFuzzProgram } from "../src/generate-fuzz-program.js";
 import { loadFuzzCorpus } from "../src/load-fuzz-corpus.js";
 import { createSeededRandom } from "../src/seeded-random.js";
+import { buildAstEquivalentFuzzVariants } from "../src/ast-equivalent-fuzz-variants.js";
 import { buildVerdictPreservingVariants } from "../src/verdict-preserving-variants.js";
 import { runRule } from "../../oxlint-plugin-react-doctor/src/test-utils/run-rule.js";
 import type { Rule } from "../../oxlint-plugin-react-doctor/src/plugin/utils/rule.js";
@@ -120,5 +121,32 @@ describe("fuzz harness oracles", () => {
       checkInvariants: true,
     });
     expect(findings.some((finding) => finding.kind === "invariant-violation")).toBe(true);
+  });
+
+  it("extracts inline effect callbacks to exact const bindings", () => {
+    const variants = buildAstEquivalentFuzzVariants(
+      `const Widget = ({ url }) => {
+  useEffect(() => fetch(url), [url]);
+  React.useLayoutEffect(function measure() { readLayout(); }, []);
+  useInsertionEffect((() => track()) as () => void, []);
+  return null;
+};`,
+      "fixture.tsx",
+      true,
+    );
+    const aliasVariant = variants.find(
+      (variant) => variant.label === "inline effect callbacks extracted to const bindings",
+    );
+    expect(aliasVariant?.code).toContain(
+      "const __reactDoctorFuzzEffectCallback0 = () => fetch(url);",
+    );
+    expect(aliasVariant?.code).toContain("useEffect(__reactDoctorFuzzEffectCallback0, [url]);");
+    expect(aliasVariant?.code).toContain(
+      "React.useLayoutEffect(__reactDoctorFuzzEffectCallback1, []);",
+    );
+    expect(aliasVariant?.code).toContain(
+      "useInsertionEffect(__reactDoctorFuzzEffectCallback2, []);",
+    );
+    expect(runRule(NOOP_RULE, aliasVariant?.code ?? "").parseErrors).toEqual([]);
   });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-cascading-set-state.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-cascading-set-state.regressions.test.ts
@@ -1158,4 +1158,25 @@ describe("no-cascading-set-state — fuzz-hardening: nested function scope bound
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toEqual([]);
   });
+
+  it("flags cascading updates through a function declaration callback", () => {
+    const result = runRule(
+      noCascadingSetState,
+      `function Widget({ mode }) {
+        const [first, setFirst] = useState(0);
+        const [second, setSecond] = useState(0);
+        const [third, setThird] = useState(0);
+        function synchronizeState() {
+          setFirst(1);
+          setSecond(2);
+          setThird(3);
+        }
+        const effectCallback = synchronizeState;
+        useEffect(effectCallback, [mode]);
+        return null;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-cascading-set-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-cascading-set-state.ts
@@ -481,7 +481,7 @@ export const noCascadingSetState = defineRule({
     CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
       if (!isHookCall(node, EFFECT_HOOK_NAMES)) return;
       if (isInitOnlyEffect(node)) return;
-      const callback = getEffectCallback(node);
+      const callback = getEffectCallback(node, context.scopes);
       if (!callback) return;
       if (isDevOnlyGuardedEffect(callback)) return;
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.regressions.test.ts
@@ -116,4 +116,22 @@ describe("no-effect-chain — regressions", () => {
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics.length).toBeGreaterThan(0);
   });
+
+  it("flags a state chain through exact effect callback bindings", () => {
+    const result = runRule(
+      noEffectChain,
+      `function Widget() {
+        const [first, setFirst] = useState(0);
+        const [second, setSecond] = useState(0);
+        const writeFirst = () => { setFirst(1); };
+        const writeSecond = () => { setSecond(first + 1); };
+        const downstreamEffect = writeSecond;
+        useEffect(writeFirst, []);
+        useEffect(downstreamEffect, [first]);
+        return second;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.regressions.test.ts
@@ -381,6 +381,35 @@ describe("no-effect-chain — regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("stays silent for a block-bodied opaque context setter", () => {
+    const result = runRule(
+      noEffectChain,
+      `function Widget({ disabled, setAutoPlaying }) {
+        const [playing, setPlaying] = useState(false);
+        useEffect(() => { if (disabled) setPlaying(false); }, [disabled]);
+        useEffect(() => { setAutoPlaying(playing); }, [playing, setAutoPlaying]);
+        return null;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("flags a block-bodied setter proven to come from local state", () => {
+    const result = runRule(
+      noEffectChain,
+      `function Widget({ disabled }) {
+        const [playing, setPlaying] = useState(false);
+        const [autoPlaying, setAutoPlaying] = useState(false);
+        useEffect(() => { if (disabled) setPlaying(false); }, [disabled]);
+        useEffect(() => { setAutoPlaying(playing); }, [playing]);
+        return autoPlaying;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("flags a state chain whose downstream effect calls a concise helper", () => {
     const result = runRule(
       noEffectChain,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.regressions.test.ts
@@ -185,6 +185,134 @@ describe("no-effect-chain — regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("stays silent when a declared callback only defers its state write", () => {
+    const result = runRule(
+      noEffectChain,
+      `function Widget() {
+        const [source, setSource] = useState(0);
+        const [target, setTarget] = useState(0);
+        function loadSource() { setTimeout(() => setSource(1), 0); }
+        function updateTarget() { setTarget(source + 1); }
+        useEffect(loadSource, []);
+        useEffect(updateTarget, [source]);
+        return target;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("flags a state chain through an exact alias to a declared callback", () => {
+    const result = runRule(
+      noEffectChain,
+      `function Widget() {
+        const [source, setSource] = useState(0);
+        const [target, setTarget] = useState(0);
+        function loadSource() { setSource(1); }
+        function updateTarget() { setTarget(source + 1); }
+        const aliasedUpdate = updateTarget;
+        useEffect(loadSource, []);
+        useEffect(aliasedUpdate, [source]);
+        return target;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays conservative when a declared callback is reassigned", () => {
+    const result = runRule(
+      noEffectChain,
+      `function Widget() {
+        const [source, setSource] = useState(0);
+        const [target, setTarget] = useState(0);
+        function loadSource() { setSource(1); }
+        function updateTarget() { setTarget(source + 1); }
+        updateTarget = () => consume(source);
+        useEffect(loadSource, []);
+        useEffect(updateTarget, [source]);
+        return target;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("ignores unused nested external-sync helpers", () => {
+    const result = runRule(
+      noEffectChain,
+      `function Widget() {
+        const [source, setSource] = useState(0);
+        const [target, setTarget] = useState(0);
+        function loadSource() { setSource(1); }
+        function updateTarget() {
+          function unusedPersistence() { localStorage.setItem('target', String(target)); }
+          setTarget(source + 1);
+        }
+        useEffect(loadSource, []);
+        useEffect(updateTarget, [source]);
+        return target;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays silent when a declared callback invokes a nested external-sync helper", () => {
+    const result = runRule(
+      noEffectChain,
+      `function Widget() {
+        const [source, setSource] = useState(0);
+        function loadSource() { setSource(1); }
+        function synchronizeStorage() {
+          function persistSource() { localStorage.setItem('source', String(source)); }
+          persistSource();
+        }
+        useEffect(loadSource, []);
+        useEffect(synchronizeStorage, [source]);
+        return null;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("flags a chain whose declared callback invokes a nested state writer", () => {
+    const result = runRule(
+      noEffectChain,
+      `function Widget() {
+        const [source, setSource] = useState(0);
+        const [target, setTarget] = useState(0);
+        function loadSource() {
+          function writeSource() { setSource(1); }
+          writeSource();
+        }
+        function updateTarget() { setTarget(source + 1); }
+        useEffect(loadSource, []);
+        useEffect(updateTarget, [source]);
+        return target;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays silent for a declared opaque context setter", () => {
+    const result = runRule(
+      noEffectChain,
+      `function Widget({ setAutoPlaying }) {
+        const [playing, setPlaying] = useState(false);
+        function stopPlaying() { setPlaying(false); }
+        function synchronizeContext() { return setAutoPlaying(playing); }
+        useEffect(stopPlaying, []);
+        useEffect(synchronizeContext, [playing, setAutoPlaying]);
+        return null;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("flags a state chain when the upstream effect explicitly returns a local setter call", () => {
     const result = runRule(
       noEffectChain,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.regressions.test.ts
@@ -297,6 +297,45 @@ describe("no-effect-chain — regressions", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("ignores state writes deferred inside an invoked async function", () => {
+    const result = runRule(
+      noEffectChain,
+      `function Widget() {
+        const [source, setSource] = useState(0);
+        const [target, setTarget] = useState(0);
+        function loadSource() {
+          void (async () => {
+            await loadSourceValue();
+            setSource(1);
+          })();
+        }
+        function updateTarget() { setTarget(source + 1); }
+        useEffect(loadSource, []);
+        useEffect(updateTarget, [source]);
+        return target;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("flags state writes inside an invoked synchronous function", () => {
+    const result = runRule(
+      noEffectChain,
+      `function Widget() {
+        const [source, setSource] = useState(0);
+        const [target, setTarget] = useState(0);
+        function loadSource() { (() => setSource(1))(); }
+        function updateTarget() { setTarget(source + 1); }
+        useEffect(loadSource, []);
+        useEffect(updateTarget, [source]);
+        return target;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("stays silent for a declared opaque context setter", () => {
     const result = runRule(
       noEffectChain,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.regressions.test.ts
@@ -135,6 +135,56 @@ describe("no-effect-chain — regressions", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("flags a state chain through function declaration callbacks", () => {
+    const result = runRule(
+      noEffectChain,
+      `function Widget() {
+        const [first, setFirst] = useState(0);
+        const [second, setSecond] = useState(0);
+        function writeFirst() { setFirst(1); }
+        function writeSecond() { setSecond(first + 1); }
+        useEffect(writeFirst, []);
+        useEffect(writeSecond, [first]);
+        return second;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays silent for a function declaration that synchronizes external storage", () => {
+    const result = runRule(
+      noEffectChain,
+      `function Widget() {
+        const [value, setValue] = useState('');
+        function loadValue() { setValue(compute()); }
+        function persistValue() { localStorage.setItem('value', value); }
+        useEffect(loadValue, []);
+        useEffect(persistValue, [value]);
+        return null;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent for a function declaration that calls a storage-hook setter", () => {
+    const result = runRule(
+      noEffectChain,
+      `function Widget() {
+        const [source, setSource] = useState(0);
+        const [storedValue, setStoredValue] = useLocalStorage('value', 0);
+        function loadSource() { setSource(compute()); }
+        function persistSource() { setStoredValue(source); }
+        useEffect(loadSource, []);
+        useEffect(persistSource, [source]);
+        return storedValue;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("flags a state chain when the upstream effect explicitly returns a local setter call", () => {
     const result = runRule(
       noEffectChain,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.regressions.test.ts
@@ -134,4 +134,33 @@ describe("no-effect-chain — regressions", () => {
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toHaveLength(1);
   });
+
+  it("flags a state chain when the upstream effect explicitly returns a local setter call", () => {
+    const result = runRule(
+      noEffectChain,
+      `function Widget() {
+        const [source, setSource] = useState(0);
+        const [target, setTarget] = useState(0);
+        useEffect(() => { return setSource(1); }, []);
+        useEffect(() => { setTarget(source + 1); }, [source]);
+        return target;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays silent when the downstream effect synchronizes an opaque context setter", () => {
+    const result = runRule(
+      noEffectChain,
+      `function Widget({ disabled, setAutoPlaying }) {
+        const [playing, setPlaying] = useState(false);
+        useEffect(() => { if (disabled) setPlaying(false); }, [disabled]);
+        useEffect(() => setAutoPlaying(playing), [playing, setAutoPlaying]);
+        return null;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.regressions.test.ts
@@ -410,6 +410,69 @@ describe("no-effect-chain — regressions", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("flags a chain when the upstream effect also calls an opaque prop setter", () => {
+    const result = runRule(
+      noEffectChain,
+      `function Widget({ setLoading }) {
+        const [first, setFirst] = useState(0);
+        const [second, setSecond] = useState(0);
+        useEffect(() => { setFirst(1); setLoading(false); }, []);
+        useEffect(() => { setSecond(first + 1); }, [first]);
+        return second;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays silent when the downstream effect returns a helper-owned subscription", () => {
+    const result = runRule(
+      noEffectChain,
+      `function Widget() {
+        const [ready, setReady] = useState(false);
+        useEffect(() => { setReady(true); }, []);
+        useEffect(() => { doWork(ready); return createSubscription(ready); }, [ready]);
+        return null;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent when the upstream effect returns a helper-owned subscription", () => {
+    const result = runRule(
+      noEffectChain,
+      `function Widget() {
+        const [ready, setReady] = useState(false);
+        const [status, setStatus] = useState('');
+        useEffect(() => { setReady(true); return createSubscription(); }, []);
+        useEffect(() => { setStatus(ready ? 'on' : 'off'); }, [ready]);
+        return status;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it.each(["setAlias", "applyFirst"])(
+    "flags a chain through a local state-writing wrapper named %s",
+    (wrapperName) => {
+      const result = runRule(
+        noEffectChain,
+        `function Widget() {
+          const [ready, setReady] = useState(false);
+          const [first, setFirst] = useState(0);
+          const ${wrapperName} = () => { setFirst(1); };
+          useEffect(() => { setReady(true); }, []);
+          useEffect(() => { ${wrapperName}(); }, [ready]);
+          return first;
+        }`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    },
+  );
+
   it("flags a state chain whose downstream effect calls a concise helper", () => {
     const result = runRule(
       noEffectChain,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.regressions.test.ts
@@ -163,4 +163,19 @@ describe("no-effect-chain — regressions", () => {
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toEqual([]);
   });
+
+  it("flags a state chain whose downstream effect calls a concise helper", () => {
+    const result = runRule(
+      noEffectChain,
+      `function Widget() {
+        const [source, setSource] = useState(0);
+        const syncDownstream = (value) => consume(value);
+        useEffect(() => { setSource(1); }, []);
+        useEffect(() => syncDownstream(source), [source]);
+        return null;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.ts
@@ -238,7 +238,10 @@ const callsStorageHookSetter = (
   return didFindStorageSetterCall;
 };
 
-const isExternalSyncNode = (node: EsTreeNode): boolean => {
+const isExternalSyncNode = (
+  node: EsTreeNode,
+  setterToStateName: ReadonlyMap<string, string>,
+): boolean => {
   if (isNodeOfType(node, "NewExpression")) {
     return (
       isNodeOfType(node.callee, "Identifier") &&
@@ -258,6 +261,13 @@ const isExternalSyncNode = (node: EsTreeNode): boolean => {
   if (
     isNodeOfType(node.callee, "Identifier") &&
     EXTERNAL_SYNC_DIRECT_CALLEE_NAMES.has(node.callee.name)
+  ) {
+    return true;
+  }
+  if (
+    isNodeOfType(node.callee, "Identifier") &&
+    isSetterIdentifier(node.callee.name) &&
+    !setterToStateName.has(node.callee.name)
   ) {
     return true;
   }
@@ -302,7 +312,7 @@ const isExternalSyncEffect = (
 
   let didFindExternalCall = false;
   visitSynchronousFunctionBodies(analysisFunctions, (child) => {
-    if (isExternalSyncNode(child)) didFindExternalCall = true;
+    if (isExternalSyncNode(child, setterToStateName)) didFindExternalCall = true;
   });
 
   return didFindExternalCall;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.ts
@@ -93,12 +93,8 @@ const collectSynchronouslyInvokedFunctions = (
     walkInsideStatementBlocks(currentFunction.body, (child) => {
       if (!isNodeOfType(child, "CallExpression")) return;
       const invokedFunction = resolveExactLocalFunction(child.callee, scopes);
-      if (!invokedFunction || analysisFunctions.has(invokedFunction)) {
-        return;
-      }
-      if (isFunctionLike(invokedFunction) && invokedFunction.async) {
-        return;
-      }
+      if (!invokedFunction || analysisFunctions.has(invokedFunction)) return;
+      if (isFunctionLike(invokedFunction) && invokedFunction.async) return;
       analysisFunctions.add(invokedFunction);
       pendingFunctions.push(invokedFunction);
     });
@@ -137,6 +133,8 @@ const collectWrittenStateNamesInEffect = (
   return writtenStateNames;
 };
 
+const EMPTY_CLEANUP_NAME_SET = new Set<string>();
+
 // HACK: a useEffect cleanup return value MUST be a function (or
 // undefined). Anything else is either user error or "I'm using
 // `return` for early-exit, not for cleanup". For the chain detector,
@@ -144,8 +142,6 @@ const collectWrittenStateNamesInEffect = (
 // external resource" — bare literals (`return null`, `return 0`) and
 // state reads (`return foo`) get ignored so they don't silently
 // disable chain detection.
-const EMPTY_CLEANUP_NAME_SET = new Set<string>();
-
 const isFunctionShapedReturn = (
   returnedValue: EsTreeNode,
   setterToStateName: ReadonlyMap<string, string>,
@@ -258,18 +254,10 @@ const isExternalSyncNode = (
   }
 
   if (!isNodeOfType(node, "CallExpression")) return false;
-  if (
-    isNodeOfType(node.callee, "Identifier") &&
-    EXTERNAL_SYNC_DIRECT_CALLEE_NAMES.has(node.callee.name)
-  ) {
-    return true;
-  }
-  if (
-    isNodeOfType(node.callee, "Identifier") &&
-    isSetterIdentifier(node.callee.name) &&
-    !setterToStateName.has(node.callee.name)
-  ) {
-    return true;
+  if (isNodeOfType(node.callee, "Identifier")) {
+    const calleeName = node.callee.name;
+    if (EXTERNAL_SYNC_DIRECT_CALLEE_NAMES.has(calleeName)) return true;
+    return isSetterIdentifier(calleeName) && !setterToStateName.has(calleeName);
   }
   if (
     !isNodeOfType(node.callee, "MemberExpression") ||
@@ -298,8 +286,7 @@ const isExternalSyncEffect = (
   if (!isNodeOfType(effectCallback.body, "BlockStatement")) {
     if (isFunctionShapedReturn(effectCallback.body, setterToStateName)) return true;
   } else {
-    const statements = effectCallback.body.body ?? [];
-    for (const statement of statements) {
+    for (const statement of effectCallback.body.body ?? []) {
       if (
         isNodeOfType(statement, "ReturnStatement") &&
         statement.argument &&

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.ts
@@ -1,4 +1,5 @@
 import { EXTERNAL_SYNC_OBSERVER_CONSTRUCTORS } from "../../constants/dom.js";
+import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
 import {
   EFFECT_HOOK_NAMES,
   EXTERNAL_SYNC_AMBIGUOUS_HTTP_METHOD_NAMES,
@@ -16,8 +17,8 @@ import { isHookCall } from "../../utils/is-hook-call.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isSetterIdentifier } from "../../utils/is-setter-identifier.js";
 import { isUppercaseName } from "../../utils/is-uppercase-name.js";
+import { resolveExactLocalFunction } from "../../utils/resolve-exact-local-function.js";
 import { unwrapDiscardedExpression } from "../../utils/unwrap-discarded-expression.js";
-import { walkAst } from "../../utils/walk-ast.js";
 import { walkInsideStatementBlocks } from "../../utils/walk-inside-statement-blocks.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
@@ -80,6 +81,36 @@ const collectDepIdentifierNames = (effectNode: EsTreeNode): Set<string> => {
   return depNames;
 };
 
+const collectSynchronouslyInvokedFunctions = (
+  effectCallback: EsTreeNode,
+  scopes: ScopeAnalysis,
+): ReadonlySet<EsTreeNode> => {
+  const analysisFunctions = new Set<EsTreeNode>([effectCallback]);
+  const pendingFunctions = [effectCallback];
+  while (pendingFunctions.length > 0) {
+    const currentFunction = pendingFunctions.pop();
+    if (!currentFunction || !isFunctionLike(currentFunction)) continue;
+    walkInsideStatementBlocks(currentFunction.body, (child) => {
+      if (!isNodeOfType(child, "CallExpression")) return;
+      const invokedFunction = resolveExactLocalFunction(child.callee, scopes);
+      if (!invokedFunction || analysisFunctions.has(invokedFunction)) return;
+      analysisFunctions.add(invokedFunction);
+      pendingFunctions.push(invokedFunction);
+    });
+  }
+  return analysisFunctions;
+};
+
+const visitSynchronousFunctionBodies = (
+  analysisFunctions: ReadonlySet<EsTreeNode>,
+  visitor: (child: EsTreeNode) => void,
+): void => {
+  for (const analysisFunction of analysisFunctions) {
+    if (!isFunctionLike(analysisFunction)) continue;
+    walkInsideStatementBlocks(analysisFunction.body, visitor);
+  }
+};
+
 // HACK: only count setter calls that actually run during the effect's
 // synchronous body. A `setX` inside `setTimeout(() => setX(...))` or
 // `.then(() => setX(...))` is a DEFERRED write — by the time it fires,
@@ -88,12 +119,11 @@ const collectDepIdentifierNames = (effectNode: EsTreeNode): Set<string> => {
 // stops `noEffectChain` from over-flagging the dominant debounce /
 // async-fetch shape that real codebases use.
 const collectWrittenStateNamesInEffect = (
-  effectCallback: EsTreeNode,
+  analysisFunctions: ReadonlySet<EsTreeNode>,
   setterToStateName: Map<string, string>,
 ): Set<string> => {
   const writtenStateNames = new Set<string>();
-  if (!isFunctionLike(effectCallback)) return writtenStateNames;
-  walkInsideStatementBlocks(effectCallback.body, (child: EsTreeNode) => {
+  visitSynchronousFunctionBodies(analysisFunctions, (child) => {
     if (!isNodeOfType(child, "CallExpression")) return;
     if (!isNodeOfType(child.callee, "Identifier")) return;
     const stateName = setterToStateName.get(child.callee.name);
@@ -186,13 +216,12 @@ const collectStorageHookSetterNames = (componentBody: EsTreeNode): Set<string> =
 };
 
 const callsStorageHookSetter = (
-  effectCallback: EsTreeNode,
+  analysisFunctions: ReadonlySet<EsTreeNode>,
   storageSetterNames: ReadonlySet<string>,
 ): boolean => {
   if (storageSetterNames.size === 0) return false;
-  if (!isFunctionLike(effectCallback)) return false;
   let didFindStorageSetterCall = false;
-  walkInsideStatementBlocks(effectCallback.body, (child: EsTreeNode) => {
+  visitSynchronousFunctionBodies(analysisFunctions, (child) => {
     if (
       isNodeOfType(child, "CallExpression") &&
       isNodeOfType(child.callee, "Identifier") &&
@@ -204,8 +233,47 @@ const callsStorageHookSetter = (
   return didFindStorageSetterCall;
 };
 
+const isExternalSyncNode = (node: EsTreeNode): boolean => {
+  if (isNodeOfType(node, "NewExpression")) {
+    return (
+      isNodeOfType(node.callee, "Identifier") &&
+      EXTERNAL_SYNC_OBSERVER_CONSTRUCTORS.has(node.callee.name)
+    );
+  }
+
+  if (isNodeOfType(node, "AssignmentExpression")) {
+    return (
+      isNodeOfType(node.left, "MemberExpression") &&
+      isNodeOfType(node.left.property, "Identifier") &&
+      node.left.property.name === "current"
+    );
+  }
+
+  if (!isNodeOfType(node, "CallExpression")) return false;
+  if (
+    isNodeOfType(node.callee, "Identifier") &&
+    EXTERNAL_SYNC_DIRECT_CALLEE_NAMES.has(node.callee.name)
+  ) {
+    return true;
+  }
+  if (
+    !isNodeOfType(node.callee, "MemberExpression") ||
+    !isNodeOfType(node.callee.property, "Identifier")
+  ) {
+    return false;
+  }
+
+  const propertyName = node.callee.property.name;
+  if (EXTERNAL_SYNC_MEMBER_METHOD_NAMES.has(propertyName)) return true;
+  if (isBrowserStorageReceiver(node.callee.object)) return true;
+  if (!EXTERNAL_SYNC_AMBIGUOUS_HTTP_METHOD_NAMES.has(propertyName)) return false;
+  const receiverRootName = getRootIdentifierName(node.callee.object);
+  return receiverRootName !== null && EXTERNAL_SYNC_HTTP_CLIENT_RECEIVERS.has(receiverRootName);
+};
+
 const isExternalSyncEffect = (
   effectCallback: EsTreeNode,
+  analysisFunctions: ReadonlySet<EsTreeNode>,
   setterToStateName: ReadonlyMap<string, string>,
 ): boolean => {
   if (!isFunctionLike(effectCallback)) return false;
@@ -228,68 +296,8 @@ const isExternalSyncEffect = (
   }
 
   let didFindExternalCall = false;
-  walkAst(effectCallback, (child: EsTreeNode) => {
-    if (didFindExternalCall) return false;
-
-    if (isNodeOfType(child, "NewExpression")) {
-      const constructor = child.callee;
-      if (
-        isNodeOfType(constructor, "Identifier") &&
-        EXTERNAL_SYNC_OBSERVER_CONSTRUCTORS.has(constructor.name)
-      ) {
-        didFindExternalCall = true;
-      }
-      return;
-    }
-
-    if (isNodeOfType(child, "AssignmentExpression")) {
-      if (
-        isNodeOfType(child.left, "MemberExpression") &&
-        isNodeOfType(child.left.property, "Identifier") &&
-        child.left.property.name === "current"
-      ) {
-        didFindExternalCall = true;
-      }
-      return;
-    }
-
-    if (!isNodeOfType(child, "CallExpression")) return;
-
-    if (
-      isNodeOfType(child.callee, "Identifier") &&
-      EXTERNAL_SYNC_DIRECT_CALLEE_NAMES.has(child.callee.name)
-    ) {
-      didFindExternalCall = true;
-      return;
-    }
-
-    if (
-      isNodeOfType(child.callee, "MemberExpression") &&
-      isNodeOfType(child.callee.property, "Identifier")
-    ) {
-      const propertyName = child.callee.property.name;
-      if (EXTERNAL_SYNC_MEMBER_METHOD_NAMES.has(propertyName)) {
-        didFindExternalCall = true;
-        return;
-      }
-      if (isBrowserStorageReceiver(child.callee.object)) {
-        didFindExternalCall = true;
-        return;
-      }
-      // HACK: `get` / `head` / `options` are HTTP verbs but also names
-      // of universal data-structure methods (Map.get, URLSearchParams.get,
-      // etc.). Only count them when the receiver looks like an HTTP
-      // client.
-      if (EXTERNAL_SYNC_AMBIGUOUS_HTTP_METHOD_NAMES.has(propertyName)) {
-        const receiverRootName = getRootIdentifierName(child.callee.object);
-        if (
-          receiverRootName !== null &&
-          EXTERNAL_SYNC_HTTP_CLIENT_RECEIVERS.has(receiverRootName)
-        ) {
-          didFindExternalCall = true;
-        }
-      }
-    }
+  visitSynchronousFunctionBodies(analysisFunctions, (child) => {
+    if (isExternalSyncNode(child)) didFindExternalCall = true;
   });
 
   return didFindExternalCall;
@@ -326,13 +334,14 @@ export const noEffectChain = defineRule({
       for (const effectCall of findTopLevelEffectCalls(componentBody)) {
         const callback = getEffectCallback(effectCall, context.scopes);
         if (!callback) continue;
+        const analysisFunctions = collectSynchronouslyInvokedFunctions(callback, context.scopes);
         effectInfos.push({
           node: effectCall,
           depNames: collectDepIdentifierNames(effectCall),
-          writtenStateNames: collectWrittenStateNamesInEffect(callback, setterToStateName),
+          writtenStateNames: collectWrittenStateNamesInEffect(analysisFunctions, setterToStateName),
           isExternalSync:
-            isExternalSyncEffect(callback, setterToStateName) ||
-            callsStorageHookSetter(callback, storageSetterNames),
+            isExternalSyncEffect(callback, analysisFunctions, setterToStateName) ||
+            callsStorageHookSetter(analysisFunctions, storageSetterNames),
         });
       }
       if (effectInfos.length < 2) return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.ts
@@ -22,6 +22,7 @@ import { collectUseStateBindings } from "./utils/collect-use-state-bindings.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { unwrapDiscardedExpression } from "../../utils/unwrap-discarded-expression.js";
+import { isCleanupReturn } from "./utils/is-cleanup-return.js";
 
 // HACK: §7 of "You Might Not Need an Effect" — chains of computations:
 //
@@ -112,6 +113,8 @@ const collectWrittenStateNamesInEffect = (
 // external resource" — bare literals (`return null`, `return 0`) and
 // state reads (`return foo`) get ignored so they don't silently
 // disable chain detection.
+const EMPTY_CLEANUP_NAME_SET = new Set<string>();
+
 const isFunctionShapedReturn = (
   returnedValue: EsTreeNode,
   setterToStateName: ReadonlyMap<string, string>,
@@ -126,13 +129,11 @@ const isFunctionShapedReturn = (
   // primitives (subscribe, addEventListener helpers) return a
   // function. Conservatively accept this shape.
   if (isNodeOfType(returnedValue, "CallExpression")) {
-    if (
-      isNodeOfType(returnedValue.callee, "Identifier") &&
-      setterToStateName.has(returnedValue.callee.name)
-    ) {
-      return false;
+    if (isNodeOfType(returnedValue.callee, "Identifier")) {
+      if (setterToStateName.has(returnedValue.callee.name)) return false;
+      if (isSetterIdentifier(returnedValue.callee.name)) return true;
     }
-    return true;
+    return isCleanupReturn(returnedValue, EMPTY_CLEANUP_NAME_SET, EMPTY_CLEANUP_NAME_SET);
   }
   // Returning a bare Identifier — could be the unsub binding from a
   // `const unsub = subscribe(...)` line. We can't statically prove

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.ts
@@ -11,17 +11,18 @@ import { getCalleeName } from "../../utils/get-callee-name.js";
 import { getEffectCallback } from "../../utils/get-effect-callback.js";
 import { getRootIdentifierName } from "../../utils/get-root-identifier-name.js";
 import { isComponentAssignment } from "../../utils/is-component-assignment.js";
+import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isHookCall } from "../../utils/is-hook-call.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isSetterIdentifier } from "../../utils/is-setter-identifier.js";
 import { isUppercaseName } from "../../utils/is-uppercase-name.js";
+import { unwrapDiscardedExpression } from "../../utils/unwrap-discarded-expression.js";
 import { walkAst } from "../../utils/walk-ast.js";
 import { walkInsideStatementBlocks } from "../../utils/walk-inside-statement-blocks.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { collectUseStateBindings } from "./utils/collect-use-state-bindings.js";
-import { isNodeOfType } from "../../utils/is-node-of-type.js";
-import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
-import { unwrapDiscardedExpression } from "../../utils/unwrap-discarded-expression.js";
 import { isCleanupReturn } from "./utils/is-cleanup-return.js";
 
 // HACK: §7 of "You Might Not Need an Effect" — chains of computations:
@@ -91,12 +92,7 @@ const collectWrittenStateNamesInEffect = (
   setterToStateName: Map<string, string>,
 ): Set<string> => {
   const writtenStateNames = new Set<string>();
-  if (
-    !isNodeOfType(effectCallback, "ArrowFunctionExpression") &&
-    !isNodeOfType(effectCallback, "FunctionExpression")
-  ) {
-    return writtenStateNames;
-  }
+  if (!isFunctionLike(effectCallback)) return writtenStateNames;
   walkInsideStatementBlocks(effectCallback.body, (child: EsTreeNode) => {
     if (!isNodeOfType(child, "CallExpression")) return;
     if (!isNodeOfType(child.callee, "Identifier")) return;
@@ -194,12 +190,7 @@ const callsStorageHookSetter = (
   storageSetterNames: ReadonlySet<string>,
 ): boolean => {
   if (storageSetterNames.size === 0) return false;
-  if (
-    !isNodeOfType(effectCallback, "ArrowFunctionExpression") &&
-    !isNodeOfType(effectCallback, "FunctionExpression")
-  ) {
-    return false;
-  }
+  if (!isFunctionLike(effectCallback)) return false;
   let didFindStorageSetterCall = false;
   walkInsideStatementBlocks(effectCallback.body, (child: EsTreeNode) => {
     if (
@@ -217,12 +208,7 @@ const isExternalSyncEffect = (
   effectCallback: EsTreeNode,
   setterToStateName: ReadonlyMap<string, string>,
 ): boolean => {
-  if (
-    !isNodeOfType(effectCallback, "ArrowFunctionExpression") &&
-    !isNodeOfType(effectCallback, "FunctionExpression")
-  ) {
-    return false;
-  }
+  if (!isFunctionLike(effectCallback)) return false;
   // A cleanup return is the strongest signal that the effect owns
   // an external resource — once we see one, we don't need to inspect
   // the body for an external-sync call shape.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.ts
@@ -321,7 +321,7 @@ export const noEffectChain = defineRule({
 
       const effectInfos: EffectInfo[] = [];
       for (const effectCall of findTopLevelEffectCalls(componentBody)) {
-        const callback = getEffectCallback(effectCall);
+        const callback = getEffectCallback(effectCall, context.scopes);
         if (!callback) continue;
         effectInfos.push({
           node: effectCall,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.ts
@@ -112,7 +112,10 @@ const collectWrittenStateNamesInEffect = (
 // external resource" — bare literals (`return null`, `return 0`) and
 // state reads (`return foo`) get ignored so they don't silently
 // disable chain detection.
-const isFunctionShapedReturn = (returnedValue: EsTreeNode): boolean => {
+const isFunctionShapedReturn = (
+  returnedValue: EsTreeNode,
+  setterToStateName: ReadonlyMap<string, string>,
+): boolean => {
   if (
     isNodeOfType(returnedValue, "ArrowFunctionExpression") ||
     isNodeOfType(returnedValue, "FunctionExpression")
@@ -122,7 +125,15 @@ const isFunctionShapedReturn = (returnedValue: EsTreeNode): boolean => {
   // Returning a CallExpression result — most cleanup-returning
   // primitives (subscribe, addEventListener helpers) return a
   // function. Conservatively accept this shape.
-  if (isNodeOfType(returnedValue, "CallExpression")) return true;
+  if (isNodeOfType(returnedValue, "CallExpression")) {
+    if (
+      isNodeOfType(returnedValue.callee, "Identifier") &&
+      setterToStateName.has(returnedValue.callee.name)
+    ) {
+      return false;
+    }
+    return true;
+  }
   // Returning a bare Identifier — could be the unsub binding from a
   // `const unsub = subscribe(...)` line. We can't statically prove
   // it's function-typed without scope analysis, but in idiomatic React
@@ -201,7 +212,10 @@ const callsStorageHookSetter = (
   return didFindStorageSetterCall;
 };
 
-const isExternalSyncEffect = (effectCallback: EsTreeNode): boolean => {
+const isExternalSyncEffect = (
+  effectCallback: EsTreeNode,
+  setterToStateName: ReadonlyMap<string, string>,
+): boolean => {
   if (
     !isNodeOfType(effectCallback, "ArrowFunctionExpression") &&
     !isNodeOfType(effectCallback, "FunctionExpression")
@@ -211,13 +225,15 @@ const isExternalSyncEffect = (effectCallback: EsTreeNode): boolean => {
   // A cleanup return is the strongest signal that the effect owns
   // an external resource — once we see one, we don't need to inspect
   // the body for an external-sync call shape.
-  if (isNodeOfType(effectCallback.body, "BlockStatement")) {
+  if (!isNodeOfType(effectCallback.body, "BlockStatement")) {
+    if (isFunctionShapedReturn(effectCallback.body, setterToStateName)) return true;
+  } else {
     const statements = effectCallback.body.body ?? [];
     for (const statement of statements) {
       if (
         isNodeOfType(statement, "ReturnStatement") &&
         statement.argument &&
-        isFunctionShapedReturn(statement.argument)
+        isFunctionShapedReturn(statement.argument, setterToStateName)
       ) {
         return true;
       }
@@ -328,7 +344,8 @@ export const noEffectChain = defineRule({
           depNames: collectDepIdentifierNames(effectCall),
           writtenStateNames: collectWrittenStateNamesInEffect(callback, setterToStateName),
           isExternalSync:
-            isExternalSyncEffect(callback) || callsStorageHookSetter(callback, storageSetterNames),
+            isExternalSyncEffect(callback, setterToStateName) ||
+            callsStorageHookSetter(callback, storageSetterNames),
         });
       }
       if (effectInfos.length < 2) return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.ts
@@ -145,6 +145,7 @@ const EMPTY_CLEANUP_NAME_SET = new Set<string>();
 const isFunctionShapedReturn = (
   returnedValue: EsTreeNode,
   setterToStateName: ReadonlyMap<string, string>,
+  isExplicitReturnStatement: boolean,
 ): boolean => {
   if (
     isNodeOfType(returnedValue, "ArrowFunctionExpression") ||
@@ -154,13 +155,19 @@ const isFunctionShapedReturn = (
   }
   // Returning a CallExpression result — most cleanup-returning
   // primitives (subscribe, addEventListener helpers) return a
-  // function. Conservatively accept this shape.
+  // function. An explicit `return helper()` statement keeps the
+  // opaque-cleanup benefit of the doubt; a concise arrow's implicit
+  // return (`useEffect(() => helper(x), [x])`) is usually just a call,
+  // not a cleanup contract, so it must prove itself. A proven local
+  // state write (`return setSource(1)`) is never cleanup.
   if (isNodeOfType(returnedValue, "CallExpression")) {
     if (isNodeOfType(returnedValue.callee, "Identifier")) {
       if (setterToStateName.has(returnedValue.callee.name)) return false;
       if (isSetterIdentifier(returnedValue.callee.name)) return true;
     }
-    return isCleanupReturn(returnedValue, EMPTY_CLEANUP_NAME_SET, EMPTY_CLEANUP_NAME_SET);
+    return isCleanupReturn(returnedValue, EMPTY_CLEANUP_NAME_SET, EMPTY_CLEANUP_NAME_SET, {
+      allowOpaqueReturn: isExplicitReturnStatement,
+    });
   }
   // Returning a bare Identifier — could be the unsub binding from a
   // `const unsub = subscribe(...)` line. We can't statically prove
@@ -234,10 +241,32 @@ const callsStorageHookSetter = (
   return didFindStorageSetterCall;
 };
 
-const isExternalSyncNode = (
-  node: EsTreeNode,
+// A set*-named call that resolves to no local useState setter usually
+// synchronizes an external store (a context or prop setter such as
+// `setAutoPlaying`). The bare name is a weak signal, so it only exempts
+// effects that write no proven-local state — otherwise a prop setter
+// would silence a provable chain, and a local set*-named wrapper (whose
+// useState writes already count through the analysis functions) would
+// flip the verdict on a rename.
+const callsOpaqueExternalSetter = (
+  analysisFunctions: ReadonlySet<EsTreeNode>,
   setterToStateName: ReadonlyMap<string, string>,
 ): boolean => {
+  let didFindOpaqueSetterCall = false;
+  visitSynchronousFunctionBodies(analysisFunctions, (child) => {
+    if (
+      isNodeOfType(child, "CallExpression") &&
+      isNodeOfType(child.callee, "Identifier") &&
+      isSetterIdentifier(child.callee.name) &&
+      !setterToStateName.has(child.callee.name)
+    ) {
+      didFindOpaqueSetterCall = true;
+    }
+  });
+  return didFindOpaqueSetterCall;
+};
+
+const isExternalSyncNode = (node: EsTreeNode): boolean => {
   if (isNodeOfType(node, "NewExpression")) {
     return (
       isNodeOfType(node.callee, "Identifier") &&
@@ -255,9 +284,7 @@ const isExternalSyncNode = (
 
   if (!isNodeOfType(node, "CallExpression")) return false;
   if (isNodeOfType(node.callee, "Identifier")) {
-    const calleeName = node.callee.name;
-    if (EXTERNAL_SYNC_DIRECT_CALLEE_NAMES.has(calleeName)) return true;
-    return isSetterIdentifier(calleeName) && !setterToStateName.has(calleeName);
+    return EXTERNAL_SYNC_DIRECT_CALLEE_NAMES.has(node.callee.name);
   }
   if (
     !isNodeOfType(node.callee, "MemberExpression") ||
@@ -284,13 +311,13 @@ const isExternalSyncEffect = (
   // an external resource — once we see one, we don't need to inspect
   // the body for an external-sync call shape.
   if (!isNodeOfType(effectCallback.body, "BlockStatement")) {
-    if (isFunctionShapedReturn(effectCallback.body, setterToStateName)) return true;
+    if (isFunctionShapedReturn(effectCallback.body, setterToStateName, false)) return true;
   } else {
     for (const statement of effectCallback.body.body ?? []) {
       if (
         isNodeOfType(statement, "ReturnStatement") &&
         statement.argument &&
-        isFunctionShapedReturn(statement.argument, setterToStateName)
+        isFunctionShapedReturn(statement.argument, setterToStateName, true)
       ) {
         return true;
       }
@@ -299,7 +326,7 @@ const isExternalSyncEffect = (
 
   let didFindExternalCall = false;
   visitSynchronousFunctionBodies(analysisFunctions, (child) => {
-    if (isExternalSyncNode(child, setterToStateName)) didFindExternalCall = true;
+    if (isExternalSyncNode(child)) didFindExternalCall = true;
   });
 
   return didFindExternalCall;
@@ -337,13 +364,19 @@ export const noEffectChain = defineRule({
         const callback = getEffectCallback(effectCall, context.scopes);
         if (!callback) continue;
         const analysisFunctions = collectSynchronouslyInvokedFunctions(callback, context.scopes);
+        const writtenStateNames = collectWrittenStateNamesInEffect(
+          analysisFunctions,
+          setterToStateName,
+        );
         effectInfos.push({
           node: effectCall,
           depNames: collectDepIdentifierNames(effectCall),
-          writtenStateNames: collectWrittenStateNamesInEffect(analysisFunctions, setterToStateName),
+          writtenStateNames,
           isExternalSync:
             isExternalSyncEffect(callback, analysisFunctions, setterToStateName) ||
-            callsStorageHookSetter(analysisFunctions, storageSetterNames),
+            callsStorageHookSetter(analysisFunctions, storageSetterNames) ||
+            (writtenStateNames.size === 0 &&
+              callsOpaqueExternalSetter(analysisFunctions, setterToStateName)),
         });
       }
       if (effectInfos.length < 2) return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.ts
@@ -93,7 +93,12 @@ const collectSynchronouslyInvokedFunctions = (
     walkInsideStatementBlocks(currentFunction.body, (child) => {
       if (!isNodeOfType(child, "CallExpression")) return;
       const invokedFunction = resolveExactLocalFunction(child.callee, scopes);
-      if (!invokedFunction || analysisFunctions.has(invokedFunction)) return;
+      if (!invokedFunction || analysisFunctions.has(invokedFunction)) {
+        return;
+      }
+      if (isFunctionLike(invokedFunction) && invokedFunction.async) {
+        return;
+      }
       analysisFunctions.add(invokedFunction);
       pendingFunctions.push(invokedFunction);
     });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-fetch-in-effect.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-fetch-in-effect.regressions.test.ts
@@ -428,4 +428,35 @@ describe("state-and-effects/no-fetch-in-effect — regressions", () => {
       };
     `);
   });
+
+  it.each([
+    [
+      "conditional callback",
+      `const Profile = ({ url, shouldFetch }) => {
+        const fetchProfile = () => fetch(url);
+        const effectCallback = shouldFetch ? fetchProfile : () => console.log(url);
+        useEffect(effectCallback, [url]);
+        return null;
+      };`,
+    ],
+    [
+      "mutable terminal binding",
+      `const Profile = ({ url }) => {
+        const fetchProfile = () => fetch(url);
+        let callbackImplementation = fetchProfile;
+        const effectCallback = callbackImplementation;
+        useEffect(effectCallback, [url]);
+        return null;
+      };`,
+    ],
+    [
+      "callback parameter",
+      `const Profile = ({ url, effectCallback }) => {
+        useEffect(effectCallback, [url]);
+        return null;
+      };`,
+    ],
+  ])("stays silent on a non-exact %s", (_caseName, code) => {
+    expectPass(code);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-fetch-in-effect.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-fetch-in-effect.regressions.test.ts
@@ -389,4 +389,43 @@ describe("state-and-effects/no-fetch-in-effect — regressions", () => {
       };
     `);
   });
+
+  it("flags a fetch through an exact effect callback alias", () => {
+    expectFail(`
+      const Profile = ({ url }) => {
+        const loadProfile = () => {
+          fetch(url).then((response) => response.json()).then(setProfile);
+        };
+        const effectCallback = loadProfile;
+        useEffect(effectCallback, [url]);
+        return null;
+      };
+    `);
+  });
+
+  it("stays silent when a mutable callback no longer denotes the fetching function", () => {
+    expectPass(`
+      const Profile = ({ url }) => {
+        let effectCallback = () => {
+          fetch(url).then((response) => response.json()).then(setProfile);
+        };
+        effectCallback = () => console.log(url);
+        useEffect(effectCallback, [url]);
+        return null;
+      };
+    `);
+  });
+
+  it("stays silent when a function declaration callback is reassigned", () => {
+    expectPass(`
+      const Profile = ({ url }) => {
+        function effectCallback() {
+          fetch(url).then((response) => response.json()).then(setProfile);
+        }
+        effectCallback = () => console.log(url);
+        useEffect(effectCallback, [url]);
+        return null;
+      };
+    `);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-fetch-in-effect.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-fetch-in-effect.ts
@@ -519,7 +519,7 @@ export const noFetchInEffect = defineRule({
       ) {
         return;
       }
-      const callback = getEffectCallback(node);
+      const callback = getEffectCallback(node, context.scopes);
       if (!callback) return;
 
       const analysisFunctions = collectEffectAnalysisFunctions(callback, context);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-effect-callback.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-effect-callback.ts
@@ -1,7 +1,9 @@
+import type { ScopeAnalysis } from "../semantic/scope-analysis.js";
 import type { EsTreeNode } from "./es-tree-node.js";
 import { isNodeOfType } from "./is-node-of-type.js";
+import { resolveExactLocalFunction } from "./resolve-exact-local-function.js";
 
-export const getEffectCallback = (node: EsTreeNode): EsTreeNode | null => {
+export const getEffectCallback = (node: EsTreeNode, scopes?: ScopeAnalysis): EsTreeNode | null => {
   if (!isNodeOfType(node, "CallExpression") && !isNodeOfType(node, "NewExpression")) return null;
   if (!node.arguments?.length) return null;
   const callback = node.arguments[0];
@@ -11,5 +13,5 @@ export const getEffectCallback = (node: EsTreeNode): EsTreeNode | null => {
   ) {
     return callback;
   }
-  return null;
+  return scopes ? resolveExactLocalFunction(callback, scopes) : null;
 };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-exact-local-function.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-exact-local-function.ts
@@ -1,0 +1,27 @@
+import type { ScopeAnalysis } from "../semantic/scope-analysis.js";
+import type { EsTreeNode } from "./es-tree-node.js";
+import { isFunctionLike } from "./is-function-like.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+import { resolveConstIdentifierAlias } from "./resolve-const-identifier-alias.js";
+import { stripParenExpression } from "./strip-paren-expression.js";
+
+export const resolveExactLocalFunction = (
+  expression: EsTreeNode,
+  scopes: ScopeAnalysis,
+): EsTreeNode | null => {
+  const unwrappedExpression = stripParenExpression(expression);
+  if (isFunctionLike(unwrappedExpression)) return unwrappedExpression;
+  if (!isNodeOfType(unwrappedExpression, "Identifier")) return null;
+  const symbol = resolveConstIdentifierAlias(unwrappedExpression, scopes);
+  if (!symbol || (symbol.kind !== "const" && symbol.kind !== "function")) return null;
+  if (
+    symbol.kind === "function" &&
+    symbol.references.some((reference) => reference.flag !== "read")
+  ) {
+    return null;
+  }
+  const functionValue = symbol.kind === "function" ? symbol.declarationNode : symbol.initializer;
+  if (!functionValue) return null;
+  const unwrappedFunctionValue = stripParenExpression(functionValue);
+  return isFunctionLike(unwrappedFunctionValue) ? unwrappedFunctionValue : null;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-exact-local-function.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-exact-local-function.ts
@@ -13,15 +13,11 @@ export const resolveExactLocalFunction = (
   if (isFunctionLike(unwrappedExpression)) return unwrappedExpression;
   if (!isNodeOfType(unwrappedExpression, "Identifier")) return null;
   const symbol = resolveConstIdentifierAlias(unwrappedExpression, scopes);
-  if (!symbol || (symbol.kind !== "const" && symbol.kind !== "function")) return null;
-  if (
-    symbol.kind === "function" &&
-    symbol.references.some((reference) => reference.flag !== "read")
-  ) {
-    return null;
+  if (symbol?.kind === "function") {
+    const isReassigned = symbol.references.some((reference) => reference.flag !== "read");
+    return !isReassigned && isFunctionLike(symbol.declarationNode) ? symbol.declarationNode : null;
   }
-  const functionValue = symbol.kind === "function" ? symbol.declarationNode : symbol.initializer;
-  if (!functionValue) return null;
-  const unwrappedFunctionValue = stripParenExpression(functionValue);
-  return isFunctionLike(unwrappedFunctionValue) ? unwrappedFunctionValue : null;
+  if (symbol?.kind !== "const" || !symbol.initializer) return null;
+  const unwrappedInitializer = stripParenExpression(symbol.initializer);
+  return isFunctionLike(unwrappedInitializer) ? unwrappedInitializer : null;
 };


### PR DESCRIPTION
## Why

React Doctor only analyzed inline effect callbacks, so moving the same callback into an immutable local function could hide `no-fetch-in-effect`, `no-effect-chain`, and `no-cascading-set-state` findings.

The resolver must prove an exact local binding and preserve lifecycle boundaries. Opaque callbacks, mutable aliases, deferred functions, cleanup, and external synchronization remain conservative.

## What changed

- resolve immutable local function expressions and unreassigned declarations passed to effect hooks
- follow exact, non-async local helpers that are synchronously invoked by `no-effect-chain`
- stop at mutable aliases, reassigned declarations, imports, parameters, conditionals, factories, deferred callbacks, async functions, and cleanup boundaries
- keep external synchronization through browser storage, storage hooks, and opaque context setters out of local effect-chain findings
- preserve true chains through proven local `useState` setters and synchronous helpers
- add inline-to-const callback metamorphic fuzzing, a generated effect-chain firing scenario, and permanent Lightbox/AppFlowy regression seeds

## Precision boundary

The benchmark FP was `yet-another-react-lightbox@12444d1a`, `SlideshowContext.tsx:46`. The downstream effect calls `setAutoPlaying` from `useA11yContext`; it synchronizes accessibility context and is not a proven local state setter. The candidate removes that finding while continuing to report the near-neighbor when the setter is proven to come from local `useState`.

Repo-wide A/B validation found an initial added FP in `AppFlowy-Web@b615fa5a`, where an effect invoked an async IIFE and wrote `docGuid` only after `await loadView()`. Traversal now refuses async callees. A paired synchronous-IIFE control still reports.

The remaining added verdict is a manually confirmed TP in `catho/quantum@690cffd4`: an effect on `suggestions` synchronously invokes `handleFilter`, which writes `filterSuggestions` and triggers the effect that copies its length into state.

## React Bench A/B

- merge-base: `81e6647f3c4c0dbc90881b199753a9d341cf7963`
- candidate: `d24bb519467e1d02e3108e70f4e499fbeed57a6a`
- repositories requested/successfully scanned: 9/9 exact pinned SHAs
- supported source files scanned per build: 5,795
- original-state target-rule totals: baseline 50, candidate 50
- deltas: 1 removed confirmed FP, 1 added confirmed TP, 0 added FPs, 0 removed TPs
- oracle target files: 9/9 clean on both builds
- oracle repo-wide totals: baseline 41, candidate 41
- scan failures/skipped batches: 0
- two non-runtime parser fixtures were explicitly excluded from both builds: `types/types-tests.tsx` and `flow-typed/**`

## Test plan

- oxlint plugin: 549 files, 12,251 passed, 148 skipped
- focused `no-effect-chain` regressions: 27 passed
- workspace typecheck: 15/15 tasks
- strict fuzz after the final FP fix: 2,000 iterations at seed 1010 over react-bench-5 plus 126 built-in regression seeds, 0 findings
- earlier deep campaign: 70,000 unique iterations across all three rules and react-bench-5/react-bench-4, plus 20,000 deterministic replays, 0 findings
- fuzz fire coverage is guaranteed by the generated canonical effect-chain scenario; earlier benchmark replay recorded 951 firing programs
- fuzz corpus tests: 38 passed, 400 skipped; all three new named-rule seeds stay quiet
- lint, format check, build, JSON report smoke, changed-lines React Doctor scan, and `git diff --check` pass
- changeset included for `oxlint-plugin-react-doctor`

## RDE

Cloud RDE is not used for this AST-rule validation. The local RDE checkout also accepts report schema versions 1 and 2 while this branch emits schema version 3. Exact local plugin A/B scans over the pinned React Bench repositories provide the real-repo evidence above; no eval checkout files were changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core AST analysis for three widely used rules; behavior is guarded by conservative resolution and large regression/fuzz suites, but verdict shifts on real code are possible.
> 
> **Overview**
> Effect-hook rules (`no-effect-chain`, `no-cascading-set-state`, `no-fetch-in-effect`) now analyze **immutable local callbacks** (named functions and exact `const` aliases), not only inline arrow/function expressions—so refactors that extract the same logic no longer hide diagnostics.
> 
> **`getEffectCallback`** takes optional scope analysis and delegates to new **`resolveExactLocalFunction`**, which follows unreassigned function declarations and const aliases to function literals and **stops** on reassignment, conditionals, mutable bindings, and non-exact aliases.
> 
> **`no-effect-chain`** expands analysis across **synchronously invoked** local helpers (skipping async callees), refines cleanup-return vs state-write detection, and treats effects that only call **opaque** `set*` names (e.g. context/prop setters) as external sync when they write no proven local `useState`—addressing real benchmark FPs while keeping true chains.
> 
> **Fuzz**: metamorphic “inline → const binding” variants for the three rules, a generated two-effect chain snippet, smoke test for extraction, and regression corpus seeds (async IIFE, context setter sync).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76a2c546219852e3b332ad97850759a7655fe8b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

