### PR TITLE
fix(effect-needs-cleanup): own promise-callback timers behind an active flag

### DIFF
--- a/.changeset/effect-cleanup-guarded-promise-timer.md
+++ b/.changeset/effect-cleanup-guarded-promise-timer.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Stop effect-needs-cleanup from flagging a timer created inside a Promise callback when an effect-scope active flag gates its creation and the returned cleanup both clears the handle and invalidates that flag; a self-rescheduling poll with no such flag still fires.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
@@ -4066,3 +4066,150 @@ export const LanguageProvider = ({ i18next }) => {
     expect(result.diagnostics).toHaveLength(1);
   });
 });
+
+describe("effect-needs-cleanup regressions (issue #1241 promise-callback timer with active-flag guard)", () => {
+  it("does not flag a promise-callback timer guarded by an isActive early-return with its handle cleared", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect, useState } from "react";
+export const PermissionWatcher = ({ syncReminder }) => {
+  const [, setPermissionCheckTick] = useState(0);
+  useEffect(() => {
+    let isActive = true;
+    let permissionRecheckTimeout;
+    void syncReminder().then((result) => {
+      if (!isActive || result !== "permission-pending") return;
+      permissionRecheckTimeout = setTimeout(() => {
+        if (isActive) setPermissionCheckTick((tick) => tick + 1);
+      }, 5000);
+    });
+    return () => {
+      isActive = false;
+      if (permissionRecheckTimeout) clearTimeout(permissionRecheckTimeout);
+    };
+  }, [syncReminder]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a promise-callback timer wrapped in an `if (isMounted)` block with its handle cleared", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+export const Retrier = ({ load }) => {
+  useEffect(() => {
+    let isMounted = true;
+    let retryTimer;
+    void load().then(() => {
+      if (isMounted) {
+        retryTimer = setTimeout(() => {}, 1000);
+      }
+    });
+    return () => {
+      isMounted = false;
+      clearTimeout(retryTimer);
+    };
+  }, [load]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a promise-callback timer guarded by a ref invalidated in cleanup", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect, useRef } from "react";
+export const Retrier = ({ load }) => {
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    let timer;
+    void load().then(() => {
+      if (!mountedRef.current) return;
+      timer = setTimeout(() => {}, 1000);
+    });
+    return () => {
+      mountedRef.current = false;
+      clearTimeout(timer);
+    };
+  }, [load]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still flags a self-rescheduling poll whose cleanup clears the current timer but never stops the chain", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+export const Poller = ({ fetchData }) => {
+  useEffect(() => {
+    let timeoutId;
+    const poll = () => {
+      void fetchData().then(() => {
+        timeoutId = setTimeout(poll, 1000);
+      });
+    };
+    poll();
+    return () => clearTimeout(timeoutId);
+  }, [fetchData]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a promise-callback timer whose cleanup clears the handle but never invalidates the guard", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+export const Retrier = ({ load }) => {
+  useEffect(() => {
+    let isActive = true;
+    let timer;
+    void load().then(() => {
+      if (!isActive) return;
+      timer = setTimeout(() => {}, 1000);
+    });
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [load]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a promise-callback timer created before the guard read, so a falsy-flag path leaks it", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+export const Retrier = ({ load }) => {
+  useEffect(() => {
+    let isActive = true;
+    let timer;
+    void load().then(() => {
+      timer = setTimeout(() => {}, 1000);
+      if (!isActive) return;
+    });
+    return () => {
+      isActive = false;
+      clearTimeout(timer);
+    };
+  }, [load]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -24,6 +24,7 @@ import { isEventHandlerAttribute } from "../../utils/is-event-handler-attribute.
 import { isHookCall } from "../../utils/is-hook-call.js";
 import { isReactApiCall } from "../../utils/is-react-api-call.js";
 import { resolveReactRefSymbol } from "../../utils/react-ref-origin.js";
+import { statementAlwaysExits } from "../../utils/statement-always-exits.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import { walkAst } from "../../utils/walk-ast.js";
 import { walkInsideStatementBlocks } from "../../utils/walk-inside-statement-blocks.js";
@@ -1300,6 +1301,153 @@ const hasSplitLifecycleCleanup = (
   hasRerunReleaseBeforeUsage(callback, usage, context) &&
   hasStableUnmountCleanupForUsage(callback, usage, context);
 
+// A timer created inside a nested callback the effect invokes (a Promise
+// `.then`/`.catch`/`.finally` continuation, an IIFE, a helper) can outlive the
+// synchronous effect run, so the CFG path check — which reasons within the
+// effect callback — cannot connect it to a cleanup return. Such a timer is
+// still owned when the returned cleanup both clears its stored handle AND
+// invalidates an "active" flag that gates the timer's creation: a continuation
+// resolving after unmount reads the falsy flag and never schedules, while one
+// that resolved before unmount stored a handle the cleanup clears. Without that
+// flag (e.g. a self-rescheduling poll) a trailing timer still leaks, so the
+// finding must stand.
+const SCALAR_FALSY_LITERAL_VALUES: ReadonlySet<unknown> = new Set([false, null, 0, ""]);
+
+const isScalarFalsyExpression = (expression: EsTreeNode, context: RuleContext): boolean => {
+  const value = stripParenExpression(expression);
+  if (isNodeOfType(value, "Literal")) return SCALAR_FALSY_LITERAL_VALUES.has(value.value);
+  return (
+    isNodeOfType(value, "Identifier") &&
+    value.name === "undefined" &&
+    context.scopes.isGlobalReference(value)
+  );
+};
+
+const collectCleanupInvalidatedGuardKeys = (
+  cleanupReturns: ReadonlyArray<EsTreeNode>,
+  context: RuleContext,
+): Set<string> => {
+  const guardKeys = new Set<string>();
+  for (const cleanupReturn of cleanupReturns) {
+    if (!isNodeOfType(cleanupReturn, "ReturnStatement") || !cleanupReturn.argument) continue;
+    const cleanupFunction = resolveStableValue(cleanupReturn.argument, context);
+    if (!cleanupFunction || !isFunctionLike(cleanupFunction)) continue;
+    walkAst(cleanupFunction, (node: EsTreeNode) => {
+      if (node !== cleanupFunction && isFunctionLike(node)) return false;
+      if (
+        !isNodeOfType(node, "AssignmentExpression") ||
+        node.operator !== "=" ||
+        !isScalarFalsyExpression(node.right, context)
+      ) {
+        return;
+      }
+      const targetKey = resolveExpressionKey(node.left, context);
+      if (targetKey !== null) guardKeys.add(targetKey);
+    });
+  }
+  return guardKeys;
+};
+
+const isGuardFlagExpression = (
+  expression: EsTreeNode,
+  guardKeys: ReadonlySet<string>,
+  context: RuleContext,
+): boolean => {
+  const key = resolveExpressionKey(expression, context);
+  return key !== null && guardKeys.has(key);
+};
+
+// Entering this test's truthy branch requires a guard flag to be truthy
+// (`flag`, `flag && rest`), so its guarded body never runs once invalidated.
+const testRequiresGuardFlagTruthy = (
+  test: EsTreeNode,
+  guardKeys: ReadonlySet<string>,
+  context: RuleContext,
+): boolean => {
+  const unwrappedTest = stripParenExpression(test);
+  if (isNodeOfType(unwrappedTest, "LogicalExpression") && unwrappedTest.operator === "&&") {
+    return (
+      testRequiresGuardFlagTruthy(unwrappedTest.left, guardKeys, context) ||
+      testRequiresGuardFlagTruthy(unwrappedTest.right, guardKeys, context)
+    );
+  }
+  return isGuardFlagExpression(unwrappedTest, guardKeys, context);
+};
+
+// This test is truthy whenever a guard flag is falsy (`!flag`, `!flag || rest`),
+// so a leading `if (test) return` bails before a falsy-flag path reaches a timer.
+const testBailsWhenGuardFlagFalsy = (
+  test: EsTreeNode,
+  guardKeys: ReadonlySet<string>,
+  context: RuleContext,
+): boolean => {
+  const unwrappedTest = stripParenExpression(test);
+  if (isNodeOfType(unwrappedTest, "UnaryExpression") && unwrappedTest.operator === "!") {
+    return isGuardFlagExpression(unwrappedTest.argument, guardKeys, context);
+  }
+  if (isNodeOfType(unwrappedTest, "LogicalExpression") && unwrappedTest.operator === "||") {
+    return (
+      testBailsWhenGuardFlagFalsy(unwrappedTest.left, guardKeys, context) ||
+      testBailsWhenGuardFlagFalsy(unwrappedTest.right, guardKeys, context)
+    );
+  }
+  return false;
+};
+
+const isTimerCreationGuardedByFlag = (
+  usageNode: EsTreeNode,
+  usageFunction: EsTreeNode,
+  guardKeys: ReadonlySet<string>,
+  context: RuleContext,
+): boolean => {
+  let currentNode = usageNode;
+  let parentNode = currentNode.parent;
+  while (parentNode && parentNode !== usageFunction) {
+    if (
+      isNodeOfType(parentNode, "IfStatement") &&
+      parentNode.consequent === currentNode &&
+      testRequiresGuardFlagTruthy(parentNode.test, guardKeys, context)
+    ) {
+      return true;
+    }
+    if (isNodeOfType(parentNode, "BlockStatement")) {
+      for (const precedingStatement of parentNode.body ?? []) {
+        if (precedingStatement === currentNode) break;
+        if (
+          isNodeOfType(precedingStatement, "IfStatement") &&
+          statementAlwaysExits(precedingStatement.consequent) &&
+          testBailsWhenGuardFlagFalsy(precedingStatement.test, guardKeys, context)
+        ) {
+          return true;
+        }
+      }
+    }
+    currentNode = parentNode;
+    parentNode = currentNode.parent;
+  }
+  return false;
+};
+
+const hasGuardedDeferredTimerOwnership = (
+  callback: EsTreeNode,
+  usage: SubscribeLikeUsage,
+  matchingCleanupReturns: ReadonlyArray<EsTreeNode>,
+  context: RuleContext,
+): boolean => {
+  if (usage.kind !== "timer" || usage.handleKey === null) return false;
+  const usageFunction = findEnclosingFunction(usage.node);
+  if (!usageFunction || usageFunction === callback) return false;
+  if (
+    matchingCleanupReturns.length === 0 ||
+    !doMatchingNodesCoverEveryPathFromFunctionEntry(callback, matchingCleanupReturns, context)
+  ) {
+    return false;
+  }
+  const guardKeys = collectCleanupInvalidatedGuardKeys(matchingCleanupReturns, context);
+  if (guardKeys.size === 0) return false;
+  return isTimerCreationGuardedByFlag(usage.node, usageFunction, guardKeys, context);
+};
+
 const effectHasCleanupForUsage = (
   callback: EsTreeNode,
   usage: SubscribeLikeUsage,
@@ -1376,11 +1524,16 @@ const effectHasCleanupForUsage = (
       matchingCleanupReturns.push(child);
     }
   });
-  return doMatchingNodesCoverEveryPathAfterUsage(
-    resolveCleanupPathAnchor(usage.node, callback, context),
-    matchingCleanupReturns,
-    context,
-  );
+  if (
+    doMatchingNodesCoverEveryPathAfterUsage(
+      resolveCleanupPathAnchor(usage.node, callback, context),
+      matchingCleanupReturns,
+      context,
+    )
+  ) {
+    return true;
+  }
+  return hasGuardedDeferredTimerOwnership(callback, usage, matchingCleanupReturns, context);
 };
 
 const findFirstUsageWithoutCleanup = (


### PR DESCRIPTION
## Why

Fixes #1241. `effect-needs-cleanup` flagged a `useEffect` even though every timer it can create is owned and released by the returned cleanup. A `setTimeout` created inside a Promise `.then` continuation lives in a different control-flow graph than the effect's cleanup `return`, so the rule's path-coverage check can never connect the two and the effect is reported despite proper teardown.

Before:

```tsx
useEffect(() => {
  let isActive = true
  let permissionRecheckTimeout
  void syncReminder().then((result) => {
    if (!isActive || result !== 'permission-pending') return
    permissionRecheckTimeout = setTimeout(() => {
      if (isActive) setPermissionCheckTick((tick) => tick + 1)
    }, 5_000)
  })
  return () => {
    isActive = false
    if (permissionRecheckTimeout) clearTimeout(permissionRecheckTimeout)
  }
}, [syncReminder])
// react-doctor/effect-needs-cleanup  ← false positive
```

After:

```
(no diagnostic — the timer is owned)
```

## What changed

- `effectHasCleanupForUsage`: when the standard CFG path check fails, fall back to `hasGuardedDeferredTimerOwnership`. A timer whose handle is stored in an effect-scope variable is recognized as owned when the returned cleanup **both** clears that handle **and** assigns a scalar-falsy value to an "active" flag (a `let`/`var` or `ref.current`, key-matched via `resolveExpressionKey`) that **structurally gates** the timer's creation — an enclosing `if (flag)` or a preceding `if (!flag …) return`.
- Soundness rests on the guard: a continuation that resolves after unmount reads the falsy flag and never schedules; one that resolved before unmount stored a handle the cleanup clears.
- The issue's own validation note is respected: a self-rescheduling poll whose cleanup clears the current timer but never invalidates a flag **still fires** (no guard → not exempt). Added regression tests pin this, plus the "handle cleared but flag alive" and "timer created before the guard read" leak variants.
- Reuses the shared `statementAlwaysExits` util for the early-return guard instead of a bespoke check.
- Added a changeset (`oxlint-plugin-react-doctor`, patch). The ESLint plugin re-exports this rule, so the fix propagates automatically.

This supersedes the automated triage PR #1244, which exempts on "handle cleared" alone and would turn the polling true-positive into a false negative.

## Test plan

- `pnpm --filter oxlint-plugin-react-doctor test` — 13,101 passed / 148 skipped, incl. 6 new `effect-needs-cleanup` regression tests (3 FP-fixed: reported case, `if (isMounted)` block, ref guard; 3 TP-kept: polling, flag-not-invalidated, timer-before-guard).
- `pnpm --filter oxlint-plugin-react-doctor typecheck` — clean.
- `vp lint` / `vp fmt --check` on touched files — clean.
- Built plugin + `packages/react-doctor/tests/regressions/state-rules/effect-needs-cleanup.test.ts` e2e — 37 passed.

## Follow-ups (not in this PR, to keep it scoped)

- A timer in a **synchronous anonymous IIFE** inside an effect (`(() => { timer = setTimeout(...) })(); return () => clearTimeout(timer)`) is still a false positive — same anchor-lift gap, but no guard flag to rescue it. The clean fix is lifting the cleanup path anchor to the IIFE call site for synchronously-invoked anonymous functions.
- `no-fetch-in-effect.ts` has a parallel cancellation-flag guard walker (`isCompletionSinkGuardedByCancellationFlag`). A future refactor could extract a shared, polarity-parametric guard util; kept separate here to avoid touching a second rule's behavior in a targeted fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds non-trivial static analysis to a widely used lint rule; behavior is constrained by regression tests but guard detection could miss or over-accept edge cases.
> 
> **Overview**
> Fixes **#1241** false positives where `effect-needs-cleanup` reported `useEffect` timers scheduled inside Promise `.then` handlers even when teardown was correct—the rule’s CFG path check cannot link deferred timer creation to the effect’s cleanup `return`.
> 
> **`effectHasCleanupForUsage`** now falls back to **`hasGuardedDeferredTimerOwnership`** when path coverage fails. Timers created in a nested callback (e.g. Promise continuation) count as owned only if cleanup **clears the stored handle** and **sets an effect-scope “active” flag to a scalar-falsy value** (`isActive`, `isMounted`, `ref.current`, etc.), and **`setTimeout` is structurally gated** by that flag (`if (!isActive) return`, `if (isMounted) { … }`, or similar). Self-rescheduling polls and cases that clear the timer without invalidating the guard still diagnose.
> 
> Adds six regression tests and a patch **changeset** for `oxlint-plugin-react-doctor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54262e91c0864f4e7952de5992fd4931ff60549f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->