### PR TITLE
fix(no-effect-event-handler): preserve external synchronization

### DIFF
--- a/.changeset/quiet-dodos-sync.md
+++ b/.changeset/quiet-dodos-sync.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Keep no-effect-event-handler quiet for prop-gated external store-to-router synchronization.

--- a/packages/fuzz/corpus/regressions/no-effect-event-handler--external-store-router-sync.tsx
+++ b/packages/fuzz/corpus/regressions/no-effect-event-handler--external-store-router-sync.tsx
@@ -1,0 +1,31 @@
+import { useEffect } from "react";
+import { useDirectoryStore } from "./store";
+
+interface DirectoryProviderProps {
+  directory: string;
+  draftId?: string;
+}
+
+export const DirectoryProvider = (props: DirectoryProviderProps) => {
+  const navigate = useNavigate();
+  const store = useDirectoryStore();
+  const snapshot = store();
+  const nextDirectory = snapshot.path.directory;
+
+  useEffect(() => {
+    if (props.draftId) return;
+    const next = nextDirectory;
+    if (!next || next === props.directory) return;
+    navigate(encodeDirectory(next), { replace: true });
+  }, [props.draftId, props.directory, nextDirectory, navigate]);
+
+  return null;
+};
+
+export const NotificationRelay = (props: { didSubmit: boolean }) => {
+  useEffect(() => {
+    if (props.didSubmit) toast("Submitted");
+  }, [props.didSubmit]);
+
+  return null;
+};

--- a/packages/fuzz/src/generate-fuzz-program.ts
+++ b/packages/fuzz/src/generate-fuzz-program.ts
@@ -159,6 +159,15 @@ const SCENARIO_POOL: ReadonlyArray<SnippetBuilder> = [
       `useEffect(() => { setFuzzChainSource(1); }, []);`,
       `useEffect(() => { setFuzzChainTarget(fuzzChainSource + 1); }, [fuzzChainSource]);`,
     ].join("\n  "),
+  () =>
+    [
+      `const FuzzEventRelay = (eventProps) => {`,
+      `  useEffect(() => {`,
+      `    if (eventProps.didSubmit) toast("Submitted");`,
+      `  }, [eventProps.didSubmit]);`,
+      `  return null;`,
+      `};`,
+    ].join("\n  "),
 ];
 
 const buildComponent: SnippetBuilder = (random) => {

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -55,6 +55,7 @@ export const EFFECT_SNIPPET_POOL = [
   `const [guardedSnapshot, setGuardedSnapshot] = useState(value); useEffect(() => { if (!Object.is(guardedSnapshot, value)) setGuardedSnapshot(value); }, [value]);`,
   `const equalSnapshots = () => false; const [namedGuardSnapshot, setNamedGuardSnapshot] = useState(value); useEffect(() => { if (!equalSnapshots(namedGuardSnapshot, value)) setNamedGuardSnapshot(value); }, [value]);`,
   `const [mismatchedSnapshot, setMismatchedSnapshot] = useState(value); useEffect(() => { if (mismatchedSnapshot !== value) setMismatchedSnapshot(state); }, [state, value]);`,
+  `const directoryStore = useDirectoryStore(); const directorySnapshot = directoryStore(); const nextDirectory = directorySnapshot.path.directory; useEffect(() => { if (props.draftId) return; const next = nextDirectory; if (!next || next === props.directory) return; navigate(encodeDirectory(next), { replace: true }); }, [props.draftId, props.directory, nextDirectory, navigate]);`,
 ] as const;
 
 // State — lazy initializers (incl. SSR-hazardous localStorage/matchMedia),

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-event-handler.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-event-handler.regressions.test.ts
@@ -175,4 +175,594 @@ const Redirector = ({ isLoggedIn, router }) => {
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toHaveLength(1);
   });
+
+  it("does not flag external directory-store reconciliation guarded by component props", () => {
+    const code = `
+import { useEffect, useMemo } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { useSync } from "@/context/sync";
+const DirectoryDataProvider = (props) => {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const sync = useSync();
+  const slug = useMemo(() => base64Encode(props.directory), [props.directory]);
+  const directorySync = sync();
+  const nextDirectory = directorySync.data.path.directory;
+
+  useEffect(() => {
+    if (props.draftID) return;
+    const next = nextDirectory;
+    if (!next || next === props.directory) return;
+    const path = location.pathname.slice(slug.length + 1);
+    navigate(\`/\${base64Encode(next)}\${path}\${location.search}\${location.hash}\`, {
+      replace: true,
+    });
+  }, [
+    props.draftID,
+    props.directory,
+    nextDirectory,
+    location.pathname,
+    location.search,
+    location.hash,
+    slug,
+    navigate,
+  ]);
+  return null;
+};
+`;
+    const result = runRule(noEffectEventHandler, code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("classifies external synchronization without relying on an in-effect alias", () => {
+    const code = `
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { useSync } from "@/context/sync";
+const DirectoryDataProvider = (props) => {
+  const navigate = useNavigate();
+  const sync = useSync();
+  const directorySync = sync();
+  const nextDirectory = directorySync.data.path.directory;
+
+  useEffect(() => {
+    if (props.draftID) return;
+    if (!nextDirectory || nextDirectory === props.directory) return;
+    navigate(encodeDirectory(nextDirectory), { replace: true });
+  }, [props.draftID, props.directory, nextDirectory, navigate]);
+  return null;
+};
+`;
+    const result = runRule(noEffectEventHandler, code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not assume that every opaque custom-hook value is an external snapshot", () => {
+    const code = `
+import { useEffect } from "react";
+const DirectoryProvider = ({ draftId, directory, navigate }) => {
+  const nextDirectory = useExternalDirectory();
+  useEffect(() => {
+    if (draftId) return;
+    if (!nextDirectory || nextDirectory === directory) return;
+    navigate(encodeDirectory(nextDirectory), { replace: true });
+  }, [draftId, directory, nextDirectory, navigate]);
+  return null;
+};
+`;
+    const result = runRule(noEffectEventHandler, code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("follows TypeScript wrappers and multi-hop const aliases to an external snapshot", () => {
+    const code = `
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { useSync } from "@/context/sync";
+interface Snapshot { path: { directory?: string } }
+const DirectoryProvider = ({ draftId, directory }) => {
+  const navigate = useNavigate();
+  const sync = useSync();
+  const snapshot = sync() as Snapshot;
+  const nextDirectory = snapshot.path.directory;
+  const candidateDirectory = nextDirectory;
+  useEffect(() => {
+    if (draftId) return;
+    const next = candidateDirectory;
+    if (!next || next === directory) return;
+    navigate(encodeDirectory(next), { replace: true });
+  }, [draftId, directory, candidateDirectory, navigate]);
+  return null;
+};
+`;
+    const result = runRule(noEffectEventHandler, code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still flags prop-gated notifications driven by local React state", () => {
+    const code = `
+import { useEffect, useState } from "react";
+const Notifications = ({ enabled }) => {
+  const [message] = useState();
+  useEffect(() => {
+    if (!enabled) return;
+    if (!message) return;
+    toast(message);
+  }, [enabled, message]);
+  return null;
+};
+`;
+    const result = runRule(noEffectEventHandler, code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a prop-gated event relay when the derived payload consumes props", () => {
+    const code = `
+import { useEffect } from "react";
+const Notifications = ({ enabled, product }) => {
+  const message = buildMessage(product);
+  useEffect(() => {
+    if (!enabled) return;
+    if (!message) return;
+    toast(message);
+  }, [enabled, message]);
+  return null;
+};
+`;
+    const result = runRule(noEffectEventHandler, code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a prop-gated event relay using an ordinary zero-argument builder", () => {
+    const code = `
+import { useEffect } from "react";
+const Notifications = ({ enabled }) => {
+  const message = buildMessage();
+  useEffect(() => {
+    if (!enabled) return;
+    if (!message) return;
+    toast(message);
+  }, [enabled, message]);
+  return null;
+};
+`;
+    const result = runRule(noEffectEventHandler, code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a prop-gated event relay using a factory-returned builder", () => {
+    const code = `
+import { useEffect } from "react";
+const Notifications = ({ enabled }) => {
+  const buildMessage = makeMessageBuilder();
+  const message = buildMessage();
+  useEffect(() => {
+    if (!enabled) return;
+    if (!message) return;
+    toast(message);
+  }, [enabled, message]);
+  return null;
+};
+`;
+    const result = runRule(noEffectEventHandler, code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a prop-gated event relay driven by state hidden in a local custom hook", () => {
+    const code = `
+import { useEffect, useState } from "react";
+const useMessage = () => useState("")[0];
+const Notifications = ({ enabled }) => {
+  const message = useMessage();
+  useEffect(() => {
+    if (!enabled) return;
+    if (!message) return;
+    toast(message);
+  }, [enabled, message]);
+  return null;
+};
+`;
+    const result = runRule(noEffectEventHandler, code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a local custom-hook accessor over React state", () => {
+    const code = `
+import { useEffect, useState } from "react";
+const useMessageAccessor = () => {
+  const [state] = useState({ message: "" });
+  return () => state;
+};
+const Notifications = ({ enabled }) => {
+  const readMessage = useMessageAccessor();
+  const message = readMessage().message;
+  useEffect(() => {
+    if (!enabled) return;
+    if (!message) return;
+    toast(message);
+  }, [enabled, message]);
+  return null;
+};
+`;
+    const result = runRule(noEffectEventHandler, code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags an imported custom-hook accessor without a reconciliation comparison", () => {
+    const code = `
+import { useEffect } from "react";
+import { useMessageAccessor } from "./hooks";
+const Notifications = ({ enabled }) => {
+  const readMessage = useMessageAccessor();
+  const message = readMessage().message;
+  useEffect(() => {
+    if (!enabled) return;
+    if (!message) return;
+    toast(message);
+  }, [enabled, message]);
+  return null;
+};
+`;
+    const result = runRule(noEffectEventHandler, code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags an imported custom-hook accessor used for a one-shot notification", () => {
+    const code = `
+import { useEffect } from "react";
+import { useMessageAccessor } from "./hooks";
+const Notifications = (props) => {
+  const readMessage = useMessageAccessor();
+  const message = readMessage().message;
+  useEffect(() => {
+    if (!props.enabled) return;
+    if (!message || message === props.lastNotifiedMessage) return;
+    toast(message);
+  }, [props.enabled, props.lastNotifiedMessage, message]);
+  return null;
+};
+`;
+    const result = runRule(noEffectEventHandler, code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("classifies replacement navigation independently of snapshot property mutation", () => {
+    const code = `
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { useSync } from "@/context/sync";
+const DirectoryProvider = (props) => {
+  const navigate = useNavigate();
+  const sync = useSync();
+  const snapshot = sync();
+  snapshot.data.path.directory = props.fallbackDirectory;
+  const nextDirectory = snapshot.data.path.directory;
+  useEffect(() => {
+    if (props.draftId) return;
+    if (!nextDirectory || nextDirectory === props.directory) return;
+    navigate(encodeDirectory(nextDirectory), { replace: true });
+  }, [props.draftId, props.directory, nextDirectory, navigate]);
+  return null;
+};
+`;
+    const result = runRule(noEffectEventHandler, code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("classifies replacement navigation independently of aliased snapshot mutation", () => {
+    const code = `
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { useSync } from "@/context/sync";
+const DirectoryProvider = (props) => {
+  const navigate = useNavigate();
+  const sync = useSync();
+  const snapshot = sync();
+  const snapshotAlias = snapshot;
+  snapshotAlias.data.path.directory = props.fallbackDirectory;
+  const nextDirectory = snapshot.data.path.directory;
+  useEffect(() => {
+    if (props.draftId) return;
+    if (!nextDirectory || nextDirectory === props.directory) return;
+    navigate(encodeDirectory(nextDirectory), { replace: true });
+  }, [props.draftId, props.directory, nextDirectory, navigate]);
+  return null;
+};
+`;
+    const result = runRule(noEffectEventHandler, code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not misclassify local-state-to-router reconciliation as an event relay", () => {
+    const code = `
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+const DirectoryProvider = (props) => {
+  const navigate = useNavigate();
+  const [nextDirectory] = useState(props.directory);
+  useEffect(() => {
+    if (props.draftId) return;
+    if (!nextDirectory || nextDirectory === props.directory) return;
+    navigate(encodeDirectory(nextDirectory), { replace: true });
+  }, [props.draftId, props.directory, nextDirectory, navigate]);
+  return null;
+};
+`;
+    const result = runRule(noEffectEventHandler, code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("supports aliased router imports and transparent snapshot wrappers", () => {
+    const code = `
+import { useEffect } from "react";
+import { useNavigate as useRouterNavigate } from "react-router-dom";
+import { useSync as useDirectorySync } from "@/context/sync";
+interface Snapshot { data: { path: { directory?: string } } }
+const DirectoryProvider = (props) => {
+  const navigate = useRouterNavigate();
+  const sync = useDirectorySync();
+  const navigationOptions = getNavigationOptions();
+  const snapshot = (sync() satisfies Snapshot)!;
+  const nextDirectory = snapshot.data.path.directory;
+  useEffect(() => {
+    if (props.draftId) return;
+    if (!nextDirectory || nextDirectory === props.directory) return;
+    navigate(
+      encodeDirectory(nextDirectory),
+      ({ ...navigationOptions, replace: true } satisfies { replace: boolean }),
+    );
+  }, [props.draftId, props.directory, nextDirectory, navigate]);
+  return null;
+};
+`;
+    const result = runRule(noEffectEventHandler, code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not assume replacement when a later spread can override the option", () => {
+    const code = `
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { useSync } from "@/context/sync";
+const DirectoryProvider = (props) => {
+  const navigate = useNavigate();
+  const sync = useSync();
+  const navigationOptions = getNavigationOptions();
+  const snapshot = sync();
+  const nextDirectory = snapshot.data.path.directory;
+  useEffect(() => {
+    if (props.draftId) return;
+    if (!nextDirectory || nextDirectory === props.directory) return;
+    navigate(encodeDirectory(nextDirectory), { replace: true, ...navigationOptions });
+  }, [props.draftId, props.directory, nextDirectory, navigate]);
+  return null;
+};
+`;
+    const result = runRule(noEffectEventHandler, code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("supports a computed replacement key with an immutable boolean alias", () => {
+    const code = `
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+const DirectoryProvider = (props) => {
+  const navigate = useNavigate();
+  const nextDirectory = readNextDirectory();
+  const shouldReplace = true;
+  useEffect(() => {
+    if (!props.enabled) return;
+    if (!nextDirectory || nextDirectory === props.directory) return;
+    navigate(encodeDirectory(nextDirectory), { ["replace"]: shouldReplace });
+  }, [props.enabled, props.directory, nextDirectory, navigate]);
+  return null;
+};
+`;
+    const result = runRule(noEffectEventHandler, code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not trust a dynamic navigation option key", () => {
+    const code = `
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+const DirectoryProvider = (props) => {
+  const navigate = useNavigate();
+  const nextDirectory = readNextDirectory();
+  const optionName = readOptionName();
+  useEffect(() => {
+    if (!props.enabled) return;
+    if (!nextDirectory || nextDirectory === props.directory) return;
+    navigate(encodeDirectory(nextDirectory), { replace: true, [optionName]: false });
+  }, [props.enabled, props.directory, nextDirectory, navigate]);
+  return null;
+};
+`;
+    const result = runRule(noEffectEventHandler, code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not follow an aliased mutable navigation options object", () => {
+    const code = `
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+const DirectoryProvider = (props) => {
+  const navigate = useNavigate();
+  const nextDirectory = readNextDirectory();
+  const navigationOptions = { replace: true };
+  navigationOptions.replace = props.shouldReplace;
+  useEffect(() => {
+    if (!props.enabled) return;
+    if (!nextDirectory || nextDirectory === props.directory) return;
+    navigate(encodeDirectory(nextDirectory), navigationOptions);
+  }, [props.enabled, props.directory, nextDirectory, navigate, navigationOptions]);
+  return null;
+};
+`;
+    const result = runRule(noEffectEventHandler, code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags fixed-destination navigation triggered by reconciliation state", () => {
+    const code = `
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+const Notifications = (props) => {
+  const navigate = useNavigate();
+  const message = readMessage();
+  useEffect(() => {
+    if (!props.enabled) return;
+    if (!message || message === props.lastMessage) return;
+    navigate("/notifications", { replace: true, state: { message } });
+  }, [props.enabled, props.lastMessage, message, navigate]);
+  return null;
+};
+`;
+    const result = runRule(noEffectEventHandler, code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("follows immutable destination aliases into replacement navigation", () => {
+    const code = `
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+const DirectoryProvider = (props) => {
+  const navigate = useNavigate();
+  const nextDirectory = readNextDirectory();
+  useEffect(() => {
+    if (!props.enabled) return;
+    if (!nextDirectory || nextDirectory === props.directory) return;
+    const encodedDestination = encodeDirectory(nextDirectory);
+    const destination = (encodedDestination satisfies string)!;
+    navigate(destination, { replace: true });
+  }, [props.enabled, props.directory, nextDirectory, navigate]);
+  return null;
+};
+`;
+    const result = runRule(noEffectEventHandler, code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not follow a reassigned destination into replacement navigation", () => {
+    const code = `
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+const DirectoryProvider = (props) => {
+  const navigate = useNavigate();
+  const nextDirectory = readNextDirectory();
+  useEffect(() => {
+    if (!props.enabled) return;
+    if (!nextDirectory || nextDirectory === props.directory) return;
+    let destination = encodeDirectory(nextDirectory);
+    destination = props.fallbackDestination;
+    navigate(destination, { replace: true });
+  }, [props.enabled, props.directory, nextDirectory, navigate]);
+  return null;
+};
+`;
+    const result = runRule(noEffectEventHandler, code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags additional one-shot side effects beside router reconciliation", () => {
+    const code = `
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+const DirectoryProvider = (props) => {
+  const navigate = useNavigate();
+  const nextDirectory = readNextDirectory();
+  useEffect(() => {
+    if (!props.enabled) return;
+    if (!nextDirectory || nextDirectory === props.directory) return;
+    toast("Directory changed");
+    navigate(encodeDirectory(nextDirectory), { replace: true });
+  }, [props.enabled, props.directory, nextDirectory, navigate]);
+  return null;
+};
+`;
+    const result = runRule(noEffectEventHandler, code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not confuse a shadowed useNavigate binding with the router import", () => {
+    const code = `
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+const DirectoryProvider = (props) => {
+  const useNavigate = useNotificationNavigator;
+  const navigate = useNavigate();
+  const nextDirectory = readNextDirectory();
+  useEffect(() => {
+    if (!props.enabled) return;
+    if (!nextDirectory || nextDirectory === props.directory) return;
+    navigate(encodeDirectory(nextDirectory), { replace: true });
+  }, [props.enabled, props.directory, nextDirectory, navigate]);
+  return null;
+};
+`;
+    const result = runRule(noEffectEventHandler, code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a prop-gated event relay using a stable React hook value", () => {
+    const code = `
+import { useEffect, useId } from "react";
+const Notifications = ({ enabled }) => {
+  const messageId = useId();
+  useEffect(() => {
+    if (!enabled) return;
+    if (!messageId) return;
+    toast(messageId);
+  }, [enabled, messageId]);
+  return null;
+};
+`;
+    const result = runRule(noEffectEventHandler, code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not trust a reassigned external-looking binding", () => {
+    const code = `
+import { useEffect } from "react";
+const Redirector = ({ enabled, fallbackDirectory, navigate }) => {
+  let nextDirectory = useExternalDirectory();
+  nextDirectory = fallbackDirectory;
+  useEffect(() => {
+    if (!enabled) return;
+    if (!nextDirectory) return;
+    navigate(encodeDirectory(nextDirectory), { replace: true });
+  }, [enabled, nextDirectory, navigate]);
+  return null;
+};
+`;
+    const result = runRule(noEffectEventHandler, code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-event-handler.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-event-handler.ts
@@ -15,6 +15,10 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import { getImportedNameFromModule } from "../../utils/find-import-source-for-name.js";
+import { getStaticPropertyKeyName } from "../../utils/get-static-property-key-name.js";
 
 interface GuardExpression {
   expression: EsTreeNode;
@@ -79,6 +83,47 @@ const hasEventLikeRemainingStatements = (statements: EsTreeNode[]): boolean =>
     (statement) => !isNodeOfType(statement, "ReturnStatement") && hasEventLikeNode(statement),
   );
 
+const collectLeadingEarlyReturnGuards = (statements: EsTreeNode[]): GuardExpression[] => {
+  const guardExpressions: GuardExpression[] = [];
+  for (const statement of statements) {
+    if (isNodeOfType(statement, "VariableDeclaration")) continue;
+    if (
+      !isNodeOfType(statement, "IfStatement") ||
+      statement.alternate ||
+      !isReturnOnlyStatement(statement.consequent)
+    ) {
+      break;
+    }
+    collectGuardExpressions(statement.test, guardExpressions);
+  }
+  return guardExpressions;
+};
+
+const collectImmutableExpressionOrigins = (
+  expression: EsTreeNode,
+  scopes: ScopeAnalysis,
+): EsTreeNode[] => {
+  const origins: EsTreeNode[] = [];
+  const visitedSymbolIds = new Set<number>();
+  let currentExpression: EsTreeNode | null = stripParenExpression(expression);
+  while (currentExpression) {
+    origins.push(currentExpression);
+    if (!isNodeOfType(currentExpression, "Identifier")) break;
+    const bindingSymbol = scopes.symbolFor(currentExpression);
+    if (
+      !bindingSymbol ||
+      bindingSymbol.kind !== "const" ||
+      visitedSymbolIds.has(bindingSymbol.id) ||
+      !bindingSymbol.initializer
+    ) {
+      break;
+    }
+    visitedSymbolIds.add(bindingSymbol.id);
+    currentExpression = stripParenExpression(bindingSymbol.initializer);
+  }
+  return origins;
+};
+
 const doesGuardMatchDependency = (
   guardExpression: GuardExpression,
   dependencyExpression: EsTreeNode | null | undefined,
@@ -101,6 +146,113 @@ const hasDependencyMatch = (
   dependencyExpressions.some((dependencyExpression) =>
     doesGuardMatchDependency(guardExpression, dependencyExpression),
   );
+
+const hasAliasedDependencyMatch = (
+  guardExpression: GuardExpression,
+  dependencyExpressions: Array<EsTreeNode | null | undefined>,
+  scopes: ScopeAnalysis,
+): boolean => {
+  const guardOrigins = collectImmutableExpressionOrigins(guardExpression.expression, scopes);
+  return dependencyExpressions.some((dependencyExpression) => {
+    if (!dependencyExpression) return false;
+    const dependencyOrigins = collectImmutableExpressionOrigins(dependencyExpression, scopes);
+    return guardOrigins.some((guardOrigin) =>
+      dependencyOrigins.some((dependencyOrigin) =>
+        areExpressionsStructurallyEqual(guardOrigin, dependencyOrigin),
+      ),
+    );
+  });
+};
+
+const isStaticallyTrue = (expression: EsTreeNode, scopes: ScopeAnalysis): boolean =>
+  collectImmutableExpressionOrigins(expression, scopes).some(
+    (origin) => isNodeOfType(origin, "Literal") && origin.value === true,
+  );
+
+const isReactRouterReplacementNavigation = (
+  node: EsTreeNode,
+  rootIdentifierNames: Set<string>,
+  scopes: ScopeAnalysis,
+): boolean => {
+  let didFindNavigation = false;
+  let didFindOtherTriggeredSideEffect = false;
+  walkAst(node, (child) => {
+    if (!isNodeOfType(child, "CallExpression")) return;
+    const isTriggeredSideEffect =
+      findTriggeredSideEffectCalleeName(child) !== null || hasDocumentClassListMutation(child);
+    if (!isTriggeredSideEffect) return;
+    const destinationExpression = child.arguments?.[0];
+    const doesDestinationReferenceReconciliationValue = Boolean(
+      destinationExpression &&
+      collectImmutableExpressionOrigins(destinationExpression, scopes).some((origin) =>
+        doesNodeReferenceAnyRoot(origin, rootIdentifierNames),
+      ),
+    );
+    if (!isNodeOfType(child.callee, "Identifier") || !doesDestinationReferenceReconciliationValue) {
+      didFindOtherTriggeredSideEffect = true;
+      return;
+    }
+    const navigationSymbol = scopes.symbolFor(child.callee);
+    const navigationInitializer = navigationSymbol?.initializer
+      ? stripParenExpression(navigationSymbol.initializer)
+      : null;
+    if (
+      navigationSymbol?.kind !== "const" ||
+      !isNodeOfType(navigationInitializer, "CallExpression") ||
+      !isNodeOfType(navigationInitializer.callee, "Identifier")
+    ) {
+      didFindOtherTriggeredSideEffect = true;
+      return;
+    }
+    if (scopes.symbolFor(navigationInitializer.callee)?.kind !== "import") {
+      didFindOtherTriggeredSideEffect = true;
+      return;
+    }
+    const importedHookName =
+      getImportedNameFromModule(
+        navigationInitializer.callee,
+        navigationInitializer.callee.name,
+        "react-router-dom",
+      ) ??
+      getImportedNameFromModule(
+        navigationInitializer.callee,
+        navigationInitializer.callee.name,
+        "react-router",
+      );
+    if (importedHookName !== "useNavigate") {
+      didFindOtherTriggeredSideEffect = true;
+      return;
+    }
+    const navigationOptionsArgument = child.arguments?.[1];
+    const navigationOptions = navigationOptionsArgument
+      ? stripParenExpression(navigationOptionsArgument)
+      : null;
+    if (!isNodeOfType(navigationOptions, "ObjectExpression")) {
+      didFindOtherTriggeredSideEffect = true;
+      return;
+    }
+    let isReplacementGuaranteed = false;
+    for (const property of navigationOptions.properties) {
+      if (isNodeOfType(property, "SpreadElement")) {
+        isReplacementGuaranteed = false;
+        continue;
+      }
+      const propertyName = getStaticPropertyKeyName(property, { allowComputedString: true });
+      if (propertyName === null) {
+        isReplacementGuaranteed = false;
+        continue;
+      }
+      if (propertyName !== "replace") continue;
+      isReplacementGuaranteed = isStaticallyTrue(property.value, scopes);
+    }
+    if (isReplacementGuaranteed) {
+      didFindNavigation = true;
+      return;
+    }
+    didFindOtherTriggeredSideEffect = true;
+  });
+  return didFindNavigation && !didFindOtherTriggeredSideEffect;
+};
 
 // `if (mode === 'trialregistration') return;` followed by the side effect
 // excludes ONE prop value and runs the effect for every other value —
@@ -205,9 +357,13 @@ export const noEffectEventHandler = defineRule({
         const soleStatement = statements[0];
         if (!isNodeOfType(soleStatement, "IfStatement")) return;
 
-        const guardExpressions: GuardExpression[] = [];
-        collectGuardExpressions(soleStatement.test, guardExpressions);
-        const matchingPropGuardExpressions = guardExpressions.filter(
+        const initialGuardExpressions: GuardExpression[] = [];
+        collectGuardExpressions(soleStatement.test, initialGuardExpressions);
+        const guardExpressions = collectLeadingEarlyReturnGuards(statements);
+        if (guardExpressions.length === 0) {
+          guardExpressions.push(...initialGuardExpressions);
+        }
+        const matchingPropGuardExpressions = initialGuardExpressions.filter(
           (guardExpression) =>
             hasDependencyMatch(guardExpression, dependencyExpressions) &&
             propStackTracker.isPropName(guardExpression.rootIdentifierName, node),
@@ -234,7 +390,7 @@ export const noEffectEventHandler = defineRule({
           return;
         }
 
-        const hasUnmatchedGuardExpression = guardExpressions.some(
+        const hasUnmatchedGuardExpression = initialGuardExpressions.some(
           (guardExpression) =>
             !matchingPropGuardExpressions.some(
               (matchingGuardExpression) =>
@@ -251,6 +407,69 @@ export const noEffectEventHandler = defineRule({
             ? doesEventLikeCallReferenceAnyRoot(soleStatement.consequent, matchingPropRootNames)
             : doesAnyEventLikeCallReferenceAnyRoot(statements.slice(1), matchingPropRootNames);
           if (!doesEventLikeRegionReferenceMatchedProp) return;
+        }
+
+        if (isEarlyReturnGuardedEventLikeBody) {
+          const reconciliationGuardRootNames = new Set(
+            guardExpressions
+              .filter(
+                (guardExpression) =>
+                  !propStackTracker.isPropName(guardExpression.rootIdentifierName, node) &&
+                  hasAliasedDependencyMatch(
+                    guardExpression,
+                    dependencyExpressions,
+                    context.scopes,
+                  ) &&
+                  guardExpressions.some((comparisonGuardExpression) => {
+                    if (
+                      comparisonGuardExpression.rootIdentifierName !==
+                      guardExpression.rootIdentifierName
+                    ) {
+                      return false;
+                    }
+                    const comparisonExpression = comparisonGuardExpression.expression.parent;
+                    if (
+                      !isNodeOfType(comparisonExpression, "BinaryExpression") ||
+                      (comparisonExpression.operator !== "===" &&
+                        comparisonExpression.operator !== "==")
+                    ) {
+                      return false;
+                    }
+                    const comparedExpression =
+                      comparisonExpression.left === comparisonGuardExpression.expression
+                        ? comparisonExpression.right
+                        : comparisonExpression.left;
+                    const comparedRootIdentifierName = getRootIdentifierName(comparedExpression);
+                    return Boolean(
+                      comparedRootIdentifierName &&
+                      propStackTracker.isPropName(comparedRootIdentifierName, node),
+                    );
+                  }),
+              )
+              .map((guardExpression) => guardExpression.rootIdentifierName),
+          );
+          if (reconciliationGuardRootNames.size > 0) {
+            const matchingPropRootNames = new Set(
+              matchingPropGuardExpressions.map(
+                (guardExpression) => guardExpression.rootIdentifierName,
+              ),
+            );
+            const eventLikeStatements = statements.slice(1);
+            const triggeredStatements = eventLikeStatements.filter(hasEventLikeNode);
+            if (
+              triggeredStatements.length > 0 &&
+              triggeredStatements.every((statement) =>
+                isReactRouterReplacementNavigation(
+                  statement,
+                  reconciliationGuardRootNames,
+                  context.scopes,
+                ),
+              ) &&
+              !doesAnyEventLikeCallReferenceAnyRoot(eventLikeStatements, matchingPropRootNames)
+            ) {
+              return;
+            }
+          }
         }
 
         context.report({


### PR DESCRIPTION
## Summary

- Treat proven React Router replacement navigation as external synchronization when a dependency value is compared with the current prop and becomes the replacement destination.
- Keep ordinary notifications, analytics, fixed-destination navigation, mixed side effects, unresolved router lookalikes, mutable destination aliases, and non-guaranteed `replace` options reportable.
- Add permanent regression and fuzz coverage for the authentic OpenCode directory reconciliation case and its adversarial near-neighbors.

## Precision boundary

The exemption does not guess whether an imported custom Hook is an external store. It requires all of the following file-local proof:

- the reconciled value is a listed dependency and is equality-compared with current component props;
- the value reaches the first navigation destination argument, including immutable aliases;
- the navigation function is created by the actual `useNavigate` import from `react-router-dom` or `react-router`;
- the final options object guarantees `replace: true` after static property, computed-property, alias, and spread ordering;
- every triggered side effect in the region is part of that proven replacement navigation.

## Exact reproduction

Pinned source: OpenCode `5d0f86606ac30690f79f0a6a9f41a1f49fe95d0b`, React Bench job `migrate-react-opencode-solid-to-react-home-layout-sidebar__kVLQumC`, untouched oracle `packages/app/src/pages/directory-layout.tsx:23`.

- current `origin/main` (`9fc93f865`): one `no-effect-event-handler` diagnostic at line 23;
- candidate (`aeb161ab1`): zero target diagnostics;
- scan coverage: 1/1 authentic source file analyzed on both sides, no partial failures;
- the stored job's 13 behavior tests, build, and typecheck already pass; its reward is zero solely because of this React Doctor diagnostic.

## Validation

- full oxlint plugin suite: 13,280 passed, 148 skipped;
- fuzz corpus: 43 passed, 401 opt-in cases skipped;
- strict fuzz: `FUZZ_RULE=no-effect-event-handler FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz`;
- strict-fuzz liveness: 13 firing programs, 321 executed programs, zero findings;
- no-cache RDE: 100/100 complete pinned roots, 11,437 diagnostics on each side, zero added or removed diagnostics;
- unchanged RDE target finding: manually reviewed PostHog analytics call is a true event relay;
- React Bench 5: 122/122 tasks, 121 unique pinned scan roots, target count 1 -> 1, zero added or removed diagnostics;
- relevant React Bench oracle: the Cal.com solution does not modify the one target-bearing base file, so target parity remains unchanged;
- `nr typecheck`, `nr lint`, `nr format:check`, `git diff --check`: passed;
- root `nr test`: every package except the runner package passed; three timing/PTY tests failed only in the saturated 6m25s concurrent run, then passed in isolation (`performance-harness`: 22/22; `unref-stdin-live`: 2/2);
- post-change truffler pass found no duplicate helper.

Draft only. Do not merge without maintainer review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The change expands lint heuristics in a heavily used rule; misclassification could hide real event-relay effects or reintroduce noise, though the exemption is tightly gated and heavily regression-tested.
> 
> **Overview**
> **`no-effect-event-handler`** now skips prop-gated effects that reconcile an external snapshot with props and only perform proven **React Router `replace` navigation** whose destination is derived from the reconciled value.
> 
> The rule adds scope-aware helpers to read **leading early-return guards**, follow **immutable `const` aliases**, and recognize **`useNavigate`** from `react-router` / `react-router-dom` when **`replace: true`** is statically guaranteed (with conservative handling for spreads, dynamic keys, and mutable option objects). Opaque custom hooks without prop equality proof still report; toasts, fixed routes, mixed side effects, and non-replace navigation stay flagged.
> 
> Regression tests, a fuzz corpus fixture, and snippet pools cover the OpenCode-style directory sync pattern and nearby false-positive/negative cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 745785c8513e1769a3db0332cb9ea3047550888c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->