### PR TITLE
fix(exhaustive-deps): respect same-value bailouts

### DIFF
--- a/.changeset/calm-effects-settle.md
+++ b/.changeset/calm-effects-settle.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Avoid reporting every-commit effects whose state updates can converge through React's same-value bailout.

--- a/packages/fuzz/corpus/regressions/exhaustive-deps--constant-primitive-state.tsx
+++ b/packages/fuzz/corpus/regressions/exhaustive-deps--constant-primitive-state.tsx
@@ -1,0 +1,13 @@
+// rule: exhaustive-deps
+// weakness: effect-semantics
+// source: react-bench internxt/drive-web oracle validation
+import { useEffect, useState } from "react";
+
+export const MobilePlatform = () => {
+  const [platform, setPlatform] = useState("");
+  useEffect(() => {
+    if (navigator.userAgent.includes("iPhone")) setPlatform("iphone");
+    if (navigator.userAgent.includes("Android")) setPlatform("android");
+  });
+  return <output>{platform}</output>;
+};

--- a/packages/fuzz/corpus/regressions/exhaustive-deps--derived-child-count.tsx
+++ b/packages/fuzz/corpus/regressions/exhaustive-deps--derived-child-count.tsx
@@ -1,0 +1,12 @@
+// rule: exhaustive-deps
+// weakness: effect-semantics
+// source: react-bench coreui/coreui-react oracle validation
+import { Children, useEffect, useState } from "react";
+
+export const CarouselItemCount = ({ children }) => {
+  const [itemCount, setItemCount] = useState(0);
+  useEffect(() => {
+    setItemCount(Children.toArray(children).length);
+  });
+  return <output>{itemCount}</output>;
+};

--- a/packages/fuzz/corpus/regressions/exhaustive-deps--dom-derived-stable-primitive.tsx
+++ b/packages/fuzz/corpus/regressions/exhaustive-deps--dom-derived-stable-primitive.tsx
@@ -1,0 +1,19 @@
+// rule: exhaustive-deps
+// weakness: effect-semantics
+// source: react-bench trial e010b839-cbfd-4b6e-b0d8-88360ad7df41
+import { useLayoutEffect, useState } from "react";
+
+const contextPattern = /awsui-context-([\w-]+)/;
+
+export const VisualContext = ({ elementRef }) => {
+  const [value, setValue] = useState("");
+  useLayoutEffect(() => {
+    if (elementRef.current) {
+      const contextParent = findUpUntil(elementRef.current, (node) =>
+        Boolean(node.className.match(contextPattern)),
+      );
+      setValue(contextParent?.className.match(contextPattern)?.[1] ?? "");
+    }
+  });
+  return <output>{value}</output>;
+};

--- a/packages/fuzz/corpus/regressions/exhaustive-deps--guarded-primitive-resets.tsx
+++ b/packages/fuzz/corpus/regressions/exhaustive-deps--guarded-primitive-resets.tsx
@@ -1,0 +1,16 @@
+// rule: exhaustive-deps
+// weakness: effect-semantics
+// source: react-bench glific/glific-frontend oracle validation
+import { useEffect, useState } from "react";
+
+export const ExtensionForm = ({ openDialog }) => {
+  const [name, setName] = useState("ready");
+  const [isActive, setIsActive] = useState(true);
+  useEffect(() => {
+    if (!openDialog) {
+      setName("");
+      setIsActive(false);
+    }
+  });
+  return <output>{name + String(isActive)}</output>;
+};

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -71,6 +71,10 @@ export const EFFECT_SNIPPET_POOL = [
   `const fuzzDocumentEventArguments = condition ? [] : [() => handle(value), [value]]; useFuzzDocumentEvents(...fuzzDocumentEventArguments);`,
   `const fuzzDocumentEventOptions = { callback: () => handle(value) }; fuzzDocumentEventOptions.callback = handle; useFuzzDocumentEventOptions(fuzzDocumentEventOptions);`,
   `const fuzzSessionKey = String(value); const fuzzSessionUser = { role: value ? "admin" : "user" }; useEffect(() => { showLiveRole(fuzzSessionUser.role); }, [fuzzSessionKey]);`,
+  `const [domClassName, setDomClassName] = useState(""); const domClassRef = useRef(null); useLayoutEffect(() => { setDomClassName(domClassRef.current?.className ?? ""); });`,
+  `const [loopSnapshot, setLoopSnapshot] = useState(null); useEffect(() => { setLoopSnapshot({ value }); });`,
+  `const [fuzzPlatform, setFuzzPlatform] = useState(""); useEffect(() => { setFuzzPlatform(navigator.userAgent.includes("Mobile") ? "mobile" : "desktop"); });`,
+  `const [fuzzChildCount, setFuzzChildCount] = useState(0); useEffect(() => { setFuzzChildCount(Children.toArray(children).length); });`,
 ] as const;
 
 // State — lazy initializers (incl. SSR-hazardous localStorage/matchMedia),

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/__fixtures__/oxc-divergences.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/__fixtures__/oxc-divergences.ts
@@ -17,9 +17,9 @@ export interface OxcDivergence {
 
 export const DIVERGENCES: Record<string, OxcDivergence> = {
   "exhaustive-deps": {
-    failSkips: [81],
+    failSkips: [81, 125, 126, 127],
     reason:
-      "Intentional: exact props members suppress a synthetic whole-props dependency, and useMemo accepts extra reactive invalidation tokens.",
+      "Intentional: exact props members suppress a synthetic whole-props dependency, unknown or deferred state values can converge through React's same-value bailout, and useMemo accepts extra reactive invalidation tokens.",
   },
   "no-unknown-property": {
     // fp-review: 1110 unique false positives vs 28 true positives (1%

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/__upstream-fixtures__/divergences.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/__upstream-fixtures__/divergences.ts
@@ -20,7 +20,7 @@ export const RULES_OF_HOOKS_DIVERGENCES: UpstreamDivergence = {
 };
 
 export const EXHAUSTIVE_DEPS_DIVERGENCES: UpstreamDivergence = {
-  invalidSkips: [82, 187],
+  invalidSkips: [82, 130, 131, 132, 187],
   reason:
-    "Intentional: exact props members suppress a synthetic whole-props dependency, and useMemo accepts extra reactive invalidation tokens while useCallback remains strict.",
+    "Intentional: exact props members suppress a synthetic whole-props dependency; unknown or deferred state values can converge through React's same-value bailout; and useMemo accepts extra reactive invalidation tokens while useCallback remains strict.",
 };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps-messages.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps-messages.ts
@@ -52,7 +52,7 @@ export const buildForwardedUnstableDepMessage = (depName: string): string =>
   `\`${depName}\` is rebuilt every render and reaches a Hook dependency inside this custom Hook.`;
 
 export const buildSetStateWithoutDepsMessage = (hookName: string, setterName: string): string =>
-  `\`${hookName}\` calls \`${setterName}\` with no dependency array, so it can loop forever & freeze the component.`;
+  `\`${hookName}\` calls \`${setterName}\` with a value that can change on every render and no dependency array, so it can keep triggering renders.`;
 
 export const buildRefCleanupMessage = (depName: string): string =>
   `Your cleanup may read the wrong node since the ref \`${depName}\` can change before it runs.`;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.asap.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.asap.test.ts
@@ -86,3 +86,238 @@ describe("exhaustive-deps — every-commit converging setters", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 });
+
+describe("exhaustive-deps — direct setter bailout precision", () => {
+  it("accepts the DOM-derived primitive state update from the reported Cloudscape trial", () => {
+    const result = runRule(
+      exhaustiveDeps,
+      `const contextMatch = /awsui-context-([\\w-]+)/;
+      function useVisualContext(elementRef) {
+        const [value, setValue] = useState("");
+        useLayoutEffect(() => {
+          if (elementRef.current) {
+            const contextParent = findUpUntil(
+              elementRef.current,
+              node => Boolean(node.className.match(contextMatch)),
+            );
+            setValue(contextParent?.className.match(contextMatch)?.[1] ?? "");
+          }
+        });
+        return value;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it.each([
+    'setValue(elementRef.current?.className ?? "")',
+    "setValue(value)",
+    "setValue(STABLE_VALUE)",
+    "setValue(true)",
+    'setValue("iphone")',
+    "setValue(Children.toArray(children).length)",
+    "setValue((previous) => previous)",
+    "setValue((previous) => (previous === nextValue ? previous : nextValue))",
+    'setValue((previous) => { if (nextValue === "ready") return previous; return previous + 1; })',
+    "setValue((previous) => { previous.ready = true; return previous; })",
+    "setValue(Object.assign(value, { ready: true }))",
+    "setValue(new Object(value))",
+    "setValue(nextValue)",
+  ])("accepts the potentially converging update %s", (setterStatement) => {
+    const result = runRule(
+      exhaustiveDeps,
+      `const STABLE_VALUE = "ready";
+      function Example({ nextValue, elementRef }) {
+        const [value, setValue] = useState("");
+        useEffect(() => { ${setterStatement}; });
+        return value;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it.each([
+    "setValue({ ready: true })",
+    "setValue({ ...value })",
+    "setValue([])",
+    "setValue([...value])",
+    "setValue(<span />)",
+    "setValue(/ready/)",
+    "setValue(Array())",
+    "setValue(Array(value))",
+    "setValue(Object())",
+    "setValue(new Map())",
+    "setValue(new Map(value))",
+    "setValue(new Object())",
+    "setValue(new RegExp(value))",
+    "setValue(value + 1)",
+    "setValue(value - 1)",
+    "setValue((previous) => previous + 1)",
+    "setValue((previous) => { return previous + 1; })",
+    "setValue((previous) => !previous)",
+    "setValue((previous) => ({ previous }))",
+  ])("reports the render-changing update %s", (setterStatement) => {
+    const result = runRule(
+      exhaustiveDeps,
+      `function Example() {
+        const [value, setValue] = useState(0);
+        useEffect(() => { ${setterStatement}; });
+        return value;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("follows direct aliases of the setter and state value", () => {
+    const result = runRule(
+      exhaustiveDeps,
+      `function Example() {
+        const [value, setValue] = useState(0);
+        const currentValue = value;
+        const updateValue = setValue;
+        useEffect(() => { updateValue(currentValue + 1); });
+        return value;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("follows multi-hop aliases through TypeScript expression wrappers", () => {
+    const result = runRule(
+      exhaustiveDeps,
+      `function Example() {
+        const [value, setValue] = useState(0);
+        const currentValue = value as number;
+        const firstUpdate = setValue;
+        const updateValue = firstUpdate!;
+        useEffect(() => { updateValue((currentValue) + 1); });
+        return value;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports render-changing updates behind branches and early returns", () => {
+    const result = runRule(
+      exhaustiveDeps,
+      `function Example({ ready }) {
+        const [value, setValue] = useState(null);
+        useEffect(() => {
+          if (!ready) return;
+          if (value) setValue([]);
+          else setValue({ ready });
+        });
+        return value;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("accepts multiple guarded primitive resets in one every-commit effect", () => {
+    const result = runRule(
+      exhaustiveDeps,
+      `function Extension({ openDialog }) {
+        const [name, setName] = useState("ready");
+        const [code, setCode] = useState("saved");
+        const [isActive, setIsActive] = useState(true);
+        useEffect(() => {
+          if (!openDialog) {
+            setName("");
+            setCode("");
+            setIsActive(false);
+          }
+        });
+        return name + code + isActive;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("reports fresh local aliases but accepts module-scope object references", () => {
+    const freshResult = runRule(
+      exhaustiveDeps,
+      `function Example() {
+        const [, setValue] = useState(null);
+        const freshValue = { ready: true };
+        useEffect(() => { setValue(freshValue); });
+        return null;
+      }`,
+    );
+    const stableResult = runRule(
+      exhaustiveDeps,
+      `const stableValue = { ready: true };
+      function Example() {
+        const [, setValue] = useState(null);
+        useEffect(() => { setValue(stableValue); });
+        return null;
+      }`,
+    );
+    expect(freshResult.parseErrors).toEqual([]);
+    expect(freshResult.diagnostics).toHaveLength(1);
+    expect(stableResult.parseErrors).toEqual([]);
+    expect(stableResult.diagnostics).toEqual([]);
+  });
+
+  it("ignores userland setter names and deferred React setters", () => {
+    const userlandResult = runRule(
+      exhaustiveDeps,
+      `function Example() {
+        const setValue = (value) => value;
+        useEffect(() => { setValue({ ready: true }); });
+        return null;
+      }`,
+    );
+    const deferredResult = runRule(
+      exhaustiveDeps,
+      `function Example() {
+        const [value, setValue] = useState(null);
+        useEffect(() => { queueMicrotask(() => setValue({ ready: true })); });
+        return value;
+      }`,
+    );
+    expect(userlandResult.parseErrors).toEqual([]);
+    expect(userlandResult.diagnostics).toEqual([]);
+    expect(deferredResult.parseErrors).toEqual([]);
+    expect(deferredResult.diagnostics).toEqual([]);
+  });
+
+  it("does not treat shadowed constructors as proof of fresh state", () => {
+    const result = runRule(
+      exhaustiveDeps,
+      `function Example({ stableValue }) {
+        const Array = () => stableValue;
+        const Object = () => stableValue;
+        const Map = function () { return stableValue; };
+        const [value, setValue] = useState(null);
+        useEffect(() => {
+          setValue(Array(value));
+          setValue(Object());
+          setValue(new Map());
+        });
+        return value;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not run the every-commit check when dependencies are present", () => {
+    const result = runRule(
+      exhaustiveDeps,
+      `function Example({ value }) {
+        const [, setValue] = useState(null);
+        useEffect(() => { setValue({ value }); }, [value]);
+        return null;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.ts
@@ -681,16 +681,282 @@ const hasDirectIdentifierDeclarator = (symbol: SymbolDescriptor): boolean =>
 const isFunctionValueSymbol = (symbol: SymbolDescriptor): boolean =>
   getFunctionValueNode(symbol) !== null;
 
-const isStableSetterLikeSymbol = (symbol: SymbolDescriptor, scopes: ScopeAnalysis): boolean => {
-  if (!symbolHasStableHookOrigin(symbol, scopes)) return false;
+interface StateSetterDescriptor {
+  setterSymbol: SymbolDescriptor;
+  stateSymbol: SymbolDescriptor | null;
+}
+
+const FRESH_STATE_CONSTRUCTOR_NAMES: ReadonlySet<string> = new Set([
+  "Array",
+  "Date",
+  "Error",
+  "Map",
+  "Object",
+  "RegExp",
+  "Set",
+  "WeakMap",
+  "WeakSet",
+]);
+
+const getBindingIdentifier = (node: EsTreeNode | null | undefined): EsTreeNode | null => {
+  if (!node) return null;
+  const candidate = isNodeOfType(node, "AssignmentPattern") ? node.left : node;
+  return isNodeOfType(candidate, "Identifier") ? candidate : null;
+};
+
+const resolveStateSetterSymbol = (
+  identifier: EsTreeNode,
+  scopes: ScopeAnalysis,
+): SymbolDescriptor | null => {
+  const visitedSymbolIds = new Set<number>();
+  let symbol = scopes.symbolFor(identifier);
+  while (
+    symbol?.kind === "const" &&
+    isNodeOfType(symbol.declarationNode, "VariableDeclarator") &&
+    symbol.declarationNode.id === symbol.bindingIdentifier &&
+    symbol.initializer
+  ) {
+    if (visitedSymbolIds.has(symbol.id)) return null;
+    visitedSymbolIds.add(symbol.id);
+    const initializer = unwrapExpression(symbol.initializer);
+    if (!isNodeOfType(initializer, "Identifier")) return symbol;
+    symbol = scopes.symbolFor(initializer);
+  }
+  return symbol;
+};
+
+const getStateSetterDescriptor = (
+  identifier: EsTreeNode,
+  scopes: ScopeAnalysis,
+): StateSetterDescriptor | null => {
+  const setterSymbol = resolveStateSetterSymbol(identifier, scopes);
+  if (!setterSymbol || !isNodeOfType(setterSymbol.declarationNode, "VariableDeclarator")) {
+    return null;
+  }
+  const declarator = setterSymbol.declarationNode;
+  if (!isNodeOfType(declarator.id, "ArrayPattern")) return null;
+  const setterElement = declarator.id.elements?.[1];
+  const setterBinding = isAstNode(setterElement) ? getBindingIdentifier(setterElement) : null;
+  if (!setterBinding || setterBinding !== setterSymbol.bindingIdentifier) return null;
+  const initializer = declarator.init ? unwrapExpression(declarator.init) : null;
+  if (
+    !initializer ||
+    !isNodeOfType(initializer, "CallExpression") ||
+    !isReactApiCall(initializer, "useState", scopes, {
+      allowGlobalReactNamespace: true,
+      allowUnboundBareCalls: true,
+      resolveNamedAliases: true,
+    })
+  ) {
+    return null;
+  }
+  const stateElement = declarator.id.elements?.[0];
+  const stateBinding = isAstNode(stateElement) ? getBindingIdentifier(stateElement) : null;
+  return {
+    setterSymbol,
+    stateSymbol: stateBinding ? scopes.symbolFor(stateBinding) : null,
+  };
+};
+
+const expressionReadsSymbol = (
+  node: EsTreeNode,
+  symbol: SymbolDescriptor | null,
+  scopes: ScopeAnalysis,
+  visitedSymbolIds: ReadonlySet<number> = new Set(),
+): boolean => {
+  if (!symbol) return false;
+  const candidate = unwrapExpression(node);
+  if (isNodeOfType(candidate, "Identifier")) {
+    const reference = scopes.referenceFor(candidate);
+    if (reference?.flag !== "write" && reference?.resolvedSymbol?.id === symbol.id) return true;
+    const candidateSymbol = reference?.resolvedSymbol;
+    if (
+      candidateSymbol?.kind === "const" &&
+      candidateSymbol.initializer &&
+      !isOutsideAllFunctions(candidateSymbol) &&
+      !visitedSymbolIds.has(candidateSymbol.id)
+    ) {
+      const nextVisitedSymbolIds = new Set(visitedSymbolIds);
+      nextVisitedSymbolIds.add(candidateSymbol.id);
+      return expressionReadsSymbol(
+        candidateSymbol.initializer,
+        symbol,
+        scopes,
+        nextVisitedSymbolIds,
+      );
+    }
+    return false;
+  }
+  const record = candidate as unknown as Record<string, unknown>;
+  for (const key of Object.keys(record)) {
+    if (key === "parent") continue;
+    const child = record[key];
+    if (Array.isArray(child)) {
+      if (child.some((item) => isAstNode(item) && expressionReadsSymbol(item, symbol, scopes))) {
+        return true;
+      }
+    } else if (isAstNode(child) && expressionReadsSymbol(child, symbol, scopes)) {
+      return true;
+    }
+  }
+  return false;
+};
+
+const isGuaranteedFreshStateValue = (
+  node: EsTreeNode,
+  scopes: ScopeAnalysis,
+  visitedSymbolIds: ReadonlySet<number> = new Set(),
+): boolean => {
+  const candidate = unwrapExpression(node);
+  if (
+    isNodeOfType(candidate, "ObjectExpression") ||
+    isNodeOfType(candidate, "ArrayExpression") ||
+    isNodeOfType(candidate, "JSXElement") ||
+    isNodeOfType(candidate, "JSXFragment") ||
+    isRegExpLiteral(candidate)
+  ) {
+    return true;
+  }
+  if (isNodeOfType(candidate, "SequenceExpression")) {
+    const finalExpression = candidate.expressions.at(-1);
+    return Boolean(finalExpression && isGuaranteedFreshStateValue(finalExpression, scopes));
+  }
+  if (isNodeOfType(candidate, "ConditionalExpression")) {
+    return (
+      isGuaranteedFreshStateValue(candidate.consequent, scopes, visitedSymbolIds) &&
+      isGuaranteedFreshStateValue(candidate.alternate, scopes, visitedSymbolIds)
+    );
+  }
+  if (isNodeOfType(candidate, "LogicalExpression")) {
+    return (
+      isGuaranteedFreshStateValue(candidate.left, scopes, visitedSymbolIds) &&
+      isGuaranteedFreshStateValue(candidate.right, scopes, visitedSymbolIds)
+    );
+  }
+  if (isNodeOfType(candidate, "CallExpression")) {
+    const callee = unwrapExpression(candidate.callee);
+    return (
+      isNodeOfType(callee, "Identifier") &&
+      scopes.isGlobalReference(callee) &&
+      (callee.name === "Array" || callee.name === "Object") &&
+      (callee.name === "Array" || candidate.arguments.length === 0)
+    );
+  }
+  if (isNodeOfType(candidate, "NewExpression")) {
+    const callee = unwrapExpression(candidate.callee);
+    return (
+      isNodeOfType(callee, "Identifier") &&
+      scopes.isGlobalReference(callee) &&
+      FRESH_STATE_CONSTRUCTOR_NAMES.has(callee.name) &&
+      (callee.name !== "Object" || candidate.arguments.length === 0)
+    );
+  }
+  if (!isNodeOfType(candidate, "Identifier")) return false;
+  const symbol = scopes.symbolFor(candidate);
+  if (
+    !symbol ||
+    symbol.kind !== "const" ||
+    !symbol.initializer ||
+    isOutsideAllFunctions(symbol) ||
+    visitedSymbolIds.has(symbol.id)
+  ) {
+    return false;
+  }
+  const nextVisitedSymbolIds = new Set(visitedSymbolIds);
+  nextVisitedSymbolIds.add(symbol.id);
+  return isGuaranteedFreshStateValue(symbol.initializer, scopes, nextVisitedSymbolIds);
+};
+
+const isNonZeroLiteral = (node: EsTreeNode): boolean => {
+  const candidate = unwrapExpression(node);
   return (
-    symbol.name.startsWith("set") ||
-    symbol.name.startsWith("dispatch") ||
-    symbol.name.startsWith("startTransition")
+    isNodeOfType(candidate, "Literal") &&
+    ((typeof candidate.value === "number" && candidate.value !== 0) ||
+      (typeof candidate.value === "bigint" && candidate.value !== 0n) ||
+      (typeof candidate.value === "string" && candidate.value.length > 0))
   );
 };
 
-const isConvergingFunctionalUpdater = (node: EsTreeNode, scopes: ScopeAnalysis): boolean => {
+const isProvablyChangingExpression = (
+  node: EsTreeNode,
+  previousValueSymbol: SymbolDescriptor | null,
+  scopes: ScopeAnalysis,
+): boolean => {
+  const candidate = unwrapExpression(node);
+  if (isGuaranteedFreshStateValue(candidate, scopes)) return true;
+  if (isNodeOfType(candidate, "ConditionalExpression")) {
+    const isConsequentChanging = isProvablyChangingExpression(
+      candidate.consequent,
+      previousValueSymbol,
+      scopes,
+    );
+    const isAlternateChanging = isProvablyChangingExpression(
+      candidate.alternate,
+      previousValueSymbol,
+      scopes,
+    );
+    return expressionReadsSymbol(candidate.test, previousValueSymbol, scopes)
+      ? isConsequentChanging && isAlternateChanging
+      : isConsequentChanging || isAlternateChanging;
+  }
+  if (!expressionReadsSymbol(candidate, previousValueSymbol, scopes)) return false;
+  if (isNodeOfType(candidate, "UnaryExpression")) return candidate.operator === "!";
+  if (isNodeOfType(candidate, "UpdateExpression")) return true;
+  if (!isNodeOfType(candidate, "BinaryExpression")) return false;
+  return (
+    (candidate.operator === "+" || candidate.operator === "-") &&
+    expressionReadsSymbol(candidate.left, previousValueSymbol, scopes) &&
+    isNonZeroLiteral(candidate.right)
+  );
+};
+
+const isFreshEqualityGuardUpdater = (
+  node: EsTreeNode,
+  previousValueSymbol: SymbolDescriptor | null,
+  scopes: ScopeAnalysis,
+): boolean => {
+  const candidate = unwrapExpression(node);
+  if (!isNodeOfType(candidate, "ConditionalExpression")) return false;
+  const test = unwrapExpression(candidate.test);
+  if (
+    !isNodeOfType(test, "BinaryExpression") ||
+    !["===", "!==", "==", "!="].includes(test.operator)
+  ) {
+    return false;
+  }
+  const isPreviousValue = (expression: EsTreeNode): boolean => {
+    const expressionCandidate = unwrapExpression(expression);
+    return (
+      isNodeOfType(expressionCandidate, "Identifier") &&
+      scopes.symbolFor(expressionCandidate)?.id === previousValueSymbol?.id
+    );
+  };
+  let comparedValue: EsTreeNode | null = null;
+  if (isPreviousValue(test.left)) comparedValue = test.right;
+  if (isPreviousValue(test.right)) comparedValue = test.left;
+  if (!comparedValue || !isPotentiallyFreshComparedValue(comparedValue, scopes)) return false;
+  const isComparedValue = (expression: EsTreeNode): boolean => {
+    const expressionCandidate = unwrapExpression(expression);
+    const comparedCandidate = unwrapExpression(comparedValue);
+    if (isNodeOfType(expressionCandidate, "Identifier")) {
+      return (
+        isNodeOfType(comparedCandidate, "Identifier") &&
+        scopes.symbolFor(expressionCandidate)?.id === scopes.symbolFor(comparedCandidate)?.id
+      );
+    }
+    return (
+      isNodeOfType(expressionCandidate, "Literal") &&
+      isNodeOfType(comparedCandidate, "Literal") &&
+      expressionCandidate.value === comparedCandidate.value
+    );
+  };
+  const equalityTest = test.operator === "===" || test.operator === "==";
+  return equalityTest
+    ? isPreviousValue(candidate.consequent) && isComparedValue(candidate.alternate)
+    : isComparedValue(candidate.consequent) && isPreviousValue(candidate.alternate);
+};
+
+const isProvablyChangingFunctionalUpdater = (node: EsTreeNode, scopes: ScopeAnalysis): boolean => {
   const updater = unwrapExpression(node);
   if (
     !isNodeOfType(updater, "ArrowFunctionExpression") &&
@@ -700,70 +966,48 @@ const isConvergingFunctionalUpdater = (node: EsTreeNode, scopes: ScopeAnalysis):
   }
   const previousValueParameter = updater.params?.[0];
   if (!previousValueParameter || !isNodeOfType(previousValueParameter, "Identifier")) return false;
-  let returnedExpression: EsTreeNode | null | undefined = updater.body;
-  if (isNodeOfType(updater.body, "BlockStatement")) {
-    returnedExpression = null;
-    for (const statement of updater.body.body ?? []) {
-      if (isNodeOfType(statement, "ReturnStatement") && statement.argument) {
-        returnedExpression = statement.argument;
-        break;
-      }
-    }
+  const previousValueSymbol = scopes.symbolFor(previousValueParameter);
+  if (!isNodeOfType(updater.body, "BlockStatement")) {
+    return (
+      isFreshEqualityGuardUpdater(updater.body, previousValueSymbol, scopes) ||
+      isProvablyChangingExpression(updater.body, previousValueSymbol, scopes)
+    );
   }
-  const conditional = returnedExpression ? unwrapExpression(returnedExpression) : null;
-  if (!conditional || !isNodeOfType(conditional, "ConditionalExpression")) return false;
-  const test = unwrapExpression(conditional.test);
-  if (
-    !isNodeOfType(test, "BinaryExpression") ||
-    !["===", "!==", "==", "!="].includes(test.operator)
-  ) {
+  if (updater.body.body.length !== 1) return false;
+  const soleStatement = updater.body.body[0];
+  if (!isNodeOfType(soleStatement, "ReturnStatement") || !isAstNode(soleStatement.argument)) {
     return false;
   }
-  const isPreviousValue = (expression: EsTreeNode): boolean => {
-    const candidate = unwrapExpression(expression);
-    return isNodeOfType(candidate, "Identifier") && candidate.name === previousValueParameter.name;
-  };
-  let comparedValue: EsTreeNode | null = null;
-  if (isPreviousValue(test.left)) comparedValue = test.right;
-  else if (isPreviousValue(test.right)) comparedValue = test.left;
-  if (!comparedValue) return false;
-  if (isPotentiallyFreshComparedValue(comparedValue, scopes)) return false;
-  const isSameComparedValue = (expression: EsTreeNode): boolean => {
-    const candidate = unwrapExpression(expression);
-    const compared = unwrapExpression(comparedValue);
-    if (isNodeOfType(candidate, "Identifier") && isNodeOfType(compared, "Identifier")) {
-      return candidate.name === compared.name;
-    }
-    if (isNodeOfType(candidate, "Literal") && isNodeOfType(compared, "Literal")) {
-      return candidate.value === compared.value;
-    }
-    return false;
-  };
-  const equalityTest = test.operator === "===" || test.operator === "==";
-  return equalityTest
-    ? isPreviousValue(conditional.consequent) && isSameComparedValue(conditional.alternate)
-    : isSameComparedValue(conditional.consequent) && isPreviousValue(conditional.alternate);
+  return (
+    isFreshEqualityGuardUpdater(soleStatement.argument, previousValueSymbol, scopes) ||
+    isProvablyChangingExpression(soleStatement.argument, previousValueSymbol, scopes)
+  );
 };
 
-const isGuardedStableSetterCall = (
+const isProvablyRenderChangingSetterCall = (
   identifier: EsTreeNode,
-  symbol: SymbolDescriptor,
   scopes: ScopeAnalysis,
 ): boolean => {
-  const parent = identifier.parent;
+  const setterCall = identifier.parent;
   if (
-    !parent ||
-    !isNodeOfType(parent, "CallExpression") ||
-    parent.callee !== identifier ||
-    !isStableSetterLikeSymbol(symbol, scopes)
+    !setterCall ||
+    !isNodeOfType(setterCall, "CallExpression") ||
+    setterCall.callee !== identifier
   ) {
     return false;
   }
-  const writtenValue = parent.arguments?.[0];
-  return Boolean(writtenValue && isConvergingFunctionalUpdater(writtenValue, scopes));
+  const descriptor = getStateSetterDescriptor(identifier, scopes);
+  const writtenValue = setterCall.arguments?.[0];
+  if (!descriptor || !writtenValue || !isAstNode(writtenValue)) return false;
+  return isProvablyChangingFunctionalUpdater(writtenValue, scopes)
+    ? true
+    : isProvablyChangingExpression(writtenValue, descriptor.stateSymbol, scopes);
 };
 
-const findStableSetterReference = (node: EsTreeNode, scopes: ScopeAnalysis): string | null => {
+const findRenderChangingStateSetterName = (
+  node: EsTreeNode,
+  scopes: ScopeAnalysis,
+): string | null => {
   let setterName: string | null = null;
   const visit = (current: EsTreeNode): void => {
     if (setterName) return;
@@ -776,14 +1020,9 @@ const findStableSetterReference = (node: EsTreeNode, scopes: ScopeAnalysis): str
       return;
     }
     if (isNodeOfType(current, "Identifier")) {
-      const reference = scopes.referenceFor(current);
-      const symbol = reference?.resolvedSymbol;
-      if (
-        symbol &&
-        isStableSetterLikeSymbol(symbol, scopes) &&
-        !isGuardedStableSetterCall(current, symbol, scopes)
-      ) {
-        setterName = symbol.name;
+      const descriptor = getStateSetterDescriptor(current, scopes);
+      if (descriptor && isProvablyRenderChangingSetterCall(current, scopes)) {
+        setterName = descriptor.setterSymbol.name;
         return;
       }
     }
@@ -1269,7 +1508,7 @@ If the missing value is recreated every render, move it inside the hook or stabi
 
         if (!depsArgumentRaw) {
           if (callbackToAnalyze && EFFECT_HOOKS_ALLOWING_EXTRA_REACTIVE_DEPS.has(hookName)) {
-            const setterName = findStableSetterReference(callbackToAnalyze, context.scopes);
+            const setterName = findRenderChangingStateSetterName(callbackToAnalyze, context.scopes);
             if (setterName) {
               context.report({
                 node: callbackToAnalyze,


### PR DESCRIPTION
## What changed

Narrows the no-dependency-array `exhaustive-deps` loop diagnostic to React `useState` setters whose written value is statically shown to keep changing render state.

The reported Cloudscape effect derives a primitive string from the DOM. Once that string matches the stored state, React's `Object.is` bailout skips the render, so the old definite freeze warning was a false positive. The rule now:

- proves the callee is the second tuple binding from React `useState`, including direct alias chains
- keeps findings for fresh objects, arrays, JSX, regular expressions, built-in collection instances, state increments/decrements, toggles, and changing functional updaters
- leaves unknown, primitive, same-state, module-stable, deferred, and userland setter values quiet
- uses heuristic wording for the remaining `can keep triggering renders` boundary

## Regression coverage

- exact reported `className.match(...)?[1] ?? ""` layout-effect fixture
- paired positive and negative cases for direct and multi-hop aliases, TypeScript wrappers, conditional branches, early returns, equality guards, object/array spreads, constructor arguments, shadowed built-ins, reassignment, mutation returning the same reference, multiple primitive resets, deferred callbacks, and explicit dependencies
- four permanent real-world fuzz seeds plus generator shapes for the DOM string, primitive platform, child count, and fresh-object counterpart
- upstream/OXC divergence entries only for intentional unknown/deferred primitive precision

## Validation

- focused ASAP matrix: 48/48
- oxlint plugin suite: 13,875 passed, 181 skipped
- complete repository suite: 14/14 tasks passed (`nr test`); the earlier isolated language-server startup timeout passed on the unsaturated retry
- strict fuzz: `FUZZ_RULE=exhaustive-deps FUZZ_STRICT=1 FUZZ_ITERATIONS=500` — 401 executed, 167 fired, target fire coverage 1/1
- direct target-only RDE: 100/100 pinned roots, 198 → 198 findings, zero additions/removals/failures
- pristine React Bench: 122/122 pinned checkouts, 1,721 → 1,721 target identities, zero additions/removals/failures
- reconstructed React Bench oracle solutions: 117 valid, zero added findings, six unique manually reviewed FP removals; five malformed/mismatched benchmark solutions were classified invalid rather than counted as passes
- exact pinned Cloudscape reproduction: baseline 1, candidate 0 for `visual-context/index.tsx`; only the reported diagnostic is removed
- `nr build`, `nr typecheck`, `nr lint`, `nr format:check`, `nr smoke:json-report`, `git diff --check`, and post-change truffler dedup pass

The direct RDE scan is intentional: the standard harness currently rejects the latest schema-v3 report before reaching the AST-rule layer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `exhaustive-deps` static analysis for a high-traffic lint rule; behavior changes which every-commit effects warn, with broad test coverage but heuristic boundaries on unknown primitives.
> 
> **Overview**
> Narrows the **no dependency array** `exhaustive-deps` warning so it only fires when a **React `useState` setter** is called with a value that static analysis shows can **keep changing render output**, instead of treating every every-commit `setState` as an infinite loop.
> 
> The rule now resolves the callee to the second binding from `useState` (including alias chains), then classifies the written value: fresh objects/arrays/JSX, increments, toggles, and similar patterns still report; DOM-derived primitives, guarded resets, identity functional updaters, module-stable references, deferred callbacks, and userland `set*` names stay quiet once React’s **same-value bailout** can apply. The user-facing text shifts from a definite freeze/loop claim to **can keep triggering renders**.
> 
> Regression coverage adds ASAP matrix cases, four fuzz corpus seeds, snippet-pool shapes, and updated OXC/upstream fixture skip indices for intentional primitive/deferred precision gaps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a46ce0022239aee1211a5dafe6a4910b1b24a51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->