### PR TITLE
fix(core): isolate inline-disable audit scans

### DIFF
--- a/.changeset/inline-disable-scan-isolation.md
+++ b/.changeset/inline-disable-scan-isolation.md
@@ -1,0 +1,7 @@
+---
+"@react-doctor/core": patch
+"@react-doctor/api": patch
+"react-doctor": patch
+---
+
+Isolate overlapping scans from audit-mode inline-disable rewrites.

--- a/packages/core/src/run-oxlint.ts
+++ b/packages/core/src/run-oxlint.ts
@@ -40,6 +40,7 @@ import { hashFileContents } from "./utils/hash-file-contents.js";
 import { listSourceFilesWithSize } from "./utils/list-source-files.js";
 import { planLintBatches } from "./utils/plan-lint-batches.js";
 import { resolveReactDoctorCacheDir } from "./utils/resolve-react-doctor-cache-dir.js";
+import { withRootScanIsolation } from "./utils/with-root-scan-isolation.js";
 import { yieldToEventLoop } from "./utils/yield-to-event-loop.js";
 
 interface RunOxlintOptions {
@@ -360,7 +361,7 @@ export const reactHooksJsPluginDropNote = (error: unknown): string | null => {
  *   5. on extends-related crashes, retry once with extends stripped
  *   6. always restore disable directives + clean up the temp dir
  */
-export const runOxlint = async (options: RunOxlintOptions): Promise<Diagnostic[]> => {
+const runOxlintWithoutRootIsolation = async (options: RunOxlintOptions): Promise<Diagnostic[]> => {
   const {
     rootDirectory,
     project,
@@ -1027,3 +1028,8 @@ export const runOxlint = async (options: RunOxlintOptions): Promise<Diagnostic[]
     fs.rmSync(configDirectory, { recursive: true, force: true });
   }
 };
+
+export const runOxlint = async (options: RunOxlintOptions): Promise<Diagnostic[]> =>
+  withRootScanIsolation(options.rootDirectory, options.respectInlineDisables === false, () =>
+    runOxlintWithoutRootIsolation(options),
+  );

--- a/packages/core/src/utils/with-root-scan-isolation.ts
+++ b/packages/core/src/utils/with-root-scan-isolation.ts
@@ -1,0 +1,97 @@
+import * as path from "node:path";
+import { toCanonicalPath } from "./to-canonical-path.js";
+
+interface RootScanIsolationWaiter {
+  isExclusive: boolean;
+  resolve: (release: () => void) => void;
+}
+
+interface RootScanIsolationState {
+  activeSharedCount: number;
+  isExclusiveActive: boolean;
+  waiters: RootScanIsolationWaiter[];
+}
+
+const isolationByRoot = new Map<string, RootScanIsolationState>();
+
+const deleteUnusedIsolationState = (rootKey: string, state: RootScanIsolationState): void => {
+  if (state.activeSharedCount > 0 || state.isExclusiveActive || state.waiters.length > 0) return;
+  if (isolationByRoot.get(rootKey) === state) isolationByRoot.delete(rootKey);
+};
+
+const dispatchIsolationWaiters = (rootKey: string, state: RootScanIsolationState): void => {
+  if (state.isExclusiveActive || state.activeSharedCount > 0) return;
+  const firstWaiter = state.waiters[0];
+  if (!firstWaiter) {
+    deleteUnusedIsolationState(rootKey, state);
+    return;
+  }
+  if (firstWaiter.isExclusive) {
+    state.waiters.shift();
+    state.isExclusiveActive = true;
+    firstWaiter.resolve(() => {
+      state.isExclusiveActive = false;
+      dispatchIsolationWaiters(rootKey, state);
+    });
+    return;
+  }
+  while (state.waiters[0] && !state.waiters[0].isExclusive) {
+    const waiter = state.waiters.shift();
+    if (!waiter) break;
+    state.activeSharedCount += 1;
+    waiter.resolve(() => {
+      state.activeSharedCount -= 1;
+      dispatchIsolationWaiters(rootKey, state);
+    });
+  }
+};
+
+const acquireRootScanIsolation = async (
+  rootDirectory: string,
+  requiresExclusiveAccess: boolean,
+): Promise<() => void> => {
+  const rootKey = toCanonicalPath(path.resolve(rootDirectory));
+  const state = isolationByRoot.get(rootKey) ?? {
+    activeSharedCount: 0,
+    isExclusiveActive: false,
+    waiters: [],
+  };
+  isolationByRoot.set(rootKey, state);
+
+  const hasWaitingExclusive = state.waiters.some((waiter) => waiter.isExclusive);
+  if (!requiresExclusiveAccess && !state.isExclusiveActive && !hasWaitingExclusive) {
+    state.activeSharedCount += 1;
+    return () => {
+      state.activeSharedCount -= 1;
+      dispatchIsolationWaiters(rootKey, state);
+    };
+  }
+  if (
+    requiresExclusiveAccess &&
+    !state.isExclusiveActive &&
+    state.activeSharedCount === 0 &&
+    state.waiters.length === 0
+  ) {
+    state.isExclusiveActive = true;
+    return () => {
+      state.isExclusiveActive = false;
+      dispatchIsolationWaiters(rootKey, state);
+    };
+  }
+  return new Promise((resolve) => {
+    state.waiters.push({ isExclusive: requiresExclusiveAccess, resolve });
+  });
+};
+
+export const withRootScanIsolation = async <Result>(
+  rootDirectory: string,
+  requiresExclusiveAccess: boolean,
+  operation: () => Promise<Result>,
+): Promise<Result> => {
+  const release = await acquireRootScanIsolation(rootDirectory, requiresExclusiveAccess);
+  try {
+    return await operation();
+  } finally {
+    release();
+  }
+};

--- a/packages/core/tests/with-root-scan-isolation.test.ts
+++ b/packages/core/tests/with-root-scan-isolation.test.ts
@@ -1,0 +1,175 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import { withRootScanIsolation } from "../src/utils/with-root-scan-isolation.js";
+
+const temporaryDirectories: string[] = [];
+
+const makeTemporaryDirectory = (): string => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "rd-root-scan-isolation-"));
+  temporaryDirectories.push(directory);
+  return directory;
+};
+
+const makeBarrier = () => {
+  let release: () => void = () => {};
+  const promise = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  return { promise, release };
+};
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("withRootScanIsolation", () => {
+  it("lets ordinary scans overlap", async () => {
+    const rootDirectory = makeTemporaryDirectory();
+    const firstBarrier = makeBarrier();
+    const secondStarted = makeBarrier();
+    const first = withRootScanIsolation(rootDirectory, false, async () => {
+      await firstBarrier.promise;
+    });
+    const second = withRootScanIsolation(rootDirectory, false, async () => {
+      secondStarted.release();
+    });
+
+    await secondStarted.promise;
+    firstBarrier.release();
+    await Promise.all([first, second]);
+  });
+
+  it("keeps ordinary scans outside an audit scan", async () => {
+    const rootDirectory = makeTemporaryDirectory();
+    const auditBarrier = makeBarrier();
+    const auditStarted = makeBarrier();
+    let didOrdinaryScanStart = false;
+    const audit = withRootScanIsolation(rootDirectory, true, async () => {
+      auditStarted.release();
+      await auditBarrier.promise;
+    });
+    await auditStarted.promise;
+    const ordinary = withRootScanIsolation(rootDirectory, false, async () => {
+      didOrdinaryScanStart = true;
+    });
+
+    await Promise.resolve();
+    expect(didOrdinaryScanStart).toBe(false);
+    auditBarrier.release();
+    await Promise.all([audit, ordinary]);
+    expect(didOrdinaryScanStart).toBe(true);
+  });
+
+  it("keeps audit scans outside an ordinary scan", async () => {
+    const rootDirectory = makeTemporaryDirectory();
+    const ordinaryBarrier = makeBarrier();
+    const ordinaryStarted = makeBarrier();
+    let didAuditScanStart = false;
+    const ordinary = withRootScanIsolation(rootDirectory, false, async () => {
+      ordinaryStarted.release();
+      await ordinaryBarrier.promise;
+    });
+    await ordinaryStarted.promise;
+    const audit = withRootScanIsolation(rootDirectory, true, async () => {
+      didAuditScanStart = true;
+    });
+
+    await Promise.resolve();
+    expect(didAuditScanStart).toBe(false);
+    ordinaryBarrier.release();
+    await Promise.all([ordinary, audit]);
+    expect(didAuditScanStart).toBe(true);
+  });
+
+  it("treats symlinked roots as the same scan root", async () => {
+    const rootDirectory = makeTemporaryDirectory();
+    const symlinkDirectory = `${rootDirectory}-link`;
+    fs.symlinkSync(rootDirectory, symlinkDirectory);
+    temporaryDirectories.push(symlinkDirectory);
+    const auditBarrier = makeBarrier();
+    const auditStarted = makeBarrier();
+    let didOrdinaryScanStart = false;
+    const audit = withRootScanIsolation(rootDirectory, true, async () => {
+      auditStarted.release();
+      await auditBarrier.promise;
+    });
+    await auditStarted.promise;
+    const ordinary = withRootScanIsolation(symlinkDirectory, false, async () => {
+      didOrdinaryScanStart = true;
+    });
+
+    await Promise.resolve();
+    expect(didOrdinaryScanStart).toBe(false);
+    auditBarrier.release();
+    await Promise.all([audit, ordinary]);
+    expect(didOrdinaryScanStart).toBe(true);
+  });
+
+  it("does not let new ordinary scans overtake a waiting audit", async () => {
+    const rootDirectory = makeTemporaryDirectory();
+    const firstOrdinaryBarrier = makeBarrier();
+    const firstOrdinaryStarted = makeBarrier();
+    const auditBarrier = makeBarrier();
+    const auditStarted = makeBarrier();
+    let didSecondOrdinaryStart = false;
+    const firstOrdinary = withRootScanIsolation(rootDirectory, false, async () => {
+      firstOrdinaryStarted.release();
+      await firstOrdinaryBarrier.promise;
+    });
+    await firstOrdinaryStarted.promise;
+    const audit = withRootScanIsolation(rootDirectory, true, async () => {
+      auditStarted.release();
+      await auditBarrier.promise;
+    });
+    const secondOrdinary = withRootScanIsolation(rootDirectory, false, async () => {
+      didSecondOrdinaryStart = true;
+    });
+
+    firstOrdinaryBarrier.release();
+    await auditStarted.promise;
+    expect(didSecondOrdinaryStart).toBe(false);
+    auditBarrier.release();
+    await Promise.all([firstOrdinary, audit, secondOrdinary]);
+    expect(didSecondOrdinaryStart).toBe(true);
+  });
+
+  it("releases isolation when a scan fails", async () => {
+    const rootDirectory = makeTemporaryDirectory();
+    const expectedError = new Error("scan failed");
+    await expect(
+      withRootScanIsolation(rootDirectory, true, async () => {
+        throw expectedError;
+      }),
+    ).rejects.toBe(expectedError);
+
+    let didOrdinaryScanStart = false;
+    await withRootScanIsolation(rootDirectory, false, async () => {
+      didOrdinaryScanStart = true;
+    });
+    expect(didOrdinaryScanStart).toBe(true);
+  });
+
+  it("does not serialize scans from different roots", async () => {
+    const firstRootDirectory = makeTemporaryDirectory();
+    const secondRootDirectory = makeTemporaryDirectory();
+    const firstBarrier = makeBarrier();
+    const firstStarted = makeBarrier();
+    const secondStarted = makeBarrier();
+    const first = withRootScanIsolation(firstRootDirectory, true, async () => {
+      firstStarted.release();
+      await firstBarrier.promise;
+    });
+    await firstStarted.promise;
+    const second = withRootScanIsolation(secondRootDirectory, true, async () => {
+      secondStarted.release();
+    });
+
+    await secondStarted.promise;
+    firstBarrier.release();
+    await Promise.all([first, second]);
+  });
+});

--- a/packages/react-doctor/tests/regressions/respect-lint-ignores.test.ts
+++ b/packages/react-doctor/tests/regressions/respect-lint-ignores.test.ts
@@ -45,6 +45,30 @@ export const FullName = ({ first, last }: { first: string; last: string }) => {
 };
 `;
 
+const DISABLED_DERIVED_STATE_SOURCE = DERIVED_STATE_SOURCE.replace(
+  "  useEffect(() => {",
+  "  // eslint-disable-next-line react-doctor/no-derived-state-effect\n  useEffect(() => {",
+);
+
+const makeRaceFixtureFiles = (paddingFileCount: number): Record<string, string> => ({
+  "src/candidate.tsx": DISABLED_DERIVED_STATE_SOURCE,
+  ...Object.fromEntries(
+    Array.from({ length: paddingFileCount }, (_, fileIndex) => [
+      `src/padding-${fileIndex}.tsx`,
+      `export const Padding${fileIndex} = () => <div />;\n`,
+    ]),
+  ),
+});
+
+const waitForNeutralizedDirective = async (candidatePath: string): Promise<void> => {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    if (fs.readFileSync(candidatePath, "utf8").includes("eslint_disable")) return;
+    await new Promise((resolve) => setTimeout(resolve, 1));
+  }
+  throw new Error("Timed out waiting for the audit scan to neutralize the directive");
+};
+
 describe("default behavior: respect existing eslint/oxlint suppressions", () => {
   it("a `// oxlint-disable-next-line` comment on the offending line silences the diagnostic", async () => {
     const projectDir = setupCase("oxlint-disable-next-line", {
@@ -294,5 +318,75 @@ export const FullName = ({ first, last }: { first: string; last: string }) => {
     });
 
     expect(diagnostics).toEqual([]);
+  });
+
+  it("keeps a concurrent ordinary scan outside an audit rewrite", async () => {
+    const projectDir = setupCase("audit-ordinary-race", makeRaceFixtureFiles(300));
+    const project = buildTestProject({ rootDirectory: projectDir });
+    const userConfig = {
+      rules: buildIsolatedDerivedStateRuleConfig("no-derived-state-effect"),
+    };
+    const candidatePath = path.join(projectDir, "src/candidate.tsx");
+    const auditPromise = runOxlint({
+      rootDirectory: projectDir,
+      project,
+      respectInlineDisables: false,
+      userConfig,
+    });
+    await waitForNeutralizedDirective(candidatePath);
+    const ordinaryPromise = runOxlint({
+      rootDirectory: projectDir,
+      project,
+      includePaths: ["src/candidate.tsx"],
+      respectInlineDisables: true,
+      userConfig,
+    });
+    const [auditDiagnostics, ordinaryDiagnostics] = await Promise.all([
+      auditPromise,
+      ordinaryPromise,
+    ]);
+
+    expect(
+      auditDiagnostics.filter((diagnostic) => diagnostic.rule === "no-derived-state-effect"),
+    ).toHaveLength(1);
+    expect(
+      ordinaryDiagnostics.filter((diagnostic) => diagnostic.rule === "no-derived-state-effect"),
+    ).toHaveLength(0);
+    expect(fs.readFileSync(candidatePath, "utf8")).toBe(DISABLED_DERIVED_STATE_SOURCE);
+  });
+
+  it("keeps overlapping audit scans isolated through restoration", async () => {
+    const projectDir = setupCase("audit-audit-race", makeRaceFixtureFiles(300));
+    const project = buildTestProject({ rootDirectory: projectDir });
+    const userConfig = {
+      rules: buildIsolatedDerivedStateRuleConfig("no-derived-state-effect"),
+    };
+    const candidatePath = path.join(projectDir, "src/candidate.tsx");
+    const targetedAuditPromise = runOxlint({
+      rootDirectory: projectDir,
+      project,
+      includePaths: ["src/candidate.tsx"],
+      respectInlineDisables: false,
+      userConfig,
+    });
+    await waitForNeutralizedDirective(candidatePath);
+    const fullAuditPromise = runOxlint({
+      rootDirectory: projectDir,
+      project,
+      respectInlineDisables: false,
+      userConfig,
+    });
+    const [targetedDiagnostics, fullDiagnostics] = await Promise.all([
+      targetedAuditPromise,
+      fullAuditPromise,
+    ]);
+
+    expect(
+      targetedDiagnostics.filter((diagnostic) => diagnostic.rule === "no-derived-state-effect"),
+    ).toHaveLength(1);
+    expect(
+      fullDiagnostics.filter((diagnostic) => diagnostic.rule === "no-derived-state-effect"),
+    ).toHaveLength(1);
+    expect(fs.readFileSync(candidatePath, "utf8")).toBe(DISABLED_DERIVED_STATE_SOURCE);
   });
 });


### PR DESCRIPTION
## Summary

- isolate audit-mode source rewrites per canonical scan root
- preserve ordinary/ordinary concurrency while making audit scans exclusive
- pin both false-positive and false-negative overlap schedules as permanent regressions

## Why

Audit mode temporarily rewrites `eslint-disable` / `oxlint-disable` comments. Concurrent scans of the same root could observe or overwrite those transient bytes, changing returned diagnostics in both directions.

## Validation

- exact baseline audit+ordinary oracle: ordinary `alt-text` 0 → 1 (reproduced)
- exact candidate audit+ordinary oracle: audit 1, ordinary 0, source restored
- exact baseline fast-audit+full-audit oracle: full audit 1 → 0 (reproduced)
- exact candidate fast-audit+full-audit oracle: both 1, source restored
- permanent public `runOxlint` races: 14/14
- root-isolation/restoration tests: 10/10, including symlinks, fairness, failures, same/different roots
- full repository tests: pass
- full typecheck: pass
- lint: pass with pre-existing warnings only
- format check: pass
- JSON-report smoke: pass
- post-change truffler search: no duplicate lock/isolation helper

Sequential detector logic is unchanged, so rule fuzz/RDE/React Bench deltas are not applicable; the exact concurrency oracles exercise the changed behavior directly.

## Status

Implementation is pushed. Draft remains open pending CI and final review-thread audit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core lint orchestration and on-disk source during audit mode; behavior change is narrowly scoped to concurrency but incorrect locking could stall or serialize scans unexpectedly.
> 
> **Overview**
> Fixes a concurrency bug where **audit mode** (`respectInlineDisables: false`) temporarily rewrites `eslint-disable` / `oxlint-disable` comments on disk; overlapping `runOxlint` calls on the same project could read or overwrite those transient edits and return wrong diagnostics or leave source corrupted.
> 
> Adds **`withRootScanIsolation`**, a per–canonical-root lock: normal scans still run in parallel, but any audit scan takes **exclusive** access for that root (and waits behind in-flight ordinary scans; queued audits are not overtaken by new ordinary scans). Symlinked paths share one lock; different roots stay independent. **`runOxlint`** now wraps the existing runner in this helper when audit mode is on.
> 
> Regression coverage includes unit tests for the lock semantics and end-to-end `runOxlint` races (audit + ordinary, audit + audit) with source restoration asserted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 247daed07495a7b2d6021e31d614f364b741cc5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->