### PR TITLE
fix(nextjs-no-css-link): ignore remote stylesheets

### DIFF
--- a/.changeset/lovely-hotels-sneeze.md
+++ b/.changeset/lovely-hotels-sneeze.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Prevent nextjs-no-css-link from recommending local CSS imports for statically proven remote HTTP(S) stylesheets.

--- a/packages/fuzz/corpus/regressions/nextjs-no-css-link--remote-stylesheet.tsx
+++ b/packages/fuzz/corpus/regressions/nextjs-no-css-link--remote-stylesheet.tsx
@@ -1,0 +1,7 @@
+// rule: nextjs-no-css-link
+// weakness: library-idiom
+// source: React Bench fix-react-rdh-sofn-xyz-mailing-s__SFDAGxN
+
+export const DocumentHead = () => (
+  <link rel="stylesheet" href="https://use.typekit.net/fih5ejy.css" />
+);

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -434,6 +434,8 @@ export const JSX_LEAF_POOL = [
   `<DynamicChart width={typeof window === "undefined" ? 0 : window.innerWidth} />`,
   `<a href={url}></a>`,
   `<a href="#">click here</a>`,
+  `<link rel="stylesheet" href="/styles.css" />`,
+  `<link rel="stylesheet" href="https://cdn.example.com/theme.css" />`,
   `<button onClick={handleClick}>Click here…</button>`,
   `<div onClick={condition ? undefined : () => setIsOpen(true)}>{!condition && <Button aria-label="Open" onPress={() => setIsOpen(true)}>Open</Button>}</div>`,
   `<button>Submit — now...</button>`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-no-css-link.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-no-css-link.regressions.test.ts
@@ -15,10 +15,69 @@ describe("nextjs/nextjs-no-css-link — remote stylesheets", () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it.each([
+    `href="http://cdn.example.com/theme.css"`,
+    `href="HTTPS://cdn.example.com/theme.css"`,
+    `href={"https://cdn.example.com/theme.css"}`,
+    "href={`https://cdn.example.com/theme.css`}",
+  ])("stays quiet on a statically proven remote stylesheet: %s", (hrefAttribute) => {
+    const result = runRule(
+      nextjsNoCssLink,
+      `export const DocumentHead = () => <link rel="stylesheet" ${hrefAttribute} />;`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when every statically known href branch is remote", () => {
+    const result = runRule(
+      nextjsNoCssLink,
+      `export const DocumentHead = ({ usePrimary }) => (
+        <link
+          rel="stylesheet"
+          href={usePrimary ? "https://cdn.example.com/primary.css" : "https://cdn.example.com/fallback.css"}
+        />
+      );`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet on a const alias of a remote stylesheet", () => {
+    const result = runRule(
+      nextjsNoCssLink,
+      `const themeUrl = "https://cdn.example.com/theme.css";
+      export const DocumentHead = () => <link rel="stylesheet" href={themeUrl} />;`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("still reports a local stylesheet that Next.js can bundle", () => {
     const result = runRule(
       nextjsNoCssLink,
       `export const DocumentHead = () => <link rel="stylesheet" href="/styles.css" />;`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it.each([
+    `href="styles.css"`,
+    `href="./styles.css"`,
+    `href="//cdn.example.com/theme.css"`,
+    `href={themeUrl}`,
+    `href={useRemote ? "https://cdn.example.com/theme.css" : "/styles.css"}`,
+  ])("remains conservative when the href is not proven HTTP(S): %s", (hrefAttribute) => {
+    const result = runRule(
+      nextjsNoCssLink,
+      `export const DocumentHead = ({ themeUrl, useRemote }) => (
+        <link rel="stylesheet" ${hrefAttribute} />
+      );`,
     );
 
     expect(result.parseErrors).toEqual([]);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-no-css-link.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-no-css-link.regressions.test.ts
@@ -56,6 +56,30 @@ describe("nextjs/nextjs-no-css-link — remote stylesheets", () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("still reports when a later spread can override a remote href", () => {
+    const result = runRule(
+      nextjsNoCssLink,
+      `export const DocumentHead = ({ linkProps }) => (
+        <link rel="stylesheet" href="https://cdn.example.com/theme.css" {...linkProps} />
+      );`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays quiet when an explicit remote href follows a spread", () => {
+    const result = runRule(
+      nextjsNoCssLink,
+      `export const DocumentHead = ({ linkProps }) => (
+        <link rel="stylesheet" {...linkProps} href="https://cdn.example.com/theme.css" />
+      );`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("still reports a local stylesheet that Next.js can bundle", () => {
     const result = runRule(
       nextjsNoCssLink,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-no-css-link.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-no-css-link.regressions.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { nextjsNoCssLink } from "./nextjs-no-css-link.js";
+
+describe("nextjs/nextjs-no-css-link — remote stylesheets", () => {
+  it("stays quiet on the authentic Mailing Typekit stylesheet", () => {
+    const result = runRule(
+      nextjsNoCssLink,
+      `export const DocumentHead = () => (
+        <link rel="stylesheet" href="https://use.typekit.net/fih5ejy.css" />
+      );`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still reports a local stylesheet that Next.js can bundle", () => {
+    const result = runRule(
+      nextjsNoCssLink,
+      `export const DocumentHead = () => <link rel="stylesheet" href="/styles.css" />;`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-no-css-link.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-no-css-link.ts
@@ -1,5 +1,6 @@
 import { defineRule } from "../../utils/define-rule.js";
 import { findJsxAttribute } from "../../utils/find-jsx-attribute.js";
+import { getAuthoritativeJsxAttribute } from "../../utils/get-authoritative-jsx-attribute.js";
 import { getJsxPropStaticStringValues } from "../../utils/get-jsx-prop-static-string-values.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
@@ -28,9 +29,12 @@ export const nextjsNoCssLink = defineRule({
         : null;
       if (relValue !== "stylesheet") return;
 
-      const hrefAttribute = findJsxAttribute(attributes, "href");
-      if (!hrefAttribute?.value) return;
-      const hrefCandidates = getJsxPropStaticStringValues(hrefAttribute, context.scopes);
+      const declaredHrefAttribute = findJsxAttribute(attributes, "href");
+      if (!declaredHrefAttribute?.value) return;
+      const authoritativeHrefAttribute = getAuthoritativeJsxAttribute(attributes, "href");
+      const hrefCandidates = authoritativeHrefAttribute
+        ? getJsxPropStaticStringValues(authoritativeHrefAttribute, context.scopes)
+        : null;
       if (
         hrefCandidates !== null &&
         hrefCandidates.length > 0 &&

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-no-css-link.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-no-css-link.ts
@@ -1,10 +1,12 @@
-import { GOOGLE_FONTS_PATTERN } from "../../constants/nextjs.js";
 import { defineRule } from "../../utils/define-rule.js";
 import { findJsxAttribute } from "../../utils/find-jsx-attribute.js";
+import { getJsxPropStaticStringValues } from "../../utils/get-jsx-prop-static-string-values.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { resolveJsxElementType } from "../../utils/resolve-jsx-element-type.js";
+
+const HTTP_STYLESHEET_URL_PATTERN = /^https?:\/\//i;
 
 export const nextjsNoCssLink = defineRule({
   id: "nextjs-no-css-link",
@@ -28,10 +30,14 @@ export const nextjsNoCssLink = defineRule({
 
       const hrefAttribute = findJsxAttribute(attributes, "href");
       if (!hrefAttribute?.value) return;
-      const hrefValue = isNodeOfType(hrefAttribute.value, "Literal")
-        ? hrefAttribute.value.value
-        : null;
-      if (typeof hrefValue === "string" && GOOGLE_FONTS_PATTERN.test(hrefValue)) return;
+      const hrefCandidates = getJsxPropStaticStringValues(hrefAttribute, context.scopes);
+      if (
+        hrefCandidates !== null &&
+        hrefCandidates.length > 0 &&
+        hrefCandidates.every((hrefCandidate) => HTTP_STYLESHEET_URL_PATTERN.test(hrefCandidate))
+      ) {
+        return;
+      }
 
       context.report({
         node,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/react-markdown-unsanitized-raw-html.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/react-markdown-unsanitized-raw-html.ts
@@ -2,6 +2,7 @@ import type { ScopeAnalysis, SymbolDescriptor } from "../../semantic/scope-analy
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { getAuthoritativeJsxAttribute } from "../../utils/get-authoritative-jsx-attribute.js";
 import { getImportedName } from "../../utils/get-imported-name.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { resolveConstIdentifierAlias } from "../../utils/resolve-const-identifier-alias.js";
@@ -163,24 +164,6 @@ const collectPluginEntries = (
   return entries;
 };
 
-const findEffectiveExplicitAttribute = (
-  attributes: EsTreeNode[],
-  attributeName: string,
-): EsTreeNodeOfType<"JSXAttribute"> | null => {
-  for (let attributeIndex = attributes.length - 1; attributeIndex >= 0; attributeIndex -= 1) {
-    const attribute = attributes[attributeIndex];
-    if (!attribute || isNodeOfType(attribute, "JSXSpreadAttribute")) return null;
-    if (
-      isNodeOfType(attribute, "JSXAttribute") &&
-      isNodeOfType(attribute.name, "JSXIdentifier") &&
-      attribute.name.name === attributeName
-    ) {
-      return attribute;
-    }
-  }
-  return null;
-};
-
 const getAttributeExpression = (attribute: EsTreeNodeOfType<"JSXAttribute">): EsTreeNode | null => {
   if (!isNodeOfType(attribute.value, "JSXExpressionContainer")) return null;
   return isNodeOfType(attribute.value.expression, "JSXEmptyExpression")
@@ -270,7 +253,7 @@ const hasDynamicUnsanitizedChildren = (
       return !isStaticOrSanitizedMarkdownExpression(child.expression, scopes, new Set());
     });
   }
-  const childrenAttribute = findEffectiveExplicitAttribute(openingElement.attributes, "children");
+  const childrenAttribute = getAuthoritativeJsxAttribute(openingElement.attributes, "children");
   if (!childrenAttribute) return false;
   const childrenExpression = getAttributeExpression(childrenAttribute);
   return Boolean(
@@ -288,7 +271,7 @@ export const reactMarkdownUnsanitizedRawHtml = defineRule({
   create: skipNonProductionFiles((context) => ({
     JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
       if (!isReactMarkdownComponent(node.name, context.scopes)) return;
-      const pluginsAttribute = findEffectiveExplicitAttribute(node.attributes, "rehypePlugins");
+      const pluginsAttribute = getAuthoritativeJsxAttribute(node.attributes, "rehypePlugins");
       if (!pluginsAttribute) return;
       const pluginsExpression = getAttributeExpression(pluginsAttribute);
       if (!pluginsExpression) return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-authoritative-jsx-attribute.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-authoritative-jsx-attribute.ts
@@ -1,0 +1,21 @@
+import type { EsTreeNode } from "./es-tree-node.js";
+import type { EsTreeNodeOfType } from "./es-tree-node-of-type.js";
+import { getJsxAttributeName } from "./get-jsx-attribute-name.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+
+export const getAuthoritativeJsxAttribute = (
+  attributes: ReadonlyArray<EsTreeNode>,
+  targetName: string,
+  isCaseSensitive = true,
+): EsTreeNodeOfType<"JSXAttribute"> | null => {
+  const normalizedTargetName = isCaseSensitive ? targetName : targetName.toLowerCase();
+  for (let attributeIndex = attributes.length - 1; attributeIndex >= 0; attributeIndex -= 1) {
+    const attribute = attributes[attributeIndex];
+    if (!attribute || isNodeOfType(attribute, "JSXSpreadAttribute")) return null;
+    if (!isNodeOfType(attribute, "JSXAttribute")) continue;
+    const attributeName = getJsxAttributeName(attribute.name);
+    const normalizedAttributeName = isCaseSensitive ? attributeName : attributeName?.toLowerCase();
+    if (normalizedAttributeName === normalizedTargetName) return attribute;
+  }
+  return null;
+};


### PR DESCRIPTION
<!-- motivation-example:start -->
## Motivation

Next.js can bundle local stylesheets, but it cannot turn a third-party HTTP(S) stylesheet into a local CSS import. Recommending that migration for a remote asset is inapplicable.

## Example

This Typekit stylesheet is intentionally remote and should not trigger `nextjs-no-css-link`:

```tsx
<link rel="stylesheet" href="https://use.typekit.net/fih5ejy.css" />
```

Local, relative, protocol-relative, dynamic, and mixed candidates continue to report.
<!-- motivation-example:end -->

## Why

React Bench reproduced `nextjs-no-css-link` on `sofn-xyz/mailing@90af52dd9d67089430be485449858b95322f9fca` at `packages/cli/src/pages/_document.tsx:29`:

```tsx
<link rel="stylesheet" href="https://use.typekit.net/fih5ejy.css" />
```

The rule recommended importing that CSS locally so Next.js could bundle it. That recommendation is inapplicable to a remote Typekit asset. The official Next.js `no-css-tags` detector likewise excludes literal HTTP(S) stylesheet URLs.

The model and oracle patches do not touch `_document.tsx`; the same source blob exists in the pinned base, model, and oracle states. React Doctor 0.7.4 reports the same diagnostic before and after the task patch, so this is a preexisting false positive rather than trial reward causality.

## What changed

- Exempt a stylesheet only when every statically resolved `href` candidate is an HTTP(S) URL.
- Reuse the existing JSX static-string resolver, including const aliases and conditional branches.
- Keep reporting local, relative, protocol-relative, dynamic, and mixed remote/local values.
- Add paired rule regressions, the exact React Bench seed, generated positive and negative fuzz shapes, and a patch changeset.

## Exact comparison

| Pinned state | Baseline | Candidate | Scan status |
| --- | ---: | ---: | --- |
| base `90af52dd9d67089430be485449858b95322f9fca` | 1 | 0 | complete |
| model patch | 1 | 0 | complete |
| oracle patch | 1 | 0 | complete |

All three `_document.tsx` files have blob `5558cd29f605504b39657c79d5720db67d583eeb`. Candidate control cases report local, dynamic, and protocol-relative hrefs while staying quiet on the exact remote URL.

## Validation

- Full oxlint-plugin test run: 560 files, 14,024 passed, 181 skipped
- `nr --filter oxlint-plugin-react-doctor typecheck`
- `nr --filter @react-doctor/fuzz test`: 44 passed, 402 skipped
- `nr --filter @react-doctor/fuzz typecheck`
- `FUZZ_RULE=nextjs-no-css-link FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz`
- Target-fire audit: 8 firing programs across 323 executed programs; zero findings
- `nr build`
- `nr lint` (warnings only from existing files)
- `nr format:check`
- `git diff --check`
- Post-change `truffler` duplicate search
- `nlx react-doctor@latest --verbose --scope changed`

Root `nr typecheck` remains blocked by the unrelated existing `packages/language-server/src/diagnostics/mapper.ts:103` severity typing error; both changed packages typecheck independently.

A fresh 100-repository local RDE attempt produced 0 rows and never launched workers, so it was terminated and is explicitly not counted as passing evidence.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-rule precision change with conservative fallbacks when href cannot be proven remote; no runtime or auth/data-path changes.
> 
> **Overview**
> Fixes false positives where **`nextjs-no-css-link`** told teams to import third-party stylesheets locally (e.g. Typekit URLs) even though Next.js cannot bundle remote HTTP(S) assets.
> 
> The rule now resolves the **authoritative** `href` (last explicit attribute, invalidated by a trailing spread) and skips the diagnostic only when **every** statically known `href` candidate matches `http://` or `https://`. Local, relative, protocol-relative, dynamic, and mixed remote/local hrefs still report. The old Google Fonts–only literal check is removed in favor of this pattern.
> 
> A shared **`getAuthoritativeJsxAttribute`** helper replaces duplicated “effective attribute” logic in **`react-markdown-unsanitized-raw-html`**. Coverage adds rule regressions, a fuzz corpus seed, and local/remote `<link>` snippets in fuzz pools.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cbdbd44016dd6aa9eef7f94c761dbce6ab320b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->