### PR TITLE
fix(no-unstable-nested-components): prove element-type usage

### DIFF
--- a/.changeset/silly-onions-end.md
+++ b/.changeset/silly-onions-end.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Fix no-unstable-nested-components to distinguish render callbacks from nested component element types.

--- a/packages/fuzz/corpus/regressions/no-unstable-nested-components--usememo-render-callback.tsx
+++ b/packages/fuzz/corpus/regressions/no-unstable-nested-components--usememo-render-callback.tsx
@@ -1,0 +1,11 @@
+// rule: no-unstable-nested-components
+// weakness: library-idiom
+// source: DouyinFE/semi-design@9a1d6cce203898610e44f15f1e8a698beaade0ae
+
+import { useMemo } from "react";
+
+export const Parent = ({ shouldMemoize }: { shouldMemoize: boolean }) => {
+  const RenderContent = () => <div>Hello</div>;
+
+  return shouldMemoize ? useMemo(RenderContent, []) : RenderContent();
+};

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -120,6 +120,8 @@ export const HANDLER_SNIPPET_POOL = [
   `const handlePersistToken = () => { localStorage.setItem("auth_token", String(value)); };`,
   `const handleRedirect = () => { window.location.href = String(params.next); };`,
   `const renderStatus = () => { const [open] = useState(false); return <b>{String(open)}</b>; }; const statusNode = <div>{renderStatus()}</div>;`,
+  `const FuzzMemoRenderContent = () => <div>{state}</div>; const fuzzMemoContent = useMemo(FuzzMemoRenderContent, [state]);`,
+  `const FuzzNestedComponent = () => <div>{state}</div>; const fuzzNestedElement = <FuzzNestedComponent />;`,
 ] as const;
 
 // Guards / nullability — find/match/get derefs, optional chains, splits,

--- a/packages/fuzz/tests/verdict-robustness.test.ts
+++ b/packages/fuzz/tests/verdict-robustness.test.ts
@@ -41,6 +41,7 @@ const AUDITED_RULE_IDS = [
   "no-ref-current-in-render",
   "no-render-in-render",
   "no-stale-timer-ref",
+  "no-unstable-nested-components",
   "no-usememo-simple-expression",
   "only-export-components",
   "prefer-use-sync-external-store",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-unstable-nested-components.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-unstable-nested-components.regressions.test.ts
@@ -47,6 +47,191 @@ describe("react-builtins/no-unstable-nested-components — regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("does not flag multi-hop aliases used only as a useMemo callback", () => {
+    const result = run(`
+      import * as ReactClient from "react";
+      const Parent = () => {
+        const RenderContent = () => <div>Hello</div>;
+        const firstRenderAlias = RenderContent;
+        const SecondRenderAlias = firstRenderAlias;
+        return ReactClient.useMemo(SecondRenderAlias, []);
+      };
+    `);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not flag wrapped callbacks passed through a renamed useMemo import", () => {
+    const result = run(`
+      import { useMemo as calculateMemo } from "react";
+      const Parent = () => {
+        const RenderContent = () => <div>Hello</div>;
+        return calculateMemo(RenderContent as () => React.ReactNode, []);
+      };
+    `);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("flags a nested component that is rendered as JSX on another branch", () => {
+    const result = run(`
+      import { useMemo } from "react";
+      const Parent = ({ renderAsComponent }) => {
+        const RenderContent = () => <div>Hello</div>;
+        if (renderAsComponent) return <RenderContent />;
+        return useMemo(RenderContent, []);
+      };
+    `);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a multi-hop immutable alias rendered as JSX", () => {
+    const result = run(`
+      const Parent = () => {
+        const Nested = () => <div>Hello</div>;
+        const firstNestedAlias = Nested;
+        const SecondNestedAlias = firstNestedAlias;
+        return <SecondNestedAlias />;
+      };
+    `);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a reassigned nested binding whose replacement is rendered", () => {
+    const result = run(`
+      import { External } from "./external";
+      const Parent = () => {
+        let Nested = () => <div>Hello</div>;
+        Nested = External;
+        return <Nested />;
+      };
+    `);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not treat a shadowed createElement call as React instantiation", () => {
+    const result = run(`
+      const Parent = () => {
+        const Nested = () => <div>Hello</div>;
+        const createElement = (callback) => callback();
+        return createElement(Nested);
+      };
+    `);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not treat another library namespace as React instantiation", () => {
+    const result = run(`
+      import * as Template from "template-runtime";
+      const Parent = () => {
+        const Nested = () => <div>Hello</div>;
+        return Template.createElement(Nested);
+      };
+    `);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not treat cloneElement input as a component type", () => {
+    const result = run(`
+      import { cloneElement } from "react";
+      const Parent = () => {
+        const Nested = () => <div>Hello</div>;
+        return cloneElement(Nested as unknown as React.ReactElement);
+      };
+    `);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("flags createElement calls proven to come from React", () => {
+    const namedImportResult = run(`
+      import { createElement as makeReactElement } from "react";
+      const Parent = () => {
+        const Nested = () => <div>Hello</div>;
+        return makeReactElement(Nested);
+      };
+    `);
+    const namespaceImportResult = run(`
+      import * as ReactClient from "react";
+      const Parent = () => {
+        const Nested = () => <div>Hello</div>;
+        return ReactClient.createElement(Nested);
+      };
+    `);
+    expect(namedImportResult.diagnostics).toHaveLength(1);
+    expect(namespaceImportResult.diagnostics).toHaveLength(1);
+  });
+
+  it("does not treat arbitrary JSX props or children as element-type sinks", () => {
+    const result = run(`
+      const Parent = () => {
+        const RenderContent = () => <div>Hello</div>;
+        return <Widget callback={RenderContent}>{RenderContent}</Widget>;
+      };
+    `);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("flags recognized element-type props", () => {
+    const result = run(`
+      const Parent = () => {
+        const Nested = () => <div>Hello</div>;
+        return <Widget ItemComponent={Nested} />;
+      };
+    `);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags nested functions flowing through memo wrappers into JSX", () => {
+    const result = run(`
+      import { memo } from "react";
+      const Parent = () => {
+        const Nested = () => <div>Hello</div>;
+        const MemoizedNested = memo(Nested);
+        return <MemoizedNested />;
+      };
+    `);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag an unused inline memo wrapper", () => {
+    const result = run(`
+      import { memo } from "react";
+      const Parent = () => {
+        memo(() => <div>Hello</div>);
+        return <main />;
+      };
+    `);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("flags rendered React lazy wrappers but not unused ones", () => {
+    const renderedResult = run(`
+      import { lazy as loadLazy } from "react";
+      const Parent = () => {
+        const LazyNested = loadLazy(() => import("./nested"));
+        return <LazyNested />;
+      };
+    `);
+    const unusedResult = run(`
+      import * as ReactClient from "react";
+      const Parent = () => {
+        ReactClient.lazy(() => import("./nested"));
+        return <main />;
+      };
+    `);
+    expect(renderedResult.diagnostics).toHaveLength(1);
+    expect(unusedResult.diagnostics).toEqual([]);
+  });
+
+  it("does not flag nested functions returned as values", () => {
+    const result = run(`
+      const Parent = ({ returnFactory }) => {
+        const Nested = () => <div>Hello</div>;
+        if (returnFactory) return Nested;
+        return <main />;
+      };
+    `);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("does not attribute JSX across a nested function boundary", () => {
     const result = run(`
       function Parent() {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-unstable-nested-components.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-unstable-nested-components.regressions.test.ts
@@ -179,6 +179,18 @@ describe("react-builtins/no-unstable-nested-components — regressions", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("preserves common library component-slot props", () => {
+    for (const attributeName of ["body", "calendarContainer", "fallback", "tooltip"]) {
+      const result = run(`
+        const Parent = () => {
+          const Nested = () => <div>Hello</div>;
+          return <Widget ${attributeName}={Nested} />;
+        };
+      `);
+      expect(result.diagnostics).toHaveLength(1);
+    }
+  });
+
   it("flags nested functions flowing through memo wrappers into JSX", () => {
     const result = run(`
       import { memo } from "react";

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-unstable-nested-components.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-unstable-nested-components.regressions.test.ts
@@ -36,6 +36,17 @@ describe("react-builtins/no-unstable-nested-components — regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("does not flag a render callback passed to useMemo or called inline", () => {
+    const result = run(`
+      import { useMemo } from "react";
+      export const Parent = ({ memoize }: { memoize: boolean }) => {
+        const RenderContent = () => <div>Hello</div>;
+        return memoize ? useMemo(RenderContent, []) : RenderContent();
+      };
+    `);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("does not attribute JSX across a nested function boundary", () => {
     const result = run(`
       function Parent() {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-unstable-nested-components.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-unstable-nested-components.ts
@@ -3,10 +3,10 @@ import { defineRule } from "../../utils/define-rule.js";
 import { functionReturnsMatchingExpression } from "../../utils/function-returns-matching-expression.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
-import { isCreateElementCall } from "../../utils/is-create-element-call.js";
 import { isEs6Component } from "../../utils/is-es6-component.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { isReactApiCall } from "../../utils/is-react-api-call.js";
 import { isReactComponentName } from "../../utils/is-react-component-name.js";
 import { walkAst } from "../../utils/walk-ast.js";
 import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
@@ -57,7 +57,13 @@ const resolveSettings = (
 
 // Check if a function body / expression contains JSX OR a
 // React.createElement call.
-const expressionContainsJsxOrCreateElement = (root: EsTreeNode): boolean => {
+const isReactCreateElementCall = (node: EsTreeNode, scopes: ScopeAnalysis): boolean =>
+  isReactApiCall(node, "createElement", scopes, {
+    allowGlobalReactNamespace: true,
+    resolveNamedAliases: true,
+  });
+
+const expressionContainsJsxOrCreateElement = (root: EsTreeNode, scopes: ScopeAnalysis): boolean => {
   let found = false;
   walkAst(root, (node: EsTreeNode): boolean | void => {
     if (found) return false;
@@ -66,7 +72,7 @@ const expressionContainsJsxOrCreateElement = (root: EsTreeNode): boolean => {
       found = true;
       return false;
     }
-    if (isNodeOfType(node, "CallExpression") && isCreateElementCall(node as EsTreeNode)) {
+    if (isNodeOfType(node, "CallExpression") && isReactCreateElementCall(node, scopes)) {
       found = true;
       return false;
     }
@@ -79,11 +85,11 @@ const functionContainsJsxOrCreateElement = (
   scopes: ScopeAnalysis,
   controlFlow: ControlFlowAnalysis,
 ): boolean =>
-  expressionContainsJsxOrCreateElement(functionNode) ||
+  expressionContainsJsxOrCreateElement(functionNode, scopes) ||
   functionReturnsMatchingExpression(
     functionNode,
     scopes,
-    expressionContainsJsxOrCreateElement,
+    (expression) => expressionContainsJsxOrCreateElement(expression, scopes),
     controlFlow,
   );
 
@@ -95,9 +101,9 @@ const functionContainsJsxOrCreateElement = (
 // by containing JSX / `React.createElement(...)` in any method body.
 // Catches both the canonical class-component shape and the rare hybrid
 // case where a class declares JSX in render without `extends`.
-const isReactClassComponent = (classNode: EsTreeNode): boolean => {
+const isReactClassComponent = (classNode: EsTreeNode, scopes: ScopeAnalysis): boolean => {
   if (isEs6Component(classNode)) return true;
-  return expressionContainsJsxOrCreateElement(classNode);
+  return expressionContainsJsxOrCreateElement(classNode, scopes);
 };
 
 // Walk up to find the FIRST enclosing function/class component.
@@ -128,7 +134,11 @@ const findEnclosingComponent = (
       }
     }
     if (isNodeOfType(walker, "ClassDeclaration") || isNodeOfType(walker, "ClassExpression")) {
-      if (walker.id && isReactComponentName(walker.id.name) && isReactClassComponent(walker)) {
+      if (
+        walker.id &&
+        isReactComponentName(walker.id.name) &&
+        isReactClassComponent(walker, scopes)
+      ) {
         return { component: walker, name: walker.id.name };
       }
     }
@@ -248,7 +258,10 @@ const isObjectCallbackCandidate = (node: EsTreeNode): boolean => {
   return false;
 };
 
-const hocCallContainsComponent = (call: EsTreeNodeOfType<"CallExpression">): boolean => {
+const hocCallContainsComponent = (
+  call: EsTreeNodeOfType<"CallExpression">,
+  scopes: ScopeAnalysis,
+): boolean => {
   const firstArgument = call.arguments[0] as EsTreeNode | undefined;
   if (!firstArgument) return false;
   if (
@@ -256,12 +269,12 @@ const hocCallContainsComponent = (call: EsTreeNodeOfType<"CallExpression">): boo
     isNodeOfType(firstArgument, "ArrowFunctionExpression") ||
     isNodeOfType(firstArgument, "ClassExpression")
   ) {
-    return expressionContainsJsxOrCreateElement(firstArgument);
+    return expressionContainsJsxOrCreateElement(firstArgument, scopes);
   }
   if (isNodeOfType(firstArgument, "CallExpression") && isHocCallee(firstArgument)) {
-    return hocCallContainsComponent(firstArgument);
+    return hocCallContainsComponent(firstArgument, scopes);
   }
-  return expressionContainsJsxOrCreateElement(firstArgument);
+  return expressionContainsJsxOrCreateElement(firstArgument, scopes);
 };
 
 // Returns true when this node is the FIRST argument of an HoC call
@@ -308,17 +321,6 @@ const isReturnOfMapCallback = (node: EsTreeNode): boolean => {
   return false;
 };
 
-const isCloneElementCall = (node: EsTreeNode): boolean => {
-  if (!isNodeOfType(node, "CallExpression")) return false;
-  const callee = node.callee;
-  if (isNodeOfType(callee, "Identifier")) return callee.name === "cloneElement";
-  return (
-    isNodeOfType(callee, "MemberExpression") &&
-    isNodeOfType(callee.property, "Identifier") &&
-    callee.property.name === "cloneElement"
-  );
-};
-
 // TS expression wrappers that forward their inner value unchanged.
 const TS_VALUE_PASSTHROUGH_TYPES: ReadonlySet<string> = new Set([
   "TSAsExpression",
@@ -327,17 +329,46 @@ const TS_VALUE_PASSTHROUGH_TYPES: ReadonlySet<string> = new Set([
   "TSTypeAssertion",
 ]);
 
-// A PascalCase identifier READ counts as instantiation evidence only
-// when its value flows into a render-shaped sink: a JSX expression
-// container (`component={Inner}`, `<div>{Inner}</div>`), a
-// createElement / cloneElement argument, a return value, or a
-// component-shaped (PascalCase) binding a consumer can render
-// (`const Enhanced = withAnalytics(Inner)`). Arbitrary call arguments
-// whose result is discarded (`track(Inner)`, `console.log(Inner)`) are
-// side-effect reads, not renders. A DIRECT call (`Inner()`) inlines
-// into the parent's render — no child fiber — so the callee position
-// is not instantiation evidence either.
-const isRenderFlowingReadReference = (identifier: EsTreeNode): boolean => {
+// A PascalCase read is instantiation evidence only when it reaches JSX,
+// React.createElement, or a recognized element-type prop. Immutable aliases
+// are followed to those sinks. Direct calls and React.useMemo callbacks create
+// no child fiber, so they are not instantiation evidence.
+const ELEMENT_TYPE_PROP_NAMES: ReadonlySet<string> = new Set(["as", "component"]);
+
+const isElementTypeJsxAttribute = (node: EsTreeNode): boolean => {
+  if (!isNodeOfType(node, "JSXAttribute")) return false;
+  if (!isNodeOfType(node.name, "JSXIdentifier")) return false;
+  const attributeName = node.name.name;
+  return (
+    ELEMENT_TYPE_PROP_NAMES.has(attributeName.toLowerCase()) || attributeName.endsWith("Component")
+  );
+};
+
+const isReactUseMemoCallback = (
+  call: EsTreeNodeOfType<"CallExpression">,
+  valueNode: EsTreeNode,
+  scopes: ScopeAnalysis,
+): boolean =>
+  call.arguments[0] === valueNode &&
+  isReactApiCall(call, "useMemo", scopes, {
+    allowGlobalReactNamespace: true,
+    resolveNamedAliases: true,
+  });
+
+const isReactLazyCall = (
+  call: EsTreeNodeOfType<"CallExpression">,
+  scopes: ScopeAnalysis,
+): boolean =>
+  isReactApiCall(call, "lazy", scopes, {
+    allowGlobalReactNamespace: true,
+    resolveNamedAliases: true,
+  });
+
+const isRenderFlowingReadReference = (
+  identifier: EsTreeNode,
+  scopes: ScopeAnalysis,
+  visitedSymbols: ReadonlySet<number> = new Set(),
+): boolean => {
   let valueNode: EsTreeNode = identifier;
   let parent: EsTreeNode | null | undefined = valueNode.parent;
   while (parent) {
@@ -347,32 +378,40 @@ const isRenderFlowingReadReference = (identifier: EsTreeNode): boolean => {
       continue;
     }
     switch (parent.type) {
+      case "JSXOpeningElement":
+        return parent.name === valueNode;
       case "JSXExpressionContainer":
+        return Boolean(parent.parent && isElementTypeJsxAttribute(parent.parent));
       case "ReturnStatement":
-        return true;
+        return false;
       case "ArrowFunctionExpression":
-        return parent.body === valueNode;
+        return false;
       case "CallExpression": {
         if (parent.callee === valueNode) return false;
-        if (isCreateElementCall(parent) || isCloneElementCall(parent)) return true;
+        if (isReactUseMemoCallback(parent, valueNode, scopes)) return false;
+        if (isReactCreateElementCall(parent, scopes)) return true;
         valueNode = parent;
         parent = parent.parent;
         continue;
       }
-      case "VariableDeclarator":
-        return (
-          parent.init === valueNode &&
-          isNodeOfType(parent.id, "Identifier") &&
-          isReactComponentName(parent.id.name)
-        );
-      case "AssignmentExpression": {
-        const assignmentTarget = parent.left as EsTreeNode;
-        return (
-          parent.right === valueNode &&
-          isNodeOfType(assignmentTarget, "Identifier") &&
-          isReactComponentName(assignmentTarget.name)
+      case "VariableDeclarator": {
+        if (parent.init !== valueNode || !isNodeOfType(parent.id, "Identifier")) {
+          return false;
+        }
+        const aliasSymbol = scopes.symbolFor(parent.id);
+        if (!aliasSymbol || aliasSymbol.kind !== "const" || visitedSymbols.has(aliasSymbol.id)) {
+          return false;
+        }
+        const nextVisitedSymbols = new Set(visitedSymbols);
+        nextVisitedSymbols.add(aliasSymbol.id);
+        return aliasSymbol.references.some(
+          (reference) =>
+            reference.flag === "read" &&
+            isRenderFlowingReadReference(reference.identifier, scopes, nextVisitedSymbols),
         );
       }
+      case "AssignmentExpression":
+        return false;
       case "Property": {
         if (parent.value !== valueNode) return false;
         valueNode = parent;
@@ -554,7 +593,7 @@ export const noUnstableNestedComponents = defineRule({
       },
       Identifier(node: EsTreeNodeOfType<"Identifier">) {
         if (!isReactComponentName(node.name)) return;
-        if (!isRenderFlowingReadReference(node as EsTreeNode)) return;
+        if (!isRenderFlowingReadReference(node as EsTreeNode, context.scopes)) return;
         recordInstantiation(node as EsTreeNode, node.name);
       },
       FunctionDeclaration: checkFunctionLike,
@@ -568,17 +607,17 @@ export const noUnstableNestedComponents = defineRule({
         // PascalCase-named class (`class NewRoot extends RootState` in
         // tldraw, `class Tool extends BaseTool`, etc.) as a nested React
         // component candidate.
-        if (!isReactClassComponent(node as EsTreeNode)) return;
+        if (!isReactClassComponent(node as EsTreeNode, context.scopes)) return;
         enqueueCandidate(node as EsTreeNode, null);
       },
       ClassExpression(node: EsTreeNodeOfType<"ClassExpression">) {
         const inferredName = node.id?.name ?? inferFunctionLikeName(node as EsTreeNode);
         if (!inferredName || !isReactComponentName(inferredName)) return;
-        if (!isReactClassComponent(node as EsTreeNode)) return;
+        if (!isReactClassComponent(node as EsTreeNode, context.scopes)) return;
         enqueueCandidate(node as EsTreeNode, null);
       },
       CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
-        if (isCreateElementCall(node)) {
+        if (isReactCreateElementCall(node, context.scopes)) {
           const firstArgument = node.arguments[0] as EsTreeNode | undefined;
           if (firstArgument && isNodeOfType(firstArgument, "Identifier")) {
             recordInstantiation(firstArgument, firstArgument.name);
@@ -586,13 +625,29 @@ export const noUnstableNestedComponents = defineRule({
             recordMemberChainInstantiation(firstArgument);
           }
         }
-        if (!isHocCallee(node)) return;
-        if (!hocCallContainsComponent(node)) return;
-        enqueueCandidate(node as EsTreeNode, null);
+        const isReactLazy = isReactLazyCall(node, context.scopes);
+        if (!isReactLazy && !isHocCallee(node)) return;
+        if (!isReactLazy && !hocCallContainsComponent(node, context.scopes)) {
+          return;
+        }
+        const inferredName = inferFunctionLikeName(node as EsTreeNode);
+        const propInfo = isComponentDeclaredInProp(node as EsTreeNode);
+        if (propInfo === null && (!inferredName || !isReactComponentName(inferredName))) return;
+        enqueueCandidate(node as EsTreeNode, propInfo === null ? inferredName : null);
       },
       "Program:exit"() {
         for (const report of queuedReports) {
           if (report.requiredInstantiationName !== null) {
+            const requiredSymbol = report.requiredInstantiationBinding
+              ? context.scopes.symbolFor(report.requiredInstantiationBinding)
+              : null;
+            if (
+              requiredSymbol?.references.some(
+                (reference) => reference.flag === "write" || reference.flag === "read-write",
+              )
+            ) {
+              continue;
+            }
             const isInstantiated =
               report.requiredInstantiationBinding !== null
                 ? instantiatedBindingIdentifiers.has(report.requiredInstantiationBinding)

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-unstable-nested-components.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-unstable-nested-components.ts
@@ -333,7 +333,14 @@ const TS_VALUE_PASSTHROUGH_TYPES: ReadonlySet<string> = new Set([
 // React.createElement, or a recognized element-type prop. Immutable aliases
 // are followed to those sinks. Direct calls and React.useMemo callbacks create
 // no child fiber, so they are not instantiation evidence.
-const ELEMENT_TYPE_PROP_NAMES: ReadonlySet<string> = new Set(["as", "component"]);
+const ELEMENT_TYPE_PROP_NAMES: ReadonlySet<string> = new Set([
+  "as",
+  "body",
+  "calendarcontainer",
+  "component",
+  "fallback",
+  "tooltip",
+]);
 
 const isElementTypeJsxAttribute = (node: EsTreeNode): boolean => {
   if (!isNodeOfType(node, "JSXAttribute")) return false;


### PR DESCRIPTION
## Why

Semi Design defines `FieldComponent` inside `SemiField`, then either passes it to React `useMemo` as the calculation callback or calls it directly. Neither path mounts `FieldComponent` as a React element type, so the existing state-loss diagnostic is a false positive.

Pinned reproduction: `DouyinFE/semi-design@9a1d6cce203898610e44f15f1e8a698beaade0ae`, `packages/semi-ui/form/hoc/withField.tsx`.

## What changed

- Require nested functions to flow to proven element-type sinks before reporting.
- Keep JSX, React `createElement`, immutable aliases, HOC/lazy wrappers, and common component-slot props covered.
- Exclude direct invocation, React `useMemo` callbacks, returned function values, shadowed/foreign `createElement`, and arbitrary callback props.
- Add paired adversarial regression tests, a permanent fuzz seed, generator coverage, and verdict-robustness coverage.

## Validation

- Exact pinned Semi source: baseline 1 target diagnostic, candidate 0.
- Plugin suite after rebase: 13,270 passed, 148 skipped.
- Strict fuzz: `FUZZ_RULE=no-unstable-nested-components FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz` passed; the target rule fires in the corpus.
- RDE: 100/100 scan roots completed; all diagnostics 11,799 → 11,799 and target findings 7 → 7, with zero added or removed diagnostics.
- React Bench 5 pinned bases: 121 revisions / 61,067 files, target findings 82 → 81, zero additions and one manually verified removed FP. The removed Cal.com callback is typed `(isPending: boolean) => ReactNode` and invoked as `SubmitButton(isPending)`.
- React Bench custom environment bases: 4/4 changed JS/TS files, 0 → 0.
- React Bench oracle solutions: all 122 tasks reconstructed, 601 changed JS/TS files, 1 → 1 with zero deltas.
- `nr test`, `nr lint`, `nr typecheck`, `nr format:check`, `nr smoke:json-report`, and `git diff --check`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes static-analysis heuristics for a widely used lint rule; behavior shifts on many real patterns (fewer FPs on useMemo/render helpers, stricter on mixed branches and element-type props) though benchmarks in the PR show near-zero diagnostic drift.
> 
> **Overview**
> Tightens **`no-unstable-nested-components`** so nested PascalCase helpers only count as “instantiated” when they reach **proven element-type sinks**—JSX tags, verified **React `createElement`**, immutable **const** aliases to those sinks, and props like `component` / `*Component` / common slot names—not when they’re only **called inline**, passed to **`useMemo`**, returned as values, or passed as generic callbacks/children.
> 
> **`createElement`** detection now goes through **`isReactApiCall`** (imports/aliases), and **`lazy`** / **`memo`** wrapper results are gated like other candidates; reassigned bindings with writes are skipped at report time.
> 
> Adds a large regression suite, a Semi Design fuzz corpus case, fuzz snippet seeds, and includes the rule in verdict-robustness coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3dc752857f5ad3e434868cd64ab96d87539297c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->