### PR TITLE
fix(no-reset-all-state-on-prop-change): trace async loading helpers

### DIFF
--- a/.changeset/huge-mirrors-throw.md
+++ b/.changeset/huge-mirrors-throw.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Fix `no-reset-all-state-on-prop-change` false positives for loading state completed by an exact async helper.

--- a/packages/fuzz/corpus/regressions/no-reset-all-state-on-prop-change--async-loading-helper.tsx
+++ b/packages/fuzz/corpus/regressions/no-reset-all-state-on-prop-change--async-loading-helper.tsx
@@ -1,0 +1,25 @@
+// rule: no-reset-all-state-on-prop-change
+// weakness: control-flow
+// source: React Bench Lobe UI Spline loading lifecycle
+import { useEffect, useState } from "react";
+
+interface SplineProps {
+  load: (scene: string) => Promise<void>;
+  scene: string;
+}
+
+export const Spline = ({ load, scene }: SplineProps) => {
+  const [isLoading, setIsLoading] = useState(true);
+
+  const initialize = async () => {
+    await load(scene);
+    setIsLoading(false);
+  };
+
+  useEffect(() => {
+    setIsLoading(true);
+    void initialize();
+  }, [scene]);
+
+  return <canvas hidden={isLoading} />;
+};

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -94,6 +94,7 @@ export const STATE_SNIPPET_POOL = [
   `const [internalValue, setInternalValue] = useState(value); useEffect(() => { setInternalValue(value); }, [value]);`,
   `const [previousValue, setPreviousValue] = useState(Boolean(value)); useEffect(() => { setPreviousValue(Boolean(value)); }, [value]);`,
   `const [resetDraft, setResetDraft] = useState(""); useEffect(() => { setResetDraft(""); }, [value]);`,
+  `const [fuzzLoading, setFuzzLoading] = useState(true); const loadFuzzValue = async () => { await Promise.resolve(value); setFuzzLoading(false); }; useEffect(() => { setFuzzLoading(true); void loadFuzzValue(); }, [value]);`,
   `const FuzzHiddenResetMenu = ({ visible }) => { const [open, setOpen] = useState(false); useEffect(() => { setOpen(false); }, [visible]); return visible && open && <div role="menu">Menu</div>; }; const fuzzHiddenResetMenuNode = <FuzzHiddenResetMenu visible={condition} />;`,
   `const FuzzOpaqueVisibilityPanel = ({ visible, isAllowed }) => { const [canShowPanel, setCanShowPanel] = useState(true); useEffect(() => { setCanShowPanel(true); }, [visible]); return visible && isAllowed() && canShowPanel && <output onClick={() => setCanShowPanel(false)}>Panel</output>; }; const fuzzOpaqueVisibilityPanelNode = <FuzzOpaqueVisibilityPanel visible={condition} isAllowed={() => condition} />;`,
   `const [reducerState, dispatch] = useReducer(reducer, { count: 0 });`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-reset-all-state-on-prop-change.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-reset-all-state-on-prop-change.regressions.test.ts
@@ -3,6 +3,28 @@ import { runRule } from "../../../test-utils/run-rule.js";
 import { noResetAllStateOnPropChange } from "./no-reset-all-state-on-prop-change.js";
 
 describe("no-reset-all-state-on-prop-change — regressions", () => {
+  it("stays silent for an extracted async loading lifecycle helper", () => {
+    const result = runRule(
+      noResetAllStateOnPropChange,
+      `import { useEffect, useState } from "react";
+      const Spline = ({ load, scene }) => {
+        const [isLoading, setIsLoading] = useState(true);
+        const initialize = async () => {
+          await load(scene);
+          setIsLoading(false);
+        };
+        useEffect(() => {
+          setIsLoading(true);
+          void initialize();
+        }, [scene]);
+        return <canvas hidden={isLoading} />;
+      };`,
+      { forceJsx: true },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   // excalidraw ToolPopover: the setter only runs inside an event-subscription
   // callback registered by the effect, so state resets when the emitter
   // fires — not when the `app` prop changes.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-reset-all-state-on-prop-change.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-reset-all-state-on-prop-change.regressions.test.ts
@@ -25,6 +25,134 @@ describe("no-reset-all-state-on-prop-change — regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("stays silent for the authentic conditionally started loading helper shape", () => {
+    const result = runRule(
+      noResetAllStateOnPropChange,
+      `import { useEffect, useRef, useState } from "react";
+      const Spline = ({ createApplication, onLoad, scene }) => {
+        const canvasRef = useRef(null);
+        const [isLoading, setIsLoading] = useState(true);
+        const initialize = async (application, events) => {
+          await application.load(scene);
+          for (const event of events) application.addEventListener(event.name, event.callback);
+          setIsLoading(false);
+          onLoad?.(application);
+        };
+        useEffect(() => {
+          setIsLoading(true);
+          const events = [{ callback: onLoad, name: "load" }];
+          if (canvasRef.current) {
+            const application = createApplication(canvasRef.current);
+            void initialize(application, events);
+          }
+        }, [scene]);
+        return <canvas ref={canvasRef} hidden={isLoading} />;
+      };`,
+      { forceJsx: true },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it.each([
+    [
+      "a function declaration",
+      `async function initialize() { await load(scene); setIsLoading(false); }
+      useEffect(() => { setIsLoading(true); initialize(); }, [scene]);`,
+    ],
+    [
+      "an immutable helper alias chain",
+      `const initialize = async () => { await load(scene); setIsLoading(false); };
+      const initializeAlias = initialize;
+      const runInitialize = initializeAlias;
+      useEffect(() => { setIsLoading(true); void (runInitialize as typeof initialize)(); }, [scene]);`,
+    ],
+  ])("stays silent through %s", (_label, lifecycle) => {
+    const result = runRule(
+      noResetAllStateOnPropChange,
+      `import { useEffect, useState } from "react";
+      const Spline = ({ load, scene }) => {
+        const [isLoading, setIsLoading] = useState(true);
+        ${lifecycle}
+        return <canvas hidden={isLoading} />;
+      };`,
+      { forceJsx: true },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it.each([
+    [
+      "the helper is only passed to a timer",
+      `const initialize = async () => { await load(scene); setIsLoading(false); };
+      useEffect(() => { setIsLoading(true); setTimeout(initialize, 0); }, [scene]);`,
+    ],
+    [
+      "the helper is never invoked",
+      `const initialize = async () => { await load(scene); setIsLoading(false); };
+      useEffect(() => { setIsLoading(true); void initialize; }, [scene]);`,
+    ],
+    [
+      "the helper writes before its await",
+      `const initialize = async () => { setIsLoading(false); await load(scene); };
+      useEffect(() => { setIsLoading(true); void initialize(); }, [scene]);`,
+    ],
+    [
+      "the await is conditional",
+      `const initialize = async () => { if (shouldLoad) await load(scene); setIsLoading(false); };
+      useEffect(() => { setIsLoading(true); void initialize(); }, [scene]);`,
+    ],
+    [
+      "the post-await setter belongs to different state",
+      `const initialize = async () => { await load(scene); setResult(scene); };
+      useEffect(() => { setIsLoading(true); void initialize(); }, [scene]);`,
+    ],
+    [
+      "the helper call is itself deferred",
+      `const initialize = async () => { await load(scene); setIsLoading(false); };
+      useEffect(() => { setIsLoading(true); queueMicrotask(() => initialize()); }, [scene]);`,
+    ],
+    [
+      "the post-await setter is trapped in an uninvoked nested function",
+      `const initialize = async () => {
+        await load(scene);
+        const finish = () => setIsLoading(false);
+        void finish;
+      };
+      useEffect(() => { setIsLoading(true); void initialize(); }, [scene]);`,
+    ],
+    [
+      "the helper call is unreachable",
+      `const initialize = async () => { await load(scene); setIsLoading(false); };
+      useEffect(() => { setIsLoading(true); return; initialize(); }, [scene]);`,
+    ],
+    [
+      "the post-await setter is unreachable",
+      `const initialize = async () => { await load(scene); return; setIsLoading(false); };
+      useEffect(() => { setIsLoading(true); void initialize(); }, [scene]);`,
+    ],
+    [
+      "the helper binding is reassigned",
+      `let initialize = async () => { await load(scene); setIsLoading(false); };
+      initialize = async () => load(scene);
+      useEffect(() => { setIsLoading(true); void initialize(); }, [scene]);`,
+    ],
+  ])("still reports when %s", (_label, lifecycle) => {
+    const result = runRule(
+      noResetAllStateOnPropChange,
+      `import { useEffect, useState } from "react";
+      const Spline = ({ load, scene, setResult, shouldLoad }) => {
+        const [isLoading, setIsLoading] = useState(true);
+        ${lifecycle}
+        return <canvas hidden={isLoading} />;
+      };`,
+      { forceJsx: true },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   // excalidraw ToolPopover: the setter only runs inside an event-subscription
   // callback registered by the effect, so state resets when the emitter
   // fires — not when the `app` prop changes.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-reset-all-state-on-prop-change.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-reset-all-state-on-prop-change.ts
@@ -6,11 +6,14 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
 import { getDirectConstInitializer } from "../../utils/get-direct-const-initializer.js";
+import { getRangeStart } from "../../utils/get-range-start.js";
 import { hasEnclosingTypeParameterNamed } from "../../utils/has-enclosing-type-parameter-named.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
+import { isNodeReachableWithinFunction } from "../../utils/is-node-reachable-within-function.js";
 import { isOutsideAllFunctions } from "../../utils/is-outside-all-functions.js";
 import { isReactApiCall } from "../../utils/is-react-api-call.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { resolveExactLocalFunction } from "../../utils/resolve-exact-local-function.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import { walkAst } from "../../utils/walk-ast.js";
@@ -799,6 +802,76 @@ const countUseStates = (analysis: ProgramAnalysis, componentNode: EsTreeNode | n
   return stateVariables.size;
 };
 
+const hasUnconditionalAwaitBefore = (
+  functionNode: EsTreeNode,
+  boundaryNode: EsTreeNode,
+  context: RuleContext,
+): boolean => {
+  const boundaryStart = getRangeStart(boundaryNode);
+  if (boundaryStart === null) return false;
+  let didFindAwait = false;
+  walkAst(functionNode, (child) => {
+    if (didFindAwait) return false;
+    if (child !== functionNode && isFunctionLike(child)) return false;
+    if (
+      !isNodeOfType(child, "AwaitExpression") ||
+      !isNodeReachableWithinFunction(child, context) ||
+      !context.cfg.isUnconditionalFromEntry(child)
+    ) {
+      return;
+    }
+    const awaitStart = getRangeStart(child);
+    if (awaitStart !== null && awaitStart < boundaryStart) {
+      didFindAwait = true;
+      return false;
+    }
+  });
+  return didFindAwait;
+};
+
+const helperReloadsSetterAfterAwait = (
+  analysis: ProgramAnalysis,
+  context: RuleContext,
+  helperFunction: EsTreeNode,
+  setterReference: Reference,
+): boolean =>
+  getDownstreamRefs(analysis, helperFunction).some((helperReference) => {
+    if (!setterReference.resolved || helperReference.resolved !== setterReference.resolved) {
+      return false;
+    }
+    const helperSetterCall = getCallExpr(helperReference);
+    return Boolean(
+      helperSetterCall &&
+      findEnclosingFunction(helperSetterCall) === helperFunction &&
+      isNodeReachableWithinFunction(helperSetterCall, context) &&
+      hasUnconditionalAwaitBefore(helperFunction, helperSetterCall, context),
+    );
+  });
+
+const effectInvokesAsyncSetterReloadHelper = (
+  analysis: ProgramAnalysis,
+  context: RuleContext,
+  effectReferences: ReadonlyArray<Reference>,
+  effectFunction: EsTreeNode,
+  setterReference: Reference,
+): boolean =>
+  effectReferences.some((effectReference) => {
+    const helperCall = getCallExpr(effectReference);
+    if (
+      !isNodeOfType(helperCall, "CallExpression") ||
+      findEnclosingFunction(helperCall) !== effectFunction ||
+      !isNodeReachableWithinFunction(helperCall, context)
+    ) {
+      return false;
+    }
+    const helperFunction = resolveExactLocalFunction(helperCall.callee, context.scopes);
+    return Boolean(
+      helperFunction &&
+      helperFunction !== effectFunction &&
+      helperReloadsSetterAfterAwait(analysis, context, helperFunction, setterReference),
+    );
+  });
+
 const getStateSymbolForSetter = (
   analysis: ProgramAnalysis,
   context: RuleContext,
@@ -1179,14 +1252,16 @@ const findPropUsedToResetAllState = (
   // state is set again from an async continuation inside this effect (the
   // real value arrives later; cleanup cancels stale requests) — freecut
   // inline-source-preview / inline-composition-preview in the delta audit.
-  const isEveryResetReloadedAsync = stateSetterRefs.every((setterRef) =>
-    effectFnRefs.some(
-      (otherRef) =>
-        otherRef !== setterRef &&
-        otherRef.resolved === setterRef.resolved &&
-        Boolean(getCallExpr(otherRef)) &&
-        !isSyncStateSetterCall(analysis, otherRef, effectFn),
-    ),
+  const isEveryResetReloadedAsync = stateSetterRefs.every(
+    (setterRef) =>
+      effectFnRefs.some(
+        (otherRef) =>
+          otherRef !== setterRef &&
+          otherRef.resolved === setterRef.resolved &&
+          Boolean(getCallExpr(otherRef)) &&
+          !isSyncStateSetterCall(analysis, otherRef, effectFn),
+      ) ||
+      effectInvokesAsyncSetterReloadHelper(analysis, context, effectFnRefs, effectFn, setterRef),
   );
   if (isEveryResetReloadedAsync) return null;
 


### PR DESCRIPTION
<!-- motivation-example:start -->
## Motivation

A loading flag set before an async operation and cleared after it is one lifecycle, not an all-state reset caused by a prop change. The rule understood the inline form but lost that relationship when completion moved into a local helper.

## Example

The helper completes the same loading lifecycle started by the effect:

```tsx
const initialize = async () => {
  await load(scene)
  setIsLoading(false)
}

useEffect(() => {
  setIsLoading(true)
  void initialize()
}, [scene])
```
<!-- motivation-example:end -->

## Why

A real Lobe UI loading lifecycle is reported as an all-state reset when its async completion is extracted into a local helper.

```tsx
const initialize = async () => {
  await load(scene)
  setIsLoading(false)
}

useEffect(() => {
  setIsLoading(true)
  void initialize()
}, [scene])
```

The same setter starts and completes one loading lifecycle. The rule already exempts inline async completion of the same setter, but loses that setter identity across the helper invocation boundary. The extracted and inline forms produce the same recorded React sequence: `a:true → a:false → b:true → b:false`.

Grounding:

- React Bench trial: `write-react-lobehub-lobe-ui-508__F6Q7Cj7`
- Pinned repository: `lobehub/lobe-ui@4a5a6dfdfb438ac657cd123b20da743892f71623`
- Authentic source: `src/awesome/Spline/Spine.tsx:51`
- Stored 0.7.4 before/after reports both contain the unchanged target finding in the unrelated reward-one Accordion task.

## What changed

The rule now follows an exact local helper directly invoked from the effect and associates a reachable call to the same setter with a preceding reachable, unconditional `await` in that helper. This extends the rule's existing existence-based inline async-reload contract through one statically exact invocation edge.

The implementation reuses `resolveExactLocalFunction` and the existing scope, reference, CFG, and reachability utilities. It adds paired controls for function declarations, immutable alias chains, conditional direct invocation, authentic post-load work, timers, uninvoked helpers, pre-await writes, conditional awaits, different setters, deferred calls, nested functions, unreachable calls/setters, and reassigned bindings.

## Precision boundary

Only exact same-file helpers reached through immutable bindings qualify. Imported, reassigned, merely referenced, callback-deferred, unreachable, pre-await-only, conditional-await-only, nested-uninvoked, and different-setter shapes retain the diagnostic. A direct helper call may itself be conditionally reached, matching the authentic Spline lifecycle and the rule's existing existence-based inline exemption.

## Validation

- `nr --filter oxlint-plugin-react-doctor test`: 559 files passed; 14,025 passed and 181 skipped
- `nr --filter oxlint-plugin-react-doctor typecheck`: passed
- `nr --filter @react-doctor/fuzz test`: 44 passed and 402 skipped
- `nr --filter @react-doctor/fuzz typecheck`: passed
- `FUZZ_RULE=no-reset-all-state-on-prop-change FUZZ_STRICT=1 FUZZ_ITERATIONS=500 FUZZ_PRINT_STATS=1 FUZZ_PRINT_SILENT=1 nr fuzz --reporter=verbose`: passed; 339 executed, 39 fired, target fire coverage 1/1
- `nr lint`: passed with existing repository warnings
- `nr typecheck`: 15/15 tasks passed
- `nr format:check`: passed
- `git diff --check`: passed
- local changed-scope React Doctor scan: 0 diagnostics, no scan error
- post-implementation truffler searches found no duplicate helper

Pinned React Bench audit with inline suppressions neutralized:

| Tree | Baseline target | Candidate target | Added | Removed | Scan errors |
| --- | ---: | ---: | ---: | ---: | ---: |
| Base | 1 | 0 | 0 | 1 intended FP | 0 |
| Model patch | 1 | 0 | 0 | 1 intended FP | 0 |
| Oracle patch | 1 | 0 | 0 | 1 intended FP | 0 |

The ordinary current CLI scan respects the source's inline directive, so audit mode is the relevant raw-detector comparison. Across all three pinned trees, the removed Spline diagnostic is the only baseline/candidate delta.

Local RDE was attempted with 100 requested projects but is invalid evidence: the harness produced 0 records, spawned no repository workers after setup, and was timeboxed after more than four minutes. It is not counted as a pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-rule precision change with broad regression tests; narrows false positives without relaxing unrelated reset detection paths.
> 
> **Overview**
> **`no-reset-all-state-on-prop-change`** no longer treats prop-driven loading flags as “reset all state” when completion lives in a **same-file async helper** the effect calls directly (e.g. `setIsLoading(true)` then `void initialize()` where `initialize` awaits and clears loading).
> 
> The rule’s existing inline async-reload exemption is extended by resolving **exact local functions** via `resolveExactLocalFunction`, requiring a **reachable** helper call from the effect, and confirming the **same setter** runs **after an unconditional `await`** in that helper (CFG/reachability helpers).
> 
> Regression and fuzz coverage add the Lobe UI Spline shape, positive/negative helper variants (timers, deferred calls, reassigned bindings, wrong setter, etc.), a fuzz corpus snippet, and a changeset patch note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36a93eeccfc91135ea0bf9378757d7526ed3b564. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->