### PR TITLE
test(no-static-element-interactions): lock keyboard spread parity

### DIFF
--- a/packages/fuzz/corpus/regressions/no-static-element-interactions--conditional-keyboard-spread.tsx
+++ b/packages/fuzz/corpus/regressions/no-static-element-interactions--conditional-keyboard-spread.tsx
@@ -1,0 +1,18 @@
+// rule: no-static-element-interactions
+// weakness: wrapper-transparency
+// source: React Bench fix-react-rdh-trendyol-react-carousel-index
+
+interface CarouselKeyboardProps {
+  useArrowKeys: boolean;
+  handleOnKeyDown: () => void;
+}
+
+export const DirectKeyboardCarousel = ({
+  useArrowKeys,
+  handleOnKeyDown,
+}: CarouselKeyboardProps) => <div onKeyDown={useArrowKeys ? handleOnKeyDown : undefined} />;
+
+export const SpreadKeyboardCarousel = ({
+  useArrowKeys,
+  handleOnKeyDown,
+}: CarouselKeyboardProps) => <div {...(useArrowKeys ? { onKeyDown: handleOnKeyDown } : {})} />;

--- a/packages/fuzz/corpus/targets/no-static-element-interactions--focusable-div.tsx
+++ b/packages/fuzz/corpus/targets/no-static-element-interactions--focusable-div.tsx
@@ -1,0 +1,9 @@
+// rule: no-static-element-interactions
+
+interface FocusableKeyboardTargetProps {
+  handleOnKeyDown: () => void;
+}
+
+export const FocusableKeyboardTarget = ({ handleOnKeyDown }: FocusableKeyboardTargetProps) => (
+  <div tabIndex={0} onKeyDown={handleOnKeyDown} />
+);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/no-static-element-interactions.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/no-static-element-interactions.regressions.test.ts
@@ -230,6 +230,25 @@ describe("a11y/no-static-element-interactions regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("keeps direct and conditional-spread keyboard delegation equivalent", () => {
+    const directResult = runRule(
+      noStaticElementInteractions,
+      `export const Carousel = ({ useArrowKeys, handleOnKeyDown }) => (
+        <div onKeyDown={useArrowKeys ? handleOnKeyDown : undefined} />
+      );`,
+    );
+    const spreadResult = runRule(
+      noStaticElementInteractions,
+      `export const Carousel = ({ useArrowKeys, handleOnKeyDown }) => (
+        <div {...(useArrowKeys ? { onKeyDown: handleOnKeyDown } : {})} />
+      );`,
+    );
+    expect(directResult.parseErrors).toEqual([]);
+    expect(spreadResult.parseErrors).toEqual([]);
+    expect(directResult.diagnostics).toEqual(spreadResult.diagnostics);
+    expect(directResult.diagnostics).toEqual([]);
+  });
+
   it("still flags a focusable div with only a keyboard handler", () => {
     const result = runRule(
       noStaticElementInteractions,


### PR DESCRIPTION
## Why

The Trendyol React Bench task uses a conditional object spread to attach `onKeyDown` to an unfocusable wrapper. Current main correctly treats that wrapper like the equivalent direct conditional attribute: keyboard events may delegate from interactive descendants, so neither form should receive `no-static-element-interactions`.

This is a regression-only PR. It does not change detector production code; it permanently locks the grounded direct/spread parity and keeps a focusable static element as the positive near-neighbor.

## What changed

- Add the authentic conditional-spread and direct-attribute pair to the rule regression suite.
- Add a minimized permanent fuzz regression seed.
- Add a focusable `<div tabIndex={0} onKeyDown={...}>` fuzz target so strict fuzzing proves the rule still fires.

## Precision boundary

This does not generally exempt keyboard handlers on static elements. The clean pair is specifically unfocusable wrapper delegation. A focusable static element with the same keyboard handler remains reportable.

## Validation

- Focused rule tests: 46 passed.
- Full oxlint plugin suite: 555 files, 13,254 passed, 148 skipped.
- Fuzz corpus: 43 passed, 401 skipped.
- Strict fuzz: 500 requested iterations passed with target-rule liveness.
- Repository checks: build, typecheck, lint, format check, JSON smoke test, and diff check passed.
- RDE: 100/100 complete baseline and candidate scans; `no-static-element-interactions` 236 → 236; all diagnostics 11,438 → 11,438; zero added or removed findings.
- React Bench 5: 122/122 complete baseline and candidate scans; `no-static-element-interactions` 1,289 → 1,289; all diagnostics 41,548 → 41,548; zero added or removed findings. Four repositories with unrelated nondeterministic first-pass deltas were rerun sequentially and converged exactly before comparison.
- Trendyol oracle solution: complete baseline and candidate scans; target 4 → 4, all diagnostics 56 → 56, exact diagnostic parity. The spread site itself remains clean.
- Built candidate and baseline rule/CLI artifacts are byte-identical, as expected for a test-only change.
- GitHub CI is green across lint, typecheck, build, CodeQL, and the complete Node/macOS/Windows matrix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only tests and fuzz corpus seeds; no production lint logic changes.
> 
> **Overview**
> **Test-only** coverage for `no-static-element-interactions`—no rule or detector code changes.
> 
> Adds a regression case that **direct** `onKeyDown={cond ? handler : undefined}` and **conditional spread** `{...(cond ? { onKeyDown: handler } : {})}` on unfocusable wrappers must produce **identical diagnostics** (both clean), matching the Trendyol carousel pattern.
> 
> Adds fuzz corpus entries: a permanent regression seed for that parity and a **focusable** `<div tabIndex={0} onKeyDown={...}>` target so strict fuzzing still proves the rule fires when the element can take focus.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c72415e692a558f2035d5e865e5f9a7f7e6b500b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->