### PR TITLE
fix(rule): exempt sole-writer effect equality guards

### DIFF
--- a/.changeset/tidy-guards-rest.md
+++ b/.changeset/tidy-guards-rest.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Avoid reporting state read only by its sole writer effect's equality guard as a missing dependency.

--- a/packages/fuzz/corpus/regressions/exhaustive-deps--sole-writer-equality-guard.tsx
+++ b/packages/fuzz/corpus/regressions/exhaustive-deps--sole-writer-equality-guard.tsx
@@ -1,0 +1,12 @@
+// rule: exhaustive-deps
+// weakness: effect-semantics
+// source: ISSUES_TO_FIX_ASAP.md (state is only written by this equality-guarded effect)
+import { useEffect, useState } from "react";
+
+export const SoleWriterSnapshot = ({ source }: { source: string }) => {
+  const [snapshot, setSnapshot] = useState(source);
+  useEffect(() => {
+    if (!Object.is(snapshot, source)) setSnapshot(source);
+  }, [source]);
+  return <output>{snapshot}</output>;
+};

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -51,6 +51,9 @@ export const EFFECT_SNIPPET_POOL = [
   `const deferredHandle = useCallback(() => handle(value), [value]); useEffect(() => { const timeoutId = setTimeout(() => deferredHandle(), 100); return () => clearTimeout(timeoutId); }, [deferredHandle, value]);`,
   `const [phase, setPhase] = useState(""); const [total, setTotal] = useState(0); const [ready, setReady] = useState(false); useEffect(() => { setPhase("sync"); setTotal(items.length); setReady(true); }, [items]);`,
   `const [snapshot, setSnapshot] = useState(sharedSnapshot); useEffect(() => subscribeSnapshot(setSnapshot), []);`,
+  `const [guardedSnapshot, setGuardedSnapshot] = useState(value); useEffect(() => { if (!Object.is(guardedSnapshot, value)) setGuardedSnapshot(value); }, [value]);`,
+  `const equalSnapshots = () => false; const [namedGuardSnapshot, setNamedGuardSnapshot] = useState(value); useEffect(() => { if (!equalSnapshots(namedGuardSnapshot, value)) setNamedGuardSnapshot(value); }, [value]);`,
+  `const [mismatchedSnapshot, setMismatchedSnapshot] = useState(value); useEffect(() => { if (mismatchedSnapshot !== value) setMismatchedSnapshot(state); }, [state, value]);`,
 ] as const;
 
 // State — lazy initializers (incl. SSR-hazardous localStorage/matchMedia),

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps-sole-writer-guard.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps-sole-writer-guard.ts
@@ -7,13 +7,22 @@ import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
 import { isAstDescendant } from "../../utils/is-ast-descendant.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isReactApiCall } from "../../utils/is-react-api-call.js";
-import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import {
+  stripParenExpression,
+  TRANSPARENT_EXPRESSION_WRAPPER_TYPES,
+} from "../../utils/strip-paren-expression.js";
 
 const EQUALITY_BINARY_OPERATORS: ReadonlySet<string> = new Set(["===", "!=="]);
 
 interface DirectSetterWrite {
   callExpression: EsTreeNode;
   writtenValue: EsTreeNode;
+}
+
+interface EqualityComparison {
+  comparison: EsTreeNode;
+  counterpart: EsTreeNode;
+  areValuesEqualWhenTruthy: boolean;
 }
 
 const getUseStateSetterSymbol = (
@@ -96,21 +105,33 @@ const isGlobalNaNReference = (expression: EsTreeNode, scopes: ScopeAnalysis): bo
   );
 };
 
-const getEqualityCounterpart = (
+const getEqualityComparison = (
   stateReference: EsTreeNode,
   candidate: EsTreeNode,
   scopes: ScopeAnalysis,
-): EsTreeNode | null => {
+): EqualityComparison | null => {
   const unwrappedStateReference = stripParenExpression(stateReference);
   if (
     isNodeOfType(candidate, "BinaryExpression") &&
     EQUALITY_BINARY_OPERATORS.has(candidate.operator)
   ) {
     if (stripParenExpression(candidate.left) === unwrappedStateReference) {
-      return isGlobalNaNReference(candidate.right, scopes) ? null : candidate.right;
+      return isGlobalNaNReference(candidate.right, scopes)
+        ? null
+        : {
+            comparison: candidate,
+            counterpart: candidate.right,
+            areValuesEqualWhenTruthy: candidate.operator === "===",
+          };
     }
     if (stripParenExpression(candidate.right) === unwrappedStateReference) {
-      return isGlobalNaNReference(candidate.left, scopes) ? null : candidate.left;
+      return isGlobalNaNReference(candidate.left, scopes)
+        ? null
+        : {
+            comparison: candidate,
+            counterpart: candidate.left,
+            areValuesEqualWhenTruthy: candidate.operator === "===",
+          };
     }
     return null;
   }
@@ -129,24 +150,61 @@ const getEqualityCounterpart = (
   ) {
     return null;
   }
-  if (stripParenExpression(firstArgument) === unwrappedStateReference) return secondArgument;
-  if (stripParenExpression(secondArgument) === unwrappedStateReference) return firstArgument;
+  if (stripParenExpression(firstArgument) === unwrappedStateReference) {
+    return {
+      comparison: candidate,
+      counterpart: secondArgument,
+      areValuesEqualWhenTruthy: true,
+    };
+  }
+  if (stripParenExpression(secondArgument) === unwrappedStateReference) {
+    return {
+      comparison: candidate,
+      counterpart: firstArgument,
+      areValuesEqualWhenTruthy: true,
+    };
+  }
   return null;
 };
 
-const findEqualityCounterpart = (
+const findEqualityComparison = (
   stateReference: EsTreeNode,
   test: EsTreeNode,
   scopes: ScopeAnalysis,
-): EsTreeNode | null => {
+): EqualityComparison | null => {
   let current: EsTreeNode | null | undefined = stateReference.parent;
   while (current && isAstDescendant(current, test)) {
-    const counterpart = getEqualityCounterpart(stateReference, current, scopes);
-    if (counterpart) return counterpart;
+    const comparison = getEqualityComparison(stateReference, current, scopes);
+    if (comparison) return comparison;
     if (current === test) break;
     current = current.parent;
   }
   return null;
+};
+
+const doesTestOutcomeRequireComparisonOutcome = (
+  comparison: EsTreeNode,
+  test: EsTreeNode,
+  testOutcome: boolean,
+  comparisonOutcome: boolean,
+): boolean => {
+  let requiredChildOutcome = testOutcome;
+  let current = comparison;
+  while (current !== test) {
+    const parent = current.parent;
+    if (!parent || !isAstDescendant(parent, test)) return false;
+    if (isNodeOfType(parent, "UnaryExpression") && parent.operator === "!") {
+      requiredChildOutcome = !requiredChildOutcome;
+    } else if (isNodeOfType(parent, "LogicalExpression")) {
+      if (parent.operator === "&&" && !requiredChildOutcome) return false;
+      if (parent.operator === "||" && requiredChildOutcome) return false;
+      if (parent.operator !== "&&" && parent.operator !== "||") return false;
+    } else if (!TRANSPARENT_EXPRESSION_WRAPPER_TYPES.has(parent.type)) {
+      return false;
+    }
+    current = parent;
+  }
+  return requiredChildOutcome === comparisonOutcome;
 };
 
 const resolveImmutableAliasExpression = (
@@ -232,7 +290,25 @@ const findDominatingGuardCounterpart = (
         Boolean(current.alternate && isAstDescendant(setterCall, current.alternate)) ||
         doesGuardDominateLaterSetter(current, setterCall))
     ) {
-      return findEqualityCounterpart(stateReference, current.test, scopes);
+      const setterRunsWhenTestTruthy = isAstDescendant(setterCall, current.consequent);
+      const setterRunsWhenTestFalsey =
+        Boolean(current.alternate && isAstDescendant(setterCall, current.alternate)) ||
+        doesGuardDominateLaterSetter(current, setterCall);
+      if (setterRunsWhenTestTruthy === setterRunsWhenTestFalsey) return null;
+      const equalityComparison = findEqualityComparison(stateReference, current.test, scopes);
+      if (!equalityComparison) return null;
+      const comparisonOutcomeForDifferentValues = !equalityComparison.areValuesEqualWhenTruthy;
+      if (
+        !doesTestOutcomeRequireComparisonOutcome(
+          equalityComparison.comparison,
+          current.test,
+          setterRunsWhenTestTruthy,
+          comparisonOutcomeForDifferentValues,
+        )
+      ) {
+        return null;
+      }
+      return equalityComparison.counterpart;
     }
     current = current.parent;
   }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps-sole-writer-guard.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps-sole-writer-guard.ts
@@ -1,0 +1,271 @@
+import type { ScopeAnalysis, SymbolDescriptor } from "../../semantic/scope-analysis.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
+import { findTransparentExpressionRoot } from "../../utils/find-transparent-expression-root.js";
+import { getDirectConstInitializer } from "../../utils/get-direct-const-initializer.js";
+import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
+import { isAstDescendant } from "../../utils/is-ast-descendant.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { isReactApiCall } from "../../utils/is-react-api-call.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+
+const EQUALITY_BINARY_OPERATORS: ReadonlySet<string> = new Set(["===", "!=="]);
+
+interface DirectSetterWrite {
+  callExpression: EsTreeNode;
+  writtenValue: EsTreeNode;
+}
+
+const getUseStateSetterSymbol = (
+  stateSymbol: SymbolDescriptor,
+  scopes: ScopeAnalysis,
+): SymbolDescriptor | null => {
+  const declaration = stateSymbol.declarationNode;
+  if (!isNodeOfType(declaration, "VariableDeclarator")) return null;
+  if (!isNodeOfType(declaration.id, "ArrayPattern")) return null;
+  const stateBinding = declaration.id.elements[0];
+  const setterBinding = declaration.id.elements[1];
+  if (
+    stateBinding !== stateSymbol.bindingIdentifier ||
+    !isNodeOfType(setterBinding, "Identifier")
+  ) {
+    return null;
+  }
+  const initializer = declaration.init ? stripParenExpression(declaration.init) : null;
+  if (
+    !initializer ||
+    !isReactApiCall(initializer, "useState", scopes, {
+      allowGlobalReactNamespace: true,
+      allowUnboundBareCalls: true,
+      resolveNamedAliases: true,
+    })
+  ) {
+    return null;
+  }
+  return scopes.symbolFor(setterBinding);
+};
+
+const getDirectSetterCall = (
+  setterSymbol: SymbolDescriptor,
+  callback: EsTreeNode,
+): DirectSetterWrite | null => {
+  if (setterSymbol.references.length !== 1) return null;
+  const setterReference = setterSymbol.references[0];
+  if (setterReference.flag !== "read") return null;
+  const referenceRoot = findTransparentExpressionRoot(setterReference.identifier);
+  const callExpression = referenceRoot.parent;
+  if (
+    !isNodeOfType(callExpression, "CallExpression") ||
+    callExpression.callee !== referenceRoot ||
+    callExpression.arguments.length !== 1 ||
+    findEnclosingFunction(callExpression) !== callback
+  ) {
+    return null;
+  }
+  const writtenValue = stripParenExpression(callExpression.arguments[0]);
+  if (
+    isNodeOfType(writtenValue, "ArrowFunctionExpression") ||
+    isNodeOfType(writtenValue, "FunctionExpression") ||
+    isNodeOfType(writtenValue, "SpreadElement")
+  ) {
+    return null;
+  }
+  return { callExpression, writtenValue };
+};
+
+const isGlobalObjectIsCall = (callExpression: EsTreeNode, scopes: ScopeAnalysis): boolean => {
+  if (!isNodeOfType(callExpression, "CallExpression")) return false;
+  const callee = stripParenExpression(callExpression.callee);
+  if (!isNodeOfType(callee, "MemberExpression")) return false;
+  const propertyName = getStaticPropertyName(callee);
+  const receiver = stripParenExpression(callee.object);
+  return Boolean(
+    propertyName === "is" &&
+    isNodeOfType(receiver, "Identifier") &&
+    receiver.name === "Object" &&
+    scopes.isGlobalReference(receiver),
+  );
+};
+
+const isGlobalNaNReference = (expression: EsTreeNode, scopes: ScopeAnalysis): boolean => {
+  const unwrappedExpression = stripParenExpression(expression);
+  return (
+    isNodeOfType(unwrappedExpression, "Identifier") &&
+    unwrappedExpression.name === "NaN" &&
+    scopes.isGlobalReference(unwrappedExpression)
+  );
+};
+
+const getEqualityCounterpart = (
+  stateReference: EsTreeNode,
+  candidate: EsTreeNode,
+  scopes: ScopeAnalysis,
+): EsTreeNode | null => {
+  const unwrappedStateReference = stripParenExpression(stateReference);
+  if (
+    isNodeOfType(candidate, "BinaryExpression") &&
+    EQUALITY_BINARY_OPERATORS.has(candidate.operator)
+  ) {
+    if (stripParenExpression(candidate.left) === unwrappedStateReference) {
+      return isGlobalNaNReference(candidate.right, scopes) ? null : candidate.right;
+    }
+    if (stripParenExpression(candidate.right) === unwrappedStateReference) {
+      return isGlobalNaNReference(candidate.left, scopes) ? null : candidate.left;
+    }
+    return null;
+  }
+  if (
+    !isNodeOfType(candidate, "CallExpression") ||
+    !isGlobalObjectIsCall(candidate, scopes) ||
+    candidate.arguments.length !== 2
+  ) {
+    return null;
+  }
+  const firstArgument = candidate.arguments[0];
+  const secondArgument = candidate.arguments[1];
+  if (
+    isNodeOfType(firstArgument, "SpreadElement") ||
+    isNodeOfType(secondArgument, "SpreadElement")
+  ) {
+    return null;
+  }
+  if (stripParenExpression(firstArgument) === unwrappedStateReference) return secondArgument;
+  if (stripParenExpression(secondArgument) === unwrappedStateReference) return firstArgument;
+  return null;
+};
+
+const findEqualityCounterpart = (
+  stateReference: EsTreeNode,
+  test: EsTreeNode,
+  scopes: ScopeAnalysis,
+): EsTreeNode | null => {
+  let current: EsTreeNode | null | undefined = stateReference.parent;
+  while (current && isAstDescendant(current, test)) {
+    const counterpart = getEqualityCounterpart(stateReference, current, scopes);
+    if (counterpart) return counterpart;
+    if (current === test) break;
+    current = current.parent;
+  }
+  return null;
+};
+
+const resolveImmutableAliasExpression = (
+  expression: EsTreeNode,
+  scopes: ScopeAnalysis,
+): EsTreeNode => {
+  const visitedSymbolIds = new Set<number>();
+  let current = stripParenExpression(expression);
+  while (isNodeOfType(current, "Identifier")) {
+    const symbol = scopes.symbolFor(current);
+    if (!symbol || visitedSymbolIds.has(symbol.id)) break;
+    const initializer = getDirectConstInitializer(symbol);
+    if (!initializer || !isNodeOfType(stripParenExpression(initializer), "Identifier")) break;
+    visitedSymbolIds.add(symbol.id);
+    current = stripParenExpression(initializer);
+  }
+  return current;
+};
+
+const referencesSameValue = (
+  leftExpression: EsTreeNode,
+  rightExpression: EsTreeNode,
+  scopes: ScopeAnalysis,
+): boolean => {
+  const left = resolveImmutableAliasExpression(leftExpression, scopes);
+  const right = resolveImmutableAliasExpression(rightExpression, scopes);
+  if (left === right) return true;
+  if (isNodeOfType(left, "Identifier") && isNodeOfType(right, "Identifier")) {
+    const leftSymbol = scopes.symbolFor(left);
+    const rightSymbol = scopes.symbolFor(right);
+    if (leftSymbol || rightSymbol) return leftSymbol?.id === rightSymbol?.id;
+    return left.name === right.name;
+  }
+  if (isNodeOfType(left, "Literal") && isNodeOfType(right, "Literal")) {
+    return Object.is(left.value, right.value);
+  }
+  return false;
+};
+
+const hasDeclaredTriggerDependency = (callback: EsTreeNode): boolean => {
+  const callbackRoot = findTransparentExpressionRoot(callback);
+  const hookCall = callbackRoot.parent;
+  if (!isNodeOfType(hookCall, "CallExpression")) return false;
+  const dependencyArray = hookCall.arguments[1];
+  return Boolean(
+    isNodeOfType(dependencyArray, "ArrayExpression") && dependencyArray.elements.length,
+  );
+};
+
+const doesBranchExitEffect = (branch: EsTreeNode): boolean => {
+  if (isNodeOfType(branch, "ReturnStatement") || isNodeOfType(branch, "ThrowStatement")) {
+    return true;
+  }
+  if (!isNodeOfType(branch, "BlockStatement")) return false;
+  const terminalStatement = branch.body.at(-1);
+  return Boolean(terminalStatement && doesBranchExitEffect(terminalStatement));
+};
+
+const doesGuardDominateLaterSetter = (guard: EsTreeNode, setterCall: EsTreeNode): boolean => {
+  if (!isNodeOfType(guard, "IfStatement") || guard.alternate) return false;
+  if (!doesBranchExitEffect(guard.consequent)) return false;
+  const block = guard.parent;
+  if (!isNodeOfType(block, "BlockStatement")) return false;
+  const guardIndex = block.body.findIndex((statement) => statement === guard);
+  return block.body.some(
+    (statement, statementIndex) =>
+      statementIndex > guardIndex && isAstDescendant(setterCall, statement),
+  );
+};
+
+const findDominatingGuardCounterpart = (
+  stateReference: EsTreeNode,
+  setterCall: EsTreeNode,
+  callback: EsTreeNode,
+  scopes: ScopeAnalysis,
+): EsTreeNode | null => {
+  let current: EsTreeNode | null | undefined = stateReference.parent;
+  while (current && current !== callback) {
+    if (
+      isNodeOfType(current, "IfStatement") &&
+      isAstDescendant(stateReference, current.test) &&
+      (isAstDescendant(setterCall, current.consequent) ||
+        Boolean(current.alternate && isAstDescendant(setterCall, current.alternate)) ||
+        doesGuardDominateLaterSetter(current, setterCall))
+    ) {
+      return findEqualityCounterpart(stateReference, current.test, scopes);
+    }
+    current = current.parent;
+  }
+  return null;
+};
+
+export const isSoleWriterEffectGuardCapture = (
+  stateSymbol: SymbolDescriptor,
+  callback: EsTreeNode,
+  scopes: ScopeAnalysis,
+): boolean => {
+  if (!hasDeclaredTriggerDependency(callback)) return false;
+  if (stateSymbol.references.some((reference) => reference.flag !== "read")) return false;
+  const setterSymbol = getUseStateSetterSymbol(stateSymbol, scopes);
+  if (!setterSymbol) return false;
+  const setterWrite = getDirectSetterCall(setterSymbol, callback);
+  if (!setterWrite) return false;
+  const callbackStateReferences = stateSymbol.references.filter((reference) =>
+    isAstDescendant(reference.identifier, callback),
+  );
+  if (callbackStateReferences.length !== 1) return false;
+  const stateReferenceRoot = findTransparentExpressionRoot(callbackStateReferences[0].identifier);
+  if (
+    isNodeOfType(stateReferenceRoot.parent, "MemberExpression") &&
+    stateReferenceRoot.parent.object === stateReferenceRoot
+  ) {
+    return false;
+  }
+  const counterpart = findDominatingGuardCounterpart(
+    callbackStateReferences[0].identifier,
+    setterWrite.callExpression,
+    callback,
+    scopes,
+  );
+  return Boolean(counterpart && referencesSameValue(counterpart, setterWrite.writtenValue, scopes));
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.regressions.test.ts
@@ -1014,6 +1014,200 @@ describe("react-builtins/exhaustive-deps — regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it.each([
+    `if (snapshot !== source) setSnapshot(source);`,
+    `if (!Object.is(snapshot, source)) setSnapshot(source);`,
+    `if (Object.is(snapshot, source)) return; setSnapshot(source);`,
+    `const nextSnapshot = source; const aliasedSnapshot = nextSnapshot; if (snapshot !== source) setSnapshot(aliasedSnapshot);`,
+    `const nextSnapshot = source; if (snapshot !== nextSnapshot) setSnapshot(source);`,
+  ])("accepts a sole-writer state equality guard: %s", (effectBody) => {
+    const code = `
+      function Candidate({ source }) {
+        const [snapshot, setSnapshot] = useState(source);
+        useEffect(() => { ${effectBody} }, [source]);
+        return snapshot;
+      }
+    `;
+    const result = runRule(exhaustiveDeps, code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("accepts a local source derivation used by both the guard and setter", () => {
+    const code = `
+      function Candidate({ enabled, source }) {
+        const [snapshot, setSnapshot] = useState(false);
+        useEffect(() => {
+          const nextSnapshot = enabled && computeSnapshot(source);
+          if (snapshot !== nextSnapshot) setSnapshot(nextSnapshot);
+        }, [enabled, source]);
+        return snapshot;
+      }
+    `;
+    const result = runRule(exhaustiveDeps, code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it.each([
+    `void source; if (!Object.is(snapshot, 0)) setSnapshot(0);`,
+    `void source; if (!Object.is(snapshot, NaN)) setSnapshot(NaN);`,
+  ])("uses Object.is semantics for exact primitive writes: %s", (effectBody) => {
+    const code = `
+      function Candidate({ source }) {
+        const [snapshot, setSnapshot] = useState(source);
+        useEffect(() => { ${effectBody} }, [source]);
+        return snapshot;
+      }
+    `;
+    const result = runRule(exhaustiveDeps, code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("keeps a complete sole-writer state dependency valid", () => {
+    const code = `
+      function Candidate({ source }) {
+        const [snapshot, setSnapshot] = useState(source);
+        useEffect(() => {
+          if (!Object.is(snapshot, source)) setSnapshot(source);
+        }, [snapshot, source]);
+        return snapshot;
+      }
+    `;
+    const result = runRule(exhaustiveDeps, code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("accepts the same guard in a layout effect through a named hook alias", () => {
+    const code = `
+      import { useLayoutEffect, useState as useLocalState } from "react";
+      function Candidate({ source }) {
+        const [snapshot, setSnapshot] = useLocalState(source);
+        useLayoutEffect(() => {
+          if ((snapshot!) !== source) (setSnapshot)(source);
+        }, [source]);
+        return snapshot;
+      }
+    `;
+    const result = runRule(exhaustiveDeps, code, { filename: "fixture.tsx" });
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("accepts the same guard through the React namespace", () => {
+    const code = `
+      import * as React from "react";
+      function Candidate({ source }) {
+        const [snapshot, setSnapshot] = React.useState(source);
+        React.useEffect(() => {
+          if (!Object.is(snapshot, source)) setSnapshot(source);
+        }, [source]);
+        return snapshot;
+      }
+    `;
+    const result = runRule(exhaustiveDeps, code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it.each([
+    `useEffect(() => { if (!Object.is(snapshot, source)) setSnapshot(source); }, [source]); return <button onClick={() => setSnapshot("external")}>{snapshot}</button>;`,
+    `useEffect(() => { if (!Object.is(snapshot, source)) setSnapshot(source); }, [source]); useEffect(() => { setSnapshot("external"); }, []); return snapshot;`,
+    `useEffect(() => { if (!Object.is(snapshot, source)) setSnapshot(source); }, [source]); const update = setSnapshot; return <button onClick={() => update("external")}>{snapshot}</button>;`,
+    `useEffect(() => { const update = () => setSnapshot(source); if (!Object.is(snapshot, source)) update(); }, [source]); return snapshot;`,
+    `useEffect(() => { if (!Object.is(snapshot, source)) { setSnapshot(source); setSnapshot(source); } }, [source]); return snapshot;`,
+    `useEffect(() => { if (!Object.is(snapshot, source)) setSnapshot(source); consume(snapshot); }, [source]); return snapshot;`,
+    `useEffect(() => { if (!Object.is(snapshot, source)) consume(source); setSnapshot(source); }, [source]); return snapshot;`,
+    `const Object = { is: () => false }; useEffect(() => { if (!Object.is(snapshot, source)) setSnapshot(source); }, [source]); return snapshot;`,
+    `const equal = () => false; useEffect(() => { if (!equal(snapshot, source)) setSnapshot(source); }, [source]); return snapshot;`,
+    `const notEqual = () => true; useEffect(() => { if (notEqual(snapshot, source)) setSnapshot(source); }, [source]); return snapshot;`,
+    `const compare = { equal: () => false }; useEffect(() => { if (!compare.equal(snapshot, source)) setSnapshot(source); }, [source]); return snapshot;`,
+    `useInsertionEffect(() => { if (!Object.is(snapshot, source)) setSnapshot(source); }, [source]); return snapshot;`,
+    `useEffect(() => { if (snapshot.value !== source.value) setSnapshot(source); }, [source]); return snapshot.value;`,
+  ])("reports when sole-writer ownership or guard role is not proven: %s", (componentBody) => {
+    const code = `
+      function Candidate({ source }) {
+        const [snapshot, setSnapshot] = useState(source);
+        ${componentBody}
+      }
+    `;
+    const result = runRule(exhaustiveDeps, code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("does not apply the exemption to a userland useState tuple", () => {
+    const code = `
+      const useState = (value) => [value, consume];
+      function Candidate({ source }) {
+        const [snapshot, setSnapshot] = useState(source);
+        useEffect(() => {
+          if (!Object.is(snapshot, source)) setSnapshot(source);
+        }, [source]);
+        return snapshot;
+      }
+    `;
+    const result = runRule(exhaustiveDeps, code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it.each([
+    {
+      effectBody: `if (snapshot === source) setSnapshot(Math.random());`,
+      dependencies: `[source]`,
+    },
+    {
+      effectBody: `if (snapshot !== source) setSnapshot(other);`,
+      dependencies: `[source, other]`,
+    },
+    {
+      effectBody: `if (Object.is(snapshot, source)) setSnapshot(other);`,
+      dependencies: `[source, other]`,
+    },
+    {
+      effectBody: `if (normalize(snapshot) !== source) setSnapshot(source);`,
+      dependencies: `[source]`,
+    },
+    {
+      effectBody: `if (snapshot !== source) setSnapshot(source);`,
+      dependencies: `[]`,
+    },
+    {
+      effectBody: `if (snapshot != source) setSnapshot(source);`,
+      dependencies: `[source]`,
+    },
+    {
+      effectBody: `if (snapshot !== 0) setSnapshot(-0);`,
+      dependencies: `[source]`,
+    },
+    {
+      effectBody: `void source; if (!Object.is(snapshot, 0)) setSnapshot(-0);`,
+      dependencies: `[source]`,
+    },
+    {
+      effectBody: `if (snapshot !== NaN) setSnapshot(NaN);`,
+      dependencies: `[source]`,
+    },
+  ])(
+    "reports snapshot when the guard/write/source proof fails: $effectBody $dependencies",
+    ({ effectBody, dependencies }) => {
+      const code = `
+        function Candidate({ other, source }) {
+          const [snapshot, setSnapshot] = useState(source);
+          useEffect(() => { ${effectBody} }, ${dependencies});
+          return snapshot;
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      const messages = result.diagnostics.map((diagnostic) => diagnostic.message).join("\n");
+      expect(messages).toContain("snapshot");
+    },
+  );
+
   describe("bounded identity source resolution", () => {
     it("accepts the exact derived callback dependency", () => {
       const code = `

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.regressions.test.ts
@@ -999,6 +999,21 @@ describe("react-builtins/exhaustive-deps — regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("does not report state read only by its sole writer effect's equality guard", () => {
+    const code = `
+      function Candidate({ source }) {
+        const [snapshot, setSnapshot] = useState(source);
+        useEffect(() => {
+          if (!Object.is(snapshot, source)) setSnapshot(source);
+        }, [source]);
+        return snapshot;
+      }
+    `;
+    const result = runRule(exhaustiveDeps, code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   describe("bounded identity source resolution", () => {
     it("accepts the exact derived callback dependency", () => {
       const code = `

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.regressions.test.ts
@@ -1018,6 +1018,12 @@ describe("react-builtins/exhaustive-deps — regressions", () => {
     `if (snapshot !== source) setSnapshot(source);`,
     `if (!Object.is(snapshot, source)) setSnapshot(source);`,
     `if (Object.is(snapshot, source)) return; setSnapshot(source);`,
+    `if (snapshot === source) return; setSnapshot(source);`,
+    `if (snapshot === source) consume(source); else setSnapshot(source);`,
+    `if (Object.is(snapshot, source)) consume(source); else setSnapshot(source);`,
+    `if (!!(snapshot !== source)) setSnapshot(source);`,
+    `if (ready && snapshot !== source) setSnapshot(source);`,
+    `if (!ready || snapshot === source) return; setSnapshot(source);`,
     `const nextSnapshot = source; const aliasedSnapshot = nextSnapshot; if (snapshot !== source) setSnapshot(aliasedSnapshot);`,
     `const nextSnapshot = source; if (snapshot !== nextSnapshot) setSnapshot(source);`,
   ])("accepts a sole-writer state equality guard: %s", (effectBody) => {
@@ -1160,6 +1166,30 @@ describe("react-builtins/exhaustive-deps — regressions", () => {
       dependencies: `[source]`,
     },
     {
+      effectBody: `if (snapshot === source) setSnapshot(source);`,
+      dependencies: `[source]`,
+    },
+    {
+      effectBody: `if (Object.is(snapshot, source)) setSnapshot(source);`,
+      dependencies: `[source]`,
+    },
+    {
+      effectBody: `if (!(snapshot !== source)) setSnapshot(source);`,
+      dependencies: `[source]`,
+    },
+    {
+      effectBody: `if (ready || snapshot !== source) setSnapshot(source);`,
+      dependencies: `[ready, source]`,
+    },
+    {
+      effectBody: `if (ready && snapshot === source) return; setSnapshot(source);`,
+      dependencies: `[ready, source]`,
+    },
+    {
+      effectBody: `if (snapshot !== source) consume(source); else setSnapshot(source);`,
+      dependencies: `[source]`,
+    },
+    {
       effectBody: `if (snapshot !== source) setSnapshot(other);`,
       dependencies: `[source, other]`,
     },
@@ -1195,7 +1225,7 @@ describe("react-builtins/exhaustive-deps — regressions", () => {
     "reports snapshot when the guard/write/source proof fails: $effectBody $dependencies",
     ({ effectBody, dependencies }) => {
       const code = `
-        function Candidate({ other, source }) {
+        function Candidate({ other, ready, source }) {
           const [snapshot, setSnapshot] = useState(source);
           useEffect(() => { ${effectBody} }, ${dependencies});
           return snapshot;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.ts
@@ -42,6 +42,7 @@ import {
   buildUnstableDepMessage,
 } from "./exhaustive-deps-messages.js";
 import { resolveExhaustiveDepsSettings } from "./exhaustive-deps-settings.js";
+import { isSoleWriterEffectGuardCapture } from "./exhaustive-deps-sole-writer-guard.js";
 import { isExhaustiveDepsSuppressedAt } from "./exhaustive-deps-suppression.js";
 import {
   getFunctionValueNode,
@@ -79,6 +80,8 @@ const EFFECT_HOOKS_ALLOWING_EXTRA_REACTIVE_DEPS: ReadonlySet<string> = new Set([
   "useLayoutEffect",
   "useInsertionEffect",
 ]);
+
+const SOLE_WRITER_GUARD_HOOKS: ReadonlySet<string> = new Set(["useEffect", "useLayoutEffect"]);
 
 const buildAdditionalHooksRegex = (additional: string): RegExp | null => {
   if (!additional) return null;
@@ -344,6 +347,7 @@ const collectCaptureDepKeys = (
   callback: EsTreeNode,
   scopes: ScopeAnalysis,
   declaredExactBindingKeys?: ReadonlySet<string>,
+  allowSoleWriterEffectGuards = false,
 ): CaptureCollection => {
   const keys = new Set<string>();
   const stableCapturedNames = new Set<string>();
@@ -357,6 +361,10 @@ const collectCaptureDepKeys = (
     const symbol = reference.resolvedSymbol;
     if (!symbol) continue;
     if (isRecursiveInitializerCapture(symbol, callback)) continue;
+    if (allowSoleWriterEffectGuards && isSoleWriterEffectGuardCapture(symbol, callback, scopes)) {
+      stableCapturedNames.add(symbol.name);
+      continue;
+    }
     if (symbolHasStableValue(symbol, scopes)) {
       stableCapturedNames.add(symbol.name);
       continue;
@@ -1425,6 +1433,7 @@ If the missing value is recreated every render, move it inside the hook or stabi
           callbackToAnalyze ?? callbackArgument,
           context.scopes,
           declaredExactBindingKeys,
+          SOLE_WRITER_GUARD_HOOKS.has(hookName),
         );
         for (const forcedCaptureKey of forcedCaptureKeys) captureKeys.add(forcedCaptureKey);
         addAggregatePropsDependency(


### PR DESCRIPTION
## Summary

`exhaustive-deps` no longer reports a state capture when the same dependency-keyed effect is provably the state setter's only caller, the state has exactly one callback read, that read is an equality guard, and the setter writes the exact compared value.

The exemption is deliberately narrow:

- real React `useState` plus `useEffect` or `useLayoutEffect`
- a non-empty dependency array
- one direct synchronous setter call and no setter aliases, escapes, sibling writers, or external writers
- one state read in the callback, used directly in a dominating guard
- only `===`, `!==`, or proven unshadowed global `Object.is`
- the write must resolve to the exact comparison counterpart, including bounded immutable identifier aliases
- no loose equality, transformed/member reads, functional updaters, nested callbacks, userland equality helpers, shadowed `Object.is`, or mismatched writes

## Authentic occurrence

At pinned ant-design commit `17f007fbce59a772316c70cd4ea78d44588fb7e6`, `components/typography/Base/index.tsx:352` was reported for `isNativeEllipsis`. The effect is keyed by its inputs, contains the setter's only call, reads the state only in `isNativeEllipsis !== currentEllipsis`, and writes that exact `currentEllipsis` counterpart. Adding the state dependency only schedules a redundant post-write effect pass.

The exact baseline/candidate React Bench comparison removes only this finding. A React Cosmos benchmark case using a userland `isEqual` helper remains reported because arbitrary equality-name recognition cannot prove comparator semantics.

## Coverage

Paired regressions cover direct and aliased exact values, early returns, layout effects, React namespace/named aliases, TypeScript wrappers, external and sibling writers, setter escape and duplication, nested callbacks, additional state reads, property reads, empty dependencies, insertion effects, userland `useState`, userland `equal`/`notEqual` members, shadowed `Object.is`, loose coercion, binary `NaN`, and `0` versus `-0` identity.

A permanent fuzz corpus seed and valid/invalid generator shapes exercise the rule path.

## Validation

Exact base: `e5b06905ac10d6df538a63563f357272e624f5e3`  
Candidate: `41e18a8ebe30617eb4d0a396a68c9d75df6335bc`

- focused regression: 138/138 passed
- plugin suite: 554 files; 13,032 passed; 148 skipped
- repository tests: 14/14 tasks passed; React Doctor 2,243 passed and 27 skipped
- root typecheck: 15/15 tasks passed
- lint and format checks passed; lint emitted only existing warnings
- JSON report smoke passed
- strict fuzz: `FUZZ_RULE=exhaustive-deps FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz` passed
- fuzz fire proof: 38 programs executed, 16 fired; target rule fired (1/1)
- RDE: 100/100 repositories, 25,758 files, 101 → 101 target findings, no deltas or failures
- React Bench: 120/120 repositories, 96,853 files, 2,272 → 2,271, zero additions, one verified FP removal, no failures
- oracle states: 12/12, 8,333 files, 347 → 346, same verified removal, zero additions or failures

Fresh CI is green, the worktree and pushed head are exact, and no review threads remain unresolved. Do not merge automatically; this PR is ready for human review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds non-trivial effect semantics to a widely used lint rule; exemptions are narrow and heavily tested, but incorrect proofs could hide real stale-closure bugs.
> 
> **Overview**
> **`exhaustive-deps`** no longer flags **missing** state when that state is only read inside a **dominating equality guard** in a **`useEffect` / `useLayoutEffect`** that is provably the **only writer** for that state.
> 
> A new analyzer (`isSoleWriterEffectGuardCapture`) requires a real React **`useState`** pair, a **non-empty** deps array, a **single** direct setter call in the callback, **one** state read used in **`===` / `!==` / global `Object.is`**, and a setter argument that **matches** the guard’s compared value (with bounded const aliases). Matching captures are treated like **stable** deps—omitted from required keys, not reported as missing.
> 
> **`useInsertionEffect`** and unproven patterns (external writers, setter aliases, userland `useState`, custom equality helpers, loose equality, member reads, wrong writes) **still** report. Regression tests, a fuzz corpus seed, and fuzz snippet pools cover accept/reject cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41e18a8ebe30617eb4d0a396a68c9d75df6335bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Adversarial review follow-up

A cross-review found that the first implementation ignored guard polarity and suppressed equality branches that only write when the values already match. The corrected detector now requires the setter path to imply that the values differ, including direct comparisons, `Object.is`, negation, logical conjunction/disjunction, alternate branches, and exiting guards. Exact equality-branch controls continue reporting.

Post-fix validation: 150 focused regressions passed; the complete oxlint-plugin suite passed (13,135 tests, 148 skipped); package typecheck passed; strict 500-iteration exhaustive-deps fuzz passed; repo lint and format checks passed.
