### PR TITLE
fix(no-default-props): preserve class receivers

### DIFF
--- a/.changeset/quiet-classes-remain.md
+++ b/.changeset/quiet-classes-remain.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Avoid `no-default-props` false positives for stable class receivers, which React 19 continues to support.

--- a/packages/fuzz/corpus/regressions/no-default-props--class-receiver.tsx
+++ b/packages/fuzz/corpus/regressions/no-default-props--class-receiver.tsx
@@ -1,0 +1,12 @@
+// rule: no-default-props
+// weakness: name-heuristic
+// source: man-group/dtale@d34f0a573c23d197e13cb42d2cb048b926a77cac Wordcloud.react.js
+import { Component } from "react";
+
+class Wordcloud extends Component {
+  render() {
+    return <output>{this.props.height}</output>;
+  }
+}
+
+Wordcloud.defaultProps = { height: 400 };

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -229,6 +229,7 @@ export const MODULE_SCOPE_SNIPPET_POOL = [
   `const FuzzMemoList = React.memo(({ items }) => <div>{items.length}</div>, (previousProps, nextProps) => previousProps.items.length === nextProps.items.length); const FuzzDefaultList = ({ items = [] }) => <FuzzMemoList items={items} />;`,
   `const useFuzzCollection = (items: readonly string[]) => { items.forEach((item) => consume(item)); }; const useFuzzCallback = (onVisit: (item: string) => void) => { onVisit(String(value)); };`,
   `const FuzzPropTypesPanel = ({ value }) => <div>{value}</div>; FuzzPropTypesPanel.propTypes = { value: () => true };`,
+  `const FuzzDefaultPropsPanel = ({ value }) => <div>{value}</div>; FuzzDefaultPropsPanel.defaultProps = { value: "fallback" };`,
   `function FuzzNestedWritePanel() { return <div />; } function unusedFuzzNestedWrite() { FuzzNestedWritePanel = () => null; } FuzzNestedWritePanel.propTypes = { value: () => true };`,
   `function FuzzReturnedLabel() { let output = "label"; function unusedFuzzOutputWrite() { output = <div />; } return output; } FuzzReturnedLabel.propTypes = { value: () => true };`,
   `function FuzzExitedWrite(condition: boolean) { let output; if (condition) { output = <div />; return "label"; } return output; } FuzzExitedWrite.propTypes = { value: () => true };`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-default-props.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-default-props.regressions.test.ts
@@ -28,6 +28,157 @@ Wordcloud.defaultProps = { height: 400 };`,
       expect(result.parseErrors).toEqual([]);
       expect(result.diagnostics).toHaveLength(1);
     });
+
+    it.each([
+      [
+        "renamed Component import",
+        `import { Component as BaseComponent } from "react";
+class Wordcloud extends BaseComponent {}
+Wordcloud.defaultProps = { height: 400 };`,
+      ],
+      [
+        "renamed PureComponent import",
+        `import { PureComponent as BaseComponent } from "react";
+class Wordcloud extends BaseComponent {}
+Wordcloud.defaultProps = { height: 400 };`,
+      ],
+      [
+        "React namespace Component",
+        `import * as React from "react";
+class Wordcloud extends React.Component {}
+Wordcloud.defaultProps = { height: 400 };`,
+      ],
+      [
+        "React namespace PureComponent",
+        `import * as React from "react";
+class Wordcloud extends React.PureComponent {}
+Wordcloud.defaultProps = { height: 400 };`,
+      ],
+      [
+        "intermediate subclass",
+        `import { Component } from "react";
+class BaseWordcloud extends Component {}
+class Wordcloud extends BaseWordcloud {}
+Wordcloud.defaultProps = { height: 400 };`,
+      ],
+      [
+        "class expression",
+        `import { Component } from "react";
+const Wordcloud = class extends Component {};
+Wordcloud.defaultProps = { height: 400 };`,
+      ],
+      [
+        "named class expression",
+        `import { Component } from "react";
+const Wordcloud = class WordcloudComponent extends Component {};
+Wordcloud.defaultProps = { height: 400 };`,
+      ],
+      [
+        "stable const alias chain",
+        `import { Component } from "react";
+class WordcloudClass extends Component {}
+const WordcloudAlias = WordcloudClass;
+const Wordcloud = WordcloudAlias;
+Wordcloud.defaultProps = { height: 400 };`,
+      ],
+      [
+        "class captured before its binding changes",
+        `class WordcloudClass {}
+const Wordcloud = WordcloudClass;
+WordcloudClass = () => null;
+Wordcloud.defaultProps = { height: 400 };`,
+      ],
+      [
+        "alias captured before an earlier alias changes",
+        `class WordcloudClass {}
+const WordcloudAlias = WordcloudClass;
+const Wordcloud = WordcloudAlias;
+WordcloudAlias = () => null;
+Wordcloud.defaultProps = { height: 400 };`,
+      ],
+      [
+        "userland class",
+        `class Wordcloud {}
+Wordcloud.defaultProps = { height: 400 };`,
+      ],
+      [
+        "shadowing class",
+        `const Wordcloud = () => null;
+{
+  class Wordcloud {}
+  Wordcloud.defaultProps = { height: 400 };
+}`,
+      ],
+    ])("stays silent for a %s receiver", (_description, source) => {
+      const result = runRule(noDefaultProps, source);
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it.each([
+      [
+        "reassigned class binding",
+        `class Wordcloud {}
+Wordcloud = () => null;
+Wordcloud.defaultProps = { height: 400 };`,
+      ],
+      [
+        "class binding changed before the alias captures it",
+        `class WordcloudClass {}
+WordcloudClass = () => null;
+const Wordcloud = WordcloudClass;
+Wordcloud.defaultProps = { height: 400 };`,
+      ],
+      [
+        "alias changed before the next alias captures it",
+        `class WordcloudClass {}
+const WordcloudAlias = WordcloudClass;
+WordcloudAlias = () => null;
+const Wordcloud = WordcloudAlias;
+Wordcloud.defaultProps = { height: 400 };`,
+      ],
+      [
+        "mutable alias",
+        `class WordcloudClass {}
+let Wordcloud = WordcloudClass;
+Wordcloud.defaultProps = { height: 400 };`,
+      ],
+      [
+        "opaque import",
+        `import { Wordcloud } from "./wordcloud";
+Wordcloud.defaultProps = { height: 400 };`,
+      ],
+      ["unresolved receiver", `Wordcloud.defaultProps = { height: 400 };`],
+      [
+        "HOC result",
+        `import { memo } from "react";
+const Wordcloud = memo(() => null);
+Wordcloud.defaultProps = { height: 400 };`,
+      ],
+      [
+        "shadowed function",
+        `class Wordcloud {}
+{
+  const Wordcloud = () => null;
+  Wordcloud.defaultProps = { height: 400 };
+}`,
+      ],
+    ])("still flags a %s receiver", (_description, source) => {
+      const result = runRule(noDefaultProps, source);
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    });
+
+    it("uses the reaching class value before a later reassignment", () => {
+      const result = runRule(
+        noDefaultProps,
+        `class Wordcloud {}
+Wordcloud.defaultProps = { height: 400 };
+Wordcloud = () => null;`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
   });
 
   // FN hunt (innovaccer design-system): the rule fired zero times across the

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-default-props.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-default-props.regressions.test.ts
@@ -3,6 +3,33 @@ import { runRule } from "../../../test-utils/run-rule.js";
 import { noDefaultProps } from "./no-default-props.js";
 
 describe("architecture/no-default-props — regressions", () => {
+  describe("class receivers", () => {
+    it("stays silent for the D-Tale React class component", () => {
+      const result = runRule(
+        noDefaultProps,
+        `import React, { Component } from "react";
+class Wordcloud extends Component {
+  render() {
+    return <output>{this.props.height}</output>;
+  }
+}
+Wordcloud.defaultProps = { height: 400 };`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it("still flags the equivalent function component", () => {
+      const result = runRule(
+        noDefaultProps,
+        `const Wordcloud = (props) => <output>{props.height}</output>;
+Wordcloud.defaultProps = { height: 400 };`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    });
+  });
+
   // FN hunt (innovaccer design-system): the rule fired zero times across the
   // whole corpus because `defaultEnabled: false` kept it out of the default
   // scan set ON TOP of the `react:19` gate — double-gated into permanent

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-default-props.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-default-props.regressions.test.ts
@@ -74,6 +74,18 @@ const Wordcloud = class WordcloudComponent extends Component {};
 Wordcloud.defaultProps = { height: 400 };`,
       ],
       [
+        "type-asserted class expression",
+        `import { Component } from "react";
+const Wordcloud = (class extends Component {}) as typeof Component;
+Wordcloud.defaultProps = { height: 400 };`,
+      ],
+      [
+        "satisfies-wrapped class expression",
+        `import { Component } from "react";
+const Wordcloud = (class extends Component {}) satisfies typeof Component;
+Wordcloud.defaultProps = { height: 400 };`,
+      ],
+      [
         "stable const alias chain",
         `import { Component } from "react";
 class WordcloudClass extends Component {}

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-default-props.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-default-props.ts
@@ -1,17 +1,51 @@
 import { defineRule } from "../../utils/define-rule.js";
+import { hasSymbolWriteBefore } from "../../utils/has-symbol-write-before.js";
 import { isUppercaseName } from "../../utils/is-uppercase-name.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { resolveConstIdentifierAlias } from "../../utils/resolve-const-identifier-alias.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 
-// HACK: React 19 removes `Component.defaultProps` for FUNCTION components
-// (class components still tolerate it but the team recommends ES6
-// default parameters anyway). Detection target: any
-// `<Identifier>.defaultProps = <ObjectExpression>` assignment where the
-// identifier looks like a component (uppercase first letter). We can't
-// distinguish class vs function from the assignment alone, but the
-// recommendation is the same either way — switch to ES6 default params
-// in destructured props — so the guidance is uniform.
+const hasReachingWriteOnAliasPath = (
+  receiver: EsTreeNodeOfType<"Identifier">,
+  context: RuleContext,
+): boolean => {
+  const visitedSymbolIds = new Set<number>();
+  let reference = receiver;
+  let symbol = context.scopes.symbolFor(reference);
+  while (symbol) {
+    if (
+      visitedSymbolIds.has(symbol.id) ||
+      hasSymbolWriteBefore(symbol, reference, context.scopes)
+    ) {
+      return true;
+    }
+    visitedSymbolIds.add(symbol.id);
+    if (symbol.kind !== "const" || !symbol.initializer) return false;
+    const initializer = stripParenExpression(symbol.initializer);
+    if (!isNodeOfType(initializer, "Identifier")) return false;
+    reference = initializer;
+    symbol = context.scopes.symbolFor(reference);
+  }
+  return false;
+};
+
+const isStableClassReceiver = (
+  receiver: EsTreeNodeOfType<"Identifier">,
+  context: RuleContext,
+): boolean => {
+  const symbol = resolveConstIdentifierAlias(receiver, context.scopes);
+  if (!symbol || hasReachingWriteOnAliasPath(receiver, context)) return false;
+  if (
+    isNodeOfType(symbol.declarationNode, "ClassDeclaration") ||
+    isNodeOfType(symbol.declarationNode, "ClassExpression")
+  ) {
+    return true;
+  }
+  return Boolean(symbol.kind === "const" && isNodeOfType(symbol.initializer, "ClassExpression"));
+};
+
 export const noDefaultProps = defineRule({
   id: "no-default-props",
   title: "defaultProps removed in React 19",
@@ -34,6 +68,7 @@ export const noDefaultProps = defineRule({
         return;
       if (!isNodeOfType(left.object, "Identifier")) return;
       if (!isUppercaseName(left.object.name)) return;
+      if (isStableClassReceiver(left.object, context)) return;
       context.report({
         node: left,
         message: `${left.object.name}.defaultProps stops applying in React 19, so your users see missing defaults. Set them in the destructured props parameter instead, like \`function ${left.object.name}({ size = "md" })\`.`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-default-props.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-default-props.ts
@@ -43,7 +43,8 @@ const isStableClassReceiver = (
   ) {
     return true;
   }
-  return Boolean(symbol.kind === "const" && isNodeOfType(symbol.initializer, "ClassExpression"));
+  const initializer = symbol.initializer ? stripParenExpression(symbol.initializer) : null;
+  return Boolean(symbol.kind === "const" && isNodeOfType(initializer, "ClassExpression"));
 };
 
 export const noDefaultProps = defineRule({


### PR DESCRIPTION
<!-- motivation-example:start -->
## Motivation

React 19 removed `defaultProps` support for function components, not class components. Reporting class receivers gives users migration advice that has no equivalent parameter-default replacement and changes still-supported behavior.

## Example

This remains supported in React 19 and should not be diagnosed:

```tsx
class Wordcloud extends Component {
  render() {
    return <div style={{ height: this.props.height }} />
  }
}

Wordcloud.defaultProps = { height: 400 }
```
<!-- motivation-example:end -->

## Summary

Fixes a grounded `no-default-props` false positive for class receivers without weakening the React 19 function-component migration warning.

React officially removed `defaultProps` for function components in React 19, but class components continue to support it because there is no ES6 parameter-default alternative: https://react.dev/blog/2024/04/25/react-19-upgrade-guide#removed-proptypes-and-defaultprops-for-functions

## Grounded reproduction

- Repository: `man-group/dtale@d34f0a573c23d197e13cb42d2cb048b926a77cac`
- File: `static/dash/lib/components/Wordcloud.react.js`
- Runtime: React and ReactDOM 19.2.4
- Shape: `class Wordcloud extends Component` followed by `Wordcloud.defaultProps = { height: 400 }`
- Runtime check: the omitted class prop receives its default with both automatic JSX and `React.createElement`

## Detector boundary

The rule now suppresses only receivers whose reaching local value is proven to be a class declaration or class expression. Stable `const` aliases are followed at each capture site, so writes before capture invalidate the class proof while writes after capture do not.

Function declarations, arrow functions, HOC results, mutable aliases, reassigned values, opaque imports, unresolved receivers, and computed properties retain their previous behavior. Userland classes are also suppressed because the React 19 removal applies to function components, not class syntax.

## Coverage

- Exact D-Tale regression and adjacent function positive
- Named and renamed `Component` and `PureComponent` imports
- React namespace bases and intermediate subclasses
- Named and anonymous class expressions, including transparent TypeScript wrappers
- Multi-hop const aliases with paired before and after write cases
- Shadowing, mutable aliases, opaque imports, unresolved receivers, HOCs, and userland classes
- Permanent fuzz regression corpus seed and module-scope liveness snippet
- Patch changeset

## Validation

- `nr --filter oxlint-plugin-react-doctor test`: 559 files passed, 14,034 tests passed, 181 skipped
- `nr --filter oxlint-plugin-react-doctor typecheck`
- `nr --filter @react-doctor/fuzz test`: 44 passed, 402 skipped after building the plugin
- `FUZZ_RULE=no-default-props FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz`: passed
- Direct fuzz stats: 15 firing programs, 332 executed, 186 parse skips, 0 findings
- Regression-corpus oracle: the new named seed stays quiet; existing unrelated corpus findings remain unchanged
- `nr lint`, `nr format:check`, and `git diff --check`

This PR is ready for review. Do not merge automatically.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted lint-rule heuristic change with broad regression and fuzz coverage; no runtime or auth/data paths affected.
> 
> **Overview**
> **`no-default-props`** now **skips** `Component.defaultProps = …` when scope analysis shows the receiver is a **stable class** (declaration or expression), including multi-hop `const` aliases, because React 19 still applies `defaultProps` on class components.
> 
> The rule **still warns** on function components, HOCs, reassigned/mutable bindings, opaque imports, and other non-class receivers. Implementation adds **`isStableClassReceiver`** (alias resolution plus write-before checks on the alias path) before reporting.
> 
> Coverage adds a D-Tale regression corpus seed, a fuzz module-scope snippet, a patch changeset, and a large **class receiver** regression matrix (silence vs still-flag cases).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93be82cfebe0cd1a0694b0fe6ced798811a42f40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->