### PR TITLE
fix(rules-of-hooks): recognize invariant React capability guards

### DIFF
--- a/.changeset/chubby-pianos-judge.md
+++ b/.changeset/chubby-pianos-judge.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Avoid conditional Hook-order findings after immutable React capability guards while preserving mutable control-flow diagnostics.

--- a/packages/fuzz/corpus/regressions/rules-of-hooks--react-capability-guard.tsx
+++ b/packages/fuzz/corpus/regressions/rules-of-hooks--react-capability-guard.tsx
@@ -1,0 +1,15 @@
+// rule: rules-of-hooks
+// weakness: control-flow
+// source: alibaba-fusion/next d5582ba6e5a70978bd5b90cb77d9420a333df788
+import { useEffect, useRef, useState } from "react";
+
+export const VersionGuardedDialog = () => {
+  if (!useState || !useRef || !useEffect) {
+    return null;
+  }
+
+  const [isOpen] = useState(false);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {}, []);
+  return isOpen ? <div ref={dialogRef} /> : null;
+};

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -156,6 +156,7 @@ export const HANDLER_SNIPPET_POOL = [
 // Guards / nullability — find/match/get derefs, optional chains, splits,
 // alias-then-guard, canUseDOM aliases, JSON.parse.
 export const GUARD_SNIPPET_POOL = [
+  `if (!useState || !useRef || !useEffect) return null;`,
   `const found = items.find((item) => item.id === value); if (!found) return null;`,
   `const label = items.find((item) => item.active)?.name ?? "none";`,
   `const first = items.find((item) => item.active)!.name;`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/rules-of-hooks.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/rules-of-hooks.regressions.test.ts
@@ -8,6 +8,110 @@ import { rulesOfHooks } from "./rules-of-hooks.js";
 
 const runTsx = (code: string) => runRule(rulesOfHooks, code, { filename: "fixture.tsx" });
 
+describe("react-builtins/rules-of-hooks — invariant React capability guards", () => {
+  it("stays silent after the authentic named-import capability guard", () => {
+    const result = runTsx(`
+      import { useContext, useEffect, useRef, useState } from "react";
+      const Context = createContext(null);
+      export const Dialog = ({ visible }) => {
+        if (!useState || !useRef || !useEffect) {
+          warn("need react version > 16.8.0");
+          return null;
+        }
+        const [open] = useState(visible);
+        const dialogRef = useRef(null);
+        const context = useContext(Context);
+        useEffect(() => context.track(dialogRef.current), [context]);
+        return open ? <div ref={dialogRef} /> : null;
+      };
+    `);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent after renamed, namespaced, and immutable-alias capability guards", () => {
+    const result = runTsx(`
+      import * as ReactRuntime from "react";
+      import { useEffect as importedEffect, useState } from "react";
+      const stateCapability = ReactRuntime.useState;
+      const effectCapability = importedEffect;
+      export const Panel = () => {
+        if (!(stateCapability as typeof useState) || typeof effectCapability !== "function") {
+          return null;
+        }
+        const [value] = useState(0);
+        ReactRuntime.useEffect(() => consume(value), [value]);
+        return <div>{value}</div>;
+      };
+    `);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it.each([
+    {
+      name: "prop guard",
+      guard: "if (!enabled) return null;",
+      parameter: "{ enabled }",
+    },
+    {
+      name: "mixed React and prop guard",
+      guard: "if (!useState || !enabled) return null;",
+      parameter: "{ enabled }",
+    },
+    {
+      name: "mutable local alias",
+      guard: "let capability = useState; if (!capability) return null;",
+      parameter: "{}",
+    },
+    {
+      name: "userland capability getter",
+      guard: "if (!capabilities.useState) return null;",
+      parameter: "{ capabilities }",
+    },
+  ])("still reports after a $name", ({ guard, parameter }) => {
+    const result = runTsx(`
+      import { useState } from "react";
+      export const Panel = (${parameter}) => {
+        ${guard}
+        const [value] = useState(0);
+        return <div>{value}</div>;
+      };
+    `);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0]?.message).toBe(
+      "`useState` changes Hook order between renders when called conditionally, so React can attach state to the wrong Hook.",
+    );
+  });
+
+  it("still reports a later prop-dependent early return", () => {
+    const result = runTsx(`
+      import { useEffect, useState } from "react";
+      export const Panel = ({ enabled }) => {
+        if (!useState || !useEffect) return null;
+        if (!enabled) return null;
+        const [value] = useState(0);
+        useEffect(() => consume(value), [value]);
+        return <div>{value}</div>;
+      };
+    `);
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
+  it("still reports a Hook nested under render-varying control flow after the capability guard", () => {
+    const result = runTsx(`
+      import { useState } from "react";
+      export const Panel = ({ enabled }) => {
+        if (!useState) return null;
+        if (enabled) {
+          const [value] = useState(0);
+          return <div>{value}</div>;
+        }
+        return null;
+      };
+    `);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+});
+
 describe("react-builtins/rules-of-hooks — regressions: HoC callbacks under non-PascalCase bindings", () => {
   it("does not flag hooks in a forwardRef callback bound to an underscore-prefixed name", () => {
     const result = runTsx(`

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/rules-of-hooks.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/rules-of-hooks.regressions.test.ts
@@ -48,6 +48,38 @@ describe("react-builtins/rules-of-hooks — invariant React capability guards", 
 
   it.each([
     {
+      name: "static-computed namespace member",
+      declaration: 'import * as ReactRuntime from "react";',
+      guard: 'if (ReactRuntime["useState"] == null) return null;',
+      call: "ReactRuntime.useState(0)",
+    },
+    {
+      name: "namespace alias",
+      declaration: 'import * as ReactRuntime from "react"; const RuntimeAlias = ReactRuntime;',
+      guard: 'if (typeof RuntimeAlias.useState === "undefined") return null;',
+      call: "RuntimeAlias.useState(0)",
+    },
+    {
+      name: "destructured namespace capability alias",
+      declaration:
+        'import * as ReactRuntime from "react"; const { useState: stateCapability } = ReactRuntime;',
+      guard: "if (!stateCapability) return null;",
+      call: "ReactRuntime.useState(0)",
+    },
+  ])("stays silent after a $name guard", ({ declaration, guard, call }) => {
+    const result = runTsx(`
+      ${declaration}
+      export const Panel = () => {
+        ${guard}
+        const [value] = ${call};
+        return <div>{value}</div>;
+      };
+    `);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it.each([
+    {
       name: "prop guard",
       guard: "if (!enabled) return null;",
       parameter: "{ enabled }",
@@ -105,6 +137,68 @@ describe("react-builtins/rules-of-hooks — invariant React capability guards", 
           const [value] = useState(0);
           return <div>{value}</div>;
         }
+        return null;
+      };
+    `);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still reports after a similarly named userland import guard", () => {
+    const result = runTsx(`
+      import { useState } from "./mutable-runtime";
+      export const Panel = () => {
+        if (!useState) return null;
+        const [value] = useState(0);
+        return <div>{value}</div>;
+      };
+    `);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still reports when global undefined is shadowed", () => {
+    const result = runTsx(`
+      import { useState } from "react";
+      export const Panel = ({ undefined }) => {
+        if (useState === undefined) return null;
+        const [value] = useState(0);
+        return <div>{value}</div>;
+      };
+    `);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it.each([
+    {
+      name: "namespace Hook property is reassigned",
+      setup: "ReactRuntime.useState = replacementHook;",
+    },
+    {
+      name: "namespace object escapes to unknown code",
+      setup: "installRuntime(ReactRuntime);",
+    },
+    {
+      name: "namespace has a dynamic property write",
+      setup: "ReactRuntime[capabilityName] = replacementHook;",
+    },
+  ])("still reports when the $name", ({ setup }) => {
+    const result = runTsx(`
+      import ReactRuntime from "react";
+      ${setup}
+      export const Panel = () => {
+        if (!ReactRuntime.useState) return null;
+        const [value] = ReactRuntime.useState(0);
+        return <div>{value}</div>;
+      };
+    `);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still reports a short-circuited Hook after the capability guard", () => {
+    const result = runTsx(`
+      import { useState } from "react";
+      export const Panel = ({ enabled }) => {
+        if (!useState) return null;
+        enabled && useState(0);
         return null;
       };
     `);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/rules-of-hooks.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/rules-of-hooks.ts
@@ -16,6 +16,13 @@ import { isNonReactEffectEventCallee } from "../../utils/is-non-react-effect-eve
 import { isNodeConditionallyExecuted } from "../../utils/is-node-conditionally-executed.js";
 import { symbolHasReactUseEffectEventOrigin } from "../../utils/symbol-has-react-use-effect-event-origin.js";
 import { isReactHocCallbackArgument } from "../../utils/is-react-hoc-callback-argument.js";
+import { getImportedName } from "../../utils/get-imported-name.js";
+import { getDestructuredBindingPropertyName } from "../../utils/get-destructured-binding-property-name.js";
+import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
+import { hasPossibleStaticPropertyMutationOrEscape } from "../../utils/has-static-property-write-before.js";
+import { isReactNamespaceImport } from "../../utils/is-react-api-call.js";
+import { statementAlwaysExits } from "../../utils/statement-always-exits.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import { walkAst } from "../../utils/walk-ast.js";
 import { isRulesOfHooksSuppressedAt } from "./rules-of-hooks-suppression.js";
 
@@ -368,6 +375,176 @@ const inferDestructureSourceKey = (bindingIdentifier: EsTreeNode): string | null
 // only recognized exception. We still require it to be inside a
 // component / custom hook scope.
 const isReactUseHook = (hookName: string): boolean => hookName === "use";
+
+const isReactHookCapabilityValue = (
+  expression: EsTreeNode,
+  scopes: ScopeAnalysis,
+  visitedSymbolIds: Set<number> = new Set(),
+): boolean => {
+  const unwrappedExpression = stripParenExpression(expression);
+  if (isNodeOfType(unwrappedExpression, "Identifier")) {
+    const symbol = scopes.symbolFor(unwrappedExpression);
+    if (!symbol || visitedSymbolIds.has(symbol.id)) return false;
+    visitedSymbolIds.add(symbol.id);
+    if (symbol.kind === "import") {
+      return (
+        isReactImport(symbol) && isReactHookName(getImportedName(symbol.declarationNode) ?? "")
+      );
+    }
+    if (
+      symbol.kind !== "const" ||
+      !symbol.initializer ||
+      !isNodeOfType(symbol.declarationNode, "VariableDeclarator")
+    ) {
+      return false;
+    }
+    const destructuredPropertyName = getDestructuredBindingPropertyName(symbol.bindingIdentifier);
+    if (destructuredPropertyName) {
+      const namespaceExpression = stripParenExpression(symbol.initializer);
+      return (
+        isReactHookName(destructuredPropertyName) &&
+        isNodeOfType(namespaceExpression, "Identifier") &&
+        isReactNamespaceImport(namespaceExpression, scopes) &&
+        !hasPossibleStaticPropertyMutationOrEscape(
+          namespaceExpression,
+          destructuredPropertyName,
+          scopes,
+        )
+      );
+    }
+    if (symbol.declarationNode.id !== symbol.bindingIdentifier) return false;
+    return isReactHookCapabilityValue(symbol.initializer, scopes, visitedSymbolIds);
+  }
+  if (!isNodeOfType(unwrappedExpression, "MemberExpression")) return false;
+  const propertyName = getStaticPropertyName(unwrappedExpression);
+  if (!propertyName || !isReactHookName(propertyName)) return false;
+  const namespaceExpression = stripParenExpression(unwrappedExpression.object);
+  return (
+    isNodeOfType(namespaceExpression, "Identifier") &&
+    isReactNamespaceImport(namespaceExpression, scopes) &&
+    !hasPossibleStaticPropertyMutationOrEscape(namespaceExpression, propertyName, scopes)
+  );
+};
+
+const isReactHookCapabilityComparisonOperand = (
+  expression: EsTreeNode,
+  scopes: ScopeAnalysis,
+): boolean => {
+  const unwrappedExpression = stripParenExpression(expression);
+  if (isReactHookCapabilityValue(unwrappedExpression, scopes)) return true;
+  return (
+    isNodeOfType(unwrappedExpression, "UnaryExpression") &&
+    unwrappedExpression.operator === "typeof" &&
+    isReactHookCapabilityValue(unwrappedExpression.argument, scopes)
+  );
+};
+
+const isStaticCapabilityComparisonValue = (
+  expression: EsTreeNode,
+  scopes: ScopeAnalysis,
+): boolean => {
+  const unwrappedExpression = stripParenExpression(expression);
+  if (isNodeOfType(unwrappedExpression, "Literal")) return true;
+  return (
+    isNodeOfType(unwrappedExpression, "Identifier") &&
+    unwrappedExpression.name === "undefined" &&
+    scopes.isGlobalReference(unwrappedExpression)
+  );
+};
+
+const CAPABILITY_COMPARISON_OPERATORS: ReadonlySet<string> = new Set(["==", "!=", "===", "!=="]);
+
+const isInvariantReactHookCapabilityCondition = (
+  expression: EsTreeNode,
+  scopes: ScopeAnalysis,
+): boolean => {
+  const unwrappedExpression = stripParenExpression(expression);
+  if (isReactHookCapabilityValue(unwrappedExpression, scopes)) return true;
+  if (
+    isNodeOfType(unwrappedExpression, "UnaryExpression") &&
+    unwrappedExpression.operator === "!"
+  ) {
+    return isInvariantReactHookCapabilityCondition(unwrappedExpression.argument, scopes);
+  }
+  if (isNodeOfType(unwrappedExpression, "LogicalExpression")) {
+    return (
+      isInvariantReactHookCapabilityCondition(unwrappedExpression.left, scopes) &&
+      isInvariantReactHookCapabilityCondition(unwrappedExpression.right, scopes)
+    );
+  }
+  if (
+    !isNodeOfType(unwrappedExpression, "BinaryExpression") ||
+    !CAPABILITY_COMPARISON_OPERATORS.has(unwrappedExpression.operator)
+  ) {
+    return false;
+  }
+  return (
+    (isReactHookCapabilityComparisonOperand(unwrappedExpression.left, scopes) &&
+      isStaticCapabilityComparisonValue(unwrappedExpression.right, scopes)) ||
+    (isReactHookCapabilityComparisonOperand(unwrappedExpression.right, scopes) &&
+      isStaticCapabilityComparisonValue(unwrappedExpression.left, scopes))
+  );
+};
+
+const statementContainsOwnAbruptCompletion = (statement: EsTreeNode): boolean => {
+  let doesContainAbruptCompletion = false;
+  walkAst(statement, (child) => {
+    if (child !== statement && isFunctionLike(child)) return false;
+    if (isNodeOfType(child, "ReturnStatement") || isNodeOfType(child, "ThrowStatement")) {
+      doesContainAbruptCompletion = true;
+      return false;
+    }
+  });
+  return doesContainAbruptCompletion;
+};
+
+const isInvariantReactHookCapabilityExit = (
+  statement: EsTreeNode,
+  scopes: ScopeAnalysis,
+): boolean =>
+  isNodeOfType(statement, "IfStatement") &&
+  statement.alternate === null &&
+  statementAlwaysExits(statement.consequent) &&
+  isInvariantReactHookCapabilityCondition(statement.test, scopes);
+
+const isAfterOnlyInvariantReactHookCapabilityExits = (
+  node: EsTreeNode,
+  enclosingFunction: EsTreeNode,
+  scopes: ScopeAnalysis,
+): boolean => {
+  if (
+    !isFunctionLike(enclosingFunction) ||
+    !isNodeOfType(enclosingFunction.body, "BlockStatement")
+  ) {
+    return false;
+  }
+  let containingStatement = node;
+  while (containingStatement.parent && containingStatement.parent !== enclosingFunction.body) {
+    if (isFunctionLike(containingStatement.parent)) return false;
+    if (
+      isNodeOfType(containingStatement.parent, "IfStatement") ||
+      isNodeOfType(containingStatement.parent, "SwitchStatement") ||
+      isNodeOfType(containingStatement.parent, "SwitchCase") ||
+      isNodeOfType(containingStatement.parent, "ConditionalExpression") ||
+      isNodeOfType(containingStatement.parent, "LogicalExpression")
+    ) {
+      return false;
+    }
+    containingStatement = containingStatement.parent;
+  }
+  if (containingStatement.parent !== enclosingFunction.body) return false;
+  const statementIndex = enclosingFunction.body.body.findIndex(
+    (statement) => statement === containingStatement,
+  );
+  if (statementIndex <= 0) return false;
+  const bypassingStatements = enclosingFunction.body.body
+    .slice(0, statementIndex)
+    .filter((statement) => statementContainsOwnAbruptCompletion(statement));
+  return (
+    bypassingStatements.length > 0 &&
+    bypassingStatements.every((statement) => isInvariantReactHookCapabilityExit(statement, scopes))
+  );
+};
 
 interface FunctionInfo {
   node: EsTreeNode;
@@ -918,7 +1095,10 @@ export const rulesOfHooks = defineRule({
 
         // CFG-based check: catches early-return patterns and
         // if-statement bodies.
-        if (!context.cfg.isUnconditionalFromEntry(node)) {
+        if (
+          !context.cfg.isUnconditionalFromEntry(node) &&
+          !isAfterOnlyInvariantReactHookCapabilityExits(node, enclosing.node, context.scopes)
+        ) {
           context.report({ node: node.callee, message: buildConditionalMessage(hookName) });
         }
       },


### PR DESCRIPTION
## What changed

- Recognize immutable React capability guards such as `if (!React.useId) return null` before later top-level Hooks.
- Prove the guard from React import provenance, exact immutable aliases, and an always-exiting branch.
- Preserve diagnostics for mutable, userland, prop-derived, shadowed, escaped, nested-control-flow, and mixed conditions.
- Add paired adversarial regressions, a permanent fuzz seed, and generated capability-guard fuzz shapes.

## Grounded reproduction

Pinned `fusionjs/fusion-next` at `d5582ba6e5a70978bd5b90cb77d9420a333df788`, file `components/dialog/dialog-v2.tsx`.

The component exits before any Hook when a React API is unavailable. Each React API capability is immutable for the lifetime of the loaded module, so the guard cannot change Hook order across renders of that component instance.

An exact baseline/candidate scan removed the 18 `rules-of-hooks` diagnostics in that file and added no diagnostics. The complete scan changed 45 diagnostics to 27; all 18 removals were the target findings.

## Precision boundary

The exemption applies only when all preceding abrupt exits are simple top-level guards whose condition is composed exclusively from proven immutable React Hook capabilities and static literals. Unknown provenance remains reportable.

## Validation

- `nr test`: 14/14 tasks passed; plugin 559 files, 13,841 passed, 175 skipped; CLI 209 files passed, 2 skipped, 2,243 passed, 27 skipped.
- `nr typecheck`
- `nr lint`
- `nr format:check`
- `nr smoke:json-report`
- `git diff --check`
- `FUZZ_RULE=rules-of-hooks FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz`
- Fuzz target coverage: 57 programs reached `rules-of-hooks` across 339 executed programs.
- Direct pinned RDE parity: 100/100 repositories scanned by both builds, 66 target findings to 66, no added or removed diagnostics, no scan failures.
- React Bench: 122/122 exact pinned scans succeeded for both builds; 52,380 total diagnostics to 52,380; 165 `rules-of-hooks` findings to 165; no target or all-rule deltas.
- React Bench oracle reconstruction for `fix-react-rdh-trendyol-react-carousel-index`: both builds retained 1 target finding and 57 total diagnostics; the intended oracle finding remained removed.

The official RDE wrapper currently rejects React Doctor schema v3, so those wrapper attempts were invalidated and are not counted as evidence; the parity result above used its exact pinned repository manifest and local checkouts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The change narrows when a core lint rule fires via new static analysis; mistakes could hide real conditional Hook bugs, though adversarial tests and fuzz seeds aim to bound false negatives.
> 
> **Overview**
> The **`rules-of-hooks`** linter no longer reports conditional Hook-order violations when Hooks run only after **immutable React capability guards** (e.g. `if (!useState || !useRef) return null`), while still flagging real render-varying control flow.
> 
> **`rules-of-hooks.ts`** adds scope-aware analysis that treats proven React Hook imports, namespace members, and immutable aliases as capability operands, recognizes guard conditions built from those values plus static checks (`!`, `typeof`, `== null`), and skips the CFG “unconditional from entry” diagnostic when every preceding abrupt exit is such a guard with an always-exiting branch. Mutable aliases, prop guards, userland imports, shadowed `undefined`, namespace mutation/escape, nested conditionals, and short-circuit Hook calls stay reportable.
> 
> Coverage includes a large regression suite, a fuzz corpus case from alibaba-fusion/next, and a guard snippet in **`snippet-pools.ts`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 482af6e11494d05bde40c976e4340922615ddd95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->