### PR TITLE
fix(no-impure-state-updater): don't flag data parameters forwarded to a setter

### DIFF
--- a/.changeset/spicy-parrots-forgive.md
+++ b/.changeset/spicy-parrots-forgive.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Stop no-impure-state-updater flagging a data parameter forwarded to a setter. `resolveToFunction` mistook a `Parameter` definition (whose node is the enclosing function) for the updater, so idiomatic handlers like `(row) => { setSelected(row); setOpen(true) }` were reported. The shared resolver now rejects parameter bindings, which also removes a local workaround in no-pass-data-to-parent.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-impure-state-updater.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-impure-state-updater.test.ts
@@ -322,6 +322,50 @@ describe("no-impure-state-updater", () => {
          return count;
        };`,
     ],
+    [
+      "a data parameter forwarded to a setter",
+      `import { useState } from "react";
+       const Repro = () => {
+         const [selected, setSelected] = useState(null);
+         const [open, setOpen] = useState(false);
+         const openEditModal = (row) => {
+           setSelected(row);
+           setOpen(true);
+         };
+         return <button onClick={() => openEditModal({ id: "x" })}>{String(open)}</button>;
+       };`,
+    ],
+    [
+      "a data parameter forwarded from a promise callback",
+      `import { useState } from "react";
+       const Panel = () => {
+         const [colorMode, setColorMode] = useState(null);
+         const sync = () => resolveColorMode().then((nativeColorMode) => setColorMode(nativeColorMode));
+         return <button onClick={sync}>{colorMode}</button>;
+       };`,
+    ],
+    [
+      "a destructured parameter forwarded to a setter",
+      `import { useState } from "react";
+       const Panel = () => {
+         const [colorMode, setColorMode] = useState(null);
+         const onChange = ({ colorMode: nextColorMode }) => setColorMode(nextColorMode);
+         return <select onChange={onChange}>{colorMode}</select>;
+       };`,
+    ],
+    [
+      "a data parameter forwarded inside a memoized callback",
+      `import { useCallback, useState } from "react";
+       const Panel = () => {
+         const [diff, setDiff] = useState(null);
+         const [path, setPath] = useState(null);
+         const apply = useCallback((nextDiff) => {
+           setDiff(nextDiff);
+           setPath(nextDiff.path);
+         }, []);
+         return <button onClick={() => apply({ path: "x" })}>{path}</button>;
+       };`,
+    ],
   ])("stays silent for %s", (_name, code) => {
     const result = run(code);
     expect(result.parseErrors).toEqual([]);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.ts
@@ -128,14 +128,6 @@ const getWrapperHookWrappedFunction = (initializer: EsTreeNode): EsTreeNode | nu
   return wrapped;
 };
 
-// A def whose node is the enclosing function (a Parameter) must not count
-// as "resolves to a function": the BINDING holds a value, not a callable.
-const hasParameterDef = (ref: Reference): boolean =>
-  Boolean(ref.resolved?.defs.some((def) => def.type === "Parameter"));
-
-const resolvesToFunctionBinding = (ref: Reference): boolean =>
-  !hasParameterDef(ref) && Boolean(resolveToFunction(ref));
-
 const HANDLER_NAMED_PROP_PATTERN = /^(on|handle)[A-Z]/;
 
 // A wrapped body forwards to the parent only when it touches a
@@ -838,11 +830,11 @@ export const noPassDataToParent = defineRule({
             if (isParentWiredHookResultRef(analysis, argRef)) return false;
             if (isParentWiredHookCalleeRef(analysis, argRef)) return false;
             // Only real function BINDINGS are registration callbacks; a
-            // parameter reference resolves to its enclosing function via
-            // defs[0].node, which must not be mistaken for one — parameters
-            // carry the data being handed up (cloudscape custom-forms,
-            // a delta-audit recall regression).
-            if (resolvesToFunctionBinding(argRef)) return false;
+            // parameter reference resolves to null (its binding holds data,
+            // not a callable), so a forwarded data parameter is not mistaken
+            // for one (cloudscape custom-forms, a delta-audit recall
+            // regression).
+            if (resolveToFunction(argRef)) return false;
             // An imported binding in argument (not callee) position is
             // static module config (`subscribe(EVENT_NAME, handler)`),
             // not component-derived data.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/effect/ast.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/effect/ast.ts
@@ -269,7 +269,13 @@ export const resolveToFunction = (
   | EsTreeNodeOfType<"FunctionExpression">
   | EsTreeNodeOfType<"FunctionDeclaration">
   | null => {
-  const definitionNode = ref.resolved?.defs[0]?.node as unknown as EsTreeNode | undefined;
+  const definition = ref.resolved?.defs[0];
+  // A `Parameter` def points its `node` at the ENCLOSING function that
+  // declares the parameter, not at a function bound to the parameter — the
+  // binding holds a value, not a callable. Resolving it would mistake plain
+  // data arguments (`setRow(row)`) for the updater/callback function.
+  if (!definition || definition.type === "Parameter") return null;
+  const definitionNode = definition.node as unknown as EsTreeNode | undefined;
   if (!definitionNode) return null;
   if (isFunctionLike(definitionNode)) return definitionNode;
   if (isNodeOfType(definitionNode, "VariableDeclarator")) {


### PR DESCRIPTION
Fixes #1224

## Root cause

`no-impure-state-updater` resolves the updater passed to a setter via the shared `resolveToFunction` helper. For a **function parameter**, eslint-scope's `defs[0]` is a `Parameter` definition whose `.node` is the **enclosing function** that declares the parameter. The old resolver only checked `isFunctionLike(definitionNode)` — which is `true` for that enclosing function — so it returned the *whole surrounding handler* as the "updater." The rule then walked that body, found the sibling/self setter call, and reported a bogus "nested state update."

Net effect: the most idiomatic React handler shape was flagged:

```tsx
const openEditModal = (row) => {
  setSelected(row); // ✖ flagged — `row` is data, not an updater
  setOpen(true);
};
```

## Fix

Reject `Parameter` bindings in `resolveToFunction` itself — the binding holds a value, not a callable:

```ts
const definition = ref.resolved?.defs[0];
if (!definition || definition.type === "Parameter") return null;
```

This is the shared resolver behind ~8 callsites across the effect rules, so it fixes the class of bug rather than one symptom. The same principle was already asserted in three other places (`ascend`'s `Parameter` skip, the `collect-effect` def-type guard, and a local `hasParameterDef` workaround in `no-pass-data-to-parent`). Consolidating it into the resolver let me **delete the redundant `hasParameterDef`/`resolvesToFunctionBinding` helpers** (net-negative diff, single source of truth).

## Validation

- Added 4 regression tests mapping 1:1 to the failure shapes the two independent reporters hit in production (plain multi-setter handler, single-setter promise callback, destructured param, `useCallback`-wrapped). **Mechanically confirmed** they fail without the resolver guard and pass with it.
- Full plugin suite: **13,099 passed, 148 skipped, 0 failed** (554 files) — covers every other `resolveToFunction` caller.
- `typecheck` ✓ · `format:check` ✓ · `lint` ✓ (only pre-existing warnings in unrelated files).
- The ESLint mirror re-exports from the oxlint plugin, so both published packages get the fix. Patch changeset included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, centralized AST resolver change with targeted tests; behavior only affects lint false positives, not runtime.
> 
> **Overview**
> **`resolveToFunction`** now returns `null` when a reference’s first definition is a **`Parameter`**, because eslint-scope points that def at the **enclosing function**, not a function bound to the argument. That stopped **`no-impure-state-updater`** from treating idiomatic handlers like `(row) => { setSelected(row); setOpen(true) }` as if `row` were an updater and scanning the whole handler for nested setters.
> 
> **`no-pass-data-to-parent`** drops the local **`hasParameterDef` / `resolvesToFunctionBinding`** helpers and relies on the shared resolver for the same “data param vs callable” distinction. Four regression tests cover plain handlers, promise callbacks, destructured params, and **`useCallback`**-wrapped forwarding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c91291987398e308e5b1b65525699d7a4c9a7146. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->