### PR TITLE
fix(no-impure-state-updater): stop firing on parameter-bound callbacks

### DIFF
--- a/.changeset/fix-impure-state-updater-parameter-callbacks.md
+++ b/.changeset/fix-impure-state-updater-parameter-callbacks.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Stop `no-impure-state-updater` firing on promise callbacks and event handlers. A setter call whose argument is a plain parameter (`setX(value)` inside `(value) => …`) was resolved to its enclosing function and analyzed as the updater callback, so `fetchInvites().then((data) => setInvites(data))` and `onChange={(next) => setSort(next)}` were reported as impure updaters. `resolveToFunction` now refuses to resolve a parameter binding to the function it merely lives in, which is centralized for every effect-analysis consumer.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-impure-state-updater.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-impure-state-updater.test.ts
@@ -191,6 +191,20 @@ describe("no-impure-state-updater", () => {
          return width;
        };`,
     ],
+    [
+      "a nested update inside a named updater passed to the setter",
+      `import { useState } from "react";
+       const Form = () => {
+         const [value, setValue] = useState(0);
+         const [error, setError] = useState(null);
+         const nextValue = (previousValue) => {
+           setError(null);
+           return previousValue + 1;
+         };
+         const update = () => setValue(nextValue);
+         return <button onClick={update}>{value}{error}</button>;
+       };`,
+    ],
   ])("reports %s", (_name, code) => {
     const result = run(code);
     expect(result.parseErrors).toEqual([]);
@@ -198,6 +212,48 @@ describe("no-impure-state-updater", () => {
   });
 
   it.each([
+    [
+      "a promise callback forwarding its resolved value (issue #1228)",
+      `import { useState, useCallback } from "react";
+       const Invites = () => {
+         const [invites, setInvites] = useState([]);
+         const loadInvites = useCallback(() => {
+           fetchInvites(api).then((data) => setInvites(data)).catch(() => setInvites([]));
+         }, []);
+         return <div>{invites.length}</div>;
+       };`,
+    ],
+    [
+      "an event handler forwarding its argument (issue #1228)",
+      `import { useState } from "react";
+       const Sorter = () => {
+         const [sort, setSort] = useState("name");
+         return <SelectMenu value={sort} onChange={(nextSort) => setSort(nextSort)} />;
+       };`,
+    ],
+    [
+      "a handler that calls several setters with its own parameter (issue #1228)",
+      `import { useState } from "react";
+       const Pair = () => {
+         const [first, setFirst] = useState(0);
+         const [second, setSecond] = useState(0);
+         const handleChange = (nextValue) => {
+           setFirst(nextValue);
+           setSecond(nextValue * 2);
+         };
+         return <button onClick={() => handleChange(10)}>{first}{second}</button>;
+       };`,
+    ],
+    [
+      "a setter reached through a parameter-bound helper (issue #1228)",
+      `import { useEffect, useState } from "react";
+       const invokeSetter = (setter, nextValue) => setter(nextValue);
+       const Counter = () => {
+         const [count, setCount] = useState(0);
+         useEffect(() => invokeSetter(setCount, count), [count]);
+         return count;
+       };`,
+    ],
     [
       "a pure arithmetic updater",
       `import { useState } from "react";

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.ts
@@ -128,14 +128,6 @@ const getWrapperHookWrappedFunction = (initializer: EsTreeNode): EsTreeNode | nu
   return wrapped;
 };
 
-// A def whose node is the enclosing function (a Parameter) must not count
-// as "resolves to a function": the BINDING holds a value, not a callable.
-const hasParameterDef = (ref: Reference): boolean =>
-  Boolean(ref.resolved?.defs.some((def) => def.type === "Parameter"));
-
-const resolvesToFunctionBinding = (ref: Reference): boolean =>
-  !hasParameterDef(ref) && Boolean(resolveToFunction(ref));
-
 const HANDLER_NAMED_PROP_PATTERN = /^(on|handle)[A-Z]/;
 
 // A wrapped body forwards to the parent only when it touches a
@@ -839,10 +831,10 @@ export const noPassDataToParent = defineRule({
             if (isParentWiredHookCalleeRef(analysis, argRef)) return false;
             // Only real function BINDINGS are registration callbacks; a
             // parameter reference resolves to its enclosing function via
-            // defs[0].node, which must not be mistaken for one — parameters
-            // carry the data being handed up (cloudscape custom-forms,
+            // defs[0].node, which `resolveToFunction` refuses to return, so
+            // parameters stay data being handed up (cloudscape custom-forms,
             // a delta-audit recall regression).
-            if (resolvesToFunctionBinding(argRef)) return false;
+            if (resolveToFunction(argRef)) return false;
             // An imported binding in argument (not callee) position is
             // static module config (`subscribe(EVENT_NAME, handler)`),
             // not component-derived data.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/collect-effect-state-write-facts.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/collect-effect-state-write-facts.ts
@@ -446,11 +446,9 @@ const resolveWrappedCallable = (analysis: ProgramAnalysis, node: EsTreeNode): Es
   if (isNodeOfType(candidate, "Identifier")) {
     const reference = getRef(analysis, candidate);
     if (!reference) return null;
-    if (
-      reference.resolved?.defs.some(
-        (definition) => definition.type === "Parameter" || definition.type === "ImportBinding",
-      )
-    ) {
+    // Parameter bindings bail inside `resolveToFunction`; an imported
+    // binding is module config, not a locally introspectable callable.
+    if (reference.resolved?.defs.some((definition) => definition.type === "ImportBinding")) {
       return null;
     }
     const resolved = resolveToFunction(reference);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/effect/ast.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/effect/ast.ts
@@ -257,11 +257,19 @@ const unwrapUseCallback = (node: EsTreeNode | null | undefined): EsTreeNode | nu
   return isUseCallbackCallee ? node.arguments?.[0] : node;
 };
 
+// A parameter's def node is the ENCLOSING function (eslint-scope models it
+// that way), but the binding holds a runtime value, not that function — so
+// `resolveToFunction` refuses it and callers wanting the old "unknown
+// callable" fallback opt in with `hasParameterDef(ref) || ...`.
+export const hasParameterDef = (ref: Reference): boolean =>
+  Boolean(ref.resolved?.defs.some((def) => def.type === "Parameter"));
+
 // Resolves a reference to the function-like node its first definition
 // denotes, unwrapping a `const fn = () => {}` declarator and a
 // `const fn = useCallback(() => {}, [])` wrapper. Returns null
-// when the reference doesn't resolve to a function. Shared by
-// `getEffectFn`, `isCleanupReturnArgument`, and `resolvesToAsyncFunction`.
+// when the reference doesn't resolve to a function (including a
+// parameter binding — see `hasParameterDef`). Shared by `getEffectFn`,
+// `isCleanupReturnArgument`, and `resolvesToAsyncFunction`.
 export const resolveToFunction = (
   ref: Reference,
 ):
@@ -269,6 +277,7 @@ export const resolveToFunction = (
   | EsTreeNodeOfType<"FunctionExpression">
   | EsTreeNodeOfType<"FunctionDeclaration">
   | null => {
+  if (hasParameterDef(ref)) return null;
   const definitionNode = ref.resolved?.defs[0]?.node as unknown as EsTreeNode | undefined;
   if (!definitionNode) return null;
   if (isFunctionLike(definitionNode)) return definitionNode;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/effect/react.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/effect/react.ts
@@ -12,6 +12,7 @@ import {
   getDownstreamRefs,
   getRef,
   getUpstreamRefs,
+  hasParameterDef,
   isEventualCallTo,
   isSynchronous,
   resolvesToAsyncFunction,
@@ -518,8 +519,11 @@ const isCleanupReturnArgument = (analysis: ProgramAnalysis, node: EsTreeNode): b
   if (isFunctionLike(node)) return true;
   if (isNodeOfType(node, "MemberExpression")) return true;
   if (isNodeOfType(node, "Identifier")) {
+    // A parameter binding is an unknown callable — `return cleanup` where
+    // `cleanup` is a prop/hook parameter still counts as a cleanup return,
+    // so keep the conservative fallback `resolveToFunction` no longer gives.
     const ref = getRef(analysis, node);
-    if (ref && resolveToFunction(ref)) return true;
+    if (ref && (hasParameterDef(ref) || resolveToFunction(ref))) return true;
   }
   if (isNodeOfType(node, "ConditionalExpression")) {
     return (


### PR DESCRIPTION
## Why

Fixes #1228. `no-impure-state-updater` fired on promise callbacks and JSX event handlers, not just state-updater callbacks — 75 false positives across 49 files in the reporter's Next.js 15 / React 19 app (77% of all error-severity findings, dragging the score to 29/100).

The rule resolves a `setX(arg)` argument to a function and scans its body. When `arg` is a plain **parameter** (`setInvites(data)` inside `(data) => setInvites(data)`), the shared helper `resolveToFunction` returned the wrong node: for a `Parameter`-bound reference, eslint-scope sets `def.node` to the **enclosing function**, so the rule walked that arrow's body, re-found the setter call, and reported a phantom "nested state update".

Before (all falsely reported as impure updaters):

```jsx
fetchInvites(api).then((data) => setInvites(data));   // promise callback
<SelectMenu onChange={(next) => setSort(next)} />;     // event handler
const handler = (next) => { setFirst(next); setSecond(next * 2); };
```

After: silent. The rule's real target still fires:

```jsx
setRows((prev) => {
  setTotal(prev.length);   // ← still reported
  return next;
});
```

## What changed

- **`resolveToFunction` (shared effect helper) now bails on parameter bindings** — a parameter holds a runtime value, never denotes the function it lives in. This is the single root cause; fixing it here covers every consumer (`no-impure-state-updater`, `getEffectFn`, …).
- **Dedup:** removed the two hand-rolled copies of this guard that already existed — `resolvesToFunctionBinding` in `no-pass-data-to-parent` and the `Parameter` half of `resolveWrappedCallable`'s guard in `collect-effect-state-write-facts`. Net-negative on source.
- **Preserved** `isCleanupReturnArgument`'s conservative `hasParameterDef(ref) || resolveToFunction(ref)` — a `return cleanupParam` still counts as a possible cleanup, so no false-positive-suppression path regresses. I audited all 11 call sites (report-vs-suppress polarity); this is the only one that relied on the old truthy result.
- Regression tests: the 3 issue shapes (+ a parameter-bound-helper variant) stay silent; a named-`const` updater with a nested setter still fires.

## Test plan

- `pnpm --filter oxlint-plugin-react-doctor test` — **13100 passed / 148 skipped** (554 files)
- The 3 issue-specific FP tests provably fail without the `resolveToFunction` bail and pass with it (verified by reverting the guard)
- `pnpm --filter oxlint-plugin-react-doctor typecheck`, `pnpm lint`, `vp fmt --check` — clean on touched files
- Reproduced all three issue shapes against the pre-fix build (fired) and post-fix build (silent)

Changeset: `oxlint-plugin-react-doctor` patch (the `fixed` group cascades the version bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches a shared `resolveToFunction` helper used by several state/effect rules; behavior change is narrow but cross-cutting, with tests and one explicit cleanup fallback to limit regressions.
> 
> **Overview**
> Fixes **#1228** by correcting how shared effect analysis resolves identifiers passed to state setters.
> 
> **`resolveToFunction`** now returns `null` when a reference is a **parameter binding** (eslint-scope points parameter defs at the enclosing function, so `setInvites(data)` inside `(data) => …` was wrongly treated as analyzing that whole arrow as the updater). That stops **`no-impure-state-updater`** from flagging promise `.then` handlers, JSX `onChange` forwards, and similar patterns.
> 
> Duplicate parameter guards are removed from **`no-pass-data-to-parent`** and **`resolveWrappedCallable`** in favor of the centralized helper. **`isCleanupReturnArgument`** still treats parameters as possible cleanup via **`hasParameterDef(ref) || resolveToFunction(ref)`** so effect cleanup detection stays conservative.
> 
> Regression tests cover the issue shapes plus a case where a **named** updater function with a nested setter still reports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f04bc8b1bc209249a76889de963767137283c0e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->