### PR TITLE
fix: only-export-components allows exported custom hooks

### DIFF
--- a/.changeset/fix-hook-exports-1265.md
+++ b/.changeset/fix-hook-exports-1265.md
@@ -2,4 +2,4 @@
 "oxlint-plugin-react-doctor": patch
 ---
 
-Fix false positive in `only-export-components` for exported custom hooks. The rule now correctly allows `use[A-Z]` function exports alongside component exports, matching modern Fast Refresh behavior where hooks are treated as refresh boundaries.
+Fix a false positive in `only-export-components` for exported `use[A-Z]` custom hooks alongside component exports.

--- a/.changeset/fix-hook-exports-1265.md
+++ b/.changeset/fix-hook-exports-1265.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Fix false positive in `only-export-components` for exported custom hooks. The rule now correctly allows `use[A-Z]` function exports alongside component exports, matching modern Fast Refresh behavior where hooks are treated as refresh boundaries.

--- a/packages/fuzz/corpus/regressions/only-export-components--function-declaration-hook-export.tsx
+++ b/packages/fuzz/corpus/regressions/only-export-components--function-declaration-hook-export.tsx
@@ -1,0 +1,17 @@
+// rule: only-export-components
+// weakness: name-heuristic
+// source: issue #1265
+import { useMemo } from "react";
+
+interface CountryOption {
+  code: string;
+}
+
+export function useCountryOptions(): CountryOption[] {
+  return useMemo(() => [], []);
+}
+
+export function CountryPickerSheet() {
+  const options = useCountryOptions();
+  return <div>{options.length}</div>;
+}

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -220,6 +220,7 @@ export const LIBRARY_SNIPPET_POOL = [
 
 // Module scope — SSR hazards, guard aliases, contexts, caches, styled.
 export const MODULE_SCOPE_SNIPPET_POOL = [
+  `export function useFuzzCountryOptions() { return []; } export function FuzzCountryPickerSheet() { return <div />; }`,
   `import { motion as FuzzMotion } from "framer-motion"; export const FuzzMotionPanel = () => <FuzzMotion.div animate={{ x: 120 }}>moving</FuzzMotion.div>;`,
   `import { createRoot as mountFuzzRoot } from "react-dom/client"; export const FuzzRootApp = () => <div />; export const fuzzRootConfig = getConfig(); const fuzzApplicationRoot = mountFuzzRoot(document.body); fuzzApplicationRoot.render(<FuzzRootApp />);`,
   `const GLOBAL_CACHE = new Map<string, unknown>();`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.regressions.test.ts
@@ -2,11 +2,48 @@ import { describe, expect, it } from "vite-plus/test";
 import { runRule } from "../../../test-utils/run-rule.js";
 import { onlyExportComponents } from "./only-export-components.js";
 
-// Issue #539: a missing filename must not crash the rule. When
-// `context.filename` is undefined the rule has to coalesce instead of
-// calling `normalizeFilename(undefined)`, which threw
-// "Cannot read properties of undefined (reading 'replaceAll')".
-const AXIOS_FILE = `
+const settingsForFramework = (
+  framework: "expo" | "nextjs" | "remix" | "tanstack-start" | "vite",
+) => ({ "react-doctor": { framework } });
+
+describe("react-builtins/only-export-components — regressions", () => {
+  // Issue #1265: exported custom hooks (use[A-Z]...) should not be
+  // reported as non-component exports. The rule documentation explicitly
+  // allows hook exports, and modern Fast Refresh (>= 4.x via
+  // @vitejs/plugin-react-swc + react-refresh) handles `use[A-Z]*` exports
+  // alongside components cleanly.
+  it("allows exported custom hooks (#1265)", () => {
+    const hookExportFile = `
+      import { useMemo } from 'react';
+      
+      export type CountryOption = {
+        code: string;
+        name: string;
+        searchKey: string;
+      };
+      
+      export function useCountryOptions(): CountryOption[] {
+        return useMemo(() => [], []);
+      }
+      
+      export function CountryPickerSheet() {
+        const options = useCountryOptions();
+        return <div>{options.length}</div>;
+      }
+    `;
+    const result = runRule(onlyExportComponents, hookExportFile, {
+      filename: "src/components/CountryPickerSheet.tsx",
+      settings: settingsForFramework("vite"),
+    });
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  // Issue #539: a missing filename must not crash the rule. When
+  // `context.filename` is undefined the rule has to coalesce instead of
+  // calling `normalizeFilename(undefined)`, which threw
+  // "Cannot read properties of undefined (reading 'replaceAll')".
+  const AXIOS_FILE = `
 import axios from 'axios'
 
 export const api = axios.create({
@@ -17,12 +54,6 @@ export const api = axios.create({
   },
 })
 `;
-
-const settingsForFramework = (
-  framework: "expo" | "nextjs" | "remix" | "tanstack-start" | "vite",
-) => ({ "react-doctor": { framework } });
-
-describe("react-builtins/only-export-components — regressions", () => {
   it("does not crash when the filename is unavailable (#539)", () => {
     expect(() => runRule(onlyExportComponents, AXIOS_FILE, { filename: undefined })).not.toThrow();
   });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.regressions.test.ts
@@ -7,25 +7,20 @@ const settingsForFramework = (
 ) => ({ "react-doctor": { framework } });
 
 describe("react-builtins/only-export-components — regressions", () => {
-  // Issue #1265: exported custom hooks (use[A-Z]...) should not be
-  // reported as non-component exports. The rule documentation explicitly
-  // allows hook exports, and modern Fast Refresh (>= 4.x via
-  // @vitejs/plugin-react-swc + react-refresh) handles `use[A-Z]*` exports
-  // alongside components cleanly.
   it("allows exported custom hooks (#1265)", () => {
     const hookExportFile = `
       import { useMemo } from 'react';
-      
+
       export type CountryOption = {
         code: string;
         name: string;
         searchKey: string;
       };
-      
+
       export function useCountryOptions(): CountryOption[] {
         return useMemo(() => [], []);
       }
-      
+
       export function CountryPickerSheet() {
         const options = useCountryOptions();
         return <div>{options.length}</div>;
@@ -38,6 +33,74 @@ describe("react-builtins/only-export-components — regressions", () => {
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toHaveLength(0);
   });
+
+  it.each([
+    "use",
+    "usecountryOptions",
+    "use_countryOptions",
+    "use0CountryOptions",
+    "createCountryOptions",
+  ])(
+    "still reports function exports outside the documented hook-name boundary: %s",
+    (functionName) => {
+      const result = runRule(
+        onlyExportComponents,
+        `
+          export function ${functionName}() { return []; }
+          export function CountryPickerSheet() { return <div />; }
+        `,
+        {
+          filename: "src/components/CountryPickerSheet.tsx",
+          settings: settingsForFramework("vite"),
+        },
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    },
+  );
+
+  it.each([
+    "export function countryOptions() { return []; }",
+    "export const countryOptions = () => [];",
+  ])("allows configured function and const exports equally: %s", (exportDeclaration) => {
+    const result = runRule(
+      onlyExportComponents,
+      `
+        ${exportDeclaration}
+        export function CountryPickerSheet() { return <div />; }
+      `,
+      {
+        filename: "src/components/CountryPickerSheet.tsx",
+        settings: {
+          "react-doctor": {
+            framework: "vite",
+            onlyExportComponents: { allowExportNames: ["countryOptions"] },
+          },
+        },
+      },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it.each(["export function loader() { return null; }", "export const loader = () => null;"])(
+    "allows route-contract function and const exports equally: %s",
+    (exportDeclaration) => {
+      const result = runRule(
+        onlyExportComponents,
+        `
+        ${exportDeclaration}
+        export function CountryPickerSheet() { return <div />; }
+      `,
+        {
+          filename: "src/components/CountryPickerSheet.tsx",
+          settings: settingsForFramework("remix"),
+        },
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(0);
+    },
+  );
 
   // Issue #539: a missing filename must not crash the rule. When
   // `context.filename` is undefined the rule has to coalesce instead of

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.ts
@@ -935,11 +935,18 @@ export const onlyExportComponents = defineRule({
               const declaration = child.declaration;
               if (isNodeOfType(declaration, "FunctionDeclaration") && declaration.id) {
                 isExportedNodeIds.add(declaration);
+                const classifiedExport = classifyExport(
+                  declaration.id.name,
+                  declaration.id,
+                  true,
+                  null,
+                  state,
+                );
                 exports.push(
                   functionHasReactRenderSemantics(declaration, state) ||
                     localComponentNames.has(declaration.id.name) ||
-                    /^use[A-Z]/.test(declaration.id.name)
-                    ? classifyExport(declaration.id.name, declaration.id, true, null, state)
+                    classifiedExport.kind === "allowed"
+                    ? classifiedExport
                     : { kind: "non-component", reportNode: declaration.id },
                 );
               } else if (isNodeOfType(declaration, "ClassDeclaration") && declaration.id) {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/only-export-components.ts
@@ -937,7 +937,8 @@ export const onlyExportComponents = defineRule({
                 isExportedNodeIds.add(declaration);
                 exports.push(
                   functionHasReactRenderSemantics(declaration, state) ||
-                    localComponentNames.has(declaration.id.name)
+                    localComponentNames.has(declaration.id.name) ||
+                    /^use[A-Z]/.test(declaration.id.name)
                     ? classifyExport(declaration.id.name, declaration.id, true, null, state)
                     : { kind: "non-component", reportNode: declaration.id },
                 );


### PR DESCRIPTION
<!-- motivation-example:start -->
## Motivation

`only-export-components` should protect Fast Refresh without rejecting exports React's documented convention already identifies as custom Hooks. Function declarations and `const` exports should receive the same classification.

## Example

This module should be valid because `useProject` is a custom Hook, not an unrelated non-component export:

```tsx
export function useProject() {
  return useContext(ProjectContext)
}

export const ProjectPanel = () => <section />
```
<!-- motivation-example:end -->

## Summary

Fixes #1265. `react-doctor/only-export-components` incorrectly reports exported `use[A-Z]` function declarations alongside component exports even though the existing export classifier already marks that documented hook-name shape as allowed.

## Root cause

The `ExportNamedDeclaration` path preclassified function declarations by render semantics before calling `classifyExport`. Non-rendering hook declarations therefore became `non-component` without reaching the existing hook allowance. Variable exports already reached the classifier.

## Fix

Classify the declaration once and reuse that result when the declaration has component semantics or the classifier proves it is an allowed export. This removes the duplicate hook-name check and also makes configured and framework route-contract function declarations behave like their const-export equivalents.

## Precision boundary

Still reports function declarations outside the documented `use[A-Z]` shape, including exact `use`, lowercase, underscore, digit, and ordinary helper names. Class declarations and unrelated non-component exports are unchanged.

## Validation

- Exact #1265 regression plus paired negative and function/const parity tests: 122 passed
- Full plugin: 559 files, 14,015 tests passed
- Full workspace: 14/14 tasks passed
- Typecheck, lint, format check, build, and `git diff --check origin/main...HEAD`: passed
- Fuzz corpus: 44 passed, 402 skipped
- Strict target fuzz: 500 iterations; 321 executed, 13 fired, target coverage 1/1, no findings
- Pinned real-repo comparison: 20/20 baseline and 20/20 candidate scans succeeded; 472 → 455 total diagnostics, 36 → 19 target-rule diagnostics, zero additions, 17 removals
- Manual delta audit: all 17 removals are genuine exported `use[A-Z]` hooks in tldraw; no removed true positives
- React Bench oracle audit: derived both unique persisted oracle workspaces whose stored reports contained `only-export-components`; requested 2, scanned 2 exact configured roots on both heads, 0 failures or partial scans, and 0 baseline/candidate target-rule delta. Neither oracle patch changes a function-declaration hook export, so no solution-sensitive oracle applies to this fix.

The stock local RDE command is currently incompatible with the current CLI because it still passes removed `--full`; the comparison above used the same pinned RDE repository set through direct baseline/candidate JSON scans with unrelated analyzers disabled.

Closes #1265

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to export classification for named function declarations in one lint rule, with extensive regression tests and no auth or runtime impact.
> 
> **Overview**
> Fixes a **false positive** in `only-export-components` when a module exports both a component and a **`export function useFoo()`** custom hook.
> 
> For **named function exports**, the rule used to treat non-rendering declarations as `non-component` unless they had render semantics or matched a local component name, so they never reached `classifyExport`’s existing **`use[A-Z]`** allowance (which `const` hook exports already used). The change **classifies once** via `classifyExport` and accepts the export when that result is **`allowed`**, aligning function declarations with const exports and configured / framework route-contract names.
> 
> Adds **#1265** regression coverage, boundary tests for invalid hook names, fuzz corpus/snippet coverage, and a patch changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3989e43985fe13e4f2cff3e558ff8651eee40ceb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->