### PR TITLE
fix(rule): resolve forwardRef binding provenance

### DIFF
--- a/.changeset/fuzzy-refs-resolve.md
+++ b/.changeset/fuzzy-refs-resolve.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Resolve React forwardRef imports before applying callback arity guidance.

--- a/packages/fuzz/corpus/regressions/forward-ref-uses-ref--local-name-collision.tsx
+++ b/packages/fuzz/corpus/regressions/forward-ref-uses-ref--local-name-collision.tsx
@@ -1,0 +1,6 @@
+// rule: forward-ref-uses-ref
+// weakness: name-heuristic
+// source: ISSUES_TO_FIX_ASAP.md V25 binding-provenance report
+const forwardRef = (transform: (value: string) => string): string => transform("hello");
+
+export const transformedValue = forwardRef((value) => value.toUpperCase());

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -342,7 +342,7 @@ export const IMPORT_LINE_POOL = [
   `import { useForm } from "react-hook-form";`,
   `import debounce from "lodash/debounce";`,
   `import { z } from "zod";`,
-  `import { forwardRef } from "react";`,
+  `import { forwardRef } from "react";\nconst FuzzForwardRefComponent = forwardRef((props) => <button>{props.label}</button>);`,
 ] as const;
 
 // Filenames rotate per iteration because a large rule population is

--- a/packages/fuzz/tests/verdict-robustness.test.ts
+++ b/packages/fuzz/tests/verdict-robustness.test.ts
@@ -20,6 +20,7 @@ const AUDITED_RULE_IDS = [
   "aria-role",
   "effect-listener-cleanup-mismatch",
   "effect-needs-cleanup",
+  "forward-ref-uses-ref",
   "interactive-supports-focus",
   "no-adjust-state-on-prop-change",
   "no-aria-hidden-on-focusable",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/forward-ref-uses-ref.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/forward-ref-uses-ref.regressions.test.ts
@@ -41,4 +41,90 @@ describe("react-builtins/forward-ref-uses-ref binding provenance", () => {
       0,
     );
   });
+
+  it("reports default and namespace React imports", () => {
+    expectDiagnosticCount(
+      `import ReactDefault from "react";
+       import * as ReactNamespace from "react";
+       ReactDefault.forwardRef((props) => <button>{props.label}</button>);
+       ReactNamespace.forwardRef((props) => <button>{props.label}</button>);`,
+      2,
+    );
+  });
+
+  it("reports immutable named and namespace aliases", () => {
+    expectDiagnosticCount(
+      `import ReactNamespace, { forwardRef as importedForwardRef } from "react";
+       const firstForwardRef = importedForwardRef;
+       const wrappedForwardRef = firstForwardRef as typeof firstForwardRef;
+       const firstReactAlias = ReactNamespace;
+       const secondReactAlias = firstReactAlias;
+       wrappedForwardRef((props) => <button>{props.label}</button>);
+       secondReactAlias.forwardRef((props) => <button>{props.label}</button>);`,
+      2,
+    );
+  });
+
+  it("ignores mutable aliases and lexical shadows", () => {
+    expectDiagnosticCount(
+      `import ReactNamespace, { forwardRef as importedForwardRef } from "react";
+       let mutableForwardRef = importedForwardRef;
+       mutableForwardRef = (callback) => callback("local");
+       let MutableReact = ReactNamespace;
+       MutableReact = { forwardRef: (callback) => callback("local") };
+       const run = (importedForwardRef, ReactNamespace) => {
+         importedForwardRef((value) => value.toUpperCase());
+         ReactNamespace.forwardRef((value) => value.toUpperCase());
+       };
+       mutableForwardRef((value) => value.toUpperCase());
+       MutableReact.forwardRef((value) => value.toUpperCase());
+       void run;`,
+      0,
+    );
+  });
+
+  it("ignores same-shaped imports from other packages", () => {
+    expectDiagnosticCount(
+      `import OtherReact, { forwardRef, forwardRef as wrapRef } from "other-react";
+       forwardRef((value) => value.toUpperCase());
+       wrapRef((value) => value.toUpperCase());
+       OtherReact.forwardRef((value) => value.toUpperCase());`,
+      0,
+    );
+  });
+
+  it("reports static computed, optional, and TypeScript-wrapped React calls", () => {
+    expectDiagnosticCount(
+      `import ReactNamespace, { forwardRef } from "react";
+       ReactNamespace["forwardRef"]((props) => <button>{props.label}</button>);
+       ReactNamespace?.forwardRef((props) => <button>{props.label}</button>);
+       (forwardRef as typeof forwardRef)((props) => <button>{props.label}</button>);
+       (ReactNamespace as typeof ReactNamespace).forwardRef((props) => <button>{props.label}</button>);`,
+      4,
+    );
+  });
+
+  it("only reports inline callbacks with exactly one non-rest parameter", () => {
+    expectDiagnosticCount(
+      `import { forwardRef } from "react";
+       const renderButton = (props) => <button>{props.label}</button>;
+       forwardRef(() => <button />);
+       forwardRef((props) => <button>{props.label}</button>);
+       forwardRef((props, ref) => <button ref={ref}>{props.label}</button>);
+       forwardRef((...argumentsList) => <button>{argumentsList.length}</button>);
+       forwardRef(renderButton);`,
+      1,
+    );
+  });
+
+  it("keeps CommonJS, dynamic, and unbound calls conservative", () => {
+    expectDiagnosticCount(
+      `const ReactCommonJs = require("react");
+       const propertyName = "forwardRef";
+       ReactCommonJs.forwardRef((props) => <button>{props.label}</button>);
+       ReactCommonJs[propertyName]((props) => <button>{props.label}</button>);
+       forwardRef((props) => <button>{props.label}</button>);`,
+      0,
+    );
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/forward-ref-uses-ref.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/forward-ref-uses-ref.regressions.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { forwardRefUsesRef } from "./forward-ref-uses-ref.js";
+
+const expectDiagnosticCount = (code: string, expectedCount: number): void => {
+  const result = runRule(forwardRefUsesRef, code);
+  expect(result.parseErrors).toEqual([]);
+  expect(result.diagnostics).toHaveLength(expectedCount);
+};
+
+describe("react-builtins/forward-ref-uses-ref binding provenance", () => {
+  it("ignores unrelated local functions named forwardRef", () => {
+    expectDiagnosticCount(
+      `const forwardRef = (transform: (value: string) => string): string => transform("hello");
+       forwardRef((value) => value.toUpperCase());`,
+      0,
+    );
+  });
+
+  it("reports renamed React forwardRef imports with unary callbacks", () => {
+    expectDiagnosticCount(
+      `import { forwardRef as wrapRef } from "react";
+       wrapRef((props) => <button>{props.label}</button>);`,
+      1,
+    );
+  });
+
+  it("reports direct React forwardRef imports with unary callbacks", () => {
+    expectDiagnosticCount(
+      `import { forwardRef } from "react";
+       forwardRef((props) => <button>{props.label}</button>);`,
+      1,
+    );
+  });
+
+  it("ignores direct and renamed React forwardRef callbacks that accept ref", () => {
+    expectDiagnosticCount(
+      `import { forwardRef, forwardRef as wrapRef } from "react";
+       forwardRef((props, ref) => <button ref={ref}>{props.label}</button>);
+       wrapRef((props, ref) => <button ref={ref}>{props.label}</button>);`,
+      0,
+    );
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/forward-ref-uses-ref.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/forward-ref-uses-ref.regressions.test.ts
@@ -117,6 +117,82 @@ describe("react-builtins/forward-ref-uses-ref binding provenance", () => {
     );
   });
 
+  it("reports unbound global React namespace calls", () => {
+    expectDiagnosticCount(
+      `React.forwardRef((props) => <button>{props.label}</button>);
+       SomeOtherGlobal.forwardRef((props) => <button>{props.label}</button>);`,
+      1,
+    );
+  });
+
+  it("reports named default React imports", () => {
+    expectDiagnosticCount(
+      `import { default as ReactDefault } from "react";
+       ReactDefault.forwardRef((props) => <button>{props.label}</button>);`,
+      1,
+    );
+  });
+
+  it("reports destructured forwardRef from React namespace imports", () => {
+    expectDiagnosticCount(
+      `import * as ReactNamespace from "react";
+       const { forwardRef } = ReactNamespace;
+       const { forwardRef: renamedForwardRef } = ReactNamespace;
+       forwardRef((props) => <button>{props.label}</button>);
+       renamedForwardRef((props) => <button>{props.label}</button>);`,
+      2,
+    );
+  });
+
+  it("reports destructured forwardRef from the global React namespace", () => {
+    expectDiagnosticCount(
+      `const { forwardRef } = React;
+       forwardRef((props) => <button>{props.label}</button>);`,
+      1,
+    );
+  });
+
+  it("keeps destructured lookalikes conservative", () => {
+    expectDiagnosticCount(
+      `import * as ReactNamespace from "react";
+       import * as OtherNamespace from "other-react";
+       const { forwardRef: otherForwardRef } = OtherNamespace;
+       let { forwardRef: mutableForwardRef } = ReactNamespace;
+       const { ["forwardRef"]: computedForwardRef } = ReactNamespace;
+       otherForwardRef((value) => value.toUpperCase());
+       mutableForwardRef((value) => value.toUpperCase());
+       computedForwardRef((value) => value.toUpperCase());`,
+      0,
+    );
+  });
+
+  it("ignores hoisted local forwardRef function declarations", () => {
+    expectDiagnosticCount(
+      `forwardRef((value) => value.toUpperCase());
+       function forwardRef(transform: (value: string) => string): string {
+         return transform("hello");
+       }`,
+      0,
+    );
+  });
+
+  it("reports the inner forwardRef nested inside memo", () => {
+    expectDiagnosticCount(
+      `import { memo, forwardRef } from "react";
+       memo(forwardRef((props) => <button>{props.label}</button>));`,
+      1,
+    );
+  });
+
+  it("ignores spread-argument forwardRef calls", () => {
+    expectDiagnosticCount(
+      `import { forwardRef } from "react";
+       const renderCallbacks = [(props) => <button>{props.label}</button>];
+       forwardRef(...renderCallbacks);`,
+      0,
+    );
+  });
+
   it("keeps CommonJS, dynamic, and unbound calls conservative", () => {
     expectDiagnosticCount(
       `const ReactCommonJs = require("react");

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/forward-ref-uses-ref.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/forward-ref-uses-ref.ts
@@ -1,7 +1,7 @@
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
-import { getCalleeName } from "../../utils/get-callee-name.js";
+import { isReactApiCall } from "../../utils/is-react-api-call.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 
 const MESSAGE =
@@ -20,7 +20,13 @@ export const forwardRefUsesRef = defineRule({
   category: "Architecture",
   create: (context) => ({
     CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
-      if (getCalleeName(node) !== "forwardRef") return;
+      if (
+        !isReactApiCall(node, "forwardRef", context.scopes, {
+          resolveNamedAliases: true,
+        })
+      ) {
+        return;
+      }
       const firstArgument = node.arguments[0];
       if (!firstArgument) return;
       let inner: EsTreeNode | null = null;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/forward-ref-uses-ref.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/forward-ref-uses-ref.ts
@@ -22,6 +22,7 @@ export const forwardRefUsesRef = defineRule({
     CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
       if (
         !isReactApiCall(node, "forwardRef", context.scopes, {
+          allowGlobalReactNamespace: true,
           resolveNamedAliases: true,
         })
       ) {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-react-api-call.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-react-api-call.test.ts
@@ -96,6 +96,16 @@ describe("isReactApiCall", () => {
       expectedCount: 1,
     },
     {
+      name: "static computed React members",
+      code: 'import * as ReactClient from "react"; ReactClient["useEffect"](() => {});',
+      expectedCount: 1,
+    },
+    {
+      name: "dynamic computed React members",
+      code: 'import * as ReactClient from "react"; const method = "useEffect"; ReactClient[method](() => {});',
+      expectedCount: 0,
+    },
+    {
       name: "same-named imports from another package",
       code: 'import { useEffect } from "other"; useEffect(() => {});',
       expectedCount: 0,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-react-api-call.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-react-api-call.test.ts
@@ -106,6 +106,55 @@ describe("isReactApiCall", () => {
       expectedCount: 0,
     },
     {
+      name: "named default React imports",
+      code: 'import { default as ReactClient } from "react"; ReactClient.useEffect(() => {});',
+      expectedCount: 1,
+    },
+    {
+      name: "named default imports from another package",
+      code: 'import { default as ReactClient } from "other"; ReactClient.useEffect(() => {});',
+      expectedCount: 0,
+    },
+    {
+      name: "destructured React namespace APIs with alias resolution",
+      code: `import * as ReactClient from "react";
+        const { useEffect } = ReactClient;
+        const { useLayoutEffect: runLayoutEffect } = ReactClient;
+        useEffect(() => {});
+        runLayoutEffect(() => {});`,
+      options: { resolveNamedAliases: true },
+      expectedCount: 2,
+    },
+    {
+      name: "destructured React namespace APIs by default",
+      code: 'import * as ReactClient from "react"; const { useEffect } = ReactClient; useEffect(() => {});',
+      expectedCount: 0,
+    },
+    {
+      name: "mutable destructured React namespace APIs",
+      code: 'import * as ReactClient from "react"; let { useEffect } = ReactClient; useEffect(() => {});',
+      options: { resolveNamedAliases: true },
+      expectedCount: 0,
+    },
+    {
+      name: "destructured APIs from another package",
+      code: 'import * as OtherClient from "other"; const { useEffect } = OtherClient; useEffect(() => {});',
+      options: { resolveNamedAliases: true },
+      expectedCount: 0,
+    },
+    {
+      name: "destructured global React APIs when allowed",
+      code: "const { useEffect } = React; useEffect(() => {});",
+      options: { allowGlobalReactNamespace: true, resolveNamedAliases: true },
+      expectedCount: 1,
+    },
+    {
+      name: "destructured global React APIs by default",
+      code: "const { useEffect } = React; useEffect(() => {});",
+      options: { resolveNamedAliases: true },
+      expectedCount: 0,
+    },
+    {
       name: "same-named imports from another package",
       code: 'import { useEffect } from "other"; useEffect(() => {});',
       expectedCount: 0,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-react-api-call.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-react-api-call.ts
@@ -2,6 +2,7 @@ import { REACT_RUNTIME_MODULE_SOURCES } from "../constants/react.js";
 import type { ScopeAnalysis, SymbolDescriptor } from "../semantic/scope-analysis.js";
 import type { EsTreeNode } from "./es-tree-node.js";
 import { getImportedName } from "./get-imported-name.js";
+import { getStaticPropertyName } from "./get-static-property-name.js";
 import { isNodeOfType } from "./is-node-of-type.js";
 import { resolveConstIdentifierAlias } from "./resolve-const-identifier-alias.js";
 import { stripParenExpression } from "./strip-paren-expression.js";
@@ -70,9 +71,7 @@ export const isReactApiCall = (
   }
   if (
     !isNodeOfType(callee, "MemberExpression") ||
-    callee.computed ||
-    !isNodeOfType(callee.property, "Identifier") ||
-    !includesApiName(apiNames, callee.property.name)
+    !includesApiName(apiNames, getStaticPropertyName(callee) ?? "")
   ) {
     return false;
   }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-react-api-call.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-react-api-call.ts
@@ -2,6 +2,7 @@ import { REACT_RUNTIME_MODULE_SOURCES } from "../constants/react.js";
 import type { ScopeAnalysis, SymbolDescriptor } from "../semantic/scope-analysis.js";
 import type { EsTreeNode } from "./es-tree-node.js";
 import { getImportedName } from "./get-imported-name.js";
+import { getStaticPropertyKeyName } from "./get-static-property-key-name.js";
 import { getStaticPropertyName } from "./get-static-property-name.js";
 import { isNodeOfType } from "./is-node-of-type.js";
 import { resolveConstIdentifierAlias } from "./resolve-const-identifier-alias.js";
@@ -47,8 +48,54 @@ export const isReactNamespaceImport = (identifier: EsTreeNode, scopes: ScopeAnal
   if (!symbol || !isImportedFromReact(symbol)) return false;
   return (
     isNodeOfType(symbol.declarationNode, "ImportDefaultSpecifier") ||
-    isNodeOfType(symbol.declarationNode, "ImportNamespaceSpecifier")
+    isNodeOfType(symbol.declarationNode, "ImportNamespaceSpecifier") ||
+    getImportedName(symbol.declarationNode) === "default"
   );
+};
+
+const isReactNamespaceReceiver = (
+  receiver: EsTreeNode,
+  scopes: ScopeAnalysis,
+  options: ReactApiCallOptions,
+): boolean => {
+  if (!isNodeOfType(receiver, "Identifier")) return false;
+  if (isReactNamespaceImport(receiver, scopes)) return true;
+  return Boolean(
+    options.allowGlobalReactNamespace &&
+    receiver.name === "React" &&
+    scopes.isGlobalReference(receiver),
+  );
+};
+
+const isDestructuredReactApiBinding = (
+  identifier: EsTreeNode,
+  apiNames: string | ReadonlySet<string>,
+  scopes: ScopeAnalysis,
+  options: ReactApiCallOptions,
+): boolean => {
+  const symbol = scopes.symbolFor(identifier);
+  if (
+    !symbol ||
+    symbol.kind !== "const" ||
+    !symbol.initializer ||
+    !isNodeOfType(symbol.declarationNode, "VariableDeclarator")
+  ) {
+    return false;
+  }
+  const pattern = symbol.declarationNode.id;
+  if (!isNodeOfType(pattern, "ObjectPattern")) return false;
+  for (const property of pattern.properties) {
+    if (!isNodeOfType(property, "Property") || property.value !== symbol.bindingIdentifier) {
+      continue;
+    }
+    const propertyName = getStaticPropertyKeyName(property);
+    return Boolean(
+      propertyName &&
+      includesApiName(apiNames, propertyName) &&
+      isReactNamespaceReceiver(stripParenExpression(symbol.initializer), scopes, options),
+    );
+  }
+  return false;
 };
 
 export const isReactApiCall = (
@@ -63,6 +110,12 @@ export const isReactApiCall = (
     if (isNamedReactApiImport(callee, apiNames, scopes, Boolean(options.resolveNamedAliases))) {
       return true;
     }
+    if (
+      options.resolveNamedAliases &&
+      isDestructuredReactApiBinding(callee, apiNames, scopes, options)
+    ) {
+      return true;
+    }
     return Boolean(
       options.allowUnboundBareCalls &&
       includesApiName(apiNames, callee.name) &&
@@ -75,12 +128,5 @@ export const isReactApiCall = (
   ) {
     return false;
   }
-  const receiver = stripParenExpression(callee.object);
-  if (!isNodeOfType(receiver, "Identifier")) return false;
-  if (isReactNamespaceImport(receiver, scopes)) return true;
-  return Boolean(
-    options.allowGlobalReactNamespace &&
-    receiver.name === "React" &&
-    scopes.isGlobalReference(receiver),
-  );
+  return isReactNamespaceReceiver(stripParenExpression(callee.object), scopes, options);
 };


### PR DESCRIPTION
## Problem

`forward-ref-uses-ref` inferred React semantics from the callee spelling alone. It reported unrelated local functions named `forwardRef` and missed the real React API when a named import was renamed.

## Change

Require the call to resolve to React's `forwardRef` export before applying callback arity guidance. The rule reuses the existing scope-aware React API resolver, including renamed named imports and immutable aliases. The shared resolver now also accepts statically computed members such as `React["forwardRef"]` while rejecting dynamic computed members.

Unbound globals, CommonJS calls, mutable aliases, dynamic properties, and callback identifiers remain conservative.

## Regression coverage

- unrelated local and other-package `forwardRef` helpers stay quiet
- direct, renamed, default, namespace, static-computed, optional, TypeScript-wrapped, and immutable multi-hop React aliases report
- mutable aliases, reassignment, lexical shadows, dynamic members, CommonJS, and unbound calls stay quiet
- zero-, two-, rest-parameter, and callback-identifier boundaries stay unchanged
- permanent fuzz seed covers the confirmed local-name collision false positive

## Validation

- focused rule/utility tests: 47 passed
- full oxlint plugin suite: 550 files passed; 12,320 tests passed; 148 skipped
- strict target fuzz: `FUZZ_RULE=forward-ref-uses-ref FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz`
- explicit fuzz fire coverage: 1/1 target rule fired
- fuzz corpus tests and false-positive hunt completed; no `forward-ref-uses-ref` finding on its valid seed
- performance probes remained near-linear through 2,000 direct calls and 800 multi-hop alias calls
- force-fresh RDE: 100/100 distinct pinned repositories, schema v3, no failures/partial scans; 15,047 -> 15,047 total diagnostics; target 2 -> 2; zero identity deltas; both retained target findings manually classified as true positives
- exact React Bench: 120/120 pinned repositories, no failures; 97,695 -> 97,695 extents; target 0 -> 0; zero added/removed findings; no solution-sensitive oracle shape found across 93 `forwardRef` files
- build, typecheck (15/15), lint, format check, JSON-report smoke, and `git diff --check` passed
- exact built-CLI reproduction reports the direct and renamed React violations and stays quiet on the local helper and two-parameter callbacks
- pre/post truffler and direct symbol searches found no duplicate helper; reused `isReactApiCall` and `getStaticPropertyName`
- no unresolved review threads at the pushed head

The full repository test run passed 13/14 package tasks. Its only failures were unrelated CLI harness behavior: two fixed performance timeouts and the TanStack fixture timeout passed on focused retry; `unref-stdin-live` still received empty stdout in this local environment. The plugin, core, API, language server, ESLint mirror, and fuzz suites passed. The pushed CI matrix is the clean-environment authority for those CLI tests.

This PR remains intentionally draft and must not be merged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Shared `isReactApiCall` behavior changes can affect other rules that use member/destructure resolution, though new paths are mostly gated by options; the primary user-facing change is narrower, more accurate `forward-ref-uses-ref` diagnostics.
> 
> **Overview**
> **`forward-ref-uses-ref`** no longer treats every callee named `forwardRef` as React’s API. It now uses scope-aware **`isReactApiCall`** (with global `React`, renamed imports, and immutable aliases) before flagging unary callbacks, which removes false positives from local helpers and restores coverage for renamed React imports.
> 
> The shared **`isReactApiCall`** resolver is extended for **`forwardRef`** and other callers: static computed members like `React["forwardRef"]`, `import { default as React }`, and destructured namespace bindings when **`resolveNamedAliases`** is enabled; dynamic computed access, mutable destructuring, and non-React modules stay conservative.
> 
> Regression and fuzz coverage add binding-provenance cases, a permanent corpus seed for the local-name collision, **`forward-ref-uses-ref`** in the verdict-robustness gate, and a fuzz import snippet that exercises the rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b82feab9c264a7c9ca805ba209d98204c358ff7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->