### PR TITLE
fix(no-interactive-element-to-noninteractive-role): allow native td cell role

### DIFF
--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/no-interactive-element-to-noninteractive-role.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/no-interactive-element-to-noninteractive-role.regressions.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noInteractiveElementToNoninteractiveRole } from "./no-interactive-element-to-noninteractive-role.js";
+
+describe("a11y/no-interactive-element-to-noninteractive-role regressions", () => {
+  it("accepts the native-equivalent `cell` role on an interactive `<td>`", () => {
+    const result = runRule(
+      noInteractiveElementToNoninteractiveRole,
+      `<td role="cell" tabIndex={0} onMouseDown={handleMouseDown} onKeyDown={handleKeyDown}>Value</td>`,
+    );
+
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still reports the noninteractive `cell` role on a native `<button>`", () => {
+    const result = runRule(
+      noInteractiveElementToNoninteractiveRole,
+      `<button role="cell">Value</button>`,
+    );
+
+    expect(result.diagnostics).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Why

The pinned `hyparam/hightable@6ab8470aaae96680cb5db02ce3625af19dac91cc` benchmark uses an interactive native `<td role="cell">` at `src/components/Cell/Cell.tsx:108`. React Doctor reports that the role removes the element's interactive semantics, but `cell` is the native-equivalent ARIA role of a table data cell and does not erase its focus or keyboard handlers.

The boundary remains narrow: a genuinely mismatched interactive element such as `<button role="cell">` must still report.

## Current draft state

- Adds the exact minimized Hightable shape as a regression fixture.
- Adds a paired `<button role="cell">` true-positive control.
- The valid regression intentionally fails on this draft commit.

Implementation, permanent fuzz coverage, pinned source/oracle comparisons, and full validation will follow in subsequent commits.

## Evidence

- React Bench job: `write-react-hyparam-hightable-45__fZG7bpo`
- Stored diagnostic: `src/components/Cell/Cell.tsx:108:7`
- W3C ARIA in HTML: `<td>` exposes `cell` in a semantic table; explicitly restating the implicit role is allowed though not recommended.
- WAI-ARIA: `cell` has HTML `<td>` as its base concept.
