### PR TITLE
fix(no-pass-data-to-parent): preserve register callback aliases

### DIFF
--- a/.changeset/tidy-register-aliases.md
+++ b/.changeset/tidy-register-aliases.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Preserve register command exemptions through proven ref-held callback aliases.

--- a/packages/fuzz/corpus/regressions/no-pass-data-to-parent--register-ref-object-alias.tsx
+++ b/packages/fuzz/corpus/regressions/no-pass-data-to-parent--register-ref-object-alias.tsx
@@ -1,0 +1,26 @@
+// rule: no-pass-data-to-parent
+// weakness: alias-guard
+// source: ISSUES_TO_FIX_ASAP.md react-pdf Page trial pxCcHyD
+import { useEffect, useRef } from "react";
+
+interface PageProps {
+  pageIndex: number;
+  registerPage: (pageIndex: number, element: HTMLDivElement) => void;
+}
+
+export const Page = ({ pageIndex, registerPage }: PageProps) => {
+  const pageElement = useRef<HTMLDivElement>(null);
+  const registrationPropsRef = useRef({ pageIndex, registerPage });
+
+  useEffect(() => {
+    registrationPropsRef.current = { pageIndex, registerPage };
+  }, [pageIndex, registerPage]);
+
+  useEffect(() => {
+    const { pageIndex: currentPageIndex, registerPage: currentRegisterPage } =
+      registrationPropsRef.current;
+    if (pageElement.current) currentRegisterPage(currentPageIndex, pageElement.current);
+  }, [pageIndex]);
+
+  return <div ref={pageElement} />;
+};

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -47,6 +47,7 @@ export const EFFECT_SNIPPET_POOL = [
   `useEffect(() => { setState(value); }, [value]);`,
   `useEffect(() => { if (value) { handle(value); } }, [value]);`,
   `const CallbackRefChild = ({ onSelect }) => { const callbackRef = useRef(onSelect); callbackRef.current = onSelect; const childData = buildPhoneData(); useEffect(() => { callbackRef.current(childData); }, [childData]); return null; };`,
+  `const { registerPage: fuzzRegisterPageProp } = props; const fuzzRegisterPropsRef = useRef({ registerPage: fuzzRegisterPageProp }); fuzzRegisterPropsRef.current = { registerPage: fuzzRegisterPageProp }; useEffect(() => { const { registerPage: fuzzRegisterPage } = fuzzRegisterPropsRef.current; fuzzRegisterPage(value); }, [value]);`,
   `useEffect(() => { const debounced = debounce(() => handle(value), 300); debounced(); return () => debounced.cancel(); }, [value]);`,
   `useEffect(() => { const unsubscribe = store.subscribe(handle); return unsubscribe; }, []);`,
   `useEffect(() => store.subscribe(handle), []);`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.regressions.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vite-plus/test";
 import { runRule } from "../../../test-utils/run-rule.js";
 import { noPassDataToParent } from "./no-pass-data-to-parent.js";
 
+const DEEP_REGISTER_ALIAS_CHAIN_LENGTH = 2_000;
+
 describe("no-pass-data-to-parent — regressions", () => {
   it("stays silent when a callback parameter is passed through a parent callback", () => {
     const result = runRule(
@@ -306,22 +308,468 @@ describe("no-pass-data-to-parent — regressions", () => {
     it("stays silent when a ref-held registerPage prop is destructured with an alias (react-pdf Page)", () => {
       const result = runRule(
         noPassDataToParent,
-        `function Page({ registerPage, pageIndex, page }) {
+        `import { useDocumentContext } from "./document-context";
+        function Page(props) {
+          const documentContext = useDocumentContext();
+          const mergedProps = { ...documentContext, ...props };
+          const { _enableRegisterUnregisterPage = true, pageIndex, registerPage } = mergedProps;
           const pageElement = useRef(null);
+          const page = usePage();
           const currentPageIndex = isProvided(pageIndex) ? pageIndex : null;
-          const registerPagePropsRef = useRef({ pageIndex: currentPageIndex, registerPage });
+          const registerPagePropsRef = useRef({
+            _enableRegisterUnregisterPage,
+            pageIndex: currentPageIndex,
+            registerPage,
+          });
           useEffect(() => {
-            registerPagePropsRef.current = { pageIndex: currentPageIndex, registerPage };
-          }, [currentPageIndex, registerPage]);
+            registerPagePropsRef.current = {
+              _enableRegisterUnregisterPage,
+              pageIndex: currentPageIndex,
+              registerPage,
+            };
+          }, [_enableRegisterUnregisterPage, currentPageIndex, registerPage]);
           useEffect(() => {
             const {
+              _enableRegisterUnregisterPage: enableRegisterUnregisterPage,
               pageIndex: currentPageIndex,
               registerPage: currentRegisterPage,
             } = registerPagePropsRef.current;
-            if (currentRegisterPage && pageElement.current) {
+            if (enableRegisterUnregisterPage && currentRegisterPage && pageElement.current) {
               currentRegisterPage(currentPageIndex, pageElement.current);
             }
           }, [page]);
+          return null;
+        }`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it("preserves the direct register command exemption with a default value", () => {
+      const result = runRule(
+        noPassDataToParent,
+        `function Page({ registerPage = () => {} }) {
+          const pageData = usePageData();
+          useEffect(() => registerPage(pageData), [registerPage, pageData]);
+          return null;
+        }`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it("still flags register commands injected through mutated props", () => {
+      const reassignedPropsResult = runRule(
+        noPassDataToParent,
+        `import { useDocumentContext } from "./document-context";
+        function Page(props) {
+          const documentContext = useDocumentContext();
+          props = { ...props, registerPage: props.onData };
+          const mergedProps = { ...documentContext, ...props };
+          const { registerPage } = mergedProps;
+          const callbackBagRef = useRef({ registerPage });
+          const { registerPage: notifyParent } = callbackBagRef.current;
+          const pageData = buildPageData();
+          useEffect(() => notifyParent(pageData), [notifyParent, pageData]);
+          return null;
+        }`,
+      );
+      const mutatedPropertyResult = runRule(
+        noPassDataToParent,
+        `import { useDocumentContext } from "./document-context";
+        function Page(props) {
+          const documentContext = useDocumentContext();
+          props.registerPage = props.onData;
+          const mergedProps = { ...documentContext, ...props };
+          const { registerPage } = mergedProps;
+          const callbackBagRef = useRef({ registerPage });
+          const { registerPage: notifyParent } = callbackBagRef.current;
+          const pageData = buildPageData();
+          useEffect(() => notifyParent(pageData), [notifyParent, pageData]);
+          return null;
+        }`,
+      );
+      expect(reassignedPropsResult.parseErrors).toEqual([]);
+      expect(reassignedPropsResult.diagnostics).toHaveLength(1);
+      expect(mutatedPropertyResult.parseErrors).toEqual([]);
+      expect(mutatedPropertyResult.diagnostics).toHaveLength(1);
+    });
+
+    it("still flags a register command from an escaped context object", () => {
+      const result = runRule(
+        noPassDataToParent,
+        `import { useDocumentContext } from "./document-context";
+        function Page(props) {
+          const documentContext = useDocumentContext();
+          mutate(documentContext);
+          const mergedProps = { ...documentContext, ...props };
+          const { registerPage } = mergedProps;
+          const callbackBagRef = useRef({ registerPage });
+          const { registerPage: notifyParent } = callbackBagRef.current;
+          const pageData = buildPageData();
+          useEffect(() => notifyParent(pageData), [notifyParent, pageData]);
+          return null;
+        }`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    });
+
+    it("still flags reverse-order and shadowed context merges", () => {
+      const reverseOrderResult = runRule(
+        noPassDataToParent,
+        `import { useDocumentContext } from "./document-context";
+        function Page(props) {
+          const documentContext = useDocumentContext();
+          const mergedProps = { ...props, ...documentContext };
+          const { registerPage } = mergedProps;
+          const callbackBagRef = useRef({ registerPage });
+          const { registerPage: notifyParent } = callbackBagRef.current;
+          const pageData = buildPageData();
+          useEffect(() => notifyParent(pageData), [notifyParent, pageData]);
+          return null;
+        }`,
+      );
+      const shadowedContextResult = runRule(
+        noPassDataToParent,
+        `function Page(props) {
+          const useDocumentContext = () => ({ registerPage: props.onData });
+          const documentContext = useDocumentContext();
+          const mergedProps = { ...documentContext, ...props };
+          const { registerPage } = mergedProps;
+          const callbackBagRef = useRef({ registerPage });
+          const { registerPage: notifyParent } = callbackBagRef.current;
+          const pageData = buildPageData();
+          useEffect(() => notifyParent(pageData), [notifyParent, pageData]);
+          return null;
+        }`,
+      );
+      expect(reverseOrderResult.parseErrors).toEqual([]);
+      expect(reverseOrderResult.diagnostics).toHaveLength(1);
+      expect(shadowedContextResult.parseErrors).toEqual([]);
+      expect(shadowedContextResult.diagnostics).toHaveLength(1);
+    });
+
+    it("preserves register command names through direct destructuring and immutable aliases", () => {
+      const result = runRule(
+        noPassDataToParent,
+        `function Page(props) {
+          const { registerPage: currentRegisterPage } = props;
+          const registerCurrentPage = currentRegisterPage;
+          const command = registerCurrentPage;
+          const pageData = buildPageData();
+          useEffect(() => {
+            command(pageData);
+          }, [command, pageData]);
+          return null;
+        }`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it("preserves register command names through ref aliases and static property reads", () => {
+      const result = runRule(
+        noPassDataToParent,
+        `function Page({ registerPage, pageIndex }) {
+          const registerPagePropsRef = React.useRef({ registerPage });
+          const registerPagePropsRefAlias = registerPagePropsRef;
+          registerPagePropsRefAlias.current = { registerPage };
+          const currentRegisterPage = registerPagePropsRefAlias["current"]["registerPage"];
+          const registerCurrentPage = currentRegisterPage;
+          const pageData = buildPageData(pageIndex);
+          useEffect(() => {
+            registerCurrentPage(pageData);
+          }, [pageData]);
+          return null;
+        }`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it("still flags an ordinary callback stored under a register-named object property", () => {
+      const localObjectResult = runRule(
+        noPassDataToParent,
+        `function Page({ onData }) {
+          const callbackBag = { registerPage: onData };
+          const { registerPage: notifyParent } = callbackBag;
+          const pageData = buildPageData();
+          useEffect(() => {
+            notifyParent(pageData);
+          }, [notifyParent, pageData]);
+          return null;
+        }`,
+      );
+      const refObjectResult = runRule(
+        noPassDataToParent,
+        `function Page({ onData }) {
+          const callbackBagRef = useRef({ registerPage: onData });
+          const { registerPage: notifyParent } = callbackBagRef.current;
+          const pageData = buildPageData();
+          useEffect(() => {
+            notifyParent(pageData);
+          }, [notifyParent, pageData]);
+          return null;
+        }`,
+      );
+      expect(localObjectResult.parseErrors).toEqual([]);
+      expect(localObjectResult.diagnostics).toHaveLength(1);
+      expect(refObjectResult.parseErrors).toEqual([]);
+      expect(refObjectResult.diagnostics).toHaveLength(1);
+    });
+
+    it("still flags ref-held register properties with competing or opaque assignments", () => {
+      const competingAssignmentResult = runRule(
+        noPassDataToParent,
+        `function Page({ registerPage, onData, disabled }) {
+          const callbackBagRef = useRef({ registerPage });
+          if (disabled) callbackBagRef.current = { registerPage: onData };
+          const { registerPage: notifyParent } = callbackBagRef.current;
+          const pageData = buildPageData();
+          useEffect(() => {
+            notifyParent(pageData);
+          }, [notifyParent, pageData]);
+          return null;
+        }`,
+      );
+      const opaqueAssignmentResult = runRule(
+        noPassDataToParent,
+        `function Page({ registerPage, nextCallbacks }) {
+          const callbackBagRef = useRef({ registerPage });
+          callbackBagRef.current = nextCallbacks;
+          const { registerPage: notifyParent } = callbackBagRef.current;
+          const pageData = buildPageData();
+          useEffect(() => {
+            notifyParent(pageData);
+          }, [notifyParent, pageData]);
+          return null;
+        }`,
+      );
+      expect(competingAssignmentResult.parseErrors).toEqual([]);
+      expect(competingAssignmentResult.diagnostics).toHaveLength(1);
+      expect(opaqueAssignmentResult.parseErrors).toEqual([]);
+      expect(opaqueAssignmentResult.diagnostics).toHaveLength(1);
+    });
+
+    it("still flags mutable, dynamically keyed, and shadowed ref variants", () => {
+      const mutableResult = runRule(
+        noPassDataToParent,
+        `function Page({ registerPage, onData }) {
+          const callbackBagRef = useRef({ registerPage });
+          let { registerPage: notifyParent } = callbackBagRef.current;
+          notifyParent = onData;
+          const pageData = buildPageData();
+          useEffect(() => {
+            notifyParent(pageData);
+          }, [notifyParent, pageData]);
+          return null;
+        }`,
+      );
+      const dynamicResult = runRule(
+        noPassDataToParent,
+        `function Page({ registerPage, commandName }) {
+          const callbackBagRef = useRef({ registerPage });
+          const { [commandName]: notifyParent } = callbackBagRef.current;
+          const pageData = buildPageData();
+          useEffect(() => {
+            notifyParent(pageData);
+          }, [notifyParent, pageData]);
+          return null;
+        }`,
+      );
+      const shadowedResult = runRule(
+        noPassDataToParent,
+        `function Page({ registerPage }) {
+          const useRef = (value) => ({ current: value });
+          const callbackBagRef = useRef({ registerPage });
+          const { registerPage: notifyParent } = callbackBagRef.current;
+          const pageData = buildPageData();
+          useEffect(() => {
+            notifyParent(pageData);
+          }, [notifyParent, pageData]);
+          return null;
+        }`,
+      );
+      expect(mutableResult.parseErrors).toEqual([]);
+      expect(mutableResult.diagnostics).toHaveLength(1);
+      expect(dynamicResult.parseErrors).toEqual([]);
+      expect(dynamicResult.diagnostics).toHaveLength(1);
+      expect(shadowedResult.parseErrors).toEqual([]);
+      expect(shadowedResult.diagnostics).toHaveLength(1);
+    });
+
+    it("still flags target property writes and opaque ref-object escape", () => {
+      const propertyWriteResult = runRule(
+        noPassDataToParent,
+        `function Page({ registerPage, onData }) {
+          const callbackBagRef = useRef({ registerPage });
+          callbackBagRef.current.registerPage = onData;
+          const { registerPage: notifyParent } = callbackBagRef.current;
+          const pageData = buildPageData();
+          useEffect(() => {
+            notifyParent(pageData);
+          }, [notifyParent, pageData]);
+          return null;
+        }`,
+      );
+      const escapedRefResult = runRule(
+        noPassDataToParent,
+        `function Page({ registerPage }) {
+          const callbackBagRef = useRef({ registerPage });
+          synchronizeCallbacks(callbackBagRef);
+          const { registerPage: notifyParent } = callbackBagRef.current;
+          const pageData = buildPageData();
+          useEffect(() => {
+            notifyParent(pageData);
+          }, [notifyParent, pageData]);
+          return null;
+        }`,
+      );
+      expect(propertyWriteResult.parseErrors).toEqual([]);
+      expect(propertyWriteResult.diagnostics).toHaveLength(1);
+      expect(escapedRefResult.parseErrors).toEqual([]);
+      expect(escapedRefResult.diagnostics).toHaveLength(1);
+    });
+
+    it("still flags mutable and reassigned callback sources stored under registerPage", () => {
+      const mutableAliasResult = runRule(
+        noPassDataToParent,
+        `function Page({ onData }) {
+          let registerPage = onData;
+          const callbackBagRef = useRef({ registerPage });
+          const { registerPage: notifyParent } = callbackBagRef.current;
+          const pageData = buildPageData();
+          useEffect(() => notifyParent(pageData), [notifyParent, pageData]);
+          return null;
+        }`,
+      );
+      const reassignedPropResult = runRule(
+        noPassDataToParent,
+        `function Page({ registerPage, onData }) {
+          registerPage = onData;
+          const callbackBagRef = useRef({ registerPage });
+          const { registerPage: notifyParent } = callbackBagRef.current;
+          const pageData = buildPageData();
+          useEffect(() => notifyParent(pageData), [notifyParent, pageData]);
+          return null;
+        }`,
+      );
+      expect(mutableAliasResult.parseErrors).toEqual([]);
+      expect(mutableAliasResult.diagnostics).toHaveLength(1);
+      expect(reassignedPropResult.parseErrors).toEqual([]);
+      expect(reassignedPropResult.diagnostics).toHaveLength(1);
+    });
+
+    it("still flags a mutated props member stored under registerPage", () => {
+      const result = runRule(
+        noPassDataToParent,
+        `function Page(props) {
+          props.registerPage = props.onData;
+          const callbackBagRef = useRef({ registerPage: props.registerPage });
+          const { registerPage: notifyParent } = callbackBagRef.current;
+          const pageData = buildPageData();
+          useEffect(() => notifyParent(pageData), [notifyParent, pageData]);
+          return null;
+        }`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    });
+
+    it("still flags local-bag and fallback laundering", () => {
+      const localBagResult = runRule(
+        noPassDataToParent,
+        `function Page({ registerPage, onData }) {
+          const localBag = { registerPage: onData };
+          const { registerPage: fakeRegisterPage } = localBag;
+          const callbackBagRef = useRef({ registerPage: fakeRegisterPage });
+          const { registerPage: notifyParent } = callbackBagRef.current;
+          const pageData = buildPageData();
+          useEffect(() => notifyParent(pageData), [notifyParent, pageData]);
+          return null;
+        }`,
+      );
+      const fallbackResult = runRule(
+        noPassDataToParent,
+        `function Page({ registerPage, onData }) {
+          const callbackBagRef = useRef({ registerPage });
+          const { registerPage: notifyParent = onData } = callbackBagRef.current;
+          const pageData = buildPageData();
+          useEffect(() => notifyParent(pageData), [notifyParent, pageData]);
+          return null;
+        }`,
+      );
+      expect(localBagResult.parseErrors).toEqual([]);
+      expect(localBagResult.diagnostics).toHaveLength(1);
+      expect(fallbackResult.parseErrors).toEqual([]);
+      expect(fallbackResult.diagnostics).toHaveLength(1);
+    });
+
+    it("still flags pattern and loop writes to a ref-held registerPage property", () => {
+      const patterns = [
+        `({ registerPage: callbackBagRef.current.registerPage } = { registerPage: onData });`,
+        `[callbackBagRef.current.registerPage] = [onData];`,
+        `for (callbackBagRef.current.registerPage of [onData]) break;`,
+      ];
+      for (const pattern of patterns) {
+        const result = runRule(
+          noPassDataToParent,
+          `function Page({ registerPage, onData }) {
+            const callbackBagRef = useRef({ registerPage });
+            ${pattern}
+            const { registerPage: notifyParent } = callbackBagRef.current;
+            const pageData = buildPageData();
+            useEffect(() => notifyParent(pageData), [notifyParent, pageData]);
+            return null;
+          }`,
+        );
+        expect(result.parseErrors).toEqual([]);
+        expect(result.diagnostics).toHaveLength(1);
+      }
+    });
+
+    it("preserves callback-ref diagnostics for defaulted and later-reassigned props", () => {
+      const defaultedPropResult = runRule(
+        noPassDataToParent,
+        `function Page({ onData = () => {} }) {
+          const callbackRef = useRef(onData);
+          const pageData = buildPageData();
+          useEffect(() => callbackRef.current(pageData), [pageData]);
+          return null;
+        }`,
+      );
+      const reassignedPropResult = runRule(
+        noPassDataToParent,
+        `function Page({ onData }) {
+          const callbackRef = useRef(onData);
+          onData = (pageData) => log(pageData);
+          const pageData = buildPageData();
+          useEffect(() => callbackRef.current(pageData), [pageData]);
+          return null;
+        }`,
+      );
+      expect(defaultedPropResult.parseErrors).toEqual([]);
+      expect(defaultedPropResult.diagnostics).toHaveLength(1);
+      expect(reassignedPropResult.parseErrors).toEqual([]);
+      expect(reassignedPropResult.diagnostics).toHaveLength(1);
+    });
+
+    it("does not overflow on a deep immutable callback alias chain", () => {
+      const aliasDeclarations = Array.from(
+        { length: DEEP_REGISTER_ALIAS_CHAIN_LENGTH },
+        (_, aliasIndex) => `const registerAlias${aliasIndex + 1} = registerAlias${aliasIndex};`,
+      ).join("\n");
+      const result = runRule(
+        noPassDataToParent,
+        `function Page({ registerPage }) {
+          const callbackBagRef = useRef({ registerPage });
+          const { registerPage: registerAlias0 } = callbackBagRef.current;
+          ${aliasDeclarations}
+          const pageData = buildPageData();
+          useEffect(() => {
+            registerAlias${DEEP_REGISTER_ALIAS_CHAIN_LENGTH}(pageData);
+          }, [pageData]);
           return null;
         }`,
       );

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.regressions.test.ts
@@ -552,6 +552,34 @@ describe("no-pass-data-to-parent — regressions", () => {
       expect(opaqueAssignmentResult.diagnostics).toHaveLength(1);
     });
 
+    it("still flags computed properties that can override register commands", () => {
+      const initializerResult = runRule(
+        noPassDataToParent,
+        `function Page({ registerPage, onData, commandName }) {
+          const callbackBagRef = useRef({ registerPage, [commandName]: onData });
+          const { registerPage: notifyParent } = callbackBagRef.current;
+          const pageData = buildPageData();
+          useEffect(() => notifyParent(pageData), [notifyParent, pageData]);
+          return null;
+        }`,
+      );
+      const assignmentResult = runRule(
+        noPassDataToParent,
+        `function Page({ registerPage, onData, commandName }) {
+          const callbackBagRef = useRef({ registerPage });
+          callbackBagRef.current = { registerPage, [commandName]: onData };
+          const { registerPage: notifyParent } = callbackBagRef.current;
+          const pageData = buildPageData();
+          useEffect(() => notifyParent(pageData), [notifyParent, pageData]);
+          return null;
+        }`,
+      );
+      expect(initializerResult.parseErrors).toEqual([]);
+      expect(initializerResult.diagnostics).toHaveLength(1);
+      expect(assignmentResult.parseErrors).toEqual([]);
+      expect(assignmentResult.diagnostics).toHaveLength(1);
+    });
+
     it("still flags mutable, dynamically keyed, and shadowed ref variants", () => {
       const mutableResult = runRule(
         noPassDataToParent,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.regressions.test.ts
@@ -303,6 +303,32 @@ describe("no-pass-data-to-parent — regressions", () => {
   });
 
   describe("registration / subscription and external instances (verification run)", () => {
+    it("stays silent when a ref-held registerPage prop is destructured with an alias (react-pdf Page)", () => {
+      const result = runRule(
+        noPassDataToParent,
+        `function Page({ registerPage, pageIndex, page }) {
+          const pageElement = useRef(null);
+          const currentPageIndex = isProvided(pageIndex) ? pageIndex : null;
+          const registerPagePropsRef = useRef({ pageIndex: currentPageIndex, registerPage });
+          useEffect(() => {
+            registerPagePropsRef.current = { pageIndex: currentPageIndex, registerPage };
+          }, [currentPageIndex, registerPage]);
+          useEffect(() => {
+            const {
+              pageIndex: currentPageIndex,
+              registerPage: currentRegisterPage,
+            } = registerPagePropsRef.current;
+            if (currentRegisterPage && pageElement.current) {
+              currentRegisterPage(currentPageIndex, pageElement.current);
+            }
+          }, [page]);
+          return null;
+        }`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
     it("stays silent on sensor subscription with a concise-body cleanup (lightbox usePointerEvents)", () => {
       const result = runRule(
         noPassDataToParent,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.ts
@@ -12,6 +12,7 @@ import {
 } from "../../constants/data-sink-method-names.js";
 import { getCallMethodName } from "../../utils/get-call-method-name.js";
 import { getDestructuredBindingPropertyName } from "../../utils/get-destructured-binding-property-name.js";
+import { getStaticPropertyKeyName } from "../../utils/get-static-property-key-name.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isComponentFunction } from "../../utils/is-component-function.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
@@ -504,6 +505,308 @@ const getCallbackRefProvenance = (
   return callbackPropNames.size > 0 ? { callbackPropNames } : null;
 };
 
+const isParentPropsContextMerge = (analysis: ProgramAnalysis, expression: EsTreeNode): boolean => {
+  let currentExpression = stripParenExpression(expression);
+  const visitedVariables = new Set<NonNullable<Reference["resolved"]>>();
+  while (isNodeOfType(currentExpression, "Identifier")) {
+    const currentReference = getRef(analysis, currentExpression);
+    const currentVariable = currentReference?.resolved;
+    if (
+      !currentReference ||
+      !currentVariable ||
+      visitedVariables.has(currentVariable) ||
+      hasMutableBindingWrite(currentReference)
+    ) {
+      return false;
+    }
+    visitedVariables.add(currentVariable);
+    const definitions = currentVariable.defs
+      .map((definition) => definition.node as unknown as EsTreeNode)
+      .filter((definitionNode) => isNodeOfType(definitionNode, "VariableDeclarator"));
+    if (definitions.length !== 1) return false;
+    const declarator = definitions[0];
+    if (
+      !declarator ||
+      !isNodeOfType(declarator, "VariableDeclarator") ||
+      getDeclarationKind(declarator) !== "const" ||
+      !declarator.init
+    ) {
+      return false;
+    }
+    currentExpression = stripParenExpression(declarator.init as EsTreeNode);
+  }
+  if (!isNodeOfType(currentExpression, "ObjectExpression")) return false;
+  const [contextSpread, propsSpread] = currentExpression.properties ?? [];
+  if (
+    currentExpression.properties?.length !== 2 ||
+    !contextSpread ||
+    !propsSpread ||
+    !isNodeOfType(contextSpread, "SpreadElement") ||
+    !isNodeOfType(propsSpread, "SpreadElement")
+  ) {
+    return false;
+  }
+  const propsExpression = stripParenExpression(propsSpread.argument as EsTreeNode);
+  if (!isNodeOfType(propsExpression, "Identifier")) return false;
+  const propsReference = getRef(analysis, propsExpression);
+  if (
+    !propsReference?.resolved ||
+    !isWholePropsObjectReference(analysis, propsReference) ||
+    hasMutableBindingWrite(propsReference) ||
+    propsReference.resolved.references.some(
+      (candidateReference) => candidateReference !== propsReference,
+    )
+  ) {
+    return false;
+  }
+  const contextExpression = stripParenExpression(contextSpread.argument as EsTreeNode);
+  if (!isNodeOfType(contextExpression, "Identifier")) return false;
+  const contextReference = getRef(analysis, contextExpression);
+  if (
+    !contextReference?.resolved ||
+    hasMutableBindingWrite(contextReference) ||
+    contextReference.resolved.references.some(
+      (candidateReference) => !candidateReference.init && candidateReference !== contextReference,
+    )
+  ) {
+    return false;
+  }
+  const contextInitializer = contextReference.resolved?.defs
+    .map((definition) => definition.node as unknown as EsTreeNode)
+    .find((definitionNode) => isNodeOfType(definitionNode, "VariableDeclarator"));
+  if (
+    !contextInitializer ||
+    !isNodeOfType(contextInitializer, "VariableDeclarator") ||
+    getDeclarationKind(contextInitializer) !== "const" ||
+    !contextInitializer.init ||
+    !isNodeOfType(contextInitializer.init, "CallExpression")
+  ) {
+    return false;
+  }
+  const contextHook = stripParenExpression(contextInitializer.init.callee as EsTreeNode);
+  if (!isNodeOfType(contextHook, "Identifier") || !/^use[A-Z].*Context$/.test(contextHook.name)) {
+    return false;
+  }
+  const contextHookReference = getRef(analysis, contextHook);
+  return Boolean(
+    contextHookReference?.resolved?.defs.some((definition) => definition.type === "ImportBinding"),
+  );
+};
+
+const getImmutableParentCallbackPropName = (
+  analysis: ProgramAnalysis,
+  expression: EsTreeNode,
+): string | null => {
+  let currentExpression = stripParenExpression(expression);
+  const visitedVariables = new Set<NonNullable<Reference["resolved"]>>();
+  while (isNodeOfType(currentExpression, "Identifier")) {
+    const currentReference = getRef(analysis, currentExpression);
+    const currentVariable = currentReference?.resolved;
+    if (
+      !currentReference ||
+      !currentVariable ||
+      visitedVariables.has(currentVariable) ||
+      hasMutableBindingWrite(currentReference)
+    ) {
+      return null;
+    }
+    visitedVariables.add(currentVariable);
+    const definition = currentVariable.defs.length === 1 ? currentVariable.defs[0] : null;
+    const bindingIdentifier = definition?.name as unknown as EsTreeNode | undefined;
+    if (bindingIdentifier && isNodeOfType(bindingIdentifier.parent, "AssignmentPattern")) {
+      return null;
+    }
+    const definitionNode = definition?.node as unknown as EsTreeNode | undefined;
+    if (!definitionNode || !isNodeOfType(definitionNode, "VariableDeclarator")) {
+      return getParentCallbackPropName(analysis, currentExpression);
+    }
+    if (getDeclarationKind(definitionNode) !== "const" || !definitionNode.init) return null;
+    if (isNodeOfType(definitionNode.id, "ObjectPattern")) {
+      return (
+        getParentCallbackPropName(analysis, currentExpression) ??
+        (isParentPropsContextMerge(analysis, definitionNode.init as EsTreeNode)
+          ? getDestructuredBindingPropertyName(bindingIdentifier ?? currentExpression)
+          : null)
+      );
+    }
+    if (!isNodeOfType(definitionNode.id, "Identifier")) return null;
+    currentExpression = stripParenExpression(definitionNode.init as EsTreeNode);
+    if (
+      !isNodeOfType(currentExpression, "Identifier") &&
+      !isNodeOfType(currentExpression, "MemberExpression")
+    ) {
+      return null;
+    }
+  }
+  return null;
+};
+
+const objectExpressionPreservesCallbackProperty = (
+  analysis: ProgramAnalysis,
+  expression: EsTreeNode,
+  propertyName: string,
+): boolean => {
+  const unwrappedExpression = stripParenExpression(expression);
+  if (!isNodeOfType(unwrappedExpression, "ObjectExpression")) return false;
+  let callbackSourceName: string | null = null;
+  for (const property of unwrappedExpression.properties ?? []) {
+    if (!isNodeOfType(property, "Property")) return false;
+    if (getStaticPropertyKeyName(property, { allowComputedString: true }) !== propertyName) {
+      continue;
+    }
+    if (callbackSourceName || property.kind !== "init") return false;
+    if (!isNodeOfType(stripParenExpression(property.value as EsTreeNode), "Identifier")) {
+      return false;
+    }
+    callbackSourceName = getImmutableParentCallbackPropName(analysis, property.value as EsTreeNode);
+    if (!callbackSourceName) return false;
+  }
+  return callbackSourceName === propertyName;
+};
+
+const refCurrentObjectPreservesCallbackProperty = (
+  analysis: ProgramAnalysis,
+  expression: EsTreeNode,
+  propertyName: string,
+  isReactUseRefCall: (node: EsTreeNode) => boolean,
+): boolean => {
+  const unwrappedExpression = stripParenExpression(expression);
+  if (
+    !isNodeOfType(unwrappedExpression, "MemberExpression") ||
+    getStaticMemberPropertyName(unwrappedExpression) !== "current"
+  ) {
+    return false;
+  }
+  const bindingProvenance = getRefBindingProvenance(
+    analysis,
+    stripParenExpression(unwrappedExpression.object),
+    isReactUseRefCall,
+  );
+  if (!bindingProvenance) return false;
+  const initializer = bindingProvenance.refCall.arguments?.[0] as EsTreeNode | undefined;
+  if (
+    !initializer ||
+    !objectExpressionPreservesCallbackProperty(analysis, initializer, propertyName)
+  ) {
+    return false;
+  }
+  for (const variable of bindingProvenance.variables) {
+    for (const candidateReference of variable.references) {
+      if (candidateReference.init) continue;
+      const identifier = candidateReference.identifier as unknown as EsTreeNode;
+      if (getRefAliasDeclarator(identifier)) continue;
+      const currentMember = getRefMember(identifier);
+      if (!currentMember || getStaticMemberPropertyName(currentMember) !== "current") return false;
+      const currentAssignment = getRefMemberAssignment(identifier);
+      if (currentAssignment) {
+        if (
+          currentAssignment.operator !== "=" ||
+          !objectExpressionPreservesCallbackProperty(
+            analysis,
+            currentAssignment.right as EsTreeNode,
+            propertyName,
+          )
+        ) {
+          return false;
+        }
+        continue;
+      }
+      const currentRoot = findTransparentExpressionRoot(currentMember);
+      const currentParent = currentRoot.parent;
+      if (
+        currentParent &&
+        isNodeOfType(currentParent, "VariableDeclarator") &&
+        currentParent.init === (currentRoot as unknown as typeof currentParent.init) &&
+        isNodeOfType(currentParent.id, "ObjectPattern")
+      ) {
+        continue;
+      }
+      if (
+        currentParent &&
+        isNodeOfType(currentParent, "MemberExpression") &&
+        currentParent.object === (currentRoot as unknown as typeof currentParent.object) &&
+        getStaticMemberPropertyName(currentParent) === propertyName
+      ) {
+        const propertyRoot = findTransparentExpressionRoot(currentParent);
+        const propertyParent = propertyRoot.parent;
+        if (!propertyParent || !isNodeOfType(propertyParent, "VariableDeclarator")) {
+          return false;
+        }
+        continue;
+      }
+      return false;
+    }
+  }
+  return true;
+};
+
+const getCommandCallbackPropName = (
+  analysis: ProgramAnalysis,
+  expression: EsTreeNode,
+  isReactUseRefCall: (node: EsTreeNode) => boolean,
+): string | null => {
+  const directCallbackName = getImmutableParentCallbackPropName(analysis, expression);
+  if (directCallbackName && COMMAND_PROP_NAME_PATTERN.test(directCallbackName)) {
+    return directCallbackName;
+  }
+  let currentExpression = stripParenExpression(expression);
+  const visitedVariables = new Set<NonNullable<Reference["resolved"]>>();
+  while (isNodeOfType(currentExpression, "Identifier")) {
+    const callbackReference = getRef(analysis, currentExpression);
+    const callbackVariable = callbackReference?.resolved;
+    if (
+      !callbackReference ||
+      !callbackVariable ||
+      visitedVariables.has(callbackVariable) ||
+      hasMutableBindingWrite(callbackReference)
+    ) {
+      return null;
+    }
+    visitedVariables.add(callbackVariable);
+    const definition = callbackVariable.defs.length === 1 ? callbackVariable.defs[0] : null;
+    const declarator = definition?.node as unknown as EsTreeNode | undefined;
+    if (
+      !declarator ||
+      !isNodeOfType(declarator, "VariableDeclarator") ||
+      getDeclarationKind(declarator) !== "const" ||
+      !declarator.init
+    ) {
+      return null;
+    }
+    const bindingIdentifier = definition?.name as unknown as EsTreeNode | undefined;
+    if (bindingIdentifier && isNodeOfType(bindingIdentifier.parent, "AssignmentPattern")) {
+      return null;
+    }
+    if (isNodeOfType(declarator.id, "ObjectPattern")) {
+      const propertyName = bindingIdentifier
+        ? getDestructuredBindingPropertyName(bindingIdentifier)
+        : null;
+      if (!propertyName || !COMMAND_PROP_NAME_PATTERN.test(propertyName)) return null;
+      return refCurrentObjectPreservesCallbackProperty(
+        analysis,
+        declarator.init as EsTreeNode,
+        propertyName,
+        isReactUseRefCall,
+      )
+        ? propertyName
+        : null;
+    }
+    if (!isNodeOfType(declarator.id, "Identifier")) return null;
+    currentExpression = stripParenExpression(declarator.init as EsTreeNode);
+  }
+  if (!isNodeOfType(currentExpression, "MemberExpression")) return null;
+  const propertyName = getStaticMemberPropertyName(currentExpression);
+  if (!propertyName || !COMMAND_PROP_NAME_PATTERN.test(propertyName)) return null;
+  return refCurrentObjectPreservesCallbackProperty(
+    analysis,
+    currentExpression.object as EsTreeNode,
+    propertyName,
+    isReactUseRefCall,
+  )
+    ? propertyName
+    : null;
+};
+
 // The wrapper hides the data hand-off inside the wrapped body
 // (`fireNonCancelableEvent(onNavigationChange, { open: isOpen })`), so the
 // direct call's arguments alone can be all-literal; scan the call-chain
@@ -708,6 +1011,14 @@ export const noPassDataToParent = defineRule({
             // Bare form: `onChange(data)` — callee must BE a prop (or a
             // plain alias of one), not a local function that eventually
             // mentions a prop.
+            const callbackPropName = getCommandCallbackPropName(
+              analysis,
+              identifier,
+              isReactUseRefCall,
+            );
+            if (callbackPropName && COMMAND_PROP_NAME_PATTERN.test(callbackPropName)) {
+              continue;
+            }
             if (!isDirectParentCallbackRef(analysis, ref)) continue;
             if (
               isNodeOfType(identifier, "Identifier") &&

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.ts
@@ -651,9 +651,11 @@ const objectExpressionPreservesCallbackProperty = (
   let callbackSourceName: string | null = null;
   for (const property of unwrappedExpression.properties ?? []) {
     if (!isNodeOfType(property, "Property")) return false;
-    if (getStaticPropertyKeyName(property, { allowComputedString: true }) !== propertyName) {
-      continue;
-    }
+    const candidatePropertyName = getStaticPropertyKeyName(property, {
+      allowComputedString: true,
+    });
+    if (candidatePropertyName === null) return false;
+    if (candidatePropertyName !== propertyName) continue;
     if (callbackSourceName || property.kind !== "init") return false;
     if (!isNodeOfType(stripParenExpression(property.value as EsTreeNode), "Identifier")) {
       return false;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.ts
@@ -520,11 +520,11 @@ const isParentPropsContextMerge = (analysis: ProgramAnalysis, expression: EsTree
       return false;
     }
     visitedVariables.add(currentVariable);
-    const definitions = currentVariable.defs
-      .map((definition) => definition.node as unknown as EsTreeNode)
-      .filter((definitionNode) => isNodeOfType(definitionNode, "VariableDeclarator"));
+    const definitions = currentVariable.defs.filter((definition) =>
+      isNodeOfType(definition.node as unknown as EsTreeNode, "VariableDeclarator"),
+    );
     if (definitions.length !== 1) return false;
-    const declarator = definitions[0];
+    const declarator = definitions[0]?.node as unknown as EsTreeNode | undefined;
     if (
       !declarator ||
       !isNodeOfType(declarator, "VariableDeclarator") ||


### PR DESCRIPTION
<!-- motivation-example:start -->
## Motivation

`no-pass-data-to-parent` already exempts command callbacks such as `registerPage`, but that meaning was lost when the callback traveled through a latest-values ref. The aliasing pattern should not turn a registration command into an apparent child-to-parent data notification.

## Example

React-PDF stores the command and later calls a destructured alias:

```tsx
const latest = useRef({ registerPage })
const { registerPage: currentRegisterPage } = latest.current
currentRegisterPage(pageIndex)
```

When provenance proves that alias still denotes the `registerPage` prop, the rule should preserve the command exemption.
<!-- motivation-example:end -->

## Why

The benchmark trial `fix-react-rdh-wojtekmaj-react-pd__pxCcHyD` exposes a real `no-pass-data-to-parent` false positive in `wojtekmaj/react-pdf@c2e0782d80fb0f85fc2f74a079ed0b8bd147dff6`.

`Page.tsx` stores the `registerPage` command prop in a latest-values ref and later destructures it as `currentRegisterPage`. The rule already exempts proven `register*` commands, but it lost that semantic name through the ref-held object and reported the registration call as child data mirrored to a parent.

## What changed

- Preserves a command prop name through immutable aliases and a proven React `useRef` object property.
- Supports the authentic imported context-first / whole-props-last merge used by React-PDF.
- Requires exact provenance: immutable sources, one static property, proven React ref, safe whole-object assignments, and no opaque escapes or target-property writes.
- Keeps ordinary callbacks, mutable aliases, defaults/fallbacks, dynamic keys, shadowed APIs, reverse merges, and reassigned or mutated props/context reportable.
- Adds a permanent fuzz seed and generator shape.
- Adds a patch changeset for `oxlint-plugin-react-doctor`.

## Validation

- Focused regression suite: 71/71 passed.
- Full oxlint plugin suite: 559 files, 14,028 passed, 181 skipped.
- Fuzz corpus: 44 passed, 402 skipped.
- Strict fuzz: `FUZZ_RULE=no-pass-data-to-parent FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz` passed; 325 programs executed, the target rule fired in 7, and fire coverage was 1/1.
- 50,000-hop immutable alias stress probe completed without a crash.
- Plugin and fuzz package typechecks passed.
- Root lint, format check, and `git diff --check` passed.
- Root `nr test` reached two unrelated language-server same-site identity failures; both reproduce on a clean `origin/main` worktree. All changed-package tests passed.
- Root `nr typecheck` reaches the existing unrelated language-server `mapper.ts:103` severity error; changed-package typechecks pass.
- Truffler found no missing reusable helper; the implementation reuses existing parent-callback, ref-binding, static-key, and destructuring utilities.

## Exact pinned comparison

Six AST scans completed with zero parse or scan failures:

| React-PDF state | `origin/main` | candidate | classification |
| --- | ---: | ---: | --- |
| untouched base | 0 | 0 | parity |
| authentic model patch | 1 at `src/Page.tsx:673:7` | 0 | intended FP removal |
| oracle solution | 0 | 0 | parity |

Reverse-applying either stored patch reproduced the exact base file hash. There were no added diagnostics and no removed true positives.

## RDE

The local 100-repository RDE attempt was invalid: 100 were requested, 0 completed, and the result file remained empty. This is recorded as a harness failure, not a pass. The successful pinned base/model/oracle comparison above is the real-repository evidence for this change.

This PR remains draft. It does not merge or publish anything.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The change expands static-analysis provenance in a heavily used lint rule; incorrect tracing could suppress real child-to-parent data warnings or reintroduce false positives, though the PR adds extensive negative/positive tests to bound behavior.
> 
> **Overview**
> Fixes **false positives** when command props like `registerPage` are invoked through **latest-values refs** and destructured aliases (e.g. react-pdf `Page`), where the rule already exempts direct `register*` calls but lost the prop name after ref indirection.
> 
> **`no-pass-data-to-parent`** now traces **immutable** aliases and **proven** `useRef` object bags: it recognizes context-first / props-last merges (`{ ...useDocumentContext(), ...props }`), requires static object keys and safe whole-`current` assignments, and still reports laundering (mutated props, `onData` stored as `registerPage`, competing assignments, defaults/fallbacks, shadowed hooks).
> 
> Adds a large regression matrix, a fuzz corpus case and snippet pool entry, and a patch changeset for `oxlint-plugin-react-doctor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0f4bcdf0e2e71817c8c2883461b21e1cdb66c13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->