### PR TITLE
fix(rn-no-falsy-and-render): respect DOM host ancestry

### DIFF
--- a/.changeset/brave-signs-clean.md
+++ b/.changeset/brave-signs-clean.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Keep rn-no-falsy-and-render scoped to numeric gates rendered through React Native or unknown hosts, excluding proven DOM-host output in mixed-renderer projects.

--- a/packages/fuzz/corpus/regressions/rn-no-falsy-and-render--dom-host.tsx
+++ b/packages/fuzz/corpus/regressions/rn-no-falsy-and-render--dom-host.tsx
@@ -1,0 +1,16 @@
+// rule: rn-no-falsy-and-render
+// weakness: renderer-provenance
+// source: React Bench Rozenite web panel CookieCard
+import { Text, View } from "react-native";
+
+interface CookieCountProps {
+  itemCount: number;
+}
+
+export const WebCookieCount = ({ itemCount }: CookieCountProps) => (
+  <div>{itemCount && <span>Items</span>}</div>
+);
+
+export const NativeCookieCount = ({ itemCount }: CookieCountProps) => (
+  <View>{itemCount && <Text>Items</Text>}</View>
+);

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -411,6 +411,8 @@ export const JSX_LEAF_POOL = [
   `{condition && <em>maybe</em>}`,
   `{items.length && <span>has items</span>}`,
   `{items.length > 0 && <span>has items</span>}`,
+  `<div>{items.length && <span>has items</span>}</div>`,
+  `<View>{items.length && <Text>has items</Text>}</View>`,
   `{loading ? <span>Loading…</span> : <span>{String(state)}</span>}`,
   `{error && <span role="alert">{String(error)}</span>}`,
   `{...items}`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-falsy-and-render.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-falsy-and-render.regressions.test.ts
@@ -25,6 +25,8 @@ const CookieCard = ({ cookie }: CookieCardProps) => (
     `<div>{itemCount && <span>Items</span>}</div>`,
     `<svg>{itemCount && <text>Items</text>}</svg>`,
     `<div><>{itemCount && <span>Items</span>}</></div>`,
+    `<div><Fragment>{itemCount && <span>Items</span>}</Fragment></div>`,
+    `<div><React.Fragment>{itemCount && <span>Items</span>}</React.Fragment></div>`,
     `<div children={itemCount && <span>Items</span>} />`,
     `createPortal(<div>{itemCount && <span>Items</span>}</div>, document.body)`,
   ])("stays silent when the numeric gate reaches a proven DOM host: %s", (renderedValue) => {
@@ -58,6 +60,18 @@ const Card = ({ itemCount }) => ${renderedValue};`,
       rnNoFalsyAndRender,
       `const Card = ({ itemCount }) => <Panel>{itemCount && <span>Items</span>}</Panel>;`,
       { settings: { "jsx-a11y": { components: { Panel: "div" } } } },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not treat a locally bound Fragment component as transparent", () => {
+    const result = runRule(
+      rnNoFalsyAndRender,
+      `const Fragment = ({ children }) => <Panel>{children}</Panel>;
+      const Card = ({ itemCount }) => (
+        <div><Fragment>{itemCount && <span>Items</span>}</Fragment></div>
+      );`,
     );
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toHaveLength(1);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-falsy-and-render.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-falsy-and-render.regressions.test.ts
@@ -21,6 +21,48 @@ const CookieCard = ({ cookie }: CookieCardProps) => (
     expect(result.diagnostics).toEqual([]);
   });
 
+  it.each([
+    `<div>{itemCount && <span>Items</span>}</div>`,
+    `<svg>{itemCount && <text>Items</text>}</svg>`,
+    `<div><>{itemCount && <span>Items</span>}</></div>`,
+    `<div children={itemCount && <span>Items</span>} />`,
+    `createPortal(<div>{itemCount && <span>Items</span>}</div>, document.body)`,
+  ])("stays silent when the numeric gate reaches a proven DOM host: %s", (renderedValue) => {
+    const result = runRule(rnNoFalsyAndRender, `const Card = ({ itemCount }) => ${renderedValue};`);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it.each([
+    `<View>{itemCount && <Text>Items</Text>}</View>`,
+    `<NativeView>{itemCount && <NativeText>Items</NativeText>}</NativeView>`,
+    `<>{itemCount && <Text>Items</Text>}</>`,
+    `<Panel>{itemCount && <span>Items</span>}</Panel>`,
+    `<div><Panel>{itemCount && <span>Items</span>}</Panel></div>`,
+    `createPortal(<>{itemCount && <span>Items</span>}</>, document.body)`,
+    `<div content={<>{itemCount && <span>Items</span>}</>} />`,
+    `<List renderItem={() => <>{itemCount && <Text>Items</Text>}</>} />`,
+    `<mesh>{itemCount && <group />}</mesh>`,
+  ])("retains unknown or React Native renderer positives: %s", (renderedValue) => {
+    const result = runRule(
+      rnNoFalsyAndRender,
+      `import { Text, View, Text as NativeText, View as NativeView } from "react-native";
+const Card = ({ itemCount }) => ${renderedValue};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not treat a configured custom component as intrinsic DOM proof", () => {
+    const result = runRule(
+      rnNoFalsyAndRender,
+      `const Card = ({ itemCount }) => <Panel>{itemCount && <span>Items</span>}</Panel>;`,
+      { settings: { "jsx-a11y": { components: { Panel: "div" } } } },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("stays silent on a boolean useState named with a numeric-sounding word", () => {
     const result = runRule(
       rnNoFalsyAndRender,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-falsy-and-render.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-falsy-and-render.regressions.test.ts
@@ -3,6 +3,24 @@ import { runRule } from "../../../test-utils/run-rule.js";
 import { rnNoFalsyAndRender } from "./rn-no-falsy-and-render.js";
 
 describe("react-native/rn-no-falsy-and-render — regressions", () => {
+  it("stays silent on a numeric gate rendered inside a DOM host", () => {
+    const result = runRule(
+      rnNoFalsyAndRender,
+      `interface CookieCardProps {
+  cookie: { maxAge?: string };
+}
+const CookieCard = ({ cookie }: CookieCardProps) => (
+  <div className="grid">
+    {cookie.maxAge && (
+      <div><span>Max-Age:</span> {cookie.maxAge}</div>
+    )}
+  </div>
+);`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("stays silent on a boolean useState named with a numeric-sounding word", () => {
     const result = runRule(
       rnNoFalsyAndRender,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-falsy-and-render.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-falsy-and-render.ts
@@ -1,6 +1,7 @@
 import { defineRule } from "../../utils/define-rule.js";
 import { HTML_TAGS } from "../../constants/html-tags.js";
 import { SVG_TAGS } from "../../constants/svg-tags.js";
+import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
 import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
 import { isConstDeclaredBinding } from "../../utils/is-const-declared-binding.js";
 import { hasDirective } from "../../utils/has-directive.js";
@@ -11,6 +12,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
+import { isJsxFragmentElement } from "../../utils/is-jsx-fragment-element.js";
 
 const COMPARISON_OPERATORS = new Set(["===", "!==", "==", "!=", "<", "<=", ">", ">="]);
 
@@ -196,7 +198,7 @@ const isLikelyNumericExpression = (node: EsTreeNode): boolean => {
   return false;
 };
 
-const isRenderedInsideIntrinsicDomHost = (node: EsTreeNode): boolean => {
+const isRenderedInsideIntrinsicDomHost = (node: EsTreeNode, scopes: ScopeAnalysis): boolean => {
   let ancestor = node.parent;
   while (ancestor) {
     if (isNodeOfType(ancestor, "JSXAttribute")) {
@@ -205,7 +207,10 @@ const isRenderedInsideIntrinsicDomHost = (node: EsTreeNode): boolean => {
       if (!isChildrenAttribute) return false;
     }
 
-    if (isNodeOfType(ancestor, "JSXElement")) {
+    if (
+      isNodeOfType(ancestor, "JSXElement") &&
+      !isJsxFragmentElement(ancestor.openingElement, scopes)
+    ) {
       const elementName = ancestor.openingElement.name;
       if (!isNodeOfType(elementName, "JSXIdentifier")) return false;
       return HTML_TAGS.has(elementName.name) || SVG_TAGS.has(elementName.name);
@@ -265,7 +270,7 @@ export const rnNoFalsyAndRender = defineRule({
           isNodeOfType(parent, "JSXExpressionContainer") ||
           (isNodeOfType(parent, "LogicalExpression") && parent.operator === "&&");
         if (!isInsideJsx) return;
-        if (isRenderedInsideIntrinsicDomHost(node)) return;
+        if (isRenderedInsideIntrinsicDomHost(node, context.scopes)) return;
 
         const left = node.left;
         if (!left) return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-falsy-and-render.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-falsy-and-render.ts
@@ -1,4 +1,6 @@
 import { defineRule } from "../../utils/define-rule.js";
+import { HTML_TAGS } from "../../constants/html-tags.js";
+import { SVG_TAGS } from "../../constants/svg-tags.js";
 import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
 import { isConstDeclaredBinding } from "../../utils/is-const-declared-binding.js";
 import { hasDirective } from "../../utils/has-directive.js";
@@ -8,6 +10,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { isFunctionLike } from "../../utils/is-function-like.js";
 
 const COMPARISON_OPERATORS = new Set(["===", "!==", "==", "!=", "<", "<=", ">", ">="]);
 
@@ -193,6 +196,39 @@ const isLikelyNumericExpression = (node: EsTreeNode): boolean => {
   return false;
 };
 
+const isRenderedInsideIntrinsicDomHost = (node: EsTreeNode): boolean => {
+  let ancestor = node.parent;
+  while (ancestor) {
+    if (isNodeOfType(ancestor, "JSXAttribute")) {
+      const isChildrenAttribute =
+        isNodeOfType(ancestor.name, "JSXIdentifier") && ancestor.name.name === "children";
+      if (!isChildrenAttribute) return false;
+    }
+
+    if (isNodeOfType(ancestor, "JSXElement")) {
+      const elementName = ancestor.openingElement.name;
+      if (!isNodeOfType(elementName, "JSXIdentifier")) return false;
+      return HTML_TAGS.has(elementName.name) || SVG_TAGS.has(elementName.name);
+    }
+
+    if (
+      isNodeOfType(ancestor, "CallExpression") ||
+      isNodeOfType(ancestor, "NewExpression") ||
+      isNodeOfType(ancestor, "VariableDeclarator") ||
+      isNodeOfType(ancestor, "AssignmentExpression") ||
+      isNodeOfType(ancestor, "Property") ||
+      isFunctionLike(ancestor) ||
+      isNodeOfType(ancestor, "Program")
+    ) {
+      return false;
+    }
+
+    ancestor = ancestor.parent;
+  }
+
+  return false;
+};
+
 // HACK: `{count && <Component />}` renders the raw number `0` when
 // `count` is 0. On React Native, rendering a bare number outside
 // `<Text>` causes a hard production crash. This rule flags `&&`
@@ -229,6 +265,7 @@ export const rnNoFalsyAndRender = defineRule({
           isNodeOfType(parent, "JSXExpressionContainer") ||
           (isNodeOfType(parent, "LogicalExpression") && parent.operator === "&&");
         if (!isInsideJsx) return;
+        if (isRenderedInsideIntrinsicDomHost(node)) return;
 
         const left = node.left;
         if (!left) return;


### PR DESCRIPTION
<!-- motivation-example:start -->
## Motivation

React Native can crash when a falsy number becomes raw text, but that renderer-specific risk does not apply when the expression reaches a known HTML or SVG host. Mixed native/web packages need the rule to respect the actual render destination.

## Example

Rendering zero inside a DOM host is valid web output:

```tsx
<div>{cookieCount && <span>{cookieCount}</span>}</div>
```

The same expression across an opaque component or React Native root remains diagnostic.
<!-- motivation-example:end -->

## Why

`rn-no-falsy-and-render` applied React Native raw-text crash semantics to numeric `&&` output rendered by a literal DOM host in a mixed React Native/web package.

The authentic case is `callstackincubator/rozenite@e82fa2201d6e68c0e300a08c2bc49b640aa6fd69`, `packages/network-activity-plugin/src/ui/components/CookieCard.tsx:52`, from React Bench job `write-react-callstackincubator-r__Y4uEur3`. Rozenite declares `src/ui/App.tsx` as its Vite panel entry, and the target source is unchanged by the benchmark patch.

## What changed

- Suppress the rule only when the exact logical expression reaches a known intrinsic HTML or SVG host.
- Keep diagnostics across opaque/custom components, unknown intrinsic JSX dialects, non-`children` props, function boundaries, assignments, and unknown/React Native roots.
- Add the authentic DOM shape plus paired React Native and adversarial near-neighbors.
- Add a permanent fuzz regression and DOM/native generator shapes.

## Exact comparison

All candidate scans disabled React Doctor's result and per-file caches.

- Focused mixed-renderer fixture on main `d8b2989fd5d440d70931743a88ab6f7a91cf7b89`: 2 target diagnostics (`web-candidate`, `native-positive`).
- Candidate: 1 target diagnostic; only `native-positive` remains.
- Pinned Rozenite base: 1 target diagnostic at `CookieCard.tsx:52` on main, 0 on the candidate.
- Reconstructed benchmark model state: 1 target diagnostic on main, 0 on the candidate.
- The base and model `CookieCard.tsx` are byte-identical (`2568cc6aaf1487cb45d1a24e80ecf482b8acf4bfa8bf2c39411ca2bbeb04fdce`).
- Every scan completed successfully; every added/removed target verdict was inspected.

The runtime witness renders the falsy DOM state as `<div>0</div>` without a React Native raw-text crash.

## Validation

- `nr test` in `packages/oxlint-plugin-react-doctor`: 559 files, 14,027 passed, 181 skipped.
- `nr test` at the repository root: six package tasks passed; the plugin task intermittently failed three unrelated project-platform assertions. Re-running the complete plugin suite in isolation passed all 14,027 tests, including those exact assertions.
- `FUZZ_RULE=rn-no-falsy-and-render FUZZ_STRICT=1 FUZZ_ITERATIONS=500 FUZZ_PRINT_STATS=1 nr fuzz --reporter=verbose`: passed; 327 executed, 14 fired, 194 parse-skipped, 1/1 fire coverage.
- Fuzz corpus: 44 passed, 402 skipped.
- `nr typecheck`: passed.
- `nr lint`: passed with pre-existing warnings only.
- `nr format:check`: passed.
- `nr smoke:json-report`: passed.
- `git diff --check`: passed.
- `truffler` post-implementation searches found no duplicate helper.

The local RDE harness is not valid evidence for this branch: its installed schema decoder supports reports through v2, while current React Doctor emits schema v3. The exact local AST-layer scans above are the real-repository evidence.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-rule behavior change with narrow suppression logic and extensive regression/fuzz tests; no runtime or auth/data impact.
> 
> **Overview**
> **`rn-no-falsy-and-render`** no longer reports numeric `&&` JSX gates when the expression is proven to render under an intrinsic **HTML or SVG** host, so mixed web/native packages stop getting false positives like `<div>{itemCount && <span>…</span>}</div>`.
> 
> The rule adds **`isRenderedInsideIntrinsicDomHost`**, which walks JSX ancestors (treating real fragments as transparent, stopping at non-`children` attributes, calls, assignments, and function boundaries) and bails out before reporting. Diagnostics still fire for **React Native roots**, **opaque/custom components**, unknown intrinsics (e.g. `<mesh>`), and gates that never reach a proven DOM host.
> 
> Coverage includes Rozenite-style **regression tests**, a **fuzz corpus** fixture pairing web vs native shapes, and **snippet-pool** DOM/`View` examples for fuzzing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9cd251daeadb1d08db7fc9e5e8343c782caa445. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->