### PR TITLE
fix: deduplicate conditional hook diagnostics

### DIFF
--- a/.changeset/quiet-hooks-count.md
+++ b/.changeset/quiet-hooks-count.md
@@ -2,4 +2,4 @@
 "react-doctor": patch
 ---
 
-Report one actionable conditional Hook violation when React Doctor and React Compiler flag the same source location, while preserving either finding when the other is suppressed.
+Report one actionable conditional Hook violation when React Doctor and React Compiler flag the same source location, while preserving either finding when the other is suppressed. Overlapping derived-state findings now collapse to the most specific rule even when a severity override makes their severities differ, and the surviving diagnostic carries the highest severity of the collapsed pair. The sidecar lint cache schema version is bumped so previously cached winner-only diagnostic sets are re-linted instead of replayed.

--- a/.changeset/quiet-hooks-count.md
+++ b/.changeset/quiet-hooks-count.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Report one actionable conditional Hook violation when React Doctor and React Compiler flag the same source location.

--- a/.changeset/quiet-hooks-count.md
+++ b/.changeset/quiet-hooks-count.md
@@ -2,4 +2,4 @@
 "react-doctor": patch
 ---
 
-Report one actionable conditional Hook violation when React Doctor and React Compiler flag the same source location.
+Report one actionable conditional Hook violation when React Doctor and React Compiler flag the same source location, while preserving either finding when the other is suppressed.

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -662,7 +662,7 @@ export const FILE_LINT_CACHE_MAX_FILE_COUNT = 50_000;
 // ruleset hash, each entry guarded by the file's cross-file dependency probe
 // set, so a warm rescan replays the sidecar instead of re-linting every
 // unchanged file. Shares the file cache's bucket/file caps.
-export const SIDECAR_LINT_CACHE_SCHEMA_VERSION = 1;
+export const SIDECAR_LINT_CACHE_SCHEMA_VERSION = 2;
 
 export const SIDECAR_LINT_CACHE_FILENAME = "sidecar-lint-cache.json";
 

--- a/packages/core/src/merge-and-filter-diagnostics.ts
+++ b/packages/core/src/merge-and-filter-diagnostics.ts
@@ -1,6 +1,7 @@
 import type { Diagnostic, ReactDoctorConfig } from "./types/index.js";
 import { buildDiagnosticPipeline } from "./build-diagnostic-pipeline.js";
 import { DEFAULT_SHOW_WARNINGS } from "./constants.js";
+import { dedupeRelatedDiagnostics } from "./utils/dedupe-related-diagnostics.js";
 
 interface MergeAndFilterOptions {
   respectInlineDisables?: boolean;
@@ -42,5 +43,5 @@ export const mergeAndFilterDiagnostics = (
     const filtered = pipeline.apply(diagnostic);
     if (filtered !== null) result.push(filtered);
   }
-  return result;
+  return dedupeRelatedDiagnostics(result);
 };

--- a/packages/core/src/run-inspect.ts
+++ b/packages/core/src/run-inspect.ts
@@ -14,6 +14,7 @@ import type {
   SuppressedRuleCount,
 } from "./types/index.js";
 import { assignFixGroups } from "./utils/assign-fix-groups.js";
+import { dedupeRelatedDiagnostics } from "./utils/dedupe-related-diagnostics.js";
 import { sortDiagnosticsStable } from "./utils/sort-diagnostics-stable.js";
 import { buildDiagnosticPipeline } from "./build-diagnostic-pipeline.js";
 import { checkExpoProject } from "./check-expo-project.js";
@@ -490,9 +491,11 @@ export const runInspect = <HooksR = never>(
       showWarnings,
     });
 
+    const filterPerElementPipeline = <ToEnv>(rawStream: Stream.Stream<Diagnostic, never, ToEnv>) =>
+      rawStream.pipe(Stream.filterMap(filterMapNullable<Diagnostic, Diagnostic>(transform.apply)));
+
     const applyPerElementPipeline = <ToEnv>(rawStream: Stream.Stream<Diagnostic, never, ToEnv>) =>
-      rawStream.pipe(
-        Stream.filterMap(filterMapNullable<Diagnostic, Diagnostic>(transform.apply)),
+      filterPerElementPipeline(rawStream).pipe(
         Stream.tap((diagnostic) => reporterService.emit(diagnostic)),
       );
 
@@ -841,7 +844,9 @@ export const runInspect = <HooksR = never>(
     // the existing lint-failure contract (score becomes null) with an
     // `OxlintBatchExceeded`-tagged reason so renderers dispatch on it, and
     // yield an empty chunk so the rest of the scan still completes.
-    const lintCollected = yield* Stream.runCollect(applyPerElementPipeline(rawLintStream)).pipe(
+    const filteredLintDiagnostics = yield* Stream.runCollect(
+      filterPerElementPipeline(rawLintStream),
+    ).pipe(
       Effect.timeoutOption(lintPhaseTimeoutMs),
       Effect.flatMap(
         Option.match({
@@ -858,6 +863,8 @@ export const runInspect = <HooksR = never>(
         }),
       ),
     );
+    const lintCollected = dedupeRelatedDiagnostics(filteredLintDiagnostics);
+    yield* Effect.forEach(lintCollected, reporterService.emit, { discard: true });
     const lintFailureState = yield* Ref.get(lintFailure);
     yield* afterLint(lintFailureState.didFail);
 

--- a/packages/core/src/utils/dedupe-diagnostics.ts
+++ b/packages/core/src/utils/dedupe-diagnostics.ts
@@ -7,6 +7,20 @@ const DERIVED_STATE_RULE_PRIORITY: ReadonlyMap<string, number> = new Map([
   ["no-derived-state-effect", 3],
 ]);
 
+const REACT_DOCTOR_PLUGIN = "react-doctor";
+const RULES_OF_HOOKS_RULE = "rules-of-hooks";
+const REACT_COMPILER_PLUGIN = "react-hooks-js";
+const REACT_COMPILER_HOOKS_RULE = "hooks";
+
+const buildDiagnosticSiteKey = (diagnostic: Diagnostic): string =>
+  `${diagnostic.filePath}\u0000${diagnostic.line}\u0000${diagnostic.column}`;
+
+const isReactDoctorRulesOfHooksDiagnostic = (diagnostic: Diagnostic): boolean =>
+  diagnostic.plugin === REACT_DOCTOR_PLUGIN && diagnostic.rule === RULES_OF_HOOKS_RULE;
+
+const isReactCompilerHooksDiagnostic = (diagnostic: Diagnostic): boolean =>
+  diagnostic.plugin === REACT_COMPILER_PLUGIN && diagnostic.rule === REACT_COMPILER_HOOKS_RULE;
+
 const doDiagnosticSpansOverlap = (first: Diagnostic, second: Diagnostic): boolean => {
   if (first.filePath !== second.filePath || first.plugin !== second.plugin) return false;
   if (first.offset !== undefined && second.offset !== undefined) {
@@ -20,21 +34,28 @@ const doDiagnosticSpansOverlap = (first: Diagnostic, second: Diagnostic): boolea
 };
 
 // HACK: oxlint plugin rules occasionally emit the same diagnostic
-// twice (e.g. when a rule's listener visits the same AST node through
-// two overlapping selectors). The duplicates have identical filePath,
-// line, column, plugin, rule, message, and severity. This safety net
-// collapses them on the react-doctor side so downstream consumers
-// (renderer, JSON output, score API) always see one diagnostic per
-// unique site — independent of plugin-rule correctness.
+// twice, and React Doctor plus React Compiler both report conditional
+// Hook calls. This safety net collapses those duplicate actionable
+// findings so downstream consumers (renderer, JSON output, score API)
+// always see one diagnostic per unique site.
 //
 // Field selection rationale: position + plugin + rule + message +
 // severity are the user-visible identity of a diagnostic. `help`,
 // `url`, and `category` are deterministically derived from
 // (plugin, rule), so they don't need to participate in the key.
 export const dedupeDiagnostics = (diagnostics: Diagnostic[]): Diagnostic[] => {
+  const reactDoctorHookSites = new Set(
+    diagnostics.filter(isReactDoctorRulesOfHooksDiagnostic).map(buildDiagnosticSiteKey),
+  );
   const seenKeys = new Set<string>();
   const uniqueDiagnostics: Diagnostic[] = [];
   for (const diagnostic of diagnostics) {
+    if (
+      isReactCompilerHooksDiagnostic(diagnostic) &&
+      reactDoctorHookSites.has(buildDiagnosticSiteKey(diagnostic))
+    ) {
+      continue;
+    }
     const key = `${diagnostic.filePath}\u0000${diagnostic.line}\u0000${diagnostic.column}\u0000${diagnostic.plugin}\u0000${diagnostic.rule}\u0000${diagnostic.severity}\u0000${diagnostic.message}`;
     if (seenKeys.has(key)) continue;
     seenKeys.add(key);

--- a/packages/core/src/utils/dedupe-diagnostics.ts
+++ b/packages/core/src/utils/dedupe-diagnostics.ts
@@ -1,84 +1,21 @@
 import type { Diagnostic } from "../types/index.js";
 
-const DERIVED_STATE_RULE_PRIORITY: ReadonlyMap<string, number> = new Map([
-  ["no-initialize-state", 0],
-  ["no-adjust-state-on-prop-change", 1],
-  ["no-derived-state", 2],
-  ["no-derived-state-effect", 3],
-]);
-
-const REACT_DOCTOR_PLUGIN = "react-doctor";
-const RULES_OF_HOOKS_RULE = "rules-of-hooks";
-const REACT_COMPILER_PLUGIN = "react-hooks-js";
-const REACT_COMPILER_HOOKS_RULE = "hooks";
-
-const buildDiagnosticSiteKey = (diagnostic: Diagnostic): string =>
-  `${diagnostic.filePath}\u0000${diagnostic.line}\u0000${diagnostic.column}`;
-
-const isReactDoctorRulesOfHooksDiagnostic = (diagnostic: Diagnostic): boolean =>
-  diagnostic.plugin === REACT_DOCTOR_PLUGIN && diagnostic.rule === RULES_OF_HOOKS_RULE;
-
-const isReactCompilerHooksDiagnostic = (diagnostic: Diagnostic): boolean =>
-  diagnostic.plugin === REACT_COMPILER_PLUGIN && diagnostic.rule === REACT_COMPILER_HOOKS_RULE;
-
-const doDiagnosticSpansOverlap = (first: Diagnostic, second: Diagnostic): boolean => {
-  if (first.filePath !== second.filePath || first.plugin !== second.plugin) return false;
-  if (first.offset !== undefined && second.offset !== undefined) {
-    const firstEnd = first.offset + Math.max(first.length ?? 1, 1);
-    const secondEnd = second.offset + Math.max(second.length ?? 1, 1);
-    return first.offset < secondEnd && second.offset < firstEnd;
-  }
-  const firstEndLine = first.endLine ?? first.line;
-  const secondEndLine = second.endLine ?? second.line;
-  return first.line <= secondEndLine && second.line <= firstEndLine;
-};
-
 // HACK: oxlint plugin rules occasionally emit the same diagnostic
-// twice, and React Doctor plus React Compiler both report conditional
-// Hook calls. This safety net collapses those duplicate actionable
-// findings so downstream consumers (renderer, JSON output, score API)
-// always see one diagnostic per unique site.
+// twice. This safety net collapses exact duplicates before cache storage
+// and replay. Cross-rule deduplication happens after the diagnostic
+// pipeline so independently suppressed rules cannot erase one another.
 //
 // Field selection rationale: position + plugin + rule + message +
 // severity are the user-visible identity of a diagnostic. `help`,
 // `url`, and `category` are deterministically derived from
 // (plugin, rule), so they don't need to participate in the key.
 export const dedupeDiagnostics = (diagnostics: Diagnostic[]): Diagnostic[] => {
-  const reactDoctorHookSites = new Set(
-    diagnostics.filter(isReactDoctorRulesOfHooksDiagnostic).map(buildDiagnosticSiteKey),
-  );
   const seenKeys = new Set<string>();
   const uniqueDiagnostics: Diagnostic[] = [];
   for (const diagnostic of diagnostics) {
-    if (
-      isReactCompilerHooksDiagnostic(diagnostic) &&
-      reactDoctorHookSites.has(buildDiagnosticSiteKey(diagnostic))
-    ) {
-      continue;
-    }
     const key = `${diagnostic.filePath}\u0000${diagnostic.line}\u0000${diagnostic.column}\u0000${diagnostic.plugin}\u0000${diagnostic.rule}\u0000${diagnostic.severity}\u0000${diagnostic.message}`;
     if (seenKeys.has(key)) continue;
     seenKeys.add(key);
-    const priority = DERIVED_STATE_RULE_PRIORITY.get(diagnostic.rule);
-    if (priority !== undefined) {
-      const overlappingDiagnosticIndex = uniqueDiagnostics.findIndex(
-        (candidate) =>
-          candidate.rule !== diagnostic.rule &&
-          candidate.severity === diagnostic.severity &&
-          DERIVED_STATE_RULE_PRIORITY.has(candidate.rule) &&
-          doDiagnosticSpansOverlap(candidate, diagnostic),
-      );
-      if (overlappingDiagnosticIndex >= 0) {
-        const existingDiagnostic = uniqueDiagnostics[overlappingDiagnosticIndex];
-        const existingPriority = existingDiagnostic
-          ? DERIVED_STATE_RULE_PRIORITY.get(existingDiagnostic.rule)
-          : undefined;
-        if (existingPriority !== undefined && priority < existingPriority) {
-          uniqueDiagnostics[overlappingDiagnosticIndex] = diagnostic;
-        }
-        continue;
-      }
-    }
     uniqueDiagnostics.push(diagnostic);
   }
   return uniqueDiagnostics;

--- a/packages/core/src/utils/dedupe-related-diagnostics.ts
+++ b/packages/core/src/utils/dedupe-related-diagnostics.ts
@@ -28,6 +28,14 @@ const doDiagnosticSpansOverlap = (first: Diagnostic, second: Diagnostic): boolea
   return first.line <= secondEndLine && second.line <= firstEndLine;
 };
 
+const keepHighestSeverity = (
+  survivingDiagnostic: Diagnostic,
+  collapsedDiagnostic: Diagnostic,
+): Diagnostic =>
+  collapsedDiagnostic.severity === "error" && survivingDiagnostic.severity !== "error"
+    ? { ...survivingDiagnostic, severity: "error" }
+    : survivingDiagnostic;
+
 export const dedupeRelatedDiagnostics = (diagnostics: ReadonlyArray<Diagnostic>): Diagnostic[] => {
   const reactDoctorHookSites = new Set(
     diagnostics.filter(isReactDoctorRulesOfHooksDiagnostic).map(buildDiagnosticSiteKey),
@@ -53,8 +61,11 @@ export const dedupeRelatedDiagnostics = (diagnostics: ReadonlyArray<Diagnostic>)
         const existingPriority = existingDiagnostic
           ? DERIVED_STATE_RULE_PRIORITY.get(existingDiagnostic.rule)
           : undefined;
-        if (existingPriority !== undefined && priority < existingPriority) {
-          uniqueDiagnostics[overlappingDiagnosticIndex] = diagnostic;
+        if (existingDiagnostic && existingPriority !== undefined) {
+          uniqueDiagnostics[overlappingDiagnosticIndex] =
+            priority < existingPriority
+              ? keepHighestSeverity(diagnostic, existingDiagnostic)
+              : keepHighestSeverity(existingDiagnostic, diagnostic);
         }
         continue;
       }

--- a/packages/core/src/utils/dedupe-related-diagnostics.ts
+++ b/packages/core/src/utils/dedupe-related-diagnostics.ts
@@ -45,7 +45,6 @@ export const dedupeRelatedDiagnostics = (diagnostics: ReadonlyArray<Diagnostic>)
       const overlappingDiagnosticIndex = uniqueDiagnostics.findIndex(
         (candidate) =>
           candidate.rule !== diagnostic.rule &&
-          candidate.severity === diagnostic.severity &&
           DERIVED_STATE_RULE_PRIORITY.has(candidate.rule) &&
           doDiagnosticSpansOverlap(candidate, diagnostic),
       );

--- a/packages/core/src/utils/dedupe-related-diagnostics.ts
+++ b/packages/core/src/utils/dedupe-related-diagnostics.ts
@@ -1,0 +1,66 @@
+import type { Diagnostic } from "../types/index.js";
+
+const DERIVED_STATE_RULE_PRIORITY: ReadonlyMap<string, number> = new Map([
+  ["no-initialize-state", 0],
+  ["no-adjust-state-on-prop-change", 1],
+  ["no-derived-state", 2],
+  ["no-derived-state-effect", 3],
+]);
+
+const buildDiagnosticSiteKey = (diagnostic: Diagnostic): string =>
+  `${diagnostic.filePath}\u0000${diagnostic.line}\u0000${diagnostic.column}`;
+
+const isReactDoctorRulesOfHooksDiagnostic = (diagnostic: Diagnostic): boolean =>
+  diagnostic.plugin === "react-doctor" && diagnostic.rule === "rules-of-hooks";
+
+const isReactCompilerHooksDiagnostic = (diagnostic: Diagnostic): boolean =>
+  diagnostic.plugin === "react-hooks-js" && diagnostic.rule === "hooks";
+
+const doDiagnosticSpansOverlap = (first: Diagnostic, second: Diagnostic): boolean => {
+  if (first.filePath !== second.filePath || first.plugin !== second.plugin) return false;
+  if (first.offset !== undefined && second.offset !== undefined) {
+    const firstEnd = first.offset + Math.max(first.length ?? 1, 1);
+    const secondEnd = second.offset + Math.max(second.length ?? 1, 1);
+    return first.offset < secondEnd && second.offset < firstEnd;
+  }
+  const firstEndLine = first.endLine ?? first.line;
+  const secondEndLine = second.endLine ?? second.line;
+  return first.line <= secondEndLine && second.line <= firstEndLine;
+};
+
+export const dedupeRelatedDiagnostics = (diagnostics: ReadonlyArray<Diagnostic>): Diagnostic[] => {
+  const reactDoctorHookSites = new Set(
+    diagnostics.filter(isReactDoctorRulesOfHooksDiagnostic).map(buildDiagnosticSiteKey),
+  );
+  const uniqueDiagnostics: Diagnostic[] = [];
+  for (const diagnostic of diagnostics) {
+    if (
+      isReactCompilerHooksDiagnostic(diagnostic) &&
+      reactDoctorHookSites.has(buildDiagnosticSiteKey(diagnostic))
+    ) {
+      continue;
+    }
+    const priority = DERIVED_STATE_RULE_PRIORITY.get(diagnostic.rule);
+    if (priority !== undefined) {
+      const overlappingDiagnosticIndex = uniqueDiagnostics.findIndex(
+        (candidate) =>
+          candidate.rule !== diagnostic.rule &&
+          candidate.severity === diagnostic.severity &&
+          DERIVED_STATE_RULE_PRIORITY.has(candidate.rule) &&
+          doDiagnosticSpansOverlap(candidate, diagnostic),
+      );
+      if (overlappingDiagnosticIndex >= 0) {
+        const existingDiagnostic = uniqueDiagnostics[overlappingDiagnosticIndex];
+        const existingPriority = existingDiagnostic
+          ? DERIVED_STATE_RULE_PRIORITY.get(existingDiagnostic.rule)
+          : undefined;
+        if (existingPriority !== undefined && priority < existingPriority) {
+          uniqueDiagnostics[overlappingDiagnosticIndex] = diagnostic;
+        }
+        continue;
+      }
+    }
+    uniqueDiagnostics.push(diagnostic);
+  }
+  return uniqueDiagnostics;
+};

--- a/packages/core/tests/dedupe-diagnostics.test.ts
+++ b/packages/core/tests/dedupe-diagnostics.test.ts
@@ -67,6 +67,16 @@ describe("dedupeDiagnostics", () => {
     expect(dedupeDiagnostics([stateRule, mirrorRule])).toEqual([stateRule, mirrorRule]);
   });
 
+  it("preserves overlapping related derived-state rules (cross-rule collapse happens post-pipeline)", () => {
+    const generic = buildDiagnostic({ rule: "no-derived-state", offset: 100, length: 12 });
+    const propChange = buildDiagnostic({
+      rule: "no-adjust-state-on-prop-change",
+      offset: 100,
+      length: 12,
+    });
+    expect(dedupeDiagnostics([generic, propChange])).toEqual([generic, propChange]);
+  });
+
   it("keeps the React Doctor rules-of-hooks diagnostic when the compiler reports the same site", () => {
     const reactDoctorDiagnostic = buildNativeHookDiagnostic();
     const compilerDiagnostic = buildCompilerHookDiagnostic();
@@ -125,6 +135,16 @@ describe("dedupeDiagnostics", () => {
     ]);
   });
 
+  it("preserves compiler Hook findings on a different line at the same column", () => {
+    const reactDoctorDiagnostic = buildNativeHookDiagnostic({ line: 10 });
+    const compilerDiagnostic = buildCompilerHookDiagnostic({ line: 20 });
+
+    expect(dedupeRelatedDiagnostics([reactDoctorDiagnostic, compilerDiagnostic])).toEqual([
+      reactDoctorDiagnostic,
+      compilerDiagnostic,
+    ]);
+  });
+
   it("keeps the most specific derived-state owner at one write", () => {
     const generic = buildDiagnostic({ rule: "no-derived-state", offset: 100, length: 12 });
     const effect = buildDiagnostic({
@@ -144,6 +164,41 @@ describe("dedupeDiagnostics", () => {
     const generic = buildDiagnostic({ rule: "no-derived-state", offset: 100, length: 12 });
     const mount = buildDiagnostic({ rule: "no-initialize-state", offset: 100, length: 12 });
     expect(dedupeRelatedDiagnostics([generic, mount])).toEqual([mount]);
+  });
+
+  it("carries an escalated error severity onto the surviving derived-state winner", () => {
+    const escalatedFallback = buildDiagnostic({
+      rule: "no-derived-state",
+      severity: "error",
+      offset: 100,
+      length: 12,
+    });
+    const preferredWarning = buildDiagnostic({
+      rule: "no-adjust-state-on-prop-change",
+      severity: "warning",
+      offset: 100,
+      length: 12,
+    });
+    const expected = [{ ...preferredWarning, severity: "error" }];
+    expect(dedupeRelatedDiagnostics([escalatedFallback, preferredWarning])).toEqual(expected);
+    expect(dedupeRelatedDiagnostics([preferredWarning, escalatedFallback])).toEqual(expected);
+  });
+
+  it("keeps the winner's severity when the collapsed sibling is not escalated", () => {
+    const fallbackWarning = buildDiagnostic({
+      rule: "no-derived-state",
+      severity: "warning",
+      offset: 100,
+      length: 12,
+    });
+    const preferredError = buildDiagnostic({
+      rule: "no-adjust-state-on-prop-change",
+      severity: "error",
+      offset: 100,
+      length: 12,
+    });
+    expect(dedupeRelatedDiagnostics([fallbackWarning, preferredError])).toEqual([preferredError]);
+    expect(dedupeRelatedDiagnostics([preferredError, fallbackWarning])).toEqual([preferredError]);
   });
 
   it("preserves separate writes inside one overlapping effect diagnostic", () => {

--- a/packages/core/tests/dedupe-diagnostics.test.ts
+++ b/packages/core/tests/dedupe-diagnostics.test.ts
@@ -16,6 +16,21 @@ const buildDiagnostic = (overrides: Partial<Diagnostic> = {}): Diagnostic => ({
   ...overrides,
 });
 
+const buildNativeHookDiagnostic = (overrides: Partial<Diagnostic> = {}): Diagnostic =>
+  buildDiagnostic({
+    rule: "rules-of-hooks",
+    message: "React Hook is called conditionally",
+    ...overrides,
+  });
+
+const buildCompilerHookDiagnostic = (overrides: Partial<Diagnostic> = {}): Diagnostic =>
+  buildDiagnostic({
+    plugin: "react-hooks-js",
+    rule: "hooks",
+    message: "Hooks must always be called in a consistent order",
+    ...overrides,
+  });
+
 describe("dedupeDiagnostics", () => {
   it("returns an empty array for an empty input", () => {
     expect(dedupeDiagnostics([])).toEqual([]);
@@ -53,15 +68,8 @@ describe("dedupeDiagnostics", () => {
   });
 
   it("keeps the React Doctor rules-of-hooks diagnostic when the compiler reports the same site", () => {
-    const reactDoctorDiagnostic = buildDiagnostic({
-      rule: "rules-of-hooks",
-      message: "React Hook is called conditionally",
-    });
-    const compilerDiagnostic = buildDiagnostic({
-      plugin: "react-hooks-js",
-      rule: "hooks",
-      message: "Hooks must always be called in a consistent order",
-    });
+    const reactDoctorDiagnostic = buildNativeHookDiagnostic();
+    const compilerDiagnostic = buildCompilerHookDiagnostic();
 
     expect(dedupeRelatedDiagnostics([compilerDiagnostic, reactDoctorDiagnostic])).toEqual([
       reactDoctorDiagnostic,
@@ -72,17 +80,8 @@ describe("dedupeDiagnostics", () => {
   });
 
   it("preserves compiler Hook findings at a nearby distinct site", () => {
-    const reactDoctorDiagnostic = buildDiagnostic({
-      rule: "rules-of-hooks",
-      message: "React Hook is called conditionally",
-      column: 5,
-    });
-    const compilerDiagnostic = buildDiagnostic({
-      plugin: "react-hooks-js",
-      rule: "hooks",
-      message: "Hooks must always be called in a consistent order",
-      column: 20,
-    });
+    const reactDoctorDiagnostic = buildNativeHookDiagnostic({ column: 5 });
+    const compilerDiagnostic = buildCompilerHookDiagnostic({ column: 20 });
 
     expect(dedupeRelatedDiagnostics([reactDoctorDiagnostic, compilerDiagnostic])).toEqual([
       reactDoctorDiagnostic,
@@ -91,29 +90,19 @@ describe("dedupeDiagnostics", () => {
   });
 
   it("preserves standalone compiler Hook findings", () => {
-    const compilerDiagnostic = buildDiagnostic({
-      plugin: "react-hooks-js",
-      rule: "hooks",
-      message: "Hooks must always be called in a consistent order",
-    });
+    const compilerDiagnostic = buildCompilerHookDiagnostic();
 
     expect(dedupeRelatedDiagnostics([compilerDiagnostic])).toEqual([compilerDiagnostic]);
   });
 
   it("preserves native Hook findings when the compiler is disabled", () => {
-    const reactDoctorDiagnostic = buildDiagnostic({
-      rule: "rules-of-hooks",
-      message: "React Hook is called conditionally",
-    });
+    const reactDoctorDiagnostic = buildNativeHookDiagnostic();
 
     expect(dedupeRelatedDiagnostics([reactDoctorDiagnostic])).toEqual([reactDoctorDiagnostic]);
   });
 
   it("preserves unrelated compiler diagnostics at the same site", () => {
-    const reactDoctorDiagnostic = buildDiagnostic({
-      rule: "rules-of-hooks",
-      message: "React Hook is called conditionally",
-    });
+    const reactDoctorDiagnostic = buildNativeHookDiagnostic();
     const compilerDiagnostic = buildDiagnostic({
       plugin: "react-hooks-js",
       rule: "set-state-in-effect",
@@ -127,16 +116,8 @@ describe("dedupeDiagnostics", () => {
   });
 
   it("preserves compiler Hook findings in a different file at the same position", () => {
-    const reactDoctorDiagnostic = buildDiagnostic({
-      rule: "rules-of-hooks",
-      message: "React Hook is called conditionally",
-    });
-    const compilerDiagnostic = buildDiagnostic({
-      filePath: "src/Other.tsx",
-      plugin: "react-hooks-js",
-      rule: "hooks",
-      message: "Hooks must always be called in a consistent order",
-    });
+    const reactDoctorDiagnostic = buildNativeHookDiagnostic();
+    const compilerDiagnostic = buildCompilerHookDiagnostic({ filePath: "src/Other.tsx" });
 
     expect(dedupeRelatedDiagnostics([reactDoctorDiagnostic, compilerDiagnostic])).toEqual([
       reactDoctorDiagnostic,

--- a/packages/core/tests/dedupe-diagnostics.test.ts
+++ b/packages/core/tests/dedupe-diagnostics.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vite-plus/test";
 import { dedupeDiagnostics } from "@react-doctor/core";
 import type { Diagnostic } from "@react-doctor/core";
+import { dedupeRelatedDiagnostics } from "../src/utils/dedupe-related-diagnostics.js";
 
 const buildDiagnostic = (overrides: Partial<Diagnostic> = {}): Diagnostic => ({
   filePath: "src/App.tsx",
@@ -62,10 +63,10 @@ describe("dedupeDiagnostics", () => {
       message: "Hooks must always be called in a consistent order",
     });
 
-    expect(dedupeDiagnostics([compilerDiagnostic, reactDoctorDiagnostic])).toEqual([
+    expect(dedupeRelatedDiagnostics([compilerDiagnostic, reactDoctorDiagnostic])).toEqual([
       reactDoctorDiagnostic,
     ]);
-    expect(dedupeDiagnostics([reactDoctorDiagnostic, compilerDiagnostic])).toEqual([
+    expect(dedupeRelatedDiagnostics([reactDoctorDiagnostic, compilerDiagnostic])).toEqual([
       reactDoctorDiagnostic,
     ]);
   });
@@ -83,7 +84,7 @@ describe("dedupeDiagnostics", () => {
       column: 20,
     });
 
-    expect(dedupeDiagnostics([reactDoctorDiagnostic, compilerDiagnostic])).toEqual([
+    expect(dedupeRelatedDiagnostics([reactDoctorDiagnostic, compilerDiagnostic])).toEqual([
       reactDoctorDiagnostic,
       compilerDiagnostic,
     ]);
@@ -96,7 +97,7 @@ describe("dedupeDiagnostics", () => {
       message: "Hooks must always be called in a consistent order",
     });
 
-    expect(dedupeDiagnostics([compilerDiagnostic])).toEqual([compilerDiagnostic]);
+    expect(dedupeRelatedDiagnostics([compilerDiagnostic])).toEqual([compilerDiagnostic]);
   });
 
   it("preserves native Hook findings when the compiler is disabled", () => {
@@ -105,7 +106,7 @@ describe("dedupeDiagnostics", () => {
       message: "React Hook is called conditionally",
     });
 
-    expect(dedupeDiagnostics([reactDoctorDiagnostic])).toEqual([reactDoctorDiagnostic]);
+    expect(dedupeRelatedDiagnostics([reactDoctorDiagnostic])).toEqual([reactDoctorDiagnostic]);
   });
 
   it("preserves unrelated compiler diagnostics at the same site", () => {
@@ -119,7 +120,7 @@ describe("dedupeDiagnostics", () => {
       message: "Calling setState synchronously within an effect can trigger cascading renders",
     });
 
-    expect(dedupeDiagnostics([reactDoctorDiagnostic, compilerDiagnostic])).toEqual([
+    expect(dedupeRelatedDiagnostics([reactDoctorDiagnostic, compilerDiagnostic])).toEqual([
       reactDoctorDiagnostic,
       compilerDiagnostic,
     ]);
@@ -137,7 +138,7 @@ describe("dedupeDiagnostics", () => {
       message: "Hooks must always be called in a consistent order",
     });
 
-    expect(dedupeDiagnostics([reactDoctorDiagnostic, compilerDiagnostic])).toEqual([
+    expect(dedupeRelatedDiagnostics([reactDoctorDiagnostic, compilerDiagnostic])).toEqual([
       reactDoctorDiagnostic,
       compilerDiagnostic,
     ]);
@@ -155,13 +156,13 @@ describe("dedupeDiagnostics", () => {
       offset: 100,
       length: 12,
     });
-    expect(dedupeDiagnostics([effect, generic, propChange])).toEqual([propChange]);
+    expect(dedupeRelatedDiagnostics([effect, generic, propChange])).toEqual([propChange]);
   });
 
   it("keeps mount initialization ahead of generic derived-state rules", () => {
     const generic = buildDiagnostic({ rule: "no-derived-state", offset: 100, length: 12 });
     const mount = buildDiagnostic({ rule: "no-initialize-state", offset: 100, length: 12 });
-    expect(dedupeDiagnostics([generic, mount])).toEqual([mount]);
+    expect(dedupeRelatedDiagnostics([generic, mount])).toEqual([mount]);
   });
 
   it("preserves separate writes inside one overlapping effect diagnostic", () => {
@@ -181,7 +182,10 @@ describe("dedupeDiagnostics", () => {
       length: 12,
       column: 20,
     });
-    expect(dedupeDiagnostics([effect, firstWrite, secondWrite])).toEqual([firstWrite, secondWrite]);
+    expect(dedupeRelatedDiagnostics([effect, firstWrite, secondWrite])).toEqual([
+      firstWrite,
+      secondWrite,
+    ]);
   });
 
   it("preserves diagnostics with different messages at the same location and rule", () => {

--- a/packages/core/tests/dedupe-diagnostics.test.ts
+++ b/packages/core/tests/dedupe-diagnostics.test.ts
@@ -51,6 +51,98 @@ describe("dedupeDiagnostics", () => {
     expect(dedupeDiagnostics([stateRule, mirrorRule])).toEqual([stateRule, mirrorRule]);
   });
 
+  it("keeps the React Doctor rules-of-hooks diagnostic when the compiler reports the same site", () => {
+    const reactDoctorDiagnostic = buildDiagnostic({
+      rule: "rules-of-hooks",
+      message: "React Hook is called conditionally",
+    });
+    const compilerDiagnostic = buildDiagnostic({
+      plugin: "react-hooks-js",
+      rule: "hooks",
+      message: "Hooks must always be called in a consistent order",
+    });
+
+    expect(dedupeDiagnostics([compilerDiagnostic, reactDoctorDiagnostic])).toEqual([
+      reactDoctorDiagnostic,
+    ]);
+    expect(dedupeDiagnostics([reactDoctorDiagnostic, compilerDiagnostic])).toEqual([
+      reactDoctorDiagnostic,
+    ]);
+  });
+
+  it("preserves compiler Hook findings at a nearby distinct site", () => {
+    const reactDoctorDiagnostic = buildDiagnostic({
+      rule: "rules-of-hooks",
+      message: "React Hook is called conditionally",
+      column: 5,
+    });
+    const compilerDiagnostic = buildDiagnostic({
+      plugin: "react-hooks-js",
+      rule: "hooks",
+      message: "Hooks must always be called in a consistent order",
+      column: 20,
+    });
+
+    expect(dedupeDiagnostics([reactDoctorDiagnostic, compilerDiagnostic])).toEqual([
+      reactDoctorDiagnostic,
+      compilerDiagnostic,
+    ]);
+  });
+
+  it("preserves standalone compiler Hook findings", () => {
+    const compilerDiagnostic = buildDiagnostic({
+      plugin: "react-hooks-js",
+      rule: "hooks",
+      message: "Hooks must always be called in a consistent order",
+    });
+
+    expect(dedupeDiagnostics([compilerDiagnostic])).toEqual([compilerDiagnostic]);
+  });
+
+  it("preserves native Hook findings when the compiler is disabled", () => {
+    const reactDoctorDiagnostic = buildDiagnostic({
+      rule: "rules-of-hooks",
+      message: "React Hook is called conditionally",
+    });
+
+    expect(dedupeDiagnostics([reactDoctorDiagnostic])).toEqual([reactDoctorDiagnostic]);
+  });
+
+  it("preserves unrelated compiler diagnostics at the same site", () => {
+    const reactDoctorDiagnostic = buildDiagnostic({
+      rule: "rules-of-hooks",
+      message: "React Hook is called conditionally",
+    });
+    const compilerDiagnostic = buildDiagnostic({
+      plugin: "react-hooks-js",
+      rule: "set-state-in-effect",
+      message: "Calling setState synchronously within an effect can trigger cascading renders",
+    });
+
+    expect(dedupeDiagnostics([reactDoctorDiagnostic, compilerDiagnostic])).toEqual([
+      reactDoctorDiagnostic,
+      compilerDiagnostic,
+    ]);
+  });
+
+  it("preserves compiler Hook findings in a different file at the same position", () => {
+    const reactDoctorDiagnostic = buildDiagnostic({
+      rule: "rules-of-hooks",
+      message: "React Hook is called conditionally",
+    });
+    const compilerDiagnostic = buildDiagnostic({
+      filePath: "src/Other.tsx",
+      plugin: "react-hooks-js",
+      rule: "hooks",
+      message: "Hooks must always be called in a consistent order",
+    });
+
+    expect(dedupeDiagnostics([reactDoctorDiagnostic, compilerDiagnostic])).toEqual([
+      reactDoctorDiagnostic,
+      compilerDiagnostic,
+    ]);
+  });
+
   it("keeps the most specific derived-state owner at one write", () => {
     const generic = buildDiagnostic({ rule: "no-derived-state", offset: 100, length: 12 });
     const effect = buildDiagnostic({

--- a/packages/core/tests/merge-and-filter-diagnostics.test.ts
+++ b/packages/core/tests/merge-and-filter-diagnostics.test.ts
@@ -247,6 +247,7 @@ describe("mergeAndFilterDiagnostics — conditional Hook deduplication", () => {
     });
     const fallbackDiagnostic = buildDiagnostic({
       rule: "no-derived-state",
+      severity: "warning",
       offset: 100,
       length: 12,
     });
@@ -256,6 +257,31 @@ describe("mergeAndFilterDiagnostics — conditional Hook deduplication", () => {
         [fallbackDiagnostic, preferredDiagnostic],
         projectDir,
         { rules: { "react-doctor/no-adjust-state-on-prop-change": "error" } },
+        createNodeReadFileLinesSync(projectDir),
+      ),
+    ).toEqual([{ ...preferredDiagnostic, severity: "error" }]);
+  });
+
+  it("carries a user-escalated error onto the preferred finding it collapses into", () => {
+    const projectDir = setupCase("derived-state-dedupe-escalated-fallback", "const value = 1;\n");
+    const preferredDiagnostic = buildDiagnostic({
+      rule: "no-adjust-state-on-prop-change",
+      severity: "warning",
+      offset: 100,
+      length: 12,
+    });
+    const escalatedFallbackDiagnostic = buildDiagnostic({
+      rule: "no-derived-state",
+      severity: "warning",
+      offset: 100,
+      length: 12,
+    });
+
+    expect(
+      mergeAndFilterDiagnostics(
+        [escalatedFallbackDiagnostic, preferredDiagnostic],
+        projectDir,
+        { rules: { "react-doctor/no-derived-state": "error" } },
         createNodeReadFileLinesSync(projectDir),
       ),
     ).toEqual([{ ...preferredDiagnostic, severity: "error" }]);

--- a/packages/core/tests/merge-and-filter-diagnostics.test.ts
+++ b/packages/core/tests/merge-and-filter-diagnostics.test.ts
@@ -46,6 +46,30 @@ const setupCase = (caseId: string, fileContents: string): string => {
 const baseDiagnostic = (overrides: Partial<Diagnostic> = {}): Diagnostic =>
   buildDiagnostic({ rule: "no-derived-state-effect", line: 2, ...overrides });
 
+interface ConditionalHookDiagnostics {
+  compiler: Diagnostic;
+  reactDoctor: Diagnostic;
+}
+
+const buildConditionalHookDiagnostics = (
+  filePath: string,
+  line: number = 2,
+): ConditionalHookDiagnostics => ({
+  compiler: buildDiagnostic({
+    filePath,
+    plugin: "react-hooks-js",
+    rule: "hooks",
+    message: "Hooks must always be called in a consistent order",
+    line,
+  }),
+  reactDoctor: buildDiagnostic({
+    filePath,
+    rule: "rules-of-hooks",
+    message: "React Hook is called conditionally",
+    line,
+  }),
+});
+
 describe("mergeAndFilterDiagnostics — respectInlineDisables option", () => {
   it("filters react-doctor-disable comments by default (respectInlineDisables defaults to true)", () => {
     const projectDir = setupCase(
@@ -86,6 +110,132 @@ describe("mergeAndFilterDiagnostics — respectInlineDisables option", () => {
       { respectInlineDisables: false },
     );
     expect(filtered).toHaveLength(0);
+  });
+});
+
+describe("mergeAndFilterDiagnostics — conditional Hook deduplication", () => {
+  it("prefers the React Doctor diagnostic when both findings survive", () => {
+    const projectDir = setupCase("hook-dedupe-default", "const value = 1;\n");
+    const diagnostics = buildConditionalHookDiagnostics("src/app.tsx", 1);
+
+    expect(
+      mergeAndFilterDiagnostics(
+        [diagnostics.compiler, diagnostics.reactDoctor],
+        projectDir,
+        null,
+        createNodeReadFileLinesSync(projectDir),
+      ),
+    ).toEqual([{ ...diagnostics.reactDoctor }]);
+  });
+
+  it("preserves the compiler finding when test-noise suppression drops the native rule", () => {
+    const projectDir = setupCase("hook-dedupe-test-noise", "const value = 1;\n");
+    const diagnostics = buildConditionalHookDiagnostics("src/app.test.tsx", 1);
+
+    expect(
+      mergeAndFilterDiagnostics(
+        [diagnostics.compiler, diagnostics.reactDoctor],
+        projectDir,
+        null,
+        createNodeReadFileLinesSync(projectDir),
+      ),
+    ).toEqual([{ ...diagnostics.compiler, fileContext: "test" }]);
+  });
+
+  it("preserves the compiler finding when config ignores the native rule", () => {
+    const projectDir = setupCase("hook-dedupe-config", "const value = 1;\n");
+    const diagnostics = buildConditionalHookDiagnostics("src/app.tsx", 1);
+
+    expect(
+      mergeAndFilterDiagnostics(
+        [diagnostics.compiler, diagnostics.reactDoctor],
+        projectDir,
+        { ignore: { rules: ["react-doctor/rules-of-hooks"] } },
+        createNodeReadFileLinesSync(projectDir),
+      ),
+    ).toEqual([
+      expect.objectContaining({
+        plugin: diagnostics.compiler.plugin,
+        rule: diagnostics.compiler.rule,
+      }),
+    ]);
+  });
+
+  it("preserves the compiler finding when a path override ignores the native rule", () => {
+    const projectDir = setupCase("hook-dedupe-path-override", "const value = 1;\n");
+    const diagnostics = buildConditionalHookDiagnostics("src/app.tsx", 1);
+
+    expect(
+      mergeAndFilterDiagnostics(
+        [diagnostics.compiler, diagnostics.reactDoctor],
+        projectDir,
+        {
+          ignore: {
+            overrides: [{ files: ["src/**"], rules: ["react-doctor/rules-of-hooks"] }],
+          },
+        },
+        createNodeReadFileLinesSync(projectDir),
+      ),
+    ).toEqual([diagnostics.compiler]);
+  });
+
+  it("preserves the compiler finding when an inline directive disables the native rule", () => {
+    const projectDir = setupCase(
+      "hook-dedupe-inline",
+      "// react-doctor-disable-next-line react-doctor/rules-of-hooks\nconst value = 1;\n",
+    );
+    const diagnostics = buildConditionalHookDiagnostics("src/app.tsx");
+
+    expect(
+      mergeAndFilterDiagnostics(
+        [diagnostics.compiler, diagnostics.reactDoctor],
+        projectDir,
+        null,
+        createNodeReadFileLinesSync(projectDir),
+      ),
+    ).toEqual([
+      expect.objectContaining({
+        plugin: diagnostics.compiler.plugin,
+        rule: diagnostics.compiler.rule,
+      }),
+    ]);
+  });
+
+  it("preserves the native finding when config ignores only the compiler rule", () => {
+    const projectDir = setupCase("hook-dedupe-compiler-config", "const value = 1;\n");
+    const diagnostics = buildConditionalHookDiagnostics("src/app.tsx", 1);
+
+    expect(
+      mergeAndFilterDiagnostics(
+        [diagnostics.compiler, diagnostics.reactDoctor],
+        projectDir,
+        { ignore: { rules: ["react-hooks-js/hooks"] } },
+        createNodeReadFileLinesSync(projectDir),
+      ),
+    ).toEqual([diagnostics.reactDoctor]);
+  });
+
+  it("preserves a lower-priority related finding when config ignores the preferred rule", () => {
+    const projectDir = setupCase("derived-state-dedupe-config", "const value = 1;\n");
+    const preferredDiagnostic = buildDiagnostic({
+      rule: "no-adjust-state-on-prop-change",
+      offset: 100,
+      length: 12,
+    });
+    const fallbackDiagnostic = buildDiagnostic({
+      rule: "no-derived-state",
+      offset: 100,
+      length: 12,
+    });
+
+    expect(
+      mergeAndFilterDiagnostics(
+        [fallbackDiagnostic, preferredDiagnostic],
+        projectDir,
+        { ignore: { rules: ["react-doctor/no-adjust-state-on-prop-change"] } },
+        createNodeReadFileLinesSync(projectDir),
+      ),
+    ).toEqual([fallbackDiagnostic]);
   });
 });
 

--- a/packages/core/tests/merge-and-filter-diagnostics.test.ts
+++ b/packages/core/tests/merge-and-filter-diagnostics.test.ts
@@ -237,6 +237,29 @@ describe("mergeAndFilterDiagnostics — conditional Hook deduplication", () => {
       ),
     ).toEqual([fallbackDiagnostic]);
   });
+
+  it("deduplicates related findings after a severity override", () => {
+    const projectDir = setupCase("derived-state-dedupe-severity", "const value = 1;\n");
+    const preferredDiagnostic = buildDiagnostic({
+      rule: "no-adjust-state-on-prop-change",
+      offset: 100,
+      length: 12,
+    });
+    const fallbackDiagnostic = buildDiagnostic({
+      rule: "no-derived-state",
+      offset: 100,
+      length: 12,
+    });
+
+    expect(
+      mergeAndFilterDiagnostics(
+        [fallbackDiagnostic, preferredDiagnostic],
+        projectDir,
+        { rules: { "react-doctor/no-adjust-state-on-prop-change": "error" } },
+        createNodeReadFileLinesSync(projectDir),
+      ),
+    ).toEqual([{ ...preferredDiagnostic, severity: "error" }]);
+  });
 });
 
 describe("mergeAndFilterDiagnostics — test-noise tag auto-suppression for async-parallel", () => {

--- a/packages/core/tests/run-inspect.test.ts
+++ b/packages/core/tests/run-inspect.test.ts
@@ -960,6 +960,70 @@ describe("runInspect — Reporter sees post-filter diagnostics", () => {
   });
 });
 
+describe("runInspect — related-diagnostic dedupe on the production lint path", () => {
+  const nativeHooksDiagnostic: Diagnostic = {
+    filePath: "/repo/src/App.tsx",
+    plugin: "react-doctor",
+    rule: "rules-of-hooks",
+    severity: "error",
+    message: "React Hook is called conditionally",
+    help: "",
+    line: 3,
+    column: 5,
+    category: "Correctness",
+  };
+  const compilerHooksDiagnostic: Diagnostic = {
+    ...nativeHooksDiagnostic,
+    plugin: "react-hooks-js",
+    rule: "hooks",
+    message: "Hooks must always be called in a consistent order",
+  };
+  const collectOutputAndCapturedDiagnostics = Effect.gen(function* () {
+    const output = yield* runInspect(baseInput);
+    const ref = yield* ReporterCapture;
+    const captured = yield* Ref.get(ref);
+    return { output, captured };
+  });
+
+  it("drops the compiler duplicate at a surviving native site and emits the deduped set", async () => {
+    const result = await Effect.runPromise(
+      collectOutputAndCapturedDiagnostics.pipe(
+        Effect.provide(layersOf({ diagnostics: [compilerHooksDiagnostic, nativeHooksDiagnostic] })),
+      ),
+    );
+
+    expect(result.output.diagnostics).toEqual([nativeHooksDiagnostic]);
+    expect(result.captured).toEqual(result.output.diagnostics);
+  });
+
+  it("preserves the compiler finding when config suppresses the native rule", async () => {
+    const layers = Layer.mergeAll(
+      Project.layerOf(sampleProject),
+      Config.layerOf({
+        config: { ignore: { rules: ["react-doctor/rules-of-hooks"] } },
+        resolvedDirectory: "/repo",
+        configSourceDirectory: null,
+      }),
+      Files.layerInMemory(new Map()),
+      Linter.layerOf([compilerHooksDiagnostic, nativeHooksDiagnostic]),
+      LintPartialFailures.layerLive,
+      DeadCode.layerOf([]),
+      Git.layerOf({}),
+      Score.layerOf(null),
+      SupplyChain.layerOf([]),
+      Progress.layerNoop,
+      Reporter.layerCapture,
+      Layer.succeed(DeadCodeOverlap, "off"),
+    );
+    const result = await Effect.runPromise(
+      collectOutputAndCapturedDiagnostics.pipe(Effect.provide(layers)),
+    );
+
+    expect(result.output.diagnostics).toEqual([compilerHooksDiagnostic]);
+    expect(result.captured).toEqual(result.output.diagnostics);
+  });
+});
+
 describe("runInspect — supply-chain in diff mode", () => {
   it("runs supply-chain in full scans", async () => {
     const output = await Effect.runPromise(


### PR DESCRIPTION
## Why
React Doctor and React Compiler can report the same conditional Hook call, inflating terminal, JSON, score, and React Bench change counts.

## What
- keep `react-doctor/rules-of-hooks` as the actionable diagnostic
- suppress only `react-hooks-js/hooks` at the exact same file, line, and column
- preserve nearby Hook sites, standalone compiler findings, compiler-disabled scans, and unrelated compiler diagnostics
- add a patch changeset

## Product pass
- user job: see one actionable issue per conditional Hook site
- reused signal: existing `diag.total` wide-event count
- kill boundary: revert if any distinct native Hook finding or standalone compiler finding is removed

## Validation
- 19 paired/adversarial dedupe tests
- full core suite: 117 files, 1,292 tests
- full repository `nr test`
- `nr typecheck`
- `nr lint` (pre-existing warnings only)
- `nr format:check`
- `nr smoke:json-report`
- exact HostedCart scan: four native sites retained, same-site compiler duplicates removed, five standalone compiler Hook findings retained
- 20 React Bench before/after reports: 4,924 diagnostics audited; all 89 removals were compiler Hook duplicates with an exact native counterpart
- truffler pre/post dedup search

Rule fuzzing is not applicable because this changes post-lint aggregation rather than detector behavior; the repository fuzz harness tests pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which diagnostics reach terminal, JSON, and score after lint; behavior is heavily tested but alters user-visible counts and cache replay semantics.
> 
> **Overview**
> **Post-pipeline related diagnostic deduplication** replaces cross-rule collapse that used to live in `dedupeDiagnostics` (cache/pre-lint only). `dedupeRelatedDiagnostics` now runs after `buildDiagnosticPipeline` in `mergeAndFilterDiagnostics` and on the production lint path in `runInspect`, so suppressing one rule does not hide the other at the same site.
> 
> At the **same file, line, and column**, `react-hooks-js/hooks` is dropped when `react-doctor/rules-of-hooks` survives; if the native rule is filtered out (config, inline disable, test noise), the compiler finding is kept. **Overlapping derived-state rules** still collapse to the most specific rule by priority, but matching severity is no longer required—the survivor keeps the **higher** of the two severities (e.g. after user overrides).
> 
> `runInspect` collects pipeline-filtered lint diagnostics, dedupes, then emits the final set to the reporter. **`SIDECAR_LINT_CACHE_SCHEMA_VERSION`** is bumped to **2** so stale cached winner-only sets are not replayed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fd17d3df572704431c3dffc8041d5745fefed26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->