### PR TITLE
fix(no-scale-from-zero): require motion component provenance

### DIFF
--- a/.changeset/twenty-pots-laugh.md
+++ b/.changeset/twenty-pots-laugh.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Avoid no-scale-from-zero diagnostics on ordinary JSX data props.

--- a/packages/core/tests/fixtures/basic-react/src/performance-issues.tsx
+++ b/packages/core/tests/fixtures/basic-react/src/performance-issues.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo, memo } from "react";
+import { motion } from "framer-motion";
 
 const MemoChild = memo(({ onClick }: { onClick: () => void }) => (
   <button onClick={onClick}>click</button>
@@ -11,8 +12,6 @@ const SimpleMemoComponent = ({ count }: { count: number }) => {
   return <div>{doubled}</div>;
 };
 
-declare const motion: { div: (props: Record<string, unknown>) => JSX.Element };
-
 const LayoutAnimationComponent = () => (
   <motion.div animate={{ width: 100, height: 200 }}>animated</motion.div>
 );
@@ -21,7 +20,7 @@ const TransitionAllComponent = () => <div style={{ transition: "all 0.3s ease" }
 
 const LargeBlurComponent = () => <div style={{ filter: "blur(20px)" }}>blurred</div>;
 
-const ScaleFromZeroComponent = () => <div initial={{ scale: 0 }}>scale</div>;
+const ScaleFromZeroComponent = () => <motion.div initial={{ scale: 0 }}>scale</motion.div>;
 
 const PermanentWillChangeComponent = () => <div style={{ willChange: "transform" }}>permanent</div>;
 

--- a/packages/fuzz/corpus/regressions/no-scale-from-zero--lowercase-tag-import-collision.tsx
+++ b/packages/fuzz/corpus/regressions/no-scale-from-zero--lowercase-tag-import-collision.tsx
@@ -1,0 +1,8 @@
+// rule: no-scale-from-zero
+import { div, span as MotionSpan } from "framer-motion/m";
+
+void div;
+
+export const IntrinsicCollision = () => <div initial={{ scale: 0 }} />;
+
+export const ProvenMotionTag = () => <MotionSpan initial={{ scale: 0 }} />;

--- a/packages/fuzz/corpus/regressions/no-scale-from-zero--ordinary-initial-data-prop.tsx
+++ b/packages/fuzz/corpus/regressions/no-scale-from-zero--ordinary-initial-data-prop.tsx
@@ -1,0 +1,11 @@
+// rule: no-scale-from-zero
+// weakness: name-heuristic
+// source: ISSUES_TO_FIX_ASAP.md / PR #1290
+
+interface PanelProps {
+  initial: { scale: number };
+}
+
+const Panel = ({ initial }: PanelProps) => <output>{initial.scale}</output>;
+
+export const Example = () => <Panel initial={{ scale: 0 }} />;

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -252,6 +252,7 @@ export const MODULE_SCOPE_SNIPPET_POOL = [
   `import { test as fuzzProviderTest } from "vitest"; import { FuzzProductProvider } from "./product-provider"; fuzzProviderTest("renders direct content", () => { render(<FuzzProductProvider><img src="/subject.png" /></FuzzProductProvider>); });`,
   `import { test as fuzzProviderChildrenTest } from "vitest"; import { FuzzChildrenProvider } from "./children-provider"; fuzzProviderChildrenTest("renders direct children", () => { render(<FuzzChildrenProvider children={<img src="/subject.png" />} />); });`,
   `import { motion as FuzzMotion } from "framer-motion"; export const FuzzMotionPanel = () => <FuzzMotion.div animate={{ x: 120 }}>moving</FuzzMotion.div>;`,
+  `import { motion as FuzzScaleMotion } from "framer-motion"; export const FuzzScaleEntry = () => <FuzzScaleMotion.div initial={{ scale: 0 }} animate={{ scale: 1 }}>enter</FuzzScaleMotion.div>;`,
   `import { createRoot as mountFuzzRoot } from "react-dom/client"; export const FuzzRootApp = () => <div />; export const fuzzRootConfig = getConfig(); const fuzzApplicationRoot = mountFuzzRoot(document.body); fuzzApplicationRoot.render(<FuzzRootApp />);`,
   `const GLOBAL_CACHE = new Map<string, unknown>();`,
   `class FuzzProtocolRegistry { static contextTypes = new Set(["json", "text"]); static childContextTypes = new Map(); getChildContext() { return { protocol: "json" }; } } const FuzzSchemaRegistry = {}; FuzzSchemaRegistry.contextTypes = new Set(["json", "text"]);`,

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -253,6 +253,7 @@ export const MODULE_SCOPE_SNIPPET_POOL = [
   `import { test as fuzzProviderChildrenTest } from "vitest"; import { FuzzChildrenProvider } from "./children-provider"; fuzzProviderChildrenTest("renders direct children", () => { render(<FuzzChildrenProvider children={<img src="/subject.png" />} />); });`,
   `import { motion as FuzzMotion } from "framer-motion"; export const FuzzMotionPanel = () => <FuzzMotion.div animate={{ x: 120 }}>moving</FuzzMotion.div>;`,
   `import { motion as FuzzScaleMotion } from "framer-motion"; export const FuzzScaleEntry = () => <FuzzScaleMotion.div initial={{ scale: 0 }} animate={{ scale: 1 }}>enter</FuzzScaleMotion.div>;`,
+  `import { div as fuzzMotionDiv, span as FuzzMotionSpan } from "framer-motion/m"; export const FuzzIntrinsicScaleCollision = () => <fuzzMotionDiv initial={{ scale: 0 }} />; export const FuzzProvenScaleTag = () => <FuzzMotionSpan initial={{ scale: 0 }} />;`,
   `import { createRoot as mountFuzzRoot } from "react-dom/client"; export const FuzzRootApp = () => <div />; export const fuzzRootConfig = getConfig(); const fuzzApplicationRoot = mountFuzzRoot(document.body); fuzzApplicationRoot.render(<FuzzRootApp />);`,
   `const GLOBAL_CACHE = new Map<string, unknown>();`,
   `class FuzzProtocolRegistry { static contextTypes = new Set(["json", "text"]); static childContextTypes = new Map(); getChildContext() { return { protocol: "json" }; } } const FuzzSchemaRegistry = {}; FuzzSchemaRegistry.contextTypes = new Set(["json", "text"]);`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness-fixtures.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness-fixtures.ts
@@ -836,7 +836,7 @@ export const livenessFixtures: Readonly<Record<string, LivenessFixture>> = {
     forceJsx: true,
   },
   "no-scale-from-zero": {
-    code: "const El = () => <motion.div initial={{ scale: 0 }} animate={{ scale: 1 }} />;",
+    code: 'import { motion } from "framer-motion";\nconst El = () => <motion.div initial={{ scale: 0 }} animate={{ scale: 1 }} />;',
   },
   "no-secrets-in-client-code": {
     code: 'const authEndpoint = "https://api.example.com/auth?token=supersecretvalue123";',

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-scale-from-zero.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-scale-from-zero.regressions.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noScaleFromZero } from "./no-scale-from-zero.js";
+
+const run = (code: string) => runRule(noScaleFromZero, code, { filename: "fixture.tsx" });
+
+describe("performance/no-scale-from-zero — regressions", () => {
+  it("does not treat an ordinary initial data prop as animation state", () => {
+    const result = run(`
+      interface PanelProps {
+        initial: { scale: number };
+      }
+
+      const Panel = ({ initial }: PanelProps) => <output>{initial.scale}</output>;
+      export const Candidate = () => <Panel initial={{ scale: 0 }} />;
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not treat imported or intrinsic initial props as animation state", () => {
+    const result = run(`
+      import { Panel } from "./panel";
+
+      export const Examples = () => (
+        <>
+          <Panel initial={{ scale: 0 }} />
+          <div initial={{ scale: 0 }} />
+        </>
+      );
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not trust userland motion lookalikes", () => {
+    const result = run(`
+      import { motion as importedMotion } from "./animation";
+
+      const LocalPanel = () => null;
+      const motion = { div: LocalPanel };
+
+      export const Examples = () => (
+        <>
+          <motion.div initial={{ scale: 0 }} />
+          <importedMotion.div initial={{ scale: 0 }} />
+        </>
+      );
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("flags scale zero on direct and aliased motion factory imports", () => {
+    const result = run(`
+      import { motion, m as compactMotion } from "framer-motion";
+      import { motion as aliasedMotion } from "motion/react";
+
+      export const Examples = () => (
+        <>
+          <motion.div initial={{ scale: 0 }} />
+          <compactMotion.span exit={{ scale: 0 }} />
+          <aliasedMotion.section initial={{ scale: 0 }} />
+        </>
+      );
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(3);
+  });
+
+  it("flags scale zero through motion namespace imports", () => {
+    const result = run(`
+      import * as Framer from "framer-motion";
+      import * as MotionReact from "motion/react";
+
+      export const Examples = () => (
+        <>
+          <Framer.motion.div initial={{ scale: 0 }} />
+          <MotionReact.m.span exit={{ scale: 0 }} />
+        </>
+      );
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
+  it("does not trust a shadow of a motion import", () => {
+    const result = run(`
+      import { motion } from "framer-motion";
+
+      const Panel = () => null;
+      export const Example = () => {
+        const motion = { div: Panel };
+        return <motion.div initial={{ scale: 0 }} />;
+      };
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays conservative when a later spread can replace initial", () => {
+    const result = run(`
+      import { motion } from "framer-motion";
+
+      export const Example = ({ props }) => (
+        <motion.div initial={{ scale: 0 }} {...props} />
+      );
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("flags an explicit initial prop that follows a spread", () => {
+    const result = run(`
+      import { motion } from "framer-motion";
+
+      export const Example = ({ props }) => (
+        <motion.div {...props} initial={{ scale: 0 }} />
+      );
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-scale-from-zero.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-scale-from-zero.regressions.test.ts
@@ -110,6 +110,23 @@ describe("performance/no-scale-from-zero — regressions", () => {
     expect(result.diagnostics).toHaveLength(4);
   });
 
+  it("keeps lowercase JSX tags intrinsic despite colliding tag-namespace imports", () => {
+    const result = run(`
+      import { div, span as section, article as MotionArticle } from "framer-motion/m";
+
+      export const Examples = () => (
+        <>
+          <div initial={{ scale: 0 }} />
+          <section exit={{ scale: 0 }} />
+          <MotionArticle initial={{ scale: 0 }} />
+        </>
+      );
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("does not treat animation-only mini entrypoints as tag namespaces", () => {
     const result = run(`
       import * as FramerMini from "framer-motion/mini";

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-scale-from-zero.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-scale-from-zero.regressions.test.ts
@@ -89,6 +89,67 @@ describe("performance/no-scale-from-zero — regressions", () => {
     expect(result.diagnostics).toHaveLength(2);
   });
 
+  it("flags official tag namespace subpaths", () => {
+    const result = run(`
+      import * as ClientMotion from "motion/react-client";
+      import * as LegacyClientMotion from "framer-motion/client";
+      import * as MinimalMotion from "motion/react-mini";
+      import { div as MotionDiv } from "framer-motion/m";
+
+      export const Examples = () => (
+        <>
+          <ClientMotion.div initial={{ scale: 0 }} />
+          <LegacyClientMotion.span exit={{ scale: 0 }} />
+          <MinimalMotion.section initial={{ scale: 0 }} />
+          <MotionDiv initial={{ scale: 0 }} />
+        </>
+      );
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(4);
+  });
+
+  it("does not treat a root module namespace as a tag namespace", () => {
+    const result = run(`
+      import * as Framer from "framer-motion";
+
+      export const Example = () => <Framer.div initial={{ scale: 0 }} />;
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("flags proven motion factory and component aliases", () => {
+    const result = run(`
+      import { motion as motionFactory } from "framer-motion";
+      import * as Framer from "motion/react";
+
+      const Base = () => null;
+      const factoryAlias = motionFactory as typeof motionFactory;
+      const namespaceAlias = Framer;
+      const namespaceFactory = namespaceAlias.motion;
+      const MemberComponent = factoryAlias.div;
+      const MemberAlias = MemberComponent;
+      const CreatedComponent = motionFactory.create(Base);
+      const LegacyComponent = motionFactory(Base);
+
+      export const Examples = () => (
+        <>
+          <factoryAlias.div initial={{ scale: 0 }} />
+          <namespaceFactory.span initial={{ scale: 0 }} />
+          <MemberAlias initial={{ scale: 0 }} />
+          <CreatedComponent exit={{ scale: 0 }} />
+          <LegacyComponent initial={{ scale: 0 }} />
+        </>
+      );
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(5);
+  });
+
   it("does not trust a shadow of a motion import", () => {
     const result = run(`
       import { motion } from "framer-motion";
@@ -98,6 +159,46 @@ describe("performance/no-scale-from-zero — regressions", () => {
         const motion = { div: Panel };
         return <motion.div initial={{ scale: 0 }} />;
       };
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not trust mutable or conditionally selected motion lookalikes", () => {
+    const result = run(`
+      import { motion } from "framer-motion";
+
+      const Panel = () => null;
+      let mutableFactory = motion;
+      mutableFactory = { div: Panel };
+      const MaybeAnimated = Math.random() > 0.5 ? motion.div : Panel;
+
+      export const Examples = ({ isOpen }) => (
+        <>
+          <mutableFactory.div initial={{ scale: 0 }} />
+          <MaybeAnimated initial={{ scale: 0 }} />
+          <motion.div initial={isOpen ? { scale: 0 } : { scale: 1 }} />
+          <motion.div initial={{ scale: isOpen ? 0 : 1 }} />
+        </>
+      );
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not treat type-only or default imports as motion factories", () => {
+    const result = run(`
+      import type { motion as MotionType } from "framer-motion";
+      import motion from "framer-motion";
+
+      export const Examples = () => (
+        <>
+          <MotionType.div initial={{ scale: 0 }} />
+          <motion.div initial={{ scale: 0 }} />
+        </>
+      );
     `);
 
     expect(result.parseErrors).toEqual([]);
@@ -123,6 +224,22 @@ describe("performance/no-scale-from-zero — regressions", () => {
 
       export const Example = ({ props }) => (
         <motion.div {...props} initial={{ scale: 0 }} />
+      );
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("uses only the last authoritative duplicate prop", () => {
+    const result = run(`
+      import { motion } from "framer-motion";
+
+      export const Examples = () => (
+        <>
+          <motion.div initial={{ scale: 0 }} initial={{ scale: 1 }} />
+          <motion.div initial={{ scale: 1 }} initial={{ scale: 0 }} />
+        </>
       );
     `);
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-scale-from-zero.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-scale-from-zero.regressions.test.ts
@@ -93,14 +93,14 @@ describe("performance/no-scale-from-zero — regressions", () => {
     const result = run(`
       import * as ClientMotion from "motion/react-client";
       import * as LegacyClientMotion from "framer-motion/client";
-      import * as MinimalMotion from "motion/react-mini";
+      import * as CompactMotion from "motion/react-m";
       import { div as MotionDiv } from "framer-motion/m";
 
       export const Examples = () => (
         <>
           <ClientMotion.div initial={{ scale: 0 }} />
           <LegacyClientMotion.span exit={{ scale: 0 }} />
-          <MinimalMotion.section initial={{ scale: 0 }} />
+          <CompactMotion.section initial={{ scale: 0 }} />
           <MotionDiv initial={{ scale: 0 }} />
         </>
       );
@@ -108,6 +108,23 @@ describe("performance/no-scale-from-zero — regressions", () => {
 
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toHaveLength(4);
+  });
+
+  it("does not treat animation-only mini entrypoints as tag namespaces", () => {
+    const result = run(`
+      import * as FramerMini from "framer-motion/mini";
+      import * as MotionMini from "motion/react-mini";
+
+      export const Examples = () => (
+        <>
+          <FramerMini.div initial={{ scale: 0 }} />
+          <MotionMini.section initial={{ scale: 0 }} />
+        </>
+      );
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
   });
 
   it("does not treat a root module namespace as a tag namespace", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-scale-from-zero.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-scale-from-zero.ts
@@ -3,28 +3,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { isProvenFramerMotionJsxElement } from "../../utils/is-proven-framer-motion-jsx-element.js";
-
-const isAuthoritativeAttribute = (node: EsTreeNodeOfType<"JSXAttribute">): boolean => {
-  const openingElement = node.parent;
-  if (!openingElement || !isNodeOfType(openingElement, "JSXOpeningElement")) return false;
-  const nodeIndex = openingElement.attributes.findIndex((attribute) => Object.is(attribute, node));
-  for (
-    let attributeIndex = nodeIndex + 1;
-    attributeIndex < openingElement.attributes.length;
-    attributeIndex += 1
-  ) {
-    const attribute = openingElement.attributes[attributeIndex];
-    if (!attribute || isNodeOfType(attribute, "JSXSpreadAttribute")) return false;
-    if (
-      isNodeOfType(attribute, "JSXAttribute") &&
-      isNodeOfType(attribute.name, "JSXIdentifier") &&
-      attribute.name.name === node.name.name
-    ) {
-      return false;
-    }
-  }
-  return true;
-};
+import { getAuthoritativeJsxAttribute } from "../../utils/get-authoritative-jsx-attribute.js";
 
 export const noScaleFromZero = defineRule({
   id: "no-scale-from-zero",
@@ -37,11 +16,11 @@ export const noScaleFromZero = defineRule({
     JSXAttribute(node: EsTreeNodeOfType<"JSXAttribute">) {
       if (!isNodeOfType(node.name, "JSXIdentifier")) return;
       if (node.name.name !== "initial" && node.name.name !== "exit") return;
-      if (!isAuthoritativeAttribute(node)) return;
       const openingElement = node.parent;
       if (
         !openingElement ||
         !isNodeOfType(openingElement, "JSXOpeningElement") ||
+        !Object.is(getAuthoritativeJsxAttribute(openingElement.attributes, node.name.name), node) ||
         !isProvenFramerMotionJsxElement(openingElement, context.scopes)
       ) {
         return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-scale-from-zero.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-scale-from-zero.ts
@@ -2,6 +2,29 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { isProvenFramerMotionJsxElement } from "../../utils/is-proven-framer-motion-jsx-element.js";
+
+const isAuthoritativeAttribute = (node: EsTreeNodeOfType<"JSXAttribute">): boolean => {
+  const openingElement = node.parent;
+  if (!openingElement || !isNodeOfType(openingElement, "JSXOpeningElement")) return false;
+  const nodeIndex = openingElement.attributes.findIndex((attribute) => Object.is(attribute, node));
+  for (
+    let attributeIndex = nodeIndex + 1;
+    attributeIndex < openingElement.attributes.length;
+    attributeIndex += 1
+  ) {
+    const attribute = openingElement.attributes[attributeIndex];
+    if (!attribute || isNodeOfType(attribute, "JSXSpreadAttribute")) return false;
+    if (
+      isNodeOfType(attribute, "JSXAttribute") &&
+      isNodeOfType(attribute.name, "JSXIdentifier") &&
+      attribute.name.name === node.name.name
+    ) {
+      return false;
+    }
+  }
+  return true;
+};
 
 export const noScaleFromZero = defineRule({
   id: "no-scale-from-zero",
@@ -14,6 +37,15 @@ export const noScaleFromZero = defineRule({
     JSXAttribute(node: EsTreeNodeOfType<"JSXAttribute">) {
       if (!isNodeOfType(node.name, "JSXIdentifier")) return;
       if (node.name.name !== "initial" && node.name.name !== "exit") return;
+      if (!isAuthoritativeAttribute(node)) return;
+      const openingElement = node.parent;
+      if (
+        !openingElement ||
+        !isNodeOfType(openingElement, "JSXOpeningElement") ||
+        !isProvenFramerMotionJsxElement(openingElement, context.scopes)
+      ) {
+        return;
+      }
       if (!isNodeOfType(node.value, "JSXExpressionContainer")) return;
 
       const expression = node.value.expression;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-proven-framer-motion-jsx-element.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-proven-framer-motion-jsx-element.ts
@@ -1,0 +1,144 @@
+import type { ScopeAnalysis, SymbolDescriptor } from "../semantic/scope-analysis.js";
+import type { EsTreeNode } from "./es-tree-node.js";
+import type { EsTreeNodeOfType } from "./es-tree-node-of-type.js";
+import { getImportedName } from "./get-imported-name.js";
+import { getStaticPropertyName } from "./get-static-property-name.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+import { isTypeOnlyImport } from "./is-type-only-import.js";
+import { resolveConstIdentifierAlias } from "./resolve-const-identifier-alias.js";
+import { stripParenExpression } from "./strip-paren-expression.js";
+
+const MOTION_FACTORY_MODULES: ReadonlySet<string> = new Set(["framer-motion", "motion/react"]);
+const MOTION_TAG_NAMESPACE_MODULES: ReadonlySet<string> = new Set([
+  "framer-motion/client",
+  "framer-motion/m",
+  "framer-motion/mini",
+  "motion/react-client",
+  "motion/react-m",
+  "motion/react-mini",
+]);
+const MOTION_FACTORY_EXPORTS: ReadonlySet<string> = new Set(["m", "motion"]);
+
+const getValueImportSource = (symbol: SymbolDescriptor): string | null => {
+  if (symbol.kind !== "import") return null;
+  const declaration = symbol.declarationNode.parent;
+  if (
+    !declaration ||
+    !isNodeOfType(declaration, "ImportDeclaration") ||
+    isTypeOnlyImport(declaration) ||
+    (isNodeOfType(symbol.declarationNode, "ImportSpecifier") &&
+      symbol.declarationNode.importKind === "type")
+  ) {
+    return null;
+  }
+  return typeof declaration.source.value === "string" ? declaration.source.value : null;
+};
+
+const getMemberParts = (node: EsTreeNode): [EsTreeNode, string] | null => {
+  if (isNodeOfType(node, "MemberExpression")) {
+    const propertyName = getStaticPropertyName(node);
+    return propertyName ? [node.object, propertyName] : null;
+  }
+  if (isNodeOfType(node, "JSXMemberExpression")) {
+    return isNodeOfType(node.property, "JSXIdentifier") ? [node.object, node.property.name] : null;
+  }
+  return null;
+};
+
+const resolveSymbol = (node: EsTreeNode, scopes: ScopeAnalysis): SymbolDescriptor | null => {
+  if (!isNodeOfType(node, "Identifier") && !isNodeOfType(node, "JSXIdentifier")) return null;
+  return resolveConstIdentifierAlias(node, scopes);
+};
+
+const isNamespaceFrom = (
+  node: EsTreeNode,
+  sources: ReadonlySet<string>,
+  scopes: ScopeAnalysis,
+): boolean => {
+  const symbol = resolveSymbol(stripParenExpression(node), scopes);
+  const source = symbol ? getValueImportSource(symbol) : null;
+  return Boolean(
+    source &&
+    sources.has(source) &&
+    symbol &&
+    isNodeOfType(symbol.declarationNode, "ImportNamespaceSpecifier"),
+  );
+};
+
+const isMotionFactory = (
+  rawNode: EsTreeNode,
+  scopes: ScopeAnalysis,
+  visitedSymbolIds: Set<number>,
+): boolean => {
+  const node = stripParenExpression(rawNode);
+  if (isNamespaceFrom(node, MOTION_TAG_NAMESPACE_MODULES, scopes)) return true;
+  const symbol = resolveSymbol(node, scopes);
+  if (symbol?.kind === "import") {
+    const source = getValueImportSource(symbol);
+    const importedName = getImportedName(symbol.declarationNode);
+    return Boolean(
+      source &&
+      MOTION_FACTORY_MODULES.has(source) &&
+      importedName &&
+      MOTION_FACTORY_EXPORTS.has(importedName),
+    );
+  }
+  if (symbol?.kind === "const" && symbol.initializer) {
+    if (visitedSymbolIds.has(symbol.id)) return false;
+    visitedSymbolIds.add(symbol.id);
+    return isMotionFactory(symbol.initializer, scopes, visitedSymbolIds);
+  }
+  const memberParts = getMemberParts(node);
+  return Boolean(
+    memberParts &&
+    MOTION_FACTORY_EXPORTS.has(memberParts[1]) &&
+    isNamespaceFrom(memberParts[0], MOTION_FACTORY_MODULES, scopes),
+  );
+};
+
+const isMotionComponent = (rawNode: EsTreeNode, scopes: ScopeAnalysis): boolean => {
+  return isMotionComponentWithVisitedSymbols(rawNode, scopes, new Set());
+};
+
+const isMotionComponentWithVisitedSymbols = (
+  rawNode: EsTreeNode,
+  scopes: ScopeAnalysis,
+  visitedSymbolIds: Set<number>,
+): boolean => {
+  const node = stripParenExpression(rawNode);
+  const symbol = resolveSymbol(node, scopes);
+  if (symbol?.kind === "const" && symbol.initializer) {
+    if (visitedSymbolIds.has(symbol.id)) return false;
+    visitedSymbolIds.add(symbol.id);
+    return isMotionComponentWithVisitedSymbols(symbol.initializer, scopes, visitedSymbolIds);
+  }
+  if (symbol?.kind === "import") {
+    const source = getValueImportSource(symbol);
+    return Boolean(
+      source &&
+      MOTION_TAG_NAMESPACE_MODULES.has(source) &&
+      isNodeOfType(symbol.declarationNode, "ImportSpecifier") &&
+      getImportedName(symbol.declarationNode) !== "create",
+    );
+  }
+  const memberParts = getMemberParts(node);
+  if (memberParts && isMotionFactory(memberParts[0], scopes, visitedSymbolIds)) return true;
+  if (!isNodeOfType(node, "CallExpression")) return false;
+  if (isMotionFactory(node.callee, scopes, visitedSymbolIds)) return true;
+  const calleeMemberParts = getMemberParts(stripParenExpression(node.callee));
+  return Boolean(
+    calleeMemberParts &&
+    calleeMemberParts[1] === "create" &&
+    isMotionFactory(calleeMemberParts[0], scopes, visitedSymbolIds),
+  );
+};
+
+export const isProvenFramerMotionJsxElement = (
+  openingElement: EsTreeNodeOfType<"JSXOpeningElement">,
+  scopes: ScopeAnalysis,
+): boolean => {
+  const elementName = openingElement.name;
+  if (isNodeOfType(elementName, "JSXIdentifier")) return isMotionComponent(elementName, scopes);
+  const memberParts = getMemberParts(elementName);
+  return Boolean(memberParts && isMotionFactory(memberParts[0], scopes, new Set()));
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-proven-framer-motion-jsx-element.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-proven-framer-motion-jsx-element.ts
@@ -12,10 +12,8 @@ const MOTION_FACTORY_MODULES: ReadonlySet<string> = new Set(["framer-motion", "m
 const MOTION_TAG_NAMESPACE_MODULES: ReadonlySet<string> = new Set([
   "framer-motion/client",
   "framer-motion/m",
-  "framer-motion/mini",
   "motion/react-client",
   "motion/react-m",
-  "motion/react-mini",
 ]);
 const MOTION_FACTORY_EXPORTS: ReadonlySet<string> = new Set(["m", "motion"]);
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-proven-framer-motion-jsx-element.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-proven-framer-motion-jsx-element.ts
@@ -136,7 +136,10 @@ export const isProvenFramerMotionJsxElement = (
   scopes: ScopeAnalysis,
 ): boolean => {
   const elementName = openingElement.name;
-  if (isNodeOfType(elementName, "JSXIdentifier")) return isMotionComponent(elementName, scopes);
+  if (isNodeOfType(elementName, "JSXIdentifier")) {
+    if (/^[a-z]/.test(elementName.name)) return false;
+    return isMotionComponent(elementName, scopes);
+  }
   const memberParts = getMemberParts(elementName);
   return Boolean(memberParts && isMotionFactory(memberParts[0], scopes, new Set()));
 };


### PR DESCRIPTION
<!-- motivation-example:start -->
## Motivation

A prop named `initial` with `{ scale: 0 }` is not proof that animation occurs. Diagnosing ordinary components by prop shape alone creates false positives, so the rule must prove Framer Motion ownership before reporting.

## Example

```tsx
const Panel = ({ initial }) => <output>{initial.scale}</output>

<Panel initial={{ scale: 0 }} />
```

The same prop on a provenance-proven Motion component continues to report.
<!-- motivation-example:end -->

## What changed

- Require a value import from an official Framer Motion component entrypoint before reporting.
- Follow direct and aliased `motion`/`m` factories, namespace imports, factory members, and components created with `motion.create(...)` or `motion(...)`.
- Recognize client and `m` tag-namespace entrypoints while excluding animation-only `mini` entrypoints.
- Reject local/imported lookalikes, shadows, mutable or conditional aliases, type-only/default imports, unresolved components, and lowercase intrinsic JSX tags that collide with import names.
- Use only the authoritative explicit prop when duplicate props or later spreads can override `initial` or `exit`.
- Add paired regressions, permanent fuzz seeds, generated fuzz shapes, and a patch changeset.

## Precision boundary

The rule reports only when ownership can be traced to a supported Framer Motion value import and the relevant prop is authoritative. Unknown provenance stays quiet. Proven Motion aliases and PascalCase tag-namespace imports remain reportable; lowercase JSX names remain React host intrinsics regardless of an import collision.

## Validation

| Evidence | Baseline | Candidate | Result |
| --- | ---: | ---: | --- |
| local RDE complete roots | 99 / 99 | 99 / 99 | exact parity |
| local RDE repositories | 12 | 12 | exact pinned set |
| `no-scale-from-zero` RDE diagnostics | 0 | 0 | no added FP or removed TP |
| scan failures among counted roots | 0 | 0 | valid evidence |

The same Excalidraw root exceeded the two-minute lint timeout on both sides and is rejected rather than counted as a pass. All 99 retained roots completed successfully, and full diagnostic parity passed with a 16 GB Node heap.

- focused paired regressions, including lowercase tag/import collisions and PascalCase near-neighbors
- `nr --filter oxlint-plugin-react-doctor test`: passed
- `TURBO_CONCURRENCY=4 nr test`: all 14 repository tasks passed
- `nr typecheck`
- `nr lint`
- `nr format:check`
- `git diff --check`
- strict generated fuzz: 500 iterations
- strict React Bench 5 corpus fuzz: 500 iterations
- post-change `truffler` searches found no overlapping provenance helper

### React Bench and oracle validation

| Evidence | Requested | Successful | Target diagnostics | Delta |
| --- | ---: | ---: | ---: | ---: |
| pinned repository bases | 31 | 31 | 0 → 0 | 0 |
| reconstructed oracle patches | 30 | 30 | 0 → 0 | 0 |

The base matrix scanned 14,538 application files across 31 exact repository/SHA pins. The oracle matrix scanned 14,422 files across all 30 reconstructed patches. Every target-rule delta was inspected; there were no added or removed diagnostics. Brainly’s two vendored `flow-typed/**` declarations are not parseable by oxlint and were explicitly excluded on both sides; all 421 application files in each of its four base/oracle × baseline/candidate scans completed cleanly.

- canonical React Bench strict fuzz: 2,000 iterations, target fired 33 times, no findings
- `~/Developer/react-bench-5` strict fuzz: 2,000 iterations, target fired 25 times, no findings, fire coverage 1/1
- exact semantic probes removed the ordinary-prop and lowercase-intrinsic FPs while preserving real `motion.div` and PascalCase official-tag reports

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to one oxlint rule and a new static-analysis helper; behavior is more conservative (fewer diagnostics), with broad regression and fuzz coverage.
> 
> **Overview**
> **`no-scale-from-zero`** no longer fires on any JSX with `initial`/`exit` and `{ scale: 0 }`. It now requires the element to be a **proven Framer Motion** component and only inspects the **authoritative** `initial` or `exit` prop (last duplicate wins; spreads that can override the prop suppress the report).
> 
> A new **`isProvenFramerMotionJsxElement`** helper traces value imports from official `framer-motion` / `motion/react` entrypoints (including `motion`/`m`, namespace members, client/`m` tag namespaces, and `motion.create`), while staying silent on ordinary data props, host elements like `<div>`, lowercase tags that collide with `framer-motion/m` imports, userland shadows, and `mini` / root-namespace false positives.
> 
> Coverage adds a large regression test file, fuzz corpus seeds, fixture/liveness updates, and a patch changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4340c3ea0a22836bc7cb85a786785ac28c2ef9cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

