### PR TITLE
fix(rules): normalize large-text child guards

### DIFF
--- a/.changeset/hot-dancers-bake.md
+++ b/.changeset/hot-dancers-bake.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Recognize immutable large-text threshold constants in no-polymorphic-children virtualization guards.

--- a/packages/fuzz/corpus/regressions/no-polymorphic-children--static-large-text-threshold.tsx
+++ b/packages/fuzz/corpus/regressions/no-polymorphic-children--static-large-text-threshold.tsx
@@ -1,0 +1,20 @@
+// rule: no-polymorphic-children
+// weakness: alias-guard
+// source: react-bench write-react-callstackincubator-rozenite-279
+
+import type { HTMLProps, ReactNode } from "react";
+
+interface CodeBlockProps extends HTMLProps<HTMLPreElement> {
+  children?: ReactNode;
+}
+
+const VIRTUALIZATION_THRESHOLD = 50_000;
+
+const VirtualizedCode = ({ text }: { text: string }) => <code>{text.slice(0, 100)}</code>;
+
+export const CodeBlock = ({ children, ...preProps }: CodeBlockProps) => {
+  if (typeof children === "string" && children.length > VIRTUALIZATION_THRESHOLD) {
+    return <VirtualizedCode text={children} />;
+  }
+  return <pre {...preProps}>{children}</pre>;
+};

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -198,6 +198,7 @@ export const MODULE_SCOPE_SNIPPET_POOL = [
   `const GLOBAL_CACHE = new Map<string, unknown>();`,
   `class FuzzProtocolRegistry { static contextTypes = new Set(["json", "text"]); static childContextTypes = new Map(); getChildContext() { return { protocol: "json" }; } } const FuzzSchemaRegistry = {}; FuzzSchemaRegistry.contextTypes = new Set(["json", "text"]);`,
   `const fuzzLeftItems = ["a", "b"]; const fuzzRightItems = ["a", "b"]; const fuzzItemsMatch = fuzzLeftItems.every((item, index) => item === fuzzRightItems[index]);`,
+  `const FuzzLargeTextThreshold = 50_000; const FuzzLargeTextCodeBlock = ({ children }) => { if (typeof children === "string" && children.length > FuzzLargeTextThreshold) return <VirtualizedCode text={children} />; return <pre>{children}</pre>; }; const FuzzPolymorphicChildPanel = ({ children }) => typeof children === "string" ? <span>{children}</span> : <div>{children}</div>;`,
   `const FuzzPropTypesPanel = ({ value }) => <div>{value}</div>; FuzzPropTypesPanel.propTypes = { value: () => true };`,
   `function FuzzNestedWritePanel() { return <div />; } function unusedFuzzNestedWrite() { FuzzNestedWritePanel = () => null; } FuzzNestedWritePanel.propTypes = { value: () => true };`,
   `function FuzzReturnedLabel() { let output = "label"; function unusedFuzzOutputWrite() { output = <div />; } return output; } FuzzReturnedLabel.propTypes = { value: () => true };`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-polymorphic-children.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-polymorphic-children.regressions.test.ts
@@ -106,6 +106,24 @@ describe("correctness/no-polymorphic-children — regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("stays silent when a module constant defines the large-string threshold", () => {
+    const result = runRule(
+      noPolymorphicChildren,
+      `
+      const VIRTUALIZATION_THRESHOLD = 50_000;
+
+      const CodeBlock = ({ children, ...preProps }) => {
+        if (typeof children === 'string' && children.length > VIRTUALIZATION_THRESHOLD) {
+          return <VirtualizedCode text={children} />;
+        }
+        return <pre {...preProps}>{children}</pre>;
+      };
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("stays silent when a leading guard precedes large-string virtualization", () => {
     const result = runRule(
       noPolymorphicChildren,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-polymorphic-children.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-polymorphic-children.regressions.test.ts
@@ -124,6 +124,146 @@ describe("correctness/no-polymorphic-children — regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("stays silent for aliased, wrapped, and commuted large-string guards", () => {
+    const result = runRule(
+      noPolymorphicChildren,
+      `
+      const MINIMUM_VIRTUALIZED_LENGTH = 50_000 as const;
+      const VIRTUALIZATION_THRESHOLD = MINIMUM_VIRTUALIZED_LENGTH;
+
+      const CodeBlock = ({ children }) => {
+        if ('string' === typeof children && VIRTUALIZATION_THRESHOLD < children.length) {
+          return <VirtualizedCode text={children} />;
+        }
+        return <pre>{children}</pre>;
+      };
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent for the negated fallback form of a large-string guard", () => {
+    const result = runRule(
+      noPolymorphicChildren,
+      `
+      const VIRTUALIZATION_THRESHOLD = 50_000;
+
+      const CodeBlock = ({ children }) => {
+        if (typeof children !== 'string' || children.length <= VIRTUALIZATION_THRESHOLD) {
+          return <pre>{children}</pre>;
+        }
+        return <VirtualizedCode text={children} />;
+      };
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent when a helper narrows large strings before rendering", () => {
+    const result = runRule(
+      noPolymorphicChildren,
+      `
+      const VIRTUALIZATION_THRESHOLD = 50_000;
+      const getVirtualizableText = (content) =>
+        typeof content === 'string' && content.length > VIRTUALIZATION_THRESHOLD
+          ? content
+          : null;
+
+      const CodeBlock = ({ children }) => {
+        const virtualizableText = getVirtualizableText(children);
+        if (virtualizableText !== null) {
+          return <VirtualizedCode text={virtualizableText} />;
+        }
+        return <pre>{children}</pre>;
+      };
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still flags a small module-constant threshold", () => {
+    const result = runRule(
+      noPolymorphicChildren,
+      `
+      const WIDE_LABEL_THRESHOLD = 3;
+
+      const Button = ({ children }) => {
+        if (typeof children === 'string' && children.length > WIDE_LABEL_THRESHOLD) {
+          return <button className="wide">{children}</button>;
+        }
+        return <div className="compact">{children}</div>;
+      };
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags mutable and unknown thresholds", () => {
+    const mutableResult = runRule(
+      noPolymorphicChildren,
+      `
+      let threshold = 50_000;
+      threshold = 3;
+
+      const Button = ({ children }) => {
+        if (typeof children === 'string' && children.length > threshold) {
+          return <button className="wide">{children}</button>;
+        }
+        return <div className="compact">{children}</div>;
+      };
+      `,
+    );
+    const unknownResult = runRule(
+      noPolymorphicChildren,
+      `
+      const Button = ({ children, threshold }) => {
+        if (typeof children === 'string' && children.length > threshold) {
+          return <button className="wide">{children}</button>;
+        }
+        return <div className="compact">{children}</div>;
+      };
+      `,
+    );
+    const importedResult = runRule(
+      noPolymorphicChildren,
+      `
+      import { VIRTUALIZATION_THRESHOLD } from './config';
+
+      const Button = ({ children }) => {
+        if (typeof children === 'string' && children.length > VIRTUALIZATION_THRESHOLD) {
+          return <button className="wide">{children}</button>;
+        }
+        return <div className="compact">{children}</div>;
+      };
+      `,
+    );
+    const memberResult = runRule(
+      noPolymorphicChildren,
+      `
+      const config = { virtualizationThreshold: 50_000 };
+
+      const Button = ({ children }) => {
+        if (typeof children === 'string' && children.length > config.virtualizationThreshold) {
+          return <button className="wide">{children}</button>;
+        }
+        return <div className="compact">{children}</div>;
+      };
+      `,
+    );
+    expect(mutableResult.parseErrors).toEqual([]);
+    expect(mutableResult.diagnostics).toHaveLength(1);
+    expect(unknownResult.parseErrors).toEqual([]);
+    expect(unknownResult.diagnostics).toHaveLength(1);
+    expect(importedResult.parseErrors).toEqual([]);
+    expect(importedResult.diagnostics).toHaveLength(1);
+    expect(memberResult.parseErrors).toEqual([]);
+    expect(memberResult.diagnostics).toHaveLength(1);
+  });
+
   it("stays silent when a leading guard precedes large-string virtualization", () => {
     const result = runRule(
       noPolymorphicChildren,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-polymorphic-children.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-polymorphic-children.ts
@@ -5,6 +5,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import type { ScopeAnalysis, SymbolDescriptor } from "../../semantic/scope-analysis.js";
 import { findTransparentExpressionRoot } from "../../utils/find-transparent-expression-root.js";
+import { getDirectConstInitializer } from "../../utils/get-direct-const-initializer.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
@@ -167,17 +168,32 @@ const isPropsChildrenLength = (node: EsTreeNode, scopes: ScopeAnalysis): boolean
   );
 };
 
+const resolveStaticNumericValue = (
+  node: EsTreeNode,
+  scopes: ScopeAnalysis,
+  visitedSymbolIds: ReadonlySet<number> = new Set(),
+): number | null => {
+  const unwrappedNode = stripParenExpression(node);
+  if (isNodeOfType(unwrappedNode, "Literal") && typeof unwrappedNode.value === "number") {
+    return Number.isFinite(unwrappedNode.value) ? unwrappedNode.value : null;
+  }
+  if (!isNodeOfType(unwrappedNode, "Identifier")) return null;
+  const symbol = scopes.symbolFor(unwrappedNode);
+  if (!symbol || visitedSymbolIds.has(symbol.id)) return null;
+  const initializer = getDirectConstInitializer(symbol);
+  if (!initializer) return null;
+  return resolveStaticNumericValue(initializer, scopes, new Set(visitedSymbolIds).add(symbol.id));
+};
+
 const isLargeTextLengthComparison = (node: EsTreeNode, scopes: ScopeAnalysis): boolean => {
   const unwrappedNode = stripParenExpression(node);
   if (!isNodeOfType(unwrappedNode, "BinaryExpression")) return false;
   const leftIsLength = isPropsChildrenLength(unwrappedNode.left, scopes);
   const rightIsLength = isPropsChildrenLength(unwrappedNode.right, scopes);
   const thresholdNode = leftIsLength ? unwrappedNode.right : unwrappedNode.left;
-  if ((!leftIsLength && !rightIsLength) || !isNodeOfType(thresholdNode, "Literal")) return false;
-  if (
-    typeof thresholdNode.value !== "number" ||
-    thresholdNode.value < LARGE_TEXT_OPTIMIZATION_THRESHOLD_CHARS
-  ) {
+  if (!leftIsLength && !rightIsLength) return false;
+  const thresholdValue = resolveStaticNumericValue(thresholdNode, scopes);
+  if (thresholdValue === null || thresholdValue < LARGE_TEXT_OPTIMIZATION_THRESHOLD_CHARS) {
     return false;
   }
   return leftIsLength


### PR DESCRIPTION
## Summary

- resolve finite numeric literals through immutable direct `const` aliases before classifying large-text comparisons
- keep mutable, parameter, imported, member-expression, and otherwise unproven thresholds reportable
- cover the confirmed false positive with paired adversarial tests, a permanent fuzz regression, and a live fuzz snippet

## Grounding

The authentic React Bench trials pin `callstackincubator/rozenite@e82fa2201d6e68c0e300a08c2bc49b640aa6fd69`. Their `CodeBlock` components use a large immutable numeric threshold to virtualize only unusually large string content. Replacing the named threshold with the same inline literal changes no runtime behavior but makes the old detector stay quiet, proving an alias-instability false positive.

Fresh no-cache exact-source replays:

- nine behaviorally valid trial patches: target `1 -> 0`, with exactly one intended diagnostic removed from each
- one already-clean trial: target `0 -> 0`
- untouched pinned source: target `0 -> 0`
- reconstructed oracle solution: target `0 -> 0`
- no added or unrelated diagnostic deltas in any state

## Precision boundary

The rule suppresses only when the comparison threshold is proven locally from a finite numeric literal or a cycle-safe chain of direct immutable `const` initializers. It does not guess through mutable bindings, parameters, imports, member expressions, or external provenance. Nearby true-positive shapes remain diagnostics.

## Validation

- full oxlint plugin suite: 555 files; 13,259 passed, 148 skipped
- strict fuzz: `FUZZ_RULE=no-polymorphic-children FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz` passed
- fuzz corpus: 43 passed, 401 skipped; the target rule is exercised by the added snippet
- fresh local RDE: 100/100 complete schema-v3 roots across 12 pinned repositories on both sides, 0 failures or partial scans, 11,438 total diagnostics and target `0 -> 0`, with 0 added/removed identities
- fresh no-cache React Bench: 122/122 pinned revisions successfully scanned on both sides, target `2 -> 2`, with 0 added/removed identities; both retained target findings are unchanged
- exact Rozenite base/trial/oracle matrix described above
- `nr build`
- `nr typecheck`
- `nr lint`
- `nr format:check`
- `nr smoke:json-report`
- `git diff --check`
- exact-head GitHub CI matrix passed on Linux, macOS, and Windows across Node 20, 22, 24, 25, and 26

No merge requested; maintainer review remains the terminal action.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow lint-rule precision change with explicit boundaries; only affects when diagnostics are suppressed, not runtime behavior.
> 
> **Overview**
> Fixes a false positive in **`no-polymorphic-children`** when large-string virtualization uses a **module-level `const` threshold** (e.g. `VIRTUALIZATION_THRESHOLD = 50_000`) instead of an inline literal—the rule already treated inline literals as benign optimization guards but did not follow identifier aliases.
> 
> **`isLargeTextLengthComparison`** now resolves comparison operands through **`resolveStaticNumericValue`**, which walks **cycle-safe chains of direct immutable `const` initializers** via **`getDirectConstInitializer`**. Only thresholds proven locally as finite numbers **≥ `LARGE_TEXT_OPTIMIZATION_THRESHOLD_CHARS`** still suppress the polymorphic-children diagnostic; **mutable bindings, props, imports, and member-expression thresholds** remain reportable.
> 
> Adds **regression tests** (aliased/commuted/negated guards, helper narrowing, adversarial small or unproven thresholds), a **fuzz corpus** case, a **fuzz snippet**, and a **changeset** patch note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46b0d0bfad7871d8e127e277af8d7be7351ad905. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->