### PR TITLE
fix(iframe-has-title): honor accessibility applicability

### DIFF
--- a/.changeset/easy-melons-lead.md
+++ b/.changeset/easy-melons-lead.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Align iframe-has-title with the accessibility rule's applicability boundary by ignoring frames proven hidden, excluded from sequential focus, or explicitly decorative while preserving diagnostics for uncertain and visible frames.

--- a/packages/fuzz/corpus/regressions/iframe-has-title--hidden-thumbnail.tsx
+++ b/packages/fuzz/corpus/regressions/iframe-has-title--hidden-thumbnail.tsx
@@ -1,0 +1,8 @@
+// rule: iframe-has-title
+// weakness: control-flow
+// source: React Bench Open Design hidden live-artifact thumbnail
+export const LiveArtifactThumbnail = () => (
+  <div aria-hidden className="design-card-thumb">
+    <iframe src="/preview" title="" tabIndex={-1} />
+  </div>
+);

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -448,6 +448,7 @@ export const JSX_LEAF_POOL = [
   `<video autoPlay />`,
   `<marquee>{state}</marquee>`,
   `<iframe src={url} />`,
+  `<div aria-hidden><iframe src={url} title="" tabIndex={-1} /></div>`,
   `<time>{new Date(value).toLocaleString()}</time>`,
   `<span>{new Intl.DateTimeFormat().format(state)}</span>`,
   `<time>{new Intl.DateTimeFormat("en-US", localeOptionsAlias).format(new Date(value))}</time>`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/iframe-has-title.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/iframe-has-title.regressions.test.ts
@@ -16,13 +16,13 @@ describe("a11y/iframe-has-title regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
-  it("still reports a visible unnamed preview iframe", () => {
+  it("allows a visible unnamed iframe with a negative tab index", () => {
     const result = runRule(
       iframeHasTitle,
       `const Preview = () => <iframe src="/preview" title="" tabIndex={-1} />;`,
     );
 
-    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics).toEqual([]);
   });
 
   it("still reports when the ancestor hidden state is dynamic", () => {
@@ -36,5 +36,227 @@ describe("a11y/iframe-has-title regressions", () => {
     );
 
     expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("allows an unnamed iframe with a statically hidden direct state", () => {
+    const result = runRule(
+      iframeHasTitle,
+      `const Preview = () => <iframe aria-hidden="true" src="/preview" title="" />;`,
+    );
+
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still reports when the iframe hidden state is statically false", () => {
+    const result = runRule(
+      iframeHasTitle,
+      `const Preview = () => <iframe aria-hidden={false} src="/preview" title="" />;`,
+    );
+
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still reports when the iframe hidden state is dynamic", () => {
+    const result = runRule(
+      iframeHasTitle,
+      `const Preview = ({ isHidden }) => (
+        <iframe aria-hidden={isHidden} src="/preview" title="" />
+      );`,
+    );
+
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("keeps direct hidden state conservative around spreads", () => {
+    const provenHidden = runRule(
+      iframeHasTitle,
+      `const Preview = (props) => <iframe {...props} aria-hidden src="/preview" title="" />;`,
+    );
+    const possiblyVisible = runRule(
+      iframeHasTitle,
+      `const Preview = (props) => <iframe aria-hidden {...props} src="/preview" title="" />;`,
+    );
+
+    expect(provenHidden.diagnostics).toEqual([]);
+    expect(possiblyVisible.diagnostics).toHaveLength(1);
+  });
+
+  it.each([
+    [`tabIndex="-2"`, "a negative string tab index"],
+    [`tabIndex={-3}`, "a negative expression tab index"],
+    [`{...props} tabIndex={-1}`, "a negative tab index after a spread"],
+  ])("allows an unnamed iframe with %s", (attributes) => {
+    const result = runRule(
+      iframeHasTitle,
+      `const Preview = (props) => <iframe src="/preview" title="" ${attributes} />;`,
+    );
+
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it.each([
+    [`tabIndex={0}`, "a zero tab index"],
+    [`tabIndex={1}`, "a positive tab index"],
+    [`tabIndex={tabIndex}`, "a dynamic tab index"],
+    [`tabIndex={isHidden ? -1 : 0}`, "a conditional tab index"],
+    [`tabIndex={-1} {...props}`, "a later spread that can override the negative tab index"],
+  ])("still reports an unnamed iframe with %s", (attributes) => {
+    const result = runRule(
+      iframeHasTitle,
+      `const Preview = (props) => <iframe src="/preview" title="" ${attributes} />;`,
+    );
+
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it.each(["none", "presentation", "none button", "invalid presentation"])(
+    "allows an unnamed iframe with the decorative %s role",
+    (role) => {
+      const result = runRule(
+        iframeHasTitle,
+        `const Preview = () => <iframe src="/preview" title="" role="${role}" />;`,
+      );
+
+      expect(result.diagnostics).toEqual([]);
+    },
+  );
+
+  it("still reports when the first valid role token is not decorative", () => {
+    const result = runRule(
+      iframeHasTitle,
+      `const Preview = () => <iframe src="/preview" title="" role="button none" />;`,
+    );
+
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("allows a decorative role that follows an unknown spread", () => {
+    const result = runRule(
+      iframeHasTitle,
+      `const Preview = (props) => (
+        <iframe {...props} src="/preview" title="" role="presentation" />
+      );`,
+    );
+
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it.each([
+    [`role="application"`, "a non-decorative role"],
+    [`role={role}`, "a dynamic role"],
+    [`role={isDecorative ? "none" : "application"}`, "a mixed conditional role"],
+    [`role="none" {...props}`, "a later spread that can override the decorative role"],
+  ])("still reports an unnamed iframe with %s", (attributes) => {
+    const result = runRule(
+      iframeHasTitle,
+      `const Preview = (props) => <iframe src="/preview" title="" ${attributes} />;`,
+    );
+
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not inherit a decorative role from an ancestor", () => {
+    const result = runRule(
+      iframeHasTitle,
+      `const Preview = () => <div role="presentation"><iframe src="/preview" title="" /></div>;`,
+    );
+
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("allows a hidden ancestor through fragments and conditional children", () => {
+    const result = runRule(
+      iframeHasTitle,
+      `const Preview = ({ show }) => (
+        <section aria-hidden="true">
+          <>{show && <div><iframe src="/preview" /></div>}</>
+        </section>
+      );`,
+    );
+
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("allows an iframe supplied through an intrinsic children prop", () => {
+    const result = runRule(
+      iframeHasTitle,
+      `const Preview = () => (
+        <div aria-hidden="true" children={<iframe src="/preview" title="" />} />
+      );`,
+    );
+
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not inherit hidden state through an opaque component boundary", () => {
+    const result = runRule(
+      iframeHasTitle,
+      `const Preview = () => (
+        <div aria-hidden="true">
+          <PortalTarget><iframe src="/preview" title="" /></PortalTarget>
+        </div>
+      );`,
+    );
+
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("allows a configured iframe component inside a hidden host subtree", () => {
+    const result = runRule(
+      iframeHasTitle,
+      `const Preview = () => (
+        <div aria-hidden="true"><Frame src="/preview" title="" /></div>
+      );`,
+      { settings: { "jsx-a11y": { components: { Frame: "iframe" } } } },
+    );
+
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not treat a configured host-like component as a proven DOM ancestor", () => {
+    const result = runRule(
+      iframeHasTitle,
+      `const Preview = () => (
+        <HiddenRegion aria-hidden="true"><iframe src="/preview" title="" /></HiddenRegion>
+      );`,
+      { settings: { "jsx-a11y": { components: { HiddenRegion: "div" } } } },
+    );
+
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not inherit hidden state through a non-children prop", () => {
+    const result = runRule(
+      iframeHasTitle,
+      `const Preview = () => (
+        <div aria-hidden="true">
+          <PortalTarget content={<iframe src="/preview" title="" />} />
+        </div>
+      );`,
+    );
+
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not inherit hidden state through a portal call", () => {
+    const result = runRule(
+      iframeHasTitle,
+      `const Preview = () => (
+        <div aria-hidden="true">
+          {createPortal(<iframe src="/preview" title="" />, document.body)}
+        </div>
+      );`,
+    );
+
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("keeps a visible titled iframe quiet", () => {
+    const result = runRule(
+      iframeHasTitle,
+      `const Preview = () => <iframe src="/preview" title="Design preview" />;`,
+    );
+
+    expect(result.diagnostics).toEqual([]);
   });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/iframe-has-title.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/iframe-has-title.regressions.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { iframeHasTitle } from "./iframe-has-title.js";
+
+describe("a11y/iframe-has-title regressions", () => {
+  it("allows an unnamed preview iframe inside a statically hidden subtree", () => {
+    const result = runRule(
+      iframeHasTitle,
+      `const Preview = () => (
+        <div className="design-card-thumb" aria-hidden>
+          <iframe src="/preview" title="" loading="lazy" sandbox="allow-scripts" tabIndex={-1} />
+        </div>
+      );`,
+    );
+
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still reports a visible unnamed preview iframe", () => {
+    const result = runRule(
+      iframeHasTitle,
+      `const Preview = () => <iframe src="/preview" title="" tabIndex={-1} />;`,
+    );
+
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still reports when the ancestor hidden state is dynamic", () => {
+    const result = runRule(
+      iframeHasTitle,
+      `const Preview = ({ isHidden }) => (
+        <div aria-hidden={isHidden}>
+          <iframe src="/preview" title="" />
+        </div>
+      );`,
+    );
+
+    expect(result.diagnostics).toHaveLength(1);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/iframe-has-title.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/iframe-has-title.regressions.test.ts
@@ -177,6 +177,36 @@ describe("a11y/iframe-has-title regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it.each(["Fragment", "React.Fragment"])(
+    "allows a hidden ancestor through the named fragment %s",
+    (fragmentName) => {
+      const result = runRule(
+        iframeHasTitle,
+        `const Preview = () => (
+          <section aria-hidden="true">
+            <${fragmentName}><iframe src="/preview" /></${fragmentName}>
+          </section>
+        );`,
+      );
+
+      expect(result.diagnostics).toEqual([]);
+    },
+  );
+
+  it("does not treat a locally bound Fragment component as transparent", () => {
+    const result = runRule(
+      iframeHasTitle,
+      `const Fragment = ({ children }) => <PortalTarget>{children}</PortalTarget>;
+      const Preview = () => (
+        <section aria-hidden="true">
+          <Fragment><iframe src="/preview" /></Fragment>
+        </section>
+      );`,
+    );
+
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("allows an iframe supplied through an intrinsic children prop", () => {
     const result = runRule(
       iframeHasTitle,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/iframe-has-title.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/iframe-has-title.ts
@@ -1,15 +1,121 @@
 import { defineRule } from "../../utils/define-rule.js";
+import { PRESENTATION_ROLES, VALID_ARIA_ROLES } from "../../constants/aria-roles.js";
+import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { getAuthoritativeJsxAttribute } from "../../utils/get-authoritative-jsx-attribute.js";
 import { getElementType } from "../../utils/get-element-type.js";
+import { getJsxPropStaticStringValues } from "../../utils/get-jsx-prop-static-string-values.js";
 import { getStaticTemplateLiteralValue } from "../../utils/get-static-template-literal-value.js";
 import { hasJsxPropIgnoreCase } from "../../utils/has-jsx-prop-ignore-case.js";
+import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { parseJsxValue } from "../../utils/parse-jsx-value.js";
 
 const MESSAGE =
   "Screen reader users cannot identify this `<iframe>` because it has no title. Add a `title` that describes its content.";
 
 type StaticVerdict = "ok" | "empty" | "dynamic-ok";
+
+const isStaticallyAriaHidden = (openingElement: EsTreeNodeOfType<"JSXOpeningElement">): boolean => {
+  const ariaHiddenAttribute = getAuthoritativeJsxAttribute(
+    openingElement.attributes,
+    "aria-hidden",
+    false,
+  );
+  if (!ariaHiddenAttribute) return false;
+  if (!ariaHiddenAttribute.value) return true;
+  const value = ariaHiddenAttribute.value;
+  if (isNodeOfType(value, "Literal")) {
+    return value.value === true || value.value === "true";
+  }
+  if (!isNodeOfType(value, "JSXExpressionContainer")) return false;
+  return (
+    isNodeOfType(value.expression, "Literal") &&
+    (value.expression.value === true || value.expression.value === "true")
+  );
+};
+
+const hasStaticallyNegativeTabIndex = (
+  openingElement: EsTreeNodeOfType<"JSXOpeningElement">,
+): boolean => {
+  const tabIndexAttribute = getAuthoritativeJsxAttribute(
+    openingElement.attributes,
+    "tabIndex",
+    false,
+  );
+  if (!tabIndexAttribute) return false;
+  const value = tabIndexAttribute.value;
+  if (
+    value &&
+    isNodeOfType(value, "JSXExpressionContainer") &&
+    isNodeOfType(value.expression, "ConditionalExpression") &&
+    !isNodeOfType(value.expression.test, "Literal")
+  ) {
+    return false;
+  }
+  const tabIndexValue = parseJsxValue(value);
+  return tabIndexValue !== null && tabIndexValue < 0;
+};
+
+const hasStaticallyDecorativeRole = (
+  openingElement: EsTreeNodeOfType<"JSXOpeningElement">,
+  scopes: ScopeAnalysis,
+): boolean => {
+  const roleAttribute = getAuthoritativeJsxAttribute(openingElement.attributes, "role", false);
+  if (!roleAttribute) return false;
+  const roleCandidates = getJsxPropStaticStringValues(roleAttribute, scopes);
+  return (
+    roleCandidates !== null &&
+    roleCandidates.length > 0 &&
+    roleCandidates.every((roleCandidate) => {
+      const firstValidRole = roleCandidate
+        .split(/\s+/)
+        .find((roleToken) => VALID_ARIA_ROLES.has(roleToken));
+      return firstValidRole !== undefined && PRESENTATION_ROLES.has(firstValidRole);
+    })
+  );
+};
+
+const isInsideStaticallyHiddenJsxSubtree = (
+  openingElement: EsTreeNodeOfType<"JSXOpeningElement">,
+): boolean => {
+  if (isStaticallyAriaHidden(openingElement)) return true;
+
+  let ancestor = openingElement.parent?.parent;
+  while (ancestor) {
+    if (isNodeOfType(ancestor, "JSXAttribute")) {
+      const isChildrenAttribute =
+        isNodeOfType(ancestor.name, "JSXIdentifier") && ancestor.name.name === "children";
+      if (!isChildrenAttribute) return false;
+    }
+
+    if (isNodeOfType(ancestor, "JSXElement")) {
+      const ancestorName = ancestor.openingElement.name;
+      if (!isNodeOfType(ancestorName, "JSXIdentifier")) return false;
+      const firstCharacter = ancestorName.name[0];
+      const isIntrinsicElement = firstCharacter === firstCharacter?.toLowerCase();
+      if (!isIntrinsicElement) return false;
+      if (isStaticallyAriaHidden(ancestor.openingElement)) return true;
+    }
+
+    if (
+      isNodeOfType(ancestor, "CallExpression") ||
+      isNodeOfType(ancestor, "NewExpression") ||
+      isNodeOfType(ancestor, "VariableDeclarator") ||
+      isNodeOfType(ancestor, "AssignmentExpression") ||
+      isNodeOfType(ancestor, "Property") ||
+      isFunctionLike(ancestor) ||
+      isNodeOfType(ancestor, "Program")
+    ) {
+      return false;
+    }
+
+    ancestor = ancestor.parent;
+  }
+
+  return false;
+};
 
 const evaluateTitleValue = (value: EsTreeNode | null | undefined): StaticVerdict | "missing" => {
   if (!value) return "missing";
@@ -55,6 +161,9 @@ export const iframeHasTitle = defineRule({
     JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
       const tag = getElementType(node, context.settings);
       if (tag !== "iframe") return;
+      if (isInsideStaticallyHiddenJsxSubtree(node)) return;
+      if (hasStaticallyNegativeTabIndex(node)) return;
+      if (hasStaticallyDecorativeRole(node, context.scopes)) return;
       // Spread attribute → can't statically verify; flag.
       const hasSpread = node.attributes.some((attribute) =>
         isNodeOfType(attribute as EsTreeNode, "JSXSpreadAttribute"),

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/iframe-has-title.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/iframe-has-title.ts
@@ -9,6 +9,7 @@ import { getJsxPropStaticStringValues } from "../../utils/get-jsx-prop-static-st
 import { getStaticTemplateLiteralValue } from "../../utils/get-static-template-literal-value.js";
 import { hasJsxPropIgnoreCase } from "../../utils/has-jsx-prop-ignore-case.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
+import { isJsxFragmentElement } from "../../utils/is-jsx-fragment-element.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { parseJsxValue } from "../../utils/parse-jsx-value.js";
 
@@ -79,6 +80,7 @@ const hasStaticallyDecorativeRole = (
 
 const isInsideStaticallyHiddenJsxSubtree = (
   openingElement: EsTreeNodeOfType<"JSXOpeningElement">,
+  scopes: ScopeAnalysis,
 ): boolean => {
   if (isStaticallyAriaHidden(openingElement)) return true;
 
@@ -90,7 +92,10 @@ const isInsideStaticallyHiddenJsxSubtree = (
       if (!isChildrenAttribute) return false;
     }
 
-    if (isNodeOfType(ancestor, "JSXElement")) {
+    if (
+      isNodeOfType(ancestor, "JSXElement") &&
+      !isJsxFragmentElement(ancestor.openingElement, scopes)
+    ) {
       const ancestorName = ancestor.openingElement.name;
       if (!isNodeOfType(ancestorName, "JSXIdentifier")) return false;
       const firstCharacter = ancestorName.name[0];
@@ -161,7 +166,7 @@ export const iframeHasTitle = defineRule({
     JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
       const tag = getElementType(node, context.settings);
       if (tag !== "iframe") return;
-      if (isInsideStaticallyHiddenJsxSubtree(node)) return;
+      if (isInsideStaticallyHiddenJsxSubtree(node, context.scopes)) return;
       if (hasStaticallyNegativeTabIndex(node)) return;
       if (hasStaticallyDecorativeRole(node, context.scopes)) return;
       // Spread attribute → can't statically verify; flag.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/react-markdown-unsanitized-raw-html.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/react-markdown-unsanitized-raw-html.ts
@@ -2,6 +2,7 @@ import type { ScopeAnalysis, SymbolDescriptor } from "../../semantic/scope-analy
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { getAuthoritativeJsxAttribute } from "../../utils/get-authoritative-jsx-attribute.js";
 import { getImportedName } from "../../utils/get-imported-name.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { resolveConstIdentifierAlias } from "../../utils/resolve-const-identifier-alias.js";
@@ -163,24 +164,6 @@ const collectPluginEntries = (
   return entries;
 };
 
-const findEffectiveExplicitAttribute = (
-  attributes: EsTreeNode[],
-  attributeName: string,
-): EsTreeNodeOfType<"JSXAttribute"> | null => {
-  for (let attributeIndex = attributes.length - 1; attributeIndex >= 0; attributeIndex -= 1) {
-    const attribute = attributes[attributeIndex];
-    if (!attribute || isNodeOfType(attribute, "JSXSpreadAttribute")) return null;
-    if (
-      isNodeOfType(attribute, "JSXAttribute") &&
-      isNodeOfType(attribute.name, "JSXIdentifier") &&
-      attribute.name.name === attributeName
-    ) {
-      return attribute;
-    }
-  }
-  return null;
-};
-
 const getAttributeExpression = (attribute: EsTreeNodeOfType<"JSXAttribute">): EsTreeNode | null => {
   if (!isNodeOfType(attribute.value, "JSXExpressionContainer")) return null;
   return isNodeOfType(attribute.value.expression, "JSXEmptyExpression")
@@ -270,7 +253,7 @@ const hasDynamicUnsanitizedChildren = (
       return !isStaticOrSanitizedMarkdownExpression(child.expression, scopes, new Set());
     });
   }
-  const childrenAttribute = findEffectiveExplicitAttribute(openingElement.attributes, "children");
+  const childrenAttribute = getAuthoritativeJsxAttribute(openingElement.attributes, "children");
   if (!childrenAttribute) return false;
   const childrenExpression = getAttributeExpression(childrenAttribute);
   return Boolean(
@@ -288,7 +271,7 @@ export const reactMarkdownUnsanitizedRawHtml = defineRule({
   create: skipNonProductionFiles((context) => ({
     JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
       if (!isReactMarkdownComponent(node.name, context.scopes)) return;
-      const pluginsAttribute = findEffectiveExplicitAttribute(node.attributes, "rehypePlugins");
+      const pluginsAttribute = getAuthoritativeJsxAttribute(node.attributes, "rehypePlugins");
       if (!pluginsAttribute) return;
       const pluginsExpression = getAttributeExpression(pluginsAttribute);
       if (!pluginsExpression) return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-authoritative-jsx-attribute.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-authoritative-jsx-attribute.ts
@@ -1,0 +1,21 @@
+import type { EsTreeNode } from "./es-tree-node.js";
+import type { EsTreeNodeOfType } from "./es-tree-node-of-type.js";
+import { getJsxAttributeName } from "./get-jsx-attribute-name.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+
+export const getAuthoritativeJsxAttribute = (
+  attributes: ReadonlyArray<EsTreeNode>,
+  targetName: string,
+  isCaseSensitive = true,
+): EsTreeNodeOfType<"JSXAttribute"> | null => {
+  const normalizedTargetName = isCaseSensitive ? targetName : targetName.toLowerCase();
+  for (let attributeIndex = attributes.length - 1; attributeIndex >= 0; attributeIndex -= 1) {
+    const attribute = attributes[attributeIndex];
+    if (!attribute || isNodeOfType(attribute, "JSXSpreadAttribute")) return null;
+    if (!isNodeOfType(attribute, "JSXAttribute")) continue;
+    const attributeName = getJsxAttributeName(attribute.name);
+    const normalizedAttributeName = isCaseSensitive ? attributeName : attributeName?.toLowerCase();
+    if (normalizedAttributeName === normalizedTargetName) return attribute;
+  }
+  return null;
+};


### PR DESCRIPTION
<!-- motivation-example:start -->
## Motivation

The iframe-title requirement does not apply when an iframe is provably absent from the accessibility tree, non-tabbable, or decorative. Reporting hidden thumbnail frames creates work without improving accessibility.

## Example

This preview iframe is intentionally unavailable to assistive technology and keyboard navigation:

```tsx
<div aria-hidden="true">
  <iframe src={previewUrl} tabIndex={-1} />
</div>
```

Visible, dynamic, or otherwise applicable unnamed iframes remain reportable.
<!-- motivation-example:end -->

## Why

React Doctor reports Open Design's unnamed thumbnail iframes even though they are excluded from the accessibility rule's applicability boundary. The authentic frames are inside a statically `aria-hidden` host subtree and have `tabIndex={-1}`.

Exact reproduction: `nexu-io/open-design@52611c07dbf922b775d813d6af1323c40fe20a52`, `apps/web/src/components/DesignsTab.tsx:625` and `:793`, React Bench job `fix-react-nexu-io-open-design-41__apJMibA`. The benchmark patch does not touch this file. Its SHA-256 is identical in the pinned base, model, and oracle states: `351cf765f5edacfa9cdd96eeaa2a66a10610ec05ed25be347ba188a5d588ca4c`.

The W3C ACT rule excludes iframes that are absent from the accessibility tree, have a negative `tabindex`, or are explicitly decorative: https://www.w3.org/WAI/standards-guidelines/act/rules/cae760/proposed/

## What changed

- Ignore unnamed iframes proven to be inside statically `aria-hidden` intrinsic JSX ancestry.
- Stop hiddenness proof at component, portal/call, function, property, assignment, and non-`children` prop boundaries.
- Ignore directly negative `tabIndex` and roles whose first valid ARIA token is `none` or `presentation`.
- Keep dynamic, mixed, spread-overridden, visible, non-decorative, and opaque cases reportable.
- Add paired/adversarial rule tests, a permanent fuzz regression, and a generator seed.
- Reuse one spread-order-aware JSX attribute helper in this rule and the existing React Markdown security rule.

## Validation

- Full plugin suite: 560 files passed; 14,045 tests passed and 181 skipped.
- Root typecheck: 15/15 tasks passed.
- Root lint: passed with only pre-existing warnings; no changed-file findings.
- Format check and `git diff --check`: passed.
- Fuzz corpus: 44 passed, 402 skipped.
- Strict fuzz: `FUZZ_RULE=iframe-has-title FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz` passed; target rule fired in 107 of 397 executed programs.
- Exact base/model/oracle scans: all three scans completed across three projects. `DesignsTab.tsx` changed from two target findings on current main to zero on this branch in every state. The unrelated visible finding in `IframeKeepAlivePool.tsx:352` remains reported in every state.
- Post-change truffler searches found no duplicate helper; an identical reverse-scan helper in the React Markdown rule was consolidated.

## RDE limitation

The local 100-repository RDE attempt produced zero completed roots because the shared eval harness was contended by concurrent/stale local runs. That is invalid evidence, not a pass. The exact pinned React Bench base/model/oracle comparison above completed successfully.

## Commits

- `2a135e1d0` adds the failing authentic-shape regression first.
- `e377f9326` implements the bounded fix and validation coverage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-only accessibility rule tightening with conservative static analysis; visible and uncertain cases still report, backed by extensive tests.
> 
> **Overview**
> Aligns **`iframe-has-title`** with W3C ACT applicability so unnamed iframes are not flagged when they are provably out of scope for assistive tech.
> 
> The rule now **skips** reporting when an iframe is inside a statically **`aria-hidden`** intrinsic JSX subtree (walking through fragments and `children` props, but stopping at components, portals, and opaque boundaries), has a **statically negative `tabIndex`**, or carries a **decorative** `role` (`none` / `presentation`). Dynamic or spread-overridden cases still warn.
> 
> Adds shared **`getAuthoritativeJsxAttribute`** (last explicit attribute before any spread) and uses it in **`react-markdown-unsanitized-raw-html`** in place of a local duplicate. Coverage includes a large regression suite, a fuzz corpus case, and a fuzz snippet seed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0133ba27b6f9b3696bc798e154093f693401d7d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->