### PR TITLE
fix(diagnostics): distinguish same-site occurrences

### DIFF
--- a/.changeset/social-parents-pick.md
+++ b/.changeset/social-parents-pick.md
@@ -1,0 +1,6 @@
+---
+"@react-doctor/language-server": patch
+"react-doctor": patch
+---
+
+Give same-site diagnostics distinct deterministic occurrence IDs in JSON reports and editor actions.

--- a/docs/json-report.md
+++ b/docs/json-report.md
@@ -11,8 +11,11 @@ Version 3 is the default. Versions 1 and 2 remain accepted by the exported
 Each diagnostic includes:
 
 - `id`: deterministic
-  `<reportRelativeFilePath>::<line>:<column>::<plugin>/<rule>` identity, unique
-  across workspace projects
+  `<reportRelativeFilePath>::<line>:<column>::<plugin>/<rule>::<occurrenceDigest>`
+  identity. The digest covers severity and message so content variants at one
+  normalized site receive distinct identities. Treat this as an opaque value:
+  it is stable for an unchanged finding, but changes when its user-visible
+  content changes.
 - `normalizedFilePath`: project-relative path with `/` separators
 - canonical `plugin`, `rule`, `category`, `severity`, and sorted `tags`
 - the original `filePath` and source span fields

--- a/packages/core/src/build-json-report.ts
+++ b/packages/core/src/build-json-report.ts
@@ -84,6 +84,8 @@ const toJsonReportDiagnostic = (
       column: diagnostic.column,
       plugin: diagnostic.plugin,
       rule: diagnostic.rule,
+      severity: diagnostic.severity,
+      message: diagnostic.message,
     }),
     normalizedFilePath,
     category: ruleIdentity.category,

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { FRAMEWORK_TOKENS } from "oxlint-plugin-react-doctor";
 import * as Schema from "effect/Schema";
 
@@ -69,10 +70,8 @@ export class JsonReportDiagnosticV3 extends Schema.Class<JsonReportDiagnosticV3>
 }) {}
 
 /**
- * Deterministic identity string for a diagnostic. Same diagnostic
- * across two scans yields the same identity; lets baselines,
- * suppression files, content-hash caches, and IDE "ignore this"
- * actions all key off one shared shape.
+ * Deterministic identity string for a retained diagnostic occurrence.
+ * Severity and message distinguish content variants at one normalized site.
  */
 export const buildDiagnosticIdentity = (input: {
   readonly filePath: string;
@@ -80,7 +79,14 @@ export const buildDiagnosticIdentity = (input: {
   readonly column: number;
   readonly plugin: string;
   readonly rule: string;
-}): string => `${input.filePath}::${input.line}:${input.column}::${input.plugin}/${input.rule}`;
+  readonly severity: Severity;
+  readonly message: string;
+}): string => {
+  const occurrenceDigest = createHash("sha256")
+    .update(JSON.stringify([input.severity, input.message]))
+    .digest("hex");
+  return `${input.filePath}::${input.line}:${input.column}::${input.plugin}/${input.rule}::${occurrenceDigest}`;
+};
 
 export const JsonReportMode = Schema.Literals(["full", "diff", "staged", "baseline"]);
 export type JsonReportMode = Schema.Schema.Type<typeof JsonReportMode>;

--- a/packages/core/tests/build-json-report.test.ts
+++ b/packages/core/tests/build-json-report.test.ts
@@ -90,6 +90,53 @@ describe("buildJsonReport", () => {
     expect(report.diagnostics[0]).not.toHaveProperty("location");
   });
 
+  it("assigns distinct occurrence identities to same-site findings from one rule", () => {
+    const cleanupMessage =
+      "Your cleanup may read the wrong node since the ref `sidebarRef.current` can change before it runs.";
+    const loopMessage =
+      "`useEffect` calls `setMobile` with no dependency array, so it can loop forever & freeze the component.";
+    const report = buildJsonReport({
+      version: "1.2.3",
+      directory: "/repo",
+      mode: "full",
+      diff: null,
+      scans: [
+        {
+          directory: "/repo",
+          result: result({
+            diagnostics: [
+              {
+                ...errorDiagnostic,
+                filePath: "src/components/sidebar/CSidebar.tsx",
+                rule: "exhaustive-deps",
+                severity: "warning",
+                message: cleanupMessage,
+                line: 122,
+                column: 15,
+              },
+              {
+                ...errorDiagnostic,
+                filePath: "src/components/sidebar/CSidebar.tsx",
+                rule: "exhaustive-deps",
+                severity: "warning",
+                message: loopMessage,
+                line: 122,
+                column: 15,
+              },
+            ],
+          }),
+        },
+      ],
+      totalElapsedMilliseconds: 1200,
+    });
+
+    expect(report.diagnostics.map((diagnostic) => diagnostic.message)).toEqual([
+      cleanupMessage,
+      loopMessage,
+    ]);
+    expect(new Set(report.diagnostics.map((diagnostic) => diagnostic.id)).size).toBe(2);
+  });
+
   it("scopes diagnostic identities and affected file counts to workspace projects", () => {
     const firstProject = {
       ...projectInfo,

--- a/packages/core/tests/build-json-report.test.ts
+++ b/packages/core/tests/build-json-report.test.ts
@@ -77,7 +77,9 @@ describe("buildJsonReport", () => {
       complete: true,
     });
     expect(report.diagnostics[0]).toMatchObject({
-      id: "src/App.tsx::12:1::react-doctor/no-array-index-as-key",
+      id: expect.stringMatching(
+        /^src\/App\.tsx::12:1::react-doctor\/no-array-index-as-key::[a-f0-9]{64}$/,
+      ),
       normalizedFilePath: "src/App.tsx",
       filePath: "/repo/src/../src/App.tsx",
       plugin: "react-doctor",
@@ -171,8 +173,12 @@ describe("buildJsonReport", () => {
       "src/App.tsx",
     ]);
     expect(report.diagnostics.map((diagnostic) => diagnostic.id)).toEqual([
-      "packages/first/src/App.tsx::12:1::react-doctor/no-array-index-as-key",
-      "packages/second/src/App.tsx::12:1::react-doctor/no-array-index-as-key",
+      expect.stringMatching(
+        /^packages\/first\/src\/App\.tsx::12:1::react-doctor\/no-array-index-as-key::[a-f0-9]{64}$/,
+      ),
+      expect.stringMatching(
+        /^packages\/second\/src\/App\.tsx::12:1::react-doctor\/no-array-index-as-key::[a-f0-9]{64}$/,
+      ),
     ]);
     expect(new Set(report.diagnostics.map((diagnostic) => diagnostic.id)).size).toBe(2);
     expect(report.summary.affectedFileCount).toBe(2);

--- a/packages/core/tests/schemas.test.ts
+++ b/packages/core/tests/schemas.test.ts
@@ -142,8 +142,12 @@ describe("buildDiagnosticIdentity", () => {
         column: 4,
         plugin: "react-doctor",
         rule: "no-derived-state",
+        severity: "error",
+        message: "message",
       }),
-    ).toBe("/repo/src/App.tsx::12:4::react-doctor/no-derived-state");
+    ).toBe(
+      "/repo/src/App.tsx::12:4::react-doctor/no-derived-state::051b69accd5cad53adeeb95537b4a437a702d7e3a422ca87fad64d774a71c997",
+    );
   });
 
   it("is deterministic across calls with the same input", () => {
@@ -153,6 +157,8 @@ describe("buildDiagnosticIdentity", () => {
       column: 1,
       plugin: "p",
       rule: "r",
+      severity: "warning",
+      message: "message",
     } as const;
     expect(buildDiagnosticIdentity(inputs)).toBe(buildDiagnosticIdentity(inputs));
   });
@@ -164,6 +170,8 @@ describe("buildDiagnosticIdentity", () => {
       column: 1,
       plugin: "p",
       rule: "r",
+      severity: "warning",
+      message: "message",
     } as const;
     const seen = new Set<string>();
     seen.add(buildDiagnosticIdentity(base));
@@ -172,7 +180,9 @@ describe("buildDiagnosticIdentity", () => {
     seen.add(buildDiagnosticIdentity({ ...base, column: 2 }));
     seen.add(buildDiagnosticIdentity({ ...base, plugin: "q" }));
     seen.add(buildDiagnosticIdentity({ ...base, rule: "s" }));
-    expect(seen.size).toBe(6);
+    seen.add(buildDiagnosticIdentity({ ...base, severity: "error" }));
+    seen.add(buildDiagnosticIdentity({ ...base, message: "other" }));
+    expect(seen.size).toBe(8);
   });
 });
 

--- a/packages/language-server/src/diagnostics/mapper.ts
+++ b/packages/language-server/src/diagnostics/mapper.ts
@@ -100,6 +100,8 @@ export const toLspDiagnostic = (input: MapDiagnosticInput): LspDiagnostic => {
       column: diagnostic.column,
       plugin: diagnostic.plugin,
       rule: diagnostic.rule,
+      severity: diagnostic.severity,
+      message: diagnostic.message,
     }),
     plugin: diagnostic.plugin,
     rule: diagnostic.rule,

--- a/packages/language-server/tests/unit/lsp-polish.test.ts
+++ b/packages/language-server/tests/unit/lsp-polish.test.ts
@@ -73,3 +73,44 @@ describe("file-level suppress action kind", () => {
     expect(suppressAll?.kind).not.toBe("source");
   });
 });
+
+describe("same-site diagnostic actions", () => {
+  it("targets each occurrence with a distinct explain command", () => {
+    const cleanup = toLspDiagnostic({
+      diagnostic: baseDiagnostic({
+        rule: "exhaustive-deps",
+        message:
+          "Your cleanup may read the wrong node since the ref `sidebarRef.current` can change before it runs.",
+        line: 122,
+        column: 15,
+      }),
+      fsPath: "/repo/src/App.tsx",
+      text: null,
+    });
+    const loop = toLspDiagnostic({
+      diagnostic: baseDiagnostic({
+        rule: "exhaustive-deps",
+        message:
+          "`useEffect` calls `setMobile` with no dependency array, so it can loop forever & freeze the component.",
+        line: 122,
+        column: 15,
+      }),
+      fsPath: "/repo/src/App.tsx",
+      text: null,
+    });
+    const actions = buildCodeActions({
+      uri: "file:///repo/src/App.tsx",
+      fsPath: "/repo/src/App.tsx",
+      documentText: null,
+      relativeFilePath: "src/App.tsx",
+      rangeDiagnostics: [cleanup, loop],
+      fileDiagnostics: [cleanup, loop],
+    });
+    const explainActions = actions.filter(
+      (action) => action.title === "Explain react-doctor/exhaustive-deps",
+    );
+
+    expect(explainActions).toHaveLength(2);
+    expect(explainActions[0].command?.arguments).not.toEqual(explainActions[1].command?.arguments);
+  });
+});

--- a/packages/language-server/tests/unit/mapper.test.ts
+++ b/packages/language-server/tests/unit/mapper.test.ts
@@ -98,6 +98,33 @@ describe("toLspDiagnostic", () => {
     });
   });
 
+  it("distinguishes same-site findings from one rule by occurrence", () => {
+    const cleanup = toLspDiagnostic({
+      diagnostic: makeDiagnostic({
+        rule: "exhaustive-deps",
+        message:
+          "Your cleanup may read the wrong node since the ref `sidebarRef.current` can change before it runs.",
+        line: 122,
+        column: 15,
+      }),
+      fsPath: FS_PATH,
+      text: null,
+    });
+    const loop = toLspDiagnostic({
+      diagnostic: makeDiagnostic({
+        rule: "exhaustive-deps",
+        message:
+          "`useEffect` calls `setMobile` with no dependency array, so it can loop forever & freeze the component.",
+        line: 122,
+        column: 15,
+      }),
+      fsPath: FS_PATH,
+      text: null,
+    });
+
+    expect(cleanup.data).not.toEqual(loop.data);
+  });
+
   it("nulls out optional data fields when absent", () => {
     const result = toLspDiagnostic({ diagnostic: makeDiagnostic(), fsPath: FS_PATH, text: null });
     expect(result.data).toMatchObject({ url: null, suppressionHint: null });

--- a/packages/language-server/tests/unit/mapper.test.ts
+++ b/packages/language-server/tests/unit/mapper.test.ts
@@ -84,6 +84,8 @@ describe("toLspDiagnostic", () => {
         column: 13,
         plugin: "react-doctor",
         rule: "no-array-index-key",
+        severity: "warning",
+        message: "Avoid using the array index as a key",
       }),
       plugin: "react-doctor",
       rule: "no-array-index-key",

--- a/packages/react-doctor/src/cli/utils/build-run-event.ts
+++ b/packages/react-doctor/src/cli/utils/build-run-event.ts
@@ -287,6 +287,7 @@ const buildOutcomeAttributes = (input: RunEventInput): RunEventAttributes => {
 
   let diagnosticsInTestFiles = 0;
   let diagnosticsInStoryFiles = 0;
+  const diagnosticSiteCounts = new Map<string, number>();
   // Root-cause grouping rollup: how many distinct fix groups, and how many
   // findings they cover. `fixGroupedFindings - fixGroups` is the number of
   // findings that collapse away (one fix, not N tasks) — the signal that says
@@ -295,6 +296,14 @@ const buildOutcomeAttributes = (input: RunEventInput): RunEventAttributes => {
   for (const diagnostic of result.diagnostics) {
     if (diagnostic.fileContext === "test") diagnosticsInTestFiles += 1;
     if (diagnostic.fileContext === "story") diagnosticsInStoryFiles += 1;
+    const diagnosticSite = JSON.stringify([
+      diagnostic.filePath,
+      diagnostic.line,
+      diagnostic.column,
+      diagnostic.plugin,
+      diagnostic.rule,
+    ]);
+    diagnosticSiteCounts.set(diagnosticSite, (diagnosticSiteCounts.get(diagnosticSite) ?? 0) + 1);
     if (diagnostic.fixGroupId) {
       findingsPerFixGroup.set(
         diagnostic.fixGroupId,
@@ -304,6 +313,10 @@ const buildOutcomeAttributes = (input: RunEventInput): RunEventAttributes => {
   }
   let fixGroupedFindings = 0;
   for (const count of findingsPerFixGroup.values()) fixGroupedFindings += count;
+  let sameSiteOccurrences = 0;
+  for (const count of diagnosticSiteCounts.values()) {
+    sameSiteOccurrences += Math.max(0, count - 1);
+  }
 
   // Per-category diagnostic counts, keyed so the `diag` namespace yields
   // `diag.category.<key>` once prefixed.
@@ -351,6 +364,7 @@ const buildOutcomeAttributes = (input: RunEventInput): RunEventAttributes => {
       inStoryFiles: diagnosticsInStoryFiles,
       distinctRules: countByRule.size,
       topRule,
+      sameSiteOccurrences,
       fixGroups: findingsPerFixGroup.size,
       fixGroupedFindings,
       ...categoryRollup,

--- a/packages/react-doctor/tests/build-run-event.test.ts
+++ b/packages/react-doctor/tests/build-run-event.test.ts
@@ -299,6 +299,28 @@ describe("buildRunEventAttributes", () => {
     expect(attributes["score.available"]).toBe(true);
   });
 
+  it("counts retained findings beyond the first occurrence at one rule site", () => {
+    const result = buildResult({
+      diagnostics: [
+        buildDiagnostic({
+          rule: "exhaustive-deps",
+          message: "Cleanup may read a changed ref.",
+          line: 122,
+          column: 15,
+        }),
+        buildDiagnostic({
+          rule: "exhaustive-deps",
+          message: "The setter may loop without dependencies.",
+          line: 122,
+          column: 15,
+        }),
+        buildDiagnostic({ rule: "exhaustive-deps", line: 123, column: 15 }),
+      ],
+    });
+
+    expect(buildRunEventAttributes(baseInput({ result }))["diag.sameSiteOccurrences"]).toBe(1);
+  });
+
   it("flags a blocking run when the action blocking gate would trip", () => {
     process.env[ACTION_INPUT_ENVIRONMENT_VARIABLES.blocking] = "error";
     const result = buildResult({ diagnostics: [buildDiagnostic({ severity: "error" })] });

--- a/packages/react-doctor/tests/to-json-report.test.ts
+++ b/packages/react-doctor/tests/to-json-report.test.ts
@@ -66,7 +66,7 @@ describe("toJsonReport (Node API helper)", () => {
       complete: false,
     });
     expect(report.diagnostics[0]).toMatchObject({
-      id: "src/App.tsx::7:1::react/no-danger",
+      id: expect.stringMatching(/^src\/App\.tsx::7:1::react\/no-danger::[a-f0-9]{64}$/),
       normalizedFilePath: "src/App.tsx",
       filePath: "/virtual/src/App.tsx",
       tags: [],


### PR DESCRIPTION
## Product brief: same-site diagnostic occurrence identity

Job: Developers using schema-v3 reports or editor actions need to address the exact diagnostic they selected when one rule emits multiple findings at one source span. Today the JSON records collide and the LSP Explain command selects the first finding.

Change: Preserve the schema-v3 shape while making the existing opaque `id` content-sensitive to severity and message. Use the same identity in LSP commands.

Reuse: Extend `buildDiagnosticIdentity`; the existing dedupe and stable-sort tuple already defines retained diagnostic occurrence identity. No second public identity field is needed.

Metric: Add the anonymized `diag.sameSiteOccurrences` wide-event count. Success is evidence that content-distinct same-site multiplicity exists and receives distinct occurrence IDs.

Compat: Keep `schemaVersion: 3` and the existing field shape. IDs remain deterministic but change for all diagnostics, so document the opaque/content-sensitive contract and add patch changesets for the published CLI and language server.

Kill: Remove `diag.sameSiteOccurrences` if fewer than 1 in 10,000 completed scans contain one after two releases.

## Grounded reproduction

CoreUI `CSidebar.tsx:122:15` emits two retained `exhaustive-deps` findings: a cleanup-ref warning and a no-dependency setter-loop warning. Published 0.7.6 assigns both `src/components/sidebar/CSidebar.tsx::122:15::react-doctor/exhaustive-deps`, so the LSP lookup selects the cleanup explanation for either action.

## Implementation

- Extend `buildDiagnosticIdentity` with a SHA-256 digest of the diagnostic severity and message.
- Feed those fields through both JSON report and LSP mappings.
- Keep schema v3 unchanged and document the ID as opaque and content-sensitive.
- Add the one `diag.sameSiteOccurrences` wide-event metric from the product pass.
- Add patch changesets for the CLI and language server.

## Regression coverage

- Authentic CoreUI same-site cleanup/loop pair gets two JSON IDs.
- LSP mapper produces distinct occurrence data for the pair.
- Both Explain actions target distinct command identities.
- Every identity dimension, including severity and message, has a paired determinism/distinction test.
- Node API JSON expectations cover the content digest.

Rule fuzzing is not applicable: this changes report/editor identity after rule verdicts are produced. The permanent coverage is at the JSON and LSP contract layers, with real-repository and benchmark parity below.

## Validation

- Focused core, language-server, and telemetry tests pass.
- `nr build`, `nr typecheck`, `nr lint`, `nr format:check`, `nr smoke:json-report`, and `git diff --check` pass.
- RDE: 100/100 pinned repositories scanned on both builds; 12,076/12,076 diagnostics; zero content additions/removals; the one same-site collision is removed.
- React Bench: 122/122 pinned repositories scanned on both builds; 52,380/52,380 diagnostics; zero content additions/removals; all 420 content-distinct same-site collisions are removed.
- CoreUI solution oracles: 460 is 124/124 and 464 is 122/122 with byte-equivalent diagnostic content after omitting `id`; each candidate removes its one collision.

The benchmark also exposes 73 pre-existing collisions from overlapping workspace scan roots whose displayed paths differ while the report-relative identity path is equal. Those are not content-distinct same-site collisions and are intentionally outside this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change for anyone keying off v3 diagnostic `id` strings (baselines, suppressions, caches); behavior is intentional and documented, with broad test coverage.
> 
> **Overview**
> When one rule reports **multiple findings at the same file/line/column**, schema v3 `id` values and LSP diagnostic `identity` used to collide, so JSON consumers and **Explain** code actions could not target a specific occurrence.
> 
> **`buildDiagnosticIdentity`** now appends a deterministic SHA-256 **`occurrenceDigest`** derived from **severity** and **message** to the existing site key. JSON report building and the language-server mapper both pass those fields so reports and editor actions stay aligned. **`schemaVersion: 3`** is unchanged; docs describe `id` as opaque and content-sensitive, and **every diagnostic `id` changes** under the new formula.
> 
> Scan telemetry adds **`diag.sameSiteOccurrences`** to count extra retained findings at the same rule site (beyond the first).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e60c04a37ffcb2ed89761e501c3e4c93e3c3a39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->