### PR TITLE
fix(rule): allow validated prop-seeded selection fallback

### DIFF
--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-derived-use-state.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-derived-use-state.regressions.test.ts
@@ -464,4 +464,42 @@ describe("no-derived-useState — regressions", () => {
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toHaveLength(1);
   });
+
+  it("stays silent when local selection falls back to the current prop seed", () => {
+    const result = runRule(
+      noDerivedUseState,
+      `function AccessibleNavTree({ tree, activeId: controlledActiveId }) {
+        const [internalActiveId, setInternalActiveId] = useState(tree.id);
+        const isControlled = controlledActiveId !== undefined;
+        const parentMap = useMemo(() => buildParentMap(tree), [tree]);
+        const activeId = isControlled || internalActiveId === tree.id || parentMap.has(internalActiveId)
+          ? (controlledActiveId ?? internalActiveId)
+          : tree.id;
+        return <Tree activeId={activeId} onActiveChange={(node) => setInternalActiveId(node.id)} />;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still flags a prop-seeded selection rendered without current-prop validation", () => {
+    const result = runRule(
+      noDerivedUseState,
+      `function AccessibleNavTree({ tree }) {
+        const [internalActiveId, setInternalActiveId] = useState(tree.id);
+        const activeId = tree.children.some((node) => node.id === internalActiveId)
+          ? internalActiveId
+          : tree.id;
+        return (
+          <Tree
+            activeId={activeId}
+            staleActiveId={internalActiveId}
+            onActiveChange={(node) => setInternalActiveId(node.id)}
+          />
+        );
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
 });


### PR DESCRIPTION
## Summary

- reproduce the Semiotic AccessibleNavTree false positive
- preserve a positive control where the prop-seeded state is also rendered without validation

## Current status

Regression-only draft. The valid fixture intentionally fails until the detector change is added.

## Evidence

Benchmark task: `fix-react-rdh-nteract-semiotic-accessiblenavtree`

The unchanged `useState(tree.id)` is local uncontrolled selection. The patched render path retains it only while it belongs to the current tree and otherwise falls back to the current `tree.id`; removing the old reset effect must not turn the unchanged initializer into a new stale-state finding.