### PR TITLE
fix(rule): ignore async effect callback chains

### DIFF
--- a/.changeset/tidy-effect-callbacks.md
+++ b/.changeset/tidy-effect-callbacks.md
@@ -2,4 +2,4 @@
 "oxlint-plugin-react-doctor": patch
 ---
 
-Resolve exact local function bindings passed as effect callbacks.
+Resolve exact local function bindings passed as effect callbacks while excluding async callbacks from synchronous chain analysis.

--- a/packages/fuzz/corpus/regressions/no-effect-chain--async-downstream-effect-callback.tsx
+++ b/packages/fuzz/corpus/regressions/no-effect-chain--async-downstream-effect-callback.tsx
@@ -1,0 +1,21 @@
+// rule: no-effect-chain
+// weakness: control-flow
+// source: PR #1204 independent final audit
+
+import { useEffect, useState } from "react";
+
+export const AsyncDownstreamEffectCallback = ({ loadValue }) => {
+  const [source, setSource] = useState(0);
+  const [target, setTarget] = useState(0);
+
+  useEffect(() => {
+    setSource(1);
+  }, []);
+
+  const synchronizeTarget = async () => {
+    setTarget(await loadValue(source));
+  };
+
+  useEffect(synchronizeTarget, [loadValue, source]);
+  return target;
+};

--- a/packages/fuzz/corpus/regressions/no-effect-chain--named-async-effect-callback.tsx
+++ b/packages/fuzz/corpus/regressions/no-effect-chain--named-async-effect-callback.tsx
@@ -1,0 +1,22 @@
+// rule: no-effect-chain
+// weakness: control-flow
+// source: PR #1182 Bugbot review
+
+import { useEffect, useState } from "react";
+
+export const AsyncEffectCallback = ({ loadValue }) => {
+  const [source, setSource] = useState(0);
+  const [target, setTarget] = useState(0);
+
+  const loadSource = async () => {
+    await loadValue();
+    setSource(1);
+  };
+
+  useEffect(loadSource, [loadValue]);
+  useEffect(() => {
+    setTarget(source + 1);
+  }, [source]);
+
+  return target;
+};

--- a/packages/fuzz/tests/verdict-robustness.test.ts
+++ b/packages/fuzz/tests/verdict-robustness.test.ts
@@ -29,6 +29,7 @@ const AUDITED_RULE_IDS = [
   "no-aria-hidden-on-focusable",
   "no-cascading-set-state",
   "no-derived-state-effect",
+  "no-effect-chain",
   "no-impure-state-updater",
   "no-jsx-element-type",
   "no-locale-format-in-render",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.regressions.test.ts
@@ -379,19 +379,19 @@ describe("no-effect-chain — regressions", () => {
   it.each([
     [
       "inline arrow",
-      "useEffect(async () => { const response = await fetch('/api/value'); setTarget(await response.json()); }, [source]);",
+      "useEffect(async () => { setTarget(await loadTargetValue(source)); }, [source]);",
     ],
     [
       "named declaration",
-      "async function synchronizeTarget() { const response = await fetch('/api/value'); setTarget(await response.json()); } useEffect(synchronizeTarget, [source]);",
+      "async function synchronizeTarget() { setTarget(await loadTargetValue(source)); } useEffect(synchronizeTarget, [source]);",
     ],
     [
       "exact alias",
-      "const synchronizeTarget = async () => { const response = await fetch('/api/value'); setTarget(await response.json()); }; const effectCallback = synchronizeTarget; useEffect(effectCallback, [source]);",
+      "const synchronizeTarget = async () => { setTarget(await loadTargetValue(source)); }; const effectCallback = synchronizeTarget; useEffect(effectCallback, [source]);",
     ],
     [
       "layout effect",
-      "const synchronizeTarget = async () => { const response = await fetch('/api/value'); setTarget(await response.json()); }; useLayoutEffect(synchronizeTarget, [source]);",
+      "const synchronizeTarget = async () => { setTarget(await loadTargetValue(source)); }; useLayoutEffect(synchronizeTarget, [source]);",
     ],
   ])(
     "ignores an async %s effect callback as the downstream chain link",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.regressions.test.ts
@@ -376,6 +376,41 @@ describe("no-effect-chain — regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it.each([
+    [
+      "inline arrow",
+      "useEffect(async () => { const response = await fetch('/api/value'); setTarget(await response.json()); }, [source]);",
+    ],
+    [
+      "named declaration",
+      "async function synchronizeTarget() { const response = await fetch('/api/value'); setTarget(await response.json()); } useEffect(synchronizeTarget, [source]);",
+    ],
+    [
+      "exact alias",
+      "const synchronizeTarget = async () => { const response = await fetch('/api/value'); setTarget(await response.json()); }; const effectCallback = synchronizeTarget; useEffect(effectCallback, [source]);",
+    ],
+    [
+      "layout effect",
+      "const synchronizeTarget = async () => { const response = await fetch('/api/value'); setTarget(await response.json()); }; useLayoutEffect(synchronizeTarget, [source]);",
+    ],
+  ])(
+    "ignores an async %s effect callback as the downstream chain link",
+    (_callbackShape, downstreamEffect) => {
+      const result = runRule(
+        noEffectChain,
+        `function Widget() {
+        const [source, setSource] = useState(0);
+        const [target, setTarget] = useState(0);
+        useEffect(() => { setSource(1); }, []);
+        ${downstreamEffect}
+        return target;
+      }`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    },
+  );
+
   it("flags the synchronous near-neighbor through an exact callback alias", () => {
     const result = runRule(
       noEffectChain,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.regressions.test.ts
@@ -319,6 +319,80 @@ describe("no-effect-chain — regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it.each([
+    ["inline arrow", "useEffect(async () => { await loadSourceValue(); setSource(1); }, []);"],
+    [
+      "named arrow",
+      "const loadSource = async () => { await loadSourceValue(); setSource(1); }; useEffect(loadSource, []);",
+    ],
+    [
+      "function declaration",
+      "async function loadSource() { await loadSourceValue(); setSource(1); } useEffect(loadSource, []);",
+    ],
+    [
+      "function expression",
+      "const loadSource = async function () { await loadSourceValue(); setSource(1); }; useEffect(loadSource, []);",
+    ],
+    [
+      "exact alias",
+      "const loadSource = async () => { await loadSourceValue(); setSource(1); }; const effectCallback = loadSource; useEffect(effectCallback, []);",
+    ],
+    [
+      "layout effect",
+      "const loadSource = async () => { await loadSourceValue(); setSource(1); }; useLayoutEffect(loadSource, []);",
+    ],
+  ])("ignores state writes in an async %s effect callback", (_callbackShape, upstreamEffect) => {
+    const result = runRule(
+      noEffectChain,
+      `function Widget() {
+        const [source, setSource] = useState(0);
+        const [target, setTarget] = useState(0);
+        ${upstreamEffect}
+        useEffect(() => { setTarget(source + 1); }, [source]);
+        return target;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("ignores an async effect callback whose state writes straddle await", () => {
+    const result = runRule(
+      noEffectChain,
+      `function Widget() {
+        const [source, setSource] = useState(0);
+        const [target, setTarget] = useState(0);
+        async function loadSource() {
+          setSource(1);
+          await loadSourceValue();
+          setSource(2);
+        }
+        useEffect(loadSource, []);
+        useEffect(() => { setTarget(source + 1); }, [source]);
+        return target;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("flags the synchronous near-neighbor through an exact callback alias", () => {
+    const result = runRule(
+      noEffectChain,
+      `function Widget() {
+        const [source, setSource] = useState(0);
+        const [target, setTarget] = useState(0);
+        const loadSource = () => { setSource(1); };
+        const effectCallback = loadSource;
+        useEffect(effectCallback, []);
+        useEffect(() => { setTarget(source + 1); }, [source]);
+        return target;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("flags state writes inside an invoked synchronous function", () => {
     const result = runRule(
       noEffectChain,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.ts
@@ -85,9 +85,8 @@ const collectSynchronouslyInvokedFunctions = (
   effectCallback: EsTreeNode,
   scopes: ScopeAnalysis,
 ): ReadonlySet<EsTreeNode> => {
-  if (!isFunctionLike(effectCallback) || effectCallback.async) return new Set();
   const analysisFunctions = new Set<EsTreeNode>([effectCallback]);
-  const pendingFunctions: EsTreeNode[] = [effectCallback];
+  const pendingFunctions = [effectCallback];
   while (pendingFunctions.length > 0) {
     const currentFunction = pendingFunctions.pop();
     if (!currentFunction || !isFunctionLike(currentFunction)) continue;
@@ -363,7 +362,7 @@ export const noEffectChain = defineRule({
       const effectInfos: EffectInfo[] = [];
       for (const effectCall of findTopLevelEffectCalls(componentBody)) {
         const callback = getEffectCallback(effectCall, context.scopes);
-        if (!callback) continue;
+        if (!callback || !isFunctionLike(callback) || callback.async) continue;
         const analysisFunctions = collectSynchronouslyInvokedFunctions(callback, context.scopes);
         const writtenStateNames = collectWrittenStateNamesInEffect(
           analysisFunctions,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.ts
@@ -85,8 +85,9 @@ const collectSynchronouslyInvokedFunctions = (
   effectCallback: EsTreeNode,
   scopes: ScopeAnalysis,
 ): ReadonlySet<EsTreeNode> => {
+  if (!isFunctionLike(effectCallback) || effectCallback.async) return new Set();
   const analysisFunctions = new Set<EsTreeNode>([effectCallback]);
-  const pendingFunctions = [effectCallback];
+  const pendingFunctions: EsTreeNode[] = [effectCallback];
   while (pendingFunctions.length > 0) {
     const currentFunction = pendingFunctions.pop();
     if (!currentFunction || !isFunctionLike(currentFunction)) continue;


### PR DESCRIPTION
## Summary

- exclude async effect callbacks from `no-effect-chain` synchronous chain construction in both upstream-writer and downstream-reader positions
- preserve diagnostics for synchronous callback aliases and other synchronous near-neighbors
- add paired regression coverage, two permanent fuzz seeds, and verdict-preserving liveness coverage

Follow-up to #1182, which was merged before the async-callback review fix could land. Addresses https://github.com/millionco/react-doctor/pull/1182#discussion_r3568266314.

## Precision boundary

An async function executes synchronously until its first `await`, but passing an async callback directly to `useEffect` or `useLayoutEffect` violates React's effect callback contract and is separately reported by `no-async-effect-callback`. This rule therefore excludes the whole async effect from chain analysis instead of attempting partial await-position control flow. That prevents async effects from becoming either chain writers or chain readers; inline and named arrows, declarations, expressions, exact aliases, layout effects, and writes straddling `await` stay quiet. Synchronous exact-alias near-neighbors still report.

## Validation

- exact base/candidate A/B: async named upstream 1 to 0; async alias upstream 1 to 0; async inline and named downstream 1 to 0; synchronous alias 1 to 1
- focused `no-effect-chain` regressions: 44 passed
- strict fuzz: `FUZZ_RULE=no-effect-chain FUZZ_STRICT=1 FUZZ_ITERATIONS=500`; 1/1 target rule fired, 0 findings
- fuzz corpus and verdict robustness: passed; two permanent regression seeds included
- exact pinned local RDE A/B: 100/100 repositories, 25,973 files per build, baseline 63 and candidate 63 target findings, no added or removed diagnostics
- exact pinned React Bench A/B: 120/120 repositories, 97,626 files per build, baseline 221 and candidate 221 target findings, no added or removed diagnostics
- active React Bench `no-effect-chain` solution/oracle patches contain no async effect callback shape affected by this boundary
- oxlint plugin suite: 552 files, 12,628 passed, 148 skipped
- `nr typecheck`, `nr lint`, `nr format:check`, `nr smoke:json-report`, and `git diff --check`: passed
- full `nr test`: concurrent runs hit only known load-sensitive infrastructure tests (`spawn-batches`, two `performance-harness` timeouts, and one live TTY probe); the complete core package passed 1,294/1,294 in isolation, and the React Doctor performance/TTY tests pass in isolated runs

## Changeset

Patch changeset included for `oxlint-plugin-react-doctor`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow precision fix in a lint rule with broad regression and fuzz coverage; no runtime or auth/data-path changes.
> 
> **Overview**
> **`no-effect-chain`** now skips **async** `useEffect` / `useLayoutEffect` callbacks when building cross-effect chains, so they are neither treated as upstream state writers nor downstream dep readers. The guard is `callback.async` at chain construction time (whole callback excluded, not partial control flow before `await`).
> 
> **Synchronous** chains are unchanged, including **exact local callback aliases** (e.g. `const effectCallback = loadSource`).
> 
> Adds regression tests for inline/named async upstream and downstream callbacks, layout effects, aliases, and writes straddling `await`; two fuzz corpus seeds; and **`no-effect-chain`** in verdict-preserving liveness coverage. Patch changeset for `oxlint-plugin-react-doctor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d337243bbdf7244bbf99dc493e467070d74e28a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->