### PR TITLE
fix(no-uncontrolled-input): allow read-only-value input types

### DIFF
--- a/.changeset/brown-eggs-love.md
+++ b/.changeset/brown-eggs-love.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Fix `no-uncontrolled-input` false positives for input types whose `value` is read-only in React.

--- a/.changeset/brown-eggs-love.md
+++ b/.changeset/brown-eggs-love.md
@@ -2,4 +2,4 @@
 "oxlint-plugin-react-doctor": patch
 ---
 
-Fix `no-uncontrolled-input` false positives for input types whose `value` is read-only in React.
+Fix `no-uncontrolled-input` false positives for input types whose `value` is read-only in React, including types behind deep const aliases and constant ternaries.

--- a/packages/fuzz/corpus/regressions/no-uncontrolled-input--submit-value.tsx
+++ b/packages/fuzz/corpus/regressions/no-uncontrolled-input--submit-value.tsx
@@ -1,0 +1,7 @@
+// rule: no-uncontrolled-input
+// weakness: library-idiom
+// source: DevLovers trial write-react-devloversteam-devlov__mzTqjct
+
+export const BlogHeaderSearch = () => (
+  <input id="search_submit" value="" type="submit" className="search-submit" />
+);

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -422,6 +422,7 @@ export const JSX_LEAF_POOL = [
   `<input type="checkbox" indeterminate />`,
   `<input type="radio" value="a" checked={state === "a"} onChange={() => setState("a")} />`,
   `<input type="radio" name="group" value="b" defaultChecked />`,
+  `<input type="submit" value="Search" />`,
   `<input type="number" min={0} max={100} value={state} onChange={handleAmount} />`,
   `<textarea readOnly value={String(value)} />`,
   `<ThemeContext.Provider value={{ mode: state, toggle: handle }}>{state}</ThemeContext.Provider>`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-uncontrolled-input.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-uncontrolled-input.regressions.test.ts
@@ -147,6 +147,21 @@ describe("correctness/no-uncontrolled-input — regressions", () => {
     expect(result.diagnostics).toHaveLength(2);
   });
 
+  it("stays conservative when an opaque spread appears before or after the input type", () => {
+    const result = runRule(
+      noUncontrolledInput,
+      `export default function Controls({ inputProps }) {
+        return <>
+          <input {...inputProps} type="submit" value="Action" />
+          <input type="submit" {...inputProps} value="Action" />
+        </>;
+      }`,
+      { filename: "app/controls.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("still flags an input with a missing type", () => {
     const result = runRule(
       noUncontrolledInput,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-uncontrolled-input.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-uncontrolled-input.regressions.test.ts
@@ -44,6 +44,81 @@ describe("correctness/no-uncontrolled-input — regressions", () => {
     expect(result.diagnostics.length).toBeGreaterThan(0);
   });
 
+  it.each(["button", "hidden", "image", "reset", "submit"])(
+    "still flags an undefined-state transition for a %s input without asking for onChange",
+    (inputType) => {
+      const result = runRule(
+        noUncontrolledInput,
+        `import { useState } from "react";
+        export default function Control() {
+          const [label] = useState();
+          return <input type="${inputType}" value={label} />;
+        }`,
+        { filename: "app/control.tsx" },
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+      expect(result.diagnostics[0]?.message).toContain("Give useState a starting value");
+      expect(result.diagnostics[0]?.message).not.toContain("add onChange");
+    },
+  );
+
+  it.each(["checkbox", "radio"])(
+    "does not treat value state as the controlledness signal for an exact-lowercase %s input",
+    (inputType) => {
+      const result = runRule(
+        noUncontrolledInput,
+        `import { useState } from "react";
+        export default function Control() {
+          const [value] = useState();
+          return <input type="${inputType}" value={value} />;
+        }`,
+        { filename: "app/control.tsx" },
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    },
+  );
+
+  it("still flags an undefined-state transition for uppercase CHECKBOX because React's checked controlledness test is case-sensitive", () => {
+    const result = runRule(
+      noUncontrolledInput,
+      `import { useState } from "react";
+      export default function Control() {
+        const [value] = useState();
+        return <input type="CHECKBOX" value={value} />;
+      }`,
+      { filename: "app/control.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0]?.message).not.toContain(
+      "When `type` resolves to a value-controlled input type",
+    );
+  });
+
+  it("uses conditional transition wording for dynamic and mixed checked-controlledness types", () => {
+    const result = runRule(
+      noUncontrolledInput,
+      `import { useState } from "react";
+      export default function Controls({ inputType, useCheckbox }) {
+        const [dynamicValue] = useState();
+        const [mixedValue] = useState();
+        return <>
+          <input type={inputType} value={dynamicValue} />
+          <input type={useCheckbox ? "checkbox" : "submit"} value={mixedValue} />
+        </>;
+      }`,
+      { filename: "app/controls.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(2);
+    for (const diagnostic of result.diagnostics) {
+      expect(diagnostic.message).toContain("When `type` resolves to a value-controlled input type");
+      expect(diagnostic.message).not.toContain("add onChange");
+    }
+  });
+
   it("stays silent on the DevLovers submit input whose value labels a button", () => {
     const result = runRule(
       noUncontrolledInput,
@@ -88,6 +163,17 @@ describe("correctness/no-uncontrolled-input — regressions", () => {
       expect(result.parseErrors).toEqual([]);
       expect(result.diagnostics).toEqual([]);
     });
+
+    it(`still flags value and defaultValue together on a ${inputType} input`, () => {
+      const result = runRule(
+        noUncontrolledInput,
+        `export default function Control() { return <input type="${inputType}" value="Action" defaultValue="Fallback" />; }`,
+        { filename: "app/control.tsx" },
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+      expect(result.diagnostics[0]?.message).toContain("defaultValue");
+    });
   }
 
   it.each(["text", "search"])(
@@ -111,6 +197,9 @@ describe("correctness/no-uncontrolled-input — regressions", () => {
     );
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0]?.message).toContain(
+      "When `type` resolves to an editable input type",
+    );
   });
 
   it("stays silent on expression, wrapped, const-alias, and all-bypass ternary types", () => {
@@ -123,6 +212,27 @@ describe("correctness/no-uncontrolled-input — regressions", () => {
           <input type={("IMAGE" as const)} value="Search" alt="Search" />
           <input type={inputType} value="Reset" />
           <input type={alternate ? "button" : "submit"} value="Action" />
+        </>;
+      }`,
+      { filename: "app/controls.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("resolves a constant ternary and a long const alias chain", () => {
+    const result = runRule(
+      noUncontrolledInput,
+      `export default function Controls() {
+        const firstType = "submit";
+        const secondType = firstType;
+        const thirdType = secondType;
+        const fourthType = thirdType;
+        const fifthType = fourthType;
+        const sixthType = fifthType;
+        return <>
+          <input type={true ? "submit" : editableType} value="Action" />
+          <input type={sixthType} value="Action" />
         </>;
       }`,
       { filename: "app/controls.tsx" },
@@ -145,6 +255,24 @@ describe("correctness/no-uncontrolled-input — regressions", () => {
     );
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toHaveLength(2);
+    for (const diagnostic of result.diagnostics) {
+      expect(diagnostic.message).toContain("When `type` resolves to an editable input type");
+    }
+  });
+
+  it("uses the last explicit input type when duplicate attributes are present", () => {
+    const result = runRule(
+      noUncontrolledInput,
+      `export default function Controls({ value }) {
+        return <>
+          <input type="submit" type="text" value={value} />
+          <input type="text" type="submit" value="Action" />
+        </>;
+      }`,
+      { filename: "app/controls.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
   });
 
   it("stays conservative when an opaque spread appears before or after the input type", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-uncontrolled-input.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-uncontrolled-input.regressions.test.ts
@@ -33,6 +33,30 @@ describe("correctness/no-uncontrolled-input — regressions", () => {
     expect(result.diagnostics.length).toBeGreaterThan(0);
   });
 
+  it("stays silent on the DevLovers submit input whose value labels a button", () => {
+    const result = runRule(
+      noUncontrolledInput,
+      `export default function BlogHeaderSearch() {
+        return <input id="search_submit" value="" type="submit" className="search-submit" />;
+      }`,
+      { filename: "components/blog/BlogHeaderSearch.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still flags an editable text input adjacent to the DevLovers regression", () => {
+    const result = runRule(
+      noUncontrolledInput,
+      `export default function BlogHeaderSearch({ search }) {
+        return <input id="search_query" value={search} type="text" />;
+      }`,
+      { filename: "components/blog/BlogHeaderSearch.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("stays silent on a static input mock in a __tests__ file (test-noise)", () => {
     const result = runRule(
       noUncontrolledInput,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-uncontrolled-input.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-uncontrolled-input.regressions.test.ts
@@ -1,6 +1,17 @@
 import { describe, expect, it } from "vite-plus/test";
 import { runRule } from "../../../test-utils/run-rule.js";
+import { altText } from "../a11y/alt-text.js";
 import { noUncontrolledInput } from "./no-uncontrolled-input.js";
+
+const READ_ONLY_VALUE_INPUT_TYPES = [
+  "button",
+  "checkbox",
+  "hidden",
+  "image",
+  "radio",
+  "reset",
+  "submit",
+];
 
 describe("correctness/no-uncontrolled-input — regressions", () => {
   it("stays silent on a `disabled` value input (React suppresses the missing-onChange warning)", () => {
@@ -55,6 +66,107 @@ describe("correctness/no-uncontrolled-input — regressions", () => {
     );
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toHaveLength(1);
+  });
+
+  for (const inputType of READ_ONLY_VALUE_INPUT_TYPES) {
+    it(`stays silent on a ${inputType} input whose value is not user-editable`, () => {
+      const result = runRule(
+        noUncontrolledInput,
+        `export default function Control() { return <input type="${inputType}" value="Action" />; }`,
+        { filename: "app/control.tsx" },
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it(`normalizes a statically known ${inputType} input type case-insensitively`, () => {
+      const result = runRule(
+        noUncontrolledInput,
+        `export default function Control() { return <input type="${inputType.toUpperCase()}" value="Action" />; }`,
+        { filename: "app/control.tsx" },
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+  }
+
+  it.each(["text", "search"])(
+    "still flags an editable %s input without a change handler",
+    (inputType) => {
+      const result = runRule(
+        noUncontrolledInput,
+        `export default function Field({ value }) { return <input type="${inputType}" value={value} />; }`,
+        { filename: "app/field.tsx" },
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    },
+  );
+
+  it("still flags an input with no statically known type", () => {
+    const result = runRule(
+      noUncontrolledInput,
+      `export default function Field({ value, inputType }) { return <input type={inputType} value={value} />; }`,
+      { filename: "app/field.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays silent on expression, wrapped, const-alias, and all-bypass ternary types", () => {
+    const result = runRule(
+      noUncontrolledInput,
+      `export default function Controls({ alternate }) {
+        const inputType = "reset";
+        return <>
+          <input type={"submit"} value="Submit" />
+          <input type={("IMAGE" as const)} value="Search" alt="Search" />
+          <input type={inputType} value="Reset" />
+          <input type={alternate ? "button" : "submit"} value="Action" />
+        </>;
+      }`,
+      { filename: "app/controls.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still flags mixed editable ternaries and mutable aliases", () => {
+    const result = runRule(
+      noUncontrolledInput,
+      `export default function Fields({ alternate }) {
+        let mutableInputType = "submit";
+        return <>
+          <input type={alternate ? "submit" : "text"} value="Action" />
+          <input type={mutableInputType} value="Action" />
+        </>;
+      }`,
+      { filename: "app/fields.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
+  it("still flags an input with a missing type", () => {
+    const result = runRule(
+      noUncontrolledInput,
+      `export default function Field({ value }) { return <input value={value} />; }`,
+      { filename: "app/field.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("keeps the missing-alt diagnostic for image inputs", () => {
+    const source = `export default function ImageControl() { return <input type="image" value="Search" />; }`;
+    const controlledInputResult = runRule(noUncontrolledInput, source, {
+      filename: "app/image-control.tsx",
+    });
+    const altTextResult = runRule(altText, source, { filename: "app/image-control.tsx" });
+    expect(controlledInputResult.parseErrors).toEqual([]);
+    expect(controlledInputResult.diagnostics).toEqual([]);
+    expect(altTextResult.parseErrors).toEqual([]);
+    expect(altTextResult.diagnostics).toHaveLength(1);
   });
 
   it("stays silent on a static input mock in a __tests__ file (test-noise)", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-uncontrolled-input.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-uncontrolled-input.ts
@@ -1,5 +1,6 @@
 import { defineRule } from "../../utils/define-rule.js";
 import { findJsxAttribute } from "../../utils/find-jsx-attribute.js";
+import { getJsxPropStaticStringValues } from "../../utils/get-jsx-prop-static-string-values.js";
 import { isComponentAssignment } from "../../utils/is-component-assignment.js";
 import { isHookCall } from "../../utils/is-hook-call.js";
 import { isInlineFunctionExpression } from "../../utils/is-inline-function-expression.js";
@@ -13,13 +14,17 @@ import { resolveJsxElementType } from "../../utils/resolve-jsx-element-type.js";
 
 const UNCONTROLLED_INPUT_TAGS = new Set(["input", "textarea", "select"]);
 
-// HACK: <input type="checkbox"> / "radio" use the `checked` prop to be
-// controlled; `value` is just the form-submission token. <input
-// type="hidden"> never needs onChange — React's runtime warning skips
-// it for the same reason. Limiting our `value`-needs-onChange check to
-// non-hidden, non-checkable inputs keeps us aligned with React's own
-// rules.
-const VALUE_BYPASS_INPUT_TYPES = new Set(["hidden", "checkbox", "radio"]);
+// HACK: React treats `value` as read-only for these input types, so it does not
+// require an onChange handler for them.
+const VALUE_BYPASS_INPUT_TYPES = new Set([
+  "button",
+  "checkbox",
+  "hidden",
+  "image",
+  "radio",
+  "reset",
+  "submit",
+]);
 
 // `onInput` fires on every value change in React's DOM model exactly
 // like `onChange`, so a `value`-bound input wired to `onInput` is just
@@ -36,13 +41,6 @@ const isLiteralFalseAttributeValue = (attribute: EsTreeNodeOfType<"JSXAttribute"
   isNodeOfType(attribute.value, "JSXExpressionContainer") &&
   isNodeOfType(attribute.value.expression, "Literal") &&
   attribute.value.expression.value === false;
-
-const getInputTypeLiteral = (attributes: EsTreeNode[]): string | null => {
-  const typeAttribute = findJsxAttribute(attributes, "type");
-  if (!typeAttribute || !isNodeOfType(typeAttribute.value, "Literal")) return null;
-  const value = typeAttribute.value.value;
-  return typeof value === "string" ? value : null;
-};
 
 const isUseStateUndefinedInitializer = (init: EsTreeNode | null | undefined): boolean => {
   if (!init || !isNodeOfType(init, "CallExpression")) return false;
@@ -123,8 +121,19 @@ export const noUncontrolledInput = defineRule({
         if (!valueAttribute) return;
 
         if (tagName === "input") {
-          const inputType = getInputTypeLiteral(attributes);
-          if (inputType !== null && VALUE_BYPASS_INPUT_TYPES.has(inputType)) return;
+          const typeAttribute = findJsxAttribute(attributes, "type");
+          const inputTypeCandidates = typeAttribute
+            ? getJsxPropStaticStringValues(typeAttribute, context.scopes)
+            : null;
+          if (
+            inputTypeCandidates !== null &&
+            inputTypeCandidates.length > 0 &&
+            inputTypeCandidates.every((inputTypeCandidate) =>
+              VALUE_BYPASS_INPUT_TYPES.has(inputTypeCandidate.toLowerCase()),
+            )
+          ) {
+            return;
+          }
         }
 
         const hasAllowedPartner = VALUE_PARTNER_ATTRIBUTES.some((partnerAttributeName) => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-uncontrolled-input.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-uncontrolled-input.ts
@@ -1,6 +1,6 @@
 import { defineRule } from "../../utils/define-rule.js";
 import { findJsxAttribute } from "../../utils/find-jsx-attribute.js";
-import { getJsxPropStaticStringValues } from "../../utils/get-jsx-prop-static-string-values.js";
+import { getJsxPropExhaustiveStaticStringValues } from "../../utils/get-jsx-prop-static-string-values.js";
 import { isComponentAssignment } from "../../utils/is-component-assignment.js";
 import { isHookCall } from "../../utils/is-hook-call.js";
 import { isInlineFunctionExpression } from "../../utils/is-inline-function-expression.js";
@@ -14,8 +14,8 @@ import { resolveJsxElementType } from "../../utils/resolve-jsx-element-type.js";
 
 const UNCONTROLLED_INPUT_TAGS = new Set(["input", "textarea", "select"]);
 
-// HACK: React treats `value` as read-only for these input types, so it does not
-// require an onChange handler for them.
+// HACK: React does not require an onChange handler for `value` on these input
+// types. Its value/defaultValue and controlledness warnings are separate.
 const VALUE_BYPASS_INPUT_TYPES = new Set([
   "button",
   "checkbox",
@@ -120,20 +120,40 @@ export const noUncontrolledInput = defineRule({
         const valueAttribute = findJsxAttribute(attributes, "value");
         if (!valueAttribute) return;
 
+        let inputTypeCandidates: ReadonlyArray<string> | null = null;
+        let hasExplicitInputType = false;
+        let doesTypeBypassMissingOnChange = false;
+        let doesTypeUseCheckedControlledness = false;
+        let couldTypeUseCheckedControlledness = false;
         if (tagName === "input") {
-          const typeAttribute = findJsxAttribute(attributes, "type");
-          const inputTypeCandidates = typeAttribute
-            ? getJsxPropStaticStringValues(typeAttribute, context.scopes)
+          const typeAttribute = findJsxAttribute([...attributes].reverse(), "type");
+          hasExplicitInputType = Boolean(typeAttribute);
+          inputTypeCandidates = typeAttribute
+            ? getJsxPropExhaustiveStaticStringValues(typeAttribute, context.scopes)
             : null;
-          if (
+          doesTypeBypassMissingOnChange = Boolean(
             inputTypeCandidates !== null &&
             inputTypeCandidates.length > 0 &&
             inputTypeCandidates.every((inputTypeCandidate) =>
               VALUE_BYPASS_INPUT_TYPES.has(inputTypeCandidate.toLowerCase()),
-            )
-          ) {
-            return;
-          }
+            ),
+          );
+          doesTypeUseCheckedControlledness = Boolean(
+            inputTypeCandidates !== null &&
+            inputTypeCandidates.length > 0 &&
+            inputTypeCandidates.every(
+              (inputTypeCandidate) =>
+                inputTypeCandidate === "checkbox" || inputTypeCandidate === "radio",
+            ),
+          );
+          couldTypeUseCheckedControlledness = Boolean(
+            hasExplicitInputType &&
+            (inputTypeCandidates === null ||
+              inputTypeCandidates.some(
+                (inputTypeCandidate) =>
+                  inputTypeCandidate === "checkbox" || inputTypeCandidate === "radio",
+              )),
+          );
         }
 
         const hasAllowedPartner = VALUE_PARTNER_ATTRIBUTES.some((partnerAttributeName) => {
@@ -147,15 +167,19 @@ export const noUncontrolledInput = defineRule({
         if (
           isNodeOfType(valueAttribute.value, "JSXExpressionContainer") &&
           isNodeOfType(valueAttribute.value.expression, "Identifier") &&
-          undefinedInitialStateNames.has(valueAttribute.value.expression.name)
+          undefinedInitialStateNames.has(valueAttribute.value.expression.name) &&
+          !doesTypeUseCheckedControlledness
         ) {
           const stateName = valueAttribute.value.expression.name;
-          const partnerHint = hasAllowedPartner
-            ? "Give useState a starting value"
-            : "Give useState a starting value and add onChange (or readOnly)";
+          const partnerHint =
+            hasAllowedPartner || doesTypeBypassMissingOnChange || couldTypeUseCheckedControlledness
+              ? "Give useState a starting value"
+              : "Give useState a starting value and add onChange (or readOnly)";
           context.report({
             node: child,
-            message: `This can trigger a console warning and reset the field because "${stateName}" starts undefined, so <${tagName} value={${stateName}}> flips from uncontrolled to controlled. ${partnerHint} (e.g. \`useState("")\`).`,
+            message: couldTypeUseCheckedControlledness
+              ? `When \`type\` resolves to a value-controlled input type, this can trigger a console warning and reset the field because "${stateName}" starts undefined, so <input value={${stateName}}> can flip from uncontrolled to controlled. ${partnerHint} (e.g. \`useState("")\`).`
+              : `This can trigger a console warning and reset the field because "${stateName}" starts undefined, so <${tagName} value={${stateName}}> flips from uncontrolled to controlled. ${partnerHint} (e.g. \`useState("")\`).`,
           });
           return;
         }
@@ -168,10 +192,19 @@ export const noUncontrolledInput = defineRule({
           return;
         }
 
-        if (!hasAllowedPartner) {
+        if (!hasAllowedPartner && !doesTypeBypassMissingOnChange) {
+          const couldResolveToReadOnlyValueType =
+            tagName === "input" &&
+            hasExplicitInputType &&
+            (inputTypeCandidates === null ||
+              inputTypeCandidates.some((inputTypeCandidate) =>
+                VALUE_BYPASS_INPUT_TYPES.has(inputTypeCandidate.toLowerCase()),
+              ));
           context.report({
             node: child,
-            message: `Your users can't type in this <${tagName} value={...}> because it has no \`onChange\` or \`readOnly\`, so add \`onChange\` (or \`readOnly\` if that's intended).`,
+            message: couldResolveToReadOnlyValueType
+              ? `When \`type\` resolves to an editable input type, users can't type in this <input value={...}> because it has no \`onChange\` or \`readOnly\`. Add \`onChange\` or \`readOnly\` unless \`type\` is always a read-only-value input type.`
+              : `Your users can't type in this <${tagName} value={...}> because it has no \`onChange\` or \`readOnly\`, so add \`onChange\` (or \`readOnly\` if that's intended).`,
           });
         }
       });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-jsx-prop-static-string-values.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-jsx-prop-static-string-values.test.ts
@@ -3,12 +3,20 @@ import { attachParentReferences } from "../../test-utils/attach-parent-reference
 import { parseFixture } from "../../test-utils/parse-fixture.js";
 import type { EsTreeNode } from "./es-tree-node.js";
 import type { EsTreeNodeOfType } from "./es-tree-node-of-type.js";
-import { getJsxPropStaticStringValues } from "./get-jsx-prop-static-string-values.js";
+import {
+  getJsxPropExhaustiveStaticStringValues,
+  getJsxPropStaticStringValues,
+} from "./get-jsx-prop-static-string-values.js";
 import { isNodeOfType } from "./is-node-of-type.js";
 import { walkAst } from "./walk-ast.js";
 import { analyzeScopes } from "../semantic/scope-analysis.js";
 
-const resolveFirstAttribute = (code: string): ReadonlyArray<string> | null => {
+const DEEP_ALIAS_CHAIN_LENGTH = 20_000;
+
+const resolveFirstAttribute = (
+  code: string,
+  shouldResolveExhaustively = false,
+): ReadonlyArray<string> | null => {
   const { program, errors } = parseFixture(code);
   expect(errors).toEqual([]);
   attachParentReferences(program);
@@ -19,7 +27,9 @@ const resolveFirstAttribute = (code: string): ReadonlyArray<string> | null => {
     if (isNodeOfType(child, "JSXAttribute")) attribute = child;
   });
   if (!attribute) throw new Error("fixture has no JSX attribute");
-  return getJsxPropStaticStringValues(attribute, scopes);
+  return shouldResolveExhaustively
+    ? getJsxPropExhaustiveStaticStringValues(attribute, scopes)
+    : getJsxPropStaticStringValues(attribute, scopes);
 };
 
 describe("getJsxPropStaticStringValues", () => {
@@ -62,18 +72,71 @@ describe("getJsxPropStaticStringValues", () => {
     ).toEqual(["button", "link", "menu"]);
   });
 
-  it("resolves a const chain at exactly the 4-hop cap", () => {
+  it("resolves only the reachable branch of a statically known ternary", () => {
+    expect(
+      resolveFirstAttribute(`const x = <div role={true ? "button" : dynamicRole} />;`, true),
+    ).toEqual(["button"]);
+    expect(
+      resolveFirstAttribute(`const x = <div role={false ? dynamicRole : "link"} />;`, true),
+    ).toEqual(["link"]);
+  });
+
+  it("keeps the default mode conservative across a statically unreachable dynamic branch", () => {
+    expect(
+      resolveFirstAttribute(`const x = <div role={true ? "button" : dynamicRole} />;`),
+    ).toBeNull();
+  });
+
+  it("resolves long acyclic const chains in exhaustive mode", () => {
+    expect(
+      resolveFirstAttribute(
+        `const a = "button"; const b = a; const c = b; const d = c; const e = d; const f = e;\nconst x = <div role={f} />;`,
+        true,
+      ),
+    ).toEqual(["button"]);
+  });
+
+  it("keeps the default mode's four-alias resolution limit", () => {
     expect(
       resolveFirstAttribute(
         `const a = "button"; const b = a; const c = b; const d = c;\nconst x = <div role={d} />;`,
       ),
     ).toEqual(["button"]);
-  });
-
-  it("returns null for a const chain past the 4-hop cap", () => {
     expect(
       resolveFirstAttribute(
         `const a = "button"; const b = a; const c = b; const d = c; const e = d;\nconst x = <div role={e} />;`,
+      ),
+    ).toBeNull();
+  });
+
+  it("resolves a deep acyclic const chain without overflowing the call stack", () => {
+    const declarations = Array.from({ length: DEEP_ALIAS_CHAIN_LENGTH }, (_, declarationIndex) =>
+      declarationIndex === 0
+        ? `const type0 = "button";`
+        : `const type${declarationIndex} = type${declarationIndex - 1};`,
+    ).join("\n");
+    expect(
+      resolveFirstAttribute(
+        `${declarations}\nconst x = <div role={type${DEEP_ALIAS_CHAIN_LENGTH - 1}} />;`,
+        true,
+      ),
+    ).toEqual(["button"]);
+  });
+
+  it("allows sibling ternary branches to resolve the same const alias", () => {
+    expect(
+      resolveFirstAttribute(
+        `const sharedRole = "button";\nconst x = <div role={condition ? sharedRole : sharedRole} />;`,
+        true,
+      ),
+    ).toEqual(["button", "button"]);
+  });
+
+  it("returns null for cyclic const aliases", () => {
+    expect(
+      resolveFirstAttribute(
+        `const firstRole = secondRole; const secondRole = firstRole;\nconst x = <div role={firstRole} />;`,
+        true,
       ),
     ).toBeNull();
   });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-jsx-prop-static-string-values.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-jsx-prop-static-string-values.test.ts
@@ -11,7 +11,7 @@ import { isNodeOfType } from "./is-node-of-type.js";
 import { walkAst } from "./walk-ast.js";
 import { analyzeScopes } from "../semantic/scope-analysis.js";
 
-const DEEP_ALIAS_CHAIN_LENGTH = 20_000;
+const DEEP_ALIAS_CHAIN_LENGTH = 50_000;
 
 const resolveFirstAttribute = (
   code: string,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-jsx-prop-static-string-values.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-jsx-prop-static-string-values.ts
@@ -2,56 +2,98 @@ import type { EsTreeNode } from "./es-tree-node.js";
 import type { EsTreeNodeOfType } from "./es-tree-node-of-type.js";
 import { getStaticTemplateLiteralValue } from "./get-static-template-literal-value.js";
 import { isNodeOfType } from "./is-node-of-type.js";
+import { readStaticBoolean } from "./read-static-boolean.js";
 import { stripParenExpression } from "./strip-paren-expression.js";
-import type { ScopeAnalysis } from "../semantic/scope-analysis.js";
+import type { ScopeAnalysis, SymbolDescriptor } from "../semantic/scope-analysis.js";
 
-// Chains like `const a = "x"; const role = a;` resolve one hop at a
-// time; the cap keeps a pathological alias chain from walking forever.
 const MAX_CONST_RESOLUTION_HOPS = 4;
+
+interface StaticStringWorkItem {
+  expression: EsTreeNode;
+  remainingConstAliases: number | null;
+  resolvingSymbols: Set<SymbolDescriptor>;
+}
 
 const resolveStaticStringValues = (
   rawExpression: EsTreeNode,
   scopes: ScopeAnalysis,
-  remainingHops: number,
+  maximumConstAliases: number | null,
+  shouldFoldStaticConditions: boolean,
 ): ReadonlyArray<string> | null => {
-  const expression = stripParenExpression(rawExpression);
-  if (isNodeOfType(expression, "Literal")) {
-    return typeof expression.value === "string" ? [expression.value] : null;
-  }
-  if (isNodeOfType(expression, "TemplateLiteral")) {
-    const staticValue = getStaticTemplateLiteralValue(expression);
-    return staticValue === null ? null : [staticValue];
-  }
-  if (isNodeOfType(expression, "ConditionalExpression")) {
-    const consequentValues = resolveStaticStringValues(
-      expression.consequent,
-      scopes,
-      remainingHops,
-    );
-    if (consequentValues === null) return null;
-    const alternateValues = resolveStaticStringValues(expression.alternate, scopes, remainingHops);
-    if (alternateValues === null) return null;
-    return [...consequentValues, ...alternateValues];
-  }
-  if (isNodeOfType(expression, "Identifier")) {
-    if (remainingHops === 0) return null;
-    const symbol = scopes.referenceFor(expression)?.resolvedSymbol;
-    // Only `const` bindings are safe to inline — anything reassignable
-    // (or an import/parameter, whose value we can't see) stays dynamic.
-    if (!symbol || symbol.kind !== "const" || !symbol.initializer) return null;
-    // A destructured const (`const { role = "x" } = config`) records the
-    // destructure SOURCE or per-element default as its initializer —
-    // neither is the binding's actual value — so only a plain
-    // `const name = ...` declarator inlines.
-    if (
-      !isNodeOfType(symbol.declarationNode, "VariableDeclarator") ||
-      symbol.declarationNode.id !== symbol.bindingIdentifier
-    ) {
-      return null;
+  const staticStringValues: string[] = [];
+  const workItems: StaticStringWorkItem[] = [
+    {
+      expression: rawExpression,
+      remainingConstAliases: maximumConstAliases,
+      resolvingSymbols: new Set(),
+    },
+  ];
+
+  while (workItems.length > 0) {
+    const workItem = workItems.pop();
+    if (!workItem) continue;
+    const expression = stripParenExpression(workItem.expression);
+    if (isNodeOfType(expression, "Literal")) {
+      if (typeof expression.value !== "string") return null;
+      staticStringValues.push(expression.value);
+      continue;
     }
-    return resolveStaticStringValues(symbol.initializer, scopes, remainingHops - 1);
+    if (isNodeOfType(expression, "TemplateLiteral")) {
+      const staticValue = getStaticTemplateLiteralValue(expression);
+      if (staticValue === null) return null;
+      staticStringValues.push(staticValue);
+      continue;
+    }
+    if (isNodeOfType(expression, "ConditionalExpression")) {
+      const staticTestValue = shouldFoldStaticConditions
+        ? readStaticBoolean(expression.test)
+        : null;
+      if (staticTestValue !== null) {
+        workItems.push({
+          expression: staticTestValue ? expression.consequent : expression.alternate,
+          remainingConstAliases: workItem.remainingConstAliases,
+          resolvingSymbols: workItem.resolvingSymbols,
+        });
+        continue;
+      }
+      workItems.push({
+        expression: expression.alternate,
+        remainingConstAliases: workItem.remainingConstAliases,
+        resolvingSymbols: new Set(workItem.resolvingSymbols),
+      });
+      workItems.push({
+        expression: expression.consequent,
+        remainingConstAliases: workItem.remainingConstAliases,
+        resolvingSymbols: new Set(workItem.resolvingSymbols),
+      });
+      continue;
+    }
+    if (isNodeOfType(expression, "Identifier")) {
+      const symbol = scopes.referenceFor(expression)?.resolvedSymbol;
+      if (
+        !symbol ||
+        symbol.kind !== "const" ||
+        !symbol.initializer ||
+        !isNodeOfType(symbol.declarationNode, "VariableDeclarator") ||
+        symbol.declarationNode.id !== symbol.bindingIdentifier ||
+        workItem.remainingConstAliases === 0 ||
+        workItem.resolvingSymbols.has(symbol)
+      ) {
+        return null;
+      }
+      workItem.resolvingSymbols.add(symbol);
+      workItems.push({
+        expression: symbol.initializer,
+        remainingConstAliases:
+          workItem.remainingConstAliases === null ? null : workItem.remainingConstAliases - 1,
+        resolvingSymbols: workItem.resolvingSymbols,
+      });
+      continue;
+    }
+    return null;
   }
-  return null;
+
+  return staticStringValues;
 };
 
 // Static-resolution big brother of `getJsxPropStringValue`: returns EVERY
@@ -66,9 +108,11 @@ const resolveStaticStringValues = (
 // report when ANY candidate is invalid (that branch is a bug when taken),
 // a rule whose claim must hold unconditionally should require ALL
 // candidates to violate.
-export const getJsxPropStaticStringValues = (
+const getJsxPropStaticStringValuesWithMode = (
   attribute: EsTreeNodeOfType<"JSXAttribute">,
   scopes: ScopeAnalysis,
+  maximumConstAliases: number | null,
+  shouldFoldStaticConditions: boolean,
 ): ReadonlyArray<string> | null => {
   const value = attribute.value;
   if (!value) return null;
@@ -79,8 +123,21 @@ export const getJsxPropStaticStringValues = (
     return resolveStaticStringValues(
       value.expression as EsTreeNode,
       scopes,
-      MAX_CONST_RESOLUTION_HOPS,
+      maximumConstAliases,
+      shouldFoldStaticConditions,
     );
   }
   return null;
 };
+
+export const getJsxPropStaticStringValues = (
+  attribute: EsTreeNodeOfType<"JSXAttribute">,
+  scopes: ScopeAnalysis,
+): ReadonlyArray<string> | null =>
+  getJsxPropStaticStringValuesWithMode(attribute, scopes, MAX_CONST_RESOLUTION_HOPS, false);
+
+export const getJsxPropExhaustiveStaticStringValues = (
+  attribute: EsTreeNodeOfType<"JSXAttribute">,
+  scopes: ScopeAnalysis,
+): ReadonlyArray<string> | null =>
+  getJsxPropStaticStringValuesWithMode(attribute, scopes, null, true);


### PR DESCRIPTION
<!-- motivation-example:start -->
## Motivation

React's missing-`onChange` warning applies to editable controlled values, not input types whose `value` is read-only UI data. Reporting those controls asks users to add meaningless handlers.

## Example

A button-like input may use `value` as its visible label without an `onChange` handler:

```tsx
<input type="button" value="Open settings" />
```

The same principle applies to the other non-editable value types covered by this PR, while editable and mixed dynamic types remain reportable.
<!-- motivation-example:end -->

## Why

React does not require `onChange` for the `value` prop on `<input type="button">`, `checkbox`, `hidden`, `image`, `radio`, `reset`, and `submit`. React Doctor only exempted the latter three and falsely reported the exact DevLovers submit control.

The pinned DevLovers source at `902ccde145b6877062f043e599d40928ce31c632` and the stored trial `write-react-devloversteam-devlov__mzTqjct` both reproduce the false diagnostic.

## What changed

- Completes the non-editable-value input type set.
- Adds an opt-in exhaustive mode to the existing static JSX string resolver for constant conditions and deep const aliases; all eight existing rule consumers retain the previous four-alias, non-folding default. The iterative worklist is regression-tested through 50,000 aliases without a stack overflow.
- Exempts a static ternary only when every reachable type bypasses the missing-`onChange` warning; dynamic, mutable, missing, and mixed editable candidates remain reportable with conditional wording where appropriate.
- Keeps `value`/`defaultValue` conflicts and undefined-state controlledness transitions independent from the missing-`onChange` exemption, including React's exact lowercase `checkbox`/`radio` controlledness behavior.
- Uses the last explicit `type` attribute while retaining the rule's existing abstention for any opaque JSX spread.
- Preserves the independent missing-`alt` diagnostic for direct-literal image inputs.
- Adds the DevLovers regression to the permanent fuzz corpus and generator pool.
- Adds a patch changeset for `oxlint-plugin-react-doctor`.

Static alias or ternary resolution in the separate `alt-text` rule is a pre-existing false-negative boundary and is intentionally out of scope; this PR does not claim an authentic corpus occurrence for it.

## Real-repo and benchmark replay

| Evidence | Baseline | Candidate | Classification |
| --- | ---: | ---: | --- |
| Exact untouched stored DevLovers trial file | 1 | 0 | Removed false positive |
| Pinned benchmark base, 184 component files | 1 | 0 | Only the same removed false positive |
| Reconstructed oracle, 185 component files | 1 | 0 | Only the same removed false positive |

The shared RDE harness currently rejects React Doctor schema v3 before completing a root scan. A separate direct attempt requested 100 roots but completed 0/100 after more than 150 seconds without progress and was stopped. Both runs are invalid evidence, not passes.

## Test plan

- Focused rule and resolver regressions: 72 passed
- Full `oxlint-plugin-react-doctor` suite: 559 files, 14,058 passed, 181 skipped
- `nr --filter @react-doctor/fuzz test`: 44 passed, 402 skipped
- `FUZZ_RULE=no-uncontrolled-input FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz`
- `nr build`: 10/10 tasks
- `nr typecheck`: 15/15 tasks
- `nr lint` (passes with existing warnings)
- `nr format:check`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core lint logic for all controlled `<input value>` cases and adds a new static resolver mode; behavior is heavily regression-tested but misclassification could hide real bugs or reintroduce noise.
> 
> **Overview**
> Fixes false positives on `no-uncontrolled-input` for `<input>` elements whose `value` is display or form metadata, not a user-editable field—matching React’s own exemption from the missing-`onChange` warning (e.g. DevLovers `<input type="submit" value="" />`).
> 
> The rule now treats **button, hidden, image, reset, submit** (plus existing checkbox/radio/hidden handling) as read-only-value types, resolves `type` via **`getJsxPropExhaustiveStaticStringValues`** (constant ternaries, deep `const` chains, last duplicate `type`), and uses **conditional messages** when `type` might still be editable. Undefined-`useState` and `value`+`defaultValue` checks stay separate; checkbox/radio **checked** semantics and spread abstention are preserved.
> 
> Adds **`getJsxPropExhaustiveStaticStringValues`** (iterative resolver with static condition folding; default four-hop API unchanged for other rules), broad regressions, a fuzz corpus entry, and a patch changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9efe48d09636be99a88a9f4e15f1c89216cf4938. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->