### PR TITLE
fix(rule): respect Solid component lifecycle

### DIFF
--- a/.changeset/tall-rice-rest.md
+++ b/.changeset/tall-rice-rest.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Fix no-unstable-nested-components false positives in explicitly Solid-owned JSX files while preserving React and ambiguous-file diagnostics.

--- a/packages/fuzz/corpus/regressions/no-unstable-nested-components--solid-signal-state.tsx
+++ b/packages/fuzz/corpus/regressions/no-unstable-nested-components--solid-signal-state.tsx
@@ -1,0 +1,21 @@
+// rule: no-unstable-nested-components
+// weakness: framework-gating
+// source: React Bench migrate-react-opencode-solid-to__qkdAxyJ
+import { createSignal, Show } from "solid-js";
+
+export const DialogConnectProvider = () => {
+  const ProviderOption = (props: { name: string }) => {
+    const [attempts, setAttempts] = createSignal(0);
+    return (
+      <button onClick={() => setAttempts(attempts() + 1)}>
+        {props.name}: {attempts()}
+      </button>
+    );
+  };
+
+  return (
+    <Show when={true}>
+      <ProviderOption name="OpenCode" />
+    </Show>
+  );
+};

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -56,6 +56,7 @@ export const EFFECT_SNIPPET_POOL = [
 // State — lazy initializers (incl. SSR-hazardous localStorage/matchMedia),
 // toggles, loading triples, prop mirrors, reducers, ref-sync.
 export const STATE_SNIPPET_POOL = [
+  `const FuzzNestedPanel = () => <div>nested</div>; const fuzzNestedPanelNode = <FuzzNestedPanel />;`,
   `const [state, setState] = useState(0);`,
   `const [state, setState] = useState(() => Number(localStorage.getItem("count") ?? 0));`,
   `const [theme, setTheme] = useState(() => (typeof window === "undefined" ? "light" : (localStorage.getItem("theme") ?? "light")));`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-unstable-nested-components.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-unstable-nested-components.regressions.test.ts
@@ -6,6 +6,93 @@ const run = (code: string) =>
   runRule(noUnstableNestedComponents, code, { filename: "fixture.tsx" });
 
 describe("react-builtins/no-unstable-nested-components — regressions", () => {
+  it("stays silent on an authentic Solid nested component with local signal state", () => {
+    const result = run(`
+      import { createSignal, Show } from "solid-js";
+      const DialogConnectProvider = () => {
+        const ProviderOption = (props) => {
+          const [attempts, setAttempts] = createSignal(0);
+          return <button onClick={() => setAttempts(attempts() + 1)}>{props.name}: {attempts()}</button>;
+        };
+        return <Show when={true}><ProviderOption name="OpenCode" /></Show>;
+      };
+    `);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent when solid-js/web establishes renderer ownership", () => {
+    const result = run(`
+      import { render } from "solid-js/web";
+      const App = () => {
+        const Child = () => <div>Solid</div>;
+        return <Child />;
+      };
+      render(() => <App />, document.body);
+    `);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent for a Solid runtime subpath import", () => {
+    const result = run(`
+      import { createStore } from "solid-js/store";
+      const App = () => {
+        const Child = () => <div>Solid</div>;
+        return <Child />;
+      };
+    `);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent when a later classList attribute proves Solid JSX ownership", () => {
+    const result = run(`
+      const App = () => {
+        const Child = () => <div>Solid</div>;
+        return <main><Child /><div classList={{ active: true }} /></main>;
+      };
+    `);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still reports the same nested component in an explicitly React-owned file", () => {
+    const result = run(`
+      import { useState } from "react";
+      const App = () => {
+        const Child = () => {
+          const [count] = useState(0);
+          return <div>{count}</div>;
+        };
+        return <Child />;
+      };
+    `);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still reports a nested component when JSX ownership is ambiguous", () => {
+    const result = run(`
+      const App = () => {
+        const Child = () => <div>Ambiguous</div>;
+        return <Child />;
+      };
+    `);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("keeps module-scope Solid and React components quiet", () => {
+    const solidResult = run(`
+      import { createSignal } from "solid-js";
+      const Child = () => <div>Solid</div>;
+      const App = () => <Child />;
+    `);
+    const reactResult = run(`
+      import { useState } from "react";
+      const Child = () => <div>React</div>;
+      const App = () => <Child />;
+    `);
+    expect(solidResult.diagnostics).toEqual([]);
+    expect(reactResult.diagnostics).toEqual([]);
+  });
+
   it("flags a nested PascalCase component rendered as JSX", () => {
     const result = run(`
       const Parent = () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-unstable-nested-components.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-unstable-nested-components.regressions.test.ts
@@ -78,6 +78,97 @@ describe("react-builtins/no-unstable-nested-components — regressions", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("still reports when React and Solid runtime imports make ownership mixed", () => {
+    const result = run(`
+      import { useState } from "react";
+      import { createSignal } from "solid-js";
+      const App = () => {
+        const Child = () => {
+          const [count] = useState(0);
+          return <div>{count}</div>;
+        };
+        return <Child />;
+      };
+    `);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still reports when a React file has a late Solid JSX marker", () => {
+    const result = run(`
+      import { useState } from "react";
+      const App = () => {
+        const Child = () => {
+          const [count] = useState(0);
+          return <div>{count}</div>;
+        };
+        return <main><Child /><Widget classList={{ active: true }} /></main>;
+      };
+    `);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still reports when Solid is imported only for types", () => {
+    const result = run(`
+      import type { JSX } from "solid-js";
+      const App = () => {
+        const Child = (): JSX.Element => <div>Ambiguous</div>;
+        return <Child />;
+      };
+    `);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("ignores a React type-only import in a Solid-owned file", () => {
+    const result = run(`
+      import type { ReactNode } from "react";
+      import { createSignal } from "solid-js";
+      const App = () => {
+        const Child = () => {
+          const [count] = createSignal(0);
+          return <div>{count()}</div>;
+        };
+        return <Child />;
+      };
+    `);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent for an aliased Solid runtime import", () => {
+    const result = run(`
+      import { createSignal as makeSignal } from "solid-js";
+      const App = () => {
+        const Child = () => {
+          const [count] = makeSignal(0);
+          return <div>{count()}</div>;
+        };
+        return <Child />;
+      };
+    `);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent for the explicit Solid JSX runtime", () => {
+    const result = run(`
+      import { jsx } from "solid-js/jsx-runtime";
+      const App = () => {
+        const Child = () => <div>Solid</div>;
+        return <Child />;
+      };
+    `);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not treat a similarly named userland package as Solid ownership", () => {
+    const result = run(`
+      import { createSignal } from "solid-js-userland";
+      const App = () => {
+        const Child = () => <div>Ambiguous</div>;
+        return <Child />;
+      };
+    `);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("keeps module-scope Solid and React components quiet", () => {
     const solidResult = run(`
       import { createSignal } from "solid-js";

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-unstable-nested-components.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-unstable-nested-components.ts
@@ -424,6 +424,7 @@ export const noUnstableNestedComponents = defineRule({
   recommendation:
     "Move nested components to module scope so React does not remount them and lose state on every render.",
   category: "Performance",
+  tags: ["react-jsx-only"],
   create: (context) => {
     const settings = resolveSettings(context.settings);
     const renderPropRegex = compileGlob(settings.propNamePattern);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/define-rule.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/define-rule.ts
@@ -1,6 +1,6 @@
 import type { FileScan } from "./file-scan.js";
 import {
-  fileImportsNonReactJsxDialect,
+  collectJsxRuntimeImports,
   jsxAttributeIsNonReactDialectMarker,
 } from "./non-react-jsx-dialect.js";
 import { skipNonProductionFiles } from "./skip-non-production-files.js";
@@ -36,6 +36,7 @@ const wrapCreateForReactJsxOnly = <
   ((context: Parameters<CreateFn>[0]) => {
     const innerVisitors = create(context);
     let fileIsNonReactJsx = false;
+    let fileImportsReactRuntime = false;
     // We need a Program visitor to seed the dialect status BEFORE any
     // JSX visitor fires. If the original rule already declared one,
     // wrap it; otherwise inject a fresh one.
@@ -52,14 +53,20 @@ const wrapCreateForReactJsxOnly = <
       }
       if (key === "Program") {
         wrappedVisitors.Program = (node: EsTreeNodeOfType<"Program">) => {
-          fileIsNonReactJsx = fileImportsNonReactJsxDialect(node);
+          const runtimeImports = collectJsxRuntimeImports(node);
+          fileImportsReactRuntime = runtimeImports.hasReactRuntime;
+          fileIsNonReactJsx = runtimeImports.hasNonReactRuntime && !runtimeImports.hasReactRuntime;
           (visitor as (n: EsTreeNodeOfType<"Program">) => void)(node);
         };
         continue;
       }
       if (key === "JSXOpeningElement") {
         wrappedVisitors.JSXOpeningElement = (node: EsTreeNodeOfType<"JSXOpeningElement">) => {
-          if (!fileIsNonReactJsx && jsxAttributeIsNonReactDialectMarker(node)) {
+          if (
+            !fileImportsReactRuntime &&
+            !fileIsNonReactJsx &&
+            jsxAttributeIsNonReactDialectMarker(node)
+          ) {
             fileIsNonReactJsx = true;
           }
           if (fileIsNonReactJsx) return;
@@ -74,7 +81,9 @@ const wrapCreateForReactJsxOnly = <
     }
     if (!("Program" in wrappedVisitors)) {
       wrappedVisitors.Program = (node: EsTreeNodeOfType<"Program">) => {
-        fileIsNonReactJsx = fileImportsNonReactJsxDialect(node);
+        const runtimeImports = collectJsxRuntimeImports(node);
+        fileImportsReactRuntime = runtimeImports.hasReactRuntime;
+        fileIsNonReactJsx = runtimeImports.hasNonReactRuntime && !runtimeImports.hasReactRuntime;
       };
     }
     return wrappedVisitors;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/non-react-jsx-dialect.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/non-react-jsx-dialect.ts
@@ -1,6 +1,12 @@
 import type { EsTreeNode } from "./es-tree-node.js";
 import type { EsTreeNodeOfType } from "./es-tree-node-of-type.js";
 import { isNodeOfType } from "./is-node-of-type.js";
+import { isTypeOnlyImport } from "./is-type-only-import.js";
+
+export interface JsxRuntimeImports {
+  hasNonReactRuntime: boolean;
+  hasReactRuntime: boolean;
+}
 
 // Non-React JSX dialects that use raw HTML attribute names (`class`,
 // `for`, `tabindex`, etc.) and have their own a11y / keyboard /
@@ -29,22 +35,42 @@ const NON_REACT_JSX_DIALECT_PACKAGE_PREFIXES: ReadonlyArray<string> = [
   "@builder.io/qwik",
 ];
 
+const REACT_JSX_DIALECT_PACKAGE_PREFIXES: ReadonlyArray<string> = ["react", "react-dom", "preact"];
+
 const startsWithAny = (source: string, prefixes: ReadonlyArray<string>): boolean =>
   prefixes.some((prefix) => source === prefix || source.startsWith(`${prefix}/`));
 
-export const fileImportsNonReactJsxDialect = (program: EsTreeNodeOfType<"Program">): boolean => {
+export const collectJsxRuntimeImports = (
+  program: EsTreeNodeOfType<"Program">,
+): JsxRuntimeImports => {
+  let hasNonReactRuntime = false;
+  let hasReactRuntime = false;
   for (const statement of program.body) {
     if (!isNodeOfType(statement as EsTreeNode, "ImportDeclaration")) continue;
-    const source = (statement as EsTreeNodeOfType<"ImportDeclaration">).source;
+    const importDeclaration = statement as EsTreeNodeOfType<"ImportDeclaration">;
+    if (isTypeOnlyImport(importDeclaration)) continue;
+    const source = importDeclaration.source;
     const value =
       source && typeof (source as { value?: unknown }).value === "string"
         ? (source as { value: string }).value
         : null;
     if (!value) continue;
-    if (NON_REACT_JSX_DIALECT_PACKAGES.has(value)) return true;
-    if (startsWithAny(value, NON_REACT_JSX_DIALECT_PACKAGE_PREFIXES)) return true;
+    if (
+      NON_REACT_JSX_DIALECT_PACKAGES.has(value) ||
+      startsWithAny(value, NON_REACT_JSX_DIALECT_PACKAGE_PREFIXES)
+    ) {
+      hasNonReactRuntime = true;
+    }
+    if (startsWithAny(value, REACT_JSX_DIALECT_PACKAGE_PREFIXES)) {
+      hasReactRuntime = true;
+    }
   }
-  return false;
+  return { hasNonReactRuntime, hasReactRuntime };
+};
+
+export const fileImportsNonReactJsxDialect = (program: EsTreeNodeOfType<"Program">): boolean => {
+  const runtimeImports = collectJsxRuntimeImports(program);
+  return runtimeImports.hasNonReactRuntime && !runtimeImports.hasReactRuntime;
 };
 
 // `classList={...}` is Solid-distinctive — React JSX would write


### PR DESCRIPTION
Catches React-only nested-component lifecycle advice being applied to explicitly Solid-owned JSX files.

## Why

Solid does not reexecute nested component functions on parent signal updates the way React recreates nested component types during render. The existing rule therefore reports authentic Solid components with incorrect remount and state-loss advice in mixed React/Solid packages.

The report was reproduced at 24 unique source sites in the pinned React Bench OpenCode migration tasks. A runtime control confirmed one parent execution and one nested-component execution while signal state advanced to 7, so the claimed remount/state loss does not occur.

## What changed

- Marks `no-unstable-nested-components` as `react-jsx-only`, reusing the centralized per-file JSX dialect gate.
- Strengthens framework ownership so type-only Solid imports and similarly named userland packages do not suppress React findings, while explicit Solid runtimes, aliases, and subpaths remain supported.
- Preserves findings in mixed React/Solid runtime files and in React files with later Solid-looking JSX attributes.
- Adds paired Solid/React tests, a permanent React Bench regression seed, generated target-rule fuzz coverage, and a patch changeset.

## Validation

| Check | Result |
| --- | --- |
| Authentic pinned reproduction | 24 unique Solid FP sites; baseline 24, candidate 0, no parse failures |
| Solid runtime control | parent 1 execution, nested component 1 execution, state preserved at 7, output `3:7` |
| React Bench 5 | 5 exact base states + all 5 relevant oracle states; 2,596 source parses; 0 failures |
| Bench deltas | 29 overlapping task-state removals = the 24 unique Solid FPs; 0 additions; every retained React finding and every oracle finding unchanged |
| Schema-complete RDE | 100/100 pinned scans, 12 repositories, schemaVersion 3, 0 partial scans |
| RDE full parity | 0 added and 0 removed diagnostics; target rule 7 → 7; all 7 manually confirmed React true positives |
| Strict target fuzz | 500 iterations; 329 executed, 30 fired, 210 parse-skipped; 0 findings; target liveness confirmed |
| Fuzz corpus | 43 passed, 401 skipped |
| Plugin suite | 555 files; 13,267 passed, 148 skipped |
| Repository checks | typecheck 15/15, lint clean, format clean, diff check clean |
| Full repository test run | rule/plugin/core/API/LSP suites passed; two unrelated PTY marker probes failed only under full-suite load and passed 2/2 immediately in isolation |

## Test plan

```bash
nr --filter oxlint-plugin-react-doctor test
nr --filter @react-doctor/fuzz test
FUZZ_RULE=no-unstable-nested-components FUZZ_STRICT=1 FUZZ_ITERATIONS=500 FUZZ_PRINT_STATS=1 nr fuzz --disableConsoleIntercept
nr typecheck
nr lint
nr format:check
git diff --check
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted linter gating and dialect heuristics with broad regression coverage; behavior change is limited to when the nested-components rule runs, not core scan infrastructure.
> 
> **Overview**
> **`no-unstable-nested-components`** is now tagged **`react-jsx-only`**, so it skips files that are clearly Solid (or other non-React JSX) instead of applying React remount/state-loss advice there.
> 
> **JSX dialect detection** is tightened: **`collectJsxRuntimeImports`** separates React vs non-React **value** imports (type-only Solid/React imports no longer flip ownership), treats a file as Solid-only when there is a non-React runtime **without** a React runtime, and still runs the rule when imports are mixed or ambiguous. **`classList`** and similar markers only promote a file to non-React when it does not already import a React runtime.
> 
> Regression tests, a fuzz corpus seed, and a fuzz snippet cover Solid nested components, mixed runtimes, and false package-name matches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4834c7e8e5f2d4c999e949294cad9dd87589dce1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->