### PR TITLE
fix(interactive-supports-focus): recognize editing hosts

### DIFF
--- a/.changeset/honest-signs-act.md
+++ b/.changeset/honest-signs-act.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Fix interactive-supports-focus false positives on native content-editable editing hosts while preserving nested and disabled-host diagnostics.

--- a/packages/fuzz/corpus/regressions/interactive-supports-focus--conditional-editing-host.tsx
+++ b/packages/fuzz/corpus/regressions/interactive-supports-focus--conditional-editing-host.tsx
@@ -1,0 +1,7 @@
+// rule: interactive-supports-focus
+// weakness: control-flow
+// source: React Bench write-react-frankchen021-datasto__GC3spRj
+
+export const ChatInput = ({ isRunning, handleKeyDown }) => (
+  <div role="textbox" contentEditable={!isRunning} onKeyDown={handleKeyDown} />
+);

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -424,6 +424,8 @@ export const JSX_LEAF_POOL = [
   `<input type="radio" name="group" value="b" defaultChecked />`,
   `<input type="number" min={0} max={100} value={state} onChange={handleAmount} />`,
   `<textarea readOnly value={String(value)} />`,
+  `<div role="textbox" contentEditable={!loading} onKeyDown={handleKeyDown} />`,
+  `<div role="textbox" contentEditable={false} onKeyDown={handleKeyDown} />`,
   `<ThemeContext.Provider value={{ mode: state, toggle: handle }}>{state}</ThemeContext.Provider>`,
   `<ItemsContext.Provider value={items}>{state}</ItemsContext.Provider>`,
   `{createPortal(<div>{state}</div>, document.body)}`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/aria-activedescendant-has-tabindex.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/aria-activedescendant-has-tabindex.regressions.test.ts
@@ -46,6 +46,46 @@ describe("a11y/aria-activedescendant-has-tabindex regressions", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("still flags a const-disabled editing host", () => {
+    const result = runRule(
+      ariaActivedescendantHasTabindex,
+      `const editable = false;
+      <div contentEditable={editable} aria-activedescendant={activeId} />`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags invalid inherited contentEditable values", () => {
+    const sources = [
+      `<div contentEditable="inherit" aria-activedescendant={activeId} />`,
+      `<div contentEditable="invalid" aria-activedescendant={activeId} />`,
+      `<div contentEditable><div contentEditable="inherit" aria-activedescendant={activeId} /></div>`,
+    ];
+    for (const source of sources) {
+      expect(runRule(ariaActivedescendantHasTabindex, source).diagnostics).toHaveLength(1);
+    }
+  });
+
+  it("still flags a nested enabled editing host", () => {
+    const result = runRule(
+      ariaActivedescendantHasTabindex,
+      `<div contentEditable>
+        <div contentEditable aria-activedescendant={activeId} />
+      </div>`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not assume a dynamic editing ancestor is always enabled", () => {
+    const result = runRule(
+      ariaActivedescendantHasTabindex,
+      `<div contentEditable={outerEnabled}>
+        <div contentEditable aria-activedescendant={activeId} />
+      </div>`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("still flags a plain div with aria-activedescendant and no tabIndex", () => {
     const result = runRule(
       ariaActivedescendantHasTabindex,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/aria-activedescendant-has-tabindex.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/aria-activedescendant-has-tabindex.regressions.test.ts
@@ -86,6 +86,29 @@ describe("a11y/aria-activedescendant-has-tabindex regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("does not look past uncertain or disabled editing-host boundaries", () => {
+    const sources = [
+      `<div contentEditable>
+        <div contentEditable={false}>
+          <div contentEditable aria-activedescendant={activeId} />
+        </div>
+      </div>`,
+      `<div contentEditable>
+        <div contentEditable={innerEnabled}>
+          <div contentEditable aria-activedescendant={activeId} />
+        </div>
+      </div>`,
+      `<div contentEditable>
+        <Wrapper>
+          <div contentEditable aria-activedescendant={activeId} />
+        </Wrapper>
+      </div>`,
+    ];
+    for (const source of sources) {
+      expect(runRule(ariaActivedescendantHasTabindex, source).diagnostics).toEqual([]);
+    }
+  });
+
   it("still flags a plain div with aria-activedescendant and no tabIndex", () => {
     const result = runRule(
       ariaActivedescendantHasTabindex,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/aria-activedescendant-has-tabindex.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/aria-activedescendant-has-tabindex.ts
@@ -1,35 +1,14 @@
 import { HTML_TAGS } from "../../constants/html-tags.js";
+import { canContentEditableBeTabbable } from "../../utils/can-content-editable-be-tabbable.js";
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { getElementType } from "../../utils/get-element-type.js";
-import { getJsxPropStringValue } from "../../utils/get-jsx-prop-string-value.js";
 import { hasJsxPropIgnoreCase } from "../../utils/has-jsx-prop-ignore-case.js";
 import { isInteractiveElement } from "../../utils/is-interactive-element.js";
-import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { parseJsxValue } from "../../utils/parse-jsx-value.js";
 
 const MESSAGE =
   "Keyboard users can't focus this element with `aria-activedescendant` because it isn't tabbable, so add `tabIndex={0}`.";
-
-// contentEditable editing hosts are natively focusable and tabbable, so
-// they don't need an explicit tabIndex. Only a static "false" (string or
-// boolean) rules that out; dynamic expressions may be editable at runtime.
-const mayBeContentEditable = (node: EsTreeNodeOfType<"JSXOpeningElement">): boolean => {
-  const attribute = hasJsxPropIgnoreCase(node.attributes, "contenteditable");
-  if (!attribute) return false;
-  if (!attribute.value) return true;
-  const stringValue = getJsxPropStringValue(attribute);
-  if (stringValue !== null) return stringValue !== "false";
-  const value = attribute.value as EsTreeNode;
-  if (isNodeOfType(value, "JSXExpressionContainer")) {
-    const expression = value.expression as EsTreeNode;
-    if (isNodeOfType(expression, "Literal")) {
-      return expression.value !== false && expression.value !== "false";
-    }
-  }
-  return true;
-};
 
 // Port of `oxc_linter::rules::jsx_a11y::aria_activedescendant_has_tabindex`.
 // Reports HTML elements with `aria-activedescendant` that are NOT
@@ -59,7 +38,7 @@ export const ariaActivedescendantHasTabindex = defineRule({
       }
       // No tabIndex — interactive elements are implicitly tabbable.
       if (isInteractiveElement(tag, node)) return;
-      if (mayBeContentEditable(node)) return;
+      if (canContentEditableBeTabbable(node, context.scopes, context.settings)) return;
       context.report({ node: node.name, message: MESSAGE });
     },
   }),

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/interactive-supports-focus.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/interactive-supports-focus.regressions.test.ts
@@ -175,8 +175,8 @@ const X = ({ go }) => <div role={role} onClick={go}>{label}</div>;`,
   it("does not flag a statically enabled editing host", () => {
     const result = runRule(
       interactiveSupportsFocus,
-      `const Editor = ({ handleInput }) => (
-        <div role="textbox" contentEditable="plaintext-only" onInput={handleInput} />
+      `const Editor = ({ handleKeyDown }) => (
+        <div role="textbox" contentEditable="plaintext-only" onKeyDown={handleKeyDown} />
       );`,
     );
     expect(result.diagnostics).toEqual([]);
@@ -185,10 +185,67 @@ const X = ({ go }) => <div role={role} onClick={go}>{label}</div>;`,
   it("still flags a statically disabled editing host", () => {
     const result = runRule(
       interactiveSupportsFocus,
-      `const Editor = ({ handleInput }) => (
-        <div role="textbox" contentEditable={false} onInput={handleInput} />
+      `const Editor = ({ handleKeyDown }) => (
+        <div role="textbox" contentEditable={false} onKeyDown={handleKeyDown} />
       );`,
     );
     expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("handles static editing-host value variants", () => {
+    const validSources = [
+      `<div role="textbox" contentEditable onKeyDown={handleKeyDown} />`,
+      `<div role="textbox" contentEditable="TRUE" onKeyDown={handleKeyDown} />`,
+      `<div role="textbox" contentEditable={true} onKeyDown={handleKeyDown} />`,
+      `<div role="textbox" contentEditable={enabled ? true : false} onKeyDown={handleKeyDown} />`,
+      `const editable = true; <div role="textbox" contentEditable={editable} onKeyDown={handleKeyDown} />`,
+    ];
+    for (const source of validSources) {
+      expect(runRule(interactiveSupportsFocus, source).diagnostics).toEqual([]);
+    }
+
+    const invalidSources = [
+      `<div role="textbox" contentEditable="false" onKeyDown={handleKeyDown} />`,
+      `<div role="textbox" contentEditable={false} onKeyDown={handleKeyDown} />`,
+      `<div role="textbox" contentEditable="inherit" onKeyDown={handleKeyDown} />`,
+      `<div role="textbox" contentEditable="invalid" onKeyDown={handleKeyDown} />`,
+      `const editable = false; <div role="textbox" contentEditable={editable} onKeyDown={handleKeyDown} />`,
+      `<div role="textbox" contentEditable={enabled ? false : false} onKeyDown={handleKeyDown} />`,
+      `const editable = false; <div role="textbox" contentEditable={condition ? editable : editable} onKeyDown={handleKeyDown} />`,
+    ];
+    for (const source of invalidSources) {
+      expect(runRule(interactiveSupportsFocus, source).diagnostics).toHaveLength(1);
+    }
+  });
+
+  it("still flags a nested editing host without an explicit tabIndex", () => {
+    const result = runRule(
+      interactiveSupportsFocus,
+      `<div contentEditable>
+        <div role="textbox" contentEditable onKeyDown={handleKeyDown} />
+      </div>`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a nested editing host under a const-enabled ancestor", () => {
+    const result = runRule(
+      interactiveSupportsFocus,
+      `const outerEditable = true;
+      <div contentEditable={outerEditable}>
+        <div role="textbox" contentEditable onKeyDown={handleKeyDown} />
+      </div>`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not assume a dynamic editing ancestor is always enabled", () => {
+    const result = runRule(
+      interactiveSupportsFocus,
+      `<div contentEditable={outerEnabled}>
+        <div role="textbox" contentEditable onKeyDown={handleKeyDown} />
+      </div>`,
+    );
+    expect(result.diagnostics).toEqual([]);
   });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/interactive-supports-focus.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/interactive-supports-focus.regressions.test.ts
@@ -154,4 +154,41 @@ const X = ({ go }) => <div role={role} onClick={go}>{label}</div>;`,
     );
     expect(result.diagnostics).toEqual([]);
   });
+
+  it("does not flag the Datastoria conditional editing host", () => {
+    const result = runRule(
+      interactiveSupportsFocus,
+      `const ChatInput = ({ isRunning, handleInput, handleKeyDown }) => (
+        <div
+          role="textbox"
+          aria-multiline="true"
+          contentEditable={!isRunning}
+          suppressContentEditableWarning
+          onInput={handleInput}
+          onKeyDown={handleKeyDown}
+        />
+      );`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not flag a statically enabled editing host", () => {
+    const result = runRule(
+      interactiveSupportsFocus,
+      `const Editor = ({ handleInput }) => (
+        <div role="textbox" contentEditable="plaintext-only" onInput={handleInput} />
+      );`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still flags a statically disabled editing host", () => {
+    const result = runRule(
+      interactiveSupportsFocus,
+      `const Editor = ({ handleInput }) => (
+        <div role="textbox" contentEditable={false} onInput={handleInput} />
+      );`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/interactive-supports-focus.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/interactive-supports-focus.regressions.test.ts
@@ -248,4 +248,27 @@ const X = ({ go }) => <div role={role} onClick={go}>{label}</div>;`,
     );
     expect(result.diagnostics).toEqual([]);
   });
+
+  it("does not look past uncertain or disabled editing-host boundaries", () => {
+    const sources = [
+      `<div contentEditable>
+        <div contentEditable={false}>
+          <div role="textbox" contentEditable onKeyDown={handleKeyDown} />
+        </div>
+      </div>`,
+      `<div contentEditable>
+        <div contentEditable={innerEnabled}>
+          <div role="textbox" contentEditable onKeyDown={handleKeyDown} />
+        </div>
+      </div>`,
+      `<div contentEditable>
+        <Wrapper>
+          <div role="textbox" contentEditable onKeyDown={handleKeyDown} />
+        </Wrapper>
+      </div>`,
+    ];
+    for (const source of sources) {
+      expect(runRule(interactiveSupportsFocus, source).diagnostics).toEqual([]);
+    }
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/interactive-supports-focus.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/interactive-supports-focus.ts
@@ -1,5 +1,6 @@
 import { ALL_EVENT_HANDLERS_LOWER } from "../../constants/event-handlers.js";
 import { HTML_TAGS } from "../../constants/html-tags.js";
+import { canContentEditableBeTabbable } from "../../utils/can-content-editable-be-tabbable.js";
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { getElementType } from "../../utils/get-element-type.js";
@@ -122,6 +123,7 @@ export const interactiveSupportsFocus = defineRule({
         // already handles focus correctly.
         if (!HTML_TAGS.has(elementType)) return;
         if (
+          canContentEditableBeTabbable(node, context.scopes, context.settings) ||
           isDisabledElement(node) ||
           isHiddenFromScreenReader(node, context.settings) ||
           isPresentationRole(node)

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/can-content-editable-be-tabbable.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/can-content-editable-be-tabbable.ts
@@ -1,0 +1,123 @@
+import { HTML_TAGS } from "../constants/html-tags.js";
+import type { ScopeAnalysis } from "../semantic/scope-analysis.js";
+import type { EsTreeNode } from "./es-tree-node.js";
+import type { EsTreeNodeOfType } from "./es-tree-node-of-type.js";
+import { getDirectConstInitializer } from "./get-direct-const-initializer.js";
+import { getElementType } from "./get-element-type.js";
+import { hasJsxPropIgnoreCase } from "./has-jsx-prop-ignore-case.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+import { stripParenExpression } from "./strip-paren-expression.js";
+
+interface ContentEditablePossibilities {
+  canBeDisabled: boolean;
+  canBeEnabled: boolean;
+}
+
+const ENABLED_CONTENT_EDITABLE_VALUES: ReadonlySet<string> = new Set([
+  "",
+  "plaintext-only",
+  "true",
+]);
+
+const ENABLED_CONTENT_EDITABLE: ContentEditablePossibilities = {
+  canBeDisabled: false,
+  canBeEnabled: true,
+};
+
+const DISABLED_CONTENT_EDITABLE: ContentEditablePossibilities = {
+  canBeDisabled: true,
+  canBeEnabled: false,
+};
+
+const UNKNOWN_CONTENT_EDITABLE: ContentEditablePossibilities = {
+  canBeDisabled: true,
+  canBeEnabled: true,
+};
+
+const mergeContentEditablePossibilities = (
+  left: ContentEditablePossibilities,
+  right: ContentEditablePossibilities,
+): ContentEditablePossibilities => ({
+  canBeDisabled: left.canBeDisabled || right.canBeDisabled,
+  canBeEnabled: left.canBeEnabled || right.canBeEnabled,
+});
+
+const resolveContentEditableExpression = (
+  rawExpression: EsTreeNode,
+  scopes: ScopeAnalysis,
+  visitedSymbolIds: Set<number>,
+): ContentEditablePossibilities => {
+  const expression = stripParenExpression(rawExpression);
+  if (isNodeOfType(expression, "Literal")) {
+    if (typeof expression.value === "boolean") {
+      return expression.value ? ENABLED_CONTENT_EDITABLE : DISABLED_CONTENT_EDITABLE;
+    }
+    if (typeof expression.value === "string") {
+      return ENABLED_CONTENT_EDITABLE_VALUES.has(expression.value.toLowerCase())
+        ? ENABLED_CONTENT_EDITABLE
+        : DISABLED_CONTENT_EDITABLE;
+    }
+    return DISABLED_CONTENT_EDITABLE;
+  }
+  if (isNodeOfType(expression, "ConditionalExpression")) {
+    return mergeContentEditablePossibilities(
+      resolveContentEditableExpression(expression.consequent, scopes, visitedSymbolIds),
+      resolveContentEditableExpression(expression.alternate, scopes, visitedSymbolIds),
+    );
+  }
+  if (isNodeOfType(expression, "Identifier")) {
+    const symbol = scopes.referenceFor(expression)?.resolvedSymbol;
+    if (!symbol || visitedSymbolIds.has(symbol.id)) return UNKNOWN_CONTENT_EDITABLE;
+    const initializer = getDirectConstInitializer(symbol);
+    if (!initializer) return UNKNOWN_CONTENT_EDITABLE;
+    const nextVisitedSymbolIds = new Set(visitedSymbolIds);
+    nextVisitedSymbolIds.add(symbol.id);
+    return resolveContentEditableExpression(initializer, scopes, nextVisitedSymbolIds);
+  }
+  return UNKNOWN_CONTENT_EDITABLE;
+};
+
+const getContentEditablePossibilities = (
+  node: EsTreeNodeOfType<"JSXOpeningElement">,
+  scopes: ScopeAnalysis,
+): ContentEditablePossibilities | null => {
+  const attribute = hasJsxPropIgnoreCase(node.attributes, "contenteditable");
+  if (!attribute) return null;
+  if (!attribute.value) return ENABLED_CONTENT_EDITABLE;
+  if (isNodeOfType(attribute.value, "Literal")) {
+    return resolveContentEditableExpression(attribute.value, scopes, new Set());
+  }
+  if (isNodeOfType(attribute.value, "JSXExpressionContainer")) {
+    return resolveContentEditableExpression(attribute.value.expression, scopes, new Set());
+  }
+  return UNKNOWN_CONTENT_EDITABLE;
+};
+
+const hasDefinitelyEnabledContentEditableAncestor = (
+  node: EsTreeNodeOfType<"JSXOpeningElement">,
+  scopes: ScopeAnalysis,
+  settings: Readonly<Record<string, unknown>> | undefined,
+): boolean => {
+  let ancestor = node.parent?.parent;
+  while (ancestor) {
+    if (isNodeOfType(ancestor, "JSXElement")) {
+      const openingElement = ancestor.openingElement;
+      if (HTML_TAGS.has(getElementType(openingElement, settings))) {
+        const possibilities = getContentEditablePossibilities(openingElement, scopes);
+        if (possibilities?.canBeEnabled && !possibilities.canBeDisabled) return true;
+      }
+    }
+    ancestor = ancestor.parent;
+  }
+  return false;
+};
+
+export const canContentEditableBeTabbable = (
+  node: EsTreeNodeOfType<"JSXOpeningElement">,
+  scopes: ScopeAnalysis,
+  settings: Readonly<Record<string, unknown>> | undefined,
+): boolean => {
+  const possibilities = getContentEditablePossibilities(node, scopes);
+  if (!possibilities?.canBeEnabled) return false;
+  return !hasDefinitelyEnabledContentEditableAncestor(node, scopes, settings);
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/can-content-editable-be-tabbable.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/can-content-editable-be-tabbable.ts
@@ -11,6 +11,7 @@ import { stripParenExpression } from "./strip-paren-expression.js";
 interface ContentEditablePossibilities {
   canBeDisabled: boolean;
   canBeEnabled: boolean;
+  canBeInherited: boolean;
 }
 
 const ENABLED_CONTENT_EDITABLE_VALUES: ReadonlySet<string> = new Set([
@@ -22,16 +23,25 @@ const ENABLED_CONTENT_EDITABLE_VALUES: ReadonlySet<string> = new Set([
 const ENABLED_CONTENT_EDITABLE: ContentEditablePossibilities = {
   canBeDisabled: false,
   canBeEnabled: true,
+  canBeInherited: false,
 };
 
 const DISABLED_CONTENT_EDITABLE: ContentEditablePossibilities = {
   canBeDisabled: true,
   canBeEnabled: false,
+  canBeInherited: false,
+};
+
+const INHERITED_CONTENT_EDITABLE: ContentEditablePossibilities = {
+  canBeDisabled: false,
+  canBeEnabled: false,
+  canBeInherited: true,
 };
 
 const UNKNOWN_CONTENT_EDITABLE: ContentEditablePossibilities = {
   canBeDisabled: true,
   canBeEnabled: true,
+  canBeInherited: true,
 };
 
 const mergeContentEditablePossibilities = (
@@ -40,6 +50,7 @@ const mergeContentEditablePossibilities = (
 ): ContentEditablePossibilities => ({
   canBeDisabled: left.canBeDisabled || right.canBeDisabled,
   canBeEnabled: left.canBeEnabled || right.canBeEnabled,
+  canBeInherited: left.canBeInherited || right.canBeInherited,
 });
 
 const resolveContentEditableExpression = (
@@ -53,11 +64,15 @@ const resolveContentEditableExpression = (
       return expression.value ? ENABLED_CONTENT_EDITABLE : DISABLED_CONTENT_EDITABLE;
     }
     if (typeof expression.value === "string") {
-      return ENABLED_CONTENT_EDITABLE_VALUES.has(expression.value.toLowerCase())
-        ? ENABLED_CONTENT_EDITABLE
-        : DISABLED_CONTENT_EDITABLE;
+      const contentEditableValue = expression.value.toLowerCase();
+      if (ENABLED_CONTENT_EDITABLE_VALUES.has(contentEditableValue)) {
+        return ENABLED_CONTENT_EDITABLE;
+      }
+      return contentEditableValue === "false"
+        ? DISABLED_CONTENT_EDITABLE
+        : INHERITED_CONTENT_EDITABLE;
     }
-    return DISABLED_CONTENT_EDITABLE;
+    return INHERITED_CONTENT_EDITABLE;
   }
   if (isNodeOfType(expression, "ConditionalExpression")) {
     return mergeContentEditablePossibilities(
@@ -102,9 +117,21 @@ const hasDefinitelyEnabledContentEditableAncestor = (
   while (ancestor) {
     if (isNodeOfType(ancestor, "JSXElement")) {
       const openingElement = ancestor.openingElement;
-      if (HTML_TAGS.has(getElementType(openingElement, settings))) {
-        const possibilities = getContentEditablePossibilities(openingElement, scopes);
-        if (possibilities?.canBeEnabled && !possibilities.canBeDisabled) return true;
+      if (!HTML_TAGS.has(getElementType(openingElement, settings))) return false;
+      const possibilities = getContentEditablePossibilities(openingElement, scopes);
+      if (possibilities) {
+        if (
+          possibilities.canBeEnabled &&
+          !possibilities.canBeDisabled &&
+          !possibilities.canBeInherited
+        ) {
+          return true;
+        }
+        const isDefinitelyInherited =
+          possibilities.canBeInherited &&
+          !possibilities.canBeDisabled &&
+          !possibilities.canBeEnabled;
+        if (!isDefinitelyInherited) return false;
       }
     }
     ancestor = ancestor.parent;


### PR DESCRIPTION
<!-- motivation-example:start -->
## Motivation

An enabled root editing host is already keyboard-focusable. Recommending an unconditional `tabIndex={0}` for conditional `contentEditable` can make the intentionally disabled state tabbable.

## Example

This chat editor is focusable whenever editing is enabled:

```tsx
<div
  role="textbox"
  contentEditable={!isRunning}
  onKeyDown={handleKeyDown}
/>
```

Exact `contentEditable={false}` and statically nested editing hosts still need the diagnostic.
<!-- motivation-example:end -->

## Why

A real Datastoria chat editor uses `role="textbox"` with conditional `contentEditable={!isRunning}` and native key/input handlers. React Doctor says keyboard users cannot tab to it, but a root editing host is already sequentially focusable when enabled. Adding unconditional `tabIndex={0}` would also make the deliberately disabled branch tabbable.

Before:

```tsx
<div
  role="textbox"
  contentEditable={!isRunning}
  onKeyDown={handleKeyDown}
/>
```

The inverse needed protection too: exact `contentEditable={false}` and statically nested editing hosts are not tabbable and must keep reporting.

## What changed

- Shares one content-editable tabbability predicate between `interactive-supports-focus` and `aria-activedescendant-has-tabindex`.
- Resolves boolean/string literals, conditionals, transparent wrappers, and direct const aliases.
- Treats invalid/inherited values as non-editing-host values.
- Keeps nested editing hosts reportable when a statically enabled intrinsic ancestor proves they are excluded from sequential tab order.
- Stays conservative when either the host or ancestor can vary dynamically.
- Adds paired rule regressions, a permanent fuzz regression seed, generator pool coverage, and a patch changeset.

## Exact React Bench validation

- Repository: `FrankChen021/datastoria`
- Pinned SHA: `07b31bdccc1ad26f4badc0bb83265737057525b9`
- Job: `write-react-frankchen021-datasto__GC3spRj`
- File: `src/components/chat/input/chat-input.tsx`
- Baseline: 2 `interactive-supports-focus` findings (separator + false textbox finding)
- Candidate: 1 finding (the unrelated separator only)
- Model and oracle patches do not modify the editor file; its SHA-256 is identical in base/model/oracle, and the candidate remains at 1 finding in all three states.

## Validation

- `nr --filter oxlint-plugin-react-doctor test` — 14,022 passed, 181 skipped
- `nr --filter oxlint-plugin-react-doctor typecheck` — passed
- `nr lint` — passed with pre-existing warnings only
- `nr format:check` — passed
- `nr --filter @react-doctor/fuzz test` — 44 passed, 402 skipped
- `FUZZ_RULE=interactive-supports-focus FUZZ_STRICT=1 FUZZ_ITERATIONS=500 FUZZ_PRINT_STATS=1 nr --filter @react-doctor/fuzz fuzz --reporter=verbose` — passed; target fired in 21 of 333 executed programs
- Final `truffler` searches found no duplicate helper.

RDE local was attempted against 100 manifest rows, but the current harness stalled at 0 completed rows for five minutes. That run is invalid evidence and is not presented as a pass.

## Draft status

Implementation and deterministic validation are complete. This remains draft for CI and review babysitting.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared a11y exemption logic for two rules; behavior is nuanced around nesting and dynamic props, though coverage is extensive via regressions and fuzz.
> 
> **Overview**
> Fixes **`interactive-supports-focus`** false positives on `role="textbox"` (and similar) elements that are already keyboard-focusable when **`contentEditable`** can be enabled at runtime—e.g. `contentEditable={!isRunning}`—without suggesting **`tabIndex={0}`** that would wrongly tab-stop the disabled branch.
> 
> Introduces shared **`canContentEditableBeTabbable`**, used by **`interactive-supports-focus`** and **`aria-activedescendant-has-tabindex`** (replacing the older inline **`mayBeContentEditable`** check). The helper resolves literals, conditionals, const aliases, and walks intrinsic **`contentEditable`** ancestors: nested hosts under a **statically** enabled ancestor still report; **dynamic** or blocked boundaries stay conservative (no false negatives).
> 
> Regression tests, a fuzz corpus seed, fuzz snippet pools, and a patch changeset cover the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 392fc644ceee99bde9c772a7185124107a454e38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->