### PR TITLE
fix(no-derived-useState): respect proven key remounts

### DIFF
--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-derived-use-state.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-derived-use-state.regressions.test.ts
@@ -464,4 +464,41 @@ describe("no-derived-useState — regressions", () => {
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toHaveLength(1);
   });
+
+  it("stays silent when every local use remounts for each copied prop seed", () => {
+    const result = runRule(
+      noDerivedUseState,
+      `interface BindingRule {
+        command: string;
+        key: string;
+        when?: string;
+      }
+
+      interface BindingView {
+        id: string;
+        rule: BindingRule;
+      }
+
+      function BindingRow({ view }: { view: BindingView }) {
+        const [keyDraft, setKeyDraft] = useState(view.rule.key);
+        const [whenDraft, setWhenDraft] = useState(view.rule.when);
+        return (
+          <button onClick={() => { setKeyDraft(""); setWhenDraft(undefined); }}>
+            {keyDraft}:{whenDraft}
+          </button>
+        );
+      }
+
+      function KeybindingsSettings({ rules }: { rules: BindingRule[] }) {
+        const views = useMemo(() => rules.map((rule, index) => ({
+          id: \`\${index}:\${rule.command}:\${rule.key}:\${rule.when ?? ""}\`,
+          rule,
+        })), [rules]);
+        const filteredViews = useMemo(() => views.filter(Boolean), [views]);
+        return filteredViews.map((view) => <BindingRow key={view.id} view={view} />);
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Status

Regression-only draft. CI intentionally remains red because the exact authentic regression fixture is expected to stay failing until the detector can prove the required runtime domain. No detector implementation has been pushed.

## Grounded reproduction

Pinned trial: `write-react-t3code-keybindings-s__qMERgWB` from `aws-agent-matrix-20260714-051134`, based on `pingdotgg/t3code@9b604bcae1e2cfe0e0566bc2aff660850e276c6d`.

The implementation passes all 45 owned browser checks. File-local `BindingRow` copies `view.rule.key` and `view.rule.when` into editable state. Its only JSX use is `<BindingRow key={view.id} view={view}>`, where the application builds `view.id` from index, command, key, and when. The imported shortcut and when-expression grammar makes relevant seed changes remount this row in the authentic application.

React Doctor current source and published 0.7.2, 0.7.4, and 0.7.7 report the copied state as stale. A separate applicable handler-only-state finding remains in the trial, so removing only these two diagnostics would not change its stored overall reward.

## Why the current exemption proposal is not sound

The analyzed file exposes `key` as `string` and `when` as `string | undefined`; the runtime grammar that restricts those strings lives behind imports. The local key expression is delimiter concatenation:

```tsx
id: `${index}:${rule.command}:${rule.key}:${rule.when ?? ""}`
```

That expression is not injective over the visible types. Two concrete, type-valid counterexamples preserve the React key while changing copied state:

```tsx
{ index: 0, command: "cmd", key: "a:b", when: "c" }
{ index: 0, command: "cmd", key: "a", when: "b:c" }
// Both produce "0:cmd:a:b:c".
```

```tsx
{ index: 0, command: "cmd", key: "a", when: undefined }
{ index: 0, command: "cmd", key: "a", when: "" }
// Both produce "0:cmd:a:".
```

A detector that treats template containment, a property named `id`, or local key dependency as proof would therefore hide genuine stale-state bugs. Existing same-file symbol and JSX call-site analysis can establish component ownership and exhaustive local uses, but it cannot recover this imported runtime value grammar.

## Required precision boundary

A future exemption must prove all of the following:

- The component is same-file and does not escape through exports, aliases, callbacks, spreads, or other opaque uses.
- Every reachable React instantiation is statically resolved and keyed.
- For each copied prop seed independently, the key is proven to change for every possible seed change.
- The key transform is injective over a statically proven value domain, including JavaScript coercion, delimiter, nullish, and empty-string behavior.
- Unkeyed, stable-key, incomplete-key, mixed-caller, collision-prone, imported-domain, and otherwise ambiguous cases remain reportable.

This boundary does not cover the authentic delimiter-concatenated trial with the information available to a per-file AST rule. The draft remains open as a grounded regression probe rather than landing an unsound false-negative exemption.
