### PR TITLE
fix(only-export-components): prove Fast Refresh module ownership

### DIFF
--- a/.changeset/quiet-spoons-refresh.md
+++ b/.changeset/quiet-spoons-refresh.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Only run `only-export-components` when the file is owned by a proven Fast Refresh integration, including source packages explicitly consumed by workspace Vite and Storybook apps. Strengthen component, route, wrapper, barrel, React element return, portal, default alias, and React DOM root detection to avoid filename and PascalCase-only false positives.

--- a/.changeset/quiet-spoons-refresh.md
+++ b/.changeset/quiet-spoons-refresh.md
@@ -2,4 +2,4 @@
 "oxlint-plugin-react-doctor": patch
 ---
 
-Only run `only-export-components` when the file is owned by a proven Fast Refresh integration, including source packages explicitly consumed by workspace Vite and Storybook apps. Strengthen component, route, wrapper, barrel, React element return, portal, default alias, and React DOM root detection to avoid filename and PascalCase-only false positives.
+Only run `only-export-components` when the file is owned by a proven Fast Refresh integration, including source packages explicitly consumed by workspace Vite apps, React Vite Storybooks, and Storybook Webpack projects that explicitly enable `reactOptions.fastRefresh`. Strengthen component, route, wrapper, barrel, React element return, portal, default alias, and React DOM root detection to avoid filename and PascalCase-only false positives.

--- a/.changeset/quiet-spoons-refresh.md
+++ b/.changeset/quiet-spoons-refresh.md
@@ -2,4 +2,4 @@
 "oxlint-plugin-react-doctor": patch
 ---
 
-Only run `only-export-components` when the file is owned by a proven Fast Refresh integration, including source packages explicitly consumed by workspace Vite apps, React Vite Storybooks, and Storybook Webpack projects that explicitly enable `reactOptions.fastRefresh`. Strengthen component, route, wrapper, barrel, React element return, portal, default alias, and React DOM root detection to avoid filename and PascalCase-only false positives.
+Only run `only-export-components` when the file is owned by a proven Fast Refresh integration, including source packages explicitly consumed by workspace Vite apps, serving Parcel commands, React Vite Storybooks, and Storybook Webpack projects that explicitly enable `reactOptions.fastRefresh`. Strengthen component, route, wrapper, barrel, React element return, portal, default alias, and React DOM root detection to avoid filename and PascalCase-only false positives.

--- a/packages/core/tests/cross-file-rule-ids.test.ts
+++ b/packages/core/tests/cross-file-rule-ids.test.ts
@@ -47,6 +47,7 @@ const CROSS_FILE_PRIMITIVE_FILES = [
   "utils/find-ancestor-metadata-layout.ts",
   "utils/is-barrel-index-module.ts",
   "utils/read-nearest-package-manifest.ts",
+  "utils/get-fast-refresh-file-status.ts",
 ].map((relativePath) => path.resolve(PLUGIN_SOURCE_DIRECTORY, relativePath));
 const primitiveFileSet = new Set(CROSS_FILE_PRIMITIVE_FILES);
 
@@ -154,6 +155,7 @@ describe("CROSS_FILE_RULE_IDS", () => {
       "no-match-media-in-state-initializer",
       "no-mutating-reducer-state",
       "no-unguarded-browser-global-in-render-or-hook-init",
+      "only-export-components",
       "prefer-dynamic-import",
       "rendering-hydration-mismatch-time",
       "rerender-memo-with-default-value",

--- a/packages/fuzz/corpus/regressions/only-export-components--default-component-alias.tsx
+++ b/packages/fuzz/corpus/regressions/only-export-components--default-component-alias.tsx
@@ -1,0 +1,5 @@
+export function CurrentDeploymentCard(): null {
+  return null;
+}
+
+export default CurrentDeploymentCard;

--- a/packages/fuzz/corpus/regressions/only-export-components--default-pascalcase-helper.tsx
+++ b/packages/fuzz/corpus/regressions/only-export-components--default-pascalcase-helper.tsx
@@ -1,0 +1,5 @@
+export const Card = () => <div />;
+
+const FormatCurrency = (value: number) => String(value);
+
+export default FormatCurrency;

--- a/packages/fuzz/corpus/regressions/only-export-components--portal-and-element-return.tsx
+++ b/packages/fuzz/corpus/regressions/only-export-components--portal-and-element-return.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+import { createPortal } from "react-dom";
+
+export const AssigneeResolver = ({ children }): React.ReactElement => children();
+
+export function AppShortcutMenu(): JSX.Element | null {
+  const paletteContent = <div />;
+  return createPortal(paletteContent, document.body);
+}

--- a/packages/fuzz/corpus/regressions/only-export-components--react-dom-root-mount.tsx
+++ b/packages/fuzz/corpus/regressions/only-export-components--react-dom-root-mount.tsx
@@ -1,0 +1,10 @@
+// rule: only-export-components
+// weakness: provenance
+// source: job-grounded Fast Refresh capability audit 2026-07-13
+import { createRoot as mountRoot } from "react-dom/client";
+
+export const App = () => <div />;
+export const runtimeConfig = getConfig();
+
+const applicationRoot = mountRoot(document.getElementById("root")!);
+applicationRoot.render(<App />);

--- a/packages/fuzz/corpus/true-positives/only-export-components--inline-null-component.tsx
+++ b/packages/fuzz/corpus/true-positives/only-export-components--inline-null-component.tsx
@@ -1,0 +1,5 @@
+export const formatCurrency = (value: number) => String(value);
+
+export function CurrentDeploymentCard(): null {
+  return null;
+}

--- a/packages/fuzz/corpus/true-positives/only-export-components--ordinary-next-layout.tsx
+++ b/packages/fuzz/corpus/true-positives/only-export-components--ordinary-next-layout.tsx
@@ -1,0 +1,6 @@
+// rule: only-export-components
+// weakness: framework-gating
+// source: PR #1237 adversarial audit
+
+export const Layout = () => <main />;
+export const runtimeConfig = getRuntimeConfig();

--- a/packages/fuzz/corpus/true-positives/only-export-components--pascalcase-helper-alias.tsx
+++ b/packages/fuzz/corpus/true-positives/only-export-components--pascalcase-helper-alias.tsx
@@ -1,0 +1,5 @@
+export const Card = () => <div />;
+
+const formatCurrency = (value: number) => String(value);
+
+export { formatCurrency as FormatCurrency };

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -458,6 +458,7 @@ export const EDGE_CASE_STATEMENT_POOL = [
   `export default class extends React.Component { render() { return null; } }`,
   `export function FuzzPortalComponent(): JSX.Element | null { const portalContent = <div />; return createPortal(portalContent, document.body); }`,
   `export function FuzzNullComponent(): null { return null; } export default FuzzNullComponent;`,
+  `export const FuzzCard = () => <div />; const FormatCurrency = (value: number) => String(value); export default FormatCurrency;`,
   `class EventShield extends React.Component { handleClick(event) { event.stopPropagation(); } render() { return <div onClick={this.handleClick} />; } }`,
   `const globalCount = (globalThis as any).__count = ((globalThis as any).__count ?? 0) + 1;`,
   `const emDash = \`\${value} — \${state}\`;`,

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -200,6 +200,7 @@ export const LIBRARY_SNIPPET_POOL = [
 // Module scope — SSR hazards, guard aliases, contexts, caches, styled.
 export const MODULE_SCOPE_SNIPPET_POOL = [
   `import { motion as FuzzMotion } from "framer-motion"; export const FuzzMotionPanel = () => <FuzzMotion.div animate={{ x: 120 }}>moving</FuzzMotion.div>;`,
+  `import { createRoot as mountFuzzRoot } from "react-dom/client"; export const FuzzRootApp = () => <div />; export const fuzzRootConfig = getConfig(); const fuzzApplicationRoot = mountFuzzRoot(document.body); fuzzApplicationRoot.render(<FuzzRootApp />);`,
   `const GLOBAL_CACHE = new Map<string, unknown>();`,
   `class FuzzProtocolRegistry { static contextTypes = new Set(["json", "text"]); static childContextTypes = new Map(); getChildContext() { return { protocol: "json" }; } } const FuzzSchemaRegistry = {}; FuzzSchemaRegistry.contextTypes = new Set(["json", "text"]);`,
   `const fuzzLeftItems = ["a", "b"]; const fuzzRightItems = ["a", "b"]; const fuzzItemsMatch = fuzzLeftItems.every((item, index) => item === fuzzRightItems[index]);`,
@@ -455,6 +456,8 @@ export const EDGE_CASE_STATEMENT_POOL = [
   `label: for (let index = 0; index < 3; index += 1) { continue label; }`,
   `const tagged = html\`<div onclick="\${value}"></div>\`;`,
   `export default class extends React.Component { render() { return null; } }`,
+  `export function FuzzPortalComponent(): JSX.Element | null { const portalContent = <div />; return createPortal(portalContent, document.body); }`,
+  `export function FuzzNullComponent(): null { return null; } export default FuzzNullComponent;`,
   `class EventShield extends React.Component { handleClick(event) { event.stopPropagation(); } render() { return <div onClick={this.handleClick} />; } }`,
   `const globalCount = (globalThis as any).__count = ((globalThis as any).__count ?? 0) + 1;`,
   `const emDash = \`\${value} — \${state}\`;`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/cross-file-rule-ids.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/cross-file-rule-ids.ts
@@ -52,6 +52,7 @@ export const CROSS_FILE_RULE_IDS: ReadonlySet<string> = new Set([
   "no-effect-with-fresh-deps",
   "no-initialize-state",
   "no-mutating-reducer-state",
+  "only-export-components",
   "no-unguarded-browser-global-in-render-or-hook-init",
   "prefer-dynamic-import",
   "rendering-hydration-mismatch-time",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/fast-refresh.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/fast-refresh.ts
@@ -24,4 +24,5 @@ export const MINIMUM_FAST_REFRESH_VERSIONS = {
   reactForGatsbyTwo: { major: 17, minor: 0 },
   reactNative: { major: 0, minor: 61 },
   reactScripts: { major: 4, minor: 0 },
+  storybookReact: { major: 6, minor: 1 },
 } as const;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/fast-refresh.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/fast-refresh.ts
@@ -1,0 +1,27 @@
+export const FAST_REFRESH_CONFIG_FILENAMES = [
+  "vite.config.ts",
+  "vite.config.mts",
+  "vite.config.cts",
+  "vite.config.js",
+  "vite.config.mjs",
+  "vite.config.cjs",
+  "webpack.config.ts",
+  "webpack.config.js",
+  "webpack.config.mjs",
+  "webpack.config.cjs",
+  "rsbuild.config.ts",
+  "rsbuild.config.js",
+  "rspack.config.ts",
+  "rspack.config.js",
+] as const;
+
+export const MINIMUM_FAST_REFRESH_VERSIONS = {
+  dumi: { major: 2, minor: 0 },
+  expo: { major: 36, minor: 0 },
+  gatsby: { major: 2, minor: 31 },
+  next: { major: 9, minor: 4 },
+  parcel: { major: 2, minor: 0 },
+  reactForGatsbyTwo: { major: 17, minor: 0 },
+  reactNative: { major: 0, minor: 61 },
+  reactScripts: { major: 4, minor: 0 },
+} as const;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/cross-file-dependencies.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/cross-file-dependencies.test.ts
@@ -4,6 +4,7 @@ import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
 import {
   CROSS_FILE_DEPENDENCY_COLLECTORS,
+  UNBOUNDED_CROSS_FILE_RULE_IDS,
   collectCrossFileDependencyProbes,
 } from "./cross-file-dependencies.js";
 import { CROSS_FILE_RULE_IDS } from "./constants/cross-file-rule-ids.js";
@@ -389,9 +390,9 @@ describe("react-native collectors", () => {
 });
 
 describe("collector registry", () => {
-  it("ships a collector for every cross-file rule (none unbounded today)", () => {
-    expect([...CROSS_FILE_DEPENDENCY_COLLECTORS.keys()].sort()).toEqual(
-      [...CROSS_FILE_RULE_IDS].sort(),
-    );
+  it("classifies every cross-file rule as bounded or unbounded", () => {
+    expect(
+      [...CROSS_FILE_DEPENDENCY_COLLECTORS.keys(), ...UNBOUNDED_CROSS_FILE_RULE_IDS].sort(),
+    ).toEqual([...CROSS_FILE_RULE_IDS].sort());
   });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/cross-file-dependencies.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/cross-file-dependencies.ts
@@ -444,7 +444,9 @@ export const CROSS_FILE_DEPENDENCY_COLLECTORS: ReadonlyMap<string, CrossFileDepe
  * `CROSS_FILE_DEPENDENCY_COLLECTORS` (the core guard test enforces the
  * partition), forcing a conscious classification.
  */
-export const UNBOUNDED_CROSS_FILE_RULE_IDS: ReadonlySet<string> = new Set();
+export const UNBOUNDED_CROSS_FILE_RULE_IDS: ReadonlySet<string> = new Set([
+  "only-export-components",
+]);
 
 /**
  * Runs the collectors for `ruleIds` over one file and returns every

--- a/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness-fixtures.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness-fixtures.ts
@@ -930,7 +930,7 @@ export const livenessFixtures: Readonly<Record<string, LivenessFixture>> = {
     filePath: "src/server/db/users.ts",
   },
   "only-export-components": {
-    code: "export const foo = () => {}; export const Bar = () => {};",
+    code: "export const foo = () => 'label'; export const Bar = () => <div />;",
     forceJsx: true,
   },
   "package-metadata-secret": {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/__fixtures__/oxc-divergences.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/__fixtures__/oxc-divergences.ts
@@ -96,14 +96,17 @@ export const DIVERGENCES: Record<string, OxcDivergence> = {
     reason: "Intentional: default max raised from 2 → 10 to suppress idiomatic-React FPs.",
   },
   "only-export-components": {
-    // Two intentional divergences:
+    // Three intentional divergences:
     // (1) fail[3, 4, 10, 14] — OXC defaults `allowConstantExport: false`,
     //     which flags any primitive-constant export alongside a
     //     component. We default `allowConstantExport: true` because
     //     exported constants are stable references that don't break Fast
     //     Refresh — matches the recommended config in
     //     `eslint-plugin-react-refresh`.
-    // (2) fail[12, 13, 21] — non-exported internal components are no
+    // (2) fail[6] — a pure `export *` barrel is not instrumented as a
+    //     Fast Refresh boundary by Vite's official React plugin. It only
+    //     reports when the same module also declares a local component.
+    // (3) fail[12, 13, 21] — non-exported internal components are no
     //     longer reported. The react-refresh boundary constraint is
     //     about exports only (a module that exports a component must
     //     export only components); a module whose exports carry no
@@ -113,9 +116,13 @@ export const DIVERGENCES: Record<string, OxcDivergence> = {
     //     The real breaker — a namespace-object export bundling
     //     components — is reported instead (not covered by OXC fixtures;
     //     see only-export-components.regressions.test.ts).
-    failSkips: [3, 4, 10, 14, 12, 13, 21],
+    // (4) Function exports require JSX/createElement return evidence.
+    //     OXC treats every PascalCase function as a component, which
+    //     misclassifies acronym-named formatters in utility modules.
+    passSkips: [14, 15, 16, 17, 18, 42, 51, 52, 53, 54, 56, 57, 61, 62],
+    failSkips: [0, 1, 2, 3, 4, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 18, 19, 21, 22, 23],
     reason:
-      "Intentional: default allowConstantExport=true; exports-only Fast-Refresh model (local components unreported, namespace-object exports flagged).",
+      "Intentional: require render-output proof for inspectable functions; recognize Babel Fast Refresh wrapper transforms; default allowConstantExport=true; pure export-star barrels are not refresh boundaries; exports-only Fast-Refresh model (local components unreported, namespace-object exports flagged).",
   },
   "jsx-pascal-case": {
     // OXC defaults `allowLeadingUnderscore: false`. We default to

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components-tables.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components-tables.ts
@@ -12,6 +12,7 @@ export const NOT_REACT_COMPONENT_EXPRESSION_TYPES: ReadonlySet<string> = new Set
   "ConditionalExpression",
   "Literal",
   "LogicalExpression",
+  "NewExpression",
   "ObjectExpression",
   "TemplateLiteral",
   "ThisExpression",
@@ -37,144 +38,7 @@ export const NON_FAST_REFRESH_PATH_SEGMENTS: ReadonlyArray<string> = [
   "/.storybook/",
   "/stories/",
   "/__stories__/",
-  "/playground/",
-  "/playgrounds/",
-  "/examples/",
-  "/example/",
-  "/demo/",
-  "/demos/",
-  "/sandbox/",
-  "/sandboxes/",
 ];
-
-// File basenames that conventionally are application entry points —
-// they call `createRoot(...).render(...)` / `hydrateRoot(...)` /
-// `ReactDOM.render(...)` once and never participate in Fast Refresh
-// (the dev server reloads the whole page when these change). Mixed
-// exports and local components in these files are fine.
-//
-// This set holds only the *generic* (framework-agnostic) entry-point
-// names. Framework-specific route / special files (Next.js, Expo Router,
-// TanStack Router, Remix / React Router) are detected by the dedicated
-// `is-<framework>-*-filename` helpers in `../../utils/`, which
-// `only-export-components` consults alongside this set.
-export const ENTRY_POINT_BASENAMES: ReadonlySet<string> = new Set([
-  "main.tsx",
-  "main.jsx",
-  "main.js",
-  "index.tsx",
-  "index.jsx",
-  "entry.tsx",
-  "entry.jsx",
-  "bootstrap.tsx",
-  "bootstrap.jsx",
-  "client.tsx",
-  "client.jsx",
-  "server.tsx",
-  "server.jsx",
-  // Root App component — by convention the single-render root of a CRA
-  // / Vite / Expo app, mounted directly from main/index. Co-exports of
-  // helper components and constants are conventional here.
-  "app.tsx",
-  "app.jsx",
-  "App.tsx",
-  "App.jsx",
-]);
-
-// Utility / helper / shared-config / column-renderer / node-registry
-// files. These conventionally hold a mix of component-style and
-// constant exports — `utils.tsx` for a slice that contains both a
-// render helper component and string-formatting constants, `shared.tsx`
-// for cross-component types and helpers, `nodeTypes.tsx` for an
-// xyflow / tldraw / lexical node registry that maps strings to node
-// renderer components, `*ColumnRenderers.tsx` for table column-renderer
-// collections, `*useCreate*.tsx` hooks that co-export helper constants.
-// These NEVER get edited live (the dev would Cmd+R anyway), so Fast
-// Refresh preservation isn't an actual gain — the file structure is by
-// design. Pattern requires the EXACT basename match (no fuzzy match)
-// so unrelated files (`MyUtils.tsx`, `userUtils.tsx`) only match when
-// the basename IS that.
-export const UTILITY_FILE_BASENAMES: ReadonlySet<string> = new Set([
-  // Generic utility/helper bags
-  "utils.tsx",
-  "utils.jsx",
-  "util.tsx",
-  "util.jsx",
-  "helpers.tsx",
-  "helpers.jsx",
-  "helper.tsx",
-  "helper.jsx",
-  "shared.tsx",
-  "shared.jsx",
-  "common.tsx",
-  "common.jsx",
-  "lib.tsx",
-  "lib.jsx",
-  // Node-type / cell-type / column-renderer registries
-  "nodeTypes.tsx",
-  "nodeTypes.jsx",
-  "node-types.tsx",
-  "node-types.jsx",
-  "edgeTypes.tsx",
-  "edgeTypes.jsx",
-  "edge-types.tsx",
-  "edge-types.jsx",
-  "cellTypes.tsx",
-  "cellTypes.jsx",
-  "columnTypes.tsx",
-  "columnTypes.jsx",
-  "columnDefs.tsx",
-  "columnDefs.jsx",
-  "columnRenderers.tsx",
-  "columnRenderers.jsx",
-  "columns.tsx",
-  "columns.jsx",
-  // Mappings / dictionaries / lookups
-  "mappings.tsx",
-  "mappings.jsx",
-  "mapping.tsx",
-  "mapping.jsx",
-  "lookups.tsx",
-  "lookups.jsx",
-  "lookup.tsx",
-  "lookup.jsx",
-  "registry.tsx",
-  "registry.jsx",
-  // Toast / notification helper file (typically combines provider + helper functions)
-  "toast.tsx",
-  "toast.jsx",
-  "toaster.tsx",
-  "toaster.jsx",
-  // Theme / token / palette utility files
-  "theme.tsx",
-  "theme.jsx",
-  "tokens.tsx",
-  "tokens.jsx",
-  "palette.tsx",
-  "palette.jsx",
-  "colors.tsx",
-  "colors.jsx",
-  "colours.tsx",
-  "colours.jsx",
-  // Constants / enums / type helpers (.tsx variant for component types)
-  "constants.tsx",
-  "constants.jsx",
-  "enums.tsx",
-  "enums.jsx",
-  "types.tsx",
-  "types.jsx",
-  "schemas.tsx",
-  "schemas.jsx",
-  "schema.tsx",
-  "schema.jsx",
-  // Definition / config files
-  "definitions.tsx",
-  "definitions.jsx",
-  "config.tsx",
-  "config.jsx",
-  "defaults.tsx",
-  "defaults.jsx",
-]);
 
 // Route-object factory callees from file-based routers. A call like
 // `createFileRoute("/profile")({ component: ProfilePage })` produces
@@ -184,7 +48,7 @@ export const UTILITY_FILE_BASENAMES: ReadonlySet<string> = new Set([
 // Covers TanStack Router / TanStack Start (`createFileRoute`,
 // `createLazyFileRoute`, `createRootRoute`, …) and `createBrowserRouter`
 // / `createHashRouter` / `createMemoryRouter` style data routers.
-export const ROUTE_FACTORY_CALLEE_NAMES: ReadonlySet<string> = new Set([
+export const TANSTACK_ROUTE_FACTORY_CALLEE_NAMES: ReadonlySet<string> = new Set([
   ...TANSTACK_ROUTE_CREATION_FUNCTIONS,
   "createLazyFileRoute",
   "createLazyRoute",
@@ -192,6 +56,9 @@ export const ROUTE_FACTORY_CALLEE_NAMES: ReadonlySet<string> = new Set([
   "createServerFileRoute",
   "createServerRootRoute",
   "createServerRoute",
+]);
+
+export const REACT_ROUTER_FACTORY_CALLEE_NAMES: ReadonlySet<string> = new Set([
   "createBrowserRouter",
   "createHashRouter",
   "createMemoryRouter",
@@ -203,7 +70,7 @@ export const ROUTE_FACTORY_CALLEE_NAMES: ReadonlySet<string> = new Set([
 // modules and Next.js Pages Router pages co-export these alongside the
 // route component by framework contract; the bundler plugins for those
 // frameworks special-case them during Fast Refresh.
-export const ROUTE_MODULE_ALLOWED_EXPORT_NAMES: ReadonlySet<string> = new Set([
+export const REACT_ROUTER_ALLOWED_EXPORT_NAMES: ReadonlySet<string> = new Set([
   // Remix / React Router route module exports
   "loader",
   "clientLoader",
@@ -216,7 +83,9 @@ export const ROUTE_MODULE_ALLOWED_EXPORT_NAMES: ReadonlySet<string> = new Set([
   "shouldRevalidate",
   "middleware",
   "unstable_middleware",
-  // Next.js Pages Router data exports
+]);
+
+export const NEXT_ALLOWED_EXPORT_NAMES: ReadonlySet<string> = new Set([
   "getServerSideProps",
   "getStaticProps",
   "getStaticPaths",
@@ -238,6 +107,6 @@ export const ROUTE_MODULE_ALLOWED_EXPORT_NAMES: ReadonlySet<string> = new Set([
   "preferredRegion",
   "maxDuration",
   "experimental_ppr",
-  // Expo Router route settings export
-  "unstable_settings",
 ]);
+
+export const EXPO_ALLOWED_EXPORT_NAMES: ReadonlySet<string> = new Set(["unstable_settings"]);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.fast-refresh.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.fast-refresh.test.ts
@@ -1,0 +1,405 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { resetManifestCaches } from "../../utils/read-nearest-package-manifest.js";
+import { onlyExportComponents } from "./only-export-components.js";
+
+interface ProjectFixture {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  manifestFields?: Record<string, unknown>;
+  config?: string;
+  configFilename?: string;
+}
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  resetManifestCaches();
+  for (const temporaryDirectory of temporaryDirectories.splice(0)) {
+    fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+  }
+});
+
+const createProject = ({
+  dependencies = { react: "19.0.0" },
+  devDependencies,
+  manifestFields,
+  config,
+  configFilename = "vite.config.ts",
+}: ProjectFixture): string => {
+  const projectDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-refresh-"));
+  temporaryDirectories.push(projectDirectory);
+  fs.writeFileSync(
+    path.join(projectDirectory, "package.json"),
+    JSON.stringify({
+      name: "refresh-fixture",
+      dependencies,
+      devDependencies,
+      ...(config && configFilename.startsWith("vite.config") ? { scripts: { dev: "vite" } } : {}),
+      ...manifestFields,
+    }),
+  );
+  if (config) fs.writeFileSync(path.join(projectDirectory, configFilename), config);
+  fs.mkdirSync(path.join(projectDirectory, "src", "components", "card"), { recursive: true });
+  return projectDirectory;
+};
+
+const runMixedExportRule = (projectDirectory: string, relativeFilename = "src/card.tsx") =>
+  runRule(
+    onlyExportComponents,
+    `export const Card = () => <div />; export const cardLabel = getLabel();`,
+    { filename: path.join(projectDirectory, relativeFilename) },
+  );
+
+describe("only-export-components Fast Refresh applicability", () => {
+  it.each([
+    ["plain webpack", { devDependencies: { webpack: "5.0.0", "ts-loader": "9.0.0" } }],
+    ["plain Vite", { devDependencies: { vite: "7.0.0" } }],
+    ["react-refresh runtime alone", { devDependencies: { "react-refresh": "0.18.0" } }],
+    [
+      "unregistered Vite React dependency",
+      { devDependencies: { vite: "7.0.0", "@vitejs/plugin-react": "5.0.0" } },
+    ],
+    [
+      "imported but unused Vite React plugin",
+      {
+        devDependencies: { vite: "7.0.0", "@vitejs/plugin-react": "5.0.0" },
+        config: `import react from "@vitejs/plugin-react"; export default { plugins: [] };`,
+      },
+    ],
+    [
+      "plugin call outside the config plugins list",
+      {
+        devDependencies: { vite: "7.0.0", "@vitejs/plugin-react": "5.0.0" },
+        config: `import react from "@vitejs/plugin-react"; const example = react(); export default { plugins: [] };`,
+      },
+    ],
+    [
+      "unexported plugins object",
+      {
+        devDependencies: { vite: "7.0.0", "@vitejs/plugin-react": "5.0.0" },
+        config: `import react from "@vitejs/plugin-react"; const unused = { plugins: [react()] }; export default { plugins: [] };`,
+      },
+    ],
+    [
+      "nested Babel plugins object",
+      {
+        devDependencies: { vite: "7.0.0", "@vitejs/plugin-react": "5.0.0" },
+        config: `import react from "@vitejs/plugin-react"; export default { babel: { plugins: [react()] }, plugins: [] };`,
+      },
+    ],
+    [
+      "commented plugin registration",
+      {
+        devDependencies: { vite: "7.0.0", "@vitejs/plugin-react": "5.0.0" },
+        config: `import react from "@vitejs/plugin-react"; export default { plugins: [/* react() */] };`,
+      },
+    ],
+  ] as const)("stays silent without transform proof — %s", (_label, fixture) => {
+    const result = runMixedExportRule(createProject(fixture));
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it.each([
+    [
+      "Vite React",
+      {
+        devDependencies: { vite: "7.0.0", "@vitejs/plugin-react": "5.0.0" },
+        config: `import react from "@vitejs/plugin-react"; export default { plugins: [react()] };`,
+      },
+    ],
+    [
+      "Vite React SWC alias",
+      {
+        devDependencies: { vite: "7.0.0", "@vitejs/plugin-react-swc": "4.0.0" },
+        config: `import refreshTransform from "@vitejs/plugin-react-swc"; export default { plugins: [refreshTransform()] };`,
+      },
+    ],
+    [
+      "Vite React re-exported default",
+      {
+        devDependencies: { vite: "7.0.0", "@vitejs/plugin-react": "5.0.0" },
+        config: `import { default as enableReact } from "@vitejs/plugin-react"; export default { plugins: [enableReact()] };`,
+      },
+    ],
+    [
+      "webpack React Refresh",
+      {
+        devDependencies: {
+          webpack: "5.0.0",
+          "@pmmmwh/react-refresh-webpack-plugin": "0.6.0",
+        },
+        configFilename: "webpack.config.js",
+        config: `import ReactRefreshPlugin from "@pmmmwh/react-refresh-webpack-plugin"; export default { plugins: [new ReactRefreshPlugin()] };`,
+      },
+    ],
+    [
+      "CommonJS webpack React Refresh",
+      {
+        devDependencies: {
+          webpack: "5.0.0",
+          "@pmmmwh/react-refresh-webpack-plugin": "0.6.0",
+        },
+        configFilename: "webpack.config.cjs",
+        config: `const ReactRefreshPlugin = require("@pmmmwh/react-refresh-webpack-plugin"); module.exports = { plugins: [new ReactRefreshPlugin()] };`,
+      },
+    ],
+    [
+      "Rsbuild React",
+      {
+        devDependencies: { "@rsbuild/core": "1.0.0", "@rsbuild/plugin-react": "1.0.0" },
+        configFilename: "rsbuild.config.ts",
+        config: `import { pluginReact as enableReact } from "@rsbuild/plugin-react"; export default { plugins: [enableReact()] };`,
+      },
+    ],
+    [
+      "exported config and plugin bindings",
+      {
+        devDependencies: { vite: "7.0.0", "@vitejs/plugin-react": "5.0.0" },
+        config: `import react from "@vitejs/plugin-react"; const plugins = [react()]; const config = { plugins }; export default config;`,
+      },
+    ],
+  ] as const)("reports with registered transform proof — %s", (_label, fixture) => {
+    const result = runMixedExportRule(createProject(fixture));
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it.each([
+    ["Next.js", { next: "9.4.0", react: "16.13.0" }],
+    ["Create React App", { "react-scripts": "4.0.0", react: "17.0.0" }],
+    ["Gatsby", { gatsby: "2.31.0", react: "17.0.0" }],
+    ["Expo", { expo: "36.0.0", react: "16.9.0" }],
+    ["React Native", { "react-native": "0.61.0", react: "16.9.0" }],
+  ] as const)("reports for a built-in transform — %s", (_label, dependencies) => {
+    expect(runMixedExportRule(createProject({ dependencies })).diagnostics).toHaveLength(1);
+  });
+
+  it("reports for a Parcel browser entry", () => {
+    expect(
+      runMixedExportRule(
+        createProject({
+          dependencies: { react: "18.0.0" },
+          devDependencies: { parcel: "2.0.0" },
+          manifestFields: { scripts: { start: "parcel src/index.html" } },
+        }),
+      ).diagnostics,
+    ).toHaveLength(1);
+  });
+
+  it("reports for development tooling with an owned app command", () => {
+    expect(
+      runMixedExportRule(
+        createProject({
+          dependencies: { react: "19.0.0" },
+          devDependencies: { next: "16.0.0" },
+          manifestFields: { scripts: { dev: "cross-env NODE_ENV=development next dev" } },
+        }),
+      ).diagnostics,
+    ).toHaveLength(1);
+  });
+
+  it.each([
+    ["Next.js", { next: "9.3.9", react: "16.13.0" }],
+    ["Create React App", { "react-scripts": "3.4.4", react: "16.13.0" }],
+    ["Gatsby", { gatsby: "2.30.0", react: "17.0.0" }],
+    ["Gatsby 2 with React 16", { gatsby: "2.31.0", react: "16.14.0" }],
+    ["Parcel", { parcel: "1.12.5", react: "17.0.0" }],
+    ["Expo", { expo: "35.0.0", react: "16.8.0" }],
+    ["React Native", { "react-native": "0.60.6", react: "16.8.0" }],
+  ] as const)("stays silent before built-in Fast Refresh — %s", (_label, dependencies) => {
+    expect(runMixedExportRule(createProject({ dependencies })).diagnostics).toHaveLength(0);
+  });
+
+  it.each([
+    ["react-scripts used only for tests", { "react-scripts": "4.0.0" }],
+    ["Next used only as development tooling", { next: "16.0.0" }],
+    ["Parcel library entry", { parcel: "2.0.0" }],
+  ])("stays silent for an unowned development dependency — %s", (_label, devDependencies) => {
+    expect(
+      runMixedExportRule(createProject({ dependencies: { react: "19.0.0" }, devDependencies }))
+        .diagnostics,
+    ).toHaveLength(0);
+  });
+
+  it("uses the nearest package boundary instead of a sibling or parent integration", () => {
+    const projectDirectory = createProject({
+      devDependencies: { vite: "7.0.0", "@vitejs/plugin-react": "5.0.0" },
+      config: `import react from "@vitejs/plugin-react"; export default { plugins: [react()] };`,
+    });
+    const fixtureDirectory = path.join(projectDirectory, "fixtures", "plain-webpack");
+    fs.mkdirSync(path.join(fixtureDirectory, "src"), { recursive: true });
+    fs.writeFileSync(
+      path.join(fixtureDirectory, "package.json"),
+      JSON.stringify({ dependencies: { react: "19.0.0" }, devDependencies: { webpack: "5.0.0" } }),
+    );
+
+    expect(runMixedExportRule(projectDirectory).diagnostics).toHaveLength(1);
+    expect(runMixedExportRule(fixtureDirectory).diagnostics).toHaveLength(0);
+  });
+
+  it("scopes route export contracts to the registered framework integration", () => {
+    const reactRouterProject = createProject({
+      dependencies: { react: "19.0.0", "@react-router/dev": "7.0.0" },
+      config: `import { reactRouter as routes } from "@react-router/dev/vite"; export default { plugins: [routes()] };`,
+    });
+    const genericViteProject = createProject({
+      devDependencies: { vite: "7.0.0", "@vitejs/plugin-react": "5.0.0" },
+      config: `import react from "@vitejs/plugin-react"; export default { plugins: [react()] };`,
+    });
+    const routeModule = `export const loader = () => getData(); export default function Route() { return <div />; }`;
+
+    expect(
+      runRule(onlyExportComponents, routeModule, {
+        filename: path.join(reactRouterProject, "app", "routes", "profile.tsx"),
+      }).diagnostics,
+    ).toHaveLength(0);
+    expect(
+      runRule(onlyExportComponents, routeModule, {
+        filename: path.join(genericViteProject, "src", "profile.tsx"),
+      }).diagnostics,
+    ).toHaveLength(1);
+  });
+
+  it("scopes Nextra metadata filenames to Next.js", () => {
+    const nextProject = createProject({
+      dependencies: { react: "19.0.0", next: "16.0.0" },
+    });
+    const genericViteProject = createProject({
+      devDependencies: { vite: "7.0.0", "@vitejs/plugin-react": "5.0.0" },
+      config: `import react from "@vitejs/plugin-react"; export default { plugins: [react()] };`,
+    });
+    const metadataModule = `export default () => <div />;`;
+
+    expect(
+      runRule(onlyExportComponents, metadataModule, {
+        filename: path.join(nextProject, "pages", "docs", "_meta.tsx"),
+      }).diagnostics,
+    ).toHaveLength(0);
+    expect(
+      runRule(onlyExportComponents, metadataModule, {
+        filename: path.join(genericViteProject, "src", "_meta.tsx"),
+      }).diagnostics,
+    ).toHaveLength(1);
+  });
+
+  it.each(["src/components/card/index.tsx", "src/App.tsx", "examples/demo-card.tsx"])(
+    "checks a transformed module independent of filename — %s",
+    (relativeFilename) => {
+      const projectDirectory = createProject({
+        devDependencies: { vite: "7.0.0", "@vitejs/plugin-react": "5.0.0" },
+        config: `import react from "@vitejs/plugin-react"; export default { plugins: [react()] };`,
+      });
+      expect(runMixedExportRule(projectDirectory, relativeFilename).diagnostics).toHaveLength(1);
+    },
+  );
+
+  it.each(["src/testUtils.tsx", "src/test-helpers.tsx", "src/specSetup.jsx"])(
+    "stays silent for a test support module — %s",
+    (relativeFilename) => {
+      const projectDirectory = createProject({
+        dependencies: { react: "19.0.0", "react-scripts": "5.0.1" },
+      });
+      expect(runMixedExportRule(projectDirectory, relativeFilename).diagnostics).toHaveLength(0);
+    },
+  );
+
+  it("stays silent for a pure star-export barrel", () => {
+    const projectDirectory = createProject({
+      dependencies: { react: "19.0.0", "react-scripts": "5.0.1" },
+    });
+    const result = runRule(onlyExportComponents, `export * from "./button";`, {
+      filename: path.join(projectDirectory, "src", "components", "index.tsx"),
+    });
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("reports a star export beside a local component export", () => {
+    const projectDirectory = createProject({
+      dependencies: { react: "19.0.0", "react-scripts": "5.0.1" },
+    });
+    const result = runRule(
+      onlyExportComponents,
+      `export * from "./button"; export const Card = () => <div />;`,
+      { filename: path.join(projectDirectory, "src", "components", "index.tsx") },
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays silent when a star export adds only types and a default export", () => {
+    const projectDirectory = createProject({
+      dependencies: { react: "19.0.0", "react-scripts": "5.0.1" },
+    });
+    fs.writeFileSync(
+      path.join(projectDirectory, "src", "components", "button.tsx"),
+      `export interface ButtonProps { label: string } export default () => <button />;`,
+    );
+    const result = runRule(
+      onlyExportComponents,
+      `export * from "./button"; export const Card = () => <div />;`,
+      { filename: path.join(projectDirectory, "src", "components", "index.tsx") },
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("reports when a star export adds a runtime named value", () => {
+    const projectDirectory = createProject({
+      dependencies: { react: "19.0.0", "react-scripts": "5.0.1" },
+    });
+    fs.writeFileSync(
+      path.join(projectDirectory, "src", "components", "button.tsx"),
+      `export const buttonLabel = "Button"; export default () => <button />;`,
+    );
+    const result = runRule(
+      onlyExportComponents,
+      `export * from "./button"; export const Card = () => <div />;`,
+      { filename: path.join(projectDirectory, "src", "components", "index.tsx") },
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it.each([
+    [
+      "an inline type re-export and default",
+      `interface ButtonProps { label: string } const Button = () => <button />; export { type ButtonProps, Button as default };`,
+      0,
+    ],
+    ["a default re-export", `export { default } from "./leaf";`, 0],
+    [
+      "a default renamed to a runtime named export",
+      `export { default as Button } from "./leaf";`,
+      1,
+    ],
+    ["a runtime enum", `export enum ButtonSize { Small, Large }`, 1],
+    ["a nested runtime star export", `export * from "./runtime-leaf";`, 1],
+  ] as const)(
+    "classifies a star target containing %s",
+    (_label, targetSource, expectedDiagnosticCount) => {
+      const projectDirectory = createProject({
+        dependencies: { react: "19.0.0", "react-scripts": "5.0.1" },
+      });
+      fs.writeFileSync(
+        path.join(projectDirectory, "src", "components", "button.tsx"),
+        targetSource,
+      );
+      fs.writeFileSync(
+        path.join(projectDirectory, "src", "components", "leaf.tsx"),
+        `export default () => <button />;`,
+      );
+      fs.writeFileSync(
+        path.join(projectDirectory, "src", "components", "runtime-leaf.tsx"),
+        `export const buttonLabel = "Button";`,
+      );
+      const result = runRule(
+        onlyExportComponents,
+        `export * from "./button"; export const Card = () => <div />;`,
+        { filename: path.join(projectDirectory, "src", "components", "index.tsx") },
+      );
+      expect(result.diagnostics).toHaveLength(expectedDiagnosticCount);
+    },
+  );
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.fast-refresh.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.fast-refresh.test.ts
@@ -191,6 +191,45 @@ describe("only-export-components Fast Refresh applicability", () => {
     ).toHaveLength(1);
   });
 
+  it("reports for a Parcel serve command with a manifest browser entry", () => {
+    expect(
+      runMixedExportRule(
+        createProject({
+          dependencies: { react: "18.0.0" },
+          devDependencies: { parcel: "2.0.0" },
+          manifestFields: {
+            source: "src/index.html",
+            scripts: { start: "parcel serve" },
+          },
+        }),
+      ).diagnostics,
+    ).toHaveLength(1);
+  });
+
+  it.each([
+    "parcel build src/index.html",
+    "parcel watch src/index.html",
+    "parcel help",
+    "parcel --help",
+    "parcel --version",
+    "parcel -h",
+    "parcel -V",
+    "parcel src/index.html --no-hmr",
+  ])("stays silent for a non-serving Parcel command — %s", (parcelCommand) => {
+    expect(
+      runMixedExportRule(
+        createProject({
+          dependencies: { react: "18.0.0" },
+          devDependencies: { parcel: "2.0.0" },
+          manifestFields: {
+            source: "src/index.html",
+            scripts: { build: parcelCommand },
+          },
+        }),
+      ).diagnostics,
+    ).toHaveLength(0);
+  });
+
   it("reports for development tooling with an owned app command", () => {
     expect(
       runMixedExportRule(

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.fast-refresh.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.fast-refresh.test.ts
@@ -179,6 +179,20 @@ describe("only-export-components Fast Refresh applicability", () => {
     expect(runMixedExportRule(createProject({ dependencies })).diagnostics).toHaveLength(1);
   });
 
+  it("reports same-named ordinary components in a Next.js project", () => {
+    const projectDirectory = createProject({ dependencies: { next: "16.0.0", react: "19.0.0" } });
+    expect(
+      runMixedExportRule(projectDirectory, "src/components/layout.tsx").diagnostics,
+    ).toHaveLength(1);
+  });
+
+  it("keeps actual Next.js route modules exempt", () => {
+    const projectDirectory = createProject({ dependencies: { next: "16.0.0", react: "19.0.0" } });
+    expect(
+      runMixedExportRule(projectDirectory, "app/dashboard/layout.tsx").diagnostics,
+    ).toHaveLength(0);
+  });
+
   it("reports for a Parcel browser entry", () => {
     expect(
       runMixedExportRule(

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.fast-refresh.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.fast-refresh.test.ts
@@ -298,7 +298,12 @@ describe("only-export-components Fast Refresh applicability", () => {
   it("scopes route export contracts to the registered framework integration", () => {
     const reactRouterProject = createProject({
       dependencies: { react: "19.0.0", "@react-router/dev": "7.0.0" },
-      config: `import { reactRouter as routes } from "@react-router/dev/vite"; export default { plugins: [routes()] };`,
+      devDependencies: { vite: "7.0.0", "@vitejs/plugin-react": "5.0.0" },
+      config: `
+        import react from "@vitejs/plugin-react";
+        import { reactRouter as routes } from "@react-router/dev/vite";
+        export default { plugins: [react(), routes()] };
+      `,
     });
     const genericViteProject = createProject({
       devDependencies: { vite: "7.0.0", "@vitejs/plugin-react": "5.0.0" },

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.fast-refresh.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.fast-refresh.test.ts
@@ -193,6 +193,26 @@ describe("only-export-components Fast Refresh applicability", () => {
     ).toHaveLength(0);
   });
 
+  it.each(["src/components/_layout.tsx", "src/components/+not-found.tsx"])(
+    "reports Expo reserved basenames outside the route root — %s",
+    (relativeFilename) => {
+      const projectDirectory = createProject({
+        dependencies: { expo: "55.0.0", "expo-router": "55.0.0", react: "19.0.0" },
+      });
+      expect(runMixedExportRule(projectDirectory, relativeFilename).diagnostics).toHaveLength(1);
+    },
+  );
+
+  it.each(["app/_layout.tsx", "src/app/(tabs)/+not-found.tsx"])(
+    "keeps actual Expo Router special modules exempt — %s",
+    (relativeFilename) => {
+      const projectDirectory = createProject({
+        dependencies: { expo: "55.0.0", "expo-router": "55.0.0", react: "19.0.0" },
+      });
+      expect(runMixedExportRule(projectDirectory, relativeFilename).diagnostics).toHaveLength(0);
+    },
+  );
+
   it("reports for a Parcel browser entry", () => {
     expect(
       runMixedExportRule(

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.regressions.test.ts
@@ -1092,6 +1092,51 @@ describe("react-builtins/only-export-components — regressions", () => {
   });
 
   it.each([
+    `export function CurrentDeploymentCard(): null { return null; }`,
+    `export default function CurrentDeploymentCard(): null { return null; }`,
+  ])("reports a helper next to an inline null-only component", (componentExport) => {
+    const result = runRule(
+      onlyExportComponents,
+      `
+        export const formatCurrency = (value: number) => String(value);
+        ${componentExport}
+      `,
+      { filename: "src/CurrentDeploymentCard.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports an anonymous null-only default component and its adjacent helper", () => {
+    const result = runRule(
+      onlyExportComponents,
+      `
+        export const formatCurrency = (value: number) => String(value);
+        export default (): null => null;
+      `,
+      { filename: "src/CurrentDeploymentCard.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
+  it.each([
+    `export function formatCurrency(): null { return null; }`,
+    `export function CurrentDeploymentCard() { return undefined; }`,
+  ])("does not infer a null component without component semantics", (helperExport) => {
+    const result = runRule(
+      onlyExportComponents,
+      `
+        ${helperExport}
+        export const currencySymbol = "$";
+      `,
+      { filename: "src/format-currency.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it.each([
     `const FormatCurrency = (value: number) => String(value);
      export default FormatCurrency;`,
     `const FormatCurrency = (value: number) => String(value);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.regressions.test.ts
@@ -1171,6 +1171,62 @@ describe("react-builtins/only-export-components — regressions", () => {
   });
 
   it.each([
+    `const formatCurrency = (value: number) => String(value);
+     export { formatCurrency as FormatCurrency };`,
+    `const formatCurrency = (value: number) => String(value);
+     export const FormatCurrency = formatCurrency;`,
+    `const formatCurrency = (value: number) => String(value);
+     const formatterAlias = formatCurrency;
+     export { formatterAlias as FormatCurrency };`,
+    `const formatCurrency = (value: number) => String(value);
+     const formatterAlias = formatCurrency satisfies typeof formatCurrency;
+     export const FormatCurrency = (formatterAlias);`,
+  ])("reports a PascalCase named export backed by a non-component", (namedExport) => {
+    const result = runRule(
+      onlyExportComponents,
+      `
+        export const Card = () => <div />;
+        ${namedExport}
+      `,
+      { filename: "src/Card.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("retains the runtime's PascalCase heuristic for a same-name function export", () => {
+    const result = runRule(
+      onlyExportComponents,
+      `
+        const FormatCurrency = (value: number) => String(value);
+        export { FormatCurrency };
+        export const formatLocale = getLocale();
+      `,
+      { filename: "src/format-currency.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it.each([
+    `const Card = () => <div />;
+     export { Card };`,
+    `const Card = () => <div />;
+     export { Card as ProfileCard };`,
+    `const Card = () => <div />;
+     export const ProfileCard = Card;`,
+    `const Card = () => <div />;
+     const CardAlias = Card;
+     export { CardAlias as ProfileCard };`,
+  ])("accepts a named export backed by a proven component", (namedExport) => {
+    const result = runRule(onlyExportComponents, namedExport, {
+      filename: "src/Card.tsx",
+    });
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it.each([
     `import { createRoot } from "react-dom/client";
      export const Card = () => <div />;
      export const runtimeConfig = getConfig();

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.regressions.test.ts
@@ -1092,6 +1092,40 @@ describe("react-builtins/only-export-components — regressions", () => {
   });
 
   it.each([
+    `const FormatCurrency = (value: number) => String(value);
+     export default FormatCurrency;`,
+    `const FormatCurrency = (value: number) => String(value);
+     export { FormatCurrency as default };`,
+    `function FormatCurrency(value: number) { return String(value); }
+     export default FormatCurrency;`,
+  ])("does not infer a default component from a PascalCase formatter alias", (defaultExport) => {
+    const result = runRule(
+      onlyExportComponents,
+      `
+        export const Card = () => <div />;
+        ${defaultExport}
+      `,
+      { filename: "src/Card.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("accepts a default alias with a proven React element return type", () => {
+    const result = runRule(
+      onlyExportComponents,
+      `
+        import type { ReactElement } from "react";
+        const Card = (): ReactElement => renderCard();
+        export default Card;
+      `,
+      { filename: "src/Card.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it.each([
     `import { createRoot } from "react-dom/client";
      export const Card = () => <div />;
      export const runtimeConfig = getConfig();

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.regressions.test.ts
@@ -18,6 +18,10 @@ export const api = axios.create({
 })
 `;
 
+const settingsForFramework = (
+  framework: "expo" | "nextjs" | "remix" | "tanstack-start" | "vite",
+) => ({ "react-doctor": { framework } });
+
 describe("react-builtins/only-export-components — regressions", () => {
   it("does not crash when the filename is unavailable (#539)", () => {
     expect(() => runRule(onlyExportComponents, AXIOS_FILE, { filename: undefined })).not.toThrow();
@@ -45,6 +49,7 @@ describe("react-builtins/only-export-components — regressions", () => {
     `;
     const result = runRule(onlyExportComponents, expoLayoutFile, {
       filename: "src/app/_layout.tsx",
+      settings: settingsForFramework("expo"),
     });
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toHaveLength(0);
@@ -67,6 +72,7 @@ describe("react-builtins/only-export-components — regressions", () => {
     `;
     const result = runRule(onlyExportComponents, tanstackRouteFile, {
       filename: "src/routes/profile.tsx",
+      settings: settingsForFramework("tanstack-start"),
     });
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toHaveLength(0);
@@ -93,10 +99,40 @@ describe("react-builtins/only-export-components — regressions", () => {
       [rootRouteFile, "src/routes/__root.tsx"],
       [lazyRouteFile, "src/routes/about.lazy.tsx"],
     ]) {
-      const result = runRule(onlyExportComponents, file, { filename });
+      const result = runRule(onlyExportComponents, file, {
+        filename,
+        settings: settingsForFramework("tanstack-start"),
+      });
       expect(result.parseErrors).toEqual([]);
       expect(result.diagnostics).toHaveLength(0);
     }
+  });
+
+  it("requires route-factory import provenance", () => {
+    const userlandFactory = runRule(
+      onlyExportComponents,
+      `const createFileRoute = makeUserlandFactory();
+       export const Route = createFileRoute("/profile")({ component: Profile });
+       export const Profile = () => <div />;`,
+      {
+        filename: "src/routes/profile.tsx",
+        settings: settingsForFramework("tanstack-start"),
+      },
+    );
+    const namespaceFactory = runRule(
+      onlyExportComponents,
+      `import * as Router from "@tanstack/react-router";
+       export const Route = Router.createFileRoute("/profile")({ component: Profile });
+       const Profile = () => <div />;`,
+      {
+        filename: "src/routes/profile.tsx",
+        settings: settingsForFramework("tanstack-start"),
+      },
+    );
+    expect(userlandFactory.parseErrors).toEqual([]);
+    expect(userlandFactory.diagnostics.length).toBeGreaterThan(0);
+    expect(namespaceFactory.parseErrors).toEqual([]);
+    expect(namespaceFactory.diagnostics).toHaveLength(0);
   });
 
   // React Router / Remix route modules co-export `loader` / `meta` /
@@ -111,6 +147,7 @@ describe("react-builtins/only-export-components — regressions", () => {
     `;
     const result = runRule(onlyExportComponents, remixRouteFile, {
       filename: "src/routes/profile.tsx",
+      settings: settingsForFramework("remix"),
     });
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toHaveLength(0);
@@ -125,6 +162,7 @@ describe("react-builtins/only-export-components — regressions", () => {
     `;
     const result = runRule(onlyExportComponents, nextPageFile, {
       filename: "pages/profile.tsx",
+      settings: settingsForFramework("nextjs"),
     });
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toHaveLength(0);
@@ -138,6 +176,7 @@ describe("react-builtins/only-export-components — regressions", () => {
     `;
     const result = runRule(onlyExportComponents, dataRouterFile, {
       filename: "src/router-setup.tsx",
+      settings: settingsForFramework("remix"),
     });
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toHaveLength(0);
@@ -153,6 +192,7 @@ describe("react-builtins/only-export-components — regressions", () => {
   it.each([
     [
       "Next.js opengraph-image metadata (#776)",
+      "nextjs",
       "src/app/opengraph-image.tsx",
       `import { ImageResponse } from "next/og";
        export const alt = "Open Source Showcase";
@@ -165,6 +205,7 @@ describe("react-builtins/only-export-components — regressions", () => {
     ],
     [
       "Next.js twitter-image metadata (#776)",
+      "nextjs",
       "app/about/twitter-image.tsx",
       `export const size = { width: 1200, height: 630 };
        export default function Image() {
@@ -173,6 +214,7 @@ describe("react-builtins/only-export-components — regressions", () => {
     ],
     [
       "Next.js Pages Router _document.tsx",
+      "nextjs",
       "pages/_document.tsx",
       `export const config = { amp: true };
        export default function Document() {
@@ -181,6 +223,7 @@ describe("react-builtins/only-export-components — regressions", () => {
     ],
     [
       "Expo Router +not-found special file",
+      "expo",
       "app/+not-found.tsx",
       `export const screenOptions = { headerShown: false };
        export default function NotFoundScreen() {
@@ -189,6 +232,7 @@ describe("react-builtins/only-export-components — regressions", () => {
     ],
     [
       "TanStack Router __root.tsx (no factory call required)",
+      "tanstack-start",
       "src/routes/__root.tsx",
       `export const queryClient = new QueryClient();
        export default function RootComponent() {
@@ -197,6 +241,7 @@ describe("react-builtins/only-export-components — regressions", () => {
     ],
     [
       "TanStack Router *.lazy.tsx route file",
+      "tanstack-start",
       "src/routes/about.lazy.tsx",
       `export const routeConfig = { staleTime: 1000 };
        export default function AboutPage() {
@@ -205,14 +250,18 @@ describe("react-builtins/only-export-components — regressions", () => {
     ],
     [
       "Remix / React Router root.tsx module",
+      "remix",
       "app/root.tsx",
       `export const headerLinks = [{ rel: "stylesheet", href: "/app.css" }];
        export default function App() {
          return <Outlet />;
        }`,
     ],
-  ])("skips framework route/special files — %s", (_label, filename, code) => {
-    const result = runRule(onlyExportComponents, code, { filename });
+  ] as const)("skips framework route/special files — %s", (_label, framework, filename, code) => {
+    const result = runRule(onlyExportComponents, code, {
+      filename,
+      settings: settingsForFramework(framework),
+    });
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toHaveLength(0);
   });
@@ -274,6 +323,119 @@ describe("react-builtins/only-export-components — regressions", () => {
     const result = runRule(onlyExportComponents, configFile, {
       filename: "src/tabs-config.tsx",
     });
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it.each([
+    ['export default { mode: "compact" };', "plain object"],
+    ["export default new ProgressBar();", "constructed instance"],
+    ["export default createContext(undefined);", "context"],
+  ])("does not flag a component-free default %s", (code) => {
+    const result = runRule(onlyExportComponents, code, { filename: "src/config.tsx" });
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it.each([
+    ['export default { mode: "compact" };', "non-component"],
+    ["export default new ProgressBar();", "non-component"],
+    ["export default createContext(undefined);", "context"],
+  ])("reports a default %s when the module also exports a component", (defaultExport) => {
+    const result = runRule(
+      onlyExportComponents,
+      `${defaultExport}\nexport const Panel = () => <section />;`,
+      { filename: "src/panel.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("accepts a PascalCase component member from an imported module", () => {
+    const result = runRule(
+      onlyExportComponents,
+      'import { LobeHub } from "@lobehub/icons"; export default LobeHub.Color;',
+      { filename: "src/logo.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not infer a component from a PascalCase member on a local object", () => {
+    const result = runRule(
+      onlyExportComponents,
+      'const LobeHub = { Color: "purple" }; export default LobeHub.Color;',
+      { filename: "src/color.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not infer components from PascalCase formatter functions", () => {
+    const result = runRule(
+      onlyExportComponents,
+      `
+        export function RGBToHex(value) { return value.replace("rgb", "#"); }
+        export const RGBToRGBA = (value) => value.replace("rgb", "rgba");
+        export const parseColor = (value) => value.trim();
+      `,
+      { filename: "src/color-utils.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still reports a non-component function beside a rendering component", () => {
+    const result = runRule(
+      onlyExportComponents,
+      `
+        export function ColorPreview() { return <output />; }
+        export function RGBToHex(value) { return value.replace("rgb", "#"); }
+      `,
+      { filename: "src/color-preview.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not infer a component from a constructed PascalCase constant", () => {
+    const result = runRule(
+      onlyExportComponents,
+      `
+        export const WEEKDAYS = new Set(["Monday"]);
+        export const getWeekday = (index) => [...WEEKDAYS][index];
+      `,
+      { filename: "src/date-utils.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("ignores inline type-only export specifiers", () => {
+    const result = runRule(
+      onlyExportComponents,
+      `
+        interface SkeletonItem { id: string }
+        const isSkeletonItem = (value) => Boolean(value);
+        export { isSkeletonItem, type SkeletonItem };
+        export const buildFilter = () => ({ type: "filter" });
+      `,
+      { filename: "src/filter-logic.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not treat a context Provider object as a component boundary", () => {
+    const result = runRule(
+      onlyExportComponents,
+      `
+        export const FloatingLayerContext = createContext(undefined);
+        export const FloatingLayerProvider = FloatingLayerContext.Provider;
+        export const useFloatingLayer = () => useContext(FloatingLayerContext);
+      `,
+      { filename: "src/use-floating-layer.tsx" },
+    );
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toHaveLength(0);
   });
@@ -627,14 +789,13 @@ describe("react-builtins/only-export-components — regressions", () => {
       expect(result.diagnostics[0]?.message).toContain("unnamed");
     });
 
-    it("still flags an anonymous component wrapped in a known HOC", () => {
+    it("accepts an anonymous component wrapped in a known HOC", () => {
       const anonymousMemoFile = `export default memo(() => <div />);`;
       const result = runRule(onlyExportComponents, anonymousMemoFile, {
         filename: "src/anonymous.tsx",
       });
       expect(result.parseErrors).toEqual([]);
-      expect(result.diagnostics).toHaveLength(1);
-      expect(result.diagnostics[0]?.message).toContain("unnamed");
+      expect(result.diagnostics).toHaveLength(0);
     });
 
     it("still flags an unknown curried HOC wrapping a component identifier", () => {
@@ -645,6 +806,126 @@ describe("react-builtins/only-export-components — regressions", () => {
       const result = runRule(onlyExportComponents, curriedFile, {
         filename: "src/main-view.tsx",
       });
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    });
+  });
+
+  describe("Fast Refresh registered wrapper exports", () => {
+    it.each([
+      `
+        const PageImpl = () => <main />;
+        export default withRouteProps(PageImpl);
+      `,
+      `
+        const PageImpl = () => <main />;
+        export default wrappers.withRouteProps(PageImpl);
+      `,
+      `
+        const PageImpl = () => <main />;
+        export default withRouteProps(connect(mapStateToProps)(PageImpl));
+      `,
+      `
+        import React from "react";
+        export default React.forwardRef((props, ref) => <main ref={ref} />);
+      `,
+    ])("accepts a direct wrapper call around a proven component", (source) => {
+      const result = runRule(onlyExportComponents, source, {
+        filename: "src/wrapped-page.tsx",
+      });
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(0);
+    });
+
+    it("still reports a curried unknown wrapper", () => {
+      const result = runRule(
+        onlyExportComponents,
+        `
+          const PageImpl = () => <main />;
+          export default memoize(200)(PageImpl);
+        `,
+        { filename: "src/curried-page.tsx" },
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    });
+
+    it("still reports a direct unknown call with a non-rendering argument", () => {
+      const result = runRule(
+        onlyExportComponents,
+        `
+          const FormatDate = (date) => date.toISOString();
+          export default makeView(FormatDate);
+        `,
+        { filename: "src/format-date.tsx" },
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    });
+  });
+
+  describe("next/dynamic wrapper factories", () => {
+    it("accepts PascalCase exports returned by a local next/dynamic wrapper", () => {
+      const result = runRule(
+        onlyExportComponents,
+        `
+          import loadDynamic from "next/dynamic";
+          const lazyExample = (key) => loadDynamic(() => import("./examples").then((module) => module[key]));
+          export const DashboardExample = lazyExample("DashboardExample");
+          export const StaticExample = () => <main />;
+        `,
+        {
+          filename: "src/demos.tsx",
+          settings: settingsForFramework("nextjs"),
+        },
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(0);
+    });
+
+    it("does not trust a same-named userland wrapper factory", () => {
+      const result = runRule(
+        onlyExportComponents,
+        `
+          import loadDynamic from "dynamic-loader";
+          const lazyExample = (key) => loadDynamic(() => import("./examples").then((module) => module[key]));
+          export const DashboardExample = lazyExample("DashboardExample");
+          export const StaticExample = () => <main />;
+        `,
+        {
+          filename: "src/demos.tsx",
+          settings: settingsForFramework("nextjs"),
+        },
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    });
+
+    it.each([
+      `
+        let lazyExample = (key) => loadDynamic(() => import("./examples").then((module) => module[key]));
+        lazyExample = userlandFactory;
+      `,
+      `
+        function lazyExample(key) {
+          return loadDynamic(() => import("./examples").then((module) => module[key]));
+        }
+        lazyExample = userlandFactory;
+      `,
+    ])("does not trust a reassigned next/dynamic wrapper factory", (factoryDeclaration) => {
+      const result = runRule(
+        onlyExportComponents,
+        `
+          import loadDynamic from "next/dynamic";
+          ${factoryDeclaration}
+          export const DashboardExample = lazyExample("DashboardExample");
+          export const StaticExample = () => <main />;
+        `,
+        {
+          filename: "src/demos.tsx",
+          settings: settingsForFramework("nextjs"),
+        },
+      );
       expect(result.parseErrors).toEqual([]);
       expect(result.diagnostics).toHaveLength(1);
     });
@@ -663,5 +944,205 @@ describe("react-builtins/only-export-components — regressions", () => {
     });
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it.each(["src/components/card/index.tsx", "src/App.tsx", "src/utils.tsx"])(
+    "checks transformed modules regardless of conventional filename — %s",
+    (filename) => {
+      const result = runRule(
+        onlyExportComponents,
+        `export const Card = () => <div />; export const cardLabel = getLabel();`,
+        { filename },
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    },
+  );
+
+  it.each([
+    [
+      "direct createRoot chain",
+      `import { createRoot } from "react-dom/client";
+       export const App = () => <div />;
+       export const runtimeConfig = getConfig();
+       createRoot(document.getElementById("root")!).render(<App />);`,
+    ],
+    [
+      "aliased assigned root",
+      `import { createRoot as mountRoot } from "react-dom/client";
+       export const App = () => <div />;
+       export const runtimeConfig = getConfig();
+       const applicationRoot = mountRoot(document.getElementById("root")!);
+       applicationRoot.render(<App />);`,
+    ],
+    [
+      "hydrateRoot",
+      `import { hydrateRoot as hydrateApplication } from "react-dom/client";
+       export const App = () => <div />;
+       export const runtimeConfig = getConfig();
+       hydrateApplication(document, <App />);`,
+    ],
+    [
+      "legacy namespace render",
+      `import ReactDOM from "react-dom";
+       export const App = () => <div />;
+       export const runtimeConfig = getConfig();
+       ReactDOM.render(<App />, document.getElementById("root"));`,
+    ],
+  ])("skips a proven root-mount module — %s", (_label, code) => {
+    const result = runRule(onlyExportComponents, code, { filename: "src/index.tsx" });
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it.each([
+    `const createRoot = makeUserlandRoot;
+     export const App = () => <div />;
+     export const runtimeConfig = getConfig();
+     createRoot(document.body).render(<App />);`,
+    `import { createRoot } from "userland-renderer";
+     export const App = () => <div />;
+     export const runtimeConfig = getConfig();
+     createRoot(document.body).render(<App />);`,
+  ])("does not exempt similarly named userland root APIs", (code) => {
+    const result = runRule(onlyExportComponents, code, { filename: "src/index.tsx" });
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("accepts a component that returns a react-dom portal", () => {
+    const result = runRule(
+      onlyExportComponents,
+      `
+        import { createPortal } from "react-dom";
+        export function RenderKeybind() {
+          return <kbd />;
+        }
+        export function AppShortcutMenu(): JSX.Element | null {
+          const paletteContent = <div />;
+          return createPortal(paletteContent, document.body);
+        }
+      `,
+      { filename: "src/AppShortcutMenu.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("accepts PascalCase functions with proven React element return types", () => {
+    const result = runRule(
+      onlyExportComponents,
+      `
+        import React from "react";
+        export const AssigneeResolver = ({ children }): React.ReactElement => children();
+        export const AssigneeIconDisplay = ({ value }): JSX.Element =>
+          match(value).otherwise(() => <span />);
+        export const AssigneeDisplay = () => <div />;
+      `,
+      { filename: "src/AssigneeDisplay.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it.each([
+    `import type { JSX } from "solid-js";
+     export const Card = () => <div />;
+     export const FormatValue = (): JSX.Element => getFormattedValue();`,
+    `namespace JSX { export interface Element { value: string } }
+     export const Card = () => <div />;
+     export const FormatValue = (): JSX.Element => getFormattedValue();`,
+    `import ReactNamespace from "userland-react";
+     export const Card = () => <div />;
+     export const FormatValue = (): ReactNamespace.ReactElement => getFormattedValue();`,
+  ])("does not trust userland React element return-type names", (code) => {
+    const result = runRule(onlyExportComponents, code, { filename: "src/Card.tsx" });
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it.each([
+    `export function CurrentDeploymentCard(): null {
+       return null;
+     }
+     export default CurrentDeploymentCard;`,
+    `const CurrentDeploymentCard = (): null => null;
+     export { CurrentDeploymentCard };
+     export { CurrentDeploymentCard as default };`,
+  ])("classifies two export names for the same default component consistently", (code) => {
+    const result = runRule(onlyExportComponents, code, {
+      filename: "src/CurrentDeploymentCard.tsx",
+    });
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still reports a helper next to a separately default-exported component", () => {
+    const result = runRule(
+      onlyExportComponents,
+      `
+        export const formatCurrency = (value: number) => String(value);
+        const CurrentDeploymentCard = (): null => null;
+        export default CurrentDeploymentCard;
+      `,
+      { filename: "src/CurrentDeploymentCard.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it.each([
+    `import { createRoot } from "react-dom/client";
+     export const Card = () => <div />;
+     export const runtimeConfig = getConfig();
+     export const exportToSvg = () => {
+       const transientRoot = createRoot(document.createElement("div"));
+       transientRoot.render(<Card />);
+     };`,
+    `import { hydrateRoot } from "react-dom/client";
+     export const Card = () => <div />;
+     export const runtimeConfig = getConfig();
+     queueMicrotask(() => hydrateRoot(document, <Card />));`,
+    `import ReactDOM from "react-dom";
+     export const Card = () => <div />;
+     export const runtimeConfig = getConfig();
+     const mountPreview = () => ReactDOM.render(<Card />, document.body);`,
+  ])("does not treat nested transient roots as application entry modules", (code) => {
+    const result = runRule(onlyExportComponents, code, { filename: "src/export-preview.tsx" });
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("does not trust a reassigned root binding", () => {
+    const result = runRule(
+      onlyExportComponents,
+      `import { createRoot } from "react-dom/client";
+       export const Card = () => <div />;
+       export const runtimeConfig = getConfig();
+       let applicationRoot = createRoot(document.body);
+       applicationRoot = getUserlandRoot();
+       applicationRoot.render(<Card />);`,
+      { filename: "src/index.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it.each([
+    ["vite", "loader"],
+    ["vite", "metadata"],
+    ["nextjs", "loader"],
+    ["remix", "metadata"],
+  ] as const)("does not apply %s route export semantics to %s", (framework, exportName) => {
+    const result = runRule(
+      onlyExportComponents,
+      `export const Card = () => <div />; export const ${exportName} = getConfig();`,
+      {
+        filename: "src/card.tsx",
+        settings: settingsForFramework(framework),
+      },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
   });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.ts
@@ -1,9 +1,13 @@
 import { defineRule } from "../../utils/define-rule.js";
+import { exportAllAddsRuntimeValues } from "../../utils/export-all-adds-runtime-values.js";
 import { isFrameworkRouteOrSpecialFilename } from "../../utils/is-framework-route-or-special-filename.js";
 import { normalizeFilename } from "../../utils/normalize-filename.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { functionContainsReactRenderOutput } from "../../utils/function-contains-react-render-output.js";
+import { functionHasReactElementReturnType } from "../../utils/function-has-react-element-return-type.js";
+import { getFastRefreshFileStatus } from "../../utils/get-fast-refresh-file-status.js";
+import { getImportedName } from "../../utils/get-imported-name.js";
 import { isEs6Component } from "../../utils/is-es6-component.js";
 import { isInsideFunctionScope } from "../../utils/is-inside-function-scope.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
@@ -12,12 +16,13 @@ import type { RuleVisitors } from "../../utils/rule-visitors.js";
 import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
 import type { ControlFlowAnalysis } from "../../semantic/control-flow-graph.js";
 import {
-  ENTRY_POINT_BASENAMES,
   NON_FAST_REFRESH_PATH_SEGMENTS,
+  EXPO_ALLOWED_EXPORT_NAMES,
+  NEXT_ALLOWED_EXPORT_NAMES,
   NOT_REACT_COMPONENT_EXPRESSION_TYPES,
-  ROUTE_FACTORY_CALLEE_NAMES,
-  ROUTE_MODULE_ALLOWED_EXPORT_NAMES,
-  UTILITY_FILE_BASENAMES,
+  REACT_ROUTER_ALLOWED_EXPORT_NAMES,
+  REACT_ROUTER_FACTORY_CALLEE_NAMES,
+  TANSTACK_ROUTE_FACTORY_CALLEE_NAMES,
 } from "./only-export-components-tables.js";
 
 const NAMED_EXPORT_MESSAGE =
@@ -39,6 +44,9 @@ interface OnlyExportComponentsSettings {
 }
 
 const DEFAULT_REACT_HOCS: ReadonlyArray<string> = ["memo", "forwardRef", "lazy"];
+const EMPTY_NAME_SET: ReadonlySet<string> = new Set();
+const TEST_SUPPORT_FILE_PATTERN =
+  /(?:^|\/)(?:test|spec)(?:[-_.]?(?:utils?|helpers?|setup|fixtures?))?\.(?:jsx?|tsx?)$/i;
 
 const resolveSettings = (
   settings: Readonly<Record<string, unknown>> | undefined,
@@ -95,17 +103,17 @@ const isReactCreateContext = (initializer: EsTreeNode | null | undefined): boole
   return false;
 };
 
-const isRouteFactoryName = (name: string): boolean => ROUTE_FACTORY_CALLEE_NAMES.has(name);
-
-const isRouteFactoryCall = (expression: EsTreeNode): boolean => {
+const isRouteFactoryCall = (expression: EsTreeNode, bindings: RouteFactoryBindings): boolean => {
   let currentCall: EsTreeNode = expression;
   while (isNodeOfType(currentCall, "CallExpression")) {
     const callee = currentCall.callee as EsTreeNode;
-    if (isNodeOfType(callee, "Identifier") && isRouteFactoryName(callee.name)) return true;
+    if (isNodeOfType(callee, "Identifier") && bindings.localNames.has(callee.name)) return true;
     if (
       isNodeOfType(callee, "MemberExpression") &&
+      isNodeOfType(callee.object, "Identifier") &&
+      bindings.namespaceNames.has(callee.object.name) &&
       isNodeOfType(callee.property, "Identifier") &&
-      isRouteFactoryName(callee.property.name)
+      bindings.memberNames.has(callee.property.name)
     ) {
       return true;
     }
@@ -137,11 +145,22 @@ interface AnalyzerState {
   customHocs: ReadonlySet<string>;
   allowExportNames: ReadonlySet<string>;
   allowConstantExport: boolean;
+  allowedRouteExportNames: ReadonlySet<string>;
+  routeFactoryBindings: RouteFactoryBindings;
+  componentFactorySymbolIds: ReadonlySet<number>;
+  defaultExportComponentNames: ReadonlySet<string>;
+  importSymbolIds: ReadonlySet<number>;
   // Module-scope component binding names — used to spot a component
   // reference smuggled inside a namespace-object export.
   localComponentNames: ReadonlySet<string>;
   scopes: ScopeAnalysis;
   controlFlow: ControlFlowAnalysis;
+}
+
+interface RouteFactoryBindings {
+  localNames: ReadonlySet<string>;
+  memberNames: ReadonlySet<string>;
+  namespaceNames: ReadonlySet<string>;
 }
 
 const isReactHocName = (name: string, state: AnalyzerState): boolean => state.customHocs.has(name);
@@ -186,7 +205,10 @@ const canBeReactFunctionComponent = (
     isNodeOfType(expression, "ArrowFunctionExpression") ||
     isNodeOfType(expression, "FunctionExpression")
   ) {
-    return true;
+    return (
+      functionContainsReactRenderOutput(expression, state.scopes, state.controlFlow) ||
+      functionHasReactElementReturnType(expression)
+    );
   }
   if (isNodeOfType(expression, "CallExpression")) {
     return isHocCallee(expression.callee as EsTreeNode, state);
@@ -207,6 +229,98 @@ const isReactComponentInitializer = (expression: EsTreeNode, state: AnalyzerStat
     return true;
   }
   return false;
+};
+
+const isNextDynamicCall = (
+  expression: EsTreeNode,
+  nextDynamicImportSymbolIds: ReadonlySet<number>,
+  scopes: ScopeAnalysis,
+): boolean => {
+  const stripped = skipTsExpression(expression);
+  if (!isNodeOfType(stripped, "CallExpression")) return false;
+  const callee = skipTsExpression(stripped.callee as EsTreeNode);
+  if (!isNodeOfType(callee, "Identifier")) return false;
+  const symbol = scopes.symbolFor(callee);
+  return symbol !== null && nextDynamicImportSymbolIds.has(symbol.id);
+};
+
+const functionReturnsNextDynamicComponent = (
+  expression: EsTreeNode,
+  nextDynamicImportSymbolIds: ReadonlySet<number>,
+  scopes: ScopeAnalysis,
+): boolean => {
+  const stripped = skipTsExpression(expression);
+  if (
+    !isNodeOfType(stripped, "ArrowFunctionExpression") &&
+    !isNodeOfType(stripped, "FunctionExpression") &&
+    !isNodeOfType(stripped, "FunctionDeclaration")
+  ) {
+    return false;
+  }
+  const body = stripped.body as EsTreeNode;
+  if (!isNodeOfType(body, "BlockStatement")) {
+    return isNextDynamicCall(body, nextDynamicImportSymbolIds, scopes);
+  }
+  if (body.body.length !== 1) return false;
+  const statement = body.body[0];
+  return (
+    Boolean(statement) &&
+    isNodeOfType(statement, "ReturnStatement") &&
+    Boolean(statement.argument) &&
+    isNextDynamicCall(statement.argument as EsTreeNode, nextDynamicImportSymbolIds, scopes)
+  );
+};
+
+const isComponentFactoryCall = (expression: EsTreeNode, state: AnalyzerState): boolean => {
+  const stripped = skipTsExpression(expression);
+  if (!isNodeOfType(stripped, "CallExpression")) return false;
+  const callee = skipTsExpression(stripped.callee as EsTreeNode);
+  if (!isNodeOfType(callee, "Identifier")) return false;
+  const symbol = state.scopes.symbolFor(callee);
+  return symbol !== null && state.componentFactorySymbolIds.has(symbol.id);
+};
+
+const isProvenComponentValue = (expression: EsTreeNode, state: AnalyzerState): boolean => {
+  const stripped = skipTsExpression(expression);
+  if (isNodeOfType(stripped, "Identifier")) {
+    if (state.localComponentNames.has(stripped.name)) return true;
+    return (
+      isReactComponentName(stripped.name) && state.scopes.symbolFor(stripped)?.kind === "import"
+    );
+  }
+  if (
+    isNodeOfType(stripped, "MemberExpression") &&
+    !stripped.computed &&
+    isNodeOfType(stripped.object, "Identifier") &&
+    isNodeOfType(stripped.property, "Identifier") &&
+    isReactComponentName(stripped.property.name)
+  ) {
+    const objectSymbol = state.scopes.symbolFor(stripped.object);
+    return objectSymbol !== null && state.importSymbolIds.has(objectSymbol.id);
+  }
+  if (
+    isNodeOfType(stripped, "ArrowFunctionExpression") ||
+    isNodeOfType(stripped, "FunctionExpression")
+  ) {
+    return functionContainsReactRenderOutput(stripped, state.scopes, state.controlFlow);
+  }
+  if (!isNodeOfType(stripped, "CallExpression")) return false;
+  if (!isHocCallee(stripped.callee as EsTreeNode, state)) return false;
+  return stripped.arguments.some((argument) =>
+    isProvenComponentValue(argument as EsTreeNode, state),
+  );
+};
+
+const isDirectRefreshWrapperCall = (
+  call: EsTreeNodeOfType<"CallExpression">,
+  state: AnalyzerState,
+): boolean => {
+  const callee = skipTsExpression(call.callee as EsTreeNode);
+  if (isHocCallee(callee, state)) return call.arguments.length > 0;
+  if (!isNodeOfType(callee, "Identifier") && !isNodeOfType(callee, "MemberExpression")) {
+    return false;
+  }
+  return call.arguments.some((argument) => isProvenComponentValue(argument as EsTreeNode, state));
 };
 
 // The real Fast-Refresh breaker react-refresh checks for: a module whose
@@ -259,14 +373,27 @@ const classifyExport = (
   initializer: EsTreeNode | null | undefined,
   state: AnalyzerState,
 ): ExportType => {
+  if (
+    isNodeOfType(reportNode, "Identifier") &&
+    state.defaultExportComponentNames.has(reportNode.name)
+  ) {
+    return { kind: "react-component" };
+  }
   // HoC-wrapped: `export const Foo = memo(...)` — treat as component.
   if (initializer) {
     const expression = skipTsExpression(initializer);
+    if (
+      isNodeOfType(expression, "CallExpression") &&
+      isReactComponentName(name) &&
+      isComponentFactoryCall(expression, state)
+    ) {
+      return { kind: "react-component" };
+    }
     // File-based-router route objects (`export const Route =
     // createFileRoute("/profile")({ component: ProfilePage })`) — the
     // router's bundler plugin owns HMR for these modules, so the route
     // export and any local components it references are conventional.
-    if (isRouteFactoryCall(expression)) {
+    if (isRouteFactoryCall(expression, state.routeFactoryBindings)) {
       return { kind: "react-component" };
     }
     if (
@@ -293,7 +420,7 @@ const classifyExport = (
   // Expo Router bundler plugins special-case these during Fast Refresh,
   // so co-exporting them with the route component is the documented
   // shape, not a hazard.
-  if (ROUTE_MODULE_ALLOWED_EXPORT_NAMES.has(name)) return { kind: "allowed" };
+  if (state.allowedRouteExportNames.has(name)) return { kind: "allowed" };
   // Custom hook exports — `useFoo`, `useBar`. Modern Vite Fast
   // Refresh (>= 4.x via @vitejs/plugin-react-swc + react-refresh)
   // already handles `use[A-Z]*` exports alongside components: the
@@ -333,7 +460,18 @@ const classifyExport = (
     ) {
       return { kind: "namespace-object", reportNode };
     }
+    if (isNodeOfType(stripped, "MemberExpression")) {
+      return isProvenComponentValue(stripped, state)
+        ? { kind: "react-component" }
+        : { kind: "non-component", reportNode };
+    }
     if (NOT_REACT_COMPONENT_EXPRESSION_TYPES.has(stripped.type)) {
+      return { kind: "non-component", reportNode };
+    }
+    if (
+      isNodeOfType(stripped, "ArrowFunctionExpression") ||
+      isNodeOfType(stripped, "FunctionExpression")
+    ) {
       return { kind: "non-component", reportNode };
     }
   }
@@ -342,65 +480,11 @@ const classifyExport = (
     : { kind: "non-component", reportNode };
 };
 
-const isEntryPointFile = (filename: string): boolean => {
-  // Match the last path segment regardless of separator (`/` on POSIX,
-  // `\\` on Windows — `path.basename`-style logic without depending on
-  // node:path in the rule body).
-  const lastSlash = Math.max(filename.lastIndexOf("/"), filename.lastIndexOf("\\"));
-  const basename = lastSlash === -1 ? filename : filename.slice(lastSlash + 1);
-  return ENTRY_POINT_BASENAMES.has(basename);
-};
-
-// Files that conventionally hold icon / asset / glyph exports —
-// `icons.tsx`, `Icons.tsx`, `*Icon.tsx`, `*Logo.tsx`, `sprite.tsx`,
-// `svgs.tsx`, `flags.tsx`, etc. These tend to mix component-style
-// exports (`const HomeIcon = () => <svg.../>`) with constants by
-// design; Fast Refresh isn't useful for icons (no component state
-// worth preserving). Pattern is anchored to the basename so a file
-// named `MyCardicons.tsx` doesn't accidentally match `icon`.
-const ASSET_FILE_BASENAME_PATTERN =
-  /^([A-Za-z][\w-]*[-._])?(icons?|svgs?|svg[-_]?sprites?|sprites?|emojis?|flags?|logos?|lockups?|illustrations?|glyphs?|stickers?|emotes?|avatars?|backgrounds?|patterns?|assets?|gradients?|countryVectors?|paymentVectors?|brandVectors?|brandLogos?)\.(t|j)sx?$/;
-
-// Suffix patterns for files conventionally holding MIXED exports
-// (component + constants/types/registry data). The list is
-// deliberately scoped to utility / registry / framework-specific
-// conventions — NOT general component suffixes like `Modal` /
-// `Dialog` / `Card` (those routinely ARE the single-component file
-// only-export-components correctly wants to protect).
-const UTILITY_BASENAME_SUFFIX_PATTERN =
-  /^[A-Za-z][\w-]*(Utils|Util|Helpers|Helper|Shared|Constants|Constant|Types|Type|Mappings|Mapping|Lookups|Lookup|Registry|Renderers|Renderer|NodeTypes|EdgeTypes|CellTypes|ColumnDefs|ColumnTypes|ColumnRenderers|Schemas|Schema|Definitions|Definition|Config|Configuration|Defaults|Default|Tokens|Palette|Context|Provider|Providers|Logic|Scene|Page|Layout)\.(t|j)sx?$/;
-
-// Custom hook files: `useCreateRouter.tsx`, `useTranslation.tsx`,
-// `useSafeId.tsx`. Hook files conventionally co-export helper types
-// + constants + sometimes a small helper component alongside the hook.
-// Fast Refresh doesn't preserve hook state across edits anyway.
-const HOOK_FILE_BASENAME_PATTERN = /^use[A-Z][\w-]*\.(t|j)sx?$/;
-
-// Plugin-style node-definition files for editor / notebook / flowchart
-// ecosystems (tldraw `*ShapeUtil`, xyflow `*Node` plugin registrations,
-// Lexical `*Node` declarations). These conventionally export the node
-// component + types + handlers from one file. We anchor on the
-// distinctive `*Util` / `*Node` plugin-registration shapes; bare
-// `Component.tsx` / `Block.tsx` are too generic and would over-match
-// ordinary single-component files.
-const NODE_DEFINITION_BASENAME_PATTERN =
-  /^[A-Z][\w-]*(NodeUtil|ShapeUtil|EdgeUtil|BindingUtil|InlineNode|BlockNode|NotebookNode)\.(t|j)sx?$/;
-
-const isAssetOrUtilityFile = (filename: string): boolean => {
-  const lastSlash = Math.max(filename.lastIndexOf("/"), filename.lastIndexOf("\\"));
-  const basename = lastSlash === -1 ? filename : filename.slice(lastSlash + 1);
-  if (ASSET_FILE_BASENAME_PATTERN.test(basename)) return true;
-  if (UTILITY_FILE_BASENAMES.has(basename)) return true;
-  if (UTILITY_BASENAME_SUFFIX_PATTERN.test(basename)) return true;
-  if (HOOK_FILE_BASENAME_PATTERN.test(basename)) return true;
-  if (NODE_DEFINITION_BASENAME_PATTERN.test(basename)) return true;
-  return false;
-};
-
 const isFileNameAllowed = (filename: string | undefined, checkJS: boolean): boolean => {
   // No filename means we're in a unit-test runner — keep the rule active
   // so the test suite still exercises the analyzer.
   if (!filename) return true;
+  if (TEST_SUPPORT_FILE_PATTERN.test(filename)) return false;
   // Test / Storybook / Cypress files don't participate in Fast Refresh,
   // so a mixed-export shape there can't break it.
   if (
@@ -416,26 +500,6 @@ const isFileNameAllowed = (filename: string | undefined, checkJS: boolean): bool
   for (const segment of NON_FAST_REFRESH_PATH_SEGMENTS) {
     if (filename.includes(segment)) return false;
   }
-  // Application entry points (`main.tsx`, `index.tsx`, `bootstrap.tsx`,
-  // etc.) call `createRoot(...).render(...)` once and don't participate
-  // in HMR — they get full reloaded when changed. Local-component and
-  // mixed-export warnings are unactionable here.
-  if (isEntryPointFile(filename)) return false;
-  // Framework route / special files (Next.js App + Pages Router and
-  // metadata image routes, Expo Router layouts, TanStack Router root /
-  // lazy routes, Remix / React Router root + entry modules). Their
-  // bundler plugins own HMR for these modules, and by framework contract
-  // they co-export route segment config / `metadata` / `alt` / `size` /
-  // loaders / actions alongside the default component — the documented
-  // shape, not a Fast Refresh hazard.
-  if (isFrameworkRouteOrSpecialFilename(filename)) return false;
-  // Icon / asset / utility collection files (`icons.tsx`, `*Icon.tsx`,
-  // `*Logo.tsx`, `sprite.tsx`, `assets.tsx`, `utils.tsx`, `tokens.tsx`,
-  // `theme.tsx`, `constants.tsx`, etc.) hold non-state-bearing exports
-  // by design. Fast Refresh isn't useful for preserving icon / token
-  // instances across edits — the file gets full reloaded and no
-  // component state is lost (the file doesn't define one).
-  if (isAssetOrUtilityFile(filename)) return false;
   // Only `.tsx` / `.jsx` (and `.js` when `checkJS` is on) modules run
   // through Fast Refresh. Pure `.ts` files — barrels, utility modules,
   // server code — can't break it no matter what they export, so the
@@ -460,16 +524,166 @@ export const onlyExportComponents = defineRule({
   create: (context): RuleVisitors => {
     const settings = resolveSettings(context.settings);
     const filename = normalizeFilename(context.filename ?? "");
+    const fastRefreshStatus = getFastRefreshFileStatus(context);
+    if (!fastRefreshStatus.isActive) return {};
+    if (isFrameworkRouteOrSpecialFilename(filename, fastRefreshStatus.runtime)) return {};
     if (!isFileNameAllowed(filename, settings.checkJS)) return {};
+    const allowedRouteExportNames =
+      fastRefreshStatus.runtime === "next"
+        ? NEXT_ALLOWED_EXPORT_NAMES
+        : fastRefreshStatus.runtime === "expo"
+          ? EXPO_ALLOWED_EXPORT_NAMES
+          : fastRefreshStatus.runtime === "react-router" || fastRefreshStatus.runtime === "remix"
+            ? REACT_ROUTER_ALLOWED_EXPORT_NAMES
+            : EMPTY_NAME_SET;
+    const routeFactoryMemberNames =
+      fastRefreshStatus.runtime === "tanstack"
+        ? TANSTACK_ROUTE_FACTORY_CALLEE_NAMES
+        : fastRefreshStatus.runtime === "react-router" || fastRefreshStatus.runtime === "remix"
+          ? REACT_ROUTER_FACTORY_CALLEE_NAMES
+          : EMPTY_NAME_SET;
+    const routeFactoryLocalNames = new Set<string>();
+    const routeFactoryNamespaceNames = new Set<string>();
+    const nextDynamicImportSymbolIds = new Set<number>();
+    const importSymbolIds = new Set<number>();
+    const routeFactoryBindings: RouteFactoryBindings = {
+      localNames: routeFactoryLocalNames,
+      memberNames: routeFactoryMemberNames,
+      namespaceNames: routeFactoryNamespaceNames,
+    };
     const exportNodes: EsTreeNode[] = [];
     const componentCandidates: EsTreeNode[] = [];
+    const createRootNames = new Set<string>();
+    const hydrateRootNames = new Set<string>();
+    const legacyRenderNames = new Set<string>();
+    const reactDomNamespaceNames = new Set<string>();
+    const rootNames = new Set<string>();
+    let hasRootMount = false;
+    const isCreateRootCall = (node: EsTreeNode): boolean => {
+      if (!isNodeOfType(node, "CallExpression")) return false;
+      if (isNodeOfType(node.callee, "Identifier")) {
+        return createRootNames.has(node.callee.name);
+      }
+      return (
+        isNodeOfType(node.callee, "MemberExpression") &&
+        isNodeOfType(node.callee.object, "Identifier") &&
+        reactDomNamespaceNames.has(node.callee.object.name) &&
+        isNodeOfType(node.callee.property, "Identifier") &&
+        node.callee.property.name === "createRoot"
+      );
+    };
+    const visitImportDeclaration = (node: EsTreeNode): void => {
+      if (!isNodeOfType(node, "ImportDeclaration")) return;
+      const source = node.source.value;
+      for (const specifier of node.specifiers) {
+        const symbol = context.scopes.symbolFor(specifier.local);
+        if (symbol) importSymbolIds.add(symbol.id);
+      }
+      const isRouteFactorySource =
+        typeof source === "string" &&
+        ((fastRefreshStatus.runtime === "tanstack" &&
+          (source.startsWith("@tanstack/react-router") ||
+            source.startsWith("@tanstack/react-start"))) ||
+          ((fastRefreshStatus.runtime === "react-router" ||
+            fastRefreshStatus.runtime === "remix") &&
+            (source === "react-router" ||
+              source === "react-router-dom" ||
+              source === "@remix-run/react")));
+      if (isRouteFactorySource) {
+        for (const specifier of node.specifiers) {
+          if (isNodeOfType(specifier, "ImportNamespaceSpecifier")) {
+            routeFactoryNamespaceNames.add(specifier.local.name);
+            continue;
+          }
+          const importedName = getImportedName(specifier);
+          if (importedName && routeFactoryMemberNames.has(importedName)) {
+            routeFactoryLocalNames.add(specifier.local.name);
+          }
+        }
+      }
+      if (source === "next/dynamic") {
+        for (const specifier of node.specifiers) {
+          if (!isNodeOfType(specifier, "ImportDefaultSpecifier")) continue;
+          const symbol = context.scopes.symbolFor(specifier.local);
+          if (symbol) nextDynamicImportSymbolIds.add(symbol.id);
+        }
+      }
+      if (source !== "react-dom" && source !== "react-dom/client") return;
+      for (const specifier of node.specifiers) {
+        if (
+          isNodeOfType(specifier, "ImportDefaultSpecifier") ||
+          isNodeOfType(specifier, "ImportNamespaceSpecifier")
+        ) {
+          reactDomNamespaceNames.add(specifier.local.name);
+          continue;
+        }
+        const importedName = getImportedName(specifier);
+        if (importedName === "createRoot") createRootNames.add(specifier.local.name);
+        if (importedName === "hydrateRoot") hydrateRootNames.add(specifier.local.name);
+        if (source === "react-dom" && (importedName === "render" || importedName === "hydrate")) {
+          legacyRenderNames.add(specifier.local.name);
+        }
+      }
+    };
+    const visitCallExpression = (node: EsTreeNode): void => {
+      if (!isNodeOfType(node, "CallExpression")) return;
+      if (isInsideFunctionScope(node)) return;
+      if (isNodeOfType(node.callee, "Identifier")) {
+        if (hydrateRootNames.has(node.callee.name) || legacyRenderNames.has(node.callee.name)) {
+          hasRootMount = true;
+        }
+        return;
+      }
+      if (
+        !isNodeOfType(node.callee, "MemberExpression") ||
+        !isNodeOfType(node.callee.property, "Identifier")
+      ) {
+        return;
+      }
+      const methodName = node.callee.property.name;
+      if (
+        isNodeOfType(node.callee.object, "Identifier") &&
+        reactDomNamespaceNames.has(node.callee.object.name) &&
+        (methodName === "render" || methodName === "hydrate" || methodName === "hydrateRoot")
+      ) {
+        hasRootMount = true;
+        return;
+      }
+      if (methodName !== "render") return;
+      if (isCreateRootCall(node.callee.object)) {
+        hasRootMount = true;
+        return;
+      }
+      if (
+        isNodeOfType(node.callee.object, "Identifier") &&
+        rootNames.has(node.callee.object.name)
+      ) {
+        hasRootMount = true;
+      }
+    };
     const pushExportNode = (node: EsTreeNode): void => {
       exportNodes.push(node);
     };
     const pushComponentCandidate = (node: EsTreeNode): void => {
       componentCandidates.push(node);
+      if (
+        isNodeOfType(node, "VariableDeclarator") &&
+        isNodeOfType(node.id, "Identifier") &&
+        node.init &&
+        isCreateRootCall(node.init) &&
+        !isInsideFunctionScope(node)
+      ) {
+        rootNames.add(node.id.name);
+      }
     };
     return {
+      ImportDeclaration: visitImportDeclaration,
+      CallExpression: visitCallExpression,
+      AssignmentExpression(node) {
+        if (isNodeOfType(node.left, "Identifier") && rootNames.has(node.left.name)) {
+          rootNames.delete(node.left.name);
+        }
+      },
       ExportAllDeclaration: pushExportNode,
       ExportDefaultDeclaration: pushExportNode,
       ExportNamedDeclaration: pushExportNode,
@@ -477,14 +691,76 @@ export const onlyExportComponents = defineRule({
       VariableDeclarator: pushComponentCandidate,
       ClassDeclaration: pushComponentCandidate,
       "Program:exit"() {
+        if (hasRootMount) return;
         // Module-scope component bindings (exported or not) — a component
         // declared inside another function is never a Fast Refresh
         // boundary, so only top-level names participate.
         const localComponentNames = new Set<string>();
+        const componentFactorySymbolIds = new Set<number>();
+        const defaultExportComponentNames = new Set<string>();
+        for (const child of exportNodes) {
+          if (isNodeOfType(child, "ExportDefaultDeclaration")) {
+            const declaration = skipTsExpression(child.declaration as EsTreeNode);
+            if (isNodeOfType(declaration, "Identifier") && isReactComponentName(declaration.name)) {
+              defaultExportComponentNames.add(declaration.name);
+            }
+            continue;
+          }
+          if (!isNodeOfType(child, "ExportNamedDeclaration") || Boolean(child.source)) {
+            continue;
+          }
+          for (const specifier of child.specifiers) {
+            if (!isNodeOfType(specifier, "ExportSpecifier")) continue;
+            const exported = specifier.exported;
+            const local = specifier.local;
+            const exportedName = isNodeOfType(exported, "Identifier") ? exported.name : null;
+            if (
+              exportedName === "default" &&
+              isNodeOfType(local, "Identifier") &&
+              isReactComponentName(local.name)
+            ) {
+              defaultExportComponentNames.add(local.name);
+            }
+          }
+        }
+        for (const child of componentCandidates) {
+          if (isInsideFunctionScope(child)) continue;
+          if (isNodeOfType(child, "FunctionDeclaration") && child.id) {
+            if (
+              functionReturnsNextDynamicComponent(child, nextDynamicImportSymbolIds, context.scopes)
+            ) {
+              const symbol = context.scopes.symbolFor(child.id);
+              if (symbol?.references.every((reference) => reference.flag === "read")) {
+                componentFactorySymbolIds.add(symbol.id);
+              }
+            }
+            continue;
+          }
+          if (
+            isNodeOfType(child, "VariableDeclarator") &&
+            isNodeOfType(child.id, "Identifier") &&
+            child.init &&
+            functionReturnsNextDynamicComponent(
+              child.init as EsTreeNode,
+              nextDynamicImportSymbolIds,
+              context.scopes,
+            )
+          ) {
+            const symbol = context.scopes.symbolFor(child.id);
+            if (symbol?.references.every((reference) => reference.flag === "read")) {
+              componentFactorySymbolIds.add(symbol.id);
+            }
+          }
+        }
         const state: AnalyzerState = {
           customHocs: new Set([...DEFAULT_REACT_HOCS, ...settings.customHOCs]),
           allowExportNames: new Set(settings.allowExportNames),
           allowConstantExport: settings.allowConstantExport,
+          allowedRouteExportNames,
+          routeFactoryBindings,
+          componentFactorySymbolIds,
+          defaultExportComponentNames,
+          importSymbolIds,
           localComponentNames,
           scopes: context.scopes,
           controlFlow: context.cfg,
@@ -500,7 +776,8 @@ export const onlyExportComponents = defineRule({
             if (
               isReactComponentName(child.id.name) &&
               !isInsideFunctionScope(child) &&
-              functionContainsReactRenderOutput(child, context.scopes, context.cfg)
+              (functionContainsReactRenderOutput(child, context.scopes, context.cfg) ||
+                functionHasReactElementReturnType(child))
             ) {
               localComponentNames.add(child.id.name);
             }
@@ -538,6 +815,7 @@ export const onlyExportComponents = defineRule({
         }
 
         const exports: ExportType[] = [];
+        const exportAllNodes: EsTreeNode[] = [];
         let hasReactExport = false;
         let hasAnyExports = false;
         const isExportedNodeIds = new WeakSet<object>();
@@ -548,7 +826,10 @@ export const onlyExportComponents = defineRule({
             // `export type * from '…'` is TS-type-only; skip.
             if ((child as { exportKind?: string }).exportKind === "type") continue;
             hasAnyExports = true;
-            context.report({ node: child, message: EXPORT_ALL_MESSAGE });
+            const source = child.source.value;
+            if (typeof source !== "string" || exportAllAddsRuntimeValues(filename, source)) {
+              exportAllNodes.push(child);
+            }
             continue;
           }
           if (isNodeOfType(child, "ExportDefaultDeclaration")) {
@@ -559,13 +840,22 @@ export const onlyExportComponents = defineRule({
               isNodeOfType(stripped, "FunctionDeclaration") ||
               isNodeOfType(stripped, "FunctionExpression")
             ) {
+              const hasRenderOutput =
+                functionContainsReactRenderOutput(stripped, context.scopes, context.cfg) ||
+                functionHasReactElementReturnType(stripped);
               if ((stripped as EsTreeNodeOfType<"FunctionDeclaration">).id) {
                 const idNode = (stripped as EsTreeNodeOfType<"FunctionDeclaration">).id!;
                 isExportedNodeIds.add(stripped);
-                exports.push(classifyExport(idNode.name, idNode, true, null, state));
-              } else {
+                exports.push(
+                  hasRenderOutput
+                    ? classifyExport(idNode.name, idNode, true, null, state)
+                    : { kind: "non-component", reportNode: idNode },
+                );
+              } else if (hasRenderOutput) {
                 context.report({ node: stripped, message: ANONYMOUS_MESSAGE });
                 hasReactExport = true; // anonymous default counts as a react export attempt
+              } else {
+                exports.push({ kind: "non-component", reportNode: stripped });
               }
               continue;
             }
@@ -590,33 +880,23 @@ export const onlyExportComponents = defineRule({
               exports.push(classifyExport(stripped.name, stripped, false, null, state));
               continue;
             }
+            if (isNodeOfType(stripped, "MemberExpression")) {
+              if (isProvenComponentValue(stripped, state)) hasReactExport = true;
+              else exports.push({ kind: "non-component", reportNode: stripped });
+              continue;
+            }
             if (isNodeOfType(stripped, "CallExpression")) {
-              if (isRouteFactoryCall(stripped)) {
+              if (isRouteFactoryCall(stripped, state.routeFactoryBindings)) {
                 hasReactExport = true;
                 continue;
               }
-              // is_hoc_call_expression: callee must be HoC AND first
-              // arg must be a named/identifier-like value (else
-              // anonymous).
-              const isHoc = isHocCallee(stripped.callee as EsTreeNode, state);
-              const firstArg = stripped.arguments[0] as EsTreeNode | undefined;
-              const firstArgIsValid =
-                Boolean(firstArg) &&
-                ((): boolean => {
-                  if (!firstArg) return false;
-                  const expression = skipTsExpression(firstArg);
-                  if (isNodeOfType(expression, "Identifier")) return true;
-                  if (isNodeOfType(expression, "FunctionExpression") && expression.id) return true;
-                  if (
-                    isNodeOfType(expression, "CallExpression") &&
-                    isHocCallee(expression.callee as EsTreeNode, state)
-                  )
-                    return true;
-                  return false;
-                })();
-              if (isHoc && firstArgIsValid) {
+              if (isReactCreateContext(stripped)) {
+                exports.push({ kind: "react-context", reportNode: stripped });
+                continue;
+              }
+              if (isDirectRefreshWrapperCall(stripped, state)) {
                 hasReactExport = true;
-              } else if (!isHoc && isConfigOnlyFactoryCall(stripped)) {
+              } else if (isConfigOnlyFactoryCall(stripped)) {
                 // `export default defineFrontComponent({ … })` — an unknown
                 // factory fed only config objects/literals is a library
                 // definition (SDK registrations, plugin manifests), not an
@@ -630,19 +910,24 @@ export const onlyExportComponents = defineRule({
               continue;
             }
             if (isNodeOfType(stripped, "ObjectExpression")) {
-              context.report({
-                node: stripped,
-                message: objectExpressionBundlesComponents(stripped, state)
-                  ? NAMESPACE_OBJECT_MESSAGE
-                  : ANONYMOUS_MESSAGE,
-              });
+              exports.push(
+                objectExpressionBundlesComponents(stripped, state)
+                  ? { kind: "namespace-object", reportNode: stripped }
+                  : { kind: "non-component", reportNode: stripped },
+              );
               continue;
             }
-            if (
-              isNodeOfType(stripped, "ArrowFunctionExpression") ||
-              isNodeOfType(stripped, "Literal")
-            ) {
-              context.report({ node: stripped, message: ANONYMOUS_MESSAGE });
+            if (isNodeOfType(stripped, "ArrowFunctionExpression")) {
+              if (functionContainsReactRenderOutput(stripped, context.scopes, context.cfg)) {
+                context.report({ node: stripped, message: ANONYMOUS_MESSAGE });
+                hasReactExport = true;
+              } else {
+                exports.push({ kind: "non-component", reportNode: stripped });
+              }
+              continue;
+            }
+            if (isNodeOfType(stripped, "Literal") || isNodeOfType(stripped, "NewExpression")) {
+              exports.push({ kind: "non-component", reportNode: stripped });
               continue;
             }
             // Other shapes — flag anonymous.
@@ -658,7 +943,11 @@ export const onlyExportComponents = defineRule({
               if (isNodeOfType(declaration, "FunctionDeclaration") && declaration.id) {
                 isExportedNodeIds.add(declaration);
                 exports.push(
-                  classifyExport(declaration.id.name, declaration.id, true, null, state),
+                  functionContainsReactRenderOutput(declaration, context.scopes, context.cfg) ||
+                    functionHasReactElementReturnType(declaration) ||
+                    defaultExportComponentNames.has(declaration.id.name)
+                    ? classifyExport(declaration.id.name, declaration.id, true, null, state)
+                    : { kind: "non-component", reportNode: declaration.id },
                 );
               } else if (isNodeOfType(declaration, "ClassDeclaration") && declaration.id) {
                 isExportedNodeIds.add(declaration);
@@ -709,6 +998,7 @@ export const onlyExportComponents = defineRule({
             const isReExportFromSource = Boolean((child as { source?: unknown }).source);
             for (const specifier of child.specifiers ?? []) {
               if (!isNodeOfType(specifier, "ExportSpecifier")) continue;
+              if (specifier.exportKind === "type") continue;
               const exported = (specifier as { exported?: EsTreeNode }).exported;
               const local = (specifier as { local?: EsTreeNode }).local;
               let exportedName: string | null = null;
@@ -721,7 +1011,9 @@ export const onlyExportComponents = defineRule({
               const localName = local && isNodeOfType(local, "Identifier") ? local.name : null;
               const reportNode = specifier as EsTreeNode;
               let entry: ExportType;
-              if (exportedName === "default" && localName) {
+              if (localName && defaultExportComponentNames.has(localName)) {
+                entry = { kind: "react-component" };
+              } else if (exportedName === "default" && localName) {
                 entry = classifyExport(localName, reportNode, false, null, state);
               } else if (exportedName) {
                 entry = classifyExport(exportedName, reportNode, false, null, state);
@@ -762,6 +1054,9 @@ export const onlyExportComponents = defineRule({
           }
         }
         if (hasAnyExports && hasReactExport) {
+          for (const exportAllNode of exportAllNodes) {
+            context.report({ node: exportAllNode, message: EXPORT_ALL_MESSAGE });
+          }
           for (const entry of exports) {
             if (entry.kind === "non-component") {
               context.report({ node: entry.reportNode, message: NAMED_EXPORT_MESSAGE });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.ts
@@ -7,6 +7,7 @@ import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { functionContainsReactRenderOutput } from "../../utils/function-contains-react-render-output.js";
 import { functionHasReactElementReturnType } from "../../utils/function-has-react-element-return-type.js";
 import { functionReturnsOnlyNull } from "../../utils/function-returns-only-null.js";
+import { getDirectUnreassignedInitializer } from "../../utils/get-direct-unreassigned-initializer.js";
 import { getFastRefreshFileStatus } from "../../utils/get-fast-refresh-file-status.js";
 import { getImportedName } from "../../utils/get-imported-name.js";
 import { isEs6Component } from "../../utils/is-es6-component.js";
@@ -282,13 +283,30 @@ const isComponentFactoryCall = (expression: EsTreeNode, state: AnalyzerState): b
   return symbol !== null && state.componentFactorySymbolIds.has(symbol.id);
 };
 
-const isProvenComponentValue = (expression: EsTreeNode, state: AnalyzerState): boolean => {
+const isProvenComponentValue = (
+  expression: EsTreeNode,
+  state: AnalyzerState,
+  inspectedSymbolIds: ReadonlySet<number> = new Set(),
+): boolean => {
   const stripped = skipTsExpression(expression);
   if (isNodeOfType(stripped, "Identifier")) {
-    if (state.localComponentNames.has(stripped.name)) return true;
-    return (
-      isReactComponentName(stripped.name) && state.scopes.symbolFor(stripped)?.kind === "import"
-    );
+    const symbol = state.scopes.symbolFor(stripped);
+    if (!symbol) return false;
+    if (state.localComponentNames.has(stripped.name)) {
+      return symbol.references.every((reference) => reference.flag === "read");
+    }
+    if (isReactComponentName(stripped.name) && symbol.kind === "import") return true;
+    if (inspectedSymbolIds.has(symbol.id)) return false;
+    const initializer = getDirectUnreassignedInitializer(symbol);
+    if (!initializer) return false;
+    const strippedInitializer = skipTsExpression(initializer);
+    if (
+      isNodeOfType(strippedInitializer, "ArrowFunctionExpression") ||
+      isNodeOfType(strippedInitializer, "FunctionExpression")
+    ) {
+      return false;
+    }
+    return isProvenComponentValue(initializer, state, new Set([...inspectedSymbolIds, symbol.id]));
   }
   if (
     isNodeOfType(stripped, "MemberExpression") &&
@@ -375,7 +393,7 @@ const classifyExport = (
   initializer: EsTreeNode | null | undefined,
   state: AnalyzerState,
 ): ExportType => {
-  if (isNodeOfType(reportNode, "Identifier") && state.localComponentNames.has(reportNode.name)) {
+  if (isNodeOfType(reportNode, "Identifier") && isProvenComponentValue(reportNode, state)) {
     return { kind: "react-component" };
   }
   // HoC-wrapped: `export const Foo = memo(...)` — treat as component.
@@ -460,6 +478,11 @@ const classifyExport = (
       return { kind: "namespace-object", reportNode };
     }
     if (isNodeOfType(stripped, "MemberExpression")) {
+      return isProvenComponentValue(stripped, state)
+        ? { kind: "react-component" }
+        : { kind: "non-component", reportNode };
+    }
+    if (isNodeOfType(stripped, "Identifier")) {
       return isProvenComponentValue(stripped, state)
         ? { kind: "react-component" }
         : { kind: "non-component", reportNode };
@@ -982,12 +1005,25 @@ export const onlyExportComponents = defineRule({
               let entry: ExportType;
               if (localName && localComponentNames.has(localName)) {
                 entry = { kind: "react-component" };
+              } else if (
+                !isReExportFromSource &&
+                localName === exportedName &&
+                localName !== null &&
+                isReactComponentName(localName)
+              ) {
+                entry = { kind: "react-component" };
               } else if (exportedName === "default" && localName && local) {
                 entry = isProvenComponentValue(local, state)
                   ? { kind: "react-component" }
                   : { kind: "non-component", reportNode };
               } else if (exportedName) {
-                entry = classifyExport(exportedName, reportNode, false, null, state);
+                entry = classifyExport(
+                  exportedName,
+                  reportNode,
+                  false,
+                  isReExportFromSource ? null : local,
+                  state,
+                );
               } else {
                 entry = { kind: "non-component", reportNode };
                 // `export { Foo as "🍌" }` still EXPORTS the component —

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.ts
@@ -6,6 +6,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { functionContainsReactRenderOutput } from "../../utils/function-contains-react-render-output.js";
 import { functionHasReactElementReturnType } from "../../utils/function-has-react-element-return-type.js";
+import { functionReturnsOnlyNull } from "../../utils/function-returns-only-null.js";
 import { getFastRefreshFileStatus } from "../../utils/get-fast-refresh-file-status.js";
 import { getImportedName } from "../../utils/get-imported-name.js";
 import { isEs6Component } from "../../utils/is-es6-component.js";
@@ -148,7 +149,6 @@ interface AnalyzerState {
   allowedRouteExportNames: ReadonlySet<string>;
   routeFactoryBindings: RouteFactoryBindings;
   componentFactorySymbolIds: ReadonlySet<number>;
-  defaultExportComponentNames: ReadonlySet<string>;
   importSymbolIds: ReadonlySet<number>;
   // Module-scope component binding names — used to spot a component
   // reference smuggled inside a namespace-object export.
@@ -373,10 +373,7 @@ const classifyExport = (
   initializer: EsTreeNode | null | undefined,
   state: AnalyzerState,
 ): ExportType => {
-  if (
-    isNodeOfType(reportNode, "Identifier") &&
-    state.defaultExportComponentNames.has(reportNode.name)
-  ) {
+  if (isNodeOfType(reportNode, "Identifier") && state.localComponentNames.has(reportNode.name)) {
     return { kind: "react-component" };
   }
   // HoC-wrapped: `export const Foo = memo(...)` — treat as component.
@@ -697,12 +694,12 @@ export const onlyExportComponents = defineRule({
         // boundary, so only top-level names participate.
         const localComponentNames = new Set<string>();
         const componentFactorySymbolIds = new Set<number>();
-        const defaultExportComponentNames = new Set<string>();
+        const defaultExportAliasNames = new Set<string>();
         for (const child of exportNodes) {
           if (isNodeOfType(child, "ExportDefaultDeclaration")) {
             const declaration = skipTsExpression(child.declaration as EsTreeNode);
             if (isNodeOfType(declaration, "Identifier") && isReactComponentName(declaration.name)) {
-              defaultExportComponentNames.add(declaration.name);
+              defaultExportAliasNames.add(declaration.name);
             }
             continue;
           }
@@ -719,7 +716,7 @@ export const onlyExportComponents = defineRule({
               isNodeOfType(local, "Identifier") &&
               isReactComponentName(local.name)
             ) {
-              defaultExportComponentNames.add(local.name);
+              defaultExportAliasNames.add(local.name);
             }
           }
         }
@@ -759,7 +756,6 @@ export const onlyExportComponents = defineRule({
           allowedRouteExportNames,
           routeFactoryBindings,
           componentFactorySymbolIds,
-          defaultExportComponentNames,
           importSymbolIds,
           localComponentNames,
           scopes: context.scopes,
@@ -777,7 +773,8 @@ export const onlyExportComponents = defineRule({
               isReactComponentName(child.id.name) &&
               !isInsideFunctionScope(child) &&
               (functionContainsReactRenderOutput(child, context.scopes, context.cfg) ||
-                functionHasReactElementReturnType(child))
+                functionHasReactElementReturnType(child) ||
+                (defaultExportAliasNames.has(child.id.name) && functionReturnsOnlyNull(child)))
             ) {
               localComponentNames.add(child.id.name);
             }
@@ -793,20 +790,28 @@ export const onlyExportComponents = defineRule({
           }
           if (isNodeOfType(child, "VariableDeclarator") && isNodeOfType(child.id, "Identifier")) {
             const initializer = child.init as EsTreeNode | null | undefined;
+            const expression = initializer ? skipTsExpression(initializer) : null;
+            const isDirectFunction =
+              expression !== null &&
+              (isNodeOfType(expression, "ArrowFunctionExpression") ||
+                isNodeOfType(expression, "FunctionExpression"));
+            const isDefaultNullPlaceholder =
+              defaultExportAliasNames.has(child.id.name) &&
+              expression !== null &&
+              isDirectFunction &&
+              functionReturnsOnlyNull(expression);
             if (
               isReactComponentName(child.id.name) &&
               (canBeReactFunctionComponent(initializer, state) ||
-                (initializer ? isEs6Component(skipTsExpression(initializer)) : false)) &&
+                (expression ? isEs6Component(expression) : false) ||
+                isDefaultNullPlaceholder) &&
               !isInsideFunctionScope(child)
             ) {
-              const expression = initializer ? skipTsExpression(initializer) : null;
-              const isDirectFunction =
-                expression !== null &&
-                (isNodeOfType(expression, "ArrowFunctionExpression") ||
-                  isNodeOfType(expression, "FunctionExpression"));
               if (
                 !isDirectFunction ||
-                functionContainsReactRenderOutput(expression, context.scopes, context.cfg)
+                functionContainsReactRenderOutput(expression, context.scopes, context.cfg) ||
+                functionHasReactElementReturnType(expression) ||
+                isDefaultNullPlaceholder
               ) {
                 localComponentNames.add(child.id.name);
               }
@@ -877,7 +882,11 @@ export const onlyExportComponents = defineRule({
               continue;
             }
             if (isNodeOfType(stripped, "Identifier")) {
-              exports.push(classifyExport(stripped.name, stripped, false, null, state));
+              exports.push(
+                isProvenComponentValue(stripped, state)
+                  ? { kind: "react-component" }
+                  : { kind: "non-component", reportNode: stripped },
+              );
               continue;
             }
             if (isNodeOfType(stripped, "MemberExpression")) {
@@ -945,7 +954,7 @@ export const onlyExportComponents = defineRule({
                 exports.push(
                   functionContainsReactRenderOutput(declaration, context.scopes, context.cfg) ||
                     functionHasReactElementReturnType(declaration) ||
-                    defaultExportComponentNames.has(declaration.id.name)
+                    localComponentNames.has(declaration.id.name)
                     ? classifyExport(declaration.id.name, declaration.id, true, null, state)
                     : { kind: "non-component", reportNode: declaration.id },
                 );
@@ -1011,10 +1020,12 @@ export const onlyExportComponents = defineRule({
               const localName = local && isNodeOfType(local, "Identifier") ? local.name : null;
               const reportNode = specifier as EsTreeNode;
               let entry: ExportType;
-              if (localName && defaultExportComponentNames.has(localName)) {
+              if (localName && localComponentNames.has(localName)) {
                 entry = { kind: "react-component" };
-              } else if (exportedName === "default" && localName) {
-                entry = classifyExport(localName, reportNode, false, null, state);
+              } else if (exportedName === "default" && localName && local) {
+                entry = isProvenComponentValue(local, state)
+                  ? { kind: "react-component" }
+                  : { kind: "non-component", reportNode };
               } else if (exportedName) {
                 entry = classifyExport(exportedName, reportNode, false, null, state);
               } else {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.ts
@@ -523,7 +523,7 @@ export const onlyExportComponents = defineRule({
     const filename = normalizeFilename(context.filename ?? "");
     const fastRefreshStatus = getFastRefreshFileStatus(context);
     if (!fastRefreshStatus.isActive) return {};
-    if (isFrameworkRouteOrSpecialFilename(filename, fastRefreshStatus.runtime)) return {};
+    if (isFrameworkRouteOrSpecialFilename(context, fastRefreshStatus.runtime)) return {};
     if (!isFileNameAllowed(filename, settings.checkJS)) return {};
     const allowedRouteExportNames =
       fastRefreshStatus.runtime === "next"

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.ts
@@ -205,16 +205,18 @@ const canBeReactFunctionComponent = (
     isNodeOfType(expression, "ArrowFunctionExpression") ||
     isNodeOfType(expression, "FunctionExpression")
   ) {
-    return (
-      functionContainsReactRenderOutput(expression, state.scopes, state.controlFlow) ||
-      functionHasReactElementReturnType(expression)
-    );
+    return functionHasReactRenderSemantics(expression, state);
   }
   if (isNodeOfType(expression, "CallExpression")) {
     return isHocCallee(expression.callee as EsTreeNode, state);
   }
   return false;
 };
+
+const functionHasReactRenderSemantics = (functionNode: EsTreeNode, state: AnalyzerState): boolean =>
+  functionContainsReactRenderOutput(functionNode, state.scopes, state.controlFlow) ||
+  functionHasReactElementReturnType(functionNode) ||
+  functionReturnsOnlyNull(functionNode);
 
 const isReactComponentInitializer = (expression: EsTreeNode, state: AnalyzerState): boolean => {
   const stripped = skipTsExpression(expression);
@@ -302,7 +304,7 @@ const isProvenComponentValue = (expression: EsTreeNode, state: AnalyzerState): b
     isNodeOfType(stripped, "ArrowFunctionExpression") ||
     isNodeOfType(stripped, "FunctionExpression")
   ) {
-    return functionContainsReactRenderOutput(stripped, state.scopes, state.controlFlow);
+    return functionHasReactRenderSemantics(stripped, state);
   }
   if (!isNodeOfType(stripped, "CallExpression")) return false;
   if (!isHocCallee(stripped.callee as EsTreeNode, state)) return false;
@@ -351,7 +353,7 @@ const objectExpressionBundlesComponents = (
     if (
       (isNodeOfType(value, "ArrowFunctionExpression") ||
         isNodeOfType(value, "FunctionExpression")) &&
-      functionContainsReactRenderOutput(value, state.scopes, state.controlFlow)
+      functionHasReactRenderSemantics(value, state)
     ) {
       return true;
     }
@@ -694,32 +696,6 @@ export const onlyExportComponents = defineRule({
         // boundary, so only top-level names participate.
         const localComponentNames = new Set<string>();
         const componentFactorySymbolIds = new Set<number>();
-        const defaultExportAliasNames = new Set<string>();
-        for (const child of exportNodes) {
-          if (isNodeOfType(child, "ExportDefaultDeclaration")) {
-            const declaration = skipTsExpression(child.declaration as EsTreeNode);
-            if (isNodeOfType(declaration, "Identifier") && isReactComponentName(declaration.name)) {
-              defaultExportAliasNames.add(declaration.name);
-            }
-            continue;
-          }
-          if (!isNodeOfType(child, "ExportNamedDeclaration") || Boolean(child.source)) {
-            continue;
-          }
-          for (const specifier of child.specifiers) {
-            if (!isNodeOfType(specifier, "ExportSpecifier")) continue;
-            const exported = specifier.exported;
-            const local = specifier.local;
-            const exportedName = isNodeOfType(exported, "Identifier") ? exported.name : null;
-            if (
-              exportedName === "default" &&
-              isNodeOfType(local, "Identifier") &&
-              isReactComponentName(local.name)
-            ) {
-              defaultExportAliasNames.add(local.name);
-            }
-          }
-        }
         for (const child of componentCandidates) {
           if (isInsideFunctionScope(child)) continue;
           if (isNodeOfType(child, "FunctionDeclaration") && child.id) {
@@ -772,9 +748,7 @@ export const onlyExportComponents = defineRule({
             if (
               isReactComponentName(child.id.name) &&
               !isInsideFunctionScope(child) &&
-              (functionContainsReactRenderOutput(child, context.scopes, context.cfg) ||
-                functionHasReactElementReturnType(child) ||
-                (defaultExportAliasNames.has(child.id.name) && functionReturnsOnlyNull(child)))
+              functionHasReactRenderSemantics(child, state)
             ) {
               localComponentNames.add(child.id.name);
             }
@@ -795,24 +769,13 @@ export const onlyExportComponents = defineRule({
               expression !== null &&
               (isNodeOfType(expression, "ArrowFunctionExpression") ||
                 isNodeOfType(expression, "FunctionExpression"));
-            const isDefaultNullPlaceholder =
-              defaultExportAliasNames.has(child.id.name) &&
-              expression !== null &&
-              isDirectFunction &&
-              functionReturnsOnlyNull(expression);
             if (
               isReactComponentName(child.id.name) &&
               (canBeReactFunctionComponent(initializer, state) ||
-                (expression ? isEs6Component(expression) : false) ||
-                isDefaultNullPlaceholder) &&
+                (expression ? isEs6Component(expression) : false)) &&
               !isInsideFunctionScope(child)
             ) {
-              if (
-                !isDirectFunction ||
-                functionContainsReactRenderOutput(expression, context.scopes, context.cfg) ||
-                functionHasReactElementReturnType(expression) ||
-                isDefaultNullPlaceholder
-              ) {
+              if (!isDirectFunction || functionHasReactRenderSemantics(expression, state)) {
                 localComponentNames.add(child.id.name);
               }
             }
@@ -845,9 +808,7 @@ export const onlyExportComponents = defineRule({
               isNodeOfType(stripped, "FunctionDeclaration") ||
               isNodeOfType(stripped, "FunctionExpression")
             ) {
-              const hasRenderOutput =
-                functionContainsReactRenderOutput(stripped, context.scopes, context.cfg) ||
-                functionHasReactElementReturnType(stripped);
+              const hasRenderOutput = functionHasReactRenderSemantics(stripped, state);
               if ((stripped as EsTreeNodeOfType<"FunctionDeclaration">).id) {
                 const idNode = (stripped as EsTreeNodeOfType<"FunctionDeclaration">).id!;
                 isExportedNodeIds.add(stripped);
@@ -927,7 +888,7 @@ export const onlyExportComponents = defineRule({
               continue;
             }
             if (isNodeOfType(stripped, "ArrowFunctionExpression")) {
-              if (functionContainsReactRenderOutput(stripped, context.scopes, context.cfg)) {
+              if (functionHasReactRenderSemantics(stripped, state)) {
                 context.report({ node: stripped, message: ANONYMOUS_MESSAGE });
                 hasReactExport = true;
               } else {
@@ -952,8 +913,7 @@ export const onlyExportComponents = defineRule({
               if (isNodeOfType(declaration, "FunctionDeclaration") && declaration.id) {
                 isExportedNodeIds.add(declaration);
                 exports.push(
-                  functionContainsReactRenderOutput(declaration, context.scopes, context.cfg) ||
-                    functionHasReactElementReturnType(declaration) ||
+                  functionHasReactRenderSemantics(declaration, state) ||
                     localComponentNames.has(declaration.id.name)
                     ? classifyExport(declaration.id.name, declaration.id, true, null, state)
                     : { kind: "non-component", reportNode: declaration.id },

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/export-all-adds-runtime-values.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/export-all-adds-runtime-values.ts
@@ -1,0 +1,70 @@
+import * as path from "node:path";
+import type { EsTreeNode } from "./es-tree-node.js";
+import { isEverySpecifierInlineType } from "./is-type-only-import.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+import { parseSourceFile } from "./parse-source-file.js";
+import { resolveRelativeImportPath } from "./resolve-relative-import-path.js";
+
+const getExportedName = (node: EsTreeNode | null | undefined): string | null => {
+  if (!node) return null;
+  if (isNodeOfType(node, "Identifier")) return node.name;
+  if (isNodeOfType(node, "Literal") && typeof node.value === "string") return node.value;
+  return null;
+};
+
+const programHasRuntimeNamedExports = (
+  filePath: string,
+  program: EsTreeNode,
+  visitedFilePaths: Set<string>,
+): boolean => {
+  if (!isNodeOfType(program, "Program")) return true;
+  for (const statement of program.body) {
+    if (isNodeOfType(statement, "ExportDefaultDeclaration")) continue;
+    if (isNodeOfType(statement, "ExportAllDeclaration")) {
+      if (statement.exportKind === "type") continue;
+      if (statement.exported) return true;
+      if (typeof statement.source.value !== "string") return true;
+      if (exportAllAddsRuntimeValues(filePath, statement.source.value, visitedFilePaths)) {
+        return true;
+      }
+      continue;
+    }
+    if (!isNodeOfType(statement, "ExportNamedDeclaration")) continue;
+    if (statement.exportKind === "type") continue;
+    if (statement.declaration) {
+      if (
+        statement.declaration.type !== "TSInterfaceDeclaration" &&
+        statement.declaration.type !== "TSTypeAliasDeclaration" &&
+        statement.declaration.type !== "TSDeclareFunction"
+      ) {
+        return true;
+      }
+      continue;
+    }
+    if (isEverySpecifierInlineType(statement.specifiers, "ExportSpecifier", "exportKind")) {
+      continue;
+    }
+    for (const specifier of statement.specifiers) {
+      if (!isNodeOfType(specifier, "ExportSpecifier") || specifier.exportKind === "type") {
+        continue;
+      }
+      if (getExportedName(specifier.exported) !== "default") return true;
+    }
+  }
+  return false;
+};
+
+export const exportAllAddsRuntimeValues = (
+  importerFilePath: string,
+  source: string,
+  visitedFilePaths = new Set<string>(),
+): boolean => {
+  const resolvedFilePath = resolveRelativeImportPath(importerFilePath, source);
+  if (!resolvedFilePath) return true;
+  if (path.extname(resolvedFilePath) === ".cjs" || resolvedFilePath.endsWith(".cts")) return true;
+  if (visitedFilePaths.has(resolvedFilePath)) return true;
+  visitedFilePaths.add(resolvedFilePath);
+  const program = parseSourceFile(resolvedFilePath);
+  if (!program) return true;
+  return programHasRuntimeNamedExports(resolvedFilePath, program, visitedFilePaths);
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/function-contains-react-render-output.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/function-contains-react-render-output.test.ts
@@ -217,6 +217,36 @@ describe("functionContainsReactRenderOutput", () => {
     });
   }
 
+  it.each([
+    [
+      "renamed named react-dom imports",
+      `import { createPortal as mountPortal } from "react-dom";
+       function Card() { const content = <div />; return mountPortal(content, document.body); }`,
+      true,
+    ],
+    [
+      "namespace react-dom imports",
+      `import * as ReactDOM from "react-dom";
+       function Card() { const content = <div />; return ReactDOM.createPortal(content, document.body); }`,
+      true,
+    ],
+    [
+      "same-named userland imports",
+      `import { createPortal } from "portal-utils";
+       function Card() { const content = <div />; return createPortal(content, document.body); }`,
+      false,
+    ],
+    [
+      "shadowed react-dom imports",
+      `import { createPortal } from "react-dom";
+       function Card(createPortal) { const content = <div />; return createPortal(content, document.body); }`,
+      false,
+    ],
+  ] as const)("handles %s as render output", (_name, code, expected) => {
+    const { functionNode, scopes } = parseFunctionFixture(code, "Card");
+    expect(functionContainsReactRenderOutput(functionNode, scopes)).toBe(expected);
+  });
+
   it("memoizes per (functionNode, scopes): a repeat query with the same inputs skips the re-walk", () => {
     const { functionNode, scopes, program } = parseFunctionFixture(
       `function Card() { return <div>hi</div>; }`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/function-contains-react-render-output.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/function-contains-react-render-output.ts
@@ -1,5 +1,10 @@
 import type { EsTreeNode } from "./es-tree-node.js";
-import { getImportBindingForName } from "./find-import-source-for-name.js";
+import {
+  getImportBindingForName,
+  getImportedNameFromModule,
+  isDefaultImportFromModule,
+  isNamespaceImportFromModule,
+} from "./find-import-source-for-name.js";
 import { functionReturnsMatchingExpression } from "./function-returns-matching-expression.js";
 import { getStaticPropertyName } from "./get-static-property-name.js";
 import { hasStableCallTarget } from "./has-stable-call-target.js";
@@ -143,7 +148,35 @@ const isNestedRenderEvidenceBoundary = (node: EsTreeNode, scopes: ScopeAnalysis)
 const isRenderOutputExpression = (node: EsTreeNode, scopes: ScopeAnalysis): boolean =>
   node.type === "JSXElement" ||
   node.type === "JSXFragment" ||
-  isReactApiCall(node, "createElement", scopes, REACT_CREATE_ELEMENT_OPTIONS);
+  isReactApiCall(node, "createElement", scopes, REACT_CREATE_ELEMENT_OPTIONS) ||
+  isReactDomCreatePortalCall(node, scopes);
+
+const isReactDomCreatePortalCall = (node: EsTreeNode, scopes: ScopeAnalysis): boolean => {
+  if (!isNodeOfType(node, "CallExpression")) return false;
+  const callee = stripParenExpression(node.callee);
+  if (isNodeOfType(callee, "Identifier")) {
+    const symbol = scopes.symbolFor(callee);
+    return (
+      symbol?.kind === "import" &&
+      getImportedNameFromModule(callee, callee.name, "react-dom") === "createPortal"
+    );
+  }
+  if (
+    !isNodeOfType(callee, "MemberExpression") ||
+    callee.computed ||
+    !isNodeOfType(callee.object, "Identifier") ||
+    !isNodeOfType(callee.property, "Identifier") ||
+    callee.property.name !== "createPortal"
+  ) {
+    return false;
+  }
+  const symbol = scopes.symbolFor(callee.object);
+  if (!symbol || symbol.kind !== "import") return false;
+  return (
+    isDefaultImportFromModule(callee.object, callee.object.name, "react-dom") ||
+    isNamespaceImportFromModule(callee.object, callee.object.name, "react-dom")
+  );
+};
 
 const containsRenderOutput = (rootNode: EsTreeNode, scopes: ScopeAnalysis): boolean => {
   let hasRenderOutput = false;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/function-has-react-element-return-type.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/function-has-react-element-return-type.ts
@@ -1,0 +1,67 @@
+import type { EsTreeNode } from "./es-tree-node.js";
+import {
+  getImportBindingForName,
+  getImportedNameFromModule,
+} from "./find-import-source-for-name.js";
+import { findProgramRoot } from "./find-program-root.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+
+const isReactNamespaceBinding = (node: EsTreeNode): boolean => {
+  if (!isNodeOfType(node, "Identifier")) return false;
+  const binding = getImportBindingForName(node, node.name);
+  return Boolean(
+    binding &&
+    binding.source === "react" &&
+    (binding.isNamespace || binding.exportedName === "default"),
+  );
+};
+
+const hasLocalJsxNamespace = (node: EsTreeNode): boolean => {
+  const program = findProgramRoot(node);
+  if (!program || !isNodeOfType(program, "Program")) return false;
+  return program.body.some(
+    (statement) =>
+      isNodeOfType(statement, "TSModuleDeclaration") &&
+      isNodeOfType(statement.id, "Identifier") &&
+      statement.id.name === "JSX",
+  );
+};
+
+const isReactElementTypeReference = (node: EsTreeNode): boolean => {
+  if (!isNodeOfType(node, "TSTypeReference")) return false;
+  const typeName = node.typeName;
+  if (isNodeOfType(typeName, "Identifier")) {
+    return getImportedNameFromModule(typeName, typeName.name, "react") === "ReactElement";
+  }
+  if (!isNodeOfType(typeName, "TSQualifiedName")) return false;
+  if (!isNodeOfType(typeName.right, "Identifier")) return false;
+  if (typeName.right.name === "ReactElement" && isReactNamespaceBinding(typeName.left)) {
+    return true;
+  }
+  if (typeName.right.name !== "Element") return false;
+  if (isNodeOfType(typeName.left, "Identifier")) {
+    if (typeName.left.name !== "JSX") return false;
+    const binding = getImportBindingForName(typeName.left, typeName.left.name);
+    if (!binding) return !hasLocalJsxNamespace(typeName.left);
+    return binding.source === "react" && binding.exportedName === "JSX";
+  }
+  return (
+    isNodeOfType(typeName.left, "TSQualifiedName") &&
+    isNodeOfType(typeName.left.right, "Identifier") &&
+    typeName.left.right.name === "JSX" &&
+    isReactNamespaceBinding(typeName.left.left)
+  );
+};
+
+const containsReactElementType = (node: EsTreeNode): boolean => {
+  if (isNodeOfType(node, "TSUnionType")) {
+    return node.types.some((member) => containsReactElementType(member));
+  }
+  return isReactElementTypeReference(node);
+};
+
+export const functionHasReactElementReturnType = (functionNode: EsTreeNode): boolean => {
+  const returnType = Reflect.get(functionNode, "returnType");
+  if (!isNodeOfType(returnType, "TSTypeAnnotation")) return false;
+  return containsReactElementType(returnType.typeAnnotation);
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-fast-refresh-file-status.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-fast-refresh-file-status.test.ts
@@ -1,0 +1,386 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import { __clearParseSourceFileCacheForTests } from "./parse-source-file.js";
+import { resetManifestCaches } from "./read-nearest-package-manifest.js";
+import { probeFastRefreshFileStatus } from "./get-fast-refresh-file-status.js";
+
+interface FastRefreshFixture {
+  manifest: Record<string, unknown>;
+  files?: Record<string, string>;
+}
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  resetManifestCaches();
+  __clearParseSourceFileCacheForTests();
+  for (const temporaryDirectory of temporaryDirectories.splice(0)) {
+    fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+  }
+});
+
+const createFixture = ({ manifest, files = {} }: FastRefreshFixture): string => {
+  const projectDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "rd-fast-refresh-status-"));
+  temporaryDirectories.push(projectDirectory);
+  fs.writeFileSync(path.join(projectDirectory, "package.json"), JSON.stringify(manifest));
+  for (const [relativePath, contents] of Object.entries(files)) {
+    const absolutePath = path.join(projectDirectory, relativePath);
+    fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+    fs.writeFileSync(absolutePath, contents);
+  }
+  const sourcePath = path.join(projectDirectory, "src", "Card.tsx");
+  fs.mkdirSync(path.dirname(sourcePath), { recursive: true });
+  fs.writeFileSync(sourcePath, "export const Card = () => <div />;\n");
+  return sourcePath;
+};
+
+const createWorkspaceFixture = (files: Record<string, string>): string => {
+  const workspaceDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "rd-refresh-workspace-"));
+  temporaryDirectories.push(workspaceDirectory);
+  for (const [relativePath, contents] of Object.entries(files)) {
+    const absolutePath = path.join(workspaceDirectory, relativePath);
+    fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+    fs.writeFileSync(absolutePath, contents);
+  }
+  return workspaceDirectory;
+};
+
+const viteManifest = (scripts: Record<string, string>): Record<string, unknown> => ({
+  scripts,
+  dependencies: { react: "19.0.0" },
+  devDependencies: { vite: "7.0.0", "@vitejs/plugin-react": "5.0.0" },
+});
+
+describe("probeFastRefreshFileStatus", () => {
+  it("resolves an existing relative filename against the current directory", () => {
+    const sourcePath = createFixture({
+      manifest: viteManifest({ dev: "vite" }),
+      files: {
+        "vite.config.ts":
+          'import react from "@vitejs/plugin-react"; export default { plugins: [react()] };',
+      },
+    });
+
+    expect(probeFastRefreshFileStatus(path.relative(process.cwd(), sourcePath)).isActive).toBe(
+      true,
+    );
+  });
+
+  it("rejects a Vite React plugin used only by a library build", () => {
+    const sourcePath = createFixture({
+      manifest: viteManifest({ build: "vite build" }),
+      files: {
+        "vite.config.ts":
+          'import react from "@vitejs/plugin-react"; export default { plugins: [react()], build: { lib: { entry: "src/index.ts" } } };',
+      },
+    });
+
+    expect(probeFastRefreshFileStatus(sourcePath).isActive).toBe(false);
+  });
+
+  it("follows an explicit development config path", () => {
+    const sourcePath = createFixture({
+      manifest: viteManifest({ dev: "vite --config dev/vite.config.ts" }),
+      files: {
+        "dev/vite.config.ts":
+          'import react from "@vitejs/plugin-react"; export default { plugins: [react()] };',
+      },
+    });
+
+    expect(probeFastRefreshFileStatus(sourcePath).isActive).toBe(true);
+  });
+
+  it("recognizes a quoted Vite command inside a concurrent development script", () => {
+    const sourcePath = createFixture({
+      manifest: viteManifest({
+        dev: 'concurrently -n VITE,STYLES "vite --host 0.0.0.0" "pnpm watch:styles"',
+      }),
+      files: {
+        "vite.config.ts":
+          'import react from "@vitejs/plugin-react"; export default { plugins: [react()] };',
+      },
+    });
+
+    expect(probeFastRefreshFileStatus(sourcePath).isActive).toBe(true);
+  });
+
+  it("resolves an unreassigned function-local plugin array in the exported config factory", () => {
+    const sourcePath = createFixture({
+      manifest: viteManifest({ dev: "vite --host localhost" }),
+      files: {
+        "vite.config.ts": `
+          import react from "@vitejs/plugin-react";
+          export default async () => {
+            const plugins = [react()];
+            return { plugins };
+          };
+        `,
+      },
+    });
+
+    expect(probeFastRefreshFileStatus(sourcePath).isActive).toBe(true);
+  });
+
+  it.each([
+    [
+      "reassigned plugin array",
+      `
+        import react from "@vitejs/plugin-react";
+        export default () => {
+          let plugins = [react()];
+          plugins = [];
+          return { plugins };
+        };
+      `,
+    ],
+    [
+      "shadowed plugin array",
+      `
+        import react from "@vitejs/plugin-react";
+        export default () => {
+          const plugins = [react()];
+          {
+            const plugins = [];
+            return { plugins };
+          }
+        };
+      `,
+    ],
+    [
+      "unused local config",
+      `
+        import react from "@vitejs/plugin-react";
+        export default () => {
+          const unused = { plugins: [react()] };
+          return { plugins: [] };
+        };
+      `,
+    ],
+    [
+      "nested helper return",
+      `
+        import react from "@vitejs/plugin-react";
+        export default () => {
+          const makeUnusedConfig = () => ({ plugins: [react()] });
+          return { plugins: [] };
+        };
+      `,
+    ],
+    [
+      "shadowed exported config name",
+      `
+        import react from "@vitejs/plugin-react";
+        const config = { plugins: [react()] };
+        export default () => {
+          const config = { plugins: [] };
+          return config;
+        };
+      `,
+    ],
+  ])("rejects an unproven config binding — %s", (_label, config) => {
+    const sourcePath = createFixture({
+      manifest: viteManifest({ dev: "vite" }),
+      files: { "vite.config.ts": config },
+    });
+
+    expect(probeFastRefreshFileStatus(sourcePath).isActive).toBe(false);
+  });
+
+  it("recognizes the Rozenite wrapper only when its development config registers it", () => {
+    const activeSourcePath = createFixture({
+      manifest: {
+        scripts: { dev: "rozenite dev" },
+        dependencies: { react: "19.0.0" },
+        devDependencies: { vite: "7.0.0", "@rozenite/vite-plugin": "1.9.0" },
+      },
+      files: {
+        "vite.config.ts":
+          'import { rozenitePlugin } from "@rozenite/vite-plugin"; export default { plugins: [rozenitePlugin()] };',
+        "index.html": '<main id="root"></main>',
+      },
+    });
+    const inactiveSourcePath = createFixture({
+      manifest: {
+        scripts: { dev: "rozenite dev" },
+        dependencies: { react: "19.0.0" },
+        devDependencies: { vite: "7.0.0", "@rozenite/vite-plugin": "1.9.0" },
+      },
+      files: {
+        "vite.config.ts":
+          'import { rozenitePlugin } from "@rozenite/vite-plugin"; export default { plugins: [] };',
+        "index.html": '<main id="root"></main>',
+      },
+    });
+
+    expect(probeFastRefreshFileStatus(activeSourcePath).isActive).toBe(true);
+    expect(probeFastRefreshFileStatus(inactiveSourcePath).isActive).toBe(false);
+  });
+
+  it("recognizes an explicitly configured React Vite Storybook", () => {
+    const sourcePath = createFixture({
+      manifest: {
+        scripts: { storybook: "storybook dev -p 6006" },
+        dependencies: { react: "19.0.0" },
+        devDependencies: { "@storybook/react-vite": "9.0.0" },
+      },
+      files: {
+        ".storybook/main.js":
+          'export default { framework: { name: "@storybook/react-vite", options: {} } };',
+      },
+    });
+
+    expect(probeFastRefreshFileStatus(sourcePath).isActive).toBe(true);
+  });
+
+  it.each([
+    ["non-Vite framework", 'export default { framework: "@storybook/react-webpack5" };'],
+    [
+      "unexported framework",
+      'const unused = { framework: "@storybook/react-vite" }; export default { framework: "@storybook/react-webpack5" };',
+    ],
+  ])("rejects Storybook without exported React Vite proof — %s", (_label, config) => {
+    const sourcePath = createFixture({
+      manifest: {
+        scripts: { storybook: "storybook dev -p 6006" },
+        dependencies: { react: "19.0.0" },
+        devDependencies: { "@storybook/react-vite": "9.0.0" },
+      },
+      files: { ".storybook/main.js": config },
+    });
+
+    expect(probeFastRefreshFileStatus(sourcePath).isActive).toBe(false);
+  });
+
+  it("recognizes Dumi only when the owning package runs a Fast Refresh default version", () => {
+    const activeSourcePath = createFixture({
+      manifest: {
+        scripts: { dev: "dumi dev" },
+        dependencies: { react: "18.0.0" },
+        devDependencies: { dumi: "2.4.23" },
+      },
+    });
+    const inactiveSourcePath = createFixture({
+      manifest: {
+        scripts: { test: "dumi dev" },
+        dependencies: { react: "18.0.0" },
+        devDependencies: { dumi: "1.1.53" },
+      },
+    });
+
+    expect(probeFastRefreshFileStatus(activeSourcePath).isActive).toBe(true);
+    expect(probeFastRefreshFileStatus(inactiveSourcePath).isActive).toBe(false);
+  });
+
+  it("inherits Fast Refresh through an active consumer's literal Vite alias", () => {
+    const workspaceDirectory = createWorkspaceFixture({
+      "package.json": JSON.stringify({ workspaces: ["apps/*", "packages/*"] }),
+      "apps/web/package.json": JSON.stringify(viteManifest({ dev: "vite" })),
+      "apps/web/vite.config.ts": `
+        import react from "@vitejs/plugin-react";
+        import path from "node:path";
+        export default {
+          plugins: [react()],
+          resolve: { alias: { ui: path.resolve(__dirname, "../../packages/ui/src") } },
+        };
+      `,
+      "packages/ui/package.json": JSON.stringify({ name: "ui" }),
+      "packages/ui/src/Card.tsx": "export const Card = () => <div />;",
+      "packages/ui-old/package.json": JSON.stringify({ name: "ui-old" }),
+      "packages/ui-old/src/Card.tsx": "export const Card = () => <div />;",
+    });
+
+    expect(
+      probeFastRefreshFileStatus(path.join(workspaceDirectory, "packages/ui/src/Card.tsx"))
+        .isActive,
+    ).toBe(true);
+    expect(
+      probeFastRefreshFileStatus(path.join(workspaceDirectory, "packages/ui-old/src/Card.tsx"))
+        .isActive,
+    ).toBe(false);
+  });
+
+  it("rejects aliases owned only by a Vite library build", () => {
+    const workspaceDirectory = createWorkspaceFixture({
+      "package.json": JSON.stringify({ workspaces: ["apps/*", "packages/*"] }),
+      "apps/builder/package.json": JSON.stringify(viteManifest({ build: "vite build" })),
+      "apps/builder/vite.config.ts": `
+        import react from "@vitejs/plugin-react";
+        export default {
+          plugins: [react()],
+          resolve: { alias: { ui: "../../packages/ui/src" } },
+        };
+      `,
+      "packages/ui/package.json": JSON.stringify({ name: "ui" }),
+      "packages/ui/src/Card.tsx": "export const Card = () => <div />;",
+    });
+
+    expect(
+      probeFastRefreshFileStatus(path.join(workspaceDirectory, "packages/ui/src/Card.tsx"))
+        .isActive,
+    ).toBe(false);
+  });
+
+  it("inherits Fast Refresh through a workspace dependency with a source runtime entry", () => {
+    const workspaceDirectory = createWorkspaceFixture({
+      "package.json": JSON.stringify({ workspaces: ["apps/*", "packages/*"] }),
+      "apps/web/package.json": JSON.stringify({
+        ...viteManifest({ dev: "vite" }),
+        dependencies: { react: "19.0.0", ui: "workspace:*", "dist-ui": "workspace:*" },
+        peerDependencies: { "peer-ui": "workspace:*" },
+      }),
+      "apps/web/vite.config.ts":
+        'import react from "@vitejs/plugin-react"; export default { plugins: [react()] };',
+      "packages/ui/package.json": JSON.stringify({ name: "ui", main: "./src/index.ts" }),
+      "packages/ui/src/Card.tsx": "export const Card = () => <div />;",
+      "packages/dist-ui/package.json": JSON.stringify({ name: "dist-ui", main: "./dist/index.js" }),
+      "packages/dist-ui/src/Card.tsx": "export const Card = () => <div />;",
+      "packages/peer-ui/package.json": JSON.stringify({ name: "peer-ui", main: "./src/index.ts" }),
+      "packages/peer-ui/src/Card.tsx": "export const Card = () => <div />;",
+    });
+
+    expect(
+      probeFastRefreshFileStatus(path.join(workspaceDirectory, "packages/ui/src/Card.tsx"))
+        .isActive,
+    ).toBe(true);
+    expect(
+      probeFastRefreshFileStatus(path.join(workspaceDirectory, "packages/dist-ui/src/Card.tsx"))
+        .isActive,
+    ).toBe(false);
+    expect(
+      probeFastRefreshFileStatus(path.join(workspaceDirectory, "packages/peer-ui/src/Card.tsx"))
+        .isActive,
+    ).toBe(false);
+  });
+
+  it("recognizes an Nx React Vite Storybook development target", () => {
+    const activeWorkspace = createWorkspaceFixture({
+      "package.json": JSON.stringify({ workspaces: ["packages/*"] }),
+      "packages/ui/package.json": JSON.stringify({ name: "ui" }),
+      "packages/ui/project.json": JSON.stringify({
+        targets: { "storybook:serve:dev": { options: { port: 6006 } } },
+      }),
+      "packages/ui/.storybook/main.ts":
+        'export default { framework: "@storybook/react-vite", stories: ["../src/**/*.stories.tsx"] };',
+      "packages/ui/src/Card.tsx": "export const Card = () => <div />;",
+    });
+    const staticWorkspace = createWorkspaceFixture({
+      "package.json": JSON.stringify({ workspaces: ["packages/*"] }),
+      "packages/ui/package.json": JSON.stringify({ name: "ui" }),
+      "packages/ui/project.json": JSON.stringify({
+        targets: { "storybook:serve:static": { options: { port: 6006 } } },
+      }),
+      "packages/ui/.storybook/main.ts":
+        'export default { framework: "@storybook/react-vite", stories: ["../src/**/*.stories.tsx"] };',
+      "packages/ui/src/Card.tsx": "export const Card = () => <div />;",
+    });
+
+    expect(
+      probeFastRefreshFileStatus(path.join(activeWorkspace, "packages/ui/src/Card.tsx")).isActive,
+    ).toBe(true);
+    expect(
+      probeFastRefreshFileStatus(path.join(staticWorkspace, "packages/ui/src/Card.tsx")).isActive,
+    ).toBe(false);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-fast-refresh-file-status.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-fast-refresh-file-status.test.ts
@@ -106,6 +106,76 @@ describe("probeFastRefreshFileStatus", () => {
     expect(probeFastRefreshFileStatus(sourcePath).isActive).toBe(true);
   });
 
+  it.each([
+    [
+      "generic before framework",
+      `
+        import react from "@vitejs/plugin-react";
+        import { reactRouter } from "@react-router/dev/vite";
+        export default { plugins: [react(), reactRouter()] };
+      `,
+      "react-router",
+    ],
+    [
+      "framework before generic",
+      `
+        import react from "@vitejs/plugin-react";
+        import { reactRouter } from "@react-router/dev/vite";
+        export default { plugins: [reactRouter(), react()] };
+      `,
+      "react-router",
+    ],
+    [
+      "multiple frameworks",
+      `
+        import react from "@vitejs/plugin-react";
+        import { reactRouter } from "@react-router/dev/vite";
+        import { vitePlugin } from "@remix-run/dev";
+        export default { plugins: [react(), reactRouter(), vitePlugin()] };
+      `,
+      "remix",
+    ],
+    [
+      "aliases around an unknown plugin",
+      `
+        import { default as enableReact } from "@vitejs/plugin-react";
+        import { reactRouter as enableRoutes } from "@react-router/dev/vite";
+        const makeUnknownPlugin = () => ({ name: "unknown" });
+        const plugins = [enableReact(), makeUnknownPlugin(), enableRoutes()];
+        export default { plugins };
+      `,
+      "react-router",
+    ],
+    [
+      "unknown plugin with generic React",
+      `
+        import react from "@vitejs/plugin-react";
+        const makeUnknownPlugin = () => ({ name: "unknown" });
+        export default { plugins: [makeUnknownPlugin(), react()] };
+      `,
+      "generic",
+    ],
+  ])(
+    "selects the registered runtime independent of plugin order — %s",
+    (_label, config, runtime) => {
+      const sourcePath = createFixture({
+        manifest: {
+          scripts: { dev: "vite" },
+          dependencies: {
+            react: "19.0.0",
+            "@react-router/dev": "7.0.0",
+            "@remix-run/dev": "2.17.0",
+            "@tanstack/react-start": "1.120.0",
+          },
+          devDependencies: { vite: "7.0.0", "@vitejs/plugin-react": "5.0.0" },
+        },
+        files: { "vite.config.ts": config },
+      });
+
+      expect(probeFastRefreshFileStatus(sourcePath)).toEqual({ isActive: true, runtime });
+    },
+  );
+
   it("resolves an unreassigned function-local plugin array in the exported config factory", () => {
     const sourcePath = createFixture({
       manifest: viteManifest({ dev: "vite --host localhost" }),

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-fast-refresh-file-status.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-fast-refresh-file-status.test.ts
@@ -188,6 +188,92 @@ describe("probeFastRefreshFileStatus", () => {
     expect(probeFastRefreshFileStatus(sourcePath).isActive).toBe(false);
   });
 
+  it.each([
+    ["inline CommonJS config", "module.exports = { reactOptions: { fastRefresh: true } };"],
+    [
+      "aliased TypeScript config",
+      "const fastRefresh = true; const reactOptions = { fastRefresh }; const config = { reactOptions }; export default config;",
+    ],
+  ])("recognizes explicitly enabled Storybook Webpack Fast Refresh — %s", (_label, config) => {
+    const sourcePath = createFixture({
+      manifest: {
+        scripts: { storybook: "start-storybook -p 6006" },
+        dependencies: { react: "18.0.0" },
+        devDependencies: { "@storybook/react": "6.5.14" },
+      },
+      files: { ".storybook/main.ts": config },
+    });
+
+    expect(probeFastRefreshFileStatus(sourcePath).isActive).toBe(true);
+  });
+
+  it.each([
+    ["disabled", "module.exports = { reactOptions: { fastRefresh: false } };", "6.5.14"],
+    [
+      "overridden by a later property",
+      "module.exports = { reactOptions: { fastRefresh: true, fastRefresh: false } };",
+      "6.5.14",
+    ],
+    [
+      "overridden by a later spread",
+      "const overrides = {}; module.exports = { reactOptions: { fastRefresh: true, ...overrides } };",
+      "6.5.14",
+    ],
+    [
+      "unexported decoy",
+      "const unused = { reactOptions: { fastRefresh: true } }; module.exports = { reactOptions: { fastRefresh: false } };",
+      "6.5.14",
+    ],
+    [
+      "reassigned alias",
+      "let enabled = true; enabled = false; module.exports = { reactOptions: { fastRefresh: enabled } };",
+      "6.5.14",
+    ],
+    ["string value", 'module.exports = { reactOptions: { fastRefresh: "true" } };', "6.5.14"],
+    ["unsupported version", "module.exports = { reactOptions: { fastRefresh: true } };", "6.0.28"],
+  ])("rejects unproven Storybook Webpack Fast Refresh — %s", (_label, config, storybookVersion) => {
+    const sourcePath = createFixture({
+      manifest: {
+        scripts: { storybook: "start-storybook -p 6006" },
+        dependencies: { react: "18.0.0" },
+        devDependencies: { "@storybook/react": storybookVersion },
+      },
+      files: { ".storybook/main.js": config },
+    });
+
+    expect(probeFastRefreshFileStatus(sourcePath).isActive).toBe(false);
+  });
+
+  it("rejects an explicit Storybook Webpack option without an owned development command", () => {
+    const sourcePath = createFixture({
+      manifest: {
+        scripts: { build: "build-storybook" },
+        dependencies: { react: "18.0.0" },
+        devDependencies: { "@storybook/react": "6.5.14" },
+      },
+      files: { ".storybook/main.js": "module.exports = { reactOptions: { fastRefresh: true } };" },
+    });
+
+    expect(probeFastRefreshFileStatus(sourcePath).isActive).toBe(false);
+  });
+
+  it("rejects Storybook Webpack when Fast Refresh is not explicitly enabled", () => {
+    const sourcePath = createFixture({
+      manifest: {
+        scripts: { storybook: "start-storybook -p 6006" },
+        dependencies: { react: "18.0.0" },
+        devDependencies: {
+          "@storybook/react": "6.5.14",
+          "@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
+          "react-refresh": "0.14.0",
+        },
+      },
+      files: { ".storybook/main.js": "module.exports = { stories: ['../src/**/*.stories.tsx'] };" },
+    });
+
+    expect(probeFastRefreshFileStatus(sourcePath).isActive).toBe(false);
+  });
+
   it("recognizes the Rozenite wrapper only when its development config registers it", () => {
     const activeSourcePath = createFixture({
       manifest: {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-fast-refresh-file-status.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-fast-refresh-file-status.ts
@@ -14,6 +14,7 @@ import { getImportedName } from "./get-imported-name.js";
 import { isFunctionLike } from "./is-function-like.js";
 import { isNodeOfType } from "./is-node-of-type.js";
 import { parseSourceFile } from "./parse-source-file.js";
+import { readStaticBoolean } from "./read-static-boolean.js";
 import {
   findNearestPackageDirectory,
   readPackageManifest,
@@ -21,6 +22,7 @@ import {
 } from "./read-nearest-package-manifest.js";
 import type { PackageManifest } from "./read-nearest-package-manifest.js";
 import type { RuleContext } from "./rule-context.js";
+import { stripParenExpression } from "./strip-paren-expression.js";
 import { walkAst } from "./walk-ast.js";
 
 export interface FastRefreshFileStatus {
@@ -501,12 +503,107 @@ const hasStorybookReactViteConfig = (packageDirectory: string): boolean => {
   return false;
 };
 
+const resolveDirectUnreassignedValue = (
+  value: Parameters<typeof walkAst>[0],
+  scopes: ScopeAnalysis,
+  visitedSymbolIds = new Set<number>(),
+): Parameters<typeof walkAst>[0] => {
+  const unwrappedValue = stripParenExpression(value);
+  if (!isNodeOfType(unwrappedValue, "Identifier")) return unwrappedValue;
+  const symbol = scopes.symbolFor(unwrappedValue);
+  if (!symbol || visitedSymbolIds.has(symbol.id)) return unwrappedValue;
+  const initializer = getDirectUnreassignedInitializer(symbol);
+  if (!initializer) return unwrappedValue;
+  visitedSymbolIds.add(symbol.id);
+  return resolveDirectUnreassignedValue(initializer, scopes, visitedSymbolIds);
+};
+
+const isStaticPropertyNamed = (
+  node: Parameters<typeof walkAst>[0],
+  propertyName: string,
+): boolean =>
+  isNodeOfType(node, "Property") &&
+  ((!node.computed && isNodeOfType(node.key, "Identifier") && node.key.name === propertyName) ||
+    (isNodeOfType(node.key, "Literal") && node.key.value === propertyName));
+
+const readLastStaticBooleanProperty = (
+  value: Parameters<typeof walkAst>[0],
+  propertyName: string,
+  scopes: ScopeAnalysis,
+): boolean | null => {
+  const resolvedValue = resolveDirectUnreassignedValue(value, scopes);
+  if (!isNodeOfType(resolvedValue, "ObjectExpression")) return null;
+  let propertyValue: boolean | null = null;
+  for (const property of resolvedValue.properties) {
+    if (isNodeOfType(property, "SpreadElement")) {
+      propertyValue = null;
+      continue;
+    }
+    if (!isStaticPropertyNamed(property, propertyName) || !isNodeOfType(property, "Property")) {
+      continue;
+    }
+    const resolvedPropertyValue = resolveDirectUnreassignedValue(property.value, scopes);
+    propertyValue = readStaticBoolean(resolvedPropertyValue);
+  }
+  return propertyValue;
+};
+
+const isLastStaticPropertyInObject = (
+  property: Parameters<typeof walkAst>[0],
+  propertyName: string,
+): boolean => {
+  if (!isNodeOfType(property.parent, "ObjectExpression")) return false;
+  const propertyIndex = property.parent.properties.findIndex(
+    (objectProperty) => objectProperty === property,
+  );
+  return property.parent.properties.slice(propertyIndex + 1).every((laterProperty) => {
+    if (isNodeOfType(laterProperty, "SpreadElement")) return false;
+    return !isStaticPropertyNamed(laterProperty, propertyName);
+  });
+};
+
+const hasStorybookReactWebpackFastRefreshConfig = (packageDirectory: string): boolean => {
+  for (const configFilename of ["main.ts", "main.js", "main.mjs", "main.cjs"]) {
+    const program = parseSourceFile(path.join(packageDirectory, ".storybook", configFilename));
+    if (!program) continue;
+    const scopes = analyzeScopes(program);
+    const exportedBindings = getExportedBindings(program, scopes);
+    let hasFastRefresh = false;
+    walkAst(program, (node) => {
+      if (!isStaticPropertyNamed(node, "reactOptions") || !isNodeOfType(node, "Property")) return;
+      if (!isExportedConfigProperty(node, exportedBindings, scopes)) return;
+      if (!isLastStaticPropertyInObject(node, "reactOptions")) return;
+      if (readLastStaticBooleanProperty(node.value, "fastRefresh", scopes) === true) {
+        hasFastRefresh = true;
+        return false;
+      }
+    });
+    if (hasFastRefresh) return true;
+  }
+  return false;
+};
+
 const hasStorybookReactViteIntegration = (
   packageDirectory: string,
   manifest: PackageManifest,
 ): boolean =>
   hasOwnedDevelopmentCommand(manifest, /(?:^|\s)(?:storybook\s+dev|start-storybook)(?:\s|$)/) &&
   hasStorybookReactViteConfig(packageDirectory);
+
+const hasStorybookReactWebpackFastRefreshIntegration = (
+  packageDirectory: string,
+  manifest: PackageManifest,
+): boolean => {
+  const developmentCommandPattern = /(?:^|\s)(?:storybook\s+dev|start-storybook)(?:\s|$)/;
+  if (!hasOwnedDevelopmentCommand(manifest, developmentCommandPattern)) return false;
+  const storybookReactVersion =
+    getOwnedDependencyVersion(manifest, "@storybook/react", developmentCommandPattern) ??
+    getOwnedDependencyVersion(manifest, "@storybook/react-webpack5", developmentCommandPattern);
+  return (
+    isVersionAtLeast(storybookReactVersion, MINIMUM_FAST_REFRESH_VERSIONS.storybookReact) &&
+    hasStorybookReactWebpackFastRefreshConfig(packageDirectory)
+  );
+};
 
 const hasNxStorybookReactViteIntegration = (packageDirectory: string): boolean => {
   if (!hasStorybookReactViteConfig(packageDirectory)) return false;
@@ -532,7 +629,8 @@ const getLocalFastRefreshStatus = (
   const status =
     getBuiltInStatus(manifest) ??
     (hasStorybookReactViteIntegration(packageDirectory, manifest) ||
-    hasNxStorybookReactViteIntegration(packageDirectory)
+    hasNxStorybookReactViteIntegration(packageDirectory) ||
+    hasStorybookReactWebpackFastRefreshIntegration(packageDirectory, manifest)
       ? { isActive: true, runtime: "generic" }
       : null) ??
     getRegisteredIntegration(packageDirectory, manifest) ??

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-fast-refresh-file-status.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-fast-refresh-file-status.ts
@@ -106,6 +106,13 @@ const INTEGRATION_IMPORTS: ReadonlyMap<string, IntegrationImport> = new Map([
   ],
 ]);
 
+const REGISTERED_INTEGRATION_RUNTIME_PRECEDENCE: ReadonlyArray<IntegrationImport["runtime"]> = [
+  "tanstack",
+  "remix",
+  "react-router",
+  "generic",
+];
+
 const cachedLocalStatusByManifest = new WeakMap<PackageManifest, FastRefreshFileStatus>();
 const cachedWorkspaceIndexByManifest = new WeakMap<PackageManifest, WorkspaceFastRefreshIndex>();
 
@@ -474,13 +481,16 @@ const getRegisteredIntegration = (
       inspectValue(node.value);
       return false;
     });
-    const registeredIntegration = registeredIntegrations[0];
-    if (
-      registeredIntegration &&
-      (!registeredIntegration.requiresViteDevelopmentServer ||
-        hasViteDevelopmentCommand(manifest) ||
-        hasViteBrowserEntry(manifest, packageDirectory))
-    ) {
+    const hasViteDevelopmentRuntime =
+      hasViteDevelopmentCommand(manifest) || hasViteBrowserEntry(manifest, packageDirectory);
+    const registeredIntegration = REGISTERED_INTEGRATION_RUNTIME_PRECEDENCE.flatMap((runtime) =>
+      registeredIntegrations.filter(
+        (integration) =>
+          integration.runtime === runtime &&
+          (!integration.requiresViteDevelopmentServer || hasViteDevelopmentRuntime),
+      ),
+    )[0];
+    if (registeredIntegration) {
       return { isActive: true, runtime: registeredIntegration.runtime };
     }
   }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-fast-refresh-file-status.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-fast-refresh-file-status.ts
@@ -167,6 +167,16 @@ const hasParcelBrowserEntry = (manifest: PackageManifest): boolean => {
   );
 };
 
+const hasParcelDevelopmentCommand = (manifest: PackageManifest): boolean =>
+  Object.values(manifest.scripts ?? {}).some(
+    (script) =>
+      typeof script === "string" &&
+      /(?:^|[\s;&|'\\"])parcel(?=\s|$)(?!\s+(?:build|help|watch|--help|--version|-h|-V)(?:\s|$))/.test(
+        script,
+      ) &&
+      !/(?:^|\s)--no-hmr(?:\s|$)/.test(script),
+  );
+
 const hasOwnedDevelopmentCommand = (manifest: PackageManifest, commandPattern: RegExp): boolean =>
   Object.values(manifest.scripts ?? {}).some(
     (script) => typeof script === "string" && commandPattern.test(script),
@@ -220,6 +230,7 @@ const getBuiltInStatus = (manifest: PackageManifest): FastRefreshFileStatus | nu
       MINIMUM_FAST_REFRESH_VERSIONS.parcel,
     ) &&
       declaresDependency(manifest, "react") &&
+      hasParcelDevelopmentCommand(manifest) &&
       hasParcelBrowserEntry(manifest))
   ) {
     return { isActive: true, runtime: "generic" };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-fast-refresh-file-status.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-fast-refresh-file-status.ts
@@ -1,0 +1,778 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { analyzeScopes } from "../semantic/scope-analysis.js";
+import type { ScopeAnalysis, SymbolDescriptor } from "../semantic/scope-analysis.js";
+import {
+  FAST_REFRESH_CONFIG_FILENAMES,
+  MINIMUM_FAST_REFRESH_VERSIONS,
+} from "../constants/fast-refresh.js";
+import { declaresDependency } from "./classify-package-platform.js";
+import { recordExistenceProbe } from "./cross-file-probe-recorder.js";
+import { getDirectUnreassignedInitializer } from "./get-direct-unreassigned-initializer.js";
+import { getReactDoctorStringSetting } from "./get-react-doctor-setting.js";
+import { getImportedName } from "./get-imported-name.js";
+import { isFunctionLike } from "./is-function-like.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+import { parseSourceFile } from "./parse-source-file.js";
+import {
+  findNearestPackageDirectory,
+  readPackageManifest,
+  readNearestPackageManifest,
+} from "./read-nearest-package-manifest.js";
+import type { PackageManifest } from "./read-nearest-package-manifest.js";
+import type { RuleContext } from "./rule-context.js";
+import { walkAst } from "./walk-ast.js";
+
+export interface FastRefreshFileStatus {
+  isActive: boolean;
+  runtime: "expo" | "generic" | "next" | "react-router" | "remix" | "tanstack";
+}
+
+interface ParsedVersion {
+  major: number;
+  minor: number;
+}
+
+interface MinimumVersion {
+  major: number;
+  minor: number;
+}
+
+interface IntegrationImport {
+  importedNames: ReadonlySet<string> | null;
+  requiresViteDevelopmentServer?: boolean;
+  runtime: FastRefreshFileStatus["runtime"];
+}
+
+interface WorkspacePackage {
+  directory: string;
+  manifest: PackageManifest;
+  status: FastRefreshFileStatus;
+}
+
+interface WorkspaceFastRefreshIndex {
+  aliasOwners: ReadonlyArray<{
+    rootDirectory: string;
+    status: FastRefreshFileStatus;
+  }>;
+  sourceEntryOwners: ReadonlyMap<string, FastRefreshFileStatus>;
+}
+
+const INTEGRATION_IMPORTS: ReadonlyMap<string, IntegrationImport> = new Map([
+  [
+    "@vitejs/plugin-react",
+    { importedNames: null, requiresViteDevelopmentServer: true, runtime: "generic" },
+  ],
+  [
+    "@vitejs/plugin-react-swc",
+    { importedNames: null, requiresViteDevelopmentServer: true, runtime: "generic" },
+  ],
+  ["@pmmmwh/react-refresh-webpack-plugin", { importedNames: null, runtime: "generic" }],
+  [
+    "@react-router/dev/vite",
+    {
+      importedNames: new Set(["reactRouter"]),
+      requiresViteDevelopmentServer: true,
+      runtime: "react-router",
+    },
+  ],
+  [
+    "@remix-run/dev",
+    {
+      importedNames: new Set(["vitePlugin"]),
+      requiresViteDevelopmentServer: true,
+      runtime: "remix",
+    },
+  ],
+  ["@rsbuild/plugin-react", { importedNames: new Set(["pluginReact"]), runtime: "generic" }],
+  ["@rspack/plugin-react-refresh", { importedNames: null, runtime: "generic" }],
+  [
+    "@rozenite/vite-plugin",
+    {
+      importedNames: new Set(["rozenitePlugin"]),
+      requiresViteDevelopmentServer: true,
+      runtime: "generic",
+    },
+  ],
+  [
+    "@tanstack/react-start/plugin/vite",
+    {
+      importedNames: new Set(["tanstackStart"]),
+      requiresViteDevelopmentServer: true,
+      runtime: "tanstack",
+    },
+  ],
+]);
+
+const cachedLocalStatusByManifest = new WeakMap<PackageManifest, FastRefreshFileStatus>();
+const cachedWorkspaceIndexByManifest = new WeakMap<PackageManifest, WorkspaceFastRefreshIndex>();
+
+const INACTIVE_STATUS: FastRefreshFileStatus = { isActive: false, runtime: "generic" };
+const WORKSPACE_IGNORED_DIRECTORY_NAMES: ReadonlySet<string> = new Set([
+  ".git",
+  ".next",
+  "build",
+  "coverage",
+  "dist",
+  "node_modules",
+  "out",
+]);
+
+const parseVersion = (version: unknown): ParsedVersion | null => {
+  if (typeof version !== "string") return null;
+  const match = version.match(/(?:^|[^\d])(\d+)(?:\.(\d+))?/);
+  if (!match) return null;
+  return { major: Number(match[1]), minor: Number(match[2] ?? 0) };
+};
+
+const isVersionAtLeast = (version: unknown, minimum: MinimumVersion): boolean => {
+  const parsed = parseVersion(version);
+  if (!parsed) return false;
+  return (
+    parsed.major > minimum.major ||
+    (parsed.major === minimum.major && parsed.minor >= minimum.minor)
+  );
+};
+
+const getDependencyVersion = (manifest: PackageManifest, dependencyName: string): unknown =>
+  manifest.dependencies?.[dependencyName] ??
+  manifest.devDependencies?.[dependencyName] ??
+  manifest.peerDependencies?.[dependencyName] ??
+  manifest.optionalDependencies?.[dependencyName];
+
+const getRuntimeDependencyVersion = (manifest: PackageManifest, dependencyName: string): unknown =>
+  manifest.dependencies?.[dependencyName] ?? manifest.optionalDependencies?.[dependencyName];
+
+const getOwnedDependencyVersion = (
+  manifest: PackageManifest,
+  dependencyName: string,
+  developmentCommandPattern: RegExp,
+): unknown => {
+  const runtimeVersion = getRuntimeDependencyVersion(manifest, dependencyName);
+  if (runtimeVersion !== undefined) return runtimeVersion;
+  const hasDevelopmentCommand = Object.values(manifest.scripts ?? {}).some(
+    (script) => typeof script === "string" && developmentCommandPattern.test(script),
+  );
+  return hasDevelopmentCommand ? manifest.devDependencies?.[dependencyName] : undefined;
+};
+
+const hasParcelBrowserEntry = (manifest: PackageManifest): boolean => {
+  if (typeof manifest.source === "string" && manifest.source.endsWith(".html")) return true;
+  return Object.values(manifest.scripts ?? {}).some(
+    (script) =>
+      typeof script === "string" &&
+      /(?:^|\s)parcel(?:\s+serve)?\s+[^\n]*\.html(?:\s|$)/.test(script),
+  );
+};
+
+const hasOwnedDevelopmentCommand = (manifest: PackageManifest, commandPattern: RegExp): boolean =>
+  Object.values(manifest.scripts ?? {}).some(
+    (script) => typeof script === "string" && commandPattern.test(script),
+  );
+
+const hasViteDevelopmentCommand = (manifest: PackageManifest): boolean =>
+  Object.values(manifest.scripts ?? {}).some((script) => {
+    if (typeof script !== "string") return false;
+    const commandMatches = script.matchAll(/(?:^|[\s;&|'\\"])vite(?:\s+(build|preview|test)\b)?/g);
+    return [...commandMatches].some((match) => match[1] === undefined);
+  });
+
+const hasViteBrowserEntry = (manifest: PackageManifest, packageDirectory: string): boolean => {
+  if (typeof manifest.source === "string" && manifest.source.endsWith(".html")) return true;
+  const browserEntryPath = path.join(packageDirectory, "index.html");
+  recordExistenceProbe(browserEntryPath);
+  return fs.existsSync(browserEntryPath);
+};
+
+const getBuiltInStatus = (manifest: PackageManifest): FastRefreshFileStatus | null => {
+  if (
+    isVersionAtLeast(
+      getOwnedDependencyVersion(manifest, "next", /(?:^|\s)next\s+dev(?:\s|$)/),
+      MINIMUM_FAST_REFRESH_VERSIONS.next,
+    )
+  ) {
+    return { isActive: true, runtime: "next" };
+  }
+  const gatsbyDependency = getOwnedDependencyVersion(
+    manifest,
+    "gatsby",
+    /(?:^|\s)gatsby\s+develop(?:\s|$)/,
+  );
+  const gatsbyVersion = parseVersion(gatsbyDependency);
+  const hasGatsbyFastRefresh =
+    gatsbyVersion !== null &&
+    (gatsbyVersion.major >= 3 ||
+      (isVersionAtLeast(gatsbyDependency, MINIMUM_FAST_REFRESH_VERSIONS.gatsby) &&
+        isVersionAtLeast(
+          getDependencyVersion(manifest, "react"),
+          MINIMUM_FAST_REFRESH_VERSIONS.reactForGatsbyTwo,
+        )));
+  if (
+    isVersionAtLeast(
+      getOwnedDependencyVersion(manifest, "react-scripts", /(?:^|\s)react-scripts\s+start(?:\s|$)/),
+      MINIMUM_FAST_REFRESH_VERSIONS.reactScripts,
+    ) ||
+    hasGatsbyFastRefresh ||
+    (isVersionAtLeast(
+      getDependencyVersion(manifest, "parcel"),
+      MINIMUM_FAST_REFRESH_VERSIONS.parcel,
+    ) &&
+      declaresDependency(manifest, "react") &&
+      hasParcelBrowserEntry(manifest))
+  ) {
+    return { isActive: true, runtime: "generic" };
+  }
+  if (
+    isVersionAtLeast(
+      getOwnedDependencyVersion(manifest, "expo", /(?:^|\s)expo\s+start(?:\s|$)/),
+      MINIMUM_FAST_REFRESH_VERSIONS.expo,
+    ) ||
+    isVersionAtLeast(
+      getOwnedDependencyVersion(manifest, "react-native", /(?:^|\s)react-native\s+start(?:\s|$)/),
+      MINIMUM_FAST_REFRESH_VERSIONS.reactNative,
+    )
+  ) {
+    return { isActive: true, runtime: "expo" };
+  }
+  if (
+    isVersionAtLeast(
+      getOwnedDependencyVersion(manifest, "dumi", /(?:^|\s)dumi\s+dev(?:\s|$)/),
+      MINIMUM_FAST_REFRESH_VERSIONS.dumi,
+    )
+  ) {
+    return { isActive: true, runtime: "generic" };
+  }
+  return null;
+};
+
+const getIntegrationLocalNames = (
+  program: Parameters<typeof walkAst>[0],
+  scopes: ScopeAnalysis,
+): ReadonlyMap<SymbolDescriptor, IntegrationImport> => {
+  const localBindings = new Map<SymbolDescriptor, IntegrationImport>();
+  const registerLocalName = (
+    source: string,
+    importedName: string | null,
+    localIdentifier: Parameters<typeof walkAst>[0],
+  ): void => {
+    const integration = INTEGRATION_IMPORTS.get(source);
+    if (!integration) return;
+    if (
+      integration.importedNames === null
+        ? importedName === null || importedName === "default"
+        : importedName !== null && integration.importedNames.has(importedName)
+    ) {
+      const symbol = scopes.symbolFor(localIdentifier);
+      if (symbol) localBindings.set(symbol, integration);
+    }
+  };
+  walkAst(program, (node) => {
+    if (isNodeOfType(node, "ImportDeclaration")) {
+      const source = node.source.value;
+      if (typeof source !== "string") return;
+      for (const specifier of node.specifiers) {
+        if (
+          isNodeOfType(specifier, "ImportDefaultSpecifier") ||
+          isNodeOfType(specifier, "ImportNamespaceSpecifier")
+        ) {
+          registerLocalName(source, null, specifier.local);
+          continue;
+        }
+        registerLocalName(source, getImportedName(specifier) ?? null, specifier.local);
+      }
+      return;
+    }
+    if (!isNodeOfType(node, "VariableDeclarator") || !node.init) return;
+    const initializer = node.init;
+    if (
+      !isNodeOfType(initializer, "CallExpression") ||
+      !isNodeOfType(initializer.callee, "Identifier") ||
+      initializer.callee.name !== "require"
+    ) {
+      return;
+    }
+    const sourceArgument = initializer.arguments[0];
+    if (!sourceArgument || !isNodeOfType(sourceArgument, "Literal")) return;
+    const source = sourceArgument.value;
+    if (typeof source !== "string") return;
+    if (isNodeOfType(node.id, "Identifier")) {
+      registerLocalName(source, null, node.id);
+      return;
+    }
+    if (!isNodeOfType(node.id, "ObjectPattern")) return;
+    for (const property of node.id.properties) {
+      if (!isNodeOfType(property, "Property") || !isNodeOfType(property.value, "Identifier")) {
+        continue;
+      }
+      const importedName = isNodeOfType(property.key, "Identifier")
+        ? property.key.name
+        : isNodeOfType(property.key, "Literal") && typeof property.key.value === "string"
+          ? property.key.value
+          : null;
+      registerLocalName(source, importedName, property.value);
+    }
+  });
+  return localBindings;
+};
+
+const isModuleExportsAssignment = (node: Parameters<typeof walkAst>[0]): boolean =>
+  isNodeOfType(node, "AssignmentExpression") &&
+  isNodeOfType(node.left, "MemberExpression") &&
+  isNodeOfType(node.left.object, "Identifier") &&
+  node.left.object.name === "module" &&
+  isNodeOfType(node.left.property, "Identifier") &&
+  node.left.property.name === "exports";
+
+const getExportedBindings = (
+  program: Parameters<typeof walkAst>[0],
+  scopes: ScopeAnalysis,
+): ReadonlySet<SymbolDescriptor> => {
+  const exportedBindings = new Set<SymbolDescriptor>();
+  walkAst(program, (node) => {
+    let exportRoot: Parameters<typeof walkAst>[0] | null = null;
+    if (isNodeOfType(node, "ExportDefaultDeclaration")) {
+      exportRoot = node.declaration;
+    } else if (isNodeOfType(node, "AssignmentExpression") && isModuleExportsAssignment(node)) {
+      exportRoot = node.right;
+    }
+    if (!exportRoot) return;
+    if (isFunctionLike(exportRoot) || isNodeOfType(exportRoot, "ObjectExpression")) return;
+    walkAst(exportRoot, (exportNode) => {
+      if (isFunctionLike(exportNode) || isNodeOfType(exportNode, "ObjectExpression")) return false;
+      if (!isNodeOfType(exportNode, "Identifier")) return;
+      const symbol = scopes.symbolFor(exportNode);
+      if (symbol) exportedBindings.add(symbol);
+    });
+  });
+  return exportedBindings;
+};
+
+const isExportedConfigProperty = (
+  property: Parameters<typeof walkAst>[0],
+  exportedBindings: ReadonlySet<SymbolDescriptor>,
+  scopes: ScopeAnalysis,
+): boolean => {
+  let ancestor = property.parent;
+  let didFindContainingObject = false;
+  let didCrossNestedProperty = false;
+  let didCrossFunctionBoundary = false;
+  let containingFunction: Parameters<typeof walkAst>[0] | null = null;
+  let containingReturn: Parameters<typeof walkAst>[0] | null = null;
+  while (ancestor) {
+    if (isNodeOfType(ancestor, "ObjectExpression") && !didFindContainingObject) {
+      didFindContainingObject = true;
+    } else if (didFindContainingObject && isNodeOfType(ancestor, "Property")) {
+      didCrossNestedProperty = true;
+    }
+    if (!containingReturn && isNodeOfType(ancestor, "ReturnStatement")) {
+      containingReturn = ancestor;
+    }
+    if (isFunctionLike(ancestor)) {
+      if (containingFunction) didCrossFunctionBoundary = true;
+      else containingFunction = ancestor;
+    }
+    if (isNodeOfType(ancestor, "ExportDefaultDeclaration") || isModuleExportsAssignment(ancestor)) {
+      return (
+        !didCrossNestedProperty &&
+        !didCrossFunctionBoundary &&
+        (!containingFunction ||
+          Boolean(containingReturn) ||
+          !isNodeOfType(containingFunction.body, "BlockStatement"))
+      );
+    }
+    if (isNodeOfType(ancestor, "VariableDeclarator") && isNodeOfType(ancestor.id, "Identifier")) {
+      const binding = scopes.symbolFor(ancestor.id);
+      if (binding && exportedBindings.has(binding)) {
+        return !didCrossNestedProperty && !containingFunction;
+      }
+    }
+    ancestor = ancestor.parent;
+  }
+  return false;
+};
+
+const getExplicitConfigPaths = (
+  packageDirectory: string,
+  manifest: PackageManifest,
+): ReadonlyArray<string> => {
+  const configPaths = new Set(
+    FAST_REFRESH_CONFIG_FILENAMES.map((configFilename) =>
+      path.join(packageDirectory, configFilename),
+    ),
+  );
+  for (const script of Object.values(manifest.scripts ?? {})) {
+    if (typeof script !== "string") continue;
+    for (const match of script.matchAll(
+      /(?:^|\s)--config(?:=|\s+)(?:"([^"]+)"|'([^']+)'|([^\s;&|]+))/g,
+    )) {
+      const relativeConfigPath = match[1] ?? match[2] ?? match[3];
+      if (!relativeConfigPath) continue;
+      const configPath = path.resolve(packageDirectory, relativeConfigPath);
+      const relativePath = path.relative(packageDirectory, configPath);
+      if (relativePath.startsWith("..") || path.isAbsolute(relativePath)) continue;
+      configPaths.add(configPath);
+    }
+  }
+  return [...configPaths];
+};
+
+const getRegisteredIntegration = (
+  packageDirectory: string,
+  manifest: PackageManifest,
+): FastRefreshFileStatus | null => {
+  for (const configPath of getExplicitConfigPaths(packageDirectory, manifest)) {
+    const program = parseSourceFile(configPath);
+    if (!program) continue;
+    const scopes = analyzeScopes(program);
+    const integrationLocalBindings = getIntegrationLocalNames(program, scopes);
+    if (integrationLocalBindings.size === 0) continue;
+    const exportedBindings = getExportedBindings(program, scopes);
+    const registeredIntegrations: IntegrationImport[] = [];
+    walkAst(program, (node) => {
+      if (!isNodeOfType(node, "Property")) return;
+      const isPluginsProperty =
+        (isNodeOfType(node.key, "Identifier") && node.key.name === "plugins") ||
+        (isNodeOfType(node.key, "Literal") && node.key.value === "plugins");
+      if (!isPluginsProperty) return;
+      if (!isExportedConfigProperty(node, exportedBindings, scopes)) return;
+      const inspectedBindings = new Set<number>();
+      const inspectValue = (value: Parameters<typeof walkAst>[0]): void => {
+        walkAst(value, (valueNode) => {
+          if (isNodeOfType(valueNode, "Identifier")) {
+            const symbol = scopes.symbolFor(valueNode);
+            const initializer = symbol ? getDirectUnreassignedInitializer(symbol) : null;
+            if (symbol && initializer && !inspectedBindings.has(symbol.id)) {
+              inspectedBindings.add(symbol.id);
+              inspectValue(initializer);
+            }
+          }
+          if (
+            !isNodeOfType(valueNode, "CallExpression") &&
+            !isNodeOfType(valueNode, "NewExpression")
+          ) {
+            return;
+          }
+          if (!isNodeOfType(valueNode.callee, "Identifier")) return;
+          const symbol = scopes.symbolFor(valueNode.callee);
+          const integration = symbol ? integrationLocalBindings.get(symbol) : null;
+          if (integration) registeredIntegrations.push(integration);
+        });
+      };
+      inspectValue(node.value);
+      return false;
+    });
+    const registeredIntegration = registeredIntegrations[0];
+    if (
+      registeredIntegration &&
+      (!registeredIntegration.requiresViteDevelopmentServer ||
+        hasViteDevelopmentCommand(manifest) ||
+        hasViteBrowserEntry(manifest, packageDirectory))
+    ) {
+      return { isActive: true, runtime: registeredIntegration.runtime };
+    }
+  }
+  return null;
+};
+
+const hasStorybookReactViteConfig = (packageDirectory: string): boolean => {
+  for (const configFilename of ["main.ts", "main.js", "main.mjs", "main.cjs"]) {
+    const program = parseSourceFile(path.join(packageDirectory, ".storybook", configFilename));
+    if (!program) continue;
+    const scopes = analyzeScopes(program);
+    const exportedBindings = getExportedBindings(program, scopes);
+    let hasReactViteFramework = false;
+    walkAst(program, (node) => {
+      if (!isNodeOfType(node, "Property")) return;
+      const isFrameworkProperty =
+        (isNodeOfType(node.key, "Identifier") && node.key.name === "framework") ||
+        (isNodeOfType(node.key, "Literal") && node.key.value === "framework");
+      if (!isFrameworkProperty) return;
+      if (!isExportedConfigProperty(node, exportedBindings, scopes)) return;
+      walkAst(node.value, (valueNode) => {
+        if (isNodeOfType(valueNode, "Literal") && valueNode.value === "@storybook/react-vite") {
+          hasReactViteFramework = true;
+          return false;
+        }
+      });
+      if (hasReactViteFramework) return false;
+    });
+    if (hasReactViteFramework) return true;
+  }
+  return false;
+};
+
+const hasStorybookReactViteIntegration = (
+  packageDirectory: string,
+  manifest: PackageManifest,
+): boolean =>
+  hasOwnedDevelopmentCommand(manifest, /(?:^|\s)(?:storybook\s+dev|start-storybook)(?:\s|$)/) &&
+  hasStorybookReactViteConfig(packageDirectory);
+
+const hasNxStorybookReactViteIntegration = (packageDirectory: string): boolean => {
+  if (!hasStorybookReactViteConfig(packageDirectory)) return false;
+  try {
+    const project: unknown = JSON.parse(
+      fs.readFileSync(path.join(packageDirectory, "project.json"), "utf8"),
+    );
+    if (typeof project !== "object" || project === null) return false;
+    const targets = Reflect.get(project, "targets");
+    if (typeof targets !== "object" || targets === null) return false;
+    return Object.keys(targets).some((targetName) => targetName === "storybook:serve:dev");
+  } catch {
+    return false;
+  }
+};
+
+const getLocalFastRefreshStatus = (
+  packageDirectory: string,
+  manifest: PackageManifest,
+): FastRefreshFileStatus => {
+  const cachedStatus = cachedLocalStatusByManifest.get(manifest);
+  if (cachedStatus) return cachedStatus;
+  const status =
+    getBuiltInStatus(manifest) ??
+    (hasStorybookReactViteIntegration(packageDirectory, manifest) ||
+    hasNxStorybookReactViteIntegration(packageDirectory)
+      ? { isActive: true, runtime: "generic" }
+      : null) ??
+    getRegisteredIntegration(packageDirectory, manifest) ??
+    INACTIVE_STATUS;
+  cachedLocalStatusByManifest.set(manifest, status);
+  return status;
+};
+
+const isWorkspaceRoot = (directory: string, manifest: PackageManifest | null): boolean => {
+  if (manifest?.workspaces !== undefined) return true;
+  return ["pnpm-workspace.yaml", "pnpm-workspace.yml", "nx.json"].some((filename) =>
+    fs.existsSync(path.join(directory, filename)),
+  );
+};
+
+const findWorkspaceRoot = (packageDirectory: string): string | null => {
+  let currentDirectory = packageDirectory;
+  let workspaceRoot: string | null = null;
+  while (true) {
+    const manifest = readPackageManifest(currentDirectory);
+    if (isWorkspaceRoot(currentDirectory, manifest)) workspaceRoot = currentDirectory;
+    const parentDirectory = path.dirname(currentDirectory);
+    if (parentDirectory === currentDirectory) return workspaceRoot;
+    currentDirectory = parentDirectory;
+  }
+};
+
+const collectWorkspacePackages = (workspaceRoot: string): WorkspacePackage[] => {
+  const packages: WorkspacePackage[] = [];
+  const pendingDirectories = [workspaceRoot];
+  while (pendingDirectories.length > 0) {
+    const directory = pendingDirectories.pop();
+    if (!directory) continue;
+    const manifest = readPackageManifest(directory);
+    if (manifest) {
+      packages.push({
+        directory,
+        manifest,
+        status: getLocalFastRefreshStatus(directory, manifest),
+      });
+    }
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(directory, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      if (entry.name.startsWith(".") || WORKSPACE_IGNORED_DIRECTORY_NAMES.has(entry.name)) {
+        continue;
+      }
+      pendingDirectories.push(path.join(directory, entry.name));
+    }
+  }
+  return packages;
+};
+
+const isPropertyNamed = (node: Parameters<typeof walkAst>[0], name: string): boolean =>
+  isNodeOfType(node, "Property") &&
+  ((isNodeOfType(node.key, "Identifier") && node.key.name === name) ||
+    (isNodeOfType(node.key, "Literal") && node.key.value === name));
+
+const normalizeAliasRoot = (configDirectory: string, aliasPath: string): string | null => {
+  if (!aliasPath.startsWith(".") && !path.isAbsolute(aliasPath)) return null;
+  const withoutPlaceholder = aliasPath.replace(/(?:\/)?(?:\*|\$\d+).*$/, "");
+  return path.resolve(configDirectory, withoutPlaceholder);
+};
+
+const collectAliasRootsFromValue = (
+  value: Parameters<typeof walkAst>[0],
+  configDirectory: string,
+  aliasRoots: Set<string>,
+): void => {
+  walkAst(value, (node) => {
+    if (!isPropertyNamed(node, "alias")) return;
+    if (!isNodeOfType(node, "Property")) return;
+    walkAst(node.value, (aliasNode) => {
+      if (!isNodeOfType(aliasNode, "Literal") || typeof aliasNode.value !== "string") return;
+      const aliasRoot = normalizeAliasRoot(configDirectory, aliasNode.value);
+      if (aliasRoot) aliasRoots.add(aliasRoot);
+    });
+    return false;
+  });
+};
+
+const getActivePackageAliasRoots = (
+  packageDirectory: string,
+  manifest: PackageManifest,
+): ReadonlySet<string> => {
+  const aliasRoots = new Set<string>();
+  const configPaths = [
+    ...getExplicitConfigPaths(packageDirectory, manifest),
+    ...["main.ts", "main.js", "main.mjs", "main.cjs"].map((filename) =>
+      path.join(packageDirectory, ".storybook", filename),
+    ),
+  ];
+  for (const configPath of configPaths) {
+    const program = parseSourceFile(configPath);
+    if (!program) continue;
+    const scopes = analyzeScopes(program);
+    const exportedBindings = getExportedBindings(program, scopes);
+    walkAst(program, (node) => {
+      if (!isPropertyNamed(node, "resolve") && !isPropertyNamed(node, "viteFinal")) return;
+      if (!isNodeOfType(node, "Property")) return;
+      if (!isExportedConfigProperty(node, exportedBindings, scopes)) return;
+      collectAliasRootsFromValue(node.value, path.dirname(configPath), aliasRoots);
+      return false;
+    });
+  }
+  return aliasRoots;
+};
+
+const collectStringValues = (value: unknown, values: string[]): void => {
+  if (typeof value === "string") {
+    values.push(value);
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const entry of value) collectStringValues(entry, values);
+    return;
+  }
+  if (typeof value !== "object" || value === null) return;
+  for (const entry of Object.values(value)) collectStringValues(entry, values);
+};
+
+const hasSourceRuntimeEntry = (manifest: PackageManifest): boolean => {
+  const entryValues: string[] = [];
+  collectStringValues(manifest.exports, entryValues);
+  collectStringValues(manifest.main, entryValues);
+  collectStringValues(manifest.module, entryValues);
+  return entryValues.some((entry) => /^\.\/?src(?:\/|\.|$)/.test(entry));
+};
+
+const getWorkspaceDependencyVersion = (
+  manifest: PackageManifest,
+  dependencyName: string,
+): unknown =>
+  manifest.dependencies?.[dependencyName] ?? manifest.optionalDependencies?.[dependencyName];
+
+const buildWorkspaceFastRefreshIndex = (
+  workspaceRoot: string,
+  rootManifest: PackageManifest,
+): WorkspaceFastRefreshIndex => {
+  const cached = cachedWorkspaceIndexByManifest.get(rootManifest);
+  if (cached) return cached;
+  const workspacePackages = collectWorkspacePackages(workspaceRoot);
+  const activePackages = workspacePackages.filter(
+    (workspacePackage) => workspacePackage.status.isActive,
+  );
+  const aliasOwners: Array<{ rootDirectory: string; status: FastRefreshFileStatus }> = [];
+  for (const activePackage of activePackages) {
+    for (const rootDirectory of getActivePackageAliasRoots(
+      activePackage.directory,
+      activePackage.manifest,
+    )) {
+      aliasOwners.push({ rootDirectory, status: activePackage.status });
+    }
+  }
+  const sourceEntryOwners = new Map<string, FastRefreshFileStatus>();
+  for (const producerPackage of workspacePackages) {
+    const packageName = producerPackage.manifest.name;
+    if (typeof packageName !== "string" || !hasSourceRuntimeEntry(producerPackage.manifest)) {
+      continue;
+    }
+    const owner = activePackages.find((activePackage) => {
+      const dependencyVersion = getWorkspaceDependencyVersion(activePackage.manifest, packageName);
+      return typeof dependencyVersion === "string" && dependencyVersion.startsWith("workspace:");
+    });
+    if (owner) sourceEntryOwners.set(producerPackage.directory, owner.status);
+  }
+  const index = { aliasOwners, sourceEntryOwners };
+  cachedWorkspaceIndexByManifest.set(rootManifest, index);
+  return index;
+};
+
+const isPathInside = (filePath: string, directory: string): boolean => {
+  const relativePath = path.relative(directory, filePath);
+  return (
+    relativePath === "" ||
+    (!relativePath.startsWith(`..${path.sep}`) &&
+      relativePath !== ".." &&
+      !path.isAbsolute(relativePath))
+  );
+};
+
+const getWorkspaceOwnedStatus = (
+  filename: string,
+  packageDirectory: string,
+): FastRefreshFileStatus | null => {
+  const workspaceRoot = findWorkspaceRoot(packageDirectory);
+  if (!workspaceRoot) return null;
+  const rootManifest = readPackageManifest(workspaceRoot);
+  if (!rootManifest) return null;
+  const index = buildWorkspaceFastRefreshIndex(workspaceRoot, rootManifest);
+  const aliasOwner = index.aliasOwners.find((owner) => isPathInside(filename, owner.rootDirectory));
+  if (aliasOwner) return aliasOwner.status;
+  for (const [producerDirectory, status] of index.sourceEntryOwners) {
+    if (isPathInside(filename, producerDirectory)) return status;
+  }
+  return null;
+};
+
+const resolveFastRefreshFileStatus = (filename: string): FastRefreshFileStatus => {
+  const manifest = readNearestPackageManifest(filename);
+  if (!manifest) return INACTIVE_STATUS;
+  const packageDirectory = findNearestPackageDirectory(filename);
+  if (!packageDirectory) return INACTIVE_STATUS;
+  const localStatus = getLocalFastRefreshStatus(packageDirectory, manifest);
+  if (localStatus.isActive) return localStatus;
+  return getWorkspaceOwnedStatus(filename, packageDirectory) ?? INACTIVE_STATUS;
+};
+
+export const probeFastRefreshFileStatus = (filename: string): FastRefreshFileStatus =>
+  resolveFastRefreshFileStatus(path.resolve(filename));
+
+const getConfiguredFallbackStatus = (context: RuleContext): FastRefreshFileStatus => {
+  const framework = getReactDoctorStringSetting(context.settings, "framework");
+  const runtime =
+    framework === "nextjs"
+      ? "next"
+      : framework === "expo" || framework === "react-native"
+        ? "expo"
+        : framework === "remix"
+          ? "remix"
+          : framework === "tanstack-start"
+            ? "tanstack"
+            : "generic";
+  return { isActive: true, runtime };
+};
+
+export const getFastRefreshFileStatus = (context: RuleContext): FastRefreshFileStatus => {
+  let filename = context.filename;
+  if (!filename) return getConfiguredFallbackStatus(context);
+  if (!path.isAbsolute(filename)) {
+    const absoluteFilename = path.resolve(filename);
+    if (!fs.existsSync(absoluteFilename)) return getConfiguredFallbackStatus(context);
+    filename = absoluteFilename;
+  }
+  const manifest = readNearestPackageManifest(filename);
+  if (!manifest) return INACTIVE_STATUS;
+  return resolveFastRefreshFileStatus(filename);
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-framework-route-or-special-filename.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-framework-route-or-special-filename.test.ts
@@ -3,45 +3,41 @@ import { isFrameworkRouteOrSpecialFilename } from "./is-framework-route-or-speci
 
 describe("isFrameworkRouteOrSpecialFilename", () => {
   it.each([
-    // Next.js App + Pages Router special files and metadata image routes.
-    "app/page.tsx",
-    "app/dashboard/layout.jsx",
-    "app/global-error.tsx",
-    "app/api/route.ts",
-    "pages/_app.tsx",
-    "pages/_document.tsx",
-    "pages/_error.jsx",
-    "app/opengraph-image.tsx",
-    "app/blog/twitter-image2.tsx",
-    "app/apple-icon1.tsx",
-    // Expo Router.
-    "app/_layout.tsx",
-    "src/app/(tabs)/_layout.jsx",
-    "app/+not-found.tsx",
-    "app/+native-intent.ts",
-    // TanStack Router / Start.
-    "src/routes/__root.tsx",
-    "src/routes/posts/$postId.lazy.tsx",
-    // Remix / React Router.
-    "app/root.tsx",
-    "app/entry.client.tsx",
-    "app/entry.server.jsx",
-  ])("recognizes framework route/special file %s", (filename) => {
-    expect(isFrameworkRouteOrSpecialFilename(filename)).toBe(true);
+    ["next", "app/page.tsx"],
+    ["next", "app/dashboard/layout.jsx"],
+    ["next", "app/global-error.tsx"],
+    ["next", "app/api/route.ts"],
+    ["next", "pages/_app.tsx"],
+    ["next", "pages/_document.tsx"],
+    ["next", "pages/_error.jsx"],
+    ["next", "pages/docs/_meta.tsx"],
+    ["next", "app/opengraph-image.tsx"],
+    ["next", "app/blog/twitter-image2.tsx"],
+    ["next", "app/apple-icon1.tsx"],
+    ["expo", "app/_layout.tsx"],
+    ["expo", "src/app/(tabs)/_layout.jsx"],
+    ["expo", "app/+not-found.tsx"],
+    ["expo", "app/+native-intent.ts"],
+    ["tanstack", "src/routes/__root.tsx"],
+    ["tanstack", "src/routes/posts/$postId.lazy.tsx"],
+    ["remix", "app/root.tsx"],
+    ["react-router", "app/entry.client.tsx"],
+    ["react-router", "app/entry.server.jsx"],
+  ] as const)("recognizes %s framework route/special file %s", (runtime, filename) => {
+    expect(isFrameworkRouteOrSpecialFilename(filename, runtime)).toBe(true);
   });
 
   it.each([
-    // Ordinary component / route files with no distinctive basename keep
-    // going through the rule's AST / export-name detection.
-    "components/Page.tsx",
-    "src/layout-helpers.tsx",
-    "app/index.tsx",
-    "app/routes/about.tsx",
-    "src/components/Root.tsx",
-    "app/entry.tsx",
-    "src/lazy.tsx",
-    undefined,
-  ])("does not recognize ordinary file %s", (filename) => {
-    expect(isFrameworkRouteOrSpecialFilename(filename)).toBe(false);
+    ["generic", "app/page.tsx"],
+    ["generic", "app/_layout.tsx"],
+    ["next", "app/root.tsx"],
+    ["expo", "app/page.tsx"],
+    ["tanstack", "app/+not-found.tsx"],
+    ["react-router", "pages/_document.tsx"],
+    ["generic", "pages/docs/_meta.tsx"],
+    ["generic", "components/Page.tsx"],
+    ["generic", undefined],
+  ] as const)("does not apply %s semantics to %s", (runtime, filename) => {
+    expect(isFrameworkRouteOrSpecialFilename(filename, runtime)).toBe(false);
   });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-framework-route-or-special-filename.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-framework-route-or-special-filename.test.ts
@@ -42,6 +42,9 @@ describe("isFrameworkRouteOrSpecialFilename", () => {
     ["next", "src/components/page.tsx"],
     ["next", "src/components/opengraph-image.tsx"],
     ["next", "src/components/_app.tsx"],
+    ["expo", "src/components/_layout.tsx"],
+    ["expo", "src/components/+not-found.tsx"],
+    ["expo", "src/components/app/_layout.tsx"],
   ] as const)("does not apply %s semantics to %s", (runtime, filename) => {
     expect(
       isFrameworkRouteOrSpecialFilename({ filename: `/repo/${filename}`, settings: {} }, runtime),
@@ -56,6 +59,15 @@ describe("isFrameworkRouteOrSpecialFilename", () => {
           settings: { "react-doctor": { rootDirectory: "/app/project" } },
         },
         "next",
+      ),
+    ).toBe(false);
+    expect(
+      isFrameworkRouteOrSpecialFilename(
+        {
+          filename: "/app/project/src/components/_layout.tsx",
+          settings: { "react-doctor": { rootDirectory: "/app/project" } },
+        },
+        "expo",
       ),
     ).toBe(false);
   });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-framework-route-or-special-filename.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-framework-route-or-special-filename.test.ts
@@ -24,7 +24,9 @@ describe("isFrameworkRouteOrSpecialFilename", () => {
     ["react-router", "app/entry.client.tsx"],
     ["react-router", "app/entry.server.jsx"],
   ] as const)("recognizes %s framework route/special file %s", (runtime, filename) => {
-    expect(isFrameworkRouteOrSpecialFilename(filename, runtime)).toBe(true);
+    expect(
+      isFrameworkRouteOrSpecialFilename({ filename: `/repo/${filename}`, settings: {} }, runtime),
+    ).toBe(true);
   });
 
   it.each([
@@ -36,8 +38,29 @@ describe("isFrameworkRouteOrSpecialFilename", () => {
     ["react-router", "pages/_document.tsx"],
     ["generic", "pages/docs/_meta.tsx"],
     ["generic", "components/Page.tsx"],
-    ["generic", undefined],
+    ["next", "src/components/layout.tsx"],
+    ["next", "src/components/page.tsx"],
+    ["next", "src/components/opengraph-image.tsx"],
+    ["next", "src/components/_app.tsx"],
   ] as const)("does not apply %s semantics to %s", (runtime, filename) => {
-    expect(isFrameworkRouteOrSpecialFilename(filename, runtime)).toBe(false);
+    expect(
+      isFrameworkRouteOrSpecialFilename({ filename: `/repo/${filename}`, settings: {} }, runtime),
+    ).toBe(false);
+  });
+
+  it("does not treat a project mount point as a framework directory", () => {
+    expect(
+      isFrameworkRouteOrSpecialFilename(
+        {
+          filename: "/app/project/src/components/page.tsx",
+          settings: { "react-doctor": { rootDirectory: "/app/project" } },
+        },
+        "next",
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false without a filename", () => {
+    expect(isFrameworkRouteOrSpecialFilename({ settings: {} }, "generic")).toBe(false);
   });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-framework-route-or-special-filename.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-framework-route-or-special-filename.ts
@@ -1,9 +1,15 @@
 import * as path from "node:path";
 import { NEXTJS_SOURCE_FILE_EXTENSION_GROUP } from "../constants/nextjs.js";
+import { isInProjectDirectory } from "./is-in-project-directory.js";
 import { isNextjsMetadataImageRouteFilename } from "./is-nextjs-metadata-image-route-filename.js";
+import { normalizeFilename } from "./normalize-filename.js";
+import type { RuleContext } from "./rule-context.js";
 
-const NEXT_ROUTE_FILE_PATTERN = new RegExp(
-  `^(page|layout|loading|error|not-found|template|default|global-error|route|_app|_document|_error|_meta)\\.${NEXTJS_SOURCE_FILE_EXTENSION_GROUP}$`,
+const NEXT_APP_ROUTE_FILE_PATTERN = new RegExp(
+  `^(page|layout|loading|error|not-found|template|default|global-error|route)\\.${NEXTJS_SOURCE_FILE_EXTENSION_GROUP}$`,
+);
+const NEXT_PAGES_ROUTE_FILE_PATTERN = new RegExp(
+  `^(_app|_document|_error|_meta)\\.${NEXTJS_SOURCE_FILE_EXTENSION_GROUP}$`,
 );
 const EXPO_ROUTE_FILE_PATTERN = new RegExp(
   `^(_layout|\\+html|\\+not-found|\\+native-intent)\\.${NEXTJS_SOURCE_FILE_EXTENSION_GROUP}$`,
@@ -15,15 +21,29 @@ const REACT_ROUTER_FILE_PATTERN = new RegExp(
   `^(root|entry\\.client|entry\\.server)\\.${NEXTJS_SOURCE_FILE_EXTENSION_GROUP}$`,
 );
 
+const isInNextDirectory = (
+  context: Pick<RuleContext, "filename" | "settings">,
+  directoryPath: "app" | "pages",
+): boolean => {
+  if (isInProjectDirectory(context, directoryPath)) return true;
+  const filename = normalizeFilename(context.filename ?? "");
+  if (path.isAbsolute(filename)) return false;
+  return filename.startsWith(`${directoryPath}/`) || filename.includes(`/${directoryPath}/`);
+};
+
 export const isFrameworkRouteOrSpecialFilename = (
-  rawFilename: string | undefined,
+  context: Pick<RuleContext, "filename" | "settings">,
   runtime: "expo" | "generic" | "next" | "react-router" | "remix" | "tanstack",
 ): boolean => {
+  const rawFilename = context.filename;
   if (!rawFilename) return false;
   const basename = path.basename(rawFilename);
   if (runtime === "next") {
     return (
-      isNextjsMetadataImageRouteFilename(rawFilename) || NEXT_ROUTE_FILE_PATTERN.test(basename)
+      (isInNextDirectory(context, "app") &&
+        (isNextjsMetadataImageRouteFilename(rawFilename) ||
+          NEXT_APP_ROUTE_FILE_PATTERN.test(basename))) ||
+      (isInNextDirectory(context, "pages") && NEXT_PAGES_ROUTE_FILE_PATTERN.test(basename))
     );
   }
   if (runtime === "expo") return EXPO_ROUTE_FILE_PATTERN.test(basename);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-framework-route-or-special-filename.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-framework-route-or-special-filename.ts
@@ -2,32 +2,34 @@ import * as path from "node:path";
 import { NEXTJS_SOURCE_FILE_EXTENSION_GROUP } from "../constants/nextjs.js";
 import { isNextjsMetadataImageRouteFilename } from "./is-nextjs-metadata-image-route-filename.js";
 
-// Route / special files from the React frameworks with file-based
-// routing. Each framework's bundler plugin owns HMR for these modules,
-// and by contract they co-export route config / metadata / data
-// functions next to the default component — so those non-component
-// exports are the documented shape, not a Fast Refresh hazard. Matched
-// by basename (the same JS/TS module extensions Next.js resolves) so a
-// deep route path resolves the same as a shallow one.
-const sourceFileExtensionGroup = NEXTJS_SOURCE_FILE_EXTENSION_GROUP;
+const NEXT_ROUTE_FILE_PATTERN = new RegExp(
+  `^(page|layout|loading|error|not-found|template|default|global-error|route|_app|_document|_error|_meta)\\.${NEXTJS_SOURCE_FILE_EXTENSION_GROUP}$`,
+);
+const EXPO_ROUTE_FILE_PATTERN = new RegExp(
+  `^(_layout|\\+html|\\+not-found|\\+native-intent)\\.${NEXTJS_SOURCE_FILE_EXTENSION_GROUP}$`,
+);
+const TANSTACK_ROUTE_FILE_PATTERN = new RegExp(
+  `(?:^__root|\\.lazy)\\.${NEXTJS_SOURCE_FILE_EXTENSION_GROUP}$`,
+);
+const REACT_ROUTER_FILE_PATTERN = new RegExp(
+  `^(root|entry\\.client|entry\\.server)\\.${NEXTJS_SOURCE_FILE_EXTENSION_GROUP}$`,
+);
 
-const FRAMEWORK_ROUTE_FILE_PATTERNS: ReadonlyArray<RegExp> = [
-  // Next.js App Router + Pages Router special files. (Metadata image
-  // routes — opengraph-image, icon, … — are matched separately below.)
-  new RegExp(
-    `^(page|layout|loading|error|not-found|template|default|global-error|route|_app|_document|_error)\\.${sourceFileExtensionGroup}$`,
-  ),
-  // Expo Router: `_layout` segment wrapper + `+`-prefixed reserved files.
-  new RegExp(`^(_layout|\\+html|\\+not-found|\\+native-intent)\\.${sourceFileExtensionGroup}$`),
-  // TanStack Router / Start: `__root` root route + `*.lazy` split routes.
-  new RegExp(`(?:^__root|\\.lazy)\\.${sourceFileExtensionGroup}$`),
-  // Remix / React Router: `root` route module + client/server entries.
-  new RegExp(`^(root|entry\\.client|entry\\.server)\\.${sourceFileExtensionGroup}$`),
-];
-
-export const isFrameworkRouteOrSpecialFilename = (rawFilename: string | undefined): boolean => {
+export const isFrameworkRouteOrSpecialFilename = (
+  rawFilename: string | undefined,
+  runtime: "expo" | "generic" | "next" | "react-router" | "remix" | "tanstack",
+): boolean => {
   if (!rawFilename) return false;
-  if (isNextjsMetadataImageRouteFilename(rawFilename)) return true;
   const basename = path.basename(rawFilename);
-  return FRAMEWORK_ROUTE_FILE_PATTERNS.some((pattern) => pattern.test(basename));
+  if (runtime === "next") {
+    return (
+      isNextjsMetadataImageRouteFilename(rawFilename) || NEXT_ROUTE_FILE_PATTERN.test(basename)
+    );
+  }
+  if (runtime === "expo") return EXPO_ROUTE_FILE_PATTERN.test(basename);
+  if (runtime === "tanstack") return TANSTACK_ROUTE_FILE_PATTERN.test(basename);
+  if (runtime === "react-router" || runtime === "remix") {
+    return REACT_ROUTER_FILE_PATTERN.test(basename);
+  }
+  return false;
 };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-framework-route-or-special-filename.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-framework-route-or-special-filename.ts
@@ -1,8 +1,11 @@
 import * as path from "node:path";
 import { NEXTJS_SOURCE_FILE_EXTENSION_GROUP } from "../constants/nextjs.js";
+import { getProjectRelativeFilename } from "./get-project-relative-filename.js";
+import { getReactDoctorStringSetting } from "./get-react-doctor-setting.js";
 import { isInProjectDirectory } from "./is-in-project-directory.js";
 import { isNextjsMetadataImageRouteFilename } from "./is-nextjs-metadata-image-route-filename.js";
 import { normalizeFilename } from "./normalize-filename.js";
+import { findNearestPackageDirectory } from "./read-nearest-package-manifest.js";
 import type { RuleContext } from "./rule-context.js";
 
 const NEXT_APP_ROUTE_FILE_PATTERN = new RegExp(
@@ -31,6 +34,21 @@ const isInNextDirectory = (
   return filename.startsWith(`${directoryPath}/`) || filename.includes(`/${directoryPath}/`);
 };
 
+const isInExpoRouteDirectory = (context: Pick<RuleContext, "filename" | "settings">): boolean => {
+  const filename = normalizeFilename(context.filename ?? "");
+  const configuredRootDirectory = getReactDoctorStringSetting(context.settings, "rootDirectory");
+  const packageDirectory = path.isAbsolute(filename) ? findNearestPackageDirectory(filename) : null;
+  const projectRelativeFilename = getProjectRelativeFilename(
+    filename,
+    configuredRootDirectory ?? packageDirectory ?? undefined,
+  );
+  const relativeFilename =
+    projectRelativeFilename === filename && path.isAbsolute(filename)
+      ? filename.split("/").slice(2).join("/")
+      : projectRelativeFilename;
+  return relativeFilename.startsWith("app/") || relativeFilename.startsWith("src/app/");
+};
+
 export const isFrameworkRouteOrSpecialFilename = (
   context: Pick<RuleContext, "filename" | "settings">,
   runtime: "expo" | "generic" | "next" | "react-router" | "remix" | "tanstack",
@@ -46,7 +64,9 @@ export const isFrameworkRouteOrSpecialFilename = (
       (isInNextDirectory(context, "pages") && NEXT_PAGES_ROUTE_FILE_PATTERN.test(basename))
     );
   }
-  if (runtime === "expo") return EXPO_ROUTE_FILE_PATTERN.test(basename);
+  if (runtime === "expo") {
+    return isInExpoRouteDirectory(context) && EXPO_ROUTE_FILE_PATTERN.test(basename);
+  }
   if (runtime === "tanstack") return TANSTACK_ROUTE_FILE_PATTERN.test(basename);
   if (runtime === "react-router" || runtime === "remix") {
     return REACT_ROUTER_FILE_PATTERN.test(basename);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/read-nearest-package-manifest.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/read-nearest-package-manifest.ts
@@ -16,11 +16,18 @@ import {
 // classifier reads are declared; unread fields stay unknown.
 export interface PackageManifest {
   bin?: unknown;
+  name?: unknown;
+  main?: unknown;
+  module?: unknown;
+  exports?: unknown;
+  workspaces?: unknown;
   private?: unknown;
   dependencies?: Record<string, unknown>;
   devDependencies?: Record<string, unknown>;
   peerDependencies?: Record<string, unknown>;
   optionalDependencies?: Record<string, unknown>;
+  scripts?: Record<string, unknown>;
+  source?: unknown;
   // Metro's resolution key — libraries that ship an RN-only entry
   // point declare this field at the manifest root (string path) so
   // Metro picks it over `main` / `module`. Treated as a strong
@@ -99,6 +106,10 @@ export const findNearestPackageDirectory = (filename: string): string | null => 
 export const readNearestPackageManifest = (filename: string): PackageManifest | null => {
   const packageDirectory = findNearestPackageDirectory(filename);
   if (!packageDirectory) return null;
+  return readPackageManifest(packageDirectory);
+};
+
+export const readPackageManifest = (packageDirectory: string): PackageManifest | null => {
   const packageJsonPath = path.join(packageDirectory, "package.json");
 
   // Recorded BEFORE the memo lookup — every consumer's verdict is a pure


### PR DESCRIPTION
## Why

`only-export-components` reported mixed exports where no Fast Refresh transform owned the file, while broad filename exemptions hid ordinary transformed modules that are real Refresh boundaries.

## What changed

- Gate the rule on proven development-transform capability instead of React or bundler package presence.
- Prove Vite, Next, Remix, React Router, TanStack Start, Expo, React Native, Gatsby, CRA, Parcel, Dumi, configured Webpack/Rspack/Rsbuild, and workspace source ownership.
- Recognize React Vite Storybooks and Storybook 6.1+ Webpack only when exported config explicitly sets `reactOptions.fastRefresh: true`.
- Classify component, route, wrapper, barrel, React element return, portal, default alias, and React DOM root semantics rather than relying on filenames or PascalCase alone.
- Scope Next route-file exemptions to actual `app` and `pages` directories so ordinary files such as `src/components/layout.tsx` remain reportable.
- Add paired project fixtures, adversarial rule tests, and permanent fuzz regressions.

## Precision boundaries

The detector requires evidence that the development toolchain owns Fast Refresh. Package presence alone is insufficient. Parcel requires a serving command and rejects production-only, help/version, watch, and explicit `--no-hmr` commands. Default component aliases require render semantics, while typed React-element returns and null placeholders remain supported. Next route exemptions apply only within framework route directories.

## Real-repository validation

Exact-head RDE against exact `main`, with the same 100 pinned roots:

- baseline: 100/100 valid, 11,798 diagnostics
- candidate: 100/100 valid, 11,798 diagnostics
- target-rule additions/removals: 0/0
- non-target additions/removals: 0/0

React Bench exact pinned revisions:

- 122/122 tasks scanned successfully
- baseline `only-export-components`: 2,452
- candidate `only-export-components`: 2,452
- target-rule additions/removals: 0/0
- the exact serial reports have complete target and non-target diagnostic parity

## Validation

- oxlint plugin: 559/559 files; 13,765 passed, 175 skipped
- `FUZZ_RULE=only-export-components FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz`
- `nr typecheck`
- `nr lint` (existing repository warnings only)
- `nr format:check`
- `nr build`
- `nr smoke:json-report`
- `git diff --check`
- post-implementation `truffler` duplicate-symbol audit

The branch is rebased on `main` at `af58965a7`; exact candidate head is `7820b3ccd`. No automatic merge is requested.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Substantial linter behavior change with filesystem and config probing; validated for diagnostic parity on pinned benchmarks but edge cases in monorepos or unusual toolchains may still differ.
> 
> **Overview**
> **`only-export-components`** now runs only when a file is owned by a **proven Fast Refresh integration** (Vite/React plugins, Next/CRA/Expo, Parcel serve, Storybook with explicit refresh, workspace packages aliased into active Vite apps, etc.), instead of broad filename-based skips or mere React/bundler presence.
> 
> A new **`get-fast-refresh-file-status`** layer inspects `package.json`, dev scripts, and bundler/Storybook configs to decide applicability and **runtime** (Next, Expo, TanStack, Remix, generic). Framework route exemptions are **scoped to real route trees** (e.g. Next `app`/`pages`), so ordinary paths like `src/components/layout.tsx` can still be flagged.
> 
> **Component detection** is tightened: PascalCase alone is not enough—functions need JSX/render evidence, React element return types, portals, or null-only component semantics; formatters and default aliases are handled more carefully. **`export *`** is analyzed cross-file for runtime values; pure type/default barrels stay quiet. **React DOM root mounts** skip entry-style modules; nested/transient roots do not. Route-factory and **`next/dynamic`** wrappers require import provenance.
> 
> The rule is registered as **cross-file** and **unbounded** for fingerprinting (manifest/config reads). Large fixture, fuzz, and regression test coverage accompanies the behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7820b3ccdaaf9555f5885413ba546f2b6bb9614c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



