### PR TITLE
fix(anchor-has-content): require link semantics

### DIFF
--- a/.changeset/quiet-anchors-rest.md
+++ b/.changeset/quiet-anchors-rest.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Avoid reporting `anchor-has-content` for href-less anchors without link semantics.

--- a/packages/fuzz/corpus/regressions/anchor-has-content--href-less-placeholder.tsx
+++ b/packages/fuzz/corpus/regressions/anchor-has-content--href-less-placeholder.tsx
@@ -1,0 +1,10 @@
+// rule: anchor-has-content
+// weakness: semantic-provenance
+// source: Hacker0x01/react-datepicker@548a1f3464c30741f2581c78f27fe1f20f9aeac6
+export const YearNavigation = ({ incrementYears }: { incrementYears: () => void }) => (
+  <div className="year-option" onClick={incrementYears}>
+    <a className="navigation navigation-upcoming" />
+  </div>
+);
+
+export const EmptyLink = () => <a href="/archive" />;

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -430,6 +430,8 @@ export const JSX_LEAF_POOL = [
   `<div dangerouslySetInnerHTML={{ __html: value }} />`,
   `<img src={url} />`,
   `<a href={url} target="_blank">external</a>`,
+  `<a className="navigation-placeholder" />`,
+  `<a role="link" />`,
   `<StyledButton $active={isOpen} customFlag={state}>{state}</StyledButton>`,
   `<DynamicChart width={typeof window === "undefined" ? 0 : window.innerWidth} />`,
   `<a href={url}></a>`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/__fixtures__/oxc-divergences.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/__fixtures__/oxc-divergences.ts
@@ -15,6 +15,11 @@ export interface OxcDivergence {
 }
 
 export const DIVERGENCES: Record<string, OxcDivergence> = {
+  "anchor-has-content": {
+    failSkips: [0, 1, 2, 3, 4, 5, 6],
+    reason:
+      "A bare `<a>` without `href` or an explicit link role has no hyperlink semantics, so an accessible link name is inapplicable.",
+  },
   // anchor-is-valid: `href="#"` WITHOUT a click handler is a working
   // scroll-to-top link — focusable, keyboard-reachable, and it navigates
   // (to the top of the page), so the "goes nowhere" message is false

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/anchor-has-content.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/anchor-has-content.regressions.test.ts
@@ -21,6 +21,57 @@ describe("a11y/anchor-has-content regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("exempts href-less anchors with statically non-link roles", () => {
+    const cases = [
+      `const A = () => <a />;`,
+      `const A = () => <a role="button" />;`,
+      `const A = () => <a role="none" />;`,
+      `const A = () => <a role="button link" />;`,
+      `const A = ({ isButton }) => <a role={isButton ? "button" : "menuitem"} />;`,
+    ];
+    for (const code of cases) {
+      const result = runRule(anchorHasContent, code);
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    }
+  });
+
+  it("still flags empty anchors with href or link-role semantics", () => {
+    const cases = [
+      `const A = () => <a href="" />;`,
+      `const A = () => <a href="/settings" />;`,
+      `const A = ({ destination }) => <a href={destination} />;`,
+      `const A = () => <a HREF={undefined} />;`,
+      `const A = () => <a role="link" />;`,
+      `const ROLE = "link"; const A = () => <a role={ROLE} />;`,
+      `const A = () => <a role="future-role link" />;`,
+      `const A = ({ isLink }) => <a role={isLink ? "link" : "button"} />;`,
+      `const A = ({ role }) => <a role={role} />;`,
+      `const A = () => <a href="/settings" role="presentation" />;`,
+    ];
+    for (const code of cases) {
+      const result = runRule(anchorHasContent, code);
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    }
+  });
+
+  it("exempts an href-less configured anchor alias", () => {
+    const result = runRule(anchorHasContent, `const A = () => <Link />;`, {
+      settings: { "jsx-a11y": { components: { Link: "a" } } },
+    });
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still flags a configured anchor alias with an explicit link role", () => {
+    const result = runRule(anchorHasContent, `const A = () => <Link role="link" />;`, {
+      settings: { "jsx-a11y": { components: { Link: "a" } } },
+    });
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("exempts an `<a>` named via `aria-labelledby`", () => {
     const result = runRule(
       anchorHasContent,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/anchor-has-content.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/anchor-has-content.regressions.test.ts
@@ -3,6 +3,24 @@ import { runRule } from "../../../test-utils/run-rule.js";
 import { anchorHasContent } from "./anchor-has-content.js";
 
 describe("a11y/anchor-has-content regressions", () => {
+  it("exempts href-less React Datepicker navigation placeholders", () => {
+    const result = runRule(
+      anchorHasContent,
+      `const YearNavigation = ({ incrementYears, decrementYears }) => (
+        <>
+          <div className="react-datepicker__year-option" onClick={incrementYears}>
+            <a className="react-datepicker__navigation react-datepicker__navigation--years react-datepicker__navigation--years-upcoming" />
+          </div>
+          <div className="react-datepicker__year-option" onClick={decrementYears}>
+            <a className="react-datepicker__navigation react-datepicker__navigation--years react-datepicker__navigation--years-previous" />
+          </div>
+        </>
+      );`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("exempts an `<a>` named via `aria-labelledby`", () => {
     const result = runRule(
       anchorHasContent,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/anchor-has-content.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/anchor-has-content.ts
@@ -1,8 +1,10 @@
+import { VALID_ARIA_ROLES } from "../../constants/aria-roles.js";
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { flattenJsxName } from "../../utils/flatten-jsx-name.js";
 import { getElementType } from "../../utils/get-element-type.js";
+import { getJsxPropStaticStringValues } from "../../utils/get-jsx-prop-static-string-values.js";
 import { hasJsxPropIgnoreCase } from "../../utils/has-jsx-prop-ignore-case.js";
 import { isHiddenFromScreenReader } from "../../utils/is-hidden-from-screen-reader.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
@@ -11,6 +13,12 @@ import { objectHasAccessibleChild } from "../../utils/object-has-accessible-chil
 
 const MESSAGE =
   "Blind users can't follow this link because screen readers announce nothing, so add visible text, `aria-label`, or `aria-labelledby`.";
+
+const hasLinkRole = (roleValue: string): boolean =>
+  roleValue
+    .trim()
+    .split(/\s+/)
+    .find((roleToken) => VALID_ARIA_ROLES.has(roleToken)) === "link";
 
 // An empty anchor passed as a prop of react-i18next's `<Trans>`
 // (`components={{ link: <a … /> }}`) is a template: Trans clones it and
@@ -37,7 +45,7 @@ export const anchorHasContent = defineRule({
   title: "Anchor has no content",
   tags: ["react-jsx-only"],
   severity: "warn",
-  recommendation: "Put readable text inside every `<a>`.",
+  recommendation: "Put readable text inside every link.",
   category: "Accessibility",
   create: (context) => {
     const isTestlikeFile = isTestlikeFilename(context.filename);
@@ -47,6 +55,14 @@ export const anchorHasContent = defineRule({
         const opening = node.openingElement;
         const tag = getElementType(opening, context.settings);
         if (tag !== "a") return;
+        const hrefAttribute = hasJsxPropIgnoreCase(opening.attributes, "href");
+        const roleAttribute = hasJsxPropIgnoreCase(opening.attributes, "role");
+        const roleValues = roleAttribute
+          ? getJsxPropStaticStringValues(roleAttribute, context.scopes)
+          : [];
+        const canHaveLinkRole =
+          roleValues === null || roleValues.some((roleValue) => hasLinkRole(roleValue));
+        if (!hrefAttribute && !canHaveLinkRole) return;
         if (isHiddenFromScreenReader(opening, context.settings)) return;
         if (objectHasAccessibleChild(node, context.settings)) return;
         for (const attribute of ["title", "aria-label", "aria-labelledby"]) {


### PR DESCRIPTION
<!-- motivation-example:start -->
## Motivation

`anchor-has-content` is about accessible link names. A bare `<a>` without `href` or link semantics is exposed as a generic element, so diagnosing it as an unnamed link is outside the rule's applicability.

## Example

React Datepicker uses href-less anchors as CSS placeholders inside the actual clickable control:

```tsx
<div onClick={showPreviousYears}>
  <a className="navigation-placeholder" />
</div>
```

The rule should stay quiet here but continue reporting an empty anchor that has `href` or an applicable `link` role.
<!-- motivation-example:end -->

## Why

`anchor-has-content` reports two href-less CSS navigation placeholders in `Hacker0x01/react-datepicker@548a1f3464c30741f2581c78f27fe1f20f9aeac6`, `src/year_dropdown_options.tsx:160,172`, from React Bench trial `fix-react-rdh-hacker0x01-react-d__RRgQ6gG`.

Neither node is a link: both are self-closing `<a>` elements without `href`, nested inside the actual clickable parent `<div>` elements. Browsers expose a bare anchor without `href` as a generic element rather than a link, so requiring a link name is inapplicable.

## What changed

- Require `href` or a possible explicit `link` role before applying the accessible-name check.
- Respect ARIA fallback-role order: `role="button link"` is a button, while `role="future-role link"` can fall back to link.
- Keep unresolved roles conservative and continue reporting dynamic/empty hrefs, configured anchor aliases with link semantics, and href anchors with presentational roles.
- Record the upstream OXC fixtures as intentional semantic divergences.
- Add the authentic React Datepicker seed to the permanent fuzz corpus and both valid/invalid generator shapes.
- Add a patch changeset for `oxlint-plugin-react-doctor`.

## Validation

- Exact pinned file: current main `2`, candidate `0`; the benchmark model and oracle patches only modify `src/calendar.tsx`, so all three states share this intended `2 → 0` removal.
- Plugin suite: `559` files, `14,009` passed, `188` skipped.
- Fuzz corpus: `44` passed, `402` skipped.
- Strict fuzz: `500` iterations, `329` executed programs, `17` firing programs, `1/1` fire coverage, no findings.
- Changed-package typechecks, repository build, lint, format check, and `git diff --check`: pass.
- Root test/typecheck reproduce only the existing language-server occurrence-identity failures and `mapper.ts:103` mismatch; the changed packages pass independently.
- Local RDE 100-repository run was invalid: it produced `0/100` result rows and no worker children, so it is not counted as passing evidence.
- Post-change truffler searches found no duplicate link-role helper.

No merge or package publication is included.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrower applicability for one a11y rule with broad regression and fuzz coverage; no auth, data, or runtime behavior changes.
> 
> **Overview**
> **`anchor-has-content`** now runs only when an `<a>` (or configured alias) has **`href`** or could expose **`link`** via **`role`**, so href-less CSS placeholders (e.g. React Datepicker year navigation) are no longer reported as unnamed links.
> 
> Link **`role`** detection uses the first known ARIA token in a space-separated list (`role="button link"` → not a link; unknown tokens can still fall back to **`link`**). Unresolved or dynamic **`role`** values stay conservative and keep reporting; empty anchors with **`href`**, static **`role="link"`**, or **`href` + presentational role** still fire.
> 
> Tests, an OXC fixture divergence entry, fuzz snippets, and a React Datepicker regression corpus seed document the behavior; **`oxlint-plugin-react-doctor`** gets a patch changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2845eb1897ba14520797916094033e4c3fec1bb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->