### PR TITLE
fix(effect-needs-cleanup): prove conditional timer cleanup

### DIFF
--- a/.changeset/dark-parks-double.md
+++ b/.changeset/dark-parks-double.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Fix `effect-needs-cleanup` false positives for conditionally allocated resources whose exact stable handle is released by the returned effect cleanup.

--- a/packages/fuzz/corpus/regressions/effect-needs-cleanup--conditional-timer-handle.tsx
+++ b/packages/fuzz/corpus/regressions/effect-needs-cleanup--conditional-timer-handle.tsx
@@ -1,0 +1,14 @@
+// rule: effect-needs-cleanup
+// weakness: control-flow
+// source: React Bench Divz trial fix-react-rdh-lewhunt-divz-divz__yioQpdq
+import { useEffect } from "react";
+
+export const Autoplay = ({ playing }: { playing: boolean }) => {
+  useEffect(() => {
+    const timerId = playing ? setInterval(() => advance(), 1000) : undefined;
+    return () => {
+      if (timerId) clearInterval(timerId);
+    };
+  }, [playing]);
+  return null;
+};

--- a/packages/fuzz/corpus/targets/effect-needs-cleanup--conditional-timer-without-cleanup.tsx
+++ b/packages/fuzz/corpus/targets/effect-needs-cleanup--conditional-timer-without-cleanup.tsx
@@ -1,0 +1,9 @@
+import { useEffect } from "react";
+
+export const Autoplay = ({ playing }: { playing: boolean }) => {
+  useEffect(() => {
+    const timerId = playing ? setInterval(() => advance(), 1000) : undefined;
+    void timerId;
+  }, [playing]);
+  return null;
+};

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -24,6 +24,8 @@ export const EFFECT_SNIPPET_POOL = [
   `useEffect(() => { let rafId; const loop = () => { handle(); rafId = requestAnimationFrame(loop); }; rafId = requestAnimationFrame(loop); return () => cancelAnimationFrame(rafId); }, []);`,
   `useEffect(() => { const loop = () => { handle(); requestAnimationFrame(loop); }; requestAnimationFrame(loop); }, []);`,
   `useEffect(() => { const id = setInterval(() => setState((prev) => prev + 1), 1000); return () => clearInterval(id); }, []);`,
+  `useEffect(() => { const id = enabled ? setInterval(() => handle(), 1000) : undefined; return () => { if (id) clearInterval(id); }; }, [enabled]);`,
+  `useEffect(() => { const id = enabled ? setInterval(() => handle(), 1000) : undefined; void id; }, [enabled]);`,
   `useEffect(() => { const id = window.setTimeout(() => setState(0), 500); return () => window.clearTimeout(id); }, [value]);`,
   `useEffect(() => { let cancelled = false; const load = async () => { const result = await fetch(url); if (!cancelled) setState(await result.json()); }; load(); return () => { cancelled = true; }; }, [url]);`,
   `useEffect(() => { (async () => { const result = await fetch(url); setState(await result.json()); })(); }, [url]);`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
@@ -4066,3 +4066,159 @@ export const LanguageProvider = ({ i18next }) => {
     expect(result.diagnostics).toHaveLength(1);
   });
 });
+
+describe("effect-needs-cleanup conditional resource handles", () => {
+  it.each([
+    {
+      name: "consequent timer with a guarded cleanup",
+      assignment: "const timerId = playing ? setInterval(advance, 1000) : undefined;",
+      cleanup: "if (timerId) clearInterval(timerId);",
+    },
+    {
+      name: "alternate timer with an unconditional cleanup",
+      assignment: "const timerId = playing ? undefined : setInterval(advance, 1000);",
+      cleanup: "clearInterval(timerId);",
+    },
+    {
+      name: "timers in both conditional arms",
+      assignment:
+        "const timerId = playing ? setInterval(advance, 1000) : setInterval(rewind, 1000);",
+      cleanup: "clearInterval(timerId);",
+    },
+    {
+      name: "a timer behind transparent TypeScript wrappers",
+      assignment:
+        "const timerId = (playing ? (setInterval(advance, 1000) as ReturnType<typeof setInterval>) : undefined) satisfies ReturnType<typeof setInterval> | undefined;",
+      cleanup: "if (timerId) clearInterval(timerId);",
+    },
+    {
+      name: "a timer in the final sequence position",
+      assignment:
+        "const timerId = playing ? (recordStart(), setInterval(advance, 1000)) : undefined;",
+      cleanup: "if (timerId) clearInterval(timerId);",
+    },
+  ])("accepts $name", ({ assignment, cleanup }) => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+export const Player = ({ playing }) => {
+  useEffect(() => {
+    ${assignment}
+    return () => {
+      ${cleanup}
+    };
+  }, [playing]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it.each([
+    {
+      name: "no returned cleanup",
+      assignment: "const timerId = playing ? setInterval(advance, 1000) : undefined;",
+      beforeReturn: "void timerId;",
+      cleanup: "",
+    },
+    {
+      name: "an unrelated cleanup guard",
+      assignment: "const timerId = playing ? setInterval(advance, 1000) : undefined;",
+      beforeReturn: "",
+      cleanup: "if (shouldCleanup) clearInterval(timerId);",
+    },
+    {
+      name: "an early exit inside the matching handle guard",
+      assignment: "const timerId = playing ? setInterval(advance, 1000) : undefined;",
+      beforeReturn: "",
+      cleanup: "if (timerId) { if (shouldCleanup) return; clearInterval(timerId); }",
+    },
+    {
+      name: "a mismatched timer handle",
+      assignment:
+        "const timerId = playing ? setInterval(advance, 1000) : undefined; const otherTimerId = setInterval(rewind, 1000);",
+      beforeReturn: "",
+      cleanup: "clearInterval(otherTimerId);",
+    },
+    {
+      name: "a mismatched timer release API",
+      assignment: "const timerId = playing ? setInterval(advance, 1000) : undefined;",
+      beforeReturn: "",
+      cleanup: "clearTimeout(timerId);",
+    },
+    {
+      name: "cleanup through a handle alias",
+      assignment:
+        "const timerId = playing ? setInterval(advance, 1000) : undefined; const cleanupTimerId = timerId;",
+      beforeReturn: "",
+      cleanup: "clearInterval(cleanupTimerId);",
+    },
+    {
+      name: "cleanup through an opaque handle transform",
+      assignment: "const timerId = playing ? setInterval(advance, 1000) : undefined;",
+      beforeReturn: "",
+      cleanup: "clearInterval(getTimerId(timerId));",
+    },
+    {
+      name: "a resource wrapped in an opaque call",
+      assignment: "const timerId = playing ? identity(setInterval(advance, 1000)) : undefined;",
+      beforeReturn: "",
+      cleanup: "clearInterval(timerId);",
+    },
+    {
+      name: "a resource wrapped in a construction",
+      assignment: "const timerId = playing ? new TimerBox(setInterval(advance, 1000)) : undefined;",
+      beforeReturn: "",
+      cleanup: "clearInterval(timerId);",
+    },
+    {
+      name: "an arithmetically transformed resource",
+      assignment: "const timerId = playing ? setInterval(advance, 1000) + 1 : undefined;",
+      beforeReturn: "",
+      cleanup: "clearInterval(timerId);",
+    },
+    {
+      name: "a resource in a non-final sequence position",
+      assignment: "const timerId = playing ? (setInterval(advance, 1000), undefined) : undefined;",
+      beforeReturn: "",
+      cleanup: "clearInterval(timerId);",
+    },
+    {
+      name: "a mutable conditional binding",
+      assignment:
+        "let timerId = playing ? setInterval(advance, 1000) : undefined; timerId = replacementTimerId;",
+      beforeReturn: "",
+      cleanup: "clearInterval(timerId);",
+    },
+    {
+      name: "a conditional assignment into a mutable binding",
+      assignment: "let timerId; timerId = playing ? setInterval(advance, 1000) : undefined;",
+      beforeReturn: "",
+      cleanup: "clearInterval(timerId);",
+    },
+  ])("rejects $name", ({ assignment, beforeReturn, cleanup }) => {
+    const returnedCleanup = cleanup
+      ? `return () => {
+      ${cleanup}
+    };`
+      : "return undefined;";
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+export const Player = ({ playing, shouldCleanup, replacementTimerId }) => {
+  useEffect(() => {
+    ${assignment}
+    ${beforeReturn}
+    ${returnedCleanup}
+  }, [playing, replacementTimerId, shouldCleanup]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+    expect(
+      result.diagnostics.some((diagnostic) => diagnostic.message.includes("setInterval")),
+    ).toBe(true);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -146,12 +146,15 @@ const resolveExpressionKey = (
 };
 
 const findAssignedResourceKey = (resourceNode: EsTreeNode, context: RuleContext): string | null => {
-  let currentNode = resourceNode;
-  let parentNode = currentNode.parent;
-  while (isNodeOfType(parentNode, "ChainExpression")) {
-    currentNode = parentNode;
-    parentNode = currentNode.parent;
+  const indirectBindingIdentifier = findStableIndirectResourceBindingIdentifier(
+    resourceNode,
+    context,
+  );
+  if (indirectBindingIdentifier) {
+    return resolveExpressionKey(indirectBindingIdentifier, context);
   }
+  const currentNode = findTransparentExpressionRoot(resourceNode);
+  const parentNode = currentNode.parent;
   if (isNodeOfType(parentNode, "VariableDeclarator") && parentNode.init === currentNode) {
     return resolveExpressionKey(parentNode.id, context);
   }
@@ -159,6 +162,58 @@ const findAssignedResourceKey = (resourceNode: EsTreeNode, context: RuleContext)
     return resolveExpressionKey(parentNode.left, context);
   }
   return null;
+};
+
+const findStableIndirectResourceBindingIdentifier = (
+  resourceNode: EsTreeNode,
+  context: RuleContext,
+): EsTreeNode | null => {
+  let currentNode = findTransparentExpressionRoot(resourceNode);
+  let didTraverseValuePreservingExpression = false;
+  while (currentNode.parent) {
+    const parentNode = currentNode.parent;
+    if (
+      isNodeOfType(parentNode, "ConditionalExpression") &&
+      (parentNode.consequent === currentNode || parentNode.alternate === currentNode)
+    ) {
+      currentNode = findTransparentExpressionRoot(parentNode);
+      didTraverseValuePreservingExpression = true;
+      continue;
+    }
+    if (
+      isNodeOfType(parentNode, "SequenceExpression") &&
+      parentNode.expressions[parentNode.expressions.length - 1] === currentNode
+    ) {
+      currentNode = findTransparentExpressionRoot(parentNode);
+      didTraverseValuePreservingExpression = true;
+      continue;
+    }
+    break;
+  }
+  if (!didTraverseValuePreservingExpression) return null;
+  const variableDeclarator = currentNode.parent;
+  const variableDeclaration = variableDeclarator?.parent;
+  if (
+    !isNodeOfType(variableDeclarator, "VariableDeclarator") ||
+    variableDeclarator.init !== currentNode ||
+    !isNodeOfType(variableDeclarator.id, "Identifier") ||
+    !isNodeOfType(variableDeclaration, "VariableDeclaration") ||
+    variableDeclaration.kind !== "const"
+  ) {
+    return null;
+  }
+  const symbol = context.scopes.symbolFor(variableDeclarator.id);
+  if (
+    !symbol ||
+    symbol.kind !== "const" ||
+    symbol.declarationNode !== variableDeclarator ||
+    symbol.references.some(
+      (reference) => reference.flag !== "read" || isWithinAssignmentTarget(reference.identifier),
+    )
+  ) {
+    return null;
+  }
+  return variableDeclarator.id;
 };
 
 const getCallRegistrationDetails = (
@@ -1300,6 +1355,69 @@ const hasSplitLifecycleCleanup = (
   hasRerunReleaseBeforeUsage(callback, usage, context) &&
   hasStableUnmountCleanupForUsage(callback, usage, context);
 
+const findDirectHandleGuardForRelease = (
+  releaseNode: EsTreeNode,
+  usage: SubscribeLikeUsage,
+  context: RuleContext,
+): EsTreeNode | null => {
+  if (usage.handleKey === null) return null;
+  const releaseRoot = findTransparentExpressionRoot(releaseNode);
+  const releaseStatement = releaseRoot.parent;
+  if (!isNodeOfType(releaseStatement, "ExpressionStatement")) return null;
+  const statementParent = releaseStatement.parent;
+  const guardStatement = isNodeOfType(statementParent, "IfStatement")
+    ? statementParent
+    : isNodeOfType(statementParent, "BlockStatement") &&
+        statementParent.body[0] === releaseStatement &&
+        isNodeOfType(statementParent.parent, "IfStatement") &&
+        statementParent.parent.consequent === statementParent
+      ? statementParent.parent
+      : null;
+  return guardStatement &&
+    guardStatement.alternate === null &&
+    resolveExpressionKey(guardStatement.test, context) === usage.handleKey
+    ? guardStatement
+    : null;
+};
+
+const doesPathCompleteCleanupFunctionReleaseUsage = (
+  cleanupFunction: EsTreeNode,
+  usage: SubscribeLikeUsage,
+  resourceBindingIdentifier: EsTreeNode,
+  context: RuleContext,
+): boolean => {
+  if (!isFunctionLike(cleanupFunction) || cleanupFunction.async || cleanupFunction.generator) {
+    return false;
+  }
+  const matchingReleaseAnchors: EsTreeNode[] = [];
+  walkAst(cleanupFunction.body, (cleanupChild: EsTreeNode) => {
+    if (cleanupChild !== cleanupFunction.body && isFunctionLike(cleanupChild)) return false;
+    if (!doesReleaseCallMatchUsage(cleanupChild, usage, context)) return;
+    if (usage.kind === "timer") {
+      const cleanupCall = isNodeOfType(cleanupChild, "ChainExpression")
+        ? cleanupChild.expression
+        : cleanupChild;
+      if (!isNodeOfType(cleanupCall, "CallExpression") || !cleanupCall.arguments?.[0]) return;
+      const cleanupHandle = stripParenExpression(cleanupCall.arguments[0]);
+      if (
+        !isNodeOfType(cleanupHandle, "Identifier") ||
+        context.scopes.symbolFor(cleanupHandle)?.id !==
+          context.scopes.symbolFor(resourceBindingIdentifier)?.id
+      ) {
+        return;
+      }
+    }
+    matchingReleaseAnchors.push(
+      findDirectHandleGuardForRelease(cleanupChild, usage, context) ?? cleanupChild,
+    );
+  });
+  return doMatchingNodesCoverEveryPathFromFunctionEntry(
+    cleanupFunction,
+    matchingReleaseAnchors,
+    context,
+  );
+};
+
 const effectHasCleanupForUsage = (
   callback: EsTreeNode,
   usage: SubscribeLikeUsage,
@@ -1325,6 +1443,19 @@ const effectHasCleanupForUsage = (
       callback.body === usage.node && isCleanupReturningSubscribeLikeCallExpression(callback.body)
     );
   }
+  const indirectResourceBindingIdentifier = findStableIndirectResourceBindingIdentifier(
+    usage.node,
+    context,
+  );
+  const cleanupFunctionReleasesUsage = (cleanupFunction: EsTreeNode): boolean =>
+    indirectResourceBindingIdentifier
+      ? doesPathCompleteCleanupFunctionReleaseUsage(
+          cleanupFunction,
+          usage,
+          indirectResourceBindingIdentifier,
+          context,
+        )
+      : doesCleanupFunctionReleaseUsage(cleanupFunction, usage, context);
   const matchingCleanupReturns: EsTreeNode[] = [];
   walkInsideStatementBlocks(callback.body, (child: EsTreeNode) => {
     if (!isNodeOfType(child, "ReturnStatement")) return;
@@ -1372,7 +1503,7 @@ const effectHasCleanupForUsage = (
       return;
     }
     if (!cleanupFunction || !isFunctionLike(cleanupFunction)) return;
-    if (doesCleanupFunctionReleaseUsage(cleanupFunction, usage, context)) {
+    if (cleanupFunctionReleasesUsage(cleanupFunction)) {
       matchingCleanupReturns.push(child);
     }
   });


### PR DESCRIPTION
## Summary

- recognize timers allocated in a value-preserving conditional expression and stored in an immutable local handle
- accept cleanup only when the returned effect cleanup releases that exact handle on every path
- preserve diagnostics for mutable, aliased, transformed, mismatched, or partially cleaned timer handles
- add paired rule regressions plus permanent fuzz regression and target seeds

## Grounding

React Bench job `fix-react-rdh-lewhunt-divz-divz__yioQpdq` pins `lewhunt/divz` at `9e44f95806f940df9f21273176efa552ed09b6c4`.

The verifier solution conditionally assigns `setInterval(...)` to `autoplayTimer` and returns a cleanup that guards and clears that same handle. Runtime reproduction confirms each allocated interval is cleared and the final active interval count is zero. The job tests pass, but stored React Doctor 0.7.6 reports `effect-needs-cleanup`, making `rd_ok=0`; published 0.7.2 and 0.7.4 do not reproduce this specific regression.

Exact-source target diagnostics:

| Source | `origin/main` | This PR |
| --- | ---: | ---: |
| untouched pinned source | 0 | 0 |
| verifier/model patch | 1 | 0 |
| oracle patch | 0 | 0 |

## Precision boundary

The detector follows the resource call only through transparent wrappers, a selected conditional arm, and the final position of a sequence expression into a stable `const` binding. For conditional timers, the returned cleanup must release the exact binding symbol, and the release or its exact-handle guard must cover every cleanup path.

Opaque calls, construction, arithmetic transforms, non-final sequence values, aliases, mutable assignments, wrong handles/APIs, missing cleanup, unrelated guards, and early exits remain diagnostics.

## Validation

- focused and full plugin tests: 554 files; 13,113 passed, 148 skipped
- strict fuzz: `FUZZ_RULE=effect-needs-cleanup FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz`; 354 executions, 95 target-rule firings, 0 findings
- React Bench-derived fuzz corpus: 27 of 32 target files copied, 0 missing repositories, strict 500 clean
- isolated local RDE: independent frozen installs and builds for baseline/candidate; source maps match each checked-out rule source; 100/100 pinned roots scanned across 12 repositories on both sides, 0 scan failures, target diagnostics 42 to 42, no added or removed verdicts
- exact-head GitHub CI matrix: all checks passed on Linux, macOS, and Windows across Node 20, 22, 24, 25, and 26
- `nr typecheck`
- `nr lint`
- `nr format:check`
- `nr smoke:json-report`
- `git diff --check`
