### PR TITLE
fix(no-render-in-render): ignore unreachable nested hooks

### DIFF
--- a/.changeset/calm-bananas-juggle.md
+++ b/.changeset/calm-bananas-juggle.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Fix no-render-in-render false positives from hooks in uninvoked nested closures

--- a/packages/fuzz/corpus/regressions/no-render-in-render--unreachable-nested-hook.tsx
+++ b/packages/fuzz/corpus/regressions/no-render-in-render--unreachable-nested-hook.tsx
@@ -1,0 +1,15 @@
+// rule: no-render-in-render
+// weakness: control-flow
+// source: ISSUES_TO_FIX_ASAP.md 2026-07-12 unreachable nested hook
+
+const Panel = () => {
+  const renderPanel = () => {
+    const useUnusedState = () => useState(0);
+    void useUnusedState;
+    return <div>stable</div>;
+  };
+
+  return <section>{renderPanel()}</section>;
+};
+
+void Panel;

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -157,6 +157,7 @@ export const HANDLER_SNIPPET_POOL = [
   `const handlePersistToken = () => { localStorage.setItem("auth_token", String(value)); };`,
   `const handleRedirect = () => { window.location.href = String(params.next); };`,
   `const renderStatus = () => { const [open] = useState(false); return <b>{String(open)}</b>; }; const statusNode = <div>{renderStatus()}</div>;`,
+  `const renderStablePanel = () => { const useUnusedRenderState = () => useState(0); void useUnusedRenderState; return <div>stable</div>; }; const stablePanelNode = <section>{renderStablePanel()}</section>;`,
   `const FuzzMemoRenderContent = () => <div>{state}</div>; const fuzzMemoContent = useMemo(FuzzMemoRenderContent, [state]);`,
   `const FuzzNestedComponent = () => <div>{state}</div>; const fuzzNestedElement = <FuzzNestedComponent />;`,
 ] as const;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-render-in-render.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-render-in-render.regressions.test.ts
@@ -220,6 +220,20 @@ describe("architecture/no-render-in-render — regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("does not flag a helper that only stores an uninvoked nested custom hook", () => {
+    const result = run(
+      `const Panel = () => {
+        const renderPanel = () => {
+          const useUnusedState = () => useState(0);
+          void useUnusedState;
+          return <div>stable</div>;
+        };
+        return <section>{renderPanel()}</section>;
+      };`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("still flags when a nested NON-component closure calls hooks during the helper call", () => {
     const result = run(
       `const renderRows = (items) => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-render-in-render.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-render-in-render.regressions.test.ts
@@ -368,6 +368,60 @@ describe("architecture/no-render-in-render — regressions", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("flags hooks reached through an inline Promise executor", () => {
+    const result = run(
+      `const Panel = () => {
+        const renderPanel = () => {
+          new Promise((resolve) => {
+            const [count] = useState(0);
+            resolve(count);
+          });
+          return <div>panel</div>;
+        };
+        return <section>{renderPanel()}</section>;
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags hooks reached through a named Promise executor", () => {
+    const result = run(
+      `const Panel = () => {
+        const renderPanel = () => {
+          const initializePanel = (resolve) => {
+            const [count] = useState(0);
+            resolve(count);
+          };
+          new Promise(initializePanel);
+          return <div>panel</div>;
+        };
+        return <section>{renderPanel()}</section>;
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not treat shadowed Promise constructors as synchronous", () => {
+    const result = run(
+      `class Promise {
+        constructor(executor) {
+          queueMicrotask(executor);
+        }
+      }
+      const Panel = () => {
+        const renderPanel = () => {
+          new Promise(() => {
+            const [count] = useState(0);
+            return count;
+          });
+          return <div>panel</div>;
+        };
+        return <section>{renderPanel()}</section>;
+      };`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("preserves render-phase hook callback positives", () => {
     const memoResult = run(
       `const Panel = () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-render-in-render.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-render-in-render.regressions.test.ts
@@ -234,6 +234,199 @@ describe("architecture/no-render-in-render — regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("does not flag uninvoked nested function declarations", () => {
+    const result = run(
+      `const Panel = () => {
+        const renderPanel = () => {
+          function useUnusedState() { return useState(0); }
+          return <div>{useUnusedState.name}</div>;
+        };
+        return <section>{renderPanel()}</section>;
+      };`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not flag hooks stored in deferred callbacks", () => {
+    const result = run(
+      `const Panel = () => {
+        const renderPanel = () => {
+          const useLater = () => useState(0);
+          setTimeout(useLater, 0);
+          Promise.resolve().then(useLater);
+          return <button onClick={useLater}>Open</button>;
+        };
+        return <section>{renderPanel()}</section>;
+      };`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not flag hooks stored in returned cleanup closures", () => {
+    const result = run(
+      `const Panel = () => {
+        const renderPanel = () => {
+          const subscribe = () => () => useState(0);
+          void subscribe;
+          return <div>stable</div>;
+        };
+        return <section>{renderPanel()}</section>;
+      };`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("flags hooks reached through an invoked nested helper", () => {
+    const result = run(
+      `const Panel = () => {
+        const renderPanel = () => {
+          const buildPanel = () => {
+            const [count] = useState(0);
+            return <div>{count}</div>;
+          };
+          return buildPanel();
+        };
+        return <section>{renderPanel()}</section>;
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags hooks reached through multi-hop const aliases", () => {
+    const result = run(
+      `const Panel = () => {
+        const renderPanel = () => {
+          const buildPanel = () => {
+            const [count] = useState(0);
+            return <div>{count}</div>;
+          };
+          const firstAlias = buildPanel;
+          const secondAlias = firstAlias;
+          return secondAlias();
+        };
+        return <section>{renderPanel()}</section>;
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags hooks reached through an IIFE", () => {
+    const result = run(
+      `const Panel = () => {
+        const renderPanel = () => (() => {
+          const [count] = useState(0);
+          return <div>{count}</div>;
+        })();
+        return <section>{renderPanel()}</section>;
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags hooks reached through a conditional local invocation", () => {
+    const result = run(
+      `const Panel = ({ open }) => {
+        const renderPanel = () => {
+          const buildPanel = () => {
+            const [count] = useState(0);
+            return <div>{count}</div>;
+          };
+          return open ? buildPanel() : null;
+        };
+        return <section>{renderPanel()}</section>;
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags hooks reached through a named synchronous array callback", () => {
+    const result = run(
+      `const Panel = ({ items }) => {
+        const renderPanel = () => {
+          const buildItem = (item) => {
+            const [selected] = useState(false);
+            return <li>{String(selected)} {item}</li>;
+          };
+          return <ul>{items.map(buildItem)}</ul>;
+        };
+        return <section>{renderPanel()}</section>;
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags hooks reached through inline synchronous callbacks", () => {
+    const result = run(
+      `const Panel = ({ items }) => {
+        const renderPanel = () => <ul>{items.map((item) => {
+          const [selected] = useState(false);
+          return <li>{String(selected)} {item}</li>;
+        })}</ul>;
+        return <section>{renderPanel()}</section>;
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("preserves render-phase hook callback positives", () => {
+    const memoResult = run(
+      `const Panel = () => {
+        const renderPanel = () => useMemo(() => {
+          const [count] = useState(0);
+          return <div>{count}</div>;
+        }, []);
+        return <section>{renderPanel()}</section>;
+      };`,
+    );
+    const initializerResult = run(
+      `const Panel = () => {
+        const renderPanel = () => {
+          const [value] = useState(() => {
+            const [count] = useState(0);
+            return count;
+          });
+          return <div>{value}</div>;
+        };
+        return <section>{renderPanel()}</section>;
+      };`,
+    );
+    expect(memoResult.diagnostics).toHaveLength(1);
+    expect(initializerResult.diagnostics).toHaveLength(1);
+  });
+
+  it("does not chase mutable local callback bindings", () => {
+    const result = run(
+      `const Panel = ({ replacement }) => {
+        const renderPanel = () => {
+          let buildPanel = () => {
+            const [count] = useState(0);
+            return <div>{count}</div>;
+          };
+          buildPanel = replacement;
+          return buildPanel();
+        };
+        return <section>{renderPanel()}</section>;
+      };`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("flags directly invoked PascalCase locals instead of treating them as mounted children", () => {
+    const result = run(
+      `const Panel = () => {
+        const renderPanel = () => {
+          const HiddenPanel = () => {
+            const [count] = useState(0);
+            return <div>{count}</div>;
+          };
+          return HiddenPanel();
+        };
+        return <section>{renderPanel()}</section>;
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("still flags when a nested NON-component closure calls hooks during the helper call", () => {
     const result = run(
       `const renderRows = (items) => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-render-in-render.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-render-in-render.ts
@@ -1,6 +1,7 @@
 import { RENDER_FUNCTION_PATTERN } from "../../constants/react.js";
 import { defineRule } from "../../utils/define-rule.js";
 import { executesDuringRender } from "../../utils/executes-during-render.js";
+import { isAstDescendant } from "../../utils/is-ast-descendant.js";
 import { isComponentFunction } from "../../utils/is-component-function.js";
 import { isEs5Component } from "../../utils/is-es5-component.js";
 import { isEs6Component } from "../../utils/is-es6-component.js";
@@ -64,15 +65,6 @@ const isHookCallee = (callee: EsTreeNode): boolean => {
   return false;
 };
 
-const isNestedWithinFunction = (candidate: EsTreeNode, functionNode: EsTreeNode): boolean => {
-  let ancestor = candidate.parent;
-  while (ancestor) {
-    if (ancestor === functionNode) return true;
-    ancestor = ancestor.parent ?? null;
-  }
-  return false;
-};
-
 const containsReachableHookCall = (
   functionNode: EsTreeNode,
   rootFunction: EsTreeNode,
@@ -85,26 +77,28 @@ const containsReachableHookCall = (
   walkAst(functionNode.body, (child: EsTreeNode) => {
     if (didFindReachableHook) return false;
     if (isFunctionLike(child) && !executesDuringRender(child, context.scopes)) return false;
-    if (!isNodeOfType(child, "CallExpression")) return;
-    if (isHookCallee(child.callee as EsTreeNode)) {
-      didFindReachableHook = true;
-      return false;
-    }
-    const calledFunction = resolveExactLocalFunction(child.callee, context.scopes);
-    if (
-      calledFunction &&
-      isNestedWithinFunction(calledFunction, rootFunction) &&
-      containsReachableHookCall(calledFunction, rootFunction, context, visitedFunctions)
-    ) {
-      didFindReachableHook = true;
-      return false;
+    if (!isNodeOfType(child, "CallExpression") && !isNodeOfType(child, "NewExpression")) return;
+    if (isNodeOfType(child, "CallExpression")) {
+      if (isHookCallee(child.callee as EsTreeNode)) {
+        didFindReachableHook = true;
+        return false;
+      }
+      const calledFunction = resolveExactLocalFunction(child.callee, context.scopes);
+      if (
+        calledFunction &&
+        isAstDescendant(calledFunction, rootFunction) &&
+        containsReachableHookCall(calledFunction, rootFunction, context, visitedFunctions)
+      ) {
+        didFindReachableHook = true;
+        return false;
+      }
     }
     for (const callArgument of child.arguments ?? []) {
       if (!executesDuringRender(callArgument, context.scopes)) continue;
       const callbackFunction = resolveExactLocalFunction(callArgument, context.scopes);
       if (
         callbackFunction &&
-        isNestedWithinFunction(callbackFunction, rootFunction) &&
+        isAstDescendant(callbackFunction, rootFunction) &&
         containsReachableHookCall(callbackFunction, rootFunction, context, visitedFunctions)
       ) {
         didFindReachableHook = true;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-render-in-render.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/no-render-in-render.ts
@@ -1,11 +1,13 @@
 import { RENDER_FUNCTION_PATTERN } from "../../constants/react.js";
 import { defineRule } from "../../utils/define-rule.js";
+import { executesDuringRender } from "../../utils/executes-during-render.js";
 import { isComponentFunction } from "../../utils/is-component-function.js";
 import { isEs5Component } from "../../utils/is-es5-component.js";
 import { isEs6Component } from "../../utils/is-es6-component.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isReactHookName } from "../../utils/is-react-hook-name.js";
 import { isUppercaseName } from "../../utils/is-uppercase-name.js";
+import { resolveExactLocalFunction } from "../../utils/resolve-exact-local-function.js";
 import { walkAst } from "../../utils/walk-ast.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
@@ -14,7 +16,7 @@ import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import type { SymbolDescriptor } from "../../semantic/scope-analysis.js";
 
 // A `render*` call inside JSX is only a problem when the helper carries
-// REACT-COMPONENT semantics — i.e. its body calls hooks. Such a helper
+// REACT-COMPONENT semantics — i.e. its execution reaches hooks. Such a helper
 // is a component in disguise: invoking it inline splices its hooks into
 // the caller's hook order, so a conditional call (or a changed call
 // count) corrupts hook state. A hook-free render helper is just a
@@ -35,10 +37,10 @@ const isInsideComponentContext = (node: EsTreeNode): boolean => {
   return false;
 };
 
-const functionBodyOf = (node: EsTreeNode): EsTreeNode | null => {
-  if (isFunctionLike(node)) return node.body ?? null;
+const getFunctionFromDeclaration = (node: EsTreeNode): EsTreeNode | null => {
+  if (isFunctionLike(node)) return node;
   if (isNodeOfType(node, "VariableDeclarator") && node.init && isFunctionLike(node.init)) {
-    return node.init.body ?? null;
+    return node.init;
   }
   return null;
 };
@@ -62,27 +64,65 @@ const isHookCallee = (callee: EsTreeNode): boolean => {
   return false;
 };
 
-const containsHookCall = (body: EsTreeNode): boolean => {
-  let found = false;
-  walkAst(body, (child: EsTreeNode) => {
-    if (found) return false;
-    // A component DEFINED inside the helper owns its hooks — they run under
-    // that child's fiber when it renders, not when the helper is invoked
-    // inline — so its subtree must not make the helper itself hook-calling.
-    // Non-component nested functions stay in the walk: a closure that calls
-    // hooks and runs during the helper call still splices into the caller.
-    if (child !== body && isFunctionLike(child) && isComponentFunction(child)) return false;
-    if (!isNodeOfType(child, "CallExpression")) return;
-    if (isHookCallee(child.callee as EsTreeNode)) found = true;
-  });
-  return found;
+const isNestedWithinFunction = (candidate: EsTreeNode, functionNode: EsTreeNode): boolean => {
+  let ancestor = candidate.parent;
+  while (ancestor) {
+    if (ancestor === functionNode) return true;
+    ancestor = ancestor.parent ?? null;
+  }
+  return false;
 };
 
-// Fires only when the callee resolves to a LOCAL function whose body
-// calls hooks. Everything unresolvable — render props, parameters,
+const containsReachableHookCall = (
+  functionNode: EsTreeNode,
+  rootFunction: EsTreeNode,
+  context: RuleContext,
+  visitedFunctions: Set<EsTreeNode>,
+): boolean => {
+  if (!isFunctionLike(functionNode) || visitedFunctions.has(functionNode)) return false;
+  visitedFunctions.add(functionNode);
+  let didFindReachableHook = false;
+  walkAst(functionNode.body, (child: EsTreeNode) => {
+    if (didFindReachableHook) return false;
+    if (isFunctionLike(child) && !executesDuringRender(child, context.scopes)) return false;
+    if (!isNodeOfType(child, "CallExpression")) return;
+    if (isHookCallee(child.callee as EsTreeNode)) {
+      didFindReachableHook = true;
+      return false;
+    }
+    const calledFunction = resolveExactLocalFunction(child.callee, context.scopes);
+    if (
+      calledFunction &&
+      isNestedWithinFunction(calledFunction, rootFunction) &&
+      containsReachableHookCall(calledFunction, rootFunction, context, visitedFunctions)
+    ) {
+      didFindReachableHook = true;
+      return false;
+    }
+    for (const callArgument of child.arguments ?? []) {
+      if (!executesDuringRender(callArgument, context.scopes)) continue;
+      const callbackFunction = resolveExactLocalFunction(callArgument, context.scopes);
+      if (
+        callbackFunction &&
+        isNestedWithinFunction(callbackFunction, rootFunction) &&
+        containsReachableHookCall(callbackFunction, rootFunction, context, visitedFunctions)
+      ) {
+        didFindReachableHook = true;
+        return false;
+      }
+    }
+  });
+  return didFindReachableHook;
+};
+
+// Fires only when the callee resolves to a LOCAL function whose synchronous
+// execution reaches hooks. Everything unresolvable — render props, parameters,
 // aliases, member calls — is a plain callable with no hook state to
 // corrupt, so it stays silent.
-const isHookCallingRenderHelper = (symbol: SymbolDescriptor | null): boolean => {
+const isHookCallingRenderHelper = (
+  symbol: SymbolDescriptor | null,
+  context: RuleContext,
+): boolean => {
   if (!symbol) return false;
   const declaration = symbol.declarationNode;
   if (
@@ -91,9 +131,9 @@ const isHookCallingRenderHelper = (symbol: SymbolDescriptor | null): boolean => 
   ) {
     return false;
   }
-  const body = functionBodyOf(declaration);
-  if (!body) return false;
-  return containsHookCall(body);
+  const functionNode = getFunctionFromDeclaration(declaration);
+  if (!functionNode) return false;
+  return containsReachableHookCall(functionNode, functionNode, context, new Set());
 };
 
 export const noRenderInRender = defineRule({
@@ -115,7 +155,7 @@ export const noRenderInRender = defineRule({
       const calleeName = expression.callee.name;
       if (!RENDER_FUNCTION_PATTERN.test(calleeName)) return;
       if (!isInsideComponentContext(node)) return;
-      if (!isHookCallingRenderHelper(context.scopes.symbolFor(expression.callee))) return;
+      if (!isHookCallingRenderHelper(context.scopes.symbolFor(expression.callee), context)) return;
 
       context.report({
         node: expression,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/executes-during-render.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/executes-during-render.ts
@@ -62,12 +62,23 @@ const isConstAliasOfGlobalArrayFrom = (node: EsTreeNode, scopes: ScopeAnalysis):
 };
 
 // A nested function usually runs on a user event, not during the render
-// pass — but three shapes DO execute while rendering: an immediately
+// pass — but four shapes DO execute while rendering: an immediately
 // invoked function (`{(() => new Date().toLocaleString())()}`), a
 // useMemo factory (`{useMemo(() => Date.now(), [])}`), and a synchronous
-// iteration callback (`{rows.map((row) => …)}`).
+// iteration callback (`{rows.map((row) => …)}`), or a global Promise
+// constructor executor (`new Promise((resolve) => resolve())`).
 export const executesDuringRender = (functionNode: EsTreeNode, scopes?: ScopeAnalysis): boolean => {
   const parent = functionNode.parent;
+  if (isNodeOfType(parent, "NewExpression")) {
+    const callee = stripParenExpression(parent.callee);
+    return Boolean(
+      scopes &&
+      parent.arguments?.[0] === functionNode &&
+      isNodeOfType(callee, "Identifier") &&
+      callee.name === "Promise" &&
+      scopes.isGlobalReference(callee),
+    );
+  }
   if (!isNodeOfType(parent, "CallExpression")) return false;
   if (parent.callee === functionNode) return true;
   const isRenderPhaseHook = scopes


### PR DESCRIPTION
<!-- motivation-example:start -->
## Motivation

A nested Hook changes render semantics only if its function actually executes during the render-helper call. Treating an uninvoked nested function as executed creates a false positive for otherwise ordinary render helpers.

## Example

The nested custom Hook is referenced but never called:

```tsx
const renderPanel = () => {
  const useUnusedState = () => useState(0)
  void useUnusedState
  return <div>stable</div>
}

return <section>{renderPanel()}</section>
```

Direct or synchronously invoked nested Hooks remain reportable.
<!-- motivation-example:end -->

## Why

`no-render-in-render` treated every hook inside a render helper's nested function as if the nested function executed during the helper call. An uninvoked nested custom hook therefore made an otherwise hook-free render helper look like a hidden component.

Runtime reproduction confirms the nested hook executes zero times and the rendered markup matches the hook-free control. This is implementation- and runtime-grounded only: no authentic OSS or React Bench occurrence has been found or claimed.

## What changed

- Follow only exact local functions that execute synchronously during the render-helper call.
- Preserve reports for direct hooks, invoked nested helpers, const-alias chains, IIFEs, conditional calls, synchronous iteration callbacks, and render-phase hook callbacks.
- Keep deferred callbacks, returned closures, mutable bindings, nested mounted components, module-scope transitive helpers, and unresolved callables outside the proof boundary.
- Add paired adversarial regressions, a permanent fuzz seed, a generator pool shape, and a patch changeset.

## Before and after

```tsx
const renderPanel = () => {
  const useUnusedState = () => useState(0)
  void useUnusedState
  return <div>stable</div>
}

return <section>{renderPanel()}</section>
```

- Baseline: 1 `no-render-in-render` diagnostic.
- Candidate: 0 diagnostics.
- Direct hook control: 1 diagnostic on both baseline and candidate.

## Validation

- Oxlint plugin: 559 files passed; 14,024 tests passed, 181 skipped.
- Repository typecheck: 15/15 tasks passed.
- Fuzz corpus: 44 passed, 402 skipped.
- Strict generated fuzz: 500 requested, 322 executed, target fired 7 times, no findings.
- Strict React Bench corpus fuzz: 500 requested, 319 executed, target fired 7 times, no findings.
- Formatting, lint, build, and `git diff --check`: passed.
- Final `truffler` searches found no duplicate helper or superseded logic.

Pinned React Bench 5 rule-layer comparison:

| State | Files scanned | Baseline findings | Candidate findings | Added | Removed |
| --- | ---: | ---: | ---: | ---: | ---: |
| Base task files | 27 | 0 | 0 | 0 | 0 |
| Oracle patches | 27 | 0 | 0 | 0 | 0 |
| Stored model patches | 271 | 0 | 0 | 0 | 0 |

Local RDE was attempted but is invalid evidence: the installed eval harness only decodes report schema v1/v2 while current React Doctor emits v3. It is not counted as a pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes control-flow-sensitive static analysis for a hooks rule; incorrect reachability could miss real violations or reintroduce false positives, though coverage is heavily regression-tested.
> 
> **Overview**
> **`no-render-in-render`** now treats a `render*` helper as hook-calling only when **synchronous execution during that helper’s call** can reach a hook—not when a nested function merely *defines* a hook without running.
> 
> Hook detection is replaced with **`containsReachableHookCall`**, which walks the helper body but skips nested functions that **`executesDuringRender`** says do not run in the render pass, follows **exact local** callees and **render-phase** callback arguments inside the helper, and recurses only for nested locals under the same helper. **`executesDuringRender`** also treats the **global `Promise` executor** as render-time (while **shadowed `Promise`** stays deferred).
> 
> Regression tests, a fuzz corpus case, and a handler snippet pool entry cover uninvoked nested hooks vs still-flagged paths (IIFEs, `map`, invoked nested helpers, `useMemo` factories, etc.).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84ed6d90529568a17a442a1aed048adef01ec98c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->