### PR TITLE
fix(rule): detect unsanitized react-markdown raw HTML

### DIFF
--- a/.changeset/safe-markdown-sanitize.md
+++ b/.changeset/safe-markdown-sanitize.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Detect dynamic raw HTML rendered by React Markdown without a proven sanitizer.

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -204,6 +204,7 @@ export const MODULE_SCOPE_SNIPPET_POOL = [
   `reaction(() => store.value, (next) => persist(next));`,
   `let sharedSnapshot = "idle"; const snapshotListeners = new Set(); function subscribeSnapshot(listener) { snapshotListeners.add(listener); return () => snapshotListeners.delete(listener); }`,
   `const FuzzPolyfillScript = () => <script src="https://polyfill.io/v3/polyfill.min.js" />;`,
+  `import FuzzRawMarkdown from "react-markdown"; import fuzzRawPlugin from "rehype-raw"; export const FuzzRawMarkdownPreview = ({ value }) => <FuzzRawMarkdown rehypePlugins={[fuzzRawPlugin]}>{String(value)}</FuzzRawMarkdown>;`,
 ] as const;
 
 export const SERVER_MODULE_PROGRAM_POOL = [
@@ -387,6 +388,7 @@ export const JSX_LEAF_POOL = [
   `<time>{new Date(value).toLocaleString()}</time>`,
   `<span>{new Intl.DateTimeFormat().format(state)}</span>`,
   `<time>{new Intl.DateTimeFormat("en-US", localeOptionsAlias).format(new Date(value))}</time>`,
+  `<FuzzMarkdown rehypePlugins={[fuzzRehypeRaw]}>{String(value)}</FuzzMarkdown>`,
 ] as const;
 
 // Rare-but-parseable weirdness kept from the original generator, plus
@@ -448,6 +450,7 @@ export const IMPORT_LINE_POOL = [
   `import { z as fuzzZodErrorCustomization } from "zod/v4"; const fuzzZodRequiredSchema = fuzzZodErrorCustomization.string("Required");`,
   `import { ZodError as FuzzZodError } from "zod/v4"; const fuzzZodFlattenedError = new FuzzZodError([]).flatten();`,
   `import { forwardRef } from "react";\nconst FuzzForwardRefComponent = forwardRef((props) => <button>{props.label}</button>);`,
+  `import FuzzMarkdown from "react-markdown";\nimport fuzzRehypeRaw from "rehype-raw";`,
 ] as const;
 
 // Filenames rotate per iteration because a large rule population is

--- a/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness-fixtures.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness-fixtures.ts
@@ -1042,6 +1042,10 @@ export const livenessFixtures: Readonly<Record<string, LivenessFixture>> = {
     code: "var App, a = <App />;",
     forceJsx: true,
   },
+  "react-markdown-unsanitized-raw-html": {
+    code: 'import Markdown from "react-markdown";\nimport raw from "rehype-raw";\nexport const Preview = ({ content }) => <Markdown rehypePlugins={[raw]}>{content}</Markdown>;',
+    filePath: "src/preview.tsx",
+  },
   "redux-useselector-inline-derivation": {
     code: '\n      import { useSelector } from "react-redux";\n\n      const activeUsers = useSelector((state) =>\n        state.users.filter((user) => new Date(user.loginDate).getFullYear() === 2023),\n      );\n    ',
   },

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
@@ -306,6 +306,7 @@ import { queryStableQueryClient } from "./rules/tanstack-query/query-stable-quer
 import { rawSqlInjectionRisk } from "./rules/security-scan/raw-sql-injection-risk.js";
 import { reactCompilerNoManualMemoization } from "./rules/architecture/react-compiler-no-manual-memoization.js";
 import { reactInJsxScope } from "./rules/react-builtins/react-in-jsx-scope.js";
+import { reactMarkdownUnsanitizedRawHtml } from "./rules/security/react-markdown-unsanitized-raw-html.js";
 import { reduxUseselectorInlineDerivation } from "./rules/state-and-effects/redux-useselector-inline-derivation.js";
 import { reduxUseselectorReturnsNewCollection } from "./rules/state-and-effects/redux-useselector-returns-new-collection.js";
 import { renderingAnimateSvgWrapper } from "./rules/performance/rendering-animate-svg-wrapper.js";
@@ -3926,6 +3927,17 @@ export const reactDoctorRules = [
       framework: "global",
       category: "Bugs",
       requires: [...new Set<Capability>(["react", ...(reactInJsxScope.requires ?? [])])],
+    },
+  },
+  {
+    key: "react-doctor/react-markdown-unsanitized-raw-html",
+    id: "react-markdown-unsanitized-raw-html",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...reactMarkdownUnsanitizedRawHtml,
+      framework: "global",
+      category: "Security",
     },
   },
   {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/react-markdown-unsanitized-raw-html.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/react-markdown-unsanitized-raw-html.test.ts
@@ -109,6 +109,24 @@ describe("react-markdown-unsanitized-raw-html", () => {
       `,
     },
     {
+      name: "member-expression children with sibling plugin props",
+      source: `
+        import type { Components } from "react-markdown";
+        import Markdown from "react-markdown";
+        import raw from "rehype-raw";
+        import gfm from "remark-gfm";
+        export const Preview = (props: { children?: string; components?: Components }) => (
+          <Markdown
+            rehypePlugins={[raw]}
+            remarkPlugins={[gfm]}
+            components={props.components}
+          >
+            {props.children}
+          </Markdown>
+        );
+      `,
+    },
+    {
       name: "userland sanitizer and DOMPurify lookalikes",
       source: `
         import Markdown from "react-markdown";

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/react-markdown-unsanitized-raw-html.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/react-markdown-unsanitized-raw-html.test.ts
@@ -202,6 +202,19 @@ describe("react-markdown-unsanitized-raw-html", () => {
       `,
     },
     {
+      name: "a const alias of a DOMPurify-sanitized input",
+      source: `
+        import Markdown from "react-markdown";
+        import raw from "rehype-raw";
+        import ImportedDOMPurify from "isomorphic-dompurify";
+        const DOMPurify = ImportedDOMPurify;
+        export const Preview = ({ content }) => {
+          const safeContent = DOMPurify.sanitize(content);
+          return <Markdown rehypePlugins={[raw]}>{safeContent}</Markdown>;
+        };
+      `,
+    },
+    {
       name: "literal JSX children",
       source: `
         import Markdown from "react-markdown";

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/react-markdown-unsanitized-raw-html.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/react-markdown-unsanitized-raw-html.test.ts
@@ -1,0 +1,341 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { reactMarkdownUnsanitizedRawHtml } from "./react-markdown-unsanitized-raw-html.js";
+
+const runReactMarkdownRule = (source: string) =>
+  runRule(reactMarkdownUnsanitizedRawHtml, source, { filename: "src/markdown.tsx" });
+
+describe("react-markdown-unsanitized-raw-html", () => {
+  it.each([
+    {
+      name: "direct imports",
+      source: `
+        import Markdown from "react-markdown";
+        import raw from "rehype-raw";
+        export const Preview = ({ content }) => (
+          <Markdown rehypePlugins={[raw]}>{content}</Markdown>
+        );
+      `,
+    },
+    {
+      name: "renamed default imports and exact const aliases",
+      source: `
+        import Renderer from "react-markdown";
+        import parseHtml from "rehype-raw";
+        const Markdown = Renderer;
+        const raw = parseHtml;
+        const plugins = [raw] as const;
+        export const Preview = ({ content }) => (
+          <Markdown rehypePlugins={plugins}>{content}</Markdown>
+        );
+      `,
+    },
+    {
+      name: "namespace imports",
+      source: `
+        import * as Markdown from "react-markdown";
+        import * as Raw from "rehype-raw";
+        export const Preview = ({ content }) => (
+          <Markdown.default rehypePlugins={[Raw.default]}>{content}</Markdown.default>
+        );
+      `,
+    },
+    {
+      name: "named async React Markdown export",
+      source: `
+        import { MarkdownAsync as AsyncRenderer } from "react-markdown";
+        import raw from "rehype-raw";
+        export const Preview = ({ content }) => (
+          <AsyncRenderer rehypePlugins={[[raw, { passThrough: ["custom"] }]]}>
+            {content}
+          </AsyncRenderer>
+        );
+      `,
+    },
+    {
+      name: "statically resolved plugin spreads",
+      source: `
+        import Markdown from "react-markdown";
+        import raw from "rehype-raw";
+        import katex from "rehype-katex";
+        const basePlugins = [katex];
+        const plugins = [...basePlugins, raw];
+        export const Preview = ({ content }) => (
+          <Markdown rehypePlugins={plugins}>{content}</Markdown>
+        );
+      `,
+    },
+    {
+      name: "a repeated statically resolved spread",
+      source: `
+        import Markdown from "react-markdown";
+        import raw from "rehype-raw";
+        import katex from "rehype-katex";
+        const basePlugins = [katex];
+        const plugins = [...basePlugins, ...basePlugins, raw];
+        export const Preview = ({ content }) => (
+          <Markdown rehypePlugins={plugins}>{content}</Markdown>
+        );
+      `,
+    },
+    {
+      name: "skipHtml because rehype-raw consumes raw nodes first",
+      source: `
+        import Markdown from "react-markdown";
+        import raw from "rehype-raw";
+        export const Preview = ({ content }) => (
+          <Markdown skipHtml={true} rehypePlugins={[raw]}>{content}</Markdown>
+        );
+      `,
+    },
+    {
+      name: "an explicit plugin prop after an unknown JSX spread",
+      source: `
+        import Markdown from "react-markdown";
+        import raw from "rehype-raw";
+        export const Preview = ({ content, options }) => (
+          <Markdown {...options} rehypePlugins={[raw]}>{content}</Markdown>
+        );
+      `,
+    },
+    {
+      name: "children prop",
+      source: `
+        import Markdown from "react-markdown";
+        import raw from "rehype-raw";
+        export const Preview = ({ content }) => (
+          <Markdown rehypePlugins={[raw]} children={content} />
+        );
+      `,
+    },
+    {
+      name: "userland sanitizer and DOMPurify lookalikes",
+      source: `
+        import Markdown from "react-markdown";
+        import raw from "rehype-raw";
+        const rehypeSanitize = () => {};
+        const DOMPurify = { sanitize: (value) => value };
+        export const Preview = ({ content }) => (
+          <Markdown rehypePlugins={[raw, rehypeSanitize]}>
+            {DOMPurify.sanitize(content)}
+          </Markdown>
+        );
+      `,
+    },
+  ])("reports $name", ({ source }) => {
+    const result = runReactMarkdownRule(source);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it.each([
+    {
+      name: "a rehype-sanitize plugin after rehype-raw",
+      source: `
+        import Markdown from "react-markdown";
+        import raw from "rehype-raw";
+        import sanitize from "rehype-sanitize";
+        export const Preview = ({ content }) => (
+          <Markdown rehypePlugins={[raw, [sanitize, { clobberPrefix: "safe-" }]]}>
+            {content}
+          </Markdown>
+        );
+      `,
+    },
+    {
+      name: "a rehype-sanitize plugin before rehype-raw",
+      source: `
+        import Markdown from "react-markdown";
+        import raw from "rehype-raw";
+        import sanitize from "rehype-sanitize";
+        export const Preview = ({ content }) => (
+          <Markdown rehypePlugins={[sanitize, raw]}>{content}</Markdown>
+        );
+      `,
+    },
+    {
+      name: "a sanitizer hidden in a statically resolved spread",
+      source: `
+        import Markdown from "react-markdown";
+        import raw from "rehype-raw";
+        import sanitize from "rehype-sanitize";
+        const safetyPlugins = [[sanitize, {}]];
+        const plugins = [raw, ...safetyPlugins];
+        export const Preview = ({ content }) => (
+          <Markdown rehypePlugins={plugins}>{content}</Markdown>
+        );
+      `,
+    },
+    {
+      name: "namespace and const aliases of rehype-sanitize",
+      source: `
+        import Markdown from "react-markdown";
+        import raw from "rehype-raw";
+        import * as Sanitize from "rehype-sanitize";
+        const sanitizer = Sanitize.default;
+        const sanitizerTuple = [sanitizer, { clobberPrefix: "safe-" }] as const;
+        export const Preview = ({ content }) => (
+          <Markdown rehypePlugins={[raw, sanitizerTuple]}>{content}</Markdown>
+        );
+      `,
+    },
+    {
+      name: "DOMPurify-sanitized input",
+      source: `
+        import Markdown from "react-markdown";
+        import raw from "rehype-raw";
+        import DOMPurify from "dompurify";
+        export const Preview = ({ content }) => (
+          <Markdown rehypePlugins={[raw]}>{DOMPurify.sanitize(content)}</Markdown>
+        );
+      `,
+    },
+    {
+      name: "namespace DOMPurify-sanitized input",
+      source: `
+        import Markdown from "react-markdown";
+        import raw from "rehype-raw";
+        import * as DOMPurify from "isomorphic-dompurify";
+        export const Preview = ({ content }) => (
+          <Markdown rehypePlugins={[raw]} children={DOMPurify.sanitize(content)} />
+        );
+      `,
+    },
+    {
+      name: "literal JSX children",
+      source: `
+        import Markdown from "react-markdown";
+        import raw from "rehype-raw";
+        export const Preview = () => (
+          <Markdown rehypePlugins={[raw]}>{"<details>trusted docs</details>"}</Markdown>
+        );
+      `,
+    },
+    {
+      name: "a static const child",
+      source: `
+        import Markdown from "react-markdown";
+        import raw from "rehype-raw";
+        const CONTENT = "<details>trusted docs</details>";
+        export const Preview = () => <Markdown rehypePlugins={[raw]}>{CONTENT}</Markdown>;
+      `,
+    },
+    {
+      name: "a static concatenation and non-string literal child",
+      source: `
+        import Markdown from "react-markdown";
+        import raw from "rehype-raw";
+        const TAG = "details";
+        export const Preview = () => (
+          <>
+            <Markdown rehypePlugins={[raw]}>{"<" + TAG + ">trusted docs</" + TAG + ">"}</Markdown>
+            <Markdown rehypePlugins={[raw]}>{0}</Markdown>
+          </>
+        );
+      `,
+    },
+    {
+      name: "no rehype-raw plugin",
+      source: `
+        import Markdown from "react-markdown";
+        import gfm from "remark-gfm";
+        export const Preview = ({ content }) => (
+          <Markdown remarkPlugins={[gfm]}>{content}</Markdown>
+        );
+      `,
+    },
+    {
+      name: "an unresolved plugin spread that could contain a sanitizer",
+      source: `
+        import Markdown from "react-markdown";
+        import raw from "rehype-raw";
+        export const Preview = ({ content, safetyPlugins }) => (
+          <Markdown rehypePlugins={[raw, ...safetyPlugins]}>{content}</Markdown>
+        );
+      `,
+    },
+    {
+      name: "a later unknown JSX spread that can override rehypePlugins",
+      source: `
+        import Markdown from "react-markdown";
+        import raw from "rehype-raw";
+        export const Preview = ({ content, options }) => (
+          <Markdown rehypePlugins={[raw]} {...options}>{content}</Markdown>
+        );
+      `,
+    },
+    {
+      name: "a userland component and plugin with matching names",
+      source: `
+        const ReactMarkdown = ({ children }) => <div>{children}</div>;
+        const rehypeRaw = () => {};
+        export const Preview = ({ content }) => (
+          <ReactMarkdown rehypePlugins={[rehypeRaw]}>{content}</ReactMarkdown>
+        );
+      `,
+    },
+    {
+      name: "a shadowed React Markdown import",
+      source: `
+        import ImportedMarkdown from "react-markdown";
+        import raw from "rehype-raw";
+        export const Preview = ({ content }) => {
+          const ImportedMarkdown = ({ children }) => <div>{children}</div>;
+          return <ImportedMarkdown rehypePlugins={[raw]}>{content}</ImportedMarkdown>;
+        };
+      `,
+    },
+    {
+      name: "a shadowed rehype-raw import",
+      source: `
+        import Markdown from "react-markdown";
+        import importedRaw from "rehype-raw";
+        export const Preview = ({ content }) => {
+          const importedRaw = () => {};
+          return <Markdown rehypePlugins={[importedRaw]}>{content}</Markdown>;
+        };
+      `,
+    },
+    {
+      name: "a same-named import from another package",
+      source: `
+        import Markdown from "my-react-markdown";
+        import raw from "my-rehype-raw";
+        export const Preview = ({ content }) => (
+          <Markdown rehypePlugins={[raw]}>{content}</Markdown>
+        );
+      `,
+    },
+    {
+      name: "reassignable plugin and component aliases",
+      source: `
+        import ImportedMarkdown from "react-markdown";
+        import importedRaw from "rehype-raw";
+        let Markdown = ImportedMarkdown;
+        let raw = importedRaw;
+        Markdown = CustomMarkdown;
+        raw = customPlugin;
+        export const Preview = ({ content }) => (
+          <Markdown rehypePlugins={[raw]}>{content}</Markdown>
+        );
+      `,
+    },
+    {
+      name: "a plugin prop overridden by a later safe explicit prop",
+      source: `
+        import Markdown from "react-markdown";
+        import raw from "rehype-raw";
+        import sanitize from "rehype-sanitize";
+        export const Preview = ({ content }) => (
+          <Markdown rehypePlugins={[raw]} rehypePlugins={[raw, sanitize]}>
+            {content}
+          </Markdown>
+        );
+      `,
+    },
+  ])("stays quiet for $name", ({ source }) => {
+    const result = runReactMarkdownRule(source);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/react-markdown-unsanitized-raw-html.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/react-markdown-unsanitized-raw-html.ts
@@ -8,6 +8,11 @@ import { resolveConstIdentifierAlias } from "../../utils/resolve-const-identifie
 import { skipNonProductionFiles } from "../../utils/skip-non-production-files.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 
+interface StaticMemberParts {
+  object: EsTreeNode;
+  propertyName: string;
+}
+
 const MESSAGE =
   "React Markdown parses dynamic raw HTML when `rehype-raw` is enabled. Add `rehype-sanitize` to `rehypePlugins` or sanitize the markdown before rendering it.";
 
@@ -17,7 +22,7 @@ const REHYPE_SANITIZE_MODULE = "rehype-sanitize";
 const DOMPURIFY_MODULES = new Set(["dompurify", "isomorphic-dompurify"]);
 const REACT_MARKDOWN_NAMED_EXPORTS = new Set(["MarkdownAsync", "MarkdownHooks"]);
 const REACT_MARKDOWN_NAMESPACE_EXPORTS = new Set(["default", ...REACT_MARKDOWN_NAMED_EXPORTS]);
-const DEFAULT_EXPORT_NAME = new Set(["default"]);
+const DEFAULT_EXPORT_NAMES = new Set(["default"]);
 
 const getImportDeclaration = (
   symbol: SymbolDescriptor,
@@ -47,9 +52,7 @@ const resolveImportedIdentifier = (
   return symbol?.kind === "import" ? symbol : null;
 };
 
-const getStaticMemberParts = (
-  node: EsTreeNode,
-): { object: EsTreeNode; propertyName: string } | null => {
+const getStaticMemberParts = (node: EsTreeNode): StaticMemberParts | null => {
   if (isNodeOfType(node, "MemberExpression")) {
     if (node.computed || !isNodeOfType(node.property, "Identifier")) return null;
     return { object: node.object, propertyName: node.property.name };
@@ -111,7 +114,7 @@ const isPluginFromModule = (
     visitedSymbolIds.add(symbol.id);
     return isPluginFromModule(symbol.initializer, moduleName, scopes, visitedSymbolIds);
   }
-  if (isNamespaceMemberFromModule(node, moduleName, DEFAULT_EXPORT_NAME, scopes)) return true;
+  if (isNamespaceMemberFromModule(node, moduleName, DEFAULT_EXPORT_NAMES, scopes)) return true;
   if (!isNodeOfType(node, "ArrayExpression")) return false;
   for (const element of node.elements) {
     if (!element || isNodeOfType(element, "SpreadElement")) continue;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/react-markdown-unsanitized-raw-html.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/react-markdown-unsanitized-raw-html.ts
@@ -1,0 +1,305 @@
+import type { ScopeAnalysis, SymbolDescriptor } from "../../semantic/scope-analysis.js";
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { getImportedName } from "../../utils/get-imported-name.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { resolveConstIdentifierAlias } from "../../utils/resolve-const-identifier-alias.js";
+import { skipNonProductionFiles } from "../../utils/skip-non-production-files.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+
+const MESSAGE =
+  "React Markdown parses dynamic raw HTML when `rehype-raw` is enabled. Add `rehype-sanitize` to `rehypePlugins` or sanitize the markdown before rendering it.";
+
+const REACT_MARKDOWN_MODULE = "react-markdown";
+const REHYPE_RAW_MODULE = "rehype-raw";
+const REHYPE_SANITIZE_MODULE = "rehype-sanitize";
+const DOMPURIFY_MODULES = new Set(["dompurify", "isomorphic-dompurify"]);
+const REACT_MARKDOWN_NAMED_EXPORTS = new Set(["MarkdownAsync", "MarkdownHooks"]);
+const REACT_MARKDOWN_NAMESPACE_EXPORTS = new Set(["default", ...REACT_MARKDOWN_NAMED_EXPORTS]);
+const DEFAULT_EXPORT_NAME = new Set(["default"]);
+
+const getImportDeclaration = (
+  symbol: SymbolDescriptor,
+): EsTreeNodeOfType<"ImportDeclaration"> | null => {
+  if (symbol.kind !== "import") return null;
+  const importDeclaration = symbol.declarationNode.parent;
+  return isNodeOfType(importDeclaration, "ImportDeclaration") ? importDeclaration : null;
+};
+
+const isImportFromModule = (symbol: SymbolDescriptor, moduleName: string): boolean =>
+  getImportDeclaration(symbol)?.source.value === moduleName;
+
+const isDefaultImportSymbol = (symbol: SymbolDescriptor, moduleName: string): boolean => {
+  if (!isImportFromModule(symbol, moduleName)) return false;
+  return (
+    isNodeOfType(symbol.declarationNode, "ImportDefaultSpecifier") ||
+    getImportedName(symbol.declarationNode) === "default"
+  );
+};
+
+const resolveImportedIdentifier = (
+  node: EsTreeNode,
+  scopes: ScopeAnalysis,
+): SymbolDescriptor | null => {
+  if (!isNodeOfType(node, "Identifier") && !isNodeOfType(node, "JSXIdentifier")) return null;
+  const symbol = resolveConstIdentifierAlias(node, scopes);
+  return symbol?.kind === "import" ? symbol : null;
+};
+
+const getStaticMemberParts = (
+  node: EsTreeNode,
+): { object: EsTreeNode; propertyName: string } | null => {
+  if (isNodeOfType(node, "MemberExpression")) {
+    if (node.computed || !isNodeOfType(node.property, "Identifier")) return null;
+    return { object: node.object, propertyName: node.property.name };
+  }
+  if (isNodeOfType(node, "JSXMemberExpression")) {
+    if (!isNodeOfType(node.property, "JSXIdentifier")) return null;
+    return { object: node.object, propertyName: node.property.name };
+  }
+  return null;
+};
+
+const isNamespaceMemberFromModule = (
+  node: EsTreeNode,
+  moduleName: string,
+  memberNames: ReadonlySet<string>,
+  scopes: ScopeAnalysis,
+): boolean => {
+  const memberParts = getStaticMemberParts(node);
+  if (!memberParts || !memberNames.has(memberParts.propertyName)) return false;
+  const namespaceSymbol = resolveImportedIdentifier(memberParts.object, scopes);
+  return Boolean(
+    namespaceSymbol &&
+    isImportFromModule(namespaceSymbol, moduleName) &&
+    isNodeOfType(namespaceSymbol.declarationNode, "ImportNamespaceSpecifier"),
+  );
+};
+
+const isReactMarkdownComponent = (node: EsTreeNode, scopes: ScopeAnalysis): boolean => {
+  if (isNodeOfType(node, "JSXIdentifier")) {
+    const symbol = resolveImportedIdentifier(node, scopes);
+    if (!symbol || !isImportFromModule(symbol, REACT_MARKDOWN_MODULE)) return false;
+    if (isNodeOfType(symbol.declarationNode, "ImportDefaultSpecifier")) return true;
+    const importedName = getImportedName(symbol.declarationNode);
+    return (
+      importedName === "default" ||
+      Boolean(importedName && REACT_MARKDOWN_NAMED_EXPORTS.has(importedName))
+    );
+  }
+  return isNamespaceMemberFromModule(
+    node,
+    REACT_MARKDOWN_MODULE,
+    REACT_MARKDOWN_NAMESPACE_EXPORTS,
+    scopes,
+  );
+};
+
+const isPluginFromModule = (
+  rawNode: EsTreeNode,
+  moduleName: string,
+  scopes: ScopeAnalysis,
+  visitedSymbolIds: Set<number>,
+): boolean => {
+  const node = stripParenExpression(rawNode);
+  if (isNodeOfType(node, "Identifier")) {
+    const symbol = resolveConstIdentifierAlias(node, scopes);
+    if (!symbol || visitedSymbolIds.has(symbol.id)) return false;
+    if (isDefaultImportSymbol(symbol, moduleName)) return true;
+    if (symbol.kind !== "const" || !symbol.initializer) return false;
+    visitedSymbolIds.add(symbol.id);
+    return isPluginFromModule(symbol.initializer, moduleName, scopes, visitedSymbolIds);
+  }
+  if (isNamespaceMemberFromModule(node, moduleName, DEFAULT_EXPORT_NAME, scopes)) return true;
+  if (!isNodeOfType(node, "ArrayExpression")) return false;
+  for (const element of node.elements) {
+    if (!element || isNodeOfType(element, "SpreadElement")) continue;
+    return isPluginFromModule(element, moduleName, scopes, visitedSymbolIds);
+  }
+  return false;
+};
+
+const collectPluginEntries = (
+  rawNode: EsTreeNode,
+  scopes: ScopeAnalysis,
+  visitedSymbolIds: Set<number>,
+): EsTreeNode[] | null => {
+  const node = stripParenExpression(rawNode);
+  if (isNodeOfType(node, "Identifier")) {
+    const symbol = scopes.referenceFor(node)?.resolvedSymbol;
+    if (
+      !symbol ||
+      symbol.kind !== "const" ||
+      !symbol.initializer ||
+      visitedSymbolIds.has(symbol.id) ||
+      !isNodeOfType(symbol.declarationNode, "VariableDeclarator") ||
+      symbol.declarationNode.id !== symbol.bindingIdentifier
+    ) {
+      return null;
+    }
+    visitedSymbolIds.add(symbol.id);
+    return collectPluginEntries(symbol.initializer, scopes, visitedSymbolIds);
+  }
+  if (!isNodeOfType(node, "ArrayExpression")) return null;
+  const entries: EsTreeNode[] = [];
+  for (const element of node.elements) {
+    if (!element) continue;
+    if (isNodeOfType(element, "SpreadElement")) {
+      const spreadEntries = collectPluginEntries(
+        element.argument,
+        scopes,
+        new Set(visitedSymbolIds),
+      );
+      if (spreadEntries === null) return null;
+      entries.push(...spreadEntries);
+      continue;
+    }
+    entries.push(element);
+  }
+  return entries;
+};
+
+const findEffectiveExplicitAttribute = (
+  attributes: EsTreeNode[],
+  attributeName: string,
+): EsTreeNodeOfType<"JSXAttribute"> | null => {
+  for (let attributeIndex = attributes.length - 1; attributeIndex >= 0; attributeIndex -= 1) {
+    const attribute = attributes[attributeIndex];
+    if (!attribute || isNodeOfType(attribute, "JSXSpreadAttribute")) return null;
+    if (
+      isNodeOfType(attribute, "JSXAttribute") &&
+      isNodeOfType(attribute.name, "JSXIdentifier") &&
+      attribute.name.name === attributeName
+    ) {
+      return attribute;
+    }
+  }
+  return null;
+};
+
+const getAttributeExpression = (attribute: EsTreeNodeOfType<"JSXAttribute">): EsTreeNode | null => {
+  if (!isNodeOfType(attribute.value, "JSXExpressionContainer")) return null;
+  return isNodeOfType(attribute.value.expression, "JSXEmptyExpression")
+    ? null
+    : attribute.value.expression;
+};
+
+const isDomPurifyNamespace = (node: EsTreeNode, scopes: ScopeAnalysis): boolean => {
+  const symbol = resolveImportedIdentifier(node, scopes);
+  if (!symbol) return false;
+  const importDeclaration = getImportDeclaration(symbol);
+  if (!importDeclaration || !DOMPURIFY_MODULES.has(String(importDeclaration.source.value))) {
+    return false;
+  }
+  return (
+    isNodeOfType(symbol.declarationNode, "ImportDefaultSpecifier") ||
+    isNodeOfType(symbol.declarationNode, "ImportNamespaceSpecifier") ||
+    getImportedName(symbol.declarationNode) === "default"
+  );
+};
+
+const isDomPurifySanitizeCall = (node: EsTreeNode, scopes: ScopeAnalysis): boolean => {
+  if (!isNodeOfType(node, "CallExpression")) return false;
+  const memberParts = getStaticMemberParts(stripParenExpression(node.callee));
+  return Boolean(
+    memberParts &&
+    memberParts.propertyName === "sanitize" &&
+    isDomPurifyNamespace(memberParts.object, scopes),
+  );
+};
+
+const isStaticOrSanitizedMarkdownExpression = (
+  rawNode: EsTreeNode,
+  scopes: ScopeAnalysis,
+  visitedSymbolIds: Set<number>,
+): boolean => {
+  const node = stripParenExpression(rawNode);
+  if (isNodeOfType(node, "Literal")) return true;
+  if (isNodeOfType(node, "TemplateLiteral")) {
+    return node.expressions.every((expression) =>
+      isStaticOrSanitizedMarkdownExpression(expression, scopes, new Set(visitedSymbolIds)),
+    );
+  }
+  if (isDomPurifySanitizeCall(node, scopes)) return true;
+  if (isNodeOfType(node, "ConditionalExpression")) {
+    return (
+      isStaticOrSanitizedMarkdownExpression(node.consequent, scopes, new Set(visitedSymbolIds)) &&
+      isStaticOrSanitizedMarkdownExpression(node.alternate, scopes, new Set(visitedSymbolIds))
+    );
+  }
+  if (isNodeOfType(node, "BinaryExpression") && node.operator === "+") {
+    return (
+      isStaticOrSanitizedMarkdownExpression(node.left, scopes, new Set(visitedSymbolIds)) &&
+      isStaticOrSanitizedMarkdownExpression(node.right, scopes, new Set(visitedSymbolIds))
+    );
+  }
+  if (!isNodeOfType(node, "Identifier")) return false;
+  const symbol = scopes.referenceFor(node)?.resolvedSymbol;
+  if (
+    !symbol ||
+    symbol.kind !== "const" ||
+    !symbol.initializer ||
+    visitedSymbolIds.has(symbol.id) ||
+    !isNodeOfType(symbol.declarationNode, "VariableDeclarator") ||
+    symbol.declarationNode.id !== symbol.bindingIdentifier
+  ) {
+    return false;
+  }
+  visitedSymbolIds.add(symbol.id);
+  return isStaticOrSanitizedMarkdownExpression(symbol.initializer, scopes, visitedSymbolIds);
+};
+
+const hasDynamicUnsanitizedChildren = (
+  openingElement: EsTreeNodeOfType<"JSXOpeningElement">,
+  scopes: ScopeAnalysis,
+): boolean => {
+  const jsxElement = openingElement.parent;
+  if (!isNodeOfType(jsxElement, "JSXElement")) return false;
+  const meaningfulChildren = jsxElement.children.filter(
+    (child) => !isNodeOfType(child, "JSXText") || child.value.trim().length > 0,
+  );
+  if (meaningfulChildren.length > 0) {
+    return meaningfulChildren.some((child) => {
+      if (isNodeOfType(child, "JSXText")) return false;
+      if (!isNodeOfType(child, "JSXExpressionContainer")) return true;
+      if (isNodeOfType(child.expression, "JSXEmptyExpression")) return false;
+      return !isStaticOrSanitizedMarkdownExpression(child.expression, scopes, new Set());
+    });
+  }
+  const childrenAttribute = findEffectiveExplicitAttribute(openingElement.attributes, "children");
+  if (!childrenAttribute) return false;
+  const childrenExpression = getAttributeExpression(childrenAttribute);
+  return Boolean(
+    childrenExpression &&
+    !isStaticOrSanitizedMarkdownExpression(childrenExpression, scopes, new Set()),
+  );
+};
+
+export const reactMarkdownUnsanitizedRawHtml = defineRule({
+  id: "react-markdown-unsanitized-raw-html",
+  title: "Unsanitized raw HTML in React Markdown",
+  severity: "warn",
+  recommendation:
+    "Add `rehype-sanitize` to `rehypePlugins` or sanitize dynamic markdown before rendering. `skipHtml` does not disable HTML already parsed by `rehype-raw`.",
+  create: skipNonProductionFiles((context) => ({
+    JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
+      if (!isReactMarkdownComponent(node.name, context.scopes)) return;
+      const pluginsAttribute = findEffectiveExplicitAttribute(node.attributes, "rehypePlugins");
+      if (!pluginsAttribute) return;
+      const pluginsExpression = getAttributeExpression(pluginsAttribute);
+      if (!pluginsExpression) return;
+      const pluginEntries = collectPluginEntries(pluginsExpression, context.scopes, new Set());
+      if (pluginEntries === null) return;
+      const hasRawPlugin = pluginEntries.some((entry) =>
+        isPluginFromModule(entry, REHYPE_RAW_MODULE, context.scopes, new Set()),
+      );
+      if (!hasRawPlugin) return;
+      const hasSanitizePlugin = pluginEntries.some((entry) =>
+        isPluginFromModule(entry, REHYPE_SANITIZE_MODULE, context.scopes, new Set()),
+      );
+      if (hasSanitizePlugin || !hasDynamicUnsanitizedChildren(node, context.scopes)) return;
+      context.report({ node, message: MESSAGE });
+    },
+  })),
+});


### PR DESCRIPTION
## Why

`react-markdown` escapes raw HTML by default, but enabling `rehype-raw` turns dynamic markdown into live HTML. This rule reports that exact unsafe configuration unless the plugin list includes proven `rehype-sanitize` provenance or the rendered value is proven to come from DOMPurify.

The motivating Datastoria cases render user or AI-controlled markdown with `rehype-raw`. Both the original and oracle revisions were reconstructed at their pinned commits.

## Precision boundary

- Requires proven imports from `react-markdown` and `rehype-raw`; similarly named userland code stays quiet.
- Resolves immutable component/plugin aliases, tuple entries, static arrays, and static spreads.
- Treats unresolved plugin spreads and later unknown JSX spreads conservatively because they could supply a sanitizer or override the plugin list.
- Handles JSX children and the `children` prop, including member expressions and multiline components.
- Static strings, proven DOMPurify calls, and plugin lists containing proven `rehype-sanitize` stay quiet.
- `skipHtml` is not an exemption: runtime validation with `react-markdown@10.1.0` and `rehype-raw@7.0.0` confirms `rehype-raw` consumes the raw nodes first.

## Validation

- Focused rule tests: 30/30, including paired near-neighbors, aliases, shadowing, spreads, prop order, TypeScript wrappers, static values, sanitizers, and the exact pinned Teable multiline shape.
- Full plugin suite: 554 files; 12,870 passed and 148 skipped.
- Strict fuzzing: 500 generated iterations, 311 executed, target fired 3 times, no crashes, hangs, invariant failures, or findings. Corpus tests: 43 passed.
- Real repositories: 100/100 general RDE roots scanned without process failures; complete focused scans produced 10 target findings, all manually classified true positives. Safe controls using `rehype-sanitize` or DOMPurify stayed quiet. Teable's broad RDE lint exceeded 300 seconds and was not counted as a pass; a direct target-only scan of its exact pinned file reported the expected finding at line 17.
- React Bench: 120/120 exact pinned repositories, 97,626 files in each arm, zero scan failures, six added target findings and zero removed findings; all six additions were manually classified true positives.
- Oracle census: both relevant benchmark tasks, four base/oracle states, 1,359 files, zero scan failures, and no unintended verdict delta.
- Exact Datastoria reconstruction: both relevant oracle patches retain the existing query-context finding and add the intended dynamic-message finding; all verdicts manually classified true positives.
- Repository checks: typecheck, lint, format check, diff check, JSON-report smoke test, and the complete GitHub Node 20/22/24/25/26, macOS, Windows, CodeQL, and package checks pass. The local full-suite run had only two live-stdin probes fail under the unsupported local Node 25 harness; both pass under bundled Node 24 and in GitHub's Node 25 job.
- Automated review audit: no unresolved review threads.

Ready for human review. Do not merge automatically.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New static analysis on XSS-sensitive markdown rendering; conservative heuristics may miss some unsafe cases or need tuning as patterns evolve.
> 
> **Overview**
> Adds a new **Security** lint rule `react-markdown-unsanitized-raw-html` that warns when `react-markdown` is used with `rehype-raw` and **dynamic** markdown content, unless sanitization is proven (`rehype-sanitize` in the plugin list or DOMPurify on the input).
> 
> The rule resolves real `react-markdown` / `rehype-raw` imports (aliases, namespace members, static plugin arrays/spreads) and treats unresolved plugin spreads and later unknown JSX spreads as safe to avoid false positives. Static or DOMPurify-sanitized children do not report.
> 
> Wiring includes rule registry entry, liveness fixture, fuzz snippet pools, a patch changeset, and ~30 focused unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95bbb4a23936f5e4c07709f81b173e57bf0c42b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->