### PR TITLE
fix(rules-of-hooks): preserve typed Hook adapter render provenance

### DIFF
--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/rules-of-hooks-adapters.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/rules-of-hooks-adapters.regressions.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { rulesOfHooks } from "./rules-of-hooks.js";
+
+describe("react-builtins/rules-of-hooks — typed Hook adapters", () => {
+  it("accepts the pinned alova React StatesHook adapter", () => {
+    const result = runRule(
+      rulesOfHooks,
+      `
+        import { falseValue, isNumber, noop, undefinedValue } from "@alova/shared";
+        import { StatesHook } from "alova";
+        import { MutableRefObject, useCallback, useEffect, useMemo, useRef, useState } from "react";
+        import { ReactHookExportType, ReactState } from "~/typings/stateshook/react";
+
+        const stateToData = <D>(reactState: ReactState<D>) => (2 in reactState ? reactState[2] : reactState[0]);
+        const refCurrent = <T>(ref: MutableRefObject<T>) => ref.current;
+        const setRef = <T>(ref: MutableRefObject<T>, newVal: T) => {
+          ref.current = newVal;
+        };
+
+        export default {
+          name: "React",
+          create: initialValue => useState(initialValue),
+          export: stateToData,
+          dehydrate: stateToData,
+          update: (newVal, state) => {
+            state[2] = newVal;
+            state[1](newVal);
+          },
+          memorize: fn => {
+            const fnRef = useRef(noop as typeof fn);
+            setRef(fnRef, fn);
+            return useCallback((...args: any[]) => refCurrent(fnRef)(...args), []);
+          },
+          ref: initialValue => {
+            const refObj = useRef(initialValue);
+            refCurrent(refObj) === undefinedValue && setRef(refObj, initialValue);
+            return refObj;
+          },
+          effectRequest({ handler, removeStates, immediate, watchingStates = [] }) {
+            const oldStates = useRef(watchingStates);
+
+            useEffect(() => {
+              const oldStatesValue = refCurrent(oldStates);
+              let changedIndex: number | undefined = undefinedValue;
+              for (const index in watchingStates) {
+                if (!Object.is(oldStatesValue[index], watchingStates[index])) {
+                  changedIndex = Number(index);
+                  break;
+                }
+              }
+              setRef(oldStates, watchingStates);
+              if (immediate || isNumber(changedIndex)) {
+                handler(changedIndex);
+              }
+            }, watchingStates);
+
+            useEffect(() => removeStates, []);
+          },
+          computed: (getter, depList) => {
+            const memo = useMemo(getter, depList);
+            return [memo, noop];
+          },
+          watch: (states, callback) => {
+            const needEmit = useRef(falseValue);
+            useEffect(() => {
+              needEmit.current ? callback() : (needEmit.current = true);
+            }, states);
+          },
+          onMounted: callback => {
+            useEffect(callback, []);
+          },
+          onUnmounted: callback => {
+            useEffect(() => callback, []);
+          }
+        } as StatesHook<ReactHookExportType<unknown>>;
+      `,
+      { filename: "packages/client/src/statesHook/react.ts" },
+    );
+
+    expect(result.diagnostics).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Problem

At alovajs/alova@75e3f473b24c73f6fc44fa0757d137fac38f2bad, `packages/client/src/statesHook/react.ts` exports the React implementation of alova’s typed `StatesHook` adapter. React Doctor currently reports 12 `rules-of-hooks` errors because its object methods are named `create`, `memorize`, `ref`, `effectRequest`, `computed`, `watch`, `onMounted`, and `onUnmounted`.

These methods are reached synchronously by alova custom Hooks through `statesHookHelper`; React runtime Hook identity depends on stable render execution, not on the adapter property spelling.

## Draft state

This first draft intentionally contains the exact pinned regression only. It currently fails with all 12 reproduced diagnostics. The detector change and adversarial paired controls will follow after the proof boundary is implemented.

## Precision boundary

The fix must require statically resolved render-flow provenance. It must not exempt arbitrary object callbacks or use property/type names as an allowlist. Conditional, looped, event-time, escaping, and opaque calls must continue to report.

## Validation plan

- paired direct/member/alias/wrapper/conditional/event controls
- permanent fuzz corpus seed and generator coverage
- strict 500-iteration target-rule fuzz run with target firing
- focused and full package checks
- current-vs-candidate RDE and pinned React Bench/oracle A/B
- terminal CI and unresolved review-thread audit
