### PR TITLE
fix(rule): prove native collection methods in custom hooks

### DIFF
--- a/.changeset/loud-boats-push.md
+++ b/.changeset/loud-boats-push.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Prevent no-prop-callback-in-render from treating native collection methods on custom Hook parameters as caller callbacks.

--- a/packages/fuzz/corpus/regressions/no-prop-callback-in-render--custom-hook-native-collection.tsx
+++ b/packages/fuzz/corpus/regressions/no-prop-callback-in-render--custom-hook-native-collection.tsx
@@ -1,0 +1,10 @@
+// rule: no-prop-callback-in-render
+// weakness: receiver-provenance
+// source: React Bench fix-react-cloudscape-design-components-4461
+export const useItemTotal = (items: readonly string[]) => {
+  let total = 0;
+  items.forEach((item) => {
+    total += item.length;
+  });
+  return total;
+};

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -219,6 +219,7 @@ export const MODULE_SCOPE_SNIPPET_POOL = [
   `const fuzzLeftItems = ["a", "b"]; const fuzzRightItems = ["a", "b"]; const fuzzItemsMatch = fuzzLeftItems.every((item, index) => item === fuzzRightItems[index]);`,
   `const FuzzLargeTextThreshold = 50_000; const FuzzLargeTextCodeBlock = ({ children }) => { if (typeof children === "string" && children.length > FuzzLargeTextThreshold) return <VirtualizedCode text={children} />; return <pre>{children}</pre>; }; const FuzzPolymorphicChildPanel = ({ children }) => typeof children === "string" ? <span>{children}</span> : <div>{children}</div>;`,
   `const FuzzMemoList = React.memo(({ items }) => <div>{items.length}</div>, (previousProps, nextProps) => previousProps.items.length === nextProps.items.length); const FuzzDefaultList = ({ items = [] }) => <FuzzMemoList items={items} />;`,
+  `const useFuzzCollection = (items: readonly string[]) => { items.forEach((item) => consume(item)); }; const useFuzzCallback = (onVisit: (item: string) => void) => { onVisit(String(value)); };`,
   `const FuzzPropTypesPanel = ({ value }) => <div>{value}</div>; FuzzPropTypesPanel.propTypes = { value: () => true };`,
   `function FuzzNestedWritePanel() { return <div />; } function unusedFuzzNestedWrite() { FuzzNestedWritePanel = () => null; } FuzzNestedWritePanel.propTypes = { value: () => true };`,
   `function FuzzReturnedLabel() { let output = "label"; function unusedFuzzOutputWrite() { output = <div />; } return output; } FuzzReturnedLabel.propTypes = { value: () => true };`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-prop-callback-in-render.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-prop-callback-in-render.test.ts
@@ -124,6 +124,47 @@ describe("no-prop-callback-in-render", () => {
        };`,
     ],
     [
+      "a native-looking method after its parameter is reassigned",
+      `const useItems = (items: string[], onRender: typeof items.forEach) => {
+         items = { forEach: onRender } as unknown as string[];
+         items.forEach(() => {});
+       };`,
+    ],
+    [
+      "an overwritten native method",
+      `const useItems = (items: string[], onRender: typeof items.forEach) => {
+         items.forEach = onRender;
+         items.forEach(() => {});
+       };`,
+    ],
+    [
+      "a dynamically overwritten native method",
+      `const useItems = (
+         items: string[],
+         methodName: keyof typeof items,
+         onRender: typeof items.forEach,
+       ) => {
+         items[methodName] = onRender;
+         items.forEach(() => {});
+       };`,
+    ],
+    [
+      "a native-looking method after a synchronous helper reassigns its parameter",
+      `const useItems = (items: string[], onRender: typeof items.forEach) => {
+         const replaceItems = () => {
+           items = { forEach: onRender } as unknown as string[];
+         };
+         replaceItems();
+         items.forEach(() => {});
+       };`,
+    ],
+    [
+      "a native type name shadowed by an enclosing type parameter",
+      `const useItems = <Array extends { forEach(callback: () => void): void }>(items: Array) => {
+         items.forEach(() => {});
+       };`,
+    ],
+    [
       "a mutating Set method on a custom hook parameter",
       `const useMutateValues = (values: Set<string>) => {
          values.add("next");
@@ -162,10 +203,24 @@ describe("no-prop-callback-in-render", () => {
        };`,
     ],
     [
+      "nested callback methods invoked by native iteration",
+      `interface Action { nested: { run(): void } }
+       const useRunActions = (actions: readonly Action[]) => {
+         actions.forEach((action) => action.nested.run());
+       };`,
+    ],
+    [
       "callback values invoked by a local iterator binding",
       `const useRunCallbacks = (callbacks: ReadonlyArray<() => void>) => {
          const runCallback = (callback: () => void) => callback();
          callbacks.forEach(runCallback);
+       };`,
+    ],
+    [
+      "a local iterator binding that invokes a captured callback parameter",
+      `const useVisitItems = (items: readonly string[], onVisit: (item: string) => void) => {
+         const visitItem = (item: string) => onVisit(item);
+         items.forEach(visitItem);
        };`,
     ],
     [
@@ -221,6 +276,13 @@ describe("no-prop-callback-in-render", () => {
       "a callback retrieved from a native collection",
       `const useRunCallback = (callbacks: ReadonlyMap<string, () => void>) => {
          callbacks.get("ready")?.();
+       };`,
+    ],
+    [
+      "a callback method retrieved from a native collection",
+      `interface Action { run(): void }
+       const useRunAction = (actions: ReadonlyArray<Action>) => {
+         actions.at(0)?.run();
        };`,
     ],
   ])("reports %s", (_name, code) => {
@@ -383,6 +445,14 @@ describe("no-prop-callback-in-render", () => {
        };`,
     ],
     [
+      "native iteration that defers a captured callback parameter",
+      `const useVisitItems = (items: readonly string[], onVisit: (item: string) => void) => {
+         items.forEach((item) => {
+           queueMicrotask(() => onVisit(item));
+         });
+       };`,
+    ],
+    [
       "native iteration through TypeScript and optional-chain wrappers",
       `const useItemTotal = (items: readonly string[]) => {
          (items as string[])?.forEach?.((item) => { consume(item); });
@@ -393,6 +463,23 @@ describe("no-prop-callback-in-render", () => {
       `function useItemTotal(seed: number, items: readonly string[] = []) {
          items.forEach((item) => { consume(seed, item); });
        }`,
+    ],
+    [
+      "a global Array annotation with an unrelated nested type declaration",
+      `const useItemTotal = (items: Array<string>) => {
+         items.forEach((item) => { consume(item); });
+       };
+       const unrelated = () => {
+         type Array<T> = { value: T };
+         return null as Array<string> | null;
+       };`,
+    ],
+    [
+      "native iteration before the method is overwritten",
+      `const useItems = (items: string[], replacement: typeof items.forEach) => {
+         items.forEach((item) => { consume(item); });
+         items.forEach = replacement;
+       };`,
     ],
   ])("stays silent for %s", (_name, code) => {
     const result = run(code);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-prop-callback-in-render.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-prop-callback-in-render.test.ts
@@ -67,6 +67,162 @@ describe("no-prop-callback-in-render", () => {
          if (error) onError(error);
        };`,
     ],
+    [
+      "a handler method on a custom hook options parameter",
+      `const useNotifyError = (options) => {
+         options.onError();
+       };`,
+    ],
+    [
+      "a static-computed handler method on a custom hook options parameter",
+      `const useNotifyError = (options) => {
+         options["handleError"]();
+       };`,
+    ],
+    [
+      "an optional handler method on a custom hook options parameter",
+      `const useNotifyError = (options) => {
+         options?.onError?.();
+       };`,
+    ],
+    [
+      "call on a custom hook callback parameter",
+      `const useNotifyError = (notify) => {
+         notify.call(null);
+       };`,
+    ],
+    [
+      "static-computed apply on a custom hook callback parameter",
+      `const useNotifyError = (notify) => {
+         notify["apply"](null, []);
+       };`,
+    ],
+    [
+      "a destructured callback from a custom hook options parameter",
+      `const useNotifyError = (options) => {
+         const { notify } = options;
+         notify();
+       };`,
+    ],
+    [
+      "an opaque method on a custom hook parameter",
+      `const useRegistry = (registry) => {
+         registry.query();
+       };`,
+    ],
+    [
+      "a mutating method on a typed store hook parameter",
+      `interface Store<T> { setState(value: T): void }
+       const useStoreSync = <T,>(store: Store<T>, state: T) => {
+         store.setState(state);
+       };`,
+    ],
+    [
+      "a mutating array method on a custom hook parameter",
+      `const useMutateItems = (items: string[]) => {
+         items.sort();
+       };`,
+    ],
+    [
+      "a mutating Set method on a custom hook parameter",
+      `const useMutateValues = (values: Set<string>) => {
+         values.add("next");
+       };`,
+    ],
+    [
+      "a mutating Map method on a custom hook parameter",
+      `const useMutateEntries = (entries: Map<string, number>) => {
+         entries.set("next", 1);
+       };`,
+    ],
+    [
+      "a method on a locally shadowed native type name",
+      `type Array<T> = { forEach(callback: (value: T) => void): void };
+       const useItems = (items: Array<string>) => {
+         items.forEach((item) => consume(item));
+       };`,
+    ],
+    [
+      "a callback parameter passed to native iteration",
+      `const useVisitItems = (items: readonly string[], onVisit: (item: string) => void) => {
+         items.forEach(onVisit);
+       };`,
+    ],
+    [
+      "callback values invoked by native iteration",
+      `const useRunCallbacks = (callbacks: ReadonlyArray<() => void>) => {
+         callbacks.forEach((callback) => callback());
+       };`,
+    ],
+    [
+      "callback methods invoked by native iteration",
+      `interface Action { run(): void }
+       const useRunActions = (actions: readonly Action[]) => {
+         actions.forEach((action) => action.run());
+       };`,
+    ],
+    [
+      "callback values invoked by a local iterator binding",
+      `const useRunCallbacks = (callbacks: ReadonlyArray<() => void>) => {
+         const runCallback = (callback: () => void) => callback();
+         callbacks.forEach(runCallback);
+       };`,
+    ],
+    [
+      "aliased callback values invoked by native iteration",
+      `const useRunCallbacks = (callbacks: ReadonlyArray<() => void>) => {
+         callbacks.forEach((callback) => {
+           const firstAlias = callback;
+           const secondAlias = firstAlias;
+           secondAlias();
+         });
+       };`,
+    ],
+    [
+      "destructured callback methods invoked by native iteration",
+      `interface Action { run(): void }
+       const useRunActions = (actions: readonly Action[]) => {
+         actions.forEach((action) => {
+           const { run } = action;
+           run();
+         });
+       };`,
+    ],
+    [
+      "reassigned callback values invoked by native iteration",
+      `const useRunCallbacks = (callbacks: ReadonlyArray<() => void>) => {
+         callbacks.forEach((callback) => {
+           let assignedCallback = () => {};
+           assignedCallback = callback;
+           assignedCallback();
+         });
+       };`,
+    ],
+    [
+      "rest-destructured callback methods invoked by native iteration",
+      `interface Action { run(): void }
+       const useRunActions = (actions: readonly Action[]) => {
+         actions.forEach((action) => {
+           const { ...actionAlias } = action;
+           actionAlias.run();
+         });
+       };`,
+    ],
+    [
+      "array-destructured callback values invoked by native iteration",
+      `const useRunCallbacks = (callbackGroups: ReadonlyArray<readonly [() => void]>) => {
+         callbackGroups.forEach((callbackGroup) => {
+           const [callback] = callbackGroup;
+           callback();
+         });
+       };`,
+    ],
+    [
+      "a callback retrieved from a native collection",
+      `const useRunCallback = (callbacks: ReadonlyMap<string, () => void>) => {
+         callbacks.get("ready")?.();
+       };`,
+    ],
   ])("reports %s", (_name, code) => {
     const result = run(code);
     expect(result.parseErrors).toEqual([]);
@@ -170,6 +326,73 @@ describe("no-prop-callback-in-render", () => {
          items.forEach((item) => { item.validate(); });
          return null;
        };`,
+    ],
+    [
+      "native array iteration on a typed custom hook parameter",
+      `const useItemTotal = (items: readonly string[]) => {
+         let total = 0;
+         items.forEach((item) => { total += item.length; });
+         return total;
+       };`,
+    ],
+    [
+      "native array transforms on a custom hook parameter",
+      `const useItems = (items: readonly string[]) => {
+         items.map((item) => item.length);
+         items.filter((item) => item.length > 0);
+       };`,
+    ],
+    [
+      "native Map and Set iteration on custom hook parameters",
+      `const useEntries = (entries: ReadonlyMap<string, number>, values: ReadonlySet<number>) => {
+         entries.forEach((value) => { consume(value); });
+         values.forEach((value) => { consume(value); });
+       };`,
+    ],
+    [
+      "a read method shared by native collection union members",
+      `const useEntries = (values: readonly string[] | ReadonlySet<string>) => {
+         values.forEach((value) => { consume(value); });
+       };`,
+    ],
+    [
+      "a native string method on a custom hook parameter",
+      `const useNormalizedValue = (value: string) => {
+         value.trim();
+       };`,
+    ],
+    [
+      "non-invoking function and Promise methods on typed custom hook parameters",
+      `const useDeferredValue = (callback: () => void, promise: Promise<string>) => {
+         callback.bind(null);
+         promise.then((value) => consume(value));
+       };`,
+    ],
+    [
+      "native iteration through a stable parameter alias",
+      `const useItemTotal = (items: readonly string[]) => {
+         const values = items;
+         values.forEach((item) => { consume(item); });
+       };`,
+    ],
+    [
+      "native iteration with a local callback binding",
+      `const useItemTotal = (items: readonly string[]) => {
+         const visitItem = (item: string) => consume(item);
+         items.forEach(visitItem);
+       };`,
+    ],
+    [
+      "native iteration through TypeScript and optional-chain wrappers",
+      `const useItemTotal = (items: readonly string[]) => {
+         (items as string[])?.forEach?.((item) => { consume(item); });
+       };`,
+    ],
+    [
+      "native iteration on a later function-declaration parameter",
+      `function useItemTotal(seed: number, items: readonly string[] = []) {
+         items.forEach((item) => { consume(seed, item); });
+       }`,
     ],
   ])("stays silent for %s", (_name, code) => {
     const result = run(code);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-prop-callback-in-render.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-prop-callback-in-render.ts
@@ -84,7 +84,9 @@ export const noPropCallbackInRender = defineRule({
       if (isFunctionLike(callee)) return;
       if (
         !getDownstreamRefs(analysis, callee).some((reference) =>
-          isPropCallbackInvocationRef(analysis, reference),
+          isPropCallbackInvocationRef(analysis, reference, {
+            ignoreProvenNativeCustomHookMethod: true,
+          }),
         )
       ) {
         return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-prop-callback-in-render.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-prop-callback-in-render.ts
@@ -85,7 +85,7 @@ export const noPropCallbackInRender = defineRule({
       if (
         !getDownstreamRefs(analysis, callee).some((reference) =>
           isPropCallbackInvocationRef(analysis, reference, {
-            ignoreProvenNativeCustomHookMethod: true,
+            nativeMethodScopes: context.scopes,
           }),
         )
       ) {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/effect/constants.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/effect/constants.ts
@@ -1,1 +1,3 @@
+export const FIRST_ARGUMENT_INDEX = 0;
 export const MAX_EXPRESSION_SNIPPET_ITEMS_COUNT = 3;
+export const SECOND_ARGUMENT_INDEX = 1;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/effect/is-proven-native-read-method.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/effect/is-proven-native-read-method.ts
@@ -1,6 +1,7 @@
 import type { Reference } from "eslint-scope";
 import type { EsTreeNode } from "../../../../utils/es-tree-node.js";
 import { findProgramRoot } from "../../../../utils/find-program-root.js";
+import { hasEnclosingTypeParameterNamed } from "../../../../utils/has-enclosing-type-parameter-named.js";
 import { isNodeOfType } from "../../../../utils/is-node-of-type.js";
 import { walkAst } from "../../../../utils/walk-ast.js";
 
@@ -112,39 +113,89 @@ const NATIVE_TYPE_NAMES: ReadonlySet<string> = new Set([
   "Set",
 ]);
 
-const shadowedNativeTypeNamesByProgram: WeakMap<EsTreeNode, ReadonlySet<string>> = new WeakMap();
+interface NativeTypeDeclaration {
+  name: string;
+  scope: EsTreeNode;
+}
 
-const getShadowedNativeTypeNames = (node: EsTreeNode): ReadonlySet<string> => {
-  const program = findProgramRoot(node);
-  if (!program) return NATIVE_TYPE_NAMES;
-  const cachedNames = shadowedNativeTypeNamesByProgram.get(program);
-  if (cachedNames) return cachedNames;
-  const shadowedNames = new Set<string>();
+const nativeTypeDeclarationsByProgram: WeakMap<EsTreeNode, NativeTypeDeclaration[]> = new WeakMap();
+const shadowedNativeTypeNamesByBinding: WeakMap<EsTreeNode, ReadonlySet<string>> = new WeakMap();
+
+const isWithinNode = (node: EsTreeNode, ancestor: EsTreeNode): boolean => {
+  let current: EsTreeNode | null | undefined = node;
+  while (current) {
+    if (current === ancestor) return true;
+    current = current.parent;
+  }
+  return false;
+};
+
+const findTypeDeclarationScope = (declaration: EsTreeNode): EsTreeNode | null => {
+  let current = declaration.parent;
+  while (current) {
+    if (
+      isNodeOfType(current, "Program") ||
+      isNodeOfType(current, "BlockStatement") ||
+      isNodeOfType(current, "TSModuleBlock") ||
+      isNodeOfType(current, "StaticBlock")
+    ) {
+      return current;
+    }
+    current = current.parent;
+  }
+  return null;
+};
+
+const getDeclaredTypeName = (declaration: EsTreeNode): string | null => {
+  if (
+    !isNodeOfType(declaration, "ClassDeclaration") &&
+    !isNodeOfType(declaration, "TSEnumDeclaration") &&
+    !isNodeOfType(declaration, "TSImportEqualsDeclaration") &&
+    !isNodeOfType(declaration, "TSInterfaceDeclaration") &&
+    !isNodeOfType(declaration, "TSModuleDeclaration") &&
+    !isNodeOfType(declaration, "TSTypeAliasDeclaration")
+  ) {
+    return null;
+  }
+  return declaration.id && isNodeOfType(declaration.id, "Identifier") ? declaration.id.name : null;
+};
+
+const getNativeTypeDeclarations = (program: EsTreeNode): NativeTypeDeclaration[] => {
+  const cachedDeclarations = nativeTypeDeclarationsByProgram.get(program);
+  if (cachedDeclarations) return cachedDeclarations;
+  const declarations: NativeTypeDeclaration[] = [];
   walkAst(program, (candidate) => {
     if (isNodeOfType(candidate, "ImportDeclaration")) {
       for (const specifier of candidate.specifiers) {
-        if (
-          (isNodeOfType(specifier, "ImportDefaultSpecifier") ||
-            isNodeOfType(specifier, "ImportNamespaceSpecifier") ||
-            isNodeOfType(specifier, "ImportSpecifier")) &&
-          NATIVE_TYPE_NAMES.has(specifier.local.name)
-        ) {
-          shadowedNames.add(specifier.local.name);
+        if (NATIVE_TYPE_NAMES.has(specifier.local.name)) {
+          declarations.push({ name: specifier.local.name, scope: program });
         }
       }
       return;
     }
-    if (
-      (isNodeOfType(candidate, "ClassDeclaration") ||
-        isNodeOfType(candidate, "TSInterfaceDeclaration") ||
-        isNodeOfType(candidate, "TSTypeAliasDeclaration")) &&
-      candidate.id &&
-      NATIVE_TYPE_NAMES.has(candidate.id.name)
-    ) {
-      shadowedNames.add(candidate.id.name);
-    }
+    const declaredTypeName = getDeclaredTypeName(candidate);
+    if (!declaredTypeName || !NATIVE_TYPE_NAMES.has(declaredTypeName)) return;
+    const declarationScope = findTypeDeclarationScope(candidate);
+    if (declarationScope) declarations.push({ name: declaredTypeName, scope: declarationScope });
   });
-  shadowedNativeTypeNamesByProgram.set(program, shadowedNames);
+  nativeTypeDeclarationsByProgram.set(program, declarations);
+  return declarations;
+};
+
+const getShadowedNativeTypeNames = (binding: EsTreeNode): ReadonlySet<string> => {
+  const cachedNames = shadowedNativeTypeNamesByBinding.get(binding);
+  if (cachedNames) return cachedNames;
+  const shadowedNames = new Set<string>();
+  for (const typeName of NATIVE_TYPE_NAMES) {
+    if (hasEnclosingTypeParameterNamed(binding, typeName)) shadowedNames.add(typeName);
+  }
+  const program = findProgramRoot(binding);
+  if (program) {
+    for (const declaration of getNativeTypeDeclarations(program)) {
+      if (isWithinNode(binding, declaration.scope)) shadowedNames.add(declaration.name);
+    }
+  }
+  shadowedNativeTypeNamesByBinding.set(binding, shadowedNames);
   return shadowedNames;
 };
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/effect/is-proven-native-read-method.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/effect/is-proven-native-read-method.ts
@@ -1,0 +1,241 @@
+import type { Reference } from "eslint-scope";
+import type { EsTreeNode } from "../../../../utils/es-tree-node.js";
+import { findProgramRoot } from "../../../../utils/find-program-root.js";
+import { isNodeOfType } from "../../../../utils/is-node-of-type.js";
+import { walkAst } from "../../../../utils/walk-ast.js";
+
+const ARRAY_READ_METHOD_NAMES: ReadonlySet<string> = new Set([
+  "at",
+  "concat",
+  "entries",
+  "every",
+  "filter",
+  "find",
+  "findIndex",
+  "findLast",
+  "findLastIndex",
+  "flat",
+  "flatMap",
+  "forEach",
+  "includes",
+  "indexOf",
+  "join",
+  "keys",
+  "lastIndexOf",
+  "map",
+  "reduce",
+  "reduceRight",
+  "slice",
+  "some",
+  "toLocaleString",
+  "toReversed",
+  "toSorted",
+  "toSpliced",
+  "toString",
+  "values",
+  "with",
+]);
+
+const MAP_READ_METHOD_NAMES: ReadonlySet<string> = new Set([
+  "entries",
+  "forEach",
+  "get",
+  "has",
+  "keys",
+  "values",
+]);
+
+const SET_READ_METHOD_NAMES: ReadonlySet<string> = new Set([
+  "difference",
+  "entries",
+  "forEach",
+  "has",
+  "intersection",
+  "isDisjointFrom",
+  "isSubsetOf",
+  "isSupersetOf",
+  "keys",
+  "symmetricDifference",
+  "union",
+  "values",
+]);
+
+const FUNCTION_READ_METHOD_NAMES: ReadonlySet<string> = new Set(["bind"]);
+
+const PROMISE_READ_METHOD_NAMES: ReadonlySet<string> = new Set(["catch", "finally", "then"]);
+
+const STRING_READ_METHOD_NAMES: ReadonlySet<string> = new Set([
+  "at",
+  "charAt",
+  "charCodeAt",
+  "codePointAt",
+  "concat",
+  "endsWith",
+  "includes",
+  "indexOf",
+  "isWellFormed",
+  "lastIndexOf",
+  "localeCompare",
+  "match",
+  "matchAll",
+  "normalize",
+  "padEnd",
+  "padStart",
+  "repeat",
+  "replace",
+  "replaceAll",
+  "search",
+  "slice",
+  "split",
+  "startsWith",
+  "substring",
+  "toLocaleLowerCase",
+  "toLocaleUpperCase",
+  "toLowerCase",
+  "toString",
+  "toUpperCase",
+  "toWellFormed",
+  "trim",
+  "trimEnd",
+  "trimStart",
+  "valueOf",
+]);
+
+const NATIVE_TYPE_NAMES: ReadonlySet<string> = new Set([
+  "Array",
+  "Map",
+  "Promise",
+  "PromiseLike",
+  "ReadonlyArray",
+  "ReadonlyMap",
+  "ReadonlySet",
+  "Set",
+]);
+
+const shadowedNativeTypeNamesByProgram: WeakMap<EsTreeNode, ReadonlySet<string>> = new WeakMap();
+
+const getShadowedNativeTypeNames = (node: EsTreeNode): ReadonlySet<string> => {
+  const program = findProgramRoot(node);
+  if (!program) return NATIVE_TYPE_NAMES;
+  const cachedNames = shadowedNativeTypeNamesByProgram.get(program);
+  if (cachedNames) return cachedNames;
+  const shadowedNames = new Set<string>();
+  walkAst(program, (candidate) => {
+    if (isNodeOfType(candidate, "ImportDeclaration")) {
+      for (const specifier of candidate.specifiers) {
+        if (
+          (isNodeOfType(specifier, "ImportDefaultSpecifier") ||
+            isNodeOfType(specifier, "ImportNamespaceSpecifier") ||
+            isNodeOfType(specifier, "ImportSpecifier")) &&
+          NATIVE_TYPE_NAMES.has(specifier.local.name)
+        ) {
+          shadowedNames.add(specifier.local.name);
+        }
+      }
+      return;
+    }
+    if (
+      (isNodeOfType(candidate, "ClassDeclaration") ||
+        isNodeOfType(candidate, "TSInterfaceDeclaration") ||
+        isNodeOfType(candidate, "TSTypeAliasDeclaration")) &&
+      candidate.id &&
+      NATIVE_TYPE_NAMES.has(candidate.id.name)
+    ) {
+      shadowedNames.add(candidate.id.name);
+    }
+  });
+  shadowedNativeTypeNamesByProgram.set(program, shadowedNames);
+  return shadowedNames;
+};
+
+const getParameterBinding = (definitionName: EsTreeNode): EsTreeNode | null => {
+  if (isNodeOfType(definitionName, "Identifier")) return definitionName;
+  if (!isNodeOfType(definitionName, "AssignmentPattern")) return null;
+  return isNodeOfType(definitionName.left, "Identifier") ? definitionName.left : null;
+};
+
+const getTypeAnnotation = (binding: EsTreeNode): EsTreeNode | null => {
+  if (!isNodeOfType(binding, "Identifier")) return null;
+  const annotation = binding.typeAnnotation;
+  return annotation && isNodeOfType(annotation, "TSTypeAnnotation")
+    ? annotation.typeAnnotation
+    : null;
+};
+
+const isNullishType = (typeNode: EsTreeNode): boolean =>
+  isNodeOfType(typeNode, "TSNullKeyword") || isNodeOfType(typeNode, "TSUndefinedKeyword");
+
+const isNativeReadMethod = (
+  typeNode: EsTreeNode,
+  methodName: string,
+  shadowedTypeNames: ReadonlySet<string>,
+): boolean => {
+  if (isNodeOfType(typeNode, "TSArrayType") || isNodeOfType(typeNode, "TSTupleType")) {
+    return ARRAY_READ_METHOD_NAMES.has(methodName);
+  }
+  if (isNodeOfType(typeNode, "TSStringKeyword")) return STRING_READ_METHOD_NAMES.has(methodName);
+  if (isNodeOfType(typeNode, "TSFunctionType")) {
+    return FUNCTION_READ_METHOD_NAMES.has(methodName);
+  }
+  if (
+    isNodeOfType(typeNode, "TSLiteralType") &&
+    isNodeOfType(typeNode.literal, "Literal") &&
+    typeof typeNode.literal.value === "string"
+  ) {
+    return STRING_READ_METHOD_NAMES.has(methodName);
+  }
+  if (
+    isNodeOfType(typeNode, "TSTypeOperator") &&
+    typeNode.operator === "readonly" &&
+    typeNode.typeAnnotation
+  ) {
+    return isNativeReadMethod(typeNode.typeAnnotation, methodName, shadowedTypeNames);
+  }
+  if (isNodeOfType(typeNode, "TSUnionType")) {
+    let hasNonNullishMember = false;
+    for (const memberType of typeNode.types) {
+      if (isNullishType(memberType)) continue;
+      hasNonNullishMember = true;
+      if (!isNativeReadMethod(memberType, methodName, shadowedTypeNames)) return false;
+    }
+    return hasNonNullishMember;
+  }
+  if (
+    !isNodeOfType(typeNode, "TSTypeReference") ||
+    !isNodeOfType(typeNode.typeName, "Identifier")
+  ) {
+    return false;
+  }
+  if (shadowedTypeNames.has(typeNode.typeName.name)) return false;
+  if (typeNode.typeName.name === "Array" || typeNode.typeName.name === "ReadonlyArray") {
+    return ARRAY_READ_METHOD_NAMES.has(methodName);
+  }
+  if (typeNode.typeName.name === "Map" || typeNode.typeName.name === "ReadonlyMap") {
+    return MAP_READ_METHOD_NAMES.has(methodName);
+  }
+  if (typeNode.typeName.name === "Set" || typeNode.typeName.name === "ReadonlySet") {
+    return SET_READ_METHOD_NAMES.has(methodName);
+  }
+  if (typeNode.typeName.name === "Promise" || typeNode.typeName.name === "PromiseLike") {
+    return PROMISE_READ_METHOD_NAMES.has(methodName);
+  }
+  return false;
+};
+
+export const isProvenNativeReadMethod = (ref: Reference, methodName: string): boolean =>
+  Boolean(
+    ref.resolved?.defs.some((definition) => {
+      if (definition.type !== "Parameter") return false;
+      const parameterBinding = getParameterBinding(definition.name as unknown as EsTreeNode);
+      if (!parameterBinding) return false;
+      const typeAnnotation = getTypeAnnotation(parameterBinding);
+      return Boolean(
+        typeAnnotation &&
+        isNativeReadMethod(
+          typeAnnotation,
+          methodName,
+          getShadowedNativeTypeNames(parameterBinding),
+        ),
+      );
+    }),
+  );

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/effect/react.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/effect/react.ts
@@ -1,6 +1,10 @@
 import type { Reference } from "eslint-scope";
+import type { ScopeAnalysis } from "../../../../semantic/scope-analysis.js";
 import type { EsTreeNode } from "../../../../utils/es-tree-node.js";
 import { getStaticPropertyName } from "../../../../utils/get-static-property-name.js";
+import { getRootIdentifier } from "../../../../utils/get-root-identifier.js";
+import { hasPossibleStaticPropertyWriteBefore } from "../../../../utils/has-static-property-write-before.js";
+import { hasSymbolWriteBefore } from "../../../../utils/has-symbol-write-before.js";
 import { isAstNode } from "../../../../utils/is-ast-node.js";
 import { isFunctionLike } from "../../../../utils/is-function-like.js";
 import { isNodeOfType } from "../../../../utils/is-node-of-type.js";
@@ -477,7 +481,7 @@ const SYNCHRONOUS_CALLBACK_ARGUMENT_INDEX_BY_METHOD: ReadonlyMap<string, number>
 ]);
 
 interface PropCallbackInvocationOptions {
-  ignoreProvenNativeCustomHookMethod?: boolean;
+  nativeMethodScopes?: ScopeAnalysis;
 }
 
 const addSimpleBindingNames = (pattern: EsTreeNode, names: Set<string>): boolean => {
@@ -532,10 +536,7 @@ const inlineCallbackInvokesParameter = (callback: EsTreeNode): boolean => {
         candidate.operator === "=" &&
         isNodeOfType(candidate.left, "Identifier")
       ) {
-        const assignedValue = stripParenExpression(candidate.right);
-        const assignedValueRoot = isNodeOfType(assignedValue, "MemberExpression")
-          ? stripParenExpression(assignedValue.object)
-          : assignedValue;
+        const assignedValueRoot = getRootIdentifier(candidate.right);
         if (
           isNodeOfType(assignedValueRoot, "Identifier") &&
           parameterNames.has(assignedValueRoot.name) &&
@@ -547,10 +548,7 @@ const inlineCallbackInvokesParameter = (callback: EsTreeNode): boolean => {
         return;
       }
       if (!isNodeOfType(candidate, "VariableDeclarator") || !candidate.init) return;
-      const initializer = stripParenExpression(candidate.init);
-      const initializerRoot = isNodeOfType(initializer, "MemberExpression")
-        ? stripParenExpression(initializer.object)
-        : initializer;
+      const initializerRoot = getRootIdentifier(candidate.init);
       if (
         !isNodeOfType(initializerRoot, "Identifier") ||
         !parameterNames.has(initializerRoot.name)
@@ -573,8 +571,8 @@ const inlineCallbackInvokesParameter = (callback: EsTreeNode): boolean => {
       return false;
     }
     if (isNodeOfType(callee, "MemberExpression")) {
-      const receiver = stripParenExpression(callee.object);
-      if (isNodeOfType(receiver, "Identifier") && parameterNames.has(receiver.name)) {
+      const receiverRoot = getRootIdentifier(callee.object);
+      if (receiverRoot && parameterNames.has(receiverRoot.name)) {
         didInvokeParameter = true;
         return false;
       }
@@ -583,19 +581,61 @@ const inlineCallbackInvokesParameter = (callback: EsTreeNode): boolean => {
   return didInvokeParameter;
 };
 
+const callbackInvokesPropCallback = (analysis: ProgramAnalysis, callback: EsTreeNode): boolean => {
+  if (!isFunctionLike(callback)) return false;
+  let didInvokePropCallback = false;
+  walkAst(callback.body, (candidate) => {
+    if (didInvokePropCallback) return false;
+    if (candidate !== callback.body && isFunctionLike(candidate)) return false;
+    if (!isNodeOfType(candidate, "CallExpression")) return;
+    const callee = stripParenExpression(candidate.callee);
+    if (
+      getDownstreamRefs(analysis, callee).some((reference) =>
+        isPropCallbackInvocationRef(analysis, reference),
+      )
+    ) {
+      didInvokePropCallback = true;
+      return false;
+    }
+  });
+  return didInvokePropCallback;
+};
+
 const isNativeMethodSuppressionSafe = (
   analysis: ProgramAnalysis,
   callExpression: EsTreeNode,
   methodName: string,
+  scopes: ScopeAnalysis,
 ): boolean => {
   if (!isNodeOfType(callExpression, "CallExpression")) return false;
-  const callResultParent = callExpression.parent;
-  const callResultConsumer = isNodeOfType(callResultParent, "ChainExpression")
-    ? callResultParent.parent
-    : callResultParent;
+  const callee = stripParenExpression(callExpression.callee);
+  if (!isNodeOfType(callee, "MemberExpression")) return false;
+  const receiver = stripParenExpression(callee.object);
+  if (!isNodeOfType(receiver, "Identifier")) return false;
+  const receiverSymbol = scopes.symbolFor(receiver);
+  if (
+    !receiverSymbol ||
+    hasSymbolWriteBefore(receiverSymbol, callExpression, scopes) ||
+    hasPossibleStaticPropertyWriteBefore(receiver, methodName, callExpression, scopes)
+  ) {
+    return false;
+  }
+  let callResult: EsTreeNode = callExpression;
+  let callResultConsumer = callResult.parent;
+  while (
+    callResultConsumer &&
+    ((TRANSPARENT_EXPRESSION_WRAPPER_TYPES.has(callResultConsumer.type) &&
+      "expression" in callResultConsumer &&
+      callResultConsumer.expression === callResult) ||
+      (isNodeOfType(callResultConsumer, "MemberExpression") &&
+        callResultConsumer.object === callResult))
+  ) {
+    callResult = callResultConsumer;
+    callResultConsumer = callResult.parent;
+  }
   if (
     isNodeOfType(callResultConsumer, "CallExpression") &&
-    (callResultConsumer.callee === callExpression || callResultConsumer.callee === callResultParent)
+    callResultConsumer.callee === callResult
   ) {
     return false;
   }
@@ -604,7 +644,12 @@ const isNativeMethodSuppressionSafe = (
   const callbackArgument = callExpression.arguments?.[callbackArgumentIndex];
   if (!callbackArgument) return true;
   const callbackValue = stripParenExpression(callbackArgument);
-  if (isFunctionLike(callbackValue)) return !inlineCallbackInvokesParameter(callbackValue);
+  if (isFunctionLike(callbackValue)) {
+    return (
+      !inlineCallbackInvokesParameter(callbackValue) &&
+      !callbackInvokesPropCallback(analysis, callbackValue)
+    );
+  }
   if (!isNodeOfType(callbackValue, "Identifier")) return false;
   const callbackRef = getRef(analysis, callbackValue);
   if (!callbackRef || isPropAlias(analysis, callbackRef)) return false;
@@ -612,7 +657,8 @@ const isNativeMethodSuppressionSafe = (
   return Boolean(
     callbackFunction &&
     isFunctionLike(callbackFunction) &&
-    !inlineCallbackInvokesParameter(callbackFunction),
+    !inlineCallbackInvokesParameter(callbackFunction) &&
+    !callbackInvokesPropCallback(analysis, callbackFunction),
   );
 };
 
@@ -653,11 +699,16 @@ export const isPropCallbackInvocationRef = (
         return true;
       }
       if (
-        options.ignoreProvenNativeCustomHookMethod &&
+        options.nativeMethodScopes &&
         isCustomHookParameter(ref) &&
         propertyName &&
         isProvenNativeReadMethod(ref, propertyName) &&
-        isNativeMethodSuppressionSafe(analysis, memberParent, propertyName)
+        isNativeMethodSuppressionSafe(
+          analysis,
+          memberParent,
+          propertyName,
+          options.nativeMethodScopes,
+        )
       ) {
         return false;
       }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/effect/react.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/effect/react.ts
@@ -1,5 +1,6 @@
 import type { Reference } from "eslint-scope";
 import type { EsTreeNode } from "../../../../utils/es-tree-node.js";
+import { getStaticPropertyName } from "../../../../utils/get-static-property-name.js";
 import { isAstNode } from "../../../../utils/is-ast-node.js";
 import { isFunctionLike } from "../../../../utils/is-function-like.js";
 import { isNodeOfType } from "../../../../utils/is-node-of-type.js";
@@ -8,6 +9,7 @@ import {
   TRANSPARENT_EXPRESSION_WRAPPER_TYPES,
   stripParenExpression,
 } from "../../../../utils/strip-paren-expression.js";
+import { walkAst } from "../../../../utils/walk-ast.js";
 import {
   getDownstreamRefs,
   getRef,
@@ -18,8 +20,10 @@ import {
   resolvesToAsyncFunction,
   resolveToFunction,
 } from "./ast.js";
+import { FIRST_ARGUMENT_INDEX, SECOND_ARGUMENT_INDEX } from "./constants.js";
 import { getAstChildKeys } from "./get-ast-child-keys.js";
 import { getScopeForNode, type ProgramAnalysis } from "./get-program-analysis.js";
+import { isProvenNativeReadMethod } from "./is-proven-native-read-method.js";
 
 // 1:1 port of upstream `src/util/react.js` from
 // `eslint-plugin-react-you-might-not-need-an-effect`. See `./ast.ts`
@@ -455,6 +459,162 @@ export const isPropCall = (analysis: ProgramAnalysis, ref: Reference): boolean =
   isEventualCallTo(analysis, ref, (innerRef) => isPropAlias(analysis, innerRef));
 
 const HANDLER_NAMED_METHOD_PATTERN = /^(on|handle)[A-Z]/;
+const SYNCHRONOUS_CALLBACK_ARGUMENT_INDEX_BY_METHOD: ReadonlyMap<string, number> = new Map([
+  ["every", FIRST_ARGUMENT_INDEX],
+  ["filter", FIRST_ARGUMENT_INDEX],
+  ["find", FIRST_ARGUMENT_INDEX],
+  ["findIndex", FIRST_ARGUMENT_INDEX],
+  ["findLast", FIRST_ARGUMENT_INDEX],
+  ["findLastIndex", FIRST_ARGUMENT_INDEX],
+  ["flatMap", FIRST_ARGUMENT_INDEX],
+  ["forEach", FIRST_ARGUMENT_INDEX],
+  ["map", FIRST_ARGUMENT_INDEX],
+  ["reduce", FIRST_ARGUMENT_INDEX],
+  ["reduceRight", FIRST_ARGUMENT_INDEX],
+  ["replace", SECOND_ARGUMENT_INDEX],
+  ["replaceAll", SECOND_ARGUMENT_INDEX],
+  ["some", FIRST_ARGUMENT_INDEX],
+]);
+
+interface PropCallbackInvocationOptions {
+  ignoreProvenNativeCustomHookMethod?: boolean;
+}
+
+const addSimpleBindingNames = (pattern: EsTreeNode, names: Set<string>): boolean => {
+  if (isNodeOfType(pattern, "Identifier")) {
+    if (names.has(pattern.name)) return false;
+    names.add(pattern.name);
+    return true;
+  }
+  if (isNodeOfType(pattern, "AssignmentPattern")) {
+    return addSimpleBindingNames(pattern.left, names);
+  }
+  if (isNodeOfType(pattern, "RestElement")) {
+    return addSimpleBindingNames(pattern.argument, names);
+  }
+  if (isNodeOfType(pattern, "ObjectPattern")) {
+    let didAddName = false;
+    for (const property of pattern.properties) {
+      const binding = isNodeOfType(property, "Property") ? property.value : property;
+      didAddName = addSimpleBindingNames(binding, names) || didAddName;
+    }
+    return didAddName;
+  }
+  if (isNodeOfType(pattern, "ArrayPattern")) {
+    let didAddName = false;
+    for (const element of pattern.elements) {
+      if (element) didAddName = addSimpleBindingNames(element, names) || didAddName;
+    }
+    return didAddName;
+  }
+  return false;
+};
+
+const getSimpleParameterNames = (callback: EsTreeNode): Set<string> => {
+  if (!isFunctionLike(callback)) return new Set();
+  const names = new Set<string>();
+  for (const parameter of callback.params ?? []) {
+    addSimpleBindingNames(parameter, names);
+  }
+  return names;
+};
+
+const inlineCallbackInvokesParameter = (callback: EsTreeNode): boolean => {
+  const parameterNames = getSimpleParameterNames(callback);
+  if (parameterNames.size === 0 || !isFunctionLike(callback)) return false;
+  let didAddAlias = true;
+  while (didAddAlias) {
+    didAddAlias = false;
+    walkAst(callback.body, (candidate) => {
+      if (candidate !== callback.body && isFunctionLike(candidate)) return false;
+      if (
+        isNodeOfType(candidate, "AssignmentExpression") &&
+        candidate.operator === "=" &&
+        isNodeOfType(candidate.left, "Identifier")
+      ) {
+        const assignedValue = stripParenExpression(candidate.right);
+        const assignedValueRoot = isNodeOfType(assignedValue, "MemberExpression")
+          ? stripParenExpression(assignedValue.object)
+          : assignedValue;
+        if (
+          isNodeOfType(assignedValueRoot, "Identifier") &&
+          parameterNames.has(assignedValueRoot.name) &&
+          !parameterNames.has(candidate.left.name)
+        ) {
+          parameterNames.add(candidate.left.name);
+          didAddAlias = true;
+        }
+        return;
+      }
+      if (!isNodeOfType(candidate, "VariableDeclarator") || !candidate.init) return;
+      const initializer = stripParenExpression(candidate.init);
+      const initializerRoot = isNodeOfType(initializer, "MemberExpression")
+        ? stripParenExpression(initializer.object)
+        : initializer;
+      if (
+        !isNodeOfType(initializerRoot, "Identifier") ||
+        !parameterNames.has(initializerRoot.name)
+      ) {
+        return;
+      }
+      if (addSimpleBindingNames(candidate.id, parameterNames)) {
+        didAddAlias = true;
+      }
+    });
+  }
+  let didInvokeParameter = false;
+  walkAst(callback.body, (candidate) => {
+    if (didInvokeParameter) return false;
+    if (candidate !== callback.body && isFunctionLike(candidate)) return false;
+    if (!isNodeOfType(candidate, "CallExpression")) return;
+    const callee = stripParenExpression(candidate.callee);
+    if (isNodeOfType(callee, "Identifier") && parameterNames.has(callee.name)) {
+      didInvokeParameter = true;
+      return false;
+    }
+    if (isNodeOfType(callee, "MemberExpression")) {
+      const receiver = stripParenExpression(callee.object);
+      if (isNodeOfType(receiver, "Identifier") && parameterNames.has(receiver.name)) {
+        didInvokeParameter = true;
+        return false;
+      }
+    }
+  });
+  return didInvokeParameter;
+};
+
+const isNativeMethodSuppressionSafe = (
+  analysis: ProgramAnalysis,
+  callExpression: EsTreeNode,
+  methodName: string,
+): boolean => {
+  if (!isNodeOfType(callExpression, "CallExpression")) return false;
+  const callResultParent = callExpression.parent;
+  const callResultConsumer = isNodeOfType(callResultParent, "ChainExpression")
+    ? callResultParent.parent
+    : callResultParent;
+  if (
+    isNodeOfType(callResultConsumer, "CallExpression") &&
+    (callResultConsumer.callee === callExpression || callResultConsumer.callee === callResultParent)
+  ) {
+    return false;
+  }
+  const callbackArgumentIndex = SYNCHRONOUS_CALLBACK_ARGUMENT_INDEX_BY_METHOD.get(methodName);
+  if (callbackArgumentIndex === undefined) return true;
+  const callbackArgument = callExpression.arguments?.[callbackArgumentIndex];
+  if (!callbackArgument) return true;
+  const callbackValue = stripParenExpression(callbackArgument);
+  if (isFunctionLike(callbackValue)) return !inlineCallbackInvokesParameter(callbackValue);
+  if (!isNodeOfType(callbackValue, "Identifier")) return false;
+  const callbackRef = getRef(analysis, callbackValue);
+  if (!callbackRef || isPropAlias(analysis, callbackRef)) return false;
+  const callbackFunction = resolveToFunction(callbackRef);
+  return Boolean(
+    callbackFunction &&
+    isFunctionLike(callbackFunction) &&
+    !inlineCallbackInvokesParameter(callbackFunction),
+  );
+};
 
 // A prop reference invoked AS a callback: `onEnd(x)`, an alias call, or a
 // method called on a whole (non-destructured) parameter object
@@ -465,7 +625,11 @@ const HANDLER_NAMED_METHOD_PATTERN = /^(on|handle)[A-Z]/;
 // `callbacks.onProgress(x)` invoke a parent-supplied callback grouped under
 // an object prop, so `on[A-Z]` / `handle[A-Z]` method names stay callbacks
 // (internxt FileVideoViewer, caught by the 0.7.1→sweep delta audit).
-export const isPropCallbackInvocationRef = (analysis: ProgramAnalysis, ref: Reference): boolean => {
+export const isPropCallbackInvocationRef = (
+  analysis: ProgramAnalysis,
+  ref: Reference,
+  options: PropCallbackInvocationOptions = {},
+): boolean => {
   if (!isPropAlias(analysis, ref)) return false;
   const identifier = ref.identifier as unknown as EsTreeNode;
   let effectiveNode = identifier;
@@ -484,12 +648,18 @@ export const isPropCallbackInvocationRef = (analysis: ProgramAnalysis, ref: Refe
   if (isNodeOfType(parent, "MemberExpression") && parent.object === effectiveNode) {
     const memberParent = (parent as unknown as { parent?: EsTreeNode | null }).parent;
     if (isNodeOfType(memberParent, "CallExpression") && memberParent.callee === parent) {
-      if (
-        !parent.computed &&
-        isNodeOfType(parent.property, "Identifier") &&
-        HANDLER_NAMED_METHOD_PATTERN.test(parent.property.name)
-      ) {
+      const propertyName = getStaticPropertyName(parent);
+      if (propertyName && HANDLER_NAMED_METHOD_PATTERN.test(propertyName)) {
         return true;
+      }
+      if (
+        options.ignoreProvenNativeCustomHookMethod &&
+        isCustomHookParameter(ref) &&
+        propertyName &&
+        isProvenNativeReadMethod(ref, propertyName) &&
+        isNativeMethodSuppressionSafe(analysis, memberParent, propertyName)
+      ) {
+        return false;
       }
       return isWholePropsObjectReference(analysis, ref);
     }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/has-static-property-write-before.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/has-static-property-write-before.ts
@@ -356,6 +356,38 @@ export const hasPossibleStaticPropertyWrite = (
   );
 };
 
+const canExecuteBefore = (
+  candidateNode: EsTreeNode,
+  referenceNode: EsTreeNode,
+  scopes: ScopeAnalysis,
+): boolean => {
+  const candidateBoundary = findExecutionBoundary(candidateNode);
+  const referenceBoundary = findExecutionBoundary(referenceNode);
+  if (!candidateBoundary || !referenceBoundary) return true;
+  if (candidateBoundary === referenceBoundary) {
+    return candidateNode.range[0] < referenceNode.range[0];
+  }
+  if (!isFunctionLike(candidateBoundary)) return true;
+  return isFunctionSynchronouslyInvokedBefore(candidateBoundary, referenceNode, scopes);
+};
+
+export const hasPossibleStaticPropertyWriteBefore = (
+  identifier: EsTreeNode,
+  propertyName: string,
+  referenceNode: EsTreeNode,
+  scopes: ScopeAnalysis,
+): boolean => {
+  if (!isNodeOfType(identifier, "Identifier")) return false;
+  return getPotentiallyAliasedSymbols(identifier, scopes).some((symbol) =>
+    symbol.references.some((reference) => {
+      const writeTarget = getMemberWriteTarget(reference.identifier);
+      if (!writeTarget || !canExecuteBefore(writeTarget, referenceNode, scopes)) return false;
+      const writtenPropertyName = getResolvedStaticPropertyName(writeTarget, scopes);
+      return writtenPropertyName === null || writtenPropertyName === propertyName;
+    }),
+  );
+};
+
 export const hasPossibleStaticPropertyMutationOrEscape = (
   identifier: EsTreeNode,
   propertyName: string,


### PR DESCRIPTION
## Why

`no-prop-callback-in-render` treats every method call on a custom Hook parameter as a possible caller callback. That reports native collection reads such as `items.forEach(localIterator)`, even when the callback is local and no prop callback runs during render.

React Bench reproduced six real false positives across pinned Cloudscape, Remarkable UI, HyperDX, Kubetail, and react-data-table revisions. The nearby `useStore.setState(state)` finding remains a true positive and must stay reportable.

## What changed

- Suppress only methods proven by an unshadowed TypeScript annotation to be non-mutating native Array, Map, Set, String, Function, or Promise methods.
- Require stable receiver and method provenance before the call; reassignment, exact/dynamic property writes, shadowed native types, arbitrary userland methods, and native mutators stay reportable.
- Keep handler-named methods, callbacks passed from props, callback-valued collection entries, captured prop-callback invocations, and immediate invocation of returned values reportable.
- Add paired direct, alias, destructuring, reassignment, mutation-ordering, union, lexical-shadowing, callback-flow, and returned-value regressions.
- Add a permanent fuzz corpus seed and generator shape.

## Eval results

- Baseline: current `main` at `ed241c35e`.
- Pinned OSS/RDE: 100/100 roots, 25,758 files, zero scan/parser failures; target findings 17 → 17 with no added or removed diagnostic.
- React Bench: 120/120 pinned revisions, 96,853 files, zero failures; target findings 78 → 72, zero additions, six manually classified FP removals.
- The six removals are typed native collection iteration in pinned Cloudscape (two revisions), Remarkable UI, HyperDX, Kubetail, and react-data-table sources. No caller callback executes at the reported call sites.
- The known `useStore.setState(state)` true positive remains unchanged.
- Reconstructed Cloudscape oracle: target findings 9 → 8; the only removal is the same `use-focus-control.ts` FP. The oracle does not modify that file, and all eight unrelated findings remain unchanged.

## Test plan

- Focused rule: 66 passed.
- Full oxlint plugin: 559 files; 13,884 passed, 175 skipped.
- Full repository: 14/14 Turbo test tasks passed.
- Fuzz package: 44 passed, 402 skipped.
- Strict fuzz: `FUZZ_RULE=no-prop-callback-in-render FUZZ_STRICT=1 FUZZ_ITERATIONS=500 FUZZ_PRINT_STATS=1 nr fuzz --disableConsoleIntercept` passed; 315 programs executed, 11 fired the target rule, and 203 malformed variants were skipped.
- Permanent-corpus hunter: the added pinned OSS regression seed stays silent.
- `nr typecheck` passed (15/15 tasks).
- `nr lint` passed with pre-existing warnings only.
- `nr format:check`, `nr smoke:json-report`, and `git diff --check` passed.
- Post-change truffler searches found one definition of each added helper and no equivalent existing helper; existing root-identifier, type-parameter-shadow, symbol-write, and alias utilities are reused.

Do not merge automatically; this PR is ready for human review once CI completes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands static-analysis heuristics in a core lint rule; incorrect suppression could miss render-time parent callbacks, though guards on writes, handler names, and callback-argument flow limit exposure.
> 
> **Overview**
> **`no-prop-callback-in-render`** no longer flags discarded calls that only reach **typed native read methods** on **custom Hook parameters** (e.g. `items.forEach` with a local iterator), while still reporting real render-time prop/callback invocations.
> 
> The rule passes scope analysis into **`isPropCallbackInvocationRef`**, which can **suppress** member calls when the receiver is a hook argument, the method is **proven** from TypeScript (Array/Map/Set/String/Function/Promise read APIs, respecting shadowed `Array`/`Set` names), and **`isNativeMethodSuppressionSafe`** holds: stable receiver, no prior reassignment or property overwrite of that method, and iteration/replace callbacks that do not synchronously invoke prop aliases or hook parameters. **`on*` / `handle*`** methods, mutators like **`setState`**, overwritten **`forEach`**, and callbacks passed into **`forEach`** remain reportable.
> 
> Adds **`is-proven-native-read-method`**, ordering-aware **`hasPossibleStaticPropertyWriteBefore`**, a fuzz regression seed, snippet coverage, and a large paired test matrix for suppression vs continued reporting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6afa4f6c609df246aa5bb0597a57323cdae5079c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->