### PR TITLE
fix(control-has-associated-label): recognize native title names

### DIFF
--- a/.changeset/calm-buttons-listen.md
+++ b/.changeset/calm-buttons-listen.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Recognize native controls named by their own `title` attribute in `control-has-associated-label`.

--- a/packages/fuzz/corpus/regressions/control-has-associated-label--native-title-name.tsx
+++ b/packages/fuzz/corpus/regressions/control-has-associated-label--native-title-name.tsx
@@ -1,0 +1,14 @@
+// rule: control-has-associated-label
+// weakness: name-heuristic
+// source: React Bench Lumina Note trials documented in PR #1230
+
+interface IconButtonProps {
+  label: string;
+  onActivate: () => void;
+}
+
+export const TitleNamedIconButton = ({ label, onActivate }: IconButtonProps) => (
+  <button type="button" title={label} onClick={onActivate}>
+    <svg aria-hidden="true" />
+  </button>
+);

--- a/packages/fuzz/corpus/targets/control-has-associated-label--unnamed-native-control.tsx
+++ b/packages/fuzz/corpus/targets/control-has-associated-label--unnamed-native-control.tsx
@@ -1,0 +1,5 @@
+export const UnnamedIconButton = ({ onActivate }: { onActivate: () => void }) => (
+  <button type="button" onClick={onActivate}>
+    <svg aria-hidden="true" />
+  </button>
+);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/control-has-associated-label.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/control-has-associated-label.regressions.test.ts
@@ -333,23 +333,28 @@ describe("a11y/control-has-associated-label regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
-  it("reports controls named only by their title attribute (doc: title is not an accepted label)", () => {
+  it("accepts native controls named by their own title attribute", () => {
     const result = runRule(
       controlHasAssociatedLabel,
       `
         const Demo = ({ t, color }) => (
           <div>
             <input type="color" title={t("sketch.color")} />
+            <input type="text" title="Search" />
+            <input type="checkbox" title="Select row" />
+            <select title="Sort order" />
+            <textarea title="Comment" />
             <button type="button" title={color.label} onClick={() => {}} />
+            <div role="button" tabIndex={0} title="Edit" />
           </div>
         );
       `,
     );
 
-    expect(result.diagnostics).toHaveLength(2);
+    expect(result.diagnostics).toHaveLength(0);
   });
 
-  it("reports an icon-only delete button carrying only a title (PortOS corpus shape)", () => {
+  it("accepts an icon-only delete button carrying a static title", () => {
     const result = runRule(
       controlHasAssociatedLabel,
       `
@@ -369,10 +374,10 @@ describe("a11y/control-has-associated-label regressions", () => {
       `,
     );
 
-    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics).toHaveLength(0);
   });
 
-  it("reports an icon-only toggle button with a conditional title and conditional icons (Lumina-Note corpus shape)", () => {
+  it("accepts an icon-only toggle button with a dynamic title", () => {
     const result = runRule(
       controlHasAssociatedLabel,
       `
@@ -390,10 +395,10 @@ describe("a11y/control-has-associated-label regressions", () => {
       `,
     );
 
-    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics).toHaveLength(0);
   });
 
-  it("reports a conditionally rendered title-only delete button (MediaCollections corpus shape)", () => {
+  it("accepts a conditionally rendered title-only delete button", () => {
     const result = runRule(
       controlHasAssociatedLabel,
       `
@@ -420,10 +425,10 @@ describe("a11y/control-has-associated-label regressions", () => {
       `,
     );
 
-    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics).toHaveLength(0);
   });
 
-  it("reports a title-only close button behind a logical guard (SplitEditor corpus shape)", () => {
+  it("accepts a title-only close button behind a logical guard", () => {
     const result = runRule(
       controlHasAssociatedLabel,
       `
@@ -445,13 +450,133 @@ describe("a11y/control-has-associated-label regressions", () => {
       `,
     );
 
-    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics).toHaveLength(0);
   });
 
   it("still reports a button whose only title lives on a child span", () => {
     const result = runRule(
       controlHasAssociatedLabel,
       `const Demo = () => <button><span title="This is not a real label" /></button>;`,
+    );
+
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports native buttons whose title is statically omitted or empty", () => {
+    const result = runRule(
+      controlHasAssociatedLabel,
+      `
+        const Demo = () => (
+          <div>
+            <button title=""><svg aria-hidden /></button>
+            <button title={"   "}><svg aria-hidden /></button>
+            <button title={null}><svg aria-hidden /></button>
+            <button title={false}><svg aria-hidden /></button>
+            <button title={true}><svg aria-hidden /></button>
+            <button title={undefined}><svg aria-hidden /></button>
+            <button title={void 0}><svg aria-hidden /></button>
+            <button title={() => "Edit"}><svg aria-hidden /></button>
+            <button title={Symbol("Edit")}><svg aria-hidden /></button>
+            <button title={[]}><svg aria-hidden /></button>
+            <button title={[""]}><svg aria-hidden /></button>
+            <button title={[null]}><svg aria-hidden /></button>
+            <button title><svg aria-hidden /></button>
+            <button><svg aria-hidden /></button>
+          </div>
+        );
+      `,
+    );
+
+    expect(result.diagnostics).toHaveLength(14);
+  });
+
+  it("accepts native title names through DOM string coercion and unresolved expressions", () => {
+    const result = runRule(
+      controlHasAssociatedLabel,
+      `
+        const STATIC_TITLE = "Ask AI";
+        const Demo = ({ translatedTitle, isEditing }) => (
+          <div>
+            <button title={STATIC_TITLE}><svg aria-hidden /></button>
+            <button title={translatedTitle}><svg aria-hidden /></button>
+            <button title={isEditing ? "Save" : "Edit"}><svg aria-hidden /></button>
+            <button title={\`Ask AI\`}><svg aria-hidden /></button>
+            <button title={0}><svg aria-hidden /></button>
+            <button title={0n}><svg aria-hidden /></button>
+            <button title={{}}><svg aria-hidden /></button>
+            <button title={[0]}><svg aria-hidden /></button>
+            <button title={[null, null]}><svg aria-hidden /></button>
+          </div>
+        );
+      `,
+    );
+
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("uses the last duplicate title attribute, matching React", () => {
+    const result = runRule(
+      controlHasAssociatedLabel,
+      `
+        const Demo = () => (
+          <div>
+            <button title="Edit" title=""><svg aria-hidden /></button>
+            <button title="" title="Edit"><svg aria-hidden /></button>
+          </div>
+        );
+      `,
+    );
+
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports title expressions with a statically unnamed branch", () => {
+    const result = runRule(
+      controlHasAssociatedLabel,
+      `
+        const Demo = ({ isEditing }) => (
+          <div>
+            <button title={isEditing ? "Save" : ""}><svg aria-hidden /></button>
+            <button title={isEditing ? null : "Edit"}><svg aria-hidden /></button>
+            <button title={isEditing && "Edit"}><svg aria-hidden /></button>
+            <button title={!isEditing}><svg aria-hidden /></button>
+          </div>
+        );
+      `,
+    );
+
+    expect(result.diagnostics).toHaveLength(4);
+  });
+
+  it("keeps a shadowed undefined title conservative", () => {
+    const result = runRule(
+      controlHasAssociatedLabel,
+      `const Demo = ({ undefined }) => <button title={undefined}><svg aria-hidden /></button>;`,
+    );
+
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("accepts a title fallback on a native element with an interactive role", () => {
+    const result = runRule(
+      controlHasAssociatedLabel,
+      `const Demo = ({ onActivate }) => <div role="button" tabIndex={0} title="Edit" onClick={onActivate} />;`,
+    );
+
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not assume that title names an opaque configured control component", () => {
+    const result = runRule(
+      controlHasAssociatedLabel,
+      `const Demo = () => <IconButton title="Edit" />;`,
+      {
+        settings: {
+          "react-doctor": {
+            controlHasAssociatedLabel: { controlComponents: ["IconButton"] },
+          },
+        },
+      },
     );
 
     expect(result.diagnostics).toHaveLength(1);
@@ -718,7 +843,7 @@ describe("a11y/control-has-associated-label regressions", () => {
     expect(result.diagnostics).toHaveLength(3);
   });
 
-  it("still accepts icon buttons that carry an aria-label, but reports title-only ones", () => {
+  it("accepts icon buttons carrying either an aria-label or a native title", () => {
     const result = runRule(
       controlHasAssociatedLabel,
       `
@@ -733,7 +858,7 @@ describe("a11y/control-has-associated-label regressions", () => {
       `,
     );
 
-    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics).toHaveLength(0);
   });
 
   it("still treats unknown self-closing components as potential label text", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/control-has-associated-label.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/control-has-associated-label.regressions.test.ts
@@ -476,6 +476,7 @@ describe("a11y/control-has-associated-label regressions", () => {
             <button title={undefined}><svg aria-hidden /></button>
             <button title={void 0}><svg aria-hidden /></button>
             <button title={() => "Edit"}><svg aria-hidden /></button>
+            <button title={class Title {}}><svg aria-hidden /></button>
             <button title={Symbol("Edit")}><svg aria-hidden /></button>
             <button title={[]}><svg aria-hidden /></button>
             <button title={[""]}><svg aria-hidden /></button>
@@ -487,7 +488,7 @@ describe("a11y/control-has-associated-label regressions", () => {
       `,
     );
 
-    expect(result.diagnostics).toHaveLength(14);
+    expect(result.diagnostics).toHaveLength(15);
   });
 
   it("accepts native title names through DOM string coercion and unresolved expressions", () => {
@@ -548,6 +549,53 @@ describe("a11y/control-has-associated-label regressions", () => {
     expect(result.diagnostics).toHaveLength(4);
   });
 
+  it("follows static logical title values through React DOM coercion", () => {
+    const result = runRule(
+      controlHasAssociatedLabel,
+      `
+        const Demo = () => (
+          <div>
+            <button title={0 && "Edit"}><svg aria-hidden /></button>
+            <button title={0n && "Edit"}><svg aria-hidden /></button>
+            <button title={false && "Edit"}><svg aria-hidden /></button>
+            <button title={null && "Edit"}><svg aria-hidden /></button>
+            <button title={"" && "Edit"}><svg aria-hidden /></button>
+            <button title={true && "Edit"}><svg aria-hidden /></button>
+            <button title={true && ""}><svg aria-hidden /></button>
+            <button title={false || "Edit"}><svg aria-hidden /></button>
+            <button title={true || "Edit"}><svg aria-hidden /></button>
+            <button title={0 || "Edit"}><svg aria-hidden /></button>
+            <button title={null ?? "Edit"}><svg aria-hidden /></button>
+            <button title={false ?? "Edit"}><svg aria-hidden /></button>
+            <button title={0 ?? ""}><svg aria-hidden /></button>
+            <button title={(console.log("render"), "")}><svg aria-hidden /></button>
+            <button title={(console.log("render"), "Edit")}><svg aria-hidden /></button>
+          </div>
+        );
+      `,
+    );
+
+    expect(result.diagnostics).toHaveLength(7);
+  });
+
+  it("handles transparent TypeScript wrappers around title values", () => {
+    const result = runRule(
+      controlHasAssociatedLabel,
+      `
+        const Demo = ({ label }: { label: string }) => (
+          <div>
+            <button title={("Edit" as string)!}><svg aria-hidden /></button>
+            <button title={((label satisfies string))}><svg aria-hidden /></button>
+            <button title={("" as string)!}><svg aria-hidden /></button>
+            <button title={(null as string | null)}><svg aria-hidden /></button>
+          </div>
+        );
+      `,
+    );
+
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
   it("keeps a shadowed undefined title conservative", () => {
     const result = runRule(
       controlHasAssociatedLabel,
@@ -577,6 +625,54 @@ describe("a11y/control-has-associated-label regressions", () => {
           },
         },
       },
+    );
+
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("keeps JSX spreads conservative regardless of title ordering", () => {
+    const result = runRule(
+      controlHasAssociatedLabel,
+      `
+        const Demo = ({ props }) => (
+          <div>
+            <button title="Edit" {...props}><svg aria-hidden /></button>
+            <button {...props} title="Edit"><svg aria-hidden /></button>
+            <button title="" {...props}><svg aria-hidden /></button>
+            <button {...props} title=""><svg aria-hidden /></button>
+          </div>
+        );
+      `,
+    );
+
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not apply React title semantics to Solid-owned JSX", () => {
+    const result = runRule(
+      controlHasAssociatedLabel,
+      `
+        import { createSignal } from "solid-js";
+        const Demo = () => {
+          const [label] = createSignal("Edit");
+          return <button title={label()}><svg aria-hidden /></button>;
+        };
+      `,
+    );
+
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not let a nested title-only control label its native parent", () => {
+    const result = runRule(
+      controlHasAssociatedLabel,
+      `
+        const Demo = () => (
+          <button>
+            <button title="Edit"><svg aria-hidden /></button>
+          </button>
+        );
+      `,
     );
 
     expect(result.diagnostics).toHaveLength(1);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/control-has-associated-label.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/control-has-associated-label.ts
@@ -418,6 +418,7 @@ const hasNonEmptyNativeTitleExpression = (
   if (isNodeOfType(expression, "UnaryExpression") && expression.operator === "!") return false;
   if (isNodeOfType(expression, "ArrowFunctionExpression")) return false;
   if (isNodeOfType(expression, "FunctionExpression")) return false;
+  if (isNodeOfType(expression, "ClassExpression")) return false;
   if (isNodeOfType(expression, "ArrayExpression")) {
     const staticValue = getStaticNativeTitleArrayValue(expression, scopes);
     return staticValue === null || staticValue.trim().length > 0;
@@ -435,10 +436,32 @@ const hasNonEmptyNativeTitleExpression = (
       hasNonEmptyNativeTitleExpression(expression.alternate, scopes)
     );
   }
-  if (isNodeOfType(expression, "LogicalExpression") && expression.operator === "&&") {
+  if (isNodeOfType(expression, "SequenceExpression")) {
+    const finalExpression = expression.expressions.at(-1);
+    return finalExpression ? hasNonEmptyNativeTitleExpression(finalExpression, scopes) : false;
+  }
+  if (isNodeOfType(expression, "LogicalExpression")) {
     const leftExpression = stripParenExpression(expression.left);
-    if (!isNodeOfType(leftExpression, "Literal") || !leftExpression.value) return false;
-    return hasNonEmptyNativeTitleExpression(expression.right, scopes);
+    if (!isNodeOfType(leftExpression, "Literal")) {
+      return expression.operator !== "&&";
+    }
+    if (expression.operator === "??") {
+      return hasNonEmptyNativeTitleExpression(
+        leftExpression.value === null ? expression.right : leftExpression,
+        scopes,
+      );
+    }
+    const leftValueIsTruthy = Boolean(leftExpression.value);
+    if (expression.operator === "&&") {
+      return hasNonEmptyNativeTitleExpression(
+        leftValueIsTruthy ? expression.right : leftExpression,
+        scopes,
+      );
+    }
+    return hasNonEmptyNativeTitleExpression(
+      leftValueIsTruthy ? leftExpression : expression.right,
+      scopes,
+    );
   }
   return true;
 };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/control-has-associated-label.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/control-has-associated-label.ts
@@ -14,6 +14,7 @@ import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isReactComponentName } from "../../utils/is-react-component-name.js";
 import { isTestlikeFilename } from "../../utils/is-testlike-filename.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
 import { getClassNameLiteral } from "../react-ui/utils/get-class-name-literal.js";
 
 const MESSAGE =
@@ -239,6 +240,7 @@ const LABEL_COMPONENT_NAME = "Label";
 // MUI-style polymorphic escape hatch: `<Button component="label">`
 // renders an html <label>, implicitly labelling the control inside.
 const POLYMORPHIC_COMPONENT_PROP = "component";
+const TITLE_ATTRIBUTE = "title";
 // A wrapper like `<Field label="Hotkey"><input/></Field>` injects the
 // association (htmlFor/id pair or a wrapping <label>) for its child
 // control — the visible name exists, it just lives on the wrapper.
@@ -321,6 +323,136 @@ const hasNonEmptyPropValue = (attribute: EsTreeNodeOfType<"JSXAttribute"> | unde
       if (staticValue !== null) return staticValue.trim().length > 0;
     }
     return true;
+  }
+  return true;
+};
+
+const getLastJsxPropIgnoreCase = (
+  attributes: ReadonlyArray<EsTreeNode>,
+  targetProp: string,
+): EsTreeNodeOfType<"JSXAttribute"> | undefined => {
+  const targetPropLower = targetProp.toLowerCase();
+  for (let attributeIndex = attributes.length - 1; attributeIndex >= 0; attributeIndex -= 1) {
+    const attribute = attributes[attributeIndex];
+    if (!attribute || !isNodeOfType(attribute, "JSXAttribute")) continue;
+    const attributeName = getJsxAttributeName(attribute.name);
+    if (attributeName?.toLowerCase() === targetPropLower) return attribute;
+  }
+  return undefined;
+};
+
+const getStaticNativeTitleArrayValue = (
+  expression: EsTreeNodeOfType<"ArrayExpression">,
+  scopes: ScopeAnalysis,
+): string | null => {
+  const elementValues: string[] = [];
+  for (const rawElement of expression.elements) {
+    if (rawElement === null) {
+      elementValues.push("");
+      continue;
+    }
+    if (isNodeOfType(rawElement, "SpreadElement")) return null;
+    const element = stripParenExpression(rawElement);
+    if (isNodeOfType(element, "Literal")) {
+      elementValues.push(element.value === null ? "" : String(element.value));
+      continue;
+    }
+    if (isNodeOfType(element, "TemplateLiteral")) {
+      const staticValue = getStaticTemplateLiteralValue(element);
+      if (staticValue === null) return null;
+      elementValues.push(staticValue);
+      continue;
+    }
+    if (
+      (isNodeOfType(element, "Identifier") &&
+        element.name === "undefined" &&
+        scopes.isGlobalReference(element)) ||
+      (isNodeOfType(element, "UnaryExpression") && element.operator === "void")
+    ) {
+      elementValues.push("");
+      continue;
+    }
+    if (isNodeOfType(element, "ArrayExpression")) {
+      const nestedValue = getStaticNativeTitleArrayValue(element, scopes);
+      if (nestedValue === null) return null;
+      elementValues.push(nestedValue);
+      continue;
+    }
+    return null;
+  }
+  return elementValues.join(",");
+};
+
+const isGlobalSymbolExpression = (expression: EsTreeNode, scopes: ScopeAnalysis): boolean => {
+  if (isNodeOfType(expression, "Identifier")) {
+    return expression.name === "Symbol" && scopes.isGlobalReference(expression);
+  }
+  if (!isNodeOfType(expression, "MemberExpression")) return false;
+  const object = stripParenExpression(expression.object);
+  return (
+    isNodeOfType(object, "Identifier") &&
+    object.name === "Symbol" &&
+    scopes.isGlobalReference(object)
+  );
+};
+
+const hasNonEmptyNativeTitleExpression = (
+  rawExpression: EsTreeNode,
+  scopes: ScopeAnalysis,
+): boolean => {
+  const expression = stripParenExpression(rawExpression);
+  if (isNodeOfType(expression, "Literal")) {
+    if (typeof expression.value === "string") return expression.value.trim().length > 0;
+    return expression.value !== null && typeof expression.value !== "boolean";
+  }
+  if (isNodeOfType(expression, "TemplateLiteral")) {
+    const staticValue = getStaticTemplateLiteralValue(expression);
+    return staticValue === null || staticValue.trim().length > 0;
+  }
+  if (isNodeOfType(expression, "Identifier")) {
+    return expression.name !== "undefined" || !scopes.isGlobalReference(expression);
+  }
+  if (isNodeOfType(expression, "UnaryExpression") && expression.operator === "void") {
+    return false;
+  }
+  if (isNodeOfType(expression, "UnaryExpression") && expression.operator === "!") return false;
+  if (isNodeOfType(expression, "ArrowFunctionExpression")) return false;
+  if (isNodeOfType(expression, "FunctionExpression")) return false;
+  if (isNodeOfType(expression, "ArrayExpression")) {
+    const staticValue = getStaticNativeTitleArrayValue(expression, scopes);
+    return staticValue === null || staticValue.trim().length > 0;
+  }
+  if (isGlobalSymbolExpression(expression, scopes)) return false;
+  if (
+    isNodeOfType(expression, "CallExpression") &&
+    isGlobalSymbolExpression(expression.callee, scopes)
+  ) {
+    return false;
+  }
+  if (isNodeOfType(expression, "ConditionalExpression")) {
+    return (
+      hasNonEmptyNativeTitleExpression(expression.consequent, scopes) &&
+      hasNonEmptyNativeTitleExpression(expression.alternate, scopes)
+    );
+  }
+  if (isNodeOfType(expression, "LogicalExpression") && expression.operator === "&&") {
+    const leftExpression = stripParenExpression(expression.left);
+    if (!isNodeOfType(leftExpression, "Literal") || !leftExpression.value) return false;
+    return hasNonEmptyNativeTitleExpression(expression.right, scopes);
+  }
+  return true;
+};
+
+const hasNonEmptyNativeTitle = (
+  attribute: EsTreeNodeOfType<"JSXAttribute"> | undefined,
+  scopes: ScopeAnalysis,
+): boolean => {
+  if (!attribute?.value) return false;
+  if (isNodeOfType(attribute.value, "Literal")) {
+    return typeof attribute.value.value === "string" && attribute.value.value.trim().length > 0;
+  }
+  if (isNodeOfType(attribute.value, "JSXExpressionContainer")) {
+    return hasNonEmptyNativeTitleExpression(attribute.value.expression, scopes);
   }
   return true;
 };
@@ -792,11 +924,16 @@ export const controlHasAssociatedLabel = defineRule({
           }
         }
 
-        // `title` is deliberately NOT accepted as a label (matching
-        // upstream jsx-a11y/oxc and the rule doc): a title-only name is
-        // invisible to sighted keyboard users and unreliable on touch
-        // screen readers, so icon-only buttons named solely by `title`
-        // must still be reported.
+        if (
+          isDomElement &&
+          hasNonEmptyNativeTitle(
+            getLastJsxPropIgnoreCase(opening.attributes, TITLE_ATTRIBUTE),
+            context.scopes,
+          )
+        ) {
+          return;
+        }
+
         if (
           supportsPlaceholderNameFallback(tagName, opening) &&
           hasNonEmptyPropValue(hasJsxPropIgnoreCase(opening.attributes, "placeholder"))


### PR DESCRIPTION
## Why

Native HTML controls can derive an accessible name from their own non-empty `title` attribute. Chrome accessibility-tree checks confirmed this for buttons, links, checkboxes, text inputs, selects, textareas, and interactive-role elements. The previous detector rejected those controls even though HTML-AAM and the accessible-name computation use `title` as a fallback name source.

This is job-grounded, not synthetic: five pinned React Bench Lumina solutions passed their behavior tests but lost the React Doctor gate on title-named native buttons.

## What changed

- Accept a non-empty own `title` only on native DOM controls and native elements with an interactive role.
- Model JSX last-duplicate-wins behavior and React's native attribute string coercion for static values.
- Keep reporting custom components, child-only titles, empty/whitespace/null/boolean/undefined/void/function/symbol values, conditionals with an absent branch, and a final duplicate that removes the name.
- Keep unresolved dynamic values conservative, matching the existing dynamic `aria-label` boundary: they are not definite missing-name errors.
- Add paired regression tests, a permanent fuzz regression, a liveness target, and a patch changeset.

## Validation

- Focused regression suite: 56 passed.
- Full oxlint plugin suite: 555 files, 13,265 passed, 148 skipped.
- Strict fuzzing: `FUZZ_RULE=control-has-associated-label FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz` passed with a dedicated liveness target.
- `nr typecheck`, `nr lint`, `nr format:check`, `nr build`, `nr smoke:json-report`, and `git diff --check` passed.
- GitHub CI passed the complete Linux Node 20/22/24/25/26, macOS, Windows, lint, typecheck, build, React Doctor, CodeQL, and continuous-release matrix.
- Chrome AX witnesses: non-empty `title` named buttons, links, checkboxes, text inputs, selects, textareas, and `role="button"`; absent, empty, and whitespace-only titles remained unnamed.
- Exact no-cache RDE: 100/100 requested roots completed with no skipped checks. Target diagnostics `125→109`: 16 removed, 0 added, and no other rule changed. All 16 removals were manually verified as native controls with valid own-title names.
- React Bench 5 target-only parity: 122/122 tasks across 121 pinned scan directories completed with every unrelated analyzer disabled and full file coverage. Target diagnostics `3,118→2,114`: 1,004 removed, 0 added. An AST audit verified every removal had an own `title` on a native control: 933 buttons, 38 anchors, 24 inputs, 7 selects, and 2 interactive-role spans. Static and dynamic expression groups were reviewed; none contained an explicit empty/null/undefined/boolean branch.
- Authentic Lumina states, full scope: `210→91`, `209→91`, `210→91`, `210→91`, and `210→91`; canonical oracle `207→91`. Every delta was a title-named native control, with no added finding.

The local repository-wide run exercised every package but hit three terminal/timing-only cases: one performance timeout and two live-stdin probes. The performance file passed in isolation on both candidate and baseline (22/22), and the live-stdin behavior reproduced on baseline. The authoritative GitHub full-environment matrix passed.

Standards references:

- https://www.w3.org/TR/html-aam-1.0/#accessible-name-and-description-computation
- https://www.w3.org/TR/accname-1.2/

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-only behavior change in an a11y rule with broad regression and fuzz coverage; reduces false positives without touching runtime or auth/data paths.
> 
> **Overview**
> **`control-has-associated-label`** no longer flags native DOM controls (and native elements with interactive roles) that have a **non-empty own `title`**, aligning with HTML-AAM accessible-name fallback instead of treating `title` as never sufficient.
> 
> The rule adds static checks for **`title` value semantics**: last duplicate attribute wins, React-style string coercion for literals/logicals/conditionals, empty vs unresolved dynamic values, and scope-aware handling (e.g. shadowed `undefined`). It still reports child-only `title`, custom control components, spreads, and clearly empty or invalid `title` expressions.
> 
> Regression, fuzz corpus, and a patch changeset cover the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42bb7d375bea617be3ac27bca2463dca7eef96d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->