### PR TITLE
fix(cli): fail incomplete plugin scans

### DIFF
--- a/.changeset/steady-plugin-failures.md
+++ b/.changeset/steady-plugin-failures.md
@@ -2,4 +2,4 @@
 "react-doctor": patch
 ---
 
-Mark scans incomplete and exit nonzero when oxlint reports a configured plugin or engine failure.
+Exit nonzero when the lint pass hard-fails (a configured plugin or engine failure) instead of silently reporting a clean scan. Routine code-less diagnostics (unparseable files, unused-directive warnings) no longer reject the whole lint pass, fail-open degradations (`--no-lint`, `--max-duration` truncation, supply-chain/security skips) stay advisory, and `--blocking none` keeps the scan advisory.

--- a/.changeset/steady-plugin-failures.md
+++ b/.changeset/steady-plugin-failures.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Mark scans incomplete and exit nonzero when oxlint reports a configured plugin or engine failure.

--- a/packages/core/src/runners/oxlint/parse-output.ts
+++ b/packages/core/src/runners/oxlint/parse-output.ts
@@ -11,6 +11,7 @@ import type {
 import { ERROR_PREVIEW_LENGTH_CHARS, OCCURRENCE_MATCHED_CATEGORIES } from "../../constants.js";
 import { findJsxOpenerSpan } from "../../find-jsx-opener-span.js";
 import { isLintableSourceFile } from "../../utils/is-lintable-source-file.js";
+import { isRecord } from "../../utils/is-record.js";
 import { isMinifiedSource } from "../../utils/is-minified-source.js";
 import { lineOfUtf8Offset } from "../../utils/line-of-utf8-offset.js";
 import { OxlintOutputUnparseable, ReactDoctorError } from "../../errors.js";
@@ -252,39 +253,26 @@ const buildRelatedLocations = (
 };
 
 const isOxlintSpan = (value: unknown): boolean =>
-  typeof value === "object" &&
-  value !== null &&
-  "offset" in value &&
+  isRecord(value) &&
   typeof value.offset === "number" &&
-  "length" in value &&
   typeof value.length === "number" &&
-  "line" in value &&
   typeof value.line === "number" &&
-  "column" in value &&
   typeof value.column === "number";
 
-const isOxlintLabel = (value: unknown): boolean =>
-  typeof value === "object" && value !== null && "span" in value && isOxlintSpan(value.span);
+const isOxlintLabel = (value: unknown): boolean => isRecord(value) && isOxlintSpan(value.span);
 
 const isMappableOxlintDiagnostic = (value: unknown): boolean =>
-  typeof value === "object" &&
-  value !== null &&
-  "code" in value &&
+  isRecord(value) &&
   typeof value.code === "string" &&
   value.code.length > 0 &&
-  "filename" in value &&
   typeof value.filename === "string" &&
   value.filename.length > 0 &&
-  "severity" in value &&
   (value.severity === "warning" || value.severity === "error") &&
-  "labels" in value &&
   Array.isArray(value.labels) &&
   value.labels.every(isOxlintLabel);
 
 const isOxlintOutput = (value: unknown): value is OxlintOutput =>
-  typeof value === "object" &&
-  value !== null &&
-  "diagnostics" in value &&
+  isRecord(value) &&
   Array.isArray(value.diagnostics) &&
   value.diagnostics.every(isMappableOxlintDiagnostic);
 

--- a/packages/core/src/runners/oxlint/parse-output.ts
+++ b/packages/core/src/runners/oxlint/parse-output.ts
@@ -271,10 +271,16 @@ const isMappableOxlintDiagnostic = (value: unknown): boolean =>
   Array.isArray(value.labels) &&
   value.labels.every(isOxlintLabel);
 
+// oxlint attributes every routine diagnostic — including code-less parse
+// errors and unused-directive warnings — to a file. A diagnostic without a
+// filename is the engine reporting its own failure (e.g. "Error running JS
+// plugin." from a throwing configured plugin), which means the lint results
+// are incomplete and a clean report would be a false clean.
+const isEngineFailureDiagnostic = (value: unknown): boolean =>
+  !isRecord(value) || typeof value.filename !== "string" || value.filename.length === 0;
+
 const isOxlintOutput = (value: unknown): value is OxlintOutput =>
-  isRecord(value) &&
-  Array.isArray(value.diagnostics) &&
-  value.diagnostics.every(isMappableOxlintDiagnostic);
+  isRecord(value) && Array.isArray(value.diagnostics);
 
 /**
  * Parses one oxlint subprocess's stdout into a flat `Diagnostic[]`.
@@ -312,6 +318,15 @@ export const parseOxlintOutput = (
     throw new ReactDoctorError({
       reason: new OxlintOutputUnparseable({
         preview: stdout.slice(0, ERROR_PREVIEW_LENGTH_CHARS),
+      }),
+    });
+  }
+
+  const engineFailureDiagnostic = parsed.diagnostics.find(isEngineFailureDiagnostic);
+  if (engineFailureDiagnostic !== undefined) {
+    throw new ReactDoctorError({
+      reason: new OxlintOutputUnparseable({
+        preview: JSON.stringify(engineFailureDiagnostic).slice(0, ERROR_PREVIEW_LENGTH_CHARS),
       }),
     });
   }
@@ -371,7 +386,7 @@ export const parseOxlintOutput = (
   const mappedDiagnostics = parsed.diagnostics
     .filter(
       (diagnostic) =>
-        diagnostic.code &&
+        isMappableOxlintDiagnostic(diagnostic) &&
         isLintableSourceFile(diagnostic.filename) &&
         !isMinifiedDiagnosticFile(diagnostic.filename) &&
         !shouldSuppressLocalUseHookDiagnostic(diagnostic, rootDirectory) &&

--- a/packages/core/src/runners/oxlint/parse-output.ts
+++ b/packages/core/src/runners/oxlint/parse-output.ts
@@ -251,11 +251,42 @@ const buildRelatedLocations = (
   return related;
 };
 
-const isOxlintOutput = (value: unknown): value is OxlintOutput => {
-  if (typeof value !== "object" || value === null) return false;
-  const candidate = value as { diagnostics?: unknown };
-  return Array.isArray(candidate.diagnostics);
-};
+const isOxlintSpan = (value: unknown): boolean =>
+  typeof value === "object" &&
+  value !== null &&
+  "offset" in value &&
+  typeof value.offset === "number" &&
+  "length" in value &&
+  typeof value.length === "number" &&
+  "line" in value &&
+  typeof value.line === "number" &&
+  "column" in value &&
+  typeof value.column === "number";
+
+const isOxlintLabel = (value: unknown): boolean =>
+  typeof value === "object" && value !== null && "span" in value && isOxlintSpan(value.span);
+
+const isMappableOxlintDiagnostic = (value: unknown): boolean =>
+  typeof value === "object" &&
+  value !== null &&
+  "code" in value &&
+  typeof value.code === "string" &&
+  value.code.length > 0 &&
+  "filename" in value &&
+  typeof value.filename === "string" &&
+  value.filename.length > 0 &&
+  "severity" in value &&
+  (value.severity === "warning" || value.severity === "error") &&
+  "labels" in value &&
+  Array.isArray(value.labels) &&
+  value.labels.every(isOxlintLabel);
+
+const isOxlintOutput = (value: unknown): value is OxlintOutput =>
+  typeof value === "object" &&
+  value !== null &&
+  "diagnostics" in value &&
+  Array.isArray(value.diagnostics) &&
+  value.diagnostics.every(isMappableOxlintDiagnostic);
 
 /**
  * Parses one oxlint subprocess's stdout into a flat `Diagnostic[]`.

--- a/packages/core/tests/oxlint-engine-diagnostic.test.ts
+++ b/packages/core/tests/oxlint-engine-diagnostic.test.ts
@@ -2,17 +2,29 @@ import { describe, expect, it } from "vite-plus/test";
 import { parseOxlintOutput } from "../src/runners/oxlint/parse-output.js";
 import { buildProject, TEST_ROOT_DIRECTORY } from "./helpers/oxlint-parse-harness.js";
 
-const buildEngineDiagnosticOutput = (diagnostic: unknown): string =>
+const HEALTHY_DIAGNOSTIC = {
+  message: "Avoid using array index as key",
+  code: "react-doctor(no-array-index-as-key)",
+  severity: "error",
+  causes: [],
+  url: "",
+  help: "",
+  filename: "src/components/widget.tsx",
+  labels: [{ label: "", span: { offset: 0, length: 1, line: 12, column: 3 } }],
+  related: [],
+};
+
+const buildOutput = (diagnostics: unknown[]): string =>
   JSON.stringify({
-    diagnostics: [diagnostic],
-    number_of_files: 1,
+    diagnostics,
+    number_of_files: 2,
     number_of_rules: 1,
   });
 
 describe("parseOxlintOutput engine diagnostics", () => {
   it.each([
     [
-      "plugin runtime error",
+      "plugin runtime error (empty filename)",
       {
         message: "Error running JS plugin.",
         severity: "error",
@@ -20,6 +32,42 @@ describe("parseOxlintOutput engine diagnostics", () => {
         labels: [],
       },
     ],
+    [
+      "engine error (missing filename)",
+      {
+        message: "Error running JS plugin.",
+        severity: "error",
+        labels: [],
+      },
+    ],
+    ["malformed record", null],
+  ])(
+    "hard-fails on an engine-level diagnostic even next to healthy findings: %s",
+    (_description, diagnostic) => {
+      expect(() =>
+        parseOxlintOutput(
+          buildOutput([HEALTHY_DIAGNOSTIC, diagnostic]),
+          buildProject(),
+          TEST_ROOT_DIRECTORY,
+        ),
+      ).toThrow("Failed to parse oxlint output");
+    },
+  );
+
+  it("names the engine failure in the error, not the healthy sibling", () => {
+    expect(() =>
+      parseOxlintOutput(
+        buildOutput([
+          HEALTHY_DIAGNOSTIC,
+          { message: "Error running JS plugin.", severity: "error", filename: "", labels: [] },
+        ]),
+        buildProject(),
+        TEST_ROOT_DIRECTORY,
+      ),
+    ).toThrow("Error running JS plugin");
+  });
+
+  it.each([
     [
       "syntax error",
       {
@@ -39,14 +87,34 @@ describe("parseOxlintOutput engine diagnostics", () => {
         labels: [],
       },
     ],
-    ["malformed record", null],
-  ])("rejects an unmappable diagnostic: %s", (_description, diagnostic) => {
-    expect(() =>
-      parseOxlintOutput(
-        buildEngineDiagnosticOutput(diagnostic),
+    [
+      "unused disable directive",
+      {
+        message: "Unused eslint-disable directive",
+        severity: "warning",
+        filename: `${TEST_ROOT_DIRECTORY}/src/App.tsx`,
+        labels: [],
+      },
+    ],
+    [
+      "label without a span",
+      {
+        ...HEALTHY_DIAGNOSTIC,
+        filename: `${TEST_ROOT_DIRECTORY}/src/App.tsx`,
+        labels: [{ label: "" }],
+      },
+    ],
+  ])(
+    "drops a per-file unmappable diagnostic and keeps its healthy siblings: %s",
+    (_description, diagnostic) => {
+      const diagnostics = parseOxlintOutput(
+        buildOutput([diagnostic, HEALTHY_DIAGNOSTIC]),
         buildProject(),
         TEST_ROOT_DIRECTORY,
-      ),
-    ).toThrow("Failed to parse oxlint output");
-  });
+      );
+
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0].rule).toBe("no-array-index-as-key");
+    },
+  );
 });

--- a/packages/core/tests/oxlint-engine-diagnostic.test.ts
+++ b/packages/core/tests/oxlint-engine-diagnostic.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vite-plus/test";
+import { parseOxlintOutput } from "../src/runners/oxlint/parse-output.js";
+import { buildProject, TEST_ROOT_DIRECTORY } from "./helpers/oxlint-parse-harness.js";
+
+const buildEngineDiagnosticOutput = (diagnostic: unknown): string =>
+  JSON.stringify({
+    diagnostics: [diagnostic],
+    number_of_files: 1,
+    number_of_rules: 1,
+  });
+
+describe("parseOxlintOutput engine diagnostics", () => {
+  it.each([
+    [
+      "plugin runtime error",
+      {
+        message: "Error running JS plugin.",
+        severity: "error",
+        filename: "",
+        labels: [],
+      },
+    ],
+    [
+      "syntax error",
+      {
+        message: "Unexpected token",
+        severity: "error",
+        filename: `${TEST_ROOT_DIRECTORY}/src/App.tsx`,
+        labels: [],
+      },
+    ],
+    [
+      "empty rule code",
+      {
+        message: "Missing rule identity",
+        code: "",
+        severity: "error",
+        filename: `${TEST_ROOT_DIRECTORY}/src/App.tsx`,
+        labels: [],
+      },
+    ],
+    ["malformed record", null],
+  ])("rejects an unmappable diagnostic: %s", (_description, diagnostic) => {
+    expect(() =>
+      parseOxlintOutput(
+        buildEngineDiagnosticOutput(diagnostic),
+        buildProject(),
+        TEST_ROOT_DIRECTORY,
+      ),
+    ).toThrow("Failed to parse oxlint output");
+  });
+});

--- a/packages/react-doctor/src/cli/commands/inspect.ts
+++ b/packages/react-doctor/src/cli/commands/inspect.ts
@@ -31,8 +31,8 @@ import { getStagedSourceFiles, materializeStagedFiles } from "../utils/get-stage
 import type { InspectFlags } from "../utils/inspect-flags.js";
 import { filterDiagnosticsByCategories } from "../utils/filter-diagnostics-by-categories.js";
 import { handleError, handleUserError } from "../utils/handle-error.js";
+import { hasLintHardFailure } from "../utils/has-lint-hard-failure.js";
 import { isDebugFlagEnabled } from "../utils/is-debug-flag.js";
-import { isInspectResultComplete } from "../utils/is-inspect-result-complete.js";
 import { isShareOptedOut } from "../utils/is-share-opted-out.js";
 import { isExpectedUserError } from "../utils/is-expected-user-error.js";
 import { handoffToAgent } from "../utils/handoff-to-agent.js";
@@ -126,10 +126,14 @@ interface FinalizeScansInput {
 /**
  * Post-scan finalization shared by the staged-arm and project-loop
  * paths of `inspectAction`: emit the JSON report (when in JSON mode)
- * and set `process.exitCode = 1` when any scan is incomplete or a
- * diagnostic at or above the `--blocking` threshold (default `"error"`)
- * reaches the `ciFailure` surface. `--blocking none` keeps findings
- * advisory but does not convert an incomplete analysis into success.
+ * and set `process.exitCode = 1` when any scan's lint pass hard-failed
+ * (an engine/plugin/binding failure destroys the findings, so success
+ * would be a false clean) or a diagnostic at or above the `--blocking`
+ * threshold (default `"error"`) reaches the `ciFailure` surface.
+ * `--blocking none` keeps the scan advisory (always exits 0), and
+ * fail-open degradations — `--no-lint`, `--max-duration` truncation,
+ * supply-chain/security skips — stay advisory too, surfaced through
+ * `complete: false` in the JSON report.
  */
 const finalizeScans = (input: FinalizeScansInput): void => {
   // Aggregate the per-project baseline deltas into one report-level block so the
@@ -196,10 +200,9 @@ const finalizeScans = (input: FinalizeScansInput): void => {
     );
   }
 
-  const hasIncompleteScan = input.completedScans.some(
-    ({ result }) => !isInspectResultComplete(result),
-  );
-  if (hasIncompleteScan) {
+  const blockingLevel = resolveBlockingLevel(input.flags, input.userConfig);
+  const hasHardFailedScan = input.completedScans.some(({ result }) => hasLintHardFailure(result));
+  if (hasHardFailedScan && blockingLevel !== "none") {
     process.exitCode = 1;
     return;
   }
@@ -207,7 +210,7 @@ const finalizeScans = (input: FinalizeScansInput): void => {
   if (input.isScoreOnly || baselineDegraded) return;
 
   const ciFailureDiagnostics = filterScansForSurface(input.completedScans, "ciFailure");
-  if (shouldBlockCi(ciFailureDiagnostics, resolveBlockingLevel(input.flags, input.userConfig))) {
+  if (shouldBlockCi(ciFailureDiagnostics, blockingLevel)) {
     process.exitCode = 1;
   }
 };

--- a/packages/react-doctor/src/cli/commands/inspect.ts
+++ b/packages/react-doctor/src/cli/commands/inspect.ts
@@ -32,6 +32,7 @@ import type { InspectFlags } from "../utils/inspect-flags.js";
 import { filterDiagnosticsByCategories } from "../utils/filter-diagnostics-by-categories.js";
 import { handleError, handleUserError } from "../utils/handle-error.js";
 import { isDebugFlagEnabled } from "../utils/is-debug-flag.js";
+import { isInspectResultComplete } from "../utils/is-inspect-result-complete.js";
 import { isShareOptedOut } from "../utils/is-share-opted-out.js";
 import { isExpectedUserError } from "../utils/is-expected-user-error.js";
 import { handoffToAgent } from "../utils/handoff-to-agent.js";
@@ -125,9 +126,10 @@ interface FinalizeScansInput {
 /**
  * Post-scan finalization shared by the staged-arm and project-loop
  * paths of `inspectAction`: emit the JSON report (when in JSON mode)
- * and set `process.exitCode = 1` when a diagnostic at or above the
- * `--blocking` threshold (default `"error"`) reaches the `ciFailure`
- * surface. `--blocking none` keeps the scan advisory (always exits 0).
+ * and set `process.exitCode = 1` when any scan is incomplete or a
+ * diagnostic at or above the `--blocking` threshold (default `"error"`)
+ * reaches the `ciFailure` surface. `--blocking none` keeps findings
+ * advisory but does not convert an incomplete analysis into success.
  */
 const finalizeScans = (input: FinalizeScansInput): void => {
   // Aggregate the per-project baseline deltas into one report-level block so the
@@ -192,6 +194,14 @@ const finalizeScans = (input: FinalizeScansInput): void => {
         baselineDegraded,
       }),
     );
+  }
+
+  const hasIncompleteScan = input.completedScans.some(
+    ({ result }) => !isInspectResultComplete(result),
+  );
+  if (hasIncompleteScan) {
+    process.exitCode = 1;
+    return;
   }
 
   if (input.isScoreOnly || baselineDegraded) return;

--- a/packages/react-doctor/src/cli/utils/build-run-event.ts
+++ b/packages/react-doctor/src/cli/utils/build-run-event.ts
@@ -253,10 +253,7 @@ const buildOutcomeAttributes = (input: RunEventInput): RunEventAttributes => {
   const wouldBlock =
     !input.scoreOnly && !input.gateExempt && shouldBlockCi(gateDiagnostics, blockingLevel);
   const isClean = result.diagnostics.length === 0 && complete;
-  let outcome = "ok";
-  if (!complete) outcome = "error";
-  else if (wouldBlock) outcome = "blocked";
-  else if (isClean) outcome = "clean";
+  const outcome = !complete ? "error" : wouldBlock ? "blocked" : isClean ? "clean" : "ok";
 
   const firings = summarizeRuleFirings(result.diagnostics);
   const countByRule = new Map<string, number>();

--- a/packages/react-doctor/src/cli/utils/build-run-event.ts
+++ b/packages/react-doctor/src/cli/utils/build-run-event.ts
@@ -12,6 +12,7 @@ import type {
   SuppressedRuleCount,
 } from "@react-doctor/core";
 import { buildRuleBlastRadii } from "./diagnostic-grouping.js";
+import { hasLintHardFailure } from "./has-lint-hard-failure.js";
 import { isInspectResultComplete } from "./is-inspect-result-complete.js";
 import { ACTION_INPUT_ENVIRONMENT_VARIABLES, detectRunnerOs } from "./is-ci-environment.js";
 import { summarizeRuleFirings } from "./record-scan-metrics.js";
@@ -247,13 +248,17 @@ const buildOutcomeAttributes = (input: RunEventInput): RunEventAttributes => {
   );
   const complete = isInspectResultComplete(result);
   // `scoreOnly` runs never raise a non-zero exit for ordinary findings, and a
-  // degraded baseline run (`gateExempt`) skips the finding gate. Incomplete
-  // analysis is an operational failure rather than a finding, so it exits one
-  // in every mode and remains distinct from `wouldBlock`.
+  // degraded baseline run (`gateExempt`) skips the finding gate. A hard lint
+  // failure (engine/plugin/binding) destroys the scan's findings, so it exits
+  // one in every mode except the advisory `--blocking none`; fail-open
+  // degradations and deliberate skips stay advisory and surface through
+  // `outcome.complete` instead.
+  const didLintHardFail = hasLintHardFailure(result);
+  const failsOnHardFailure = didLintHardFail && blockingLevel !== "none";
   const wouldBlock =
     !input.scoreOnly && !input.gateExempt && shouldBlockCi(gateDiagnostics, blockingLevel);
   const isClean = result.diagnostics.length === 0 && complete;
-  const outcome = !complete ? "error" : wouldBlock ? "blocked" : isClean ? "clean" : "ok";
+  const outcome = didLintHardFail ? "error" : wouldBlock ? "blocked" : isClean ? "clean" : "ok";
 
   const firings = summarizeRuleFirings(result.diagnostics);
   const countByRule = new Map<string, number>();
@@ -330,7 +335,7 @@ const buildOutcomeAttributes = (input: RunEventInput): RunEventAttributes => {
   const attributes: RunEventAttributes = {
     ...withNamespace("outcome", {
       status: outcome,
-      exitCode: !complete || wouldBlock ? 1 : 0,
+      exitCode: failsOnHardFailure || wouldBlock ? 1 : 0,
       wouldBlock,
       blocking: blockingLevel,
       clean: isClean,

--- a/packages/react-doctor/src/cli/utils/build-run-event.ts
+++ b/packages/react-doctor/src/cli/utils/build-run-event.ts
@@ -1,7 +1,6 @@
 import {
   filterDiagnosticsForSurface,
   isReactDoctorError,
-  isScanComplete,
   JSX_FILE_PATTERN,
   resolveGithubActionsScoreMetadata,
   summarizeDiagnostics,
@@ -13,6 +12,7 @@ import type {
   SuppressedRuleCount,
 } from "@react-doctor/core";
 import { buildRuleBlastRadii } from "./diagnostic-grouping.js";
+import { isInspectResultComplete } from "./is-inspect-result-complete.js";
 import { ACTION_INPUT_ENVIRONMENT_VARIABLES, detectRunnerOs } from "./is-ci-environment.js";
 import { summarizeRuleFirings } from "./record-scan-metrics.js";
 import { isValidBlockingLevel } from "./resolve-blocking-level.js";
@@ -245,19 +245,18 @@ const buildOutcomeAttributes = (input: RunEventInput): RunEventAttributes => {
     "ciFailure",
     input.userConfig,
   );
-  // `scoreOnly` runs never raise a non-zero exit (finalizeScans guards the gate
-  // on `!isScoreOnly`), and a degraded baseline run (`gateExempt`) skips the
-  // gate too — keep `outcome.wouldBlock`/`outcome.status`/`outcome.exitCode` consistent with the real exit.
+  const complete = isInspectResultComplete(result);
+  // `scoreOnly` runs never raise a non-zero exit for ordinary findings, and a
+  // degraded baseline run (`gateExempt`) skips the finding gate. Incomplete
+  // analysis is an operational failure rather than a finding, so it exits one
+  // in every mode and remains distinct from `wouldBlock`.
   const wouldBlock =
     !input.scoreOnly && !input.gateExempt && shouldBlockCi(gateDiagnostics, blockingLevel);
-  const complete = isScanComplete({
-    analyzedFileCount: result.analyzedFiles?.length,
-    scannedFileCount: result.scannedFileCount,
-    skippedCheckCount: result.skippedChecks.length,
-    skippedCheckReasonCount: Object.keys(result.skippedCheckReasons ?? {}).length,
-  });
   const isClean = result.diagnostics.length === 0 && complete;
-  const outcome = wouldBlock ? "blocked" : isClean ? "clean" : "ok";
+  let outcome = "ok";
+  if (!complete) outcome = "error";
+  else if (wouldBlock) outcome = "blocked";
+  else if (isClean) outcome = "clean";
 
   const firings = summarizeRuleFirings(result.diagnostics);
   const countByRule = new Map<string, number>();
@@ -334,7 +333,7 @@ const buildOutcomeAttributes = (input: RunEventInput): RunEventAttributes => {
   const attributes: RunEventAttributes = {
     ...withNamespace("outcome", {
       status: outcome,
-      exitCode: wouldBlock ? 1 : 0,
+      exitCode: !complete || wouldBlock ? 1 : 0,
       wouldBlock,
       blocking: blockingLevel,
       clean: isClean,

--- a/packages/react-doctor/src/cli/utils/has-lint-hard-failure.ts
+++ b/packages/react-doctor/src/cli/utils/has-lint-hard-failure.ts
@@ -1,0 +1,9 @@
+import type { InspectResult } from "@react-doctor/core";
+
+// `skippedChecks` carries "lint" only when the whole lint pass failed
+// (`didLintFail` in core's `build-skipped-checks`): an engine, plugin, or
+// native-binding failure that destroyed every finding, so a zero exit would
+// report a false clean. Deliberate skips (`--no-lint`) and fail-open
+// degradations (`lint:partial`, supply-chain, security-scan) don't qualify.
+export const hasLintHardFailure = (result: InspectResult): boolean =>
+  result.skippedChecks.includes("lint");

--- a/packages/react-doctor/src/cli/utils/is-inspect-result-complete.ts
+++ b/packages/react-doctor/src/cli/utils/is-inspect-result-complete.ts
@@ -1,0 +1,10 @@
+import { isScanComplete } from "@react-doctor/core";
+import type { InspectResult } from "@react-doctor/core";
+
+export const isInspectResultComplete = (result: InspectResult): boolean =>
+  isScanComplete({
+    analyzedFileCount: result.analyzedFiles?.length,
+    scannedFileCount: result.scannedFileCount,
+    skippedCheckCount: result.skippedChecks.length,
+    skippedCheckReasonCount: Object.keys(result.skippedCheckReasons ?? {}).length,
+  });

--- a/packages/react-doctor/tests/build-run-event.test.ts
+++ b/packages/react-doctor/tests/build-run-event.test.ts
@@ -193,6 +193,9 @@ describe("buildRunEventAttributes", () => {
       }),
     );
     expect(incompleteAttributes["outcome.complete"]).toBe(false);
+    expect(incompleteAttributes["outcome.status"]).toBe("error");
+    expect(incompleteAttributes["outcome.exitCode"]).toBe(1);
+    expect(incompleteAttributes["outcome.wouldBlock"]).toBe(false);
     const partialCheckAttributes = buildRunEventAttributes(
       baseInput({
         result: buildResult({
@@ -204,7 +207,8 @@ describe("buildRunEventAttributes", () => {
       }),
     );
     expect(partialCheckAttributes["outcome.complete"]).toBe(false);
-    expect(partialCheckAttributes["outcome.status"]).toBe("ok");
+    expect(partialCheckAttributes["outcome.status"]).toBe("error");
+    expect(partialCheckAttributes["outcome.exitCode"]).toBe(1);
     expect(partialCheckAttributes["outcome.clean"]).toBe(false);
     expect(
       buildRunEventAttributes(baseInput({ error: new Error("boom") }))["outcome.complete"],

--- a/packages/react-doctor/tests/build-run-event.test.ts
+++ b/packages/react-doctor/tests/build-run-event.test.ts
@@ -193,8 +193,8 @@ describe("buildRunEventAttributes", () => {
       }),
     );
     expect(incompleteAttributes["outcome.complete"]).toBe(false);
-    expect(incompleteAttributes["outcome.status"]).toBe("error");
-    expect(incompleteAttributes["outcome.exitCode"]).toBe(1);
+    expect(incompleteAttributes["outcome.status"]).toBe("ok");
+    expect(incompleteAttributes["outcome.exitCode"]).toBe(0);
     expect(incompleteAttributes["outcome.wouldBlock"]).toBe(false);
     const partialCheckAttributes = buildRunEventAttributes(
       baseInput({
@@ -207,12 +207,37 @@ describe("buildRunEventAttributes", () => {
       }),
     );
     expect(partialCheckAttributes["outcome.complete"]).toBe(false);
-    expect(partialCheckAttributes["outcome.status"]).toBe("error");
-    expect(partialCheckAttributes["outcome.exitCode"]).toBe(1);
+    expect(partialCheckAttributes["outcome.status"]).toBe("ok");
+    expect(partialCheckAttributes["outcome.exitCode"]).toBe(0);
     expect(partialCheckAttributes["outcome.clean"]).toBe(false);
     expect(
       buildRunEventAttributes(baseInput({ error: new Error("boom") }))["outcome.complete"],
     ).toBe(false);
+  });
+
+  it("mirrors the exit-code gate for a hard lint failure, including `blocking: none`", () => {
+    const hardFailedResult = buildResult({
+      analyzedFiles: [],
+      skippedChecks: ["lint"],
+      skippedCheckReasons: { lint: "Failed to parse oxlint output: Error running JS plugin." },
+    });
+
+    const hardFailureAttributes = buildRunEventAttributes(baseInput({ result: hardFailedResult }));
+    expect(hardFailureAttributes["outcome.complete"]).toBe(false);
+    expect(hardFailureAttributes["outcome.status"]).toBe("error");
+    expect(hardFailureAttributes["outcome.exitCode"]).toBe(1);
+    expect(hardFailureAttributes["outcome.wouldBlock"]).toBe(false);
+
+    const scoreOnlyAttributes = buildRunEventAttributes(
+      baseInput({ result: hardFailedResult, scoreOnly: true }),
+    );
+    expect(scoreOnlyAttributes["outcome.exitCode"]).toBe(1);
+
+    const advisoryAttributes = buildRunEventAttributes(
+      baseInput({ result: hardFailedResult, userConfig: { blocking: "none" } }),
+    );
+    expect(advisoryAttributes["outcome.status"]).toBe("error");
+    expect(advisoryAttributes["outcome.exitCode"]).toBe(0);
   });
 
   it("records the widest-blast-radius rule for migration-scale calibration", () => {

--- a/packages/react-doctor/tests/inspect-action-exit-code.test.ts
+++ b/packages/react-doctor/tests/inspect-action-exit-code.test.ts
@@ -1,0 +1,167 @@
+import * as fs from "node:fs";
+import os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import type { InspectResult } from "@react-doctor/core";
+import { inspectAction } from "../src/cli/commands/inspect.js";
+import type { InspectFlags } from "../src/cli/utils/inspect-flags.js";
+import { buildDiagnostic, buildTestProject } from "./regressions/_helpers.js";
+
+const mockState = vi.hoisted(() => ({
+  projectDirectories: [] as string[],
+  result: undefined as InspectResult | undefined,
+}));
+
+vi.mock("ora", () => ({
+  default: () => ({
+    text: "",
+    start: function () {
+      return this;
+    },
+    stop: function () {
+      return this;
+    },
+    succeed: () => {},
+    fail: () => {},
+  }),
+}));
+
+vi.mock("@react-doctor/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@react-doctor/core")>();
+  return {
+    ...actual,
+    resolveScanTarget: vi.fn(async (requestedDirectory: string) => ({
+      resolvedDirectory: requestedDirectory,
+      requestedDirectory,
+      userConfig: null,
+      configSourceDirectory: null,
+      didRedirectViaRootDir: false,
+    })),
+    filterDiagnosticsForSurface: vi.fn((diagnostics) => diagnostics),
+  };
+});
+
+vi.mock("../src/inspect.js", () => ({
+  inspect: vi.fn(async (): Promise<InspectResult> => {
+    if (mockState.result === undefined) throw new Error("mockState.result not set");
+    return mockState.result;
+  }),
+}));
+
+vi.mock("../src/cli/utils/select-projects.js", () => ({
+  selectProjects: vi.fn(async () => mockState.projectDirectories),
+}));
+
+vi.mock("../src/cli/utils/should-skip-prompts.js", () => ({
+  shouldSkipPrompts: vi.fn(() => true),
+}));
+
+vi.mock("../src/cli/utils/prompt-install-setup.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/cli/utils/prompt-install-setup.js")>();
+  return {
+    ...actual,
+    shouldShowAgentInstallHint: vi.fn(() => false),
+  };
+});
+
+const buildResult = (
+  projectDirectory: string,
+  overrides: Partial<InspectResult> = {},
+): InspectResult => ({
+  diagnostics: [],
+  score: null,
+  skippedChecks: [],
+  project: buildTestProject({ rootDirectory: projectDirectory }),
+  elapsedMilliseconds: 1,
+  scannedFileCount: 2,
+  analyzedFiles: ["src/app.tsx", "src/widget.tsx"],
+  ...overrides,
+});
+
+const HARD_LINT_FAILURE: Partial<InspectResult> = {
+  skippedChecks: ["lint"],
+  skippedCheckReasons: { lint: "Failed to parse oxlint output: Error running JS plugin." },
+  analyzedFiles: [],
+};
+
+describe("inspectAction exit-code gate", () => {
+  let projectDirectory: string;
+  let savedExitCode: typeof process.exitCode;
+
+  beforeEach(() => {
+    savedExitCode = process.exitCode;
+    process.exitCode = undefined;
+    projectDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-exit-code-"));
+    mockState.projectDirectories = [projectDirectory];
+  });
+
+  afterEach(() => {
+    process.exitCode = savedExitCode;
+    mockState.result = undefined;
+    mockState.projectDirectories = [];
+    fs.rmSync(projectDirectory, { recursive: true, force: true });
+    vi.clearAllMocks();
+  });
+
+  const runInspectAction = async (
+    resultOverrides: Partial<InspectResult>,
+    flags: InspectFlags = {},
+  ): Promise<void> => {
+    mockState.result = buildResult(projectDirectory, resultOverrides);
+    await inspectAction(projectDirectory, flags);
+  };
+
+  it("exits 1 when the lint pass hard-failed under default blocking", async () => {
+    await runInspectAction(HARD_LINT_FAILURE);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("exits 1 on a hard lint failure even in `--score` mode", async () => {
+    await runInspectAction(HARD_LINT_FAILURE, { score: true });
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("keeps `--blocking none` advisory even on a hard lint failure", async () => {
+    await runInspectAction(HARD_LINT_FAILURE, { blocking: "none" });
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it("exits 0 on a healthy `--no-lint` run (no lint coverage, nothing skipped)", async () => {
+    await runInspectAction({ analyzedFiles: [] }, { lint: false });
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it("exits 0 when `--max-duration` truncated the lint pass (`lint:partial`)", async () => {
+    await runInspectAction({
+      analyzedFiles: ["src/app.tsx"],
+      skippedCheckReasons: { "lint:partial": "1 file was skipped after the scan budget ran out." },
+    });
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it("exits 0 when a fail-open pass was skipped (supply-chain timeout)", async () => {
+    await runInspectAction({
+      skippedChecks: ["supply-chain"],
+      skippedCheckReasons: { "supply-chain": "Supply-chain analysis timed out and was skipped." },
+    });
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it("exits 0 on a complete clean scan", async () => {
+    await runInspectAction({});
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it("still exits 1 when a complete scan has a blocking finding", async () => {
+    await runInspectAction({ diagnostics: [buildDiagnostic({ severity: "error" })] });
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("keeps `--blocking none` advisory for blocking findings", async () => {
+    await runInspectAction(
+      { diagnostics: [buildDiagnostic({ severity: "error" })] },
+      { blocking: "none" },
+    );
+    expect(process.exitCode).toBeUndefined();
+  });
+});

--- a/packages/react-doctor/tests/user-plugins.test.ts
+++ b/packages/react-doctor/tests/user-plugins.test.ts
@@ -1,9 +1,10 @@
+import * as fs from "node:fs";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
 import { afterAll, describe, expect, it } from "vite-plus/test";
 import { runOxlint } from "@react-doctor/core";
+import { inspect } from "../src/inspect.js";
 import { buildTestProject, setupReactProject } from "./regressions/_helpers.js";
-import * as fs from "node:fs";
 
 const tempRoot = fs.mkdtempSync(path.join(tmpdir(), "rd-user-plugins-"));
 
@@ -109,6 +110,47 @@ describe("user plugins (config.plugins)", () => {
     const userHits = diagnostics.filter((diagnostic) => diagnostic.rule === "no-forbidden-word");
     expect(userHits.length).toBeGreaterThan(0);
     expect(userHits[0].severity).toBe("warning");
+  });
+
+  it("marks lint incomplete when a configured rule throws", async () => {
+    const projectDir = setupReactProject(tempRoot, "throwing-plugin", {
+      files: {
+        "src/App.tsx": `export const App = () => <img src="x" />;\n`,
+        "lint/throwing-plugin.cjs": `
+module.exports = {
+  meta: { name: "team" },
+  rules: {
+    "runtime-rule": {
+      create: () => ({
+        Program() {
+          throw new Error("plugin runtime failure");
+        },
+      }),
+    },
+  },
+};
+`,
+      },
+    });
+    fs.writeFileSync(
+      path.join(projectDir, "doctor.config.json"),
+      JSON.stringify({
+        plugins: ["./lint/throwing-plugin.cjs"],
+        rules: { "team/runtime-rule": "error" },
+      }),
+    );
+
+    const result = await inspect(projectDir, {
+      lint: true,
+      deadCode: false,
+      noScore: true,
+      silent: true,
+    });
+
+    expect(result.skippedChecks).toContain("lint");
+    expect(result.skippedCheckReasons?.lint).toContain("Error running JS plugin");
+    expect(result.analyzedFiles).toEqual([]);
+    expect(result.diagnostics.some((diagnostic) => diagnostic.rule === "alt-text")).toBe(false);
   });
 
   it("skips a plugin that can't be resolved and continues the scan", async () => {


### PR DESCRIPTION
## Why

A configured oxlint plugin can throw while the engine is analyzing a file. Oxlint then emits an engine diagnostic without a rule code, but React Doctor previously accepted the JSON envelope, mapped no finding, and could report a clean successful scan after silently losing the entire lint batch.

CI must not trust a false-clean report when an analyzer did not complete.

Before:

```json
{ "ok": true, "complete": true, "diagnostics": [] }
```

After:

```json
{ "ok": true, "complete": false, "skippedChecks": ["lint"], "diagnostics": [] }
```

The CLI exits 1 for the incomplete report, including under `--blocking none` and score-only output. `ok` remains true because a structured report was produced; `complete` carries analyzer integrity.

## What changed

- reject unmappable oxlint diagnostics before mapping them as ordinary rule findings
- fold plugin runtime errors, syntax diagnostics, empty rule codes, and malformed records into the existing lint-partial-failure path
- centralize `InspectResult` completeness through the existing core `isScanComplete` contract
- exit nonzero whenever any project scan is incomplete
- record incomplete scan outcomes as `status=error`, `complete=false`, and `exitCode=1` in the existing wide event
- add core parser, real throwing-plugin, telemetry, CLI JSON, and changeset coverage

## Compatibility

- JSON report schema remains version 3; no wire fields change
- no new telemetry metric or high-cardinality dimension is introduced
- existing `complete`, `skippedChecks`, and `skippedCheckReasons` fields become authoritative for this failure mode
- patch changeset included for `react-doctor`

## Test plan

- core engine-diagnostic regression: 4 passed
- user-plugin, run-event, and JSON-output regressions: 40 passed
- full core suite: 1,290 passed
- API suite: 19 passed
- CLI suite: 2,205 ordinary tests passed; three unrelated load-sensitive tests failed in the broad parallel run and passed in isolated reruns (two performance harness timeouts and one live stdin prompt race)
- workspace typecheck: 15/15 tasks
- lint and format check pass
- built CLI JSON schema-v3 smoke passes
- manual built-CLI throwing-plugin reproduction returns `complete=false`, a lint skip reason, zero analyzed files, and exit code 1
- changed-project React Doctor scan: 100/100, no issues

## Product guardrail

User job: prevent CI and agents from accepting a clean verdict after configured analyzer failure. Reuses existing completeness/report fields and the existing wide event. Kill invariant: zero authoritative clean reports after an engine diagnostic.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI exit behavior and oxlint output parsing on the critical lint path; mistakes could block pipelines or miss real engine failures, but behavior is heavily tested and scoped to `skippedChecks: ["lint"]` vs advisory partial skips.
> 
> **Overview**
> Stops CI from treating a **failed oxlint run** as a clean scan when a configured plugin or the engine throws. **`parseOxlintOutput`** now treats diagnostics **without a filename** (e.g. `"Error running JS plugin."`) as a hard parse failure, and only maps diagnostics that pass stricter shape checks; routine per-file noise (syntax errors, empty rule codes, bad labels) is **dropped** without failing the whole batch.
> 
> The CLI sets **`exitCode = 1`** when any project has **`skippedChecks: ["lint"]`** (full lint pass failure), including **`--score`**, unless **`--blocking none`**. **`lint:partial`**, **`--no-lint`**, and fail-open skips (supply-chain, etc.) stay advisory. Telemetry wide events use **`outcome.status: error`**, **`complete: false`**, and matching **`exitCode`** via **`hasLintHardFailure`** and **`isInspectResultComplete`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f41685d0444ff4f81e8516c6fb394f41f14bfda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->