### PR TITLE
fix(rule): preserve compound async freshness guards

### DIFF
--- a/.changeset/tender-seas-yell.md
+++ b/.changeset/tender-seas-yell.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Prevent async-defer-await from flagging compound post-await freshness comparisons while preserving preflight guard diagnostics.

--- a/packages/fuzz/corpus/regressions/async-defer-await--compound-freshness-guard.tsx
+++ b/packages/fuzz/corpus/regressions/async-defer-await--compound-freshness-guard.tsx
@@ -1,0 +1,15 @@
+// rule: async-defer-await
+// weakness: control-flow
+// source: react-bench Bindery trial and PR #1272
+
+declare const load: () => Promise<string[]>;
+declare const latestRequest: { current: number };
+declare const latestReview: { current: number };
+
+export const run = async () => {
+  const requestId = latestRequest.current;
+  const reviewVersion = latestReview.current;
+  const rows = await load();
+  if (requestId !== latestRequest.current || reviewVersion !== latestReview.current) return [];
+  return rows;
+};

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -115,6 +115,7 @@ export const STATE_SNIPPET_POOL = [
 // Handlers — async submits with loading flags, keyboard commit paths,
 // numeric input parsing, window.open, clipboard, toggles.
 export const HANDLER_SNIPPET_POOL = [
+  `const latestRequest = { current: 0 }; const latestReview = { current: 0 }; const handleFreshRequest = async () => { const requestId = latestRequest.current; const reviewVersion = latestReview.current; const response = await fetch(url); if (requestId !== latestRequest.current || reviewVersion !== latestReview.current) return; setState(await response.json()); };`,
   `const handleSyncRequest = () => { const request = new XMLHttpRequest(); request.open("GET", String(url), false); request.send(); };`,
   `const handleSubmit = async () => { setLoading(true); try { await fetch(url, { method: "POST", body: JSON.stringify(values) }); setState(true); } catch (submitError) { setError(submitError); } finally { setLoading(false); } };`,
   `const handleSubmit = async () => { setLoading(true); const result = await api.post(url, values); setState(result); setLoading(false); };`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/async-defer-await.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/async-defer-await.regressions.test.ts
@@ -325,6 +325,27 @@ describe("performance/async-defer-await — regressions", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("still flags compound comparisons between invariant parameters", () => {
+    const result = runRule(
+      asyncDeferAwait,
+      `
+      declare const load: () => Promise<string[]>;
+      export const run = async (
+        enabled: boolean,
+        expectedEnabled: boolean,
+        mode: string,
+        expectedMode: string,
+      ) => {
+        const rows = await load();
+        if (enabled === expectedEnabled || mode === expectedMode) return [];
+        return rows;
+      };
+    `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("stays silent when the guard reads a flag reassigned around the await", () => {
     const result = runRule(
       asyncDeferAwait,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/async-defer-await.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/async-defer-await.regressions.test.ts
@@ -241,8 +241,6 @@ describe("performance/async-defer-await — regressions", () => {
       "wrapped literal branch",
       `requestId !== latestRequest.current && minimumCount !== (0 as number)`,
     ],
-    ["cancellation branch", `cancelled || enabled`],
-    ["mutable helper branch", `isCurrent() && enabled`],
   ])("still flags a compound guard with an unrelated %s", (_label, guardTest) => {
     const result = runRule(
       asyncDeferAwait,
@@ -252,8 +250,6 @@ describe("performance/async-defer-await — regressions", () => {
       declare const enabled: boolean;
       declare const mode: string;
       declare const minimumCount: number;
-      declare const cancelled: boolean;
-      declare const isCurrent: () => boolean;
       export const run = async () => {
         const requestId = latestRequest.current;
         const rows = await load();
@@ -264,6 +260,28 @@ describe("performance/async-defer-await — regressions", () => {
     );
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it.each([
+    ["cancellation flag", `cancelled || enabled`],
+    ["mutable helper", `isCurrent() && enabled`],
+  ])("preserves the existing whole-guard exemption for a %s", (_label, guardTest) => {
+    const result = runRule(
+      asyncDeferAwait,
+      `
+      declare const load: () => Promise<string[]>;
+      declare const enabled: boolean;
+      declare const cancelled: boolean;
+      declare const isCurrent: () => boolean;
+      export const run = async () => {
+        const rows = await load();
+        if (${guardTest}) return [];
+        return rows;
+      };
+    `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
   });
 
   it("still flags a compound invariant preflight guard", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/async-defer-await.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/async-defer-await.regressions.test.ts
@@ -264,6 +264,7 @@ describe("performance/async-defer-await — regressions", () => {
 
   it.each([
     ["cancellation flag", `cancelled || enabled`],
+    ["cancellation ref", `cancelledRef.current || enabled`],
     ["mutable helper", `isCurrent() && enabled`],
   ])("preserves the existing whole-guard exemption for a %s", (_label, guardTest) => {
     const result = runRule(
@@ -272,10 +273,32 @@ describe("performance/async-defer-await — regressions", () => {
       declare const load: () => Promise<string[]>;
       declare const enabled: boolean;
       declare const cancelled: boolean;
+      declare const cancelledRef: { current: boolean };
       declare const isCurrent: () => boolean;
       export const run = async () => {
         const rows = await load();
         if (${guardTest}) return [];
+        return rows;
+      };
+    `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("preserves the existing whole-guard exemption for a reassigned local", () => {
+    const result = runRule(
+      asyncDeferAwait,
+      `
+      declare const load: () => Promise<string[]>;
+      declare const enabled: boolean;
+      export const run = async () => {
+        let failed = false;
+        const rows = await load().catch(() => {
+          failed = true;
+          return [];
+        });
+        if (failed || enabled) return [];
         return rows;
       };
     `,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/async-defer-await.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/async-defer-await.regressions.test.ts
@@ -175,6 +175,28 @@ describe("performance/async-defer-await — regressions", () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("stays silent when every branch of a compound guard checks response freshness", () => {
+    const result = runRule(
+      asyncDeferAwait,
+      `
+      declare const load: () => Promise<string[]>;
+      declare const latestRequest: { current: number };
+      declare const latestReview: { current: number };
+      export const run = async () => {
+        const requestId = latestRequest.current;
+        const reviewVersion = latestReview.current;
+        const rows = await load();
+        if (requestId !== latestRequest.current || reviewVersion !== latestReview.current) {
+          return [];
+        }
+        return rows;
+      };
+    `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("stays silent when the guard reads a flag reassigned around the await", () => {
     const result = runRule(
       asyncDeferAwait,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/async-defer-await.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/async-defer-await.regressions.test.ts
@@ -197,6 +197,93 @@ describe("performance/async-defer-await — regressions", () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it.each([
+    [
+      "scalar tokens joined with AND",
+      `requestId !== latestRequestId && reviewVersion !== latestReviewVersion`,
+    ],
+    [
+      "nested ref comparisons",
+      `(requestId !== latestRequest.current || reviewVersion !== latestReview.current) && scanId !== latestScan.current`,
+    ],
+    [
+      "transparent TypeScript wrappers",
+      `((requestId !== (latestRequest.current as number)) || ((reviewVersion !== latestReview.current) satisfies boolean)) as boolean`,
+    ],
+  ])("stays silent on compound freshness guards using %s", (_label, guardTest) => {
+    const result = runRule(
+      asyncDeferAwait,
+      `
+      declare const load: () => Promise<string[]>;
+      declare let latestRequestId: number;
+      declare let latestReviewVersion: number;
+      declare const latestRequest: { current: number };
+      declare const latestReview: { current: number };
+      declare const latestScan: { current: number };
+      export const run = async () => {
+        const requestId = latestRequest.current;
+        const reviewVersion = latestReview.current;
+        const scanId = latestScan.current;
+        const rows = await load();
+        if (${guardTest}) return [];
+        return rows;
+      };
+    `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it.each([
+    ["plain invariant branch", `requestId !== latestRequest.current || enabled`],
+    ["literal comparison branch", `requestId !== latestRequest.current || mode === "off"`],
+    [
+      "wrapped literal branch",
+      `requestId !== latestRequest.current && minimumCount !== (0 as number)`,
+    ],
+    ["cancellation branch", `cancelled || enabled`],
+    ["mutable helper branch", `isCurrent() && enabled`],
+  ])("still flags a compound guard with an unrelated %s", (_label, guardTest) => {
+    const result = runRule(
+      asyncDeferAwait,
+      `
+      declare const load: () => Promise<string[]>;
+      declare const latestRequest: { current: number };
+      declare const enabled: boolean;
+      declare const mode: string;
+      declare const minimumCount: number;
+      declare const cancelled: boolean;
+      declare const isCurrent: () => boolean;
+      export const run = async () => {
+        const requestId = latestRequest.current;
+        const rows = await load();
+        if (${guardTest}) return [];
+        return rows;
+      };
+    `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a compound invariant preflight guard", () => {
+    const result = runRule(
+      asyncDeferAwait,
+      `
+      declare const load: () => Promise<string[]>;
+      declare const enabled: boolean;
+      declare const minimumCount: number;
+      export const run = async () => {
+        const rows = await load();
+        if (!enabled || minimumCount === 0) return [];
+        return rows;
+      };
+    `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("stays silent when the guard reads a flag reassigned around the await", () => {
     const result = runRule(
       asyncDeferAwait,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/async-defer-await.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/async-defer-await.ts
@@ -250,27 +250,30 @@ const isNonLiteralComparisonTest = (test: EsTreeNode | null): boolean => {
   return !isLiteralOperand(unwrappedTest.left) && !isLiteralOperand(unwrappedTest.right);
 };
 
-const isPostAwaitFreshnessGuardTest = (
-  test: EsTreeNode | null,
-  guardStatement: EsTreeNode,
-): boolean => {
+const isLogicalCompositionOfNonLiteralComparisons = (test: EsTreeNode | null): boolean => {
   if (!test) return false;
   const unwrappedTest = stripParenExpression(test);
   if (
-    isNodeOfType(unwrappedTest, "LogicalExpression") &&
-    (unwrappedTest.operator === "&&" || unwrappedTest.operator === "||")
+    !isNodeOfType(unwrappedTest, "LogicalExpression") ||
+    (unwrappedTest.operator !== "&&" && unwrappedTest.operator !== "||")
   ) {
-    return (
-      isPostAwaitFreshnessGuardTest(unwrappedTest.left, guardStatement) &&
-      isPostAwaitFreshnessGuardTest(unwrappedTest.right, guardStatement)
-    );
+    return false;
   }
-  return (
-    isCancellationGuardTest(unwrappedTest) ||
-    guardTestReadsMutableEnvironment(unwrappedTest) ||
-    isNonLiteralComparisonTest(unwrappedTest) ||
-    guardTestReadsReassignedLocal(unwrappedTest, guardStatement)
-  );
+  const pendingTests = [unwrappedTest.left, unwrappedTest.right];
+  while (pendingTests.length > 0) {
+    const candidateTest = pendingTests.pop();
+    if (!candidateTest) continue;
+    const unwrappedCandidateTest = stripParenExpression(candidateTest);
+    if (
+      isNodeOfType(unwrappedCandidateTest, "LogicalExpression") &&
+      (unwrappedCandidateTest.operator === "&&" || unwrappedCandidateTest.operator === "||")
+    ) {
+      pendingTests.push(unwrappedCandidateTest.left, unwrappedCandidateTest.right);
+      continue;
+    }
+    if (!isNonLiteralComparisonTest(unwrappedCandidateTest)) return false;
+  }
+  return true;
 };
 
 // A guard whose consequent performs its own effect calls (`if (smime) {
@@ -428,7 +431,11 @@ export const asyncDeferAwait = defineRule({
           continue;
         }
         if (
-          isPostAwaitFreshnessGuardTest(guardStatement.test, guardStatement) ||
+          isCancellationGuardTest(guardStatement.test) ||
+          guardTestReadsMutableEnvironment(guardStatement.test) ||
+          isNonLiteralComparisonTest(guardStatement.test) ||
+          isLogicalCompositionOfNonLiteralComparisons(guardStatement.test) ||
+          guardTestReadsReassignedLocal(guardStatement.test, guardStatement) ||
           guardConsequentPerformsSideEffects(guardStatement.consequent)
         ) {
           statementIndex = window.guardCandidateIndex - 1;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/async-defer-await.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/async-defer-await.ts
@@ -1,4 +1,9 @@
 import { defineRule } from "../../utils/define-rule.js";
+import {
+  isDescendantScope,
+  type ScopeAnalysis,
+  type ScopeDescriptor,
+} from "../../semantic/scope-analysis.js";
 import { collectPatternDefaultReferenceNames } from "../../utils/collect-pattern-default-reference-names.js";
 import { collectPatternNames } from "../../utils/collect-pattern-names.js";
 import { collectReferenceIdentifierNames } from "../../utils/collect-reference-identifier-names.js";
@@ -250,7 +255,60 @@ const isNonLiteralComparisonTest = (test: EsTreeNode | null): boolean => {
   return !isLiteralOperand(unwrappedTest.left) && !isLiteralOperand(unwrappedTest.right);
 };
 
-const isLogicalCompositionOfNonLiteralComparisons = (test: EsTreeNode | null): boolean => {
+const isLocalConstSnapshotOperand = (
+  operand: EsTreeNode,
+  scopes: ScopeAnalysis,
+  functionScope: ScopeDescriptor,
+): boolean => {
+  const unwrappedOperand = stripParenExpression(operand);
+  if (!isNodeOfType(unwrappedOperand, "Identifier")) return false;
+  const symbol = scopes.symbolFor(unwrappedOperand);
+  return Boolean(
+    symbol &&
+    symbol.kind === "const" &&
+    symbol.initializer &&
+    isDescendantScope(symbol.scope, functionScope),
+  );
+};
+
+const isLiveFreshnessOperand = (
+  operand: EsTreeNode,
+  scopes: ScopeAnalysis,
+  functionScope: ScopeDescriptor,
+): boolean => {
+  const unwrappedOperand = stripParenExpression(operand);
+  if (isNodeOfType(unwrappedOperand, "MemberExpression")) return true;
+  if (!isNodeOfType(unwrappedOperand, "Identifier")) return false;
+  const symbol = scopes.symbolFor(unwrappedOperand);
+  return Boolean(
+    symbol &&
+    (symbol.kind === "let" || symbol.kind === "var" || symbol.kind === "import") &&
+    !isDescendantScope(symbol.scope, functionScope),
+  );
+};
+
+const isProvenFreshnessComparison = (
+  test: EsTreeNode,
+  scopes: ScopeAnalysis,
+  functionScope: ScopeDescriptor,
+): boolean => {
+  const unwrappedTest = stripParenExpression(test);
+  if (!isNonLiteralComparisonTest(unwrappedTest)) return false;
+  if (!isNodeOfType(unwrappedTest, "BinaryExpression")) return false;
+  return (
+    (isLocalConstSnapshotOperand(unwrappedTest.left, scopes, functionScope) &&
+      isLiveFreshnessOperand(unwrappedTest.right, scopes, functionScope)) ||
+    (isLocalConstSnapshotOperand(unwrappedTest.right, scopes, functionScope) &&
+      isLiveFreshnessOperand(unwrappedTest.left, scopes, functionScope))
+  );
+};
+
+const isLogicalCompositionOfFreshnessComparisons = (
+  test: EsTreeNode | null,
+  scopes: ScopeAnalysis,
+  functionScope: ScopeDescriptor | null,
+): boolean => {
+  if (!functionScope) return false;
   if (!test) return false;
   const unwrappedTest = stripParenExpression(test);
   if (
@@ -271,7 +329,7 @@ const isLogicalCompositionOfNonLiteralComparisons = (test: EsTreeNode | null): b
       pendingTests.push(unwrappedCandidateTest.left, unwrappedCandidateTest.right);
       continue;
     }
-    if (!isNonLiteralComparisonTest(unwrappedCandidateTest)) return false;
+    if (!isProvenFreshnessComparison(unwrappedCandidateTest, scopes, functionScope)) return false;
   }
   return true;
 };
@@ -430,11 +488,19 @@ export const asyncDeferAwait = defineRule({
           statementIndex = window.guardCandidateIndex - 1;
           continue;
         }
+        const enclosingFunction = findEnclosingFunction(guardStatement);
+        const functionScope = enclosingFunction
+          ? context.scopes.ownScopeFor(enclosingFunction)
+          : null;
         if (
           isCancellationGuardTest(guardStatement.test) ||
           guardTestReadsMutableEnvironment(guardStatement.test) ||
           isNonLiteralComparisonTest(guardStatement.test) ||
-          isLogicalCompositionOfNonLiteralComparisons(guardStatement.test) ||
+          isLogicalCompositionOfFreshnessComparisons(
+            guardStatement.test,
+            context.scopes,
+            functionScope,
+          ) ||
           guardTestReadsReassignedLocal(guardStatement.test, guardStatement) ||
           guardConsequentPerformsSideEffects(guardStatement.consequent)
         ) {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/async-defer-await.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/async-defer-await.ts
@@ -9,6 +9,7 @@ import { isEarlyExitIfStatement } from "../../utils/is-early-exit-if-statement.j
 import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import { walkAst } from "../../utils/walk-ast.js";
 
 interface DeclarationProcessResult {
@@ -234,13 +235,42 @@ const guardTestReadsMutableEnvironment = (test: EsTreeNode | null): boolean => {
 // comparisons (`if (mode === "off") return`) stay reportable.
 const isNonLiteralComparisonTest = (test: EsTreeNode | null): boolean => {
   if (!test) return false;
-  if (!isNodeOfType(test, "BinaryExpression")) return false;
-  if (!["===", "!==", "==", "!="].includes(test.operator)) return false;
-  const isLiteralOperand = (operand: EsTreeNode): boolean =>
-    isNodeOfType(operand, "Literal") ||
-    isNodeOfType(operand, "TemplateLiteral") ||
-    (isNodeOfType(operand, "UnaryExpression") && isLiteralOperand(operand.argument));
-  return !isLiteralOperand(test.left) && !isLiteralOperand(test.right);
+  const unwrappedTest = stripParenExpression(test);
+  if (!isNodeOfType(unwrappedTest, "BinaryExpression")) return false;
+  if (!["===", "!==", "==", "!="].includes(unwrappedTest.operator)) return false;
+  const isLiteralOperand = (operand: EsTreeNode): boolean => {
+    const unwrappedOperand = stripParenExpression(operand);
+    return (
+      isNodeOfType(unwrappedOperand, "Literal") ||
+      isNodeOfType(unwrappedOperand, "TemplateLiteral") ||
+      (isNodeOfType(unwrappedOperand, "UnaryExpression") &&
+        isLiteralOperand(unwrappedOperand.argument))
+    );
+  };
+  return !isLiteralOperand(unwrappedTest.left) && !isLiteralOperand(unwrappedTest.right);
+};
+
+const isPostAwaitFreshnessGuardTest = (
+  test: EsTreeNode | null,
+  guardStatement: EsTreeNode,
+): boolean => {
+  if (!test) return false;
+  const unwrappedTest = stripParenExpression(test);
+  if (
+    isNodeOfType(unwrappedTest, "LogicalExpression") &&
+    (unwrappedTest.operator === "&&" || unwrappedTest.operator === "||")
+  ) {
+    return (
+      isPostAwaitFreshnessGuardTest(unwrappedTest.left, guardStatement) &&
+      isPostAwaitFreshnessGuardTest(unwrappedTest.right, guardStatement)
+    );
+  }
+  return (
+    isCancellationGuardTest(unwrappedTest) ||
+    guardTestReadsMutableEnvironment(unwrappedTest) ||
+    isNonLiteralComparisonTest(unwrappedTest) ||
+    guardTestReadsReassignedLocal(unwrappedTest, guardStatement)
+  );
 };
 
 // A guard whose consequent performs its own effect calls (`if (smime) {
@@ -398,10 +428,7 @@ export const asyncDeferAwait = defineRule({
           continue;
         }
         if (
-          isCancellationGuardTest(guardStatement.test) ||
-          guardTestReadsMutableEnvironment(guardStatement.test) ||
-          isNonLiteralComparisonTest(guardStatement.test) ||
-          guardTestReadsReassignedLocal(guardStatement.test, guardStatement) ||
+          isPostAwaitFreshnessGuardTest(guardStatement.test, guardStatement) ||
           guardConsequentPerformsSideEffects(guardStatement.consequent)
         ) {
           statementIndex = window.guardCandidateIndex - 1;


### PR DESCRIPTION
<!-- motivation-example:start -->
## Motivation

A post-request freshness guard prevents stale async results from committing. Treating a compound guard as movable preflight logic would erase that protection because every comparison would run before the request.

## Example

Both identities must still match after the await:

```tsx
const requestId = batchRequest.current
const reviewId = reviewVersion.current
const response = await importBatch()

if (
  requestId !== batchRequest.current ||
  reviewId !== reviewVersion.current
) return
```

The rule already understood one comparison; this PR preserves equivalent `&&`/`||` compositions.
<!-- motivation-example:end -->

## Why

`async-defer-await` mistakes a logical composition of post-await freshness comparisons for a preflight guard. In the grounded Bindery trial, either a newer request or a newer review invalidates the completed response:

```tsx
const requestId = batchRequest.current
const requestReviewVersion = reviewVersion.current
const response = await api.batchManualImport(submitted)
if (
  requestId !== batchRequest.current ||
  requestReviewVersion !== reviewVersion.current
) return
```

Moving that guard before the request would make both comparisons observe their captured values and allow a stale response to commit. Published 0.7.2, published 0.7.4, and current `main` report the compound guard even though the equivalent single comparison is already recognized as completion-time freshness checking.

## What changed

- Iteratively normalize `&&` / `||` trees and accept them only when every leaf is an equality or inequality between non-literal operands.
- Unwrap parentheses and transparent TypeScript expressions around comparisons and operands.
- Keep invariant, literal, and mixed freshness/invariant guards reportable.
- Preserve the existing whole-expression exemptions for cancellation flags, ref-current checks, mutable helper calls, and reassigned locals.
- Add the exact Bindery regression plus paired scalar/ref, nested, TypeScript-wrapper, invariant, literal, mixed-leaf, and parity controls.
- Add a permanent fuzz regression seed and a generator snippet for compound freshness guards.
- Add a patch changeset for `oxlint-plugin-react-doctor`.

Negated comparisons and other new guard grammars remain out of scope because the grounded issue does not require them.

## Grounded validation

Pinned repository: `vavallee/bindery@1be8a17df47fd03b83b19eb8fc5bda6412ce1350`.

| Source | `main` | Candidate | Delta |
| --- | ---: | ---: | --- |
| Untouched base `ImportTab.tsx` | 0 | 0 | none |
| Authentic trial `BulkFolderImportSection.tsx` | 1 | 0 | removes the reported FP |
| Official benchmark solution `ImportTab.tsx` | 0 | 0 | none |

A runtime probe started a request, advanced the review identity while it was pending, then resolved it; the compound guard rejected the stale completion. The task's owned behavior tests were already green, while React Doctor alone rejected the trial.

Local RDE evidence is invalid rather than a pass: 100 rootDir scans were requested, 0 completed, and the JSONL remained empty after about 80 seconds in the existing dirty/stalled harness. No RDE verdict is claimed.

## Test plan

- `nr --filter oxlint-plugin-react-doctor test -- async-defer-await.regressions.test.ts` — 559 files, 14,023 passed, 181 skipped
- `nr --filter oxlint-plugin-react-doctor typecheck`
- `nr --filter @react-doctor/fuzz test` — 44 passed, 402 skipped
- `FUZZ_RULE=async-defer-await FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz`
- `nr build` — 10/10 tasks
- `nr lint`
- `nr format:check`
- `git diff --check`
- `nr typecheck` and `nr test` were also run; both reach unrelated language-server failures reproduced unchanged on `origin/main` (`mapper.ts` TS2353 and two same-site occurrence identity tests).
- Final `truffler` searches found no duplicate helper or superseded implementation.

Independent semantic re-review found no remaining blocker. This PR remains draft for review; it does not publish or merge anything.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped linter heuristic change in one performance rule, covered by extensive regressions and fuzz; no runtime app or auth/data paths.
> 
> **Overview**
> Fixes a **false positive** in `async-defer-await` when an early-return guard is a **`&&` / `||` tree** of post-await staleness checks (e.g. `requestId !== latestRequest.current || reviewVersion !== latestReview.current`), which must run **after** the `await` so stale async results are not committed.
> 
> The rule now walks logical compositions and treats the guard as non-hoistable only when **every leaf** is a proven freshness comparison: a **local `const` snapshot** paired with a **live** ref/member or outer `let`/`var` read, with parentheses and transparent TS wrappers stripped. **Mixed** guards (freshness plus unrelated flags or literals) and **invariant preflight** compound guards still report; existing whole-guard exemptions (cancellation, reassigned locals, etc.) are unchanged.
> 
> Adds regression tests, a fuzz corpus seed, a handler snippet for compound guards, and a patch changeset for `oxlint-plugin-react-doctor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a9fc3d34a863dc77d7957dda653241470f65105. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->