### PR TITLE
fix(rule): recognize equal-length object projections

### DIFF
--- a/.changeset/tidy-pandas-compare.md
+++ b/.changeset/tidy-pandas-compare.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Avoid `js-length-check-first` diagnostics when `Object.keys` and `Object.values` project the same proven frozen plain object.

--- a/packages/fuzz/corpus/regressions/js-length-check-first--same-object-projections.tsx
+++ b/packages/fuzz/corpus/regressions/js-length-check-first--same-object-projections.tsx
@@ -1,0 +1,11 @@
+// rule: js-length-check-first
+// weakness: other
+// source: ISSUES_TO_FIX_ASAP.md same-object key/value projection report
+
+const defaultBindings = Object.freeze({ next: "j", previous: "k" });
+
+export const hasCompleteBindings = (bindings: Record<string, unknown>): boolean =>
+  Object.values(defaultBindings).every((_, index) => {
+    const key = Object.keys(defaultBindings)[index];
+    return typeof bindings[key] === "string";
+  });

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -196,6 +196,7 @@ export const MODULE_SCOPE_SNIPPET_POOL = [
   `import { motion as FuzzMotion } from "framer-motion"; export const FuzzMotionPanel = () => <FuzzMotion.div animate={{ x: 120 }}>moving</FuzzMotion.div>;`,
   `const GLOBAL_CACHE = new Map<string, unknown>();`,
   `class FuzzProtocolRegistry { static contextTypes = new Set(["json", "text"]); static childContextTypes = new Map(); getChildContext() { return { protocol: "json" }; } } const FuzzSchemaRegistry = {}; FuzzSchemaRegistry.contextTypes = new Set(["json", "text"]);`,
+  `const fuzzLeftItems = ["a", "b"]; const fuzzRightItems = ["a", "b"]; const fuzzItemsMatch = fuzzLeftItems.every((item, index) => item === fuzzRightItems[index]);`,
   `const FuzzPropTypesPanel = ({ value }) => <div>{value}</div>; FuzzPropTypesPanel.propTypes = { value: () => true };`,
   `function FuzzNestedWritePanel() { return <div />; } function unusedFuzzNestedWrite() { FuzzNestedWritePanel = () => null; } FuzzNestedWritePanel.propTypes = { value: () => true };`,
   `function FuzzReturnedLabel() { let output = "label"; function unusedFuzzOutputWrite() { output = <div />; } return output; } FuzzReturnedLabel.propTypes = { value: () => true };`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-length-check-first.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-length-check-first.regressions.test.ts
@@ -216,6 +216,23 @@ describe("js-performance/js-length-check-first — regressions", () => {
       );`);
   });
 
+  it("stays silent through length-preserving wrappers around complementary projections", () => {
+    expectPass(`const DEFAULTS = Object.freeze({ next: "j", previous: "k" });
+    const isComplete = (bindings) =>
+      [...Object.values(DEFAULTS)].map((value) => value).every((_, index) =>
+        typeof bindings[Object.keys(DEFAULTS).toSorted()[index]] === "string"
+      );`);
+  });
+
+  it("flags length-preserving wrappers around projections from different frozen objects", () => {
+    expectFail(`const LEFT = Object.freeze({ next: "j" });
+    const RIGHT = Object.freeze({ next: "j", previous: "k" });
+    const isComplete = (bindings) =>
+      [...Object.values(LEFT)].map((value) => value).every((_, index) =>
+        typeof bindings[Object.keys(RIGHT).toSorted()[index]] === "string"
+      );`);
+  });
+
   it("flags a non-frozen const plain object", () => {
     expectFail(`const DEFAULTS = { next: "j", previous: "k" } as const;
     const isComplete = (bindings) =>

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-length-check-first.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-length-check-first.regressions.test.ts
@@ -208,6 +208,14 @@ describe("js-performance/js-length-check-first — regressions", () => {
       );`);
   });
 
+  it("flags a computed Object.freeze call outside the shared integrity-method boundary", () => {
+    expectFail(`const DEFAULTS = Object["freeze"]({ next: "j", previous: "k" });
+    const isComplete = (bindings) =>
+      Object.values(DEFAULTS).every((_, index) =>
+        typeof bindings[Object.keys(DEFAULTS)[index]] === "string"
+      );`);
+  });
+
   it("stays silent when keys are iterated and values are indexed", () => {
     expectPass(`const DEFAULTS = Object.freeze({ next: "j", previous: "k" });
     const isComplete = (bindings) =>

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-length-check-first.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-length-check-first.regressions.test.ts
@@ -156,4 +156,188 @@ describe("js-performance/js-length-check-first — regressions", () => {
       return head.every((value, index) => value === b[index]);
     }`);
   });
+
+  it("stays silent for key and value projections of the same frozen plain object", () => {
+    expectPass(`interface KeyBindings {
+      next: string;
+      previous: string;
+    }
+    const DEFAULT_KEY_BINDINGS = Object.freeze<KeyBindings>({
+      next: "j",
+      previous: "k",
+    });
+    const isKeyBindings = (bindings) =>
+      Object.values(DEFAULT_KEY_BINDINGS).every((_, index) => {
+        const key = Object.keys(DEFAULT_KEY_BINDINGS)[index];
+        return typeof bindings[key] === "string";
+      });`);
+  });
+
+  it("stays silent for multi-hop const aliases of the same frozen source", () => {
+    expectPass(`const DEFAULTS = Object.freeze({ next: "j", previous: "k" });
+    const valuesSource = DEFAULTS;
+    const keysSource = valuesSource;
+    const isComplete = (bindings) =>
+      Object.values(valuesSource).every((_, index) =>
+        typeof bindings[Object.keys(keysSource)[index]] === "string"
+      );`);
+  });
+
+  it("stays silent when the frozen source is exported and passed to unknown callers", () => {
+    expectPass(`export const DEFAULTS = Object.freeze({ next: "j", previous: "k" });
+    registerDefaults(DEFAULTS);
+    const isComplete = (bindings) =>
+      Object.values(DEFAULTS).every((_, index) =>
+        typeof bindings[Object.keys(DEFAULTS)[index]] === "string"
+      );`);
+  });
+
+  it("flags projections of an imported source whose object shape is unknown", () => {
+    expectFail(`import { DEFAULTS } from "./defaults";
+    const isComplete = (bindings) =>
+      Object.values(DEFAULTS).every((_, index) =>
+        typeof bindings[Object.keys(DEFAULTS)[index]] === "string"
+      );`);
+  });
+
+  it("stays silent for statically computed Object projection methods", () => {
+    expectPass(`const DEFAULTS = Object.freeze({ next: "j", previous: "k" });
+    const isComplete = (bindings) =>
+      (Object["values"] as typeof Object.values)(DEFAULTS).every((_, index) =>
+        typeof bindings[Object[\`keys\`](DEFAULTS)[index]] === "string"
+      );`);
+  });
+
+  it("stays silent when keys are iterated and values are indexed", () => {
+    expectPass(`const DEFAULTS = Object.freeze({ next: "j", previous: "k" });
+    const isComplete = (bindings) =>
+      Object.keys(DEFAULTS).every((key, index) =>
+        bindings[key] === Object.values(DEFAULTS)[index]
+      );`);
+  });
+
+  it("flags a non-frozen const plain object", () => {
+    expectFail(`const DEFAULTS = { next: "j", previous: "k" } as const;
+    const isComplete = (bindings) =>
+      Object.values(DEFAULTS).every((_, index) =>
+        typeof bindings[Object.keys(DEFAULTS)[index]] === "string"
+      );`);
+  });
+
+  it("flags key and value projections from different frozen objects", () => {
+    expectFail(`const LEFT = Object.freeze({ next: "j" });
+    const RIGHT = Object.freeze({ next: "j", previous: "k" });
+    const isComplete = (bindings) =>
+      Object.values(LEFT).every((_, index) =>
+        typeof bindings[Object.keys(RIGHT)[index]] === "string"
+      );`);
+  });
+
+  it("flags a mutable plain object written between its projections", () => {
+    expectFail(`const defaults = { next: "j", previous: "k" };
+    const isComplete = (bindings) =>
+      Object.values(defaults).every((_, index) => {
+        if (index === 0) defaults.extra = "x";
+        return typeof bindings[Object.keys(defaults)[index]] === "string";
+      });`);
+  });
+
+  it("flags a mutable plain object that escapes to an unknown call", () => {
+    expectFail(`const defaults = { next: "j", previous: "k" };
+    registerDefaults(defaults);
+    const isComplete = (bindings) =>
+      Object.values(defaults).every((_, index) =>
+        typeof bindings[Object.keys(defaults)[index]] === "string"
+      );`);
+  });
+
+  it("flags object projections whose value getter can change cardinality", () => {
+    expectFail(`const defaults = {
+      get next() { delete this.previous; return "j"; },
+      previous: "k",
+    };
+    const isComplete = (bindings) =>
+      Object.values(defaults).every((_, index) =>
+        typeof bindings[Object.keys(defaults)[index]] === "string"
+      );`);
+  });
+
+  it("flags frozen accessor objects outside the primitive-data boundary", () => {
+    expectFail(`const defaults = Object.freeze({
+      get next() { return "j"; },
+      previous: "k",
+    });
+    const isComplete = (bindings) =>
+      Object.values(defaults).every((_, index) =>
+        typeof bindings[Object.keys(defaults)[index]] === "string"
+      );`);
+  });
+
+  it("stays silent after an ineffective property write to a frozen source", () => {
+    expectPass(`const defaults = Object.freeze({ next: "j", previous: "k" });
+    defaults.extra = "x";
+    const isComplete = (bindings) =>
+      Object.values(defaults).every((_, index) =>
+        typeof bindings[Object.keys(defaults)[index]] === "string"
+      );`);
+  });
+
+  it("flags projections of a proxy with runtime-defined own keys", () => {
+    expectFail(`const defaults = new Proxy({ next: "j" }, {
+      ownKeys: () => Math.random() > 0.5 ? ["next"] : ["next", "previous"],
+    });
+    const isComplete = (bindings) =>
+      Object.values(defaults).every((_, index) =>
+        typeof bindings[Object.keys(defaults)[index]] === "string"
+      );`);
+  });
+
+  it("flags a frozen proxy because its source is not a plain object literal", () => {
+    expectFail(`const defaults = Object.freeze(new Proxy({ next: "j" }, {}));
+    const isComplete = (bindings) =>
+      Object.values(defaults).every((_, index) =>
+        typeof bindings[Object.keys(defaults)[index]] === "string"
+      );`);
+  });
+
+  it("flags repeated effectful source evaluations", () => {
+    expectFail(`const isComplete = (bindings) =>
+      Object.values(getDefaults()).every((_, index) =>
+        typeof bindings[Object.keys(getDefaults())[index]] === "string"
+      );`);
+  });
+
+  it("flags similarly named methods on a shadowed Object binding", () => {
+    expectFail(`const Object = {
+      values: (source) => source.left,
+      keys: (source) => source.right,
+      freeze: (source) => source,
+    };
+    const defaults = Object.freeze({ left: ["j"], right: ["next", "previous"] });
+    const isComplete = (bindings) =>
+      Object.values(defaults).every((_, index) =>
+        typeof bindings[Object.keys(defaults)[index]] === "string"
+      );`);
+  });
+
+  it("flags a reassignable alias even when it starts from a frozen object", () => {
+    expectFail(`const DEFAULTS = Object.freeze({ next: "j" });
+    let source = DEFAULTS;
+    source = getOtherDefaults();
+    const isComplete = (bindings) =>
+      Object.values(source).every((_, index) =>
+        typeof bindings[Object.keys(DEFAULTS)[index]] === "string"
+      );`);
+  });
+
+  it("flags complementary projections through distinct frozen roots", () => {
+    expectFail(`const LEFT = Object.freeze({ next: "j" });
+    const RIGHT = Object.freeze({ previous: "k" });
+    const valuesSource = LEFT;
+    const keysSource = RIGHT;
+    const isComplete = (bindings) =>
+      Object.values(valuesSource).every((_, index) =>
+        typeof bindings[Object.keys(keysSource)[index]] === "string"
+      );`);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-length-check-first.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-length-check-first.ts
@@ -1,17 +1,132 @@
+import type { SymbolDescriptor } from "../../semantic/scope-analysis.js";
 import { areExpressionsStructurallyEqual } from "../../utils/are-expressions-structurally-equal.js";
 import { collectEarlierAndGuardOperands } from "../../utils/collect-earlier-and-guard-operands.js";
 import { collectPatternNames } from "../../utils/collect-pattern-names.js";
 import { defineRule } from "../../utils/define-rule.js";
 import { flattenLogicalAndChain } from "../../utils/flatten-logical-and-chain.js";
+import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
 import { getRootIdentifierName } from "../../utils/get-root-identifier-name.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isInlineFunctionExpression } from "../../utils/is-inline-function-expression.js";
 import { isMemberProperty } from "../../utils/is-member-property.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import { walkAst } from "../../utils/walk-ast.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
-import type { RuleContext } from "../../utils/rule-context.js";
-import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+
+interface ObjectProjection {
+  methodName: string;
+  source: EsTreeNode;
+}
+
+interface DirectConstSymbol extends SymbolDescriptor {
+  readonly initializer: EsTreeNode;
+}
+
+const OBJECT_CARDINALITY_PROJECTION_METHOD_NAMES: ReadonlySet<string> = new Set(["keys", "values"]);
+
+const getGlobalObjectProjection = (
+  expression: EsTreeNode,
+  context: RuleContext,
+): ObjectProjection | null => {
+  const callExpression = stripParenExpression(expression);
+  if (!isNodeOfType(callExpression, "CallExpression")) return null;
+  const callee = stripParenExpression(callExpression.callee);
+  if (!isNodeOfType(callee, "MemberExpression")) return null;
+  const receiver = stripParenExpression(callee.object);
+  if (
+    !isNodeOfType(receiver, "Identifier") ||
+    receiver.name !== "Object" ||
+    !context.scopes.isGlobalReference(receiver)
+  ) {
+    return null;
+  }
+  const methodName = getStaticPropertyName(callee);
+  if (!methodName || !OBJECT_CARDINALITY_PROJECTION_METHOD_NAMES.has(methodName)) return null;
+  const callArguments = callExpression.arguments ?? [];
+  if (callArguments.length !== 1 || isNodeOfType(callArguments[0], "SpreadElement")) return null;
+  return { methodName, source: callArguments[0] };
+};
+
+const isPlainDataObjectLiteral = (expression: EsTreeNode): boolean => {
+  const objectExpression = stripParenExpression(expression);
+  if (!isNodeOfType(objectExpression, "ObjectExpression")) return false;
+  return (objectExpression.properties ?? []).every((property) => {
+    if (
+      !isNodeOfType(property, "Property") ||
+      property.kind !== "init" ||
+      property.method === true
+    ) {
+      return false;
+    }
+    const propertyValue = stripParenExpression(property.value);
+    return (
+      isNodeOfType(propertyValue, "Literal") ||
+      (isNodeOfType(propertyValue, "TemplateLiteral") && propertyValue.expressions.length === 0)
+    );
+  });
+};
+
+const getGlobalObjectFreezeArgument = (
+  expression: EsTreeNode,
+  context: RuleContext,
+): EsTreeNode | null => {
+  const callExpression = stripParenExpression(expression);
+  if (!isNodeOfType(callExpression, "CallExpression")) return null;
+  const callee = stripParenExpression(callExpression.callee);
+  if (!isNodeOfType(callee, "MemberExpression") || getStaticPropertyName(callee) !== "freeze") {
+    return null;
+  }
+  const receiver = stripParenExpression(callee.object);
+  if (
+    !isNodeOfType(receiver, "Identifier") ||
+    receiver.name !== "Object" ||
+    !context.scopes.isGlobalReference(receiver)
+  ) {
+    return null;
+  }
+  const callArguments = callExpression.arguments ?? [];
+  if (callArguments.length !== 1 || isNodeOfType(callArguments[0], "SpreadElement")) return null;
+  return callArguments[0];
+};
+
+const isDirectConstSymbol = (symbol: SymbolDescriptor): symbol is DirectConstSymbol =>
+  symbol.kind === "const" &&
+  isNodeOfType(symbol.declarationNode, "VariableDeclarator") &&
+  symbol.declarationNode.id === symbol.bindingIdentifier &&
+  Boolean(symbol.initializer);
+
+const resolveStablePlainObjectRootId = (
+  expression: EsTreeNode,
+  context: RuleContext,
+  visitedSymbolIds: Set<number> = new Set(),
+): number | null => {
+  const source = stripParenExpression(expression);
+  if (!isNodeOfType(source, "Identifier")) return null;
+  const symbol = context.scopes.symbolFor(source);
+  if (!symbol || !isDirectConstSymbol(symbol) || visitedSymbolIds.has(symbol.id)) return null;
+  visitedSymbolIds.add(symbol.id);
+  const initializer = stripParenExpression(symbol.initializer);
+  const frozenValue = getGlobalObjectFreezeArgument(initializer, context);
+  if (frozenValue) return isPlainDataObjectLiteral(frozenValue) ? symbol.id : null;
+  return resolveStablePlainObjectRootId(initializer, context, visitedSymbolIds);
+};
+
+const areEqualCardinalityObjectProjections = (
+  receiverArray: EsTreeNode,
+  indexedArray: EsTreeNode,
+  context: RuleContext,
+): boolean => {
+  const receiverProjection = getGlobalObjectProjection(receiverArray, context);
+  const indexedProjection = getGlobalObjectProjection(indexedArray, context);
+  if (!receiverProjection || !indexedProjection) return false;
+  if (receiverProjection.methodName === indexedProjection.methodName) return false;
+  const receiverRootId = resolveStablePlainObjectRootId(receiverProjection.source, context);
+  const indexedRootId = resolveStablePlainObjectRootId(indexedProjection.source, context);
+  return receiverRootId !== null && receiverRootId === indexedRootId;
+};
 
 const findIndexedArrayObject = (
   callbackBody: EsTreeNode,
@@ -392,6 +507,9 @@ export const jsLengthCheckFirst = defineRule({
       // derivation like `.map()`): lengths are equal by construction, a
       // length precheck would be dead code.
       if (areExpressionsStructurallyEqual(resolvedReceiverSource, resolvedIndexedSource)) return;
+      if (areEqualCardinalityObjectProjections(receiverArrayObject, indexedArrayObject, context)) {
+        return;
+      }
 
       const comparedArrayPairs: [EsTreeNode, EsTreeNode][] = [
         [receiverArrayObject, indexedArrayObject],

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-length-check-first.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-length-check-first.ts
@@ -10,6 +10,7 @@ import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isInlineFunctionExpression } from "../../utils/is-inline-function-expression.js";
 import { isMemberProperty } from "../../utils/is-member-property.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import { getObjectIntegrityMethodName } from "../../utils/unwrap-object-integrity-expression.js";
 import { walkAst } from "../../utils/walk-ast.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
@@ -71,18 +72,7 @@ const getGlobalObjectFreezeArgument = (
 ): EsTreeNode | null => {
   const callExpression = stripParenExpression(expression);
   if (!isNodeOfType(callExpression, "CallExpression")) return null;
-  const callee = stripParenExpression(callExpression.callee);
-  if (!isNodeOfType(callee, "MemberExpression") || getStaticPropertyName(callee) !== "freeze") {
-    return null;
-  }
-  const receiver = stripParenExpression(callee.object);
-  if (
-    !isNodeOfType(receiver, "Identifier") ||
-    receiver.name !== "Object" ||
-    !context.scopes.isGlobalReference(receiver)
-  ) {
-    return null;
-  }
+  if (getObjectIntegrityMethodName(callExpression, context.scopes) !== "freeze") return null;
   const callArguments = callExpression.arguments ?? [];
   if (callArguments.length !== 1 || isNodeOfType(callArguments[0], "SpreadElement")) return null;
   return callArguments[0];

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-length-check-first.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-length-check-first.ts
@@ -1,9 +1,9 @@
-import type { SymbolDescriptor } from "../../semantic/scope-analysis.js";
 import { areExpressionsStructurallyEqual } from "../../utils/are-expressions-structurally-equal.js";
 import { collectEarlierAndGuardOperands } from "../../utils/collect-earlier-and-guard-operands.js";
 import { collectPatternNames } from "../../utils/collect-pattern-names.js";
 import { defineRule } from "../../utils/define-rule.js";
 import { flattenLogicalAndChain } from "../../utils/flatten-logical-and-chain.js";
+import { getDirectConstInitializer } from "../../utils/get-direct-const-initializer.js";
 import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
 import { getRootIdentifierName } from "../../utils/get-root-identifier-name.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
@@ -19,10 +19,6 @@ import type { RuleContext } from "../../utils/rule-context.js";
 interface ObjectProjection {
   methodName: string;
   source: EsTreeNode;
-}
-
-interface DirectConstSymbol extends SymbolDescriptor {
-  readonly initializer: EsTreeNode;
 }
 
 const OBJECT_CARDINALITY_PROJECTION_METHOD_NAMES: ReadonlySet<string> = new Set(["keys", "values"]);
@@ -92,12 +88,6 @@ const getGlobalObjectFreezeArgument = (
   return callArguments[0];
 };
 
-const isDirectConstSymbol = (symbol: SymbolDescriptor): symbol is DirectConstSymbol =>
-  symbol.kind === "const" &&
-  isNodeOfType(symbol.declarationNode, "VariableDeclarator") &&
-  symbol.declarationNode.id === symbol.bindingIdentifier &&
-  Boolean(symbol.initializer);
-
 const resolveStablePlainObjectRootId = (
   expression: EsTreeNode,
   context: RuleContext,
@@ -106,9 +96,11 @@ const resolveStablePlainObjectRootId = (
   const source = stripParenExpression(expression);
   if (!isNodeOfType(source, "Identifier")) return null;
   const symbol = context.scopes.symbolFor(source);
-  if (!symbol || !isDirectConstSymbol(symbol) || visitedSymbolIds.has(symbol.id)) return null;
+  if (!symbol || visitedSymbolIds.has(symbol.id)) return null;
+  const directConstInitializer = getDirectConstInitializer(symbol);
+  if (!directConstInitializer) return null;
   visitedSymbolIds.add(symbol.id);
-  const initializer = stripParenExpression(symbol.initializer);
+  const initializer = stripParenExpression(directConstInitializer);
   const frozenValue = getGlobalObjectFreezeArgument(initializer, context);
   if (frozenValue) return isPlainDataObjectLiteral(frozenValue) ? symbol.id : null;
   return resolveStablePlainObjectRootId(initializer, context, visitedSymbolIds);
@@ -507,7 +499,10 @@ export const jsLengthCheckFirst = defineRule({
       // derivation like `.map()`): lengths are equal by construction, a
       // length precheck would be dead code.
       if (areExpressionsStructurallyEqual(resolvedReceiverSource, resolvedIndexedSource)) return;
-      if (areEqualCardinalityObjectProjections(receiverArrayObject, indexedArrayObject, context)) {
+      if (
+        areEqualCardinalityObjectProjections(receiverArrayObject, indexedArrayObject, context) ||
+        areEqualCardinalityObjectProjections(resolvedReceiverSource, resolvedIndexedSource, context)
+      ) {
         return;
       }
 


### PR DESCRIPTION
## Summary

- Suppress js-length-check-first only when complementary global Object.keys and Object.values calls resolve through direct const aliases to the same Object.freeze primitive-data object literal.
- Reuse the canonical direct-const initializer and object-integrity helpers, and carry the proof through existing length-preserving wrappers such as spread, map, and toSorted.
- Keep imported, non-frozen, reassignable, accessor, proxy, shadowed-global, effectful, computed-integrity-method, and different-root cases reportable.
- Add paired adversarial regressions, a permanent fuzz seed, generator liveness coverage, and a patch changeset.

## Precision boundary

This is intentionally a same-file proof. The authentic React Bench model imports a non-frozen object from another module, so it remains reported. Cross-file shape and mutation proof is a non-goal for this patch.

## Validation

- Focused rule regressions: 41 passed.
- Plugin suite: 13,117 passed, 148 skipped.
- Package and root typecheck, lint, format check, diff check, build, and JSON-report smoke check passed.
- Strict target fuzz: 500 requested; 319 executed, 193 parser-skipped, target fired 8 times, zero findings.
- Fuzz corpus: 43 passed, 400 opt-in tests skipped.
- Final target-only OSS parity: 100 of 100 repository scans succeeded across 10,522 files with zero target or global deltas. A whole-repository rescan of the three pinned repositories containing every known target finding covered 27,693 files and preserved all seven findings 7 to 7 with no added or removed diagnostics. The official RDE CLI attempts were excluded because its current schema accepts report versions 1 and 2 while both exact builds emit version 3.
- Independent frozen-object fixture: target findings 2 to 1; only the intended same-object diagnostic was removed while the independent-array control remained.
- Exact pinned benchmark reconstruction: model 1 to 1 and oracle 0 to 0. The model source is imported and non-frozen, so this PR does not claim to resolve that cross-file report.
- Full repository run: 2,241 tests passed and 27 skipped; two unrelated built-CLI performance tests exceeded the 30-second timeout under full-suite load. The complete performance harness then passed 22 of 22 in isolation, including those cases in 21.9s and 18.8s.
- Bugbot findings reproduced and fixed: length-preserving projection wrappers now share the proof, duplicate direct-const logic uses the existing helper, and Object.freeze provenance uses the shared integrity-method detector while retaining the conservative non-computed boundary.

Do not merge automatically.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-only precision change in one rule with broad regression coverage; no runtime or API impact.
> 
> **Overview**
> **`js-length-check-first`** no longer reports when `.every()` pairs **`Object.values(…)`** with **`Object.keys(…)[index]`** (or the reverse) and both projections trace to the **same** `const` binding whose initializer is **`Object.freeze`** on a **plain literal-only** object. The rule reuses existing scope helpers (`getDirectConstInitializer`, `getObjectIntegrityMethodName`) and applies the exemption after length-preserving peels (spread, `map`, `toSorted`, etc.).
> 
> **Still flagged:** imported defaults, mutable or reassigned sources, accessors/getters, proxies, shadowed `Object`, computed `Object["freeze"]`, different frozen roots, and effectful `getDefaults()`-style calls.
> 
> Adds a large regression matrix, a fuzz corpus fixture, a module-scope fuzz seed, and a patch changeset for `oxlint-plugin-react-doctor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a115d62123c7438ccc6d5f0662cf8c6bbfc9a4b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->