### PR TITLE
fix(effect-needs-cleanup): prove Promise timer ownership

### DIFF
--- a/.changeset/fix-promise-callback-timers.md
+++ b/.changeset/fix-promise-callback-timers.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Recognize timers created in Promise callbacks when an effect cleanup invalidates the callback's boolean guard and releases the same timer handle. Unguarded callbacks remain diagnostics because they can create resources after unmount.

--- a/packages/fuzz/corpus/regressions/effect-needs-cleanup--guarded-promise-timer.tsx
+++ b/packages/fuzz/corpus/regressions/effect-needs-cleanup--guarded-promise-timer.tsx
@@ -1,0 +1,33 @@
+// rule: effect-needs-cleanup
+// weakness: control-flow
+// source: https://github.com/millionco/react-doctor/issues/1241
+import { useEffect, useState } from "react";
+
+const PERMISSION_RECHECK_DELAY_MS = 5_000;
+
+interface ReminderProps {
+  syncReminder: () => Promise<"permission-pending" | "complete">;
+}
+
+export const Reminder = ({ syncReminder }: ReminderProps) => {
+  const [, setPermissionCheckTick] = useState(0);
+
+  useEffect(() => {
+    let isActive = true;
+    let permissionRecheckTimeout: ReturnType<typeof setTimeout> | undefined;
+
+    void syncReminder().then((result) => {
+      if (!isActive || result !== "permission-pending") return;
+      permissionRecheckTimeout = setTimeout(() => {
+        if (isActive) setPermissionCheckTick((currentTick) => currentTick + 1);
+      }, PERMISSION_RECHECK_DELAY_MS);
+    });
+
+    return () => {
+      isActive = false;
+      if (permissionRecheckTimeout) clearTimeout(permissionRecheckTimeout);
+    };
+  }, [syncReminder]);
+
+  return null;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
@@ -4066,3 +4066,305 @@ export const LanguageProvider = ({ i18next }) => {
     expect(result.diagnostics).toHaveLength(1);
   });
 });
+
+describe("effect-needs-cleanup Promise callback timers (issue #1241)", () => {
+  it("flags a timer in an unguarded Promise callback with conditional cleanup", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+export const Component = () => {
+  useEffect(() => {
+    let timeoutId;
+    Promise.resolve().then(() => {
+      timeoutId = setTimeout(() => console.log('fired'), 1000);
+    });
+    return () => {
+      if (timeoutId) clearTimeout(timeoutId);
+    };
+  }, []);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a timer in an unguarded Promise callback with unconditional cleanup", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+export const Component = () => {
+  useEffect(() => {
+    let timeoutId;
+    Promise.resolve().then(() => {
+      timeoutId = setTimeout(() => console.log('fired'), 1000);
+    });
+    return () => clearTimeout(timeoutId);
+  }, []);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a timer in Promise callback with active flag guard", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+export const Component = ({ syncReminder }) => {
+  useEffect(() => {
+    let isActive = true;
+    let timeoutId;
+    void syncReminder().then((result) => {
+      if (!isActive || result !== 'permission-pending') return;
+      timeoutId = setTimeout(() => {
+        if (isActive) console.log('tick');
+      }, 5000);
+    });
+    return () => {
+      isActive = false;
+      if (timeoutId) clearTimeout(timeoutId);
+    };
+  }, [syncReminder]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a timer in .then() callback with TypeScript type annotation", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+export const Component = () => {
+  useEffect(() => {
+    let isActive = true;
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    Promise.resolve().then(() => {
+      if (!isActive) return;
+      timeoutId = setTimeout(() => console.log('fired'), 1000);
+    });
+    return () => {
+      isActive = false;
+      if (timeoutId) clearTimeout(timeoutId);
+    };
+  }, []);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a cancelled timer in a .catch() callback", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+export const Component = ({ asyncCall }) => {
+  useEffect(() => {
+    let didCancel = false;
+    let timeoutId;
+    asyncCall().catch(() => {
+      if (didCancel) return;
+      timeoutId = setTimeout(() => console.log('error recovery'), 3000);
+    });
+    return () => {
+      didCancel = true;
+      if (timeoutId) clearTimeout(timeoutId);
+    };
+  }, [asyncCall]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a timer inside an active branch in a .finally() callback", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+export const Component = ({ asyncCall }) => {
+  useEffect(() => {
+    let isActive = true;
+    let timeoutId;
+    asyncCall().finally(() => {
+      if (isActive) {
+        timeoutId = setTimeout(() => console.log('cleanup'), 1000);
+      }
+    });
+    return () => {
+      isActive = false;
+      if (timeoutId) clearTimeout(timeoutId);
+    };
+  }, [asyncCall]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still flags a timer in Promise callback without any cleanup", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+export const Component = () => {
+  useEffect(() => {
+    Promise.resolve().then(() => {
+      setTimeout(() => console.log('leaked'), 1000);
+    });
+  }, []);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a timer in Promise callback with cleanup for different handle", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+export const Component = () => {
+  useEffect(() => {
+    let timeoutId;
+    let otherTimeoutId;
+    Promise.resolve().then(() => {
+      timeoutId = setTimeout(() => console.log('leaked'), 1000);
+    });
+    return () => clearTimeout(otherTimeoutId);
+  }, []);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags an async Promise callback when the guard is not rechecked after await", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+export const Component = ({ asyncCall }) => {
+  useEffect(() => {
+    let isActive = true;
+    let timeoutId;
+    asyncCall().then(async () => {
+      if (!isActive) return;
+      await Promise.resolve();
+      timeoutId = setTimeout(() => console.log('late'), 1000);
+    });
+    return () => {
+      isActive = false;
+      if (timeoutId) clearTimeout(timeoutId);
+    };
+  }, [asyncCall]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a Promise callback when cleanup invalidates its guard conditionally", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+export const Component = ({ asyncCall, shouldCancel }) => {
+  useEffect(() => {
+    let isActive = true;
+    let timeoutId;
+    asyncCall().then(() => {
+      if (!isActive) return;
+      timeoutId = setTimeout(() => console.log('late'), 1000);
+    });
+    return () => {
+      if (shouldCancel) isActive = false;
+      if (timeoutId) clearTimeout(timeoutId);
+    };
+  }, [asyncCall, shouldCancel]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a Promise callback when async cleanup defers guard invalidation", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+export const Component = ({ asyncCall }) => {
+  useEffect(() => {
+    let isActive = true;
+    let timeoutId;
+    asyncCall().then(() => {
+      if (!isActive) return;
+      timeoutId = setTimeout(() => console.log('late'), 1000);
+    });
+    return async () => {
+      await Promise.resolve();
+      isActive = false;
+      if (timeoutId) clearTimeout(timeoutId);
+    };
+  }, [asyncCall]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a Promise callback that overwrites its guard before scheduling a timer", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+export const Component = ({ asyncCall }) => {
+  useEffect(() => {
+    let isActive = true;
+    let timeoutId;
+    asyncCall().then(() => {
+      isActive = true;
+      if (!isActive) return;
+      timeoutId = setTimeout(() => console.log('late'), 1000);
+    });
+    return () => {
+      isActive = false;
+      if (timeoutId) clearTimeout(timeoutId);
+    };
+  }, [asyncCall]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not require cleanup on an early-return path before the Promise chain", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+export const Component = ({ asyncCall, disabled }) => {
+  useEffect(() => {
+    if (disabled) return;
+    let isActive = true;
+    let timeoutId;
+    asyncCall().then(() => {
+      if (!isActive) return;
+      timeoutId = setTimeout(() => console.log('late'), 1000);
+    });
+    return () => {
+      isActive = false;
+      if (timeoutId) clearTimeout(timeoutId);
+    };
+  }, [asyncCall, disabled]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -10,7 +10,10 @@ import {
   SUBSCRIPTION_METHOD_NAMES,
 } from "../../constants/react.js";
 import { defineRule } from "../../utils/define-rule.js";
-import { collectEffectInvokedFunctions } from "../../utils/collect-effect-invoked-functions.js";
+import {
+  collectEffectInvokedFunctions,
+  getPromiseChainCallForCallback,
+} from "../../utils/collect-effect-invoked-functions.js";
 import { enclosingComponentOrHookName } from "../../utils/enclosing-component-or-hook-name.js";
 import { findRenderPhaseComponentOrHook } from "../../utils/find-render-phase-component-or-hook.js";
 import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
@@ -23,6 +26,7 @@ import { getStaticPropertyKeyName } from "../../utils/get-static-property-key-na
 import { isEventHandlerAttribute } from "../../utils/is-event-handler-attribute.js";
 import { isHookCall } from "../../utils/is-hook-call.js";
 import { isReactApiCall } from "../../utils/is-react-api-call.js";
+import { readStaticBoolean } from "../../utils/read-static-boolean.js";
 import { resolveReactRefSymbol } from "../../utils/react-ref-origin.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import { walkAst } from "../../utils/walk-ast.js";
@@ -62,6 +66,11 @@ interface RefOwnedHandlerStorage {
   refCurrentKey: string;
   refKey: string;
   assignmentNode: EsTreeNode;
+}
+
+interface BooleanGuardState {
+  key: string;
+  value: boolean;
 }
 
 const RESOURCE_NOUN_BY_KIND = {
@@ -1300,6 +1309,175 @@ const hasSplitLifecycleCleanup = (
   hasRerunReleaseBeforeUsage(callback, usage, context) &&
   hasStableUnmountCleanupForUsage(callback, usage, context);
 
+const collectBlockingBooleanStates = (
+  expression: EsTreeNode,
+  blockedExpressionValue: boolean,
+  context: RuleContext,
+): BooleanGuardState[] => {
+  const unwrappedExpression = stripParenExpression(expression);
+  if (
+    isNodeOfType(unwrappedExpression, "UnaryExpression") &&
+    unwrappedExpression.operator === "!"
+  ) {
+    return collectBlockingBooleanStates(
+      unwrappedExpression.argument,
+      !blockedExpressionValue,
+      context,
+    );
+  }
+  if (isNodeOfType(unwrappedExpression, "LogicalExpression")) {
+    const canEitherOperandBlock =
+      (unwrappedExpression.operator === "||" && blockedExpressionValue) ||
+      (unwrappedExpression.operator === "&&" && !blockedExpressionValue);
+    if (!canEitherOperandBlock) return [];
+    return [
+      ...collectBlockingBooleanStates(unwrappedExpression.left, blockedExpressionValue, context),
+      ...collectBlockingBooleanStates(unwrappedExpression.right, blockedExpressionValue, context),
+    ];
+  }
+  if (
+    isNodeOfType(unwrappedExpression, "BinaryExpression") &&
+    ["===", "==", "!==", "!="].includes(unwrappedExpression.operator)
+  ) {
+    const leftValue = readStaticBoolean(unwrappedExpression.left);
+    const rightValue = readStaticBoolean(unwrappedExpression.right);
+    const booleanValue = leftValue ?? rightValue;
+    const comparedExpression =
+      leftValue === null ? unwrappedExpression.left : unwrappedExpression.right;
+    const comparedKey = resolveExpressionKey(comparedExpression, context);
+    if (booleanValue === null || comparedKey === null) return [];
+    const isEquality =
+      unwrappedExpression.operator === "===" || unwrappedExpression.operator === "==";
+    return [
+      {
+        key: comparedKey,
+        value: isEquality === blockedExpressionValue ? booleanValue : !booleanValue,
+      },
+    ];
+  }
+  const expressionKey = resolveExpressionKey(unwrappedExpression, context);
+  return expressionKey === null ? [] : [{ key: expressionKey, value: blockedExpressionValue }];
+};
+
+const isDirectEarlyReturnConsequent = (ifStatement: EsTreeNode): boolean => {
+  if (!isNodeOfType(ifStatement, "IfStatement") || ifStatement.alternate) return false;
+  if (isNodeOfType(ifStatement.consequent, "ReturnStatement")) return true;
+  return (
+    isNodeOfType(ifStatement.consequent, "BlockStatement") &&
+    ifStatement.consequent.body.length === 1 &&
+    isNodeOfType(ifStatement.consequent.body[0], "ReturnStatement")
+  );
+};
+
+const collectDeferredUsageGuardStates = (
+  callback: EsTreeNode,
+  usageNode: EsTreeNode,
+  context: RuleContext,
+): BooleanGuardState[] => {
+  if (!isFunctionLike(callback) || callback.async) return [];
+  const guardStates: BooleanGuardState[] = [];
+  walkAst(callback.body, (child: EsTreeNode) => {
+    if (child !== callback.body && isFunctionLike(child)) return false;
+    if (
+      isNodeOfType(child, "IfStatement") &&
+      isDirectEarlyReturnConsequent(child) &&
+      doMatchingNodesCoverEveryPathBeforeUsage(usageNode, [child], callback, context)
+    ) {
+      guardStates.push(...collectBlockingBooleanStates(child.test, true, context));
+    }
+  });
+  let descendant = usageNode;
+  let ancestor = descendant.parent;
+  while (ancestor && ancestor !== callback) {
+    if (isNodeOfType(ancestor, "IfStatement") && ancestor.consequent === descendant) {
+      guardStates.push(...collectBlockingBooleanStates(ancestor.test, false, context));
+    }
+    descendant = ancestor;
+    ancestor = ancestor.parent;
+  }
+  return guardStates;
+};
+
+const cleanupReturnInvalidatesGuard = (
+  cleanupReturn: EsTreeNode,
+  guardState: BooleanGuardState,
+  context: RuleContext,
+): boolean => {
+  if (!isNodeOfType(cleanupReturn, "ReturnStatement") || !cleanupReturn.argument) return false;
+  const cleanupFunction = resolveStableValue(cleanupReturn.argument, context);
+  if (!cleanupFunction || !isFunctionLike(cleanupFunction) || cleanupFunction.async) return false;
+  let didInvalidateGuard = false;
+  walkAst(cleanupFunction.body, (child: EsTreeNode) => {
+    if (didInvalidateGuard) return false;
+    if (child !== cleanupFunction.body && isFunctionLike(child)) return false;
+    if (
+      isNodeOfType(child, "AssignmentExpression") &&
+      child.operator === "=" &&
+      resolveExpressionKey(child.left, context) === guardState.key &&
+      readStaticBoolean(child.right) === guardState.value &&
+      context.cfg.isUnconditionalFromEntry(child)
+    ) {
+      didInvalidateGuard = true;
+      return false;
+    }
+  });
+  return didInvalidateGuard;
+};
+
+const deferredUsageWritesGuardBeforeUsage = (
+  callback: EsTreeNode,
+  usageNode: EsTreeNode,
+  guardState: BooleanGuardState,
+  context: RuleContext,
+): boolean => {
+  const usageStart = getRangeStart(usageNode);
+  if (!isFunctionLike(callback) || usageStart === null) return true;
+  let didWriteGuard = false;
+  walkAst(callback.body, (child: EsTreeNode) => {
+    if (didWriteGuard) return false;
+    if (child !== callback.body && isFunctionLike(child)) return false;
+    const childStart = getRangeStart(child);
+    if (childStart === null || childStart >= usageStart) return;
+    const writtenExpression = isNodeOfType(child, "AssignmentExpression")
+      ? child.left
+      : isNodeOfType(child, "UpdateExpression")
+        ? child.argument
+        : null;
+    if (writtenExpression && resolveExpressionKey(writtenExpression, context) === guardState.key) {
+      didWriteGuard = true;
+      return false;
+    }
+  });
+  return didWriteGuard;
+};
+
+const hasGuardedDeferredCleanup = (
+  callback: EsTreeNode,
+  usage: SubscribeLikeUsage,
+  cleanupReturns: ReadonlyArray<EsTreeNode>,
+  context: RuleContext,
+): boolean => {
+  const usageFunction = findEnclosingFunction(usage.node);
+  const promiseChainCall = usageFunction ? getPromiseChainCallForCallback(usageFunction) : null;
+  if (
+    usage.handleKey === null ||
+    !usageFunction ||
+    usageFunction === callback ||
+    !promiseChainCall ||
+    !collectEffectInvokedFunctions(callback).has(usageFunction) ||
+    !doMatchingNodesCoverEveryPathAfterUsage(promiseChainCall, cleanupReturns, context)
+  ) {
+    return false;
+  }
+  return collectDeferredUsageGuardStates(usageFunction, usage.node, context).some(
+    (guardState) =>
+      !deferredUsageWritesGuardBeforeUsage(usageFunction, usage.node, guardState, context) &&
+      cleanupReturns.every((cleanupReturn) =>
+        cleanupReturnInvalidatesGuard(cleanupReturn, guardState, context),
+      ),
+  );
+};
+
 const effectHasCleanupForUsage = (
   callback: EsTreeNode,
   usage: SubscribeLikeUsage,
@@ -1376,6 +1554,9 @@ const effectHasCleanupForUsage = (
       matchingCleanupReturns.push(child);
     }
   });
+  if (hasGuardedDeferredCleanup(callback, usage, matchingCleanupReturns, context)) {
+    return true;
+  }
   return doMatchingNodesCoverEveryPathAfterUsage(
     resolveCleanupPathAnchor(usage.node, callback, context),
     matchingCleanupReturns,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/collect-effect-invoked-functions.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/collect-effect-invoked-functions.ts
@@ -1,10 +1,35 @@
 import type { EsTreeNode } from "./es-tree-node.js";
 import { isFunctionLike } from "./is-function-like.js";
 import { isNodeOfType } from "./is-node-of-type.js";
-import { stripParenExpression } from "./strip-paren-expression.js";
+import {
+  stripParenExpression,
+  TRANSPARENT_EXPRESSION_WRAPPER_TYPES,
+} from "./strip-paren-expression.js";
 import { walkAst } from "./walk-ast.js";
 
 const PROMISE_CHAIN_METHOD_NAMES = new Set(["then", "catch", "finally"]);
+
+const isPromiseChainCall = (callee: EsTreeNode): boolean =>
+  isNodeOfType(callee, "MemberExpression") &&
+  isNodeOfType(callee.property, "Identifier") &&
+  PROMISE_CHAIN_METHOD_NAMES.has(callee.property.name) &&
+  isNodeOfType(stripParenExpression(callee.object), "CallExpression");
+
+export const getPromiseChainCallForCallback = (candidate: EsTreeNode): EsTreeNode | null => {
+  let callbackContainer = candidate.parent;
+  while (callbackContainer && TRANSPARENT_EXPRESSION_WRAPPER_TYPES.has(callbackContainer.type)) {
+    callbackContainer = callbackContainer.parent;
+  }
+  if (!isNodeOfType(callbackContainer, "CallExpression")) return null;
+  if (
+    !callbackContainer.arguments?.some((argument) => stripParenExpression(argument) === candidate)
+  ) {
+    return null;
+  }
+  return isPromiseChainCall(stripParenExpression(callbackContainer.callee))
+    ? callbackContainer
+    : null;
+};
 
 // Nested functions the effect body executes as part of running the effect —
 // IIFEs, locally-declared functions invoked by a bare call on the synchronous
@@ -23,12 +48,6 @@ export const collectEffectInvokedFunctions = (effectCallback: EsTreeNode): Set<E
     invokedFunctions.add(strippedCandidate);
     pendingFunctions.push(strippedCandidate);
   };
-
-  const isPromiseChainCall = (callee: EsTreeNode): boolean =>
-    isNodeOfType(callee, "MemberExpression") &&
-    isNodeOfType(callee.property, "Identifier") &&
-    PROMISE_CHAIN_METHOD_NAMES.has(callee.property.name) &&
-    isNodeOfType(stripParenExpression(callee.object), "CallExpression");
 
   while (pendingFunctions.length > 0) {
     const currentFunction = pendingFunctions.pop();


### PR DESCRIPTION
## Summary

- recognize a timer created in a Promise callback only when synchronous control-flow proves that cleanup prevents post-unmount creation and clears the same handle
- require a dominating boolean guard, unconditional cleanup invalidation, cleanup coverage on every path, and matching resource ownership
- retain diagnostics for unguarded callbacks, wrong handles, async callbacks or cleanups, conditional invalidation, and callbacks that overwrite the guard
- add adversarial regressions and a permanent fuzz-corpus seed

This hardens the broader bypass explored in #1244, which could suppress a real leak when an unguarded Promise settles after unmount.

Closes #1241

## Safety model

The diagnostic is suppressed only when both sides of the lifecycle are proven:

1. cleanup synchronously flips the same boolean state that dominates the deferred resource creation, so a callback settling after unmount cannot create the timer
2. cleanup releases the exact captured timer handle on every relevant effect path, so a timer created before unmount is cleared

If either proof fails, the rule remains diagnostic.

## Validation

- full plugin suite passed; the final targeted suite passed all 258 `effect-needs-cleanup` regressions
- final strict `effect-needs-cleanup` fuzz: 500 generated iterations passed
- strict fuzz against 27 extracted React Bench targets passed
- React Bench no-cache comparison across 41 relevant repositories: 263 target diagnostics before and after, with no added or removed findings
- RDE comparison across 100 OSS repositories: 42 target diagnostics before and after, with no added or removed findings
- `nr build`, `nr lint`, `nr typecheck`, and `nr format:check` passed
- the three timing-sensitive files that flaked only while two full monorepo suites ran concurrently passed sequentially on both branches: 44/44 tests

## Risk

The implementation is intentionally conservative. It does not suppress diagnostics for async Promise callbacks, async cleanup functions, non-dominating guards, conditional cleanup assignments, reassigned guards, unmatched handles, or uncovered paths.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes static analysis for a widely used lint rule; false negatives could hide real post-unmount timer leaks, though the implementation is intentionally conservative and heavily regression-tested.
> 
> **Overview**
> **`effect-needs-cleanup`** now treats timers scheduled inside Promise `.then`/`.catch`/`.finally` callbacks as cleaned up when control-flow analysis can prove both sides of the lifecycle: cleanup **unconditionally** flips the same boolean guard that blocks the callback after unmount, and cleanup **clears the same timer handle** on every relevant path.
> 
> The rule adds boolean-guard tracking (`collectBlockingBooleanStates`, `hasGuardedDeferredCleanup`, etc.) and exports **`getPromiseChainCallForCallback`** so deferred usages tie back to promise-chain callbacks invoked from the effect. Diagnostics **stay** for unguarded callbacks, wrong handles, async callbacks/cleanups, conditional guard invalidation, guard reassignment, and missing path coverage.
> 
> Adds a large regression suite for issue #1241, a fuzz corpus seed for the guarded-permission-recheck pattern, and a patch changeset for `oxlint-plugin-react-doctor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2787b4687b33c81c77f9df513a148b1f9d6edab7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->