### PR TITLE
fix(parallel-await): resolve shadowed dependencies by symbol

### DIFF
--- a/.changeset/curvy-icons-slide.md
+++ b/.changeset/curvy-icons-slide.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Fix async-parallel and server-sequential-independent-await to distinguish shadowed callback bindings from genuine result dependencies.

--- a/packages/fuzz/corpus/true-positives/async-parallel--shadowed-callback-dependencies.tsx
+++ b/packages/fuzz/corpus/true-positives/async-parallel--shadowed-callback-dependencies.tsx
@@ -1,0 +1,14 @@
+// rule: async-parallel
+// weakness: name-heuristic
+// source: ISSUES_TO_FIX_ASAP.md 2026-07-12 shadowed callback parameters
+
+declare const loadFirst: () => Promise<number>;
+declare const loadSecond: (selector: (first: number) => number) => Promise<number>;
+declare const loadThird: (selector: (second: number) => number) => Promise<number>;
+
+export const loadAll = async (): Promise<number[]> => {
+  const first = await loadFirst();
+  const second = await loadSecond((first) => first + 1);
+  const third = await loadThird((second) => second + 1);
+  return [first, second, third];
+};

--- a/packages/fuzz/corpus/true-positives/server-sequential-independent-await--shadowed-callback-dependency.tsx
+++ b/packages/fuzz/corpus/true-positives/server-sequential-independent-await--shadowed-callback-dependency.tsx
@@ -1,0 +1,12 @@
+// rule: server-sequential-independent-await
+// weakness: name-heuristic
+// source: ISSUES_TO_FIX_ASAP.md 2026-07-12 shadowed callback parameters
+
+declare const loadFirst: () => Promise<number>;
+declare const loadSecond: (selector: (first: number) => number) => Promise<number>;
+
+export const loadAll = async (): Promise<number[]> => {
+  const first = await loadFirst();
+  const second = await loadSecond((first) => first + 1);
+  return [first, second];
+};

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -154,6 +154,7 @@ export const HANDLER_SNIPPET_POOL = [
   `const handleReplaceAll = (text: string) => { for (const item of items) { text.replaceAll(new RegExp("token", "g"), String(item)); } };`,
   `globalThis.RegExp = CustomRegExp; const handleCustomMatch = () => { for (const item of items) { new RegExp("token", "i").test(String(item)); } };`,
   `const handleSequence = async () => { const first = await fetch(url); const second = await fetch(url); handle(first, second); };`,
+  `const handleShadowedAwaitDependencies = async () => { const first = await fetch(url); const second = await api.post(url, (first) => first); const third = await api.put(url, (second) => second); handle(first, second, third); };`,
   `const handlePersistToken = () => { localStorage.setItem("auth_token", String(value)); };`,
   `const handleRedirect = () => { window.location.href = String(params.next); };`,
   `const renderStatus = () => { const [open] = useState(false); return <b>{String(open)}</b>; }; const statusNode = <div>{renderStatus()}</div>;`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/async-parallel.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/async-parallel.regressions.test.ts
@@ -55,6 +55,18 @@ describe("js-performance/async-parallel — regressions", () => {
     expectPass(code);
   });
 
+  it("ignores write-only references to earlier results", () => {
+    expectFail(
+      `async function load() { let first = await loadFirst(); let second = await loadSecond((first = fallback)); const third = await loadThird((second = fallback)); return [first, second, third]; }`,
+    );
+  });
+
+  it("retains read-write references to earlier results", () => {
+    expectPass(
+      `async function load() { let first = await loadFirst(); let second = await loadSecond((first += fallback)); const third = await loadThird((second += fallback)); return [first, second, third]; }`,
+    );
+  });
+
   it("flags independent visible helpers even when they are named query", () => {
     expectFail(
       `const query = async (item) => { await Promise.resolve(); return item * 2; }; async function load() { const first = await query(1); const second = await query(2); const third = await query(3); return [first, second, third]; }`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/async-parallel.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/async-parallel.regressions.test.ts
@@ -15,6 +15,12 @@ const expectPass = (code: string): void => {
 };
 
 describe("js-performance/async-parallel — regressions", () => {
+  it("ignores callback parameters that shadow earlier await results", () => {
+    expectFail(
+      `declare const loadFirst: () => Promise<number>; declare const loadSecond: (selector: (first: number) => number) => Promise<number>; declare const loadThird: (selector: (second: number) => number) => Promise<number>; export const loadAll = async (): Promise<number[]> => { const first = await loadFirst(); const second = await loadSecond((first) => first + 1); const third = await loadThird((second) => second + 1); return [first, second, third]; };`,
+    );
+  });
+
   it("flags independent visible helpers even when they are named query", () => {
     expectFail(
       `const query = async (item) => { await Promise.resolve(); return item * 2; }; async function load() { const first = await query(1); const second = await query(2); const third = await query(3); return [first, second, third]; }`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/async-parallel.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/async-parallel.regressions.test.ts
@@ -15,10 +15,44 @@ const expectPass = (code: string): void => {
 };
 
 describe("js-performance/async-parallel — regressions", () => {
-  it("ignores callback parameters that shadow earlier await results", () => {
+  it("flags awaits when callback parameters shadow earlier results", () => {
     expectFail(
       `declare const loadFirst: () => Promise<number>; declare const loadSecond: (selector: (first: number) => number) => Promise<number>; declare const loadThird: (selector: (second: number) => number) => Promise<number>; export const loadAll = async (): Promise<number[]> => { const first = await loadFirst(); const second = await loadSecond((first) => first + 1); const third = await loadThird((second) => second + 1); return [first, second, third]; };`,
     );
+  });
+
+  it.each([
+    ["(first) => first + 1", "(second) => second + 1"],
+    [
+      "({ first }: { first: number }) => first + 1",
+      "({ second }: { second: number }) => second + 1",
+    ],
+    [
+      "() => { const first = 1; return first + 1; }",
+      "() => { const second = 2; return second + 1; }",
+    ],
+    [
+      "Promise.resolve(1).then((first) => first + 1)",
+      "Promise.resolve(2).then((second) => second + 1)",
+    ],
+    [
+      "Promise.reject(1).catch((first) => first + 1)",
+      "Promise.reject(2).catch((second) => second + 1)",
+    ],
+    ["function (first) { return first + 1; }", "function (second) { return second + 1; }"],
+  ])("does not fabricate dependencies from nested bindings", (secondArgument, thirdArgument) => {
+    expectFail(
+      `async function load() { const first = await loadFirst(); const second = await loadSecond(${secondArgument}); const third = await loadThird(${thirdArgument}); return [first, second, third]; }`,
+    );
+  });
+
+  it.each([
+    `async function load() { const first = await loadFirst(); const second = await loadSecond((value) => value + first); const third = await loadThird(); return [first, second, third]; }`,
+    `async function load() { const first = await loadFirst(); const second = await loadSecond({ [first]: true }); const third = await loadThird(); return [first, second, third]; }`,
+    `async function load() { const first = await loadFirst(); const second = await first.loadSecond(); const third = await loadThird(); return [first, second, third]; }`,
+    `async function load() { const first = await loadFirst(); const second = await loadSecond(); const third = await loadThird((value) => value + second); return [first, second, third]; }`,
+  ])("retains genuine symbol dependencies", (code) => {
+    expectPass(code);
   });
 
   it("flags independent visible helpers even when they are named query", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/async-parallel.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/async-parallel.ts
@@ -5,8 +5,8 @@ import {
   ORDERED_UI_FLOW_CALLEE_PREFIXES,
 } from "../../constants/js.js";
 import { SEQUENTIAL_AWAIT_THRESHOLD } from "../../constants/thresholds.js";
-import { collectPatternNames } from "../../utils/collect-pattern-names.js";
 import { defineRule } from "../../utils/define-rule.js";
+import { expressionReadsPatternBinding } from "../../utils/expression-reads-pattern-binding.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
 import { normalizeFilename } from "../../utils/normalize-filename.js";
 import { getCalleeIdentifierTrail } from "../../utils/get-callee-identifier-trail.js";
@@ -14,7 +14,6 @@ import { getOrderIndependentLocalFunction } from "../../utils/get-order-independ
 import { hasPossibleStaticMemberCallWrite } from "../../utils/has-static-property-write-before.js";
 import { isTestLibraryImportSource } from "../../utils/is-test-library-import-source.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
-import { walkAst } from "../../utils/walk-ast.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
@@ -148,27 +147,20 @@ const isInsideTransactionCallback = (node: EsTreeNode): boolean => {
 };
 
 const reportIfIndependent = (statements: EsTreeNode[], context: RuleContext): void => {
-  const declaredNames = new Set<string>();
+  const declaredPatterns: EsTreeNode[] = [];
 
   for (const statement of statements) {
     const awaitArgument = getAwaitedCall(statement);
     if (!awaitArgument) continue;
 
-    let referencesEarlierResult = false;
-    walkAst(awaitArgument, (child: EsTreeNode) => {
-      if (isNodeOfType(child, "Identifier") && declaredNames.has(child.name)) {
-        referencesEarlierResult = true;
-      }
-    });
-
-    if (referencesEarlierResult) return;
+    if (expressionReadsPatternBinding(awaitArgument, declaredPatterns, context.scopes)) return;
 
     // Destructured results (`const { prepareConfig } = await import(…)`,
     // `const [row] = await db.insert(…)`) bind names a later await may
     // consume, so every pattern-bound name must join the dependency set —
     // not just plain identifier declarations.
     if (isNodeOfType(statement, "VariableDeclaration") && statement.declarations[0]?.id) {
-      collectPatternNames(statement.declarations[0].id, declaredNames);
+      declaredPatterns.push(statement.declarations[0].id);
     }
   }
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-sequential-independent-await.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-sequential-independent-await.regressions.test.ts
@@ -3,13 +3,39 @@ import { runRule } from "../../../test-utils/run-rule.js";
 import { serverSequentialIndependentAwait } from "./server-sequential-independent-await.js";
 
 describe("server-sequential-independent-await — regressions", () => {
-  it("ignores callback parameters that shadow the previous await result", () => {
+  it("flags awaits when a callback parameter shadows the previous result", () => {
     const result = runRule(
       serverSequentialIndependentAwait,
       `declare const loadFirst: () => Promise<number>; declare const loadSecond: (selector: (first: number) => number) => Promise<number>; export const loadAll = async (): Promise<number[]> => { const first = await loadFirst(); const second = await loadSecond((first) => first + 1); return [first, second]; };`,
     );
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it.each([
+    "(first) => first + 1",
+    "({ first }: { first: number }) => first + 1",
+    "() => { const first = 1; return first + 1; }",
+    "Promise.resolve(1).then((first) => first + 1)",
+    "Promise.reject(1).catch((first) => first + 1)",
+    "function (first) { return first + 1; }",
+  ])("does not fabricate a dependency from nested bindings", (secondArgument) => {
+    const result = runRule(
+      serverSequentialIndependentAwait,
+      `async function load() { const first = await loadFirst(); const second = await loadSecond(${secondArgument}); return [first, second]; }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it.each([
+    `async function load() { const first = await loadFirst(); const second = await loadSecond((value) => value + first); return [first, second]; }`,
+    `async function load() { const first = await loadFirst(); const second = await loadSecond({ [first]: true }); return [first, second]; }`,
+    `async function load() { const first = await loadFirst(); const second = await first.loadSecond(); return [first, second]; }`,
+  ])("retains genuine symbol dependencies", (code) => {
+    const result = runRule(serverSequentialIndependentAwait, code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
   });
 
   it("flags an independent visible helper even when its name starts with initialize", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-sequential-independent-await.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-sequential-independent-await.regressions.test.ts
@@ -3,6 +3,15 @@ import { runRule } from "../../../test-utils/run-rule.js";
 import { serverSequentialIndependentAwait } from "./server-sequential-independent-await.js";
 
 describe("server-sequential-independent-await — regressions", () => {
+  it("ignores callback parameters that shadow the previous await result", () => {
+    const result = runRule(
+      serverSequentialIndependentAwait,
+      `declare const loadFirst: () => Promise<number>; declare const loadSecond: (selector: (first: number) => number) => Promise<number>; export const loadAll = async (): Promise<number[]> => { const first = await loadFirst(); const second = await loadSecond((first) => first + 1); return [first, second]; };`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
   it("flags an independent visible helper even when its name starts with initialize", () => {
     const result = runRule(
       serverSequentialIndependentAwait,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-sequential-independent-await.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-sequential-independent-await.regressions.test.ts
@@ -38,6 +38,24 @@ describe("server-sequential-independent-await — regressions", () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("ignores write-only references to the previous result", () => {
+    const result = runRule(
+      serverSequentialIndependentAwait,
+      `async function load() { let first = await loadFirst(); const second = await loadSecond((first = fallback)); return [first, second]; }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("retains read-write references to the previous result", () => {
+    const result = runRule(
+      serverSequentialIndependentAwait,
+      `async function load() { let first = await loadFirst(); const second = await loadSecond((first += fallback)); return [first, second]; }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("flags an independent visible helper even when its name starts with initialize", () => {
     const result = runRule(
       serverSequentialIndependentAwait,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-sequential-independent-await.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-sequential-independent-await.ts
@@ -1,12 +1,11 @@
-import { collectPatternNames } from "../../utils/collect-pattern-names.js";
 import { defineRule } from "../../utils/define-rule.js";
+import { expressionReadsPatternBinding } from "../../utils/expression-reads-pattern-binding.js";
 import { getCalleeName } from "../../utils/get-callee-name.js";
 import { getOrderIndependentLocalFunction } from "../../utils/get-order-independent-local-function.js";
 import { hasPossibleStaticMemberCallWrite } from "../../utils/has-static-property-write-before.js";
 import { getImportedNameFromModule } from "../../utils/find-import-source-for-name.js";
 import { isAuthGuardName } from "../../utils/is-auth-guard-name.js";
 import { tokenizeIdentifierWords } from "../../utils/tokenize-identifier-words.js";
-import { walkAst } from "../../utils/walk-ast.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
@@ -22,15 +21,6 @@ import { isNodeOfType } from "../../utils/is-node-of-type.js";
 // where the second's initializer reads no identifier introduced by the
 // first declaration. We require both declarations to be at the top
 // level of the same block to keep precision high.
-const collectDeclaredNames = (declaration: EsTreeNode): Set<string> => {
-  const names = new Set<string>();
-  if (!isNodeOfType(declaration, "VariableDeclaration")) return names;
-  for (const declarator of declaration.declarations ?? []) {
-    collectPatternNames(declarator.id, names);
-  }
-  return names;
-};
-
 const declarationStartsWithAwait = (declaration: EsTreeNode): boolean => {
   if (!isNodeOfType(declaration, "VariableDeclaration")) return false;
   for (const declarator of declaration.declarations ?? []) {
@@ -44,18 +34,18 @@ const declarationStartsWithAwait = (declaration: EsTreeNode): boolean => {
 // b()` after `const { data } = await a()`) is a re-bind evaluated after
 // the await resolves, not a read of the first result — counting it would
 // miss the waterfall.
-const declarationReadsAnyName = (declaration: EsTreeNode, names: Set<string>): boolean => {
-  if (names.size === 0) return false;
+const declarationReadsAnyPatternBinding = (
+  declaration: EsTreeNode,
+  patterns: ReadonlyArray<EsTreeNode>,
+  context: RuleContext,
+): boolean => {
+  if (patterns.length === 0) return false;
   if (!isNodeOfType(declaration, "VariableDeclaration")) return false;
-  let didRead = false;
   for (const declarator of declaration.declarations ?? []) {
     if (!declarator.init) continue;
-    walkAst(declarator.init, (child: EsTreeNode) => {
-      if (didRead) return;
-      if (isNodeOfType(child, "Identifier") && names.has(child.name)) didRead = true;
-    });
+    if (expressionReadsPatternBinding(declarator.init, patterns, context.scopes)) return true;
   }
-  return didRead;
+  return false;
 };
 
 // Leading verbs that mark an await run for ordering / a side effect rather
@@ -168,13 +158,13 @@ export const serverSequentialIndependentAwait = defineRule({
         const currentStatement = statements[statementIndex];
         if (!isNodeOfType(currentStatement, "VariableDeclaration")) continue;
         if (!declarationStartsWithAwait(currentStatement)) continue;
-        const declaredNames = collectDeclaredNames(currentStatement);
+        const declaredPatterns = currentStatement.declarations.map((declarator) => declarator.id);
 
         const nextStatement = statements[statementIndex + 1];
         if (!isNodeOfType(nextStatement, "VariableDeclaration")) continue;
         if (!declarationStartsWithAwait(nextStatement)) continue;
 
-        if (declarationReadsAnyName(nextStatement, declaredNames)) continue;
+        if (declarationReadsAnyPatternBinding(nextStatement, declaredPatterns, context)) continue;
         // The second await is on a promise that already exists
         // (`const p = fetchPosts(); … const posts = await p;`,
         // `await props.params`) — already running, so there's no

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/expression-reads-pattern-binding.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/expression-reads-pattern-binding.ts
@@ -1,0 +1,27 @@
+import type { ScopeAnalysis } from "../semantic/scope-analysis.js";
+import type { EsTreeNode } from "./es-tree-node.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+import { walkAst } from "./walk-ast.js";
+
+export const expressionReadsPatternBinding = (
+  expression: EsTreeNode,
+  patterns: ReadonlyArray<EsTreeNode>,
+  scopes: ScopeAnalysis,
+): boolean => {
+  const bindingSymbolIds = new Set<number>();
+  for (const pattern of patterns) {
+    walkAst(pattern, (child: EsTreeNode) => {
+      if (!isNodeOfType(child, "Identifier")) return;
+      const symbol = scopes.symbolFor(child);
+      if (symbol?.bindingIdentifier === child) bindingSymbolIds.add(symbol.id);
+    });
+  }
+
+  let didReadBinding = false;
+  walkAst(expression, (child: EsTreeNode) => {
+    if (didReadBinding || !isNodeOfType(child, "Identifier")) return;
+    const symbol = scopes.symbolFor(child);
+    if (symbol && bindingSymbolIds.has(symbol.id)) didReadBinding = true;
+  });
+  return didReadBinding;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/expression-reads-pattern-binding.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/expression-reads-pattern-binding.ts
@@ -20,8 +20,14 @@ export const expressionReadsPatternBinding = (
   let didReadBinding = false;
   walkAst(expression, (child: EsTreeNode) => {
     if (didReadBinding || !isNodeOfType(child, "Identifier")) return;
-    const symbol = scopes.symbolFor(child);
-    if (symbol && bindingSymbolIds.has(symbol.id)) didReadBinding = true;
+    const reference = scopes.referenceFor(child);
+    if (
+      reference?.flag !== "write" &&
+      reference?.resolvedSymbol &&
+      bindingSymbolIds.has(reference.resolvedSymbol.id)
+    ) {
+      didReadBinding = true;
+    }
   });
   return didReadBinding;
 };


### PR DESCRIPTION
<!-- motivation-example:start -->
## Motivation

The parallel-await rules compared identifier text instead of resolved symbols. A callback-local variable that reused an earlier result's name fabricated a dependency and hid a real sequential waterfall.

## Example

The callback parameter shadows the outer `record`, so the second operation does not consume the first result:

```tsx
const record = await loadRecord()
await Promise.all(items.map(async (record) => saveItem(record)))
```

Symbol-aware analysis should distinguish this from a callback that genuinely captures the outer binding.
<!-- motivation-example:end -->

## Why

Both parallel-await rules used identifier text to decide whether a later await consumed an earlier result. A callback-local binding with the same spelling therefore fabricated a dependency and hid a real sequential waterfall.

This changes the dependency check to compare resolved scope symbols. The rules now distinguish a shadowed callback or nested-block binding from a genuine capture of the earlier await result.

The source report is implementation-led. There is no authentic React Bench job, model patch, or oracle for this case, so this PR makes no benchmark-delta claim. The detector inconsistency is reproduced against the untouched base and published 0.7.2/0.7.4 builds, and the runtime waterfall was measured directly.

## Evidence

- Base `d8b2989fd`: the shadowed candidate is silent in both rules; the alpha-renamed control reports both rules.
- Candidate `74879731c`: the shadowed candidate reports both rules; the alpha-renamed control and genuine-dependency controls are unchanged.
- Runtime reproduction: sequential 108.25 ms vs parallel 38.42 ms (2.82x) with identical `[1, 11, 21]` results.
- Added paired coverage for arrow/function parameters, destructuring, nested block declarations, `then`/`catch` parameters, computed keys, member receivers, and genuine outer captures.
- Added permanent true-positive fuzz seeds for both rules and a generator pool shape.

## Validation

- `nr --filter oxlint-plugin-react-doctor test` — 559 files, 14,032 passed, 181 skipped.
- `FUZZ_RULE=async-parallel FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz` — 323 executed, 11 rule firings, no findings.
- `FUZZ_RULE=server-sequential-independent-await FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz` — 326 executed, 18 rule firings, no findings.
- Fuzz corpus — 44 passed, 402 skipped.
- `nr typecheck`
- `nr lint`
- `nr format:check`
- `git diff --check`
- `nr smoke:json-report`
- `REACT_DOCTOR_NO_CACHE=1 nr build --force`
- Post-change `truffler` search found no duplicate helper.

The monorepo-wide `nr test` was also attempted. It hit three unrelated, nondeterministic plugin assertions while packages ran concurrently; an immediate isolated full plugin rerun passed all 14,032 tests. A local RDE invocation produced zero scans because the shared harness was contended, so it is recorded as invalid evidence rather than a pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when performance lint rules fire (more warnings on previously silent shadowed-callback waterfalls); logic is localized to dependency detection with broad regression coverage.
> 
> **Overview**
> **`async-parallel`** and **`server-sequential-independent-await`** no longer treat “same identifier text” as a data dependency between sequential awaits. They now use scope-aware **`expressionReadsPatternBinding`**, which tracks binding **symbols** from earlier declaration patterns and only blocks reporting when a later await **reads** those bindings.
> 
> That fixes false negatives where a callback parameter or nested binding reused a name like `first` or `record` and incorrectly suppressed waterfall warnings. Genuine captures (outer binding in the callback body, computed keys, member access on the prior result) still suppress the rule. **Write-only** uses of the outer name (e.g. assignment in a callback) no longer count as a read; **read-write** (`+=`) still do.
> 
> Shared helper **`expression-reads-pattern-binding.ts`** replaces per-rule `collectPatternNames` + identifier-set walks. Regression tests, fuzz true-positive seeds, and a handler snippet pool entry cover shadowed-callback shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4af50aaf482d27660d9f2333a0586a3a281b6dfc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->