### PR TITLE
fix(effect-needs-cleanup): prove pre-allocation timer release

### DIFF
--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
@@ -2685,6 +2685,42 @@ export const Debounced = ({ value }) => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("accepts helper-mediated timer cleanup after non-allocating early returns", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect, useRef } from "react";
+export const Tooltip = ({ delayShow }) => {
+  const pendingOpenRef = useRef(null);
+  const tooltipShowDelayTimerRef = useRef(null);
+  const cancelPendingOpen = () => {
+    if (tooltipShowDelayTimerRef.current) {
+      clearTimeout(tooltipShowDelayTimerRef.current);
+      tooltipShowDelayTimerRef.current = null;
+    }
+    pendingOpenRef.current = null;
+  };
+  useEffect(() => {
+    const pendingOpen = pendingOpenRef.current;
+    if (!pendingOpen) return;
+    if (!pendingOpen.anchor.isConnected) {
+      cancelPendingOpen();
+      return;
+    }
+    cancelPendingOpen();
+    const remainingDelay = Math.max(0, delayShow - pendingOpen.elapsed);
+    if (remainingDelay === 0) return;
+    tooltipShowDelayTimerRef.current = setTimeout(() => {
+      commitPendingOpen(pendingOpen);
+    }, remainingDelay);
+  }, [delayShow]);
+  useEffect(() => () => cancelPendingOpen(), []);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("rejects split cleanup that releases a different timer", () => {
     const result = runRule(
       effectNeedsCleanup,


### PR DESCRIPTION
## Why

`effect-needs-cleanup` rejects a ref-held timeout whose previous handle is cleared before every replacement and whose current handle is cleared by a separate unmount effect. The false positive occurs when non-allocating early returns appear before or after the rerun clear.

This draft starts with the exact failing regression. The detector change and adversarial controls will follow before review.

## Current MVP

- Adds the helper-mediated split-cleanup regression grounded in the ReactTooltip timing trial.
- Confirms current `origin/main` reports one diagnostic where zero are expected.

## Required before review

- Prove release dominance only on paths reaching the allocation.
- Add allocation, reassignment, reschedule, mismatched-ref, and orphan controls.
- Run focused/full tests, strict fuzz, RDE, React Bench parity, and review-thread audit.

Do not merge automatically.