### PR TITLE
fix(rule): preserve exact derived hook dependencies

### DIFF
--- a/.changeset/violet-friends-sink.md
+++ b/.changeset/violet-friends-sink.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Preserve exact derived hook dependency identities while retaining missing-source diagnostics.

--- a/packages/fuzz/corpus/regressions/exhaustive-deps--exact-derived-binding.tsx
+++ b/packages/fuzz/corpus/regressions/exhaustive-deps--exact-derived-binding.tsx
@@ -1,0 +1,20 @@
+// rule: exhaustive-deps
+// weakness: alias-guard
+// source: React Bench write-react-hyparam-hightable-468
+
+import { type Context, useCallback, useContext } from "react";
+
+interface CallbackContextValue {
+  onSelect?: () => void;
+}
+
+interface DerivedCallbackProps {
+  onSelect?: () => void;
+  callbackContext: Context<CallbackContextValue>;
+}
+
+export const DerivedCallback = ({ onSelect, callbackContext }: DerivedCallbackProps) => {
+  const contextCallbacks = useContext(callbackContext);
+  const effectiveOnSelect = onSelect ?? contextCallbacks.onSelect;
+  return useCallback(() => effectiveOnSelect?.(), [effectiveOnSelect]);
+};

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -387,6 +387,7 @@ export const JSX_LEAF_POOL = [
 // Rare-but-parseable weirdness kept from the original generator, plus
 // trace-mined oddities (unicode, globalThis gymnastics, labels).
 export const EDGE_CASE_STATEMENT_POOL = [
+  `const contextCallback = config.onSelect; const effectiveCallback = onSelect ?? contextCallback; const derivedHandler = useCallback(() => effectiveCallback?.(), [effectiveCallback]);`,
   `const localeOptionsBase = { timeZone: "UTC" }; const localeOptionsAlias = localeOptionsBase; const { timeZone: localeTimeZone } = localeOptionsAlias;`,
   `const useState = () => [0, () => {}] as const;`,
   `const { useEffect: renamedEffect } = React;`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.regressions.test.ts
@@ -1004,6 +1004,248 @@ describe("react-builtins/exhaustive-deps — regressions", () => {
       expect(result.diagnostics).toEqual([]);
     });
 
+    const authenticCellFixtures = [
+      [
+        "564623E direct-first whole-context callbacks",
+        `function Cell({ value, stringify, renderCellContent, onMouseDownCell, onDoubleClickCell, onKeyDownCell }) {
+          const contextStringify = useContext(StringifyContext);
+          const contextRenderCellContent = useContext(RenderCellContentContext);
+          const contextCallbacks = useContext(CellCallbacksContext);
+          const stringifyCell = stringify ?? contextStringify;
+          const renderContent = renderCellContent ?? contextRenderCellContent;
+          const onMouseDown = onMouseDownCell ?? contextCallbacks.onMouseDownCell;
+          const onDoubleClick = onDoubleClickCell ?? contextCallbacks.onDoubleClickCell;
+          const onKeyDown = onKeyDownCell ?? contextCallbacks.onKeyDownCell;
+          useMemo(() => stringifyCell(value), [stringifyCell, value]);
+          useMemo(() => renderContent?.({ value, stringify: stringifyCell }), [renderContent, stringifyCell, value]);
+          useCallback(() => onMouseDown?.(), [onMouseDown]);
+          useCallback(() => onDoubleClick?.(), [onDoubleClick]);
+          useCallback(() => onKeyDown?.(), [onKeyDown]);
+        }`,
+      ],
+      [
+        "nkHS2Qe context-first whole-context callbacks",
+        `function Cell({ value, stringify, renderCellContent, onMouseDownCell, onDoubleClickCell, onKeyDownCell }) {
+          const stringifyFromContext = useContext(StringifyContext);
+          const renderCellContentFromContext = useContext(RenderCellContentContext);
+          const callbacks = useContext(CellCallbacksContext);
+          const stringifyFunction = stringify ?? stringifyFromContext;
+          const renderCellContentFunction = renderCellContent ?? renderCellContentFromContext;
+          const onMouseDown = callbacks.onMouseDownCell ?? onMouseDownCell;
+          const onDoubleClick = callbacks.onDoubleClickCell ?? onDoubleClickCell;
+          const onKeyDown = callbacks.onKeyDownCell ?? onKeyDownCell;
+          useMemo(() => stringifyFunction(value), [stringifyFunction, value]);
+          useMemo(() => renderCellContentFunction?.({ value, stringify: stringifyFunction }), [renderCellContentFunction, stringifyFunction, value]);
+          useCallback(() => onMouseDown?.(), [onMouseDown]);
+          useCallback(() => onDoubleClick?.(), [onDoubleClick]);
+          useCallback(() => onKeyDown?.(), [onKeyDown]);
+        }`,
+      ],
+      [
+        "EiAdw4h renamed destructured props",
+        `function Cell({ value, stringify: stringifyProp, renderCellContent: renderCellContentProp, onMouseDownCell: onMouseDownCellProp, onDoubleClickCell: onDoubleClickCellProp, onKeyDownCell: onKeyDownCellProp }) {
+          const stringifyFromContext = useContext(StringifyContext);
+          const renderCellContentFromContext = useContext(RenderCellContentContext);
+          const callbacks = useContext(CellCallbacksContext);
+          const stringify = stringifyProp ?? stringifyFromContext;
+          const renderCellContent = renderCellContentProp ?? renderCellContentFromContext;
+          const onMouseDownCell = onMouseDownCellProp ?? callbacks.onMouseDownCell;
+          const onDoubleClickCell = onDoubleClickCellProp ?? callbacks.onDoubleClickCell;
+          const onKeyDownCell = onKeyDownCellProp ?? callbacks.onKeyDownCell;
+          useMemo(() => stringify(value), [stringify, value]);
+          useMemo(() => renderCellContent?.({ value, stringify }), [renderCellContent, stringify, value]);
+          useCallback(() => onMouseDownCell?.(), [onMouseDownCell]);
+          useCallback(() => onDoubleClickCell?.(), [onDoubleClickCell]);
+          useCallback(() => onKeyDownCell?.(), [onKeyDownCell]);
+        }`,
+      ],
+      [
+        "ERLwxXr destructured context members",
+        `function Cell({ value, stringify: directStringify, renderCellContent: directRenderCellContent, onMouseDownCell: directOnMouseDownCell, onDoubleClickCell: directOnDoubleClickCell, onKeyDownCell: directOnKeyDownCell }) {
+          const { onMouseDownCell: contextOnMouseDownCell, onDoubleClickCell: contextOnDoubleClickCell, onKeyDownCell: contextOnKeyDownCell } = useContext(CellCallbacksContext);
+          const contextStringify = useContext(StringifyContext);
+          const contextRenderCellContent = useContext(RenderCellContentContext);
+          const stringify = directStringify ?? contextStringify;
+          const renderCellContent = directRenderCellContent ?? contextRenderCellContent;
+          const onMouseDownCell = directOnMouseDownCell ?? contextOnMouseDownCell;
+          const onDoubleClickCell = directOnDoubleClickCell ?? contextOnDoubleClickCell;
+          const onKeyDownCell = directOnKeyDownCell ?? contextOnKeyDownCell;
+          useMemo(() => stringify(value), [stringify, value]);
+          useMemo(() => renderCellContent?.({ value, stringify }), [renderCellContent, stringify, value]);
+          useCallback(() => onMouseDownCell?.(), [onMouseDownCell]);
+          useCallback(() => onDoubleClickCell?.(), [onDoubleClickCell]);
+          useCallback(() => onKeyDownCell?.(), [onKeyDownCell]);
+        }`,
+      ],
+      [
+        "wJWmEDA resolved binding names",
+        `function Cell({ value, stringify, renderCellContent, onMouseDownCell, onDoubleClickCell, onKeyDownCell }) {
+          const contextStringify = useContext(StringifyContext);
+          const contextRenderCellContent = useContext(RenderCellContentContext);
+          const contextCallbacks = useContext(CellCallbacksContext);
+          const resolvedStringify = stringify ?? contextStringify;
+          const resolvedRenderCellContent = renderCellContent ?? contextRenderCellContent;
+          const resolvedOnMouseDownCell = onMouseDownCell ?? contextCallbacks.onMouseDownCell;
+          const resolvedOnDoubleClickCell = onDoubleClickCell ?? contextCallbacks.onDoubleClickCell;
+          const resolvedOnKeyDownCell = onKeyDownCell ?? contextCallbacks.onKeyDownCell;
+          useMemo(() => resolvedStringify(value), [resolvedStringify, value]);
+          useMemo(() => resolvedRenderCellContent?.({ value, stringify: resolvedStringify }), [resolvedRenderCellContent, resolvedStringify, value]);
+          useCallback(() => resolvedOnMouseDownCell?.(), [resolvedOnMouseDownCell]);
+          useCallback(() => resolvedOnDoubleClickCell?.(), [resolvedOnDoubleClickCell]);
+          useCallback(() => resolvedOnKeyDownCell?.(), [resolvedOnKeyDownCell]);
+        }`,
+      ],
+      [
+        "359ukck independently named context bindings",
+        `function Cell({ value, stringify: stringifyProp, renderCellContent: renderCellContentProp, onMouseDownCell: onMouseDownCellProp, onDoubleClickCell: onDoubleClickCellProp, onKeyDownCell: onKeyDownCellProp }) {
+          const stringifyContext = useContext(StringifyContext);
+          const renderCellContentContext = useContext(RenderCellContentContext);
+          const cellCallbacks = useContext(CellCallbacksContext);
+          const stringify = stringifyProp ?? stringifyContext;
+          const renderCellContent = renderCellContentProp ?? renderCellContentContext;
+          const onMouseDownCell = onMouseDownCellProp ?? cellCallbacks.onMouseDownCell;
+          const onDoubleClickCell = onDoubleClickCellProp ?? cellCallbacks.onDoubleClickCell;
+          const onKeyDownCell = onKeyDownCellProp ?? cellCallbacks.onKeyDownCell;
+          useMemo(() => stringify(value), [stringify, value]);
+          useMemo(() => renderCellContent?.({ value, stringify }), [renderCellContent, stringify, value]);
+          useCallback(() => onMouseDownCell?.(), [onMouseDownCell]);
+          useCallback(() => onDoubleClickCell?.(), [onDoubleClickCell]);
+          useCallback(() => onKeyDownCell?.(), [onKeyDownCell]);
+        }`,
+      ],
+    ] as const;
+
+    for (const [fixtureName, code] of authenticCellFixtures) {
+      it(`accepts all five exact derived dependencies from ${fixtureName}`, () => {
+        const result = runRule(exhaustiveDeps, code);
+        expect(result.parseErrors).toEqual([]);
+        expect(result.diagnostics).toEqual([]);
+      });
+    }
+
+    it("accepts exact conditional and logical derived dependencies", () => {
+      const code = `
+        function Cell({ direct, fallback, preferDirect }) {
+          const conditionalCallback = preferDirect ? direct : fallback;
+          const logicalCallback = direct || fallback;
+          useCallback(() => conditionalCallback?.(), [conditionalCallback]);
+          useEffect(() => logicalCallback?.(), [logicalCallback]);
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it("reports an omitted derived dependency", () => {
+      const code = `
+        function Cell({ direct, fallback }) {
+          const effectiveCallback = direct ?? fallback;
+          return useCallback(() => effectiveCallback?.(), []);
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      const messages = result.diagnostics.map((diagnostic) => diagnostic.message).join("\n");
+      expect(messages).toContain("direct, fallback");
+    });
+
+    it("reports every omitted initializer source when one source is listed", () => {
+      const code = `
+        function Cell({ direct, fallback }) {
+          const effectiveCallback = direct ?? fallback;
+          return useCallback(() => effectiveCallback?.(), [direct]);
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      const messages = result.diagnostics.map((diagnostic) => diagnostic.message).join("\n");
+      expect(messages).toContain("fallback");
+    });
+
+    it("reports initializer inputs read directly by the hook closure", () => {
+      const code = `
+        function Cell({ direct, fallback }) {
+          const effectiveCallback = direct ?? fallback;
+          return useCallback(() => {
+            direct?.();
+            fallback?.();
+          }, [effectiveCallback]);
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      const messages = result.diagnostics.map((diagnostic) => diagnostic.message).join("\n");
+      expect(messages).toContain("direct, fallback");
+    });
+
+    it("accepts an exact dependency on a reassigned derived binding", () => {
+      const code = `
+        function Cell({ direct, fallback, override }) {
+          let effectiveCallback = direct ?? fallback;
+          effectiveCallback = override ?? effectiveCallback;
+          return useCallback(() => effectiveCallback?.(), [effectiveCallback]);
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it("reports an omitted reassigned derived binding", () => {
+      const code = `
+        function Cell({ direct, fallback, override }) {
+          let effectiveCallback = direct ?? fallback;
+          effectiveCallback = override ?? effectiveCallback;
+          return useCallback(() => effectiveCallback?.(), []);
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      const messages = result.diagnostics.map((diagnostic) => diagnostic.message).join("\n");
+      expect(messages).toContain("effectiveCallback");
+    });
+
+    it("still reports an exact derived dependency with a fresh fallback as unstable", () => {
+      const code = `
+        function Cell({ direct }) {
+          const effectiveCallback = direct ?? (() => {});
+          return useCallback(() => effectiveCallback(), [effectiveCallback]);
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      const messages = result.diagnostics.map((diagnostic) => diagnostic.message).join("\n");
+      expect(messages).toContain("effectiveCallback");
+      expect(messages).toContain("rebuilt every render");
+    });
+
+    it("does not let a narrower member satisfy an exact derived binding", () => {
+      const code = `
+        function Cell({ direct, fallback }) {
+          const effectiveCallback = direct ?? fallback;
+          return useCallback(() => consume(effectiveCallback), [effectiveCallback.current]);
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      const messages = result.diagnostics.map((diagnostic) => diagnostic.message).join("\n");
+      expect(messages).toContain("direct, fallback");
+    });
+
+    it("ignores a userland function named useCallback", () => {
+      const code = `
+        const useCallback = (callback, dependencies) => ({ callback, dependencies });
+        function Cell({ direct, fallback }) {
+          const effectiveCallback = direct ?? fallback;
+          return useCallback(() => effectiveCallback?.(), []);
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
     it("treats an immutable local alias of an imported function as stable", () => {
       const code = `
         import { setConnectionStatus } from "./connection-status";

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.regressions.test.ts
@@ -1004,6 +1004,19 @@ describe("react-builtins/exhaustive-deps — regressions", () => {
       expect(result.diagnostics).toEqual([]);
     });
 
+    it("does not treat a call dependency as the exact derived binding", () => {
+      const code = `
+        function Cell({ direct, fallback }) {
+          const effectiveCallback = direct ?? fallback;
+          return useCallback(() => effectiveCallback?.(), [effectiveCallback()]);
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      const messages = result.diagnostics.map((diagnostic) => diagnostic.message).join("\n");
+      expect(messages).toContain("direct, fallback");
+    });
+
     const authenticCellFixtures = [
       [
         "564623E direct-first whole-context callbacks",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.regressions.test.ts
@@ -986,6 +986,19 @@ describe("react-builtins/exhaustive-deps — regressions", () => {
     expect(messages).toContain("unrelated");
   });
 
+  it("ignores a userland function named useCallback", () => {
+    const code = `
+      const useCallback = (callback, dependencies) => ({ callback, dependencies });
+      function Cell({ direct, fallback }) {
+        const effectiveCallback = direct ?? fallback;
+        return useCallback(() => effectiveCallback?.(), []);
+      }
+    `;
+    const result = runRule(exhaustiveDeps, code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   describe("bounded identity source resolution", () => {
     it("accepts the exact derived callback dependency", () => {
       const code = `
@@ -1192,6 +1205,19 @@ describe("react-builtins/exhaustive-deps — regressions", () => {
       expect(messages).toContain("direct, fallback");
     });
 
+    it("accepts an exact dependency on a chained const derived binding", () => {
+      const code = `
+        function Cell({ direct, fallback, override }) {
+          const baseCallback = direct ?? fallback;
+          const effectiveCallback = override ?? baseCallback;
+          return useCallback(() => effectiveCallback?.(), [effectiveCallback]);
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
     it("accepts an exact dependency on a reassigned derived binding", () => {
       const code = `
         function Cell({ direct, fallback, override }) {
@@ -1233,6 +1259,20 @@ describe("react-builtins/exhaustive-deps — regressions", () => {
       expect(messages).toContain("rebuilt every render");
     });
 
+    it("still reports an exact derived dependency with a fresh ternary branch as unstable", () => {
+      const code = `
+        function Cell({ direct, preferDirect }) {
+          const effectiveCallback = preferDirect ? direct : (() => {});
+          return useCallback(() => effectiveCallback(), [effectiveCallback]);
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      const messages = result.diagnostics.map((diagnostic) => diagnostic.message).join("\n");
+      expect(messages).toContain("effectiveCallback");
+      expect(messages).toContain("rebuilt every render");
+    });
+
     it("does not let a narrower member satisfy an exact derived binding", () => {
       const code = `
         function Cell({ direct, fallback }) {
@@ -1244,19 +1284,6 @@ describe("react-builtins/exhaustive-deps — regressions", () => {
       expect(result.parseErrors).toEqual([]);
       const messages = result.diagnostics.map((diagnostic) => diagnostic.message).join("\n");
       expect(messages).toContain("direct, fallback");
-    });
-
-    it("ignores a userland function named useCallback", () => {
-      const code = `
-        const useCallback = (callback, dependencies) => ({ callback, dependencies });
-        function Cell({ direct, fallback }) {
-          const effectiveCallback = direct ?? fallback;
-          return useCallback(() => effectiveCallback?.(), []);
-        }
-      `;
-      const result = runRule(exhaustiveDeps, code);
-      expect(result.parseErrors).toEqual([]);
-      expect(result.diagnostics).toEqual([]);
     });
 
     it("treats an immutable local alias of an imported function as stable", () => {
@@ -1452,6 +1479,31 @@ describe("react-builtins/exhaustive-deps — regressions", () => {
             () => readPosition(chart),
             [chart, chartWidth, chartHeight],
           );
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it("flags an unused useMemo dependency derived from a nested fresh fallback", () => {
+      const code = `
+        function Cell({ direct, other }) {
+          const derivedCallback = direct ?? (() => {});
+          return useMemo(() => other, [derivedCallback, other]);
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      const messages = result.diagnostics.map((diagnostic) => diagnostic.message).join("\n");
+      expect(messages).toContain("`derivedCallback` changes even though it never uses it");
+    });
+
+    it("allows an unused useMemo dependency derived from reactive sources", () => {
+      const code = `
+        function Cell({ direct, fallback, other }) {
+          const derivedCallback = direct ?? fallback;
+          return useMemo(() => other, [derivedCallback, other]);
         }
       `;
       const result = runRule(exhaustiveDeps, code);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.regressions.test.ts
@@ -987,6 +987,23 @@ describe("react-builtins/exhaustive-deps — regressions", () => {
   });
 
   describe("bounded identity source resolution", () => {
+    it("accepts the exact derived callback dependency", () => {
+      const code = `
+        function Cell({ onMouseDownCell }) {
+          const contextCallbacks = useContext(CellCallbacksContext);
+          const effectiveOnMouseDownCell =
+            onMouseDownCell ?? contextCallbacks.onMouseDownCell;
+          return useCallback(
+            (event) => effectiveOnMouseDownCell?.(event),
+            [effectiveOnMouseDownCell],
+          );
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
     it("treats an immutable local alias of an imported function as stable", () => {
       const code = `
         import { setConnectionStatus } from "./connection-status";

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.ts
@@ -343,7 +343,7 @@ interface CaptureCollection {
 const collectCaptureDepKeys = (
   callback: EsTreeNode,
   scopes: ScopeAnalysis,
-  declaredKeys?: ReadonlySet<string>,
+  declaredExactBindingKeys?: ReadonlySet<string>,
 ): CaptureCollection => {
   const keys = new Set<string>();
   const stableCapturedNames = new Set<string>();
@@ -382,7 +382,7 @@ const collectCaptureDepKeys = (
       continue;
     }
     if (depKey === symbol.name) {
-      if (declaredKeys?.has(depKey)) {
+      if (declaredExactBindingKeys?.has(depKey)) {
         keys.add(depKey);
         continue;
       }
@@ -1338,6 +1338,7 @@ If the missing value is recreated every render, move it inside the hook or stabi
         }
 
         const declaredKeys = new Set<string>();
+        const declaredExactBindingKeys = new Set<string>();
         const declaredKeyToReportNode = new Map<string, EsTreeNode>();
         const seenDeclaredKeys = new Set<string>();
         let didReportRefCurrentDep = false;
@@ -1412,6 +1413,7 @@ If the missing value is recreated every render, move it inside the hook or stabi
           }
           seenDeclaredKeys.add(key);
           declaredKeys.add(key);
+          if (isNodeOfType(stripped, "Identifier")) declaredExactBindingKeys.add(key);
           declaredKeyToReportNode.set(key, elementNode);
         }
         const {
@@ -1422,7 +1424,7 @@ If the missing value is recreated every render, move it inside the hook or stabi
         } = collectCaptureDepKeys(
           callbackToAnalyze ?? callbackArgument,
           context.scopes,
-          declaredKeys,
+          declaredExactBindingKeys,
         );
         for (const forcedCaptureKey of forcedCaptureKeys) captureKeys.add(forcedCaptureKey);
         addAggregatePropsDependency(

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.ts
@@ -340,7 +340,11 @@ interface CaptureCollection {
 
 // Walks captures grouping by "dep key" (the canonical name of the
 // outermost member-expression chain).
-const collectCaptureDepKeys = (callback: EsTreeNode, scopes: ScopeAnalysis): CaptureCollection => {
+const collectCaptureDepKeys = (
+  callback: EsTreeNode,
+  scopes: ScopeAnalysis,
+  declaredKeys?: ReadonlySet<string>,
+): CaptureCollection => {
   const keys = new Set<string>();
   const stableCapturedNames = new Set<string>();
   const moduleScopeCapturedNames = new Set<string>();
@@ -378,6 +382,10 @@ const collectCaptureDepKeys = (callback: EsTreeNode, scopes: ScopeAnalysis): Cap
       continue;
     }
     if (depKey === symbol.name) {
+      if (declaredKeys?.has(depKey)) {
+        keys.add(depKey);
+        continue;
+      }
       const identitySourceKeys = resolveReactiveIdentitySourceKeys(symbol, scopes);
       if (identitySourceKeys) {
         if (identitySourceKeys.size === 0) stableCapturedNames.add(depKey);
@@ -581,19 +589,27 @@ const isRegExpLiteral = (node: EsTreeNode): boolean => {
   return Boolean((node as { regex?: unknown }).regex);
 };
 
-const isUnstableInitializer = (node: EsTreeNode | null): boolean => {
+const isUnstableInitializer = (node: EsTreeNode | null, isNestedInitializer = false): boolean => {
   if (!node) return false;
   const stripped = unwrapExpression(node);
   if (isRegExpLiteral(stripped)) return true;
   if (isNodeOfType(stripped, "ConditionalExpression")) {
-    return isUnstableInitializer(stripped.consequent) || isUnstableInitializer(stripped.alternate);
+    return (
+      isUnstableInitializer(stripped.consequent, true) ||
+      isUnstableInitializer(stripped.alternate, true)
+    );
   }
   if (isNodeOfType(stripped, "LogicalExpression")) {
-    return isUnstableInitializer(stripped.left) || isUnstableInitializer(stripped.right);
+    return (
+      isUnstableInitializer(stripped.left, true) || isUnstableInitializer(stripped.right, true)
+    );
   }
   return (
     isNodeOfType(stripped, "ObjectExpression") ||
     isNodeOfType(stripped, "ArrayExpression") ||
+    (isNestedInitializer &&
+      (isNodeOfType(stripped, "ArrowFunctionExpression") ||
+        isNodeOfType(stripped, "FunctionExpression"))) ||
     isNodeOfType(stripped, "ClassExpression") ||
     isNodeOfType(stripped, "ClassDeclaration") ||
     isNodeOfType(stripped, "JSXElement") ||
@@ -1302,14 +1318,6 @@ If the missing value is recreated every render, move it inside the hook or stabi
           return;
         }
 
-        const {
-          keys: captureKeys,
-          stableCapturedNames,
-          moduleScopeCapturedNames,
-          outerFunctionCapturedNames,
-        } = collectCaptureDepKeys(callbackToAnalyze ?? callbackArgument, context.scopes);
-        for (const forcedCaptureKey of forcedCaptureKeys) captureKeys.add(forcedCaptureKey);
-
         // Pre-scan: emit a single "literal deps" warning when the
         // deps array contains a non-string-literal value (numeric /
         // boolean / null / bigint). String-literal deps are usually
@@ -1406,6 +1414,17 @@ If the missing value is recreated every render, move it inside the hook or stabi
           declaredKeys.add(key);
           declaredKeyToReportNode.set(key, elementNode);
         }
+        const {
+          keys: captureKeys,
+          stableCapturedNames,
+          moduleScopeCapturedNames,
+          outerFunctionCapturedNames,
+        } = collectCaptureDepKeys(
+          callbackToAnalyze ?? callbackArgument,
+          context.scopes,
+          declaredKeys,
+        );
+        for (const forcedCaptureKey of forcedCaptureKeys) captureKeys.add(forcedCaptureKey);
         addAggregatePropsDependency(
           captureKeys,
           declaredKeys,


### PR DESCRIPTION
## Summary

Preserve a hook closure's exact captured binding when that same binding is present in the dependency array. React compares the derived binding value itself; requiring its initializer inputs produces false stale-dependency and unnecessary-dependency reports.

Initializer-source expansion remains active when the exact binding is absent. Omitted bindings, partial source lists, direct initializer-source reads, narrower member dependencies, mutable omitted bindings, and fresh fallback values still report.

This PR is ready for maintainer review. Do not merge automatically.

## Authentic reproduction

- Pinned base: `hyparam/hightable@08a65fd3957f42994ea1ff76fd3d2d1a20e74f85`
- Affected trials: `564623E`, `nkHS2Qe`, `EiAdw4h`, `ERLwxXr`, `wJWmEDA`, `359ukck`
- Baseline: five false `exhaustive-deps` findings per trial, 30 total, zero parse failures
- Candidate: zero findings across all six trials, zero parse failures
- Accepted `??=` controls: `opbLYkk`, `pKGJKHK`, `r34yUiP`; zero findings before and after
- Reconstructed task oracle: zero findings before and after

## Precision boundary

The detector only bypasses initializer-source expansion when the dependency array contains the exact captured identifier. A zero-argument call dependency such as `effective()` does not activate the bypass and retains initializer-source diagnostics. It remains scope-aware and does not infer arbitrary semantic equivalence. Paired regressions cover:

- six authentic prop/context fallback shapes
- nullish, logical, and conditional derived values
- omitted and partial dependency lists
- direct source reads despite the derived dependency
- reassigned bindings, both present and omitted
- narrower member dependencies
- fresh inline function fallbacks
- shadowed userland `useCallback`

The fresh-fallback case also exposed a missed unstable nested function value. Nested function branches of logical/conditional initializers now retain the existing “rebuilt every render” diagnostic without duplicating direct-function reports.

## Validation

| Gate | Result |
| --- | --- |
| Plugin suite | 553 files; 12,856 passed; 148 skipped |
| ESLint mirror | 4 passed |
| Root typecheck | 15/15 tasks |
| Lint / format / diff | clean |
| JSON smoke | schema v3, clean |
| Fuzz corpus | 43 passed; 400 skipped |
| Strict fuzz | 500 iterations; target fire coverage 1/1 |
| Authentic replay | 30 → 0 affected findings; controls unchanged |
| RDE pinned roots | 100/100 roots; 25,758 files each; 209 → 101; 1 added TP; 109 removed FPs; 0 scan/parse failures |
| React Bench pinned repos | 120/120 repos; 96,853 files each; 3,679 → 2,272; 10 added TPs; 1,417 removed FPs; 0 scan failures; parser parity 5/5 |
| Active target oracles | 12/12 states; 8,345 files each; 442 → 347; 1 added TP; 96 removed FPs; 0 failures |
| CI | full matrix green at `ff3cb78e29efb36b35dcd40f951e09715e2f78c6` |
| Review threads | 0 unresolved |

Every added real-repository verdict was inspected. They are desirable findings previously masked by the false missing-source report: unstable derived arrays or valid unnecessary module-scope/unused dependencies. Every removal is the corrected exact-binding family: 1,396 stale plus 21 false unnecessary findings in React Bench, 104 stale plus 5 false unnecessary findings in RDE, and 94 stale plus 2 false unnecessary findings in the oracle set.

## Release

- Patch changeset for `oxlint-plugin-react-doctor`
- Permanent fuzz seed: `exhaustive-deps--exact-derived-binding.tsx`
- Generator pool includes the exact derived callback shape

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core dependency-matching logic in a heavily used lint rule; behavior shifts across many real repos (mostly FP removal) but incorrect bypass could hide real missing-deps bugs.
> 
> **Overview**
> The **`exhaustive-deps`** rule no longer expands a closure capture into its initializer sources when the dependency array already lists that **exact identifier** (e.g. `[effectiveOnSelect]` for `const effectiveOnSelect = onSelect ?? contextCallbacks.onSelect`). That matches React’s identity comparison and removes false missing/unnecessary reports for prop/context fallback patterns.
> 
> When the exact binding is **not** in deps, initializer-source diagnostics behave as before. **Nested inline functions** inside `??` / `||` / ternary initializers are now treated as unstable so “rebuilt every render” still fires for fresh fallbacks without duplicating direct-function noise.
> 
> Adds a large regression suite (including real hightable cell shapes), a fuzz corpus seed, and a patch changeset for `oxlint-plugin-react-doctor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bb09452a4b40f5a71c35b87b3d5c8266ef63334. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->