### PR TITLE
fix(rule): require legacy context component provenance

### DIFF
--- a/.changeset/soft-squids-work.md
+++ b/.changeset/soft-squids-work.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Prevent no-legacy-context-api from reporting unrelated classes and registries.

--- a/packages/fuzz/corpus/regressions/no-legacy-context-api--unrelated-context-registry.tsx
+++ b/packages/fuzz/corpus/regressions/no-legacy-context-api--unrelated-context-registry.tsx
@@ -1,0 +1,22 @@
+// rule: no-legacy-context-api
+// weakness: component-provenance
+// source: ISSUES_TO_FIX_ASAP.md unrelated registry false positive
+import React from "react";
+
+export class ProtocolRegistry {
+  static contextTypes = new Set<string>(["json", "text"]);
+  static childContextTypes = new Map<string, unknown>();
+  getChildContext() {
+    return { protocol: "json" };
+  }
+}
+
+export const Registry: { contextTypes?: ReadonlySet<string> } = {};
+Registry.contextTypes = new Set<string>(["json", "text"]);
+
+class Component {}
+export class ShadowedWidget extends Component {
+  static contextTypes = {};
+}
+
+export const ReactVersion = React.version;

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -176,6 +176,7 @@ export const LIBRARY_SNIPPET_POOL = [
 // Module scope — SSR hazards, guard aliases, contexts, caches, styled.
 export const MODULE_SCOPE_SNIPPET_POOL = [
   `const GLOBAL_CACHE = new Map<string, unknown>();`,
+  `class FuzzProtocolRegistry { static contextTypes = new Set(["json", "text"]); static childContextTypes = new Map(); getChildContext() { return { protocol: "json" }; } } const FuzzSchemaRegistry = {}; FuzzSchemaRegistry.contextTypes = new Set(["json", "text"]);`,
   `const FuzzPropTypesPanel = ({ value }) => <div>{value}</div>; FuzzPropTypesPanel.propTypes = { value: () => true };`,
   `function FuzzNestedWritePanel() { return <div />; } function unusedFuzzNestedWrite() { FuzzNestedWritePanel = () => null; } FuzzNestedWritePanel.propTypes = { value: () => true };`,
   `function FuzzReturnedLabel() { let output = "label"; function unusedFuzzOutputWrite() { output = <div />; } return output; } FuzzReturnedLabel.propTypes = { value: () => true };`,
@@ -427,6 +428,7 @@ export const EDGE_CASE_STATEMENT_POOL = [
 export const IMPORT_LINE_POOL = [
   `import React from "react";`,
   `import * as React from "react";`,
+  `import ReactLegacyContext from "react";\nclass FuzzLegacyContextProvider extends ReactLegacyContext.Component { static contextTypes = {}; render() { return null; } }`,
   `import { useState, useEffect, useMemo, useCallback, useRef, useContext, useReducer, useTransition, useDeferredValue, useId, useLayoutEffect, useSyncExternalStore } from "react";`,
   `import { useState as useLocalState } from "react";`,
   `import { createPortal } from "react-dom";`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness-fixtures.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness-fixtures.ts
@@ -712,7 +712,7 @@ export const livenessFixtures: Readonly<Record<string, LivenessFixture>> = {
     code: 'import { Component } from "react";\nclass Board extends Component {\n  componentWillMount() {}\n  render() { return null; }\n}',
   },
   "no-legacy-context-api": {
-    code: 'class ColorProvider extends React.Component {\n  static childContextTypes = { color: PropTypes.string };\n  getChildContext() {\n    return { color: "red" };\n  }\n  render() {\n    return <div>{this.props.children}</div>;\n  }\n}',
+    code: 'import React from "react";\nclass ColorProvider extends React.Component {\n  static childContextTypes = { color: PropTypes.string };\n  getChildContext() {\n    return { color: "red" };\n  }\n  render() {\n    return <div>{this.props.children}</div>;\n  }\n}',
   },
   "no-locale-format-in-render": {
     code: '"use client";\nexport const Timestamp = ({ value }) => <time>{new Date(value).toLocaleString()}</time>;',

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-legacy-context-api.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-legacy-context-api.regressions.test.ts
@@ -6,7 +6,8 @@ describe("architecture/no-legacy-context-api — regressions", () => {
   it("flags a provider class using childContextTypes and getChildContext", () => {
     const result = runRule(
       noLegacyContextApi,
-      `class ColorProvider extends React.Component {
+      `import React from "react";
+class ColorProvider extends React.Component {
   static childContextTypes = { color: PropTypes.string };
   getChildContext() {
     return { color: "red" };
@@ -28,5 +29,140 @@ Button.contextTypes = { color: PropTypes.string };`,
     );
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("ignores unrelated classes and uppercase registries", () => {
+    const result = runRule(
+      noLegacyContextApi,
+      `export class ProtocolRegistry {
+  static contextTypes = new Set<string>(["json", "text"]);
+  static childContextTypes = new Map();
+  getChildContext() { return { protocol: "json" }; }
+}
+export const Registry: { contextTypes?: ReadonlySet<string> } = {};
+Registry.contextTypes = new Set<string>(["json", "text"]);
+class Schema extends Map<string, unknown> { static contextTypes = {}; }
+class Component {}
+class ShadowedWidget extends Component { static contextTypes = {}; }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("reports only legacy-shaped members on proven React classes", () => {
+    const result = runRule(
+      noLegacyContextApi,
+      `import ReactDefault, { Component as ReactComponent } from "react";
+class Provider extends ReactDefault.Component {
+  static childContextTypes = { theme: () => null };
+  getChildContext() { return { theme: "dark" }; }
+  static getChildContext = () => ({ theme: "ignored" });
+}
+class ConsumerBase extends ReactComponent {}
+class Consumer extends ConsumerBase {
+  static contextTypes = { theme: () => null };
+  contextTypes = { applicationData: true };
+}
+class Modern extends ReactComponent { static contextType = ThemeContext; }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(3);
+  });
+
+  it("reports proven function, class, alias, and typed component assignments", () => {
+    const result = runRule(
+      noLegacyContextApi,
+      `import ReactDefault, { type FunctionComponent as ReactFunctionComponent } from "react";
+const Panel = () => <div />;
+const PanelAlias = Panel;
+PanelAlias.contextTypes = { theme: () => null };
+class Dialog extends ReactDefault.Component {}
+Dialog.contextTypes = { theme: () => null };
+const Sheet: ReactFunctionComponent & { contextTypes?: object } = () => null;
+Sheet.contextTypes = { theme: () => null };
+const Modal: ReactDefault.FC & { contextTypes?: object } = () => null;
+(Modal as typeof Modal).contextTypes = { theme: () => null };`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(4);
+  });
+
+  it("follows React component type aliases and opaque component initializers", () => {
+    const result = runRule(
+      noLegacyContextApi,
+      `import type { ComponentType as ReactView } from "react";
+type LegacyView = (ReactView<{ theme: string }>) & { contextTypes?: object };
+declare const loadView: () => ReactView<{ theme: string }>;
+const LoadedView: LegacyView = loadView();
+LoadedView.contextTypes = { theme: () => null };
+const NullView: ReactView = null as unknown as ReactView;
+NullView.childContextTypes = { theme: () => null };`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
+  it("reports imported legacy component factory results and their aliases", () => {
+    const result = runRule(
+      noLegacyContextApi,
+      `import createLegacyComponent from "create-react-class";
+import React from "react";
+const Provider = createLegacyComponent({ render() { return null; } });
+const ProviderAlias = Provider;
+ProviderAlias.childContextTypes = { theme: () => null };
+const Consumer = React.createClass({ render() { return null; } });
+Consumer.contextTypes = { theme: () => null };`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
+  it("keeps component-like names and shadowed component types conservative", () => {
+    const result = runRule(
+      noLegacyContextApi,
+      `type FunctionComponent = () => null;
+const Registry: FunctionComponent & { contextTypes?: object } = () => null;
+Registry.contextTypes = {};
+const Namespace = { FC: class {} };
+const Schema: Namespace.FC & { contextTypes?: object } = {};
+Schema.contextTypes = {};
+function Formatter() { return "plain text"; }
+Formatter.contextTypes = {};
+const createLegacyComponent = () => ({ render: () => null });
+const FactoryRegistry = createLegacyComponent();
+FactoryRegistry.contextTypes = {};
+type MaybeComponent = React.FC | (() => string);
+const MaybeRegistry: MaybeComponent & { contextTypes?: object } = () => "plain";
+MaybeRegistry.contextTypes = {};
+let TypedPanel: React.FC & { contextTypes?: object } = () => null;
+TypedPanel = () => null;
+TypedPanel.contextTypes = {};
+let Panel = () => <div />;
+Panel = () => null;
+Panel.contextTypes = {};
+import ReactNamespace from "react";
+ReactNamespace.Component = class {};
+class FalseComponent extends ReactNamespace.Component {
+  static contextTypes = {};
+}`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("keeps computed and renamed application members out of this detector", () => {
+    const result = runRule(
+      noLegacyContextApi,
+      `import { Component } from "react";
+class Panel extends Component {
+  static ["contextTypes"] = {};
+  static supportedContextTypes = {};
+}
+Panel["childContextTypes"] = {};
+Panel.supportedContextTypes = {};
+Panel.getChildContext = () => ({ theme: "dark" });`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
   });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-legacy-context-api.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-legacy-context-api.ts
@@ -1,10 +1,13 @@
 import { defineRule } from "../../utils/define-rule.js";
-import { isFunctionLike } from "../../utils/is-function-like.js";
-import { isUppercaseName } from "../../utils/is-uppercase-name.js";
+import { isProvenReactClassComponent } from "../../utils/is-proven-react-class-component.js";
+import { isProvenReactComponentSymbol } from "../../utils/is-proven-react-component-symbol.js";
+import { hasSymbolWriteBefore } from "../../utils/has-symbol-write-before.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import { symbolHasReactComponentTypeAnnotation } from "../../utils/symbol-has-react-component-type-annotation.js";
 
 // HACK: legacy context (`childContextTypes` + `getChildContext` on
 // providers, `contextTypes` on consumers) was deprecated in 16.3, warns
@@ -26,27 +29,11 @@ const buildLegacyContextMessage = (memberName: string): string => {
   return "contextTypes uses the old context API that React 19 removes, so your component stops receiving context. Use `static contextType = MyContext` or `useContext()` in a function component, & update the provider too.";
 };
 
-const isInsideClassBody = (node: EsTreeNode): boolean => {
-  let current = node.parent;
-  while (current) {
-    if (isNodeOfType(current, "ClassBody")) return true;
-    if (isFunctionLike(current)) {
-      return false;
-    }
-    current = current.parent;
-  }
-  return false;
-};
-
 export const noLegacyContextApi = defineRule({
   id: "no-legacy-context-api",
   title: "Legacy context API",
   severity: "error",
   category: "Correctness",
-  // Matches purely on the member NAME (`contextTypes`, `getChildContext`,
-  // `childContextTypes`) with no React guard, so a same-named method on a
-  // non-React class would false-fire. The legacy context API is React-only,
-  // so require it.
   requires: ["react"],
   tags: ["migration-hint"],
   recommendation:
@@ -61,6 +48,8 @@ export const noLegacyContextApi = defineRule({
         return;
       if (!isNodeOfType(memberNode.key, "Identifier")) return;
       if (!LEGACY_CONTEXT_NAMES.has(memberNode.key.name)) return;
+      if (memberNode.key.name === "getChildContext" ? memberNode.static : !memberNode.static)
+        return;
       context.report({
         node: memberNode.key,
         message: buildLegacyContextMessage(memberNode.key.name),
@@ -69,6 +58,8 @@ export const noLegacyContextApi = defineRule({
 
     return {
       ClassBody(node: EsTreeNodeOfType<"ClassBody">) {
+        const classNode = node.parent;
+        if (!classNode || !isProvenReactClassComponent(classNode, context.scopes)) return;
         for (const member of node.body ?? []) {
           checkMember(member);
         }
@@ -80,9 +71,18 @@ export const noLegacyContextApi = defineRule({
         if (left.computed) return;
         if (!isNodeOfType(left.property, "Identifier")) return;
         if (!LEGACY_CONTEXT_NAMES.has(left.property.name)) return;
-        if (!isNodeOfType(left.object, "Identifier")) return;
-        if (!isUppercaseName(left.object.name)) return;
-        if (isInsideClassBody(node)) return;
+        if (left.property.name === "getChildContext") return;
+        const component = stripParenExpression(left.object);
+        if (!isNodeOfType(component, "Identifier")) return;
+        const symbol = context.scopes.symbolFor(component);
+        if (
+          !symbol ||
+          (!isProvenReactComponentSymbol(symbol, context.scopes, context.cfg, component) &&
+            (hasSymbolWriteBefore(symbol, component, context.scopes) ||
+              !symbolHasReactComponentTypeAnnotation(symbol, context.scopes)))
+        ) {
+          return;
+        }
         context.report({
           node: left,
           message: buildLegacyContextMessage(left.property.name),

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-proven-react-component-symbol.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-proven-react-component-symbol.ts
@@ -6,6 +6,7 @@ import { functionContainsReactRenderOutput } from "./function-contains-react-ren
 import { functionContainsProvenReactHookCall } from "./function-contains-proven-react-hook-call.js";
 import { functionReturnsPropsChildren } from "./function-returns-props-children.js";
 import { functionReturnsOnlyNull } from "./function-returns-only-null.js";
+import { isDefaultImportFromModule } from "./find-import-source-for-name.js";
 import { hasStableCallTarget } from "./has-stable-call-target.js";
 import { hasSymbolWriteBefore } from "./has-symbol-write-before.js";
 import { isComponentDeclaration } from "./is-component-declaration.js";
@@ -18,6 +19,10 @@ import { isUppercaseName } from "./is-uppercase-name.js";
 import { stripParenExpression } from "./strip-paren-expression.js";
 
 const REACT_COMPONENT_HOC_NAMES: ReadonlySet<string> = new Set(["memo", "forwardRef"]);
+const LEGACY_REACT_COMPONENT_FACTORY_NAMES: ReadonlySet<string> = new Set([
+  "createClass",
+  "createReactClass",
+]);
 
 const functionHasComponentEvidence = (
   functionNode: EsTreeNode,
@@ -69,6 +74,14 @@ const isProvenReactComponentExpression = (
   }
   if (!isNodeOfType(candidate, "CallExpression")) return false;
   if (!hasStableCallTarget(candidate, scopes)) return false;
+  const factoryCallee = stripParenExpression(candidate.callee);
+  if (
+    (isNodeOfType(factoryCallee, "Identifier") &&
+      isDefaultImportFromModule(factoryCallee, factoryCallee.name, "create-react-class")) ||
+    isReactApiCall(candidate, LEGACY_REACT_COMPONENT_FACTORY_NAMES, scopes)
+  ) {
+    return true;
+  }
   if (isReactApiCall(candidate, REACT_COMPONENT_HOC_NAMES, scopes, { resolveNamedAliases: true })) {
     const wrappedComponent = candidate.arguments[0];
     return Boolean(

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/symbol-has-react-component-type-annotation.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/symbol-has-react-component-type-annotation.ts
@@ -1,0 +1,86 @@
+import type { ScopeAnalysis, SymbolDescriptor } from "../semantic/scope-analysis.js";
+import type { EsTreeNode } from "./es-tree-node.js";
+import { getImportedName } from "./get-imported-name.js";
+import { isImportedFromReact } from "./is-react-api-call.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+
+const REACT_COMPONENT_TYPE_NAMES: ReadonlySet<string> = new Set([
+  "ComponentClass",
+  "ComponentType",
+  "FC",
+  "FunctionComponent",
+]);
+
+const findVisibleSymbol = (
+  identifier: EsTreeNode,
+  scopes: ScopeAnalysis,
+): SymbolDescriptor | null => {
+  if (!isNodeOfType(identifier, "Identifier")) return null;
+  let scope = scopes.scopeFor(identifier);
+  while (true) {
+    const symbol = scope.symbolsByName.get(identifier.name);
+    if (symbol) return symbol;
+    if (!scope.parent) return null;
+    scope = scope.parent;
+  }
+};
+
+const isReactNamespaceType = (identifier: EsTreeNode, scopes: ScopeAnalysis): boolean => {
+  const symbol = findVisibleSymbol(identifier, scopes);
+  return Boolean(
+    symbol &&
+    isImportedFromReact(symbol) &&
+    (isNodeOfType(symbol.declarationNode, "ImportDefaultSpecifier") ||
+      isNodeOfType(symbol.declarationNode, "ImportNamespaceSpecifier")),
+  );
+};
+
+const isReactComponentType = (
+  typeNode: EsTreeNode | null | undefined,
+  scopes: ScopeAnalysis,
+  visitedSymbolIds: Set<number>,
+): boolean => {
+  if (!typeNode) return false;
+  if (isNodeOfType(typeNode, "TSTypeAnnotation")) {
+    return isReactComponentType(typeNode.typeAnnotation, scopes, visitedSymbolIds);
+  }
+  if (isNodeOfType(typeNode, "TSParenthesizedType")) {
+    return isReactComponentType(typeNode.typeAnnotation, scopes, visitedSymbolIds);
+  }
+  if (isNodeOfType(typeNode, "TSIntersectionType")) {
+    return (typeNode.types ?? []).some((member) =>
+      isReactComponentType(member, scopes, visitedSymbolIds),
+    );
+  }
+  if (!isNodeOfType(typeNode, "TSTypeReference")) return false;
+  const typeName = typeNode.typeName;
+  if (isNodeOfType(typeName, "TSQualifiedName")) {
+    return (
+      isNodeOfType(typeName.left, "Identifier") &&
+      isNodeOfType(typeName.right, "Identifier") &&
+      REACT_COMPONENT_TYPE_NAMES.has(typeName.right.name) &&
+      isReactNamespaceType(typeName.left, scopes)
+    );
+  }
+  if (!isNodeOfType(typeName, "Identifier")) return false;
+  const typeSymbol = findVisibleSymbol(typeName, scopes);
+  if (!typeSymbol || visitedSymbolIds.has(typeSymbol.id)) return false;
+  if (isImportedFromReact(typeSymbol)) {
+    const importedName = getImportedName(typeSymbol.declarationNode);
+    return Boolean(importedName && REACT_COMPONENT_TYPE_NAMES.has(importedName));
+  }
+  if (!isNodeOfType(typeSymbol.declarationNode, "TSTypeAliasDeclaration")) return false;
+  visitedSymbolIds.add(typeSymbol.id);
+  return isReactComponentType(typeSymbol.declarationNode.typeAnnotation, scopes, visitedSymbolIds);
+};
+
+export const symbolHasReactComponentTypeAnnotation = (
+  symbol: SymbolDescriptor,
+  scopes: ScopeAnalysis,
+): boolean => {
+  const bindingIdentifier = symbol.bindingIdentifier;
+  return (
+    isNodeOfType(bindingIdentifier, "Identifier") &&
+    isReactComponentType(bindingIdentifier.typeAnnotation, scopes, new Set())
+  );
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/symbol-has-react-component-type-annotation.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/symbol-has-react-component-type-annotation.ts
@@ -44,9 +44,6 @@ const isReactComponentType = (
   if (isNodeOfType(typeNode, "TSTypeAnnotation")) {
     return isReactComponentType(typeNode.typeAnnotation, scopes, visitedSymbolIds);
   }
-  if (isNodeOfType(typeNode, "TSParenthesizedType")) {
-    return isReactComponentType(typeNode.typeAnnotation, scopes, visitedSymbolIds);
-  }
   if (isNodeOfType(typeNode, "TSIntersectionType")) {
     return (typeNode.types ?? []).some((member) =>
       isReactComponentType(member, scopes, visitedSymbolIds),


### PR DESCRIPTION
## Why

`no-legacy-context-api` reported ordinary classes and registry objects solely because they owned a member named `contextTypes`. Those values never participate in React context, so React 19 migration advice was a false positive.

## What changed

- Require proven React component provenance before reporting class members or post-declaration assignments.
- Preserve true positives for React class components, typed function components, `create-react-class`, and React legacy factories.
- Respect static versus instance legacy API shapes and stable bindings.
- Add paired and adversarial regressions for aliases, shadowing, reassignment, TypeScript wrappers, intersections, unions, and static/instance near-neighbors.
- Add a permanent fuzz regression plus generation shapes that exercise both the false-positive and true-positive paths.

## Validation

- Exact A/B reproduction: baseline 4 findings; candidate 2. The only removed diagnostics are the unrelated registry class and assignment; both real React findings remain.
- Focused and liveness tests: 472/472 passing.
- Oxlint plugin suite: 12,869 passing, 148 skipped.
- Fuzz package: 43 passing, 400 skipped.
- Strict fuzz: `FUZZ_RULE=no-legacy-context-api FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz`; target fired and no finding occurred.
- RDE: 100/100 repositories, 25,973 files per build, target diagnostics 8 → 8, zero added/removed diagnostics or scan failures.
- React Bench: 120/120 repositories, 97,695 files per build, target diagnostics 0 → 0, zero deltas or scan failures.
- Root typecheck: 15/15 tasks passing.
- Root lint, format check, and `git diff --check`: passing.
- Pushed-head CI: full matrix green.
- Review audit: zero unresolved threads.
- Head: `8b8c8873e00cf65671edaf8d51c4c8e529335d79`.

## Precision boundary

Unknown userland values remain quiet. A diagnostic requires evidence that the receiver is a React component or legacy React component factory result; similarly named classes, registries, shadowed imports, and unstable bindings do not qualify.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes lint precision for a React 19 migration rule; false negatives are possible where provenance is ambiguous, but scope is limited to static analysis heuristics, not runtime behavior.
> 
> **Overview**
> **`no-legacy-context-api`** no longer fires on unrelated code that merely uses names like `contextTypes` or `getChildContext`. Diagnostics now require evidence that the receiver is a real React component (or legacy factory output).
> 
> Class members are checked only on **proven React class components**, with correct **static vs instance** handling for legacy API shapes. Top-level assignments drop the old uppercase-name heuristic in favor of **proven component symbols**, **React component TypeScript annotations**, and **stable bindings** (reassigned or shadowed names stay quiet). **`getChildContext` assignments** are no longer reported.
> 
> Shared detection grows via **`symbolHasReactComponentTypeAnnotation`** and broader **`isProvenReactComponentSymbol`** coverage (`create-react-class`, `React.createClass`). Regressions, a fuzz corpus fixture, and fuzz snippet pools lock in both suppressed false positives and preserved true positives.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01e9974a30c20d2f43c3c1d70083862f732f5e96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->