### PR TITLE
fix(core): preserve error-boundary diagnostic semantics

### DIFF
--- a/.changeset/warm-otters-tan.md
+++ b/.changeset/warm-otters-tan.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Preserve `react-hooks-js/error-boundaries` as a Bugs diagnostic about uncaught child render failures instead of rewriting it as a React Compiler performance bailout.

--- a/packages/core/src/runners/oxlint/parse-output.ts
+++ b/packages/core/src/runners/oxlint/parse-output.ts
@@ -37,6 +37,9 @@ const REACT_COMPILER_TITLE = "React Compiler can't optimize this";
 // an unsupported-syntax bail-out, not an optimization miss in the
 // user's code, so it gets its own headline.
 const REACT_COMPILER_TODO_TITLE = "React Compiler doesn't support this syntax";
+const REACT_ERROR_BOUNDARY_TITLE = "JSX render errors need an Error Boundary";
+const REACT_ERROR_BOUNDARY_MESSAGE =
+  "This try/catch cannot catch errors thrown while the JSX child renders. Use an Error Boundary instead.";
 const REACT_COMPILER_IMPACT =
   "This component misses React Compiler's automatic memoization & re-renders more than it should";
 const REACT_COMPILER_ACTION = "Rewrite the flagged code so the compiler can optimize it.";
@@ -127,6 +130,7 @@ const getRuleTitle = (ruleName: string): string | undefined =>
 // diagnostics get a fixed human headline instead of their bare id.
 const resolveDiagnosticTitle = (plugin: string, rule: string): string | undefined => {
   if (plugin !== "react-hooks-js") return getRuleTitle(rule);
+  if (rule === "error-boundaries") return REACT_ERROR_BOUNDARY_TITLE;
   return rule === "todo" ? REACT_COMPILER_TODO_TITLE : REACT_COMPILER_TITLE;
 };
 
@@ -187,6 +191,12 @@ const resolveCleanedDiagnostic = (
     // and only the elaboration stays in `help`.
     const [reasonSummary = "", ...reasonDetailLines] = bailoutReason.split("\n");
     const reasonDetail = reasonDetailLines.join("\n").trim();
+    if (rule === "error-boundaries") {
+      return {
+        message: REACT_ERROR_BOUNDARY_MESSAGE,
+        help: reasonDetail || help,
+      };
+    }
     return {
       message: buildReactCompilerMessage(
         reasonSummary.trim(),
@@ -210,8 +220,10 @@ const parseRuleCode = (code: string): { plugin: string; rule: string } => {
   return { plugin: match[1].replace(/^eslint-plugin-/, ""), rule: match[2] };
 };
 
-const resolveDiagnosticCategory = (plugin: string, rule: string): string =>
-  getRuleCategory(rule) ?? lookupOwnString(PLUGIN_CATEGORY_MAP, plugin) ?? "Bugs";
+const resolveDiagnosticCategory = (plugin: string, rule: string): string => {
+  if (plugin === "react-hooks-js" && rule === "error-boundaries") return "Bugs";
+  return getRuleCategory(rule) ?? lookupOwnString(PLUGIN_CATEGORY_MAP, plugin) ?? "Bugs";
+};
 
 // Whether the finding's identity is the flagged element rather than the
 // flagged line's text, so `computeDiagnosticDelta` matches it by

--- a/packages/core/tests/react-compiler-diagnostic-title.test.ts
+++ b/packages/core/tests/react-compiler-diagnostic-title.test.ts
@@ -17,8 +17,9 @@ describe("parseOxlintOutput react-hooks-js diagnostic titles", () => {
     expect(diagnostic).toMatchObject({
       title: "JSX render errors need an Error Boundary",
       category: "Bugs",
+      message:
+        "This try/catch cannot catch errors thrown while the JSX child renders. Use an Error Boundary instead.",
     });
-    expect(diagnostic.message).toContain("cannot catch errors thrown while the JSX child renders");
     expect(diagnostic.message).not.toContain("React Compiler");
     expect(diagnostic.message).not.toContain("re-renders");
     expect(diagnostic.help).toContain("React does not immediately render components");
@@ -56,5 +57,18 @@ describe("parseOxlintOutput react-hooks-js diagnostic titles", () => {
     const [diagnostic] = parseOxlintOutput(stdout, buildProject(), TEST_ROOT_DIRECTORY);
 
     expect(diagnostic.title).toBe("React Compiler can't optimize this");
+    expect(diagnostic.category).toBe("Performance");
+    expect(diagnostic.message).toContain("misses React Compiler's automatic memoization");
+  });
+
+  it("does not apply the adopted-rule override to another plugin", () => {
+    const stdout = buildOxlintStdout(
+      "custom(error-boundaries)",
+      "A custom rule with the same name",
+    );
+    const [diagnostic] = parseOxlintOutput(stdout, buildProject(), TEST_ROOT_DIRECTORY);
+
+    expect(diagnostic.title).toBeUndefined();
+    expect(diagnostic.message).toBe("A custom rule with the same name");
   });
 });

--- a/packages/core/tests/react-compiler-diagnostic-title.test.ts
+++ b/packages/core/tests/react-compiler-diagnostic-title.test.ts
@@ -7,6 +7,24 @@ import {
 } from "./helpers/oxlint-parse-harness.js";
 
 describe("parseOxlintOutput react-hooks-js diagnostic titles", () => {
+  it("preserves error-boundaries as a correctness diagnostic", () => {
+    const stdout = buildOxlintStdout(
+      "react-hooks-js(error-boundaries)",
+      "Error: Avoid constructing JSX within try/catch\n\nReact does not immediately render components when JSX is rendered, so any errors from this component will not be caught by the try/catch. To catch errors in rendering a given component, wrap that component in an error boundary. (https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary).",
+    );
+    const [diagnostic] = parseOxlintOutput(stdout, buildProject(), TEST_ROOT_DIRECTORY);
+
+    expect(diagnostic).toMatchObject({
+      title: "JSX render errors need an Error Boundary",
+      category: "Bugs",
+    });
+    expect(diagnostic.message).toContain("cannot catch errors thrown while the JSX child renders");
+    expect(diagnostic.message).not.toContain("React Compiler");
+    expect(diagnostic.message).not.toContain("re-renders");
+    expect(diagnostic.help).toContain("React does not immediately render components");
+    expect(diagnostic.help).toContain("error boundary");
+  });
+
   it("titles `todo` diagnostics as unsupported syntax", () => {
     const stdout = buildOxlintStdout(
       "react-hooks-js(todo)",


### PR DESCRIPTION
## Why

`react-hooks-js/error-boundaries` is a correctness rule: JSX is constructed lazily, so a surrounding `try/catch` cannot catch a child render failure. React Doctor rewrote that finding as a React Compiler performance bailout, even when the emitted component is compiled successfully or has no client rerender surface.

The exact real-repo reproduction is Jumper Exchange commit `523d1cc2c3ab763dd00336aea6ff758526f88d62`, `src/app/[lng]/swap/[segments]/page.tsx:93`, where `<SwapPage />` is constructed inside `try/catch`. The upstream diagnostic itself says to use an Error Boundary.

## What changed

- Classifies only `react-hooks-js/error-boundaries` as `Bugs`.
- Gives it an Error-Boundary correctness title and message.
- Preserves the upstream child-render explanation in help.
- Leaves other React Compiler diagnostics, including `refs` and `todo`, on their existing Performance paths.
- Does not apply the override to a same-named rule from another plugin.

## Exact React Bench / real-repo A/B

Used the pinned Jumper source and applied the benchmark oracle patch from `tasks/fix-react-jumperexchange-jumper-exchange-2917/solution/fix.patch`. Direct `eslint-plugin-react-hooks@7.1.1` analysis produced one `error-boundaries` finding at the same file, line, column, and span before and after this change.

| Check | Baseline | Candidate |
| --- | --- | --- |
| Raw target findings | 1 | 1 |
| Parsed target findings | 1 | 1 |
| Identity/location parity | yes | yes |
| Category | Performance | Bugs |
| Title | React Compiler can't optimize this | JSX render errors need an Error Boundary |

No detector, AST visitor, or verdict logic changed, so RDE/fuzz would exercise identical findings and cannot test this parser-only metadata contract. The exact raw-diagnostic parser regression is the permanent coverage for this issue.

## Test plan

- `nr test`
- `nr --filter @react-doctor/core typecheck`
- `nr lint` (passes with existing repository warnings)
- `nr format:check`
- `git diff --check`
- Exact pinned Jumper base + benchmark-oracle raw diagnostic A/B

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Parser-only metadata mapping in oxlint output with no detector or verdict changes; scoped to one rule id with regression tests.
> 
> **Overview**
> **Fixes mislabeled `react-hooks-js/error-boundaries` findings** that were shown as React Compiler performance bailouts (memoization / re-renders) even though the rule is about **correctness**: a `try/catch` around JSX cannot catch errors thrown during child render.
> 
> In `parse-output.ts`, only **`react-hooks-js/error-boundaries`** is overridden to category **Bugs**, title **"JSX render errors need an Error Boundary"**, and a dedicated primary message; the upstream React explanation stays in **help**. Other `react-hooks-js` rules (`refs`, `todo`, etc.) keep the existing Performance headlines and compiler-style copy. A same-named rule from another plugin is unchanged.
> 
> Tests lock in the new metadata and assert compiler wording is not applied to `error-boundaries`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 003e0ac930f260dc0780430a4040d80dc22a21f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->