### PR TITLE
fix(rule): allow proven write-only createRef adapters

### DIFF
--- a/.changeset/calm-refs-attach.md
+++ b/.changeset/calm-refs-attach.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Improve `no-create-ref-in-function-component` precision for render-local attachment refs while preserving stale-ref diagnostics.

--- a/packages/core/tests/cross-file-rule-ids.test.ts
+++ b/packages/core/tests/cross-file-rule-ids.test.ts
@@ -142,6 +142,7 @@ describe("CROSS_FILE_RULE_IDS", () => {
       "nextjs-no-use-search-params-without-suspense",
       "no-adjust-state-on-prop-change",
       "no-barrel-import",
+      "no-create-ref-in-function-component",
       "no-derived-state",
       "no-derived-state-effect",
       "no-dynamic-import-path",

--- a/packages/fuzz/corpus/regressions/no-create-ref-in-function-component--write-only-ref-adapter.tsx
+++ b/packages/fuzz/corpus/regressions/no-create-ref-in-function-component--write-only-ref-adapter.tsx
@@ -1,0 +1,44 @@
+// rule: no-create-ref-in-function-component
+// weakness: cross-file
+// source: Cloudscape React Bench issue 4461
+
+import { createRef, type RefObject } from "react";
+
+interface FocusControl {
+  refs: {
+    toggle: RefObject<HTMLButtonElement | null>;
+    close: RefObject<HTMLButtonElement | null>;
+    slider: RefObject<HTMLDivElement | null>;
+  };
+  setFocus(): void;
+  loseFocus(): void;
+}
+
+interface NavigationProps {
+  focusControl: FocusControl;
+}
+
+const Navigation = ({ focusControl }: NavigationProps) => (
+  <button ref={focusControl.refs.close}>Close navigation</button>
+);
+
+export const PendingAdapter = ({ isPending }: { isPending: boolean }) => {
+  if (!isPending) return <main>Ready content</main>;
+
+  const focusControl: FocusControl = {
+    refs: {
+      toggle: createRef<HTMLButtonElement>(),
+      close: createRef<HTMLButtonElement>(),
+      slider: createRef<HTMLDivElement>(),
+    },
+    setFocus: () => {},
+    loseFocus: () => {},
+  };
+
+  return (
+    <>
+      <button ref={focusControl.refs.toggle}>Open navigation</button>
+      <Navigation focusControl={focusControl} />
+    </>
+  );
+};

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -99,6 +99,7 @@ export const STATE_SNIPPET_POOL = [
   `const [reducerState, dispatch] = useReducer(reducer, { count: 0 });`,
   `const containerRef = useRef(null);`,
   `const fuzzWriteOnlyFocusControl = { refs: { toggle: createRef(), close: createRef(), slider: createRef() }, setFocus: () => {}, loseFocus: () => {} }; const fuzzWriteOnlyFocusNode = <button ref={fuzzWriteOnlyFocusControl.refs.toggle}>Open</button>;`,
+  `const fuzzObservedTarget = createRef(); useEffect(() => handle(fuzzObservedTarget), [fuzzObservedTarget]);`,
   `const handleRef = useRef(handle); handleRef.current = handle;`,
   `const [copied, setCopied] = useState(false);`,
   `const [cache] = useState(new Map());`,

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -98,6 +98,7 @@ export const STATE_SNIPPET_POOL = [
   `const FuzzOpaqueVisibilityPanel = ({ visible, isAllowed }) => { const [canShowPanel, setCanShowPanel] = useState(true); useEffect(() => { setCanShowPanel(true); }, [visible]); return visible && isAllowed() && canShowPanel && <output onClick={() => setCanShowPanel(false)}>Panel</output>; }; const fuzzOpaqueVisibilityPanelNode = <FuzzOpaqueVisibilityPanel visible={condition} isAllowed={() => condition} />;`,
   `const [reducerState, dispatch] = useReducer(reducer, { count: 0 });`,
   `const containerRef = useRef(null);`,
+  `const fuzzWriteOnlyFocusControl = { refs: { toggle: createRef(), close: createRef(), slider: createRef() }, setFocus: () => {}, loseFocus: () => {} }; const fuzzWriteOnlyFocusNode = <button ref={fuzzWriteOnlyFocusControl.refs.toggle}>Open</button>;`,
   `const handleRef = useRef(handle); handleRef.current = handle;`,
   `const [copied, setCopied] = useState(false);`,
   `const [cache] = useState(new Map());`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/cross-file-rule-ids.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/cross-file-rule-ids.ts
@@ -45,6 +45,7 @@ export const CROSS_FILE_RULE_IDS: ReadonlySet<string> = new Set([
   "no-indeterminate-attribute",
   "no-locale-format-in-render",
   "no-match-media-in-state-initializer",
+  "no-create-ref-in-function-component",
   "no-adjust-state-on-prop-change",
   "no-derived-state",
   "no-derived-state-effect",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/thresholds.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/thresholds.ts
@@ -46,6 +46,7 @@ export const MIN_OVERPRECISE_SVG_TOKEN_OCCURRENCES = 2;
 export const CROSS_FILE_PARSE_MAX_BYTES = 2_000_000;
 export const CROSS_FILE_BARREL_FOLLOW_DEPTH = 4;
 export const CUSTOM_HOOK_DEPENDENCY_FORWARD_DEPTH = 4;
+export const CREATE_REF_PROP_FLOW_MAX_DEPTH = 12;
 
 // Bounds for upward directory walks used by cross-file resolvers:
 // `CROSS_FILE_DIRECTORY_WALK_MAX_LEVELS` caps how many parent

--- a/packages/oxlint-plugin-react-doctor/src/plugin/cross-file-dependencies.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/cross-file-dependencies.test.ts
@@ -390,16 +390,18 @@ describe("react-native collectors", () => {
 });
 
 describe("no-create-ref-in-function-component collector", () => {
-  it("records every module in a bounded ref-forwarding chain on warm and cold collection", () => {
+  it("records the modules in the createRef consumer chain on warm and cold collection", () => {
     writeFixtureFile(
       "src/use-forward-focus.ts",
-      `export default function useForwardFocus(ref) {
+      `import { useImperativeHandle } from "react";
+export default function useForwardFocus(ref) {
   useImperativeHandle(ref, () => ({}));
 }`,
     );
     writeFixtureFile(
       "src/button.tsx",
-      `import useForwardFocus from "./use-forward-focus";
+      `import React from "react";
+import useForwardFocus from "./use-forward-focus";
 export const Button = React.forwardRef((props, ref) => {
   useForwardFocus(ref);
   return <button {...props} />;
@@ -412,8 +414,12 @@ export const Navigation = ({ target }) => <Button ref={target} />;`,
     );
     const appPath = writeFixtureFile(
       "src/App.tsx",
-      `import { Navigation } from "./navigation";
-export const App = () => <Navigation target={createRef()} />;`,
+      `import { createRef } from "react";
+import { Navigation } from "./navigation";
+export const App = () => {
+  const target = createRef();
+  return <Navigation target={target} />;
+};`,
     );
 
     const firstTrace = collectFor(appPath, ["no-create-ref-in-function-component"]);
@@ -423,6 +429,27 @@ export const App = () => <Navigation target={createRef()} />;`,
       expect(trace?.contentPaths.has(fixturePath("src/button.tsx"))).toBe(true);
       expect(trace?.contentPaths.has(fixturePath("src/use-forward-focus.ts"))).toBe(true);
     }
+  });
+
+  it("does not traverse unrelated import fan-out while fingerprinting", () => {
+    for (let moduleIndex = 0; moduleIndex < 100; moduleIndex += 1) {
+      writeFixtureFile(
+        `src/unrelated-${moduleIndex}.tsx`,
+        `export const unrelated${moduleIndex} = ${moduleIndex};\n`,
+      );
+    }
+    const appPath = writeFixtureFile(
+      "src/App.tsx",
+      `${Array.from(
+        { length: 100 },
+        (_, moduleIndex) => `import { unrelated${moduleIndex} } from "./unrelated-${moduleIndex}";`,
+      ).join("\n")}
+export const App = () => <div>{unrelated0}</div>;`,
+    );
+    const trace = collectFor(appPath, ["no-create-ref-in-function-component"]);
+    expect(trace).not.toBeNull();
+    expect(trace?.contentPaths.size).toBe(0);
+    expect(trace?.existencePaths.size).toBe(0);
   });
 });
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/cross-file-dependencies.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/cross-file-dependencies.test.ts
@@ -389,6 +389,43 @@ describe("react-native collectors", () => {
   });
 });
 
+describe("no-create-ref-in-function-component collector", () => {
+  it("records every module in a bounded ref-forwarding chain on warm and cold collection", () => {
+    writeFixtureFile(
+      "src/use-forward-focus.ts",
+      `export default function useForwardFocus(ref) {
+  useImperativeHandle(ref, () => ({}));
+}`,
+    );
+    writeFixtureFile(
+      "src/button.tsx",
+      `import useForwardFocus from "./use-forward-focus";
+export const Button = React.forwardRef((props, ref) => {
+  useForwardFocus(ref);
+  return <button {...props} />;
+});`,
+    );
+    writeFixtureFile(
+      "src/navigation.tsx",
+      `import { Button } from "./button";
+export const Navigation = ({ target }) => <Button ref={target} />;`,
+    );
+    const appPath = writeFixtureFile(
+      "src/App.tsx",
+      `import { Navigation } from "./navigation";
+export const App = () => <Navigation target={createRef()} />;`,
+    );
+
+    const firstTrace = collectFor(appPath, ["no-create-ref-in-function-component"]);
+    const repeatTrace = collectFor(appPath, ["no-create-ref-in-function-component"]);
+    for (const trace of [firstTrace, repeatTrace]) {
+      expect(trace?.contentPaths.has(fixturePath("src/navigation.tsx"))).toBe(true);
+      expect(trace?.contentPaths.has(fixturePath("src/button.tsx"))).toBe(true);
+      expect(trace?.contentPaths.has(fixturePath("src/use-forward-focus.ts"))).toBe(true);
+    }
+  });
+});
+
 describe("collector registry", () => {
   it("classifies every cross-file rule as bounded or unbounded", () => {
     expect(

--- a/packages/oxlint-plugin-react-doctor/src/plugin/cross-file-dependencies.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/cross-file-dependencies.test.ts
@@ -438,18 +438,33 @@ export const App = () => {
         `export const unrelated${moduleIndex} = ${moduleIndex};\n`,
       );
     }
+    writeFixtureFile(
+      "src/ref-sink.tsx",
+      `export const RefSink = ({ target }) => <input ref={target} />;\n`,
+    );
     const appPath = writeFixtureFile(
       "src/App.tsx",
-      `${Array.from(
-        { length: 100 },
-        (_, moduleIndex) => `import { unrelated${moduleIndex} } from "./unrelated-${moduleIndex}";`,
-      ).join("\n")}
-export const App = () => <div>{unrelated0}</div>;`,
+      `import { createRef } from "react";
+import { RefSink } from "./ref-sink";
+${Array.from(
+  { length: 100 },
+  (_, moduleIndex) => `import { unrelated${moduleIndex} } from "./unrelated-${moduleIndex}";`,
+).join("\n")}
+export const App = () => {
+  const target = createRef();
+  return <><RefSink target={target} /><div>{unrelated0}</div></>;
+};`,
     );
     const trace = collectFor(appPath, ["no-create-ref-in-function-component"]);
     expect(trace).not.toBeNull();
-    expect(trace?.contentPaths.size).toBe(0);
-    expect(trace?.existencePaths.size).toBe(0);
+    expect(trace?.contentPaths).toEqual(new Set([fixturePath("src/ref-sink.tsx")]));
+    expect(trace?.existencePaths.size).toBeLessThan(20);
+    for (let moduleIndex = 0; moduleIndex < 100; moduleIndex += 1) {
+      expect(trace?.contentPaths.has(fixturePath(`src/unrelated-${moduleIndex}.tsx`))).toBe(false);
+      expect(trace?.existencePaths.has(fixturePath(`src/unrelated-${moduleIndex}.tsx`))).toBe(
+        false,
+      );
+    }
   });
 });
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/cross-file-dependencies.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/cross-file-dependencies.ts
@@ -1,22 +1,23 @@
 import { parseSync } from "oxc-parser";
 import type { StaticImport } from "oxc-parser";
+import { analyzeScopes } from "./semantic/scope-analysis.js";
 import {
   INTERNAL_PAGE_PATH_PATTERN,
   PAGE_FILE_PATTERN,
   PAGE_OR_LAYOUT_FILE_PATTERN,
 } from "./constants/nextjs.js";
-import {
-  CREATE_REF_PROP_FLOW_MAX_DEPTH,
-  CUSTOM_HOOK_DEPENDENCY_FORWARD_DEPTH,
-} from "./constants/thresholds.js";
+import { CUSTOM_HOOK_DEPENDENCY_FORWARD_DEPTH } from "./constants/thresholds.js";
 import { classifyPackagePlatform } from "./utils/classify-package-platform.js";
 import { collectCrossFileProbes } from "./utils/cross-file-probe-recorder.js";
 import type { CrossFileProbeTrace } from "./utils/cross-file-probe-recorder.js";
 import type { EsTreeNode } from "./utils/es-tree-node.js";
+import { attachParentReferences } from "./utils/attach-parent-references.js";
 import { hasAncestorMetadataLayout } from "./utils/find-ancestor-metadata-layout.js";
 import { hasAncestorSuspenseLayout } from "./utils/find-ancestor-suspense-layout.js";
 import { isBarrelIndexModule } from "./utils/is-barrel-index-module.js";
 import { isLegacyArchReactNativeFile } from "./utils/is-legacy-arch-react-native-file.js";
+import { isNodeOfType } from "./utils/is-node-of-type.js";
+import { isReactApiCall } from "./utils/is-react-api-call.js";
 import { normalizeFilename } from "./utils/normalize-filename.js";
 import { resolveLang } from "./utils/parse-source-file.js";
 import { resolveBarrelExportFilePath } from "./utils/resolve-barrel-export-file-path.js";
@@ -27,6 +28,7 @@ import {
 import { resolveRelativeImportPath } from "./utils/resolve-relative-import-path.js";
 import { stripParenExpression } from "./utils/strip-paren-expression.js";
 import { walkAst } from "./utils/walk-ast.js";
+import { isCreateRefResultWriteOnly } from "./rules/react-builtins/is-create-ref-result-write-only.js";
 
 /**
  * Per-rule cross-file dependency collectors — the foundation of the sidecar
@@ -204,49 +206,67 @@ const flattenProgramImportEntries = (program: EsTreeNode): ImportEntryName[] => 
   return entries;
 };
 
-const collectForwardedValueDependencies =
-  (maximumDepth: number): CrossFileDependencyCollector =>
-  ({ absoluteFilePath, staticImports }) => {
-    const greatestTraversedDepthByFilePath = new Map<string, number>();
+const collectForwardedHookDependencies: CrossFileDependencyCollector = ({
+  absoluteFilePath,
+  staticImports,
+}) => {
+  const greatestTraversedDepthByFilePath = new Map<string, number>();
 
-    const collectProgramDependencies = (
-      filePath: string,
-      program: EsTreeNode,
-      remainingDepth: number,
-    ): void => {
-      const previousDepth = greatestTraversedDepthByFilePath.get(filePath) ?? -1;
-      if (previousDepth >= remainingDepth) return;
-      greatestTraversedDepthByFilePath.set(filePath, remainingDepth);
+  const collectProgramDependencies = (
+    filePath: string,
+    program: EsTreeNode,
+    remainingDepth: number,
+  ): void => {
+    const previousDepth = greatestTraversedDepthByFilePath.get(filePath) ?? -1;
+    if (previousDepth >= remainingDepth) return;
+    greatestTraversedDepthByFilePath.set(filePath, remainingDepth);
 
-      for (const entry of flattenProgramImportEntries(program)) {
-        const resolved = resolveCrossFileValueExportWithFilePath(
-          filePath,
-          entry.source,
-          entry.exportedName,
-        );
-        if (!resolved || remainingDepth === 0) continue;
-        collectProgramDependencies(resolved.filePath, resolved.programNode, remainingDepth - 1);
-      }
-    };
-
-    for (const entry of flattenImportEntries(staticImports)) {
+    for (const entry of flattenProgramImportEntries(program)) {
       const resolved = resolveCrossFileValueExportWithFilePath(
-        absoluteFilePath,
+        filePath,
         entry.source,
         entry.exportedName,
       );
-      if (!resolved) continue;
-      collectProgramDependencies(resolved.filePath, resolved.programNode, maximumDepth);
+      if (!resolved || remainingDepth === 0) continue;
+      collectProgramDependencies(resolved.filePath, resolved.programNode, remainingDepth - 1);
     }
   };
 
-const collectForwardedHookDependencies = collectForwardedValueDependencies(
-  CUSTOM_HOOK_DEPENDENCY_FORWARD_DEPTH,
-);
+  for (const entry of flattenImportEntries(staticImports)) {
+    const resolved = resolveCrossFileValueExportWithFilePath(
+      absoluteFilePath,
+      entry.source,
+      entry.exportedName,
+    );
+    if (!resolved) continue;
+    collectProgramDependencies(
+      resolved.filePath,
+      resolved.programNode,
+      CUSTOM_HOOK_DEPENDENCY_FORWARD_DEPTH,
+    );
+  }
+};
 
-const collectCreateRefDependencies = collectForwardedValueDependencies(
-  CREATE_REF_PROP_FLOW_MAX_DEPTH,
-);
+const collectCreateRefDependencies: CrossFileDependencyCollector = ({
+  absoluteFilePath,
+  program,
+}) => {
+  attachParentReferences(program);
+  const scopes = analyzeScopes(program);
+  walkAst(program, (node) => {
+    if (
+      !isNodeOfType(node, "CallExpression") ||
+      !isReactApiCall(node, "createRef", scopes, {
+        allowGlobalReactNamespace: true,
+        allowUnboundBareCalls: true,
+        resolveNamedAliases: true,
+      })
+    ) {
+      return;
+    }
+    isCreateRefResultWriteOnly(node, absoluteFilePath, scopes);
+  });
+};
 
 // no-mutating-reducer-state only reads another file when a `useReducer`
 // call's reducer argument resolves to an imported binding, and the call must

--- a/packages/oxlint-plugin-react-doctor/src/plugin/cross-file-dependencies.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/cross-file-dependencies.ts
@@ -5,7 +5,10 @@ import {
   PAGE_FILE_PATTERN,
   PAGE_OR_LAYOUT_FILE_PATTERN,
 } from "./constants/nextjs.js";
-import { CUSTOM_HOOK_DEPENDENCY_FORWARD_DEPTH } from "./constants/thresholds.js";
+import {
+  CREATE_REF_PROP_FLOW_MAX_DEPTH,
+  CUSTOM_HOOK_DEPENDENCY_FORWARD_DEPTH,
+} from "./constants/thresholds.js";
 import { classifyPackagePlatform } from "./utils/classify-package-platform.js";
 import { collectCrossFileProbes } from "./utils/cross-file-probe-recorder.js";
 import type { CrossFileProbeTrace } from "./utils/cross-file-probe-recorder.js";
@@ -201,46 +204,49 @@ const flattenProgramImportEntries = (program: EsTreeNode): ImportEntryName[] => 
   return entries;
 };
 
-const collectForwardedHookDependencies: CrossFileDependencyCollector = ({
-  absoluteFilePath,
-  staticImports,
-}) => {
-  const greatestTraversedDepthByFilePath = new Map<string, number>();
+const collectForwardedValueDependencies =
+  (maximumDepth: number): CrossFileDependencyCollector =>
+  ({ absoluteFilePath, staticImports }) => {
+    const greatestTraversedDepthByFilePath = new Map<string, number>();
 
-  const collectProgramDependencies = (
-    filePath: string,
-    program: EsTreeNode,
-    remainingDepth: number,
-  ): void => {
-    const previousDepth = greatestTraversedDepthByFilePath.get(filePath) ?? -1;
-    if (previousDepth >= remainingDepth) return;
-    greatestTraversedDepthByFilePath.set(filePath, remainingDepth);
+    const collectProgramDependencies = (
+      filePath: string,
+      program: EsTreeNode,
+      remainingDepth: number,
+    ): void => {
+      const previousDepth = greatestTraversedDepthByFilePath.get(filePath) ?? -1;
+      if (previousDepth >= remainingDepth) return;
+      greatestTraversedDepthByFilePath.set(filePath, remainingDepth);
 
-    for (const entry of flattenProgramImportEntries(program)) {
+      for (const entry of flattenProgramImportEntries(program)) {
+        const resolved = resolveCrossFileValueExportWithFilePath(
+          filePath,
+          entry.source,
+          entry.exportedName,
+        );
+        if (!resolved || remainingDepth === 0) continue;
+        collectProgramDependencies(resolved.filePath, resolved.programNode, remainingDepth - 1);
+      }
+    };
+
+    for (const entry of flattenImportEntries(staticImports)) {
       const resolved = resolveCrossFileValueExportWithFilePath(
-        filePath,
+        absoluteFilePath,
         entry.source,
         entry.exportedName,
       );
-      if (!resolved || remainingDepth === 0) continue;
-      collectProgramDependencies(resolved.filePath, resolved.programNode, remainingDepth - 1);
+      if (!resolved) continue;
+      collectProgramDependencies(resolved.filePath, resolved.programNode, maximumDepth);
     }
   };
 
-  for (const entry of flattenImportEntries(staticImports)) {
-    const resolved = resolveCrossFileValueExportWithFilePath(
-      absoluteFilePath,
-      entry.source,
-      entry.exportedName,
-    );
-    if (!resolved) continue;
-    collectProgramDependencies(
-      resolved.filePath,
-      resolved.programNode,
-      CUSTOM_HOOK_DEPENDENCY_FORWARD_DEPTH,
-    );
-  }
-};
+const collectForwardedHookDependencies = collectForwardedValueDependencies(
+  CUSTOM_HOOK_DEPENDENCY_FORWARD_DEPTH,
+);
+
+const collectCreateRefDependencies = collectForwardedValueDependencies(
+  CREATE_REF_PROP_FLOW_MAX_DEPTH,
+);
 
 // no-mutating-reducer-state only reads another file when a `useReducer`
 // call's reducer argument resolves to an imported binding, and the call must
@@ -420,6 +426,7 @@ export const CROSS_FILE_DEPENDENCY_COLLECTORS: ReadonlyMap<string, CrossFileDepe
     ["no-indeterminate-attribute", collectNearestManifestDependencies],
     ["no-locale-format-in-render", collectNearestManifestDependencies],
     ["no-match-media-in-state-initializer", collectNearestManifestDependencies],
+    ["no-create-ref-in-function-component", collectCreateRefDependencies],
     ["no-adjust-state-on-prop-change", collectEffectValueHelperDependencies],
     ["no-derived-state", collectEffectValueHelperDependencies],
     ["no-derived-state-effect", collectEffectValueHelperDependencies],

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/__fixtures__/create-ref-children-consumers.js
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/__fixtures__/create-ref-children-consumers.js
@@ -1,0 +1,6 @@
+export const ForwardingChildren = ({ children }) => children;
+
+export const RetainingChildren = ({ children, retain }) => {
+  retain(children);
+  return null;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/__fixtures__/create-ref-namespace-child.js
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/__fixtures__/create-ref-namespace-child.js
@@ -1,0 +1,8 @@
+import { createElement, useEffect } from "react";
+
+export const Child = ({ target }) => createElement("input", { ref: target });
+
+export const RetainingChild = ({ target, observe }) => {
+  useEffect(() => observe(target), [observe, target]);
+  return createElement("input", { ref: target });
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/is-create-ref-result-write-only.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/is-create-ref-result-write-only.ts
@@ -1,24 +1,22 @@
 import { CREATE_REF_PROP_FLOW_MAX_DEPTH } from "../../constants/thresholds.js";
 import { analyzeScopes } from "../../semantic/scope-analysis.js";
 import type { ScopeAnalysis, SymbolDescriptor } from "../../semantic/scope-analysis.js";
+import { collectFunctionChildrenReferences } from "../../utils/collect-function-children-references.js";
 import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
 import { findProgramRoot } from "../../utils/find-program-root.js";
 import { findTransparentExpressionRoot } from "../../utils/find-transparent-expression-root.js";
 import { functionContainsReactRenderOutput } from "../../utils/function-contains-react-render-output.js";
 import { getImportBindingForName } from "../../utils/find-import-source-for-name.js";
 import { getJsxAttributeName } from "../../utils/get-jsx-attribute-name.js";
-import { getImportedName } from "../../utils/get-imported-name.js";
 import { getStaticPropertyKeyName } from "../../utils/get-static-property-key-name.js";
 import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
+import { hasSymbolWriteBefore } from "../../utils/has-symbol-write-before.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { isProvenReactClassComponent as isProvenReactClassNode } from "../../utils/is-proven-react-class-component.js";
 import { isProvenIntrinsicJsxElement } from "../../utils/is-proven-intrinsic-jsx-element.js";
 import { walkAst } from "../../utils/walk-ast.js";
-import {
-  isImportedFromReact,
-  isReactApiCall,
-  isReactNamespaceImport,
-} from "../../utils/is-react-api-call.js";
+import { isReactApiCall } from "../../utils/is-react-api-call.js";
 import {
   resolveCrossFileValueExportWithFilePath,
   type ResolvedCrossFileValueExport,
@@ -173,7 +171,14 @@ const unwrapProvenReactHocFunction = (
   if (isFunctionLike(current)) return current;
   if (isNodeOfType(current, "Identifier")) {
     const symbol = scopes.symbolFor(current);
-    if (!symbol || visitedSymbolIds.has(symbol.id) || !symbol.initializer) return null;
+    if (
+      !symbol ||
+      visitedSymbolIds.has(symbol.id) ||
+      !symbol.initializer ||
+      hasSymbolWriteBefore(symbol, current, scopes)
+    ) {
+      return null;
+    }
     visitedSymbolIds.add(symbol.id);
     return unwrapProvenReactHocFunction(symbol.initializer, scopes, visitedSymbolIds);
   }
@@ -197,7 +202,14 @@ const isForwardRefValue = (
   const current = findTransparentExpressionRoot(node);
   if (isNodeOfType(current, "Identifier")) {
     const symbol = scopes.symbolFor(current);
-    if (!symbol || !symbol.initializer || visitedSymbolIds.has(symbol.id)) return false;
+    if (
+      !symbol ||
+      !symbol.initializer ||
+      visitedSymbolIds.has(symbol.id) ||
+      hasSymbolWriteBefore(symbol, current, scopes)
+    ) {
+      return false;
+    }
     visitedSymbolIds.add(symbol.id);
     return isForwardRefValue(symbol.initializer, scopes, visitedSymbolIds);
   }
@@ -233,6 +245,7 @@ const resolveFunctionValue = (
   }
   const symbol = environment.scopes.symbolFor(identifier);
   if (symbol && symbol.kind !== "import") {
+    if (hasSymbolWriteBefore(symbol, identifier, environment.scopes)) return null;
     const functionNode = unwrapProvenReactHocFunction(symbol.initializer, environment.scopes);
     if (!functionNode) return null;
     return {
@@ -277,7 +290,7 @@ const resolveJsxFunctionValue = (
   return resolved ? functionFromExport(resolved, state) : null;
 };
 
-const isProvenReactClassComponent = (
+const isProvenReactClassValue = (
   node: EsTreeNode,
   environment: AnalysisEnvironment,
   visitedSymbolIds: Set<number> = new Set(),
@@ -285,36 +298,18 @@ const isProvenReactClassComponent = (
   const current = findTransparentExpressionRoot(node);
   if (isNodeOfType(current, "Identifier")) {
     const symbol = environment.scopes.symbolFor(current);
-    if (!symbol || !symbol.initializer || visitedSymbolIds.has(symbol.id)) return false;
-    visitedSymbolIds.add(symbol.id);
-    return isProvenReactClassComponent(symbol.initializer, environment, visitedSymbolIds);
-  }
-  if (!isNodeOfType(current, "ClassDeclaration") && !isNodeOfType(current, "ClassExpression")) {
-    return false;
-  }
-  const isProvenReactComponentBase = (baseNode: EsTreeNode): boolean => {
-    const base = findTransparentExpressionRoot(baseNode);
-    if (isNodeOfType(base, "Identifier")) {
-      const symbol = environment.scopes.symbolFor(base);
-      if (symbol?.kind === "const" && symbol.initializer && !visitedSymbolIds.has(symbol.id)) {
-        visitedSymbolIds.add(symbol.id);
-        return isProvenReactComponentBase(symbol.initializer);
-      }
-      const importedName = symbol ? getImportedName(symbol.declarationNode) : null;
-      return Boolean(
-        symbol &&
-        isImportedFromReact(symbol) &&
-        (importedName === "Component" || importedName === "PureComponent"),
-      );
+    if (
+      !symbol ||
+      !symbol.initializer ||
+      visitedSymbolIds.has(symbol.id) ||
+      hasSymbolWriteBefore(symbol, current, environment.scopes)
+    ) {
+      return false;
     }
-    if (!isNodeOfType(base, "MemberExpression")) return false;
-    const propertyName = getStaticPropertyName(base);
-    return Boolean(
-      (propertyName === "Component" || propertyName === "PureComponent") &&
-      isReactNamespaceImport(base.object, environment.scopes),
-    );
-  };
-  return Boolean(current.superClass && isProvenReactComponentBase(current.superClass));
+    visitedSymbolIds.add(symbol.id);
+    return isProvenReactClassValue(symbol.initializer, environment, visitedSymbolIds);
+  }
+  return isProvenReactClassNode(current, environment.scopes);
 };
 
 const isProvenClassComponentIdentifier = (
@@ -325,9 +320,8 @@ const isProvenClassComponentIdentifier = (
   if (!isNodeOfType(identifier, "JSXIdentifier")) return false;
   const symbol = environment.scopes.symbolFor(identifier);
   if (symbol && symbol.kind !== "import") {
-    return Boolean(
-      symbol.initializer && isProvenReactClassComponent(symbol.initializer, environment),
-    );
+    if (hasSymbolWriteBefore(symbol, identifier, environment.scopes)) return false;
+    return Boolean(symbol.initializer && isProvenReactClassValue(symbol.initializer, environment));
   }
   const binding = getImportBindingForName(identifier, identifier.name);
   if (!binding || binding.isNamespace || binding.exportedName === null) return false;
@@ -338,7 +332,7 @@ const isProvenClassComponentIdentifier = (
   );
   if (!resolved) return false;
   const resolvedEnvironment = getEnvironment(resolved.programNode, resolved.filePath, state);
-  return isProvenReactClassComponent(resolved.exportedNode, resolvedEnvironment);
+  return isProvenReactClassValue(resolved.exportedNode, resolvedEnvironment);
 };
 
 const resolveClassValue = (
@@ -349,7 +343,7 @@ const resolveClassValue = (
   const classNode = findTransparentExpressionRoot(node);
   if (
     (!isNodeOfType(classNode, "ClassDeclaration") && !isNodeOfType(classNode, "ClassExpression")) ||
-    !isProvenReactClassComponent(classNode, environment)
+    !isProvenReactClassValue(classNode, environment)
   ) {
     return null;
   }
@@ -364,6 +358,7 @@ const resolveJsxClassValue = (
   if (!isNodeOfType(elementName, "JSXIdentifier")) return null;
   const symbol = environment.scopes.symbolFor(elementName);
   if (symbol && symbol.kind !== "import") {
+    if (hasSymbolWriteBefore(symbol, elementName, environment.scopes)) return null;
     return resolveClassValue(symbol.initializer, environment);
   }
   const binding = getImportBindingForName(elementName, elementName.name);
@@ -566,33 +561,6 @@ const analyzeFunctionInput = (
   );
 };
 
-const getFunctionChildrenSymbol = (
-  resolvedFunction: ResolvedFunctionValue,
-): SymbolDescriptor | null => {
-  const { functionNode } = resolvedFunction;
-  if (
-    !isNodeOfType(functionNode, "ArrowFunctionExpression") &&
-    !isNodeOfType(functionNode, "FunctionExpression") &&
-    !isNodeOfType(functionNode, "FunctionDeclaration")
-  ) {
-    return null;
-  }
-  const propsParameter = functionNode.params[0];
-  if (!propsParameter || !isNodeOfType(propsParameter, "ObjectPattern")) return null;
-  const childrenProperty = propsParameter.properties.find(
-    (property) =>
-      isNodeOfType(property, "Property") &&
-      getStaticPropertyKeyName(property, { allowComputedString: true }) === "children",
-  );
-  if (!childrenProperty || !isNodeOfType(childrenProperty, "Property")) return null;
-  const childrenBinding = isNodeOfType(childrenProperty.value, "AssignmentPattern")
-    ? childrenProperty.value.left
-    : childrenProperty.value;
-  return isNodeOfType(childrenBinding, "Identifier")
-    ? resolvedFunction.environment.scopes.symbolFor(childrenBinding)
-    : null;
-};
-
 const isThisPropsChildren = (node: EsTreeNode): boolean => {
   if (!isNodeOfType(node, "MemberExpression") || getStaticPropertyName(node) !== "children") {
     return false;
@@ -654,18 +622,19 @@ const doesFunctionComponentRenderChildren = (
   ) {
     return false;
   }
-  const childrenSymbol = getFunctionChildrenSymbol(resolvedFunction);
-  if (!childrenSymbol || childrenSymbol.references.length === 0) return false;
+  const childrenReferences = collectFunctionChildrenReferences(
+    functionNode,
+    resolvedFunction.environment.scopes,
+  );
+  if (!childrenReferences) return false;
   state.activeRenderedChildrenComponents.add(functionNode);
-  const isRendered = childrenSymbol.references.every(
-    (reference) =>
-      reference.flag === "read" &&
-      isValueRenderedForEnvironment(
-        reference.identifier,
-        resolvedFunction.environment,
-        state,
-        remainingDepth,
-      ),
+  const isRendered = childrenReferences.every((childrenReference) =>
+    isValueRenderedForEnvironment(
+      childrenReference,
+      resolvedFunction.environment,
+      state,
+      remainingDepth,
+    ),
   );
   state.activeRenderedChildrenComponents.delete(functionNode);
   return isRendered;
@@ -894,7 +863,13 @@ const analyzeValueUse = (
       parent.operator === "==" ||
       parent.operator === "!=")
   ) {
-    return true;
+    const comparedExpression = parent.left === expression ? parent.right : parent.left;
+    return Boolean(
+      isNodeOfType(expression, "Identifier") &&
+      isNodeOfType(comparedExpression, "Identifier") &&
+      environment.scopes.symbolFor(expression)?.id ===
+        environment.scopes.symbolFor(comparedExpression)?.id,
+    );
   }
   if (isIntrinsicJsxSpreadRefUse(expression, propertyPath, environment, state, remainingDepth)) {
     return true;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/is-create-ref-result-write-only.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/is-create-ref-result-write-only.ts
@@ -4,20 +4,23 @@ import type { ScopeAnalysis, SymbolDescriptor } from "../../semantic/scope-analy
 import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
 import { findProgramRoot } from "../../utils/find-program-root.js";
 import { findTransparentExpressionRoot } from "../../utils/find-transparent-expression-root.js";
-import {
-  getImportBindingForName,
-  getImportedNameFromModule,
-  isImportedFromModule,
-} from "../../utils/find-import-source-for-name.js";
+import { getImportBindingForName } from "../../utils/find-import-source-for-name.js";
 import { getJsxAttributeName } from "../../utils/get-jsx-attribute-name.js";
+import { getImportedName } from "../../utils/get-imported-name.js";
 import { getStaticPropertyKeyName } from "../../utils/get-static-property-key-name.js";
 import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import {
+  isImportedFromReact,
+  isReactApiCall,
+  isReactNamespaceImport,
+} from "../../utils/is-react-api-call.js";
+import {
   resolveCrossFileValueExportWithFilePath,
   type ResolvedCrossFileValueExport,
 } from "../../utils/resolve-cross-file-function-export.js";
+import { walkAst } from "../../utils/walk-ast.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
@@ -29,6 +32,7 @@ interface AnalysisEnvironment {
 
 interface SymbolValuePath {
   readonly environment: AnalysisEnvironment;
+  readonly originWriteReference?: EsTreeNode;
   readonly propertyPath: ReadonlyArray<string>;
   readonly symbol: SymbolDescriptor;
 }
@@ -66,25 +70,10 @@ const isProvenReactCall = (
   callExpression: EsTreeNodeOfType<"CallExpression">,
   expectedName: string,
   scopes: ScopeAnalysis,
-): boolean => {
-  if (isNodeOfType(callExpression.callee, "Identifier")) {
-    const symbol = scopes.symbolFor(callExpression.callee);
-    return Boolean(
-      symbol?.kind === "import" &&
-      getImportedNameFromModule(callExpression.callee, callExpression.callee.name, "react") ===
-        expectedName,
-    );
-  }
-  if (!isNodeOfType(callExpression.callee, "MemberExpression")) return false;
-  const propertyName = getStaticPropertyName(callExpression.callee);
-  if (propertyName !== expectedName) return false;
-  const receiver = callExpression.callee.object;
-  if (!isNodeOfType(receiver, "Identifier")) return false;
-  const symbol = scopes.symbolFor(receiver);
-  return Boolean(
-    symbol?.kind === "import" && isImportedFromModule(receiver, receiver.name, "react"),
-  );
-};
+): boolean =>
+  isReactApiCall(callExpression, expectedName, scopes, {
+    resolveNamedAliases: true,
+  });
 
 const objectHasOnlyClosedNoopFunctions = (
   objectExpression: EsTreeNode,
@@ -122,6 +111,20 @@ const objectHasOnlyClosedNoopFunctions = (
   });
 };
 
+const getValuePathPropertyName = (
+  memberExpression: EsTreeNodeOfType<"MemberExpression">,
+): string | null => {
+  const propertyName = getStaticPropertyName(memberExpression);
+  if (propertyName) return propertyName;
+  return memberExpression.computed &&
+    isNodeOfType(memberExpression.property, "Literal") &&
+    typeof memberExpression.property.value === "number" &&
+    Number.isSafeInteger(memberExpression.property.value) &&
+    memberExpression.property.value >= 0
+    ? String(memberExpression.property.value)
+    : null;
+};
+
 const collectMemberAccess = (identifier: EsTreeNode): MemberAccess | null => {
   const propertyPath: string[] = [];
   let expression = findTransparentExpressionRoot(identifier);
@@ -130,7 +133,7 @@ const collectMemberAccess = (identifier: EsTreeNode): MemberAccess | null => {
     isNodeOfType(expression.parent, "MemberExpression") &&
     expression.parent.object === expression
   ) {
-    const propertyName = getStaticPropertyName(expression.parent);
+    const propertyName = getValuePathPropertyName(expression.parent);
     if (!propertyName) return null;
     propertyPath.push(propertyName);
     expression = findTransparentExpressionRoot(expression.parent);
@@ -176,16 +179,24 @@ const unwrapProvenReactHocFunction = (
   return unwrapProvenReactHocFunction(firstArgument, scopes, visitedSymbolIds);
 };
 
-const isForwardRefValue = (node: EsTreeNode, scopes: ScopeAnalysis): boolean => {
-  let current = findTransparentExpressionRoot(node);
-  while (isNodeOfType(current, "CallExpression")) {
-    if (isProvenReactCall(current, "forwardRef", scopes)) return true;
-    if (!isProvenReactCall(current, "memo", scopes)) return false;
-    const firstArgument = current.arguments[0];
-    if (!firstArgument || isNodeOfType(firstArgument, "SpreadElement")) return false;
-    current = findTransparentExpressionRoot(firstArgument);
+const isForwardRefValue = (
+  node: EsTreeNode,
+  scopes: ScopeAnalysis,
+  visitedSymbolIds: Set<number> = new Set(),
+): boolean => {
+  const current = findTransparentExpressionRoot(node);
+  if (isNodeOfType(current, "Identifier")) {
+    const symbol = scopes.symbolFor(current);
+    if (!symbol || !symbol.initializer || visitedSymbolIds.has(symbol.id)) return false;
+    visitedSymbolIds.add(symbol.id);
+    return isForwardRefValue(symbol.initializer, scopes, visitedSymbolIds);
   }
-  return false;
+  if (!isNodeOfType(current, "CallExpression")) return false;
+  if (isProvenReactCall(current, "forwardRef", scopes)) return true;
+  if (!isProvenReactCall(current, "memo", scopes)) return false;
+  const firstArgument = current.arguments[0];
+  if (!firstArgument || isNodeOfType(firstArgument, "SpreadElement")) return false;
+  return isForwardRefValue(firstArgument, scopes, visitedSymbolIds);
 };
 
 const functionFromExport = (
@@ -232,6 +243,103 @@ const resolveFunctionValue = (
   return resolved ? functionFromExport(resolved, state) : null;
 };
 
+const isProvenReactClassComponent = (
+  node: EsTreeNode,
+  environment: AnalysisEnvironment,
+  visitedSymbolIds: Set<number> = new Set(),
+): boolean => {
+  const current = findTransparentExpressionRoot(node);
+  if (isNodeOfType(current, "Identifier")) {
+    const symbol = environment.scopes.symbolFor(current);
+    if (!symbol || !symbol.initializer || visitedSymbolIds.has(symbol.id)) return false;
+    visitedSymbolIds.add(symbol.id);
+    return isProvenReactClassComponent(symbol.initializer, environment, visitedSymbolIds);
+  }
+  if (!isNodeOfType(current, "ClassDeclaration") && !isNodeOfType(current, "ClassExpression")) {
+    return false;
+  }
+  const isProvenReactComponentBase = (baseNode: EsTreeNode): boolean => {
+    const base = findTransparentExpressionRoot(baseNode);
+    if (isNodeOfType(base, "Identifier")) {
+      const symbol = environment.scopes.symbolFor(base);
+      if (symbol?.kind === "const" && symbol.initializer && !visitedSymbolIds.has(symbol.id)) {
+        visitedSymbolIds.add(symbol.id);
+        return isProvenReactComponentBase(symbol.initializer);
+      }
+      const importedName = symbol ? getImportedName(symbol.declarationNode) : null;
+      return Boolean(
+        symbol &&
+        isImportedFromReact(symbol) &&
+        (importedName === "Component" || importedName === "PureComponent"),
+      );
+    }
+    if (!isNodeOfType(base, "MemberExpression")) return false;
+    const propertyName = getStaticPropertyName(base);
+    return Boolean(
+      (propertyName === "Component" || propertyName === "PureComponent") &&
+      isReactNamespaceImport(base.object, environment.scopes),
+    );
+  };
+  return Boolean(current.superClass && isProvenReactComponentBase(current.superClass));
+};
+
+const isProvenIntrinsicJsxElement = (
+  openingElement: EsTreeNodeOfType<"JSXOpeningElement">,
+  scopes: ScopeAnalysis,
+): boolean => {
+  if (!isNodeOfType(openingElement.name, "JSXIdentifier")) return false;
+  if (openingElement.name.name[0] === openingElement.name.name[0]?.toLowerCase()) return true;
+  const visitedSymbolIds = new Set<number>();
+  const isIntrinsicValue = (node: EsTreeNode): boolean => {
+    const current = findTransparentExpressionRoot(node);
+    if (isNodeOfType(current, "Literal")) return typeof current.value === "string";
+    if (isNodeOfType(current, "Identifier") || isNodeOfType(current, "JSXIdentifier")) {
+      const symbol = scopes.symbolFor(current);
+      if (
+        !symbol ||
+        symbol.kind !== "const" ||
+        !symbol.initializer ||
+        visitedSymbolIds.has(symbol.id)
+      ) {
+        return false;
+      }
+      visitedSymbolIds.add(symbol.id);
+      const isIntrinsic = isIntrinsicValue(symbol.initializer);
+      visitedSymbolIds.delete(symbol.id);
+      return isIntrinsic;
+    }
+    if (isNodeOfType(current, "ConditionalExpression")) {
+      return isIntrinsicValue(current.consequent) && isIntrinsicValue(current.alternate);
+    }
+    return false;
+  };
+  return isIntrinsicValue(openingElement.name);
+};
+
+const isProvenClassComponentIdentifier = (
+  identifier: EsTreeNode,
+  environment: AnalysisEnvironment,
+  state: AnalysisState,
+): boolean => {
+  if (!isNodeOfType(identifier, "JSXIdentifier")) return false;
+  const symbol = environment.scopes.symbolFor(identifier);
+  if (symbol && symbol.kind !== "import") {
+    return Boolean(
+      symbol.initializer && isProvenReactClassComponent(symbol.initializer, environment),
+    );
+  }
+  const binding = getImportBindingForName(identifier, identifier.name);
+  if (!binding || binding.isNamespace || binding.exportedName === null) return false;
+  const resolved = resolveCrossFileValueExportWithFilePath(
+    environment.filename,
+    binding.source,
+    binding.exportedName,
+  );
+  if (!resolved) return false;
+  const resolvedEnvironment = getEnvironment(resolved.programNode, resolved.filePath, state);
+  return isProvenReactClassComponent(resolved.exportedNode, resolvedEnvironment);
+};
+
 const findOwnedSymbolValue = (
   expressionNode: EsTreeNode,
   initialPropertyPath: ReadonlyArray<string>,
@@ -241,6 +349,16 @@ const findOwnedSymbolValue = (
   let expression = findTransparentExpressionRoot(expressionNode);
   while (expression.parent) {
     const parent = expression.parent;
+    if (isNodeOfType(parent, "ArrayExpression")) {
+      if (parent.elements.some((element) => element && isNodeOfType(element, "SpreadElement"))) {
+        return null;
+      }
+      const elementIndex = parent.elements.findIndex((element) => element === expression);
+      if (elementIndex < 0) return null;
+      propertyPath.unshift(String(elementIndex));
+      expression = findTransparentExpressionRoot(parent);
+      continue;
+    }
     if (isNodeOfType(parent, "Property") && parent.value === expression) {
       const propertyName = getStaticPropertyKeyName(parent, { allowComputedString: true });
       const objectExpression = parent.parent;
@@ -273,25 +391,242 @@ const findOwnedSymbolValue = (
       if (!symbol || symbol.kind !== "const") return null;
       return { environment, propertyPath, symbol };
     }
+    if (
+      isNodeOfType(parent, "AssignmentExpression") &&
+      parent.operator === "=" &&
+      parent.right === expression &&
+      isNodeOfType(parent.left, "MemberExpression")
+    ) {
+      const assignedPropertyPath: string[] = [];
+      let assignedExpression: EsTreeNode = parent.left;
+      while (isNodeOfType(assignedExpression, "MemberExpression")) {
+        const propertyName = getValuePathPropertyName(assignedExpression);
+        if (!propertyName) return null;
+        assignedPropertyPath.unshift(propertyName);
+        assignedExpression = findTransparentExpressionRoot(assignedExpression.object);
+      }
+      if (!isNodeOfType(assignedExpression, "Identifier")) return null;
+      const symbol = environment.scopes.symbolFor(assignedExpression);
+      if (!symbol || symbol.kind !== "const") return null;
+      return {
+        environment,
+        originWriteReference: assignedExpression,
+        propertyPath: [...assignedPropertyPath, ...propertyPath],
+        symbol,
+      };
+    }
     return null;
   }
   return null;
 };
 
-const isFreshInlineEventHandler = (functionNode: EsTreeNode): boolean => {
+const getIntrinsicEventAttribute = (
+  expressionNode: EsTreeNode,
+  scopes: ScopeAnalysis,
+): EsTreeNode | null => {
+  let expression = findTransparentExpressionRoot(expressionNode);
+  while (
+    expression.parent &&
+    ((isNodeOfType(expression.parent, "ConditionalExpression") &&
+      (expression.parent.consequent === expression ||
+        expression.parent.alternate === expression)) ||
+      (isNodeOfType(expression.parent, "LogicalExpression") &&
+        (expression.parent.left === expression || expression.parent.right === expression)))
+  ) {
+    expression = findTransparentExpressionRoot(expression.parent);
+  }
+  const container = expression.parent;
+  if (!container || !isNodeOfType(container, "JSXExpressionContainer")) return null;
+  const attribute = container.parent;
+  if (!attribute || !isNodeOfType(attribute, "JSXAttribute")) return null;
+  const attributeName = getJsxAttributeName(attribute.name);
+  const openingElement = attribute.parent;
+  if (
+    !attributeName?.startsWith("on") ||
+    !openingElement ||
+    !isNodeOfType(openingElement, "JSXOpeningElement")
+  ) {
+    return null;
+  }
+  return isProvenIntrinsicJsxElement(openingElement, scopes) ? attribute : null;
+};
+
+const isFreshEventHandler = (
+  functionNode: EsTreeNode,
+  environment: AnalysisEnvironment,
+): boolean => {
   const functionExpression = findTransparentExpressionRoot(functionNode);
+  if (!isFunctionLike(functionExpression)) return false;
+  if (getIntrinsicEventAttribute(functionExpression, environment.scopes)) return true;
+  const bindingIdentifier =
+    functionExpression.id ??
+    (functionExpression.parent &&
+    isNodeOfType(functionExpression.parent, "VariableDeclarator") &&
+    functionExpression.parent.init === functionExpression &&
+    isNodeOfType(functionExpression.parent.id, "Identifier")
+      ? functionExpression.parent.id
+      : null);
+  if (!bindingIdentifier) return false;
+  const symbol = environment.scopes.symbolFor(bindingIdentifier);
+  return Boolean(
+    symbol &&
+    symbol.references.length > 0 &&
+    symbol.references.every((reference) =>
+      Boolean(getIntrinsicEventAttribute(reference.identifier, environment.scopes)),
+    ),
+  );
+};
+
+const isInlineIntrinsicRefCallback = (
+  functionNode: EsTreeNode,
+  environment: AnalysisEnvironment,
+): boolean => {
+  const functionExpression = findTransparentExpressionRoot(functionNode);
+  if (
+    !isFunctionLike(functionExpression) ||
+    functionExpression.async ||
+    functionExpression.generator
+  ) {
+    return false;
+  }
   const container = functionExpression.parent;
   if (!container || !isNodeOfType(container, "JSXExpressionContainer")) return false;
   const attribute = container.parent;
-  if (!attribute || !isNodeOfType(attribute, "JSXAttribute")) return false;
-  const attributeName = getJsxAttributeName(attribute.name);
+  if (
+    !attribute ||
+    !isNodeOfType(attribute, "JSXAttribute") ||
+    getJsxAttributeName(attribute.name) !== "ref"
+  ) {
+    return false;
+  }
   const openingElement = attribute.parent;
+  if (!openingElement || !isNodeOfType(openingElement, "JSXOpeningElement")) return false;
+  return isProvenIntrinsicJsxElement(openingElement, environment.scopes);
+};
+
+const isInlineIntrinsicRefCurrentWrite = (
+  referenceNode: EsTreeNode,
+  accessedPropertyPath: ReadonlyArray<string>,
+  targetPropertyPath: ReadonlyArray<string>,
+  environment: AnalysisEnvironment,
+): boolean => {
+  if (
+    accessedPropertyPath.length !== targetPropertyPath.length + 1 ||
+    !pathStartsWith(accessedPropertyPath, targetPropertyPath) ||
+    accessedPropertyPath[targetPropertyPath.length] !== "current"
+  ) {
+    return false;
+  }
+  const memberAccess = collectMemberAccess(referenceNode);
+  const assignment = memberAccess?.expression.parent;
+  if (
+    !memberAccess ||
+    !assignment ||
+    !isNodeOfType(assignment, "AssignmentExpression") ||
+    assignment.operator !== "=" ||
+    assignment.left !== memberAccess.expression
+  ) {
+    return false;
+  }
+  let enclosingFunction = findEnclosingFunction(referenceNode);
+  while (enclosingFunction) {
+    if (isInlineIntrinsicRefCallback(enclosingFunction, environment)) return true;
+    enclosingFunction = findEnclosingFunction(enclosingFunction);
+  }
+  return false;
+};
+
+const findEnclosingLoop = (node: EsTreeNode, boundary: EsTreeNode): EsTreeNode | null => {
+  let current = node.parent;
+  while (current && current !== boundary) {
+    if (
+      isNodeOfType(current, "ForStatement") ||
+      isNodeOfType(current, "ForInStatement") ||
+      isNodeOfType(current, "ForOfStatement") ||
+      isNodeOfType(current, "WhileStatement") ||
+      isNodeOfType(current, "DoWhileStatement")
+    ) {
+      return current;
+    }
+    current = current.parent;
+  }
+  return null;
+};
+
+const isReactStateSetterCall = (
+  callExpression: EsTreeNodeOfType<"CallExpression">,
+  scopes: ScopeAnalysis,
+): boolean => {
+  const callee = findTransparentExpressionRoot(callExpression.callee);
+  if (!isNodeOfType(callee, "Identifier")) return false;
+  const symbol = scopes.symbolFor(callee);
+  if (!symbol || symbol.references.some((reference) => reference.flag !== "read")) return false;
+  const arrayPattern = symbol.bindingIdentifier.parent;
+  if (
+    !arrayPattern ||
+    !isNodeOfType(arrayPattern, "ArrayPattern") ||
+    arrayPattern.elements[1] !== symbol.bindingIdentifier
+  ) {
+    return false;
+  }
+  const declarator = arrayPattern.parent;
+  if (!declarator || !isNodeOfType(declarator, "VariableDeclarator") || !declarator.init) {
+    return false;
+  }
+  return (
+    isReactApiCall(declarator.init, "useState", scopes, { resolveNamedAliases: true }) ||
+    isReactApiCall(declarator.init, "useReducer", scopes, { resolveNamedAliases: true })
+  );
+};
+
+const isProvenNonCommittingCall = (
+  callExpression: EsTreeNodeOfType<"CallExpression">,
+  eventHandler: EsTreeNode,
+  scopes: ScopeAnalysis,
+): boolean => {
+  if (isReactStateSetterCall(callExpression, scopes)) return true;
+  if (isReactApiCall(callExpression, "startTransition", scopes, { resolveNamedAliases: true })) {
+    const callback = callExpression.arguments[0];
+    if (!callback || isNodeOfType(callback, "SpreadElement") || !isFunctionLike(callback)) {
+      return false;
+    }
+    let isPureTransitionCallback = true;
+    walkAst(callback, (node) => {
+      if (!isPureTransitionCallback || findEnclosingFunction(node) !== callback) return;
+      if (isNodeOfType(node, "CallExpression")) {
+        if (!isReactStateSetterCall(node, scopes)) isPureTransitionCallback = false;
+        return;
+      }
+      if (
+        isNodeOfType(node, "MemberExpression") ||
+        isNodeOfType(node, "AwaitExpression") ||
+        isNodeOfType(node, "YieldExpression") ||
+        isNodeOfType(node, "NewExpression")
+      ) {
+        isPureTransitionCallback = false;
+      }
+    });
+    return isPureTransitionCallback;
+  }
+  const callee = findTransparentExpressionRoot(callExpression.callee);
+  if (!isNodeOfType(callee, "MemberExpression")) return false;
+  const methodName = getStaticPropertyName(callee);
+  const receiver = findTransparentExpressionRoot(callee.object);
+  if (
+    isNodeOfType(receiver, "Identifier") &&
+    receiver.name === "console" &&
+    scopes.isGlobalReference(receiver)
+  ) {
+    return true;
+  }
+  if (methodName !== "preventDefault" && methodName !== "stopPropagation") return false;
+  if (!isFunctionLike(eventHandler)) return false;
+  const eventParameter = eventHandler.params[0];
   return Boolean(
-    attributeName?.startsWith("on") &&
-    openingElement &&
-    isNodeOfType(openingElement, "JSXOpeningElement") &&
-    isNodeOfType(openingElement.name, "JSXIdentifier") &&
-    openingElement.name.name[0] === openingElement.name.name[0]?.toLowerCase(),
+    eventParameter &&
+    isNodeOfType(eventParameter, "Identifier") &&
+    isNodeOfType(receiver, "Identifier") &&
+    scopes.symbolFor(eventParameter) === scopes.symbolFor(receiver),
   );
 };
 
@@ -299,11 +634,79 @@ const isSafeSameRenderCurrentRead = (
   referenceNode: EsTreeNode,
   accessedPropertyPath: ReadonlyArray<string>,
   targetPropertyPath: ReadonlyArray<string>,
+  environment: AnalysisEnvironment,
 ): boolean => {
   if (!pathStartsWith(accessedPropertyPath, targetPropertyPath)) return false;
   if (accessedPropertyPath[targetPropertyPath.length] !== "current") return false;
-  const enclosingFunction = findEnclosingFunction(referenceNode);
-  return Boolean(enclosingFunction && isFreshInlineEventHandler(enclosingFunction));
+  const executedFunctions = new Set<EsTreeNode>();
+  let enclosingFunction = findEnclosingFunction(referenceNode);
+  let eventHandler: EsTreeNode | null = null;
+  while (enclosingFunction) {
+    executedFunctions.add(enclosingFunction);
+    if (isFreshEventHandler(enclosingFunction, environment)) {
+      eventHandler = enclosingFunction;
+      break;
+    }
+    const functionExpression = findTransparentExpressionRoot(enclosingFunction);
+    const callExpression = functionExpression.parent;
+    if (
+      !callExpression ||
+      !isNodeOfType(callExpression, "CallExpression") ||
+      findTransparentExpressionRoot(callExpression.callee) !== functionExpression
+    ) {
+      return false;
+    }
+    enclosingFunction = findEnclosingFunction(callExpression);
+  }
+  if (!eventHandler) return false;
+  if (findEnclosingLoop(referenceNode, eventHandler)) return false;
+  const provenNonCommittingCalleeRanges: Array<readonly [number, number]> = [];
+  let hasPotentialCommit = false;
+  walkAst(eventHandler, (node) => {
+    if (hasPotentialCommit || !executedFunctions.has(findEnclosingFunction(node) ?? eventHandler)) {
+      return;
+    }
+    if (
+      provenNonCommittingCalleeRanges.some(
+        ([start, end]) => start <= node.range[0] && end >= node.range[1],
+      )
+    ) {
+      return;
+    }
+    if (isNodeOfType(node, "AwaitExpression") || isNodeOfType(node, "YieldExpression")) {
+      if (node.range[0] < referenceNode.range[0]) hasPotentialCommit = true;
+      return;
+    }
+    if (isNodeOfType(node, "CallExpression")) {
+      const callee = findTransparentExpressionRoot(node.callee);
+      if (isFunctionLike(callee) && executedFunctions.has(callee)) return;
+      if (
+        node.callee.range[0] <= referenceNode.range[0] &&
+        node.callee.range[1] >= referenceNode.range[1]
+      ) {
+        return;
+      }
+      if (isProvenNonCommittingCall(node, eventHandler, environment.scopes)) {
+        provenNonCommittingCalleeRanges.push(node.callee.range);
+        return;
+      }
+      if (node.range[0] < referenceNode.range[0]) hasPotentialCommit = true;
+      return;
+    }
+    if (node.range[0] >= referenceNode.range[0]) return;
+    if (
+      isNodeOfType(node, "MemberExpression") ||
+      isNodeOfType(node, "BinaryExpression") ||
+      isNodeOfType(node, "UnaryExpression") ||
+      isNodeOfType(node, "UpdateExpression") ||
+      isNodeOfType(node, "AssignmentExpression") ||
+      isNodeOfType(node, "TemplateLiteral") ||
+      isNodeOfType(node, "NewExpression")
+    ) {
+      hasPotentialCommit = true;
+    }
+  });
+  return !hasPotentialCommit;
 };
 
 const analyzePatternPath = (
@@ -328,6 +731,7 @@ const analyzePatternPath = (
   for (const property of pattern.properties) {
     if (!isNodeOfType(property, "Property")) continue;
     const propertyName = getStaticPropertyKeyName(property, { allowComputedString: true });
+    if (!propertyName) return false;
     if (propertyName !== firstPropertyName) continue;
     return analyzePatternPath(
       property.value,
@@ -343,6 +747,37 @@ const analyzePatternPath = (
     : true;
 };
 
+const isIntrinsicCreateElementRefProperty = (
+  expression: EsTreeNode,
+  propertyPath: ReadonlyArray<string>,
+  environment: AnalysisEnvironment,
+): boolean => {
+  if (propertyPath.length > 0) return false;
+  const property = expression.parent;
+  if (!property || !isNodeOfType(property, "Property") || property.value !== expression) {
+    return false;
+  }
+  if (getStaticPropertyKeyName(property, { allowComputedString: true }) !== "ref") return false;
+  const props = property.parent;
+  if (!props || !isNodeOfType(props, "ObjectExpression")) return false;
+  const callExpression = props.parent;
+  if (
+    !callExpression ||
+    !isNodeOfType(callExpression, "CallExpression") ||
+    callExpression.arguments[1] !== props ||
+    !isProvenReactCall(callExpression, "createElement", environment.scopes)
+  ) {
+    return false;
+  }
+  const elementType = callExpression.arguments[0];
+  return Boolean(
+    elementType &&
+    !isNodeOfType(elementType, "SpreadElement") &&
+    isNodeOfType(elementType, "Literal") &&
+    typeof elementType.value === "string",
+  );
+};
+
 const analyzeFunctionInput = (
   resolvedFunction: ResolvedFunctionValue,
   parameterIndex: number,
@@ -350,7 +785,14 @@ const analyzeFunctionInput = (
   state: AnalysisState,
   remainingDepth: number,
 ): boolean => {
-  if (remainingDepth <= 0 || !isFunctionLike(resolvedFunction.functionNode)) return false;
+  if (
+    remainingDepth <= 0 ||
+    !isFunctionLike(resolvedFunction.functionNode) ||
+    resolvedFunction.functionNode.async ||
+    resolvedFunction.functionNode.generator
+  ) {
+    return false;
+  }
   const parameter = resolvedFunction.functionNode.params[parameterIndex];
   return Boolean(
     parameter &&
@@ -377,9 +819,15 @@ const analyzeJsxAttributeUse = (
     return false;
   }
   if (!isNodeOfType(openingElement.name, "JSXIdentifier")) return false;
-  const elementName = openingElement.name.name;
-  if (elementName[0] === elementName[0]?.toLowerCase()) {
+  if (isProvenIntrinsicJsxElement(openingElement, environment.scopes)) {
     return attributeName === "ref" && propertyPath.length === 0;
+  }
+  if (
+    attributeName === "ref" &&
+    propertyPath.length === 0 &&
+    isProvenClassComponentIdentifier(openingElement.name, environment, state)
+  ) {
+    return true;
   }
   const resolvedFunction = resolveFunctionValue(openingElement.name, environment, state);
   if (!resolvedFunction) return false;
@@ -413,12 +861,48 @@ const analyzeCallArgumentUse = (
   ) {
     return propertyPath.length === 0;
   }
+  const inlineCallee = findTransparentExpressionRoot(callExpression.callee);
+  if (isFunctionLike(inlineCallee)) {
+    return analyzeFunctionInput(
+      { environment, functionNode: inlineCallee, isForwardRef: false },
+      argumentIndex,
+      propertyPath,
+      state,
+      remainingDepth,
+    );
+  }
   if (!isNodeOfType(callExpression.callee, "Identifier")) return false;
   const resolvedFunction = resolveFunctionValue(callExpression.callee, environment, state);
   return Boolean(
     resolvedFunction &&
     analyzeFunctionInput(resolvedFunction, argumentIndex, propertyPath, state, remainingDepth),
   );
+};
+
+const isIntrinsicJsxSpreadRefUse = (
+  expression: EsTreeNode,
+  propertyPath: ReadonlyArray<string>,
+  environment: AnalysisEnvironment,
+): boolean => {
+  let spreadAttribute: EsTreeNode | null | undefined;
+  if (propertyPath.length === 1 && propertyPath[0] === "ref") {
+    spreadAttribute = expression.parent;
+  } else if (propertyPath.length === 0) {
+    const property = expression.parent;
+    if (
+      !property ||
+      !isNodeOfType(property, "Property") ||
+      property.value !== expression ||
+      getStaticPropertyKeyName(property, { allowComputedString: true }) !== "ref"
+    ) {
+      return false;
+    }
+    spreadAttribute = property.parent?.parent;
+  }
+  if (!spreadAttribute || !isNodeOfType(spreadAttribute, "JSXSpreadAttribute")) return false;
+  const openingElement = spreadAttribute.parent;
+  if (!openingElement || !isNodeOfType(openingElement, "JSXOpeningElement")) return false;
+  return isProvenIntrinsicJsxElement(openingElement, environment.scopes);
 };
 
 const analyzeValueUse = (
@@ -431,6 +915,9 @@ const analyzeValueUse = (
   const expression = findTransparentExpressionRoot(expressionNode);
   const parent = expression.parent;
   if (!parent) return false;
+  if (isNodeOfType(parent, "ExpressionStatement")) return true;
+  if (isIntrinsicJsxSpreadRefUse(expression, propertyPath, environment)) return true;
+  if (isIntrinsicCreateElementRefProperty(expression, propertyPath, environment)) return true;
   if (
     propertyPath.length > 0 &&
     ((isNodeOfType(parent, "LogicalExpression") && parent.left === expression) ||
@@ -484,6 +971,7 @@ const analyzeSymbolValuePath = (
   state.activePaths.add(activePathKey);
   const bindingFunction = findEnclosingFunction(valuePath.symbol.bindingIdentifier);
   const result = valuePath.symbol.references.every((reference) => {
+    if (reference.identifier === valuePath.originWriteReference) return true;
     const referenceParent = reference.identifier.parent;
     if (
       referenceParent &&
@@ -497,15 +985,27 @@ const analyzeSymbolValuePath = (
     const memberAccess = collectMemberAccess(reference.identifier);
     if (!memberAccess) return false;
     if (!pathsOverlap(memberAccess.propertyPath, valuePath.propertyPath)) return true;
-    if (reference.flag !== "read") return false;
     const referenceFunction = findEnclosingFunction(reference.identifier);
     if (referenceFunction !== bindingFunction) {
+      if (
+        isInlineIntrinsicRefCurrentWrite(
+          reference.identifier,
+          memberAccess.propertyPath,
+          valuePath.propertyPath,
+          valuePath.environment,
+        )
+      ) {
+        return true;
+      }
+      if (reference.flag !== "read") return false;
       return isSafeSameRenderCurrentRead(
         reference.identifier,
         memberAccess.propertyPath,
         valuePath.propertyPath,
+        valuePath.environment,
       );
     }
+    if (reference.flag !== "read") return false;
     if (pathStartsWith(memberAccess.propertyPath, valuePath.propertyPath)) {
       if (memberAccess.propertyPath.length > valuePath.propertyPath.length) return false;
       return analyzeValueUse(
@@ -542,7 +1042,7 @@ export const isCreateRefResultWriteOnly = (
     environmentsByProgram: new WeakMap([[program, environment]]),
   };
   const ownedValue = findOwnedSymbolValue(createRefCall, [], environment);
-  return Boolean(
-    ownedValue && analyzeSymbolValuePath(ownedValue, state, CREATE_REF_PROP_FLOW_MAX_DEPTH),
-  );
+  return ownedValue
+    ? analyzeSymbolValuePath(ownedValue, state, CREATE_REF_PROP_FLOW_MAX_DEPTH)
+    : analyzeValueUse(createRefCall, [], environment, state, CREATE_REF_PROP_FLOW_MAX_DEPTH);
 };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/is-create-ref-result-write-only.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/is-create-ref-result-write-only.ts
@@ -4,6 +4,7 @@ import type { ScopeAnalysis, SymbolDescriptor } from "../../semantic/scope-analy
 import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
 import { findProgramRoot } from "../../utils/find-program-root.js";
 import { findTransparentExpressionRoot } from "../../utils/find-transparent-expression-root.js";
+import { functionContainsReactRenderOutput } from "../../utils/function-contains-react-render-output.js";
 import { getImportBindingForName } from "../../utils/find-import-source-for-name.js";
 import { getJsxAttributeName } from "../../utils/get-jsx-attribute-name.js";
 import { getImportedName } from "../../utils/get-imported-name.js";
@@ -11,6 +12,8 @@ import { getStaticPropertyKeyName } from "../../utils/get-static-property-key-na
 import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { isProvenIntrinsicJsxElement } from "../../utils/is-proven-intrinsic-jsx-element.js";
+import { walkAst } from "../../utils/walk-ast.js";
 import {
   isImportedFromReact,
   isReactApiCall,
@@ -20,7 +23,8 @@ import {
   resolveCrossFileValueExportWithFilePath,
   type ResolvedCrossFileValueExport,
 } from "../../utils/resolve-cross-file-function-export.js";
-import { walkAst } from "../../utils/walk-ast.js";
+import { isSafeCreateRefCallbackCurrentWrite } from "./is-safe-create-ref-callback-current-write.js";
+import { isValueRenderedInSameRender } from "./is-value-rendered-in-same-render.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
@@ -48,8 +52,14 @@ interface ResolvedFunctionValue {
   readonly isForwardRef: boolean;
 }
 
+interface ResolvedClassValue {
+  readonly classNode: EsTreeNode;
+  readonly environment: AnalysisEnvironment;
+}
+
 interface AnalysisState {
   readonly activePaths: Set<string>;
+  readonly activeRenderedChildrenComponents: WeakSet<EsTreeNode>;
   readonly environmentsByProgram: WeakMap<EsTreeNode, AnalysisEnvironment>;
 }
 
@@ -243,6 +253,30 @@ const resolveFunctionValue = (
   return resolved ? functionFromExport(resolved, state) : null;
 };
 
+const resolveJsxFunctionValue = (
+  elementName: EsTreeNode,
+  environment: AnalysisEnvironment,
+  state: AnalysisState,
+): ResolvedFunctionValue | null => {
+  if (isNodeOfType(elementName, "JSXIdentifier")) {
+    return resolveFunctionValue(elementName, environment, state);
+  }
+  if (
+    !isNodeOfType(elementName, "JSXMemberExpression") ||
+    !isNodeOfType(elementName.object, "JSXIdentifier")
+  ) {
+    return null;
+  }
+  const namespaceBinding = getImportBindingForName(elementName.object, elementName.object.name);
+  if (!namespaceBinding?.isNamespace) return null;
+  const resolved = resolveCrossFileValueExportWithFilePath(
+    environment.filename,
+    namespaceBinding.source,
+    elementName.property.name,
+  );
+  return resolved ? functionFromExport(resolved, state) : null;
+};
+
 const isProvenReactClassComponent = (
   node: EsTreeNode,
   environment: AnalysisEnvironment,
@@ -283,39 +317,6 @@ const isProvenReactClassComponent = (
   return Boolean(current.superClass && isProvenReactComponentBase(current.superClass));
 };
 
-const isProvenIntrinsicJsxElement = (
-  openingElement: EsTreeNodeOfType<"JSXOpeningElement">,
-  scopes: ScopeAnalysis,
-): boolean => {
-  if (!isNodeOfType(openingElement.name, "JSXIdentifier")) return false;
-  if (openingElement.name.name[0] === openingElement.name.name[0]?.toLowerCase()) return true;
-  const visitedSymbolIds = new Set<number>();
-  const isIntrinsicValue = (node: EsTreeNode): boolean => {
-    const current = findTransparentExpressionRoot(node);
-    if (isNodeOfType(current, "Literal")) return typeof current.value === "string";
-    if (isNodeOfType(current, "Identifier") || isNodeOfType(current, "JSXIdentifier")) {
-      const symbol = scopes.symbolFor(current);
-      if (
-        !symbol ||
-        symbol.kind !== "const" ||
-        !symbol.initializer ||
-        visitedSymbolIds.has(symbol.id)
-      ) {
-        return false;
-      }
-      visitedSymbolIds.add(symbol.id);
-      const isIntrinsic = isIntrinsicValue(symbol.initializer);
-      visitedSymbolIds.delete(symbol.id);
-      return isIntrinsic;
-    }
-    if (isNodeOfType(current, "ConditionalExpression")) {
-      return isIntrinsicValue(current.consequent) && isIntrinsicValue(current.alternate);
-    }
-    return false;
-  };
-  return isIntrinsicValue(openingElement.name);
-};
-
 const isProvenClassComponentIdentifier = (
   identifier: EsTreeNode,
   environment: AnalysisEnvironment,
@@ -338,6 +339,43 @@ const isProvenClassComponentIdentifier = (
   if (!resolved) return false;
   const resolvedEnvironment = getEnvironment(resolved.programNode, resolved.filePath, state);
   return isProvenReactClassComponent(resolved.exportedNode, resolvedEnvironment);
+};
+
+const resolveClassValue = (
+  node: EsTreeNode | null | undefined,
+  environment: AnalysisEnvironment,
+): ResolvedClassValue | null => {
+  if (!node) return null;
+  const classNode = findTransparentExpressionRoot(node);
+  if (
+    (!isNodeOfType(classNode, "ClassDeclaration") && !isNodeOfType(classNode, "ClassExpression")) ||
+    !isProvenReactClassComponent(classNode, environment)
+  ) {
+    return null;
+  }
+  return { classNode, environment };
+};
+
+const resolveJsxClassValue = (
+  elementName: EsTreeNode,
+  environment: AnalysisEnvironment,
+  state: AnalysisState,
+): ResolvedClassValue | null => {
+  if (!isNodeOfType(elementName, "JSXIdentifier")) return null;
+  const symbol = environment.scopes.symbolFor(elementName);
+  if (symbol && symbol.kind !== "import") {
+    return resolveClassValue(symbol.initializer, environment);
+  }
+  const binding = getImportBindingForName(elementName, elementName.name);
+  if (!binding || binding.isNamespace || binding.exportedName === null) return null;
+  const resolved = resolveCrossFileValueExportWithFilePath(
+    environment.filename,
+    binding.source,
+    binding.exportedName,
+  );
+  if (!resolved) return null;
+  const resolvedEnvironment = getEnvironment(resolved.programNode, resolved.filePath, state);
+  return resolveClassValue(resolved.exportedNode, resolvedEnvironment);
 };
 
 const findOwnedSymbolValue = (
@@ -420,335 +458,6 @@ const findOwnedSymbolValue = (
   return null;
 };
 
-const getIntrinsicEventAttribute = (
-  expressionNode: EsTreeNode,
-  scopes: ScopeAnalysis,
-): EsTreeNode | null => {
-  let expression = findTransparentExpressionRoot(expressionNode);
-  while (
-    expression.parent &&
-    ((isNodeOfType(expression.parent, "ConditionalExpression") &&
-      (expression.parent.consequent === expression ||
-        expression.parent.alternate === expression)) ||
-      (isNodeOfType(expression.parent, "LogicalExpression") &&
-        (expression.parent.left === expression || expression.parent.right === expression)))
-  ) {
-    expression = findTransparentExpressionRoot(expression.parent);
-  }
-  const container = expression.parent;
-  if (!container || !isNodeOfType(container, "JSXExpressionContainer")) return null;
-  const attribute = container.parent;
-  if (!attribute || !isNodeOfType(attribute, "JSXAttribute")) return null;
-  const attributeName = getJsxAttributeName(attribute.name);
-  const openingElement = attribute.parent;
-  if (
-    !attributeName?.startsWith("on") ||
-    !openingElement ||
-    !isNodeOfType(openingElement, "JSXOpeningElement")
-  ) {
-    return null;
-  }
-  return isProvenIntrinsicJsxElement(openingElement, scopes) ? attribute : null;
-};
-
-const isFreshEventHandler = (
-  functionNode: EsTreeNode,
-  environment: AnalysisEnvironment,
-): boolean => {
-  const functionExpression = findTransparentExpressionRoot(functionNode);
-  if (!isFunctionLike(functionExpression)) return false;
-  if (getIntrinsicEventAttribute(functionExpression, environment.scopes)) return true;
-  const bindingIdentifier =
-    functionExpression.id ??
-    (functionExpression.parent &&
-    isNodeOfType(functionExpression.parent, "VariableDeclarator") &&
-    functionExpression.parent.init === functionExpression &&
-    isNodeOfType(functionExpression.parent.id, "Identifier")
-      ? functionExpression.parent.id
-      : null);
-  if (!bindingIdentifier) return false;
-  const symbol = environment.scopes.symbolFor(bindingIdentifier);
-  return Boolean(
-    symbol &&
-    symbol.references.length > 0 &&
-    symbol.references.every((reference) =>
-      Boolean(getIntrinsicEventAttribute(reference.identifier, environment.scopes)),
-    ),
-  );
-};
-
-const isInlineIntrinsicRefCallback = (
-  functionNode: EsTreeNode,
-  environment: AnalysisEnvironment,
-): boolean => {
-  const functionExpression = findTransparentExpressionRoot(functionNode);
-  if (
-    !isFunctionLike(functionExpression) ||
-    functionExpression.async ||
-    functionExpression.generator
-  ) {
-    return false;
-  }
-  const container = functionExpression.parent;
-  if (!container || !isNodeOfType(container, "JSXExpressionContainer")) return false;
-  const attribute = container.parent;
-  if (
-    !attribute ||
-    !isNodeOfType(attribute, "JSXAttribute") ||
-    getJsxAttributeName(attribute.name) !== "ref"
-  ) {
-    return false;
-  }
-  const openingElement = attribute.parent;
-  if (!openingElement || !isNodeOfType(openingElement, "JSXOpeningElement")) return false;
-  return isProvenIntrinsicJsxElement(openingElement, environment.scopes);
-};
-
-const isInlineIntrinsicRefCurrentWrite = (
-  referenceNode: EsTreeNode,
-  accessedPropertyPath: ReadonlyArray<string>,
-  targetPropertyPath: ReadonlyArray<string>,
-  environment: AnalysisEnvironment,
-): boolean => {
-  if (
-    accessedPropertyPath.length !== targetPropertyPath.length + 1 ||
-    !pathStartsWith(accessedPropertyPath, targetPropertyPath) ||
-    accessedPropertyPath[targetPropertyPath.length] !== "current"
-  ) {
-    return false;
-  }
-  const memberAccess = collectMemberAccess(referenceNode);
-  const assignment = memberAccess?.expression.parent;
-  if (
-    !memberAccess ||
-    !assignment ||
-    !isNodeOfType(assignment, "AssignmentExpression") ||
-    assignment.operator !== "=" ||
-    assignment.left !== memberAccess.expression
-  ) {
-    return false;
-  }
-  let enclosingFunction = findEnclosingFunction(referenceNode);
-  while (enclosingFunction) {
-    if (isInlineIntrinsicRefCallback(enclosingFunction, environment)) return true;
-    enclosingFunction = findEnclosingFunction(enclosingFunction);
-  }
-  return false;
-};
-
-const findEnclosingLoop = (node: EsTreeNode, boundary: EsTreeNode): EsTreeNode | null => {
-  let current = node.parent;
-  while (current && current !== boundary) {
-    if (
-      isNodeOfType(current, "ForStatement") ||
-      isNodeOfType(current, "ForInStatement") ||
-      isNodeOfType(current, "ForOfStatement") ||
-      isNodeOfType(current, "WhileStatement") ||
-      isNodeOfType(current, "DoWhileStatement")
-    ) {
-      return current;
-    }
-    current = current.parent;
-  }
-  return null;
-};
-
-const isReactStateSetterCall = (
-  callExpression: EsTreeNodeOfType<"CallExpression">,
-  scopes: ScopeAnalysis,
-): boolean => {
-  const callee = findTransparentExpressionRoot(callExpression.callee);
-  if (!isNodeOfType(callee, "Identifier")) return false;
-  let symbol = scopes.symbolFor(callee);
-  const visitedSymbolIds = new Set<number>();
-  while (
-    symbol?.kind === "const" &&
-    symbol.initializer &&
-    isNodeOfType(symbol.initializer, "Identifier") &&
-    isNodeOfType(symbol.declarationNode, "VariableDeclarator") &&
-    symbol.declarationNode.id === symbol.bindingIdentifier &&
-    !visitedSymbolIds.has(symbol.id)
-  ) {
-    visitedSymbolIds.add(symbol.id);
-    symbol = scopes.symbolFor(symbol.initializer);
-  }
-  if (!symbol || symbol.references.some((reference) => reference.flag !== "read")) return false;
-  const arrayPattern = symbol.bindingIdentifier.parent;
-  if (
-    !arrayPattern ||
-    !isNodeOfType(arrayPattern, "ArrayPattern") ||
-    arrayPattern.elements[1] !== symbol.bindingIdentifier
-  ) {
-    return false;
-  }
-  const declarator = arrayPattern.parent;
-  if (!declarator || !isNodeOfType(declarator, "VariableDeclarator") || !declarator.init) {
-    return false;
-  }
-  return (
-    isReactApiCall(declarator.init, "useState", scopes, { resolveNamedAliases: true }) ||
-    isReactApiCall(declarator.init, "useReducer", scopes, { resolveNamedAliases: true })
-  );
-};
-
-const isProvenNonCommittingCall = (
-  callExpression: EsTreeNodeOfType<"CallExpression">,
-  eventHandler: EsTreeNode,
-  scopes: ScopeAnalysis,
-): boolean => {
-  if (isReactStateSetterCall(callExpression, scopes)) return true;
-  if (isReactApiCall(callExpression, "startTransition", scopes, { resolveNamedAliases: true })) {
-    const callback = callExpression.arguments[0];
-    if (!callback || isNodeOfType(callback, "SpreadElement") || !isFunctionLike(callback)) {
-      return false;
-    }
-    const isInertSetterArgument = (argument: EsTreeNode): boolean => {
-      const value = findTransparentExpressionRoot(argument);
-      if (
-        isNodeOfType(value, "Literal") ||
-        isNodeOfType(value, "Identifier") ||
-        isFunctionLike(value)
-      ) {
-        return true;
-      }
-      if (isNodeOfType(value, "ArrayExpression")) {
-        return value.elements.every(
-          (element) =>
-            !element || (!isNodeOfType(element, "SpreadElement") && isInertSetterArgument(element)),
-        );
-      }
-      if (isNodeOfType(value, "ObjectExpression")) {
-        return value.properties.every(
-          (property) =>
-            isNodeOfType(property, "Property") &&
-            property.kind === "init" &&
-            !property.computed &&
-            isInertSetterArgument(property.value),
-        );
-      }
-      return false;
-    };
-    const isInertSetterCall = (node: EsTreeNode): boolean =>
-      isNodeOfType(node, "CallExpression") &&
-      isReactStateSetterCall(node, scopes) &&
-      node.arguments.every(
-        (argument) => !isNodeOfType(argument, "SpreadElement") && isInertSetterArgument(argument),
-      );
-    if (!isNodeOfType(callback.body, "BlockStatement")) {
-      return isInertSetterCall(callback.body);
-    }
-    return callback.body.body.every(
-      (statement) =>
-        isNodeOfType(statement, "EmptyStatement") ||
-        (isNodeOfType(statement, "ExpressionStatement") &&
-          isNodeOfType(statement.expression, "CallExpression") &&
-          isInertSetterCall(statement.expression)),
-    );
-  }
-  const callee = findTransparentExpressionRoot(callExpression.callee);
-  if (!isNodeOfType(callee, "MemberExpression")) return false;
-  const methodName = getStaticPropertyName(callee);
-  const receiver = findTransparentExpressionRoot(callee.object);
-  if (
-    isNodeOfType(receiver, "Identifier") &&
-    receiver.name === "console" &&
-    scopes.isGlobalReference(receiver)
-  ) {
-    return true;
-  }
-  if (methodName !== "preventDefault" && methodName !== "stopPropagation") return false;
-  if (!isFunctionLike(eventHandler)) return false;
-  const eventParameter = eventHandler.params[0];
-  return Boolean(
-    eventParameter &&
-    isNodeOfType(eventParameter, "Identifier") &&
-    isNodeOfType(receiver, "Identifier") &&
-    scopes.symbolFor(eventParameter) === scopes.symbolFor(receiver),
-  );
-};
-
-const isSafeSameRenderCurrentRead = (
-  referenceNode: EsTreeNode,
-  accessedPropertyPath: ReadonlyArray<string>,
-  targetPropertyPath: ReadonlyArray<string>,
-  environment: AnalysisEnvironment,
-): boolean => {
-  if (!pathStartsWith(accessedPropertyPath, targetPropertyPath)) return false;
-  if (accessedPropertyPath[targetPropertyPath.length] !== "current") return false;
-  const executedFunctions = new Set<EsTreeNode>();
-  let enclosingFunction = findEnclosingFunction(referenceNode);
-  let eventHandler: EsTreeNode | null = null;
-  while (enclosingFunction) {
-    executedFunctions.add(enclosingFunction);
-    if (isFreshEventHandler(enclosingFunction, environment)) {
-      eventHandler = enclosingFunction;
-      break;
-    }
-    const functionExpression = findTransparentExpressionRoot(enclosingFunction);
-    const callExpression = functionExpression.parent;
-    if (
-      !callExpression ||
-      !isNodeOfType(callExpression, "CallExpression") ||
-      findTransparentExpressionRoot(callExpression.callee) !== functionExpression
-    ) {
-      return false;
-    }
-    enclosingFunction = findEnclosingFunction(callExpression);
-  }
-  if (!eventHandler) return false;
-  if (findEnclosingLoop(referenceNode, eventHandler)) return false;
-  const provenNonCommittingCalleeRanges: Array<readonly [number, number]> = [];
-  let hasPotentialCommit = false;
-  walkAst(eventHandler, (node) => {
-    if (hasPotentialCommit || !executedFunctions.has(findEnclosingFunction(node) ?? eventHandler)) {
-      return;
-    }
-    if (
-      provenNonCommittingCalleeRanges.some(
-        ([start, end]) => start <= node.range[0] && end >= node.range[1],
-      )
-    ) {
-      return;
-    }
-    if (isNodeOfType(node, "AwaitExpression") || isNodeOfType(node, "YieldExpression")) {
-      if (node.range[0] < referenceNode.range[0]) hasPotentialCommit = true;
-      return;
-    }
-    if (isNodeOfType(node, "CallExpression")) {
-      const callee = findTransparentExpressionRoot(node.callee);
-      if (isFunctionLike(callee) && executedFunctions.has(callee)) return;
-      if (
-        node.callee.range[0] <= referenceNode.range[0] &&
-        node.callee.range[1] >= referenceNode.range[1]
-      ) {
-        return;
-      }
-      if (isProvenNonCommittingCall(node, eventHandler, environment.scopes)) {
-        provenNonCommittingCalleeRanges.push(node.callee.range);
-        return;
-      }
-      if (node.range[0] < referenceNode.range[0]) hasPotentialCommit = true;
-      return;
-    }
-    if (node.range[0] >= referenceNode.range[0]) return;
-    if (
-      isNodeOfType(node, "MemberExpression") ||
-      isNodeOfType(node, "BinaryExpression") ||
-      isNodeOfType(node, "UnaryExpression") ||
-      isNodeOfType(node, "UpdateExpression") ||
-      isNodeOfType(node, "AssignmentExpression") ||
-      isNodeOfType(node, "TemplateLiteral") ||
-      isNodeOfType(node, "NewExpression") ||
-      isNodeOfType(node, "SpreadElement") ||
-      (isNodeOfType(node, "VariableDeclarator") &&
-        (isNodeOfType(node.id, "ObjectPattern") || isNodeOfType(node.id, "ArrayPattern")))
-    ) {
-      hasPotentialCommit = true;
-    }
-  });
-  return !hasPotentialCommit;
-};
-
 const analyzePatternPath = (
   pattern: EsTreeNode,
   propertyPath: ReadonlyArray<string>,
@@ -787,10 +496,26 @@ const analyzePatternPath = (
     : true;
 };
 
-const isIntrinsicCreateElementRefProperty = (
+const isIntrinsicReactElementFactoryCall = (
+  callExpression: EsTreeNodeOfType<"CallExpression">,
+  environment: AnalysisEnvironment,
+): boolean => {
+  const element = callExpression.arguments[0];
+  if (!element || isNodeOfType(element, "SpreadElement")) return false;
+  if (isProvenReactCall(callExpression, "createElement", environment.scopes)) {
+    return isNodeOfType(element, "Literal") && typeof element.value === "string";
+  }
+  if (!isProvenReactCall(callExpression, "cloneElement", environment.scopes)) return false;
+  if (!isNodeOfType(element, "JSXElement")) return false;
+  return isProvenIntrinsicJsxElement(element.openingElement, environment.scopes);
+};
+
+const isIntrinsicReactElementRefProperty = (
   expression: EsTreeNode,
   propertyPath: ReadonlyArray<string>,
   environment: AnalysisEnvironment,
+  state: AnalysisState,
+  remainingDepth: number,
 ): boolean => {
   if (propertyPath.length > 0) return false;
   const property = expression.parent;
@@ -805,17 +530,12 @@ const isIntrinsicCreateElementRefProperty = (
     !callExpression ||
     !isNodeOfType(callExpression, "CallExpression") ||
     callExpression.arguments[1] !== props ||
-    !isProvenReactCall(callExpression, "createElement", environment.scopes)
+    !isIntrinsicReactElementFactoryCall(callExpression, environment) ||
+    !isValueRenderedForEnvironment(callExpression, environment, state, remainingDepth)
   ) {
     return false;
   }
-  const elementType = callExpression.arguments[0];
-  return Boolean(
-    elementType &&
-    !isNodeOfType(elementType, "SpreadElement") &&
-    isNodeOfType(elementType, "Literal") &&
-    typeof elementType.value === "string",
-  );
+  return true;
 };
 
 const analyzeFunctionInput = (
@@ -846,6 +566,165 @@ const analyzeFunctionInput = (
   );
 };
 
+const getFunctionChildrenSymbol = (
+  resolvedFunction: ResolvedFunctionValue,
+): SymbolDescriptor | null => {
+  const { functionNode } = resolvedFunction;
+  if (
+    !isNodeOfType(functionNode, "ArrowFunctionExpression") &&
+    !isNodeOfType(functionNode, "FunctionExpression") &&
+    !isNodeOfType(functionNode, "FunctionDeclaration")
+  ) {
+    return null;
+  }
+  const propsParameter = functionNode.params[0];
+  if (!propsParameter || !isNodeOfType(propsParameter, "ObjectPattern")) return null;
+  const childrenProperty = propsParameter.properties.find(
+    (property) =>
+      isNodeOfType(property, "Property") &&
+      getStaticPropertyKeyName(property, { allowComputedString: true }) === "children",
+  );
+  if (!childrenProperty || !isNodeOfType(childrenProperty, "Property")) return null;
+  const childrenBinding = isNodeOfType(childrenProperty.value, "AssignmentPattern")
+    ? childrenProperty.value.left
+    : childrenProperty.value;
+  return isNodeOfType(childrenBinding, "Identifier")
+    ? resolvedFunction.environment.scopes.symbolFor(childrenBinding)
+    : null;
+};
+
+const isThisPropsChildren = (node: EsTreeNode): boolean => {
+  if (!isNodeOfType(node, "MemberExpression") || getStaticPropertyName(node) !== "children") {
+    return false;
+  }
+  const propsMember = findTransparentExpressionRoot(node.object);
+  return Boolean(
+    isNodeOfType(propsMember, "MemberExpression") &&
+    getStaticPropertyName(propsMember) === "props" &&
+    isNodeOfType(findTransparentExpressionRoot(propsMember.object), "ThisExpression"),
+  );
+};
+
+const isProvenReactContextProvider = (
+  openingElement: EsTreeNode,
+  environment: AnalysisEnvironment,
+): boolean => {
+  if (
+    !isNodeOfType(openingElement, "JSXOpeningElement") ||
+    !isNodeOfType(openingElement.name, "JSXMemberExpression") ||
+    openingElement.name.property.name !== "Provider" ||
+    !isNodeOfType(openingElement.name.object, "JSXIdentifier")
+  ) {
+    return false;
+  }
+  const contextSymbol = environment.scopes.symbolFor(openingElement.name.object);
+  return Boolean(
+    contextSymbol?.kind === "const" &&
+    contextSymbol.initializer &&
+    isNodeOfType(contextSymbol.initializer, "CallExpression") &&
+    isProvenReactCall(contextSymbol.initializer, "createContext", environment.scopes),
+  );
+};
+
+const isValueRenderedForEnvironment = (
+  expression: EsTreeNode,
+  environment: AnalysisEnvironment,
+  state: AnalysisState,
+  remainingDepth: number,
+): boolean =>
+  isValueRenderedInSameRender(expression, environment.scopes, {
+    doesCustomElementRenderChildren: (openingElement) =>
+      doesCustomElementRenderChildren(openingElement, environment, state, remainingDepth - 1),
+  });
+
+const doesFunctionComponentRenderChildren = (
+  resolvedFunction: ResolvedFunctionValue,
+  state: AnalysisState,
+  remainingDepth: number,
+): boolean => {
+  const { functionNode } = resolvedFunction;
+  if (
+    remainingDepth <= 0 ||
+    state.activeRenderedChildrenComponents.has(functionNode) ||
+    (!isNodeOfType(functionNode, "ArrowFunctionExpression") &&
+      !isNodeOfType(functionNode, "FunctionExpression") &&
+      !isNodeOfType(functionNode, "FunctionDeclaration")) ||
+    functionNode.async ||
+    functionNode.generator
+  ) {
+    return false;
+  }
+  const childrenSymbol = getFunctionChildrenSymbol(resolvedFunction);
+  if (!childrenSymbol || childrenSymbol.references.length === 0) return false;
+  state.activeRenderedChildrenComponents.add(functionNode);
+  const isRendered = childrenSymbol.references.every(
+    (reference) =>
+      reference.flag === "read" &&
+      isValueRenderedForEnvironment(
+        reference.identifier,
+        resolvedFunction.environment,
+        state,
+        remainingDepth,
+      ),
+  );
+  state.activeRenderedChildrenComponents.delete(functionNode);
+  return isRendered;
+};
+
+const doesClassComponentRenderChildren = (
+  resolvedClass: ResolvedClassValue,
+  state: AnalysisState,
+  remainingDepth: number,
+): boolean => {
+  const { classNode, environment } = resolvedClass;
+  if (
+    remainingDepth <= 0 ||
+    state.activeRenderedChildrenComponents.has(classNode) ||
+    (!isNodeOfType(classNode, "ClassDeclaration") && !isNodeOfType(classNode, "ClassExpression"))
+  ) {
+    return false;
+  }
+  const renderMethod = classNode.body.body.find(
+    (element) =>
+      isNodeOfType(element, "MethodDefinition") &&
+      !element.computed &&
+      isNodeOfType(element.key, "Identifier") &&
+      element.key.name === "render",
+  );
+  if (!renderMethod || !isNodeOfType(renderMethod, "MethodDefinition")) return false;
+  const childrenReads: EsTreeNode[] = [];
+  walkAst(classNode, (node) => {
+    if (isThisPropsChildren(node)) childrenReads.push(node);
+  });
+  if (childrenReads.length === 0) return false;
+  state.activeRenderedChildrenComponents.add(classNode);
+  const isRendered = childrenReads.every(
+    (childrenRead) =>
+      findEnclosingFunction(childrenRead) === renderMethod.value &&
+      isValueRenderedForEnvironment(childrenRead, environment, state, remainingDepth),
+  );
+  state.activeRenderedChildrenComponents.delete(classNode);
+  return isRendered;
+};
+
+const doesCustomElementRenderChildren = (
+  openingElement: EsTreeNode,
+  environment: AnalysisEnvironment,
+  state: AnalysisState,
+  remainingDepth: number,
+): boolean => {
+  if (remainingDepth <= 0 || !isNodeOfType(openingElement, "JSXOpeningElement")) return false;
+  if (isProvenReactContextProvider(openingElement, environment)) return true;
+  const resolvedFunction = resolveJsxFunctionValue(openingElement.name, environment, state);
+  if (resolvedFunction) {
+    return doesFunctionComponentRenderChildren(resolvedFunction, state, remainingDepth);
+  }
+  const resolvedClass = resolveJsxClassValue(openingElement.name, environment, state);
+  return Boolean(
+    resolvedClass && doesClassComponentRenderChildren(resolvedClass, state, remainingDepth),
+  );
+};
+
 const analyzeJsxAttributeUse = (
   attribute: EsTreeNodeOfType<"JSXAttribute">,
   propertyPath: ReadonlyArray<string>,
@@ -858,18 +737,26 @@ const analyzeJsxAttributeUse = (
   if (!attributeName || !openingElement || !isNodeOfType(openingElement, "JSXOpeningElement")) {
     return false;
   }
-  if (!isNodeOfType(openingElement.name, "JSXIdentifier")) return false;
+  const jsxElement = openingElement.parent;
+  if (
+    !jsxElement ||
+    !isNodeOfType(jsxElement, "JSXElement") ||
+    !isValueRenderedForEnvironment(jsxElement, environment, state, remainingDepth)
+  ) {
+    return false;
+  }
   if (isProvenIntrinsicJsxElement(openingElement, environment.scopes)) {
     return attributeName === "ref" && propertyPath.length === 0;
   }
   if (
+    isNodeOfType(openingElement.name, "JSXIdentifier") &&
     attributeName === "ref" &&
     propertyPath.length === 0 &&
     isProvenClassComponentIdentifier(openingElement.name, environment, state)
   ) {
     return true;
   }
-  const resolvedFunction = resolveFunctionValue(openingElement.name, environment, state);
+  const resolvedFunction = resolveJsxFunctionValue(openingElement.name, environment, state);
   if (!resolvedFunction) return false;
   if (attributeName === "ref" && resolvedFunction.isForwardRef) {
     return analyzeFunctionInput(resolvedFunction, 1, propertyPath, state, remainingDepth);
@@ -909,8 +796,23 @@ const analyzeCallArgumentUse = (
   ) {
     return propertyPath.length === 0;
   }
+  if (
+    argumentIndex === 1 &&
+    propertyPath.length === 1 &&
+    propertyPath[0] === "ref" &&
+    isIntrinsicReactElementFactoryCall(callExpression, environment) &&
+    isValueRenderedForEnvironment(callExpression, environment, state, remainingDepth)
+  ) {
+    return true;
+  }
   const inlineCallee = findTransparentExpressionRoot(callExpression.callee);
   if (isFunctionLike(inlineCallee)) {
+    if (
+      functionContainsReactRenderOutput(inlineCallee, environment.scopes) &&
+      !isValueRenderedForEnvironment(callExpression, environment, state, remainingDepth)
+    ) {
+      return false;
+    }
     return analyzeFunctionInput(
       { environment, functionNode: inlineCallee, isForwardRef: false },
       argumentIndex,
@@ -923,6 +825,11 @@ const analyzeCallArgumentUse = (
   const resolvedFunction = resolveFunctionValue(callExpression.callee, environment, state);
   return Boolean(
     resolvedFunction &&
+    (!functionContainsReactRenderOutput(
+      resolvedFunction.functionNode,
+      resolvedFunction.environment.scopes,
+    ) ||
+      isValueRenderedForEnvironment(callExpression, environment, state, remainingDepth)) &&
     analyzeFunctionInput(resolvedFunction, argumentIndex, propertyPath, state, remainingDepth),
   );
 };
@@ -931,6 +838,8 @@ const isIntrinsicJsxSpreadRefUse = (
   expression: EsTreeNode,
   propertyPath: ReadonlyArray<string>,
   environment: AnalysisEnvironment,
+  state: AnalysisState,
+  remainingDepth: number,
 ): boolean => {
   let spreadAttribute: EsTreeNode | null | undefined;
   if (propertyPath.length === 1 && propertyPath[0] === "ref") {
@@ -950,7 +859,13 @@ const isIntrinsicJsxSpreadRefUse = (
   if (!spreadAttribute || !isNodeOfType(spreadAttribute, "JSXSpreadAttribute")) return false;
   const openingElement = spreadAttribute.parent;
   if (!openingElement || !isNodeOfType(openingElement, "JSXOpeningElement")) return false;
-  return isProvenIntrinsicJsxElement(openingElement, environment.scopes);
+  const jsxElement = openingElement.parent;
+  return Boolean(
+    isProvenIntrinsicJsxElement(openingElement, environment.scopes) &&
+    jsxElement &&
+    isNodeOfType(jsxElement, "JSXElement") &&
+    isValueRenderedForEnvironment(jsxElement, environment, state, remainingDepth),
+  );
 };
 
 const analyzeValueUse = (
@@ -981,8 +896,14 @@ const analyzeValueUse = (
   ) {
     return true;
   }
-  if (isIntrinsicJsxSpreadRefUse(expression, propertyPath, environment)) return true;
-  if (isIntrinsicCreateElementRefProperty(expression, propertyPath, environment)) return true;
+  if (isIntrinsicJsxSpreadRefUse(expression, propertyPath, environment, state, remainingDepth)) {
+    return true;
+  }
+  if (
+    isIntrinsicReactElementRefProperty(expression, propertyPath, environment, state, remainingDepth)
+  ) {
+    return true;
+  }
   if (
     propertyPath.length > 0 &&
     ((isNodeOfType(parent, "LogicalExpression") && parent.left === expression) ||
@@ -1025,6 +946,71 @@ const analyzeValueUse = (
   );
 };
 
+const getFunctionBindingIdentifier = (
+  functionNode: EsTreeNode,
+): EsTreeNodeOfType<"Identifier"> | null => {
+  const parent = functionNode.parent;
+  if (
+    parent &&
+    isNodeOfType(parent, "VariableDeclarator") &&
+    parent.init === functionNode &&
+    isNodeOfType(parent.id, "Identifier")
+  ) {
+    return parent.id;
+  }
+  if (
+    (isNodeOfType(functionNode, "FunctionDeclaration") ||
+      isNodeOfType(functionNode, "FunctionExpression")) &&
+    functionNode.id
+  ) {
+    return functionNode.id;
+  }
+  return null;
+};
+
+const isSynchronouslyInvokedLocalFunction = (
+  functionNode: EsTreeNode | null,
+  callerFunction: EsTreeNode | null,
+  scopes: ScopeAnalysis,
+): boolean => {
+  if (
+    !functionNode ||
+    !callerFunction ||
+    !isFunctionLike(functionNode) ||
+    functionNode.async ||
+    functionNode.generator
+  ) {
+    return false;
+  }
+  const bindingIdentifier = getFunctionBindingIdentifier(functionNode);
+  if (!bindingIdentifier) return false;
+  const bindingOwner =
+    (isNodeOfType(functionNode, "FunctionDeclaration") ||
+      isNodeOfType(functionNode, "FunctionExpression")) &&
+    functionNode.id === bindingIdentifier
+      ? findEnclosingFunction(functionNode)
+      : findEnclosingFunction(bindingIdentifier);
+  if (bindingOwner !== callerFunction) return false;
+  const symbol = isNodeOfType(functionNode, "FunctionDeclaration")
+    ? scopes.ownScopeFor(callerFunction)?.symbolsByName.get(bindingIdentifier.name)
+    : scopes.symbolFor(bindingIdentifier);
+  return Boolean(
+    symbol &&
+    symbol.references.length > 0 &&
+    symbol.references.every((reference) => {
+      const referenceExpression = findTransparentExpressionRoot(reference.identifier);
+      const callExpression = referenceExpression.parent;
+      return Boolean(
+        callExpression &&
+        isNodeOfType(callExpression, "CallExpression") &&
+        callExpression.callee === referenceExpression &&
+        findEnclosingFunction(callExpression) === callerFunction &&
+        isValueRenderedInSameRender(callExpression, scopes),
+      );
+    }),
+  );
+};
+
 const analyzeSymbolValuePath = (
   valuePath: SymbolValuePath,
   state: AnalysisState,
@@ -1051,24 +1037,25 @@ const analyzeSymbolValuePath = (
     if (!memberAccess) return false;
     if (!pathsOverlap(memberAccess.propertyPath, valuePath.propertyPath)) return true;
     const referenceFunction = findEnclosingFunction(reference.identifier);
-    if (referenceFunction !== bindingFunction) {
+    if (
+      referenceFunction !== bindingFunction &&
+      !isSynchronouslyInvokedLocalFunction(
+        referenceFunction,
+        bindingFunction,
+        valuePath.environment.scopes,
+      )
+    ) {
       if (
-        isInlineIntrinsicRefCurrentWrite(
+        isSafeCreateRefCallbackCurrentWrite(
           reference.identifier,
           memberAccess.propertyPath,
           valuePath.propertyPath,
-          valuePath.environment,
+          valuePath.environment.scopes,
         )
       ) {
         return true;
       }
-      if (reference.flag !== "read") return false;
-      return isSafeSameRenderCurrentRead(
-        reference.identifier,
-        memberAccess.propertyPath,
-        valuePath.propertyPath,
-        valuePath.environment,
-      );
+      return false;
     }
     if (reference.flag !== "read") return false;
     if (pathStartsWith(memberAccess.propertyPath, valuePath.propertyPath)) {
@@ -1114,6 +1101,7 @@ export const isCreateRefResultWriteOnly = (
   const environment = { filename, program, scopes };
   const state: AnalysisState = {
     activePaths: new Set(),
+    activeRenderedChildrenComponents: new WeakSet(),
     environmentsByProgram: new WeakMap([[program, environment]]),
   };
   const ownedValue = findOwnedSymbolValue(createRefCall, [], environment);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/is-create-ref-result-write-only.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/is-create-ref-result-write-only.ts
@@ -559,7 +559,19 @@ const isReactStateSetterCall = (
 ): boolean => {
   const callee = findTransparentExpressionRoot(callExpression.callee);
   if (!isNodeOfType(callee, "Identifier")) return false;
-  const symbol = scopes.symbolFor(callee);
+  let symbol = scopes.symbolFor(callee);
+  const visitedSymbolIds = new Set<number>();
+  while (
+    symbol?.kind === "const" &&
+    symbol.initializer &&
+    isNodeOfType(symbol.initializer, "Identifier") &&
+    isNodeOfType(symbol.declarationNode, "VariableDeclarator") &&
+    symbol.declarationNode.id === symbol.bindingIdentifier &&
+    !visitedSymbolIds.has(symbol.id)
+  ) {
+    visitedSymbolIds.add(symbol.id);
+    symbol = scopes.symbolFor(symbol.initializer);
+  }
   if (!symbol || symbol.references.some((reference) => reference.flag !== "read")) return false;
   const arrayPattern = symbol.bindingIdentifier.parent;
   if (
@@ -590,23 +602,19 @@ const isProvenNonCommittingCall = (
     if (!callback || isNodeOfType(callback, "SpreadElement") || !isFunctionLike(callback)) {
       return false;
     }
-    let isPureTransitionCallback = true;
-    walkAst(callback, (node) => {
-      if (!isPureTransitionCallback || findEnclosingFunction(node) !== callback) return;
-      if (isNodeOfType(node, "CallExpression")) {
-        if (!isReactStateSetterCall(node, scopes)) isPureTransitionCallback = false;
-        return;
-      }
-      if (
-        isNodeOfType(node, "MemberExpression") ||
-        isNodeOfType(node, "AwaitExpression") ||
-        isNodeOfType(node, "YieldExpression") ||
-        isNodeOfType(node, "NewExpression")
-      ) {
-        isPureTransitionCallback = false;
-      }
-    });
-    return isPureTransitionCallback;
+    if (!isNodeOfType(callback.body, "BlockStatement")) {
+      return (
+        isNodeOfType(callback.body, "CallExpression") &&
+        isReactStateSetterCall(callback.body, scopes)
+      );
+    }
+    return callback.body.body.every(
+      (statement) =>
+        isNodeOfType(statement, "EmptyStatement") ||
+        (isNodeOfType(statement, "ExpressionStatement") &&
+          isNodeOfType(statement.expression, "CallExpression") &&
+          isReactStateSetterCall(statement.expression, scopes)),
+    );
   }
   const callee = findTransparentExpressionRoot(callExpression.callee);
   if (!isNodeOfType(callee, "MemberExpression")) return false;
@@ -701,7 +709,10 @@ const isSafeSameRenderCurrentRead = (
       isNodeOfType(node, "UpdateExpression") ||
       isNodeOfType(node, "AssignmentExpression") ||
       isNodeOfType(node, "TemplateLiteral") ||
-      isNodeOfType(node, "NewExpression")
+      isNodeOfType(node, "NewExpression") ||
+      isNodeOfType(node, "SpreadElement") ||
+      (isNodeOfType(node, "VariableDeclarator") &&
+        (isNodeOfType(node.id, "ObjectPattern") || isNodeOfType(node.id, "ArrayPattern")))
     ) {
       hasPotentialCommit = true;
     }
@@ -857,6 +868,14 @@ const analyzeCallArgumentUse = (
   if (argumentIndex < 0) return false;
   if (
     argumentIndex === 0 &&
+    isNodeOfType(callExpression.callee, "Identifier") &&
+    callExpression.callee.name === "Boolean" &&
+    environment.scopes.isGlobalReference(callExpression.callee)
+  ) {
+    return true;
+  }
+  if (
+    argumentIndex === 0 &&
     isProvenReactCall(callExpression, "useImperativeHandle", environment.scopes)
   ) {
     return propertyPath.length === 0;
@@ -916,6 +935,23 @@ const analyzeValueUse = (
   const parent = expression.parent;
   if (!parent) return false;
   if (isNodeOfType(parent, "ExpressionStatement")) return true;
+  if (
+    isNodeOfType(parent, "UnaryExpression") &&
+    parent.operator === "void" &&
+    parent.argument === expression
+  ) {
+    return true;
+  }
+  if (
+    propertyPath.length === 0 &&
+    isNodeOfType(parent, "BinaryExpression") &&
+    (parent.operator === "===" ||
+      parent.operator === "!==" ||
+      parent.operator === "==" ||
+      parent.operator === "!=")
+  ) {
+    return true;
+  }
   if (isIntrinsicJsxSpreadRefUse(expression, propertyPath, environment)) return true;
   if (isIntrinsicCreateElementRefProperty(expression, propertyPath, environment)) return true;
   if (
@@ -1007,7 +1043,17 @@ const analyzeSymbolValuePath = (
     }
     if (reference.flag !== "read") return false;
     if (pathStartsWith(memberAccess.propertyPath, valuePath.propertyPath)) {
-      if (memberAccess.propertyPath.length > valuePath.propertyPath.length) return false;
+      if (memberAccess.propertyPath.length > valuePath.propertyPath.length) {
+        const parent = memberAccess.expression.parent;
+        return Boolean(
+          memberAccess.propertyPath.length === valuePath.propertyPath.length + 1 &&
+          memberAccess.propertyPath[valuePath.propertyPath.length] === "current" &&
+          parent &&
+          isNodeOfType(parent, "UnaryExpression") &&
+          parent.operator === "void" &&
+          parent.argument === memberAccess.expression,
+        );
+      }
       return analyzeValueUse(
         memberAccess.expression,
         [],

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/is-create-ref-result-write-only.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/is-create-ref-result-write-only.ts
@@ -602,18 +602,47 @@ const isProvenNonCommittingCall = (
     if (!callback || isNodeOfType(callback, "SpreadElement") || !isFunctionLike(callback)) {
       return false;
     }
-    if (!isNodeOfType(callback.body, "BlockStatement")) {
-      return (
-        isNodeOfType(callback.body, "CallExpression") &&
-        isReactStateSetterCall(callback.body, scopes)
+    const isInertSetterArgument = (argument: EsTreeNode): boolean => {
+      const value = findTransparentExpressionRoot(argument);
+      if (
+        isNodeOfType(value, "Literal") ||
+        isNodeOfType(value, "Identifier") ||
+        isFunctionLike(value)
+      ) {
+        return true;
+      }
+      if (isNodeOfType(value, "ArrayExpression")) {
+        return value.elements.every(
+          (element) =>
+            !element || (!isNodeOfType(element, "SpreadElement") && isInertSetterArgument(element)),
+        );
+      }
+      if (isNodeOfType(value, "ObjectExpression")) {
+        return value.properties.every(
+          (property) =>
+            isNodeOfType(property, "Property") &&
+            property.kind === "init" &&
+            !property.computed &&
+            isInertSetterArgument(property.value),
+        );
+      }
+      return false;
+    };
+    const isInertSetterCall = (node: EsTreeNode): boolean =>
+      isNodeOfType(node, "CallExpression") &&
+      isReactStateSetterCall(node, scopes) &&
+      node.arguments.every(
+        (argument) => !isNodeOfType(argument, "SpreadElement") && isInertSetterArgument(argument),
       );
+    if (!isNodeOfType(callback.body, "BlockStatement")) {
+      return isInertSetterCall(callback.body);
     }
     return callback.body.body.every(
       (statement) =>
         isNodeOfType(statement, "EmptyStatement") ||
         (isNodeOfType(statement, "ExpressionStatement") &&
           isNodeOfType(statement.expression, "CallExpression") &&
-          isReactStateSetterCall(statement.expression, scopes)),
+          isInertSetterCall(statement.expression)),
     );
   }
   const callee = findTransparentExpressionRoot(callExpression.callee);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/is-create-ref-result-write-only.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/is-create-ref-result-write-only.ts
@@ -1,0 +1,548 @@
+import { CREATE_REF_PROP_FLOW_MAX_DEPTH } from "../../constants/thresholds.js";
+import { analyzeScopes } from "../../semantic/scope-analysis.js";
+import type { ScopeAnalysis, SymbolDescriptor } from "../../semantic/scope-analysis.js";
+import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
+import { findProgramRoot } from "../../utils/find-program-root.js";
+import { findTransparentExpressionRoot } from "../../utils/find-transparent-expression-root.js";
+import {
+  getImportBindingForName,
+  getImportedNameFromModule,
+  isImportedFromModule,
+} from "../../utils/find-import-source-for-name.js";
+import { getJsxAttributeName } from "../../utils/get-jsx-attribute-name.js";
+import { getStaticPropertyKeyName } from "../../utils/get-static-property-key-name.js";
+import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
+import { isFunctionLike } from "../../utils/is-function-like.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import {
+  resolveCrossFileValueExportWithFilePath,
+  type ResolvedCrossFileValueExport,
+} from "../../utils/resolve-cross-file-function-export.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+
+interface AnalysisEnvironment {
+  readonly filename: string;
+  readonly program: EsTreeNode;
+  readonly scopes: ScopeAnalysis;
+}
+
+interface SymbolValuePath {
+  readonly environment: AnalysisEnvironment;
+  readonly propertyPath: ReadonlyArray<string>;
+  readonly symbol: SymbolDescriptor;
+}
+
+interface MemberAccess {
+  readonly expression: EsTreeNode;
+  readonly propertyPath: ReadonlyArray<string>;
+}
+
+interface ResolvedFunctionValue {
+  readonly environment: AnalysisEnvironment;
+  readonly functionNode: EsTreeNode;
+  readonly isForwardRef: boolean;
+}
+
+interface AnalysisState {
+  readonly activePaths: Set<string>;
+  readonly environmentsByProgram: WeakMap<EsTreeNode, AnalysisEnvironment>;
+}
+
+const pathStartsWith = (
+  propertyPath: ReadonlyArray<string>,
+  prefix: ReadonlyArray<string>,
+): boolean => prefix.every((propertyName, index) => propertyPath[index] === propertyName);
+
+const pathsOverlap = (
+  firstPath: ReadonlyArray<string>,
+  secondPath: ReadonlyArray<string>,
+): boolean => pathStartsWith(firstPath, secondPath) || pathStartsWith(secondPath, firstPath);
+
+const isClosedNoopFunction = (node: EsTreeNode): boolean =>
+  isFunctionLike(node) && isNodeOfType(node.body, "BlockStatement") && node.body.body.length === 0;
+
+const isProvenReactCall = (
+  callExpression: EsTreeNodeOfType<"CallExpression">,
+  expectedName: string,
+  scopes: ScopeAnalysis,
+): boolean => {
+  if (isNodeOfType(callExpression.callee, "Identifier")) {
+    const symbol = scopes.symbolFor(callExpression.callee);
+    return Boolean(
+      symbol?.kind === "import" &&
+      getImportedNameFromModule(callExpression.callee, callExpression.callee.name, "react") ===
+        expectedName,
+    );
+  }
+  if (!isNodeOfType(callExpression.callee, "MemberExpression")) return false;
+  const propertyName = getStaticPropertyName(callExpression.callee);
+  if (propertyName !== expectedName) return false;
+  const receiver = callExpression.callee.object;
+  if (!isNodeOfType(receiver, "Identifier")) return false;
+  const symbol = scopes.symbolFor(receiver);
+  return Boolean(
+    symbol?.kind === "import" && isImportedFromModule(receiver, receiver.name, "react"),
+  );
+};
+
+const objectHasOnlyClosedNoopFunctions = (
+  objectExpression: EsTreeNode,
+  scopes: ScopeAnalysis,
+  visitedSymbolIds: Set<number> = new Set(),
+): boolean => {
+  if (!isNodeOfType(objectExpression, "ObjectExpression")) return false;
+  return objectExpression.properties.every((property) => {
+    if (isNodeOfType(property, "SpreadElement")) {
+      const spreadArgument = findTransparentExpressionRoot(property.argument);
+      if (isNodeOfType(spreadArgument, "ObjectExpression")) {
+        return objectHasOnlyClosedNoopFunctions(spreadArgument, scopes, visitedSymbolIds);
+      }
+      if (!isNodeOfType(spreadArgument, "Identifier")) return false;
+      const symbol = scopes.symbolFor(spreadArgument);
+      if (
+        !symbol ||
+        symbol.kind !== "const" ||
+        visitedSymbolIds.has(symbol.id) ||
+        !isNodeOfType(symbol.initializer, "ObjectExpression")
+      ) {
+        return false;
+      }
+      visitedSymbolIds.add(symbol.id);
+      const isClosed = objectHasOnlyClosedNoopFunctions(
+        symbol.initializer,
+        scopes,
+        visitedSymbolIds,
+      );
+      visitedSymbolIds.delete(symbol.id);
+      return isClosed;
+    }
+    if (!isNodeOfType(property, "Property")) return false;
+    return !isFunctionLike(property.value) || isClosedNoopFunction(property.value);
+  });
+};
+
+const collectMemberAccess = (identifier: EsTreeNode): MemberAccess | null => {
+  const propertyPath: string[] = [];
+  let expression = findTransparentExpressionRoot(identifier);
+  while (
+    expression.parent &&
+    isNodeOfType(expression.parent, "MemberExpression") &&
+    expression.parent.object === expression
+  ) {
+    const propertyName = getStaticPropertyName(expression.parent);
+    if (!propertyName) return null;
+    propertyPath.push(propertyName);
+    expression = findTransparentExpressionRoot(expression.parent);
+  }
+  return { expression, propertyPath };
+};
+
+const getEnvironment = (
+  program: EsTreeNode,
+  filename: string,
+  state: AnalysisState,
+): AnalysisEnvironment => {
+  const cached = state.environmentsByProgram.get(program);
+  if (cached) return cached;
+  const environment = { filename, program, scopes: analyzeScopes(program) };
+  state.environmentsByProgram.set(program, environment);
+  return environment;
+};
+
+const unwrapProvenReactHocFunction = (
+  node: EsTreeNode | null,
+  scopes: ScopeAnalysis,
+  visitedSymbolIds: Set<number> = new Set(),
+): EsTreeNode | null => {
+  if (!node) return null;
+  const current = findTransparentExpressionRoot(node);
+  if (isFunctionLike(current)) return current;
+  if (isNodeOfType(current, "Identifier")) {
+    const symbol = scopes.symbolFor(current);
+    if (!symbol || visitedSymbolIds.has(symbol.id) || !symbol.initializer) return null;
+    visitedSymbolIds.add(symbol.id);
+    return unwrapProvenReactHocFunction(symbol.initializer, scopes, visitedSymbolIds);
+  }
+  if (!isNodeOfType(current, "CallExpression")) return null;
+  if (
+    !isProvenReactCall(current, "memo", scopes) &&
+    !isProvenReactCall(current, "forwardRef", scopes)
+  ) {
+    return null;
+  }
+  const firstArgument = current.arguments[0];
+  if (!firstArgument || isNodeOfType(firstArgument, "SpreadElement")) return null;
+  return unwrapProvenReactHocFunction(firstArgument, scopes, visitedSymbolIds);
+};
+
+const isForwardRefValue = (node: EsTreeNode, scopes: ScopeAnalysis): boolean => {
+  let current = findTransparentExpressionRoot(node);
+  while (isNodeOfType(current, "CallExpression")) {
+    if (isProvenReactCall(current, "forwardRef", scopes)) return true;
+    if (!isProvenReactCall(current, "memo", scopes)) return false;
+    const firstArgument = current.arguments[0];
+    if (!firstArgument || isNodeOfType(firstArgument, "SpreadElement")) return false;
+    current = findTransparentExpressionRoot(firstArgument);
+  }
+  return false;
+};
+
+const functionFromExport = (
+  resolved: ResolvedCrossFileValueExport,
+  state: AnalysisState,
+): ResolvedFunctionValue | null => {
+  const environment = getEnvironment(resolved.programNode, resolved.filePath, state);
+  const functionNode = unwrapProvenReactHocFunction(resolved.exportedNode, environment.scopes);
+  if (!functionNode) return null;
+  return {
+    environment,
+    functionNode,
+    isForwardRef: isForwardRefValue(resolved.exportedNode, environment.scopes),
+  };
+};
+
+const resolveFunctionValue = (
+  identifier: EsTreeNode,
+  environment: AnalysisEnvironment,
+  state: AnalysisState,
+): ResolvedFunctionValue | null => {
+  if (!isNodeOfType(identifier, "Identifier") && !isNodeOfType(identifier, "JSXIdentifier")) {
+    return null;
+  }
+  const symbol = environment.scopes.symbolFor(identifier);
+  if (symbol && symbol.kind !== "import") {
+    const functionNode = unwrapProvenReactHocFunction(symbol.initializer, environment.scopes);
+    if (!functionNode) return null;
+    return {
+      environment,
+      functionNode,
+      isForwardRef: Boolean(
+        symbol.initializer && isForwardRefValue(symbol.initializer, environment.scopes),
+      ),
+    };
+  }
+  const binding = getImportBindingForName(identifier, identifier.name);
+  if (!binding || binding.isNamespace || binding.exportedName === null) return null;
+  const resolved = resolveCrossFileValueExportWithFilePath(
+    environment.filename,
+    binding.source,
+    binding.exportedName,
+  );
+  return resolved ? functionFromExport(resolved, state) : null;
+};
+
+const findOwnedSymbolValue = (
+  expressionNode: EsTreeNode,
+  initialPropertyPath: ReadonlyArray<string>,
+  environment: AnalysisEnvironment,
+): SymbolValuePath | null => {
+  const propertyPath = [...initialPropertyPath];
+  let expression = findTransparentExpressionRoot(expressionNode);
+  while (expression.parent) {
+    const parent = expression.parent;
+    if (isNodeOfType(parent, "Property") && parent.value === expression) {
+      const propertyName = getStaticPropertyKeyName(parent, { allowComputedString: true });
+      const objectExpression = parent.parent;
+      if (
+        !propertyName ||
+        !objectExpression ||
+        !objectHasOnlyClosedNoopFunctions(objectExpression, environment.scopes)
+      ) {
+        return null;
+      }
+      propertyPath.unshift(propertyName);
+      expression = findTransparentExpressionRoot(objectExpression);
+      continue;
+    }
+    if (
+      (isNodeOfType(parent, "ConditionalExpression") &&
+        (parent.consequent === expression || parent.alternate === expression)) ||
+      (isNodeOfType(parent, "LogicalExpression") &&
+        (parent.left === expression || parent.right === expression))
+    ) {
+      expression = findTransparentExpressionRoot(parent);
+      continue;
+    }
+    if (
+      isNodeOfType(parent, "VariableDeclarator") &&
+      parent.init === expression &&
+      isNodeOfType(parent.id, "Identifier")
+    ) {
+      const symbol = environment.scopes.symbolFor(parent.id);
+      if (!symbol || symbol.kind !== "const") return null;
+      return { environment, propertyPath, symbol };
+    }
+    return null;
+  }
+  return null;
+};
+
+const isFreshInlineEventHandler = (functionNode: EsTreeNode): boolean => {
+  const functionExpression = findTransparentExpressionRoot(functionNode);
+  const container = functionExpression.parent;
+  if (!container || !isNodeOfType(container, "JSXExpressionContainer")) return false;
+  const attribute = container.parent;
+  if (!attribute || !isNodeOfType(attribute, "JSXAttribute")) return false;
+  const attributeName = getJsxAttributeName(attribute.name);
+  const openingElement = attribute.parent;
+  return Boolean(
+    attributeName?.startsWith("on") &&
+    openingElement &&
+    isNodeOfType(openingElement, "JSXOpeningElement") &&
+    isNodeOfType(openingElement.name, "JSXIdentifier") &&
+    openingElement.name.name[0] === openingElement.name.name[0]?.toLowerCase(),
+  );
+};
+
+const isSafeSameRenderCurrentRead = (
+  referenceNode: EsTreeNode,
+  accessedPropertyPath: ReadonlyArray<string>,
+  targetPropertyPath: ReadonlyArray<string>,
+): boolean => {
+  if (!pathStartsWith(accessedPropertyPath, targetPropertyPath)) return false;
+  if (accessedPropertyPath[targetPropertyPath.length] !== "current") return false;
+  const enclosingFunction = findEnclosingFunction(referenceNode);
+  return Boolean(enclosingFunction && isFreshInlineEventHandler(enclosingFunction));
+};
+
+const analyzePatternPath = (
+  pattern: EsTreeNode,
+  propertyPath: ReadonlyArray<string>,
+  environment: AnalysisEnvironment,
+  state: AnalysisState,
+  remainingDepth: number,
+): boolean => {
+  if (isNodeOfType(pattern, "AssignmentPattern")) {
+    return analyzePatternPath(pattern.left, propertyPath, environment, state, remainingDepth);
+  }
+  if (isNodeOfType(pattern, "Identifier")) {
+    const symbol = environment.scopes.symbolFor(pattern);
+    return Boolean(
+      symbol &&
+      analyzeSymbolValuePath({ environment, propertyPath, symbol }, state, remainingDepth - 1),
+    );
+  }
+  if (!isNodeOfType(pattern, "ObjectPattern") || propertyPath.length === 0) return false;
+  const [firstPropertyName, ...remainingPropertyPath] = propertyPath;
+  for (const property of pattern.properties) {
+    if (!isNodeOfType(property, "Property")) continue;
+    const propertyName = getStaticPropertyKeyName(property, { allowComputedString: true });
+    if (propertyName !== firstPropertyName) continue;
+    return analyzePatternPath(
+      property.value,
+      remainingPropertyPath,
+      environment,
+      state,
+      remainingDepth,
+    );
+  }
+  const restProperty = pattern.properties.find((property) => isNodeOfType(property, "RestElement"));
+  return restProperty
+    ? analyzePatternPath(restProperty.argument, propertyPath, environment, state, remainingDepth)
+    : true;
+};
+
+const analyzeFunctionInput = (
+  resolvedFunction: ResolvedFunctionValue,
+  parameterIndex: number,
+  propertyPath: ReadonlyArray<string>,
+  state: AnalysisState,
+  remainingDepth: number,
+): boolean => {
+  if (remainingDepth <= 0 || !isFunctionLike(resolvedFunction.functionNode)) return false;
+  const parameter = resolvedFunction.functionNode.params[parameterIndex];
+  return Boolean(
+    parameter &&
+    analyzePatternPath(
+      parameter,
+      propertyPath,
+      resolvedFunction.environment,
+      state,
+      remainingDepth,
+    ),
+  );
+};
+
+const analyzeJsxAttributeUse = (
+  attribute: EsTreeNodeOfType<"JSXAttribute">,
+  propertyPath: ReadonlyArray<string>,
+  environment: AnalysisEnvironment,
+  state: AnalysisState,
+  remainingDepth: number,
+): boolean => {
+  const attributeName = getJsxAttributeName(attribute.name);
+  const openingElement = attribute.parent;
+  if (!attributeName || !openingElement || !isNodeOfType(openingElement, "JSXOpeningElement")) {
+    return false;
+  }
+  if (!isNodeOfType(openingElement.name, "JSXIdentifier")) return false;
+  const elementName = openingElement.name.name;
+  if (elementName[0] === elementName[0]?.toLowerCase()) {
+    return attributeName === "ref" && propertyPath.length === 0;
+  }
+  const resolvedFunction = resolveFunctionValue(openingElement.name, environment, state);
+  if (!resolvedFunction) return false;
+  if (attributeName === "ref" && resolvedFunction.isForwardRef) {
+    return analyzeFunctionInput(resolvedFunction, 1, propertyPath, state, remainingDepth);
+  }
+  return analyzeFunctionInput(
+    resolvedFunction,
+    0,
+    [attributeName, ...propertyPath],
+    state,
+    remainingDepth,
+  );
+};
+
+const analyzeCallArgumentUse = (
+  callExpression: EsTreeNodeOfType<"CallExpression">,
+  argumentExpression: EsTreeNode,
+  propertyPath: ReadonlyArray<string>,
+  environment: AnalysisEnvironment,
+  state: AnalysisState,
+  remainingDepth: number,
+): boolean => {
+  const argumentIndex = callExpression.arguments.findIndex(
+    (argument) => argument === argumentExpression,
+  );
+  if (argumentIndex < 0) return false;
+  if (
+    argumentIndex === 0 &&
+    isProvenReactCall(callExpression, "useImperativeHandle", environment.scopes)
+  ) {
+    return propertyPath.length === 0;
+  }
+  if (!isNodeOfType(callExpression.callee, "Identifier")) return false;
+  const resolvedFunction = resolveFunctionValue(callExpression.callee, environment, state);
+  return Boolean(
+    resolvedFunction &&
+    analyzeFunctionInput(resolvedFunction, argumentIndex, propertyPath, state, remainingDepth),
+  );
+};
+
+const analyzeValueUse = (
+  expressionNode: EsTreeNode,
+  propertyPath: ReadonlyArray<string>,
+  environment: AnalysisEnvironment,
+  state: AnalysisState,
+  remainingDepth: number,
+): boolean => {
+  const expression = findTransparentExpressionRoot(expressionNode);
+  const parent = expression.parent;
+  if (!parent) return false;
+  if (
+    propertyPath.length > 0 &&
+    ((isNodeOfType(parent, "LogicalExpression") && parent.left === expression) ||
+      (isNodeOfType(parent, "ConditionalExpression") && parent.test === expression) ||
+      (isNodeOfType(parent, "IfStatement") && parent.test === expression) ||
+      (isNodeOfType(parent, "UnaryExpression") &&
+        parent.operator === "!" &&
+        parent.argument === expression))
+  ) {
+    return true;
+  }
+  if (isNodeOfType(parent, "JSXExpressionContainer") && parent.expression === expression) {
+    const attribute = parent.parent;
+    return Boolean(
+      attribute &&
+      isNodeOfType(attribute, "JSXAttribute") &&
+      analyzeJsxAttributeUse(attribute, propertyPath, environment, state, remainingDepth),
+    );
+  }
+  if (isNodeOfType(parent, "CallExpression")) {
+    return analyzeCallArgumentUse(
+      parent,
+      expression,
+      propertyPath,
+      environment,
+      state,
+      remainingDepth,
+    );
+  }
+  if (
+    isNodeOfType(parent, "VariableDeclarator") &&
+    parent.init === expression &&
+    !isNodeOfType(parent.id, "Identifier")
+  ) {
+    return analyzePatternPath(parent.id, propertyPath, environment, state, remainingDepth);
+  }
+  const propagatedValue = findOwnedSymbolValue(expression, propertyPath, environment);
+  return Boolean(
+    propagatedValue && analyzeSymbolValuePath(propagatedValue, state, remainingDepth - 1),
+  );
+};
+
+const analyzeSymbolValuePath = (
+  valuePath: SymbolValuePath,
+  state: AnalysisState,
+  remainingDepth: number,
+): boolean => {
+  if (remainingDepth <= 0) return false;
+  const activePathKey = `${valuePath.environment.filename}:${valuePath.symbol.id}:${valuePath.propertyPath.join(".")}`;
+  if (state.activePaths.has(activePathKey)) return false;
+  state.activePaths.add(activePathKey);
+  const bindingFunction = findEnclosingFunction(valuePath.symbol.bindingIdentifier);
+  const result = valuePath.symbol.references.every((reference) => {
+    const referenceParent = reference.identifier.parent;
+    if (
+      referenceParent &&
+      isNodeOfType(referenceParent, "Property") &&
+      !referenceParent.computed &&
+      referenceParent.key === reference.identifier &&
+      referenceParent.value !== reference.identifier
+    ) {
+      return true;
+    }
+    const memberAccess = collectMemberAccess(reference.identifier);
+    if (!memberAccess) return false;
+    if (!pathsOverlap(memberAccess.propertyPath, valuePath.propertyPath)) return true;
+    if (reference.flag !== "read") return false;
+    const referenceFunction = findEnclosingFunction(reference.identifier);
+    if (referenceFunction !== bindingFunction) {
+      return isSafeSameRenderCurrentRead(
+        reference.identifier,
+        memberAccess.propertyPath,
+        valuePath.propertyPath,
+      );
+    }
+    if (pathStartsWith(memberAccess.propertyPath, valuePath.propertyPath)) {
+      if (memberAccess.propertyPath.length > valuePath.propertyPath.length) return false;
+      return analyzeValueUse(
+        memberAccess.expression,
+        [],
+        valuePath.environment,
+        state,
+        remainingDepth,
+      );
+    }
+    return analyzeValueUse(
+      memberAccess.expression,
+      valuePath.propertyPath.slice(memberAccess.propertyPath.length),
+      valuePath.environment,
+      state,
+      remainingDepth,
+    );
+  });
+  state.activePaths.delete(activePathKey);
+  return result;
+};
+
+export const isCreateRefResultWriteOnly = (
+  createRefCall: EsTreeNodeOfType<"CallExpression">,
+  filename: string | undefined,
+  scopes: ScopeAnalysis,
+): boolean => {
+  if (!filename) return false;
+  const program = findProgramRoot(createRefCall);
+  if (!program) return false;
+  const environment = { filename, program, scopes };
+  const state: AnalysisState = {
+    activePaths: new Set(),
+    environmentsByProgram: new WeakMap([[program, environment]]),
+  };
+  const ownedValue = findOwnedSymbolValue(createRefCall, [], environment);
+  return Boolean(
+    ownedValue && analyzeSymbolValuePath(ownedValue, state, CREATE_REF_PROP_FLOW_MAX_DEPTH),
+  );
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/is-safe-create-ref-callback-current-write.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/is-safe-create-ref-callback-current-write.ts
@@ -1,0 +1,86 @@
+import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
+import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
+import { findTransparentExpressionRoot } from "../../utils/find-transparent-expression-root.js";
+import { getJsxAttributeName } from "../../utils/get-jsx-attribute-name.js";
+import { isFunctionLike } from "../../utils/is-function-like.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { isProvenIntrinsicJsxElement } from "../../utils/is-proven-intrinsic-jsx-element.js";
+import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+
+const pathStartsWith = (
+  propertyPath: ReadonlyArray<string>,
+  prefix: ReadonlyArray<string>,
+): boolean => prefix.every((propertyName, index) => propertyPath[index] === propertyName);
+
+const collectMemberExpression = (identifier: EsTreeNode): EsTreeNode | null => {
+  let expression = findTransparentExpressionRoot(identifier);
+  while (
+    expression.parent &&
+    isNodeOfType(expression.parent, "MemberExpression") &&
+    expression.parent.object === expression
+  ) {
+    if (!getStaticPropertyName(expression.parent)) return null;
+    expression = findTransparentExpressionRoot(expression.parent);
+  }
+  return expression;
+};
+
+const isInlineIntrinsicRefCallback = (functionNode: EsTreeNode, scopes: ScopeAnalysis): boolean => {
+  const functionExpression = findTransparentExpressionRoot(functionNode);
+  if (
+    !isFunctionLike(functionExpression) ||
+    functionExpression.async ||
+    functionExpression.generator
+  ) {
+    return false;
+  }
+  const container = functionExpression.parent;
+  if (!container || !isNodeOfType(container, "JSXExpressionContainer")) return false;
+  const attribute = container.parent;
+  if (
+    !attribute ||
+    !isNodeOfType(attribute, "JSXAttribute") ||
+    getJsxAttributeName(attribute.name) !== "ref"
+  ) {
+    return false;
+  }
+  const openingElement = attribute.parent;
+  return Boolean(
+    openingElement &&
+    isNodeOfType(openingElement, "JSXOpeningElement") &&
+    isProvenIntrinsicJsxElement(openingElement, scopes),
+  );
+};
+
+export const isSafeCreateRefCallbackCurrentWrite = (
+  referenceNode: EsTreeNode,
+  accessedPropertyPath: ReadonlyArray<string>,
+  targetPropertyPath: ReadonlyArray<string>,
+  scopes: ScopeAnalysis,
+): boolean => {
+  if (
+    accessedPropertyPath.length !== targetPropertyPath.length + 1 ||
+    !pathStartsWith(accessedPropertyPath, targetPropertyPath) ||
+    accessedPropertyPath[targetPropertyPath.length] !== "current"
+  ) {
+    return false;
+  }
+  const memberExpression = collectMemberExpression(referenceNode);
+  const assignment = memberExpression?.parent;
+  if (
+    !memberExpression ||
+    !assignment ||
+    !isNodeOfType(assignment, "AssignmentExpression") ||
+    assignment.operator !== "=" ||
+    assignment.left !== memberExpression
+  ) {
+    return false;
+  }
+  let enclosingFunction = findEnclosingFunction(referenceNode);
+  while (enclosingFunction) {
+    if (isInlineIntrinsicRefCallback(enclosingFunction, scopes)) return true;
+    enclosingFunction = findEnclosingFunction(enclosingFunction);
+  }
+  return false;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/is-safe-create-ref-callback-current-write.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/is-safe-create-ref-callback-current-write.ts
@@ -77,10 +77,25 @@ export const isSafeCreateRefCallbackCurrentWrite = (
   ) {
     return false;
   }
-  let enclosingFunction = findEnclosingFunction(referenceNode);
-  while (enclosingFunction) {
-    if (isInlineIntrinsicRefCallback(enclosingFunction, scopes)) return true;
-    enclosingFunction = findEnclosingFunction(enclosingFunction);
+  const enclosingFunction = findEnclosingFunction(referenceNode);
+  if (!enclosingFunction) return false;
+  if (isInlineIntrinsicRefCallback(enclosingFunction, scopes)) return true;
+  if (
+    !isFunctionLike(enclosingFunction) ||
+    enclosingFunction.async ||
+    enclosingFunction.generator
+  ) {
+    return false;
   }
-  return false;
+  const callbackFunction = findEnclosingFunction(enclosingFunction);
+  if (!callbackFunction || !isInlineIntrinsicRefCallback(callbackFunction, scopes)) return false;
+  const cleanupFunction = findTransparentExpressionRoot(enclosingFunction);
+  const cleanupContainer = cleanupFunction.parent;
+  return Boolean(
+    (isNodeOfType(cleanupContainer, "ReturnStatement") &&
+      cleanupContainer.argument === cleanupFunction &&
+      findEnclosingFunction(cleanupContainer) === callbackFunction) ||
+    (isNodeOfType(callbackFunction, "ArrowFunctionExpression") &&
+      callbackFunction.body === cleanupFunction),
+  );
 };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/is-value-rendered-in-same-render.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/is-value-rendered-in-same-render.ts
@@ -1,0 +1,109 @@
+import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
+import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
+import { findTransparentExpressionRoot } from "../../utils/find-transparent-expression-root.js";
+import { isJsxFragmentElement } from "../../utils/is-jsx-fragment-element.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { isProvenIntrinsicJsxElement } from "../../utils/is-proven-intrinsic-jsx-element.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+
+interface ValueRenderedInSameRenderOptions {
+  readonly doesCustomElementRenderChildren?: (openingElement: EsTreeNode) => boolean;
+}
+
+const isValueRenderedFromOwner = (
+  expressionNode: EsTreeNode,
+  renderOwner: EsTreeNode | null,
+  scopes: ScopeAnalysis,
+  visitedSymbolIds: Set<number>,
+  options: ValueRenderedInSameRenderOptions,
+): boolean => {
+  const expression = findTransparentExpressionRoot(expressionNode);
+  const parent = expression.parent;
+  if (!parent) return false;
+  if (isNodeOfType(parent, "ReturnStatement") && parent.argument === expression) {
+    return findEnclosingFunction(parent) === renderOwner;
+  }
+  if (isNodeOfType(parent, "ArrowFunctionExpression") && parent.body === expression) {
+    return parent === renderOwner;
+  }
+  if (
+    isNodeOfType(parent, "JSXFragment") &&
+    parent.children.some((child) => child === expression)
+  ) {
+    return isValueRenderedFromOwner(parent, renderOwner, scopes, visitedSymbolIds, options);
+  }
+  if (
+    isNodeOfType(parent, "JSXElement") &&
+    parent.children.some((child) => child === expression) &&
+    (isProvenIntrinsicJsxElement(parent.openingElement, scopes) ||
+      isJsxFragmentElement(parent.openingElement, scopes) ||
+      options.doesCustomElementRenderChildren?.(parent.openingElement))
+  ) {
+    return isValueRenderedFromOwner(parent, renderOwner, scopes, visitedSymbolIds, options);
+  }
+  if (
+    isNodeOfType(parent, "JSXExpressionContainer") &&
+    parent.expression === expression &&
+    parent.parent &&
+    (isNodeOfType(parent.parent, "JSXFragment") ||
+      (isNodeOfType(parent.parent, "JSXElement") &&
+        (isProvenIntrinsicJsxElement(parent.parent.openingElement, scopes) ||
+          isJsxFragmentElement(parent.parent.openingElement, scopes) ||
+          options.doesCustomElementRenderChildren?.(parent.parent.openingElement))))
+  ) {
+    return isValueRenderedFromOwner(parent.parent, renderOwner, scopes, visitedSymbolIds, options);
+  }
+  if (
+    (isNodeOfType(parent, "ConditionalExpression") &&
+      (parent.consequent === expression || parent.alternate === expression)) ||
+    (isNodeOfType(parent, "LogicalExpression") &&
+      (parent.left === expression || parent.right === expression)) ||
+    (isNodeOfType(parent, "ArrayExpression") &&
+      parent.elements.some((element) => element === expression))
+  ) {
+    return isValueRenderedFromOwner(parent, renderOwner, scopes, visitedSymbolIds, options);
+  }
+  if (
+    !isNodeOfType(parent, "VariableDeclarator") ||
+    parent.init !== expression ||
+    !isNodeOfType(parent.id, "Identifier")
+  ) {
+    return false;
+  }
+  const symbol = scopes.symbolFor(parent.id);
+  if (
+    !symbol ||
+    symbol.kind !== "const" ||
+    symbol.references.length === 0 ||
+    visitedSymbolIds.has(symbol.id)
+  ) {
+    return false;
+  }
+  visitedSymbolIds.add(symbol.id);
+  const isRendered = symbol.references.every(
+    (reference) =>
+      reference.flag === "read" &&
+      isValueRenderedFromOwner(
+        reference.identifier,
+        renderOwner,
+        scopes,
+        visitedSymbolIds,
+        options,
+      ),
+  );
+  visitedSymbolIds.delete(symbol.id);
+  return isRendered;
+};
+
+export const isValueRenderedInSameRender = (
+  expressionNode: EsTreeNode,
+  scopes: ScopeAnalysis,
+  options: ValueRenderedInSameRenderOptions = {},
+): boolean =>
+  isValueRenderedFromOwner(
+    expressionNode,
+    findEnclosingFunction(expressionNode),
+    scopes,
+    new Set<number>(),
+    options,
+  );

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-create-ref-in-function-component.cross-file.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-create-ref-in-function-component.cross-file.test.ts
@@ -1,0 +1,126 @@
+import * as fs from "node:fs";
+import os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { __clearParseSourceFileCacheForTests } from "../../utils/parse-source-file.js";
+import { __clearTsconfigAliasCacheForTests } from "../../utils/resolve-tsconfig-alias.js";
+import { noCreateRefInFunctionComponent } from "./no-create-ref-in-function-component.js";
+
+let temporaryDirectory: string;
+
+beforeEach(() => {
+  temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "create-ref-write-only-"));
+  __clearParseSourceFileCacheForTests();
+  __clearTsconfigAliasCacheForTests();
+});
+
+afterEach(() => {
+  fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+});
+
+const writeFile = (relativePath: string, contents: string): string => {
+  const absolutePath = path.join(temporaryDirectory, relativePath);
+  fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+  fs.writeFileSync(absolutePath, contents, "utf8");
+  return absolutePath;
+};
+
+const writeForwardingModules = (navigationBody: string): string => {
+  writeFile(
+    "use-forward-focus.ts",
+    `import { useImperativeHandle, useRef } from "react";
+
+export default function useForwardFocus(mainRef) {
+  const controlRef = useRef(null);
+  useImperativeHandle(mainRef, () => ({ focus: () => controlRef.current?.focus() }), [controlRef]);
+  return controlRef;
+}`,
+  );
+  writeFile(
+    "internal-button.tsx",
+    `import React from "react";
+import useForwardFocus from "./use-forward-focus";
+
+export const InternalButton = React.forwardRef((props, ref) => {
+  const controlRef = useForwardFocus(ref);
+  return <button {...props} ref={controlRef} />;
+});`,
+  );
+  writeFile(
+    "navigation.tsx",
+    `import { useLayoutEffect } from "react";
+import { InternalButton } from "./internal-button";
+
+export const Navigation = ({ focusControl }) => {
+  ${navigationBody}
+};`,
+  );
+  return writeFile(
+    "pending-adapter.tsx",
+    `import { createRef } from "react";
+import { Navigation } from "./navigation";
+
+export const PendingAdapter = ({ isPending }) => {
+  if (!isPending) return <main>Ready</main>;
+  const focusControl = {
+    refs: {
+      toggle: createRef(),
+      close: createRef(),
+      slider: createRef(),
+    },
+    setFocus: () => {},
+    loseFocus: () => {},
+  };
+  return <Navigation focusControl={focusControl} />;
+};`,
+  );
+};
+
+describe("no-create-ref-in-function-component — cross-file write sinks", () => {
+  it("stays silent when every imported consumer resolves to a React ref write sink", () => {
+    const consumerPath = writeForwardingModules(
+      "return <InternalButton ref={focusControl.refs.close}>Close</InternalButton>;",
+    );
+    const result = runRule(noCreateRefInFunctionComponent, fs.readFileSync(consumerPath, "utf8"), {
+      filename: consumerPath,
+    });
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("reports when an imported consumer retains and observes the ref", () => {
+    const consumerPath = writeForwardingModules(
+      `useLayoutEffect(() => {
+    globalThis.observedRef = focusControl.refs.close;
+  }, []);
+  return <InternalButton ref={focusControl.refs.close}>Close</InternalButton>;`,
+    );
+    const result = runRule(noCreateRefInFunctionComponent, fs.readFileSync(consumerPath, "utf8"), {
+      filename: consumerPath,
+    });
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports when an imported consumer cannot be resolved", () => {
+    const consumerPath = writeFile(
+      "pending-adapter.tsx",
+      `import { createRef } from "react";
+import { Navigation } from "opaque-navigation";
+
+export const PendingAdapter = () => {
+  const target = createRef();
+  return <Navigation target={target} />;
+};`,
+    );
+    const result = runRule(noCreateRefInFunctionComponent, fs.readFileSync(consumerPath, "utf8"), {
+      filename: consumerPath,
+    });
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-create-ref-in-function-component.cross-file.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-create-ref-in-function-component.cross-file.test.ts
@@ -42,19 +42,21 @@ export default function useForwardFocus(mainRef) {
     `import React from "react";
 import useForwardFocus from "./use-forward-focus";
 
-export const InternalButton = React.forwardRef((props, ref) => {
+const InternalButtonImplementation = (props, ref) => {
   const controlRef = useForwardFocus(ref);
   return <button {...props} ref={controlRef} />;
-});`,
+};
+
+export const InternalButton = React.forwardRef(InternalButtonImplementation);`,
   );
   writeFile(
     "navigation.tsx",
     `import { useLayoutEffect } from "react";
 import { InternalButton } from "./internal-button";
 
-export const Navigation = ({ focusControl }) => {
+export function Navigation({ focusControl }) {
   ${navigationBody}
-};`,
+}`,
   );
   return writeFile(
     "pending-adapter.tsx",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-create-ref-in-function-component.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-create-ref-in-function-component.regressions.test.ts
@@ -165,6 +165,143 @@ export const FocusButton = () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("reports when an async inline event handler reads the ref after suspension", () => {
+    const result = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+
+export const FocusButton = () => {
+  const target = createRef<HTMLButtonElement>();
+  return <button ref={target} onClick={async () => { await Promise.resolve(); target.current?.focus(); }}>Focus</button>;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports when a dynamic computed destructuring key may extract the ref", () => {
+    const result = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef, useEffect } from "react";
+
+export const FocusButton = ({ keyName, observe }) => {
+  const control = { target: createRef<HTMLButtonElement>() };
+  const { [keyName]: extracted } = control;
+  useEffect(() => observe(extracted), [extracted, observe]);
+  return <button ref={control.target}>Focus</button>;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays silent for direct intrinsic JSX and React createElement ref sinks", () => {
+    const jsxResult = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+export const Input = () => <input ref={createRef<HTMLInputElement>()} />;`,
+    );
+    const createElementResult = runRule(
+      noCreateRefInFunctionComponent,
+      `import React, { createRef } from "react";
+export const Input = () => {
+  const target = createRef<HTMLInputElement>();
+  return React.createElement("input", { ref: target });
+};`,
+    );
+    expect(jsxResult.parseErrors).toEqual([]);
+    expect(jsxResult.diagnostics).toEqual([]);
+    expect(createElementResult.parseErrors).toEqual([]);
+    expect(createElementResult.diagnostics).toEqual([]);
+  });
+
+  it("stays silent for named-alias and namespace React createElement ref sinks", () => {
+    const namedAliasResult = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createElement as h, createRef } from "react";
+export const Input = () => {
+  const target = createRef<HTMLInputElement>();
+  return h("input", { ref: target });
+};`,
+    );
+    const namespaceResult = runRule(
+      noCreateRefInFunctionComponent,
+      `import * as ReactRuntime from "react";
+export const Input = () => {
+  const target = ReactRuntime.createRef<HTMLInputElement>();
+  return ReactRuntime.createElement("input", { ref: target });
+};`,
+    );
+    expect(namedAliasResult.parseErrors).toEqual([]);
+    expect(namedAliasResult.diagnostics).toEqual([]);
+    expect(namespaceResult.parseErrors).toEqual([]);
+    expect(namespaceResult.diagnostics).toEqual([]);
+  });
+
+  it("reports a ref passed to a userland createElement lookalike", () => {
+    const result = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+const createElement = (type, props) => ({ type, props });
+export const Input = () => {
+  const target = createRef<HTMLInputElement>();
+  const input = createElement("input", { ref: target });
+  return <>{input}</>;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports a ref passed through an async helper from a fresh event handler", () => {
+    const result = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+
+export const FocusButton = () => {
+  const target = createRef<HTMLButtonElement>();
+  const focusLater = async (ref) => { await Promise.resolve(); ref.current?.focus(); };
+  return <button ref={target} onClick={() => { void focusLater(target); }}>Focus</button>;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports an async helper that attaches the ref after suspension", () => {
+    const result = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+
+const mountLater = async (target) => {
+  await Promise.resolve();
+  mount(<input ref={target} />);
+};
+
+export const Input = () => {
+  const target = createRef<HTMLInputElement>();
+  void mountLater(target);
+  return <main>Input</main>;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports when a generator event handler can resume with a stale ref", () => {
+    const result = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+
+export const FocusButton = () => {
+  const target = createRef<HTMLButtonElement>();
+  return <button ref={target} onClick={function* () { yield; target.current?.focus(); }}>Focus</button>;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("still flags a ref captured by a retained event handler", () => {
     const result = runRule(
       noCreateRefInFunctionComponent,
@@ -246,5 +383,290 @@ export const FocusButton = () => {
     );
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("preserves forwardRef provenance through a local alias", () => {
+    const result = runRule(
+      noCreateRefInFunctionComponent,
+      `import React, { createRef, useLayoutEffect } from "react";
+
+const Base = React.forwardRef((props, forwardedRef) => {
+  useLayoutEffect(() => { globalThis.observedRef = forwardedRef; }, [forwardedRef]);
+  return <button {...props} ref={forwardedRef} />;
+});
+const Alias = Base;
+
+export const FocusButton = () => {
+  const target = createRef<HTMLButtonElement>();
+  return <Alias ref={target}>Focus</Alias>;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("describes unresolved consumers as uncertain escape", () => {
+    const result = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+import { UnknownConsumer } from "unknown-package";
+export const Input = () => <UnknownConsumer target={createRef()} />;`,
+    );
+    expect(result.diagnostics[0]?.message).toContain("may escape");
+  });
+
+  it("stays silent for unused createRef results and synchronous render IIFEs", () => {
+    const unusedResult = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+export const Input = () => { createRef(); return <input />; };`,
+    );
+    const iifeResult = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+export const Input = () => {
+  const target = createRef();
+  return ((forwarded) => <input ref={forwarded} />)(target);
+};`,
+    );
+    const helperResult = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+const renderInput = (forwarded) => <input ref={forwarded} />;
+export const Input = () => { const target = createRef(); return renderInput(target); };`,
+    );
+    expect(unusedResult.diagnostics).toEqual([]);
+    expect(iifeResult.diagnostics).toEqual([]);
+    expect(helperResult.diagnostics).toEqual([]);
+  });
+
+  it("stays silent for intrinsic ref props in closed JSX spreads", () => {
+    const result = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+export const Input = () => {
+  const first = createRef();
+  const second = createRef();
+  const props = { ref: second };
+  return <><input {...{ ref: first }} /><input {...props} /></>;
+};`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent for callback-ref current writes including cleanup", () => {
+    const result = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+export const Input = () => {
+  const target = createRef();
+  return <input ref={(node) => { target.current = node; return () => { target.current = null; }; }} />;
+};`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("reports a callback ref that reads the fresh ref", () => {
+    const result = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+export const Input = () => {
+  const target = createRef();
+  return <input ref={(node) => { observe(target.current); target.current = node; }} />;
+};`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("tracks an exact array index into an intrinsic ref sink", () => {
+    const cleanResult = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+export const Input = () => { const tuple = [createRef()]; return <input ref={tuple[0]} />; };`,
+    );
+    const observedResult = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef, useEffect } from "react";
+export const Input = () => { const tuple = [createRef()]; useEffect(() => observe(tuple[0]), []); return <input ref={tuple[0]} />; };`,
+    );
+    expect(cleanResult.diagnostics).toEqual([]);
+    expect(observedResult.diagnostics).toHaveLength(1);
+  });
+
+  it("recognizes proven React class and const intrinsic element ref sinks", () => {
+    const result = runRule(
+      noCreateRefInFunctionComponent,
+      `import React, { createRef } from "react";
+class LegacyInput extends React.Component { render() { return <input />; } }
+const Tag = "input";
+export const Input = () => {
+  const instance = createRef();
+  const element = createRef();
+  return <><LegacyInput ref={instance} /><Tag ref={element} /></>;
+};`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("recognizes closed intrinsic unions, aliases, and React class-base aliases", () => {
+    const result = runRule(
+      noCreateRefInFunctionComponent,
+      `import React, { createRef } from "react";
+const Host = "div";
+const Tag = Host;
+const Base = React.Component;
+class LegacyInput extends Base { render() { return <input />; } }
+export const Input = ({ span }) => {
+  const UnionTag = span ? "span" : "div";
+  const first = createRef(); const second = createRef(); const third = createRef();
+  return <><Tag ref={first} /><UnionTag ref={second} /><LegacyInput ref={third} /></>;
+};`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not treat a userland Component base as a proven class ref sink", () => {
+    const result = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+class Component {}
+class UserlandInput extends Component {}
+export const Input = () => { const target = createRef(); return <UserlandInput ref={target} />; };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("tracks a locally owned property assignment into an intrinsic ref sink", () => {
+    const result = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+export const Input = () => { const owner = {}; owner.target = createRef(); return <input ref={owner.target} />; };`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("reports a fresh handler read after an unknown synchronous call", () => {
+    const result = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+export const Input = () => { const target = createRef(); return <button ref={target} onClick={() => { unknownCall(); target.current?.focus(); }}>Focus</button>; };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports a fresh handler read after an unknown getter access", () => {
+    const result = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+export const Input = ({ controller }) => { const target = createRef(); return <button ref={target} onClick={() => { void controller.value; target.current?.focus(); }}>Focus</button>; };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("keeps an ordinary state setter before the fresh handler read safe", () => {
+    const result = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef, useState } from "react";
+export const Input = () => { const [active, setActive] = useState(false); const target = createRef(); return <button aria-pressed={active} ref={target} onClick={() => { setActive(true); target.current?.focus(); }}>Focus</button>; };`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("keeps proven non-committing calls before the fresh handler read safe", () => {
+    const result = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef, startTransition } from "react";
+export const Input = () => { const target = createRef(); return <button ref={target} onClick={(event) => { event.preventDefault(); event.stopPropagation(); console.log("focus"); startTransition(() => {}); target.current?.focus(); }}>Focus</button>; };`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not trust shadowed non-committing call lookalikes", () => {
+    const result = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+export const Input = ({ console, startTransition }) => { const target = createRef(); return <button ref={target} onClick={(event) => { console.log(); startTransition(); event.customPreventDefault(); target.current?.focus(); }}>Focus</button>; };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still inspects arguments and callbacks of non-committing calls", () => {
+    const result = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef, startTransition, useState } from "react";
+import { flushSync } from "react-dom";
+export const Input = () => { const [active, setActive] = useState(false); const target = createRef(); return <button key={String(active)} ref={target} onClick={(event) => { event.preventDefault(flushSync(() => setActive(true))); startTransition(() => { flushSync(() => setActive(false)); }); target.current?.focus(); }}>Focus</button>; };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not trust a reassigned useState setter", () => {
+    const result = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef, useState } from "react";
+import { flushSync } from "react-dom";
+export const Input = () => { let [active, setActive] = useState(false); const originalSetActive = setActive; setActive = () => flushSync(() => originalSetActive((value) => !value)); const target = createRef(); return <button key={String(active)} ref={target} onClick={() => { setActive(true); target.current?.focus(); }}>Focus</button>; };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports a fresh handler read after a synchronous flush", () => {
+    const result = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef, useState } from "react";
+import { flushSync as commitNow } from "react-dom";
+export const Input = () => { const [active, setActive] = useState(false); const target = createRef(); return <button key={String(active)} ref={target} onClick={() => { commitNow(() => setActive((value) => !value)); target.current?.focus(); }}>Focus</button>; };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports a loop read that can follow a prior iteration's synchronous flush", () => {
+    const result = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef, useState } from "react";
+import { flushSync } from "react-dom";
+export const Input = () => { const [active, setActive] = useState(false); const target = createRef(); return <button key={String(active)} ref={target} onClick={() => { for (let index = 0; index < 2; index += 1) { target.current?.focus(); flushSync(() => setActive((value) => !value)); } }}>Focus</button>; };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("allows an async fresh handler read before suspension", () => {
+    const result = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+export const Input = () => { const target = createRef(); return <button ref={target} onClick={async () => { target.current?.focus(); await Promise.resolve(); }}>Focus</button>; };`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("supports named, conditional, logical, and nested synchronous fresh handlers", () => {
+    const result = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+export const Input = ({ enabled }) => {
+  const first = createRef(); const second = createRef(); const third = createRef(); const fourth = createRef();
+  const named = () => first.current?.focus();
+  return <><button ref={first} onClick={named} /><button ref={second} onClick={enabled ? () => second.current?.focus() : undefined} /><button ref={third} onClick={enabled && (() => third.current?.focus())} /><button ref={fourth} onClick={() => { (() => fourth.current?.focus())(); }} /></>;
+};`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("uses scope-proven React createRef provenance", () => {
+    const positiveResult = runRule(
+      noCreateRefInFunctionComponent,
+      `import ReactRuntime, { createRef as makeRef } from "react";
+const namespaceAlias = ReactRuntime;
+const { createRef: destructured } = namespaceAlias;
+export const Input = () => { const a = makeRef(); const b = namespaceAlias["createRef"](); const c = destructured(); observe(a, b, c); return <input />; };`,
+    );
+    const negativeResult = runRule(
+      noCreateRefInFunctionComponent,
+      `import React from "preact/compat";
+const localReact = { createRef: () => ({ current: null }) };
+export const Input = () => { React.createRef(); localReact.createRef(); return <input />; };`,
+    );
+    expect(positiveResult.diagnostics).toHaveLength(3);
+    expect(negativeResult.diagnostics).toEqual([]);
   });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-create-ref-in-function-component.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-create-ref-in-function-component.regressions.test.ts
@@ -150,4 +150,33 @@ export const StableObservedRef = ({ label, observe }: StableObservedRefProps) =>
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toEqual([]);
   });
+
+  it("stays silent when a fresh event handler reads the ref from the same render", () => {
+    const result = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+
+export const FocusButton = () => {
+  const target = createRef<HTMLButtonElement>();
+  return <button ref={target} onClick={() => target.current?.focus()}>Focus</button>;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still flags a ref captured by a retained event handler", () => {
+    const result = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef, useCallback } from "react";
+
+export const FocusButton = () => {
+  const target = createRef<HTMLButtonElement>();
+  const focus = useCallback(() => target.current?.focus(), []);
+  return <button ref={target} onClick={focus}>Focus</button>;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-create-ref-in-function-component.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-create-ref-in-function-component.regressions.test.ts
@@ -179,4 +179,72 @@ export const FocusButton = () => {
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toHaveLength(1);
   });
+
+  it("stays silent with a proven closed object spread", () => {
+    const result = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+
+const closedControls = { setFocus: () => {}, loseFocus: () => {} };
+
+export const FocusButton = () => {
+  const control = {
+    ...closedControls,
+    refs: { target: createRef<HTMLButtonElement>() },
+  };
+  return <button ref={control.refs.target}>Focus</button>;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("reports when the containing object has an unknown spread", () => {
+    const result = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+
+export const FocusButton = ({ controls }) => {
+  const control = {
+    ...controls,
+    refs: { target: createRef<HTMLButtonElement>() },
+  };
+  return <button ref={control.refs.target}>Focus</button>;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports an on-prefixed handler passed to an unresolved custom component", () => {
+    const result = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+import { RetainingControl } from "opaque-control";
+
+export const FocusButton = () => {
+  const target = createRef<HTMLButtonElement>();
+  return <RetainingControl onFocusRequest={() => target.current?.focus()} />;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports refs passed through a userland forwardRef lookalike", () => {
+    const result = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+
+const forwardRef = (render) => render;
+const RefSink = forwardRef((props, ref) => <button {...props} />);
+
+export const FocusButton = () => {
+  const target = createRef<HTMLButtonElement>();
+  return <RefSink ref={target}>Focus</RefSink>;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-create-ref-in-function-component.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-create-ref-in-function-component.regressions.test.ts
@@ -57,4 +57,97 @@ function Editor() {
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toEqual([]);
   });
+
+  it("stays silent for render-local refs used only as React attachment sinks", () => {
+    const result = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef, type RefObject } from "react";
+
+interface FocusControl {
+  refs: {
+    toggle: RefObject<HTMLButtonElement | null>;
+    close: RefObject<HTMLButtonElement | null>;
+    slider: RefObject<HTMLDivElement | null>;
+  };
+  setFocus(): void;
+  loseFocus(): void;
+}
+
+interface NavigationProps {
+  focusControl: FocusControl;
+}
+
+interface PendingAdapterProps {
+  isPending: boolean;
+}
+
+const Navigation = ({ focusControl }: NavigationProps) => (
+  <button ref={focusControl.refs.close}>Close navigation</button>
+);
+
+export const PendingAdapter = ({ isPending }: PendingAdapterProps) => {
+  if (!isPending) return <main>Ready content</main>;
+
+  const focusControl: FocusControl = {
+    refs: {
+      toggle: createRef<HTMLButtonElement>(),
+      close: createRef<HTMLButtonElement>(),
+      slider: createRef<HTMLDivElement>(),
+    },
+    setFocus: () => {},
+    loseFocus: () => {},
+  };
+
+  return (
+    <>
+      <button ref={focusControl.refs.toggle}>Open navigation</button>
+      <Navigation focusControl={focusControl} />
+      <div>Navigation</div>
+    </>
+  );
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still flags a render-local ref whose identity is observed after attachment", () => {
+    const result = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef, useLayoutEffect, type RefObject } from "react";
+
+interface ObservedRefProps {
+  label: string;
+  observe(ref: RefObject<HTMLButtonElement | null>): void;
+}
+
+export const ObservedRef = ({ label, observe }: ObservedRefProps) => {
+  const target = createRef<HTMLButtonElement>();
+  useLayoutEffect(() => observe(target), [observe, target]);
+  return <button ref={target}>{label}</button>;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays silent for an observed useRef equivalent", () => {
+    const result = runRule(
+      noCreateRefInFunctionComponent,
+      `import { useLayoutEffect, useRef, type RefObject } from "react";
+
+interface StableObservedRefProps {
+  label: string;
+  observe(ref: RefObject<HTMLButtonElement | null>): void;
+}
+
+export const StableObservedRef = ({ label, observe }: StableObservedRefProps) => {
+  const target = useRef<HTMLButtonElement>(null);
+  useLayoutEffect(() => observe(target), [observe, target]);
+  return <button ref={target}>{label}</button>;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-create-ref-in-function-component.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-create-ref-in-function-component.regressions.test.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vite-plus/test";
 import { runRule } from "../../../test-utils/run-rule.js";
 import { noCreateRefInFunctionComponent } from "./no-create-ref-in-function-component.js";
@@ -18,6 +19,30 @@ export default useDriveItemActions;`,
     );
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics.length).toBe(1);
+  });
+
+  it("flags aliased React useMemo and createRef calls inside a custom hook", () => {
+    const result = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef as makeRef, useMemo as cache } from "react";
+const useThing = () => cache(() => makeRef(), []);`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not treat a userland useMemo callback as render-transparent", () => {
+    const result = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+const useMemo = (callback) => callback();
+export const Input = () => {
+  const target = useMemo(() => createRef(), []);
+  return <input data-present={Boolean(target)} />;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
   });
 
   it("flags useMemo(() => createRef(), []) inside a component", () => {
@@ -151,34 +176,6 @@ export const StableObservedRef = ({ label, observe }: StableObservedRefProps) =>
     expect(result.diagnostics).toEqual([]);
   });
 
-  it("stays silent when a fresh event handler reads the ref from the same render", () => {
-    const result = runRule(
-      noCreateRefInFunctionComponent,
-      `import { createRef } from "react";
-
-export const FocusButton = () => {
-  const target = createRef<HTMLButtonElement>();
-  return <button ref={target} onClick={() => target.current?.focus()}>Focus</button>;
-};`,
-    );
-    expect(result.parseErrors).toEqual([]);
-    expect(result.diagnostics).toEqual([]);
-  });
-
-  it("reports when an async inline event handler reads the ref after suspension", () => {
-    const result = runRule(
-      noCreateRefInFunctionComponent,
-      `import { createRef } from "react";
-
-export const FocusButton = () => {
-  const target = createRef<HTMLButtonElement>();
-  return <button ref={target} onClick={async () => { await Promise.resolve(); target.current?.focus(); }}>Focus</button>;
-};`,
-    );
-    expect(result.parseErrors).toEqual([]);
-    expect(result.diagnostics).toHaveLength(1);
-  });
-
   it("reports when a dynamic computed destructuring key may extract the ref", () => {
     const result = runRule(
       noCreateRefInFunctionComponent,
@@ -238,6 +235,190 @@ export const Input = () => {
     expect(namespaceResult.diagnostics).toEqual([]);
   });
 
+  it("stays silent for intrinsic cloneElement and aliased createElement props", () => {
+    const cloneElementResult = runRule(
+      noCreateRefInFunctionComponent,
+      `import React, { createRef } from "react";
+export const Input = () => { const target = createRef(); return React.cloneElement(<input />, { ref: target }); };`,
+    );
+    const aliasedPropsResult = runRule(
+      noCreateRefInFunctionComponent,
+      `import React, { createRef } from "react";
+export const Input = () => { const target = createRef(); const props = { ref: target }; return React.createElement("input", props); };`,
+    );
+    expect(cloneElementResult.diagnostics).toEqual([]);
+    expect(aliasedPropsResult.diagnostics).toEqual([]);
+  });
+
+  it("reports cloneElement refs on custom elements and aliased props that escape", () => {
+    const customElementResult = runRule(
+      noCreateRefInFunctionComponent,
+      `import React, { createRef } from "react";
+const Custom = () => <input />;
+export const Input = () => { const target = createRef(); return React.cloneElement(<Custom />, { ref: target }); };`,
+    );
+    const escapedPropsResult = runRule(
+      noCreateRefInFunctionComponent,
+      `import React, { createRef } from "react";
+export const Input = ({ observe }) => { const target = createRef(); const props = { ref: target }; observe(props); return React.createElement("input", props); };`,
+    );
+    expect(customElementResult.diagnostics).toHaveLength(1);
+    expect(escapedPropsResult.diagnostics).toHaveLength(1);
+  });
+
+  it("reports intrinsic element results that retain the ref beyond the render", () => {
+    const jsxResult = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+export const Input = ({ retain }) => { const target = createRef(); retain(<input ref={target} />); return <div />; };`,
+    );
+    const aliasResult = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+export const Input = ({ retain }) => { const target = createRef(); const element = <input ref={target} />; retain(element); return <div />; };`,
+    );
+    const createElementResult = runRule(
+      noCreateRefInFunctionComponent,
+      `import React, { createRef } from "react";
+export const Input = ({ retain }) => { const target = createRef(); retain(React.createElement("input", { ref: target })); return <div />; };`,
+    );
+    const cloneElementResult = runRule(
+      noCreateRefInFunctionComponent,
+      `import React, { createRef } from "react";
+export const Input = ({ retain }) => { const target = createRef(); retain(React.cloneElement(<input />, { ref: target })); return <div />; };`,
+    );
+    expect(jsxResult.diagnostics).toHaveLength(1);
+    expect(aliasResult.diagnostics).toHaveLength(1);
+    expect(createElementResult.diagnostics).toHaveLength(1);
+    expect(cloneElementResult.diagnostics).toHaveLength(1);
+  });
+
+  it("reports an intrinsic ref hidden beneath a local component that retains children", () => {
+    const result = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+const Sink = ({ children, retain }) => { retain(children); return null; };
+export const Input = ({ retain }) => { const target = createRef(); return <Sink retain={retain}><input ref={target} /></Sink>; };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports intrinsic refs hidden beneath unresolved custom component children", () => {
+    const directResult = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+import { Sink } from "opaque";
+export const Input = () => { const target = createRef(); return <Sink><input ref={target} /></Sink>; };`,
+    );
+    const conditionalResult = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+import { Sink } from "opaque";
+export const Input = ({ visible }) => { const target = createRef(); return <Sink>{visible && <input ref={target} />}</Sink>; };`,
+    );
+    expect(directResult.diagnostics).toHaveLength(1);
+    expect(conditionalResult.diagnostics).toHaveLength(1);
+  });
+
+  it("distinguishes resolved imported children forwarding from retention", () => {
+    const filename = fileURLToPath(
+      new URL("./__fixtures__/create-ref-children-consumer.tsx", import.meta.url),
+    );
+    const forwardingResult = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+import { ForwardingChildren } from "./create-ref-children-consumers";
+export const Input = () => { const target = createRef(); return <ForwardingChildren><input ref={target} /></ForwardingChildren>; };`,
+      { filename },
+    );
+    const retainingResult = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+import { RetainingChildren } from "./create-ref-children-consumers";
+export const Input = ({ retain }) => { const target = createRef(); return <RetainingChildren retain={retain}><input ref={target} /></RetainingChildren>; };`,
+      { filename },
+    );
+    expect(forwardingResult.diagnostics).toEqual([]);
+    expect(retainingResult.diagnostics).toHaveLength(1);
+  });
+
+  it("keeps direct and aliased intrinsic element returns quiet", () => {
+    const directResult = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+export const Input = () => { const target = createRef(); return <input ref={target} />; };`,
+    );
+    const aliasResult = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+export const Input = () => { const target = createRef(); const element = <input ref={target} />; return element; };`,
+    );
+    expect(directResult.diagnostics).toEqual([]);
+    expect(aliasResult.diagnostics).toEqual([]);
+  });
+
+  it("keeps intrinsic refs beneath proven React fragments quiet", () => {
+    const namespaceResult = runRule(
+      noCreateRefInFunctionComponent,
+      `import React, { createRef } from "react";
+export const Input = () => { const target = createRef(); return <React.Fragment><input ref={target} /></React.Fragment>; };`,
+    );
+    const namedResult = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef, Fragment } from "react";
+export const Input = () => { const target = createRef(); return <Fragment><input ref={target} /></Fragment>; };`,
+    );
+    expect(namespaceResult.diagnostics).toEqual([]);
+    expect(namedResult.diagnostics).toEqual([]);
+  });
+
+  it("reports intrinsic refs beneath shadowed and userland Fragment components", () => {
+    const shadowedResult = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+const Fragment = ({ children, retain }) => { retain(children); return null; };
+export const Input = ({ retain }) => { const target = createRef(); return <Fragment retain={retain}><input ref={target} /></Fragment>; };`,
+    );
+    const userlandResult = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+import { Fragment } from "userland";
+export const Input = () => { const target = createRef(); return <Fragment><input ref={target} /></Fragment>; };`,
+    );
+    expect(shadowedResult.diagnostics).toHaveLength(1);
+    expect(userlandResult.diagnostics).toHaveLength(1);
+  });
+
+  it("resolves a namespace component that forwards a ref prop to an intrinsic element", () => {
+    const result = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+import * as UI from "./create-ref-namespace-child";
+export const Input = () => { const target = createRef(); return <UI.Child target={target} />; };`,
+      {
+        filename: fileURLToPath(
+          new URL("./__fixtures__/create-ref-namespace-consumer.tsx", import.meta.url),
+        ),
+      },
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("reports a namespace component that retains the ref prop", () => {
+    const result = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+import * as UI from "./create-ref-namespace-child";
+export const Input = ({ observe }) => { const target = createRef(); return <UI.RetainingChild target={target} observe={observe} />; };`,
+      {
+        filename: fileURLToPath(
+          new URL("./__fixtures__/create-ref-namespace-consumer.tsx", import.meta.url),
+        ),
+      },
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("reports a ref passed to a userland createElement lookalike", () => {
     const result = runRule(
       noCreateRefInFunctionComponent,
@@ -247,21 +428,6 @@ export const Input = () => {
   const target = createRef<HTMLInputElement>();
   const input = createElement("input", { ref: target });
   return <>{input}</>;
-};`,
-    );
-    expect(result.parseErrors).toEqual([]);
-    expect(result.diagnostics).toHaveLength(1);
-  });
-
-  it("reports a ref passed through an async helper from a fresh event handler", () => {
-    const result = runRule(
-      noCreateRefInFunctionComponent,
-      `import { createRef } from "react";
-
-export const FocusButton = () => {
-  const target = createRef<HTMLButtonElement>();
-  const focusLater = async (ref) => { await Promise.resolve(); ref.current?.focus(); };
-  return <button ref={target} onClick={() => { void focusLater(target); }}>Focus</button>;
 };`,
     );
     expect(result.parseErrors).toEqual([]);
@@ -282,20 +448,6 @@ export const Input = () => {
   const target = createRef<HTMLInputElement>();
   void mountLater(target);
   return <main>Input</main>;
-};`,
-    );
-    expect(result.parseErrors).toEqual([]);
-    expect(result.diagnostics).toHaveLength(1);
-  });
-
-  it("reports when a generator event handler can resume with a stale ref", () => {
-    const result = runRule(
-      noCreateRefInFunctionComponent,
-      `import { createRef } from "react";
-
-export const FocusButton = () => {
-  const target = createRef<HTMLButtonElement>();
-  return <button ref={target} onClick={function* () { yield; target.current?.focus(); }}>Focus</button>;
 };`,
     );
     expect(result.parseErrors).toEqual([]);
@@ -440,6 +592,77 @@ export const Input = () => { const target = createRef(); return renderInput(targ
     expect(helperResult.diagnostics).toEqual([]);
   });
 
+  it("stays silent for named functions invoked only during the same render", () => {
+    const arrowResult = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+export const Input = () => { const target = createRef(); const render = () => <input ref={target} />; return render(); };`,
+    );
+    const declarationResult = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+export const Input = () => { const target = createRef(); function render() { return <input ref={target} />; } return render(); };`,
+    );
+    expect(arrowResult.diagnostics).toEqual([]);
+    expect(declarationResult.diagnostics).toEqual([]);
+  });
+
+  it("reports named render functions that are retained, deferred, or async", () => {
+    const retainedResult = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+export const Input = ({ retain }) => { const target = createRef(); const render = () => <input ref={target} />; retain(render); return render(); };`,
+    );
+    const deferredResult = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef, useEffect } from "react";
+export const Input = () => { const target = createRef(); const render = () => <input ref={target} />; useEffect(render, []); return <main />; };`,
+    );
+    const asyncResult = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+export const Input = () => { const target = createRef(); const render = async () => <input ref={target} />; void render(); return <main />; };`,
+    );
+    expect(retainedResult.diagnostics).toHaveLength(1);
+    expect(deferredResult.diagnostics).toHaveLength(1);
+    expect(asyncResult.diagnostics).toHaveLength(1);
+  });
+
+  it("reports a retained result from a synchronous render helper", () => {
+    const result = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+const renderInput = (target) => <input ref={target} />;
+export const Input = ({ retain }) => { const target = createRef(); retain(renderInput(target)); return <div />; };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports discarded render helpers and retained functions that close over elements", () => {
+    const discardedResult = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+export const Input = () => { const target = createRef(); const render = () => <input ref={target} />; render(); return <div />; };`,
+    );
+    const retainedFunctionResult = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+export const Input = ({ retain }) => { const target = createRef(); const element = <input ref={target} />; const make = () => element; retain(make); return <div />; };`,
+    );
+    expect(discardedResult.diagnostics).toHaveLength(1);
+    expect(retainedFunctionResult.diagnostics).toHaveLength(1);
+  });
+
+  it("reports a named render-only function that attaches the ref to a custom component", () => {
+    const result = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+import { Unknown } from "unknown-package";
+export const Input = () => { const target = createRef(); const render = () => <Unknown ref={target} />; return render(); };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("stays silent for intrinsic ref props in closed JSX spreads", () => {
     const result = runRule(
       noCreateRefInFunctionComponent,
@@ -452,6 +675,21 @@ export const Input = () => {
 };`,
     );
     expect(result.diagnostics).toEqual([]);
+  });
+
+  it("reports intrinsic JSX spread refs when the element result escapes", () => {
+    const inlineResult = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+export const Input = ({ retain }) => { const target = createRef(); retain(<input {...{ ref: target }} />); return <div />; };`,
+    );
+    const aliasResult = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+export const Input = ({ retain }) => { const target = createRef(); const props = { ref: target }; retain(<input {...props} />); return <div />; };`,
+    );
+    expect(inlineResult.diagnostics).toHaveLength(1);
+    expect(aliasResult.diagnostics).toHaveLength(1);
   });
 
   it("stays silent for callback-ref current writes including cleanup", () => {
@@ -545,99 +783,6 @@ export const Input = () => { const owner = {}; owner.target = createRef(); retur
     expect(result.diagnostics).toEqual([]);
   });
 
-  it("reports a fresh handler read after an unknown synchronous call", () => {
-    const result = runRule(
-      noCreateRefInFunctionComponent,
-      `import { createRef } from "react";
-export const Input = () => { const target = createRef(); return <button ref={target} onClick={() => { unknownCall(); target.current?.focus(); }}>Focus</button>; };`,
-    );
-    expect(result.diagnostics).toHaveLength(1);
-  });
-
-  it("reports a fresh handler read after an unknown getter access", () => {
-    const result = runRule(
-      noCreateRefInFunctionComponent,
-      `import { createRef } from "react";
-export const Input = ({ controller }) => { const target = createRef(); return <button ref={target} onClick={() => { void controller.value; target.current?.focus(); }}>Focus</button>; };`,
-    );
-    expect(result.diagnostics).toHaveLength(1);
-  });
-
-  it("reports handler reads after destructuring or spread can execute user code", () => {
-    const result = runRule(
-      noCreateRefInFunctionComponent,
-      `import { createRef } from "react";
-export const Input = ({ value }) => { const target = createRef(); return <button ref={target} onClick={() => { const { item } = value; const copy = { ...value }; consume(item, copy); target.current?.focus(); }}>Focus</button>; };`,
-    );
-    expect(result.diagnostics).toHaveLength(1);
-  });
-
-  it("keeps an ordinary state setter before the fresh handler read safe", () => {
-    const result = runRule(
-      noCreateRefInFunctionComponent,
-      `import { createRef, useState } from "react";
-export const Input = () => { const [active, setActive] = useState(false); const target = createRef(); return <button aria-pressed={active} ref={target} onClick={() => { setActive(true); target.current?.focus(); }}>Focus</button>; };`,
-    );
-    expect(result.diagnostics).toEqual([]);
-  });
-
-  it("keeps proven non-committing calls before the fresh handler read safe", () => {
-    const result = runRule(
-      noCreateRefInFunctionComponent,
-      `import { createRef, startTransition } from "react";
-export const Input = () => { const target = createRef(); return <button ref={target} onClick={(event) => { event.preventDefault(); event.stopPropagation(); console.log("focus"); startTransition(() => {}); target.current?.focus(); }}>Focus</button>; };`,
-    );
-    expect(result.diagnostics).toEqual([]);
-  });
-
-  it("does not trust shadowed non-committing call lookalikes", () => {
-    const result = runRule(
-      noCreateRefInFunctionComponent,
-      `import { createRef } from "react";
-export const Input = ({ console, startTransition }) => { const target = createRef(); return <button ref={target} onClick={(event) => { console.log(); startTransition(); event.customPreventDefault(); target.current?.focus(); }}>Focus</button>; };`,
-    );
-    expect(result.diagnostics).toHaveLength(1);
-  });
-
-  it("still inspects arguments and callbacks of non-committing calls", () => {
-    const result = runRule(
-      noCreateRefInFunctionComponent,
-      `import { createRef, startTransition, useState } from "react";
-import { flushSync } from "react-dom";
-export const Input = () => { const [active, setActive] = useState(false); const target = createRef(); return <button key={String(active)} ref={target} onClick={(event) => { event.preventDefault(flushSync(() => setActive(true))); startTransition(() => { flushSync(() => setActive(false)); }); target.current?.focus(); }}>Focus</button>; };`,
-    );
-    expect(result.diagnostics).toHaveLength(1);
-  });
-
-  it("rejects startTransition setter arguments that can execute user code", () => {
-    const result = runRule(
-      noCreateRefInFunctionComponent,
-      `import { createRef, startTransition, useState } from "react";
-import { flushSync } from "react-dom";
-export const Input = ({ value }) => { const [active, setActive] = useState(false); const target = createRef(); return <button key={String(active)} ref={target} onClick={() => { startTransition(() => setActive((flushSync(() => setActive(true)), value.next))); target.current?.focus(); }}>Focus</button>; };`,
-    );
-    expect(result.diagnostics).toHaveLength(1);
-  });
-
-  it("does not trust a reassigned useState setter", () => {
-    const result = runRule(
-      noCreateRefInFunctionComponent,
-      `import { createRef, useState } from "react";
-import { flushSync } from "react-dom";
-export const Input = () => { let [active, setActive] = useState(false); const originalSetActive = setActive; setActive = () => flushSync(() => originalSetActive((value) => !value)); const target = createRef(); return <button key={String(active)} ref={target} onClick={() => { setActive(true); target.current?.focus(); }}>Focus</button>; };`,
-    );
-    expect(result.diagnostics).toHaveLength(1);
-  });
-
-  it("keeps immutable useState setter aliases before the ref read safe", () => {
-    const result = runRule(
-      noCreateRefInFunctionComponent,
-      `import { createRef, useState } from "react";
-export const Input = () => { const [active, setActive] = useState(false); const update = setActive; const target = createRef(); return <button aria-pressed={active} ref={target} onClick={() => { update(true); target.current?.focus(); }}>Focus</button>; };`,
-    );
-    expect(result.diagnostics).toEqual([]);
-  });
-
   it("keeps render-local identity, Boolean, and void observations local", () => {
     const result = runRule(
       noCreateRefInFunctionComponent,
@@ -660,48 +805,6 @@ export const Input = () => { const target = createRef(); return <span>{Boolean(t
     );
     expect(discardedResult.diagnostics).toEqual([]);
     expect(observedResult.diagnostics).toHaveLength(1);
-  });
-
-  it("reports a fresh handler read after a synchronous flush", () => {
-    const result = runRule(
-      noCreateRefInFunctionComponent,
-      `import { createRef, useState } from "react";
-import { flushSync as commitNow } from "react-dom";
-export const Input = () => { const [active, setActive] = useState(false); const target = createRef(); return <button key={String(active)} ref={target} onClick={() => { commitNow(() => setActive((value) => !value)); target.current?.focus(); }}>Focus</button>; };`,
-    );
-    expect(result.diagnostics).toHaveLength(1);
-  });
-
-  it("reports a loop read that can follow a prior iteration's synchronous flush", () => {
-    const result = runRule(
-      noCreateRefInFunctionComponent,
-      `import { createRef, useState } from "react";
-import { flushSync } from "react-dom";
-export const Input = () => { const [active, setActive] = useState(false); const target = createRef(); return <button key={String(active)} ref={target} onClick={() => { for (let index = 0; index < 2; index += 1) { target.current?.focus(); flushSync(() => setActive((value) => !value)); } }}>Focus</button>; };`,
-    );
-    expect(result.diagnostics).toHaveLength(1);
-  });
-
-  it("allows an async fresh handler read before suspension", () => {
-    const result = runRule(
-      noCreateRefInFunctionComponent,
-      `import { createRef } from "react";
-export const Input = () => { const target = createRef(); return <button ref={target} onClick={async () => { target.current?.focus(); await Promise.resolve(); }}>Focus</button>; };`,
-    );
-    expect(result.diagnostics).toEqual([]);
-  });
-
-  it("supports named, conditional, logical, and nested synchronous fresh handlers", () => {
-    const result = runRule(
-      noCreateRefInFunctionComponent,
-      `import { createRef } from "react";
-export const Input = ({ enabled }) => {
-  const first = createRef(); const second = createRef(); const third = createRef(); const fourth = createRef();
-  const named = () => first.current?.focus();
-  return <><button ref={first} onClick={named} /><button ref={second} onClick={enabled ? () => second.current?.focus() : undefined} /><button ref={third} onClick={enabled && (() => third.current?.focus())} /><button ref={fourth} onClick={() => { (() => fourth.current?.focus())(); }} /></>;
-};`,
-    );
-    expect(result.diagnostics).toEqual([]);
   });
 
   it("uses scope-proven React createRef provenance", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-create-ref-in-function-component.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-create-ref-in-function-component.regressions.test.ts
@@ -156,6 +156,20 @@ export const ObservedRef = ({ label, observe }: ObservedRefProps) => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("reports comparison against another ref identity", () => {
+    const result = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+export const Input = ({ previousTarget }) => {
+  const target = createRef();
+  const didRefIdentityChange = target !== previousTarget;
+  return <input ref={target} data-changed={didRefIdentityChange} />;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("stays silent for an observed useRef equivalent", () => {
     const result = runRule(
       noCreateRefInFunctionComponent,
@@ -663,6 +677,24 @@ export const Input = () => { const target = createRef(); const render = () => <U
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("reports a ref passed through a component binding reassigned before render", () => {
+    const result = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+let Sink = ({ target }) => <input ref={target} />;
+Sink = ({ target, observe }) => {
+  observe(target);
+  return null;
+};
+export const Input = ({ observe }) => {
+  const target = createRef();
+  return <Sink target={target} observe={observe} />;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("stays silent for intrinsic ref props in closed JSX spreads", () => {
     const result = runRule(
       noCreateRefInFunctionComponent,
@@ -702,6 +734,19 @@ export const Input = () => {
 };`,
     );
     expect(result.diagnostics).toEqual([]);
+  });
+
+  it("reports callback-ref writes deferred through another closure", () => {
+    const result = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+export const Input = () => {
+  const target = createRef();
+  return <input ref={(node) => { queueMicrotask(() => { target.current = node; }); }} />;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
   });
 
   it("reports a callback ref that reads the fresh ref", () => {
@@ -760,6 +805,20 @@ export const Input = ({ span }) => {
   return <><Tag ref={first} /><UnionTag ref={second} /><LegacyInput ref={third} /></>;
 };`,
     );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("recognizes props.children forwarded during the same render", () => {
+    const result = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+const Wrapper = (props) => <section>{props.children}</section>;
+export const Input = () => {
+  const target = createRef();
+  return <Wrapper><input ref={target} /></Wrapper>;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toEqual([]);
   });
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-create-ref-in-function-component.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-create-ref-in-function-component.regressions.test.ts
@@ -563,6 +563,15 @@ export const Input = ({ controller }) => { const target = createRef(); return <b
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("reports handler reads after destructuring or spread can execute user code", () => {
+    const result = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+export const Input = ({ value }) => { const target = createRef(); return <button ref={target} onClick={() => { const { item } = value; const copy = { ...value }; consume(item, copy); target.current?.focus(); }}>Focus</button>; };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("keeps an ordinary state setter before the fresh handler read safe", () => {
     const result = runRule(
       noCreateRefInFunctionComponent,
@@ -608,6 +617,39 @@ import { flushSync } from "react-dom";
 export const Input = () => { let [active, setActive] = useState(false); const originalSetActive = setActive; setActive = () => flushSync(() => originalSetActive((value) => !value)); const target = createRef(); return <button key={String(active)} ref={target} onClick={() => { setActive(true); target.current?.focus(); }}>Focus</button>; };`,
     );
     expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("keeps immutable useState setter aliases before the ref read safe", () => {
+    const result = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef, useState } from "react";
+export const Input = () => { const [active, setActive] = useState(false); const update = setActive; const target = createRef(); return <button aria-pressed={active} ref={target} onClick={() => { update(true); target.current?.focus(); }}>Focus</button>; };`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("keeps render-local identity, Boolean, and void observations local", () => {
+    const result = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+export const Input = () => { const first = createRef(); const second = createRef(); const third = createRef(); void first; const isPresent = Boolean(second); const isSame = third === third; return <input aria-label={String(isPresent && isSame)} />; };`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("suppresses only a discarded current read during render", () => {
+    const discardedResult = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+export const Input = () => { const target = createRef(); void target.current; return <input ref={target} />; };`,
+    );
+    const observedResult = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef } from "react";
+export const Input = () => { const target = createRef(); return <span>{Boolean(target.current)} {String(target.current)}</span>; };`,
+    );
+    expect(discardedResult.diagnostics).toEqual([]);
+    expect(observedResult.diagnostics).toHaveLength(1);
   });
 
   it("reports a fresh handler read after a synchronous flush", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-create-ref-in-function-component.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-create-ref-in-function-component.regressions.test.ts
@@ -609,6 +609,16 @@ export const Input = () => { const [active, setActive] = useState(false); const 
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("rejects startTransition setter arguments that can execute user code", () => {
+    const result = runRule(
+      noCreateRefInFunctionComponent,
+      `import { createRef, startTransition, useState } from "react";
+import { flushSync } from "react-dom";
+export const Input = ({ value }) => { const [active, setActive] = useState(false); const target = createRef(); return <button key={String(active)} ref={target} onClick={() => { startTransition(() => setActive((flushSync(() => setActive(true)), value.next))); target.current?.focus(); }}>Focus</button>; };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("does not trust a reassigned useState setter", () => {
     const result = runRule(
       noCreateRefInFunctionComponent,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-create-ref-in-function-component.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-create-ref-in-function-component.test.ts
@@ -3,28 +3,28 @@ import { runRule } from "../../../test-utils/run-rule.js";
 import { noCreateRefInFunctionComponent } from "./no-create-ref-in-function-component.js";
 
 describe("no-create-ref-in-function-component", () => {
-  it("flags `createRef()` in a function-declaration component", () => {
+  it("flags an observed `createRef()` in a function-declaration component", () => {
     const result = runRule(
       noCreateRefInFunctionComponent,
-      `function App() { const ref = createRef(); return <div ref={ref} />; }`,
+      `function App() { const ref = createRef(); globalThis.observedRef = ref; return <div ref={ref} />; }`,
     );
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].message).toContain("useRef");
   });
 
-  it("flags `createRef()` in an arrow-function component", () => {
+  it("flags an observed `createRef()` in an arrow-function component", () => {
     const result = runRule(
       noCreateRefInFunctionComponent,
-      `const App = () => { const ref = createRef(); return <div ref={ref} />; };`,
+      `const App = () => { const ref = createRef(); globalThis.observedRef = ref; return <div ref={ref} />; };`,
     );
     expect(result.diagnostics).toHaveLength(1);
   });
 
-  it("flags `React.createRef()` via the namespace", () => {
+  it("flags an observed `React.createRef()` via the namespace", () => {
     const result = runRule(
       noCreateRefInFunctionComponent,
-      `function App() { const ref = React.createRef(); return <div ref={ref} />; }`,
+      `function App() { const ref = React.createRef(); globalThis.observedRef = ref; return <div ref={ref} />; }`,
     );
     expect(result.diagnostics).toHaveLength(1);
   });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-create-ref-in-function-component.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-create-ref-in-function-component.ts
@@ -3,6 +3,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
 import { functionContainsReactRenderOutput } from "../../utils/function-contains-react-render-output.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { isReactApiCall } from "../../utils/is-react-api-call.js";
 import { isReactFunctionCall } from "../../utils/is-react-function-call.js";
 import { isReactHookName } from "../../utils/is-react-hook-name.js";
 import { isCreateRefResultWriteOnly } from "./is-create-ref-result-write-only.js";
@@ -10,7 +11,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 const MESSAGE =
-  "`createRef()` is observed beyond the render that created it, so a later render replaces the ref object and detaches the observed one. Hoist a `useRef()` call to the component's unconditional top level instead.";
+  "`createRef()` may escape or be observed beyond the render that created it, so a later render can replace the ref object and detach the observed one. Hoist a `useRef()` call to the component's unconditional top level instead.";
 
 // `useMemo(() => createRef(), [])` runs its callback during the enclosing
 // component/hook's render, so the memo callback is transparent when
@@ -46,14 +47,14 @@ export const noCreateRefInFunctionComponent = defineRule({
     "Replace `createRef()` with the `useRef()` hook inside function components and hooks. `createRef` is only for class components.",
   create: (context) => ({
     CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
-      if (!isReactFunctionCall(node, "createRef")) return;
-
-      // Guard the bare `createRef()` form against a shadowing local binding
-      // (`const createRef = () => ({})`). If the identifier resolves to a
-      // non-import declaration it isn't React's `createRef`, so skip.
-      if (isNodeOfType(node.callee, "Identifier")) {
-        const symbol = context.scopes.symbolFor(node.callee);
-        if (symbol && symbol.kind !== "import") return;
+      if (
+        !isReactApiCall(node, "createRef", context.scopes, {
+          allowGlobalReactNamespace: true,
+          allowUnboundBareCalls: true,
+          resolveNamedAliases: true,
+        })
+      ) {
+        return;
       }
 
       const enclosingFunction = findEnclosingRenderFunction(node);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-create-ref-in-function-component.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-create-ref-in-function-component.ts
@@ -4,9 +4,9 @@ import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
 import { functionContainsReactRenderOutput } from "../../utils/function-contains-react-render-output.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isReactApiCall } from "../../utils/is-react-api-call.js";
-import { isReactFunctionCall } from "../../utils/is-react-function-call.js";
 import { isReactHookName } from "../../utils/is-react-hook-name.js";
 import { isCreateRefResultWriteOnly } from "./is-create-ref-result-write-only.js";
+import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
@@ -16,16 +16,19 @@ const MESSAGE =
 // `useMemo(() => createRef(), [])` runs its callback during the enclosing
 // component/hook's render, so the memo callback is transparent when
 // resolving where the createRef really lives — the fix is still `useRef`.
-const isUseMemoCallbackArgument = (functionNode: EsTreeNode): boolean => {
+const isUseMemoCallbackArgument = (functionNode: EsTreeNode, scopes: ScopeAnalysis): boolean => {
   const parent = functionNode.parent;
   if (!parent || !isNodeOfType(parent, "CallExpression")) return false;
   if (parent.arguments?.[0] !== functionNode) return false;
-  return isReactFunctionCall(parent, "useMemo");
+  return isReactApiCall(parent, "useMemo", scopes, { resolveNamedAliases: true });
 };
 
-const findEnclosingRenderFunction = (node: EsTreeNode): EsTreeNode | null => {
+const findEnclosingRenderFunction = (
+  node: EsTreeNode,
+  scopes: ScopeAnalysis,
+): EsTreeNode | null => {
   let enclosingFunction = findEnclosingFunction(node);
-  while (enclosingFunction && isUseMemoCallbackArgument(enclosingFunction)) {
+  while (enclosingFunction && isUseMemoCallbackArgument(enclosingFunction, scopes)) {
     enclosingFunction = findEnclosingFunction(enclosingFunction);
   }
   return enclosingFunction;
@@ -57,7 +60,7 @@ export const noCreateRefInFunctionComponent = defineRule({
         return;
       }
 
-      const enclosingFunction = findEnclosingRenderFunction(node);
+      const enclosingFunction = findEnclosingRenderFunction(node, context.scopes);
       if (!enclosingFunction) return;
       const displayName = componentOrHookDisplayNameForFunction(enclosingFunction);
       if (!displayName) return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-create-ref-in-function-component.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-create-ref-in-function-component.ts
@@ -5,11 +5,12 @@ import { functionContainsReactRenderOutput } from "../../utils/function-contains
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isReactFunctionCall } from "../../utils/is-react-function-call.js";
 import { isReactHookName } from "../../utils/is-react-hook-name.js";
+import { isCreateRefResultWriteOnly } from "./is-create-ref-result-write-only.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
 const MESSAGE =
-  "`createRef()` in a function component allocates a brand-new ref on every render, so it never holds a value between renders. Use the `useRef()` hook instead.";
+  "`createRef()` is observed beyond the render that created it, so a later render replaces the ref object and detaches the observed one. Hoist a `useRef()` call to the component's unconditional top level instead.";
 
 // `useMemo(() => createRef(), [])` runs its callback during the enclosing
 // component/hook's render, so the memo callback is transparent when
@@ -66,6 +67,7 @@ export const noCreateRefInFunctionComponent = defineRule({
         isReactHookName(displayName) ||
         functionContainsReactRenderOutput(enclosingFunction, context.scopes, context.cfg);
       if (!isComponentOrHook) return;
+      if (isCreateRefResultWriteOnly(node, context.filename, context.scopes)) return;
 
       context.report({ node, message: MESSAGE });
     },

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/collect-function-children-references.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/collect-function-children-references.ts
@@ -1,0 +1,70 @@
+import type { ScopeAnalysis } from "../semantic/scope-analysis.js";
+import type { EsTreeNode } from "./es-tree-node.js";
+import { findTransparentExpressionRoot } from "./find-transparent-expression-root.js";
+import { getStaticPropertyKeyName } from "./get-static-property-key-name.js";
+import { getStaticPropertyName } from "./get-static-property-name.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+
+export const collectFunctionChildrenReferences = (
+  functionNode: EsTreeNode,
+  scopes: ScopeAnalysis,
+): ReadonlyArray<EsTreeNode> | null => {
+  if (
+    !isNodeOfType(functionNode, "ArrowFunctionExpression") &&
+    !isNodeOfType(functionNode, "FunctionExpression") &&
+    !isNodeOfType(functionNode, "FunctionDeclaration")
+  ) {
+    return null;
+  }
+  const rawPropsParameter = functionNode.params[0];
+  const propsParameter = isNodeOfType(rawPropsParameter, "AssignmentPattern")
+    ? rawPropsParameter.left
+    : rawPropsParameter;
+  if (isNodeOfType(propsParameter, "ObjectPattern")) {
+    const childrenProperty = propsParameter.properties.find(
+      (property) =>
+        isNodeOfType(property, "Property") &&
+        getStaticPropertyKeyName(property, { allowComputedString: true }) === "children",
+    );
+    if (!childrenProperty || !isNodeOfType(childrenProperty, "Property")) return null;
+    const childrenBinding = isNodeOfType(childrenProperty.value, "AssignmentPattern")
+      ? childrenProperty.value.left
+      : childrenProperty.value;
+    if (!isNodeOfType(childrenBinding, "Identifier")) return null;
+    const childrenSymbol = scopes.symbolFor(childrenBinding);
+    if (
+      !childrenSymbol ||
+      childrenSymbol.references.length === 0 ||
+      childrenSymbol.references.some((reference) => reference.flag !== "read")
+    ) {
+      return null;
+    }
+    return childrenSymbol.references.map((reference) => reference.identifier);
+  }
+  if (!isNodeOfType(propsParameter, "Identifier")) return null;
+  const propsSymbol = scopes.symbolFor(propsParameter);
+  if (!propsSymbol || propsSymbol.references.length === 0) return null;
+  const childrenReferences: EsTreeNode[] = [];
+  for (const reference of propsSymbol.references) {
+    if (reference.flag !== "read") return null;
+    const propertyPath: string[] = [];
+    let expression = findTransparentExpressionRoot(reference.identifier);
+    while (
+      expression.parent &&
+      isNodeOfType(expression.parent, "MemberExpression") &&
+      expression.parent.object === expression
+    ) {
+      const propertyName = getStaticPropertyName(expression.parent);
+      if (!propertyName) return null;
+      propertyPath.push(propertyName);
+      expression = findTransparentExpressionRoot(expression.parent);
+    }
+    if (propertyPath[0] !== "children") {
+      if (propertyPath.length === 0) return null;
+      continue;
+    }
+    if (propertyPath.length !== 1) return null;
+    childrenReferences.push(expression);
+  }
+  return childrenReferences.length > 0 ? childrenReferences : null;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-proven-intrinsic-jsx-element.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-proven-intrinsic-jsx-element.ts
@@ -1,0 +1,40 @@
+import type { ScopeAnalysis } from "../semantic/scope-analysis.js";
+import { findTransparentExpressionRoot } from "./find-transparent-expression-root.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+import { resolveJsxElementType } from "./resolve-jsx-element-type.js";
+import type { EsTreeNode } from "./es-tree-node.js";
+import type { EsTreeNodeOfType } from "./es-tree-node-of-type.js";
+
+export const isProvenIntrinsicJsxElement = (
+  openingElement: EsTreeNodeOfType<"JSXOpeningElement">,
+  scopes: ScopeAnalysis,
+): boolean => {
+  if (!isNodeOfType(openingElement.name, "JSXIdentifier")) return false;
+  const resolvedElementType = resolveJsxElementType(openingElement);
+  if (resolvedElementType[0] === resolvedElementType[0]?.toLowerCase()) return true;
+  const visitedSymbolIds = new Set<number>();
+  const isIntrinsicValue = (node: EsTreeNode): boolean => {
+    const current = findTransparentExpressionRoot(node);
+    if (isNodeOfType(current, "Literal")) return typeof current.value === "string";
+    if (isNodeOfType(current, "Identifier") || isNodeOfType(current, "JSXIdentifier")) {
+      const symbol = scopes.symbolFor(current);
+      if (
+        !symbol ||
+        symbol.kind !== "const" ||
+        !symbol.initializer ||
+        visitedSymbolIds.has(symbol.id)
+      ) {
+        return false;
+      }
+      visitedSymbolIds.add(symbol.id);
+      const isIntrinsic = isIntrinsicValue(symbol.initializer);
+      visitedSymbolIds.delete(symbol.id);
+      return isIntrinsic;
+    }
+    if (isNodeOfType(current, "ConditionalExpression")) {
+      return isIntrinsicValue(current.consequent) && isIntrinsicValue(current.alternate);
+    }
+    return false;
+  };
+  return isIntrinsicValue(openingElement.name);
+};


### PR DESCRIPTION
<!-- motivation-example:start -->
## Motivation

The rule should catch refs whose identity or `.current` value matters across renders, but it should not reject a ref that exists only as a write-only attachment during the current render. Recommending `useRef` for a conditionally created attachment can introduce a Hook-ordering violation or persistence the component does not need.

## Example

A pending adapter can create a ref and forward it to an intrinsic element without ever reading it:

```tsx
const closeButtonRef = createRef<HTMLButtonElement>()
return <button ref={closeButtonRef}>Close navigation</button>
```

If every path ends at a render-local React ref sink and no code observes `.current`, the rule should stay quiet.
<!-- motivation-example:end -->

Fixes an overreach in `no-create-ref-in-function-component`: a render-local `createRef()` is valid when static analysis proves that every use remains a write-only React attachment or discard path in the current render.

## Why

The authentic Cloudscape skeleton and pending adapters allocate refs only for pending navigation state, pass them through local and cross-file adapter objects, then forward them through a proven error-boundary/children chain to intrinsic ref sinks. The ref identity and `.current` value are never observed across renders. A conditional `useRef` replacement would violate Hook ordering, while hoisting the ref would introduce persistence that the implementation does not consume.

## What changed

- Trace owned ref values through closed objects and arrays, destructuring, static aliases, JSX props/spreads, synchronous render helpers, relative imports, `forwardRef`/`memo`, proven React class components, callback-ref writes, and `useImperativeHandle`.
- Require element factories and JSX ref sinks to reach the current render. Retained React elements, discarded render-helper results, opaque custom children wrappers, deferred callbacks, and unknown consumers remain diagnostic.
- Follow `children` only through provenance-resolved forwarding function/class components, React fragments, and proven React context providers. Retaining and unresolved wrappers remain conservative.
- Use scope-proven React API provenance and reject shadowed or userland lookalikes.
- Add a demand-driven cross-file dependency collector, paired regression coverage, permanent fuzz seed/pool coverage, and a patch changeset.

## Precision boundary

A candidate is suppressed only when every overlapping use is proven write-only and render-local. Any `.current` observation in render, an effect, or an event handler still reports. Dynamic paths, mutations, retained/async/generator closures, unresolved imports, returned `.map` callbacks, and unproven component wrappers also continue to report. The diagnostic says the ref *may* escape or be observed because unresolved cases are intentionally heuristic.

## Validation

- Plugin: 560/560 files, 14,062 passed, 181 skipped.
- Workspace typecheck: 15/15 tasks passed. Lint, format check, JSON-report smoke, and `git diff --check` passed.
- Other package suites passed independently: core 1,376 tests; API 19; language server 65; ESLint plugin 4; fuzz corpus 44; CLI package 2,244.
- The aggregate workspace test command still reproduces three unrelated platform-context test flakes (`no-barrel-import` ×2 and `rn-prefer-expo-image`) while the complete plugin suite passes standalone; this change does not touch those rules or their platform detection.
- Strict fuzz: 500 requested; 345 executed, target fired 44 times, 218 generated parse skips, 0 findings.
- Direct pinned RDE equivalent: 100/100 repositories scanned, 3→3 target locations, no deltas. The 17/17 target-bearing subset changed 50→47 with zero additions; all three removals were manually verified write-only intrinsic attachments (Mastodon ×2, wp-calypso ×1). Stock RDE was invalid because its v1/v2 decoder rejected schema v3.
- Pinned React Bench/Cloudscape: 8/8 baseline/candidate scans, 0 failures or partials. Target counts were base 1→1, skeleton 4→1, pending 4→1, oracle 1→1. Six removed findings were the authentic FPs; the existing `ref.current` focus/select TP remained.
- Demand-driven collector on the two authentic files: 31 probes/~3 ms and 59 probes/~8 ms, versus 1,913 probes/160–290 ms for the rejected all-import collector.

This PR remains draft pending fresh CI and review-thread audit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a large cross-file static-analysis path and new lint-cache dependency classification for an existing rule; incorrect suppression could miss real stale-ref bugs, though unknown paths stay conservative.
> 
> **Overview**
> **`no-create-ref-in-function-component`** no longer reports every `createRef()` in hooks/components. It now bails out when static analysis proves the ref is **write-only and render-local** (e.g. passed through adapter objects into intrinsic `ref` sinks without observing identity or `.current` across renders). The diagnostic text shifts from “new ref every render” to **possible escape or cross-render observation**, and `useMemo` transparency uses scope-aware **`isReactApiCall`** instead of the older React call helper.
> 
> The core addition is **`isCreateRefResultWriteOnly`** (plus small helpers for same-render rendering, callback-ref `.current` writes, and intrinsic JSX proof), with cross-file prop flow capped by **`CREATE_REF_PROP_FLOW_MAX_DEPTH`**.
> 
> Because the rule can depend on imported consumers, it is registered as **cross-file** with a **demand-driven dependency collector** that reuses the same analysis for sidecar cache fingerprints (without fanning out into unrelated imports). Regression, cross-file, fuzz corpus, and snippet-pool coverage accompany a patch changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c55038269dced1de556b874b4330411e92536a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->