### PR TITLE
fix(zod): recognize the official v4 export

### DIFF
--- a/.changeset/tidy-zod-subpaths.md
+++ b/.changeset/tidy-zod-subpaths.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Recognize the official `zod/v4` export in Zod migration rules.

--- a/packages/fuzz/corpus/targets/README.md
+++ b/packages/fuzz/corpus/targets/README.md
@@ -1,0 +1,5 @@
+# Fuzz liveness targets
+
+These programs intentionally contain diagnostics. They keep changed rules on their reporting paths during fuzzing so strict runs exercise more than early exits.
+
+False-positive hunting loads only `corpus/regressions/`, where every program is valid by contract.

--- a/packages/fuzz/corpus/targets/zod-v4-no-deprecated-error-apis--official-v4-export.tsx
+++ b/packages/fuzz/corpus/targets/zod-v4-no-deprecated-error-apis--official-v4-export.tsx
@@ -1,0 +1,3 @@
+import { ZodError } from "zod/v4";
+
+export const flattenedError = new ZodError([]).flatten();

--- a/packages/fuzz/corpus/targets/zod-v4-no-deprecated-error-customization--official-v4-export.tsx
+++ b/packages/fuzz/corpus/targets/zod-v4-no-deprecated-error-customization--official-v4-export.tsx
@@ -1,0 +1,3 @@
+import { z } from "zod/v4";
+
+export const requiredSchema = z.string("Required");

--- a/packages/fuzz/corpus/targets/zod-v4-no-deprecated-schema-apis--official-v4-export.tsx
+++ b/packages/fuzz/corpus/targets/zod-v4-no-deprecated-schema-apis--official-v4-export.tsx
@@ -1,0 +1,3 @@
+import { z } from "zod/v4";
+
+export const strictSchema = z.object({ value: z.string() }).strict();

--- a/packages/fuzz/corpus/targets/zod-v4-prefer-top-level-string-formats--official-v4-export.tsx
+++ b/packages/fuzz/corpus/targets/zod-v4-prefer-top-level-string-formats--official-v4-export.tsx
@@ -1,0 +1,3 @@
+import { z } from "zod/v4";
+
+export const emailSchema = z.string().email();

--- a/packages/fuzz/scripts/hunt-false-positives.ts
+++ b/packages/fuzz/scripts/hunt-false-positives.ts
@@ -15,7 +15,7 @@ import { loadFuzzCorpus } from "../src/load-fuzz-corpus.js";
 //   HUNT_CORPUS_DIR=tmp/corpus-repos bun scripts/hunt-false-positives.ts
 
 const packageRoot = path.resolve(import.meta.dirname, "..");
-const regressionsDirectory = path.join(packageRoot, "corpus");
+const regressionsDirectory = path.join(packageRoot, "corpus", "regressions");
 
 interface SeedHit {
   seed: string;

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -157,6 +157,7 @@ export const GUARD_SNIPPET_POOL = [
 
 // Library idioms — tanstack, mobx, styled-components, next/dynamic, redux.
 export const LIBRARY_SNIPPET_POOL = [
+  `const zodSchema = z.object({ value: z.string() }).strict();`,
   `const subscribeStore = useCallback((onStoreChange) => { store.on("change", onStoreChange); return () => store.off("change", onStoreChange); }, [store]); const snapshot = useSyncExternalStore(subscribeStore, getSnapshot);`,
   `const { data: queryData, isPending } = useQuery({ queryKey: ["items", value], queryFn: () => fetch(url).then((response) => response.json()) });`,
   `const mutation = useMutation({ mutationFn: (payload) => api.post(url, payload) });`,
@@ -433,6 +434,7 @@ export const IMPORT_LINE_POOL = [
   `import { useForm } from "react-hook-form";`,
   `import debounce from "lodash/debounce";`,
   `import { z } from "zod";`,
+  `import * as fuzzZod from "zod/v4"; const fuzzZodSchema = fuzzZod.object({ email: fuzzZod.string().email() }).strict();`,
   `import { forwardRef } from "react";\nconst FuzzForwardRefComponent = forwardRef((props) => <button>{props.label}</button>);`,
 ] as const;
 

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -435,6 +435,8 @@ export const IMPORT_LINE_POOL = [
   `import debounce from "lodash/debounce";`,
   `import { z } from "zod";`,
   `import * as fuzzZod from "zod/v4"; const fuzzZodSchema = fuzzZod.object({ email: fuzzZod.string().email() }).strict();`,
+  `import { z as fuzzZodErrorCustomization } from "zod/v4"; const fuzzZodRequiredSchema = fuzzZodErrorCustomization.string("Required");`,
+  `import { ZodError as FuzzZodError } from "zod/v4"; const fuzzZodFlattenedError = new FuzzZodError([]).flatten();`,
   `import { forwardRef } from "react";\nconst FuzzForwardRefComponent = forwardRef((props) => <button>{props.label}</button>);`,
 ] as const;
 

--- a/packages/fuzz/tests/fuzz-rules.test.ts
+++ b/packages/fuzz/tests/fuzz-rules.test.ts
@@ -41,9 +41,9 @@ const fuzzTestTimeoutMs = Math.max(
 );
 const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
-// The built-in regression corpus (confirmed historical false positives —
-// see corpus/README.md) is always fuzzed; FUZZ_CORPUS_DIR adds external
-// real-world files on top.
+// The built-in corpus combines confirmed false-positive regressions with
+// intentional liveness targets; FUZZ_CORPUS_DIR adds external real-world
+// files on top.
 const corpusDirectory = process.env.FUZZ_CORPUS_DIR;
 const builtinCorpus: FuzzCorpusEntry[] = isFuzzEnabled
   ? loadFuzzCorpus(path.join(packageRoot, "corpus"))

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/zod/__fixtures__/non-full-zod-v4-module-sources.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/zod/__fixtures__/non-full-zod-v4-module-sources.ts
@@ -1,0 +1,12 @@
+export const NON_FULL_ZOD_V4_MODULE_SOURCES: ReadonlyArray<string> = [
+  "zod/v3",
+  "zod/mini",
+  "zod/locales",
+  "zod/v4-mini",
+  "zod/v4/mini",
+  "zod/v4/core",
+  "zod/v4/locales",
+  "zod/v4/locales/en.js",
+  "zod/v4/classic",
+  "@acme/zod/v4",
+];

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/zod/utils/zod-ast.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/zod/utils/zod-ast.ts
@@ -5,12 +5,7 @@ import { getStaticPropertyName } from "../../../utils/get-static-property-name.j
 import { isNodeOfType } from "../../../utils/is-node-of-type.js";
 import { stripParenExpression } from "../../../utils/strip-paren-expression.js";
 
-const ZOD_MODULE = "zod";
-
-// Every zod detection below bottoms out in `getImportInfoForIdentifier`,
-// which requires an import whose source is exactly `ZOD_MODULE` — so a file
-// with no such import can never report, and rules gate their visitors on it.
-export const ZOD_MODULE_SOURCES: ReadonlyArray<string> = [ZOD_MODULE];
+export const ZOD_MODULE_SOURCES: ReadonlyArray<string> = ["zod", "zod/v4"];
 
 interface ZodImportInfo {
   imported: string | null;
@@ -49,7 +44,7 @@ const computeImportInfoForIdentifier = (
   const declaration = specifier.parent;
   if (!declaration || !isNodeOfType(declaration, "ImportDeclaration")) return null;
   const source = declaration.source?.value;
-  if (source !== ZOD_MODULE) return null;
+  if (typeof source !== "string" || !ZOD_MODULE_SOURCES.includes(source)) return null;
 
   if (isNodeOfType(specifier, "ImportNamespaceSpecifier")) {
     return { imported: null, isDefault: false, isNamespace: true };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/zod/zod-v4-no-deprecated-error-apis.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/zod/zod-v4-no-deprecated-error-apis.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
 import { runRule } from "../../../test-utils/run-rule.js";
+import { NON_FULL_ZOD_V4_MODULE_SOURCES } from "./__fixtures__/non-full-zod-v4-module-sources.js";
 import { zodV4NoDeprecatedErrorApis } from "./zod-v4-no-deprecated-error-apis.js";
 
 describe("zod-v4-no-deprecated-error-apis", () => {
@@ -11,6 +12,51 @@ describe("zod-v4-no-deprecated-error-apis", () => {
     const result = runRule(zodV4NoDeprecatedErrorApis, code);
     expect(result.diagnostics).toHaveLength(1);
   });
+
+  it.each([
+    {
+      importStatement: 'import { z } from "zod/v4";',
+      errorExpression: "z.ZodError",
+    },
+    {
+      importStatement: 'import * as schema from "zod/v4";',
+      errorExpression: "schema.ZodError",
+    },
+    {
+      importStatement: 'import { z as schema } from "zod/v4";',
+      errorExpression: "schema.ZodError",
+    },
+    {
+      importStatement: 'import schema from "zod/v4";',
+      errorExpression: "schema.ZodError",
+    },
+    {
+      importStatement: 'import { ZodError as ValidationError } from "zod/v4";',
+      errorExpression: "ValidationError",
+    },
+  ])(
+    "flags deprecated error APIs from the official v4 export: $importStatement",
+    ({ importStatement, errorExpression }) => {
+      const code = `
+        ${importStatement}
+        const flattened = new ${errorExpression}([]).flatten();
+      `;
+      const result = runRule(zodV4NoDeprecatedErrorApis, code);
+      expect(result.diagnostics).toHaveLength(1);
+    },
+  );
+
+  it.each(NON_FULL_ZOD_V4_MODULE_SOURCES)(
+    "does NOT assign the full Zod v4 error API to %s",
+    (moduleSource) => {
+      const code = `
+        import { ZodError } from "${moduleSource}";
+        const flattened = new ZodError([]).flatten();
+      `;
+      const result = runRule(zodV4NoDeprecatedErrorApis, code);
+      expect(result.diagnostics).toHaveLength(0);
+    },
+  );
 
   it("flags namespace and renamed ZodError imports", () => {
     const code = `

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/zod/zod-v4-no-deprecated-error-customization.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/zod/zod-v4-no-deprecated-error-customization.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
 import { runRule } from "../../../test-utils/run-rule.js";
+import { NON_FULL_ZOD_V4_MODULE_SOURCES } from "./__fixtures__/non-full-zod-v4-module-sources.js";
 import { zodV4NoDeprecatedErrorCustomization } from "./zod-v4-no-deprecated-error-customization.js";
 
 describe("zod-v4-no-deprecated-error-customization", () => {
@@ -11,6 +12,51 @@ describe("zod-v4-no-deprecated-error-customization", () => {
     const result = runRule(zodV4NoDeprecatedErrorCustomization, code);
     expect(result.diagnostics).toHaveLength(1);
   });
+
+  it.each([
+    {
+      importStatement: 'import { z } from "zod/v4";',
+      factoryExpression: "z.string",
+    },
+    {
+      importStatement: 'import * as schema from "zod/v4";',
+      factoryExpression: "schema.string",
+    },
+    {
+      importStatement: 'import { z as schema } from "zod/v4";',
+      factoryExpression: "schema.string",
+    },
+    {
+      importStatement: 'import { string as createString } from "zod/v4";',
+      factoryExpression: "createString",
+    },
+    {
+      importStatement: 'import schema from "zod/v4";',
+      factoryExpression: "schema.string",
+    },
+  ])(
+    "flags legacy error customization from the official v4 export: $importStatement",
+    ({ importStatement, factoryExpression }) => {
+      const code = `
+        ${importStatement}
+        const requiredSchema = ${factoryExpression}("Required");
+      `;
+      const result = runRule(zodV4NoDeprecatedErrorCustomization, code);
+      expect(result.diagnostics).toHaveLength(1);
+    },
+  );
+
+  it.each(NON_FULL_ZOD_V4_MODULE_SOURCES)(
+    "does NOT assign the full Zod v4 error-customization API to %s",
+    (moduleSource) => {
+      const code = `
+        import { z } from "${moduleSource}";
+        const schema = z.string("Required");
+      `;
+      const result = runRule(zodV4NoDeprecatedErrorCustomization, code);
+      expect(result.diagnostics).toHaveLength(0);
+    },
+  );
 
   it("flags aliased named factory imports with legacy message parameters", () => {
     const code = `

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/zod/zod-v4-no-deprecated-schema-apis.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/zod/zod-v4-no-deprecated-schema-apis.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
 import { runRule } from "../../../test-utils/run-rule.js";
+import { NON_FULL_ZOD_V4_MODULE_SOURCES } from "./__fixtures__/non-full-zod-v4-module-sources.js";
 import { zodV4NoDeprecatedSchemaApis } from "./zod-v4-no-deprecated-schema-apis.js";
 
 describe("zod-v4-no-deprecated-schema-apis", () => {
@@ -31,20 +32,30 @@ describe("zod-v4-no-deprecated-schema-apis", () => {
   });
 
   it.each([
-    'import { z } from "zod/v4";',
-    'import * as z from "zod/v4";',
-    'import { z as schema } from "zod/v4";',
-  ])("flags deprecated schemas from the official v4 export: %s", (importStatement) => {
-    const namespaceName = importStatement.includes("as schema") ? "schema" : "z";
-    const code = `
-      ${importStatement}
-      const strict = ${namespaceName}.object({}).strict();
-    `;
-    const result = runRule(zodV4NoDeprecatedSchemaApis, code);
-    expect(result.diagnostics).toHaveLength(1);
-  });
+    { importStatement: 'import { z } from "zod/v4";', factoryExpression: "z.object" },
+    { importStatement: 'import * as schema from "zod/v4";', factoryExpression: "schema.object" },
+    {
+      importStatement: 'import { z as schema } from "zod/v4";',
+      factoryExpression: "schema.object",
+    },
+    { importStatement: 'import schema from "zod/v4";', factoryExpression: "schema.object" },
+    {
+      importStatement: 'import { object as createObject } from "zod/v4";',
+      factoryExpression: "createObject",
+    },
+  ])(
+    "flags deprecated schemas from the official v4 export: $importStatement",
+    ({ importStatement, factoryExpression }) => {
+      const code = `
+        ${importStatement}
+        const strict = ${factoryExpression}({}).strict();
+      `;
+      const result = runRule(zodV4NoDeprecatedSchemaApis, code);
+      expect(result.diagnostics).toHaveLength(1);
+    },
+  );
 
-  it.each(["zod/v3", "zod/v4-mini", "zod/v4/core", "@acme/zod/v4"])(
+  it.each(NON_FULL_ZOD_V4_MODULE_SOURCES)(
     "does NOT assign the full Zod v4 API to %s",
     (moduleSource) => {
       const code = `

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/zod/zod-v4-no-deprecated-schema-apis.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/zod/zod-v4-no-deprecated-schema-apis.test.ts
@@ -30,6 +30,32 @@ describe("zod-v4-no-deprecated-schema-apis", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it.each([
+    'import { z } from "zod/v4";',
+    'import * as z from "zod/v4";',
+    'import { z as schema } from "zod/v4";',
+  ])("flags deprecated schemas from the official v4 export: %s", (importStatement) => {
+    const namespaceName = importStatement.includes("as schema") ? "schema" : "z";
+    const code = `
+      ${importStatement}
+      const strict = ${namespaceName}.object({}).strict();
+    `;
+    const result = runRule(zodV4NoDeprecatedSchemaApis, code);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it.each(["zod/v3", "zod/v4-mini", "zod/v4/core", "@acme/zod/v4"])(
+    "does NOT assign the full Zod v4 API to %s",
+    (moduleSource) => {
+      const code = `
+        import { z } from "${moduleSource}";
+        const strict = z.object({}).strict();
+      `;
+      const result = runRule(zodV4NoDeprecatedSchemaApis, code);
+      expect(result.diagnostics).toHaveLength(0);
+    },
+  );
+
   it("flags deprecated top-level factories and optional aliases", () => {
     const code = `
       import * as z from "zod";

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/zod/zod-v4-prefer-top-level-string-formats.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/zod/zod-v4-prefer-top-level-string-formats.regressions.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
 import { runRule } from "../../../test-utils/run-rule.js";
+import { NON_FULL_ZOD_V4_MODULE_SOURCES } from "./__fixtures__/non-full-zod-v4-module-sources.js";
 import { zodV4PreferTopLevelStringFormats } from "./zod-v4-prefer-top-level-string-formats.js";
 
 describe("zod-v4-prefer-top-level-string-formats — regressions", () => {
@@ -29,22 +30,32 @@ describe("zod-v4-prefer-top-level-string-formats — regressions", () => {
   });
 
   it.each([
-    'import { z } from "zod/v4";',
-    'import * as z from "zod/v4";',
-    'import { z as schema } from "zod/v4";',
-  ])("flags legacy string formats from the official v4 export: %s", (importStatement) => {
-    const namespaceName = importStatement.includes("as schema") ? "schema" : "z";
-    const code = `
-      ${importStatement}
-      const schemaValue = ${namespaceName}.string().email();
-    `;
-    const result = runRule(zodV4PreferTopLevelStringFormats, code, {
-      filename: "/repo/src/lib/schema.ts",
-    });
-    expect(result.diagnostics).toHaveLength(1);
-  });
+    { importStatement: 'import { z } from "zod/v4";', factoryExpression: "z.string" },
+    { importStatement: 'import * as schema from "zod/v4";', factoryExpression: "schema.string" },
+    {
+      importStatement: 'import { z as schema } from "zod/v4";',
+      factoryExpression: "schema.string",
+    },
+    { importStatement: 'import schema from "zod/v4";', factoryExpression: "schema.string" },
+    {
+      importStatement: 'import { string as createString } from "zod/v4";',
+      factoryExpression: "createString",
+    },
+  ])(
+    "flags legacy string formats from the official v4 export: $importStatement",
+    ({ importStatement, factoryExpression }) => {
+      const code = `
+        ${importStatement}
+        const schemaValue = ${factoryExpression}().email();
+      `;
+      const result = runRule(zodV4PreferTopLevelStringFormats, code, {
+        filename: "/repo/src/lib/schema.ts",
+      });
+      expect(result.diagnostics).toHaveLength(1);
+    },
+  );
 
-  it.each(["zod/v3", "zod/v4-mini", "zod/v4/core", "@acme/zod/v4"])(
+  it.each(NON_FULL_ZOD_V4_MODULE_SOURCES)(
     "does NOT assign the full Zod v4 API to %s",
     (moduleSource) => {
       const code = `

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/zod/zod-v4-prefer-top-level-string-formats.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/zod/zod-v4-prefer-top-level-string-formats.regressions.test.ts
@@ -27,4 +27,34 @@ describe("zod-v4-prefer-top-level-string-formats — regressions", () => {
     });
     expect(result.diagnostics).toHaveLength(1);
   });
+
+  it.each([
+    'import { z } from "zod/v4";',
+    'import * as z from "zod/v4";',
+    'import { z as schema } from "zod/v4";',
+  ])("flags legacy string formats from the official v4 export: %s", (importStatement) => {
+    const namespaceName = importStatement.includes("as schema") ? "schema" : "z";
+    const code = `
+      ${importStatement}
+      const schemaValue = ${namespaceName}.string().email();
+    `;
+    const result = runRule(zodV4PreferTopLevelStringFormats, code, {
+      filename: "/repo/src/lib/schema.ts",
+    });
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it.each(["zod/v3", "zod/v4-mini", "zod/v4/core", "@acme/zod/v4"])(
+    "does NOT assign the full Zod v4 API to %s",
+    (moduleSource) => {
+      const code = `
+        import { z } from "${moduleSource}";
+        const schema = z.string().email();
+      `;
+      const result = runRule(zodV4PreferTopLevelStringFormats, code, {
+        filename: "/repo/src/lib/schema.ts",
+      });
+      expect(result.diagnostics).toHaveLength(0);
+    },
+  );
 });


### PR DESCRIPTION
## Why

Catches Zod 4 migration issues when projects import the full classic API from the official `zod/v4` export instead of the package root.

Before:

```ts
import { z } from "zod/v4";

const email = z.string().email();
const schema = z.object({ value: z.string() }).strict();
```

After:

```ts
import { z } from "zod/v4";

const email = z.email();
const schema = z.strictObject({ value: z.string() });
```

## What changed

- Recognizes only the exact `zod` and `zod/v4` module sources across all four shared Zod migration-rule consumers.
- Keeps `zod/v3`, mini, core, locales, locale wildcards, internal-looking subpaths, and package lookalikes excluded.
- Covers named, renamed, namespace, default, and direct factory imports.
- Adds dedicated fuzz targets and generator snippets for all four affected rules.
- Keeps intentional liveness targets out of the confirmed-valid false-positive corpus oracle.

RDE was not run because cloud RDE does not exercise this AST-rule layer. The exact pinned local fixture was compared against its baseline: two diagnostics were added, both intended, with none removed.

## Test plan

- `nr --filter oxlint-plugin-react-doctor test src/plugin/rules/zod/zod-v4-no-deprecated-schema-apis.test.ts src/plugin/rules/zod/zod-v4-prefer-top-level-string-formats.regressions.test.ts src/plugin/rules/zod/zod-v4-no-deprecated-error-customization.test.ts src/plugin/rules/zod/zod-v4-no-deprecated-error-apis.test.ts`
- `FUZZ_RULE=zod-v4 FUZZ_STRICT=1 FUZZ_ITERATIONS=500 FUZZ_PRINT_SILENT=1 nr fuzz`
- `nr --filter @react-doctor/fuzz test`
- `nr lint`
- `nr typecheck`
- `nr format:check`
- `nr smoke:json-report`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped change to Zod import-source matching and test/fuzz harness updates; no auth or runtime behavior outside lint rule coverage for two exact module strings.
> 
> **Overview**
> Zod v4 migration lint rules now treat imports from **`zod/v4`** the same as **`zod`**, so deprecated schema/error APIs and legacy string formats are reported when projects use the official v4 entry point.
> 
> Shared import resolution in `zod-ast.ts` uses `ZOD_MODULE_SOURCES` (`zod` and `zod/v4` only); subpaths like `zod/v4/core` and package lookalikes stay excluded. Four rules gain parameterized tests for named, namespace, default, and renamed imports from `zod/v4`, plus shared negative cases via `NON_FULL_ZOD_V4_MODULE_SOURCES`.
> 
> Fuzzing adds intentional **`corpus/targets`** programs for those rules, **`zod/v4`** snippets in generator pools, and narrows false-positive hunting to **`corpus/regressions`** so liveness targets are not treated as valid-code oracles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad02991ea4e5180b17c66d9bd25488e66be25518. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->