### PR TITLE
fix(require-reduced-motion): require executable evidence

### DIFF
--- a/.changeset/mighty-nails-wear.md
+++ b/.changeset/mighty-nails-wear.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Require executable motion-library usage and semantic reduced-motion handling before reporting the project-level accessibility diagnostic.

--- a/packages/core/src/check-reduced-motion.ts
+++ b/packages/core/src/check-reduced-motion.ts
@@ -1,25 +1,74 @@
-import { spawnSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { MOTION_LIBRARY_PACKAGES } from "oxlint-plugin-react-doctor";
+import ts from "typescript";
 import type { Diagnostic } from "./types/index.js";
-import { hasIgnoredPathSegment } from "./utils/has-ignored-path-segment.js";
 import { walkSourceTreeFiles } from "./utils/walk-source-tree-files.js";
 import { isFile, readPackageJson } from "./project-info/index.js";
 
-// Single source for both search paths: `git grep -E` takes the string form,
-// the filesystem fallback compiles it — so the two can never test different
-// patterns on one tree. Same for the extensions: the git file globs are
-// derived from the fallback's extension set.
-const REDUCED_MOTION_GREP_PATTERN =
-  "prefers-reduced-motion|useReducedMotion|MotionConfig|reducedMotion";
-const REDUCED_MOTION_PATTERN = new RegExp(REDUCED_MOTION_GREP_PATTERN);
-const REDUCED_MOTION_FILE_EXTENSIONS = new Set([".ts", ".tsx", ".js", ".jsx", ".css", ".scss"]);
-const REDUCED_MOTION_FILE_GLOBS = [...REDUCED_MOTION_FILE_EXTENSIONS].map(
-  (extension) => `*${extension}`,
-);
+interface MotionExpressionEvidence {
+  isAnimationFunction: boolean;
+  isMotionComponent: boolean;
+  isMotionComponentFactory: boolean;
+  isMotionConfig: boolean;
+  isMotionNamespace: boolean;
+  isReducedMotionHook: boolean;
+}
 
-const GIT_GREP_NO_MATCH_STATUS = 1;
+export interface ProjectMotionEvidence {
+  hasMotionUse: boolean;
+  hasReducedMotionHandling: boolean;
+}
+
+export interface AnalyzeReducedMotionSourceInput {
+  fileName: string;
+  sourceText: string;
+}
+
+const EMPTY_MOTION_EXPRESSION_EVIDENCE: MotionExpressionEvidence = {
+  isAnimationFunction: false,
+  isMotionComponent: false,
+  isMotionComponentFactory: false,
+  isMotionConfig: false,
+  isMotionNamespace: false,
+  isReducedMotionHook: false,
+};
+
+const MOTION_COMPONENT_FACTORY_EXPORT_NAMES = new Set(["m", "motion"]);
+const MOTION_COMPONENT_EXPORT_NAMES = new Set([
+  "AnimatePresence",
+  "LayoutGroup",
+  "LazyMotion",
+  "MotionConfig",
+  "Reorder",
+]);
+const MOTION_ANIMATION_FUNCTION_EXPORT_NAMES = new Set([
+  "animate",
+  "inView",
+  "scroll",
+  "spring",
+  "stagger",
+  "useAnimate",
+  "useAnimation",
+  "useAnimationControls",
+  "useMotionValue",
+  "useScroll",
+  "useSpring",
+  "useTime",
+  "useTransform",
+  "useVelocity",
+]);
+const REDUCED_MOTION_HOOK_EXPORT_NAME = "useReducedMotion";
+const MOTION_CONFIG_EXPORT_NAME = "MotionConfig";
+const REDUCED_MOTION_PROP_NAME = "reducedMotion";
+const REDUCED_MOTION_CONFIG_VALUES = new Set(["always", "user"]);
+const SCRIPT_FILE_EXTENSIONS = new Set([".js", ".jsx", ".ts", ".tsx"]);
+const STYLE_FILE_EXTENSIONS = new Set([".css", ".scss"]);
+const MOTION_SOURCE_PREFILTER =
+  /framer-motion|["']motion(?:\/[A-Za-z0-9_./-]+)?["']|MotionConfig|useReducedMotion/;
+const REDUCED_MOTION_MEDIA_QUERY_PATTERN =
+  /@media\s+([^{}]*\(\s*prefers-reduced-motion\s*:\s*reduce\s*\)[^{}]*)\{/gi;
+const CSS_DECLARATION_PATTERN = /(?:^|[;{])\s*[-_A-Za-z][-_A-Za-z0-9]*\s*:/;
 
 const MISSING_REDUCED_MOTION_DIAGNOSTIC: Diagnostic = {
   filePath: "package.json",
@@ -34,59 +83,438 @@ const MISSING_REDUCED_MOTION_DIAGNOSTIC: Diagnostic = {
   category: "Accessibility",
 };
 
-// Fallback for trees where `git grep` can't run (no git binary, not a
-// repository). Mirrors the git path's file globs and must reach the same
-// verdict so scans of one tree don't diverge on git availability.
-const hasReducedMotionHandlingViaFilesystem = (rootDirectory: string): boolean => {
+const isMotionModuleSource = (moduleSource: string): boolean => {
+  for (const packageName of MOTION_LIBRARY_PACKAGES) {
+    if (moduleSource === packageName || moduleSource.startsWith(`${packageName}/`)) return true;
+  }
+  return false;
+};
+
+const classifyMotionExport = (exportName: string): MotionExpressionEvidence => ({
+  isAnimationFunction: MOTION_ANIMATION_FUNCTION_EXPORT_NAMES.has(exportName),
+  isMotionComponent: MOTION_COMPONENT_EXPORT_NAMES.has(exportName),
+  isMotionComponentFactory: MOTION_COMPONENT_FACTORY_EXPORT_NAMES.has(exportName),
+  isMotionConfig: exportName === MOTION_CONFIG_EXPORT_NAME,
+  isMotionNamespace: false,
+  isReducedMotionHook: exportName === REDUCED_MOTION_HOOK_EXPORT_NAME,
+});
+
+const unwrapExpression = (expression: ts.Expression): ts.Expression => {
+  let currentExpression = expression;
+  while (
+    ts.isParenthesizedExpression(currentExpression) ||
+    ts.isAsExpression(currentExpression) ||
+    ts.isSatisfiesExpression(currentExpression) ||
+    ts.isNonNullExpression(currentExpression) ||
+    ts.isTypeAssertionExpression(currentExpression)
+  ) {
+    currentExpression = currentExpression.expression;
+  }
+  return currentExpression;
+};
+
+const getImportModuleSource = (node: ts.Node): string | null => {
+  let currentNode: ts.Node | undefined = node;
+  while (currentNode) {
+    if (ts.isImportDeclaration(currentNode) && ts.isStringLiteral(currentNode.moduleSpecifier)) {
+      return currentNode.moduleSpecifier.text;
+    }
+    currentNode = currentNode.parent;
+  }
+  return null;
+};
+
+const getImportedBindingEvidence = (
+  declaration: ts.Declaration,
+): MotionExpressionEvidence | null => {
+  const moduleSource = getImportModuleSource(declaration);
+  if (!moduleSource || !isMotionModuleSource(moduleSource)) return null;
+
+  if (ts.isNamespaceImport(declaration)) {
+    return { ...EMPTY_MOTION_EXPRESSION_EVIDENCE, isMotionNamespace: true };
+  }
+  if (ts.isImportSpecifier(declaration)) {
+    if (declaration.isTypeOnly) return null;
+    return classifyMotionExport(declaration.propertyName?.text ?? declaration.name.text);
+  }
+  if (ts.isImportClause(declaration)) {
+    if (declaration.isTypeOnly) return null;
+    return EMPTY_MOTION_EXPRESSION_EVIDENCE;
+  }
+  return null;
+};
+
+const mergeMotionExpressionEvidence = (
+  leftEvidence: MotionExpressionEvidence,
+  rightEvidence: MotionExpressionEvidence,
+): MotionExpressionEvidence => ({
+  isAnimationFunction: leftEvidence.isAnimationFunction || rightEvidence.isAnimationFunction,
+  isMotionComponent: leftEvidence.isMotionComponent || rightEvidence.isMotionComponent,
+  isMotionComponentFactory:
+    leftEvidence.isMotionComponentFactory || rightEvidence.isMotionComponentFactory,
+  isMotionConfig: leftEvidence.isMotionConfig || rightEvidence.isMotionConfig,
+  isMotionNamespace: leftEvidence.isMotionNamespace || rightEvidence.isMotionNamespace,
+  isReducedMotionHook: leftEvidence.isReducedMotionHook || rightEvidence.isReducedMotionHook,
+});
+
+const resolveMotionExpressionEvidence = (
+  expression: ts.Expression,
+  typeChecker: ts.TypeChecker,
+  visitedSymbols: Set<ts.Symbol> = new Set(),
+): MotionExpressionEvidence => {
+  const unwrappedExpression = unwrapExpression(expression);
+
+  if (ts.isIdentifier(unwrappedExpression)) {
+    const symbol = typeChecker.getSymbolAtLocation(unwrappedExpression);
+    if (!symbol || visitedSymbols.has(symbol)) return EMPTY_MOTION_EXPRESSION_EVIDENCE;
+    const nextVisitedSymbols = new Set(visitedSymbols);
+    nextVisitedSymbols.add(symbol);
+
+    let resolvedEvidence = EMPTY_MOTION_EXPRESSION_EVIDENCE;
+    for (const declaration of symbol.declarations ?? []) {
+      const importedEvidence = getImportedBindingEvidence(declaration);
+      if (importedEvidence) {
+        resolvedEvidence = mergeMotionExpressionEvidence(resolvedEvidence, importedEvidence);
+        continue;
+      }
+      if (ts.isVariableDeclaration(declaration) && declaration.initializer) {
+        resolvedEvidence = mergeMotionExpressionEvidence(
+          resolvedEvidence,
+          resolveMotionExpressionEvidence(declaration.initializer, typeChecker, nextVisitedSymbols),
+        );
+      }
+    }
+    return resolvedEvidence;
+  }
+
+  if (ts.isPropertyAccessExpression(unwrappedExpression)) {
+    const receiverEvidence = resolveMotionExpressionEvidence(
+      unwrappedExpression.expression,
+      typeChecker,
+      visitedSymbols,
+    );
+    if (receiverEvidence.isMotionNamespace) {
+      return classifyMotionExport(unwrappedExpression.name.text);
+    }
+    if (receiverEvidence.isMotionComponentFactory) {
+      return { ...EMPTY_MOTION_EXPRESSION_EVIDENCE, isMotionComponent: true };
+    }
+    return receiverEvidence;
+  }
+
+  if (
+    ts.isElementAccessExpression(unwrappedExpression) &&
+    unwrappedExpression.argumentExpression &&
+    (ts.isStringLiteral(unwrappedExpression.argumentExpression) ||
+      ts.isNoSubstitutionTemplateLiteral(unwrappedExpression.argumentExpression))
+  ) {
+    const receiverEvidence = resolveMotionExpressionEvidence(
+      unwrappedExpression.expression,
+      typeChecker,
+      visitedSymbols,
+    );
+    if (receiverEvidence.isMotionNamespace) {
+      return classifyMotionExport(unwrappedExpression.argumentExpression.text);
+    }
+    if (receiverEvidence.isMotionComponentFactory) {
+      return { ...EMPTY_MOTION_EXPRESSION_EVIDENCE, isMotionComponent: true };
+    }
+    return receiverEvidence;
+  }
+
+  if (ts.isCallExpression(unwrappedExpression)) {
+    const calleeEvidence = resolveMotionExpressionEvidence(
+      unwrappedExpression.expression,
+      typeChecker,
+      visitedSymbols,
+    );
+    if (calleeEvidence.isMotionComponentFactory) {
+      return { ...EMPTY_MOTION_EXPRESSION_EVIDENCE, isMotionComponent: true };
+    }
+    return calleeEvidence;
+  }
+
+  return EMPTY_MOTION_EXPRESSION_EVIDENCE;
+};
+
+const getStaticJsxAttributeValue = (attribute: ts.JsxAttribute): string | null => {
+  if (!attribute.initializer) return null;
+  if (ts.isStringLiteral(attribute.initializer)) return attribute.initializer.text;
+  if (!ts.isJsxExpression(attribute.initializer) || !attribute.initializer.expression) return null;
+  const expression = unwrapExpression(attribute.initializer.expression);
+  if (ts.isStringLiteral(expression) || ts.isNoSubstitutionTemplateLiteral(expression)) {
+    return expression.text;
+  }
+  return null;
+};
+
+const jsxElementHasReducedMotionConfiguration = (attributes: ts.JsxAttributes): boolean =>
+  attributes.properties.some(
+    (attribute) =>
+      ts.isJsxAttribute(attribute) &&
+      ts.isIdentifier(attribute.name) &&
+      attribute.name.text === REDUCED_MOTION_PROP_NAME &&
+      REDUCED_MOTION_CONFIG_VALUES.has(getStaticJsxAttributeValue(attribute) ?? ""),
+  );
+
+const collectScriptMotionEvidence = (
+  sourceFile: ts.SourceFile,
+  typeChecker: ts.TypeChecker,
+): ProjectMotionEvidence => {
+  const evidence: ProjectMotionEvidence = {
+    hasMotionUse: false,
+    hasReducedMotionHandling: false,
+  };
+
+  const visitNode = (node: ts.Node): void => {
+    if (ts.isCallExpression(node)) {
+      const calleeEvidence = resolveMotionExpressionEvidence(node.expression, typeChecker);
+      if (
+        calleeEvidence.isAnimationFunction ||
+        calleeEvidence.isMotionComponentFactory ||
+        calleeEvidence.isReducedMotionHook
+      ) {
+        evidence.hasMotionUse = true;
+      }
+      if (calleeEvidence.isReducedMotionHook) evidence.hasReducedMotionHandling = true;
+    }
+
+    if (ts.isVariableDeclaration(node) && node.initializer) {
+      const initializerEvidence = resolveMotionExpressionEvidence(node.initializer, typeChecker);
+      if (initializerEvidence.isMotionComponent) evidence.hasMotionUse = true;
+    }
+
+    if (ts.isJsxOpeningElement(node) || ts.isJsxSelfClosingElement(node)) {
+      const tagEvidence = ts.isJsxNamespacedName(node.tagName)
+        ? EMPTY_MOTION_EXPRESSION_EVIDENCE
+        : resolveMotionExpressionEvidence(node.tagName, typeChecker);
+      if (
+        tagEvidence.isMotionComponent ||
+        tagEvidence.isMotionComponentFactory ||
+        tagEvidence.isMotionConfig
+      ) {
+        evidence.hasMotionUse = true;
+      }
+      if (tagEvidence.isMotionConfig && jsxElementHasReducedMotionConfiguration(node.attributes)) {
+        evidence.hasReducedMotionHandling = true;
+      }
+    }
+
+    ts.forEachChild(node, visitNode);
+  };
+
+  visitNode(sourceFile);
+  return evidence;
+};
+
+const getScriptKind = (fileName: string): ts.ScriptKind => {
+  if (fileName.endsWith(".tsx")) return ts.ScriptKind.TSX;
+  if (fileName.endsWith(".jsx")) return ts.ScriptKind.JSX;
+  if (fileName.endsWith(".ts")) return ts.ScriptKind.TS;
+  return ts.ScriptKind.JS;
+};
+
+export const analyzeReducedMotionSource = ({
+  fileName,
+  sourceText,
+}: AnalyzeReducedMotionSourceInput): ProjectMotionEvidence => {
+  if (!MOTION_SOURCE_PREFILTER.test(sourceText)) {
+    return { hasMotionUse: false, hasReducedMotionHandling: false };
+  }
+
+  const compilerOptions: ts.CompilerOptions = {
+    allowJs: true,
+    checkJs: false,
+    jsx: ts.JsxEmit.Preserve,
+    noEmit: true,
+    noLib: true,
+    noResolve: true,
+    skipLibCheck: true,
+    target: ts.ScriptTarget.Latest,
+  };
+  const normalizedFileName = path.resolve(fileName);
+  const compilerHost = ts.createCompilerHost(compilerOptions);
+  const getDefaultSourceFile = compilerHost.getSourceFile.bind(compilerHost);
+  compilerHost.getSourceFile = (
+    requestedFileName,
+    languageVersionOrOptions,
+    onError,
+    shouldCreateNewSourceFile,
+  ) =>
+    path.resolve(requestedFileName) === normalizedFileName
+      ? ts.createSourceFile(
+          normalizedFileName,
+          sourceText,
+          languageVersionOrOptions,
+          true,
+          getScriptKind(normalizedFileName),
+        )
+      : getDefaultSourceFile(
+          requestedFileName,
+          languageVersionOrOptions,
+          onError,
+          shouldCreateNewSourceFile,
+        );
+  const program = ts.createProgram([normalizedFileName], compilerOptions, compilerHost);
+  const sourceFile = program.getSourceFile(normalizedFileName);
+  if (!sourceFile) return { hasMotionUse: false, hasReducedMotionHandling: false };
+  return collectScriptMotionEvidence(sourceFile, program.getTypeChecker());
+};
+
+const removeCssCommentsAndStrings = (content: string): string => {
+  let sanitizedContent = "";
+  let quote: '"' | "'" | null = null;
+  let isInsideComment = false;
+  let isInsideLineComment = false;
+
+  for (let characterIndex = 0; characterIndex < content.length; characterIndex += 1) {
+    const character = content[characterIndex];
+    const nextCharacter = content[characterIndex + 1];
+
+    if (isInsideLineComment) {
+      sanitizedContent += character === "\n" ? "\n" : " ";
+      if (character === "\n") isInsideLineComment = false;
+      continue;
+    }
+
+    if (isInsideComment) {
+      if (character === "*" && nextCharacter === "/") {
+        sanitizedContent += "  ";
+        characterIndex += 1;
+        isInsideComment = false;
+      } else {
+        sanitizedContent += character === "\n" ? "\n" : " ";
+      }
+      continue;
+    }
+
+    if (quote) {
+      if (character === "\\") {
+        sanitizedContent += "  ";
+        characterIndex += 1;
+        continue;
+      }
+      if (character === quote) quote = null;
+      sanitizedContent += character === "\n" ? "\n" : " ";
+      continue;
+    }
+
+    if (character === "/" && nextCharacter === "*") {
+      sanitizedContent += "  ";
+      characterIndex += 1;
+      isInsideComment = true;
+      continue;
+    }
+
+    if (character === "/" && nextCharacter === "/") {
+      sanitizedContent += "  ";
+      characterIndex += 1;
+      isInsideLineComment = true;
+      continue;
+    }
+
+    if (character === '"' || character === "'") {
+      sanitizedContent += " ";
+      quote = character;
+      continue;
+    }
+
+    sanitizedContent += character;
+  }
+
+  return sanitizedContent;
+};
+
+const findMatchingClosingBrace = (content: string, openingBraceIndex: number): number => {
+  let depth = 0;
+  for (
+    let characterIndex = openingBraceIndex;
+    characterIndex < content.length;
+    characterIndex += 1
+  ) {
+    if (content[characterIndex] === "{") depth += 1;
+    if (content[characterIndex] !== "}") continue;
+    depth -= 1;
+    if (depth === 0) return characterIndex;
+  }
+  return -1;
+};
+
+const hasReducedMotionMediaQuery = (content: string): boolean => {
+  const sanitizedContent = removeCssCommentsAndStrings(content);
+  REDUCED_MOTION_MEDIA_QUERY_PATTERN.lastIndex = 0;
+
+  for (const match of sanitizedContent.matchAll(REDUCED_MOTION_MEDIA_QUERY_PATTERN)) {
+    const mediaPrelude = match[1];
+    if (/\bnot\b/i.test(mediaPrelude)) continue;
+    const openingBraceIndex = (match.index ?? 0) + match[0].lastIndexOf("{");
+    const closingBraceIndex = findMatchingClosingBrace(sanitizedContent, openingBraceIndex);
+    if (closingBraceIndex === -1) continue;
+    const body = sanitizedContent.slice(openingBraceIndex + 1, closingBraceIndex);
+    if (CSS_DECLARATION_PATTERN.test(body)) return true;
+  }
+
+  return false;
+};
+
+const collectProjectMotionEvidence = (rootDirectory: string): ProjectMotionEvidence => {
+  const scriptFiles: Array<{ absolutePath: string; content: string }> = [];
+  let hasReducedMotionHandling = false;
+
   for (const { absolutePath, name } of walkSourceTreeFiles(rootDirectory)) {
-    if (!REDUCED_MOTION_FILE_EXTENSIONS.has(path.extname(name))) continue;
+    const extension = path.extname(name);
+    if (!SCRIPT_FILE_EXTENSIONS.has(extension) && !STYLE_FILE_EXTENSIONS.has(extension)) continue;
+
     let content: string;
     try {
       content = fs.readFileSync(absolutePath, "utf-8");
     } catch {
       continue;
     }
-    if (REDUCED_MOTION_PATTERN.test(content)) return true;
+
+    if (STYLE_FILE_EXTENSIONS.has(extension)) {
+      if (hasReducedMotionMediaQuery(content)) hasReducedMotionHandling = true;
+      continue;
+    }
+    if (MOTION_SOURCE_PREFILTER.test(content)) scriptFiles.push({ absolutePath, content });
   }
-  return false;
+
+  if (scriptFiles.length === 0) {
+    return { hasMotionUse: false, hasReducedMotionHandling };
+  }
+
+  let hasMotionUse = false;
+  for (const { absolutePath, content } of scriptFiles) {
+    const fileEvidence = analyzeReducedMotionSource({
+      fileName: absolutePath,
+      sourceText: content,
+    });
+    hasMotionUse ||= fileEvidence.hasMotionUse;
+    hasReducedMotionHandling ||= fileEvidence.hasReducedMotionHandling;
+    if (hasMotionUse && hasReducedMotionHandling) break;
+  }
+
+  return { hasMotionUse, hasReducedMotionHandling };
 };
 
 export const checkReducedMotion = (rootDirectory: string): Diagnostic[] => {
   const packageJsonPath = path.join(rootDirectory, "package.json");
   if (!isFile(packageJsonPath)) return [];
 
-  let hasMotionLibrary = false;
   try {
     const packageJson = readPackageJson(packageJsonPath);
     const allDependencies = { ...packageJson.dependencies, ...packageJson.devDependencies };
-    hasMotionLibrary = Object.keys(allDependencies).some((packageName) =>
-      MOTION_LIBRARY_PACKAGES.has(packageName),
-    );
+    if (
+      !Object.keys(allDependencies).some((packageName) => MOTION_LIBRARY_PACKAGES.has(packageName))
+    ) {
+      return [];
+    }
   } catch {
     return [];
   }
-  if (!hasMotionLibrary) return [];
 
-  const result = spawnSync(
-    "git",
-    ["grep", "--untracked", "-lE", REDUCED_MOTION_GREP_PATTERN, "--", ...REDUCED_MOTION_FILE_GLOBS],
-    { cwd: rootDirectory, encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] },
-  );
-  const gitRan =
-    !result.error && (result.status === 0 || result.status === GIT_GREP_NO_MATCH_STATUS);
-  if (!gitRan) {
-    return hasReducedMotionHandlingViaFilesystem(rootDirectory)
-      ? []
-      : [MISSING_REDUCED_MOTION_DIAGNOSTIC];
-  }
-  // Ignore matches inside ignored build directories so the verdict matches the
-  // filesystem fallback (which never descends into them) — a committed bundle
-  // that mentions `prefers-reduced-motion` doesn't prove the app source handles
-  // it, so `git grep` and the walk agree on one tree.
-  const hasHandlingInSource =
-    result.status === 0 &&
-    result.stdout
-      .split("\n")
-      .some((filePath) => filePath.length > 0 && !hasIgnoredPathSegment(filePath));
-  return hasHandlingInSource ? [] : [MISSING_REDUCED_MOTION_DIAGNOSTIC];
+  const evidence = collectProjectMotionEvidence(rootDirectory);
+  return evidence.hasMotionUse && !evidence.hasReducedMotionHandling
+    ? [MISSING_REDUCED_MOTION_DIAGNOSTIC]
+    : [];
 };

--- a/packages/core/src/check-reduced-motion.ts
+++ b/packages/core/src/check-reduced-motion.ts
@@ -121,8 +121,13 @@ const getImportedBindingEvidence = (
     if (declaration.isTypeOnly) return null;
     return EMPTY_MOTION_EXPRESSION_EVIDENCE;
   }
-  if (ts.isImportSpecifier(declaration) && !declaration.isTypeOnly) {
-    const importedName = declaration.propertyName?.text ?? declaration.name.text;
+  if (
+    (ts.isImportSpecifier(declaration) && !declaration.isTypeOnly) ||
+    (ts.isImportClause(declaration) && !declaration.isTypeOnly && declaration.name)
+  ) {
+    const importedName = ts.isImportSpecifier(declaration)
+      ? (declaration.propertyName?.text ?? declaration.name.text)
+      : "default";
     const importingSourceFile = declaration.getSourceFile();
     const moduleSourceFile = getLocalModuleSourceFile(
       moduleSource,
@@ -188,6 +193,16 @@ const resolveModuleExportEvidence = (
   if (moduleSymbol) nextVisitedSymbols.add(moduleSymbol);
 
   for (const statement of sourceFile.statements) {
+    if (exportName === "default" && ts.isExportAssignment(statement) && !statement.isExportEquals) {
+      const evidence = resolveMotionExpressionEvidence(
+        statement.expression,
+        typeChecker,
+        program,
+        nextVisitedSymbols,
+      );
+      if (hasMotionExpressionEvidence(evidence)) return evidence;
+      continue;
+    }
     if (!ts.isExportDeclaration(statement) || !statement.moduleSpecifier) continue;
     if (statement.isTypeOnly) continue;
     if (!ts.isStringLiteral(statement.moduleSpecifier)) continue;

--- a/packages/core/src/check-reduced-motion.ts
+++ b/packages/core/src/check-reduced-motion.ts
@@ -3,6 +3,8 @@ import * as path from "node:path";
 import { MOTION_LIBRARY_PACKAGES } from "oxlint-plugin-react-doctor";
 import ts from "typescript";
 import type { Diagnostic } from "./types/index.js";
+import { getTypescriptScriptKind } from "./utils/get-typescript-script-kind.js";
+import { unwrapTypescriptExpression } from "./utils/unwrap-typescript-expression.js";
 import { walkSourceTreeFiles } from "./utils/walk-source-tree-files.js";
 import { isFile, readPackageJson } from "./project-info/index.js";
 
@@ -10,6 +12,7 @@ interface MotionExpressionEvidence {
   isAnimationFunction: boolean;
   isMotionComponent: boolean;
   isMotionComponentFactory: boolean;
+  isMotionComponentNamespace: boolean;
   isMotionConfig: boolean;
   isMotionNamespace: boolean;
   isReducedMotionHook: boolean;
@@ -25,44 +28,31 @@ export interface AnalyzeReducedMotionSourceInput {
   sourceText: string;
 }
 
+interface ScriptMotionSource {
+  fileName: string;
+  sourceText: string;
+}
+
 const EMPTY_MOTION_EXPRESSION_EVIDENCE: MotionExpressionEvidence = {
   isAnimationFunction: false,
   isMotionComponent: false,
   isMotionComponentFactory: false,
+  isMotionComponentNamespace: false,
   isMotionConfig: false,
   isMotionNamespace: false,
   isReducedMotionHook: false,
 };
 
 const MOTION_COMPONENT_FACTORY_EXPORT_NAMES = new Set(["m", "motion"]);
-const MOTION_COMPONENT_EXPORT_NAMES = new Set([
-  "AnimatePresence",
-  "LayoutGroup",
-  "LazyMotion",
-  "MotionConfig",
-  "Reorder",
-]);
-const MOTION_ANIMATION_FUNCTION_EXPORT_NAMES = new Set([
-  "animate",
-  "inView",
-  "scroll",
-  "spring",
-  "stagger",
-  "useAnimate",
-  "useAnimation",
-  "useAnimationControls",
-  "useMotionValue",
-  "useScroll",
-  "useSpring",
-  "useTime",
-  "useTransform",
-  "useVelocity",
-]);
+const MOTION_COMPONENT_NAMESPACE_EXPORT_NAMES = new Set(["Reorder"]);
+const MOTION_COMPONENT_NAMESPACE_MEMBER_NAMES = new Set(["Item"]);
+const MOTION_ANIMATION_FUNCTION_EXPORT_NAMES = new Set(["animate"]);
 const REDUCED_MOTION_HOOK_EXPORT_NAME = "useReducedMotion";
 const MOTION_CONFIG_EXPORT_NAME = "MotionConfig";
 const REDUCED_MOTION_PROP_NAME = "reducedMotion";
 const REDUCED_MOTION_CONFIG_VALUES = new Set(["always", "user"]);
-const SCRIPT_FILE_EXTENSIONS = new Set([".js", ".jsx", ".ts", ".tsx"]);
+const SCRIPT_MODULE_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx"];
+const SCRIPT_FILE_EXTENSIONS = new Set(SCRIPT_MODULE_EXTENSIONS);
 const STYLE_FILE_EXTENSIONS = new Set([".css", ".scss"]);
 const MOTION_SOURCE_PREFILTER =
   /framer-motion|["']motion(?:\/[A-Za-z0-9_./-]+)?["']|MotionConfig|useReducedMotion/;
@@ -92,26 +82,13 @@ const isMotionModuleSource = (moduleSource: string): boolean => {
 
 const classifyMotionExport = (exportName: string): MotionExpressionEvidence => ({
   isAnimationFunction: MOTION_ANIMATION_FUNCTION_EXPORT_NAMES.has(exportName),
-  isMotionComponent: MOTION_COMPONENT_EXPORT_NAMES.has(exportName),
+  isMotionComponent: false,
   isMotionComponentFactory: MOTION_COMPONENT_FACTORY_EXPORT_NAMES.has(exportName),
+  isMotionComponentNamespace: MOTION_COMPONENT_NAMESPACE_EXPORT_NAMES.has(exportName),
   isMotionConfig: exportName === MOTION_CONFIG_EXPORT_NAME,
   isMotionNamespace: false,
   isReducedMotionHook: exportName === REDUCED_MOTION_HOOK_EXPORT_NAME,
 });
-
-const unwrapExpression = (expression: ts.Expression): ts.Expression => {
-  let currentExpression = expression;
-  while (
-    ts.isParenthesizedExpression(currentExpression) ||
-    ts.isAsExpression(currentExpression) ||
-    ts.isSatisfiesExpression(currentExpression) ||
-    ts.isNonNullExpression(currentExpression) ||
-    ts.isTypeAssertionExpression(currentExpression)
-  ) {
-    currentExpression = currentExpression.expression;
-  }
-  return currentExpression;
-};
 
 const getImportModuleSource = (node: ts.Node): string | null => {
   let currentNode: ts.Node | undefined = node;
@@ -126,22 +103,176 @@ const getImportModuleSource = (node: ts.Node): string | null => {
 
 const getImportedBindingEvidence = (
   declaration: ts.Declaration,
+  typeChecker: ts.TypeChecker,
+  program: ts.Program,
+  visitedSymbols: Set<ts.Symbol>,
 ): MotionExpressionEvidence | null => {
   const moduleSource = getImportModuleSource(declaration);
-  if (!moduleSource || !isMotionModuleSource(moduleSource)) return null;
+  if (!moduleSource) return null;
 
-  if (ts.isNamespaceImport(declaration)) {
+  if (isMotionModuleSource(moduleSource) && ts.isNamespaceImport(declaration)) {
     return { ...EMPTY_MOTION_EXPRESSION_EVIDENCE, isMotionNamespace: true };
   }
-  if (ts.isImportSpecifier(declaration)) {
+  if (isMotionModuleSource(moduleSource) && ts.isImportSpecifier(declaration)) {
     if (declaration.isTypeOnly) return null;
     return classifyMotionExport(declaration.propertyName?.text ?? declaration.name.text);
   }
-  if (ts.isImportClause(declaration)) {
+  if (isMotionModuleSource(moduleSource) && ts.isImportClause(declaration)) {
     if (declaration.isTypeOnly) return null;
     return EMPTY_MOTION_EXPRESSION_EVIDENCE;
   }
+  if (ts.isImportSpecifier(declaration) && !declaration.isTypeOnly) {
+    const importedName = declaration.propertyName?.text ?? declaration.name.text;
+    const importingSourceFile = declaration.getSourceFile();
+    const moduleSourceFile = getLocalModuleSourceFile(
+      moduleSource,
+      importingSourceFile.fileName,
+      program,
+    );
+    if (!moduleSourceFile) return null;
+    return resolveModuleExportEvidence(
+      moduleSourceFile,
+      importedName,
+      typeChecker,
+      program,
+      visitedSymbols,
+    );
+  }
   return null;
+};
+
+const getLocalModuleSourceFile = (
+  moduleSource: string,
+  importingFileName: string,
+  program: ts.Program,
+): ts.SourceFile | null => {
+  if (!moduleSource.startsWith(".")) return null;
+  const moduleBasePath = path.resolve(path.dirname(importingFileName), moduleSource);
+  const moduleBaseExtension = path.extname(moduleBasePath);
+  const typescriptModuleBasePath =
+    moduleBaseExtension === ".js" || moduleBaseExtension === ".jsx"
+      ? moduleBasePath.slice(0, -moduleBaseExtension.length)
+      : null;
+  const candidates = [
+    moduleBasePath,
+    ...(typescriptModuleBasePath
+      ? [
+          `${typescriptModuleBasePath}.ts`,
+          `${typescriptModuleBasePath}.tsx`,
+          path.join(typescriptModuleBasePath, "index.ts"),
+          path.join(typescriptModuleBasePath, "index.tsx"),
+        ]
+      : []),
+    ...SCRIPT_MODULE_EXTENSIONS.map((extension) => `${moduleBasePath}${extension}`),
+    ...SCRIPT_MODULE_EXTENSIONS.map((extension) => path.join(moduleBasePath, `index${extension}`)),
+  ];
+  for (const candidate of candidates) {
+    const sourceFile = program.getSourceFile(candidate);
+    if (sourceFile) return sourceFile;
+  }
+  return null;
+};
+
+const resolveModuleExportEvidence = (
+  sourceFile: ts.SourceFile,
+  exportName: string,
+  typeChecker: ts.TypeChecker,
+  program: ts.Program,
+  visitedSymbols: Set<ts.Symbol>,
+): MotionExpressionEvidence => {
+  const moduleSymbol = typeChecker.getSymbolAtLocation(sourceFile);
+  if (moduleSymbol && visitedSymbols.has(moduleSymbol)) {
+    return EMPTY_MOTION_EXPRESSION_EVIDENCE;
+  }
+  const nextVisitedSymbols = new Set(visitedSymbols);
+  if (moduleSymbol) nextVisitedSymbols.add(moduleSymbol);
+
+  for (const statement of sourceFile.statements) {
+    if (!ts.isExportDeclaration(statement) || !statement.moduleSpecifier) continue;
+    if (statement.isTypeOnly) continue;
+    if (!ts.isStringLiteral(statement.moduleSpecifier)) continue;
+    const moduleSource = statement.moduleSpecifier.text;
+    if (!statement.exportClause) {
+      if (isMotionModuleSource(moduleSource)) return classifyMotionExport(exportName);
+      const moduleSourceFile = getLocalModuleSourceFile(moduleSource, sourceFile.fileName, program);
+      if (moduleSourceFile) {
+        const evidence = resolveModuleExportEvidence(
+          moduleSourceFile,
+          exportName,
+          typeChecker,
+          program,
+          nextVisitedSymbols,
+        );
+        if (hasMotionExpressionEvidence(evidence)) return evidence;
+      }
+      continue;
+    }
+    if (!ts.isNamedExports(statement.exportClause)) continue;
+    for (const exportSpecifier of statement.exportClause.elements) {
+      if (exportSpecifier.name.text !== exportName || exportSpecifier.isTypeOnly) continue;
+      const sourceExportName = exportSpecifier.propertyName?.text ?? exportSpecifier.name.text;
+      if (isMotionModuleSource(moduleSource)) return classifyMotionExport(sourceExportName);
+      const moduleSourceFile = getLocalModuleSourceFile(moduleSource, sourceFile.fileName, program);
+      if (!moduleSourceFile) continue;
+      return resolveModuleExportEvidence(
+        moduleSourceFile,
+        sourceExportName,
+        typeChecker,
+        program,
+        nextVisitedSymbols,
+      );
+    }
+  }
+
+  if (!moduleSymbol) return EMPTY_MOTION_EXPRESSION_EVIDENCE;
+  const exportedSymbol = typeChecker
+    .getExportsOfModule(moduleSymbol)
+    .find((candidateSymbol) => candidateSymbol.name === exportName);
+  if (!exportedSymbol || nextVisitedSymbols.has(exportedSymbol)) {
+    return EMPTY_MOTION_EXPRESSION_EVIDENCE;
+  }
+  nextVisitedSymbols.add(exportedSymbol);
+
+  let resolvedEvidence = EMPTY_MOTION_EXPRESSION_EVIDENCE;
+  for (const declaration of exportedSymbol.declarations ?? []) {
+    if (ts.isExportSpecifier(declaration)) {
+      const targetSymbol = typeChecker.getExportSpecifierLocalTargetSymbol(declaration);
+      for (const targetDeclaration of targetSymbol?.declarations ?? []) {
+        const importedEvidence = getImportedBindingEvidence(
+          targetDeclaration,
+          typeChecker,
+          program,
+          nextVisitedSymbols,
+        );
+        if (importedEvidence) {
+          resolvedEvidence = mergeMotionExpressionEvidence(resolvedEvidence, importedEvidence);
+        }
+        if (ts.isVariableDeclaration(targetDeclaration) && targetDeclaration.initializer) {
+          resolvedEvidence = mergeMotionExpressionEvidence(
+            resolvedEvidence,
+            resolveMotionExpressionEvidence(
+              targetDeclaration.initializer,
+              typeChecker,
+              program,
+              nextVisitedSymbols,
+            ),
+          );
+        }
+      }
+    }
+    if (ts.isVariableDeclaration(declaration) && declaration.initializer) {
+      resolvedEvidence = mergeMotionExpressionEvidence(
+        resolvedEvidence,
+        resolveMotionExpressionEvidence(
+          declaration.initializer,
+          typeChecker,
+          program,
+          nextVisitedSymbols,
+        ),
+      );
+    }
+  }
+  return resolvedEvidence;
 };
 
 const mergeMotionExpressionEvidence = (
@@ -152,17 +283,46 @@ const mergeMotionExpressionEvidence = (
   isMotionComponent: leftEvidence.isMotionComponent || rightEvidence.isMotionComponent,
   isMotionComponentFactory:
     leftEvidence.isMotionComponentFactory || rightEvidence.isMotionComponentFactory,
+  isMotionComponentNamespace:
+    leftEvidence.isMotionComponentNamespace || rightEvidence.isMotionComponentNamespace,
   isMotionConfig: leftEvidence.isMotionConfig || rightEvidence.isMotionConfig,
   isMotionNamespace: leftEvidence.isMotionNamespace || rightEvidence.isMotionNamespace,
   isReducedMotionHook: leftEvidence.isReducedMotionHook || rightEvidence.isReducedMotionHook,
 });
 
+const hasMotionExpressionEvidence = (evidence: MotionExpressionEvidence): boolean =>
+  evidence.isAnimationFunction ||
+  evidence.isMotionComponent ||
+  evidence.isMotionComponentFactory ||
+  evidence.isMotionComponentNamespace ||
+  evidence.isMotionConfig ||
+  evidence.isMotionNamespace ||
+  evidence.isReducedMotionHook;
+
+const classifyMotionMember = (
+  receiverEvidence: MotionExpressionEvidence,
+  memberName: string,
+): MotionExpressionEvidence => {
+  if (receiverEvidence.isMotionNamespace) return classifyMotionExport(memberName);
+  if (receiverEvidence.isMotionComponentFactory) {
+    return { ...EMPTY_MOTION_EXPRESSION_EVIDENCE, isMotionComponent: true };
+  }
+  if (
+    receiverEvidence.isMotionComponentNamespace &&
+    MOTION_COMPONENT_NAMESPACE_MEMBER_NAMES.has(memberName)
+  ) {
+    return { ...EMPTY_MOTION_EXPRESSION_EVIDENCE, isMotionComponent: true };
+  }
+  return EMPTY_MOTION_EXPRESSION_EVIDENCE;
+};
+
 const resolveMotionExpressionEvidence = (
   expression: ts.Expression,
   typeChecker: ts.TypeChecker,
+  program: ts.Program,
   visitedSymbols: Set<ts.Symbol> = new Set(),
 ): MotionExpressionEvidence => {
-  const unwrappedExpression = unwrapExpression(expression);
+  const unwrappedExpression = unwrapTypescriptExpression(expression);
 
   if (ts.isIdentifier(unwrappedExpression)) {
     const symbol = typeChecker.getSymbolAtLocation(unwrappedExpression);
@@ -172,7 +332,12 @@ const resolveMotionExpressionEvidence = (
 
     let resolvedEvidence = EMPTY_MOTION_EXPRESSION_EVIDENCE;
     for (const declaration of symbol.declarations ?? []) {
-      const importedEvidence = getImportedBindingEvidence(declaration);
+      const importedEvidence = getImportedBindingEvidence(
+        declaration,
+        typeChecker,
+        program,
+        nextVisitedSymbols,
+      );
       if (importedEvidence) {
         resolvedEvidence = mergeMotionExpressionEvidence(resolvedEvidence, importedEvidence);
         continue;
@@ -180,8 +345,33 @@ const resolveMotionExpressionEvidence = (
       if (ts.isVariableDeclaration(declaration) && declaration.initializer) {
         resolvedEvidence = mergeMotionExpressionEvidence(
           resolvedEvidence,
-          resolveMotionExpressionEvidence(declaration.initializer, typeChecker, nextVisitedSymbols),
+          resolveMotionExpressionEvidence(
+            declaration.initializer,
+            typeChecker,
+            program,
+            nextVisitedSymbols,
+          ),
         );
+      }
+      if (
+        ts.isBindingElement(declaration) &&
+        ts.isObjectBindingPattern(declaration.parent) &&
+        ts.isVariableDeclaration(declaration.parent.parent) &&
+        declaration.parent.parent.initializer
+      ) {
+        const propertyName = declaration.propertyName ?? declaration.name;
+        if (ts.isIdentifier(propertyName) || ts.isStringLiteral(propertyName)) {
+          const receiverEvidence = resolveMotionExpressionEvidence(
+            declaration.parent.parent.initializer,
+            typeChecker,
+            program,
+            nextVisitedSymbols,
+          );
+          resolvedEvidence = mergeMotionExpressionEvidence(
+            resolvedEvidence,
+            classifyMotionMember(receiverEvidence, propertyName.text),
+          );
+        }
       }
     }
     return resolvedEvidence;
@@ -191,15 +381,10 @@ const resolveMotionExpressionEvidence = (
     const receiverEvidence = resolveMotionExpressionEvidence(
       unwrappedExpression.expression,
       typeChecker,
+      program,
       visitedSymbols,
     );
-    if (receiverEvidence.isMotionNamespace) {
-      return classifyMotionExport(unwrappedExpression.name.text);
-    }
-    if (receiverEvidence.isMotionComponentFactory) {
-      return { ...EMPTY_MOTION_EXPRESSION_EVIDENCE, isMotionComponent: true };
-    }
-    return receiverEvidence;
+    return classifyMotionMember(receiverEvidence, unwrappedExpression.name.text);
   }
 
   if (
@@ -211,21 +396,39 @@ const resolveMotionExpressionEvidence = (
     const receiverEvidence = resolveMotionExpressionEvidence(
       unwrappedExpression.expression,
       typeChecker,
+      program,
       visitedSymbols,
     );
-    if (receiverEvidence.isMotionNamespace) {
-      return classifyMotionExport(unwrappedExpression.argumentExpression.text);
-    }
-    if (receiverEvidence.isMotionComponentFactory) {
-      return { ...EMPTY_MOTION_EXPRESSION_EVIDENCE, isMotionComponent: true };
-    }
-    return receiverEvidence;
+    return classifyMotionMember(receiverEvidence, unwrappedExpression.argumentExpression.text);
   }
 
   if (ts.isCallExpression(unwrappedExpression)) {
+    if (
+      ts.isIdentifier(unwrappedExpression.expression) &&
+      unwrappedExpression.expression.text === "require" &&
+      !typeChecker.getSymbolAtLocation(unwrappedExpression.expression) &&
+      unwrappedExpression.arguments.length === 1 &&
+      ts.isStringLiteral(unwrappedExpression.arguments[0]) &&
+      isMotionModuleSource(unwrappedExpression.arguments[0].text)
+    ) {
+      return { ...EMPTY_MOTION_EXPRESSION_EVIDENCE, isMotionNamespace: true };
+    }
+    if (
+      ts.isPropertyAccessExpression(unwrappedExpression.expression) &&
+      unwrappedExpression.expression.name.text === "bind"
+    ) {
+      const boundReceiverEvidence = resolveMotionExpressionEvidence(
+        unwrappedExpression.expression.expression,
+        typeChecker,
+        program,
+        visitedSymbols,
+      );
+      if (boundReceiverEvidence.isAnimationFunction) return boundReceiverEvidence;
+    }
     const calleeEvidence = resolveMotionExpressionEvidence(
       unwrappedExpression.expression,
       typeChecker,
+      program,
       visitedSymbols,
     );
     if (calleeEvidence.isMotionComponentFactory) {
@@ -237,29 +440,80 @@ const resolveMotionExpressionEvidence = (
   return EMPTY_MOTION_EXPRESSION_EVIDENCE;
 };
 
-const getStaticJsxAttributeValue = (attribute: ts.JsxAttribute): string | null => {
-  if (!attribute.initializer) return null;
-  if (ts.isStringLiteral(attribute.initializer)) return attribute.initializer.text;
-  if (!ts.isJsxExpression(attribute.initializer) || !attribute.initializer.expression) return null;
-  const expression = unwrapExpression(attribute.initializer.expression);
-  if (ts.isStringLiteral(expression) || ts.isNoSubstitutionTemplateLiteral(expression)) {
-    return expression.text;
+const getStaticStringExpressionValue = (
+  expression: ts.Expression,
+  typeChecker: ts.TypeChecker,
+  visitedSymbols: Set<ts.Symbol> = new Set(),
+): string | null => {
+  const unwrappedExpression = unwrapTypescriptExpression(expression);
+  if (
+    ts.isStringLiteral(unwrappedExpression) ||
+    ts.isNoSubstitutionTemplateLiteral(unwrappedExpression)
+  ) {
+    return unwrappedExpression.text;
+  }
+  if (!ts.isIdentifier(unwrappedExpression)) return null;
+  const symbol = typeChecker.getSymbolAtLocation(unwrappedExpression);
+  if (!symbol || visitedSymbols.has(symbol)) return null;
+  const nextVisitedSymbols = new Set(visitedSymbols);
+  nextVisitedSymbols.add(symbol);
+  for (const declaration of symbol.declarations ?? []) {
+    if (!ts.isVariableDeclaration(declaration) || !declaration.initializer) continue;
+    if (!ts.isVariableDeclarationList(declaration.parent)) continue;
+    if (!(declaration.parent.flags & ts.NodeFlags.Const)) continue;
+    const value = getStaticStringExpressionValue(
+      declaration.initializer,
+      typeChecker,
+      nextVisitedSymbols,
+    );
+    if (value !== null) return value;
   }
   return null;
 };
 
-const jsxElementHasReducedMotionConfiguration = (attributes: ts.JsxAttributes): boolean =>
+const getStaticJsxAttributeValue = (
+  attribute: ts.JsxAttribute,
+  typeChecker: ts.TypeChecker,
+): string | null => {
+  if (!attribute.initializer) return null;
+  if (ts.isStringLiteral(attribute.initializer)) return attribute.initializer.text;
+  if (!ts.isJsxExpression(attribute.initializer) || !attribute.initializer.expression) return null;
+  return getStaticStringExpressionValue(attribute.initializer.expression, typeChecker);
+};
+
+const isExpressionValueConsumed = (expression: ts.Expression): boolean => {
+  let currentExpression = expression;
+  while (
+    ts.isParenthesizedExpression(currentExpression.parent) ||
+    ts.isAsExpression(currentExpression.parent) ||
+    ts.isSatisfiesExpression(currentExpression.parent) ||
+    ts.isNonNullExpression(currentExpression.parent) ||
+    ts.isTypeAssertionExpression(currentExpression.parent)
+  ) {
+    currentExpression = currentExpression.parent;
+  }
+  return (
+    !ts.isExpressionStatement(currentExpression.parent) &&
+    !ts.isVoidExpression(currentExpression.parent)
+  );
+};
+
+const jsxElementHasReducedMotionConfiguration = (
+  attributes: ts.JsxAttributes,
+  typeChecker: ts.TypeChecker,
+): boolean =>
   attributes.properties.some(
     (attribute) =>
       ts.isJsxAttribute(attribute) &&
       ts.isIdentifier(attribute.name) &&
       attribute.name.text === REDUCED_MOTION_PROP_NAME &&
-      REDUCED_MOTION_CONFIG_VALUES.has(getStaticJsxAttributeValue(attribute) ?? ""),
+      REDUCED_MOTION_CONFIG_VALUES.has(getStaticJsxAttributeValue(attribute, typeChecker) ?? ""),
   );
 
 const collectScriptMotionEvidence = (
   sourceFile: ts.SourceFile,
   typeChecker: ts.TypeChecker,
+  program: ts.Program,
 ): ProjectMotionEvidence => {
   const evidence: ProjectMotionEvidence = {
     hasMotionUse: false,
@@ -268,34 +522,37 @@ const collectScriptMotionEvidence = (
 
   const visitNode = (node: ts.Node): void => {
     if (ts.isCallExpression(node)) {
-      const calleeEvidence = resolveMotionExpressionEvidence(node.expression, typeChecker);
-      if (
-        calleeEvidence.isAnimationFunction ||
-        calleeEvidence.isMotionComponentFactory ||
-        calleeEvidence.isReducedMotionHook
-      ) {
+      const calleeEvidence = resolveMotionExpressionEvidence(node.expression, typeChecker, program);
+      const isAnimationFunctionCallViaCallOrApply =
+        ((ts.isPropertyAccessExpression(node.expression) &&
+          (node.expression.name.text === "call" || node.expression.name.text === "apply")) ||
+          (ts.isElementAccessExpression(node.expression) &&
+            node.expression.argumentExpression &&
+            (ts.isStringLiteral(node.expression.argumentExpression) ||
+              ts.isNoSubstitutionTemplateLiteral(node.expression.argumentExpression)) &&
+            (node.expression.argumentExpression.text === "call" ||
+              node.expression.argumentExpression.text === "apply"))) &&
+        resolveMotionExpressionEvidence(node.expression.expression, typeChecker, program)
+          .isAnimationFunction;
+      if (calleeEvidence.isAnimationFunction || isAnimationFunctionCallViaCallOrApply) {
         evidence.hasMotionUse = true;
       }
-      if (calleeEvidence.isReducedMotionHook) evidence.hasReducedMotionHandling = true;
-    }
-
-    if (ts.isVariableDeclaration(node) && node.initializer) {
-      const initializerEvidence = resolveMotionExpressionEvidence(node.initializer, typeChecker);
-      if (initializerEvidence.isMotionComponent) evidence.hasMotionUse = true;
+      if (calleeEvidence.isReducedMotionHook && isExpressionValueConsumed(node)) {
+        evidence.hasReducedMotionHandling = true;
+      }
     }
 
     if (ts.isJsxOpeningElement(node) || ts.isJsxSelfClosingElement(node)) {
       const tagEvidence = ts.isJsxNamespacedName(node.tagName)
         ? EMPTY_MOTION_EXPRESSION_EVIDENCE
-        : resolveMotionExpressionEvidence(node.tagName, typeChecker);
-      if (
-        tagEvidence.isMotionComponent ||
-        tagEvidence.isMotionComponentFactory ||
-        tagEvidence.isMotionConfig
-      ) {
+        : resolveMotionExpressionEvidence(node.tagName, typeChecker, program);
+      if (tagEvidence.isMotionComponent || tagEvidence.isMotionComponentFactory) {
         evidence.hasMotionUse = true;
       }
-      if (tagEvidence.isMotionConfig && jsxElementHasReducedMotionConfiguration(node.attributes)) {
+      if (
+        tagEvidence.isMotionConfig &&
+        jsxElementHasReducedMotionConfiguration(node.attributes, typeChecker)
+      ) {
         evidence.hasReducedMotionHandling = true;
       }
     }
@@ -307,13 +564,6 @@ const collectScriptMotionEvidence = (
   return evidence;
 };
 
-const getScriptKind = (fileName: string): ts.ScriptKind => {
-  if (fileName.endsWith(".tsx")) return ts.ScriptKind.TSX;
-  if (fileName.endsWith(".jsx")) return ts.ScriptKind.JSX;
-  if (fileName.endsWith(".ts")) return ts.ScriptKind.TS;
-  return ts.ScriptKind.JS;
-};
-
 export const analyzeReducedMotionSource = ({
   fileName,
   sourceText,
@@ -322,17 +572,33 @@ export const analyzeReducedMotionSource = ({
     return { hasMotionUse: false, hasReducedMotionHandling: false };
   }
 
+  const sources = [{ fileName, sourceText }];
+  return analyzeReducedMotionSources(sources);
+};
+
+const analyzeReducedMotionSources = (sources: ScriptMotionSource[]): ProjectMotionEvidence => {
+  if (!sources.some(({ sourceText }) => MOTION_SOURCE_PREFILTER.test(sourceText))) {
+    return { hasMotionUse: false, hasReducedMotionHandling: false };
+  }
+
   const compilerOptions: ts.CompilerOptions = {
     allowJs: true,
     checkJs: false,
     jsx: ts.JsxEmit.Preserve,
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
     noEmit: true,
     noLib: true,
     noResolve: true,
     skipLibCheck: true,
     target: ts.ScriptTarget.Latest,
   };
-  const normalizedFileName = path.resolve(fileName);
+  const sourceTextByFileName = new Map(
+    sources.map(({ fileName: sourceFileName, sourceText: content }) => [
+      path.resolve(sourceFileName),
+      content,
+    ]),
+  );
   const compilerHost = ts.createCompilerHost(compilerOptions);
   const getDefaultSourceFile = compilerHost.getSourceFile.bind(compilerHost);
   compilerHost.getSourceFile = (
@@ -341,13 +607,13 @@ export const analyzeReducedMotionSource = ({
     onError,
     shouldCreateNewSourceFile,
   ) =>
-    path.resolve(requestedFileName) === normalizedFileName
+    sourceTextByFileName.has(path.resolve(requestedFileName))
       ? ts.createSourceFile(
-          normalizedFileName,
-          sourceText,
+          path.resolve(requestedFileName),
+          sourceTextByFileName.get(path.resolve(requestedFileName)) ?? "",
           languageVersionOrOptions,
           true,
-          getScriptKind(normalizedFileName),
+          getTypescriptScriptKind(requestedFileName),
         )
       : getDefaultSourceFile(
           requestedFileName,
@@ -355,10 +621,20 @@ export const analyzeReducedMotionSource = ({
           onError,
           shouldCreateNewSourceFile,
         );
-  const program = ts.createProgram([normalizedFileName], compilerOptions, compilerHost);
-  const sourceFile = program.getSourceFile(normalizedFileName);
-  if (!sourceFile) return { hasMotionUse: false, hasReducedMotionHandling: false };
-  return collectScriptMotionEvidence(sourceFile, program.getTypeChecker());
+  const program = ts.createProgram([...sourceTextByFileName.keys()], compilerOptions, compilerHost);
+  const typeChecker = program.getTypeChecker();
+  const evidence: ProjectMotionEvidence = {
+    hasMotionUse: false,
+    hasReducedMotionHandling: false,
+  };
+  for (const sourceFileName of sourceTextByFileName.keys()) {
+    const sourceFile = program.getSourceFile(sourceFileName);
+    if (!sourceFile) continue;
+    const fileEvidence = collectScriptMotionEvidence(sourceFile, typeChecker, program);
+    evidence.hasMotionUse ||= fileEvidence.hasMotionUse;
+    evidence.hasReducedMotionHandling ||= fileEvidence.hasReducedMotionHandling;
+  }
+  return evidence;
 };
 
 const removeCssCommentsAndStrings = (content: string): string => {
@@ -458,7 +734,7 @@ const hasReducedMotionMediaQuery = (content: string): boolean => {
 };
 
 const collectProjectMotionEvidence = (rootDirectory: string): ProjectMotionEvidence => {
-  const scriptFiles: Array<{ absolutePath: string; content: string }> = [];
+  const scriptSources: ScriptMotionSource[] = [];
   let hasReducedMotionHandling = false;
 
   for (const { absolutePath, name } of walkSourceTreeFiles(rootDirectory)) {
@@ -476,23 +752,16 @@ const collectProjectMotionEvidence = (rootDirectory: string): ProjectMotionEvide
       if (hasReducedMotionMediaQuery(content)) hasReducedMotionHandling = true;
       continue;
     }
-    if (MOTION_SOURCE_PREFILTER.test(content)) scriptFiles.push({ absolutePath, content });
+    scriptSources.push({ fileName: absolutePath, sourceText: content });
   }
 
-  if (scriptFiles.length === 0) {
+  if (scriptSources.length === 0) {
     return { hasMotionUse: false, hasReducedMotionHandling };
   }
 
-  let hasMotionUse = false;
-  for (const { absolutePath, content } of scriptFiles) {
-    const fileEvidence = analyzeReducedMotionSource({
-      fileName: absolutePath,
-      sourceText: content,
-    });
-    hasMotionUse ||= fileEvidence.hasMotionUse;
-    hasReducedMotionHandling ||= fileEvidence.hasReducedMotionHandling;
-    if (hasMotionUse && hasReducedMotionHandling) break;
-  }
+  const scriptEvidence = analyzeReducedMotionSources(scriptSources);
+  const hasMotionUse = scriptEvidence.hasMotionUse;
+  hasReducedMotionHandling ||= scriptEvidence.hasReducedMotionHandling;
 
   return { hasMotionUse, hasReducedMotionHandling };
 };

--- a/packages/core/src/check-reduced-motion.ts
+++ b/packages/core/src/check-reduced-motion.ts
@@ -193,7 +193,11 @@ const resolveModuleExportEvidence = (
     if (!ts.isStringLiteral(statement.moduleSpecifier)) continue;
     const moduleSource = statement.moduleSpecifier.text;
     if (!statement.exportClause) {
-      if (isMotionModuleSource(moduleSource)) return classifyMotionExport(exportName);
+      if (isMotionModuleSource(moduleSource)) {
+        const evidence = classifyMotionExport(exportName);
+        if (hasMotionExpressionEvidence(evidence)) return evidence;
+        continue;
+      }
       const moduleSourceFile = getLocalModuleSourceFile(moduleSource, sourceFile.fileName, program);
       if (moduleSourceFile) {
         const evidence = resolveModuleExportEvidence(

--- a/packages/core/src/runners/oxlint/resolve-use-call-binding.ts
+++ b/packages/core/src/runners/oxlint/resolve-use-call-binding.ts
@@ -1,4 +1,6 @@
 import ts from "typescript";
+import { getTypescriptScriptKind } from "../../utils/get-typescript-script-kind.js";
+import { unwrapTypescriptExpression } from "../../utils/unwrap-typescript-expression.js";
 
 interface ReactImportBindings {
   namespaceNames: Set<string>;
@@ -29,36 +31,15 @@ const REACT_USE_BINDING_RESOLUTION: BindingResolution = {
   isReactNamespaceBinding: false,
 };
 
-const getScriptKind = (filename: string): ts.ScriptKind => {
-  if (filename.endsWith(".tsx")) return ts.ScriptKind.TSX;
-  if (filename.endsWith(".jsx")) return ts.ScriptKind.JSX;
-  if (filename.endsWith(".ts")) return ts.ScriptKind.TS;
-  return ts.ScriptKind.JS;
-};
-
 const getUtf16Offset = (sourceText: string, utf8Offset: number): number =>
   Buffer.from(sourceText).subarray(0, utf8Offset).toString("utf8").length;
-
-const unwrapExpression = (expression: ts.Expression): ts.Expression => {
-  let currentExpression = expression;
-  while (
-    ts.isParenthesizedExpression(currentExpression) ||
-    ts.isAsExpression(currentExpression) ||
-    ts.isSatisfiesExpression(currentExpression) ||
-    ts.isNonNullExpression(currentExpression) ||
-    ts.isTypeAssertionExpression(currentExpression)
-  ) {
-    currentExpression = currentExpression.expression;
-  }
-  return currentExpression;
-};
 
 const getStaticPropertyName = (node: ts.PropertyName | undefined): string | null => {
   if (!node) return null;
   if (ts.isIdentifier(node) || ts.isStringLiteral(node) || ts.isNumericLiteral(node))
     return node.text;
   if (ts.isComputedPropertyName(node)) {
-    const expression = unwrapExpression(node.expression);
+    const expression = unwrapTypescriptExpression(node.expression);
     if (ts.isStringLiteral(expression) || ts.isNoSubstitutionTemplateLiteral(expression)) {
       return expression.text;
     }
@@ -102,7 +83,7 @@ const isReactUseObjectBindingElement = (bindingElement: ts.BindingElement): bool
 };
 
 const isReactRequireCall = (expression: ts.Expression): boolean => {
-  const unwrappedExpression = unwrapExpression(expression);
+  const unwrappedExpression = unwrapTypescriptExpression(expression);
   return (
     ts.isCallExpression(unwrappedExpression) &&
     ts.isIdentifier(unwrappedExpression.expression) &&
@@ -273,7 +254,7 @@ const isReactNamespaceExpression = (
   sourceFile: ts.SourceFile,
   visitedDeclarations: Set<ts.Node>,
 ): boolean => {
-  const unwrappedExpression = unwrapExpression(expression);
+  const unwrappedExpression = unwrapTypescriptExpression(expression);
   if (isReactRequireCall(unwrappedExpression)) return true;
   if (!ts.isIdentifier(unwrappedExpression)) return false;
   if (
@@ -299,7 +280,7 @@ const isReactUseExpression = (
   visitedDeclarations: Set<ts.Node>,
 ): boolean => {
   if (!expression) return false;
-  const unwrappedExpression = unwrapExpression(expression);
+  const unwrappedExpression = unwrapTypescriptExpression(expression);
   if (ts.isIdentifier(unwrappedExpression)) {
     if (
       reactImportBindings.useImportNames.has(unwrappedExpression.text) &&
@@ -604,7 +585,7 @@ export const resolveUseCallBinding = (
     sourceText,
     ts.ScriptTarget.Latest,
     true,
-    getScriptKind(filename),
+    getTypescriptScriptKind(filename),
   );
   const useOffset = getUtf16Offset(sourceText, utf8Offset);
   const useIdentifier = findUseCallIdentifier(sourceFile, useOffset);

--- a/packages/core/src/runners/oxlint/should-suppress-compiler-finding-in-worklet.ts
+++ b/packages/core/src/runners/oxlint/should-suppress-compiler-finding-in-worklet.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import ts from "typescript";
 import type { ProjectInfo } from "../../types/index.js";
+import { getTypescriptScriptKind } from "../../utils/get-typescript-script-kind.js";
 
 // React Compiler diagnostics fire on `sharedValue.value` reads/writes even
 // inside Reanimated worklets. A worklet body is extracted by Reanimated's
@@ -48,13 +49,6 @@ interface OxlintDiagnosticCandidate {
   filename: string;
   labels: OxlintLabel[];
 }
-
-const getScriptKind = (filename: string): ts.ScriptKind => {
-  if (filename.endsWith(".tsx")) return ts.ScriptKind.TSX;
-  if (filename.endsWith(".jsx")) return ts.ScriptKind.JSX;
-  if (filename.endsWith(".ts")) return ts.ScriptKind.TS;
-  return ts.ScriptKind.JS;
-};
 
 const getUtf16Offset = (sourceText: string, utf8Offset: number): number =>
   Buffer.from(sourceText).subarray(0, utf8Offset).toString("utf8").length;
@@ -160,7 +154,7 @@ export const shouldSuppressCompilerFindingInWorklet = (
     sourceText,
     ts.ScriptTarget.Latest,
     true,
-    getScriptKind(absolutePath),
+    getTypescriptScriptKind(absolutePath),
   );
   return isOffsetInsideWorklet(sourceFile, getUtf16Offset(sourceText, primaryLabel.span.offset));
 };

--- a/packages/core/src/runners/oxlint/suppress-memoization-in-bailed-out-functions.ts
+++ b/packages/core/src/runners/oxlint/suppress-memoization-in-bailed-out-functions.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import ts from "typescript";
 import type { Diagnostic } from "../../types/index.js";
+import { getTypescriptScriptKind } from "../../utils/get-typescript-script-kind.js";
 import { lineOfUtf8Offset } from "../../utils/line-of-utf8-offset.js";
 
 const MANUAL_MEMOIZATION_PLUGIN = "react-doctor";
@@ -12,13 +13,6 @@ interface LineRange {
   readonly startLine: number;
   readonly endLine: number;
 }
-
-const getScriptKind = (filename: string): ts.ScriptKind => {
-  if (filename.endsWith(".tsx")) return ts.ScriptKind.TSX;
-  if (filename.endsWith(".jsx")) return ts.ScriptKind.JSX;
-  if (filename.endsWith(".ts")) return ts.ScriptKind.TS;
-  return ts.ScriptKind.JS;
-};
 
 const isManualMemoizationDiagnostic = (diagnostic: Diagnostic): boolean =>
   diagnostic.plugin === MANUAL_MEMOIZATION_PLUGIN && diagnostic.rule === MANUAL_MEMOIZATION_RULE;
@@ -107,7 +101,7 @@ export const suppressMemoizationInBailedOutFunctions = (
           buffer.toString("utf8"),
           ts.ScriptTarget.Latest,
           true,
-          getScriptKind(absolutePath),
+          getTypescriptScriptKind(absolutePath),
         ),
         buffer,
       };

--- a/packages/core/src/utils/get-typescript-script-kind.ts
+++ b/packages/core/src/utils/get-typescript-script-kind.ts
@@ -1,0 +1,8 @@
+import ts from "typescript";
+
+export const getTypescriptScriptKind = (fileName: string): ts.ScriptKind => {
+  if (fileName.endsWith(".tsx")) return ts.ScriptKind.TSX;
+  if (fileName.endsWith(".jsx")) return ts.ScriptKind.JSX;
+  if (fileName.endsWith(".ts")) return ts.ScriptKind.TS;
+  return ts.ScriptKind.JS;
+};

--- a/packages/core/src/utils/unwrap-typescript-expression.ts
+++ b/packages/core/src/utils/unwrap-typescript-expression.ts
@@ -1,0 +1,15 @@
+import ts from "typescript";
+
+export const unwrapTypescriptExpression = (expression: ts.Expression): ts.Expression => {
+  let currentExpression = expression;
+  while (
+    ts.isParenthesizedExpression(currentExpression) ||
+    ts.isAsExpression(currentExpression) ||
+    ts.isSatisfiesExpression(currentExpression) ||
+    ts.isNonNullExpression(currentExpression) ||
+    ts.isTypeAssertionExpression(currentExpression)
+  ) {
+    currentExpression = currentExpression.expression;
+  }
+  return currentExpression;
+};

--- a/packages/core/tests/check-reduced-motion.test.ts
+++ b/packages/core/tests/check-reduced-motion.test.ts
@@ -22,74 +22,520 @@ describe("checkReducedMotion", () => {
     fs.writeFileSync(filePath, contents);
   };
 
-  const writePackageJsonWithMotionLibrary = (): void => {
+  const writePackageJson = (
+    motionDependencySection: "dependencies" | "devDependencies" | null = "dependencies",
+  ): void => {
+    const packageJson =
+      motionDependencySection === null
+        ? { name: "app", dependencies: { react: "^19.0.0" } }
+        : {
+            name: "app",
+            [motionDependencySection]: { react: "^19.0.0", "framer-motion": "^12.0.0" },
+          };
+    writeNestedFile("package.json", JSON.stringify(packageJson));
+  };
+
+  const writeDirectMotionUse = (): void => {
     writeNestedFile(
-      "package.json",
-      JSON.stringify({ name: "app", dependencies: { "framer-motion": "^11.0.0" } }),
+      "src/app.tsx",
+      `import { motion } from "framer-motion";
+export const App = () => <motion.div animate={{ x: 120 }}>moving</motion.div>;
+`,
     );
   };
 
-  // Issue: `git grep` exits 128 outside a repository, and the old code
-  // conflated that failure with "no match" — a non-git tree with a motion
-  // library was ALWAYS flagged, so the same tree produced different
-  // diagnostic sets depending on git availability.
-  it("finds reduced-motion handling via the filesystem when the tree is not a git repository", () => {
-    writePackageJsonWithMotionLibrary();
-    writeNestedFile("src/app.tsx", "const reduced = useReducedMotion();\n");
+  const initializeGitRepository = (): void => {
+    const runGit = (...arguments_: string[]): void => {
+      const result = spawnSync("git", arguments_, { cwd: temporaryDirectory });
+      expect(result.status).toBe(0);
+    };
+    runGit("init", "--quiet");
+    runGit("add", "-A");
+    runGit(
+      "-c",
+      "user.email=test@example.com",
+      "-c",
+      "user.name=Test",
+      "commit",
+      "--quiet",
+      "-m",
+      "initial",
+    );
+  };
+
+  it("stays clean when a motion dependency is declared but unused", () => {
+    writePackageJson();
+    writeNestedFile("src/app.ts", `export const renderLabel = (): string => "ready";\n`);
 
     expect(checkReducedMotion(temporaryDirectory)).toEqual([]);
   });
 
-  it("reports the diagnostic when a non-git tree has no reduced-motion handling", () => {
-    writePackageJsonWithMotionLibrary();
-    writeNestedFile("src/app.tsx", "export const App = () => null;\n");
+  it("stays clean when an unused motion import is present", () => {
+    writePackageJson();
+    writeNestedFile(
+      "src/app.tsx",
+      `import { motion } from "framer-motion";
+export const App = () => <div>still</div>;
+`,
+    );
+
+    expect(checkReducedMotion(temporaryDirectory)).toEqual([]);
+  });
+
+  it("stays clean when only a type import is present", () => {
+    writePackageJson();
+    writeNestedFile(
+      "src/app.ts",
+      `import type { MotionProps } from "framer-motion";
+export const props: MotionProps = {};
+`,
+    );
+
+    expect(checkReducedMotion(temporaryDirectory)).toEqual([]);
+  });
+
+  it("stays clean when runtime motion and type imports are both unused", () => {
+    writePackageJson();
+    writeNestedFile(
+      "src/app.tsx",
+      `import { motion, type MotionProps } from "framer-motion";
+export const App = (_props: MotionProps) => <div>still</div>;
+`,
+    );
+
+    expect(checkReducedMotion(temporaryDirectory)).toEqual([]);
+  });
+
+  it("stays clean when an unused motion dependency is declared as a dev dependency", () => {
+    writePackageJson("devDependencies");
+    writeNestedFile("src/app.ts", `export const renderLabel = (): string => "ready";\n`);
+
+    expect(checkReducedMotion(temporaryDirectory)).toEqual([]);
+  });
+
+  it("reports direct motion component use without handling", () => {
+    writePackageJson();
+    writeDirectMotionUse();
 
     const diagnostics = checkReducedMotion(temporaryDirectory);
 
     expect(diagnostics).toHaveLength(1);
-    expect(diagnostics[0]!.rule).toBe("require-reduced-motion");
+    expect(diagnostics[0]).toMatchObject({
+      filePath: "package.json",
+      rule: "require-reduced-motion",
+      line: 0,
+      column: 0,
+    });
   });
 
-  it("ignores reduced-motion handling that only lives in ignored directories", () => {
-    writePackageJsonWithMotionLibrary();
-    writeNestedFile("dist/bundle.js", "matchMedia('(prefers-reduced-motion: reduce)');\n");
+  it("reports an aliased motion component import", () => {
+    writePackageJson();
+    writeNestedFile(
+      "src/app.tsx",
+      `import { motion as animated } from "framer-motion";
+export const App = () => <animated.div>moving</animated.div>;
+`,
+    );
 
     expect(checkReducedMotion(temporaryDirectory)).toHaveLength(1);
   });
 
-  const initGitRepo = (): void => {
-    const run = (...args: string[]): void => {
-      const result = spawnSync("git", args, { cwd: temporaryDirectory });
-      expect(result.status).toBe(0);
-    };
-    run("init", "--quiet");
-    run("add", "-A");
-    run("-c", "user.email=t@e.com", "-c", "user.name=t", "commit", "--quiet", "-m", "init");
-  };
-
-  // Issue: `git grep` matches committed build output, so a `prefers-reduced-motion`
-  // string inside `dist/` cleared the diagnostic on the git path while the
-  // filesystem fallback (which skips `dist/`) still reported it — the same tree
-  // diverged on git availability.
-  it("ignores git-tracked reduced-motion handling that only lives in ignored directories", () => {
-    writePackageJsonWithMotionLibrary();
-    writeNestedFile("dist/bundle.js", "matchMedia('(prefers-reduced-motion: reduce)');\n");
-    writeNestedFile("src/app.tsx", "export const App = () => null;\n");
-    initGitRepo();
+  it("reports a namespace motion component", () => {
+    writePackageJson();
+    writeNestedFile(
+      "src/app.tsx",
+      `import * as Framer from "framer-motion";
+export const App = () => <Framer.motion.div>moving</Framer.motion.div>;
+`,
+    );
 
     expect(checkReducedMotion(temporaryDirectory)).toHaveLength(1);
   });
 
-  it("finds git-tracked reduced-motion handling in real source", () => {
-    writePackageJsonWithMotionLibrary();
-    writeNestedFile("src/app.tsx", "const reduced = useReducedMotion();\n");
-    initGitRepo();
+  it("reports motion use imported from the motion react subpath", () => {
+    writePackageJson();
+    writeNestedFile(
+      "src/app.tsx",
+      `import { motion } from "motion/react";
+export const App = () => <motion.div animate={{ x: 120 }}>moving</motion.div>;
+`,
+    );
+
+    expect(checkReducedMotion(temporaryDirectory)).toHaveLength(1);
+  });
+
+  it("reports a computed namespace motion component alias", () => {
+    writePackageJson();
+    writeNestedFile(
+      "src/app.tsx",
+      `import * as Framer from "framer-motion";
+const AnimatedCard = Framer["motion"]["div"];
+export const App = () => <AnimatedCard>moving</AnimatedCard>;
+`,
+    );
+
+    expect(checkReducedMotion(temporaryDirectory)).toHaveLength(1);
+  });
+
+  it("reports a module-local motion component wrapper", () => {
+    writePackageJson();
+    writeNestedFile(
+      "src/app.tsx",
+      `import { motion } from "framer-motion";
+const AnimatedCard = motion.div;
+export const App = () => <AnimatedCard>moving</AnimatedCard>;
+`,
+    );
+
+    expect(checkReducedMotion(temporaryDirectory)).toHaveLength(1);
+  });
+
+  it("reports a real animate function call", () => {
+    writePackageJson();
+    writeNestedFile(
+      "src/app.ts",
+      `import { animate as runAnimation } from "framer-motion";
+export const start = (): void => { runAnimation("#box", { x: 120 }); };
+`,
+    );
+
+    expect(checkReducedMotion(temporaryDirectory)).toHaveLength(1);
+  });
+
+  it("accepts MotionConfig from the real library with user preference handling", () => {
+    writePackageJson();
+    writeNestedFile(
+      "src/app.tsx",
+      `import { MotionConfig as Config, motion } from "framer-motion";
+export const App = () => (
+  <Config reducedMotion="user">
+    <motion.div animate={{ x: 120 }}>moving</motion.div>
+  </Config>
+);
+`,
+    );
 
     expect(checkReducedMotion(temporaryDirectory)).toEqual([]);
   });
 
+  it("accepts namespace MotionConfig with always-reduced handling", () => {
+    writePackageJson();
+    writeNestedFile(
+      "src/app.tsx",
+      `import * as Framer from "framer-motion";
+export const App = () => (
+  <Framer.MotionConfig reducedMotion={"always"}>
+    <Framer.motion.div animate={{ x: 120 }}>moving</Framer.motion.div>
+  </Framer.MotionConfig>
+);
+`,
+    );
+
+    expect(checkReducedMotion(temporaryDirectory)).toEqual([]);
+  });
+
+  it("does not accept MotionConfig configured to ignore reduced-motion preferences", () => {
+    writePackageJson();
+    writeNestedFile(
+      "src/app.tsx",
+      `import { MotionConfig, motion } from "framer-motion";
+export const App = () => (
+  <MotionConfig reducedMotion="never">
+    <motion.div animate={{ x: 120 }}>moving</motion.div>
+  </MotionConfig>
+);
+`,
+    );
+
+    expect(checkReducedMotion(temporaryDirectory)).toHaveLength(1);
+  });
+
+  it("does not accept a dynamic MotionConfig preference", () => {
+    writePackageJson();
+    writeNestedFile(
+      "src/app.tsx",
+      `import { MotionConfig, motion } from "framer-motion";
+const preference = "user";
+export const App = () => (
+  <MotionConfig reducedMotion={preference}>
+    <motion.div animate={{ x: 120 }}>moving</motion.div>
+  </MotionConfig>
+);
+`,
+    );
+
+    expect(checkReducedMotion(temporaryDirectory)).toHaveLength(1);
+  });
+
+  it("accepts a called useReducedMotion import from the real library", () => {
+    writePackageJson();
+    writeNestedFile(
+      "src/app.tsx",
+      `import { motion, useReducedMotion as usePreference } from "framer-motion";
+export const App = () => {
+  const shouldReduceMotion = usePreference();
+  return <motion.div animate={{ x: shouldReduceMotion ? 0 : 120 }}>moving</motion.div>;
+};
+`,
+    );
+
+    expect(checkReducedMotion(temporaryDirectory)).toEqual([]);
+  });
+
+  it("does not accept an unused useReducedMotion import", () => {
+    writePackageJson();
+    writeNestedFile(
+      "src/app.tsx",
+      `import { motion, useReducedMotion } from "framer-motion";
+export const App = () => <motion.div animate={{ x: 120 }}>moving</motion.div>;
+`,
+    );
+
+    expect(checkReducedMotion(temporaryDirectory)).toHaveLength(1);
+  });
+
+  it("does not mistake a shadowing local motion binding for library use", () => {
+    writePackageJson();
+    writeNestedFile(
+      "src/app.tsx",
+      `import { motion } from "framer-motion";
+const renderLocalElement = (motion: { div: string }) => motion.div;
+export const App = () => <div>{renderLocalElement({ div: "still" })}</div>;
+`,
+    );
+
+    expect(checkReducedMotion(temporaryDirectory)).toEqual([]);
+  });
+
+  it("does not mistake a similarly named package for motion-library use", () => {
+    writePackageJson();
+    writeNestedFile(
+      "src/app.tsx",
+      `import { motion } from "framer-motion-utils";
+export const App = () => <motion.div>still</motion.div>;
+`,
+    );
+
+    expect(checkReducedMotion(temporaryDirectory)).toEqual([]);
+  });
+
+  it("does not accept a MotionConfig token in a comment", () => {
+    writePackageJson();
+    writeNestedFile(
+      "src/app.tsx",
+      `import { motion } from "framer-motion";
+// Documentation mentions MotionConfig but no provider is installed.
+export const App = () => <motion.div animate={{ x: 120 }}>moving</motion.div>;
+`,
+    );
+
+    expect(checkReducedMotion(temporaryDirectory)).toHaveLength(1);
+  });
+
+  it("does not accept a useReducedMotion token in a string", () => {
+    writePackageJson();
+    writeNestedFile(
+      "src/app.tsx",
+      `import { motion } from "framer-motion";
+const documentationSearchTerm = "useReducedMotion";
+export const App = () => <motion.div data-docs={documentationSearchTerm} animate={{ x: 120 }}>moving</motion.div>;
+`,
+    );
+
+    expect(checkReducedMotion(temporaryDirectory)).toHaveLength(1);
+  });
+
+  it("does not accept an unrelated reducedMotion identifier", () => {
+    writePackageJson();
+    writeNestedFile(
+      "src/app.tsx",
+      `import { motion } from "framer-motion";
+const reducedMotionDocumentationUrl = "/help/animation";
+export const App = () => <motion.div data-docs={reducedMotionDocumentationUrl} animate={{ x: 120 }}>moving</motion.div>;
+`,
+    );
+
+    expect(checkReducedMotion(temporaryDirectory)).toHaveLength(1);
+  });
+
+  it("does not accept a locally defined useReducedMotion lookalike", () => {
+    writePackageJson();
+    writeNestedFile(
+      "src/app.tsx",
+      `import { motion } from "framer-motion";
+const useReducedMotion = (): boolean => true;
+export const App = () => {
+  useReducedMotion();
+  return <motion.div animate={{ x: 120 }}>moving</motion.div>;
+};
+`,
+    );
+
+    expect(checkReducedMotion(temporaryDirectory)).toHaveLength(1);
+  });
+
+  it("does not accept a locally defined MotionConfig lookalike", () => {
+    writePackageJson();
+    writeNestedFile(
+      "src/app.tsx",
+      `import { motion } from "framer-motion";
+const MotionConfig = ({ children }: { children: unknown }) => children;
+export const App = () => (
+  <MotionConfig reducedMotion="user">
+    <motion.div animate={{ x: 120 }}>moving</motion.div>
+  </MotionConfig>
+);
+`,
+    );
+
+    expect(checkReducedMotion(temporaryDirectory)).toHaveLength(1);
+  });
+
+  it("accepts a parsed reduced-motion CSS media rule", () => {
+    writePackageJson();
+    writeDirectMotionUse();
+    writeNestedFile(
+      "src/styles.css",
+      `@media screen and (prefers-reduced-motion: reduce) {
+  * { animation-duration: 0.01ms; }
+}
+`,
+    );
+
+    expect(checkReducedMotion(temporaryDirectory)).toEqual([]);
+  });
+
+  it("does not accept a reduced-motion token in a CSS comment", () => {
+    writePackageJson();
+    writeDirectMotionUse();
+    writeNestedFile(
+      "src/styles.css",
+      `/* prefers-reduced-motion support is tracked separately. */
+.card { transform: translateX(0); }
+`,
+    );
+
+    expect(checkReducedMotion(temporaryDirectory)).toHaveLength(1);
+  });
+
+  it("does not accept a reduced-motion media query in a Sass line comment", () => {
+    writePackageJson();
+    writeDirectMotionUse();
+    writeNestedFile(
+      "src/styles.scss",
+      `// @media (prefers-reduced-motion: reduce) { * { animation: none; } }
+.card { transform: translateX(0); }
+`,
+    );
+
+    expect(checkReducedMotion(temporaryDirectory)).toHaveLength(1);
+  });
+
+  it("does not accept a reduced-motion media query inside a CSS string", () => {
+    writePackageJson();
+    writeDirectMotionUse();
+    writeNestedFile(
+      "src/styles.css",
+      `.card::before { content: "@media (prefers-reduced-motion: reduce) { * { animation: none; } }"; }
+`,
+    );
+
+    expect(checkReducedMotion(temporaryDirectory)).toHaveLength(1);
+  });
+
+  it("does not accept an inverted reduced-motion media query", () => {
+    writePackageJson();
+    writeDirectMotionUse();
+    writeNestedFile(
+      "src/styles.css",
+      `@media not (prefers-reduced-motion: reduce) {
+  .card { animation: pulse 1s infinite; }
+}
+`,
+    );
+
+    expect(checkReducedMotion(temporaryDirectory)).toHaveLength(1);
+  });
+
+  it("does not accept an empty reduced-motion media query", () => {
+    writePackageJson();
+    writeDirectMotionUse();
+    writeNestedFile("src/styles.css", `@media (prefers-reduced-motion: reduce) {}\n`);
+
+    expect(checkReducedMotion(temporaryDirectory)).toHaveLength(1);
+  });
+
+  it("combines motion use and handling from separate source files", () => {
+    writePackageJson();
+    writeDirectMotionUse();
+    writeNestedFile(
+      "src/providers.tsx",
+      `import { MotionConfig } from "framer-motion";
+export const Providers = ({ children }: { children: unknown }) => (
+  <MotionConfig reducedMotion="user">{children}</MotionConfig>
+);
+`,
+    );
+
+    expect(checkReducedMotion(temporaryDirectory)).toEqual([]);
+  });
+
+  it("ignores handling that only lives in an ignored build directory", () => {
+    writePackageJson();
+    writeDirectMotionUse();
+    writeNestedFile(
+      "dist/bundle.css",
+      `@media (prefers-reduced-motion: reduce) { * { animation: none; } }\n`,
+    );
+
+    expect(checkReducedMotion(temporaryDirectory)).toHaveLength(1);
+  });
+
+  it("ignores motion use that only lives in an ignored build directory", () => {
+    writePackageJson();
+    writeNestedFile("src/app.ts", `export const renderLabel = (): string => "ready";\n`);
+    writeNestedFile(
+      "dist/bundle.js",
+      `import { motion } from "framer-motion"; motion.div({ animate: { x: 120 } });\n`,
+    );
+
+    expect(checkReducedMotion(temporaryDirectory)).toEqual([]);
+  });
+
+  it("finds real handling in an untracked source file", () => {
+    writePackageJson();
+    writeDirectMotionUse();
+    initializeGitRepository();
+    writeNestedFile(
+      "src/providers.tsx",
+      `import { MotionConfig } from "framer-motion";
+export const Providers = ({ children }: { children: unknown }) => (
+  <MotionConfig reducedMotion="user">{children}</MotionConfig>
+);
+`,
+    );
+
+    expect(checkReducedMotion(temporaryDirectory)).toEqual([]);
+  });
+
+  it("returns the same verdict for Git and non-Git trees", () => {
+    writePackageJson();
+    writeDirectMotionUse();
+    const nonGitDiagnostics = checkReducedMotion(temporaryDirectory);
+    initializeGitRepository();
+
+    expect(checkReducedMotion(temporaryDirectory)).toEqual(nonGitDiagnostics);
+    expect(nonGitDiagnostics).toHaveLength(1);
+  });
+
   it("returns no diagnostics when the project has no motion library", () => {
-    writeNestedFile("package.json", JSON.stringify({ name: "app", dependencies: {} }));
+    writePackageJson(null);
+    writeNestedFile(
+      "src/app.tsx",
+      `const motion = { div: "div" };
+export const App = () => <motion.div>still</motion.div>;
+`,
+    );
 
     expect(checkReducedMotion(temporaryDirectory)).toEqual([]);
   });

--- a/packages/core/tests/check-reduced-motion.test.ts
+++ b/packages/core/tests/check-reduced-motion.test.ts
@@ -300,6 +300,42 @@ export const App = () => <motion.div animate={{ x: 120 }}>moving</motion.div>;
     expect(checkReducedMotion(temporaryDirectory)).toHaveLength(1);
   });
 
+  it("continues past an unrelated star re-export to a later motion alias", () => {
+    writePackageJson();
+    writeNestedFile(
+      "src/motion.ts",
+      `export * from "framer-motion";
+export { motion as animated } from "framer-motion";
+`,
+    );
+    writeNestedFile(
+      "src/app.tsx",
+      `import { animated } from "./motion";
+export const App = () => <animated.div animate={{ x: 120 }}>moving</animated.div>;
+`,
+    );
+
+    expect(checkReducedMotion(temporaryDirectory)).toHaveLength(1);
+  });
+
+  it("keeps a non-motion alias after a star re-export clean", () => {
+    writePackageJson();
+    writeNestedFile(
+      "src/motion.ts",
+      `export * from "framer-motion";
+export { useScroll as readScroll } from "framer-motion";
+`,
+    );
+    writeNestedFile(
+      "src/app.tsx",
+      `import { readScroll } from "./motion";
+export const usePosition = () => readScroll();
+`,
+    );
+
+    expect(checkReducedMotion(temporaryDirectory)).toEqual([]);
+  });
+
   it("stays clean when a motion re-export is never imported", () => {
     writePackageJson();
     writeNestedFile("src/motion.ts", `export { motion } from "framer-motion";\n`);

--- a/packages/core/tests/check-reduced-motion.test.ts
+++ b/packages/core/tests/check-reduced-motion.test.ts
@@ -152,6 +152,42 @@ export const App = () => <Framer.motion.div>moving</Framer.motion.div>;
     expect(checkReducedMotion(temporaryDirectory)).toHaveLength(1);
   });
 
+  it("reports a Reorder item", () => {
+    writePackageJson();
+    writeNestedFile(
+      "src/app.tsx",
+      `import { Reorder } from "framer-motion";
+export const App = () => <Reorder.Item value="one">moving</Reorder.Item>;
+`,
+    );
+
+    expect(checkReducedMotion(temporaryDirectory)).toHaveLength(1);
+  });
+
+  it("stays clean when only a Reorder group is rendered", () => {
+    writePackageJson();
+    writeNestedFile(
+      "src/app.tsx",
+      `import { Reorder } from "framer-motion";
+export const App = () => <Reorder.Group values={[]} onReorder={() => {}} />;
+`,
+    );
+
+    expect(checkReducedMotion(temporaryDirectory)).toEqual([]);
+  });
+
+  it("stays clean when AnimatePresence has no motion child", () => {
+    writePackageJson();
+    writeNestedFile(
+      "src/app.tsx",
+      `import { AnimatePresence } from "framer-motion";
+export const App = () => <AnimatePresence><div>still</div></AnimatePresence>;
+`,
+    );
+
+    expect(checkReducedMotion(temporaryDirectory)).toEqual([]);
+  });
+
   it("reports motion use imported from the motion react subpath", () => {
     writePackageJson();
     writeNestedFile(
@@ -190,6 +226,137 @@ export const App = () => <AnimatedCard>moving</AnimatedCard>;
     expect(checkReducedMotion(temporaryDirectory)).toHaveLength(1);
   });
 
+  it("stays clean when a module-local motion component wrapper is never rendered", () => {
+    writePackageJson();
+    writeNestedFile(
+      "src/app.tsx",
+      `import { motion } from "framer-motion";
+const AnimatedCard = motion.div;
+export const App = () => <div>still</div>;
+`,
+    );
+
+    expect(checkReducedMotion(temporaryDirectory)).toEqual([]);
+  });
+
+  it("reports a motion component imported through a local re-export", () => {
+    writePackageJson();
+    writeNestedFile(
+      "src/motion.ts",
+      `export { motion as animated } from "framer-motion";
+`,
+    );
+    writeNestedFile(
+      "src/app.tsx",
+      `import { animated } from "./motion";
+export const App = () => <animated.div animate={{ x: 120 }}>moving</animated.div>;
+`,
+    );
+
+    expect(checkReducedMotion(temporaryDirectory)).toHaveLength(1);
+  });
+
+  it("reports an exported module-local motion wrapper", () => {
+    writePackageJson();
+    writeNestedFile(
+      "src/motion.ts",
+      `import { motion } from "framer-motion";
+export const AnimatedCard = motion.div;
+`,
+    );
+    writeNestedFile(
+      "src/app.tsx",
+      `import { AnimatedCard } from "./motion";
+export const App = () => <AnimatedCard animate={{ x: 120 }}>moving</AnimatedCard>;
+`,
+    );
+
+    expect(checkReducedMotion(temporaryDirectory)).toHaveLength(1);
+  });
+
+  it("reports a local re-export imported with an explicit JavaScript extension", () => {
+    writePackageJson();
+    writeNestedFile("src/motion.ts", `export { motion } from "framer-motion";\n`);
+    writeNestedFile(
+      "src/app.tsx",
+      `import { motion } from "./motion.js";
+export const App = () => <motion.div animate={{ x: 120 }}>moving</motion.div>;
+`,
+    );
+
+    expect(checkReducedMotion(temporaryDirectory)).toHaveLength(1);
+  });
+
+  it("reports a motion component imported through a star re-export", () => {
+    writePackageJson();
+    writeNestedFile("src/motion.ts", `export * from "framer-motion";\n`);
+    writeNestedFile(
+      "src/app.tsx",
+      `import { motion } from "./motion";
+export const App = () => <motion.div animate={{ x: 120 }}>moving</motion.div>;
+`,
+    );
+
+    expect(checkReducedMotion(temporaryDirectory)).toHaveLength(1);
+  });
+
+  it("stays clean when a motion re-export is never imported", () => {
+    writePackageJson();
+    writeNestedFile("src/motion.ts", `export { motion } from "framer-motion";\n`);
+    writeNestedFile("src/app.tsx", `export const App = () => <div>still</div>;\n`);
+
+    expect(checkReducedMotion(temporaryDirectory)).toEqual([]);
+  });
+
+  it("resolves a motion component through circular star re-exports", () => {
+    writePackageJson();
+    writeNestedFile(
+      "src/motion-a.ts",
+      `export * from "./motion-b";
+`,
+    );
+    writeNestedFile(
+      "src/motion-b.ts",
+      `export * from "./motion-a";
+export * from "framer-motion";
+`,
+    );
+    writeNestedFile(
+      "src/app.tsx",
+      `import { motion } from "./motion-a";
+export const App = () => <motion.div animate={{ x: 120 }}>moving</motion.div>;
+`,
+    );
+
+    expect(checkReducedMotion(temporaryDirectory)).toHaveLength(1);
+  });
+
+  it("reports a destructured namespace motion component", () => {
+    writePackageJson();
+    writeNestedFile(
+      "src/app.tsx",
+      `import * as Framer from "framer-motion";
+const { motion: animated } = Framer;
+export const App = () => <animated.div animate={{ x: 120 }}>moving</animated.div>;
+`,
+    );
+
+    expect(checkReducedMotion(temporaryDirectory)).toHaveLength(1);
+  });
+
+  it("reports a destructured motion element", () => {
+    writePackageJson();
+    writeNestedFile(
+      "src/app.tsx",
+      `import { motion } from "framer-motion";
+const { div: AnimatedDiv } = motion;
+export const App = () => <AnimatedDiv animate={{ x: 120 }}>moving</AnimatedDiv>;
+`,
+    );
+
+    expect(checkReducedMotion(temporaryDirectory)).toHaveLength(1);
+  });
+
   it("reports a real animate function call", () => {
     writePackageJson();
     writeNestedFile(
@@ -200,6 +367,104 @@ export const start = (): void => { runAnimation("#box", { x: 120 }); };
     );
 
     expect(checkReducedMotion(temporaryDirectory)).toHaveLength(1);
+  });
+
+  it("reports a motion component loaded through global require", () => {
+    writePackageJson();
+    writeNestedFile(
+      "src/app.tsx",
+      `const { motion } = require("framer-motion");
+export const App = () => <motion.div animate={{ x: 120 }}>moving</motion.div>;
+`,
+    );
+
+    expect(checkReducedMotion(temporaryDirectory)).toHaveLength(1);
+  });
+
+  it("stays clean when require is a local lookalike", () => {
+    writePackageJson();
+    writeNestedFile(
+      "src/app.tsx",
+      `const require = (_moduleName: string) => ({ motion: { div: "div" } });
+const { motion } = require("framer-motion");
+export const App = () => <motion.div>still</motion.div>;
+`,
+    );
+
+    expect(checkReducedMotion(temporaryDirectory)).toEqual([]);
+  });
+
+  it("reports animate invoked through Function call", () => {
+    writePackageJson();
+    writeNestedFile(
+      "src/app.ts",
+      `import { animate } from "framer-motion";
+export const start = (): void => { animate.call(undefined, "#box", { x: 120 }); };
+`,
+    );
+
+    expect(checkReducedMotion(temporaryDirectory)).toHaveLength(1);
+  });
+
+  it("reports a bound animate function when the bound function is invoked", () => {
+    writePackageJson();
+    writeNestedFile(
+      "src/app.ts",
+      `import { animate } from "framer-motion";
+const animateBox = animate.bind(undefined, "#box");
+export const start = (): void => { animateBox({ x: 120 }); };
+`,
+    );
+
+    expect(checkReducedMotion(temporaryDirectory)).toHaveLength(1);
+  });
+
+  it("stays clean when a non-animation property on animate is called", () => {
+    writePackageJson();
+    writeNestedFile(
+      "src/app.ts",
+      `import { animate } from "framer-motion";
+export const describe = (): string => animate.toString();
+`,
+    );
+
+    expect(checkReducedMotion(temporaryDirectory)).toEqual([]);
+  });
+
+  it("stays clean when inView only observes visibility", () => {
+    writePackageJson();
+    writeNestedFile(
+      "src/app.ts",
+      `import { inView } from "framer-motion";
+export const observe = (): void => { inView("#target", () => undefined); };
+`,
+    );
+
+    expect(checkReducedMotion(temporaryDirectory)).toEqual([]);
+  });
+
+  it("stays clean when a motion value is created without visual motion", () => {
+    writePackageJson();
+    writeNestedFile(
+      "src/app.ts",
+      `import { useMotionValue } from "framer-motion";
+export const useCurrentPosition = () => useMotionValue(0);
+`,
+    );
+
+    expect(checkReducedMotion(temporaryDirectory)).toEqual([]);
+  });
+
+  it("stays clean when stagger only creates a delay function", () => {
+    writePackageJson();
+    writeNestedFile(
+      "src/app.ts",
+      `import { stagger } from "framer-motion";
+export const delayByIndex = stagger(0.1);
+`,
+    );
+
+    expect(checkReducedMotion(temporaryDirectory)).toEqual([]);
   });
 
   it("accepts MotionConfig from the real library with user preference handling", () => {
@@ -250,7 +515,7 @@ export const App = () => (
     expect(checkReducedMotion(temporaryDirectory)).toHaveLength(1);
   });
 
-  it("does not accept a dynamic MotionConfig preference", () => {
+  it("accepts a statically resolved MotionConfig preference", () => {
     writePackageJson();
     writeNestedFile(
       "src/app.tsx",
@@ -260,6 +525,51 @@ export const App = () => (
   <MotionConfig reducedMotion={preference}>
     <motion.div animate={{ x: 120 }}>moving</motion.div>
   </MotionConfig>
+);
+`,
+    );
+
+    expect(checkReducedMotion(temporaryDirectory)).toEqual([]);
+  });
+
+  it("does not accept a runtime MotionConfig preference", () => {
+    writePackageJson();
+    writeNestedFile(
+      "src/app.tsx",
+      `import { MotionConfig, motion } from "framer-motion";
+export const App = ({ preference }: { preference: "always" | "never" | "user" }) => (
+  <MotionConfig reducedMotion={preference}>
+    <motion.div animate={{ x: 120 }}>moving</motion.div>
+  </MotionConfig>
+);
+`,
+    );
+
+    expect(checkReducedMotion(temporaryDirectory)).toHaveLength(1);
+  });
+
+  it("stays clean when MotionConfig is rendered without any motion component", () => {
+    writePackageJson();
+    writeNestedFile(
+      "src/app.tsx",
+      `import { MotionConfig } from "framer-motion";
+export const App = () => <MotionConfig reducedMotion="never"><div>still</div></MotionConfig>;
+`,
+    );
+
+    expect(checkReducedMotion(temporaryDirectory)).toEqual([]);
+  });
+
+  it("does not accept reduced-motion configuration on an arbitrary nested member", () => {
+    writePackageJson();
+    writeNestedFile(
+      "src/app.tsx",
+      `import { MotionConfig, motion } from "framer-motion";
+const Provider = (MotionConfig as unknown as { Provider: typeof MotionConfig }).Provider;
+export const App = () => (
+  <Provider reducedMotion="user">
+    <motion.div animate={{ x: 120 }}>moving</motion.div>
+  </Provider>
 );
 `,
     );
@@ -280,6 +590,36 @@ export const App = () => {
     );
 
     expect(checkReducedMotion(temporaryDirectory)).toEqual([]);
+  });
+
+  it("does not accept an ignored useReducedMotion result", () => {
+    writePackageJson();
+    writeNestedFile(
+      "src/app.tsx",
+      `import { motion, useReducedMotion } from "framer-motion";
+export const App = () => {
+  useReducedMotion();
+  return <motion.div animate={{ x: 120 }}>moving</motion.div>;
+};
+`,
+    );
+
+    expect(checkReducedMotion(temporaryDirectory)).toHaveLength(1);
+  });
+
+  it("does not accept a voided useReducedMotion result", () => {
+    writePackageJson();
+    writeNestedFile(
+      "src/app.tsx",
+      `import { motion, useReducedMotion } from "framer-motion";
+export const App = () => {
+  void useReducedMotion();
+  return <motion.div animate={{ x: 120 }}>moving</motion.div>;
+};
+`,
+    );
+
+    expect(checkReducedMotion(temporaryDirectory)).toHaveLength(1);
   });
 
   it("does not accept an unused useReducedMotion import", () => {

--- a/packages/core/tests/check-reduced-motion.test.ts
+++ b/packages/core/tests/check-reduced-motion.test.ts
@@ -274,6 +274,42 @@ export const App = () => <AnimatedCard animate={{ x: 120 }}>moving</AnimatedCard
     expect(checkReducedMotion(temporaryDirectory)).toHaveLength(1);
   });
 
+  it("reports a default-exported motion wrapper", () => {
+    writePackageJson();
+    writeNestedFile(
+      "src/motion.ts",
+      `import { motion } from "framer-motion";
+export default motion;
+`,
+    );
+    writeNestedFile(
+      "src/app.tsx",
+      `import animated from "./motion";
+export const App = () => <animated.div animate={{ x: 120 }}>moving</animated.div>;
+`,
+    );
+
+    expect(checkReducedMotion(temporaryDirectory)).toHaveLength(1);
+  });
+
+  it("keeps a default-exported non-motion binding clean", () => {
+    writePackageJson();
+    writeNestedFile(
+      "src/motion.ts",
+      `import { useScroll } from "framer-motion";
+export default useScroll;
+`,
+    );
+    writeNestedFile(
+      "src/app.ts",
+      `import readScroll from "./motion";
+export const usePosition = () => readScroll();
+`,
+    );
+
+    expect(checkReducedMotion(temporaryDirectory)).toEqual([]);
+  });
+
   it("reports a local re-export imported with an explicit JavaScript extension", () => {
     writePackageJson();
     writeNestedFile("src/motion.ts", `export { motion } from "framer-motion";\n`);

--- a/packages/fuzz/corpus/regressions/require-reduced-motion--unused-dependency.tsx
+++ b/packages/fuzz/corpus/regressions/require-reduced-motion--unused-dependency.tsx
@@ -1,0 +1,5 @@
+// rule: require-reduced-motion
+// weakness: dependency-presence
+// source: verified unused framer-motion dependency false positive
+
+export const renderLabel = (): string => "ready";

--- a/packages/fuzz/corpus/regressions/require-reduced-motion--unused-wrapper.tsx
+++ b/packages/fuzz/corpus/regressions/require-reduced-motion--unused-wrapper.tsx
@@ -1,0 +1,9 @@
+// rule: require-reduced-motion
+// weakness: wrapper-transparency
+// source: PR 1238 adversarial validation
+
+import { animate } from "framer-motion";
+
+const getAnimation = () => animate;
+
+export const App = () => <div>{typeof getAnimation}</div>;

--- a/packages/fuzz/corpus/true-positives/require-reduced-motion--ignored-hook-result.tsx
+++ b/packages/fuzz/corpus/true-positives/require-reduced-motion--ignored-hook-result.tsx
@@ -1,0 +1,9 @@
+// rule: require-reduced-motion
+// source: PR 1238 adversarial validation
+
+import { motion, useReducedMotion } from "framer-motion";
+
+export const App = () => {
+  useReducedMotion();
+  return <motion.div animate={{ x: 120 }}>moving</motion.div>;
+};

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -180,7 +180,7 @@ export const LIBRARY_SNIPPET_POOL = [
 
 // Module scope — SSR hazards, guard aliases, contexts, caches, styled.
 export const MODULE_SCOPE_SNIPPET_POOL = [
-  `import { motion as FuzzMotion } from "framer-motion"; const FuzzMotionComponent = FuzzMotion.div;`,
+  `import { motion as FuzzMotion } from "framer-motion"; export const FuzzMotionPanel = () => <FuzzMotion.div animate={{ x: 120 }}>moving</FuzzMotion.div>;`,
   `const GLOBAL_CACHE = new Map<string, unknown>();`,
   `const FuzzPropTypesPanel = ({ value }) => <div>{value}</div>; FuzzPropTypesPanel.propTypes = { value: () => true };`,
   `function FuzzNestedWritePanel() { return <div />; } function unusedFuzzNestedWrite() { FuzzNestedWritePanel = () => null; } FuzzNestedWritePanel.propTypes = { value: () => true };`,

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -180,6 +180,7 @@ export const LIBRARY_SNIPPET_POOL = [
 
 // Module scope — SSR hazards, guard aliases, contexts, caches, styled.
 export const MODULE_SCOPE_SNIPPET_POOL = [
+  `import { motion as FuzzMotion } from "framer-motion"; const FuzzMotionComponent = FuzzMotion.div;`,
   `const GLOBAL_CACHE = new Map<string, unknown>();`,
   `const FuzzPropTypesPanel = ({ value }) => <div>{value}</div>; FuzzPropTypesPanel.propTypes = { value: () => true };`,
   `function FuzzNestedWritePanel() { return <div />; } function unusedFuzzNestedWrite() { FuzzNestedWritePanel = () => null; } FuzzNestedWritePanel.propTypes = { value: () => true };`,
@@ -432,6 +433,7 @@ export const EDGE_CASE_STATEMENT_POOL = [
 ] as const;
 
 export const IMPORT_LINE_POOL = [
+  `import { motion, MotionConfig, useReducedMotion } from "framer-motion";`,
   `import React from "react";`,
   `import * as React from "react";`,
   `import { useState, useEffect, useMemo, useCallback, useRef, useContext, useReducer, useTransition, useDeferredValue, useId, useLayoutEffect, useSyncExternalStore } from "react";`,

--- a/packages/fuzz/tests/fuzz-rules.test.ts
+++ b/packages/fuzz/tests/fuzz-rules.test.ts
@@ -2,7 +2,9 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterAll, describe, expect, it } from "vite-plus/test";
+import { analyzeReducedMotionSource } from "../../core/src/check-reduced-motion.js";
 import { reactDoctorRules } from "../../oxlint-plugin-react-doctor/src/plugin/rule-registry.js";
+import { defineRule } from "../../oxlint-plugin-react-doctor/src/plugin/utils/define-rule.js";
 import { fuzzRuleWithStats } from "../src/fuzz-rule.js";
 import type { FuzzFinding } from "../src/fuzz-rule.js";
 import { loadFuzzCorpus } from "../src/load-fuzz-corpus.js";
@@ -41,6 +43,27 @@ const fuzzTestTimeoutMs = Math.max(
 );
 const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
+const requireReducedMotionFuzzRule = defineRule({
+  id: "require-reduced-motion",
+  title: "Missing reduced-motion handling",
+  severity: "error",
+  recommendation: "Add real reduced-motion handling for motion-library use.",
+  scan: (file) => {
+    const evidence = analyzeReducedMotionSource({
+      fileName: file.relativePath,
+      sourceText: file.content,
+    });
+    return evidence.hasMotionUse && !evidence.hasReducedMotionHandling
+      ? [{ message: "Motion use has no reduced-motion handling.", line: 1, column: 1 }]
+      : [];
+  },
+});
+
+const fuzzRuleEntries = [
+  ...reactDoctorRules,
+  { id: requireReducedMotionFuzzRule.id, rule: requireReducedMotionFuzzRule },
+];
+
 // The built-in corpus combines confirmed false-positive regressions with
 // intentional liveness targets; FUZZ_CORPUS_DIR adds external real-world
 // files on top.
@@ -78,7 +101,7 @@ const formatFinding = (finding: FuzzFinding, reproducerPath: string): string =>
     `reproducer: ${reproducerPath}`,
   ].join("\n");
 
-const selectedRules = reactDoctorRules.filter(
+const selectedRules = fuzzRuleEntries.filter(
   (entry) => ruleFilter === undefined || entry.id === ruleFilter || entry.id.includes(ruleFilter),
 );
 

--- a/packages/react-doctor/tests/regressions/rn-and-motion.test.ts
+++ b/packages/react-doctor/tests/regressions/rn-and-motion.test.ts
@@ -574,7 +574,12 @@ export const App = () => {
       name: "issue-94-negative",
       dependencies: { react: "^19.0.0", "framer-motion": "^11.0.0" },
     });
-    writeFile(path.join(projectDir, "src", "App.tsx"), `export const App = () => null;\n`);
+    writeFile(
+      path.join(projectDir, "src", "App.tsx"),
+      `import { motion } from "framer-motion";
+export const App = () => <motion.div animate={{ x: 120 }}>moving</motion.div>;
+`,
+    );
     initGitRepo(projectDir, { commit: true });
 
     const diagnostics = checkReducedMotion(projectDir);


### PR DESCRIPTION
## Why

`require-reduced-motion` treated a dependency declaration as executable motion use and raw text tokens as reduced-motion handling. That reported unused libraries and let comments, strings, lookalike identifiers, unconsumed hooks, and incomplete `MotionConfig` usage hide real unhandled animations.

## What changed

- Require a supported motion binding to be executed as a component or animation call before reporting.
- Resolve aliases, namespaces, CommonJS imports, static computed members, local wrappers, and local named/star re-export barrels through binding identity.
- Continue export resolution when an unrelated star re-export precedes a later named motion alias.
- Resolve motion factories and components through local default exports and default imports.
- Accept only a consumed `useReducedMotion` result, `MotionConfig reducedMotion="user"|"always"`, or an active parsed reduced-motion CSS/SCSS media rule.
- Ignore dependency-only and type-only imports, unused wrappers, helper-only APIs, shadowed bindings, comments, strings, empty/inverted media rules, ignored hook results, and dynamic or missing `MotionConfig` policies.
- Share TypeScript expression-unwrapping and script-kind helpers instead of duplicating them.
- Add permanent regression, true-positive, generator, and strict-fuzz coverage.

## Precision boundary

This remains a project-wide accessibility check. It proves supported import/use and handling forms; it does not treat arbitrary documentation text, opaque runtime configuration, or similarly named userland APIs as evidence.

## Validation

- Focused semantic suite: 66/66
- Core suite: 118 files, 1,375 tests passed
- Full repository rule suites: core 1,375 passed; oxlint plugin 13,253 passed / 148 skipped; React Doctor 2,242 passed / 27 skipped with one unrelated 30-second performance-harness timeout under shared load; that exact case passed alone in 21.6 seconds
- React Doctor focused regression suite: 25/25
- Fuzz corpus: 43 passed / 402 opt-in cases skipped; no target-rule corpus regression
- Strict fuzz: 500 iterations; direct true-positive liveness replay confirms `hasMotionUse=true` and `hasReducedMotionHandling=false`
- Exact minimized schema-v3 matrix: unused dependency 1→0; genuine animation 1→1; handled/no-library remain 0; five text/comment/identifier bypasses 0→1
- RDE A/B: 100/100 pinned schema-v3 roots rescanned, target 2→3; the sole addition is a manually verified true positive in Twenty, which renders many Framer Motion components and has no reduced-motion handling
- React Bench-5 A/B: 122/122 exact pinned base scans complete on both sides with cache disabled; target 11→11
  - removed: LeafWiki unused-dependency false positive
  - added: Boemly executed Framer Motion true positive (`MotionConfig` has no reduced-motion policy)
- React Bench-5 solution oracles: all 11 persisted target-relevant oracle reports rescanned; target 10→10 with no new deltas
- Complete self-scan: no diagnostics in changed files
- `nr typecheck`
- `nr lint` (pre-existing warnings only)
- `nr format:check`
- `nr smoke:json-report`
- `git diff --check`

## Status

Do not merge until the pushed head's CI and review-thread audits are complete.
