### PR TITLE
fix(rule): preserve visibility proof around opaque conditions

### DIFF
--- a/.changeset/gentle-owls-gate.md
+++ b/.changeset/gentle-owls-gate.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Preserve proven Boolean visibility gates when opaque short-circuit conditions are present

--- a/packages/fuzz/corpus/regressions/no-reset-all-state-on-prop-change--opaque-visibility-sibling.tsx
+++ b/packages/fuzz/corpus/regressions/no-reset-all-state-on-prop-change--opaque-visibility-sibling.tsx
@@ -1,0 +1,23 @@
+// rule: no-reset-all-state-on-prop-change
+// weakness: control-flow
+// source: PR #1264 opaque visibility sibling regression
+import { useEffect, useState } from "react";
+
+interface OpaqueVisibilityPanelProps {
+  isAllowed: () => boolean;
+  visible: boolean;
+}
+
+export const OpaqueVisibilityPanel = ({ isAllowed, visible }: OpaqueVisibilityPanelProps) => {
+  const [canShowPanel, setCanShowPanel] = useState(true);
+
+  useEffect(() => {
+    setCanShowPanel(true);
+  }, [visible]);
+
+  return (
+    visible &&
+    isAllowed() &&
+    canShowPanel && <output onClick={() => setCanShowPanel(false)}>Panel</output>
+  );
+};

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -95,6 +95,7 @@ export const STATE_SNIPPET_POOL = [
   `const [previousValue, setPreviousValue] = useState(Boolean(value)); useEffect(() => { setPreviousValue(Boolean(value)); }, [value]);`,
   `const [resetDraft, setResetDraft] = useState(""); useEffect(() => { setResetDraft(""); }, [value]);`,
   `const FuzzHiddenResetMenu = ({ visible }) => { const [open, setOpen] = useState(false); useEffect(() => { setOpen(false); }, [visible]); return visible && open && <div role="menu">Menu</div>; }; const fuzzHiddenResetMenuNode = <FuzzHiddenResetMenu visible={condition} />;`,
+  `const FuzzOpaqueVisibilityPanel = ({ visible, isAllowed }) => { const [canShowPanel, setCanShowPanel] = useState(true); useEffect(() => { setCanShowPanel(true); }, [visible]); return visible && isAllowed() && canShowPanel && <output onClick={() => setCanShowPanel(false)}>Panel</output>; }; const fuzzOpaqueVisibilityPanelNode = <FuzzOpaqueVisibilityPanel visible={condition} isAllowed={() => condition} />;`,
   `const [reducerState, dispatch] = useReducer(reducer, { count: 0 });`,
   `const containerRef = useRef(null);`,
   `const handleRef = useRef(handle); handleRef.current = handle;`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-reset-all-state-on-prop-change.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-reset-all-state-on-prop-change.regressions.test.ts
@@ -175,6 +175,58 @@ describe("no-reset-all-state-on-prop-change — regressions", () => {
 
     it.each([
       [
+        "after the visibility gate",
+        `return visible && isAllowed() && open && <output>{String(open)}</output>;`,
+      ],
+      [
+        "before the visibility gate",
+        `return isAllowed() && visible && open && <output>{String(open)}</output>;`,
+      ],
+    ])("stays silent when an opaque condition appears %s", (_label, renderBody) => {
+      const result = runRule(
+        noResetAllStateOnPropChange,
+        `import { useEffect, useState } from "react";
+        const Menu = ({ visible, isAllowed }: { visible: boolean; isAllowed: () => boolean }) => {
+          const [open, setOpen] = useState(false);
+          useEffect(() => setOpen(false), [visible]);
+          ${renderBody}
+        };`,
+        { forceJsx: true },
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it.each([
+      [
+        "there is no proven visibility gate",
+        `return isAllowed() && open && <output>{String(open)}</output>;`,
+      ],
+      [
+        "the visibility condition is only one branch of a disjunction",
+        `return (visible || isAllowed()) && open && <output>{String(open)}</output>;`,
+      ],
+      [
+        "the state is read before the visibility gate",
+        `return isAllowed(open) && visible && <output>{String(open)}</output>;`,
+      ],
+    ])("still reports when %s", (_label, renderBody) => {
+      const result = runRule(
+        noResetAllStateOnPropChange,
+        `import { useEffect, useState } from "react";
+        const Menu = ({ visible, isAllowed }: { visible: boolean; isAllowed: (value?: boolean) => boolean }) => {
+          const [open, setOpen] = useState(false);
+          useEffect(() => setOpen(false), [visible]);
+          ${renderBody}
+        };`,
+        { forceJsx: true },
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    });
+
+    it.each([
+      [
         "a string dependency remains visible across value changes",
         `import { useEffect, useState } from "react";
         const Menu = ({ userId }: { userId: string }) => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-reset-all-state-on-prop-change.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-reset-all-state-on-prop-change.regressions.test.ts
@@ -214,6 +214,26 @@ describe("no-reset-all-state-on-prop-change — regressions", () => {
         "repeated opaque calls can produce different values",
         `return (visible || isAllowed()) && !isAllowed() && open && <output onClick={() => setOpen(false)}>{String(open)}</output>;`,
       ],
+      [
+        "the dependency is reassigned before its projected gate",
+        `return (visible = true) && visible && open && <output onClick={() => setOpen(false)}>{String(open)}</output>;`,
+      ],
+      [
+        "a local helper reassigns the dependency before its projected gate",
+        `const reveal = () => {
+          visible = true;
+          return true;
+        };
+        return reveal() && visible && open && <output onClick={() => setOpen(false)}>{String(open)}</output>;`,
+      ],
+      [
+        "a local helper conditionally mutates the dependency",
+        `const toggleVisibility = () => {
+          if (isAllowed()) visible = !visible;
+          return true;
+        };
+        return toggleVisibility() && visible && open && <output onClick={() => setOpen(false)}>{String(open)}</output>;`,
+      ],
     ])("still reports when %s", (_label, renderBody) => {
       const result = runRule(
         noResetAllStateOnPropChange,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-reset-all-state-on-prop-change.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-reset-all-state-on-prop-change.regressions.test.ts
@@ -176,19 +176,19 @@ describe("no-reset-all-state-on-prop-change — regressions", () => {
     it.each([
       [
         "after the visibility gate",
-        `return visible && isAllowed() && open && <output>{String(open)}</output>;`,
+        `return visible && isAllowed() && open && <output onClick={() => setOpen(false)}>{String(open)}</output>;`,
       ],
       [
         "before the visibility gate",
-        `return isAllowed() && visible && open && <output>{String(open)}</output>;`,
+        `return isAllowed() && visible && open && <output onClick={() => setOpen(false)}>{String(open)}</output>;`,
       ],
     ])("stays silent when an opaque condition appears %s", (_label, renderBody) => {
       const result = runRule(
         noResetAllStateOnPropChange,
         `import { useEffect, useState } from "react";
         const Menu = ({ visible, isAllowed }: { visible: boolean; isAllowed: () => boolean }) => {
-          const [open, setOpen] = useState(false);
-          useEffect(() => setOpen(false), [visible]);
+          const [open, setOpen] = useState(true);
+          useEffect(() => setOpen(true), [visible]);
           ${renderBody}
         };`,
         { forceJsx: true },
@@ -200,23 +200,27 @@ describe("no-reset-all-state-on-prop-change — regressions", () => {
     it.each([
       [
         "there is no proven visibility gate",
-        `return isAllowed() && open && <output>{String(open)}</output>;`,
+        `return isAllowed() && open && <output onClick={() => setOpen(false)}>{String(open)}</output>;`,
       ],
       [
         "the visibility condition is only one branch of a disjunction",
-        `return (visible || isAllowed()) && open && <output>{String(open)}</output>;`,
+        `return (visible || isAllowed()) && open && <output onClick={() => setOpen(false)}>{String(open)}</output>;`,
       ],
       [
         "the state is read before the visibility gate",
-        `return isAllowed(open) && visible && <output>{String(open)}</output>;`,
+        `return isAllowed(open) && visible && <output onClick={() => setOpen(false)}>{String(open)}</output>;`,
+      ],
+      [
+        "repeated opaque calls can produce different values",
+        `return (visible || isAllowed()) && !isAllowed() && open && <output onClick={() => setOpen(false)}>{String(open)}</output>;`,
       ],
     ])("still reports when %s", (_label, renderBody) => {
       const result = runRule(
         noResetAllStateOnPropChange,
         `import { useEffect, useState } from "react";
         const Menu = ({ visible, isAllowed }: { visible: boolean; isAllowed: (value?: boolean) => boolean }) => {
-          const [open, setOpen] = useState(false);
-          useEffect(() => setOpen(false), [visible]);
+          const [open, setOpen] = useState(true);
+          useEffect(() => setOpen(true), [visible]);
           ${renderBody}
         };`,
         { forceJsx: true },

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-reset-all-state-on-prop-change.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-reset-all-state-on-prop-change.ts
@@ -1091,7 +1091,11 @@ const areAllResetStateReadsHiddenUntilReset = (
   );
   if (
     dependencySymbols.length === 0 ||
-    dependencySymbols.some((symbol) => !isBooleanExpression(context, symbol.bindingIdentifier))
+    dependencySymbols.some(
+      (symbol) =>
+        !isBooleanExpression(context, symbol.bindingIdentifier) ||
+        symbol.references.some((reference) => reference.flag !== "read"),
+    )
   ) {
     return false;
   }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-reset-all-state-on-prop-change.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-reset-all-state-on-prop-change.ts
@@ -348,6 +348,24 @@ const getBooleanFormula = (
   return null;
 };
 
+const getRequiredTruthyConditions = (
+  analysis: ProgramAnalysis,
+  context: RuleContext,
+  node: EsTreeNode,
+  protectedSymbolIds: ReadonlySet<number>,
+): BooleanFormula[] => {
+  const formula = getBooleanFormula(analysis, context, node, protectedSymbolIds);
+  if (formula) return [formula];
+  const expression = stripParenExpression(node);
+  if (!isNodeOfType(expression, "LogicalExpression") || expression.operator !== "&&") {
+    return [];
+  }
+  return [
+    ...getRequiredTruthyConditions(analysis, context, expression.left, protectedSymbolIds),
+    ...getRequiredTruthyConditions(analysis, context, expression.right, protectedSymbolIds),
+  ];
+};
+
 const evaluateBooleanFormula = (
   formula: BooleanFormula,
   assignments: ReadonlyMap<string, boolean>,
@@ -567,9 +585,15 @@ const collectExposureConditions = (
   let parent: EsTreeNode | null | undefined = node.parent;
   while (parent) {
     if (isNodeOfType(parent, "LogicalExpression") && parent.right === child) {
-      const leftFormula = getBooleanFormula(analysis, context, parent.left, protectedSymbolIds);
-      if (leftFormula && parent.operator === "&&") conditions.push(leftFormula);
-      if (leftFormula && parent.operator === "||") conditions.push(createNotFormula(leftFormula));
+      if (parent.operator === "&&") {
+        conditions.push(
+          ...getRequiredTruthyConditions(analysis, context, parent.left, protectedSymbolIds),
+        );
+      }
+      if (parent.operator === "||") {
+        const leftFormula = getBooleanFormula(analysis, context, parent.left, protectedSymbolIds);
+        if (leftFormula) conditions.push(createNotFormula(leftFormula));
+      }
     } else if (isNodeOfType(parent, "ConditionalExpression")) {
       const testFormula = getBooleanFormula(analysis, context, parent.test, protectedSymbolIds);
       if (testFormula && parent.consequent === child) conditions.push(testFormula);


### PR DESCRIPTION
## Why

A proven Boolean visibility gate still dominates a state read when another short-circuit condition is opaque to static analysis. Current main discards the whole conjunction and reports a stale-state reset even though the reset state cannot be evaluated outside the visibility gate.

Example:

    return visible && isAllowed() && open && <output>{String(open)}</output>

## What changed

- Project known truthy conjuncts from an otherwise opaque logical-AND chain.
- Require every projected dependency symbol to be read-only, so assignment before the gate cannot manufacture a false visibility proof.
- Preserve uncertainty for opaque disjunctions, negations, conditionals, repeated calls, reads before the visibility gate, and mutated dependencies.
- Add paired regressions for both opaque-sibling orders and seven reportable near-neighbors, including direct, helper, and conditional mutation.
- Add a permanent control-flow fuzz seed and generator snippet.
- Add a patch changeset.

## Precision boundary

The detector does not model opaque calls as stable Boolean atoms. It also refuses visibility projection for a dependency symbol with any write reference. For example, repeated opaque calls remain reportable because they may return different values, and assignment followed by a visibility read remains reportable because the render mutates the dependency before the gate.

## Validation

- Full repository test suite: pass
- Plugin suite: 559 files, 14,011 tests pass
- Typecheck: pass
- Lint: pass with pre-existing warnings
- Format check and diff check: pass
- Fuzz corpus: 44 tests pass
- Strict target fuzz, 500 iterations: pass; 342 executable programs, 41 target fires, 224 parse-skipped
- Cache-disabled pinned React Bench comparison:
  - Cloudscape base 151ff09468259fe42a989de1ffcddd9d21c5eb87: 2,859 files; total diagnostics 729 to 729; target rule 4 to 4; no added or removed diagnostics
  - Cloudscape oracle c9a81e7b96f32d7279030e302dacce9701cae7fd: 2,860 files; total diagnostics 730 to 730; target rule 4 to 4; no added or removed diagnostics
  - Requested/scanned 2/2; scan failures 0; partial scans 0; all target verdicts unchanged
- Local RDE: invalid evidence because the harness rejects report schema version 3 before producing scan rows
- GitHub review threads: 0 unresolved

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted static-analysis refinement in one lint rule with broad regression coverage; bench comparisons reported unchanged diagnostics.
> 
> **Overview**
> Fixes false positives on **`no-reset-all-state-on-prop-change`** when render uses short-circuit `&&` with a proven Boolean visibility prop plus an opaque sibling (e.g. `visible && isAllowed() && state`).
> 
> **Rule logic:** Adds **`getRequiredTruthyConditions`** to peel `&&` chains and keep analyzable truthy conjuncts even when the full left operand is not one boolean formula. **`collectExposureConditions`** uses that for `&&` gates instead of requiring a single formula for the whole left side. Visibility projection now requires prop-derived dependency symbols to be **read-only** (any write reference disqualifies the gate).
> 
> **Tests & fuzz:** Regression cases for both gate orderings, seven shapes that should still report, a permanent fuzz corpus file, and a matching snippet in **`snippet-pools`**. Patch changeset for **`oxlint-plugin-react-doctor`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e6ab78a2f69a1fde41ddb8a0e455c99f061b810. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->