### PR TITLE
fix(rule): ignore proven analytics-only interactions

### DIFF
--- a/.changeset/afraid-regions-look.md
+++ b/.changeset/afraid-regions-look.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Avoid no-noninteractive-element-interactions false positives for handlers proven to perform analytics-only observation.

--- a/packages/core/tests/cross-file-rule-ids.test.ts
+++ b/packages/core/tests/cross-file-rule-ids.test.ts
@@ -154,6 +154,7 @@ describe("CROSS_FILE_RULE_IDS", () => {
       "no-locale-format-in-render",
       "no-match-media-in-state-initializer",
       "no-mutating-reducer-state",
+      "no-noninteractive-element-interactions",
       "no-unguarded-browser-global-in-render-or-hook-init",
       "only-export-components",
       "prefer-dynamic-import",

--- a/packages/fuzz/corpus/regressions/no-noninteractive-element-interactions--analytics-only-handler.tsx
+++ b/packages/fuzz/corpus/regressions/no-noninteractive-element-interactions--analytics-only-handler.tsx
@@ -1,0 +1,16 @@
+// rule: no-noninteractive-element-interactions
+// weakness: cross-file
+// source: Nexu open-design 52611c07, IntegrationsView.tsx:170
+
+import posthog from "posthog-js";
+
+const recordSkillsObservation = (capture: typeof posthog.capture): void => {
+  capture("skills_coming_soon_viewed", { area: "skills" });
+};
+
+export const SkillsComingSoon = () => (
+  <section onClick={() => recordSkillsObservation(posthog.capture)}>
+    <h2>Skills</h2>
+    <p>Coming soon</p>
+  </section>
+);

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -438,6 +438,7 @@ export const JSX_LEAF_POOL = [
   `<h2></h2>`,
   `<img src={url} onError={(event) => { event.currentTarget.src = "/fallback.png"; }} />`,
   `<div role="button" onClick={handleClick}>{state}</div>`,
+  `<section onClick={() => posthog.capture("skills_coming_soon_viewed", { area: "skills" })}>Coming soon</section>`,
   `<div style={{ paddingLeft: 8, paddingRight: 8, width: 100, height: 100 }}>{state}</div>`,
   `<div style={{ marginTop: 4, marginBottom: 4 }}>{state}</div>`,
   `<div style={{ backgroundColor: "#000", boxShadow: "0 0 60px rgb(255 0 0 / 0%)" }}>{state}</div>`,
@@ -518,6 +519,7 @@ export const IMPORT_LINE_POOL = [
   `import { ZodError as FuzzZodError } from "zod/v4"; const fuzzZodFlattenedError = new FuzzZodError([]).flatten();`,
   `import { forwardRef } from "react";\nconst FuzzForwardRefComponent = forwardRef((props) => <button>{props.label}</button>);`,
   `import FuzzMarkdown from "react-markdown";\nimport fuzzRehypeRaw from "rehype-raw";`,
+  `import posthog from "posthog-js";`,
 ] as const;
 
 // Filenames rotate per iteration because a large rule population is

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/cross-file-rule-ids.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/cross-file-rule-ids.ts
@@ -10,6 +10,7 @@
 // Two flavors live here:
 //   - Source-file readers — resolve imports / walk ancestor layouts and read
 //     OTHER source files (`no-barrel-import`, the two `nextjs-*` rules,
+//     `no-noninteractive-element-interactions`,
 //     `no-mutating-reducer-state`, and `rn-no-raw-text`, which resolves an
 //     imported component to see whether it forwards its children into a
 //     `<Text>` or a non-text host).
@@ -52,6 +53,7 @@ export const CROSS_FILE_RULE_IDS: ReadonlySet<string> = new Set([
   "no-effect-with-fresh-deps",
   "no-initialize-state",
   "no-mutating-reducer-state",
+  "no-noninteractive-element-interactions",
   "only-export-components",
   "no-unguarded-browser-global-in-render-or-hook-init",
   "prefer-dynamic-import",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/thresholds.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/thresholds.ts
@@ -46,6 +46,7 @@ export const MIN_OVERPRECISE_SVG_TOKEN_OCCURRENCES = 2;
 export const CROSS_FILE_PARSE_MAX_BYTES = 2_000_000;
 export const CROSS_FILE_BARREL_FOLLOW_DEPTH = 4;
 export const CUSTOM_HOOK_DEPENDENCY_FORWARD_DEPTH = 4;
+export const OBSERVATION_ONLY_HANDLER_MAX_CALL_DEPTH = 6;
 
 // Bounds for upward directory walks used by cross-file resolvers:
 // `CROSS_FILE_DIRECTORY_WALK_MAX_LEVELS` caps how many parent

--- a/packages/oxlint-plugin-react-doctor/src/plugin/cross-file-dependencies.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/cross-file-dependencies.ts
@@ -195,7 +195,7 @@ const collectObservationHandlerDependencies: CrossFileDependencyCollector = ({
     if (previousDepth >= remainingDepth) return;
     greatestTraversedDepthByFilePath.set(filePath, remainingDepth);
 
-    const entries = flattenProgramImportEntries(programNode);
+    const importEntriesByLocalName = new Map<string, ImportEntryName>();
     const namespaceSourcesByLocalName = new Map<string, string>();
     for (const statement of (programNode as { body?: ReadonlyArray<EsTreeNode> }).body ?? []) {
       if (statement.type !== "ImportDeclaration") continue;
@@ -203,14 +203,37 @@ const collectObservationHandlerDependencies: CrossFileDependencyCollector = ({
       if (typeof source !== "string") continue;
       for (const specifier of (statement as { specifiers?: ReadonlyArray<EsTreeNode> })
         .specifiers ?? []) {
-        if (specifier.type !== "ImportNamespaceSpecifier") continue;
         const localName = (specifier as { local?: { name?: unknown } }).local?.name;
-        if (typeof localName === "string") namespaceSourcesByLocalName.set(localName, source);
+        if (typeof localName !== "string") continue;
+        if (specifier.type === "ImportNamespaceSpecifier") {
+          namespaceSourcesByLocalName.set(localName, source);
+        } else if (specifier.type === "ImportDefaultSpecifier") {
+          importEntriesByLocalName.set(localName, { source, exportedName: "default" });
+        } else if (specifier.type === "ImportSpecifier") {
+          const imported = (specifier as { imported?: { name?: unknown; value?: unknown } })
+            .imported;
+          const exportedName =
+            typeof imported?.name === "string"
+              ? imported.name
+              : typeof imported?.value === "string"
+                ? imported.value
+                : null;
+          if (exportedName) importEntriesByLocalName.set(localName, { source, exportedName });
+        }
       }
     }
+    const entriesByIdentity = new Map<string, ImportEntryName>();
     walkAst(programNode, (node) => {
-      if (node.type !== "MemberExpression") return;
-      const member = node as {
+      if (node.type !== "CallExpression") return;
+      const callee = (node as { callee?: EsTreeNode }).callee;
+      if (!callee) return;
+      if (callee.type === "Identifier") {
+        const entry = importEntriesByLocalName.get((callee as { name?: string }).name ?? "");
+        if (entry) entriesByIdentity.set(`${entry.source}\0${entry.exportedName}`, entry);
+        return;
+      }
+      if (callee.type !== "MemberExpression") return;
+      const member = callee as {
         object?: EsTreeNode;
         property?: EsTreeNode;
         computed?: boolean;
@@ -226,10 +249,12 @@ const collectObservationHandlerDependencies: CrossFileDependencyCollector = ({
           : member.computed && member.property.type === "Literal"
             ? ((member.property as { value?: unknown }).value ?? null)
             : null;
-      if (typeof exportedName === "string") entries.push({ source, exportedName });
+      if (typeof exportedName !== "string") return;
+      const entry = { source, exportedName };
+      entriesByIdentity.set(`${source}\0${exportedName}`, entry);
     });
 
-    for (const entry of entries) {
+    for (const entry of entriesByIdentity.values()) {
       const resolved = resolveCrossFileFunctionExportWithFilePath(
         filePath,
         entry.source,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/cross-file-dependencies.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/cross-file-dependencies.ts
@@ -5,7 +5,10 @@ import {
   PAGE_FILE_PATTERN,
   PAGE_OR_LAYOUT_FILE_PATTERN,
 } from "./constants/nextjs.js";
-import { CUSTOM_HOOK_DEPENDENCY_FORWARD_DEPTH } from "./constants/thresholds.js";
+import {
+  CUSTOM_HOOK_DEPENDENCY_FORWARD_DEPTH,
+  OBSERVATION_ONLY_HANDLER_MAX_CALL_DEPTH,
+} from "./constants/thresholds.js";
 import { classifyPackagePlatform } from "./utils/classify-package-platform.js";
 import { collectCrossFileProbes } from "./utils/cross-file-probe-recorder.js";
 import type { CrossFileProbeTrace } from "./utils/cross-file-probe-recorder.js";
@@ -19,6 +22,7 @@ import { resolveLang } from "./utils/parse-source-file.js";
 import { resolveBarrelExportFilePath } from "./utils/resolve-barrel-export-file-path.js";
 import {
   resolveCrossFileFunctionExport,
+  resolveCrossFileFunctionExportWithFilePath,
   resolveCrossFileValueExportWithFilePath,
 } from "./utils/resolve-cross-file-function-export.js";
 import { resolveRelativeImportPath } from "./utils/resolve-relative-import-path.js";
@@ -174,6 +178,69 @@ const collectEffectValueHelperDependencies: CrossFileDependencyCollector = ({
   for (const entry of flattenImportEntries(staticImports)) {
     resolveCrossFileFunctionExport(absoluteFilePath, entry.source, entry.exportedName);
   }
+};
+
+const collectObservationHandlerDependencies: CrossFileDependencyCollector = ({
+  absoluteFilePath,
+  program,
+}) => {
+  const greatestTraversedDepthByFilePath = new Map<string, number>();
+
+  const collectProgramDependencies = (
+    filePath: string,
+    programNode: EsTreeNode,
+    remainingDepth: number,
+  ): void => {
+    const previousDepth = greatestTraversedDepthByFilePath.get(filePath) ?? -1;
+    if (previousDepth >= remainingDepth) return;
+    greatestTraversedDepthByFilePath.set(filePath, remainingDepth);
+
+    const entries = flattenProgramImportEntries(programNode);
+    const namespaceSourcesByLocalName = new Map<string, string>();
+    for (const statement of (programNode as { body?: ReadonlyArray<EsTreeNode> }).body ?? []) {
+      if (statement.type !== "ImportDeclaration") continue;
+      const source = (statement as { source?: { value?: unknown } }).source?.value;
+      if (typeof source !== "string") continue;
+      for (const specifier of (statement as { specifiers?: ReadonlyArray<EsTreeNode> })
+        .specifiers ?? []) {
+        if (specifier.type !== "ImportNamespaceSpecifier") continue;
+        const localName = (specifier as { local?: { name?: unknown } }).local?.name;
+        if (typeof localName === "string") namespaceSourcesByLocalName.set(localName, source);
+      }
+    }
+    walkAst(programNode, (node) => {
+      if (node.type !== "MemberExpression") return;
+      const member = node as {
+        object?: EsTreeNode;
+        property?: EsTreeNode;
+        computed?: boolean;
+      };
+      if (member.object?.type !== "Identifier" || !member.property) return;
+      const source = namespaceSourcesByLocalName.get(
+        (member.object as { name?: string }).name ?? "",
+      );
+      if (!source) return;
+      const exportedName =
+        member.property.type === "Identifier"
+          ? ((member.property as { name?: string }).name ?? null)
+          : member.computed && member.property.type === "Literal"
+            ? ((member.property as { value?: unknown }).value ?? null)
+            : null;
+      if (typeof exportedName === "string") entries.push({ source, exportedName });
+    });
+
+    for (const entry of entries) {
+      const resolved = resolveCrossFileFunctionExportWithFilePath(
+        filePath,
+        entry.source,
+        entry.exportedName,
+      );
+      if (!resolved || remainingDepth === 0) continue;
+      collectProgramDependencies(resolved.filePath, resolved.programNode, remainingDepth - 1);
+    }
+  };
+
+  collectProgramDependencies(absoluteFilePath, program, OBSERVATION_ONLY_HANDLER_MAX_CALL_DEPTH);
 };
 
 const flattenProgramImportEntries = (program: EsTreeNode): ImportEntryName[] => {
@@ -420,6 +487,7 @@ export const CROSS_FILE_DEPENDENCY_COLLECTORS: ReadonlyMap<string, CrossFileDepe
     ["no-indeterminate-attribute", collectNearestManifestDependencies],
     ["no-locale-format-in-render", collectNearestManifestDependencies],
     ["no-match-media-in-state-initializer", collectNearestManifestDependencies],
+    ["no-noninteractive-element-interactions", collectObservationHandlerDependencies],
     ["no-adjust-state-on-prop-change", collectEffectValueHelperDependencies],
     ["no-derived-state", collectEffectValueHelperDependencies],
     ["no-derived-state-effect", collectEffectValueHelperDependencies],

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/no-noninteractive-element-interactions.cross-file.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/no-noninteractive-element-interactions.cross-file.test.ts
@@ -1,0 +1,90 @@
+import * as fs from "node:fs";
+import os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { __clearParseSourceFileCacheForTests } from "../../utils/parse-source-file.js";
+import { noNoninteractiveElementInteractions } from "./no-noninteractive-element-interactions.js";
+
+let temporaryDirectory: string;
+
+beforeEach(() => {
+  temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "noninteractive-analytics-"));
+  __clearParseSourceFileCacheForTests();
+});
+
+afterEach(() => {
+  fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+});
+
+const writeFile = (relativePath: string, contents: string): string => {
+  const absolutePath = path.join(temporaryDirectory, relativePath);
+  fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+  fs.writeFileSync(absolutePath, contents, "utf8");
+  return absolutePath;
+};
+
+const runConsumer = (source: string): ReturnType<typeof runRule> => {
+  const consumerPath = writeFile("src/integrations-view.tsx", source);
+  return runRule(noNoninteractiveElementInteractions, source, { filename: consumerPath });
+};
+
+describe("a11y/no-noninteractive-element-interactions — analytics-only callbacks", () => {
+  it("stays silent for the Nexu analytics-only informational section", () => {
+    writeFile(
+      "src/analytics/events.ts",
+      `
+export const trackIntegrationsSkillsTabClick = (
+  track: (event: string, properties: Record<string, string>) => void,
+  properties: Record<string, string>,
+) => track("ui_click", properties);
+`,
+    );
+
+    const result = runConsumer(`
+import { trackIntegrationsSkillsTabClick } from "./analytics/events";
+
+interface SkillsComingSoonPanelProps {
+  track: (event: string, properties: Record<string, string>) => void;
+}
+
+export const SkillsComingSoonPanel = ({ track }: SkillsComingSoonPanelProps) => (
+  <section
+    aria-labelledby="integration-skills-title"
+    onClick={() =>
+      trackIntegrationsSkillsTabClick(track, {
+        page_name: "integrations",
+        area: "skills_tab",
+        element: "coming_soon",
+      })
+    }
+  >
+    <h2 id="integration-skills-title">Skills</h2>
+    <p>Coming soon</p>
+  </section>
+);
+`);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("reports the same section when its handler exposes user-facing state", () => {
+    const result = runConsumer(`
+import { useState } from "react";
+
+export const SkillsPanel = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  return (
+    <section onClick={() => setIsOpen(true)}>
+      Skills
+      {isOpen ? <p>Available skills</p> : null}
+    </section>
+  );
+};
+`);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/no-noninteractive-element-interactions.cross-file.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/no-noninteractive-element-interactions.cross-file.test.ts
@@ -32,6 +32,17 @@ const runConsumer = (source: string): ReturnType<typeof runRule> => {
 describe("a11y/no-noninteractive-element-interactions — analytics-only callbacks", () => {
   it("stays silent for the Nexu analytics-only informational section", () => {
     writeFile(
+      "src/analytics/provider.ts",
+      `
+export const useAnalytics = () => ({
+  track: (event: string, properties: Record<string, string>) => {
+    void event;
+    void properties;
+  },
+});
+`,
+    );
+    writeFile(
       "src/analytics/events.ts",
       `
 export const trackIntegrationsSkillsTabClick = (
@@ -43,26 +54,26 @@ export const trackIntegrationsSkillsTabClick = (
 
     const result = runConsumer(`
 import { trackIntegrationsSkillsTabClick } from "./analytics/events";
+import { useAnalytics } from "./analytics/provider";
 
-interface SkillsComingSoonPanelProps {
-  track: (event: string, properties: Record<string, string>) => void;
-}
-
-export const SkillsComingSoonPanel = ({ track }: SkillsComingSoonPanelProps) => (
-  <section
-    aria-labelledby="integration-skills-title"
-    onClick={() =>
-      trackIntegrationsSkillsTabClick(track, {
-        page_name: "integrations",
-        area: "skills_tab",
-        element: "coming_soon",
-      })
-    }
-  >
-    <h2 id="integration-skills-title">Skills</h2>
-    <p>Coming soon</p>
-  </section>
-);
+export const SkillsComingSoonPanel = () => {
+  const analytics = useAnalytics();
+  return (
+    <section
+      aria-labelledby="integration-skills-title"
+      onClick={() =>
+        trackIntegrationsSkillsTabClick(analytics.track, {
+          page_name: "integrations",
+          area: "skills_tab",
+          element: "coming_soon",
+        })
+      }
+    >
+      <h2 id="integration-skills-title">Skills</h2>
+      <p>Coming soon</p>
+    </section>
+  );
+};
 `);
 
     expect(result.parseErrors).toEqual([]);
@@ -82,6 +93,197 @@ export const SkillsPanel = () => {
     </section>
   );
 };
+`);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("follows import aliases and stable local wrapper aliases", () => {
+    writeFile(
+      "src/analytics/provider.ts",
+      `export const useAnalytics = () => ({ track: (event: string) => void event });`,
+    );
+    writeFile(
+      "src/analytics/events.ts",
+      `export const recordSkill = (track: (event: string) => void) => track("skill_viewed");`,
+    );
+    const result = runConsumer(`
+import { recordSkill as importedRecordSkill } from "./analytics/events";
+import { useAnalytics as useTelemetryClient } from "./analytics/provider";
+
+export const Panel = () => {
+  const analytics = useTelemetryClient();
+  const recordSkill = importedRecordSkill;
+  const handleClick = () => recordSkill(analytics.track);
+  return <section onClick={handleClick}>Coming soon</section>;
+};
+`);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("follows namespace imports and optional calls", () => {
+    writeFile(
+      "src/analytics/provider.ts",
+      `export const useAnalytics = () => ({ track: (event: string) => void event });`,
+    );
+    writeFile(
+      "src/analytics/events.ts",
+      `export const recordSkill = (track: (event: string) => void) => track?.("skill_viewed");`,
+    );
+    const result = runConsumer(`
+import * as events from "./analytics/events";
+import * as provider from "./analytics/provider";
+
+export const Panel = () => {
+  const analytics = provider.useAnalytics();
+  return <section onClick={() => events.recordSkill?.(analytics.track)}>Coming soon</section>;
+};
+`);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent for a proven PostHog capture", () => {
+    const result = runConsumer(`
+import posthog from "posthog-js";
+export const Panel = () => (
+  <section onClick={() => posthog.capture("skill_viewed", { area: "skills" })}>
+    Coming soon
+  </section>
+);
+`);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("reports telemetry combined with a state update", () => {
+    const result = runConsumer(`
+import posthog from "posthog-js";
+import { useState } from "react";
+export const Panel = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  return (
+    <section onClick={() => { posthog.capture("skill_viewed"); setIsOpen(true); }}>
+      Coming soon
+      {isOpen ? <p>Available skills</p> : null}
+    </section>
+  );
+};
+`);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports a state update evaluated as a telemetry argument", () => {
+    const result = runConsumer(`
+import posthog from "posthog-js";
+import { useState } from "react";
+export const Panel = () => {
+  const [, setIsOpen] = useState(false);
+  return <section onClick={() => posthog.capture("skill_viewed", setIsOpen(true))}>Skills</section>;
+};
+`);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports an opaque callback prop named track", () => {
+    const result = runConsumer(`
+interface PanelProps { track: () => void }
+export const Panel = ({ track }: PanelProps) => <section onClick={() => track()}>Skills</section>;
+`);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports a local track lookalike that changes state", () => {
+    const result = runConsumer(`
+import { useState } from "react";
+export const Panel = () => {
+  const [, setIsOpen] = useState(false);
+  const analytics = { track: () => setIsOpen(true) };
+  return <section onClick={() => analytics.track()}>Skills</section>;
+};
+`);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports an analytics-path helper that invokes an opaque UI callback", () => {
+    writeFile(
+      "src/analytics/events.ts",
+      `export const trackSkill = (performAction: () => void) => performAction();`,
+    );
+    const result = runConsumer(`
+import { useState } from "react";
+import { trackSkill } from "./analytics/events";
+export const Panel = () => {
+  const [, setIsOpen] = useState(false);
+  return <section onClick={() => trackSkill(() => setIsOpen(true))}>Skills</section>;
+};
+`);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports an unresolved analytics-path import", () => {
+    const result = runConsumer(`
+import { track } from "./analytics/missing-events";
+export const Panel = () => <section onClick={() => track("skill_viewed")}>Skills</section>;
+`);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports a reassigned helper", () => {
+    const result = runConsumer(`
+import posthog from "posthog-js";
+import { useState } from "react";
+export const Panel = () => {
+  const [, setIsOpen] = useState(false);
+  let record = posthog.capture;
+  record = () => setIsOpen(true);
+  return <section onClick={() => record("skill_viewed")}>Skills</section>;
+};
+`);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports mixed branches with navigation", () => {
+    const result = runConsumer(`
+import posthog from "posthog-js";
+interface PanelProps { shouldNavigate: boolean }
+export const Panel = ({ shouldNavigate }: PanelProps) => (
+  <section onClick={() => shouldNavigate ? location.assign("/skills") : posthog.capture("skill_viewed")}>
+    Skills
+  </section>
+);
+`);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports a dynamic computed analytics method", () => {
+    const result = runConsumer(`
+import posthog from "posthog-js";
+interface PanelProps { method: string }
+export const Panel = ({ method }: PanelProps) => (
+  <section onClick={() => posthog[method]("skill_viewed")}>Skills</section>
+);
 `);
 
     expect(result.parseErrors).toEqual([]);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/no-noninteractive-element-interactions.cross-file.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/no-noninteractive-element-interactions.cross-file.test.ts
@@ -34,11 +34,9 @@ describe("a11y/no-noninteractive-element-interactions — analytics-only callbac
     writeFile(
       "src/analytics/provider.ts",
       `
+import posthog from "posthog-js";
 export const useAnalytics = () => ({
-  track: (event: string, properties: Record<string, string>) => {
-    void event;
-    void properties;
-  },
+  track: posthog.capture,
 });
 `,
     );
@@ -102,7 +100,8 @@ export const SkillsPanel = () => {
   it("follows import aliases and stable local wrapper aliases", () => {
     writeFile(
       "src/analytics/provider.ts",
-      `export const useAnalytics = () => ({ track: (event: string) => void event });`,
+      `import posthog from "posthog-js";
+export const useAnalytics = () => ({ track: posthog.capture });`,
     );
     writeFile(
       "src/analytics/events.ts",
@@ -127,7 +126,8 @@ export const Panel = () => {
   it("follows namespace imports and optional calls", () => {
     writeFile(
       "src/analytics/provider.ts",
-      `export const useAnalytics = () => ({ track: (event: string) => void event });`,
+      `import posthog from "posthog-js";
+export const useAnalytics = () => ({ track: posthog.capture });`,
     );
     writeFile(
       "src/analytics/events.ts",
@@ -339,5 +339,116 @@ export const Panel = () => {
 
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports an analytics-named factory without SDK provenance", () => {
+    writeFile(
+      "src/analytics/provider.ts",
+      `export const useAnalytics = () => ({ track: () => location.assign("/skills") });`,
+    );
+    const result = runConsumer(`
+import { useAnalytics } from "./analytics/provider";
+export const Panel = () => {
+  const analytics = useAnalytics();
+  return <section onClick={() => analytics.track("skill_viewed")}>Skills</section>;
+};
+`);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports a callback argument passed to a trusted analytics method", () => {
+    const result = runConsumer(`
+import { AnalyticsBrowser } from "@segment/analytics-next";
+import { useState } from "react";
+const analytics = AnalyticsBrowser.load({ writeKey: "test" });
+export const Panel = () => {
+  const [, setOpen] = useState(false);
+  const afterTrack = () => setOpen(true);
+  return <section onClick={() => analytics.track("skill_viewed", {}, {}, afterTrack)}>Skills</section>;
+};
+`);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports getter-backed analytics payload reads", () => {
+    const result = runConsumer(`
+import posthog from "posthog-js";
+import { useState } from "react";
+export const Panel = () => {
+  const [, setOpen] = useState(false);
+  const payload = { get value() { setOpen(true); return "skills"; } };
+  return <section onClick={() => posthog.capture("skill_viewed", { value: payload.value })}>Skills</section>;
+};
+`);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports destructuring from an object with an effectful getter", () => {
+    const result = runConsumer(`
+import posthog from "posthog-js";
+import { useState } from "react";
+export const Panel = () => {
+  const [, setOpen] = useState(false);
+  const payload = { get value() { setOpen(true); return "skills"; } };
+  return <section onClick={() => {
+    const { value } = payload;
+    posthog.capture("skill_viewed", { value });
+  }}>Skills</section>;
+};
+`);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays silent when a supplied argument skips an unsafe default", () => {
+    const result = runConsumer(`
+import posthog from "posthog-js";
+import { useState } from "react";
+export const Panel = () => {
+  const [, setOpen] = useState(false);
+  const record = (event = (setOpen(true), "fallback")) => posthog.capture(event);
+  return <section onClick={() => record("skill_viewed")}>Skills</section>;
+};
+`);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent for telemetry-only switch branches with breaks", () => {
+    const result = runConsumer(`
+import posthog from "posthog-js";
+export const Panel = ({ kind }: { kind: string }) => (
+  <section onClick={() => {
+    switch (kind) {
+      case "skills": posthog.capture("skill_viewed"); break;
+      default: posthog.capture("other_viewed"); break;
+    }
+  }}>Skills</section>
+);
+`);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent for a stable computed analytics method", () => {
+    const result = runConsumer(`
+import posthog from "posthog-js";
+export const Panel = () => {
+  const method = "capture";
+  return <section onClick={() => posthog[method]("skill_viewed")}>Skills</section>;
+};
+`);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
   });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/no-noninteractive-element-interactions.cross-file.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/no-noninteractive-element-interactions.cross-file.test.ts
@@ -289,4 +289,55 @@ export const Panel = ({ method }: PanelProps) => (
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toHaveLength(1);
   });
+
+  it("reports a state update in a switch case test", () => {
+    const result = runConsumer(`
+import posthog from "posthog-js";
+import { useState } from "react";
+export const Panel = () => {
+  const [, setIsOpen] = useState(false);
+  return <section onClick={() => {
+    switch ("skill") {
+      case (setIsOpen(true), "skill"):
+        posthog.capture("skill_viewed");
+    }
+  }}>Skills</section>;
+};
+`);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports a state update in a helper parameter default", () => {
+    const result = runConsumer(`
+import posthog from "posthog-js";
+import { useState } from "react";
+export const Panel = () => {
+  const [, setIsOpen] = useState(false);
+  const record = (event = (setIsOpen(true), "skill_viewed")) => posthog.capture(event);
+  return <section onClick={() => record()}>Skills</section>;
+};
+`);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports state updates in destructuring defaults and computed keys", () => {
+    const result = runConsumer(`
+import posthog from "posthog-js";
+import { useState } from "react";
+export const Panel = () => {
+  const [, setIsOpen] = useState(false);
+  return <section onClick={() => {
+    const { value = setIsOpen(true), [String(setIsOpen(true))]: selected } = {};
+    posthog.capture("skill_viewed", { value, selected });
+  }}>Skills</section>;
+};
+`);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/no-noninteractive-element-interactions.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/no-noninteractive-element-interactions.ts
@@ -11,6 +11,7 @@ import { isInteractiveElement } from "../../utils/is-interactive-element.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isPresentationRole } from "../../utils/is-presentation-role.js";
 import { isPureEventBlockerHandler } from "../../utils/is-pure-event-blocker-handler.js";
+import { isProvenObservationOnlyJsxHandler } from "../../utils/is-proven-observation-only-jsx-handler.js";
 import { isTestlikeFilename } from "../../utils/is-testlike-filename.js";
 import { NON_INTERACTIVE_ELEMENTS } from "../../constants/html-tags.js";
 import { INTERACTIVE_ROLES } from "../../constants/aria-roles.js";
@@ -181,6 +182,7 @@ export const noNoninteractiveElementInteractions = defineRule({
           const attributeName = getJsxAttributeName(attribute.name);
           if (!attributeName || !MOUSE_HANDLERS_LOWER.has(attributeName.toLowerCase())) continue;
           if (isPureEventBlockerHandler(attribute)) continue;
+          if (isProvenObservationOnlyJsxHandler(attribute, context)) continue;
           hasActionableMouseHandler = true;
           break;
         }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-proven-observation-only-jsx-handler.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-proven-observation-only-jsx-handler.ts
@@ -339,6 +339,42 @@ const buildObservationParameterSymbolIds = (
   return observationParameterSymbolIds;
 };
 
+const isObservationSafePattern = (
+  pattern: EsTreeNode | null | undefined,
+  context: ObservationAnalysisContext,
+): boolean => {
+  if (!pattern || isNodeOfType(pattern, "Identifier")) return true;
+  if (isNodeOfType(pattern, "RestElement")) {
+    return isObservationSafePattern(pattern.argument, context);
+  }
+  if (isNodeOfType(pattern, "AssignmentPattern")) {
+    return (
+      isObservationSafePattern(pattern.left as EsTreeNode, context) &&
+      isObservationSafeExpression(pattern.right as EsTreeNode, context)
+    );
+  }
+  if (isNodeOfType(pattern, "ArrayPattern")) {
+    return pattern.elements.every((element) =>
+      isObservationSafePattern(element as EsTreeNode | null, context),
+    );
+  }
+  if (isNodeOfType(pattern, "ObjectPattern")) {
+    return pattern.properties.every((property) => {
+      if (isNodeOfType(property, "RestElement")) {
+        return isObservationSafePattern(property.argument, context);
+      }
+      if (!isNodeOfType(property, "Property") || property.kind !== "init" || property.method) {
+        return false;
+      }
+      return (
+        (!property.computed || isObservationSafeExpression(property.key as EsTreeNode, context)) &&
+        isObservationSafePattern(property.value as EsTreeNode, context)
+      );
+    });
+  }
+  return false;
+};
+
 const isObservationSafeStatement = (
   statement: EsTreeNode,
   context: ObservationAnalysisContext,
@@ -355,8 +391,10 @@ const isObservationSafeStatement = (
     return isObservationSafeExpression(statement.argument as EsTreeNode | null, context);
   }
   if (isNodeOfType(statement, "VariableDeclaration")) {
-    return statement.declarations.every((declaration) =>
-      isObservationSafeExpression(declaration.init as EsTreeNode | null, context),
+    return statement.declarations.every(
+      (declaration) =>
+        isObservationSafePattern(declaration.id as EsTreeNode, context) &&
+        isObservationSafeExpression(declaration.init as EsTreeNode | null, context),
     );
   }
   if (isNodeOfType(statement, "IfStatement")) {
@@ -371,8 +409,11 @@ const isObservationSafeStatement = (
     return (
       isObservationSafeExpression(statement.discriminant as EsTreeNode, context) &&
       statement.cases.every((switchCase) =>
-        switchCase.consequent.every((innerStatement) =>
-          isObservationSafeStatement(innerStatement as EsTreeNode, context),
+        Boolean(
+          isObservationSafeExpression(switchCase.test as EsTreeNode | null, context) &&
+          switchCase.consequent.every((innerStatement) =>
+            isObservationSafeStatement(innerStatement as EsTreeNode, context),
+          ),
         ),
       )
     );
@@ -406,8 +447,11 @@ const isObservationSafeFunction = (
     evidence: callerContext.evidence,
   };
   return (
-    isObservationSafeExpression(target.functionNode.body as EsTreeNode, context) ||
-    isObservationSafeStatement(target.functionNode.body as EsTreeNode, context)
+    target.functionNode.params.every((parameter) =>
+      isObservationSafePattern(parameter as EsTreeNode, context),
+    ) &&
+    (isObservationSafeExpression(target.functionNode.body as EsTreeNode, context) ||
+      isObservationSafeStatement(target.functionNode.body as EsTreeNode, context))
   );
 };
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-proven-observation-only-jsx-handler.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-proven-observation-only-jsx-handler.ts
@@ -9,6 +9,7 @@ import { isFunctionLike } from "./is-function-like.js";
 import { isNodeOfType } from "./is-node-of-type.js";
 import { resolveConstIdentifierAlias } from "./resolve-const-identifier-alias.js";
 import { resolveCrossFileFunctionExportWithFilePath } from "./resolve-cross-file-function-export.js";
+import { resolveCrossFileValueExportWithFilePath } from "./resolve-cross-file-function-export.js";
 import { resolveExactLocalFunction } from "./resolve-exact-local-function.js";
 import type { RuleContext } from "./rule-context.js";
 import { stripParenExpression } from "./strip-paren-expression.js";
@@ -83,6 +84,9 @@ const isObservationFactoryName = (name: string | null): boolean =>
   name === "useTelemetry" ||
   name === "useTracking";
 
+const hasObservationName = (name: string): boolean =>
+  /analytics|capture|instrumentation|telemetry|track/i.test(name);
+
 const getStableSymbol = (
   identifier: EsTreeNodeOfType<"Identifier">,
   scopes: ScopeAnalysis,
@@ -103,6 +107,79 @@ const getImportedBinding = (
   return getImportBindingForName(identifier, importedIdentifier.name);
 };
 
+const hasTrustedObservationPackageProvenance = (
+  filename: string,
+  programNode: EsTreeNode,
+  remainingDepth: number,
+  visitedFilePaths: ReadonlySet<string>,
+): boolean => {
+  if (remainingDepth < 0 || visitedFilePaths.has(filename)) return false;
+  const nextVisitedFilePaths = new Set(visitedFilePaths);
+  nextVisitedFilePaths.add(filename);
+  for (const statement of (programNode as { body?: ReadonlyArray<EsTreeNode> }).body ?? []) {
+    if (statement.type !== "ImportDeclaration") continue;
+    const importDeclaration = statement as {
+      source?: { value?: unknown };
+      specifiers?: ReadonlyArray<EsTreeNode>;
+    };
+    const source = importDeclaration.source?.value;
+    if (typeof source !== "string") continue;
+    if (OBSERVATION_PACKAGE_SOURCES.has(source)) return true;
+    if (!source.startsWith(".") || remainingDepth === 0) continue;
+    for (const specifier of importDeclaration.specifiers ?? []) {
+      let exportedName: string | null = null;
+      if (specifier.type === "ImportDefaultSpecifier") {
+        const localName = (specifier as { local?: { name?: unknown } }).local?.name;
+        if (typeof localName === "string" && hasObservationName(localName)) {
+          exportedName = "default";
+        }
+      } else if (specifier.type === "ImportSpecifier") {
+        const imported = (specifier as { imported?: { name?: unknown; value?: unknown } }).imported;
+        const importedName =
+          typeof imported?.name === "string"
+            ? imported.name
+            : typeof imported?.value === "string"
+              ? imported.value
+              : null;
+        if (importedName && hasObservationName(importedName)) exportedName = importedName;
+      }
+      if (!exportedName) continue;
+      const resolved = resolveCrossFileValueExportWithFilePath(filename, source, exportedName);
+      if (
+        resolved &&
+        hasTrustedObservationPackageProvenance(
+          resolved.filePath,
+          resolved.programNode,
+          remainingDepth - 1,
+          nextVisitedFilePaths,
+        )
+      ) {
+        return true;
+      }
+    }
+  }
+  return false;
+};
+
+const isVerifiedObservationFactory = (
+  filename: string,
+  source: string,
+  exportedName: string,
+): boolean => {
+  if (OBSERVATION_PACKAGE_SOURCES.has(source)) return true;
+  if (!isObservationModuleSource(source) || !isObservationFactoryName(exportedName)) return false;
+  const resolved = resolveCrossFileFunctionExportWithFilePath(filename, source, exportedName);
+  return Boolean(
+    resolved &&
+    hasTrustedObservationPackageProvenance(
+      resolved.filePath,
+      resolved.programNode,
+      OBSERVATION_ONLY_HANDLER_MAX_CALL_DEPTH,
+      new Set(),
+    ),
+  );
+};
+
 const isObservationFactoryCall = (
   expression: EsTreeNode,
   context: ObservationAnalysisContext,
@@ -114,8 +191,12 @@ const isObservationFactoryCall = (
     const importBinding = getImportedBinding(callee, context);
     return Boolean(
       importBinding &&
-      isObservationModuleSource(importBinding.source) &&
-      isObservationFactoryName(importBinding.exportedName),
+      importBinding.exportedName &&
+      isVerifiedObservationFactory(
+        context.filename,
+        importBinding.source,
+        importBinding.exportedName,
+      ),
     );
   }
   if (!isNodeOfType(callee, "MemberExpression")) return false;
@@ -124,9 +205,31 @@ const isObservationFactoryCall = (
   const importBinding = getImportedBinding(receiver, context);
   return Boolean(
     importBinding?.isNamespace &&
-    isObservationModuleSource(importBinding.source) &&
-    isObservationFactoryName(getStaticPropertyName(callee)),
+    getStaticPropertyName(callee) &&
+    isVerifiedObservationFactory(
+      context.filename,
+      importBinding.source,
+      getStaticPropertyName(callee) ?? "",
+    ),
   );
+};
+
+const getResolvedStaticPropertyName = (
+  memberExpression: EsTreeNodeOfType<"MemberExpression">,
+  context: ObservationAnalysisContext,
+): string | null => {
+  const directName = getStaticPropertyName(memberExpression);
+  if (directName) return directName;
+  if (!memberExpression.computed) return null;
+  const property = stripParenExpression(memberExpression.property as EsTreeNode);
+  if (!isNodeOfType(property, "Identifier")) return null;
+  const symbol = getStableSymbol(property, context.scopes);
+  const initializer = symbol?.initializer && stripParenExpression(symbol.initializer);
+  return initializer &&
+    isNodeOfType(initializer, "Literal") &&
+    typeof initializer.value === "string"
+    ? initializer.value
+    : null;
 };
 
 const isObservationReceiver = (
@@ -172,7 +275,7 @@ const isObservationFunctionExpression = (
     );
   }
   if (!isNodeOfType(unwrappedExpression, "MemberExpression")) return false;
-  const propertyName = getStaticPropertyName(unwrappedExpression);
+  const propertyName = getResolvedStaticPropertyName(unwrappedExpression, context);
   return Boolean(
     propertyName &&
     OBSERVATION_METHOD_NAMES.has(propertyName) &&
@@ -227,6 +330,52 @@ const resolveFunctionTarget = (
   return resolveImportedFunction(callee, context);
 };
 
+const isProvenPlainDataExpression = (
+  expression: EsTreeNode | null | undefined,
+  context: ObservationAnalysisContext,
+  visitedSymbolIds: ReadonlySet<number> = new Set(),
+): boolean => {
+  if (!expression) return true;
+  const unwrappedExpression = stripParenExpression(expression);
+  if (isNodeOfType(unwrappedExpression, "Literal")) return true;
+  if (isNodeOfType(unwrappedExpression, "Identifier")) {
+    const symbol = getStableSymbol(unwrappedExpression, context.scopes);
+    if (!symbol?.initializer || visitedSymbolIds.has(symbol.id)) return false;
+    const nextVisitedSymbolIds = new Set(visitedSymbolIds);
+    nextVisitedSymbolIds.add(symbol.id);
+    return isProvenPlainDataExpression(symbol.initializer, context, nextVisitedSymbolIds);
+  }
+  if (isNodeOfType(unwrappedExpression, "ArrayExpression")) {
+    return unwrappedExpression.elements.every((element) => {
+      if (!element) return true;
+      if (isNodeOfType(element as EsTreeNode, "SpreadElement")) {
+        return isProvenPlainDataExpression(
+          (element as EsTreeNodeOfType<"SpreadElement">).argument,
+          context,
+          visitedSymbolIds,
+        );
+      }
+      return isProvenPlainDataExpression(element as EsTreeNode, context, visitedSymbolIds);
+    });
+  }
+  if (isNodeOfType(unwrappedExpression, "ObjectExpression")) {
+    return unwrappedExpression.properties.every((property) => {
+      if (isNodeOfType(property, "SpreadElement")) {
+        return isProvenPlainDataExpression(property.argument, context, visitedSymbolIds);
+      }
+      return (
+        isNodeOfType(property, "Property") &&
+        property.kind === "init" &&
+        !property.method &&
+        (!property.computed ||
+          isProvenPlainDataExpression(property.key as EsTreeNode, context, visitedSymbolIds)) &&
+        isProvenPlainDataExpression(property.value as EsTreeNode, context, visitedSymbolIds)
+      );
+    });
+  }
+  return false;
+};
+
 const isObservationSafeExpression = (
   expression: EsTreeNode | null | undefined,
   context: ObservationAnalysisContext,
@@ -245,10 +394,11 @@ const isObservationSafeExpression = (
     return isObservationSafeCall(unwrappedExpression, context);
   }
   if (isNodeOfType(unwrappedExpression, "MemberExpression")) {
+    if (isObservationFunctionExpression(unwrappedExpression, context)) return true;
     return (
-      isObservationSafeExpression(unwrappedExpression.object as EsTreeNode, context) &&
+      isProvenPlainDataExpression(unwrappedExpression.object as EsTreeNode, context) &&
       (!unwrappedExpression.computed ||
-        isObservationSafeExpression(unwrappedExpression.property as EsTreeNode, context))
+        isProvenPlainDataExpression(unwrappedExpression.property as EsTreeNode, context))
     );
   }
   if (
@@ -375,6 +525,39 @@ const isObservationSafePattern = (
   return false;
 };
 
+const isDefinitelyDefinedExpression = (expression: EsTreeNode): boolean => {
+  const unwrappedExpression = stripParenExpression(expression);
+  return (
+    isNodeOfType(unwrappedExpression, "Literal") ||
+    isNodeOfType(unwrappedExpression, "ArrayExpression") ||
+    isNodeOfType(unwrappedExpression, "ObjectExpression") ||
+    isFunctionLike(unwrappedExpression)
+  );
+};
+
+const isObservationSafeParameter = (
+  parameter: EsTreeNode,
+  argument: EsTreeNode | undefined,
+  context: ObservationAnalysisContext,
+): boolean => {
+  if (isNodeOfType(parameter, "AssignmentPattern")) {
+    return (
+      isObservationSafePattern(parameter.left as EsTreeNode, context) &&
+      Boolean(
+        (argument && isDefinitelyDefinedExpression(argument)) ||
+        isObservationSafeExpression(parameter.right as EsTreeNode, context),
+      )
+    );
+  }
+  if (
+    (isNodeOfType(parameter, "ObjectPattern") || isNodeOfType(parameter, "ArrayPattern")) &&
+    (!argument || !isProvenPlainDataExpression(argument, context))
+  ) {
+    return false;
+  }
+  return isObservationSafePattern(parameter, context);
+};
+
 const isObservationSafeStatement = (
   statement: EsTreeNode,
   context: ObservationAnalysisContext,
@@ -394,6 +577,8 @@ const isObservationSafeStatement = (
     return statement.declarations.every(
       (declaration) =>
         isObservationSafePattern(declaration.id as EsTreeNode, context) &&
+        (isNodeOfType(declaration.id as EsTreeNode, "Identifier") ||
+          isProvenPlainDataExpression(declaration.init as EsTreeNode | null, context)) &&
         isObservationSafeExpression(declaration.init as EsTreeNode | null, context),
     );
   }
@@ -419,7 +604,9 @@ const isObservationSafeStatement = (
     );
   }
   return (
-    isNodeOfType(statement, "EmptyStatement") || isNodeOfType(statement, "FunctionDeclaration")
+    isNodeOfType(statement, "EmptyStatement") ||
+    isNodeOfType(statement, "BreakStatement") ||
+    isNodeOfType(statement, "FunctionDeclaration")
   );
 };
 
@@ -447,8 +634,8 @@ const isObservationSafeFunction = (
     evidence: callerContext.evidence,
   };
   return (
-    target.functionNode.params.every((parameter) =>
-      isObservationSafePattern(parameter as EsTreeNode, context),
+    target.functionNode.params.every((parameter, parameterIndex) =>
+      isObservationSafeParameter(parameter as EsTreeNode, argumentsList[parameterIndex], context),
     ) &&
     (isObservationSafeExpression(target.functionNode.body as EsTreeNode, context) ||
       isObservationSafeStatement(target.functionNode.body as EsTreeNode, context))
@@ -473,6 +660,13 @@ const isObservationSafeCall = (
 
   const callee = callExpression.callee as EsTreeNode;
   if (isObservationFunctionExpression(callee, context)) {
+    if (
+      argumentsList.some((argument) =>
+        Boolean(isFunctionLike(argument) || resolveFunctionTarget(argument, context)),
+      )
+    ) {
+      return false;
+    }
     context.evidence.didFindObservationCall = true;
     return true;
   }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-proven-observation-only-jsx-handler.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-proven-observation-only-jsx-handler.ts
@@ -1,0 +1,463 @@
+import type { ScopeAnalysis, SymbolDescriptor } from "../semantic/scope-analysis.js";
+import { analyzeScopes } from "../semantic/scope-analysis.js";
+import { OBSERVATION_ONLY_HANDLER_MAX_CALL_DEPTH } from "../constants/thresholds.js";
+import type { EsTreeNode } from "./es-tree-node.js";
+import type { EsTreeNodeOfType } from "./es-tree-node-of-type.js";
+import { getImportBindingForName } from "./find-import-source-for-name.js";
+import { getStaticPropertyName } from "./get-static-property-name.js";
+import { isFunctionLike } from "./is-function-like.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+import { resolveConstIdentifierAlias } from "./resolve-const-identifier-alias.js";
+import { resolveCrossFileFunctionExportWithFilePath } from "./resolve-cross-file-function-export.js";
+import { resolveExactLocalFunction } from "./resolve-exact-local-function.js";
+import type { RuleContext } from "./rule-context.js";
+import { stripParenExpression } from "./strip-paren-expression.js";
+
+interface ObservationAnalysisContext {
+  readonly filename: string;
+  readonly scopes: ScopeAnalysis;
+  readonly observationParameterSymbolIds: ReadonlySet<number>;
+  readonly visitedFunctions: ReadonlySet<EsTreeNode>;
+  readonly callDepth: number;
+  readonly evidence: ObservationEvidence;
+}
+
+interface ObservationEvidence {
+  didFindObservationCall: boolean;
+}
+
+interface ResolvedFunctionTarget {
+  readonly filename: string;
+  readonly functionNode: EsTreeNode;
+  readonly scopes: ScopeAnalysis;
+}
+
+const OBSERVATION_MODULE_SEGMENTS: ReadonlySet<string> = new Set([
+  "analytics",
+  "instrumentation",
+  "telemetry",
+  "tracking",
+]);
+
+const OBSERVATION_PACKAGE_SOURCES: ReadonlySet<string> = new Set([
+  "@amplitude/analytics-browser",
+  "@segment/analytics-next",
+  "@sentry/browser",
+  "@sentry/nextjs",
+  "@sentry/react",
+  "firebase/analytics",
+  "mixpanel-browser",
+  "posthog-js",
+]);
+
+const OBSERVATION_METHOD_NAMES: ReadonlySet<string> = new Set([
+  "capture",
+  "captureEvent",
+  "captureException",
+  "captureMessage",
+  "event",
+  "logEvent",
+  "record",
+  "track",
+]);
+
+const crossFileScopes = new WeakMap<EsTreeNode, ScopeAnalysis>();
+
+const getCrossFileScopes = (programNode: EsTreeNode): ScopeAnalysis => {
+  const cached = crossFileScopes.get(programNode);
+  if (cached) return cached;
+  const scopes = analyzeScopes(programNode);
+  crossFileScopes.set(programNode, scopes);
+  return scopes;
+};
+
+const isObservationModuleSource = (source: string): boolean => {
+  if (OBSERVATION_PACKAGE_SOURCES.has(source)) return true;
+  const sourceSegments = source.replaceAll("\\", "/").split("/").filter(Boolean);
+  return sourceSegments.some((sourceSegment) => OBSERVATION_MODULE_SEGMENTS.has(sourceSegment));
+};
+
+const isObservationFactoryName = (name: string | null): boolean =>
+  name === "useAnalytics" ||
+  name === "useInstrumentation" ||
+  name === "useTelemetry" ||
+  name === "useTracking";
+
+const getStableSymbol = (
+  identifier: EsTreeNodeOfType<"Identifier">,
+  scopes: ScopeAnalysis,
+): SymbolDescriptor | null => {
+  const symbol = resolveConstIdentifierAlias(identifier, scopes);
+  if (!symbol) return null;
+  return symbol.references.some((reference) => reference.flag !== "read") ? null : symbol;
+};
+
+const getImportedBinding = (
+  identifier: EsTreeNodeOfType<"Identifier">,
+  context: ObservationAnalysisContext,
+): ReturnType<typeof getImportBindingForName> => {
+  const stableSymbol = getStableSymbol(identifier, context.scopes);
+  if (!stableSymbol || stableSymbol.kind !== "import") return null;
+  const importedIdentifier = stableSymbol.bindingIdentifier;
+  if (!isNodeOfType(importedIdentifier, "Identifier")) return null;
+  return getImportBindingForName(identifier, importedIdentifier.name);
+};
+
+const isObservationFactoryCall = (
+  expression: EsTreeNode,
+  context: ObservationAnalysisContext,
+): boolean => {
+  const unwrappedExpression = stripParenExpression(expression);
+  if (!isNodeOfType(unwrappedExpression, "CallExpression")) return false;
+  const callee = stripParenExpression(unwrappedExpression.callee as EsTreeNode);
+  if (isNodeOfType(callee, "Identifier")) {
+    const importBinding = getImportedBinding(callee, context);
+    return Boolean(
+      importBinding &&
+      isObservationModuleSource(importBinding.source) &&
+      isObservationFactoryName(importBinding.exportedName),
+    );
+  }
+  if (!isNodeOfType(callee, "MemberExpression")) return false;
+  const receiver = stripParenExpression(callee.object as EsTreeNode);
+  if (!isNodeOfType(receiver, "Identifier")) return false;
+  const importBinding = getImportedBinding(receiver, context);
+  return Boolean(
+    importBinding?.isNamespace &&
+    isObservationModuleSource(importBinding.source) &&
+    isObservationFactoryName(getStaticPropertyName(callee)),
+  );
+};
+
+const isObservationReceiver = (
+  expression: EsTreeNode,
+  context: ObservationAnalysisContext,
+): boolean => {
+  const unwrappedExpression = stripParenExpression(expression);
+  if (isObservationFactoryCall(unwrappedExpression, context)) return true;
+  if (isNodeOfType(unwrappedExpression, "MemberExpression")) {
+    return isObservationReceiver(unwrappedExpression.object as EsTreeNode, context);
+  }
+  if (!isNodeOfType(unwrappedExpression, "Identifier")) return false;
+  const importBinding = getImportedBinding(unwrappedExpression, context);
+  if (importBinding && OBSERVATION_PACKAGE_SOURCES.has(importBinding.source)) return true;
+  const stableSymbol = getStableSymbol(unwrappedExpression, context.scopes);
+  return Boolean(
+    stableSymbol?.initializer && isObservationFactoryCall(stableSymbol.initializer, context),
+  );
+};
+
+const isObservationFunctionExpression = (
+  expression: EsTreeNode,
+  context: ObservationAnalysisContext,
+): boolean => {
+  const unwrappedExpression = stripParenExpression(expression);
+  if (isNodeOfType(unwrappedExpression, "Identifier")) {
+    const symbol = context.scopes.symbolFor(unwrappedExpression);
+    if (symbol && context.observationParameterSymbolIds.has(symbol.id)) return true;
+    const importBinding = getImportedBinding(unwrappedExpression, context);
+    if (
+      importBinding &&
+      OBSERVATION_PACKAGE_SOURCES.has(importBinding.source) &&
+      importBinding.exportedName &&
+      OBSERVATION_METHOD_NAMES.has(importBinding.exportedName)
+    ) {
+      return true;
+    }
+    const stableSymbol = getStableSymbol(unwrappedExpression, context.scopes);
+    return Boolean(
+      stableSymbol?.initializer &&
+      stableSymbol.initializer !== unwrappedExpression &&
+      isObservationFunctionExpression(stableSymbol.initializer, context),
+    );
+  }
+  if (!isNodeOfType(unwrappedExpression, "MemberExpression")) return false;
+  const propertyName = getStaticPropertyName(unwrappedExpression);
+  return Boolean(
+    propertyName &&
+    OBSERVATION_METHOD_NAMES.has(propertyName) &&
+    isObservationReceiver(unwrappedExpression.object as EsTreeNode, context),
+  );
+};
+
+const resolveImportedFunction = (
+  callee: EsTreeNode,
+  context: ObservationAnalysisContext,
+): ResolvedFunctionTarget | null => {
+  const unwrappedCallee = stripParenExpression(callee);
+  let source: string | null = null;
+  let exportedName: string | null = null;
+
+  if (isNodeOfType(unwrappedCallee, "Identifier")) {
+    const importBinding = getImportedBinding(unwrappedCallee, context);
+    source = importBinding?.source ?? null;
+    exportedName = importBinding?.exportedName ?? null;
+  } else if (isNodeOfType(unwrappedCallee, "MemberExpression")) {
+    const receiver = stripParenExpression(unwrappedCallee.object as EsTreeNode);
+    const propertyName = getStaticPropertyName(unwrappedCallee);
+    if (!propertyName || !isNodeOfType(receiver, "Identifier")) return null;
+    const importBinding = getImportedBinding(receiver, context);
+    if (!importBinding?.isNamespace) return null;
+    source = importBinding.source;
+    exportedName = propertyName;
+  }
+
+  if (!source || !exportedName) return null;
+  const resolved = resolveCrossFileFunctionExportWithFilePath(
+    context.filename,
+    source,
+    exportedName,
+  );
+  if (!resolved) return null;
+  return {
+    filename: resolved.filePath,
+    functionNode: resolved.functionNode,
+    scopes: getCrossFileScopes(resolved.programNode),
+  };
+};
+
+const resolveFunctionTarget = (
+  callee: EsTreeNode,
+  context: ObservationAnalysisContext,
+): ResolvedFunctionTarget | null => {
+  const localFunction = resolveExactLocalFunction(callee, context.scopes);
+  if (localFunction) {
+    return { filename: context.filename, functionNode: localFunction, scopes: context.scopes };
+  }
+  return resolveImportedFunction(callee, context);
+};
+
+const isObservationSafeExpression = (
+  expression: EsTreeNode | null | undefined,
+  context: ObservationAnalysisContext,
+): boolean => {
+  if (!expression) return true;
+  const unwrappedExpression = stripParenExpression(expression);
+
+  if (
+    isNodeOfType(unwrappedExpression, "Identifier") ||
+    isNodeOfType(unwrappedExpression, "Literal") ||
+    isNodeOfType(unwrappedExpression, "ThisExpression")
+  ) {
+    return true;
+  }
+  if (isNodeOfType(unwrappedExpression, "CallExpression")) {
+    return isObservationSafeCall(unwrappedExpression, context);
+  }
+  if (isNodeOfType(unwrappedExpression, "MemberExpression")) {
+    return (
+      isObservationSafeExpression(unwrappedExpression.object as EsTreeNode, context) &&
+      (!unwrappedExpression.computed ||
+        isObservationSafeExpression(unwrappedExpression.property as EsTreeNode, context))
+    );
+  }
+  if (
+    isNodeOfType(unwrappedExpression, "BinaryExpression") ||
+    isNodeOfType(unwrappedExpression, "LogicalExpression")
+  ) {
+    return (
+      isObservationSafeExpression(unwrappedExpression.left as EsTreeNode, context) &&
+      isObservationSafeExpression(unwrappedExpression.right as EsTreeNode, context)
+    );
+  }
+  if (isNodeOfType(unwrappedExpression, "ConditionalExpression")) {
+    return (
+      isObservationSafeExpression(unwrappedExpression.test as EsTreeNode, context) &&
+      isObservationSafeExpression(unwrappedExpression.consequent as EsTreeNode, context) &&
+      isObservationSafeExpression(unwrappedExpression.alternate as EsTreeNode, context)
+    );
+  }
+  if (isNodeOfType(unwrappedExpression, "UnaryExpression")) {
+    return (
+      unwrappedExpression.operator !== "delete" &&
+      isObservationSafeExpression(unwrappedExpression.argument as EsTreeNode, context)
+    );
+  }
+  if (isNodeOfType(unwrappedExpression, "AwaitExpression")) {
+    return isObservationSafeExpression(unwrappedExpression.argument as EsTreeNode, context);
+  }
+  if (isNodeOfType(unwrappedExpression, "SequenceExpression")) {
+    return unwrappedExpression.expressions.every((innerExpression) =>
+      isObservationSafeExpression(innerExpression as EsTreeNode, context),
+    );
+  }
+  if (isNodeOfType(unwrappedExpression, "ArrayExpression")) {
+    return unwrappedExpression.elements.every((element) => {
+      if (!element) return true;
+      if (isNodeOfType(element as EsTreeNode, "SpreadElement")) {
+        return isObservationSafeExpression(
+          (element as EsTreeNodeOfType<"SpreadElement">).argument,
+          context,
+        );
+      }
+      return isObservationSafeExpression(element as EsTreeNode, context);
+    });
+  }
+  if (isNodeOfType(unwrappedExpression, "ObjectExpression")) {
+    return unwrappedExpression.properties.every((property) => {
+      if (isNodeOfType(property, "SpreadElement")) {
+        return isObservationSafeExpression(property.argument, context);
+      }
+      if (!isNodeOfType(property, "Property") || property.kind !== "init" || property.method) {
+        return false;
+      }
+      return (
+        (!property.computed || isObservationSafeExpression(property.key as EsTreeNode, context)) &&
+        isObservationSafeExpression(property.value as EsTreeNode, context)
+      );
+    });
+  }
+  if (isNodeOfType(unwrappedExpression, "TemplateLiteral")) {
+    return unwrappedExpression.expressions.every((innerExpression) =>
+      isObservationSafeExpression(innerExpression as EsTreeNode, context),
+    );
+  }
+  return false;
+};
+
+const buildObservationParameterSymbolIds = (
+  functionNode: ResolvedFunctionTarget["functionNode"],
+  functionScopes: ScopeAnalysis,
+  argumentsList: ReadonlyArray<EsTreeNode>,
+  callerContext: ObservationAnalysisContext,
+): ReadonlySet<number> => {
+  const observationParameterSymbolIds = new Set<number>();
+  if (!isFunctionLike(functionNode)) return observationParameterSymbolIds;
+  for (let parameterIndex = 0; parameterIndex < functionNode.params.length; parameterIndex += 1) {
+    const parameter = functionNode.params[parameterIndex] as EsTreeNode;
+    const argument = argumentsList[parameterIndex];
+    if (
+      !argument ||
+      !isNodeOfType(parameter, "Identifier") ||
+      !isObservationFunctionExpression(argument, callerContext)
+    ) {
+      continue;
+    }
+    const parameterSymbol = functionScopes.symbolFor(parameter);
+    if (parameterSymbol) observationParameterSymbolIds.add(parameterSymbol.id);
+  }
+  return observationParameterSymbolIds;
+};
+
+const isObservationSafeStatement = (
+  statement: EsTreeNode,
+  context: ObservationAnalysisContext,
+): boolean => {
+  if (isNodeOfType(statement, "BlockStatement")) {
+    return statement.body.every((innerStatement) =>
+      isObservationSafeStatement(innerStatement as EsTreeNode, context),
+    );
+  }
+  if (isNodeOfType(statement, "ExpressionStatement")) {
+    return isObservationSafeExpression(statement.expression as EsTreeNode, context);
+  }
+  if (isNodeOfType(statement, "ReturnStatement")) {
+    return isObservationSafeExpression(statement.argument as EsTreeNode | null, context);
+  }
+  if (isNodeOfType(statement, "VariableDeclaration")) {
+    return statement.declarations.every((declaration) =>
+      isObservationSafeExpression(declaration.init as EsTreeNode | null, context),
+    );
+  }
+  if (isNodeOfType(statement, "IfStatement")) {
+    return (
+      isObservationSafeExpression(statement.test as EsTreeNode, context) &&
+      isObservationSafeStatement(statement.consequent as EsTreeNode, context) &&
+      (!statement.alternate ||
+        isObservationSafeStatement(statement.alternate as EsTreeNode, context))
+    );
+  }
+  if (isNodeOfType(statement, "SwitchStatement")) {
+    return (
+      isObservationSafeExpression(statement.discriminant as EsTreeNode, context) &&
+      statement.cases.every((switchCase) =>
+        switchCase.consequent.every((innerStatement) =>
+          isObservationSafeStatement(innerStatement as EsTreeNode, context),
+        ),
+      )
+    );
+  }
+  return (
+    isNodeOfType(statement, "EmptyStatement") || isNodeOfType(statement, "FunctionDeclaration")
+  );
+};
+
+const isObservationSafeFunction = (
+  target: ResolvedFunctionTarget,
+  argumentsList: ReadonlyArray<EsTreeNode>,
+  callerContext: ObservationAnalysisContext,
+): boolean => {
+  if (!isFunctionLike(target.functionNode)) return false;
+  if (callerContext.callDepth >= OBSERVATION_ONLY_HANDLER_MAX_CALL_DEPTH) return false;
+  if (callerContext.visitedFunctions.has(target.functionNode)) return false;
+  const visitedFunctions = new Set(callerContext.visitedFunctions);
+  visitedFunctions.add(target.functionNode);
+  const context: ObservationAnalysisContext = {
+    filename: target.filename,
+    scopes: target.scopes,
+    observationParameterSymbolIds: buildObservationParameterSymbolIds(
+      target.functionNode,
+      target.scopes,
+      argumentsList,
+      callerContext,
+    ),
+    visitedFunctions,
+    callDepth: callerContext.callDepth + 1,
+    evidence: callerContext.evidence,
+  };
+  return (
+    isObservationSafeExpression(target.functionNode.body as EsTreeNode, context) ||
+    isObservationSafeStatement(target.functionNode.body as EsTreeNode, context)
+  );
+};
+
+const isObservationSafeCall = (
+  callExpression: EsTreeNodeOfType<"CallExpression">,
+  context: ObservationAnalysisContext,
+): boolean => {
+  const argumentsList: EsTreeNode[] = [];
+  for (const argument of callExpression.arguments) {
+    const argumentNode = argument as EsTreeNode;
+    if (isNodeOfType(argumentNode, "SpreadElement")) {
+      if (!isObservationSafeExpression(argumentNode.argument, context)) return false;
+      argumentsList.push(argumentNode.argument);
+      continue;
+    }
+    if (!isObservationSafeExpression(argumentNode, context)) return false;
+    argumentsList.push(argumentNode);
+  }
+
+  const callee = callExpression.callee as EsTreeNode;
+  if (isObservationFunctionExpression(callee, context)) {
+    context.evidence.didFindObservationCall = true;
+    return true;
+  }
+  const target = resolveFunctionTarget(callee, context);
+  return Boolean(target && isObservationSafeFunction(target, argumentsList, context));
+};
+
+export const isProvenObservationOnlyJsxHandler = (
+  attribute: EsTreeNodeOfType<"JSXAttribute">,
+  context: RuleContext,
+): boolean => {
+  if (!context.filename || !attribute.value) return false;
+  const attributeValue = attribute.value as EsTreeNode;
+  if (!isNodeOfType(attributeValue, "JSXExpressionContainer")) return false;
+  const handlerExpression = stripParenExpression(attributeValue.expression as EsTreeNode);
+  const handlerFunction = resolveExactLocalFunction(handlerExpression, context.scopes);
+  if (!handlerFunction) return false;
+  const analysisContext: ObservationAnalysisContext = {
+    filename: context.filename,
+    scopes: context.scopes,
+    observationParameterSymbolIds: new Set<number>(),
+    visitedFunctions: new Set<EsTreeNode>(),
+    callDepth: 0,
+    evidence: { didFindObservationCall: false },
+  };
+  const isSafe = isObservationSafeFunction(
+    { filename: context.filename, functionNode: handlerFunction, scopes: context.scopes },
+    [],
+    analysisContext,
+  );
+  return isSafe && analysisContext.evidence.didFindObservationCall;
+};


### PR DESCRIPTION
## Why

Nexu open-design at `52611c07dbf922b775d813d6af1323c40fe20a52` attaches an `onClick` to `IntegrationsView.tsx:170` solely to emit the `integrations / skills_tab / coming_soon` analytics event. The section exposes no navigation, state change, submission, selection, or other user-facing operation. Runtime replay records the analytics event while leaving the DOM unchanged, so keyboard activation is not an equivalent product action that the section must expose.

Baseline `ece35b3ff` reports one `no-noninteractive-element-interactions` diagnostic at that exact site. This branch reports zero there.

## What changed

- Ignores an interaction handler only when every analyzed path is observation-only and at least one observation call has verified SDK provenance.
- Follows stable local wrappers and bounded named/namespace cross-file calls used by the authentic Nexu chain.
- Keeps unknown callbacks, unverified analytics-named factories, state/navigation, assignments, opaque member/destructuring reads, mixed branches, and function callbacks passed to analytics methods reportable.
- Declares the rule cross-file and fingerprints its actually called imports for sidecar-cache correctness.
- Adds a patch changeset and permanent fuzz corpus seed.

## Precision boundary

This does not infer safety from names such as `track` or from an `analytics/` path alone. A local factory must lead to a recognized analytics SDK import. Getter/proxy-capable reads and callback arguments remain conservative unless the value is proven plain local data. Analysis is depth-bounded; unresolved or deeper call graphs continue to report.

## Tests

- Exact pinned Nexu source: target diagnostic `1 -> 0`, parse-clean.
- Paired positives cover state, navigation, opaque callbacks, reassignment, dynamic methods, mixed branches, switch-case effects, unsafe defaults, unverified factories, callback invocation, and getter-backed payload/destructuring reads.
- Clean counterexamples cover direct PostHog capture, stable aliases, namespace/optional calls, supplied arguments that skip defaults, switch `break`, and stable computed analytics methods.
- Focused cross-file rule tests: 24 passed.
- Full oxlint plugin: 560 files, 13,988 passed, 181 skipped.
- Full core: 118 files, 1,376 passed.
- Plugin typecheck and cross-file registry tests pass.
- Strict fuzz: `FUZZ_RULE=no-noninteractive-element-interactions FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz` passes; direct stats show 40 fired programs / 333 executed, 221 parse skips, zero findings.

The PR remains draft until the replacement CI matrix and review audit are both clean.
