### PR TITLE
fix(rule): detect redundant controlled value sync

### DIFF
--- a/.changeset/controlled-values-render.md
+++ b/.changeset/controlled-values-render.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Detect redundant controlled-value copies that schedule a second render from an effect.


### PR DESCRIPTION
## Why

The pinned Treely RangeSelect implementation renders the controlled prop directly, then copies that same prop into state from an effect. In the controlled branch the copied state cannot affect the committed output, so the effect schedules a redundant post-commit render.

## MVP

- Add the package changeset first so detector work stays on one visible draft.
- Reproduce the exact pinned source and runtime render behavior.
- Implement only after proving the controlled/uncontrolled branch boundary and preserving legitimate edit buffers, external subscriptions, and controlled-to-uncontrolled semantics.

## Validation status

Implementation, paired regressions, strict fuzzing, RDE, React Bench, and CI are pending. Keep this PR in draft until all evidence agrees.
