### PR TITLE
fix(rule): recognize live prop normalization trackers

### DIFF
--- a/.changeset/calm-flies-track.md
+++ b/.changeset/calm-flies-track.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Avoid reporting live Boolean-normalized prop trackers as all-state resets.

--- a/packages/fuzz/corpus/regressions/no-reset-all-state-on-prop-change--live-boolean-prop-tracker.tsx
+++ b/packages/fuzz/corpus/regressions/no-reset-all-state-on-prop-change--live-boolean-prop-tracker.tsx
@@ -1,0 +1,27 @@
+// rule: no-reset-all-state-on-prop-change
+// weakness: alias-guard
+// source: React Bench Cloudscape focus-lock transition tracker
+import { useEffect, useRef, useState } from "react";
+
+interface FocusLockProps {
+  disabled?: boolean;
+  restoreFocus: boolean;
+}
+
+export const FocusLock = ({ disabled, restoreFocus }: FocusLockProps) => {
+  const target = useRef<HTMLButtonElement>(null);
+  const [previouslyDisabled, setPreviouslyDisabled] = useState(Boolean(disabled));
+
+  useEffect(() => {
+    if (previouslyDisabled !== Boolean(disabled)) {
+      setPreviouslyDisabled(Boolean(disabled));
+      if (restoreFocus && disabled) target.current?.focus();
+    }
+  }, [previouslyDisabled, disabled, restoreFocus]);
+
+  return (
+    <button ref={target} type="button">
+      Target
+    </button>
+  );
+};

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -74,6 +74,8 @@ export const STATE_SNIPPET_POOL = [
   `const [selected, setSelected] = useState<string[]>([]);`,
   `const [loading, setLoading] = useState(false); const [error, setError] = useState(null); const [data, setData] = useState(null);`,
   `const [internalValue, setInternalValue] = useState(value); useEffect(() => { setInternalValue(value); }, [value]);`,
+  `const [previousValue, setPreviousValue] = useState(Boolean(value)); useEffect(() => { setPreviousValue(Boolean(value)); }, [value]);`,
+  `const [resetDraft, setResetDraft] = useState(""); useEffect(() => { setResetDraft(""); }, [value]);`,
   `const [reducerState, dispatch] = useReducer(reducer, { count: 0 });`,
   `const containerRef = useRef(null);`,
   `const handleRef = useRef(handle); handleRef.current = handle;`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps-low-level.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps-low-level.ts
@@ -1,8 +1,9 @@
-import type { ScopeAnalysis, SymbolDescriptor } from "../../semantic/scope-analysis.js";
+import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import { getImportedName } from "../../utils/get-imported-name.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { resolveConstIdentifierAlias } from "../../utils/resolve-const-identifier-alias.js";
+export { isOutsideAllFunctions } from "../../utils/is-outside-all-functions.js";
 
 /**
  * Lowest-level helpers consumed by both the main `exhaustive-deps`
@@ -70,21 +71,4 @@ export const getHookName = (callee: EsTreeNode, scopes?: ScopeAnalysis): string 
     return strippedCallee.property.name;
   }
   return null;
-};
-
-const FUNCTION_SCOPE_KINDS: ReadonlySet<string> = new Set(["function", "arrow-function", "method"]);
-
-/**
- * True for symbols declared at module scope (outside any function
- * scope). Module-scope bindings don't change between renders so they
- * don't need to live in dependency arrays.
- */
-export const isOutsideAllFunctions = (symbol: SymbolDescriptor): boolean => {
-  let scope: SymbolDescriptor["scope"] | null = symbol.scope;
-  while (scope) {
-    if (FUNCTION_SCOPE_KINDS.has(scope.kind)) return false;
-    if (scope.kind === "module") return true;
-    scope = scope.parent ?? null;
-  }
-  return true;
 };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-reset-all-state-on-prop-change.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-reset-all-state-on-prop-change.regressions.test.ts
@@ -243,10 +243,26 @@ describe("no-reset-all-state-on-prop-change — regressions", () => {
           setPreviouslyDisabled(Boolean(disabled));
         }, [disabled]);`,
       ],
+      [
+        "module-scoped initial object",
+        `const [previouslyDisabled, setPreviouslyDisabled] = useState(INITIAL_STATE);
+        useEffect(() => {
+          setPreviouslyDisabled(INITIAL_STATE);
+        }, [disabled]);`,
+      ],
+      [
+        "module-scoped initial primitive",
+        `const [previouslyDisabled, setPreviouslyDisabled] = useState(INITIAL_TAG);
+        useEffect(() => {
+          setPreviouslyDisabled(INITIAL_TAG);
+        }, [disabled]);`,
+      ],
     ])("retains the diagnostic for a %s", (_label, componentBody) => {
       const result = runRule(
         noResetAllStateOnPropChange,
         `import { useEffect, useMemo, useRef, useState } from "react";
+        const INITIAL_STATE = {};
+        const INITIAL_TAG = "all";
         const Tracker = ({ disabled }: { disabled?: boolean }) => {
           ${componentBody}
           return previouslyDisabled;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-reset-all-state-on-prop-change.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-reset-all-state-on-prop-change.regressions.test.ts
@@ -165,6 +165,25 @@ describe("no-reset-all-state-on-prop-change — regressions", () => {
       expect(result.diagnostics).toEqual([]);
     });
 
+    it("stays silent when a transient reset accompanies a live prop mirror", () => {
+      const result = runRule(
+        noResetAllStateOnPropChange,
+        `import { useEffect, useState } from "react";
+        const Editor = ({ disabled }: { disabled?: boolean }) => {
+          const [previouslyDisabled, setPreviouslyDisabled] = useState(Boolean(disabled));
+          const [draft, setDraft] = useState("");
+          useEffect(() => {
+            setPreviouslyDisabled(Boolean(disabled));
+            setDraft("");
+          }, [disabled]);
+          return <output>{String(previouslyDisabled)}{draft}</output>;
+        };`,
+        { forceJsx: true },
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
     it("does not treat a shadowed useMemo lookalike as a React mount snapshot", () => {
       const result = runRule(
         noResetAllStateOnPropChange,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-reset-all-state-on-prop-change.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-reset-all-state-on-prop-change.regressions.test.ts
@@ -44,6 +44,219 @@ describe("no-reset-all-state-on-prop-change — regressions", () => {
     expect(result.diagnostics[0]?.message).toContain("clears all state");
   });
 
+  describe("live prop normalizations", () => {
+    it("stays silent when a transition tracker records the current Boolean-normalized prop", () => {
+      const result = runRule(
+        noResetAllStateOnPropChange,
+        `import React, { useEffect, useRef, useState } from "react";
+        function FocusLock({ disabled, restoreFocus }, ref) {
+          const target = useRef(null);
+          const [previouslyDisabled, setPreviouslyDisabled] = useState(!!disabled);
+          useEffect(() => {
+            if (previouslyDisabled !== !!disabled) {
+              setPreviouslyDisabled(!!disabled);
+              if (restoreFocus && disabled) target.current?.focus();
+            }
+          }, [previouslyDisabled, disabled, restoreFocus]);
+          return <button ref={target} type="button">Target</button>;
+        }
+        export default React.forwardRef(FocusLock);`,
+        { forceJsx: true },
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it.each([
+      ["double negation", "!!disabled", "!!disabled"],
+      ["equivalent Boolean forms", "Boolean(disabled)", "!!disabled"],
+      [
+        "TypeScript wrappers",
+        "(Boolean(disabled) as boolean)",
+        "((Boolean(disabled) satisfies boolean)!)",
+      ],
+      ["whole-props member", "Boolean(props.disabled)", "!!props.disabled"],
+    ])("stays silent through %s", (_label, initializer, nextValue) => {
+      const result = runRule(
+        noResetAllStateOnPropChange,
+        `import { useEffect, useState } from "react";
+        const Tracker = (props: { disabled?: boolean }) => {
+          const { disabled } = props;
+          const [previouslyDisabled, setPreviouslyDisabled] = useState(${initializer});
+          useEffect(() => {
+            setPreviouslyDisabled(${nextValue});
+          }, [disabled]);
+          return previouslyDisabled;
+        };`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it("stays silent through an exact immutable normalization alias", () => {
+      const result = runRule(
+        noResetAllStateOnPropChange,
+        `import { useEffect, useState } from "react";
+        const Tracker = ({ disabled }: { disabled?: boolean }) => {
+          const normalizedDisabled = Boolean(disabled);
+          const [previouslyDisabled, setPreviouslyDisabled] = useState(Boolean(disabled));
+          useEffect(() => {
+            setPreviouslyDisabled(normalizedDisabled as boolean);
+          }, [normalizedDisabled]);
+          return previouslyDisabled;
+        };`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it("stays silent through multi-hop immutable normalization aliases", () => {
+      const result = runRule(
+        noResetAllStateOnPropChange,
+        `import { useEffect, useState } from "react";
+        const Tracker = ({ disabled }: { disabled?: boolean }) => {
+          const directNormalization = Boolean(disabled);
+          const normalizedDisabled = directNormalization;
+          const [previouslyDisabled, setPreviouslyDisabled] = useState(Boolean(disabled));
+          useEffect(() => {
+            setPreviouslyDisabled(normalizedDisabled);
+          }, [normalizedDisabled]);
+          return previouslyDisabled;
+        };`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it("preserves the existing live-binding exemption for an opaque prop-derived const", () => {
+      const result = runRule(
+        noResetAllStateOnPropChange,
+        `import { useEffect, useState } from "react";
+        const Tracker = ({ disabled }: { disabled?: boolean }) => {
+          const normalizedDisabled = normalizeDisabled(disabled);
+          const [previouslyDisabled, setPreviouslyDisabled] = useState(normalizedDisabled);
+          useEffect(() => {
+            setPreviouslyDisabled(normalizedDisabled);
+          }, [normalizedDisabled]);
+          return previouslyDisabled;
+        };`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it("preserves the existing live-binding exemption for a custom hook result", () => {
+      const result = runRule(
+        noResetAllStateOnPropChange,
+        `import { useEffect, useState } from "react";
+        const DropdownOnToggleEffect = ({ onDropdownOpen }) => {
+          const isDropdownOpen = useAtomComponentStateValue(isDropdownOpenComponentState);
+          const [currentIsDropdownOpen, setCurrentIsDropdownOpen] = useState(isDropdownOpen);
+          useEffect(() => {
+            if (isDropdownOpen && !currentIsDropdownOpen) {
+              setCurrentIsDropdownOpen(isDropdownOpen);
+              onDropdownOpen?.();
+            }
+          }, [currentIsDropdownOpen, isDropdownOpen, onDropdownOpen]);
+          return null;
+        };`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it("does not treat a shadowed useMemo lookalike as a React mount snapshot", () => {
+      const result = runRule(
+        noResetAllStateOnPropChange,
+        `import { useEffect, useState } from "react";
+        const Tracker = ({ disabled }: { disabled?: boolean }) => {
+          const useMemo = (callback: () => boolean) => callback();
+          const normalizedDisabled = useMemo(() => Boolean(disabled));
+          const [previouslyDisabled, setPreviouslyDisabled] = useState(normalizedDisabled);
+          useEffect(() => {
+            setPreviouslyDisabled(normalizedDisabled);
+          }, [normalizedDisabled]);
+          return previouslyDisabled;
+        };`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it.each([
+      [
+        "mutable alias",
+        `let normalizedDisabled = Boolean(disabled);
+        const [previouslyDisabled, setPreviouslyDisabled] = useState(normalizedDisabled);
+        useEffect(() => {
+          normalizedDisabled = Boolean(disabled);
+          setPreviouslyDisabled(normalizedDisabled);
+        }, [disabled]);`,
+      ],
+      [
+        "constant normalization",
+        `const normalizedDisabled = Boolean(false);
+        const [previouslyDisabled, setPreviouslyDisabled] = useState(normalizedDisabled);
+        useEffect(() => {
+          setPreviouslyDisabled(normalizedDisabled);
+        }, [disabled]);`,
+      ],
+      [
+        "mount snapshot",
+        `const initialDisabledRef = useRef(Boolean(disabled));
+        const [previouslyDisabled, setPreviouslyDisabled] = useState(initialDisabledRef.current);
+        useEffect(() => {
+          setPreviouslyDisabled(initialDisabledRef.current);
+        }, [disabled]);`,
+      ],
+      [
+        "aliased mount snapshot",
+        `const initialDisabledRef = useRef(Boolean(disabled));
+        const initialDisabled = initialDisabledRef.current;
+        const [previouslyDisabled, setPreviouslyDisabled] = useState(initialDisabled);
+        useEffect(() => {
+          setPreviouslyDisabled(initialDisabled);
+        }, [disabled]);`,
+      ],
+      [
+        "memoized mount snapshot",
+        `const initialDisabled = useMemo(() => Boolean(disabled), []);
+        const [previouslyDisabled, setPreviouslyDisabled] = useState(initialDisabled);
+        useEffect(() => {
+          setPreviouslyDisabled(initialDisabled);
+        }, [disabled]);`,
+      ],
+      [
+        "aliased memoized mount snapshot",
+        `const initialDisabled = useMemo(() => Boolean(disabled), []);
+        const aliasedInitialDisabled = initialDisabled;
+        const [previouslyDisabled, setPreviouslyDisabled] = useState(aliasedInitialDisabled);
+        useEffect(() => {
+          setPreviouslyDisabled(aliasedInitialDisabled);
+        }, [disabled]);`,
+      ],
+      [
+        "shadowed Boolean",
+        `const Boolean = (value: unknown) => value;
+        const [previouslyDisabled, setPreviouslyDisabled] = useState(Boolean(disabled));
+        useEffect(() => {
+          setPreviouslyDisabled(Boolean(disabled));
+        }, [disabled]);`,
+      ],
+    ])("retains the diagnostic for a %s", (_label, componentBody) => {
+      const result = runRule(
+        noResetAllStateOnPropChange,
+        `import { useEffect, useMemo, useRef, useState } from "react";
+        const Tracker = ({ disabled }: { disabled?: boolean }) => {
+          ${componentBody}
+          return previouslyDisabled;
+        };`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    });
+  });
+
   describe("delta audit vs 0.7.1", () => {
     it("stays silent on the leading reset of an async resolve effect with cancellation cleanup (freecut inline-source-preview)", () => {
       const result = runRule(

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-reset-all-state-on-prop-change.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-reset-all-state-on-prop-change.ts
@@ -2,8 +2,11 @@ import type { Reference } from "eslint-scope";
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { getDirectConstInitializer } from "../../utils/get-direct-const-initializer.js";
+import { isReactApiCall } from "../../utils/is-react-api-call.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import { getCallExpr, getDownstreamRefs, getRef, getUpstreamRefs } from "./utils/effect/ast.js";
 import { getProgramAnalysis, type ProgramAnalysis } from "./utils/effect/get-program-analysis.js";
 import {
@@ -14,12 +17,20 @@ import {
   getUseStateDecl,
   isCustomHook,
   isProp,
+  isRefCurrent,
   isState,
   isSyncStateSetterCall,
   isUseEffect,
 } from "./utils/effect/react.js";
+import { getStaticMemberPropertyName } from "./utils/static-member-property-name.js";
 
 // 1:1 port of upstream `src/rules/no-reset-all-state-on-prop-change.js`.
+
+interface LivePropExpressionIdentity {
+  propSymbolId: number;
+  memberPath: string[];
+  booleanNormalization: "identity" | "normalized" | "negated";
+}
 
 const isUndefinedNode = (node: EsTreeNode | null | undefined): boolean => {
   if (node === null || node === undefined) return true;
@@ -36,25 +47,226 @@ const getNodeText = (node: EsTreeNode | null | undefined): string => {
   });
 };
 
-const isLiteralConstantIdentifier = (
+const normalizeAsBoolean = (identity: LivePropExpressionIdentity): LivePropExpressionIdentity => ({
+  ...identity,
+  booleanNormalization:
+    identity.booleanNormalization === "identity" ? "normalized" : identity.booleanNormalization,
+});
+
+const negateBoolean = (identity: LivePropExpressionIdentity): LivePropExpressionIdentity => ({
+  ...identity,
+  booleanNormalization: identity.booleanNormalization === "negated" ? "normalized" : "negated",
+});
+
+const getLivePropExpressionIdentity = (
   analysis: ProgramAnalysis,
+  context: RuleContext,
+  node: EsTreeNode,
+  visitedSymbolIds: Set<number> = new Set(),
+): LivePropExpressionIdentity | null => {
+  const expression = stripParenExpression(node);
+
+  if (isNodeOfType(expression, "Identifier")) {
+    const reference = getRef(analysis, expression);
+    const symbol = context.scopes.symbolFor(expression);
+    if (!reference || !symbol) return null;
+    if (isProp(analysis, reference)) {
+      return {
+        propSymbolId: symbol.id,
+        memberPath: [],
+        booleanNormalization: "identity",
+      };
+    }
+    if (visitedSymbolIds.has(symbol.id) || symbol.kind !== "const") return null;
+    visitedSymbolIds.add(symbol.id);
+    const initializer = getDirectConstInitializer(symbol);
+    if (initializer) {
+      return getLivePropExpressionIdentity(analysis, context, initializer, visitedSymbolIds);
+    }
+    const hasPropSource = getUpstreamRefs(analysis, reference).some((upstreamReference) =>
+      isProp(analysis, upstreamReference),
+    );
+    return hasPropSource
+      ? {
+          propSymbolId: symbol.id,
+          memberPath: [],
+          booleanNormalization: "identity",
+        }
+      : null;
+  }
+
+  if (isNodeOfType(expression, "MemberExpression")) {
+    const propertyName = getStaticMemberPropertyName(expression);
+    if (!propertyName) return null;
+    const objectIdentity = getLivePropExpressionIdentity(
+      analysis,
+      context,
+      expression.object as EsTreeNode,
+      visitedSymbolIds,
+    );
+    if (!objectIdentity) return null;
+    return {
+      ...objectIdentity,
+      memberPath: [...objectIdentity.memberPath, propertyName],
+    };
+  }
+
+  if (
+    isNodeOfType(expression, "CallExpression") &&
+    isNodeOfType(expression.callee, "Identifier") &&
+    expression.callee.name === "Boolean" &&
+    context.scopes.isGlobalReference(expression.callee) &&
+    expression.arguments?.length === 1
+  ) {
+    const argument = expression.arguments[0] as EsTreeNode;
+    const argumentIdentity = getLivePropExpressionIdentity(
+      analysis,
+      context,
+      argument,
+      visitedSymbolIds,
+    );
+    return argumentIdentity ? normalizeAsBoolean(argumentIdentity) : null;
+  }
+
+  if (isNodeOfType(expression, "UnaryExpression") && expression.operator === "!") {
+    const argumentIdentity = getLivePropExpressionIdentity(
+      analysis,
+      context,
+      expression.argument as EsTreeNode,
+      visitedSymbolIds,
+    );
+    return argumentIdentity ? negateBoolean(argumentIdentity) : null;
+  }
+
+  return null;
+};
+
+const isMountSnapshotInitializer = (context: RuleContext, node: EsTreeNode): boolean => {
+  if (
+    !isReactApiCall(node, "useMemo", context.scopes, {
+      resolveNamedAliases: true,
+    }) ||
+    !isNodeOfType(node, "CallExpression")
+  ) {
+    return false;
+  }
+  const dependencies = node.arguments?.[1];
+  return isNodeOfType(dependencies, "ArrayExpression") && dependencies.elements.length === 0;
+};
+
+const isMountSnapshotBinding = (
+  context: RuleContext,
+  identifier: EsTreeNode,
+  visitedSymbolIds: Set<number> = new Set(),
+): boolean => {
+  const symbol = context.scopes.symbolFor(identifier);
+  if (!symbol || visitedSymbolIds.has(symbol.id)) return false;
+  visitedSymbolIds.add(symbol.id);
+  const initializer = getDirectConstInitializer(symbol);
+  if (!initializer) return false;
+  if (isMountSnapshotInitializer(context, initializer)) return true;
+  const expression = stripParenExpression(initializer);
+  return (
+    isNodeOfType(expression, "Identifier") &&
+    isMountSnapshotBinding(context, expression, visitedSymbolIds)
+  );
+};
+
+const isConstantBooleanExpression = (
+  context: RuleContext,
+  node: EsTreeNode,
+  visitedSymbolIds: Set<number> = new Set(),
+): boolean => {
+  const expression = stripParenExpression(node);
+  if (isNodeOfType(expression, "Literal")) return true;
+  if (isNodeOfType(expression, "Identifier")) {
+    const symbol = context.scopes.symbolFor(expression);
+    if (!symbol || visitedSymbolIds.has(symbol.id)) return false;
+    visitedSymbolIds.add(symbol.id);
+    const initializer = getDirectConstInitializer(symbol);
+    return Boolean(
+      initializer && isConstantBooleanExpression(context, initializer, visitedSymbolIds),
+    );
+  }
+  if (isNodeOfType(expression, "UnaryExpression") && expression.operator === "!") {
+    return isConstantBooleanExpression(
+      context,
+      expression.argument as EsTreeNode,
+      visitedSymbolIds,
+    );
+  }
+  if (
+    isNodeOfType(expression, "CallExpression") &&
+    isNodeOfType(expression.callee, "Identifier") &&
+    expression.callee.name === "Boolean" &&
+    context.scopes.isGlobalReference(expression.callee) &&
+    expression.arguments?.length === 1
+  ) {
+    return isConstantBooleanExpression(
+      context,
+      expression.arguments[0] as EsTreeNode,
+      visitedSymbolIds,
+    );
+  }
+  return false;
+};
+
+const isProvenLiveBinding = (
+  analysis: ProgramAnalysis,
+  context: RuleContext,
   identifier: EsTreeNode,
 ): boolean => {
   const reference = getRef(analysis, identifier);
-  const definitions = reference?.resolved?.defs;
-  if (!definitions || definitions.length !== 1) return false;
-  const definition = definitions[0];
-  if (definition.type !== "Variable") return false;
-  const declarator = definition.node as unknown as EsTreeNode;
-  if (!isNodeOfType(declarator, "VariableDeclarator")) return false;
-  const declaration = declarator.parent;
-  if (!isNodeOfType(declaration, "VariableDeclaration") || declaration.kind !== "const") {
+  const symbol = context.scopes.symbolFor(identifier);
+  if (!reference || !symbol || symbol.kind !== "const") return false;
+  const initializer = symbol.initializer;
+  if (!initializer || isMountSnapshotBinding(context, identifier)) return false;
+  const initializerReferences = getDownstreamRefs(analysis, initializer);
+  if (initializerReferences.some((initializerReference) => isRefCurrent(initializerReference))) {
     return false;
   }
-  return isNodeOfType(declarator.init, "Literal");
+  return !isConstantBooleanExpression(context, initializer);
 };
 
-const isSetStateToInitialValue = (analysis: ProgramAnalysis, setterRef: Reference): boolean => {
+const areSameProvenLiveBinding = (
+  analysis: ProgramAnalysis,
+  context: RuleContext,
+  left: EsTreeNode,
+  right: EsTreeNode,
+): boolean => {
+  const leftExpression = stripParenExpression(left);
+  const rightExpression = stripParenExpression(right);
+  if (!isNodeOfType(leftExpression, "Identifier") || !isNodeOfType(rightExpression, "Identifier")) {
+    return false;
+  }
+  const leftSymbol = context.scopes.symbolFor(leftExpression);
+  const rightSymbol = context.scopes.symbolFor(rightExpression);
+  return Boolean(
+    leftSymbol &&
+    leftSymbol === rightSymbol &&
+    isProvenLiveBinding(analysis, context, leftExpression),
+  );
+};
+
+const haveSameLivePropExpressionIdentity = (
+  left: LivePropExpressionIdentity,
+  right: LivePropExpressionIdentity,
+): boolean => {
+  if (
+    left.propSymbolId !== right.propSymbolId ||
+    left.booleanNormalization !== right.booleanNormalization ||
+    left.memberPath.length !== right.memberPath.length
+  ) {
+    return false;
+  }
+  return left.memberPath.every((propertyName, index) => propertyName === right.memberPath[index]);
+};
+
+const isSetStateToInitialValue = (
+  analysis: ProgramAnalysis,
+  context: RuleContext,
+  setterRef: Reference,
+): boolean => {
   const callExpr = getCallExpr(setterRef);
   if (!callExpr || !isNodeOfType(callExpr, "CallExpression")) return false;
   const setStateToValue: EsTreeNode | undefined = callExpr.arguments?.[0] as EsTreeNode | undefined;
@@ -68,18 +280,23 @@ const isSetStateToInitialValue = (analysis: ProgramAnalysis, setterRef: Referenc
   if ((setStateToValue && !stateInitialValue) || (!setStateToValue && stateInitialValue)) {
     return false;
   }
-  // `useState(value)` seeded from a LIVE binding: `setX(value)` later
-  // re-syncs to the binding's CURRENT value, not the mount-time initial —
-  // a draft re-sync, not a reset (ant-design-mobile picker, delta audit).
-  // A `const x = <literal>` named constant is NOT live: resetting to it is
-  // resetting to the initial value (upstream parity "shared var" case).
-  if (
-    stateInitialValue &&
-    isNodeOfType(stateInitialValue, "Identifier") &&
-    stateInitialValue.name !== "undefined" &&
-    !isLiteralConstantIdentifier(analysis, stateInitialValue)
-  ) {
-    return false;
+  if (stateInitialValue && setStateToValue) {
+    const initialLivePropIdentity = getLivePropExpressionIdentity(
+      analysis,
+      context,
+      stateInitialValue,
+    );
+    const nextLivePropIdentity = getLivePropExpressionIdentity(analysis, context, setStateToValue);
+    if (
+      initialLivePropIdentity &&
+      nextLivePropIdentity &&
+      haveSameLivePropExpressionIdentity(initialLivePropIdentity, nextLivePropIdentity)
+    ) {
+      return false;
+    }
+    if (areSameProvenLiveBinding(analysis, context, stateInitialValue, setStateToValue)) {
+      return false;
+    }
   }
   return getNodeText(setStateToValue) === getNodeText(stateInitialValue);
 };
@@ -95,6 +312,7 @@ const countUseStates = (analysis: ProgramAnalysis, componentNode: EsTreeNode | n
 
 const findPropUsedToResetAllState = (
   analysis: ProgramAnalysis,
+  context: RuleContext,
   effectFnRefs: Reference[],
   depsRefs: Reference[],
   useEffectNode: EsTreeNode,
@@ -108,7 +326,9 @@ const findPropUsedToResetAllState = (
   );
   if (stateSetterRefs.length === 0) return null;
 
-  const allResetToInitial = stateSetterRefs.every((ref) => isSetStateToInitialValue(analysis, ref));
+  const allResetToInitial = stateSetterRefs.every((ref) =>
+    isSetStateToInitialValue(analysis, context, ref),
+  );
   if (!allResetToInitial) return null;
 
   // The sync reset is the loading phase of a fetch lifecycle when the SAME
@@ -163,6 +383,7 @@ export const noResetAllStateOnPropChange = defineRule({
 
       const propUsedToReset = findPropUsedToResetAllState(
         analysis,
+        context,
         effectFnRefs,
         depsRefs,
         node,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-reset-all-state-on-prop-change.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-reset-all-state-on-prop-change.ts
@@ -3,6 +3,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { getDirectConstInitializer } from "../../utils/get-direct-const-initializer.js";
+import { isOutsideAllFunctions } from "../../utils/is-outside-all-functions.js";
 import { isReactApiCall } from "../../utils/is-react-api-call.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { RuleContext } from "../../utils/rule-context.js";
@@ -218,7 +219,9 @@ const isProvenLiveBinding = (
 ): boolean => {
   const reference = getRef(analysis, identifier);
   const symbol = context.scopes.symbolFor(identifier);
-  if (!reference || !symbol || symbol.kind !== "const") return false;
+  if (!reference || !symbol || symbol.kind !== "const" || isOutsideAllFunctions(symbol)) {
+    return false;
+  }
   const initializer = symbol.initializer;
   if (!initializer || isMountSnapshotBinding(context, identifier)) return false;
   const initializerReferences = getDownstreamRefs(analysis, initializer);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-outside-all-functions.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-outside-all-functions.ts
@@ -1,0 +1,13 @@
+import type { SymbolDescriptor } from "../semantic/scope-analysis.js";
+
+const FUNCTION_SCOPE_KINDS: ReadonlySet<string> = new Set(["function", "arrow-function", "method"]);
+
+export const isOutsideAllFunctions = (symbol: SymbolDescriptor): boolean => {
+  let scope: SymbolDescriptor["scope"] | null = symbol.scope;
+  while (scope) {
+    if (FUNCTION_SCOPE_KINDS.has(scope.kind)) return false;
+    if (scope.kind === "module") return true;
+    scope = scope.parent;
+  }
+  return true;
+};


### PR DESCRIPTION
## Why

Cloudscape focus-lock initializes a transition tracker from `!!disabled` and later records the current `!!disabled` value. React Doctor treated that current prop mirror as a reset to the mount-time initial state, even though the value is recomputed from the live prop every render.

Before: `no-reset-all-state-on-prop-change` reports `src/internal/components/focus-lock/index.tsx:60` at Cloudscape commit `151ff09468259fe42a989de1ffcddd9d21c5eb87`.

After: that grounded finding is quiet while the five neighboring genuine reset-all-state diagnostics remain.

## What changed

- Resolve live prop identities through static member paths, global `Boolean(...)`, negation, transparent TypeScript wrappers, and exact immutable aliases.
- Preserve diagnostics for mutable aliases, literal normalizations, `useRef` snapshots, imported React `useMemo(..., [])` mount snapshots, and module-scoped initial constants.
- Preserve the existing live-binding behavior for opaque prop-derived values and custom-hook results.
- Reuse the shared module-scope proof rather than duplicating scope traversal.
- Add paired adversarial regressions, a permanent fuzz seed, generator valid/invalid shapes, and a patch changeset.

## Eval results

| Corpus | Baseline | Candidate | Delta |
| --- | ---: | ---: | ---: |
| RDE, 12 pinned OSS repos / 100 roots | 23 | 22 | 1 removed FP, 0 additions |
| React Bench 5, 122 pinned tasks | 182 | 173 | 12 removed FPs, 3 added TPs |
| Cloudscape pinned base | 6 | 5 | focus-lock FP removed; 5 TPs retained |
| Cloudscape exact oracle | 6 | 5 | same intended FP removed; 5 TPs retained |

All 100 RDE roots completed after replacing three resource-failed candidate rows with successful low-concurrency retries. The only RDE delta is Formbricks' `args.value` controlled-state mirror.

All 122 baseline and candidate React Bench scans completed without partial lint. Every target-rule delta was inspected:

- Removed FPs: Cloudscape's live Boolean transition tracker; Mapguide's current prop mirrors; PortOS and Tracecat editing drafts; CoreUI's controlled chip mirror; DevLovers' current catalog sync; and Freecut's current migration tracker.
- Added TPs retained by the module-scope hardening: Jumper's reset to `TAG_ALL`, t3code's complete wizard reset on open, and Freecut's EQ draft reset on `targetLabel`.

## Test plan

- `nr --filter oxlint-plugin-react-doctor test src/plugin/rules/state-and-effects/no-reset-all-state-on-prop-change.regressions.test.ts src/plugin/rules/react-builtins/exhaustive-deps.test.ts`
- `nr --filter oxlint-plugin-react-doctor typecheck`
- `nr --filter @react-doctor/fuzz test`
- `FUZZ_RULE=no-reset-all-state-on-prop-change FUZZ_STRICT=1 FUZZ_ITERATIONS=500 FUZZ_PRINT_STATS=1 nr --filter @react-doctor/fuzz fuzz --silent=false --reporter=verbose` — target fired in 3/317 executed programs; no findings
- `nr test`
- `nr typecheck`
- `nr lint`
- `nr format:check`
- `git diff --check`
- Post-change `truffler` search: one `isOutsideAllFunctions` definition

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes heuristic lint logic for a widely enabled rule; bench evals show intentional new true positives alongside many removed false positives, so downstream CI noise may shift.
> 
> **Overview**
> **`no-reset-all-state-on-prop-change`** no longer treats syncing state to the **current** live prop (especially `Boolean` / `!!` transition trackers) as “reset all state to mount-time initial,” fixing false positives such as Cloudscape focus-lock.
> 
> The rule now compares **live prop expression identities** (props, static members, global `Boolean`, negation, transparent TS wrappers, immutable `const` alias chains) and **proven live bindings** when deciding if `setState(initialShape)` is a mirror vs a real reset. It still reports mutable aliases, literal-only normalizations, `useRef` / `useMemo([], …)` mount snapshots, shadowed globals, and module-scoped initial constants.
> 
> **`isOutsideAllFunctions`** is moved to a shared util (re-exported from `exhaustive-deps-low-level`) for module-scope live-binding checks. Regressions, a fuzz corpus fixture, and fuzz snippet seeds cover the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2c464cf95e6e26a7bf45bdaad5ffb7b1b93db24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->