### PR TITLE
fix: improve lint timeout error message with env var guidance

### DIFF
--- a/.changeset/improve-lint-timeout-message.md
+++ b/.changeset/improve-lint-timeout-message.md
@@ -1,0 +1,12 @@
+---
+"@react-doctor/core": patch
+"react-doctor": patch
+---
+
+Improve lint timeout error message to guide users on increasing the timeout
+
+When lint analysis exceeds the 300s timeout on large projects, the error message now includes guidance about the `REACT_DOCTOR_LINT_PHASE_TIMEOUT_MS` environment variable and suggests a concrete value to try. This addresses user confusion when encountering timeouts after TypeScript upgrades or on large codebases (~7000+ files).
+
+Example new message: "Lint analysis exceeded 300s and was skipped. For large projects, increase the timeout: REACT_DOCTOR_LINT_PHASE_TIMEOUT_MS=600000 (or higher)."
+
+Closes #1267

--- a/packages/core/src/run-inspect.ts
+++ b/packages/core/src/run-inspect.ts
@@ -855,7 +855,9 @@ export const runInspect = <HooksR = never>(
               didFail: true,
               reason: `Lint analysis exceeded ${
                 lintPhaseTimeoutMs / MILLISECONDS_PER_SECOND
-              }s and was skipped.`,
+              }s and was skipped. For large projects, increase the timeout: REACT_DOCTOR_LINT_PHASE_TIMEOUT_MS=${
+                Math.ceil((lintPhaseTimeoutMs * 2) / 1000) * 1000
+              } (or higher).`,
               reasonTag: "OxlintBatchExceeded",
               reasonKind: null,
             }).pipe(Effect.as<Diagnostic[]>([])),

--- a/packages/core/tests/run-inspect.test.ts
+++ b/packages/core/tests/run-inspect.test.ts
@@ -207,6 +207,8 @@ describe("runInspect — phase timeouts & overall deadline", () => {
     expect(output.didLintFail).toBe(true);
     expect(output.lintFailureReasonTag).toBe("OxlintBatchExceeded");
     expect(output.lintFailureReason).toContain("Lint analysis exceeded");
+    expect(output.lintFailureReason).toContain("REACT_DOCTOR_LINT_PHASE_TIMEOUT_MS");
+    expect(output.lintFailureReason).toMatch(/REACT_DOCTOR_LINT_PHASE_TIMEOUT_MS=\d+/);
     expect(output.score).toBeNull();
     expect(output.diagnostics).toHaveLength(0);
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Root Cause

When lint analysis exceeds the 300s timeout on large projects (~7000+ files), users see an error message but don't know how to increase the timeout budget. The `REACT_DOCTOR_LINT_PHASE_TIMEOUT_MS` environment variable exists but wasn't surfaced in the error.

## Scope

This is a **documentation/UX fix**, not a performance regression. The 300s timeout is designed for "healthy-but-slow large repos" (per `constants.ts` comments). For very large projects or after TypeScript upgrades that may introduce new syntax, this timeout can legitimately be exceeded.

## Changes

1. **Updated error message** in `run-inspect.ts` (line 856-860) to include:
   - Reference to `REACT_DOCTOR_LINT_PHASE_TIMEOUT_MS` env var
   - Suggested value (2x current timeout) for quick resolution
   
2. **Added test coverage** in `run-inspect.test.ts` to ensure:
   - Error message includes env var name
   - Error message includes numeric value suggestion

## Example

**Before:**
```
Lint analysis exceeded 300s and was skipped.
```

**After:**
```
Lint analysis exceeded 300s and was skipped. For large projects, increase the timeout: REACT_DOCTOR_LINT_PHASE_TIMEOUT_MS=600000 (or higher).
```

## Testing

- ✅ Unit tests pass (`packages/core/tests/run-inspect.test.ts`)
- ✅ Lint checks pass
- ✅ Type checks pass
- Regression test included for timeout message format

## Related Context

- TypeScript 6.0.3 is supported (see #890, #963)
- The timeout exists specifically for this use case (see `constants.ts` line 365-372)
- Large projects (7000+ files) may legitimately need >300s
- ESLint comparison (35s) isn't apples-to-apples: react-doctor runs 100+ custom rules vs ESLint's typical 20-50

Closes #1267
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8cf8f119-a3f1-481a-bfd0-d83a339a3cd1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8cf8f119-a3f1-481a-bfd0-d83a339a3cd1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

