### PR TITLE
fix(no-array-index-as-key): follow reachable key fallbacks

### DIFF
--- a/.changeset/upset-turkeys-fry.md
+++ b/.changeset/upset-turkeys-fry.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Make no-array-index-as-key detect reachable nullish, logical, and conditional fallbacks to the iteration index

--- a/packages/fuzz/corpus/true-positives/no-array-index-as-key--nullish-index-fallback.tsx
+++ b/packages/fuzz/corpus/true-positives/no-array-index-as-key--nullish-index-fallback.tsx
@@ -1,0 +1,11 @@
+// rule: no-array-index-as-key
+// weakness: reachable-expression-branch
+// source: React Bench write-react-lobehub-lobe-ui-508__EAtLqrE
+
+interface RowData {
+  id?: string;
+  label: string;
+}
+
+export const StatefulRows = ({ rows }: { rows: RowData[] }) =>
+  rows.map((row, index) => <div key={row.id ?? index}>{row.label}</div>);

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -403,6 +403,7 @@ export const JSX_ATTRIBUTE_POOL = [
 export const JSX_LEAF_POOL = [
   `{state}`,
   `{items.map((item, index) => <li key={index}>{item}</li>)}`,
+  `{items.map((item, index) => <Row key={item.id ?? index} item={item} />)}`,
   `{items.map((item) => <li key={item.id}>{item.name}</li>)}`,
   `{Array.from({ length: 4 }).map((_, index) => <div key={index}>{index}</div>)}`,
   `{Array(3).fill(null).map((cell) => <td key={cell}>{cell}</td>)}`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-array-index-as-key.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-array-index-as-key.regressions.test.ts
@@ -74,6 +74,70 @@ const Rows = ({ rows }: { rows: RowData[] }) => rows.map((row, index) => (
       expect(result.diagnostics).toHaveLength(1);
     });
 
+    it("flags fallbacks nested inside string coercions and templates", () => {
+      const stringResult = runRule(
+        noArrayIndexAsKey,
+        `const Rows = ({ rows }) => rows.map((row, index) => (
+  <Row key={String(row.id ?? index)} row={row} />
+));
+`,
+      );
+      const templateResult = runRule(
+        noArrayIndexAsKey,
+        `const Rows = ({ rows }) => rows.map((row, index) => (
+  <Row key={\`row-\${row.id ?? index}\`} row={row} />
+));
+`,
+      );
+      const methodResult = runRule(
+        noArrayIndexAsKey,
+        `const Rows = ({ rows }) => rows.map((row, index) => (
+  <Row key={(row.id ?? index).toString()} row={row} />
+));
+`,
+      );
+      expect(stringResult.parseErrors).toEqual([]);
+      expect(templateResult.parseErrors).toEqual([]);
+      expect(methodResult.parseErrors).toEqual([]);
+      expect(stringResult.diagnostics).toHaveLength(1);
+      expect(templateResult.diagnostics).toHaveLength(1);
+      expect(methodResult.diagnostics).toHaveLength(1);
+    });
+
+    it("flags reachable arithmetic and sequence-expression fallbacks", () => {
+      const arithmeticResult = runRule(
+        noArrayIndexAsKey,
+        `const Rows = ({ rows }) => rows.map((row, index) => (
+  <Row key={row.id ?? index + 1} row={row} />
+));
+`,
+      );
+      const sequenceResult = runRule(
+        noArrayIndexAsKey,
+        `const Rows = ({ rows, observe }) => rows.map((row, index) => {
+  const key = (observe(row), row.id ?? index);
+  return <Row key={key} row={row} />;
+});
+`,
+      );
+      expect(arithmeticResult.parseErrors).toEqual([]);
+      expect(sequenceResult.parseErrors).toEqual([]);
+      expect(arithmeticResult.diagnostics).toHaveLength(1);
+      expect(sequenceResult.diagnostics).toHaveLength(1);
+    });
+
+    it("does not treat an index used only as a condition as the resulting key", () => {
+      const result = runRule(
+        noArrayIndexAsKey,
+        `const Rows = ({ rows }) => rows.map((row, index) => (
+  <Row key={index ? row.id : row.slug} position={index} row={row} />
+));
+`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
     it("flags a destructured item key falling back to the index", () => {
       const result = runRule(
         noArrayIndexAsKey,
@@ -121,12 +185,116 @@ const Rows = ({ rows }: { rows: RowData[] }) => rows.map((row, index) => (
 ));
 `,
       );
+      const staticallyStableNullishResult = runRule(
+        noArrayIndexAsKey,
+        `const Rows = ({ rows }) => rows.map((row, index) => {
+  const stableKey = "always-stable";
+  return <Row key={stableKey ?? index} position={index} row={row} />;
+});
+`,
+      );
+      const staticallyFalsyAndResult = runRule(
+        noArrayIndexAsKey,
+        `const Rows = ({ rows }) => rows.map((row, index) => (
+  <Row key={false && index} position={index} row={row} />
+));
+`,
+      );
+      const nonNullishBinaryResult = runRule(
+        noArrayIndexAsKey,
+        `const Rows = ({ rows }) => rows.map((row, index) => (
+  <Row key={(row.rank + 1) ?? index} position={index} row={row} />
+));
+`,
+      );
+      const truthyObjectResult = runRule(
+        noArrayIndexAsKey,
+        `const Rows = ({ rows }) => rows.map((row, index) => (
+  <Row key={[] || index} position={index} row={row} />
+));
+`,
+      );
+      const nonNullishTemplateResult = runRule(
+        noArrayIndexAsKey,
+        `const Rows = ({ rows }) => rows.map((row, index) => (
+  <Row key={\`\${row.id}\` ?? index} position={index} row={row} />
+));
+`,
+      );
+      const nestedLogicalResult = runRule(
+        noArrayIndexAsKey,
+        `const Rows = ({ rows }) => rows.map((row, index) => (
+  <Row key={(row.id || "always-stable") || index} position={index} row={row} />
+));
+`,
+      );
+      const nestedNullishResult = runRule(
+        noArrayIndexAsKey,
+        `const Rows = ({ rows }) => rows.map((row, index) => (
+  <Row key={(row.id ?? 0) ?? index} position={index} row={row} />
+));
+`,
+      );
+      const nestedConditionalResult = runRule(
+        noArrayIndexAsKey,
+        `const Rows = ({ rows, condition }) => rows.map((row, index) => (
+  <Row key={(condition ? "first" : "second") ?? index} position={index} row={row} />
+));
+`,
+      );
+      const coercedValueResult = runRule(
+        noArrayIndexAsKey,
+        `const Rows = ({ rows }) => rows.map((row, index) => (
+  <Row key={String(row.id) ?? index} position={index} row={row} />
+));
+`,
+      );
+      const globalNumberResult = runRule(
+        noArrayIndexAsKey,
+        `const Rows = ({ rows }) => rows.map((row, index) => (
+  <Row key={NaN ?? index} position={index} row={row} />
+));
+`,
+      );
       expect(stableFallbackResult.parseErrors).toEqual([]);
       expect(unreachableLogicalResult.parseErrors).toEqual([]);
       expect(unreachableConditionalResult.parseErrors).toEqual([]);
+      expect(staticallyStableNullishResult.parseErrors).toEqual([]);
+      expect(staticallyFalsyAndResult.parseErrors).toEqual([]);
+      expect(nonNullishBinaryResult.parseErrors).toEqual([]);
+      expect(truthyObjectResult.parseErrors).toEqual([]);
+      expect(nonNullishTemplateResult.parseErrors).toEqual([]);
+      expect(nestedLogicalResult.parseErrors).toEqual([]);
+      expect(nestedNullishResult.parseErrors).toEqual([]);
+      expect(nestedConditionalResult.parseErrors).toEqual([]);
+      expect(coercedValueResult.parseErrors).toEqual([]);
+      expect(globalNumberResult.parseErrors).toEqual([]);
       expect(stableFallbackResult.diagnostics).toEqual([]);
       expect(unreachableLogicalResult.diagnostics).toEqual([]);
       expect(unreachableConditionalResult.diagnostics).toEqual([]);
+      expect(staticallyStableNullishResult.diagnostics).toEqual([]);
+      expect(staticallyFalsyAndResult.diagnostics).toEqual([]);
+      expect(nonNullishBinaryResult.diagnostics).toEqual([]);
+      expect(truthyObjectResult.diagnostics).toEqual([]);
+      expect(nonNullishTemplateResult.diagnostics).toEqual([]);
+      expect(nestedLogicalResult.diagnostics).toEqual([]);
+      expect(nestedNullishResult.diagnostics).toEqual([]);
+      expect(nestedConditionalResult.diagnostics).toEqual([]);
+      expect(coercedValueResult.diagnostics).toEqual([]);
+      expect(globalNumberResult.diagnostics).toEqual([]);
+    });
+
+    it("keeps a shadowed String fallback reachable", () => {
+      const result = runRule(
+        noArrayIndexAsKey,
+        `const String = () => undefined;
+const Rows = ({ rows }) => rows.map((row, index) => (
+  <Row key={String(row.id) ?? index} position={index} row={row} />
+));
+`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
     });
   });
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-array-index-as-key.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-array-index-as-key.regressions.test.ts
@@ -163,6 +163,19 @@ const Rows = ({ rows }: { rows: RowData[] }) => rows.map((row, index) => (
       expect(result.diagnostics).toHaveLength(1);
     });
 
+    it("keeps a destructuring default dynamic when the source can supply the index branch", () => {
+      const result = runRule(
+        noArrayIndexAsKey,
+        `const Rows = ({ rows }) => rows.map((row, index) => {
+  const { useIndex = false } = row;
+  return <Row key={useIndex ? index : row.id} row={row} />;
+});
+`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    });
+
     it("stays silent when every reachable branch is stable", () => {
       const stableFallbackResult = runRule(
         noArrayIndexAsKey,
@@ -295,6 +308,19 @@ const Rows = ({ rows }) => rows.map((row, index) => (
       );
       expect(result.parseErrors).toEqual([]);
       expect(result.diagnostics).toHaveLength(1);
+    });
+
+    it("does not treat a shadowed String call as a coercion of its argument", () => {
+      const result = runRule(
+        noArrayIndexAsKey,
+        `const String = () => "stable";
+const Rows = ({ rows }) => rows.map((row, index) => (
+  <Row key={String(row.id ?? index)} position={index} row={row} />
+));
+`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
     });
   });
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-array-index-as-key.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-array-index-as-key.regressions.test.ts
@@ -3,6 +3,133 @@ import { runRule } from "../../../test-utils/run-rule.js";
 import { noArrayIndexAsKey } from "./no-array-index-as-key.js";
 
 describe("correctness/no-array-index-as-key regressions", () => {
+  describe("reachable index fallbacks", () => {
+    it("flags the authentic Lobe nullish fallback after it is inlined", () => {
+      const result = runRule(
+        noArrayIndexAsKey,
+        `const AccordionRows = ({ children }) => (
+  <div>
+    {children.map((child, index) => (
+      <AccordionRow key={(child.props as { itemKey?: string }).itemKey ?? index} child={child} />
+    ))}
+  </div>
+);
+`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    });
+
+    it("flags the authentic Lobe nullish fallback through its local key alias", () => {
+      const result = runRule(
+        noArrayIndexAsKey,
+        `const AccordionRows = ({ children }) => (
+  <div>
+    {children.map((child, index) => {
+      const childKey = child.props.itemKey ?? index;
+      return <AccordionRow key={childKey} child={child} />;
+    })}
+  </div>
+);
+`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    });
+
+    it("flags logical and conditional index fallbacks", () => {
+      const logicalResult = runRule(
+        noArrayIndexAsKey,
+        `const Rows = ({ rows }) => rows.map((row, index) => (
+  <Row key={row.id || index} row={row} />
+));
+`,
+      );
+      const conditionalResult = runRule(
+        noArrayIndexAsKey,
+        `const Rows = ({ rows }) => rows.map((row, index) => (
+  <Row key={row.id ? row.id : index} row={row} />
+));
+`,
+      );
+      expect(logicalResult.parseErrors).toEqual([]);
+      expect(conditionalResult.parseErrors).toEqual([]);
+      expect(logicalResult.diagnostics).toHaveLength(1);
+      expect(conditionalResult.diagnostics).toHaveLength(1);
+    });
+
+    it("flags nested fallbacks through transparent TypeScript wrappers", () => {
+      const result = runRule(
+        noArrayIndexAsKey,
+        `interface RowData {
+  id?: string;
+  slug?: string;
+}
+const Rows = ({ rows }: { rows: RowData[] }) => rows.map((row, index) => (
+  <Row key={(row?.id as string | undefined) ?? row.slug ?? (index as number)} row={row} />
+));
+`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    });
+
+    it("flags a destructured item key falling back to the index", () => {
+      const result = runRule(
+        noArrayIndexAsKey,
+        `const Rows = ({ rows }) => rows.map(({ id, label }, index) => (
+  <Row key={id ?? index} label={label} />
+));
+`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    });
+
+    it("flags a fallback through an exact local index alias", () => {
+      const result = runRule(
+        noArrayIndexAsKey,
+        `const Rows = ({ rows }) => rows.map((row, index) => {
+  const fallbackKey = index;
+  return <Row key={row.id ?? fallbackKey} row={row} />;
+});
+`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    });
+
+    it("stays silent when every reachable branch is stable", () => {
+      const stableFallbackResult = runRule(
+        noArrayIndexAsKey,
+        `const Rows = ({ rows }) => rows.map((row, index) => (
+  <Row key={row.id ?? row.slug} position={index} row={row} />
+));
+`,
+      );
+      const unreachableLogicalResult = runRule(
+        noArrayIndexAsKey,
+        `const Rows = ({ rows }) => rows.map((row, index) => (
+  <Row key={"stable" || index} position={index} row={row} />
+));
+`,
+      );
+      const unreachableConditionalResult = runRule(
+        noArrayIndexAsKey,
+        `const Rows = ({ rows }) => rows.map((row, index) => (
+  <Row key={true ? row.id : index} position={index} row={row} />
+));
+`,
+      );
+      expect(stableFallbackResult.parseErrors).toEqual([]);
+      expect(unreachableLogicalResult.parseErrors).toEqual([]);
+      expect(unreachableConditionalResult.parseErrors).toEqual([]);
+      expect(stableFallbackResult.diagnostics).toEqual([]);
+      expect(unreachableLogicalResult.diagnostics).toEqual([]);
+      expect(unreachableConditionalResult.diagnostics).toEqual([]);
+    });
+  });
+
   describe("identifiers named like an index that are NOT the positional index (mined FP cluster)", () => {
     it("stays silent when `index` is destructured from the item itself (cloudscape show-more)", () => {
       const result = runRule(

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-array-index-as-key.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-array-index-as-key.ts
@@ -132,6 +132,15 @@ const readStaticKeyBranchValue = (
       return null;
     }
     if (!isConstDeclaredBinding(binding) || !binding.initializer) return null;
+    const declarator = binding.bindingIdentifier.parent;
+    if (
+      !declarator ||
+      !isNodeOfType(declarator, "VariableDeclarator") ||
+      declarator.id !== binding.bindingIdentifier ||
+      declarator.init !== binding.initializer
+    ) {
+      return null;
+    }
     return readStaticKeyBranchValue(binding.initializer, depth + 1);
   }
   if (isNodeOfType(node, "CallExpression") && isNodeOfType(node.callee, "Identifier")) {
@@ -285,6 +294,7 @@ const extractCandidateIdentifiers = (
     if (
       isNodeOfType(node.callee, "Identifier") &&
       STRING_COERCION_FUNCTIONS.has(node.callee.name) &&
+      !findVariableInitializer(node.callee, node.callee.name) &&
       node.arguments?.[0]
     ) {
       return extractCandidateIdentifiers(node.arguments[0], depth + 1);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-array-index-as-key.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-array-index-as-key.ts
@@ -7,6 +7,7 @@ import { getRootIdentifierName } from "../../utils/get-root-identifier-name.js";
 import { collectPatternNames } from "../../utils/collect-pattern-names.js";
 import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
+import { isConstDeclaredBinding } from "../../utils/is-const-declared-binding.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import { walkAst } from "../../utils/walk-ast.js";
@@ -70,13 +71,150 @@ const TYPE_RESOLUTION_DEPTH_LIMIT = 4;
 const ARITHMETIC_KEY_OPERATORS = new Set(["+", "-", "*", "/", "%"]);
 const bindingMutationResultsByProgram = new WeakMap<EsTreeNode, Map<string, boolean>>();
 
+interface StaticKeyBranchValue {
+  isNullish: boolean | null;
+  isTruthy: boolean | null;
+}
+
+const UNKNOWN_STATIC_KEY_BRANCH_VALUE: StaticKeyBranchValue = {
+  isNullish: null,
+  isTruthy: null,
+};
+
+const mergeStaticKeyBranchValues = (
+  firstValue: StaticKeyBranchValue,
+  secondValue: StaticKeyBranchValue,
+): StaticKeyBranchValue => ({
+  isNullish: firstValue.isNullish === secondValue.isNullish ? firstValue.isNullish : null,
+  isTruthy: firstValue.isTruthy === secondValue.isTruthy ? firstValue.isTruthy : null,
+});
+
+const readStaticKeyBranchValue = (
+  expression: EsTreeNode,
+  depth: number,
+): StaticKeyBranchValue | null => {
+  if (depth > TYPE_RESOLUTION_DEPTH_LIMIT) return null;
+  const node = stripParenExpression(expression);
+  if (isNodeOfType(node, "Literal")) {
+    return {
+      isNullish: node.value === null,
+      isTruthy: Boolean(node.value),
+    };
+  }
+  if (
+    isNodeOfType(node, "ArrayExpression") ||
+    isNodeOfType(node, "ObjectExpression") ||
+    isNodeOfType(node, "ArrowFunctionExpression") ||
+    isNodeOfType(node, "FunctionExpression") ||
+    isNodeOfType(node, "ClassExpression") ||
+    isNodeOfType(node, "NewExpression")
+  ) {
+    return { isNullish: false, isTruthy: true };
+  }
+  if (isNodeOfType(node, "TemplateLiteral")) {
+    const hasStaticContent = (node.quasis ?? []).some(
+      (quasi) => typeof quasi.value?.cooked === "string" && quasi.value.cooked.length > 0,
+    );
+    return {
+      isNullish: false,
+      isTruthy: hasStaticContent ? true : null,
+    };
+  }
+  if (isNodeOfType(node, "BinaryExpression")) {
+    return { isNullish: false, isTruthy: null };
+  }
+  if (isNodeOfType(node, "Identifier")) {
+    const binding = findVariableInitializer(node, node.name);
+    if (!binding) {
+      if (node.name === "undefined") return { isNullish: true, isTruthy: false };
+      if (node.name === "NaN") return { isNullish: false, isTruthy: false };
+      if (node.name === "Infinity") return { isNullish: false, isTruthy: true };
+      return null;
+    }
+    if (!isConstDeclaredBinding(binding) || !binding.initializer) return null;
+    return readStaticKeyBranchValue(binding.initializer, depth + 1);
+  }
+  if (isNodeOfType(node, "CallExpression") && isNodeOfType(node.callee, "Identifier")) {
+    const hasLocalBinding = Boolean(findVariableInitializer(node.callee, node.callee.name));
+    if (!hasLocalBinding && STRING_COERCION_FUNCTIONS.has(node.callee.name)) {
+      return { isNullish: false, isTruthy: null };
+    }
+  }
+  if (isNodeOfType(node, "UnaryExpression")) {
+    if (node.operator === "void") return { isNullish: true, isTruthy: false };
+    if (node.operator === "typeof") return { isNullish: false, isTruthy: true };
+    if (node.operator === "+" || node.operator === "-" || node.operator === "~") {
+      return { isNullish: false, isTruthy: null };
+    }
+    if (node.operator !== "!") return null;
+    const argumentValue = readStaticKeyBranchValue(node.argument, depth + 1);
+    if (!argumentValue || argumentValue.isTruthy === null) return null;
+    return { isNullish: false, isTruthy: !argumentValue.isTruthy };
+  }
+  if (isNodeOfType(node, "SequenceExpression")) {
+    const finalExpression = node.expressions.at(-1);
+    return finalExpression ? readStaticKeyBranchValue(finalExpression, depth + 1) : null;
+  }
+  if (isNodeOfType(node, "LogicalExpression")) {
+    const leftValue =
+      readStaticKeyBranchValue(node.left, depth + 1) ?? UNKNOWN_STATIC_KEY_BRANCH_VALUE;
+    if (node.operator === "&&" && leftValue.isTruthy !== null) {
+      return leftValue.isTruthy ? readStaticKeyBranchValue(node.right, depth + 1) : leftValue;
+    }
+    if (node.operator === "||" && leftValue.isTruthy !== null) {
+      return leftValue.isTruthy ? leftValue : readStaticKeyBranchValue(node.right, depth + 1);
+    }
+    if (node.operator === "??" && leftValue.isNullish !== null) {
+      return leftValue.isNullish ? readStaticKeyBranchValue(node.right, depth + 1) : leftValue;
+    }
+    const rightValue =
+      readStaticKeyBranchValue(node.right, depth + 1) ?? UNKNOWN_STATIC_KEY_BRANCH_VALUE;
+    if (node.operator === "||") {
+      return {
+        isNullish: rightValue.isNullish === false ? false : null,
+        isTruthy: rightValue.isTruthy === true ? true : null,
+      };
+    }
+    if (node.operator === "&&") {
+      return {
+        isNullish: leftValue.isNullish === false && rightValue.isNullish === false ? false : null,
+        isTruthy: rightValue.isTruthy === false ? false : null,
+      };
+    }
+    return {
+      isNullish: rightValue.isNullish === false ? false : null,
+      isTruthy:
+        leftValue.isTruthy !== null && leftValue.isTruthy === rightValue.isTruthy
+          ? leftValue.isTruthy
+          : null,
+    };
+  }
+  if (isNodeOfType(node, "ConditionalExpression")) {
+    const testValue = readStaticKeyBranchValue(node.test, depth + 1);
+    if (testValue?.isTruthy !== null && testValue?.isTruthy !== undefined) {
+      return readStaticKeyBranchValue(
+        testValue.isTruthy ? node.consequent : node.alternate,
+        depth + 1,
+      );
+    }
+    const consequentValue =
+      readStaticKeyBranchValue(node.consequent, depth + 1) ?? UNKNOWN_STATIC_KEY_BRANCH_VALUE;
+    const alternateValue =
+      readStaticKeyBranchValue(node.alternate, depth + 1) ?? UNKNOWN_STATIC_KEY_BRANCH_VALUE;
+    return mergeStaticKeyBranchValues(consequentValue, alternateValue);
+  }
+  return null;
+};
+
 // The identifiers a key expression could get its value from — the bare
 // identifier, template-literal slots, `x.toString()`, `String(x)` /
 // `Number(x)`, `x + ""` / `"" + x` coercions, arithmetic offsets
 // (`x + 1`, `x * 2`), and unary negation (`-x`).
 const extractCandidateIdentifiers = (
   expression: EsTreeNode,
+  depth = 0,
 ): Array<EsTreeNodeOfType<"Identifier">> => {
+  if (depth > TYPE_RESOLUTION_DEPTH_LIMIT) return [];
   const node = stripParenExpression(expression);
   if (isNodeOfType(node, "Identifier")) return [node];
 
@@ -85,34 +223,71 @@ const extractCandidateIdentifiers = (
   if (
     isNodeOfType(node, "UnaryExpression") &&
     (node.operator === "-" || node.operator === "+" || node.operator === "~") &&
-    isNodeOfType(node.argument, "Identifier")
+    node.argument
   ) {
-    return [node.argument];
+    return extractCandidateIdentifiers(node.argument, depth + 1);
   }
 
   if (isNodeOfType(node, "TemplateLiteral")) {
     const identifiers: Array<EsTreeNodeOfType<"Identifier">> = [];
     for (const templateExpression of node.expressions ?? []) {
-      if (isNodeOfType(templateExpression, "Identifier")) identifiers.push(templateExpression);
+      identifiers.push(...extractCandidateIdentifiers(templateExpression, depth + 1));
     }
     return identifiers;
+  }
+
+  if (isNodeOfType(node, "LogicalExpression")) {
+    const leftValue = readStaticKeyBranchValue(node.left, 0);
+    if (leftValue) {
+      if (node.operator === "&&" && leftValue.isTruthy !== null) {
+        return extractCandidateIdentifiers(leftValue.isTruthy ? node.right : node.left, depth + 1);
+      }
+      if (node.operator === "||" && leftValue.isTruthy !== null) {
+        return extractCandidateIdentifiers(leftValue.isTruthy ? node.left : node.right, depth + 1);
+      }
+      if (node.operator === "??" && leftValue.isNullish !== null) {
+        return extractCandidateIdentifiers(leftValue.isNullish ? node.right : node.left, depth + 1);
+      }
+    }
+    return [
+      ...extractCandidateIdentifiers(node.left, depth + 1),
+      ...extractCandidateIdentifiers(node.right, depth + 1),
+    ];
+  }
+
+  if (isNodeOfType(node, "ConditionalExpression")) {
+    const testValue = readStaticKeyBranchValue(node.test, 0);
+    if (testValue && testValue.isTruthy !== null) {
+      return extractCandidateIdentifiers(
+        testValue.isTruthy ? node.consequent : node.alternate,
+        depth + 1,
+      );
+    }
+    return [
+      ...extractCandidateIdentifiers(node.consequent, depth + 1),
+      ...extractCandidateIdentifiers(node.alternate, depth + 1),
+    ];
+  }
+
+  if (isNodeOfType(node, "SequenceExpression")) {
+    const finalExpression = node.expressions.at(-1);
+    return finalExpression ? extractCandidateIdentifiers(finalExpression, depth + 1) : [];
   }
 
   if (isNodeOfType(node, "CallExpression")) {
     if (
       isNodeOfType(node.callee, "MemberExpression") &&
-      isNodeOfType(node.callee.object, "Identifier") &&
       isNodeOfType(node.callee.property, "Identifier") &&
       node.callee.property.name === "toString"
     ) {
-      return [node.callee.object];
+      return extractCandidateIdentifiers(node.callee.object, depth + 1);
     }
     if (
       isNodeOfType(node.callee, "Identifier") &&
       STRING_COERCION_FUNCTIONS.has(node.callee.name) &&
-      isNodeOfType(node.arguments?.[0], "Identifier")
+      node.arguments?.[0]
     ) {
-      return [node.arguments[0]];
+      return extractCandidateIdentifiers(node.arguments[0], depth + 1);
     }
     return [];
   }


### PR DESCRIPTION
<!-- motivation-example:start -->
## Motivation

An index used as a fallback key still controls identity whenever the preferred key is absent. Missing that reachable branch allows state to move between rows after prepend, reorder, or filtering.

## Example

This key is unstable for items without `itemKey`:

```tsx
{items.map((item, index) => (
  <Row key={item.itemKey ?? index} item={item} />
))}
```

Statically unreachable index branches stay quiet, while reachable logical, conditional, nullish, and sequence fallbacks report.
<!-- motivation-example:end -->

## Why

`no-array-index-as-key` only followed direct and coercion-shaped references to a map callback's index. It missed reachable fallback expressions such as `key={item.itemKey ?? index}`, even though absent item keys still remint component identities after prepend, reorder, or filtering.

The pinned Lobe UI trial `write-react-lobehub-lobe-ui-508__EAtLqrE` reproduces the miss. A runtime prepend oracle transfers row state under the fallback key and preserves it under stable keys.

## What changed

- Follow result-producing branches of nullish, logical, conditional, and sequence expressions.
- Prune statically unreachable branches, including immutable const aliases, so dead index references stay quiet.
- Preserve detection through TypeScript wrappers, coercions, templates, arithmetic, aliases, and destructuring.
- Add paired adversarial regressions, a permanent true-positive fuzz seed, a generated snippet-pool shape, and a patch changeset.

## Eval results

- Exact prebuilt Lobe base/model/oracle A/B: `21 → 23` target findings in each state. Both additions were manually classified as true positives: the Accordion index fallback and independent `key={c?.key || i}` in ColorSwatches. No diagnostics were removed.
- React Bench metadata corpus: 27/27 copied target files scanned successfully. Candidate changed `2 → 3`; the sole addition, `key={photo.photo || `${index}`}`, is a true positive. No removals or nested short-circuit false positives.
- Strict generated fuzz, 500 iterations: pass.
- Strict React Bench corpus fuzz, 500 iterations: pass. Direct fire coverage recorded 47 firing programs across 328 executed programs with zero findings.

## Test plan

- `nr --filter oxlint-plugin-react-doctor test` — 14,022 passed, 181 skipped
- `nr --filter oxlint-plugin-react-doctor typecheck`
- `nr --filter @react-doctor/fuzz test` — 44 passed, 402 skipped
- `nr --filter @react-doctor/fuzz typecheck`
- `FUZZ_RULE=no-array-index-as-key FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz`
- `FUZZ_RULE=no-array-index-as-key FUZZ_STRICT=1 FUZZ_ITERATIONS=500 FUZZ_CORPUS_DIR=packages/fuzz/tmp/bench-corpus nr fuzz`
- `nr lint`
- `nr format:check`
- `nr smoke:json-report`
- `git diff --check`

Repository-wide test and typecheck currently hit pre-existing language-server failures that reproduce unchanged on the pinned canonical base: two same-site occurrence assertions and `mapper.ts` TS2353 respectively.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Increases lint surface on real JSX keys via new static analysis; false positives are mitigated by branch pruning and extensive tests, but behavior change can affect CI noise for consumers.
> 
> **Overview**
> Extends **`no-array-index-as-key`** so it flags list keys where the map callback’s index can still determine identity through **nullish (`??`), logical (`||` / `&&`), conditional, and sequence** expressions—not only bare `key={index}` or simple coercions.
> 
> The rule adds **static branch analysis** (`readStaticKeyBranchValue`) to decide which expression arms are reachable, then **prunes dead arms** (e.g. `"stable" || index`, `true ? row.id : index`, const-stable nullish left sides) so those stay quiet. **`extractCandidateIdentifiers`** now recurses through those shapes plus templates, `String`/`toString`, and respects **shadowed `String`** vs global coercion.
> 
> Adds a large **regression suite**, a **fuzz true-positive seed** (`row.id ?? index`), a **snippet-pool** shape, and a **patch changeset** for `oxlint-plugin-react-doctor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce2118c90ab190750d50cf8e619184ec8ef76f5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->