### PR TITLE
fix(rules): require Web API receiver provenance

### DIFF
--- a/.changeset/wise-web-apis-prove.md
+++ b/.changeset/wise-web-apis-prove.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Require proven browser API receiver provenance in synchronous XHR and passive event-listener diagnostics.

--- a/packages/core/tests/cross-file-rule-ids.test.ts
+++ b/packages/core/tests/cross-file-rule-ids.test.ts
@@ -135,6 +135,7 @@ describe("CROSS_FILE_RULE_IDS", () => {
 
   it("contains the verified set and nothing the analysis can't justify", () => {
     expect([...CROSS_FILE_RULE_IDS].sort()).toEqual([
+      "client-passive-event-listeners",
       "nextjs-missing-metadata",
       "nextjs-no-use-search-params-without-suspense",
       "no-adjust-state-on-prop-change",

--- a/packages/fuzz/corpus/regressions/client-passive-event-listeners--computed-cancellation.tsx
+++ b/packages/fuzz/corpus/regressions/client-passive-event-listeners--computed-cancellation.tsx
@@ -1,0 +1,7 @@
+// rule: client-passive-event-listeners
+// weakness: cancellation-alias
+// source: ISSUES_TO_FIX_ASAP.md Web API receiver adversarial review
+const cancelEvent = (event: Event) => event["preventDefault"]();
+const target = new EventTarget();
+
+target.addEventListener("wheel", (event) => cancelEvent(event));

--- a/packages/fuzz/corpus/regressions/client-passive-event-listeners--forwarded-event.tsx
+++ b/packages/fuzz/corpus/regressions/client-passive-event-listeners--forwarded-event.tsx
@@ -1,0 +1,6 @@
+// rule: client-passive-event-listeners
+// weakness: event-escape
+// source: React Bench siberiacancode/reactuse useContextMenu
+export const attachGestureHandler = (element: HTMLElement, onMove: (event: Event) => void) => {
+  element.addEventListener("touchmove", (event) => onMove(event));
+};

--- a/packages/fuzz/corpus/regressions/client-passive-event-listeners--shadowed-deferred-api.tsx
+++ b/packages/fuzz/corpus/regressions/client-passive-event-listeners--shadowed-deferred-api.tsx
@@ -1,0 +1,7 @@
+// rule: client-passive-event-listeners
+// weakness: global-provenance
+// source: ISSUES_TO_FIX_ASAP.md Web API receiver adversarial review
+const setTimeout = (callback: () => void) => callback();
+const target = new EventTarget();
+
+target.addEventListener("wheel", (event) => setTimeout(() => onMove(event)));

--- a/packages/fuzz/corpus/regressions/client-passive-event-listeners--unrelated-event-bus.tsx
+++ b/packages/fuzz/corpus/regressions/client-passive-event-listeners--unrelated-event-bus.tsx
@@ -1,0 +1,10 @@
+// rule: client-passive-event-listeners
+// weakness: name-heuristic
+// source: ISSUES_TO_FIX_ASAP.md Web API receiver provenance matrix
+interface GestureBus {
+  addEventListener(eventName: "wheel", handler: (delta: number) => void, priority?: number): void;
+}
+
+export const subscribeToGestureBus = (gestureBus: GestureBus) => {
+  gestureBus.addEventListener("wheel", (delta) => console.log(delta));
+};

--- a/packages/fuzz/corpus/regressions/no-sync-xhr--mutated-browser-receiver.tsx
+++ b/packages/fuzz/corpus/regressions/no-sync-xhr--mutated-browser-receiver.tsx
@@ -1,0 +1,10 @@
+// rule: no-sync-xhr
+// weakness: receiver-provenance
+// source: ISSUES_TO_FIX_ASAP.md Web API receiver adversarial review
+const request = new XMLHttpRequest();
+const replaceOpen = (receiver: XMLHttpRequest) => {
+  receiver.open = customOpen;
+};
+
+replaceOpen(request);
+request.open("GET", "/api", false);

--- a/packages/fuzz/corpus/regressions/no-sync-xhr--unrelated-open-receiver.tsx
+++ b/packages/fuzz/corpus/regressions/no-sync-xhr--unrelated-open-receiver.tsx
@@ -1,0 +1,10 @@
+// rule: no-sync-xhr
+// weakness: name-heuristic
+// source: ISSUES_TO_FIX_ASAP.md Web API receiver provenance matrix
+interface Archive {
+  open(mode: string, path: string, createIfMissing: boolean): void;
+}
+
+export const openExistingArchive = (archive: Archive) => {
+  archive.open("read", "/documents.zip", false);
+};

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -10,6 +10,7 @@
 // Effects — listener pairs (matched and mismatched), observers, rAF loops,
 // timers, async IIFEs with and without cancellation, body mutations.
 export const EFFECT_SNIPPET_POOL = [
+  `useEffect(() => { window.addEventListener("wheel", handle); return () => window.removeEventListener("wheel", handle); }, []);`,
   `useEffect(() => { window.addEventListener("resize", handle); return () => window.removeEventListener("resize", handle); }, []);`,
   `useEffect(() => { window.addEventListener("scroll", handle, { passive: true, capture: true }); return () => window.removeEventListener("scroll", handle, { capture: true }); }, []);`,
   `useEffect(() => { document.addEventListener("keydown", handle); return () => document.removeEventListener("keydown", handle); }, []);`,
@@ -75,6 +76,7 @@ export const STATE_SNIPPET_POOL = [
 // Handlers — async submits with loading flags, keyboard commit paths,
 // numeric input parsing, window.open, clipboard, toggles.
 export const HANDLER_SNIPPET_POOL = [
+  `const handleSyncRequest = () => { const request = new XMLHttpRequest(); request.open("GET", String(url), false); request.send(); };`,
   `const handleSubmit = async () => { setLoading(true); try { await fetch(url, { method: "POST", body: JSON.stringify(values) }); setState(true); } catch (submitError) { setError(submitError); } finally { setLoading(false); } };`,
   `const handleSubmit = async () => { setLoading(true); const result = await api.post(url, values); setState(result); setLoading(false); };`,
   `const handleSave = async () => { if (loading) return; setLoading(true); await api.put(url, values); setLoading(false); };`,

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -10,7 +10,8 @@
 // Effects — listener pairs (matched and mismatched), observers, rAF loops,
 // timers, async IIFEs with and without cancellation, body mutations.
 export const EFFECT_SNIPPET_POOL = [
-  `useEffect(() => { window.addEventListener("wheel", handle); return () => window.removeEventListener("wheel", handle); }, []);`,
+  `useEffect(() => { const handleWheel = () => handle(); window.addEventListener("wheel", handleWheel); return () => window.removeEventListener("wheel", handleWheel); }, []);`,
+  `useEffect(() => { const handleWheel = (event) => handle(event); window.addEventListener("wheel", handleWheel); return () => window.removeEventListener("wheel", handleWheel); }, []);`,
   `useEffect(() => { window.addEventListener("resize", handle); return () => window.removeEventListener("resize", handle); }, []);`,
   `useEffect(() => { window.addEventListener("scroll", handle, { passive: true, capture: true }); return () => window.removeEventListener("scroll", handle, { capture: true }); }, []);`,
   `useEffect(() => { document.addEventListener("keydown", handle); return () => document.removeEventListener("keydown", handle); }, []);`,
@@ -370,6 +371,7 @@ export const FUZZ_FILENAME_POOL = [
   "src/fuzz-widget.server.tsx",
   "next.config.js",
   "src/utils/fuzz-helper.ts",
+  "packages/docs/archive/v1/static/docs.js",
 ] as const;
 
 // Identifiers rules key on by NAME (guard aliases, visibility gates,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/cross-file-rule-ids.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/cross-file-rule-ids.ts
@@ -34,6 +34,7 @@
 // also forces every rule here into the bounded/unbounded classification in
 // `cross-file-dependencies.ts`.
 export const CROSS_FILE_RULE_IDS: ReadonlySet<string> = new Set([
+  "client-passive-event-listeners",
   "no-barrel-import",
   "nextjs-missing-metadata",
   "nextjs-no-use-search-params-without-suspense",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/cross-file-dependencies.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/cross-file-dependencies.test.ts
@@ -209,6 +209,7 @@ describe("no-mutating-reducer-state collector", () => {
 
 describe("effect value helper collectors", () => {
   const affectedRuleIds = [
+    "client-passive-event-listeners",
     "no-adjust-state-on-prop-change",
     "no-derived-state",
     "no-derived-state-effect",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/cross-file-dependencies.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/cross-file-dependencies.ts
@@ -339,6 +339,7 @@ const collectLegacyArchDependencies: CrossFileDependencyCollector = ({ absoluteF
 
 export const CROSS_FILE_DEPENDENCY_COLLECTORS: ReadonlyMap<string, CrossFileDependencyCollector> =
   new Map([
+    ["client-passive-event-listeners", collectEffectValueHelperDependencies],
     ["no-barrel-import", collectNoBarrelImportDependencies],
     ["nextjs-missing-metadata", collectNextjsMissingMetadataDependencies],
     ["nextjs-no-use-search-params-without-suspense", collectNextjsSearchParamsDependencies],

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/client/client-passive-event-listeners.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/client/client-passive-event-listeners.regressions.test.ts
@@ -468,6 +468,27 @@ function attach(el: HTMLElement) {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("does not trust DOM assertions laundered through const aliases", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `const attach = (source) => {
+         const target = source;
+         (target as EventTarget).addEventListener("wheel", () => trackPosition());
+       };`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("keeps constructed DOM receivers proven through asserted const aliases", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `const source = new EventTarget();
+       const target = source;
+       (target as EventTarget).addEventListener("wheel", () => trackPosition());`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("keeps typed DOM parameters proven through redundant assertions", () => {
     const result = runRule(
       clientPassiveEventListeners,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/client/client-passive-event-listeners.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/client/client-passive-event-listeners.regressions.test.ts
@@ -26,7 +26,7 @@ const onDocumentWheel = (callback) => {
   it("stays silent on a referenced handler that calls preventDefault", () => {
     const result = runRule(
       clientPassiveEventListeners,
-      `function setup(el) {
+      `function setup(el: HTMLElement) {
   const onTouchMove = (event) => { event.preventDefault(); doSomething(); };
   el.addEventListener("touchmove", onTouchMove);
 }`,
@@ -38,7 +38,7 @@ const onDocumentWheel = (callback) => {
   it("still flags a referenced handler with no preventDefault", () => {
     const result = runRule(
       clientPassiveEventListeners,
-      `function setup(el) {
+      `function setup(el: HTMLElement) {
   const onWheel = () => { trackPosition(); };
   el.addEventListener("wheel", onWheel);
 }`,
@@ -50,7 +50,7 @@ const onDocumentWheel = (callback) => {
   it("stays silent on a let-declared handler assigned preventDefault after declaration", () => {
     const result = runRule(
       clientPassiveEventListeners,
-      `function setup(el) {
+      `function setup(el: HTMLElement) {
   let onTouchMove;
   onTouchMove = (event) => { event.preventDefault(); };
   el.addEventListener("touchmove", onTouchMove);
@@ -63,7 +63,7 @@ const onDocumentWheel = (callback) => {
   it("still flags a let-declared handler whose later assignment has no preventDefault", () => {
     const result = runRule(
       clientPassiveEventListeners,
-      `function setup(el) {
+      `function setup(el: HTMLElement) {
   let onWheel;
   onWheel = () => { trackPosition(); };
   el.addEventListener("wheel", onWheel);
@@ -76,7 +76,7 @@ const onDocumentWheel = (callback) => {
   it("still flags an outer touchmove handler when only a nested callback calls preventDefault", () => {
     const result = runRule(
       clientPassiveEventListeners,
-      `function setup(el) {
+      `function setup(el: HTMLElement) {
   el.addEventListener("touchmove", () => {
     updateHeader();
     attachDragGuard((dragEvent) => dragEvent.preventDefault());
@@ -92,7 +92,7 @@ const onDocumentWheel = (callback) => {
       clientPassiveEventListeners,
       `class GestureSurface {
   handleMove(event) { event.preventDefault(); }
-  attach(el) { el.addEventListener("touchmove", this.handleMove); }
+  attach(el: HTMLElement) { el.addEventListener("touchmove", this.handleMove); }
 }`,
     );
     expect(result.parseErrors).toEqual([]);
@@ -104,7 +104,7 @@ const onDocumentWheel = (callback) => {
       clientPassiveEventListeners,
       `class Tracker {
   onWheel() { this.record(); }
-  attach(el) { el.addEventListener("wheel", this.onWheel); }
+  attach(el: HTMLElement) { el.addEventListener("wheel", this.onWheel); }
 }`,
     );
     expect(result.parseErrors).toEqual([]);
@@ -116,7 +116,7 @@ const onDocumentWheel = (callback) => {
       clientPassiveEventListeners,
       `class GestureSurface {
   #handleMove(event) { event.preventDefault(); }
-  attach(el) { el.addEventListener("touchmove", this.#handleMove); }
+  attach(el: HTMLElement) { el.addEventListener("touchmove", this.#handleMove); }
 }`,
     );
     expect(result.parseErrors).toEqual([]);
@@ -128,7 +128,7 @@ const onDocumentWheel = (callback) => {
       clientPassiveEventListeners,
       `class Tracker {
   #onWheel() { this.record(); }
-  attach(el) { el.addEventListener("wheel", this.#onWheel); }
+  attach(el: HTMLElement) { el.addEventListener("wheel", this.#onWheel); }
 }`,
     );
     expect(result.parseErrors).toEqual([]);
@@ -140,7 +140,7 @@ const onDocumentWheel = (callback) => {
       clientPassiveEventListeners,
       `const controller = {
   onTouchMove(event) { event.preventDefault(); },
-  attach(el) { el.addEventListener("touchmove", this.onTouchMove); },
+  attach(el: HTMLElement) { el.addEventListener("touchmove", this.onTouchMove); },
 };`,
     );
     expect(result.parseErrors).toEqual([]);
@@ -152,17 +152,17 @@ const onDocumentWheel = (callback) => {
       clientPassiveEventListeners,
       `const controller = {
   onWheel() { this.record(); },
-  attach(el) { el.addEventListener("wheel", this.onWheel); },
+  attach(el: HTMLElement) { el.addEventListener("wheel", this.onWheel); },
 };`,
     );
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics.length).toBeGreaterThan(0);
   });
 
-  it("still flags an unresolved member handler from a parameter (flag unless proven unsafe)", () => {
+  it("still flags an unresolved member handler on a typed DOM target", () => {
     const result = runRule(
       clientPassiveEventListeners,
-      `function attach(el, handlers) {
+      `function attach(el: HTMLElement, handlers) {
   el.addEventListener("wheel", handlers.onWheel);
 }`,
     );
@@ -173,7 +173,7 @@ const onDocumentWheel = (callback) => {
   it("still flags a ref-style `.current` handler with no passive option", () => {
     const result = runRule(
       clientPassiveEventListeners,
-      `function useAttach(el) {
+      `function useAttach(el: HTMLElement) {
   const handlerRef = useRef(() => trackPosition());
   el.addEventListener("wheel", handlerRef.current);
 }`,
@@ -186,7 +186,7 @@ const onDocumentWheel = (callback) => {
     const result = runRule(
       clientPassiveEventListeners,
       `import { onWheel } from "./handlers";
-function attach(el) {
+function attach(el: HTMLElement) {
   el.addEventListener("wheel", onWheel);
 }`,
     );
@@ -197,7 +197,7 @@ function attach(el) {
   it("stays silent on a function-declaration handler that calls preventDefault", () => {
     const result = runRule(
       clientPassiveEventListeners,
-      `function setup(el) {
+      `function setup(el: HTMLElement) {
   function onTouchMove(event) { event.preventDefault(); }
   el.addEventListener("touchmove", onTouchMove);
 }`,
@@ -209,7 +209,7 @@ function attach(el) {
   it("still flags a function-declaration handler with no preventDefault", () => {
     const result = runRule(
       clientPassiveEventListeners,
-      `function setup(el) {
+      `function setup(el: HTMLElement) {
   function onTouchMove(event) { doStuff(event); }
   el.addEventListener("touchmove", onTouchMove);
 }`,
@@ -221,7 +221,7 @@ function attach(el) {
   it("stays silent on an explicit { passive: false } opt-out", () => {
     const result = runRule(
       clientPassiveEventListeners,
-      `function attach(el) {
+      `function attach(el: HTMLElement) {
   el.addEventListener("touchmove", (event) => track(event), { passive: false });
 }`,
     );
@@ -232,7 +232,7 @@ function attach(el) {
   it("stays silent on an explicit { passive: true }", () => {
     const result = runRule(
       clientPassiveEventListeners,
-      `function attach(el) {
+      `function attach(el: HTMLElement) {
   el.addEventListener("wheel", (event) => track(event), { passive: true });
 }`,
     );
@@ -243,7 +243,7 @@ function attach(el) {
   it("still flags an options object without a passive key", () => {
     const result = runRule(
       clientPassiveEventListeners,
-      `function attach(el) {
+      `function attach(el: HTMLElement) {
   el.addEventListener("wheel", (event) => track(event), { capture: true });
 }`,
     );
@@ -254,7 +254,7 @@ function attach(el) {
   it("stays silent on a scroll listener (scroll is not cancelable, passive is a no-op)", () => {
     const result = runRule(
       clientPassiveEventListeners,
-      `function attach(el) {
+      `function attach(el: HTMLElement) {
   el.addEventListener("scroll", () => updateHeader());
 }`,
     );
@@ -265,7 +265,7 @@ function attach(el) {
   it("stays silent on a touchend listener (touchend does not block scroll starts)", () => {
     const result = runRule(
       clientPassiveEventListeners,
-      `function attach(el) {
+      `function attach(el: HTMLElement) {
   el.addEventListener("touchend", (event) => finishGesture(event));
 }`,
     );
@@ -280,5 +280,98 @@ function attach(el) {
     );
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent on an unrelated typed event bus", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `interface GestureBus {
+        addEventListener(eventName: "wheel", handler: (delta: number) => void, priority?: number): void;
+      }
+      const subscribe = (gestureBus: GestureBus) => {
+        gestureBus.addEventListener("wheel", (delta) => track(delta));
+      };`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent on an unresolved receiver", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `const subscribe = (target) => target.addEventListener("wheel", handleWheel);`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("flags typed DOM targets and nullable unions", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `const subscribe = (element: HTMLElement, target: EventTarget | null) => {
+        element.addEventListener("wheel", handleWheel);
+        target?.addEventListener("touchmove", handleTouchMove);
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
+  it("does not trust a shadowed DOM type name", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `interface HTMLElement {
+        addEventListener(eventName: "wheel", handler: () => void, priority?: number): void;
+      }
+      const subscribe = (element: HTMLElement) => {
+        element.addEventListener("wheel", handleWheel);
+      };`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("flags global DOM targets and DOM acquisition aliases", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `window.addEventListener("wheel", handleWheel);
+       document.addEventListener("touchmove", handleTouchMove);
+       const found = document.querySelector("main");
+       const firstAlias = found;
+       const secondAlias = firstAlias;
+       secondAlias?.addEventListener("wheel", handleWheel);`,
+    );
+    expect(result.diagnostics).toHaveLength(3);
+  });
+
+  it("flags global EventTarget constructions and constructor aliases", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `const Target = EventTarget;
+       const first = new EventTarget();
+       const second = new Target();
+       first.addEventListener("wheel", handleWheel);
+       second.addEventListener("touchmove", handleTouchMove);`,
+    );
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
+  it("does not trust a shadowed EventTarget constructor", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `class EventTarget {
+        addEventListener(eventName: string, handler: () => void, priority?: number) {}
+      }
+      new EventTarget().addEventListener("wheel", handleWheel);`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("flags typed React ref targets through aliases", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `import { useRef } from "react";
+       const elementRef = useRef<HTMLDivElement | null>(null);
+       const alias = elementRef;
+       alias.current?.addEventListener("wheel", handleWheel);`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
   });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/client/client-passive-event-listeners.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/client/client-passive-event-listeners.regressions.test.ts
@@ -1,6 +1,24 @@
-import { describe, expect, it } from "vite-plus/test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vite-plus/test";
 import { runRule } from "../../../test-utils/run-rule.js";
 import { clientPassiveEventListeners } from "./client-passive-event-listeners.js";
+
+const temporaryDirectories: string[] = [];
+
+const writeImportedPredicate = (source: string): string => {
+  const directory = mkdtempSync(join(tmpdir(), "react-doctor-passive-predicate-"));
+  temporaryDirectories.push(directory);
+  writeFileSync(join(directory, "events.ts"), source);
+  return join(directory, "consumer.ts");
+};
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { force: true, recursive: true });
+  }
+});
 
 describe("client/client-passive-event-listeners — regressions", () => {
   it("still flags the inline rAF-throttled wheel handler", () => {
@@ -60,7 +78,7 @@ const onDocumentWheel = (callback) => {
     expect(result.diagnostics).toEqual([]);
   });
 
-  it("still flags a let-declared handler whose later assignment has no preventDefault", () => {
+  it("still flags an assigned safe handler", () => {
     const result = runRule(
       clientPassiveEventListeners,
       `function setup(el: HTMLElement) {
@@ -170,7 +188,7 @@ const onDocumentWheel = (callback) => {
     expect(result.diagnostics.length).toBeGreaterThan(0);
   });
 
-  it("still flags a ref-style `.current` handler with no passive option", () => {
+  it("still flags an unresolved ref-style `.current` handler", () => {
     const result = runRule(
       clientPassiveEventListeners,
       `function useAttach(el: HTMLElement) {
@@ -182,7 +200,7 @@ const onDocumentWheel = (callback) => {
     expect(result.diagnostics.length).toBeGreaterThan(0);
   });
 
-  it("still flags an imported identifier handler (symmetric with member handlers)", () => {
+  it("still flags an imported identifier handler", () => {
     const result = runRule(
       clientPassiveEventListeners,
       `import { onWheel } from "./handlers";
@@ -206,7 +224,7 @@ function attach(el: HTMLElement) {
     expect(result.diagnostics).toEqual([]);
   });
 
-  it("still flags a function-declaration handler with no preventDefault", () => {
+  it("stays silent when a function-declaration handler forwards the event", () => {
     const result = runRule(
       clientPassiveEventListeners,
       `function setup(el: HTMLElement) {
@@ -215,7 +233,7 @@ function attach(el: HTMLElement) {
 }`,
     );
     expect(result.parseErrors).toEqual([]);
-    expect(result.diagnostics.length).toBeGreaterThan(0);
+    expect(result.diagnostics).toEqual([]);
   });
 
   it("stays silent on an explicit { passive: false } opt-out", () => {
@@ -240,11 +258,11 @@ function attach(el: HTMLElement) {
     expect(result.diagnostics).toEqual([]);
   });
 
-  it("still flags an options object without a passive key", () => {
+  it("still flags an options object without a passive key for a proven-safe handler", () => {
     const result = runRule(
       clientPassiveEventListeners,
       `function attach(el: HTMLElement) {
-  el.addEventListener("wheel", (event) => track(event), { capture: true });
+  el.addEventListener("wheel", () => trackPosition(), { capture: true });
 }`,
     );
     expect(result.parseErrors).toEqual([]);
@@ -308,8 +326,8 @@ function attach(el: HTMLElement) {
     const result = runRule(
       clientPassiveEventListeners,
       `const subscribe = (element: HTMLElement, target: EventTarget | null) => {
-        element.addEventListener("wheel", handleWheel);
-        target?.addEventListener("touchmove", handleTouchMove);
+        element.addEventListener("wheel", () => trackPosition());
+        target?.addEventListener("touchmove", () => trackPosition());
       };`,
     );
     expect(result.diagnostics).toHaveLength(2);
@@ -331,12 +349,12 @@ function attach(el: HTMLElement) {
   it("flags global DOM targets and DOM acquisition aliases", () => {
     const result = runRule(
       clientPassiveEventListeners,
-      `window.addEventListener("wheel", handleWheel);
-       document.addEventListener("touchmove", handleTouchMove);
+      `window.addEventListener("wheel", () => trackPosition());
+       document.addEventListener("touchmove", () => trackPosition());
        const found = document.querySelector("main");
        const firstAlias = found;
        const secondAlias = firstAlias;
-       secondAlias?.addEventListener("wheel", handleWheel);`,
+       secondAlias?.addEventListener("wheel", () => trackPosition());`,
     );
     expect(result.diagnostics).toHaveLength(3);
   });
@@ -347,8 +365,8 @@ function attach(el: HTMLElement) {
       `const Target = EventTarget;
        const first = new EventTarget();
        const second = new Target();
-       first.addEventListener("wheel", handleWheel);
-       second.addEventListener("touchmove", handleTouchMove);`,
+       first.addEventListener("wheel", () => trackPosition());
+       second.addEventListener("touchmove", () => trackPosition());`,
     );
     expect(result.diagnostics).toHaveLength(2);
   });
@@ -370,8 +388,831 @@ function attach(el: HTMLElement) {
       `import { useRef } from "react";
        const elementRef = useRef<HTMLDivElement | null>(null);
        const alias = elementRef;
-       alias.current?.addEventListener("wheel", handleWheel);`,
+       alias.current?.addEventListener("wheel", () => trackPosition());`,
     );
     expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays silent after addEventListener is replaced", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `const target = new EventTarget();
+       target.addEventListener = ((...args: unknown[]) => {}) as EventTarget["addEventListener"];
+       target.addEventListener("wheel", () => trackPosition());`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("follows aliases when checking for addEventListener replacement", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `const target = new EventTarget();
+       const alias = target;
+       alias.addEventListener = ((...args: unknown[]) => {}) as EventTarget["addEventListener"];
+       target.addEventListener("wheel", () => trackPosition());`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("follows EventTarget escapes through aliases and containers", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `const first = new EventTarget();
+       const firstAlias = first;
+       customize(firstAlias);
+       first.addEventListener("wheel", () => trackPosition());
+
+       const second = new EventTarget();
+       customize({ second });
+       second.addEventListener("wheel", () => trackPosition());
+
+       const third = new EventTarget();
+       const registry = {};
+       registry.target = third;
+       customize(registry);
+       third.addEventListener("wheel", () => trackPosition());`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still reports when addEventListener is replaced only after registration", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `const target = new EventTarget();
+       target.addEventListener("wheel", () => trackPosition());
+       target.addEventListener = ((...args: unknown[]) => {}) as EventTarget["addEventListener"];`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags DOM type assertions and asserted initializers", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `(getTarget() as HTMLElement).addEventListener("wheel", () => trackPosition());
+       const element = getTarget() satisfies Element;
+       element.addEventListener("touchmove", () => trackPosition());`,
+    );
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
+  it("does not trust DOM assertions on mutable bindings, parameters, or members", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `let mutableTarget = customTarget;
+       (mutableTarget as EventTarget).addEventListener("wheel", handleWheel);
+       const attach = (target) => {
+         (target as EventTarget).addEventListener("wheel", handleWheel);
+       };
+       (holder.target as EventTarget).addEventListener("wheel", handleWheel);`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("keeps typed DOM parameters proven through redundant assertions", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `const attach = (target: EventTarget) => {
+         (target as EventTarget).addEventListener("wheel", () => trackPosition());
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags destructured DOM target parameters", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `const attach = ({ element }: { element: HTMLElement }) => {
+         element.addEventListener("wheel", () => trackPosition());
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags DOM class fields by initializer and annotation", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `class View {
+         first = document.createElement("div");
+         second: HTMLElement;
+         attach() {
+           this.first.addEventListener("wheel", () => trackPosition());
+           this.second.addEventListener("touchmove", () => trackPosition());
+         }
+       }`,
+    );
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
+  it("flags same-file factories that return DOM targets", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `const createTarget = () => document.createElement("div");
+       function makeTarget() { return createTarget(); }
+       makeTarget().addEventListener("wheel", () => trackPosition());`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not trust invented DOM-looking interface names", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `interface HTMLGestureElement {
+         addEventListener(eventName: "wheel", handler: () => void, priority?: number): void;
+       }
+       const attach = (element: HTMLGestureElement) => {
+         element.addEventListener("wheel", handleWheel);
+       };`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent when an inline handler forwards the event", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `const target = new EventTarget();
+       target.addEventListener("wheel", (event) => onMove(event));`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent on generated archived documentation bundles", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `document.addEventListener("touchmove", this.handleMove);`,
+      { filename: "/repo/packages/skin/docs/archive/v6.3/static/ds4/docs.js" },
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still reports the same code in authored source", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `document.addEventListener("touchmove", this.handleMove);`,
+      { filename: "/repo/src/docs.js" },
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still reports authored source beside generated archived documentation", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `document.addEventListener("touchmove", () => trackPosition());`,
+      { filename: "/repo/packages/skin/docs/archive/v6.3/static/ds4/authored-feature.ts" },
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("follows local handlers that forward the event to an unknown callback", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `const target = new EventTarget();
+       const forwardEvent = (event: Event) => optionsRef.current?.onMove(event);
+       const handleMove = (event: Event) => forwardEvent(event);
+       target.addEventListener("touchmove", handleMove);`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("follows asserted aliases when a handler forwards the event", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `const target = new EventTarget();
+       const handleMove = (event: Event) => {
+         const touchEvent = event as TouchEvent;
+         optionsRef.current?.onMove(touchEvent);
+       };
+       target.addEventListener("touchmove", handleMove);`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still reports when a handler forwards only an event property", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `const target = new EventTarget();
+       target.addEventListener("wheel", (event: WheelEvent) => onMove(event.deltaY));`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still reports when a handler only reads event properties", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `const target = new EventTarget();
+       const handleMove = (event: TouchEvent) => {
+         const touch = event.touches[0];
+         updatePosition(touch.clientX, touch.clientY);
+       };
+       target.addEventListener("touchmove", handleMove);`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not prove a mixed-return DOM factory", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `class GestureBus { addEventListener() {} }
+       const makeTarget = (native: boolean) => native ? document.body : new GestureBus();
+       makeTarget(false).addEventListener("wheel", () => trackPosition());`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("proves a factory only when every return is a DOM target", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `const makeTarget = (useBody: boolean) => useBody ? document.body : document.documentElement;
+       makeTarget(false).addEventListener("wheel", () => trackPosition());`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("recognizes representative built-in HTML and SVG element types", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `const attach = (audio: HTMLAudioElement, circle: SVGCircleElement) => {
+         audio.addEventListener("wheel", () => trackPosition());
+         circle.addEventListener("touchmove", () => trackPosition());
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
+  it("stays silent after a class receiver field is reassigned", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `class GestureBus { addEventListener() {} }
+       class View {
+         target = document.body;
+         attach() {
+           this.target = new GestureBus();
+           this.target.addEventListener("wheel", () => trackPosition());
+         }
+       }`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still reports when a class receiver field is reassigned only after registration", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `class GestureBus { addEventListener() {} }
+       class View {
+         target = document.body;
+         attach() {
+           this.target.addEventListener("wheel", () => trackPosition());
+           this.target = new GestureBus();
+         }
+       }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not bind nested ordinary-function this to the outer class", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `class View {
+         target = document.body;
+         attach() {
+           function register() {
+             this.target.addEventListener("wheel", () => trackPosition());
+           }
+           register.call({ target: new EventTarget() });
+         }
+       }`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still binds arrow-function this to the outer class", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `class View {
+         target = document.body;
+         attach() {
+           const register = () => this.target.addEventListener("wheel", () => trackPosition());
+           register();
+         }
+       }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays silent when a method is replaced before a declared function runs", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `const target = new EventTarget();
+       function attach() {
+         target.addEventListener("wheel", () => trackPosition());
+       }
+       target.addEventListener = customListener;
+       attach();`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still reports after a non-dominating conditional method replacement", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `const target = new EventTarget();
+       if (replaceListener) target.addEventListener = customListener;
+       target.addEventListener("wheel", () => trackPosition());`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays silent after EventTarget prototype replacement", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `EventTarget.prototype.addEventListener = customListener;
+       const target = new EventTarget();
+       target.addEventListener("wheel", () => trackPosition());`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("follows event escape through synchronous nested callbacks", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `const target = new EventTarget();
+       target.addEventListener("wheel", (event) => {
+         (() => onMove(event))();
+         [onMove].forEach((callback) => callback(event));
+       });`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("ignores event escape through a deferred callback", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `const target = new EventTarget();
+       target.addEventListener("wheel", (event) => {
+         requestAnimationFrame(() => onMove(event));
+       });`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("tracks separate parameter indexes for the same helper", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `const forward = (first: unknown, second: Event) => onMove(second);
+       const target = new EventTarget();
+       target.addEventListener("wheel", (event) => {
+         forward(event, 0);
+         forward(0, event);
+       });`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("detects wrapped, spread, and assignment-based event escape", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `const first = new EventTarget();
+       first.addEventListener("wheel", (event) => onMove({ event }));
+       const second = new EventTarget();
+       second.addEventListener("wheel", (event) => onMove([event]));
+       const third = new EventTarget();
+       third.addEventListener("wheel", (event) => onMove(...[event]));
+       const fourth = new EventTarget();
+       fourth.addEventListener("wheel", (event) => {
+         let alias;
+         alias = event;
+         onMove(alias);
+       });`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("conservatively follows wrapped events into destructured helper parameters", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `const forward = ({ event }: { event: Event }) => onMove(event);
+       const target = new EventTarget();
+       target.addEventListener("wheel", (event) => forward({ event }));`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still reports a root handler that only destructures event properties", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `const target = new EventTarget();
+       target.addEventListener("wheel", ({ target }) => track(target));`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("resolves an assigned safe handler", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `let handler;
+       handler = (event: WheelEvent) => track(event.deltaY);
+       const target = new EventTarget();
+       target.addEventListener("wheel", handler);`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still reports when a proven-pure imported predicate only classifies the event", () => {
+    const filename = writeImportedPredicate(
+      `export const isTouchEvent = (event: Event): boolean => "touches" in event;`,
+    );
+    const result = runRule(
+      clientPassiveEventListeners,
+      `import { isTouchEvent } from "./events";
+       const target = new EventTarget();
+       target.addEventListener("touchmove", (event) => {
+         const point = isTouchEvent(event) ? event.touches[0] : event;
+         track(point.clientX);
+       });`,
+      { filename },
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still reports when an imported predicate passes only a derived scalar", () => {
+    const filename = writeImportedPredicate(
+      `export const isWheelEvent = (event: Event): boolean => Boolean(event.type);`,
+    );
+    const result = runRule(
+      clientPassiveEventListeners,
+      `import { isWheelEvent } from "./events";
+       const target = new EventTarget();
+       target.addEventListener("wheel", (event) => {
+         if (isWheelEvent(event)) track();
+       });`,
+      { filename },
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays silent when an imported predicate can cancel the event", () => {
+    const filename = writeImportedPredicate(
+      `export const isTouchEvent = (event: Event): boolean => {
+         event.preventDefault();
+         return true;
+       };`,
+    );
+    const result = runRule(
+      clientPassiveEventListeners,
+      `import { isTouchEvent } from "./events";
+       const target = new EventTarget();
+       target.addEventListener("touchmove", (event) => {
+         if (isTouchEvent(event)) track();
+       });`,
+      { filename },
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent when an imported predicate cancels through aliases", () => {
+    const filename = writeImportedPredicate(
+      `export const isTouchEvent = (event: Event): boolean => {
+         const first = event;
+         const second = first;
+         second.preventDefault();
+         return true;
+       };`,
+    );
+    const result = runRule(
+      clientPassiveEventListeners,
+      `import { isTouchEvent } from "./events";
+       const target = new EventTarget();
+       target.addEventListener("touchmove", (event) => {
+         if (isTouchEvent(event)) track();
+       });`,
+      { filename },
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent when an imported callable consumes the event", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `import { onMove } from "./events";
+       const target = new EventTarget();
+       target.addEventListener("touchmove", (event) => onMove(event));`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent on computed and helper-mediated cancellation", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `const cancel = (event: Event) => event["preventDefault"]();
+       const forward = (event: Event) => cancel(event);
+       const target = new EventTarget();
+       target.addEventListener("wheel", (event) => forward(event));`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("recognizes legacy returnValue cancellation", () => {
+    const cancelling = runRule(
+      clientPassiveEventListeners,
+      `const target = new EventTarget();
+       target.addEventListener("wheel", (event) => { event.returnValue = false; });`,
+    );
+    const nonCancelling = runRule(
+      clientPassiveEventListeners,
+      `const target = new EventTarget();
+       target.addEventListener("wheel", (event) => { event.returnValue = true; });`,
+    );
+    expect(cancelling.diagnostics).toEqual([]);
+    expect(nonCancelling.diagnostics).toHaveLength(1);
+  });
+
+  it("does not trust a shadowed deferred callback name", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `const setTimeout = (callback: () => void) => callback();
+       const target = new EventTarget();
+       target.addEventListener("wheel", (event) => setTimeout(() => onMove(event)));`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("recognizes callbacks deferred by proven Promise receivers", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `const target = new EventTarget();
+       target.addEventListener("wheel", (event) => {
+         Promise.resolve().then(() => onMove(event));
+       });`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("recognizes callbacks deferred by aliased and chained proven Promises", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `const target = new EventTarget();
+       const pending = Promise.resolve();
+       target.addEventListener("wheel", (event) => {
+         pending.then(() => true).then(() => onMove(event));
+       });`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("recognizes callbacks registered on proven EventTarget receivers", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `const target = new EventTarget();
+       target.addEventListener("wheel", (event) => {
+         window.addEventListener("click", () => onMove(event));
+       });`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("invalidates an assigned handler after an opaque reassignment", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `import { external } from "./events";
+       let handler;
+       handler = (event: WheelEvent) => track(event.deltaY);
+       if (condition) handler = external;
+       const target = new EventTarget();
+       target.addEventListener("wheel", handler);`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not prove reassigned EventTarget factories", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `let make = () => new EventTarget();
+       make = () => custom;
+       make().addEventListener("wheel", () => track());`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("recognizes EventTarget mutations on factory return values", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `const make = () => {
+         const target = new EventTarget();
+         target.addEventListener = customListener;
+         return target;
+       };
+       make().addEventListener("wheel", () => track());`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("tracks event aliases introduced by object and array destructuring", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `const target = new EventTarget();
+       target.addEventListener("wheel", (event) => {
+         const { value: firstAlias } = { value: event };
+         const [secondAlias] = [firstAlias];
+         onMove(secondAlias);
+       });`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("distinguishes synchronous Promise executors from deferred Promise callbacks", () => {
+    const synchronous = runRule(
+      clientPassiveEventListeners,
+      `const target = new EventTarget();
+       target.addEventListener("wheel", (event) => {
+         new Promise(() => onMove(event));
+       });`,
+    );
+    const deferred = runRule(
+      clientPassiveEventListeners,
+      `const later = async () => {};
+       const alias = later;
+       const target = new EventTarget();
+       target.addEventListener("wheel", (event) => {
+         alias().then(() => onMove(event));
+         Promise.reject().catch(() => onMove(event));
+         Promise.resolve().finally(() => onMove(event));
+       });`,
+    );
+    expect(synchronous.diagnostics).toEqual([]);
+    expect(deferred.diagnostics).toHaveLength(1);
+  });
+
+  it("recognizes aliased proven deferred callback APIs", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `const defer = requestAnimationFrame;
+       const target = new EventTarget();
+       target.addEventListener("wheel", (event) => defer(() => onMove(event)));`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("audits the imported predicate parameter that receives the event", () => {
+    const filename = writeImportedPredicate(
+      `export const isWheelEvent = (mode: string, event: Event): boolean => {
+         event.preventDefault();
+         return mode === "wheel";
+       };`,
+    );
+    const result = runRule(
+      clientPassiveEventListeners,
+      `import { isWheelEvent } from "./events";
+       const target = new EventTarget();
+       target.addEventListener("wheel", (event) => {
+         if (isWheelEvent("wheel", event)) track();
+       });`,
+      { filename },
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("recognizes EventTarget mutations across branches and constructors", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `const first = new EventTarget();
+       if (condition) first.addEventListener = firstListener;
+       else first.addEventListener = secondListener;
+       first.addEventListener("wheel", () => track());
+
+       class View {
+         target = new EventTarget();
+         constructor() { this.target.addEventListener = customListener; }
+         run() { this.target.addEventListener("wheel", () => track()); }
+       }
+       new View().run();`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("recognizes specific and reflected EventTarget prototype replacement", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `Window.prototype.addEventListener = customListener;
+       window.addEventListener("wheel", () => track());
+       Document.prototype.addEventListener = customListener;
+       document.addEventListener("wheel", () => track());
+       HTMLElement.prototype.addEventListener = customListener;
+       document.body.addEventListener("wheel", () => track());
+       Reflect.defineProperty(EventTarget.prototype, "addEventListener", {
+         value: customListener,
+       });
+       new EventTarget().addEventListener("wheel", () => track());`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("retains findings after proven native EventTarget replacement", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `let first: EventTarget = new EventTarget();
+       first = first;
+       first.addEventListener("wheel", () => track());
+       let second: EventTarget = new EventTarget();
+       second = new EventTarget();
+       second.addEventListener("wheel", () => track());`,
+    );
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
+  it("recognizes typed DOM receiver prototype replacement", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `HTMLElement.prototype.addEventListener = customListener;
+       const attach = (target: HTMLElement) => {
+         target.addEventListener("wheel", () => track());
+       };
+       Element.prototype.addEventListener = customListener;
+       document.querySelector("main")?.addEventListener("wheel", () => track());`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("tracks rest aliases and inline wrapper extraction", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `const target = new EventTarget();
+       target.addEventListener("wheel", (event) => {
+         const { ...box } = { event };
+         const [...items] = [event];
+         onMove(box.event);
+         onMove(items[0]);
+         onMove(({ value: event }).value);
+         onMove([event][0]);
+       });`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("treats event constructor arguments as synchronous exposure", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `new EventTarget().addEventListener("wheel", (event) => {
+         new Handler(event);
+       });`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("tracks destructured aliases in imported predicates", () => {
+    const filename = writeImportedPredicate(
+      `export const isWheelEvent = (event: Event): boolean => {
+         const { value: firstAlias } = { value: event };
+         const [secondAlias] = [firstAlias];
+         secondAlias.preventDefault();
+         return true;
+       };`,
+    );
+    const result = runRule(
+      clientPassiveEventListeners,
+      `import { isWheelEvent } from "./events";
+       new EventTarget().addEventListener("wheel", (event) => {
+         if (isWheelEvent(event)) track();
+       });`,
+      { filename },
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("follows EventTarget escapes through object spreads", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `const target = new EventTarget();
+       const box = { ...target };
+       customize(box);
+       target.addEventListener("wheel", () => track());`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("tracks constructor exposure inside synchronous nested callbacks", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `new EventTarget().addEventListener("wheel", (event) => {
+         runNow(() => new Handler(event));
+       });`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("rejects imported predicates that pass events to constructors", () => {
+    const filename = writeImportedPredicate(
+      `export const isWheelEvent = (event: Event): boolean => {
+         new Handler(event);
+         return true;
+       };`,
+    );
+    const result = runRule(
+      clientPassiveEventListeners,
+      `import { isWheelEvent } from "./events";
+       new EventTarget().addEventListener("wheel", (event) => {
+         if (isWheelEvent(event)) track();
+       });`,
+      { filename },
+    );
+    expect(result.diagnostics).toEqual([]);
   });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/client/client-passive-event-listeners.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/client/client-passive-event-listeners.regressions.test.ts
@@ -359,6 +359,27 @@ function attach(el: HTMLElement) {
     expect(result.diagnostics).toHaveLength(3);
   });
 
+  it("flags an un-reassigned let receiver with a proven DOM initializer", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `let el = document.createElement("div");
+       el.addEventListener("wheel", handleWheel);`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not trust a reassigned let receiver with a proven DOM initializer", () => {
+    const result = runRule(
+      clientPassiveEventListeners,
+      `let el = document.createElement("div");
+       el = getCustomTarget();
+       el.addEventListener("wheel", handleWheel);`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("flags global EventTarget constructions and constructor aliases", () => {
     const result = runRule(
       clientPassiveEventListeners,
@@ -908,6 +929,65 @@ function attach(el: HTMLElement) {
       { filename },
     );
     expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent when an imported predicate cancels inside a synchronous callback", () => {
+    const filename = writeImportedPredicate(
+      `export const isTouchEvent = (event: Event): boolean => {
+         [1].forEach(() => event.preventDefault());
+         return true;
+       };`,
+    );
+    const result = runRule(
+      clientPassiveEventListeners,
+      `import { isTouchEvent } from "./events";
+       const target = new EventTarget();
+       target.addEventListener("touchmove", (event) => {
+         if (isTouchEvent(event)) track();
+       });`,
+      { filename },
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent when an imported predicate cancels inside an IIFE", () => {
+    const filename = writeImportedPredicate(
+      `export const isTouchEvent = (event: Event): boolean => {
+         (() => {
+           event.preventDefault();
+         })();
+         return true;
+       };`,
+    );
+    const result = runRule(
+      clientPassiveEventListeners,
+      `import { isTouchEvent } from "./events";
+       const target = new EventTarget();
+       target.addEventListener("touchmove", (event) => {
+         if (isTouchEvent(event)) track();
+       });`,
+      { filename },
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still reports when an imported predicate only runs event-free nested callbacks", () => {
+    const filename = writeImportedPredicate(
+      `export const isTouchEvent = (event: Event): boolean => {
+         ["touchstart", "touchmove"].forEach((eventName) => registerSeenEvent(eventName));
+         return "touches" in event;
+       };`,
+    );
+    const result = runRule(
+      clientPassiveEventListeners,
+      `import { isTouchEvent } from "./events";
+       const target = new EventTarget();
+       target.addEventListener("touchmove", (event) => {
+         if (isTouchEvent(event)) track();
+       });`,
+      { filename },
+    );
+    expect(result.diagnostics).toHaveLength(1);
   });
 
   it("stays silent when an imported callable consumes the event", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/client/client-passive-event-listeners.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/client/client-passive-event-listeners.ts
@@ -697,21 +697,19 @@ export const clientPassiveEventListeners = defineRule({
       if (doesHandlerExposeEvent) return;
 
       const optionsArgument = node.arguments[2];
-      if (!optionsArgument) {
-        context.report({
-          node,
-          message: `"${eventName}" listener without { passive: true } makes scrolling janky for your users. Only add it if the handler doesn't call event.preventDefault(), since passive listeners silently ignore preventDefault().`,
-        });
-        return;
+      if (optionsArgument) {
+        if (!isNodeOfType(optionsArgument, "ObjectExpression")) return;
+        if (
+          hasExplicitPassiveValue(optionsArgument, false) ||
+          hasExplicitPassiveValue(optionsArgument, true)
+        ) {
+          return;
+        }
       }
-      if (!isNodeOfType(optionsArgument, "ObjectExpression")) return;
-      if (hasExplicitPassiveValue(optionsArgument, false)) return;
-      if (!hasExplicitPassiveValue(optionsArgument, true)) {
-        context.report({
-          node,
-          message: `"${eventName}" listener without { passive: true } makes scrolling janky for your users. Only add it if the handler doesn't call event.preventDefault(), since passive listeners silently ignore preventDefault().`,
-        });
-      }
+      context.report({
+        node,
+        message: `"${eventName}" listener without { passive: true } makes scrolling janky for your users. Only add it if the handler doesn't call event.preventDefault(), since passive listeners silently ignore preventDefault().`,
+      });
     };
     return {
       AssignmentExpression(node: EsTreeNode) {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/client/client-passive-event-listeners.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/client/client-passive-event-listeners.ts
@@ -2,12 +2,14 @@ import { PASSIVE_EVENT_NAMES } from "../../constants/dom.js";
 import { defineRule } from "../../utils/define-rule.js";
 import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
 import { isMemberProperty } from "../../utils/is-member-property.js";
+import { isProvenBrowserApiReceiver } from "../../utils/is-proven-browser-api-receiver.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { walkAst } from "../../utils/walk-ast.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 
 // A handler that calls `event.preventDefault()` MUST run non-passively —
 // passive listeners silently ignore preventDefault(). Recommending
@@ -186,7 +188,9 @@ export const clientPassiveEventListeners = defineRule({
     "Add `{ passive: true }` as the third argument: `addEventListener('touchmove', handler, { passive: true })`. Only do this if the handler doesn't call `event.preventDefault()`, since passive listeners ignore it (which breaks pull-to-refresh, custom gestures, and nested scrolling).",
   create: (context: RuleContext) => ({
     CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
-      if (!isMemberProperty(node.callee, "addEventListener")) return;
+      const callee = stripParenExpression(node.callee);
+      if (!isMemberProperty(callee, "addEventListener")) return;
+      if (!isProvenBrowserApiReceiver(callee.object, "dom-event-target", context.scopes)) return;
       if ((node.arguments?.length ?? 0) < 2) return;
 
       const eventNameNode = node.arguments[0];

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/client/client-passive-event-listeners.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/client/client-passive-event-listeners.ts
@@ -1,15 +1,43 @@
 import { PASSIVE_EVENT_NAMES } from "../../constants/dom.js";
 import { defineRule } from "../../utils/define-rule.js";
 import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
-import { isMemberProperty } from "../../utils/is-member-property.js";
-import { isProvenBrowserApiReceiver } from "../../utils/is-proven-browser-api-receiver.js";
+import { getDirectConstInitializer } from "../../utils/get-direct-const-initializer.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { createMethodMutationAnalysis } from "../../utils/has-proven-method-mutation.js";
+import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
+import { isMemberProperty } from "../../utils/is-member-property.js";
+import {
+  getProvenDomEventTargetPrototypeOwnerNames,
+  isProvenBrowserApiReceiver,
+} from "../../utils/is-proven-browser-api-receiver.js";
+import { isGeneratedDocsArchiveFilename } from "../../utils/is-generated-docs-archive-filename.js";
+import { isProvenPureImportedPredicateCall } from "../../utils/is-proven-pure-imported-predicate-call.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import type { RuleVisitors } from "../../utils/rule-visitors.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
-import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { walkAst } from "../../utils/walk-ast.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+
+const DEFERRED_CALLBACK_API_NAMES = new Set([
+  "queueMicrotask",
+  "requestAnimationFrame",
+  "requestIdleCallback",
+  "setImmediate",
+  "setInterval",
+  "setTimeout",
+]);
+const PROMISE_FACTORY_METHOD_NAMES = new Set([
+  "all",
+  "allSettled",
+  "any",
+  "race",
+  "reject",
+  "resolve",
+]);
+const PROMISE_DEFERRED_METHOD_NAMES = new Set(["catch", "finally", "then"]);
+const EMPTY_VISITORS: RuleVisitors = {};
 
 // A handler that calls `event.preventDefault()` MUST run non-passively —
 // passive listeners silently ignore preventDefault(). Recommending
@@ -27,8 +55,7 @@ const handlerCallsPreventDefault = (handler: EsTreeNode | undefined): boolean =>
     if (
       isNodeOfType(child, "CallExpression") &&
       isNodeOfType(child.callee, "MemberExpression") &&
-      isNodeOfType(child.callee.property, "Identifier") &&
-      child.callee.property.name === "preventDefault"
+      getStaticPropertyName(child.callee) === "preventDefault"
     ) {
       didFindPreventDefault = true;
     }
@@ -161,6 +188,439 @@ const handlerArgumentCallsPreventDefault = (handler: EsTreeNode | undefined): bo
   return false;
 };
 
+const resolveHandlerFunction = (
+  handler: EsTreeNode | undefined,
+  context: RuleContext,
+): EsTreeNode | undefined => {
+  if (!handler) return undefined;
+  const unwrappedHandler = stripParenExpression(handler);
+  if (isFunctionLike(unwrappedHandler)) return unwrappedHandler;
+  if (isNodeOfType(unwrappedHandler, "Identifier")) {
+    const symbol = context.scopes.symbolFor(unwrappedHandler);
+    const candidate = symbol?.initializer ?? symbol?.declarationNode;
+    if (candidate && isFunctionLike(candidate)) return candidate;
+    const binding = findVariableInitializer(unwrappedHandler, unwrappedHandler.name);
+    let assignedFunction: EsTreeNode | undefined;
+    if (symbol && binding) {
+      walkAst(binding.scopeOwner, (child) => {
+        if (child.range[0] >= unwrappedHandler.range[0]) return false;
+        if (
+          isNodeOfType(child, "AssignmentExpression") &&
+          child.operator === "=" &&
+          isNodeOfType(child.left, "Identifier") &&
+          context.scopes.symbolFor(child.left) === symbol
+        ) {
+          const assignedValue = stripParenExpression(child.right);
+          assignedFunction = isFunctionLike(assignedValue) ? assignedValue : undefined;
+        }
+      });
+    }
+    return assignedFunction;
+  }
+  return isNodeOfType(unwrappedHandler, "MemberExpression")
+    ? resolveMemberHandlerFunction(unwrappedHandler)
+    : undefined;
+};
+
+const isImportedPredicateCall = (
+  callExpression: EsTreeNode,
+  eventArgumentIndex: number,
+  context: RuleContext,
+): boolean => {
+  if (!isProvenPureImportedPredicateCall(callExpression, eventArgumentIndex, context)) {
+    return false;
+  }
+  let expression: EsTreeNode = callExpression;
+  while (expression.parent) {
+    const parent: EsTreeNode = expression.parent;
+    if (
+      stripParenExpression(parent) === expression ||
+      (isNodeOfType(parent, "UnaryExpression") && parent.operator === "!") ||
+      isNodeOfType(parent, "LogicalExpression")
+    ) {
+      expression = parent;
+      continue;
+    }
+    return (
+      (isNodeOfType(parent, "IfStatement") && parent.test === expression) ||
+      (isNodeOfType(parent, "ConditionalExpression") && parent.test === expression) ||
+      (isNodeOfType(parent, "WhileStatement") && parent.test === expression) ||
+      (isNodeOfType(parent, "DoWhileStatement") && parent.test === expression) ||
+      (isNodeOfType(parent, "ForStatement") && parent.test === expression)
+    );
+  }
+  return false;
+};
+
+const handlerMayExposeEvent = (handler: EsTreeNode | undefined, context: RuleContext): boolean => {
+  const rootFunction = resolveHandlerFunction(handler, context);
+  if (!rootFunction) {
+    const unwrappedHandler = handler ? stripParenExpression(handler) : undefined;
+    if (!unwrappedHandler || !isNodeOfType(unwrappedHandler, "Identifier")) return false;
+    const symbol = context.scopes.symbolFor(unwrappedHandler);
+    return Boolean(
+      symbol &&
+      (symbol.kind === "let" || symbol.kind === "var") &&
+      symbol.references.some(
+        (reference) =>
+          reference.identifier.range[0] < unwrappedHandler.range[0] && reference.flag !== "read",
+      ),
+    );
+  }
+  const visitedParameterIndexesByFunction = new Map<EsTreeNode, Set<number>>();
+
+  const isAsyncFunctionReference = (
+    rawExpression: EsTreeNode,
+    visitedSymbolIds: Set<number>,
+  ): boolean => {
+    const expression = stripParenExpression(rawExpression);
+    if (isFunctionLike(expression)) return expression.async;
+    if (!isNodeOfType(expression, "Identifier")) return false;
+    const symbol = context.scopes.symbolFor(expression);
+    if (!symbol || visitedSymbolIds.has(symbol.id)) return false;
+    const candidate = symbol.initializer ?? symbol.declarationNode;
+    if (!candidate) return false;
+    const nextVisitedSymbolIds = new Set(visitedSymbolIds);
+    nextVisitedSymbolIds.add(symbol.id);
+    return isAsyncFunctionReference(candidate, nextVisitedSymbolIds);
+  };
+
+  const isProvenPromiseExpression = (
+    rawExpression: EsTreeNode,
+    visitedSymbolIds: Set<number> = new Set(),
+  ): boolean => {
+    const expression = stripParenExpression(rawExpression);
+    if (isNodeOfType(expression, "Identifier")) {
+      const symbol = context.scopes.symbolFor(expression);
+      if (!symbol || visitedSymbolIds.has(symbol.id)) return false;
+      const initializer = symbol.initializer;
+      if (!initializer) return false;
+      const nextVisitedSymbolIds = new Set(visitedSymbolIds);
+      nextVisitedSymbolIds.add(symbol.id);
+      return isProvenPromiseExpression(initializer, nextVisitedSymbolIds);
+    }
+    if (isNodeOfType(expression, "NewExpression")) {
+      const callee = stripParenExpression(expression.callee);
+      return (
+        isNodeOfType(callee, "Identifier") &&
+        callee.name === "Promise" &&
+        context.scopes.isGlobalReference(callee)
+      );
+    }
+    if (!isNodeOfType(expression, "CallExpression")) return false;
+    const callee = stripParenExpression(expression.callee);
+    if (isNodeOfType(callee, "Identifier")) {
+      return isAsyncFunctionReference(callee, visitedSymbolIds);
+    }
+    if (!isNodeOfType(callee, "MemberExpression")) return false;
+    const calleeObject = stripParenExpression(callee.object);
+    if (PROMISE_DEFERRED_METHOD_NAMES.has(getStaticPropertyName(callee) ?? "")) {
+      return isProvenPromiseExpression(callee.object, visitedSymbolIds);
+    }
+    return (
+      PROMISE_FACTORY_METHOD_NAMES.has(getStaticPropertyName(callee) ?? "") &&
+      isNodeOfType(calleeObject, "Identifier") &&
+      calleeObject.name === "Promise" &&
+      context.scopes.isGlobalReference(calleeObject)
+    );
+  };
+
+  const isProvenDeferredCallbackCallee = (
+    rawCallee: EsTreeNode,
+    visitedSymbolIds: Set<number> = new Set(),
+  ): boolean => {
+    const callee = stripParenExpression(rawCallee);
+    if (isNodeOfType(callee, "Identifier")) {
+      if (
+        DEFERRED_CALLBACK_API_NAMES.has(callee.name) &&
+        context.scopes.isGlobalReference(callee)
+      ) {
+        return true;
+      }
+      const symbol = context.scopes.symbolFor(callee);
+      if (!symbol || visitedSymbolIds.has(symbol.id)) return false;
+      const initializer = getDirectConstInitializer(symbol);
+      if (!initializer) return false;
+      const nextVisitedSymbolIds = new Set(visitedSymbolIds);
+      nextVisitedSymbolIds.add(symbol.id);
+      return isProvenDeferredCallbackCallee(initializer, nextVisitedSymbolIds);
+    }
+    if (!isNodeOfType(callee, "MemberExpression")) return false;
+    const calleeObject = stripParenExpression(callee.object);
+    return (
+      DEFERRED_CALLBACK_API_NAMES.has(getStaticPropertyName(callee) ?? "") &&
+      isNodeOfType(calleeObject, "Identifier") &&
+      (calleeObject.name === "window" || calleeObject.name === "globalThis") &&
+      context.scopes.isGlobalReference(calleeObject)
+    );
+  };
+
+  const shouldVisitNestedFunction = (functionNode: EsTreeNode): boolean => {
+    let expression = functionNode;
+    while (
+      expression.parent &&
+      stripParenExpression(expression.parent) === stripParenExpression(expression)
+    ) {
+      expression = expression.parent;
+    }
+    const callExpression = expression.parent;
+    if (isNodeOfType(callExpression, "NewExpression")) {
+      const callee = stripParenExpression(callExpression.callee);
+      return (
+        callExpression.arguments.some((argument) => argument === expression) &&
+        isNodeOfType(callee, "Identifier") &&
+        callee.name === "Promise" &&
+        context.scopes.isGlobalReference(callee)
+      );
+    }
+    if (!isNodeOfType(callExpression, "CallExpression")) return false;
+    if (stripParenExpression(callExpression.callee) === stripParenExpression(expression))
+      return true;
+    if (!callExpression.arguments.some((argument) => argument === expression)) return false;
+    const callee = stripParenExpression(callExpression.callee);
+    if (isProvenDeferredCallbackCallee(callee)) return false;
+    if (isNodeOfType(callee, "Identifier")) return true;
+    if (!isNodeOfType(callee, "MemberExpression")) return true;
+    const methodName = getStaticPropertyName(callee);
+    if (
+      PROMISE_DEFERRED_METHOD_NAMES.has(methodName ?? "") &&
+      isProvenPromiseExpression(callee.object)
+    ) {
+      return false;
+    }
+    if (
+      methodName === "addEventListener" &&
+      isProvenBrowserApiReceiver(callee.object, "dom-event-target", context.scopes)
+    ) {
+      return false;
+    }
+    return true;
+  };
+
+  const functionMayExposeParameter = (
+    functionNode: EsTreeNode,
+    parameterIndex: number,
+    isRootHandler = false,
+  ): boolean => {
+    if (!isFunctionLike(functionNode)) return false;
+    const visitedParameterIndexes =
+      visitedParameterIndexesByFunction.get(functionNode) ?? new Set();
+    if (visitedParameterIndexes.has(parameterIndex)) return false;
+    visitedParameterIndexes.add(parameterIndex);
+    visitedParameterIndexesByFunction.set(functionNode, visitedParameterIndexes);
+    const rawParameter = functionNode.params[parameterIndex];
+    if (!rawParameter) return !isRootHandler;
+    const parameter = isNodeOfType(rawParameter, "AssignmentPattern")
+      ? rawParameter.left
+      : rawParameter;
+    if (!isNodeOfType(parameter, "Identifier")) {
+      return !(isRootHandler && isNodeOfType(parameter, "ObjectPattern"));
+    }
+    const parameterSymbol = context.scopes.symbolFor(parameter);
+    if (!parameterSymbol) return false;
+    const parameterAliasSymbols = new Set([parameterSymbol]);
+    const parameterContainerAliasSymbols = new Set<typeof parameterSymbol>();
+    const isParameterAlias = (candidate: EsTreeNode): boolean => {
+      const unwrappedCandidate = stripParenExpression(candidate);
+      if (!isNodeOfType(unwrappedCandidate, "Identifier")) return false;
+      const candidateSymbol = context.scopes.symbolFor(unwrappedCandidate);
+      return Boolean(candidateSymbol && parameterAliasSymbols.has(candidateSymbol));
+    };
+    const expressionContainsParameterAlias: (candidate: EsTreeNode) => boolean = (candidate) => {
+      const expression = stripParenExpression(candidate);
+      if (isParameterAlias(expression)) return true;
+      if (isNodeOfType(expression, "SpreadElement")) {
+        return expressionContainsParameterAlias(expression.argument);
+      }
+      if (isNodeOfType(expression, "MemberExpression")) {
+        const memberObject = stripParenExpression(expression.object);
+        if (isNodeOfType(memberObject, "Identifier")) {
+          const objectSymbol = context.scopes.symbolFor(memberObject);
+          if (objectSymbol && parameterContainerAliasSymbols.has(objectSymbol)) return true;
+        }
+        const propertyName = getStaticPropertyName(expression);
+        if (isNodeOfType(memberObject, "ObjectExpression") && propertyName) {
+          const property = memberObject.properties.find(
+            (candidate) =>
+              isNodeOfType(candidate, "Property") && memberKeyName(candidate.key) === propertyName,
+          );
+          return Boolean(
+            isNodeOfType(property, "Property") && expressionContainsParameterAlias(property.value),
+          );
+        }
+        if (
+          isNodeOfType(memberObject, "ArrayExpression") &&
+          isNodeOfType(expression.property, "Literal") &&
+          typeof expression.property.value === "number"
+        ) {
+          const element = memberObject.elements[expression.property.value];
+          return Boolean(element && expressionContainsParameterAlias(element));
+        }
+        return false;
+      }
+      if (isNodeOfType(expression, "ObjectExpression")) {
+        return expression.properties.some((property) =>
+          isNodeOfType(property, "Property")
+            ? expressionContainsParameterAlias(property.value)
+            : isNodeOfType(property, "SpreadElement") &&
+              expressionContainsParameterAlias(property.argument),
+        );
+      }
+      if (isNodeOfType(expression, "ArrayExpression")) {
+        return expression.elements.some(
+          (element) => element && expressionContainsParameterAlias(element),
+        );
+      }
+      if (isNodeOfType(expression, "ConditionalExpression")) {
+        return (
+          expressionContainsParameterAlias(expression.consequent) ||
+          expressionContainsParameterAlias(expression.alternate)
+        );
+      }
+      if (isNodeOfType(expression, "LogicalExpression")) {
+        return (
+          expressionContainsParameterAlias(expression.left) ||
+          expressionContainsParameterAlias(expression.right)
+        );
+      }
+      if (isNodeOfType(expression, "SequenceExpression")) {
+        return expression.expressions.some(expressionContainsParameterAlias);
+      }
+      return false;
+    };
+    const addAliasesFromPattern = (pattern: EsTreeNode, rawSource: EsTreeNode): void => {
+      const source = stripParenExpression(rawSource);
+      if (isNodeOfType(pattern, "Identifier")) {
+        if (!expressionContainsParameterAlias(source)) return;
+        const aliasSymbol = context.scopes.symbolFor(pattern);
+        if (aliasSymbol) parameterAliasSymbols.add(aliasSymbol);
+        return;
+      }
+      if (isNodeOfType(pattern, "AssignmentPattern")) {
+        addAliasesFromPattern(pattern.left, source);
+        return;
+      }
+      if (isNodeOfType(pattern, "RestElement") && isNodeOfType(pattern.argument, "Identifier")) {
+        if (!expressionContainsParameterAlias(source)) return;
+        const aliasSymbol = context.scopes.symbolFor(pattern.argument);
+        if (aliasSymbol) parameterContainerAliasSymbols.add(aliasSymbol);
+        return;
+      }
+      if (isNodeOfType(pattern, "ObjectPattern") && isNodeOfType(source, "ObjectExpression")) {
+        for (const patternProperty of pattern.properties) {
+          if (isNodeOfType(patternProperty, "RestElement")) {
+            addAliasesFromPattern(patternProperty, source);
+            continue;
+          }
+          if (!isNodeOfType(patternProperty, "Property")) continue;
+          const propertyName = memberKeyName(patternProperty.key);
+          if (!propertyName) continue;
+          const sourceProperty = source.properties.find(
+            (property) =>
+              isNodeOfType(property, "Property") && memberKeyName(property.key) === propertyName,
+          );
+          if (isNodeOfType(sourceProperty, "Property")) {
+            addAliasesFromPattern(patternProperty.value, sourceProperty.value);
+          }
+        }
+        return;
+      }
+      if (isNodeOfType(pattern, "ArrayPattern") && isNodeOfType(source, "ArrayExpression")) {
+        for (const [elementIndex, patternElement] of pattern.elements.entries()) {
+          const sourceElement = source.elements[elementIndex];
+          if (patternElement && sourceElement) addAliasesFromPattern(patternElement, sourceElement);
+        }
+      }
+    };
+    let didExposeEvent = false;
+    walkAst(functionNode.body, (child) => {
+      if (didExposeEvent) return false;
+      if (
+        child !== functionNode.body &&
+        isFunctionLike(child) &&
+        !shouldVisitNestedFunction(child)
+      ) {
+        return false;
+      }
+      if (isNodeOfType(child, "VariableDeclarator") && child.init) {
+        addAliasesFromPattern(child.id, child.init);
+        return;
+      }
+      if (
+        isNodeOfType(child, "AssignmentExpression") &&
+        expressionContainsParameterAlias(child.right)
+      ) {
+        if (isNodeOfType(child.left, "Identifier")) {
+          const aliasSymbol = context.scopes.symbolFor(child.left);
+          if (aliasSymbol) parameterAliasSymbols.add(aliasSymbol);
+        } else {
+          didExposeEvent = true;
+        }
+        return;
+      }
+      if (isNodeOfType(child, "AssignmentExpression")) {
+        const assignmentTarget = stripParenExpression(child.left);
+        const assignmentValue = stripParenExpression(child.right);
+        if (
+          isNodeOfType(assignmentTarget, "MemberExpression") &&
+          getStaticPropertyName(assignmentTarget) === "returnValue" &&
+          isParameterAlias(assignmentTarget.object) &&
+          isNodeOfType(assignmentValue, "Literal") &&
+          assignmentValue.value === false
+        ) {
+          didExposeEvent = true;
+          return;
+        }
+      }
+      if (
+        isNodeOfType(child, "ReturnStatement") &&
+        child.argument &&
+        expressionContainsParameterAlias(child.argument)
+      ) {
+        didExposeEvent = true;
+        return;
+      }
+      if (isNodeOfType(child, "NewExpression")) {
+        if (
+          child.arguments.some(
+            (argument) =>
+              !isNodeOfType(argument, "SpreadElement") &&
+              expressionContainsParameterAlias(argument),
+          )
+        ) {
+          didExposeEvent = true;
+        }
+        return;
+      }
+      if (!isNodeOfType(child, "CallExpression")) return;
+      const childCallee = stripParenExpression(child.callee);
+      if (
+        isNodeOfType(childCallee, "MemberExpression") &&
+        getStaticPropertyName(childCallee) === "preventDefault" &&
+        isParameterAlias(childCallee.object)
+      ) {
+        didExposeEvent = true;
+        return;
+      }
+      const eventArgumentIndex = child.arguments.findIndex((argument) => {
+        return expressionContainsParameterAlias(argument);
+      });
+      if (eventArgumentIndex < 0) return;
+      const calledFunction = resolveHandlerFunction(child.callee, context);
+      if (
+        (!calledFunction && !isImportedPredicateCall(child, eventArgumentIndex, context)) ||
+        (calledFunction && functionMayExposeParameter(calledFunction, eventArgumentIndex))
+      ) {
+        didExposeEvent = true;
+      }
+      return;
+    });
+    return didExposeEvent;
+  };
+
+  return functionMayExposeParameter(rootFunction, 0, true);
+};
+
 // An explicit `{ passive: false }` is a deliberate opt-out (the author
 // needs preventDefault to work). Treat it like `passive: true` for the
 // purposes of this rule: not a forgotten passive flag.
@@ -186,29 +646,57 @@ export const clientPassiveEventListeners = defineRule({
   severity: "warn",
   recommendation:
     "Add `{ passive: true }` as the third argument: `addEventListener('touchmove', handler, { passive: true })`. Only do this if the handler doesn't call `event.preventDefault()`, since passive listeners ignore it (which breaks pull-to-refresh, custom gestures, and nested scrolling).",
-  create: (context: RuleContext) => ({
-    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+  create: (context: RuleContext) => {
+    if (isGeneratedDocsArchiveFilename(context.filename)) return EMPTY_VISITORS;
+    const methodMutationAnalysis = createMethodMutationAnalysis(context);
+    const addEventListenerCalls: EsTreeNodeOfType<"CallExpression">[] = [];
+    const callsPreventDefaultByHandler = new WeakMap<EsTreeNode, boolean>();
+    const exposesEventByHandler = new WeakMap<EsTreeNode, boolean>();
+    const analyzeAddEventListenerCall = (node: EsTreeNodeOfType<"CallExpression">): void => {
       const callee = stripParenExpression(node.callee);
       if (!isMemberProperty(callee, "addEventListener")) return;
       if (!isProvenBrowserApiReceiver(callee.object, "dom-event-target", context.scopes)) return;
-      if ((node.arguments?.length ?? 0) < 2) return;
+      if (
+        methodMutationAnalysis.hasProvenMutation(
+          callee.object,
+          "addEventListener",
+          node,
+          getProvenDomEventTargetPrototypeOwnerNames(callee.object, context.scopes),
+          (replacement) =>
+            isProvenBrowserApiReceiver(replacement, "dom-event-target", context.scopes),
+        )
+      ) {
+        return;
+      }
+      if (node.arguments.length < 2) return;
 
       const eventNameNode = node.arguments[0];
       if (
         !isNodeOfType(eventNameNode, "Literal") ||
         typeof eventNameNode.value !== "string" ||
         !PASSIVE_EVENT_NAMES.has(eventNameNode.value)
-      )
+      ) {
         return;
+      }
 
       const eventName = eventNameNode.value;
-
-      // A handler that needs preventDefault() can't be passive — skip it
-      // regardless of how (or whether) options are passed.
-      if (handlerArgumentCallsPreventDefault(node.arguments[1] as EsTreeNode | undefined)) return;
+      const handlerArgument = node.arguments[1];
+      if (!handlerArgument || isNodeOfType(handlerArgument, "SpreadElement")) return;
+      const handlerCacheKey = resolveHandlerFunction(handlerArgument, context) ?? handlerArgument;
+      let doesHandlerCallPreventDefault = callsPreventDefaultByHandler.get(handlerCacheKey);
+      if (doesHandlerCallPreventDefault === undefined) {
+        doesHandlerCallPreventDefault = handlerArgumentCallsPreventDefault(handlerArgument);
+        callsPreventDefaultByHandler.set(handlerCacheKey, doesHandlerCallPreventDefault);
+      }
+      if (doesHandlerCallPreventDefault) return;
+      let doesHandlerExposeEvent = exposesEventByHandler.get(handlerCacheKey);
+      if (doesHandlerExposeEvent === undefined) {
+        doesHandlerExposeEvent = handlerMayExposeEvent(handlerArgument, context);
+        exposesEventByHandler.set(handlerCacheKey, doesHandlerExposeEvent);
+      }
+      if (doesHandlerExposeEvent) return;
 
       const optionsArgument = node.arguments[2];
-
       if (!optionsArgument) {
         context.report({
           node,
@@ -216,21 +704,31 @@ export const clientPassiveEventListeners = defineRule({
         });
         return;
       }
-
       if (!isNodeOfType(optionsArgument, "ObjectExpression")) return;
-
-      // Explicit `{ passive: false }` is an intentional opt-out, not a
-      // forgotten flag.
       if (hasExplicitPassiveValue(optionsArgument, false)) return;
-
-      const hasPassiveTrue = hasExplicitPassiveValue(optionsArgument, true);
-
-      if (!hasPassiveTrue) {
+      if (!hasExplicitPassiveValue(optionsArgument, true)) {
         context.report({
           node,
           message: `"${eventName}" listener without { passive: true } makes scrolling janky for your users. Only add it if the handler doesn't call event.preventDefault(), since passive listeners silently ignore preventDefault().`,
         });
       }
-    },
-  }),
+    };
+    return {
+      AssignmentExpression(node: EsTreeNode) {
+        methodMutationAnalysis.record(node);
+      },
+      CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+        methodMutationAnalysis.record(node);
+        const callee = stripParenExpression(node.callee);
+        if (!isMemberProperty(callee, "addEventListener")) return;
+        addEventListenerCalls.push(node);
+      },
+      UnaryExpression(node: EsTreeNode) {
+        methodMutationAnalysis.record(node);
+      },
+      "Program:exit"() {
+        for (const node of addEventListenerCalls) analyzeAddEventListenerCall(node);
+      },
+    };
+  },
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-indeterminate-attribute.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-indeterminate-attribute.test.ts
@@ -81,6 +81,28 @@ describe("no-indeterminate-attribute", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("reports destructured HTMLInputElement parameters", () => {
+    const result = runRuleForCode(`
+      const updateCheckbox = ({ node }: { node: HTMLInputElement }) => {
+        node.setAttribute("indeterminate", "true");
+      };
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not report destructured parameters of other element types", () => {
+    const result = runRuleForCode(`
+      const updateContainer = ({ node }: { node: HTMLDivElement }) => {
+        node.setAttribute("indeterminate", "true");
+      };
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("reports native checkbox JSX attribute forms", () => {
     const result = runRuleForCode(`
       const CheckboxExamples = ({ mixed }) => (

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-indeterminate-attribute.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-indeterminate-attribute.ts
@@ -1,9 +1,13 @@
-import type { ScopeAnalysis, SymbolDescriptor } from "../../semantic/scope-analysis.js";
+import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
 import { classifyReactNativeFileTarget } from "../../utils/is-react-native-file.js";
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { getJsxPropStaticStringValues } from "../../utils/get-jsx-prop-static-string-values.js";
+import { getDirectConstInitializer } from "../../utils/get-direct-const-initializer.js";
+import { getSymbolTypeAnnotation } from "../../utils/get-symbol-type-annotation.js";
+import { hasEnclosingTypeParameterNamed } from "../../utils/has-enclosing-type-parameter-named.js";
+import { hasVisibleBindingNamed } from "../../utils/has-visible-binding-named.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isReactApiCall, type ReactApiCallOptions } from "../../utils/is-react-api-call.js";
 import type { RuleVisitors } from "../../utils/rule-visitors.js";
@@ -15,42 +19,6 @@ const MESSAGE =
 const REACT_USE_REF_OPTIONS: ReactApiCallOptions = {
   allowGlobalReactNamespace: false,
   allowUnboundBareCalls: false,
-};
-
-const hasVisibleBindingNamed = (
-  node: EsTreeNode,
-  bindingName: string,
-  scopes: ScopeAnalysis,
-): boolean => {
-  let scope = scopes.scopeFor(node);
-  while (true) {
-    if (scope.symbolsByName.has(bindingName)) return true;
-    if (!scope.parent) return false;
-    scope = scope.parent;
-  }
-};
-
-const hasEnclosingTypeParameterNamed = (node: EsTreeNode, typeParameterName: string): boolean => {
-  let ancestor = node.parent;
-  while (ancestor) {
-    if ("typeParameters" in ancestor) {
-      const typeParameters = ancestor.typeParameters;
-      if (
-        typeParameters &&
-        isNodeOfType(typeParameters, "TSTypeParameterDeclaration") &&
-        typeParameters.params.some(
-          (typeParameter) =>
-            isNodeOfType(typeParameter, "TSTypeParameter") &&
-            isNodeOfType(typeParameter.name, "Identifier") &&
-            typeParameter.name.name === typeParameterName,
-        )
-      ) {
-        return true;
-      }
-    }
-    ancestor = ancestor.parent;
-  }
-  return false;
 };
 
 const isHtmlInputElementType = (typeNode: EsTreeNode, scopes: ScopeAnalysis): boolean => {
@@ -76,24 +44,6 @@ const isHtmlInputElementType = (typeNode: EsTreeNode, scopes: ScopeAnalysis): bo
     hasHtmlInputElementMember = true;
   }
   return hasHtmlInputElementMember;
-};
-
-const getBindingTypeAnnotation = (symbol: SymbolDescriptor): EsTreeNode | null => {
-  if (!isNodeOfType(symbol.bindingIdentifier, "Identifier")) return null;
-  const annotation = symbol.bindingIdentifier.typeAnnotation;
-  if (!annotation || !isNodeOfType(annotation, "TSTypeAnnotation")) return null;
-  return annotation.typeAnnotation;
-};
-
-const getDirectConstInitializer = (symbol: SymbolDescriptor): EsTreeNode | null => {
-  if (
-    symbol.kind !== "const" ||
-    !isNodeOfType(symbol.declarationNode, "VariableDeclarator") ||
-    symbol.declarationNode.id !== symbol.bindingIdentifier
-  ) {
-    return null;
-  }
-  return symbol.initializer;
 };
 
 const hasTypedHtmlInputRefOrigin = (rawExpression: EsTreeNode, scopes: ScopeAnalysis): boolean => {
@@ -130,7 +80,7 @@ const isProvenHtmlInputElement = (rawExpression: EsTreeNode, scopes: ScopeAnalys
 
     const symbol = scopes.symbolFor(expression);
     if (!symbol || visitedSymbolIds.has(symbol.id)) return false;
-    const typeAnnotation = getBindingTypeAnnotation(symbol);
+    const typeAnnotation = getSymbolTypeAnnotation(symbol);
     if (typeAnnotation && isHtmlInputElementType(typeAnnotation, scopes)) return true;
     const initializer = getDirectConstInitializer(symbol);
     if (!initializer) return false;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-sync-xhr.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-sync-xhr.regressions.test.ts
@@ -24,4 +24,31 @@ describe("js-performance/no-sync-xhr — regressions", () => {
     );
     expect(diagnostics).toHaveLength(1);
   });
+
+  it("still flags a synchronous XHR on an un-reassigned let receiver", () => {
+    const { diagnostics } = runRule(
+      noSyncXhr,
+      `let request = new XMLHttpRequest();\nrequest.open("GET", "/api", false);\nrequest.send(null);`,
+      { filename: "/repo/src/lib/fetch-sync.ts" },
+    );
+    expect(diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a synchronous XHR on an un-reassigned var receiver", () => {
+    const { diagnostics } = runRule(
+      noSyncXhr,
+      `var request = new XMLHttpRequest();\nrequest.open("GET", "/api", false);\nrequest.send(null);`,
+      { filename: "/repo/src/lib/fetch-sync.ts" },
+    );
+    expect(diagnostics).toHaveLength(1);
+  });
+
+  it("does not trust a reassigned let receiver", () => {
+    const { diagnostics } = runRule(
+      noSyncXhr,
+      `let request = new XMLHttpRequest();\nrequest = createTransport();\nrequest.open("GET", "/api", false);\nrequest.send(null);`,
+      { filename: "/repo/src/lib/fetch-sync.ts" },
+    );
+    expect(diagnostics).toEqual([]);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-sync-xhr.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-sync-xhr.test.ts
@@ -32,4 +32,69 @@ describe("no-sync-xhr", () => {
     const result = runRule(noSyncXhr, `xhr.open("GET", url, isSync);`);
     expect(result.diagnostics).toHaveLength(0);
   });
+
+  it("does not flag an unrelated typed open method", () => {
+    const result = runRule(
+      noSyncXhr,
+      `interface Archive { open(mode: string, path: string, createIfMissing: boolean): void; }
+       const openArchive = (archive: Archive) => archive.open("read", "/documents.zip", false);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags typed XMLHttpRequest parameters and nullable unions", () => {
+    const result = runRule(
+      noSyncXhr,
+      `const load = (first: XMLHttpRequest, second: XMLHttpRequest | null) => {
+         first.open("GET", "/one", false);
+         second?.open("GET", "/two", false);
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
+  it("follows direct and multi-hop XMLHttpRequest value aliases", () => {
+    const result = runRule(
+      noSyncXhr,
+      `const request = new XMLHttpRequest();
+       const firstAlias = request;
+       const secondAlias = firstAlias;
+       secondAlias.open("GET", "/api", false);`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("follows aliases of global and window XMLHttpRequest constructors", () => {
+    const result = runRule(
+      noSyncXhr,
+      `const GlobalRequest = XMLHttpRequest;
+       const WindowRequest = window.XMLHttpRequest;
+       new GlobalRequest().open("GET", "/one", false);
+       new WindowRequest().open("GET", "/two", false);`,
+    );
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
+  it("does not trust shadowed XMLHttpRequest constructor or type names", () => {
+    const result = runRule(
+      noSyncXhr,
+      `class XMLHttpRequest {
+         open(mode: string, path: string, createIfMissing: boolean) {}
+       }
+       const request = new XMLHttpRequest();
+       request.open("read", "/archive", false);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not trust unresolved or mutable aliases", () => {
+    const result = runRule(
+      noSyncXhr,
+      `let request = new XMLHttpRequest();
+       request = archive;
+       request.open("read", "/archive", false);
+       unknown.open("read", "/archive", false);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-sync-xhr.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-sync-xhr.test.ts
@@ -97,4 +97,487 @@ describe("no-sync-xhr", () => {
     );
     expect(result.diagnostics).toHaveLength(0);
   });
+
+  it("does not report after the XMLHttpRequest open method is replaced", () => {
+    const result = runRule(
+      noSyncXhr,
+      `const request = new XMLHttpRequest();
+       request.open = ((...args: unknown[]) => {}) as XMLHttpRequest["open"];
+       request.open("read", "/archive", false);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("follows aliases when checking for open method replacement", () => {
+    const result = runRule(
+      noSyncXhr,
+      `const request = new XMLHttpRequest();
+       const alias = request;
+       alias.open = ((...args: unknown[]) => {}) as XMLHttpRequest["open"];
+       request.open("read", "/archive", false);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still reports when the open method is replaced only after the synchronous call", () => {
+    const result = runRule(
+      noSyncXhr,
+      `const request = new XMLHttpRequest();
+       request.open("GET", "/api", false);
+       request.open = ((...args: unknown[]) => {}) as XMLHttpRequest["open"];`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports XMLHttpRequest type assertions and asserted initializers", () => {
+    const result = runRule(
+      noSyncXhr,
+      `(getRequest() as XMLHttpRequest).open("GET", "/one", false);
+       const request = getRequest() satisfies XMLHttpRequest;
+       request.open("GET", "/two", false);`,
+    );
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
+  it("reports destructured XMLHttpRequest parameters", () => {
+    const result = runRule(
+      noSyncXhr,
+      `const load = ({ request }: { request: XMLHttpRequest }) => {
+         request.open("GET", "/api", false);
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports XMLHttpRequest class fields by initializer and annotation", () => {
+    const result = runRule(
+      noSyncXhr,
+      `class Loader {
+         first = new XMLHttpRequest();
+         second: XMLHttpRequest;
+         load() {
+           this.first.open("GET", "/one", false);
+           this.second.open("GET", "/two", false);
+         }
+       }`,
+    );
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
+  it("reports same-file factories that return XMLHttpRequest instances", () => {
+    const result = runRule(
+      noSyncXhr,
+      `const createRequest = () => new XMLHttpRequest();
+       function makeRequest() { return createRequest(); }
+       makeRequest().open("GET", "/api", false);`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not prove a mixed-return XMLHttpRequest factory", () => {
+    const result = runRule(
+      noSyncXhr,
+      `class Archive { open() {} }
+       const makeRequest = (useXhr: boolean) => useXhr ? new XMLHttpRequest() : new Archive();
+       makeRequest(false).open("read", "/archive", false);`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("proves a factory only when every return is XMLHttpRequest", () => {
+    const result = runRule(
+      noSyncXhr,
+      `const makeRequest = (useFirst: boolean) => useFirst
+         ? new XMLHttpRequest()
+         : new window.XMLHttpRequest();
+       makeRequest(false).open("GET", "/api", false);`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays silent after an XMLHttpRequest class field is reassigned", () => {
+    const result = runRule(
+      noSyncXhr,
+      `class Archive { open() {} }
+       class Loader {
+         request = new XMLHttpRequest();
+         load() {
+           this.request = new Archive();
+           this.request.open("read", "/archive", false);
+         }
+       }`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still reports when an XMLHttpRequest class field is reassigned only after opening", () => {
+    const result = runRule(
+      noSyncXhr,
+      `class Archive { open() {} }
+       class Loader {
+         request = new XMLHttpRequest();
+         load() {
+           this.request.open("GET", "/api", false);
+           this.request = new Archive();
+         }
+       }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not bind nested ordinary-function this to the outer loader", () => {
+    const result = runRule(
+      noSyncXhr,
+      `class Loader {
+         request = new XMLHttpRequest();
+         load() {
+           function run() { this.request.open("read", "/archive", false); }
+           run.call({ request: { open() {} } });
+         }
+       }`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still binds arrow-function this to the outer loader", () => {
+    const result = runRule(
+      noSyncXhr,
+      `class Loader {
+         request = new XMLHttpRequest();
+         load() {
+           const run = () => this.request.open("GET", "/api", false);
+           run();
+         }
+       }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays silent when open is replaced before a declared function runs", () => {
+    const result = runRule(
+      noSyncXhr,
+      `const request = new XMLHttpRequest();
+       function run() { request.open("GET", "/api", false); }
+       request.open = customOpen;
+       run();`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still reports when open is replaced only after a declared function runs", () => {
+    const result = runRule(
+      noSyncXhr,
+      `const request = new XMLHttpRequest();
+       function run() { request.open("GET", "/api", false); }
+       run();
+       request.open = customOpen;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("follows synchronous helpers that replace open", () => {
+    const result = runRule(
+      noSyncXhr,
+      `const request = new XMLHttpRequest();
+       const replace = () => { request.open = customOpen; };
+       replace();
+       request.open("GET", "/api", false);`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("follows helper parameters through mutations and opaque multi-hop escapes", () => {
+    const directMutation = runRule(
+      noSyncXhr,
+      `const request = new XMLHttpRequest();
+       const patch = (receiver) => { receiver.open = customOpen; };
+       patch(request);
+       request.open("GET", "/api", false);`,
+    );
+    const opaqueEscape = runRule(
+      noSyncXhr,
+      `const request = new XMLHttpRequest();
+       const second = (receiver) => external(receiver);
+       const first = (receiver) => second(receiver);
+       first(request);
+       request.open("GET", "/api", false);`,
+    );
+    expect(directMutation.diagnostics).toEqual([]);
+    expect(opaqueEscape.diagnostics).toEqual([]);
+  });
+
+  it("does not overflow on recursive helper invocation", () => {
+    const result = runRule(
+      noSyncXhr,
+      `const request = new XMLHttpRequest();
+       const run = () => {
+         request.open("GET", "/api", false);
+         if (more) run();
+       };
+       request.open = customOpen;
+       run();`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent after an opaque receiver escape", () => {
+    const result = runRule(
+      noSyncXhr,
+      `const request = new XMLHttpRequest();
+       customize(request);
+       request.open("GET", "/api", false);`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("follows receiver escapes through aliases and containers", () => {
+    const result = runRule(
+      noSyncXhr,
+      `const first = new XMLHttpRequest();
+       const firstAlias = first;
+       customize(firstAlias);
+       first.open("GET", "/one", false);
+
+       const second = new XMLHttpRequest();
+       customize({ second });
+       second.open("GET", "/two", false);
+
+       const third = new XMLHttpRequest();
+       const registry = {};
+       registry.request = third;
+       customize(registry);
+       third.open("GET", "/three", false);`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not treat derived receiver properties as receiver escapes", () => {
+    const result = runRule(
+      noSyncXhr,
+      `const request = new XMLHttpRequest();
+       inspect(request.responseURL);
+       request.open("GET", "/api", false);`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still reports after a non-dominating conditional open replacement", () => {
+    const result = runRule(
+      noSyncXhr,
+      `const request = new XMLHttpRequest();
+       if (replaceOpen) request.open = customOpen;
+       request.open("GET", "/api", false);`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays silent after XMLHttpRequest prototype replacement", () => {
+    const result = runRule(
+      noSyncXhr,
+      `XMLHttpRequest.prototype.open = customOpen;
+       const request = new XMLHttpRequest();
+       request.open("GET", "/api", false);`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent after prototype replacement on an immediate receiver", () => {
+    const result = runRule(
+      noSyncXhr,
+      `XMLHttpRequest.prototype.open = customOpen;
+       new XMLHttpRequest().open("GET", "/api", false);`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not trust a double assertion through unknown", () => {
+    const result = runRule(
+      noSyncXhr,
+      `class Archive { open() {} }
+       (new Archive() as unknown as XMLHttpRequest).open("read", "/archive", false);`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not trust an asserted userland construction", () => {
+    const result = runRule(
+      noSyncXhr,
+      `class Archive { open() {} }
+       (new Archive() as XMLHttpRequest).open("read", "/archive", false);`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not trust asserted object literals or const userland initializers", () => {
+    const result = runRule(
+      noSyncXhr,
+      `const archive = { open() {} };
+       (archive as XMLHttpRequest).open("read", "/archive", false);
+       ({ open() {} } as XMLHttpRequest).open("read", "/archive", false);`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not trust assertions on mutable bindings, parameters, or members", () => {
+    const result = runRule(
+      noSyncXhr,
+      `let mutableRequest = archive;
+       (mutableRequest as XMLHttpRequest).open("read", "/one", false);
+       const load = (request) => {
+         (request as XMLHttpRequest).open("read", "/two", false);
+       };
+       (holder.request as XMLHttpRequest).open("read", "/three", false);`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("keeps typed parameters proven through redundant assertions", () => {
+    const result = runRule(
+      noSyncXhr,
+      `const load = (request: XMLHttpRequest) => {
+         (request as XMLHttpRequest).open("GET", "/api", false);
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not prove reassigned receiver factories", () => {
+    const result = runRule(
+      noSyncXhr,
+      `let make = () => new XMLHttpRequest();
+       make = () => archive;
+       make().open("GET", "/", false);`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("recognizes method mutations on factory return values", () => {
+    const result = runRule(
+      noSyncXhr,
+      `const make = () => {
+         const request = new XMLHttpRequest();
+         request.open = customOpen;
+         return request;
+       };
+       make().open("GET", "/", false);`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("recognizes mutations across sibling helpers, branches, and constructors", () => {
+    const result = runRule(
+      noSyncXhr,
+      `const first = new XMLHttpRequest();
+       function patch() { first.open = customOpen; }
+       function attach() { first.open("GET", "/one", false); }
+       function setup() { patch(); attach(); }
+       setup();
+
+       const second = new XMLHttpRequest();
+       if (condition) second.open = firstOpen;
+       else second.open = secondOpen;
+       second.open("GET", "/two", false);
+
+       class View {
+         request = new XMLHttpRequest();
+         constructor() { this.request.open = customOpen; }
+         run() { this.request.open("GET", "/three", false); }
+       }
+       new View().run();`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("recognizes Reflect prototype replacement", () => {
+    const result = runRule(
+      noSyncXhr,
+      `Reflect.defineProperty(XMLHttpRequest.prototype, "open", { value: customOpen });
+       const request = new XMLHttpRequest();
+       request.open("GET", "/", false);`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("retains findings after proven native receiver replacement", () => {
+    const result = runRule(
+      noSyncXhr,
+      `let first: XMLHttpRequest = new XMLHttpRequest();
+       first = first;
+       first.open("GET", "/one", false);
+       let second: XMLHttpRequest = new XMLHttpRequest();
+       second = new XMLHttpRequest();
+       second.open("GET", "/two", false);`,
+    );
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
+  it("recognizes factory receiver escapes and defineProperty mutations", () => {
+    const opaqueEscape = runRule(
+      noSyncXhr,
+      `const make = () => {
+         const request = new XMLHttpRequest();
+         customize(request);
+         return request;
+       };
+       make().open("GET", "/", false);`,
+    );
+    const definedMethod = runRule(
+      noSyncXhr,
+      `const make = () => {
+         const request = new XMLHttpRequest();
+         Reflect.defineProperty(request, "open", { value: customOpen });
+         return request;
+       };
+       make().open("GET", "/", false);`,
+    );
+    expect(opaqueEscape.diagnostics).toEqual([]);
+    expect(definedMethod.diagnostics).toEqual([]);
+  });
+
+  it("follows receiver escapes through identity-return helpers", () => {
+    const result = runRule(
+      noSyncXhr,
+      `const request = new XMLHttpRequest();
+       const identity = (value) => value;
+       const alias = identity(request);
+       customize(alias);
+       request.open("GET", "/", false);`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("recognizes mutations before mutually recursive helper calls", () => {
+    const result = runRule(
+      noSyncXhr,
+      `const request = new XMLHttpRequest();
+       function first() {
+         request.open = customOpen;
+         second();
+       }
+       function second() {
+         request.open("GET", "/", false);
+         if (more) first();
+       }
+       first();`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("follows receiver escapes through object spreads", () => {
+    const inline = runRule(
+      noSyncXhr,
+      `const request = new XMLHttpRequest();
+       customize({ ...request });
+       request.open("GET", "/one", false);`,
+    );
+    const aliased = runRule(
+      noSyncXhr,
+      `const request = new XMLHttpRequest();
+       const box = { ...request };
+       customize(box);
+       request.open("GET", "/two", false);`,
+    );
+    expect(inline.diagnostics).toEqual([]);
+    expect(aliased.diagnostics).toEqual([]);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-sync-xhr.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-sync-xhr.test.ts
@@ -431,6 +431,27 @@ describe("no-sync-xhr", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("does not trust assertions laundered through const aliases", () => {
+    const result = runRule(
+      noSyncXhr,
+      `const load = (source) => {
+         const request = source;
+         (request as XMLHttpRequest).open("read", "/archive", false);
+       };`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("keeps constructed receivers proven through asserted const aliases", () => {
+    const result = runRule(
+      noSyncXhr,
+      `const source = new XMLHttpRequest();
+       const request = source;
+       (request as XMLHttpRequest).open("GET", "/api", false);`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("keeps typed parameters proven through redundant assertions", () => {
     const result = runRule(
       noSyncXhr,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-sync-xhr.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-sync-xhr.ts
@@ -1,11 +1,12 @@
 import { defineRule } from "../../utils/define-rule.js";
-import { isNodeOfType } from "../../utils/is-node-of-type.js";
-import { isProvenBrowserApiReceiver } from "../../utils/is-proven-browser-api-receiver.js";
-import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { createMethodMutationAnalysis } from "../../utils/has-proven-method-mutation.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { isProvenBrowserApiReceiver } from "../../utils/is-proven-browser-api-receiver.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import type { RuleVisitors } from "../../utils/rule-visitors.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 
 const MESSAGE =
   "A synchronous `XMLHttpRequest` (`.open(method, url, false)`) freezes the main thread until the request finishes, blocking all rendering and input. Use `fetch()` or an async XHR (`open(method, url, true)`).";
@@ -27,17 +28,46 @@ export const noSyncXhr = defineRule({
     "Never open an XMLHttpRequest synchronously (`async` = `false`). It blocks the main thread. Use `fetch()` or pass `true` and handle the response asynchronously.",
   create: (context: RuleContext): RuleVisitors => {
     if (PUBLIC_ASSET_PATH_PATTERN.test(context.filename ?? "")) return {};
+    const methodMutationAnalysis = createMethodMutationAnalysis(context);
+    const openCalls: EsTreeNodeOfType<"CallExpression">[] = [];
+    const analyzeOpenCall = (node: EsTreeNodeOfType<"CallExpression">): void => {
+      const callee = stripParenExpression(node.callee);
+      if (!isNodeOfType(callee, "MemberExpression")) return;
+      if (!isProvenBrowserApiReceiver(callee.object, "xml-http-request", context.scopes)) return;
+      if (
+        methodMutationAnalysis.hasProvenMutation(
+          callee.object,
+          "open",
+          node,
+          ["XMLHttpRequest"],
+          (replacement) =>
+            isProvenBrowserApiReceiver(replacement, "xml-http-request", context.scopes),
+        )
+      ) {
+        return;
+      }
+      const asyncArgument = node.arguments[2];
+      if (!asyncArgument || !isFalseLiteral(stripParenExpression(asyncArgument))) return;
+      context.report({ node, message: MESSAGE });
+    };
     return {
+      AssignmentExpression(node: EsTreeNode) {
+        methodMutationAnalysis.record(node);
+      },
       CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+        methodMutationAnalysis.record(node);
         const callee = stripParenExpression(node.callee);
         if (!isNodeOfType(callee, "MemberExpression") || callee.computed) return;
         if (!isNodeOfType(callee.property, "Identifier") || callee.property.name !== "open") {
           return;
         }
-        if (!isProvenBrowserApiReceiver(callee.object, "xml-http-request", context.scopes)) return;
-        const asyncArgument = node.arguments?.[2];
-        if (!asyncArgument || !isFalseLiteral(stripParenExpression(asyncArgument))) return;
-        context.report({ node, message: MESSAGE });
+        openCalls.push(node);
+      },
+      UnaryExpression(node: EsTreeNode) {
+        methodMutationAnalysis.record(node);
+      },
+      "Program:exit"() {
+        for (const node of openCalls) analyzeOpenCall(node);
       },
     };
   },

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-sync-xhr.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-sync-xhr.ts
@@ -1,5 +1,6 @@
 import { defineRule } from "../../utils/define-rule.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { isProvenBrowserApiReceiver } from "../../utils/is-proven-browser-api-receiver.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
@@ -18,10 +19,6 @@ const isFalseLiteral = (node: EsTreeNode): boolean =>
 // rewriting the generated file is not an applicable fix.
 const PUBLIC_ASSET_PATH_PATTERN = /(?:^|\/)public\//i;
 
-// `<receiver>.open(method, url, false)` — the canonical synchronous-XHR
-// signature. The literal `false` third argument (the `async` flag) is the
-// distinctive, high-precision marker; we don't need to prove the receiver is
-// an XMLHttpRequest.
 export const noSyncXhr = defineRule({
   id: "no-sync-xhr",
   title: "Synchronous XMLHttpRequest",
@@ -32,11 +29,12 @@ export const noSyncXhr = defineRule({
     if (PUBLIC_ASSET_PATH_PATTERN.test(context.filename ?? "")) return {};
     return {
       CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
-        const callee = node.callee;
+        const callee = stripParenExpression(node.callee);
         if (!isNodeOfType(callee, "MemberExpression") || callee.computed) return;
         if (!isNodeOfType(callee.property, "Identifier") || callee.property.name !== "open") {
           return;
         }
+        if (!isProvenBrowserApiReceiver(callee.object, "xml-http-request", context.scopes)) return;
         const asyncArgument = node.arguments?.[2];
         if (!asyncArgument || !isFalseLiteral(stripParenExpression(asyncArgument))) return;
         context.report({ node, message: MESSAGE });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/function-returns-matching-expression.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/function-returns-matching-expression.test.ts
@@ -7,7 +7,7 @@ import { functionReturnsMatchingExpression } from "./function-returns-matching-e
 import { isNodeOfType } from "./is-node-of-type.js";
 import { walkAst } from "./walk-ast.js";
 
-const mainFunctionReturnsJsx = (code: string): boolean => {
+const mainFunctionReturnsJsx = (code: string, matchMode: "some" | "every" = "some"): boolean => {
   const parsed = parseFixture(code);
   expect(parsed.errors).toEqual([]);
   attachParentReferences(parsed.program);
@@ -23,6 +23,7 @@ const mainFunctionReturnsJsx = (code: string): boolean => {
     analyzeScopes(parsed.program),
     (expression) =>
       isNodeOfType(expression, "JSXElement") || isNodeOfType(expression, "JSXFragment"),
+    matchMode,
   );
 };
 
@@ -72,6 +73,33 @@ describe("functionReturnsMatchingExpression", () => {
     expect(
       mainFunctionReturnsJsx(
         `function Main() { const render = async () => <main />; return render(); }`,
+      ),
+    ).toBe(false);
+  });
+
+  it("requires every reachable return in every mode", () => {
+    expect(
+      mainFunctionReturnsJsx(
+        `function Main(condition) { return condition ? <main /> : null; }`,
+        "every",
+      ),
+    ).toBe(false);
+    expect(
+      mainFunctionReturnsJsx(
+        `function Main(condition) { if (condition) return <main />; return <aside />; }`,
+        "every",
+      ),
+    ).toBe(true);
+    expect(
+      mainFunctionReturnsJsx(
+        `function Main(condition) { if (condition) return <main />; }`,
+        "every",
+      ),
+    ).toBe(false);
+    expect(
+      mainFunctionReturnsJsx(
+        `function Main(condition) { if (condition) return <main />; return; }`,
+        "every",
       ),
     ).toBe(false);
   });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/function-returns-matching-expression.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/function-returns-matching-expression.ts
@@ -107,20 +107,17 @@ export const functionReturnsMatchingExpression = (
     }
 
     if (isNodeOfType(unwrappedExpression, "ConditionalExpression")) {
-      const branchMatches = [
-        expressionMatches(unwrappedExpression.consequent),
-        expressionMatches(unwrappedExpression.alternate),
-      ];
-      return matchMode === "every" ? branchMatches.every(Boolean) : branchMatches.some(Boolean);
+      return branchesMatch(unwrappedExpression.consequent, unwrappedExpression.alternate);
     }
     if (isNodeOfType(unwrappedExpression, "LogicalExpression")) {
-      const operandMatches = [
-        expressionMatches(unwrappedExpression.left),
-        expressionMatches(unwrappedExpression.right),
-      ];
-      return matchMode === "every" ? operandMatches.every(Boolean) : operandMatches.some(Boolean);
+      return branchesMatch(unwrappedExpression.left, unwrappedExpression.right);
     }
     return false;
+  };
+
+  const branchesMatch = (firstBranch: EsTreeNode, secondBranch: EsTreeNode): boolean => {
+    const didBranchMatch = [expressionMatches(firstBranch), expressionMatches(secondBranch)];
+    return matchMode === "every" ? didBranchMatch.every(Boolean) : didBranchMatch.some(Boolean);
   };
 
   return functionMatches(functionNode);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/function-returns-matching-expression.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/function-returns-matching-expression.ts
@@ -3,6 +3,7 @@ import type { EsTreeNode } from "./es-tree-node.js";
 import { isFunctionLike } from "./is-function-like.js";
 import { isNodeOfType } from "./is-node-of-type.js";
 import { stripParenExpression } from "./strip-paren-expression.js";
+import { statementAlwaysExits } from "./statement-always-exits.js";
 import { walkAst } from "./walk-ast.js";
 
 const collectReturnedExpressions = (functionNode: EsTreeNode): EsTreeNode[] => {
@@ -27,10 +28,24 @@ const collectReturnedExpressions = (functionNode: EsTreeNode): EsTreeNode[] => {
   return returnedExpressions;
 };
 
+const functionHasBareReturn = (functionNode: EsTreeNode): boolean => {
+  if (!isFunctionLike(functionNode) || !isNodeOfType(functionNode.body, "BlockStatement")) {
+    return false;
+  }
+  let didFindBareReturn = false;
+  walkAst(functionNode.body, (node) => {
+    if (didFindBareReturn) return false;
+    if (node !== functionNode.body && isFunctionLike(node)) return false;
+    if (isNodeOfType(node, "ReturnStatement") && !node.argument) didFindBareReturn = true;
+  });
+  return didFindBareReturn;
+};
+
 export const functionReturnsMatchingExpression = (
   functionNode: EsTreeNode,
   scopes: ScopeAnalysis,
   matchesExpression: (expression: EsTreeNode) => boolean,
+  matchMode: "some" | "every" = "some",
 ): boolean => {
   const visitedExpressions = new Set<EsTreeNode>();
   const visitedFunctions = new Set<EsTreeNode>();
@@ -38,7 +53,21 @@ export const functionReturnsMatchingExpression = (
   const functionMatches = (candidateFunction: EsTreeNode): boolean => {
     if (visitedFunctions.has(candidateFunction)) return false;
     visitedFunctions.add(candidateFunction);
-    return collectReturnedExpressions(candidateFunction).some(expressionMatches);
+    const returnedExpressions = collectReturnedExpressions(candidateFunction);
+    if (
+      matchMode === "every" &&
+      isFunctionLike(candidateFunction) &&
+      isNodeOfType(candidateFunction.body, "BlockStatement") &&
+      (!statementAlwaysExits(candidateFunction.body) || functionHasBareReturn(candidateFunction))
+    ) {
+      return false;
+    }
+    return (
+      returnedExpressions.length > 0 &&
+      (matchMode === "every"
+        ? returnedExpressions.every(expressionMatches)
+        : returnedExpressions.some(expressionMatches))
+    );
   };
 
   const expressionMatches = (expression: EsTreeNode): boolean => {
@@ -78,15 +107,18 @@ export const functionReturnsMatchingExpression = (
     }
 
     if (isNodeOfType(unwrappedExpression, "ConditionalExpression")) {
-      return (
-        expressionMatches(unwrappedExpression.consequent) ||
-        expressionMatches(unwrappedExpression.alternate)
-      );
+      const branchMatches = [
+        expressionMatches(unwrappedExpression.consequent),
+        expressionMatches(unwrappedExpression.alternate),
+      ];
+      return matchMode === "every" ? branchMatches.every(Boolean) : branchMatches.some(Boolean);
     }
     if (isNodeOfType(unwrappedExpression, "LogicalExpression")) {
-      return (
-        expressionMatches(unwrappedExpression.left) || expressionMatches(unwrappedExpression.right)
-      );
+      const operandMatches = [
+        expressionMatches(unwrappedExpression.left),
+        expressionMatches(unwrappedExpression.right),
+      ];
+      return matchMode === "every" ? operandMatches.every(Boolean) : operandMatches.some(Boolean);
     }
     return false;
   };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-direct-const-initializer.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-direct-const-initializer.ts
@@ -1,0 +1,14 @@
+import type { SymbolDescriptor } from "../semantic/scope-analysis.js";
+import type { EsTreeNode } from "./es-tree-node.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+
+export const getDirectConstInitializer = (symbol: SymbolDescriptor): EsTreeNode | null => {
+  if (
+    symbol.kind !== "const" ||
+    !isNodeOfType(symbol.declarationNode, "VariableDeclarator") ||
+    symbol.declarationNode.id !== symbol.bindingIdentifier
+  ) {
+    return null;
+  }
+  return symbol.initializer;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-direct-unreassigned-initializer.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-direct-unreassigned-initializer.ts
@@ -1,0 +1,21 @@
+import type { SymbolDescriptor } from "../semantic/scope-analysis.js";
+import type { EsTreeNode } from "./es-tree-node.js";
+import { getDirectConstInitializer } from "./get-direct-const-initializer.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+
+export const getDirectUnreassignedInitializer = (symbol: SymbolDescriptor): EsTreeNode | null => {
+  const constInitializer = getDirectConstInitializer(symbol);
+  if (constInitializer) return constInitializer;
+  if (
+    (symbol.kind !== "let" && symbol.kind !== "var") ||
+    !isNodeOfType(symbol.declarationNode, "VariableDeclarator") ||
+    symbol.declarationNode.id !== symbol.bindingIdentifier ||
+    !symbol.references.every((reference) => reference.flag === "read") ||
+    symbol.scope.symbols.some(
+      (siblingSymbol) => siblingSymbol !== symbol && siblingSymbol.name === symbol.name,
+    )
+  ) {
+    return null;
+  }
+  return symbol.initializer;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-static-key-name.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-static-key-name.ts
@@ -1,0 +1,8 @@
+import type { EsTreeNode } from "./es-tree-node.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+
+export const getStaticKeyName = (keyNode: EsTreeNode | null | undefined): string | null => {
+  if (isNodeOfType(keyNode, "Identifier")) return keyNode.name;
+  if (isNodeOfType(keyNode, "Literal") && typeof keyNode.value === "string") return keyNode.value;
+  return null;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-symbol-type-annotation.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-symbol-type-annotation.ts
@@ -1,5 +1,6 @@
 import type { SymbolDescriptor } from "../semantic/scope-analysis.js";
 import type { EsTreeNode } from "./es-tree-node.js";
+import { getStaticKeyName } from "./get-static-key-name.js";
 import { isNodeOfType } from "./is-node-of-type.js";
 
 export const getSymbolTypeAnnotation = (symbol: SymbolDescriptor): EsTreeNode | null => {
@@ -19,20 +20,11 @@ export const getSymbolTypeAnnotation = (symbol: SymbolDescriptor): EsTreeNode | 
   if (!patternAnnotation || !isNodeOfType(patternAnnotation, "TSTypeAnnotation")) return null;
   const objectType = patternAnnotation.typeAnnotation;
   if (!isNodeOfType(objectType, "TSTypeLiteral")) return null;
-  const propertyName = isNodeOfType(bindingProperty.key, "Identifier")
-    ? bindingProperty.key.name
-    : isNodeOfType(bindingProperty.key, "Literal") && typeof bindingProperty.key.value === "string"
-      ? bindingProperty.key.value
-      : null;
+  const propertyName = getStaticKeyName(bindingProperty.key);
   if (!propertyName) return null;
   for (const typeMember of objectType.members) {
     if (!isNodeOfType(typeMember, "TSPropertySignature")) continue;
-    const memberName = isNodeOfType(typeMember.key, "Identifier")
-      ? typeMember.key.name
-      : isNodeOfType(typeMember.key, "Literal") && typeof typeMember.key.value === "string"
-        ? typeMember.key.value
-        : null;
-    if (memberName !== propertyName) continue;
+    if (getStaticKeyName(typeMember.key) !== propertyName) continue;
     return typeMember.typeAnnotation?.typeAnnotation ?? null;
   }
   return null;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-symbol-type-annotation.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-symbol-type-annotation.ts
@@ -1,0 +1,10 @@
+import type { SymbolDescriptor } from "../semantic/scope-analysis.js";
+import type { EsTreeNode } from "./es-tree-node.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+
+export const getSymbolTypeAnnotation = (symbol: SymbolDescriptor): EsTreeNode | null => {
+  if (!isNodeOfType(symbol.bindingIdentifier, "Identifier")) return null;
+  const annotation = symbol.bindingIdentifier.typeAnnotation;
+  if (!annotation || !isNodeOfType(annotation, "TSTypeAnnotation")) return null;
+  return annotation.typeAnnotation;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-symbol-type-annotation.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-symbol-type-annotation.ts
@@ -5,6 +5,35 @@ import { isNodeOfType } from "./is-node-of-type.js";
 export const getSymbolTypeAnnotation = (symbol: SymbolDescriptor): EsTreeNode | null => {
   if (!isNodeOfType(symbol.bindingIdentifier, "Identifier")) return null;
   const annotation = symbol.bindingIdentifier.typeAnnotation;
-  if (!annotation || !isNodeOfType(annotation, "TSTypeAnnotation")) return null;
-  return annotation.typeAnnotation;
+  if (annotation && isNodeOfType(annotation, "TSTypeAnnotation")) return annotation.typeAnnotation;
+
+  const bindingProperty = symbol.bindingIdentifier.parent;
+  const bindingPattern = bindingProperty?.parent;
+  if (
+    !isNodeOfType(bindingProperty, "Property") ||
+    !isNodeOfType(bindingPattern, "ObjectPattern")
+  ) {
+    return null;
+  }
+  const patternAnnotation = bindingPattern.typeAnnotation;
+  if (!patternAnnotation || !isNodeOfType(patternAnnotation, "TSTypeAnnotation")) return null;
+  const objectType = patternAnnotation.typeAnnotation;
+  if (!isNodeOfType(objectType, "TSTypeLiteral")) return null;
+  const propertyName = isNodeOfType(bindingProperty.key, "Identifier")
+    ? bindingProperty.key.name
+    : isNodeOfType(bindingProperty.key, "Literal") && typeof bindingProperty.key.value === "string"
+      ? bindingProperty.key.value
+      : null;
+  if (!propertyName) return null;
+  for (const typeMember of objectType.members) {
+    if (!isNodeOfType(typeMember, "TSPropertySignature")) continue;
+    const memberName = isNodeOfType(typeMember.key, "Identifier")
+      ? typeMember.key.name
+      : isNodeOfType(typeMember.key, "Literal") && typeof typeMember.key.value === "string"
+        ? typeMember.key.value
+        : null;
+    if (memberName !== propertyName) continue;
+    return typeMember.typeAnnotation?.typeAnnotation ?? null;
+  }
+  return null;
 };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/has-enclosing-type-parameter-named.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/has-enclosing-type-parameter-named.ts
@@ -1,0 +1,28 @@
+import type { EsTreeNode } from "./es-tree-node.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+
+export const hasEnclosingTypeParameterNamed = (
+  node: EsTreeNode,
+  typeParameterName: string,
+): boolean => {
+  let ancestor = node.parent;
+  while (ancestor) {
+    if ("typeParameters" in ancestor) {
+      const typeParameters = ancestor.typeParameters;
+      if (
+        typeParameters &&
+        isNodeOfType(typeParameters, "TSTypeParameterDeclaration") &&
+        typeParameters.params.some(
+          (typeParameter) =>
+            isNodeOfType(typeParameter, "TSTypeParameter") &&
+            isNodeOfType(typeParameter.name, "Identifier") &&
+            typeParameter.name.name === typeParameterName,
+        )
+      ) {
+        return true;
+      }
+    }
+    ancestor = ancestor.parent;
+  }
+  return false;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/has-proven-method-mutation.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/has-proven-method-mutation.ts
@@ -19,12 +19,6 @@ interface SymbolEscape {
   callExpression: EsTreeNode;
 }
 
-const createMethodMutationIndex = (): MethodMutationIndex => ({
-  memberMutationCandidatesByReceiverIdentity: new Map(),
-  memberMutationCandidatesByReceiverIdentityAndMethod: new Map(),
-  receiverAssignmentCandidatesByIdentity: new Map(),
-});
-
 const addCandidate = (map: Map<string, EsTreeNode[]>, key: string, node: EsTreeNode): void => {
   const candidates = map.get(key) ?? [];
   candidates.push(node);
@@ -55,6 +49,21 @@ const getMethodCandidates = (
     .get(receiverIdentity)
     ?.get(methodName) ?? [];
 
+const recordMemberMutationTarget = (
+  index: MethodMutationIndex,
+  mutationTarget: EsTreeNode,
+  node: EsTreeNode,
+  context: RuleContext,
+): void => {
+  if (!isNodeOfType(mutationTarget, "MemberExpression")) return;
+  const methodName = getStaticPropertyName(mutationTarget);
+  const receiverIdentity = resolveExpressionKey(mutationTarget.object, context);
+  if (methodName && receiverIdentity) {
+    addCandidate(index.memberMutationCandidatesByReceiverIdentity, receiverIdentity, node);
+    addMethodCandidate(index, receiverIdentity, methodName, node);
+  }
+};
+
 const recordMethodMutationNode = (
   index: MethodMutationIndex,
   node: EsTreeNode,
@@ -66,24 +75,9 @@ const recordMethodMutationNode = (
     if (assignmentIdentity) {
       addCandidate(index.receiverAssignmentCandidatesByIdentity, assignmentIdentity, node);
     }
-    if (isNodeOfType(assignmentTarget, "MemberExpression")) {
-      const methodName = getStaticPropertyName(assignmentTarget);
-      const receiverIdentity = resolveExpressionKey(assignmentTarget.object, context);
-      if (methodName && receiverIdentity) {
-        addCandidate(index.memberMutationCandidatesByReceiverIdentity, receiverIdentity, node);
-        addMethodCandidate(index, receiverIdentity, methodName, node);
-      }
-    }
+    recordMemberMutationTarget(index, assignmentTarget, node, context);
   } else if (isNodeOfType(node, "UnaryExpression") && node.operator === "delete") {
-    const deletedTarget = stripParenExpression(node.argument);
-    if (isNodeOfType(deletedTarget, "MemberExpression")) {
-      const methodName = getStaticPropertyName(deletedTarget);
-      const receiverIdentity = resolveExpressionKey(deletedTarget.object, context);
-      if (methodName && receiverIdentity) {
-        addCandidate(index.memberMutationCandidatesByReceiverIdentity, receiverIdentity, node);
-        addMethodCandidate(index, receiverIdentity, methodName, node);
-      }
-    }
+    recordMemberMutationTarget(index, stripParenExpression(node.argument), node, context);
   }
   if (!isNodeOfType(node, "CallExpression")) return;
   const callee = stripParenExpression(node.callee);
@@ -107,6 +101,25 @@ const recordMethodMutationNode = (
       addMethodCandidate(index, targetIdentity, methodArgument.value, node);
     }
   }
+};
+
+const isGlobalDefinePropertyCallForMethod = (
+  callExpression: EsTreeNode,
+  methodName: string,
+  context: RuleContext,
+): boolean => {
+  if (!isNodeOfType(callExpression, "CallExpression")) return false;
+  const callee = stripParenExpression(callExpression.callee);
+  if (!isNodeOfType(callee, "MemberExpression")) return false;
+  const calleeObject = stripParenExpression(callee.object);
+  return (
+    getStaticPropertyName(callee) === "defineProperty" &&
+    isNodeOfType(calleeObject, "Identifier") &&
+    (calleeObject.name === "Object" || calleeObject.name === "Reflect") &&
+    context.scopes.isGlobalReference(calleeObject) &&
+    isNodeOfType(callExpression.arguments[1], "Literal") &&
+    callExpression.arguments[1].value === methodName
+  );
 };
 
 const isScopeAncestorOf = (ancestor: ScopeDescriptor, descendant: ScopeDescriptor): boolean => {
@@ -312,16 +325,6 @@ const mutationsCollectivelyDominateCall = (
   return true;
 };
 
-const isPrototypeReceiver = (
-  receiver: EsTreeNode,
-  prototypeOwnerNames: readonly string[],
-  context: RuleContext,
-): boolean =>
-  prototypeOwnerNames.some(
-    (prototypeOwnerName) =>
-      resolveExpressionKey(receiver, context) === `global:${prototypeOwnerName}.prototype`,
-  );
-
 const getLocalCalledFunction = (
   callExpression: EsTreeNode,
   context: RuleContext,
@@ -335,6 +338,25 @@ const getLocalCalledFunction = (
     ? stripParenExpression(candidate)
     : null;
 };
+
+const hasDominatingEscapeMutation = (
+  symbol: SymbolDescriptor,
+  callNode: EsTreeNode,
+  context: RuleContext,
+  mutationIndex: MethodMutationIndex,
+): boolean =>
+  getSymbolEscapeCalls(symbol, context).some(
+    (escape) =>
+      escape.callExpression !== callNode &&
+      mutationDominatesCall(escape.callExpression, callNode, context) &&
+      callMayMutateArgument(
+        escape.callExpression,
+        escape.argumentIndex,
+        context,
+        mutationIndex,
+        new Map(),
+      ),
+  );
 
 const factoryReturnsMutatedReceiver = (
   receiver: EsTreeNode,
@@ -363,17 +385,7 @@ const factoryReturnsMutatedReceiver = (
         : null;
       if (
         returnedSymbol &&
-        getSymbolEscapeCalls(returnedSymbol, context).some(
-          (escape) =>
-            mutationDominatesCall(escape.callExpression, returnStatement, context) &&
-            callMayMutateArgument(
-              escape.callExpression,
-              escape.argumentIndex,
-              context,
-              mutationIndex,
-              new Map(),
-            ),
-        )
+        hasDominatingEscapeMutation(returnedSymbol, returnStatement, context, mutationIndex)
       ) {
         return true;
       }
@@ -392,18 +404,10 @@ const factoryReturnsMutatedReceiver = (
               ),
             );
             if (isNodeOfType(mutationNode, "CallExpression")) {
-              const callee = stripParenExpression(mutationNode.callee);
-              const calleeObject = isNodeOfType(callee, "MemberExpression")
-                ? stripParenExpression(callee.object)
-                : null;
-              doesMutateMethod = Boolean(
-                isNodeOfType(callee, "MemberExpression") &&
-                getStaticPropertyName(callee) === "defineProperty" &&
-                isNodeOfType(calleeObject, "Identifier") &&
-                (calleeObject.name === "Object" || calleeObject.name === "Reflect") &&
-                context.scopes.isGlobalReference(calleeObject) &&
-                isNodeOfType(mutationNode.arguments[1], "Literal") &&
-                mutationNode.arguments[1].value === methodName,
+              doesMutateMethod = isGlobalDefinePropertyCallForMethod(
+                mutationNode,
+                methodName,
+                context,
               );
             }
             return (
@@ -428,6 +432,17 @@ const getSymbolEscapeCalls = (
   const nextVisitedSymbols = new Set(visitedSymbols);
   nextVisitedSymbols.add(symbol);
   const escapeCalls = new Map<EsTreeNode, Set<number>>();
+  const addEscapeCall = (callExpression: EsTreeNode, argumentIndex: number): void => {
+    const argumentIndexes = escapeCalls.get(callExpression) ?? new Set();
+    argumentIndexes.add(argumentIndex);
+    escapeCalls.set(callExpression, argumentIndexes);
+  };
+  const mergeAliasEscapeCalls = (aliasSymbol: SymbolDescriptor | null | undefined): void => {
+    if (!aliasSymbol) return;
+    for (const escape of getSymbolEscapeCalls(aliasSymbol, context, nextVisitedSymbols)) {
+      addEscapeCall(escape.callExpression, escape.argumentIndex);
+    }
+  };
   for (const reference of symbol.references) {
     let argumentExpression = reference.identifier;
     let didResolveExpression = true;
@@ -467,16 +482,9 @@ const getSymbolEscapeCalls = (
       expressionParent.init === argumentExpression &&
       isNodeOfType(expressionParent.id, "Identifier")
     ) {
-      const aliasSymbol = context.scopes
-        .scopeFor(expressionParent)
-        .symbolsByName.get(expressionParent.id.name);
-      if (aliasSymbol) {
-        for (const escape of getSymbolEscapeCalls(aliasSymbol, context, nextVisitedSymbols)) {
-          const argumentIndexes = escapeCalls.get(escape.callExpression) ?? new Set();
-          argumentIndexes.add(escape.argumentIndex);
-          escapeCalls.set(escape.callExpression, argumentIndexes);
-        }
-      }
+      mergeAliasEscapeCalls(
+        context.scopes.scopeFor(expressionParent).symbolsByName.get(expressionParent.id.name),
+      );
       continue;
     }
     if (
@@ -490,24 +498,14 @@ const getSymbolEscapeCalls = (
             isNodeOfType(stripParenExpression(assignmentTarget.object), "Identifier")
           ? stripParenExpression(assignmentTarget.object)
           : null;
-      const aliasSymbol = aliasIdentifier ? context.scopes.symbolFor(aliasIdentifier) : null;
-      if (aliasSymbol) {
-        for (const escape of getSymbolEscapeCalls(aliasSymbol, context, nextVisitedSymbols)) {
-          const argumentIndexes = escapeCalls.get(escape.callExpression) ?? new Set();
-          argumentIndexes.add(escape.argumentIndex);
-          escapeCalls.set(escape.callExpression, argumentIndexes);
-        }
-      }
+      mergeAliasEscapeCalls(aliasIdentifier ? context.scopes.symbolFor(aliasIdentifier) : null);
       continue;
     }
     if (isNodeOfType(expressionParent, "CallExpression")) {
       const argumentIndex = expressionParent.arguments.findIndex(
         (argument) => argument === argumentExpression,
       );
-      if (argumentIndex < 0) continue;
-      const argumentIndexes = escapeCalls.get(expressionParent) ?? new Set();
-      argumentIndexes.add(argumentIndex);
-      escapeCalls.set(expressionParent, argumentIndexes);
+      if (argumentIndex >= 0) addEscapeCall(expressionParent, argumentIndex);
     }
   }
   const result = [...escapeCalls].flatMap(([callExpression, argumentIndexes]) =>
@@ -600,7 +598,6 @@ const callMayMutateArgument = (
     return true;
   }
   const doesParameterEscape = getSymbolEscapeCalls(parameterSymbol, context).some((escape) => {
-    if (!isNodeOfType(escape.callExpression, "CallExpression")) return false;
     if (context.cfg.enclosingFunction(escape.callExpression) !== calledFunction) return false;
     return callMayMutateArgument(
       escape.callExpression,
@@ -643,22 +640,7 @@ const hasProvenMethodMutation = (
   if (
     receiverIdentity &&
     receiverSymbol &&
-    getSymbolEscapeCalls(receiverSymbol, context).some((escape) => {
-      if (!isNodeOfType(escape.callExpression, "CallExpression")) return false;
-      if (
-        escape.callExpression === callNode ||
-        !mutationDominatesCall(escape.callExpression, callNode, context)
-      ) {
-        return false;
-      }
-      return callMayMutateArgument(
-        escape.callExpression,
-        escape.argumentIndex,
-        context,
-        mutationIndex,
-        new Map(),
-      );
-    })
+    hasDominatingEscapeMutation(receiverSymbol, callNode, context, mutationIndex)
   ) {
     return true;
   }
@@ -700,29 +682,21 @@ const hasProvenMethodMutation = (
       mutatedReceiver = readsMutatedMemberReceiver(child.left, methodName);
     } else if (isNodeOfType(child, "UnaryExpression") && child.operator === "delete") {
       mutatedReceiver = readsMutatedMemberReceiver(child.argument, methodName);
-    } else if (isNodeOfType(child, "CallExpression")) {
-      const callee = stripParenExpression(child.callee);
-      const calleeObject = isNodeOfType(callee, "MemberExpression")
-        ? stripParenExpression(callee.object)
-        : null;
-      if (
-        isNodeOfType(callee, "MemberExpression") &&
-        getStaticPropertyName(callee) === "defineProperty" &&
-        isNodeOfType(calleeObject, "Identifier") &&
-        (calleeObject.name === "Object" || calleeObject.name === "Reflect") &&
-        context.scopes.isGlobalReference(calleeObject) &&
-        isNodeOfType(child.arguments[1], "Literal") &&
-        child.arguments[1].value === methodName
-      ) {
-        const target = child.arguments[0];
-        mutatedReceiver = target && !isNodeOfType(target, "SpreadElement") ? target : null;
-      }
+    } else if (
+      isNodeOfType(child, "CallExpression") &&
+      isGlobalDefinePropertyCallForMethod(child, methodName, context)
+    ) {
+      const target = child.arguments[0];
+      mutatedReceiver = target && !isNodeOfType(target, "SpreadElement") ? target : null;
     }
     if (!mutatedReceiver) continue;
+    const mutatedReceiverIdentity = resolveExpressionKey(mutatedReceiver, context);
     const doesMutationMatchReceiver =
-      (receiverIdentity !== null &&
-        resolveExpressionKey(mutatedReceiver, context) === receiverIdentity) ||
-      isPrototypeReceiver(mutatedReceiver, prototypeOwnerNames, context);
+      (receiverIdentity !== null && mutatedReceiverIdentity === receiverIdentity) ||
+      prototypeOwnerNames.some(
+        (prototypeOwnerName) =>
+          mutatedReceiverIdentity === `global:${prototypeOwnerName}.prototype`,
+      );
     if (!doesMutationMatchReceiver) continue;
     matchingMutationCandidates.push(child);
     if (mutationDominatesCall(child, callNode, context)) {
@@ -747,7 +721,11 @@ export interface MethodMutationAnalysis {
 }
 
 export const createMethodMutationAnalysis = (context: RuleContext): MethodMutationAnalysis => {
-  const mutationIndex = createMethodMutationIndex();
+  const mutationIndex: MethodMutationIndex = {
+    memberMutationCandidatesByReceiverIdentity: new Map(),
+    memberMutationCandidatesByReceiverIdentityAndMethod: new Map(),
+    receiverAssignmentCandidatesByIdentity: new Map(),
+  };
   return {
     record: (node) => recordMethodMutationNode(mutationIndex, node, context),
     hasProvenMutation: (

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/has-proven-method-mutation.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/has-proven-method-mutation.ts
@@ -1,0 +1,770 @@
+import type { ScopeDescriptor, SymbolDescriptor } from "../semantic/scope-analysis.js";
+import type { EsTreeNode } from "./es-tree-node.js";
+import { getStaticPropertyName } from "./get-static-property-name.js";
+import { isFunctionLike } from "./is-function-like.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+import { resolveExpressionKey } from "./resolve-expression-key.js";
+import type { RuleContext } from "./rule-context.js";
+import { stripParenExpression } from "./strip-paren-expression.js";
+import { walkAst } from "./walk-ast.js";
+
+interface MethodMutationIndex {
+  memberMutationCandidatesByReceiverIdentity: Map<string, EsTreeNode[]>;
+  memberMutationCandidatesByReceiverIdentityAndMethod: Map<string, Map<string, EsTreeNode[]>>;
+  receiverAssignmentCandidatesByIdentity: Map<string, EsTreeNode[]>;
+}
+
+interface SymbolEscape {
+  argumentIndex: number;
+  callExpression: EsTreeNode;
+}
+
+const createMethodMutationIndex = (): MethodMutationIndex => ({
+  memberMutationCandidatesByReceiverIdentity: new Map(),
+  memberMutationCandidatesByReceiverIdentityAndMethod: new Map(),
+  receiverAssignmentCandidatesByIdentity: new Map(),
+});
+
+const addCandidate = (map: Map<string, EsTreeNode[]>, key: string, node: EsTreeNode): void => {
+  const candidates = map.get(key) ?? [];
+  candidates.push(node);
+  map.set(key, candidates);
+};
+
+const addMethodCandidate = (
+  index: MethodMutationIndex,
+  receiverIdentity: string,
+  methodName: string,
+  node: EsTreeNode,
+): void => {
+  const candidatesByMethod =
+    index.memberMutationCandidatesByReceiverIdentityAndMethod.get(receiverIdentity) ?? new Map();
+  addCandidate(candidatesByMethod, methodName, node);
+  index.memberMutationCandidatesByReceiverIdentityAndMethod.set(
+    receiverIdentity,
+    candidatesByMethod,
+  );
+};
+
+const getMethodCandidates = (
+  index: MethodMutationIndex,
+  receiverIdentity: string,
+  methodName: string,
+): EsTreeNode[] =>
+  index.memberMutationCandidatesByReceiverIdentityAndMethod
+    .get(receiverIdentity)
+    ?.get(methodName) ?? [];
+
+const recordMethodMutationNode = (
+  index: MethodMutationIndex,
+  node: EsTreeNode,
+  context: RuleContext,
+): void => {
+  if (isNodeOfType(node, "AssignmentExpression")) {
+    const assignmentTarget = stripParenExpression(node.left);
+    const assignmentIdentity = resolveExpressionKey(assignmentTarget, context);
+    if (assignmentIdentity) {
+      addCandidate(index.receiverAssignmentCandidatesByIdentity, assignmentIdentity, node);
+    }
+    if (isNodeOfType(assignmentTarget, "MemberExpression")) {
+      const methodName = getStaticPropertyName(assignmentTarget);
+      const receiverIdentity = resolveExpressionKey(assignmentTarget.object, context);
+      if (methodName && receiverIdentity) {
+        addCandidate(index.memberMutationCandidatesByReceiverIdentity, receiverIdentity, node);
+        addMethodCandidate(index, receiverIdentity, methodName, node);
+      }
+    }
+  } else if (isNodeOfType(node, "UnaryExpression") && node.operator === "delete") {
+    const deletedTarget = stripParenExpression(node.argument);
+    if (isNodeOfType(deletedTarget, "MemberExpression")) {
+      const methodName = getStaticPropertyName(deletedTarget);
+      const receiverIdentity = resolveExpressionKey(deletedTarget.object, context);
+      if (methodName && receiverIdentity) {
+        addCandidate(index.memberMutationCandidatesByReceiverIdentity, receiverIdentity, node);
+        addMethodCandidate(index, receiverIdentity, methodName, node);
+      }
+    }
+  }
+  if (!isNodeOfType(node, "CallExpression")) return;
+  const callee = stripParenExpression(node.callee);
+  if (
+    !isNodeOfType(callee, "MemberExpression") ||
+    getStaticPropertyName(callee) !== "defineProperty"
+  ) {
+    return;
+  }
+  const methodArgument = node.arguments[1];
+  const targetArgument = node.arguments[0];
+  if (
+    isNodeOfType(methodArgument, "Literal") &&
+    typeof methodArgument.value === "string" &&
+    targetArgument &&
+    !isNodeOfType(targetArgument, "SpreadElement")
+  ) {
+    const targetIdentity = resolveExpressionKey(targetArgument, context);
+    if (targetIdentity) {
+      addCandidate(index.memberMutationCandidatesByReceiverIdentity, targetIdentity, node);
+      addMethodCandidate(index, targetIdentity, methodArgument.value, node);
+    }
+  }
+};
+
+const isScopeAncestorOf = (ancestor: ScopeDescriptor, descendant: ScopeDescriptor): boolean => {
+  let scope: ScopeDescriptor | null = descendant;
+  while (scope) {
+    if (scope === ancestor) return true;
+    scope = scope.parent;
+  }
+  return false;
+};
+
+const readsMutatedMemberReceiver = (node: EsTreeNode, methodName: string): EsTreeNode | null => {
+  const expression = stripParenExpression(node);
+  if (!isNodeOfType(expression, "MemberExpression")) return null;
+  return getStaticPropertyName(expression) === methodName ? expression.object : null;
+};
+
+const isAstAncestorOf = (ancestor: EsTreeNode, descendant: EsTreeNode): boolean => {
+  let current: EsTreeNode | null | undefined = descendant;
+  while (current) {
+    if (current === ancestor) return true;
+    current = current.parent;
+  }
+  return false;
+};
+
+const getDirectFunctionInvocations = (
+  functionNode: EsTreeNode,
+  context: RuleContext,
+): EsTreeNode[] | null => {
+  const bindingIdentifier = isNodeOfType(functionNode, "FunctionDeclaration")
+    ? functionNode.id
+    : isNodeOfType(functionNode.parent, "VariableDeclarator") &&
+        functionNode.parent.init === functionNode &&
+        isNodeOfType(functionNode.parent.id, "Identifier")
+      ? functionNode.parent.id
+      : null;
+  const functionSymbol = bindingIdentifier
+    ? context.scopes.scopeFor(functionNode).symbolsByName.get(bindingIdentifier.name)
+    : undefined;
+  if (!functionSymbol || functionSymbol.references.length === 0) return null;
+  const invocations: EsTreeNode[] = [];
+  for (const reference of functionSymbol.references) {
+    const referenceParent = reference.identifier.parent;
+    if (
+      !isNodeOfType(referenceParent, "CallExpression") ||
+      stripParenExpression(referenceParent.callee) !== reference.identifier
+    ) {
+      return null;
+    }
+    if (context.cfg.enclosingFunction(referenceParent) === functionNode) continue;
+    invocations.push(referenceParent);
+  }
+  return invocations.length > 0 ? invocations : null;
+};
+
+const isConstructorMutationForMethodCall = (
+  mutationOwner: EsTreeNode,
+  callOwner: EsTreeNode,
+  mutationNode: EsTreeNode,
+  context: RuleContext,
+): boolean => {
+  const mutationDefinition = mutationOwner.parent;
+  const callDefinition = callOwner.parent;
+  if (
+    !isNodeOfType(mutationDefinition, "MethodDefinition") ||
+    !isNodeOfType(callDefinition, "MethodDefinition") ||
+    mutationDefinition.parent !== callDefinition.parent ||
+    !isNodeOfType(mutationDefinition.key, "Identifier") ||
+    mutationDefinition.key.name !== "constructor"
+  ) {
+    return false;
+  }
+  return context.cfg.isUnconditionalFromEntry(mutationNode);
+};
+
+const mutationDominatesCall = (
+  mutationNode: EsTreeNode,
+  callNode: EsTreeNode,
+  context: RuleContext,
+  visitedCallNodesByMutation: Map<EsTreeNode, Set<EsTreeNode>> = new Map(),
+): boolean => {
+  const visitedCallNodes = visitedCallNodesByMutation.get(mutationNode) ?? new Set();
+  if (visitedCallNodes.has(callNode)) return false;
+  const nextVisitedCallNodesByMutation = new Map(visitedCallNodesByMutation);
+  nextVisitedCallNodesByMutation.set(mutationNode, new Set([...visitedCallNodes, callNode]));
+  const mutationOwner = context.cfg.enclosingFunction(mutationNode);
+  const callOwner = context.cfg.enclosingFunction(callNode);
+  if (!mutationOwner || !callOwner) return false;
+  if (mutationOwner !== callOwner) {
+    if (isConstructorMutationForMethodCall(mutationOwner, callOwner, mutationNode, context)) {
+      return true;
+    }
+    if (isAstAncestorOf(mutationOwner, callOwner)) {
+      const callOwnerInvocations = getDirectFunctionInvocations(callOwner, context);
+      if (
+        !callOwnerInvocations &&
+        isNodeOfType(mutationOwner, "Program") &&
+        context.cfg.isUnconditionalFromEntry(mutationNode)
+      ) {
+        return true;
+      }
+      return Boolean(
+        callOwnerInvocations &&
+        callOwnerInvocations.every((invocation) =>
+          mutationDominatesCall(mutationNode, invocation, context, nextVisitedCallNodesByMutation),
+        ),
+      );
+    }
+    if (isAstAncestorOf(callOwner, mutationOwner)) {
+      const mutationOwnerInvocations = getDirectFunctionInvocations(mutationOwner, context);
+      return Boolean(
+        context.cfg.isUnconditionalFromEntry(mutationNode) &&
+        mutationOwnerInvocations?.some((invocation) =>
+          mutationDominatesCall(invocation, callNode, context, nextVisitedCallNodesByMutation),
+        ),
+      );
+    }
+    const mutationOwnerInvocations = getDirectFunctionInvocations(mutationOwner, context);
+    const callOwnerInvocations = getDirectFunctionInvocations(callOwner, context);
+    if (
+      context.cfg.isUnconditionalFromEntry(mutationNode) &&
+      mutationOwnerInvocations &&
+      callOwnerInvocations
+    ) {
+      return callOwnerInvocations.every(
+        (callInvocation) =>
+          mutationDominatesCall(
+            mutationNode,
+            callInvocation,
+            context,
+            nextVisitedCallNodesByMutation,
+          ) ||
+          mutationOwnerInvocations.some((mutationInvocation) =>
+            mutationDominatesCall(
+              mutationInvocation,
+              callInvocation,
+              context,
+              nextVisitedCallNodesByMutation,
+            ),
+          ),
+      );
+    }
+    return false;
+  }
+  const cfg = context.cfg.cfgFor(callOwner);
+  const mutationBlock = cfg?.blockOf(mutationNode);
+  const callBlock = cfg?.blockOf(callNode);
+  if (!cfg || !mutationBlock || !callBlock) return mutationNode.range[0] < callNode.range[0];
+  if (mutationBlock === callBlock) return mutationNode.range[0] < callNode.range[0];
+  const visitedBlocks = new Set<typeof cfg.entry>();
+  const pendingBlocks = mutationBlock === cfg.entry ? [] : [cfg.entry];
+  while (pendingBlocks.length > 0) {
+    const block = pendingBlocks.shift();
+    if (!block || visitedBlocks.has(block)) continue;
+    if (block === callBlock) return false;
+    visitedBlocks.add(block);
+    for (const edge of block.successors) {
+      if (edge.to !== mutationBlock) pendingBlocks.push(edge.to);
+    }
+  }
+  return true;
+};
+
+const mutationsCollectivelyDominateCall = (
+  mutationNodes: readonly EsTreeNode[],
+  callNode: EsTreeNode,
+  context: RuleContext,
+): boolean => {
+  const callOwner = context.cfg.enclosingFunction(callNode);
+  if (!callOwner || mutationNodes.length < 2) return false;
+  if (
+    mutationNodes.some((mutationNode) => context.cfg.enclosingFunction(mutationNode) !== callOwner)
+  ) {
+    return false;
+  }
+  const cfg = context.cfg.cfgFor(callOwner);
+  const callBlock = cfg?.blockOf(callNode);
+  if (!cfg || !callBlock) return false;
+  const mutationBlocks = new Set(
+    mutationNodes
+      .map((mutationNode) => cfg.blockOf(mutationNode))
+      .filter((block) => block !== null),
+  );
+  if (
+    mutationNodes.some(
+      (mutationNode) =>
+        cfg.blockOf(mutationNode) === callBlock && mutationNode.range[0] < callNode.range[0],
+    )
+  ) {
+    return true;
+  }
+  mutationBlocks.delete(callBlock);
+  const visitedBlocks = new Set<typeof cfg.entry>();
+  const pendingBlocks = [cfg.entry];
+  while (pendingBlocks.length > 0) {
+    const block = pendingBlocks.shift();
+    if (!block || visitedBlocks.has(block) || mutationBlocks.has(block)) continue;
+    if (block === callBlock) return false;
+    visitedBlocks.add(block);
+    for (const edge of block.successors) pendingBlocks.push(edge.to);
+  }
+  return true;
+};
+
+const isPrototypeReceiver = (
+  receiver: EsTreeNode,
+  prototypeOwnerNames: readonly string[],
+  context: RuleContext,
+): boolean =>
+  prototypeOwnerNames.some(
+    (prototypeOwnerName) =>
+      resolveExpressionKey(receiver, context) === `global:${prototypeOwnerName}.prototype`,
+  );
+
+const getLocalCalledFunction = (
+  callExpression: EsTreeNode,
+  context: RuleContext,
+): EsTreeNode | null => {
+  if (!isNodeOfType(callExpression, "CallExpression")) return null;
+  const callee = stripParenExpression(callExpression.callee);
+  if (!isNodeOfType(callee, "Identifier")) return null;
+  const symbol = context.scopes.symbolFor(callee);
+  const candidate = symbol?.initializer ?? symbol?.declarationNode;
+  return candidate && isFunctionLike(stripParenExpression(candidate))
+    ? stripParenExpression(candidate)
+    : null;
+};
+
+const factoryReturnsMutatedReceiver = (
+  receiver: EsTreeNode,
+  methodName: string,
+  context: RuleContext,
+  mutationIndex: MethodMutationIndex,
+): boolean => {
+  const factory = getLocalCalledFunction(stripParenExpression(receiver), context);
+  if (!factory || !isFunctionLike(factory)) return false;
+  const returnStatements: EsTreeNode[] = [];
+  walkAst(factory.body, (node) => {
+    if (node !== factory.body && isFunctionLike(node)) return false;
+    if (isNodeOfType(node, "ReturnStatement") && node.argument) returnStatements.push(node);
+  });
+  return (
+    returnStatements.length > 0 &&
+    returnStatements.every((returnStatement) => {
+      if (!isNodeOfType(returnStatement, "ReturnStatement") || !returnStatement.argument) {
+        return false;
+      }
+      const returnedIdentity = resolveExpressionKey(returnStatement.argument, context);
+      if (!returnedIdentity) return false;
+      const returnedExpression = stripParenExpression(returnStatement.argument);
+      const returnedSymbol = isNodeOfType(returnedExpression, "Identifier")
+        ? context.scopes.symbolFor(returnedExpression)
+        : null;
+      if (
+        returnedSymbol &&
+        getSymbolEscapeCalls(returnedSymbol, context).some(
+          (escape) =>
+            mutationDominatesCall(escape.callExpression, returnStatement, context) &&
+            callMayMutateArgument(
+              escape.callExpression,
+              escape.argumentIndex,
+              context,
+              mutationIndex,
+              new Map(),
+            ),
+        )
+      ) {
+        return true;
+      }
+      return Boolean(
+        mutationIndex.memberMutationCandidatesByReceiverIdentity
+          .get(returnedIdentity)
+          ?.some((mutationNode) => {
+            let doesMutateMethod = Boolean(
+              readsMutatedMemberReceiver(
+                isNodeOfType(mutationNode, "AssignmentExpression")
+                  ? mutationNode.left
+                  : isNodeOfType(mutationNode, "UnaryExpression")
+                    ? mutationNode.argument
+                    : mutationNode,
+                methodName,
+              ),
+            );
+            if (isNodeOfType(mutationNode, "CallExpression")) {
+              const callee = stripParenExpression(mutationNode.callee);
+              const calleeObject = isNodeOfType(callee, "MemberExpression")
+                ? stripParenExpression(callee.object)
+                : null;
+              doesMutateMethod = Boolean(
+                isNodeOfType(callee, "MemberExpression") &&
+                getStaticPropertyName(callee) === "defineProperty" &&
+                isNodeOfType(calleeObject, "Identifier") &&
+                (calleeObject.name === "Object" || calleeObject.name === "Reflect") &&
+                context.scopes.isGlobalReference(calleeObject) &&
+                isNodeOfType(mutationNode.arguments[1], "Literal") &&
+                mutationNode.arguments[1].value === methodName,
+              );
+            }
+            return (
+              doesMutateMethod && mutationDominatesCall(mutationNode, returnStatement, context)
+            );
+          }),
+      );
+    })
+  );
+};
+
+const escapeCallsBySymbol = new WeakMap<SymbolDescriptor, SymbolEscape[]>();
+
+const getSymbolEscapeCalls = (
+  symbol: SymbolDescriptor,
+  context: RuleContext,
+  visitedSymbols: Set<SymbolDescriptor> = new Set(),
+): SymbolEscape[] => {
+  const cachedEscapeCalls = escapeCallsBySymbol.get(symbol);
+  if (cachedEscapeCalls) return cachedEscapeCalls;
+  if (visitedSymbols.has(symbol)) return [];
+  const nextVisitedSymbols = new Set(visitedSymbols);
+  nextVisitedSymbols.add(symbol);
+  const escapeCalls = new Map<EsTreeNode, Set<number>>();
+  for (const reference of symbol.references) {
+    let argumentExpression = reference.identifier;
+    let didResolveExpression = true;
+    while (argumentExpression.parent && didResolveExpression) {
+      const parent = argumentExpression.parent;
+      didResolveExpression = false;
+      if (stripParenExpression(parent) === argumentExpression) {
+        argumentExpression = parent;
+        didResolveExpression = true;
+      } else if (
+        isNodeOfType(parent, "Property") &&
+        parent.value === argumentExpression &&
+        isNodeOfType(parent.parent, "ObjectExpression")
+      ) {
+        argumentExpression = parent.parent;
+        didResolveExpression = true;
+      } else if (
+        isNodeOfType(parent, "ArrayExpression") &&
+        parent.elements.some((element) => element === argumentExpression)
+      ) {
+        argumentExpression = parent;
+        didResolveExpression = true;
+      } else if (
+        isNodeOfType(parent, "ObjectExpression") &&
+        parent.properties.some((property) => property === argumentExpression)
+      ) {
+        argumentExpression = parent;
+        didResolveExpression = true;
+      } else if (isNodeOfType(parent, "SpreadElement") && parent.argument === argumentExpression) {
+        argumentExpression = parent;
+        didResolveExpression = true;
+      }
+    }
+    const expressionParent = argumentExpression.parent;
+    if (
+      isNodeOfType(expressionParent, "VariableDeclarator") &&
+      expressionParent.init === argumentExpression &&
+      isNodeOfType(expressionParent.id, "Identifier")
+    ) {
+      const aliasSymbol = context.scopes
+        .scopeFor(expressionParent)
+        .symbolsByName.get(expressionParent.id.name);
+      if (aliasSymbol) {
+        for (const escape of getSymbolEscapeCalls(aliasSymbol, context, nextVisitedSymbols)) {
+          const argumentIndexes = escapeCalls.get(escape.callExpression) ?? new Set();
+          argumentIndexes.add(escape.argumentIndex);
+          escapeCalls.set(escape.callExpression, argumentIndexes);
+        }
+      }
+      continue;
+    }
+    if (
+      isNodeOfType(expressionParent, "AssignmentExpression") &&
+      expressionParent.right === argumentExpression
+    ) {
+      const assignmentTarget = stripParenExpression(expressionParent.left);
+      const aliasIdentifier = isNodeOfType(assignmentTarget, "Identifier")
+        ? assignmentTarget
+        : isNodeOfType(assignmentTarget, "MemberExpression") &&
+            isNodeOfType(stripParenExpression(assignmentTarget.object), "Identifier")
+          ? stripParenExpression(assignmentTarget.object)
+          : null;
+      const aliasSymbol = aliasIdentifier ? context.scopes.symbolFor(aliasIdentifier) : null;
+      if (aliasSymbol) {
+        for (const escape of getSymbolEscapeCalls(aliasSymbol, context, nextVisitedSymbols)) {
+          const argumentIndexes = escapeCalls.get(escape.callExpression) ?? new Set();
+          argumentIndexes.add(escape.argumentIndex);
+          escapeCalls.set(escape.callExpression, argumentIndexes);
+        }
+      }
+      continue;
+    }
+    if (isNodeOfType(expressionParent, "CallExpression")) {
+      const argumentIndex = expressionParent.arguments.findIndex(
+        (argument) => argument === argumentExpression,
+      );
+      if (argumentIndex < 0) continue;
+      const argumentIndexes = escapeCalls.get(expressionParent) ?? new Set();
+      argumentIndexes.add(argumentIndex);
+      escapeCalls.set(expressionParent, argumentIndexes);
+    }
+  }
+  const result = [...escapeCalls].flatMap(([callExpression, argumentIndexes]) =>
+    [...argumentIndexes].map((argumentIndex) => ({ argumentIndex, callExpression })),
+  );
+  escapeCallsBySymbol.set(symbol, result);
+  return result;
+};
+
+const functionReturnsParameter = (
+  functionNode: EsTreeNode,
+  parameterIdentity: string,
+  context: RuleContext,
+): boolean => {
+  if (!isFunctionLike(functionNode)) return false;
+  if (
+    isNodeOfType(functionNode, "ArrowFunctionExpression") &&
+    !isNodeOfType(functionNode.body, "BlockStatement")
+  ) {
+    return resolveExpressionKey(functionNode.body, context) === parameterIdentity;
+  }
+  const returnStatements: EsTreeNode[] = [];
+  walkAst(functionNode.body, (node) => {
+    if (node !== functionNode.body && isFunctionLike(node)) return false;
+    if (isNodeOfType(node, "ReturnStatement")) returnStatements.push(node);
+  });
+  return (
+    returnStatements.length > 0 &&
+    returnStatements.every(
+      (returnStatement) =>
+        isNodeOfType(returnStatement, "ReturnStatement") &&
+        returnStatement.argument &&
+        resolveExpressionKey(returnStatement.argument, context) === parameterIdentity,
+    )
+  );
+};
+
+const getCallResultSymbol = (
+  callExpression: EsTreeNode,
+  context: RuleContext,
+): SymbolDescriptor | null => {
+  let expression = callExpression;
+  while (expression.parent && stripParenExpression(expression.parent) === expression) {
+    expression = expression.parent;
+  }
+  const declarator = expression.parent;
+  if (
+    !isNodeOfType(declarator, "VariableDeclarator") ||
+    declarator.init !== expression ||
+    !isNodeOfType(declarator.id, "Identifier")
+  ) {
+    return null;
+  }
+  let scope: ScopeDescriptor | null = context.scopes.scopeFor(declarator);
+  while (scope) {
+    const symbol = scope.symbolsByName.get(declarator.id.name);
+    if (symbol) return symbol;
+    scope = scope.parent;
+  }
+  return null;
+};
+
+const callMayMutateArgument = (
+  callExpression: EsTreeNode,
+  argumentIndex: number,
+  context: RuleContext,
+  mutationIndex: MethodMutationIndex,
+  visitedParameterIndexesByFunction: Map<EsTreeNode, Set<number>>,
+): boolean => {
+  const calledFunction = getLocalCalledFunction(callExpression, context);
+  if (!calledFunction || !isFunctionLike(calledFunction)) return true;
+  if (calledFunction.generator) return false;
+  const visitedParameterIndexes =
+    visitedParameterIndexesByFunction.get(calledFunction) ?? new Set<number>();
+  if (visitedParameterIndexes.has(argumentIndex)) return false;
+  visitedParameterIndexes.add(argumentIndex);
+  visitedParameterIndexesByFunction.set(calledFunction, visitedParameterIndexes);
+  const parameter = calledFunction.params[argumentIndex];
+  if (!isNodeOfType(parameter, "Identifier")) return true;
+  const parameterSymbol = context.scopes
+    .ownScopeFor(calledFunction)
+    ?.symbolsByName.get(parameter.name);
+  if (!parameterSymbol) return true;
+  const parameterIdentity = `symbol:${parameterSymbol.id}`;
+  if (
+    mutationIndex.memberMutationCandidatesByReceiverIdentity
+      .get(parameterIdentity)
+      ?.some((mutation) => context.cfg.enclosingFunction(mutation) === calledFunction)
+  ) {
+    return true;
+  }
+  const doesParameterEscape = getSymbolEscapeCalls(parameterSymbol, context).some((escape) => {
+    if (!isNodeOfType(escape.callExpression, "CallExpression")) return false;
+    if (context.cfg.enclosingFunction(escape.callExpression) !== calledFunction) return false;
+    return callMayMutateArgument(
+      escape.callExpression,
+      escape.argumentIndex,
+      context,
+      mutationIndex,
+      visitedParameterIndexesByFunction,
+    );
+  });
+  if (doesParameterEscape) return true;
+  if (!functionReturnsParameter(calledFunction, parameterIdentity, context)) return false;
+  const resultSymbol = getCallResultSymbol(callExpression, context);
+  if (!resultSymbol) return false;
+  return getSymbolEscapeCalls(resultSymbol, context).some((escape) =>
+    callMayMutateArgument(
+      escape.callExpression,
+      escape.argumentIndex,
+      context,
+      mutationIndex,
+      visitedParameterIndexesByFunction,
+    ),
+  );
+};
+
+const hasProvenMethodMutation = (
+  mutationIndex: MethodMutationIndex,
+  receiver: EsTreeNode,
+  methodName: string,
+  callNode: EsTreeNode,
+  context: RuleContext,
+  prototypeOwnerNames: readonly string[] = [],
+  isProvenReceiverReplacement?: (expression: EsTreeNode) => boolean,
+): boolean => {
+  if (factoryReturnsMutatedReceiver(receiver, methodName, context, mutationIndex)) return true;
+  const receiverIdentity = resolveExpressionKey(receiver, context);
+  const receiverExpression = stripParenExpression(receiver);
+  const receiverSymbol = isNodeOfType(receiverExpression, "Identifier")
+    ? context.scopes.symbolFor(receiverExpression)
+    : null;
+  if (
+    receiverIdentity &&
+    receiverSymbol &&
+    getSymbolEscapeCalls(receiverSymbol, context).some((escape) => {
+      if (!isNodeOfType(escape.callExpression, "CallExpression")) return false;
+      if (
+        escape.callExpression === callNode ||
+        !mutationDominatesCall(escape.callExpression, callNode, context)
+      ) {
+        return false;
+      }
+      return callMayMutateArgument(
+        escape.callExpression,
+        escape.argumentIndex,
+        context,
+        mutationIndex,
+        new Map(),
+      );
+    })
+  ) {
+    return true;
+  }
+  const callScope = context.scopes.scopeFor(callNode);
+  let didFindMutation = false;
+  const mutationCandidates = new Set([
+    ...(receiverIdentity ? getMethodCandidates(mutationIndex, receiverIdentity, methodName) : []),
+    ...prototypeOwnerNames.flatMap((prototypeOwnerName) =>
+      getMethodCandidates(mutationIndex, `global:${prototypeOwnerName}.prototype`, methodName),
+    ),
+    ...(receiverIdentity
+      ? (mutationIndex.receiverAssignmentCandidatesByIdentity.get(receiverIdentity) ?? [])
+      : []),
+  ]);
+  const matchingMutationCandidates: EsTreeNode[] = [];
+  for (const child of mutationCandidates) {
+    if (didFindMutation) break;
+    const childScope = context.scopes.scopeFor(child);
+    if (
+      !isScopeAncestorOf(childScope, callScope) &&
+      !mutationDominatesCall(child, callNode, context)
+    ) {
+      continue;
+    }
+    let mutatedReceiver: EsTreeNode | null = null;
+    if (isNodeOfType(child, "AssignmentExpression")) {
+      if (
+        receiverIdentity !== null &&
+        resolveExpressionKey(child.left, context) === receiverIdentity
+      ) {
+        if (isProvenReceiverReplacement?.(child.right)) continue;
+        matchingMutationCandidates.push(child);
+        if (mutationDominatesCall(child, callNode, context)) {
+          didFindMutation = true;
+          break;
+        }
+        continue;
+      }
+      mutatedReceiver = readsMutatedMemberReceiver(child.left, methodName);
+    } else if (isNodeOfType(child, "UnaryExpression") && child.operator === "delete") {
+      mutatedReceiver = readsMutatedMemberReceiver(child.argument, methodName);
+    } else if (isNodeOfType(child, "CallExpression")) {
+      const callee = stripParenExpression(child.callee);
+      const calleeObject = isNodeOfType(callee, "MemberExpression")
+        ? stripParenExpression(callee.object)
+        : null;
+      if (
+        isNodeOfType(callee, "MemberExpression") &&
+        getStaticPropertyName(callee) === "defineProperty" &&
+        isNodeOfType(calleeObject, "Identifier") &&
+        (calleeObject.name === "Object" || calleeObject.name === "Reflect") &&
+        context.scopes.isGlobalReference(calleeObject) &&
+        isNodeOfType(child.arguments[1], "Literal") &&
+        child.arguments[1].value === methodName
+      ) {
+        const target = child.arguments[0];
+        mutatedReceiver = target && !isNodeOfType(target, "SpreadElement") ? target : null;
+      }
+    }
+    if (!mutatedReceiver) continue;
+    const doesMutationMatchReceiver =
+      (receiverIdentity !== null &&
+        resolveExpressionKey(mutatedReceiver, context) === receiverIdentity) ||
+      isPrototypeReceiver(mutatedReceiver, prototypeOwnerNames, context);
+    if (!doesMutationMatchReceiver) continue;
+    matchingMutationCandidates.push(child);
+    if (mutationDominatesCall(child, callNode, context)) {
+      didFindMutation = true;
+    }
+  }
+  return (
+    didFindMutation ||
+    mutationsCollectivelyDominateCall(matchingMutationCandidates, callNode, context)
+  );
+};
+
+export interface MethodMutationAnalysis {
+  readonly record: (node: EsTreeNode) => void;
+  readonly hasProvenMutation: (
+    receiver: EsTreeNode,
+    methodName: string,
+    callNode: EsTreeNode,
+    prototypeOwnerNames?: readonly string[],
+    isProvenReceiverReplacement?: (expression: EsTreeNode) => boolean,
+  ) => boolean;
+}
+
+export const createMethodMutationAnalysis = (context: RuleContext): MethodMutationAnalysis => {
+  const mutationIndex = createMethodMutationIndex();
+  return {
+    record: (node) => recordMethodMutationNode(mutationIndex, node, context),
+    hasProvenMutation: (
+      receiver,
+      methodName,
+      callNode,
+      prototypeOwnerNames,
+      isProvenReceiverReplacement,
+    ) =>
+      hasProvenMethodMutation(
+        mutationIndex,
+        receiver,
+        methodName,
+        callNode,
+        context,
+        prototypeOwnerNames,
+        isProvenReceiverReplacement,
+      ),
+  };
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/has-visible-binding-named.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/has-visible-binding-named.ts
@@ -1,0 +1,15 @@
+import type { ScopeAnalysis } from "../semantic/scope-analysis.js";
+import type { EsTreeNode } from "./es-tree-node.js";
+
+export const hasVisibleBindingNamed = (
+  node: EsTreeNode,
+  bindingName: string,
+  scopes: ScopeAnalysis,
+): boolean => {
+  let scope = scopes.scopeFor(node);
+  while (true) {
+    if (scope.symbolsByName.has(bindingName)) return true;
+    if (!scope.parent) return false;
+    scope = scope.parent;
+  }
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-generated-docs-archive-filename.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-generated-docs-archive-filename.ts
@@ -1,0 +1,7 @@
+import { normalizeFilename } from "./normalize-filename.js";
+
+const GENERATED_DOCS_ARCHIVE_PATH_PATTERN =
+  /(?:^|\/)(?:docs?|documentation)\/archive\/[^/]+\/static\/(?:[^/]+\/)*docs\.js$/i;
+
+export const isGeneratedDocsArchiveFilename = (filename: string | undefined): boolean =>
+  GENERATED_DOCS_ARCHIVE_PATH_PATTERN.test(normalizeFilename(filename ?? ""));

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-proven-browser-api-receiver.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-proven-browser-api-receiver.ts
@@ -2,6 +2,7 @@ import type { ScopeAnalysis } from "../semantic/scope-analysis.js";
 import type { EsTreeNode } from "./es-tree-node.js";
 import { functionReturnsMatchingExpression } from "./function-returns-matching-expression.js";
 import { getDirectConstInitializer } from "./get-direct-const-initializer.js";
+import { getDirectUnreassignedInitializer } from "./get-direct-unreassigned-initializer.js";
 import { getStaticKeyName } from "./get-static-key-name.js";
 import { getStaticPropertyName } from "./get-static-property-name.js";
 import { getSymbolTypeAnnotation } from "./get-symbol-type-annotation.js";
@@ -170,7 +171,7 @@ export const getProvenDomEventTargetPrototypeOwnerNames = (
     const typeAnnotation = getSymbolTypeAnnotation(symbol);
     const typeName = typeAnnotation ? getUnshadowedDomTargetTypeName(typeAnnotation, scopes) : null;
     if (typeName) return getDomPrototypeOwnerNamesForType(typeName);
-    const initializer = getDirectConstInitializer(symbol);
+    const initializer = getDirectUnreassignedInitializer(symbol);
     if (!initializer) return ["EventTarget"];
     const nextVisitedSymbolIds = new Set(visitedSymbolIds);
     nextVisitedSymbolIds.add(symbol.id);
@@ -395,7 +396,7 @@ export const isProvenBrowserApiReceiver = (
     if (!symbol || visitedSymbolIds.has(symbol.id)) return false;
     const typeAnnotation = getSymbolTypeAnnotation(symbol);
     if (typeAnnotation && isUnshadowedTargetType(typeAnnotation, scopes, receiverKind)) return true;
-    const initializer = getDirectConstInitializer(symbol);
+    const initializer = getDirectUnreassignedInitializer(symbol);
     if (!initializer) return false;
     visitedSymbolIds.add(symbol.id);
     return isProvenBrowserApiReceiver(initializer, receiverKind, scopes, visitedSymbolIds);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-proven-browser-api-receiver.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-proven-browser-api-receiver.ts
@@ -1,11 +1,13 @@
 import type { ScopeAnalysis } from "../semantic/scope-analysis.js";
 import type { EsTreeNode } from "./es-tree-node.js";
+import { functionReturnsMatchingExpression } from "./function-returns-matching-expression.js";
 import { getDirectConstInitializer } from "./get-direct-const-initializer.js";
 import { getStaticPropertyName } from "./get-static-property-name.js";
 import { getSymbolTypeAnnotation } from "./get-symbol-type-annotation.js";
 import { hasEnclosingTypeParameterNamed } from "./has-enclosing-type-parameter-named.js";
 import { hasVisibleBindingNamed } from "./has-visible-binding-named.js";
 import { isNodeOfType } from "./is-node-of-type.js";
+import { isFunctionLike } from "./is-function-like.js";
 import { isReactApiCall } from "./is-react-api-call.js";
 import { stripParenExpression } from "./strip-paren-expression.js";
 
@@ -16,10 +18,29 @@ const DOM_EVENT_TARGET_TYPE_NAMES = new Set([
   "Element",
   "EventTarget",
   "HTMLElement",
+  "HTMLAnchorElement",
+  "HTMLButtonElement",
+  "HTMLCanvasElement",
+  "HTMLDivElement",
+  "HTMLFormElement",
+  "HTMLIFrameElement",
+  "HTMLImageElement",
+  "HTMLInputElement",
+  "HTMLLabelElement",
+  "HTMLLIElement",
+  "HTMLMediaElement",
+  "HTMLParagraphElement",
+  "HTMLSelectElement",
+  "HTMLSpanElement",
+  "HTMLTableElement",
+  "HTMLTextAreaElement",
+  "HTMLUListElement",
+  "HTMLVideoElement",
   "MediaQueryList",
   "Node",
   "ShadowRoot",
   "SVGElement",
+  "SVGSVGElement",
   "Window",
   "XMLDocument",
 ]);
@@ -48,8 +69,28 @@ const DOM_EVENT_TARGET_MEMBER_NAMES = new Set([
   "lastElementChild",
   "ownerDocument",
   "parentElement",
+  "parentNode",
   "shadowRoot",
 ]);
+
+const getDomPrototypeOwnerNamesForType = (typeName: string): readonly string[] => {
+  if (typeName === "Window") return ["Window", "EventTarget"];
+  if (typeName === "Document" || typeName === "XMLDocument") {
+    return [typeName, "Node", "EventTarget"];
+  }
+  if (typeName === "DocumentFragment" || typeName === "ShadowRoot") {
+    return [typeName, "Node", "EventTarget"];
+  }
+  if (typeName === "HTMLElement" || typeName.startsWith("HTML")) {
+    return [typeName, "HTMLElement", "Element", "Node", "EventTarget"];
+  }
+  if (typeName === "SVGElement" || typeName.startsWith("SVG")) {
+    return [typeName, "SVGElement", "Element", "Node", "EventTarget"];
+  }
+  if (typeName === "Element") return ["Element", "Node", "EventTarget"];
+  if (typeName === "Node") return ["Node", "EventTarget"];
+  return [typeName, "EventTarget"];
+};
 
 const isDomEventTargetTypeName = (typeName: string): boolean =>
   DOM_EVENT_TARGET_TYPE_NAMES.has(typeName) || DOM_ELEMENT_TYPE_NAME_PATTERN.test(typeName);
@@ -92,6 +133,20 @@ const isUnshadowedTargetType = (
   return hasTargetType;
 };
 
+const getUnshadowedDomTargetTypeName = (
+  typeNode: EsTreeNode,
+  scopes: ScopeAnalysis,
+): string | null => {
+  if (
+    !isNodeOfType(typeNode, "TSTypeReference") ||
+    !isNodeOfType(typeNode.typeName, "Identifier") ||
+    !isUnshadowedTargetType(typeNode, scopes, "dom-event-target")
+  ) {
+    return null;
+  }
+  return typeNode.typeName.name;
+};
+
 const isGlobalIdentifier = (
   node: EsTreeNode,
   identifierName: string,
@@ -100,6 +155,170 @@ const isGlobalIdentifier = (
   isNodeOfType(node, "Identifier") &&
   node.name === identifierName &&
   scopes.isGlobalReference(node);
+
+export const getProvenDomEventTargetPrototypeOwnerNames = (
+  rawExpression: EsTreeNode,
+  scopes: ScopeAnalysis,
+  visitedSymbolIds: Set<number> = new Set(),
+): readonly string[] => {
+  const expression = stripParenExpression(rawExpression);
+  if (isGlobalIdentifier(expression, "window", scopes)) return ["Window", "EventTarget"];
+  if (isGlobalIdentifier(expression, "document", scopes)) {
+    return ["Document", "Node", "EventTarget"];
+  }
+  if (isNodeOfType(expression, "Identifier")) {
+    const symbol = scopes.symbolFor(expression);
+    if (!symbol || visitedSymbolIds.has(symbol.id)) return ["EventTarget"];
+    const typeAnnotation = getSymbolTypeAnnotation(symbol);
+    const typeName = typeAnnotation ? getUnshadowedDomTargetTypeName(typeAnnotation, scopes) : null;
+    if (typeName) return getDomPrototypeOwnerNamesForType(typeName);
+    const initializer = getDirectConstInitializer(symbol);
+    if (!initializer) return ["EventTarget"];
+    const nextVisitedSymbolIds = new Set(visitedSymbolIds);
+    nextVisitedSymbolIds.add(symbol.id);
+    return getProvenDomEventTargetPrototypeOwnerNames(initializer, scopes, nextVisitedSymbolIds);
+  }
+  if (isNodeOfType(expression, "NewExpression")) {
+    const callee = stripParenExpression(expression.callee);
+    if (isNodeOfType(callee, "Identifier") && DOM_EVENT_TARGET_CONSTRUCTOR_NAMES.has(callee.name)) {
+      const typeName =
+        callee.name === "Image"
+          ? "HTMLImageElement"
+          : callee.name === "Option"
+            ? "HTMLOptionElement"
+            : callee.name;
+      return getDomPrototypeOwnerNamesForType(typeName);
+    }
+  }
+  if (isNodeOfType(expression, "MemberExpression")) {
+    const memberName = getStaticPropertyName(expression);
+    if (memberName === "body" || memberName === "documentElement") {
+      return getDomPrototypeOwnerNamesForType("HTMLElement");
+    }
+  }
+  if (isNodeOfType(expression, "CallExpression")) {
+    const callee = stripParenExpression(expression.callee);
+    const methodName = isNodeOfType(callee, "MemberExpression")
+      ? getStaticPropertyName(callee)
+      : null;
+    if (methodName === "createElement") {
+      return getDomPrototypeOwnerNamesForType("HTMLElement");
+    }
+    if (methodName === "createElementNS") {
+      return getDomPrototypeOwnerNamesForType("SVGElement");
+    }
+    if (methodName && DOM_EVENT_TARGET_FACTORY_METHOD_NAMES.has(methodName)) {
+      return getDomPrototypeOwnerNamesForType("Element");
+    }
+  }
+  return ["EventTarget"];
+};
+
+const hasAssertedTargetType = (
+  expression: EsTreeNode,
+  scopes: ScopeAnalysis,
+  receiverKind: "dom-event-target" | "xml-http-request",
+): boolean => {
+  let wrapper = expression;
+  let didFindTargetAssertion = false;
+  while (
+    isNodeOfType(wrapper, "TSAsExpression") ||
+    isNodeOfType(wrapper, "TSTypeAssertion") ||
+    isNodeOfType(wrapper, "TSSatisfiesExpression")
+  ) {
+    if (isUnshadowedTargetType(wrapper.typeAnnotation, scopes, receiverKind)) {
+      didFindTargetAssertion = true;
+    } else if (didFindTargetAssertion) {
+      return false;
+    }
+    wrapper = wrapper.expression;
+  }
+  let assertedSource: EsTreeNode = wrapper;
+  if (isNodeOfType(assertedSource, "Identifier")) {
+    const assertedSymbol = scopes.symbolFor(assertedSource);
+    const assertedInitializer = assertedSymbol ? getDirectConstInitializer(assertedSymbol) : null;
+    if (!assertedInitializer) return false;
+    assertedSource = stripParenExpression(assertedInitializer);
+  }
+  if (didFindTargetAssertion && isNodeOfType(assertedSource, "MemberExpression")) return false;
+  if (didFindTargetAssertion && isNodeOfType(assertedSource, "ObjectExpression")) return false;
+  if (didFindTargetAssertion && isNodeOfType(assertedSource, "NewExpression")) {
+    if (receiverKind === "xml-http-request") {
+      return isGlobalConstructorReference(
+        assertedSource.callee,
+        "XMLHttpRequest",
+        scopes,
+        new Set(),
+      );
+    }
+    return [...DOM_EVENT_TARGET_CONSTRUCTOR_NAMES].some((constructorName) =>
+      isGlobalConstructorReference(assertedSource.callee, constructorName, scopes, new Set()),
+    );
+  }
+  return didFindTargetAssertion;
+};
+
+const getClassMemberDefinition = (memberExpression: EsTreeNode): EsTreeNode | null => {
+  if (!isNodeOfType(memberExpression, "MemberExpression")) return null;
+  if (!isNodeOfType(stripParenExpression(memberExpression.object), "ThisExpression")) return null;
+  const propertyName = getStaticPropertyName(memberExpression);
+  if (!propertyName) return null;
+  let ancestor = memberExpression.parent;
+  while (ancestor && !isNodeOfType(ancestor, "ClassBody")) {
+    if (
+      (isNodeOfType(ancestor, "FunctionDeclaration") ||
+        isNodeOfType(ancestor, "FunctionExpression")) &&
+      !isNodeOfType(ancestor.parent, "MethodDefinition")
+    ) {
+      return null;
+    }
+    ancestor = ancestor.parent;
+  }
+  if (!ancestor) return null;
+  for (const classElement of ancestor.body) {
+    if (!isNodeOfType(classElement, "PropertyDefinition") || classElement.static) continue;
+    const memberName = isNodeOfType(classElement.key, "Identifier")
+      ? classElement.key.name
+      : isNodeOfType(classElement.key, "Literal") && typeof classElement.key.value === "string"
+        ? classElement.key.value
+        : null;
+    if (memberName === propertyName) return classElement;
+  }
+  return null;
+};
+
+const getClassMemberTypeAnnotation = (classMember: EsTreeNode): EsTreeNode | null => {
+  if (!isNodeOfType(classMember, "PropertyDefinition")) return null;
+  const annotation = classMember.typeAnnotation;
+  return annotation && isNodeOfType(annotation, "TSTypeAnnotation")
+    ? annotation.typeAnnotation
+    : null;
+};
+
+const getSameFileCalledFunction = (
+  callExpression: EsTreeNode,
+  scopes: ScopeAnalysis,
+  visitedSymbolIds: Set<number>,
+): EsTreeNode | null => {
+  if (!isNodeOfType(callExpression, "CallExpression")) return null;
+  const callee = stripParenExpression(callExpression.callee);
+  if (!isNodeOfType(callee, "Identifier")) return null;
+  const symbol = scopes.symbolFor(callee);
+  if (!symbol || visitedSymbolIds.has(symbol.id)) return null;
+  if (
+    symbol.kind !== "const" &&
+    !(
+      symbol.kind === "function" &&
+      symbol.references.every((reference) => reference.flag === "read")
+    )
+  ) {
+    return null;
+  }
+  const candidate = symbol.initializer ?? symbol.declarationNode;
+  if (!isFunctionLike(candidate) || candidate.async || candidate.generator) return null;
+  visitedSymbolIds.add(symbol.id);
+  return candidate;
+};
 
 const isGlobalConstructorReference = (
   rawExpression: EsTreeNode,
@@ -162,6 +381,7 @@ const isProvenDomEventTarget = (
   scopes: ScopeAnalysis,
   visitedSymbolIds: Set<number>,
 ): boolean => {
+  if (hasAssertedTargetType(rawExpression, scopes, "dom-event-target")) return true;
   const expression = stripParenExpression(rawExpression);
   if (isNodeOfType(expression, "Identifier")) {
     if (
@@ -191,13 +411,36 @@ const isProvenDomEventTarget = (
   }
   if (isNodeOfType(expression, "CallExpression")) {
     const callee = stripParenExpression(expression.callee);
-    return (
+    if (
       isNodeOfType(callee, "MemberExpression") &&
       DOM_EVENT_TARGET_FACTORY_METHOD_NAMES.has(getStaticPropertyName(callee) ?? "") &&
       isProvenDomEventTarget(callee.object, scopes, visitedSymbolIds)
+    ) {
+      return true;
+    }
+    const calledFunction = getSameFileCalledFunction(expression, scopes, visitedSymbolIds);
+    return Boolean(
+      calledFunction &&
+      functionReturnsMatchingExpression(
+        calledFunction,
+        scopes,
+        (returnedExpression) =>
+          isProvenDomEventTarget(returnedExpression, scopes, new Set(visitedSymbolIds)),
+        "every",
+      ),
     );
   }
   if (!isNodeOfType(expression, "MemberExpression")) return false;
+  const classMember = getClassMemberDefinition(expression);
+  if (classMember && isNodeOfType(classMember, "PropertyDefinition")) {
+    const classMemberType = getClassMemberTypeAnnotation(classMember);
+    if (classMemberType && isUnshadowedTargetType(classMemberType, scopes, "dom-event-target")) {
+      return true;
+    }
+    if (classMember.value && isProvenDomEventTarget(classMember.value, scopes, visitedSymbolIds)) {
+      return true;
+    }
+  }
   const propertyName = getStaticPropertyName(expression);
   if (propertyName === "current") {
     return hasTypedReactRefOrigin(expression.object, scopes, visitedSymbolIds);
@@ -222,9 +465,34 @@ const isProvenXmlHttpRequest = (
   scopes: ScopeAnalysis,
   visitedSymbolIds: Set<number>,
 ): boolean => {
+  if (hasAssertedTargetType(rawExpression, scopes, "xml-http-request")) return true;
   const expression = stripParenExpression(rawExpression);
   if (isNodeOfType(expression, "NewExpression")) {
     return isGlobalConstructorReference(expression.callee, "XMLHttpRequest", scopes, new Set());
+  }
+  if (isNodeOfType(expression, "CallExpression")) {
+    const calledFunction = getSameFileCalledFunction(expression, scopes, visitedSymbolIds);
+    return Boolean(
+      calledFunction &&
+      functionReturnsMatchingExpression(
+        calledFunction,
+        scopes,
+        (returnedExpression) =>
+          isProvenXmlHttpRequest(returnedExpression, scopes, new Set(visitedSymbolIds)),
+        "every",
+      ),
+    );
+  }
+  if (isNodeOfType(expression, "MemberExpression")) {
+    const classMember = getClassMemberDefinition(expression);
+    if (!classMember || !isNodeOfType(classMember, "PropertyDefinition")) return false;
+    const classMemberType = getClassMemberTypeAnnotation(classMember);
+    if (classMemberType && isUnshadowedTargetType(classMemberType, scopes, "xml-http-request")) {
+      return true;
+    }
+    return Boolean(
+      classMember.value && isProvenXmlHttpRequest(classMember.value, scopes, visitedSymbolIds),
+    );
   }
   if (!isNodeOfType(expression, "Identifier")) return false;
   const symbol = scopes.symbolFor(expression);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-proven-browser-api-receiver.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-proven-browser-api-receiver.ts
@@ -240,6 +240,7 @@ const hasAssertedTargetType = (
     if (!assertedInitializer) return false;
     assertedSource = stripParenExpression(assertedInitializer);
   }
+  if (didFindTargetAssertion && isNodeOfType(assertedSource, "Identifier")) return false;
   if (didFindTargetAssertion && isNodeOfType(assertedSource, "MemberExpression")) return false;
   if (didFindTargetAssertion && isNodeOfType(assertedSource, "ObjectExpression")) return false;
   if (didFindTargetAssertion && isNodeOfType(assertedSource, "NewExpression")) {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-proven-browser-api-receiver.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-proven-browser-api-receiver.ts
@@ -2,6 +2,7 @@ import type { ScopeAnalysis } from "../semantic/scope-analysis.js";
 import type { EsTreeNode } from "./es-tree-node.js";
 import { functionReturnsMatchingExpression } from "./function-returns-matching-expression.js";
 import { getDirectConstInitializer } from "./get-direct-const-initializer.js";
+import { getStaticKeyName } from "./get-static-key-name.js";
 import { getStaticPropertyName } from "./get-static-property-name.js";
 import { getSymbolTypeAnnotation } from "./get-symbol-type-annotation.js";
 import { hasEnclosingTypeParameterNamed } from "./has-enclosing-type-parameter-named.js";
@@ -92,16 +93,13 @@ const getDomPrototypeOwnerNamesForType = (typeName: string): readonly string[] =
   return [typeName, "EventTarget"];
 };
 
-const isDomEventTargetTypeName = (typeName: string): boolean =>
-  DOM_EVENT_TARGET_TYPE_NAMES.has(typeName) || DOM_ELEMENT_TYPE_NAME_PATTERN.test(typeName);
-
 const isTargetTypeName = (
   typeName: string,
   receiverKind: "dom-event-target" | "xml-http-request",
 ): boolean =>
   receiverKind === "xml-http-request"
     ? typeName === "XMLHttpRequest"
-    : isDomEventTargetTypeName(typeName);
+    : DOM_EVENT_TARGET_TYPE_NAMES.has(typeName) || DOM_ELEMENT_TYPE_NAME_PATTERN.test(typeName);
 
 const isUnshadowedTargetType = (
   typeNode: EsTreeNode,
@@ -214,6 +212,20 @@ export const getProvenDomEventTargetPrototypeOwnerNames = (
   return ["EventTarget"];
 };
 
+const isProvenTargetConstructorCall = (
+  callee: EsTreeNode,
+  receiverKind: "dom-event-target" | "xml-http-request",
+  scopes: ScopeAnalysis,
+): boolean => {
+  const constructorNames =
+    receiverKind === "xml-http-request"
+      ? ["XMLHttpRequest"]
+      : [...DOM_EVENT_TARGET_CONSTRUCTOR_NAMES];
+  return constructorNames.some((constructorName) =>
+    isGlobalConstructorReference(callee, constructorName, scopes, new Set()),
+  );
+};
+
 const hasAssertedTargetType = (
   expression: EsTreeNode,
   scopes: ScopeAnalysis,
@@ -244,17 +256,7 @@ const hasAssertedTargetType = (
   if (didFindTargetAssertion && isNodeOfType(assertedSource, "MemberExpression")) return false;
   if (didFindTargetAssertion && isNodeOfType(assertedSource, "ObjectExpression")) return false;
   if (didFindTargetAssertion && isNodeOfType(assertedSource, "NewExpression")) {
-    if (receiverKind === "xml-http-request") {
-      return isGlobalConstructorReference(
-        assertedSource.callee,
-        "XMLHttpRequest",
-        scopes,
-        new Set(),
-      );
-    }
-    return [...DOM_EVENT_TARGET_CONSTRUCTOR_NAMES].some((constructorName) =>
-      isGlobalConstructorReference(assertedSource.callee, constructorName, scopes, new Set()),
-    );
+    return isProvenTargetConstructorCall(assertedSource.callee, receiverKind, scopes);
   }
   return didFindTargetAssertion;
 };
@@ -278,12 +280,7 @@ const getClassMemberDefinition = (memberExpression: EsTreeNode): EsTreeNode | nu
   if (!ancestor) return null;
   for (const classElement of ancestor.body) {
     if (!isNodeOfType(classElement, "PropertyDefinition") || classElement.static) continue;
-    const memberName = isNodeOfType(classElement.key, "Identifier")
-      ? classElement.key.name
-      : isNodeOfType(classElement.key, "Literal") && typeof classElement.key.value === "string"
-        ? classElement.key.value
-        : null;
-    if (memberName === propertyName) return classElement;
+    if (getStaticKeyName(classElement.key) === propertyName) return classElement;
   }
   return null;
 };
@@ -377,45 +374,42 @@ const hasTypedReactRefOrigin = (
   return Boolean(typeArgument && isUnshadowedTargetType(typeArgument, scopes, "dom-event-target"));
 };
 
-const isProvenDomEventTarget = (
-  rawExpression: EsTreeNode,
+export const isProvenBrowserApiReceiver = (
+  receiver: EsTreeNode,
+  receiverKind: "dom-event-target" | "xml-http-request",
   scopes: ScopeAnalysis,
-  visitedSymbolIds: Set<number>,
+  visitedSymbolIds: Set<number> = new Set(),
 ): boolean => {
-  if (hasAssertedTargetType(rawExpression, scopes, "dom-event-target")) return true;
-  const expression = stripParenExpression(rawExpression);
+  const isDomEventTarget = receiverKind === "dom-event-target";
+  if (hasAssertedTargetType(receiver, scopes, receiverKind)) return true;
+  const expression = stripParenExpression(receiver);
   if (isNodeOfType(expression, "Identifier")) {
     if (
-      isGlobalIdentifier(expression, "document", scopes) ||
-      isGlobalIdentifier(expression, "window", scopes)
+      isDomEventTarget &&
+      (isGlobalIdentifier(expression, "document", scopes) ||
+        isGlobalIdentifier(expression, "window", scopes))
     ) {
       return true;
     }
     const symbol = scopes.symbolFor(expression);
     if (!symbol || visitedSymbolIds.has(symbol.id)) return false;
     const typeAnnotation = getSymbolTypeAnnotation(symbol);
-    if (typeAnnotation && isUnshadowedTargetType(typeAnnotation, scopes, "dom-event-target")) {
-      return true;
-    }
+    if (typeAnnotation && isUnshadowedTargetType(typeAnnotation, scopes, receiverKind)) return true;
     const initializer = getDirectConstInitializer(symbol);
     if (!initializer) return false;
     visitedSymbolIds.add(symbol.id);
-    return isProvenDomEventTarget(initializer, scopes, visitedSymbolIds);
+    return isProvenBrowserApiReceiver(initializer, receiverKind, scopes, visitedSymbolIds);
   }
   if (isNodeOfType(expression, "NewExpression")) {
-    for (const constructorName of DOM_EVENT_TARGET_CONSTRUCTOR_NAMES) {
-      if (isGlobalConstructorReference(expression.callee, constructorName, scopes, new Set())) {
-        return true;
-      }
-    }
-    return false;
+    return isProvenTargetConstructorCall(expression.callee, receiverKind, scopes);
   }
   if (isNodeOfType(expression, "CallExpression")) {
     const callee = stripParenExpression(expression.callee);
     if (
+      isDomEventTarget &&
       isNodeOfType(callee, "MemberExpression") &&
       DOM_EVENT_TARGET_FACTORY_METHOD_NAMES.has(getStaticPropertyName(callee) ?? "") &&
-      isProvenDomEventTarget(callee.object, scopes, visitedSymbolIds)
+      isProvenBrowserApiReceiver(callee.object, receiverKind, scopes, visitedSymbolIds)
     ) {
       return true;
     }
@@ -426,7 +420,12 @@ const isProvenDomEventTarget = (
         calledFunction,
         scopes,
         (returnedExpression) =>
-          isProvenDomEventTarget(returnedExpression, scopes, new Set(visitedSymbolIds)),
+          isProvenBrowserApiReceiver(
+            returnedExpression,
+            receiverKind,
+            scopes,
+            new Set(visitedSymbolIds),
+          ),
         "every",
       ),
     );
@@ -435,13 +434,17 @@ const isProvenDomEventTarget = (
   const classMember = getClassMemberDefinition(expression);
   if (classMember && isNodeOfType(classMember, "PropertyDefinition")) {
     const classMemberType = getClassMemberTypeAnnotation(classMember);
-    if (classMemberType && isUnshadowedTargetType(classMemberType, scopes, "dom-event-target")) {
+    if (classMemberType && isUnshadowedTargetType(classMemberType, scopes, receiverKind)) {
       return true;
     }
-    if (classMember.value && isProvenDomEventTarget(classMember.value, scopes, visitedSymbolIds)) {
+    if (
+      classMember.value &&
+      isProvenBrowserApiReceiver(classMember.value, receiverKind, scopes, visitedSymbolIds)
+    ) {
       return true;
     }
   }
+  if (!isDomEventTarget) return false;
   const propertyName = getStaticPropertyName(expression);
   if (propertyName === "current") {
     return hasTypedReactRefOrigin(expression.object, scopes, visitedSymbolIds);
@@ -457,62 +460,6 @@ const isProvenDomEventTarget = (
   return (
     propertyName !== null &&
     DOM_EVENT_TARGET_MEMBER_NAMES.has(propertyName) &&
-    isProvenDomEventTarget(object, scopes, visitedSymbolIds)
+    isProvenBrowserApiReceiver(object, receiverKind, scopes, visitedSymbolIds)
   );
 };
-
-const isProvenXmlHttpRequest = (
-  rawExpression: EsTreeNode,
-  scopes: ScopeAnalysis,
-  visitedSymbolIds: Set<number>,
-): boolean => {
-  if (hasAssertedTargetType(rawExpression, scopes, "xml-http-request")) return true;
-  const expression = stripParenExpression(rawExpression);
-  if (isNodeOfType(expression, "NewExpression")) {
-    return isGlobalConstructorReference(expression.callee, "XMLHttpRequest", scopes, new Set());
-  }
-  if (isNodeOfType(expression, "CallExpression")) {
-    const calledFunction = getSameFileCalledFunction(expression, scopes, visitedSymbolIds);
-    return Boolean(
-      calledFunction &&
-      functionReturnsMatchingExpression(
-        calledFunction,
-        scopes,
-        (returnedExpression) =>
-          isProvenXmlHttpRequest(returnedExpression, scopes, new Set(visitedSymbolIds)),
-        "every",
-      ),
-    );
-  }
-  if (isNodeOfType(expression, "MemberExpression")) {
-    const classMember = getClassMemberDefinition(expression);
-    if (!classMember || !isNodeOfType(classMember, "PropertyDefinition")) return false;
-    const classMemberType = getClassMemberTypeAnnotation(classMember);
-    if (classMemberType && isUnshadowedTargetType(classMemberType, scopes, "xml-http-request")) {
-      return true;
-    }
-    return Boolean(
-      classMember.value && isProvenXmlHttpRequest(classMember.value, scopes, visitedSymbolIds),
-    );
-  }
-  if (!isNodeOfType(expression, "Identifier")) return false;
-  const symbol = scopes.symbolFor(expression);
-  if (!symbol || visitedSymbolIds.has(symbol.id)) return false;
-  const typeAnnotation = getSymbolTypeAnnotation(symbol);
-  if (typeAnnotation && isUnshadowedTargetType(typeAnnotation, scopes, "xml-http-request")) {
-    return true;
-  }
-  const initializer = getDirectConstInitializer(symbol);
-  if (!initializer) return false;
-  visitedSymbolIds.add(symbol.id);
-  return isProvenXmlHttpRequest(initializer, scopes, visitedSymbolIds);
-};
-
-export const isProvenBrowserApiReceiver = (
-  receiver: EsTreeNode,
-  receiverKind: "dom-event-target" | "xml-http-request",
-  scopes: ScopeAnalysis,
-): boolean =>
-  receiverKind === "xml-http-request"
-    ? isProvenXmlHttpRequest(receiver, scopes, new Set())
-    : isProvenDomEventTarget(receiver, scopes, new Set());

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-proven-browser-api-receiver.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-proven-browser-api-receiver.ts
@@ -1,0 +1,249 @@
+import type { ScopeAnalysis } from "../semantic/scope-analysis.js";
+import type { EsTreeNode } from "./es-tree-node.js";
+import { getDirectConstInitializer } from "./get-direct-const-initializer.js";
+import { getStaticPropertyName } from "./get-static-property-name.js";
+import { getSymbolTypeAnnotation } from "./get-symbol-type-annotation.js";
+import { hasEnclosingTypeParameterNamed } from "./has-enclosing-type-parameter-named.js";
+import { hasVisibleBindingNamed } from "./has-visible-binding-named.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+import { isReactApiCall } from "./is-react-api-call.js";
+import { stripParenExpression } from "./strip-paren-expression.js";
+
+const DOM_EVENT_TARGET_TYPE_NAMES = new Set([
+  "AbortSignal",
+  "Document",
+  "DocumentFragment",
+  "Element",
+  "EventTarget",
+  "HTMLElement",
+  "MediaQueryList",
+  "Node",
+  "ShadowRoot",
+  "SVGElement",
+  "Window",
+  "XMLDocument",
+]);
+const DOM_ELEMENT_TYPE_NAME_PATTERN = /^(?:HTML|SVG)[A-Za-z0-9]+Element$/;
+const DOM_EVENT_TARGET_CONSTRUCTOR_NAMES = new Set([
+  "DocumentFragment",
+  "EventTarget",
+  "Image",
+  "Option",
+]);
+const DOM_EVENT_TARGET_FACTORY_METHOD_NAMES = new Set([
+  "cloneNode",
+  "closest",
+  "createElement",
+  "createElementNS",
+  "elementFromPoint",
+  "getElementById",
+  "getRootNode",
+  "querySelector",
+]);
+const DOM_EVENT_TARGET_MEMBER_NAMES = new Set([
+  "activeElement",
+  "body",
+  "documentElement",
+  "firstElementChild",
+  "lastElementChild",
+  "ownerDocument",
+  "parentElement",
+  "shadowRoot",
+]);
+
+const isDomEventTargetTypeName = (typeName: string): boolean =>
+  DOM_EVENT_TARGET_TYPE_NAMES.has(typeName) || DOM_ELEMENT_TYPE_NAME_PATTERN.test(typeName);
+
+const isTargetTypeName = (
+  typeName: string,
+  receiverKind: "dom-event-target" | "xml-http-request",
+): boolean =>
+  receiverKind === "xml-http-request"
+    ? typeName === "XMLHttpRequest"
+    : isDomEventTargetTypeName(typeName);
+
+const isUnshadowedTargetType = (
+  typeNode: EsTreeNode,
+  scopes: ScopeAnalysis,
+  receiverKind: "dom-event-target" | "xml-http-request",
+): boolean => {
+  if (isNodeOfType(typeNode, "TSTypeReference")) {
+    if (!isNodeOfType(typeNode.typeName, "Identifier")) return false;
+    const typeName = typeNode.typeName.name;
+    return (
+      isTargetTypeName(typeName, receiverKind) &&
+      !hasVisibleBindingNamed(typeNode, typeName, scopes) &&
+      !hasEnclosingTypeParameterNamed(typeNode, typeName)
+    );
+  }
+  if (!isNodeOfType(typeNode, "TSUnionType")) return false;
+
+  let hasTargetType = false;
+  for (const unionMember of typeNode.types) {
+    if (
+      isNodeOfType(unionMember, "TSNullKeyword") ||
+      isNodeOfType(unionMember, "TSUndefinedKeyword")
+    ) {
+      continue;
+    }
+    if (!isUnshadowedTargetType(unionMember, scopes, receiverKind)) return false;
+    hasTargetType = true;
+  }
+  return hasTargetType;
+};
+
+const isGlobalIdentifier = (
+  node: EsTreeNode,
+  identifierName: string,
+  scopes: ScopeAnalysis,
+): boolean =>
+  isNodeOfType(node, "Identifier") &&
+  node.name === identifierName &&
+  scopes.isGlobalReference(node);
+
+const isGlobalConstructorReference = (
+  rawExpression: EsTreeNode,
+  constructorName: string,
+  scopes: ScopeAnalysis,
+  visitedSymbolIds: Set<number>,
+): boolean => {
+  const expression = stripParenExpression(rawExpression);
+  if (isNodeOfType(expression, "Identifier")) {
+    if (expression.name === constructorName && scopes.isGlobalReference(expression)) return true;
+    const symbol = scopes.symbolFor(expression);
+    if (!symbol || visitedSymbolIds.has(symbol.id)) return false;
+    const initializer = getDirectConstInitializer(symbol);
+    if (!initializer) return false;
+    visitedSymbolIds.add(symbol.id);
+    return isGlobalConstructorReference(initializer, constructorName, scopes, visitedSymbolIds);
+  }
+  if (!isNodeOfType(expression, "MemberExpression")) return false;
+  if (getStaticPropertyName(expression) !== constructorName) return false;
+  const object = stripParenExpression(expression.object);
+  return (
+    isGlobalIdentifier(object, "window", scopes) || isGlobalIdentifier(object, "globalThis", scopes)
+  );
+};
+
+const hasTypedReactRefOrigin = (
+  rawExpression: EsTreeNode,
+  scopes: ScopeAnalysis,
+  visitedSymbolIds: Set<number>,
+): boolean => {
+  let expression = stripParenExpression(rawExpression);
+  while (isNodeOfType(expression, "Identifier")) {
+    const symbol = scopes.symbolFor(expression);
+    if (!symbol || visitedSymbolIds.has(symbol.id)) return false;
+    const initializer = getDirectConstInitializer(symbol);
+    if (!initializer) return false;
+    visitedSymbolIds.add(symbol.id);
+    expression = stripParenExpression(initializer);
+  }
+  if (!isNodeOfType(expression, "CallExpression")) return false;
+  if (
+    !isReactApiCall(expression, "useRef", scopes, {
+      allowGlobalReactNamespace: false,
+      allowUnboundBareCalls: false,
+    }) &&
+    !isReactApiCall(expression, "createRef", scopes, {
+      allowGlobalReactNamespace: false,
+      allowUnboundBareCalls: false,
+    })
+  ) {
+    return false;
+  }
+  if (!isNodeOfType(expression.typeArguments, "TSTypeParameterInstantiation")) return false;
+  const typeArgument = expression.typeArguments.params[0];
+  return Boolean(typeArgument && isUnshadowedTargetType(typeArgument, scopes, "dom-event-target"));
+};
+
+const isProvenDomEventTarget = (
+  rawExpression: EsTreeNode,
+  scopes: ScopeAnalysis,
+  visitedSymbolIds: Set<number>,
+): boolean => {
+  const expression = stripParenExpression(rawExpression);
+  if (isNodeOfType(expression, "Identifier")) {
+    if (
+      isGlobalIdentifier(expression, "document", scopes) ||
+      isGlobalIdentifier(expression, "window", scopes)
+    ) {
+      return true;
+    }
+    const symbol = scopes.symbolFor(expression);
+    if (!symbol || visitedSymbolIds.has(symbol.id)) return false;
+    const typeAnnotation = getSymbolTypeAnnotation(symbol);
+    if (typeAnnotation && isUnshadowedTargetType(typeAnnotation, scopes, "dom-event-target")) {
+      return true;
+    }
+    const initializer = getDirectConstInitializer(symbol);
+    if (!initializer) return false;
+    visitedSymbolIds.add(symbol.id);
+    return isProvenDomEventTarget(initializer, scopes, visitedSymbolIds);
+  }
+  if (isNodeOfType(expression, "NewExpression")) {
+    for (const constructorName of DOM_EVENT_TARGET_CONSTRUCTOR_NAMES) {
+      if (isGlobalConstructorReference(expression.callee, constructorName, scopes, new Set())) {
+        return true;
+      }
+    }
+    return false;
+  }
+  if (isNodeOfType(expression, "CallExpression")) {
+    const callee = stripParenExpression(expression.callee);
+    return (
+      isNodeOfType(callee, "MemberExpression") &&
+      DOM_EVENT_TARGET_FACTORY_METHOD_NAMES.has(getStaticPropertyName(callee) ?? "") &&
+      isProvenDomEventTarget(callee.object, scopes, visitedSymbolIds)
+    );
+  }
+  if (!isNodeOfType(expression, "MemberExpression")) return false;
+  const propertyName = getStaticPropertyName(expression);
+  if (propertyName === "current") {
+    return hasTypedReactRefOrigin(expression.object, scopes, visitedSymbolIds);
+  }
+  const object = stripParenExpression(expression.object);
+  if (
+    propertyName === "document" &&
+    (isGlobalIdentifier(object, "window", scopes) ||
+      isGlobalIdentifier(object, "globalThis", scopes))
+  ) {
+    return true;
+  }
+  return (
+    propertyName !== null &&
+    DOM_EVENT_TARGET_MEMBER_NAMES.has(propertyName) &&
+    isProvenDomEventTarget(object, scopes, visitedSymbolIds)
+  );
+};
+
+const isProvenXmlHttpRequest = (
+  rawExpression: EsTreeNode,
+  scopes: ScopeAnalysis,
+  visitedSymbolIds: Set<number>,
+): boolean => {
+  const expression = stripParenExpression(rawExpression);
+  if (isNodeOfType(expression, "NewExpression")) {
+    return isGlobalConstructorReference(expression.callee, "XMLHttpRequest", scopes, new Set());
+  }
+  if (!isNodeOfType(expression, "Identifier")) return false;
+  const symbol = scopes.symbolFor(expression);
+  if (!symbol || visitedSymbolIds.has(symbol.id)) return false;
+  const typeAnnotation = getSymbolTypeAnnotation(symbol);
+  if (typeAnnotation && isUnshadowedTargetType(typeAnnotation, scopes, "xml-http-request")) {
+    return true;
+  }
+  const initializer = getDirectConstInitializer(symbol);
+  if (!initializer) return false;
+  visitedSymbolIds.add(symbol.id);
+  return isProvenXmlHttpRequest(initializer, scopes, visitedSymbolIds);
+};
+
+export const isProvenBrowserApiReceiver = (
+  receiver: EsTreeNode,
+  receiverKind: "dom-event-target" | "xml-http-request",
+  scopes: ScopeAnalysis,
+): boolean =>
+  receiverKind === "xml-http-request"
+    ? isProvenXmlHttpRequest(receiver, scopes, new Set())
+    : isProvenDomEventTarget(receiver, scopes, new Set());

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-proven-pure-imported-predicate-call.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-proven-pure-imported-predicate-call.ts
@@ -1,0 +1,185 @@
+import { resolveImportedExportName } from "./find-exported-function-body.js";
+import { getStaticPropertyName } from "./get-static-property-name.js";
+import { isFunctionLike } from "./is-function-like.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+import { resolveCrossFileFunctionExport } from "./resolve-cross-file-function-export.js";
+import type { EsTreeNode } from "./es-tree-node.js";
+import type { RuleContext } from "./rule-context.js";
+import { stripParenExpression } from "./strip-paren-expression.js";
+import { walkAst } from "./walk-ast.js";
+
+const expressionContainsEventAlias = (
+  expression: EsTreeNode,
+  identifierNames: ReadonlySet<string>,
+): boolean => {
+  const candidate = stripParenExpression(expression);
+  if (isNodeOfType(candidate, "Identifier")) return identifierNames.has(candidate.name);
+  if (isNodeOfType(candidate, "SpreadElement")) {
+    return expressionContainsEventAlias(candidate.argument, identifierNames);
+  }
+  if (isNodeOfType(candidate, "ObjectExpression")) {
+    return candidate.properties.some((property) =>
+      isNodeOfType(property, "Property")
+        ? expressionContainsEventAlias(property.value, identifierNames)
+        : isNodeOfType(property, "SpreadElement") &&
+          expressionContainsEventAlias(property.argument, identifierNames),
+    );
+  }
+  if (isNodeOfType(candidate, "ArrayExpression")) {
+    return candidate.elements.some(
+      (element) => element && expressionContainsEventAlias(element, identifierNames),
+    );
+  }
+  if (isNodeOfType(candidate, "ConditionalExpression")) {
+    return (
+      expressionContainsEventAlias(candidate.consequent, identifierNames) ||
+      expressionContainsEventAlias(candidate.alternate, identifierNames)
+    );
+  }
+  if (isNodeOfType(candidate, "LogicalExpression")) {
+    return (
+      expressionContainsEventAlias(candidate.left, identifierNames) ||
+      expressionContainsEventAlias(candidate.right, identifierNames)
+    );
+  }
+  if (isNodeOfType(candidate, "SequenceExpression")) {
+    return candidate.expressions.some((innerExpression) =>
+      expressionContainsEventAlias(innerExpression, identifierNames),
+    );
+  }
+  return false;
+};
+
+const getPatternPropertyName = (node: EsTreeNode): string | null =>
+  isNodeOfType(node, "Identifier")
+    ? node.name
+    : isNodeOfType(node, "Literal") && typeof node.value === "string"
+      ? node.value
+      : null;
+
+const addAliasNamesFromPattern = (
+  pattern: EsTreeNode,
+  rawSource: EsTreeNode,
+  aliasNames: Set<string>,
+): void => {
+  const source = stripParenExpression(rawSource);
+  if (isNodeOfType(pattern, "Identifier")) {
+    if (expressionContainsEventAlias(source, aliasNames)) aliasNames.add(pattern.name);
+    return;
+  }
+  if (isNodeOfType(pattern, "AssignmentPattern")) {
+    addAliasNamesFromPattern(pattern.left, source, aliasNames);
+    return;
+  }
+  if (isNodeOfType(pattern, "ObjectPattern") && isNodeOfType(source, "ObjectExpression")) {
+    for (const patternProperty of pattern.properties) {
+      if (!isNodeOfType(patternProperty, "Property")) continue;
+      const propertyName = getPatternPropertyName(patternProperty.key);
+      if (!propertyName) continue;
+      const sourceProperty = source.properties.find(
+        (property) =>
+          isNodeOfType(property, "Property") &&
+          getPatternPropertyName(property.key) === propertyName,
+      );
+      if (isNodeOfType(sourceProperty, "Property")) {
+        addAliasNamesFromPattern(patternProperty.value, sourceProperty.value, aliasNames);
+      }
+    }
+    return;
+  }
+  if (isNodeOfType(pattern, "ArrayPattern") && isNodeOfType(source, "ArrayExpression")) {
+    for (const [elementIndex, patternElement] of pattern.elements.entries()) {
+      const sourceElement = source.elements[elementIndex];
+      if (patternElement && sourceElement) {
+        addAliasNamesFromPattern(patternElement, sourceElement, aliasNames);
+      }
+    }
+  }
+};
+
+export const isProvenPureImportedPredicateCall = (
+  callExpression: EsTreeNode,
+  eventArgumentIndex: number,
+  context: RuleContext,
+): boolean => {
+  if (!isNodeOfType(callExpression, "CallExpression") || !context.filename) return false;
+  const callee = stripParenExpression(callExpression.callee);
+  if (!isNodeOfType(callee, "Identifier")) return false;
+  const symbol = context.scopes.symbolFor(callee);
+  if (!symbol || symbol.kind !== "import") return false;
+  const importSpecifier = symbol.declarationNode;
+  const importDeclaration = importSpecifier.parent;
+  const exportedName = resolveImportedExportName(importSpecifier);
+  if (
+    !exportedName ||
+    !isNodeOfType(importDeclaration, "ImportDeclaration") ||
+    typeof importDeclaration.source.value !== "string"
+  ) {
+    return false;
+  }
+  const importedFunction = resolveCrossFileFunctionExport(
+    context.filename,
+    importDeclaration.source.value,
+    exportedName,
+  );
+  if (!importedFunction || !isFunctionLike(importedFunction)) return false;
+  const parameter = importedFunction.params[eventArgumentIndex];
+  if (!isNodeOfType(parameter, "Identifier")) return false;
+  const aliasNames = new Set([parameter.name]);
+  let didFindUnsafeUse = false;
+  walkAst(importedFunction.body, (node) => {
+    if (didFindUnsafeUse) return false;
+    if (node !== importedFunction.body && isFunctionLike(node)) return false;
+    if (isNodeOfType(node, "VariableDeclarator") && node.init) {
+      addAliasNamesFromPattern(node.id, node.init, aliasNames);
+      return;
+    }
+    if (
+      isNodeOfType(node, "AssignmentExpression") &&
+      isNodeOfType(node.left, "Identifier") &&
+      expressionContainsEventAlias(node.right, aliasNames)
+    ) {
+      aliasNames.add(node.left.name);
+      return;
+    }
+    if (isNodeOfType(node, "CallExpression")) {
+      const nestedCallee = stripParenExpression(node.callee);
+      if (
+        (isNodeOfType(nestedCallee, "MemberExpression") &&
+          getStaticPropertyName(nestedCallee) === "preventDefault" &&
+          expressionContainsEventAlias(nestedCallee.object, aliasNames)) ||
+        node.arguments.some(
+          (argument) =>
+            !isNodeOfType(argument, "SpreadElement") &&
+            expressionContainsEventAlias(argument, aliasNames),
+        )
+      ) {
+        didFindUnsafeUse = true;
+      }
+      return;
+    }
+    if (
+      isNodeOfType(node, "NewExpression") &&
+      node.arguments.some(
+        (argument) =>
+          !isNodeOfType(argument, "SpreadElement") &&
+          expressionContainsEventAlias(argument, aliasNames),
+      )
+    ) {
+      didFindUnsafeUse = true;
+      return;
+    }
+    const assignmentTarget = isNodeOfType(node, "AssignmentExpression")
+      ? stripParenExpression(node.left)
+      : null;
+    if (
+      isNodeOfType(node, "AssignmentExpression") &&
+      ((isNodeOfType(assignmentTarget, "MemberExpression") &&
+        expressionContainsEventAlias(assignmentTarget.object, aliasNames)) ||
+        expressionContainsEventAlias(node.right, aliasNames))
+    ) {
+      didFindUnsafeUse = true;
+    }
+  });
+  return !didFindUnsafeUse;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-proven-pure-imported-predicate-call.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-proven-pure-imported-predicate-call.ts
@@ -122,7 +122,6 @@ export const isProvenPureImportedPredicateCall = (
   let didFindUnsafeUse = false;
   walkAst(importedFunction.body, (node) => {
     if (didFindUnsafeUse) return false;
-    if (node !== importedFunction.body && isFunctionLike(node)) return false;
     if (isNodeOfType(node, "VariableDeclarator") && node.init) {
       addAliasNamesFromPattern(node.id, node.init, aliasNames);
       return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-proven-pure-imported-predicate-call.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-proven-pure-imported-predicate-call.ts
@@ -1,4 +1,5 @@
 import { resolveImportedExportName } from "./find-exported-function-body.js";
+import { getStaticKeyName } from "./get-static-key-name.js";
 import { getStaticPropertyName } from "./get-static-property-name.js";
 import { isFunctionLike } from "./is-function-like.js";
 import { isNodeOfType } from "./is-node-of-type.js";
@@ -50,13 +51,6 @@ const expressionContainsEventAlias = (
   return false;
 };
 
-const getPatternPropertyName = (node: EsTreeNode): string | null =>
-  isNodeOfType(node, "Identifier")
-    ? node.name
-    : isNodeOfType(node, "Literal") && typeof node.value === "string"
-      ? node.value
-      : null;
-
 const addAliasNamesFromPattern = (
   pattern: EsTreeNode,
   rawSource: EsTreeNode,
@@ -74,12 +68,11 @@ const addAliasNamesFromPattern = (
   if (isNodeOfType(pattern, "ObjectPattern") && isNodeOfType(source, "ObjectExpression")) {
     for (const patternProperty of pattern.properties) {
       if (!isNodeOfType(patternProperty, "Property")) continue;
-      const propertyName = getPatternPropertyName(patternProperty.key);
+      const propertyName = getStaticKeyName(patternProperty.key);
       if (!propertyName) continue;
       const sourceProperty = source.properties.find(
         (property) =>
-          isNodeOfType(property, "Property") &&
-          getPatternPropertyName(property.key) === propertyName,
+          isNodeOfType(property, "Property") && getStaticKeyName(property.key) === propertyName,
       );
       if (isNodeOfType(sourceProperty, "Property")) {
         addAliasNamesFromPattern(patternProperty.value, sourceProperty.value, aliasNames);


### PR DESCRIPTION
## Problem

`no-sync-xhr` and `client-passive-event-listeners` inferred browser APIs from method spelling and arguments alone. Unrelated typed receivers such as archive.open(..., false) and gestureBus.addEventListener(...) could therefore report.

## Fix

Require browser receiver provenance before reporting. The hardened implementation preserves real XMLHttpRequest and DOM EventTarget findings while accounting for aliases, reassignment, method and prototype mutation, object containers and spreads, helper and factory returns, conditional dominance, destructuring, wrappers, forwarded handlers, deferred callbacks, imported pure predicates, shadowed globals, and generated documentation archives.

Cross-file dependency metadata now includes client-passive-event-listeners so sidecar cache invalidation remains correct. Review follow-up `ed58a8365` also rejects assertions laundered through const aliases of unknown parameters/imports while retaining independently proven constructed receivers.

## Regression coverage

- paired valid/invalid tests for both rules, including asserted unknown aliases and constructed controls
- adversarial aliases, mutations, destructuring, branches, callbacks, helpers, factories, constructors, TypeScript wrappers, shadowing, and cross-file predicates
- permanent fuzz seeds and snippet-pool coverage
- strict 500-iteration fuzz for each target rule with nonzero fire coverage
- linear detector performance through 2,000 adversarial statements

## Validation

Exact head: `ed58a83650374c71254139a49ce8b949754a259b`

- full repository tests: 14/14 tasks passed
  - final oxlint plugin follow-up: 12,428 passed, 148 skipped
  - core: 1,286 passed
  - CLI: 2,208 passed, 27 skipped
  - fuzz harness: 37 passed, 400 opt-in rules skipped
- `nr typecheck`, `nr lint`, `nr format:check`, `nr build`, `git diff --check`: passed
- built CLI JSON report smoke test: passed
- exact reproductions: unrelated typed receivers and asserted unknown aliases quiet; browser controls still report
- force-fresh RDE A/B: 100/100 baseline and candidate, zero failures, no-sync-xhr 0→0, passive listeners 7→7, zero diagnostic deltas
- exact cold/no-cache React Bench: 120/120 pinned repositories, zero failures or incomplete scans, 109,048 file extents
  - no-sync-xhr: 1→1
  - client-passive-event-listeners: 51→31
  - zero additions
  - 20 removals, all manually classified false positives (Victory 2, reactuse 18)
  - zero removed true positives
  - exact identity parity with the pre-review candidate, so the assertion fix adds no corpus regression
- DevLovers reconstructed oracle: zero target diagnostics
- full CI matrix: green across Linux Node 20/22/24/25/26, macOS, Windows, lint, typecheck, builds, CodeQL, React Doctor, and preview publication
- direct review-thread audit: all concrete feedback reproduced, fixed with paired tests, explained, and resolved

## Precision boundary

Unknown userland receivers remain quiet unless browser provenance is established. Mutated, escaped, or assertion-laundered receivers are treated conservatively. Real browser objects with stable provenance continue to report.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large behavioral change to two lint rules via new static-analysis primitives; bench data shows many fewer passive-listener findings with no reported true-positive regressions, but complex provenance logic could still miss or misclassify edge cases.
> 
> **Overview**
> **`no-sync-xhr`** and **`client-passive-event-listeners`** no longer fire on method shape alone (e.g. `archive.open(..., false)` or a typed `GestureBus.addEventListener`). Both rules now require a **proven browser receiver** via new shared analysis (`isProvenBrowserApiReceiver`, method-mutation / prototype tracking, and related symbol/type helpers) before reporting.
> 
> **`client-passive-event-listeners`** is substantially reworked: deferred `Program:exit` pass, skips generated docs archive paths, treats forwarded events / `preventDefault` / imported pure predicates more precisely, and registers as a **cross-file** rule for cache invalidation. **`no-indeterminate-attribute`** only picks up shared type/symbol utilities (e.g. destructured `HTMLInputElement` params).
> 
> Regression and fuzz coverage expand for adversarial aliases, mutations, shadowing, and name-heuristic false positives.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2141de4a6266844cb7b8c8dff04a0f628ba9abcd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->