### PR TITLE
test(no-event-handler): preserve registration lifecycle effects

### DIFF
--- a/packages/fuzz/corpus/regressions/no-event-handler--guarded-registration-cleanup.tsx
+++ b/packages/fuzz/corpus/regressions/no-event-handler--guarded-registration-cleanup.tsx
@@ -1,0 +1,22 @@
+// rule: no-event-handler
+// weakness: guarded-lifecycle
+// source: React Bench write-react-lobehub-lobe-ui-508
+import { useEffect } from "react";
+
+interface AccordionItemState {
+  registerItemKey: (itemKey: string) => () => void;
+}
+
+interface AccordionItemProps {
+  isStandalone: boolean;
+  itemKey: string;
+  itemState: AccordionItemState | undefined;
+}
+
+export const AccordionItem = ({ isStandalone, itemKey, itemState }: AccordionItemProps) => {
+  useEffect(() => {
+    if (!isStandalone) return itemState?.registerItemKey(itemKey);
+  }, [isStandalone, itemKey, itemState]);
+
+  return <div>{itemKey}</div>;
+};

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -49,6 +49,7 @@ export const EFFECT_SNIPPET_POOL = [
   `const onTick = useEffectEvent(() => handle(value)); useEffect(() => { onTick(); }, [onTick]);`,
   `const [, setOpen] = useState(false); const stableHandle = useCallback(() => setOpen(true), [setOpen]); useEffect(() => { const timeoutId = setTimeout(() => stableHandle(), 100); return () => clearTimeout(timeoutId); }, [stableHandle, value]);`,
   `const deferredHandle = useCallback(() => handle(value), [value]); useEffect(() => { const timeoutId = setTimeout(() => deferredHandle(), 100); return () => clearTimeout(timeoutId); }, [deferredHandle, value]);`,
+  `const [didSubmit, setDidSubmit] = useState(false); useEffect(() => { if (didSubmit) handle(value); }, [didSubmit, value]); const eventRelayButton = <button onClick={() => setDidSubmit(true)}>Submit</button>;`,
   `const [phase, setPhase] = useState(""); const [total, setTotal] = useState(0); const [ready, setReady] = useState(false); useEffect(() => { setPhase("sync"); setTotal(items.length); setReady(true); }, [items]);`,
   `const [snapshot, setSnapshot] = useState(sharedSnapshot); useEffect(() => subscribeSnapshot(setSnapshot), []);`,
 ] as const;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-event-handler.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-event-handler.regressions.test.ts
@@ -510,6 +510,36 @@ describe("no-event-handler — must-detect regressions", () => {
 });
 
 describe("no-event-handler — regressions", () => {
+  it("stays silent on guarded parent registration with the returned cleanup", () => {
+    const result = runRule(
+      noEventHandler,
+      `function AccordionItem({ isStandalone, itemKey }) {
+        const itemStateContext = useAccordionItemState();
+        useEffect(() => {
+          if (!isStandalone) return itemStateContext?.registerItemKey(itemKey);
+        }, [isStandalone, itemKey, itemStateContext]);
+        return <div>{itemKey}</div>;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still reports handler-written state relayed through a guarded effect", () => {
+    const result = runRule(
+      noEventHandler,
+      `function AccordionItem({ onOpen }) {
+        const [didRequestOpen, setDidRequestOpen] = useState(false);
+        useEffect(() => {
+          if (didRequestOpen) onOpen();
+        }, [didRequestOpen, onOpen]);
+        return <button onClick={() => setDidRequestOpen(true)}>Open</button>;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
   // Flipped by the 67k-diagnostic verification run: a `[]`-deps effect whose
   // tested state is only ever set by the mount effect itself is one-time
   // initialization (no-initialize-state territory), not a faked event


### PR DESCRIPTION
## Why

Published React Doctor 0.7.2 and 0.7.4 report the authentic Lobe UI Accordion registration lifecycle as `no-event-handler`. The effect synchronously registers an item key on mount/key change and returns the exact unregister function as cleanup. It does not relay UI-event state or invoke an event callback.

The current detector already classifies this shape correctly. This PR therefore preserves that precision boundary with permanent regression and fuzz coverage instead of adding redundant detector logic.

Grounding: React Bench job `write-react-lobehub-lobe-ui-508__xxxBuj3` has 11 passing unit tests and 2 passing browser tests; its stored 0.7.3 result is rejected solely by the two false diagnostics.

## What changed

- adds the exact guarded optional registration call with its returned cleanup as a valid regression
- adds a handler-written-state effect relay as the invalid near-neighbor
- adds the authentic lifecycle shape to the permanent fuzz regression corpus
- adds a minimal genuine event-relay snippet so strict target fuzzing proves `no-event-handler` actually fires

No detector or public behavior changes. No changeset is needed for test/private-fuzz-only coverage.

## Validation

### Rule and fuzz

- oxlint plugin: 554 files passed; 13,224 tests passed, 148 skipped
- fuzz package: 43 passed, 401 skipped
- strict fuzz: 500 requested iterations, 317 generated programs executed, target fired 4 times, 0 findings, target coverage 1/1
- permanent corpus FP hunt: the new registration seed stays silent for `no-event-handler`

### Real repositories

| Corpus | Coverage | Baseline target | Candidate target | Added | Removed |
| --- | ---: | ---: | ---: | ---: | ---: |
| local RDE | 100 roots / 12 repos, 0 failures | 2 | 2 | 0 | 0 |
| React Bench 5 pinned bases | 122/122 tasks, 0 failures | 18 | 18 | 0 | 0 |
| Trendyol solution-sensitive oracle | 1/1, 5 total diagnostics each | 0 | 0 | 0 | 0 |

React Bench compared all 48,708 diagnostics by task, file, plugin, rule, line, column, severity, and message; baseline and candidate hashes are identical. The built plugin and CLI artifacts are also byte-identical because this PR changes only tests and private fuzz inputs.

### Repository checks

- `nr typecheck`
- `nr lint` (existing warnings only)
- `nr format:check`
- `nr build`
- `nr smoke:json-report`
- React Doctor package: 2,243 passed, 27 skipped
- focused performance/TTY rerun: 24 passed
- `git diff --check`
- pre/post `truffler` deduplication searches

CI is green across the complete matrix. The PR intentionally remains draft for maintainer review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only tests and private fuzz inputs; no production rule or CLI logic changes.
> 
> **Overview**
> **Test and fuzz coverage only** — no changes to the `no-event-handler` rule or shipped behavior.
> 
> Adds regression tests that **keep** guarded parent registration (`useEffect` returns `registerItemKey` cleanup when not standalone) **silent**, while a near-neighbor pattern (click sets state → guarded effect calls `onOpen`) **still reports**.
> 
> Adds a permanent fuzz corpus seed from the Lobe UI Accordion lifecycle and a minimal **handler-written-state → effect relay** snippet in `EFFECT_SNIPPET_POOL` so strict fuzzing proves the rule still fires on genuine event relays.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08a53156cde52517a280db5a2c5d8429b8253263. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->