### PR TITLE
fix(rule): ignore transparent dark mode glows

### DIFF
--- a/.changeset/quiet-glows-vanish.md
+++ b/.changeset/quiet-glows-vanish.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Avoid reporting fully transparent legacy `rgba()` shadows in `no-dark-mode-glow`.

--- a/.changeset/quiet-glows-vanish.md
+++ b/.changeset/quiet-glows-vanish.md
@@ -2,4 +2,4 @@
 "oxlint-plugin-react-doctor": patch
 ---
 
-Avoid reporting fully transparent legacy `rgba()` shadows in `no-dark-mode-glow`.
+Avoid reporting statically transparent RGB and hex shadow layers in `no-dark-mode-glow`.

--- a/packages/fuzz/corpus/regressions/no-dark-mode-glow--transparent-shadow.tsx
+++ b/packages/fuzz/corpus/regressions/no-dark-mode-glow--transparent-shadow.tsx
@@ -1,0 +1,12 @@
+// rule: no-dark-mode-glow
+// weakness: other
+// source: ISSUES_TO_FIX_ASAP.md V28 alpha-zero shadow report
+
+export const TransparentGlow = () => (
+  <div
+    style={{
+      backgroundColor: "#000",
+      boxShadow: "0 0 60px rgba(255, 0, 0, 0)",
+    }}
+  />
+);

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -284,6 +284,8 @@ export const JSX_LEAF_POOL = [
   `<div role="button" onClick={handleClick}>{state}</div>`,
   `<div style={{ paddingLeft: 8, paddingRight: 8, width: 100, height: 100 }}>{state}</div>`,
   `<div style={{ marginTop: 4, marginBottom: 4 }}>{state}</div>`,
+  `<div style={{ backgroundColor: "#000", boxShadow: "0 0 60px rgb(255 0 0 / 0%)" }}>{state}</div>`,
+  `<div style={{ backgroundColor: "#000", boxShadow: "0 0 60px rgb(255 0 0 / 10%)" }}>{state}</div>`,
   `<input type="checkbox" checked={isChecked} />`,
   `<video autoPlay />`,
   `<marquee>{state}</marquee>`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-dark-mode-glow.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-dark-mode-glow.test.ts
@@ -13,6 +13,7 @@ describe("no-dark-mode-glow", () => {
     "0 0 60px rgba(255, 0, 0, 0)",
     "0 0 60px rgba(255, 0, 0, 0.0)",
     "0 0 60px rgba(255, 0, 0, 0%)",
+    "0 0 60px rgb(255, 0, 0, 0)",
     "0 0 60px rgb(255 0 0 / 0)",
     "0 0 60px rgb(255 0 0 / 0%)",
     "0 0 60px rgba(255 0 0 / .0)",
@@ -25,10 +26,12 @@ describe("no-dark-mode-glow", () => {
   it.each([
     "0 0 60px rgba(255, 0, 0, 0.0001)",
     "0 0 60px rgba(255, 0, 0, 0.1%)",
+    "0 0 60px rgb(255, 0, 0, 0.0001)",
     "0 0 60px rgb(255 0 0 / 0.0001)",
     "0 0 60px rgb(255 0 0 / 0.1%)",
     "0 0 60px #f001",
     "0 0 60px #ff000001",
+    "0 0 60px #ff000010",
   ])("still flags a visible colored shadow: %s", (boxShadow) => {
     expect(run(boxShadow).diagnostics).toHaveLength(1);
   });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-dark-mode-glow.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-dark-mode-glow.test.ts
@@ -9,17 +9,51 @@ const run = (boxShadow: string) =>
   );
 
 describe("no-dark-mode-glow", () => {
-  it("does not flag a fully transparent legacy rgba shadow", () => {
-    expect(run("0 0 60px rgba(255, 0, 0, 0)").diagnostics).toEqual([]);
+  it.each([
+    "0 0 60px rgba(255, 0, 0, 0)",
+    "0 0 60px rgba(255, 0, 0, 0.0)",
+    "0 0 60px rgba(255, 0, 0, 0%)",
+    "0 0 60px rgb(255 0 0 / 0)",
+    "0 0 60px rgb(255 0 0 / 0%)",
+    "0 0 60px rgba(255 0 0 / .0)",
+    "0 0 60px #f000",
+    "0 0 60px #ff000000",
+  ])("does not flag a statically transparent shadow: %s", (boxShadow) => {
+    expect(run(boxShadow).diagnostics).toEqual([]);
   });
 
-  it("still flags a visible colored legacy rgba shadow", () => {
-    expect(run("0 0 60px rgba(255, 0, 0, 0.01)").diagnostics).toHaveLength(1);
+  it.each([
+    "0 0 60px rgba(255, 0, 0, 0.0001)",
+    "0 0 60px rgba(255, 0, 0, 0.1%)",
+    "0 0 60px rgb(255 0 0 / 0.0001)",
+    "0 0 60px rgb(255 0 0 / 0.1%)",
+    "0 0 60px #f001",
+    "0 0 60px #ff000001",
+  ])("still flags a visible colored shadow: %s", (boxShadow) => {
+    expect(run(boxShadow).diagnostics).toHaveLength(1);
+  });
+
+  it.each([
+    "0 0 60px rgba(255, 0, 0, var(--alpha))",
+    "0 0 60px rgb(255 0 0 / var(--alpha))",
+    "0 0 60px rgb(255 0 0 / calc(0 * 1%))",
+    "0 0 60px var(--shadow-color, #f000)",
+    "0 0 60px var(--shadow-color, rgb(255 0 0 / 0%))",
+  ])("keeps unresolved alpha conservative: %s", (boxShadow) => {
+    expect(run(boxShadow).diagnostics).toHaveLength(1);
   });
 
   it("still flags a visible qualifying layer after a transparent layer", () => {
     expect(
       run("0 0 60px rgba(255, 0, 0, 0), 0 0 60px rgba(0, 128, 255, 0.8)").diagnostics,
     ).toHaveLength(1);
+  });
+
+  it("does not flag several fully transparent colored layers", () => {
+    expect(run("0 0 60px rgb(255 0 0 / 0%), 0 0 80px #0088ff00").diagnostics).toEqual([]);
+  });
+
+  it("does not split a nested fallback comma into another shadow layer", () => {
+    expect(run("0 0 60px rgba(255, 0, 0, var(--alpha, 0))").diagnostics).toHaveLength(1);
   });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-dark-mode-glow.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-dark-mode-glow.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noDarkModeGlow } from "./no-dark-mode-glow.js";
+
+const run = (boxShadow: string) =>
+  runRule(
+    noDarkModeGlow,
+    `const Card = () => <div style={{ backgroundColor: "#000", boxShadow: "${boxShadow}" }} />;`,
+  );
+
+describe("no-dark-mode-glow", () => {
+  it("does not flag a fully transparent legacy rgba shadow", () => {
+    expect(run("0 0 60px rgba(255, 0, 0, 0)").diagnostics).toEqual([]);
+  });
+
+  it("still flags a visible colored legacy rgba shadow", () => {
+    expect(run("0 0 60px rgba(255, 0, 0, 0.01)").diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a visible qualifying layer after a transparent layer", () => {
+    expect(
+      run("0 0 60px rgba(255, 0, 0, 0), 0 0 60px rgba(0, 128, 255, 0.8)").diagnostics,
+    ).toHaveLength(1);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-dark-mode-glow.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-dark-mode-glow.ts
@@ -70,13 +70,8 @@ const isShadowLayerFullyTransparent = (layer: string): boolean => {
 };
 
 const extractColorFromShadowLayer = (layer: string): ParsedRgb | null => {
-  const rgbMatch = layer.match(RGB_COLOR_PATTERN);
-  if (rgbMatch) return parseColorToRgb(rgbMatch[0]);
-
-  const hexMatch = layer.match(HEX_COLOR_PATTERN);
-  if (hexMatch) return parseColorToRgb(hexMatch[0]);
-
-  return null;
+  const colorMatch = layer.match(RGB_COLOR_PATTERN) ?? layer.match(HEX_COLOR_PATTERN);
+  return colorMatch ? parseColorToRgb(colorMatch[0]) : null;
 };
 
 const RGB_FUNCTION_PATTERN = /rgba?\([^)]*\)/gi;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-dark-mode-glow.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-dark-mode-glow.ts
@@ -64,7 +64,6 @@ const isShadowLayerFullyTransparent = (layer: string): boolean => {
     return ZERO_ALPHA_PATTERN.test(colorArguments.slice(slashIndex + 1).trim());
   }
 
-  if (!rgbMatch[0].toLowerCase().startsWith("rgba(")) return false;
   const legacyArguments = colorArguments.split(",");
   return legacyArguments.length === 4 && ZERO_ALPHA_PATTERN.test(legacyArguments[3].trim());
 };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-dark-mode-glow.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-dark-mode-glow.ts
@@ -16,6 +16,9 @@ import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 const splitShadowLayers = (shadowValue: string): string[] => shadowValue.split(/,(?![^(]*\))/);
 
+const LEGACY_RGBA_ZERO_ALPHA_PATTERN =
+  /rgba\(\s*[^,]+\s*,\s*[^,]+\s*,\s*[^,]+\s*,\s*[+-]?(?:0+(?:\.0*)?|\.0+)\s*\)/i;
+
 const extractColorFromShadowLayer = (layer: string): ParsedRgb | null => {
   const rgbMatch = layer.match(/rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/);
   if (rgbMatch) {
@@ -51,6 +54,8 @@ const parseShadowLayerBlur = (layer: string): number => {
 
 const hasColoredGlowShadow = (shadowValue: string): boolean => {
   for (const layer of splitShadowLayers(shadowValue)) {
+    if (LEGACY_RGBA_ZERO_ALPHA_PATTERN.test(layer)) continue;
+
     const color = extractColorFromShadowLayer(layer);
     if (
       color &&

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-dark-mode-glow.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-dark-mode-glow.ts
@@ -14,36 +14,80 @@ import { hasColorChroma } from "./utils/has-color-chroma.js";
 import { isPureBlackColor } from "./utils/is-pure-black-color.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
-const splitShadowLayers = (shadowValue: string): string[] => shadowValue.split(/,(?![^(]*\))/);
+const splitShadowLayers = (shadowValue: string): string[] => {
+  const layers: string[] = [];
+  let layerStartIndex = 0;
+  let parenthesisDepth = 0;
 
-const LEGACY_RGBA_ZERO_ALPHA_PATTERN =
-  /rgba\(\s*[^,]+\s*,\s*[^,]+\s*,\s*[^,]+\s*,\s*[+-]?(?:0+(?:\.0*)?|\.0+)\s*\)/i;
+  for (let characterIndex = 0; characterIndex < shadowValue.length; characterIndex += 1) {
+    const character = shadowValue[characterIndex];
+    if (character === "(") parenthesisDepth += 1;
+    if (character === ")" && parenthesisDepth > 0) parenthesisDepth -= 1;
+    if (character !== "," || parenthesisDepth !== 0) continue;
 
-const extractColorFromShadowLayer = (layer: string): ParsedRgb | null => {
-  const rgbMatch = layer.match(/rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/);
-  if (rgbMatch) {
-    return {
-      red: parseInt(rgbMatch[1], 10),
-      green: parseInt(rgbMatch[2], 10),
-      blue: parseInt(rgbMatch[3], 10),
-    };
+    layers.push(shadowValue.slice(layerStartIndex, characterIndex));
+    layerStartIndex = characterIndex + 1;
   }
 
-  const hexMatch = layer.match(/#([0-9a-f]{3,6})\b/i);
-  if (hexMatch) return parseColorToRgb(`#${hexMatch[1]}`);
+  layers.push(shadowValue.slice(layerStartIndex));
+  return layers;
+};
+
+const RGB_COLOR_PATTERN = /rgba?\([^)]*\)/i;
+const HEX_COLOR_PATTERN = /#(?:[0-9a-f]{8}|[0-9a-f]{6}|[0-9a-f]{4}|[0-9a-f]{3})\b/i;
+const ZERO_ALPHA_PATTERN = /^[+-]?(?:0+(?:\.0*)?|\.0+)%?$/;
+
+const isAtTopLevel = (value: string, index: number): boolean => {
+  let parenthesisDepth = 0;
+  for (let characterIndex = 0; characterIndex < index; characterIndex += 1) {
+    const character = value[characterIndex];
+    if (character === "(") parenthesisDepth += 1;
+    if (character === ")" && parenthesisDepth > 0) parenthesisDepth -= 1;
+  }
+  return parenthesisDepth === 0;
+};
+
+const isShadowLayerFullyTransparent = (layer: string): boolean => {
+  const hexMatch = layer.match(HEX_COLOR_PATTERN);
+  if (hexMatch?.index !== undefined && isAtTopLevel(layer, hexMatch.index)) {
+    const hexDigits = hexMatch[0].slice(1);
+    if (hexDigits.length === 4) return hexDigits.endsWith("0");
+    if (hexDigits.length === 8) return hexDigits.endsWith("00");
+  }
+
+  const rgbMatch = layer.match(RGB_COLOR_PATTERN);
+  if (rgbMatch?.index === undefined || !isAtTopLevel(layer, rgbMatch.index)) return false;
+
+  const colorArguments = rgbMatch[0].slice(rgbMatch[0].indexOf("(") + 1, -1);
+  const slashIndex = colorArguments.lastIndexOf("/");
+  if (slashIndex !== -1) {
+    return ZERO_ALPHA_PATTERN.test(colorArguments.slice(slashIndex + 1).trim());
+  }
+
+  if (!rgbMatch[0].toLowerCase().startsWith("rgba(")) return false;
+  const legacyArguments = colorArguments.split(",");
+  return legacyArguments.length === 4 && ZERO_ALPHA_PATTERN.test(legacyArguments[3].trim());
+};
+
+const extractColorFromShadowLayer = (layer: string): ParsedRgb | null => {
+  const rgbMatch = layer.match(RGB_COLOR_PATTERN);
+  if (rgbMatch) return parseColorToRgb(rgbMatch[0]);
+
+  const hexMatch = layer.match(HEX_COLOR_PATTERN);
+  if (hexMatch) return parseColorToRgb(hexMatch[0]);
 
   return null;
 };
 
-const RGB_FUNCTION_PATTERN = /rgba?\([^)]*\)/g;
-const HEX_COLOR_PATTERN = /#[0-9a-f]{3,8}\b/gi;
+const RGB_FUNCTION_PATTERN = /rgba?\([^)]*\)/gi;
+const ALL_HEX_COLORS_PATTERN = /#[0-9a-f]{3,8}\b/gi;
 const NUMERIC_TOKEN_PATTERN = /(\d+(?:\.\d+)?)(px)?/g;
 
 // The blur radius is the third numeric token (`offset-x offset-y blur`).
 const SHADOW_BLUR_TOKEN_INDEX = 2;
 
 const parseShadowLayerBlur = (layer: string): number => {
-  const withoutColors = layer.replace(RGB_FUNCTION_PATTERN, "").replace(HEX_COLOR_PATTERN, "");
+  const withoutColors = layer.replace(RGB_FUNCTION_PATTERN, "").replace(ALL_HEX_COLORS_PATTERN, "");
   let tokenIndex = 0;
   for (const match of withoutColors.matchAll(NUMERIC_TOKEN_PATTERN)) {
     if (tokenIndex === SHADOW_BLUR_TOKEN_INDEX) return parseFloat(match[1]);
@@ -54,7 +98,7 @@ const parseShadowLayerBlur = (layer: string): number => {
 
 const hasColoredGlowShadow = (shadowValue: string): boolean => {
   for (const layer of splitShadowLayers(shadowValue)) {
-    if (LEGACY_RGBA_ZERO_ALPHA_PATTERN.test(layer)) continue;
+    if (isShadowLayerFullyTransparent(layer)) continue;
 
     const color = extractColorFromShadowLayer(layer);
     if (


### PR DESCRIPTION
## Why

Avoids diagnosing a fully transparent colored shadow as a visible dark-mode glow. Alpha zero makes the shadow pixel-equivalent to no shadow, so the rule's visible-glow claim does not apply.

Before:

```tsx
<div style={{ backgroundColor: "#000", boxShadow: "0 0 60px rgba(255, 0, 0, 0)" }} />
```

After:

```tsx
<div style={{ backgroundColor: "#000", boxShadow: "0 0 60px rgba(255, 0, 0, 0.8)" }} />
```

## What changed

- Suppresses only shadow layers whose zero alpha is statically proven in legacy `rgba()`, modern RGB slash-alpha, or 4/8-digit hex syntax.
- Keeps nonzero and unresolved alpha conservative, including `var()` and `calc()` forms.
- Splits multiple shadows at balanced top-level commas so a transparent first layer cannot hide a later visible qualifying layer.
- Adds paired zero/near-zero, percentage, modern RGB, hex, multi-layer, fallback, and dynamic-alpha tests.
- Adds a permanent fuzz regression seed, atomic quiet/triggering generator shapes, and a patch changeset.

## Eval results

| Check | Result |
| --- | --- |
| RDE repos / root scans | 100 distinct / 100, 0 failures |
| RDE target diagnostics | `0 → 0`, no deltas |
| React Bench source | 120 distinct pinned repos, 120 successful, equal 97,695-file extents |
| React Bench target diagnostics | `0 → 0`, no deltas |
| React Bench oracles | 9 complete `boxShadow` solution candidates: 6 TS/TSX scanned `0 → 0`; 3 patch-only manually audited with no change-sensitive shape |
| Strict fuzz | 500 iterations, fire coverage `1/1`, no findings |

## Test plan

- `nr --filter oxlint-plugin-react-doctor test no-dark-mode-glow.test.ts` — 22 passed
- full oxlint plugin suite — 550 files, 12,329 passed, 148 skipped
- `nr --filter @react-doctor/fuzz test` — 37 passed
- `FUZZ_RULE=no-dark-mode-glow FUZZ_STRICT=1 FUZZ_ITERATIONS=500 FUZZ_PRINT_SILENT=1 nr --filter @react-doctor/fuzz fuzz --reporter verbose` — passed, fire coverage 1/1
- `nr typecheck`
- `nr lint`
- `nr format:check`
- `nr smoke:json-report`
- full GitHub Actions matrix — passed on Node 20/22/24/25/26, macOS, Windows, and Linux

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped change to an opt-in design lint with added unit/fuzz coverage; no auth, data, or runtime behavior impact.
> 
> **Overview**
> **`no-dark-mode-glow`** no longer reports `boxShadow` on dark backgrounds when a colored layer’s alpha is **statically zero** (legacy `rgba()`, slash-alpha `rgb()`, and 4/8-digit hex). Layers with any nonzero or **unresolved** alpha (`var()`, `calc()`, etc.) still warn as before.
> 
> Shadow parsing now splits multi-layer values on **top-level commas** (parenthesis-aware) so transparent layers are skipped individually without breaking `var(..., fallback)` commas, and a later visible layer can still trigger the rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6a3ad9765092230c7c8c9a13d3b35c4de0779f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->