### PR TITLE
fix(action): write JSON report when --explain is used with --json

### DIFF
--- a/.changeset/fix-action-json-explain.md
+++ b/.changeset/fix-action-json-explain.md
@@ -1,0 +1,9 @@
+---
+"react-doctor": patch
+---
+
+fix(action): write JSON report when --explain is used with --json
+
+When the CLI is invoked with both --json and --explain (via the 'why' command), it would exit with status 0 after running the explain logic but without writing a JSON report. This caused the GitHub Action's ensure-json-report.mjs validation to fail with "react-doctor exited with status 0 before producing a JSON report."
+
+The fix ensures an empty JSON report is written when JSON mode is active and the explain path is taken, allowing the Action to complete successfully.

--- a/packages/react-doctor/src/cli/commands/inspect.ts
+++ b/packages/react-doctor/src/cli/commands/inspect.ts
@@ -331,6 +331,18 @@ export const inspectAction = async (directory: string, flags: InspectFlags): Pro
         scanOptions: resolveCliInspectOptions(flags, userConfig),
         projectFlag: flags.project,
       });
+      if (isJsonMode) {
+        writeJsonReport(
+          buildJsonReport({
+            version: VERSION,
+            directory: resolvedDirectory,
+            mode: "full",
+            diff: null,
+            scans: [],
+            totalElapsedMilliseconds: performance.now() - startTime,
+          }),
+        );
+      }
       return;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Root Cause

When the CLI is invoked with both `--json` and `--explain` (e.g., via `react-doctor --json why src/App.tsx:42`), it would:
1. Enable JSON mode
2. Run the explain logic (which prints explanation to stdout, but this is silenced by JSON mode's `installSilentConsole()`)
3. Return early without calling `writeJsonReport()`
4. Exit with status 0

This caused the GitHub Action's `ensure-json-report.mjs` validation to fail with:
```
react-doctor exited with status 0 before producing a JSON report.
```

The issue occurs at this early return in `inspect.ts`:

```typescript
const explainArgument = flags.explain;
if (explainArgument !== undefined) {
  await runExplain(explainArgument, { ... });
  return;  // ← exits without writing JSON report
}
```

## Fix

Added a check to write an empty JSON report when JSON mode is active and the explain path is taken:

```typescript
if (explainArgument !== undefined) {
  await runExplain(explainArgument, { ... });
  if (isJsonMode) {
    writeJsonReport(
      buildJsonReport({
        version: VERSION,
        directory: resolvedDirectory,
        mode: "full",
        diff: null,
        scans: [],
        totalElapsedMilliseconds: performance.now() - startTime,
      }),
    );
  }
  return;
}
```

## Scope

This fix is **narrowly scoped** to the `--explain` early return path. Other code paths already call `finalizeScans()` which writes the JSON report when `isJsonMode` is true.

The bug only affects scenarios where someone runs `react-doctor --json why <file:line>`, which is not a typical scan command. Normal GitHub Action runs are unaffected since the action doesn't use the `why` command.

## Testing

- ✅ Typecheck passes
- ✅ Build succeeds
- ✅ Lint passes
- ✅ Parity check skipped (fix only affects `--explain` path, not normal scans)

## Changeset

Patch changeset included for `react-doctor` package.

Closes #1258
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ee4b5363-77f4-410e-9f6d-87cd69aba446"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ee4b5363-77f4-410e-9f6d-87cd69aba446"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

