### PR TITLE
fix(cli): write JSON error report when why command used with --json

### DIFF
--- a/.changeset/fix-why-json-mode.md
+++ b/.changeset/fix-why-json-mode.md
@@ -1,0 +1,7 @@
+---
+"react-doctor": patch
+---
+
+fix(cli): write JSON error report when `why` command used with `--json`
+
+Fixes issue #1235 where the `why` command would exit with status 0 without producing a JSON report when `--json` was specified. Now properly detects JSON mode and writes a structured error report indicating that the `why` command does not support JSON mode.

--- a/packages/react-doctor/src/cli/commands/inspect.ts
+++ b/packages/react-doctor/src/cli/commands/inspect.ts
@@ -325,6 +325,13 @@ export const inspectAction = async (directory: string, flags: InspectFlags): Pro
 
     const explainArgument = flags.explain;
     if (explainArgument !== undefined) {
+      if (isJsonMode) {
+        writeJsonErrorReport(
+          new Error("The `why` command is not supported in JSON mode. Remove --json to use it."),
+        );
+        process.exitCode = 1;
+        return;
+      }
       await runExplain(explainArgument, {
         resolvedDirectory,
         userConfig,

--- a/packages/react-doctor/src/cli/commands/why.ts
+++ b/packages/react-doctor/src/cli/commands/why.ts
@@ -3,6 +3,7 @@ import { inspectAction } from "./inspect.js";
 interface WhyOptions {
   cwd?: string;
   project?: string;
+  json?: boolean;
 }
 
 /**
@@ -12,8 +13,10 @@ interface WhyOptions {
  * and clean error handling. (Replaces the former `--explain` / `--why` flags.)
  */
 export const whyAction = async (location: string, options: WhyOptions): Promise<void> => {
+  const hasJsonFlag = process.argv.includes("--json");
   await inspectAction(options.cwd ?? process.cwd(), {
     explain: location,
     project: options.project,
+    json: hasJsonFlag || options.json,
   });
 };

--- a/packages/react-doctor/src/cli/index.ts
+++ b/packages/react-doctor/src/cli/index.ts
@@ -244,7 +244,7 @@ program
   .option("-c, --cwd <cwd>", "working directory", process.cwd())
   .option("--color", "force colored output")
   .option("--no-color", "disable colored output (also honors NO_COLOR)")
-  .action((location, options) => whyAction(location, options));
+  .action((location, _options, command) => whyAction(location, command.optsWithGlobals()));
 
 program
   .command("install")

--- a/packages/react-doctor/tests/e2e/json-out-flag.test.ts
+++ b/packages/react-doctor/tests/e2e/json-out-flag.test.ts
@@ -122,4 +122,31 @@ describe.skipIf(!hasBuiltCli)("--json-out flag", () => {
     expect(report.schemaVersion).toBe(3);
     expect(report.diagnostics).toEqual([]);
   }, 60_000);
+
+  it("produces JSON error report when why command used with --json", async () => {
+    const projectDirectory = setupReactProject(tempRoot, "json-why-error", {
+      files: {
+        "src/App.tsx": `export const App = () => null;\n`,
+      },
+    });
+
+    const { stdout, stderr, exitCode } = await runCli(
+      ["why", "src/App.tsx:1", "--json"],
+      projectDirectory,
+    );
+
+    if (exitCode !== 1) {
+      console.error("STDOUT:", stdout);
+      console.error("STDERR:", stderr);
+      console.error("EXIT CODE:", exitCode);
+    }
+
+    expect(exitCode).toBe(1);
+    const report = JSON.parse(stdout);
+    expect(report.ok).toBe(false);
+    expect(report.schemaVersion).toBe(3);
+    expect(report.error).toBeDefined();
+    expect(report.error.message).toContain("why");
+    expect(report.error.message).toContain("not supported in JSON mode");
+  }, 60_000);
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #1235 where the `why` command would exit with status 0 without producing a JSON report when `--json` was specified.

## Root Cause

The issue was that the `why` command is routed through `inspectAction` with the `explain` flag set, but it was returning early without checking if JSON mode was active. This caused the CLI to exit successfully without writing any output when `--json` was passed.

When the GitHub Action's `ensure-json-report.mjs` script checked for a valid JSON report, it found none and created a fallback error report with the message "react-doctor exited with status 0 before producing a JSON report."

## Changes

- Modified `inspectAction` to check if JSON mode is active when the explain path is taken, and write a JSON error report if so
- Updated `whyAction` to properly detect `--json` flag from `process.argv` (needed because Commander treats `--json` as a global option on the root program)
- Updated the `why` command action handler to use `command.optsWithGlobals()` to access parent options
- Added regression test to ensure JSON error report is produced with exit code 1
- The error message clearly indicates that the `why` command does not support JSON mode

## Testing

Added a regression test in `tests/e2e/json-out-flag.test.ts` that verifies:
1. Running `react-doctor why <location> --json` produces a JSON error report
2. The exit code is 1 (indicates error)
3. The error message contains appropriate text about JSON mode not being supported
4. The report has the correct schema structure

All existing tests pass, including the new regression test.

## Technical Details

The fix works by:
1. Checking `process.argv` for the `--json` flag in `whyAction` (workaround for Commander's global option handling)
2. Passing the JSON flag through to `inspectAction`
3. In `inspectAction`, checking if both the explain path is active AND JSON mode is enabled
4. If both are true, writing a structured JSON error report and setting exit code to 1
5. Otherwise, proceeding with the normal explain flow

This ensures that all code paths in JSON mode produce either a valid report or a valid error report, preventing the "exited without producing JSON" error.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-408efc0c-a179-4c26-96a4-6adfd039fe93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-408efc0c-a179-4c26-96a4-6adfd039fe93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

