### PR TITLE
fix(no-chain-state-updates): follow effect hook aliases

### DIFF
--- a/.changeset/calm-ravens-listen.md
+++ b/.changeset/calm-ravens-listen.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Recognize immutable and isomorphic React effect aliases in `no-chain-state-updates`.

--- a/packages/fuzz/corpus/regressions/no-chain-state-updates--isomorphic-effect-alias.tsx
+++ b/packages/fuzz/corpus/regressions/no-chain-state-updates--isomorphic-effect-alias.tsx
@@ -1,0 +1,24 @@
+// rule: no-chain-state-updates
+// weakness: effect-hook-provenance
+// source: nteract/semiotic AccessibleNavTree benchmark trial
+
+import * as React from "react";
+
+const useIsomorphicLayoutEffect =
+  typeof window !== "undefined" ? React.useLayoutEffect : React.useEffect;
+
+export const NavigationTree = () => {
+  const [activeId, setActiveId] = React.useState("");
+  const [selectedId, setSelectedId] = React.useState("");
+  const clearLater = () => setTimeout(() => setActiveId(""), 100);
+
+  useIsomorphicLayoutEffect(() => {
+    setSelectedId(activeId);
+  }, [activeId]);
+
+  return (
+    <button onClick={() => setActiveId("next")} onBlur={clearLater}>
+      {selectedId}
+    </button>
+  );
+};

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -10,6 +10,7 @@
 // Effects — listener pairs (matched and mismatched), observers, rAF loops,
 // timers, async IIFEs with and without cancellation, body mutations.
 export const EFFECT_SNIPPET_POOL = [
+  `{ const [fuzzEffectSource, setFuzzEffectSource] = useState(0); const [fuzzEffectTarget, setFuzzEffectTarget] = useState(0); const useFuzzIsomorphicLayoutEffect = typeof window !== "undefined" ? React.useLayoutEffect : React.useEffect; useEffect(() => { setFuzzEffectSource(1); }, []); useFuzzIsomorphicLayoutEffect(() => { setFuzzEffectTarget(fuzzEffectSource + 1); }, [fuzzEffectSource]); }`,
   `useEffect(() => { const handleWheel = () => handle(); window.addEventListener("wheel", handleWheel); return () => window.removeEventListener("wheel", handleWheel); }, []);`,
   `useEffect(() => { const handleWheel = (event) => handle(event); window.addEventListener("wheel", handleWheel); return () => window.removeEventListener("wheel", handleWheel); }, []);`,
   `useEffect(() => { window.addEventListener("resize", handle); return () => window.removeEventListener("resize", handle); }, []);`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-chain-state-updates.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-chain-state-updates.regressions.test.ts
@@ -1562,4 +1562,65 @@ export const Search = () => {
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toEqual([]);
   });
+
+  it("reports state chains through an isomorphic layout effect alias", () => {
+    const result = runRule(
+      noChainStateUpdates,
+      `import * as React from "react";
+      const useIsomorphicLayoutEffect =
+        typeof window !== "undefined" ? React.useLayoutEffect : React.useEffect;
+
+      const NavigationTree = ({ activeId, parentMap }) => {
+        const [expanded, setExpanded] = React.useState(() => new Set());
+        useIsomorphicLayoutEffect(() => {
+          const parent = parentMap.get(activeId);
+          if (parent) setExpanded((current) => new Set(current).add(parent.id));
+        }, [activeId, parentMap, expanded]);
+        return null;
+      };`,
+      { forceJsx: true },
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports the same state chain in a direct layout effect", () => {
+    const result = runRule(
+      noChainStateUpdates,
+      `import { useLayoutEffect, useState } from "react";
+      const NavigationTree = ({ activeId, parentMap }) => {
+        const [expanded, setExpanded] = useState(() => new Set());
+        useLayoutEffect(() => {
+          const parent = parentMap.get(activeId);
+          if (parent) setExpanded((current) => new Set(current).add(parent.id));
+        }, [activeId, parentMap, expanded]);
+        return null;
+      };`,
+      { forceJsx: true },
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays conservative when an effect alias can select an opaque hook", () => {
+    const result = runRule(
+      noChainStateUpdates,
+      `import { useEffect, useState } from "react";
+      const useMaybeEffect = Math.random() > 0.5 ? useEffect : useCustomEffect;
+      const NavigationTree = ({ activeId, parentMap }) => {
+        const [expanded, setExpanded] = useState(() => new Set());
+        useMaybeEffect(() => {
+          const parent = parentMap.get(activeId);
+          if (parent) setExpanded((current) => new Set(current).add(parent.id));
+        }, [activeId, parentMap, expanded]);
+        return null;
+      };`,
+      { forceJsx: true },
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-chain-state-updates.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-chain-state-updates.regressions.test.ts
@@ -1570,13 +1570,15 @@ export const Search = () => {
       const useIsomorphicLayoutEffect =
         typeof window !== "undefined" ? React.useLayoutEffect : React.useEffect;
 
-      const NavigationTree = ({ activeId, parentMap }) => {
-        const [expanded, setExpanded] = React.useState(() => new Set());
+      const NavigationTree = () => {
+        const [activeId, setActiveId] = React.useState("");
+        const [selectedId, setSelectedId] = React.useState("");
+        const clearLater = () => setTimeout(() => setActiveId(""), 100);
+        const onChange = (event) => setActiveId(event.target.value);
         useIsomorphicLayoutEffect(() => {
-          const parent = parentMap.get(activeId);
-          if (parent) setExpanded((current) => new Set(current).add(parent.id));
-        }, [activeId, parentMap, expanded]);
-        return null;
+          setSelectedId("");
+        }, [activeId]);
+        return <input value={selectedId} onChange={onChange} onBlur={clearLater} />;
       };`,
       { forceJsx: true },
     );
@@ -1589,13 +1591,15 @@ export const Search = () => {
     const result = runRule(
       noChainStateUpdates,
       `import { useLayoutEffect, useState } from "react";
-      const NavigationTree = ({ activeId, parentMap }) => {
-        const [expanded, setExpanded] = useState(() => new Set());
+      const NavigationTree = () => {
+        const [activeId, setActiveId] = useState("");
+        const [selectedId, setSelectedId] = useState("");
+        const clearLater = () => setTimeout(() => setActiveId(""), 100);
+        const onChange = (event) => setActiveId(event.target.value);
         useLayoutEffect(() => {
-          const parent = parentMap.get(activeId);
-          if (parent) setExpanded((current) => new Set(current).add(parent.id));
-        }, [activeId, parentMap, expanded]);
-        return null;
+          setSelectedId("");
+        }, [activeId]);
+        return <input value={selectedId} onChange={onChange} onBlur={clearLater} />;
       };`,
       { forceJsx: true },
     );
@@ -1609,13 +1613,15 @@ export const Search = () => {
       noChainStateUpdates,
       `import { useEffect, useState } from "react";
       const useMaybeEffect = Math.random() > 0.5 ? useEffect : useCustomEffect;
-      const NavigationTree = ({ activeId, parentMap }) => {
-        const [expanded, setExpanded] = useState(() => new Set());
+      const NavigationTree = () => {
+        const [activeId, setActiveId] = useState("");
+        const [selectedId, setSelectedId] = useState("");
+        const clearLater = () => setTimeout(() => setActiveId(""), 100);
+        const onChange = (event) => setActiveId(event.target.value);
         useMaybeEffect(() => {
-          const parent = parentMap.get(activeId);
-          if (parent) setExpanded((current) => new Set(current).add(parent.id));
-        }, [activeId, parentMap, expanded]);
-        return null;
+          setSelectedId("");
+        }, [activeId]);
+        return <input value={selectedId} onChange={onChange} onBlur={clearLater} />;
       };`,
       { forceJsx: true },
     );

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-chain-state-updates.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-chain-state-updates.ts
@@ -3,6 +3,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import { getRootIdentifierName } from "../../utils/get-root-identifier-name.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { isReactApiCall } from "../../utils/is-react-api-call.js";
 import { walkAst } from "../../utils/walk-ast.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
@@ -21,11 +22,12 @@ import {
   hasCleanup,
   isState,
   isSyncStateSetterCall,
-  isUseEffect,
 } from "./utils/effect/react.js";
 
 // Port of upstream `src/rules/no-chain-state-updates.js`, plus the
 // guarded-self-sync exemption below (prod telemetry review 2026-07).
+
+const APPLICABLE_EFFECT_HOOK_NAMES: ReadonlySet<string> = new Set(["useEffect", "useLayoutEffect"]);
 
 const getUseStateDeclarator = (ref: Reference): EsTreeNode | null =>
   (ref.resolved?.defs ?? [])
@@ -117,7 +119,16 @@ export const noChainStateUpdates = defineRule({
     "Set all the related state together in the event handler that starts it, instead of having one useEffect react to a state change and set more state. See https://react.dev/learn/you-might-not-need-an-effect#chains-of-computations",
   create: (context: RuleContext) => ({
     CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
-      if (!isUseEffect(node)) return;
+      if (
+        !isReactApiCall(node, APPLICABLE_EFFECT_HOOK_NAMES, context.scopes, {
+          allowGlobalReactNamespace: true,
+          allowUnboundBareCalls: true,
+          resolveConditionalAliases: true,
+          resolveNamedAliases: true,
+        })
+      ) {
+        return;
+      }
       const analysis = getProgramAnalysis(node);
       if (!analysis) return;
       if (hasCleanup(analysis, node)) return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-react-api-call.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-react-api-call.test.ts
@@ -54,6 +54,33 @@ describe("isReactApiCall", () => {
       expectedCount: 1,
     },
     {
+      name: "conditional aliases whose branches are React APIs",
+      code: `import { useEffect, useLayoutEffect } from "react";
+        const useIsomorphicLayoutEffect =
+          typeof window !== "undefined" ? useLayoutEffect : useEffect;
+        useIsomorphicLayoutEffect(() => {});`,
+      options: { resolveConditionalAliases: true, resolveNamedAliases: true },
+      expectedCount: 1,
+    },
+    {
+      name: "conditional aliases with an opaque branch",
+      code: `import { useEffect } from "react";
+        const useMaybeEffect = Math.random() > 0.5 ? useEffect : useCustomEffect;
+        useMaybeEffect(() => {});`,
+      options: { resolveConditionalAliases: true, resolveNamedAliases: true },
+      expectedCount: 0,
+    },
+    {
+      name: "multi-hop aliases of conditional React APIs",
+      code: `import * as ReactClient from "react";
+        const useIsomorphicLayoutEffect =
+          typeof window !== "undefined" ? ReactClient.useLayoutEffect : ReactClient.useEffect;
+        const useAliasedEffect = useIsomorphicLayoutEffect;
+        useAliasedEffect(() => {});`,
+      options: { resolveConditionalAliases: true, resolveNamedAliases: true },
+      expectedCount: 1,
+    },
+    {
       name: "default React receivers",
       code: 'import ReactClient from "react"; ReactClient.useEffect(() => {});',
       expectedCount: 1,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-react-api-call.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-react-api-call.ts
@@ -11,6 +11,7 @@ import { stripParenExpression } from "./strip-paren-expression.js";
 export interface ReactApiCallOptions {
   allowGlobalReactNamespace?: boolean;
   allowUnboundBareCalls?: boolean;
+  resolveConditionalAliases?: boolean;
   resolveNamedAliases?: boolean;
 }
 
@@ -105,7 +106,23 @@ export const isReactApiCall = (
   options: ReactApiCallOptions = {},
 ): boolean => {
   if (!isNodeOfType(node, "CallExpression")) return false;
-  const callee = stripParenExpression(node.callee);
+  return isReactApiCallee(node.callee, apiNames, scopes, options, new Set());
+};
+
+const isReactApiCallee = (
+  rawCallee: EsTreeNode,
+  apiNames: string | ReadonlySet<string>,
+  scopes: ScopeAnalysis,
+  options: ReactApiCallOptions,
+  visitedSymbolIds: Set<number>,
+): boolean => {
+  const callee = stripParenExpression(rawCallee);
+  if (options.resolveConditionalAliases && isNodeOfType(callee, "ConditionalExpression")) {
+    return (
+      isReactApiCallee(callee.consequent, apiNames, scopes, options, new Set(visitedSymbolIds)) &&
+      isReactApiCallee(callee.alternate, apiNames, scopes, options, new Set(visitedSymbolIds))
+    );
+  }
   if (isNodeOfType(callee, "Identifier")) {
     if (isNamedReactApiImport(callee, apiNames, scopes, Boolean(options.resolveNamedAliases))) {
       return true;
@@ -115,6 +132,13 @@ export const isReactApiCall = (
       isDestructuredReactApiBinding(callee, apiNames, scopes, options)
     ) {
       return true;
+    }
+    if (options.resolveConditionalAliases) {
+      const symbol = scopes.symbolFor(callee);
+      if (symbol?.kind === "const" && symbol.initializer && !visitedSymbolIds.has(symbol.id)) {
+        visitedSymbolIds.add(symbol.id);
+        return isReactApiCallee(symbol.initializer, apiNames, scopes, options, visitedSymbolIds);
+      }
     }
     return Boolean(
       options.allowUnboundBareCalls &&


### PR DESCRIPTION
<!-- motivation-example:start -->
## Motivation

Applications commonly alias `useEffect` and `useLayoutEffect` behind an isomorphic Hook. The effect still chains state, so recognizing only direct Hook calls creates a false negative.

## Example

Both branches resolve to authoritative React effect APIs:

```tsx
const useIsomorphicEffect =
  typeof window === "undefined" ? React.useEffect : React.useLayoutEffect

useIsomorphicEffect(() => {
  setDerived(source)
}, [source])
```

Mixed React/custom or mutable aliases remain outside the proof.
<!-- motivation-example:end -->

## Reproduction

The pinned React Bench model patch replaces `React.useEffect` with an immutable isomorphic alias that selects `React.useLayoutEffect` in the browser and `React.useEffect` on the server. The effect still reacts to one state value and sets another, but `no-chain-state-updates` previously stopped analyzing it because the effect recognizer accepted only direct calls.

## Fix

- Prove `useEffect` and `useLayoutEffect` provenance through named imports, namespace imports, immutable aliases, and conditional aliases.
- Require every conditional branch to resolve to an allowed React effect API.
- Keep custom hooks, mutable bindings, mixed React/opaque conditionals, and shadowed lookalikes conservative.
- Add paired regression tests, utility-level provenance tests, a permanent fuzz regression seed, and a generated alias shape.

## Validation

- Focused rule and utility tests: 97 passed.
- Full oxlint plugin suite: 559 files, 14,017 passed, 181 skipped.
- Full repository typecheck, lint, format check, diff check, build, and fuzz corpus tests pass.
- Strict generated fuzz, 500 iterations: 326 executed, target fired 16 times, 201 parse-skipped, no crash/slowness/metamorphic finding.
- Strict React Bench corpus fuzz, 500 iterations: 319 executed, target fired 23 times, 214 parse-skipped, no finding.
- Exact pushed-head, cache-disabled, prebuilt base/model/oracle comparison:
  - base: 1 -> 1, no delta;
  - model: 0 -> 1, one manually verified true positive at AccessibleNavTree line 88;
  - oracle: 0 -> 0, no delta.
  All six scans completed successfully with no partial projects.
- Independent 18-case alias audit covered direct, renamed, namespace, default-like, destructured, multi-hop, nested conditional, TypeScript wrapper, shadowed, mutable, opaque, cycle, logical, computed, and optional-call shapes; no blocker found.
- Local RDE was attempted but is invalid evidence because the current harness accepts report schema versions 1/2 while this checkout emits schema version 3.
- Truffler post-change searches found no duplicate alias/provenance helper.
- Ordinary CI, CodeQL, lint, typecheck, and React Doctor checks are green; zero unresolved review threads; exact local and remote heads match.

## Precision boundary

This does not infer logical-expression aliases, mutable aliases, imported/custom wrappers, or interprocedural hook-returning helpers. A conditional alias is recognized only when every branch is proven to be an applicable React effect API, preventing opaque custom hooks from being treated as effects.

## Status

Terminal-ready draft. Intentionally unmerged; no stable release requested.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static-analysis-only change with conservative handling of opaque aliases; no runtime, auth, or data-path impact.
> 
> **Overview**
> Fixes a false negative where **`no-chain-state-updates`** ignored state chains when effects ran through common **`useIsomorphicLayoutEffect`**-style aliases instead of direct **`useEffect`** / **`useLayoutEffect`** calls.
> 
> **`isReactApiCall`** gains optional **`resolveConditionalAliases`**: it walks **`const`** initializers and ternary callees, and treats a call as a React effect only when **every** branch resolves to an allowed hook (mixed React/custom branches stay unrecognized). **`no-chain-state-updates`** switches from **`isUseEffect`** to **`isReactApiCall`** with named and conditional alias resolution for **`useEffect`** and **`useLayoutEffect`**.
> 
> Regression coverage adds rule tests (isomorphic alias, direct layout effect, opaque conditional), **`isReactApiCall`** unit cases, a fuzz corpus seed, and an effect snippet in the fuzz pool.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb0dcc60e1cb78dd043598ae6aad00e48ceb4b8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->