### PR TITLE
fix(state-and-effects): preserve parameter-provided cleanups

### DIFF
--- a/.changeset/fix-impure-updater-false-positives.md
+++ b/.changeset/fix-impure-updater-false-positives.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Preserve parameter-provided cleanup callbacks and forwarded callback values as conservative external functions after parameter bindings stopped resolving to their enclosing function. This prevents false positives across shared state and effect analysis.

--- a/packages/fuzz/corpus/regressions/no-impure-state-updater--function-parameter-as-data.tsx
+++ b/packages/fuzz/corpus/regressions/no-impure-state-updater--function-parameter-as-data.tsx
@@ -1,0 +1,24 @@
+// rule: no-impure-state-updater
+// weakness: alias-guard
+// source: https://github.com/millionco/react-doctor/issues/1224
+import { useState } from "react";
+
+interface Row {
+  readonly id: string;
+}
+
+export const Component = () => {
+  const [, setSelectedRow] = useState<Row | null>(null);
+  const [, setIsOpen] = useState(false);
+
+  const openEditModal = (row: Row): void => {
+    setSelectedRow(row);
+    setIsOpen(true);
+  };
+
+  return (
+    <button type="button" onClick={() => openEditModal({ id: "example" })}>
+      Open
+    </button>
+  );
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-chain-state-updates.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-chain-state-updates.regressions.test.ts
@@ -167,6 +167,19 @@ describe("no-chain-state-updates — must-detect regressions", () => {
 });
 
 describe("no-chain-state-updates — regressions", () => {
+  it("stays silent when an effect passes a setter through a parameter-bound helper", () => {
+    const result = runRule(
+      noChainStateUpdates,
+      `const useForwardedSetter = (invoke) => {
+  const [value, setValue] = useState(0);
+  useEffect(() => invoke(setValue), []);
+  return value;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("fires on mixed-origin state (handler setter plus one setTimeout site — basis form)", () => {
     const result = runRule(
       noChainStateUpdates,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.regressions.test.ts
@@ -3,6 +3,20 @@ import { runRule } from "../../../test-utils/run-rule.js";
 import { noEffectChain } from "./no-effect-chain.js";
 
 describe("no-effect-chain — regressions", () => {
+  it("stays silent when an effect callback is received as a custom-hook parameter", () => {
+    const result = runRule(
+      noEffectChain,
+      `const useForwardedEffect = (effect) => {
+  const [value, setValue] = useState(0);
+  useEffect(effect, []);
+  setValue(value + 1);
+  return value;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it.each(["$", "($)", "void ($)", "(0, $)"])(
     "flags a cross-effect chain through discarded wrapper %s",
     (wrapper) => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-event-handler.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-event-handler.regressions.test.ts
@@ -3,6 +3,21 @@ import { runRule } from "../../../test-utils/run-rule.js";
 import { noEffectEventHandler } from "./no-effect-event-handler.js";
 
 describe("state-and-effects/no-effect-event-handler regressions", () => {
+  it("does not flag a guarded effect returning an unknown cleanup parameter", () => {
+    const result = runRule(
+      noEffectEventHandler,
+      `const Component = ({ active, onEvent, cleanup }) => {
+  useEffect(() => {
+    if (active) onEvent();
+    return cleanup;
+  }, [active]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   // Mined cloudscape FP (app-layout/mobile-toolbar): a prop-guarded body
   // scroll lock with a cleanup half. The cleanup cannot move into an
   // event handler, so the effect is synchronizing with an external

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-event-handler.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-event-handler.regressions.test.ts
@@ -21,6 +21,22 @@ const expectBroadInferenceStaysSilent = (
 };
 
 describe("no-event-handler — must-detect regressions", () => {
+  it("stays silent when an effect returns an unknown cleanup parameter", () => {
+    const result = runRule(
+      noEventHandler,
+      `const useForwardedEffect = (cleanup) => {
+  const [active, setActive] = useState(false);
+  useEffect(() => {
+    if (active) window.alert("active");
+    return cleanup;
+  }, [active]);
+  return setActive;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("stays silent on memo-derived state with mixed async writers", () => {
     expectBroadInferenceStaysSilent(
       `

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-impure-state-updater.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-impure-state-updater.test.ts
@@ -199,6 +199,16 @@ describe("no-impure-state-updater", () => {
 
   it.each([
     [
+      "a setter parameter invoked from an effect helper",
+      `import { useEffect, useState } from "react";
+       const invokeSetter = (setter, nextValue) => setter(nextValue);
+       const Component = () => {
+         const [value, setValue] = useState(0);
+         useEffect(() => invokeSetter(setValue, value), [value]);
+         return value;
+       };`,
+    ],
+    [
       "a pure arithmetic updater",
       `import { useState } from "react";
        const Counter = () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.regressions.test.ts
@@ -3,6 +3,20 @@ import { runRule } from "../../../test-utils/run-rule.js";
 import { noPassDataToParent } from "./no-pass-data-to-parent.js";
 
 describe("no-pass-data-to-parent — regressions", () => {
+  it("stays silent when a callback parameter is passed through a parent callback", () => {
+    const result = runRule(
+      noPassDataToParent,
+      `const useForwarder = (onRegister, callback) => {
+  useEffect(() => {
+    onRegister(callback);
+  }, [onRegister, callback]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   describe("external subscription notifications", () => {
     it("stays silent when notifying a parent of a media-query hook transition", () => {
       const result = runRule(

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-live-state-to-parent.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-live-state-to-parent.regressions.test.ts
@@ -19,6 +19,20 @@ const expectFiresAtLeast = (code: string, minimumDiagnosticCount: number): void 
 };
 
 describe("no-pass-live-state-to-parent — must-detect regressions", () => {
+  it("stays silent when a callback parameter is passed through a parent callback", () => {
+    const result = runRule(
+      noPassLiveStateToParent,
+      `const useForwarder = (onRegister, callback) => {
+  useEffect(() => {
+    onRegister(callback);
+  }, [onRegister, callback]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("fires on onError(error) in an effect when the setter is also called in async handlers (inrupt Image)", () => {
     expectFiresAtLeast(
       `

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/prefer-use-sync-external-store.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/prefer-use-sync-external-store.regressions.test.ts
@@ -31,6 +31,19 @@ function subscribePushState(listener) {
 `;
 
 describe("prefer-use-sync-external-store — module-scope store shape", () => {
+  it("stays silent when a subscription callback is received as a custom-hook parameter", () => {
+    const result = run(
+      `import { useEffect, useState } from "react";
+export function useForwardedSubscription(subscribe) {
+  const [state, setState] = useState("default");
+  useEffect(() => subscribe(setState), []);
+  return state;
+}`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("flags useState(sharedState) + useEffect(() => subscribe(setState), []) (ground-truth shape)", () => {
     const result = run(
       `${MODULE_STORE_PREAMBLE}

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/collect-effect-state-write-facts.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/collect-effect-state-write-facts.ts
@@ -446,11 +446,7 @@ const resolveWrappedCallable = (analysis: ProgramAnalysis, node: EsTreeNode): Es
   if (isNodeOfType(candidate, "Identifier")) {
     const reference = getRef(analysis, candidate);
     if (!reference) return null;
-    if (
-      reference.resolved?.defs.some(
-        (definition) => definition.type === "Parameter" || definition.type === "ImportBinding",
-      )
-    ) {
+    if (reference.resolved?.defs.some((definition) => definition.type === "ImportBinding")) {
       return null;
     }
     const resolved = resolveToFunction(reference);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/effect/ast.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/effect/ast.ts
@@ -257,6 +257,9 @@ const unwrapUseCallback = (node: EsTreeNode | null | undefined): EsTreeNode | nu
   return isUseCallbackCallee ? node.arguments?.[0] : node;
 };
 
+export const hasParameterDefinition = (ref: Reference): boolean =>
+  Boolean(ref.resolved?.defs.some((definition) => definition.type === "Parameter"));
+
 // Resolves a reference to the function-like node its first definition
 // denotes, unwrapping a `const fn = () => {}` declarator and a
 // `const fn = useCallback(() => {}, [])` wrapper. Returns null
@@ -274,7 +277,7 @@ export const resolveToFunction = (
   // declares the parameter, not at a function bound to the parameter — the
   // binding holds a value, not a callable. Resolving it would mistake plain
   // data arguments (`setRow(row)`) for the updater/callback function.
-  if (!definition || definition.type === "Parameter") return null;
+  if (!definition || hasParameterDefinition(ref)) return null;
   const definitionNode = definition.node as unknown as EsTreeNode | undefined;
   if (!definitionNode) return null;
   if (isFunctionLike(definitionNode)) return definitionNode;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/effect/react.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/effect/react.ts
@@ -12,6 +12,7 @@ import {
   getDownstreamRefs,
   getRef,
   getUpstreamRefs,
+  hasParameterDefinition,
   isEventualCallTo,
   isSynchronous,
   resolvesToAsyncFunction,
@@ -519,7 +520,7 @@ const isCleanupReturnArgument = (analysis: ProgramAnalysis, node: EsTreeNode): b
   if (isNodeOfType(node, "MemberExpression")) return true;
   if (isNodeOfType(node, "Identifier")) {
     const ref = getRef(analysis, node);
-    if (ref && resolveToFunction(ref)) return true;
+    if (ref && (hasParameterDefinition(ref) || resolveToFunction(ref))) return true;
   }
   if (isNodeOfType(node, "ConditionalExpression")) {
     return (


### PR DESCRIPTION
## Summary

- preserve parameter-provided cleanup callbacks as conservative external cleanups after #1246 stopped parameter bindings from resolving to their enclosing function
- rely on the corrected shared resolver in state-write collection instead of maintaining another parameter-specific exclusion
- add cross-rule regressions for every shared state/effect consumer affected by the resolver change
- add a permanent fuzz-corpus seed for the original parameter-as-data failure

This is a hardening follow-up to #1246. That merge fixed the central resolver while this PR preserves the one conservative caller behavior that depended on the old truthy result and verifies the shared consumers end to end.

Closes #1228

## Why this follow-up is needed

`resolveToFunction(parameterReference)` now correctly returns `null`. Most callers want exactly that. Cleanup detection is the exception: `return cleanupParameter` must still be treated as a possible cleanup even though the parameter cannot be traversed as a locally defined function. Otherwise effect rules can report code whose cleanup implementation is supplied by the caller.

The exported parameter-definition predicate keeps that distinction explicit: the binding is not resolved or walked, but it remains a conservative cleanup value.

## Validation

- post-rebase full plugin suite: 554 files and 13,107 tests passed
- post-rebase strict `no-impure-state-updater` fuzz: 500 generated iterations passed
- strict fuzz against 27 extracted React Bench targets passed
- React Bench no-cache comparison across 35 relevant tasks: 681 target diagnostics before and after, with no added or removed findings
- RDE comparison across 100 OSS repositories: exact target-rule parity, 456 diagnostics before and after
- plugin typecheck and repository formatting passed after rebasing onto #1246
- earlier full repository build, lint, typecheck, and format gates passed

## Risk

Low. The central resolver behavior from #1246 is unchanged. The only production behavior added here is conservative recognition of unknown parameter-provided cleanup functions; the remaining changes remove a redundant check and add regression coverage.
