### PR TITLE
test(exhaustive-deps): pin intentional session snapshot boundary

### DIFF
--- a/packages/fuzz/corpus/targets/exhaustive-deps--live-session-role.tsx
+++ b/packages/fuzz/corpus/targets/exhaustive-deps--live-session-role.tsx
@@ -1,0 +1,14 @@
+import { useEffect } from "react";
+
+interface User {
+  role: "user" | "admin";
+}
+
+declare const showLiveRole: (role: User["role"]) => void;
+
+export const LiveSessionRole = ({ sessionKey, user }: { sessionKey: string; user: User }) => {
+  useEffect(() => {
+    showLiveRole(user.role);
+  }, [sessionKey]);
+  return null;
+};

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -70,6 +70,7 @@ export const EFFECT_SNIPPET_POOL = [
   `useFuzzDocumentEvents(() => handle(value), [value]);`,
   `const fuzzDocumentEventArguments = condition ? [] : [() => handle(value), [value]]; useFuzzDocumentEvents(...fuzzDocumentEventArguments);`,
   `const fuzzDocumentEventOptions = { callback: () => handle(value) }; fuzzDocumentEventOptions.callback = handle; useFuzzDocumentEventOptions(fuzzDocumentEventOptions);`,
+  `const fuzzSessionKey = String(value); const fuzzSessionUser = { role: value ? "admin" : "user" }; useEffect(() => { showLiveRole(fuzzSessionUser.role); }, [fuzzSessionKey]);`,
 ] as const;
 
 // State — lazy initializers (incl. SSR-hazardous localStorage/matchMedia),

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.regressions.test.ts
@@ -1943,6 +1943,69 @@ describe("react-builtins/exhaustive-deps — upstream disable-comment suppressio
     });
   });
 
+  it("honors an explicitly annotated session snapshot", () => {
+    const code = `
+      interface User { role: "user" | "admin" }
+      declare const warmupRouteChunks: (role: User["role"], sessionKey: string) => void;
+
+      function IntentionalSessionSnapshot({ sessionKey, user }: { sessionKey: string; user: User }) {
+        useEffect(() => {
+          const role = user.role;
+          warmupRouteChunks(role, sessionKey);
+          // eslint-disable-next-line react-hooks/exhaustive-deps -- role is intentionally snapshotted for this session
+        }, [sessionKey]);
+      }
+    `;
+    withTempFile(code, (filename) => {
+      const result = runRule(exhaustiveDeps, code, { filename });
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+  });
+
+  it("retains the syntax-identical unmarked live-role warning", () => {
+    const code = `
+      interface User { role: "user" | "admin" }
+      declare const warmupRouteChunks: (role: User["role"], sessionKey: string) => void;
+
+      function LiveRole({ sessionKey, user }: { sessionKey: string; user: User }) {
+        useEffect(() => {
+          const role = user.role;
+          warmupRouteChunks(role, sessionKey);
+        }, [sessionKey]);
+      }
+    `;
+    withTempFile(code, (filename) => {
+      const result = runRule(exhaustiveDeps, code, { filename });
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+      expect(result.diagnostics[0]?.message).toContain("user.role");
+    });
+  });
+
+  it("accepts the explicit session-object encoding", () => {
+    const code = `
+      interface User { role: "user" | "admin" }
+      declare const warmupRouteChunks: (role: User["role"], sessionKey: string) => void;
+
+      function ExplicitSessionSnapshot({ sessionKey, user }: { sessionKey: string; user: User }) {
+        const sessionRef = useRef<{ key: string; role: User["role"] } | null>(null);
+        if (sessionRef.current?.key !== sessionKey) {
+          sessionRef.current = { key: sessionKey, role: user.role };
+        }
+        const session = sessionRef.current;
+        useEffect(() => {
+          warmupRouteChunks(session.role, session.key);
+        }, [session]);
+      }
+    `;
+    withTempFile(code, (filename) => {
+      const result = runRule(exhaustiveDeps, code, { filename });
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+  });
+
   it("ignores disable comments naming a different rule", () => {
     const code = [
       "function MyComponent({ autoStart }) {",


### PR DESCRIPTION
## Summary

- Pin the authenticated-session snapshot precision boundary from `ISSUES_TO_FIX_ASAP.md`.
- Keep the existing explicit `eslint-disable-next-line react-hooks/exhaustive-deps` opt-out clean.
- Keep the syntax-identical unmarked live-role capture diagnostic.
- Keep the explicit session-object encoding clean.
- Add an `exhaustive-deps` liveness target and generator coverage for the genuine missing-role case.

This intentionally does not add a detector heuristic. The untouched benchmark snapshot and a true live-role read have the same AST, and inferring intent from names such as `sessionKey` would introduce false negatives. The benchmark source must encode the invariant explicitly with the supported suppression annotation or an explicit session object.

## Runtime finding

The authentic task expects the role to be frozen at authentication time. A runtime harness confirmed that the original omission loads once with `user`, adding `role` loads again with `admin`, and the explicit session-object encoding loads once with `user`. That makes the application intent real, but it does not make the unmarked source statically distinguishable from a stale-role bug.

## Validation

- Exact production fixture: annotated snapshot 0 findings; unmarked live neighbor 1 `user.role` finding; explicit session object 0 findings.
- Focused/full plugin validation: 559 files passed; 13,822 tests passed and 175 skipped.
- Strict fuzz: `FUZZ_RULE=exhaustive-deps FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz` passed.
- Fuzz fire proof: 396 executed programs, 168 fired programs, 350 parse-skipped mutations; target coverage 1/1.
- Fuzz corpus: 44 passed and 402 skipped; package tests 2 passed and 1 skipped.
- Exact local RDE A/B: 100/100 pinned roots completed for baseline and candidate, 0 failures, 11,799 total diagnostics, 101 `exhaustive-deps` diagnostics, 0 added or removed verdicts.
- Exact React Bench 5 A/B: 122/122 pinned roots completed for baseline and candidate, 0 failures, 52,380 total diagnostics, 1,964 `exhaustive-deps` diagnostics, 0 added or removed verdicts, 0 lost verified true positives.
- Built baseline and candidate artifacts are byte-identical: oxlint plugin `8dd8422c…`, CLI `ea289645…`. Reconstructable oracle inputs therefore have exact production parity as well.
- Full repository: `nr test` (2,243 passed, 27 skipped), `nr typecheck`, `nr lint`, `nr format:check`, `nr smoke:json-report`, and `git diff --check` passed.
- Final truffler deduplication search found no overlapping helper or superseded logic.
- Exact base: `dc5c828d8`; head: `c0ffded08`.

No changeset: production detector behavior and published output are unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and fuzz corpus changes only; production rule logic and lint output are unchanged per the PR description.
> 
> **Overview**
> Adds **regression and fuzz coverage** for the authenticated-session “role snapshotted per `sessionKey`” boundary without changing `exhaustive-deps` detector behavior.
> 
> New regression cases assert that an **`eslint-disable-next-line react-hooks/exhaustive-deps`** on the effect stays clean, a **syntax-identical** unmarked neighbor still reports **`user.role`**, and an **explicit `useRef` session object** (`{ key, role }` updated when the key changes) stays clean. A fuzz corpus target **`LiveSessionRole`** mirrors the live-role read (`user.role` in the effect, deps only `[sessionKey]`), and **`EFFECT_SNIPPET_POOL`** gains a matching snippet so strict fuzz can still hit the genuine missing-role path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0ffded08d5dcb3b09b672f4906fe031a0c83df8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->