### PR TITLE
fix(role-supports-aria-props): recognize number inputs

### DIFF
--- a/.changeset/bumpy-hornets-ask.md
+++ b/.changeset/bumpy-hornets-ask.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Fix `role-supports-aria-props` false positives for native number inputs and unresolved input types.

--- a/packages/fuzz/corpus/regressions/role-supports-aria-props--number-input-spinbutton.tsx
+++ b/packages/fuzz/corpus/regressions/role-supports-aria-props--number-input-spinbutton.tsx
@@ -1,0 +1,14 @@
+// rule: role-supports-aria-props
+// weakness: library-idiom
+// source: React Bench write-react-musama619-react-photo-editor-286
+export const NumberInput = ({ minimum, maximum, value }) => (
+  <input
+    type="number"
+    min={minimum}
+    max={maximum}
+    value={value}
+    aria-valuemin={minimum}
+    aria-valuemax={maximum}
+    aria-valuenow={value}
+  />
+);

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -423,6 +423,8 @@ export const JSX_LEAF_POOL = [
   `<input type="radio" value="a" checked={state === "a"} onChange={() => setState("a")} />`,
   `<input type="radio" name="group" value="b" defaultChecked />`,
   `<input type="number" min={0} max={100} value={state} onChange={handleAmount} />`,
+  `<input type="number" min={0} max={100} value={state} aria-valuemin={0} aria-valuemax={100} aria-valuenow={state} onChange={handleAmount} />`,
+  `<input type="number" aria-expanded={isOpen} />`,
   `<textarea readOnly value={String(value)} />`,
   `<ThemeContext.Provider value={{ mode: state, toggle: handle }}>{state}</ThemeContext.Provider>`,
   `<ItemsContext.Provider value={items}>{state}</ItemsContext.Provider>`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/no-redundant-roles.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/no-redundant-roles.regressions.test.ts
@@ -50,6 +50,14 @@ describe("a11y/no-redundant-roles regressions", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("flags a redundant spinbutton role when the number type is an expression literal", () => {
+    const result = runRule(
+      noRedundantRoles,
+      `const F = () => <input type={"number"} role="spinbutton" />;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("does not assume a redundant role when an input type is unresolved", () => {
     const result = runRule(
       noRedundantRoles,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/no-redundant-roles.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/no-redundant-roles.regressions.test.ts
@@ -42,6 +42,22 @@ describe("a11y/no-redundant-roles regressions", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("flags a spinbutton role repeated on a native number input", () => {
+    const result = runRule(
+      noRedundantRoles,
+      `const F = () => <input type="number" role="spinbutton" />;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not assume a redundant role when an input type is unresolved", () => {
+    const result = runRule(
+      noRedundantRoles,
+      `const F = ({ inputType }) => <input type={inputType} role="textbox" />;`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it('exempts `<a role="link">` without `href` (a bare anchor has no implicit role)', () => {
     const result = runRule(
       noRedundantRoles,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/no-redundant-roles.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/no-redundant-roles.ts
@@ -134,7 +134,7 @@ export const noRedundantRoles = defineRule({
           if (findSameFileTableContext(node, context.settings) !== "table") return;
           implicitRoles = [getTableCellPrimaryRole(node, tag)];
         } else if (ATTRIBUTE_DEPENDENT_IMPLICIT_ROLE_TAGS.has(tag)) {
-          implicitRoles = [getImplicitRole(node, tag)].filter(
+          implicitRoles = [getImplicitRole(node, tag, context.scopes)].filter(
             (resolvedRole): resolvedRole is string => resolvedRole !== null,
           );
         } else {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/role-supports-aria-props.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/role-supports-aria-props.regressions.test.ts
@@ -25,14 +25,11 @@ describe("a11y/role-supports-aria-props regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
-  it("recognizes case-insensitive and expression-literal number input types", () => {
+  it("recognizes an expression-literal number input type", () => {
     const result = runRule(
       roleSupportsAriaProps,
       `const NumberInputs = ({ value }) => (
-        <>
-          <input TYPE="NUMBER" aria-valuenow={value} />
-          <input type={"number"} aria-valuenow={value} />
-        </>
+        <input type={"number"} aria-valuenow={value} />
       );`,
     );
     expect(result.diagnostics).toEqual([]);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/role-supports-aria-props.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/role-supports-aria-props.regressions.test.ts
@@ -25,14 +25,39 @@ describe("a11y/role-supports-aria-props regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
-  it("recognizes an expression-literal number input type", () => {
+  it("recognizes case-insensitive and expression-literal number input types", () => {
     const result = runRule(
       roleSupportsAriaProps,
       `const NumberInputs = ({ value }) => (
-        <input type={"number"} aria-valuenow={value} />
+        <>
+          <input TYPE="NUMBER" aria-valuenow={value} />
+          <input type={"number"} aria-valuenow={value} />
+        </>
       );`,
     );
     expect(result.diagnostics).toEqual([]);
+  });
+
+  it("normalizes existing range and button input role branches", () => {
+    const result = runRule(
+      roleSupportsAriaProps,
+      `const Inputs = ({ value, pressed }) => (
+        <>
+          <input type="RANGE" aria-valuenow={value} />
+          <input type="BUTTON" aria-pressed={pressed} />
+        </>
+      );`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still treats an uppercase text input type as a textbox", () => {
+    const result = runRule(
+      roleSupportsAriaProps,
+      `const TextInput = ({ value }) => <input type="TEXT" aria-valuenow={value} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("role `textbox`");
   });
 
   it("stays silent when a native input type cannot be resolved statically", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/role-supports-aria-props.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/role-supports-aria-props.regressions.test.ts
@@ -124,6 +124,17 @@ describe("a11y/role-supports-aria-props regressions", () => {
     expect(result.diagnostics[0].message).toContain("role `spinbutton`");
   });
 
+  it("flags unsupported props when the number type is an expression literal", () => {
+    const result = runRule(
+      roleSupportsAriaProps,
+      `const NumberInput = ({ expanded }) => (
+        <input type={"number"} aria-expanded={expanded} />
+      );`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("role `spinbutton`");
+  });
+
   it("stays silent on range ARIA props supported by slider and explicit spinbutton roles", () => {
     const result = runRule(
       roleSupportsAriaProps,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/role-supports-aria-props.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/role-supports-aria-props.regressions.test.ts
@@ -25,6 +25,19 @@ describe("a11y/role-supports-aria-props regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("recognizes case-insensitive and expression-literal number input types", () => {
+    const result = runRule(
+      roleSupportsAriaProps,
+      `const NumberInputs = ({ value }) => (
+        <>
+          <input TYPE="NUMBER" aria-valuenow={value} />
+          <input type={"number"} aria-valuenow={value} />
+        </>
+      );`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("stays silent when a native input type cannot be resolved statically", () => {
     const result = runRule(
       roleSupportsAriaProps,
@@ -53,6 +66,40 @@ describe("a11y/role-supports-aria-props regressions", () => {
       );`,
     );
     expect(result.diagnostics).toHaveLength(3);
+  });
+
+  it("still treats a missing or invalid static input type as a textbox", () => {
+    const result = runRule(
+      roleSupportsAriaProps,
+      `const TextInputs = ({ value }) => (
+        <>
+          <input aria-valuenow={value} />
+          <input type="counter" aria-valuenow={value} />
+        </>
+      );`,
+    );
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
+  it("still honors an explicit role over a native number input role", () => {
+    const result = runRule(
+      roleSupportsAriaProps,
+      `const TextInput = ({ value }) => (
+        <input type="number" role="textbox" aria-valuenow={value} />
+      );`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags props unsupported by a native number input spinbutton", () => {
+    const result = runRule(
+      roleSupportsAriaProps,
+      `const NumberInput = ({ expanded }) => (
+        <input type="number" aria-expanded={expanded} />
+      );`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("role `spinbutton`");
   });
 
   it("stays silent on range ARIA props supported by slider and explicit spinbutton roles", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/role-supports-aria-props.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/role-supports-aria-props.regressions.test.ts
@@ -7,6 +7,78 @@ import { roleSupportsAriaProps } from "./role-supports-aria-props.js";
 // role="combobox". These cases pin the revert of the ARIA-1.2 combobox
 // heuristic in utils/get-implicit-role.ts (oxc parity).
 describe("a11y/role-supports-aria-props regressions", () => {
+  it("stays silent on range ARIA props supported by a native number input", () => {
+    const result = runRule(
+      roleSupportsAriaProps,
+      `const NumberInput = ({ minimum, maximum, value }) => (
+        <input
+          type="number"
+          min={minimum}
+          max={maximum}
+          value={value}
+          aria-valuemin={minimum}
+          aria-valuemax={maximum}
+          aria-valuenow={value}
+        />
+      );`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent when a native input type cannot be resolved statically", () => {
+    const result = runRule(
+      roleSupportsAriaProps,
+      `const Input = ({ inputType, minimum, maximum, value }) => (
+        <input
+          type={inputType}
+          aria-valuemin={minimum}
+          aria-valuemax={maximum}
+          aria-valuenow={value}
+        />
+      );`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still flags range ARIA props on a native text input", () => {
+    const result = runRule(
+      roleSupportsAriaProps,
+      `const TextInput = ({ minimum, maximum, value }) => (
+        <input
+          type="text"
+          aria-valuemin={minimum}
+          aria-valuemax={maximum}
+          aria-valuenow={value}
+        />
+      );`,
+    );
+    expect(result.diagnostics).toHaveLength(3);
+  });
+
+  it("stays silent on range ARIA props supported by slider and explicit spinbutton roles", () => {
+    const result = runRule(
+      roleSupportsAriaProps,
+      `const RangeInputs = ({ minimum, maximum, value }) => (
+        <>
+          <input
+            type="range"
+            aria-valuemin={minimum}
+            aria-valuemax={maximum}
+            aria-valuenow={value}
+          />
+          <input
+            type="text"
+            role="spinbutton"
+            aria-valuemin={minimum}
+            aria-valuemax={maximum}
+            aria-valuenow={value}
+          />
+        </>
+      );`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("flags aria-expanded on a plain text input (implicit textbox, oxc parity)", () => {
     const result = runRule(
       roleSupportsAriaProps,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/role-supports-aria-props.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/role-supports-aria-props.ts
@@ -66,7 +66,9 @@ export const roleSupportsAriaProps = defineRule({
       // roles have to be known and all have to lack support for the prop.
       const roleCandidates = roleAttribute
         ? getJsxPropStaticStringValues(roleAttribute, context.scopes)
-        : [getImplicitRole(node, elementType)].filter((role): role is string => role !== null);
+        : [getImplicitRole(node, elementType, context.scopes)].filter(
+            (role): role is string => role !== null,
+          );
       if (roleCandidates === null || roleCandidates.length === 0) return;
       const supportedSets: Array<ReadonlySet<string>> = [];
       for (const role of roleCandidates) {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-implicit-role.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-implicit-role.ts
@@ -79,7 +79,7 @@ export const getImplicitRole = (
         implicit = "";
         break;
       }
-      const inputType = inputTypeValue.toLowerCase();
+      const inputType = inputTypeValue;
       if (
         inputType === "button" ||
         inputType === "image" ||

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-implicit-role.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-implicit-role.ts
@@ -69,9 +69,18 @@ export const getImplicitRole = (
       break;
     }
     case "input": {
-      const inputType = propStringValue("type");
-      if (inputType === null) implicit = "textbox";
-      else if (
+      const inputTypeAttribute = hasJsxPropIgnoreCase(node.attributes, "type");
+      if (!inputTypeAttribute) {
+        implicit = "textbox";
+        break;
+      }
+      const inputTypeValue = getJsxPropStringValue(inputTypeAttribute);
+      if (inputTypeValue === null) {
+        implicit = "";
+        break;
+      }
+      const inputType = inputTypeValue.toLowerCase();
+      if (
         inputType === "button" ||
         inputType === "image" ||
         inputType === "reset" ||
@@ -79,6 +88,7 @@ export const getImplicitRole = (
       )
         implicit = "button";
       else if (inputType === "checkbox") implicit = "checkbox";
+      else if (inputType === "number") implicit = "spinbutton";
       else if (inputType === "radio") implicit = "radio";
       else if (inputType === "range") implicit = "slider";
       else implicit = "textbox";

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-implicit-role.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-implicit-role.ts
@@ -79,7 +79,7 @@ export const getImplicitRole = (
         implicit = "";
         break;
       }
-      const inputType = inputTypeValue;
+      const inputType = inputTypeValue.toLowerCase();
       if (
         inputType === "button" ||
         inputType === "image" ||

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-implicit-role.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-implicit-role.ts
@@ -1,13 +1,33 @@
 import { VALID_ARIA_ROLES } from "../constants/aria-roles.js";
+import type { ScopeAnalysis } from "../semantic/scope-analysis.js";
 import type { EsTreeNodeOfType } from "./es-tree-node-of-type.js";
+import { getJsxPropStaticStringValues } from "./get-jsx-prop-static-string-values.js";
 import { getJsxPropStringValue } from "./get-jsx-prop-string-value.js";
 import { hasJsxPropIgnoreCase } from "./has-jsx-prop-ignore-case.js";
+
+const getInputTypeImplicitRole = (inputTypeValue: string): string => {
+  const inputType = inputTypeValue.toLowerCase();
+  if (
+    inputType === "button" ||
+    inputType === "image" ||
+    inputType === "reset" ||
+    inputType === "submit"
+  ) {
+    return "button";
+  }
+  if (inputType === "checkbox") return "checkbox";
+  if (inputType === "number") return "spinbutton";
+  if (inputType === "radio") return "radio";
+  if (inputType === "range") return "slider";
+  return "textbox";
+};
 
 // Port of `get_implicit_role` from OXC. Returns the implicit ARIA
 // role for an HTML element, or null if there isn't one.
 export const getImplicitRole = (
   node: EsTreeNodeOfType<"JSXOpeningElement">,
   elementType: string,
+  scopes: ScopeAnalysis,
 ): string | null => {
   const propStringValue = (propName: string): string | null => {
     const attribute = hasJsxPropIgnoreCase(node.attributes, propName);
@@ -74,24 +94,13 @@ export const getImplicitRole = (
         implicit = "textbox";
         break;
       }
-      const inputTypeValue = getJsxPropStringValue(inputTypeAttribute);
-      if (inputTypeValue === null) {
+      const inputTypeValues = getJsxPropStaticStringValues(inputTypeAttribute, scopes);
+      if (inputTypeValues === null) {
         implicit = "";
         break;
       }
-      const inputType = inputTypeValue.toLowerCase();
-      if (
-        inputType === "button" ||
-        inputType === "image" ||
-        inputType === "reset" ||
-        inputType === "submit"
-      )
-        implicit = "button";
-      else if (inputType === "checkbox") implicit = "checkbox";
-      else if (inputType === "number") implicit = "spinbutton";
-      else if (inputType === "radio") implicit = "radio";
-      else if (inputType === "range") implicit = "slider";
-      else implicit = "textbox";
+      const implicitRoles = new Set(inputTypeValues.map(getInputTypeImplicitRole));
+      implicit = implicitRoles.size === 1 ? (implicitRoles.values().next().value ?? "") : "";
       break;
     }
     case "li":


### PR DESCRIPTION
<!-- motivation-example:start -->
## Motivation

Native number inputs have implicit `spinbutton` semantics, and spinbuttons support range-value ARIA properties. Treating them as textboxes produces false accessibility diagnostics.

## Example

This is a valid native spinbutton and should not be reported:

```tsx
<input
  type="number"
  aria-valuemin={minimum}
  aria-valuemax={maximum}
  aria-valuenow={value}
/>
```
<!-- motivation-example:end -->

## Why

Fixes a grounded false positive where native number inputs are treated as textboxes, so valid range-value ARIA properties are reported as ignored.

HTML AAM maps `input[type=number]` to the `spinbutton` role. WAI-ARIA permits `aria-valuemin`, `aria-valuemax`, and `aria-valuenow` on spinbuttons. The exact React Bench source at `musama619/react-photo-editor@db1db3632a6802819522e40e2f14b7b75f427833` uses that native control.

Before:

```tsx
<input
  type="number"
  aria-valuemin={minimum}
  aria-valuemax={maximum}
  aria-valuenow={value}
/>
```

After: no diagnostic. Inputs with an unresolved dynamic `type` also stay quiet because the rule cannot prove which implicit role will exist at runtime.

## What changed

- Maps a statically known, ASCII case-insensitive `input[type=number]` to `spinbutton` in the shared implicit-role resolver.
- Distinguishes a missing `type` (the native textbox default) from an unresolved dynamic `type` (unknown, so no definite role claim).
- Preserves positives for text inputs, invalid static input types, explicit textbox roles, and properties unsupported by spinbuttons.
- Adds shared-consumer controls for redundant native spinbutton roles.
- Adds a permanent React Bench regression seed and generator snippets for both valid and invalid number-input shapes.
- Adds a patch changeset for `oxlint-plugin-react-doctor`.

## Precision boundary

- `type="number"`, `type="NUMBER"`, and `type={"number"}` resolve to `spinbutton`.
- Dynamic `type={inputType}` returns unknown instead of asserting `textbox`.
- An absent `type` and invalid static values retain the existing textbox default.
- Existing button, image, reset, submit, checkbox, radio, and range mappings are preserved after the same keyword normalization.
- Existing mappings for hidden, file, search, password, and the date/time family are unchanged. Some are known incomplete relative to HTML AAM (for example, hidden/file/date-family inputs have no corresponding WAI-ARIA role and search maps to searchbox); they need separately grounded fixes rather than expansion of this PR.

## Exact React Bench replay

Target: `src/components/ReactPhotoEditor.tsx` in `musama619/react-photo-editor@db1db3632a6802819522e40e2f14b7b75f427833`.

| State | Main | Candidate | Classification |
| --- | ---: | ---: | --- |
| Untouched base | 6 | 0 | 6 removed false positives |
| Model patch | 6 | 0 | 6 removed false positives |
| Oracle patch | 6 | 0 | 6 removed false positives |

Three findings were on the statically known number input and three were on the adjacent unresolved `type={input.type}` input. The benchmark patches do not change either ARIA pattern, so the result is solution-independent. Scan failures: 0.

## Validation

- `nr --filter oxlint-plugin-react-doctor test` — 559 files, 14,023 passed, 181 skipped.
- `nr --filter oxlint-plugin-react-doctor typecheck` — passed.
- `nr --filter @react-doctor/fuzz test` — 44 passed, 402 skipped.
- `nr --filter @react-doctor/fuzz typecheck` — passed.
- `FUZZ_RULE=role-supports-aria-props FUZZ_STRICT=1 FUZZ_ITERATIONS=500 FUZZ_PRINT_STATS=1 FUZZ_PRINT_SILENT=1 nr fuzz --reporter=verbose` — passed; 330 programs executed, 22 fired, fire coverage 1/1.
- `nr lint` — passed with pre-existing warnings only.
- `nr format:check` — passed.
- `git diff --check` — passed.
- React Doctor changed-scope scan — 0 diagnostics.
- Post-change `truffler` searches found no duplicate implicit-role implementation.

The repository-wide `nr typecheck` reaches the known unrelated `packages/language-server/src/diagnostics/mapper.ts:103` failure (`severity` is not in the expected object type). Both touched-package typechecks pass, and the PR's CI typecheck passed on the prior head.

A local 100-repository RDE run produced a zero-byte artifact with 0 successful rows, so it is invalid evidence and is not represented as an eval pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted a11y lint logic in a shared implicit-role helper with conservative behavior for dynamic input types; extensive regression and fuzz coverage limits blast radius.
> 
> **Overview**
> Fixes **`role-supports-aria-props`** false positives on native `<input type="number">` with valid range ARIA (`aria-valuemin` / `aria-valuemax` / `aria-valuenow`) by teaching the shared **`getImplicitRole`** resolver that a statically known number type maps to **`spinbutton`**, not **`textbox`**.
> 
> **`getImplicitRole`** now resolves `input` **`type`** with **`getJsxPropStaticStringValues`** (case-insensitive literals and `type={"number"}`). Missing **`type`** still defaults to textbox; **unresolved dynamic `type`** yields no definite implicit role so both **`role-supports-aria-props`** and **`no-redundant-roles`** bail instead of assuming textbox. **`number`** is added alongside existing button/checkbox/radio/range mappings via a shared **`getInputTypeImplicitRole`** helper.
> 
> Regression tests, a React Bench fuzz seed, and fuzz snippet pools cover valid number spinbuttons, unsupported props on number inputs, redundant `role="spinbutton"`, and dynamic types. Patch changeset for **`oxlint-plugin-react-doctor`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 905a197cde28e0aa930e8acdbc02057968350ae3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->