### PR TITLE
fix(rule): ignore URL fragments in polyfill detection

### DIFF
--- a/.changeset/wet-brooms-study.md
+++ b/.changeset/wet-brooms-study.md
@@ -2,4 +2,4 @@
 "oxlint-plugin-react-doctor": patch
 ---
 
-Ignore URL fragments when detecting polyfill script requests.
+Match polyfill script diagnostics against network request identity, ignoring fragments and non-network URL schemes.

--- a/.changeset/wet-brooms-study.md
+++ b/.changeset/wet-brooms-study.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Ignore URL fragments when detecting polyfill script requests.

--- a/packages/fuzz/corpus/regressions/nextjs-no-polyfill-script--fragment-request-identity.tsx
+++ b/packages/fuzz/corpus/regressions/nextjs-no-polyfill-script--fragment-request-identity.tsx
@@ -1,0 +1,6 @@
+// rule: nextjs-no-polyfill-script
+// weakness: other
+// source: ISSUES_TO_FIX_ASAP.md V28 URL-fragment request-identity report
+export const AnalyticsScript = () => (
+  <script defer src="/analytics.js#https://polyfill.io/v3/polyfill.min.js" />
+);

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -178,6 +178,7 @@ export const MODULE_SCOPE_SNIPPET_POOL = [
   `const defaults = { title: "untitled", pageSize: 20 };`,
   `reaction(() => store.value, (next) => persist(next));`,
   `let sharedSnapshot = "idle"; const snapshotListeners = new Set(); function subscribeSnapshot(listener) { snapshotListeners.add(listener); return () => snapshotListeners.delete(listener); }`,
+  `const FuzzPolyfillScript = () => <script src="https://polyfill.io/v3/polyfill.min.js" />;`,
 ] as const;
 
 // Attributes that specifically trip a11y validity rules — misspelled aria

--- a/packages/fuzz/tests/verdict-robustness.test.ts
+++ b/packages/fuzz/tests/verdict-robustness.test.ts
@@ -21,6 +21,7 @@ const AUDITED_RULE_IDS = [
   "effect-listener-cleanup-mismatch",
   "effect-needs-cleanup",
   "interactive-supports-focus",
+  "nextjs-no-polyfill-script",
   "no-adjust-state-on-prop-change",
   "no-aria-hidden-on-focusable",
   "no-cascading-set-state",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-no-polyfill-script.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-no-polyfill-script.regressions.test.ts
@@ -12,16 +12,63 @@ const expectDiagnosticCount = (sourceUrl: string, expectedCount: number): void =
 };
 
 describe("nextjs-no-polyfill-script request identity", () => {
-  it("ignores polyfill text in a URL fragment", () => {
-    expectDiagnosticCount("/analytics.js#https://polyfill.io/v3/polyfill.min.js", 0);
+  it("ignores polyfill text after the first URL fragment delimiter", () => {
+    for (const sourceUrl of [
+      "/analytics.js#https://polyfill.io/v3/polyfill.min.js",
+      "/analytics.js##polyfill.min.js",
+      "/analytics.js#section#polyfill.min.js",
+      "https://example.com/analytics.js#polyfill.min.js",
+      "//example.com/analytics.js#polyfill.min.js",
+      "analytics.js#polyfill.min.js",
+    ]) {
+      expectDiagnosticCount(sourceUrl, 0);
+    }
   });
 
-  it("reports a polyfill URL with or without a fragment", () => {
-    expectDiagnosticCount("https://polyfill.io/v3/polyfill.min.js", 1);
-    expectDiagnosticCount("https://polyfill.io/v3/polyfill.min.js#ignored", 1);
+  it("reports network polyfill URLs with empty or non-empty fragments", () => {
+    for (const sourceUrl of [
+      "https://polyfill.io/v3/polyfill.min.js",
+      "https://polyfill.io/v3/polyfill.min.js#",
+      "https://polyfill.io/v3/polyfill.min.js#ignored",
+      "HTTPS://user:secret@polyfill.io:443/v3/polyfill.min.js#ignored",
+      "//polyfill.io/v3/polyfill.min.js#ignored",
+      "/assets/polyfill.min.js#ignored",
+      "assets/polyfill.min.js#ignored",
+    ]) {
+      expectDiagnosticCount(sourceUrl, 1);
+    }
   });
 
-  it("keeps query text because it is sent in the request", () => {
-    expectDiagnosticCount("/analytics.js?fallback=polyfill.min.js", 1);
+  it("keeps literal and percent-encoded request data before the fragment", () => {
+    for (const sourceUrl of [
+      "/analytics.js?fallback=polyfill.min.js#ignored",
+      "/analytics.js?fallback=%23polyfill.min.js#ignored",
+      "/assets/%23polyfill.min.js#ignored",
+    ]) {
+      expectDiagnosticCount(sourceUrl, 1);
+    }
+  });
+
+  it("ignores non-network script URL schemes", () => {
+    for (const sourceUrl of [
+      "data:text/javascript,polyfill.min.js",
+      "blob:https://polyfill.io/polyfill.min.js",
+      "javascript:polyfill.min.js",
+      "  DATA:text/javascript,polyfill.min.js",
+    ]) {
+      expectDiagnosticCount(sourceUrl, 0);
+    }
+  });
+
+  it("ignores empty, fragment-only, and dynamic sources", () => {
+    expectDiagnosticCount("", 0);
+    expectDiagnosticCount("#polyfill.min.js", 0);
+
+    const result = runRule(
+      nextjsNoPolyfillScript,
+      `export const Page = ({ sourceUrl }) => <script src={sourceUrl} />;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
   });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-no-polyfill-script.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-no-polyfill-script.regressions.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { nextjsNoPolyfillScript } from "./nextjs-no-polyfill-script.js";
+
+const expectDiagnosticCount = (sourceUrl: string, expectedCount: number): void => {
+  const result = runRule(
+    nextjsNoPolyfillScript,
+    `export const Page = () => <script src=${JSON.stringify(sourceUrl)} />;`,
+  );
+  expect(result.parseErrors).toEqual([]);
+  expect(result.diagnostics).toHaveLength(expectedCount);
+};
+
+describe("nextjs-no-polyfill-script request identity", () => {
+  it("ignores polyfill text in a URL fragment", () => {
+    expectDiagnosticCount("/analytics.js#https://polyfill.io/v3/polyfill.min.js", 0);
+  });
+
+  it("reports a polyfill URL with or without a fragment", () => {
+    expectDiagnosticCount("https://polyfill.io/v3/polyfill.min.js", 1);
+    expectDiagnosticCount("https://polyfill.io/v3/polyfill.min.js#ignored", 1);
+  });
+
+  it("keeps query text because it is sent in the request", () => {
+    expectDiagnosticCount("/analytics.js?fallback=polyfill.min.js", 1);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-no-polyfill-script.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-no-polyfill-script.regressions.test.ts
@@ -2,73 +2,73 @@ import { describe, expect, it } from "vite-plus/test";
 import { runRule } from "../../../test-utils/run-rule.js";
 import { nextjsNoPolyfillScript } from "./nextjs-no-polyfill-script.js";
 
-const expectDiagnosticCount = (sourceUrl: string, expectedCount: number): void => {
-  const result = runRule(
-    nextjsNoPolyfillScript,
-    `export const Page = () => <script src=${JSON.stringify(sourceUrl)} />;`,
-  );
+const expectDiagnosticCount = (code: string, expectedCount: number): void => {
+  const result = runRule(nextjsNoPolyfillScript, code);
   expect(result.parseErrors).toEqual([]);
   expect(result.diagnostics).toHaveLength(expectedCount);
 };
 
 describe("nextjs-no-polyfill-script request identity", () => {
   it("ignores polyfill text after the first URL fragment delimiter", () => {
-    for (const sourceUrl of [
-      "/analytics.js#https://polyfill.io/v3/polyfill.min.js",
-      "/analytics.js##polyfill.min.js",
-      "/analytics.js#section#polyfill.min.js",
-      "https://example.com/analytics.js#polyfill.min.js",
-      "//example.com/analytics.js#polyfill.min.js",
-      "analytics.js#polyfill.min.js",
-    ]) {
-      expectDiagnosticCount(sourceUrl, 0);
-    }
+    expectDiagnosticCount(
+      `export const Page = () => <>
+        <script src="/analytics.js#https://polyfill.io/v3/polyfill.min.js" />
+        <script src="/analytics.js##polyfill.min.js" />
+        <script src="/analytics.js#section#polyfill.min.js" />
+        <script src="https://example.com/analytics.js#polyfill.min.js" />
+        <script src="//example.com/analytics.js#polyfill.min.js" />
+        <script src="analytics.js#polyfill.min.js" />
+      </>;`,
+      0,
+    );
   });
 
   it("reports network polyfill URLs with empty or non-empty fragments", () => {
-    for (const sourceUrl of [
-      "https://polyfill.io/v3/polyfill.min.js",
-      "https://polyfill.io/v3/polyfill.min.js#",
-      "https://polyfill.io/v3/polyfill.min.js#ignored",
-      "HTTPS://user:secret@polyfill.io:443/v3/polyfill.min.js#ignored",
-      "//polyfill.io/v3/polyfill.min.js#ignored",
-      "/assets/polyfill.min.js#ignored",
-      "assets/polyfill.min.js#ignored",
-    ]) {
-      expectDiagnosticCount(sourceUrl, 1);
-    }
+    expectDiagnosticCount(
+      `export const Page = () => <>
+        <script src="https://polyfill.io/v3/polyfill.min.js" />
+        <script src="https://polyfill.io/v3/polyfill.min.js#" />
+        <script src="https://polyfill.io/v3/polyfill.min.js#ignored" />
+        <script src="HTTPS://user:secret@polyfill.io:443/v3/polyfill.min.js#ignored" />
+        <script src="//polyfill.io/v3/polyfill.min.js#ignored" />
+        <script src="/assets/polyfill.min.js#ignored" />
+        <script src="assets/polyfill.min.js#ignored" />
+      </>;`,
+      7,
+    );
   });
 
   it("keeps literal and percent-encoded request data before the fragment", () => {
-    for (const sourceUrl of [
-      "/analytics.js?fallback=polyfill.min.js#ignored",
-      "/analytics.js?fallback=%23polyfill.min.js#ignored",
-      "/assets/%23polyfill.min.js#ignored",
-    ]) {
-      expectDiagnosticCount(sourceUrl, 1);
-    }
+    expectDiagnosticCount(
+      `export const Page = () => <>
+        <script src="/analytics.js?fallback=polyfill.min.js#ignored" />
+        <script src="/analytics.js?fallback=%23polyfill.min.js#ignored" />
+        <script src="/assets/%23polyfill.min.js#ignored" />
+      </>;`,
+      3,
+    );
   });
 
   it("ignores non-network script URL schemes", () => {
-    for (const sourceUrl of [
-      "data:text/javascript,polyfill.min.js",
-      "blob:https://polyfill.io/polyfill.min.js",
-      "javascript:polyfill.min.js",
-      "  DATA:text/javascript,polyfill.min.js",
-    ]) {
-      expectDiagnosticCount(sourceUrl, 0);
-    }
+    expectDiagnosticCount(
+      `export const Page = () => <>
+        <script src="data:text/javascript,polyfill.min.js" />
+        <script src="blob:https://polyfill.io/polyfill.min.js" />
+        <script src="javascript:polyfill.min.js" />
+        <script src="  DATA:text/javascript,polyfill.min.js" />
+      </>;`,
+      0,
+    );
   });
 
   it("ignores empty, fragment-only, and dynamic sources", () => {
-    expectDiagnosticCount("", 0);
-    expectDiagnosticCount("#polyfill.min.js", 0);
-
-    const result = runRule(
-      nextjsNoPolyfillScript,
-      `export const Page = ({ sourceUrl }) => <script src={sourceUrl} />;`,
+    expectDiagnosticCount(
+      `export const Page = ({ sourceUrl }) => <>
+        <script src="" />
+        <script src="#polyfill.min.js" />
+        <script src={sourceUrl} />
+      </>;`,
+      0,
     );
-    expect(result.parseErrors).toEqual([]);
-    expect(result.diagnostics).toHaveLength(0);
   });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-no-polyfill-script.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-no-polyfill-script.ts
@@ -26,7 +26,9 @@ export const nextjsNoPolyfillScript = defineRule({
         ? srcAttribute.value.value
         : null;
 
-      if (typeof srcValue === "string" && POLYFILL_SCRIPT_PATTERN.test(srcValue)) {
+      const requestUrl = typeof srcValue === "string" ? srcValue.split("#", 1)[0] : null;
+
+      if (requestUrl && POLYFILL_SCRIPT_PATTERN.test(requestUrl)) {
         context.report({
           node,
           message:

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-no-polyfill-script.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-no-polyfill-script.ts
@@ -6,6 +6,8 @@ import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { resolveJsxElementType } from "../../utils/resolve-jsx-element-type.js";
 
+const ABSOLUTE_URL_SCHEME_PATTERN = /^[a-z][a-z\d+.-]*:/i;
+
 export const nextjsNoPolyfillScript = defineRule({
   id: "nextjs-no-polyfill-script",
   title: "Redundant polyfill script",
@@ -27,8 +29,16 @@ export const nextjsNoPolyfillScript = defineRule({
         : null;
 
       const requestUrl = typeof srcValue === "string" ? srcValue.split("#", 1)[0] : null;
+      const requestScheme = requestUrl
+        ?.trimStart()
+        .match(ABSOLUTE_URL_SCHEME_PATTERN)?.[0]
+        .toLowerCase();
 
-      if (requestUrl && POLYFILL_SCRIPT_PATTERN.test(requestUrl)) {
+      if (
+        requestUrl &&
+        (!requestScheme || requestScheme === "http:" || requestScheme === "https:") &&
+        POLYFILL_SCRIPT_PATTERN.test(requestUrl)
+      ) {
         context.report({
           node,
           message:


### PR DESCRIPTION
## Why

Prevents `nextjs-no-polyfill-script` from treating inert URL-fragment text or non-network URL schemes as a fetched polyfill script.

Before:

```tsx
<script src="/analytics.js#https://polyfill.io/v3/polyfill.min.js" />
```

After:

```tsx
<script src="https://polyfill.io/v3/polyfill.min.js#ignored" />
```

The first source fetches `/analytics.js` and stays quiet. The genuine polyfill request still reports.

## What changed

- Removes the fragment before applying the existing polyfill request pattern.
- Preserves request-relevant paths, query strings, and percent-encoded request data.
- Keeps absolute HTTP(S), protocol-relative, root-relative, and relative network requests eligible.
- Excludes statically known non-network schemes such as `data:`, `blob:`, and `javascript:`.
- Keeps dynamic sources conservative.
- Adds a permanent false-positive fuzz seed, generator trigger, and verdict-liveness coverage.
- Adds a patch changeset.

## Eval results

| Check | Result |
| --- | --- |
| RDE repositories | 100/100 distinct pinned repositories |
| RDE scan integrity | schema v3; 0 failures; 0 partial projects or skipped checks |
| RDE diagnostics | 15,047 -> 15,047 overall; target 0 -> 0; 0 added/removed identities |
| React Bench | 120/120 pinned repositories; 97,695 files each; 0 failures |
| React Bench target | 0 -> 0; 0 added/removed diagnostics |
| Relevant oracles | no polyfill or fragment-sensitive shapes found across React Bench 4, 5, or internal |

## Test plan

- focused request-identity regressions: 5 passed
- full oxlint plugin suite: 550 files passed; 12,312 tests passed; 148 skipped
- fuzz package: 38 passed; 400 registry cases skipped by design
- `FUZZ_RULE=nextjs-no-polyfill-script FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz`
- explicit target fire coverage: 1/1
- build: 10/10 tasks
- typecheck: 15/15 tasks
- lint, format check, JSON-report smoke, and `git diff --check`
- built-CLI reproduction on the original V28 fixture: fragment candidate quiet; clean local script quiet; genuine CDN script reports
- staged pre-commit reproduction: 0 diagnostics and 0 skipped checks
- pre/post truffler and deslop review: no reusable request-identity helper or duplicate implementation found

This PR remains intentionally draft and must not be merged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow lint-rule precision fix with no auth or runtime behavior changes; risk is limited to false positive/negative balance for static script `src` literals.
> 
> **Overview**
> **`nextjs-no-polyfill-script`** no longer flags `<script src>` values because of **URL fragment** text or **non-network** schemes. Matching runs on the part before `#`, still honoring query strings and percent-encoded path segments, and only for HTTP(S), protocol-relative, and relative network URLs—not `data:`, `blob:`, or `javascript:`.
> 
> Adds focused request-identity regressions, a fuzz regression for `/analytics.js#…polyfill…`, a fuzz snippet trigger, verdict-robustness coverage for this rule, and a patch changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05fbcb7f07ca03dcc4c7d450c18f15ee310ca080. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->