### PR TITLE
fix(prefer-module-scope-static-value): follow nested mutations

### DIFF
--- a/.changeset/rare-parts-clean.md
+++ b/.changeset/rare-parts-clean.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Fix prefer-module-scope-static-value false positives for per-render arrays and objects mutated through nested members.

--- a/packages/fuzz/corpus/regressions/prefer-module-scope-static-value--nested-receiver-mutation.tsx
+++ b/packages/fuzz/corpus/regressions/prefer-module-scope-static-value--nested-receiver-mutation.tsx
@@ -1,0 +1,17 @@
+// rule: prefer-module-scope-static-value
+// weakness: nested receiver mutation
+// source: facebook/docusaurus 5997f3ab website/src/pages/index.tsx
+const tweets = [{ showOnHomepage: true }, { showOnHomepage: false }];
+
+export const TweetColumns = () => {
+  const tweetColumns = [[], [], []];
+  tweets
+    .filter((tweet) => tweet.showOnHomepage)
+    .forEach((tweet, index) => tweetColumns[index % 3]!.push(tweet));
+  return <div>{tweetColumns.map((column) => column.length)}</div>;
+};
+
+export const ReadOnlyColumns = () => {
+  const columns = [["first"], ["second"]];
+  return <div>{columns.length}</div>;
+};

--- a/packages/fuzz/corpus/regressions/prefer-module-scope-static-value--nested-receiver-mutation.tsx
+++ b/packages/fuzz/corpus/regressions/prefer-module-scope-static-value--nested-receiver-mutation.tsx
@@ -11,6 +11,14 @@ export const TweetColumns = () => {
   return <div>{tweetColumns.map((column) => column.length)}</div>;
 };
 
+export const WrappedTweetColumns = () => {
+  const tweetColumns = [[], []];
+  tweets.forEach((tweet) =>
+    (tweetColumns[0]!.push as (value: (typeof tweets)[number]) => number)(tweet),
+  );
+  return <div>{tweetColumns.map((column) => column.length)}</div>;
+};
+
 export const ReadOnlyColumns = () => {
   const columns = [["first"], ["second"]];
   return <div>{columns.length}</div>;

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -88,6 +88,7 @@ export const EFFECT_SNIPPET_POOL = [
 export const STATE_SNIPPET_POOL = [
   `const fuzzRandomIdentity = { id: globalThis.crypto.randomUUID() };`,
   `const fuzzTweetColumns = [[], [], []]; items.forEach((item, index) => fuzzTweetColumns[index % 3]!.push(item)); const fuzzTweetColumnsNode = <Grid columns={fuzzTweetColumns} />;`,
+  `const fuzzWrappedColumns = [[], []]; items.forEach((item) => (fuzzWrappedColumns[0]!.push as (value: typeof item) => number)(item)); const fuzzWrappedColumnsNode = <Grid columns={fuzzWrappedColumns} />;`,
   `const fuzzReadOnlyColumns = [["first"], ["second"]]; const fuzzReadOnlyColumnsNode = <Grid columns={fuzzReadOnlyColumns} />;`,
   `const FuzzNestedPanel = () => <div>nested</div>; const fuzzNestedPanelNode = <FuzzNestedPanel />;`,
   `const [state, setState] = useState(0);`,

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -87,6 +87,8 @@ export const EFFECT_SNIPPET_POOL = [
 // toggles, loading triples, prop mirrors, reducers, ref-sync.
 export const STATE_SNIPPET_POOL = [
   `const fuzzRandomIdentity = { id: globalThis.crypto.randomUUID() };`,
+  `const fuzzTweetColumns = [[], [], []]; items.forEach((item, index) => fuzzTweetColumns[index % 3]!.push(item)); const fuzzTweetColumnsNode = <Grid columns={fuzzTweetColumns} />;`,
+  `const fuzzReadOnlyColumns = [["first"], ["second"]]; const fuzzReadOnlyColumnsNode = <Grid columns={fuzzReadOnlyColumns} />;`,
   `const FuzzNestedPanel = () => <div>nested</div>; const fuzzNestedPanelNode = <FuzzNestedPanel />;`,
   `const [state, setState] = useState(0);`,
   `const [state, setState] = useState(() => Number(localStorage.getItem("count") ?? 0));`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/prefer-module-scope-static-value.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/prefer-module-scope-static-value.regressions.test.ts
@@ -303,6 +303,9 @@ describe("architecture/prefer-module-scope-static-value — regressions", () => 
     "(matrix[0] as number[]).push(1)",
     "matrix['0']['push'](1)",
     "matrix[0]!.sort()",
+    "(matrix.push as (value: number[]) => number)([])",
+    "(matrix[0]!.push as (value: number) => number)(1)",
+    "((matrix['push'] as (value: number[]) => number))([])",
   ])("recognizes a nested receiver mutation through %s", (mutation) => {
     const result = run(`
       function Matrix() {
@@ -330,19 +333,20 @@ describe("architecture/prefer-module-scope-static-value — regressions", () => 
     expect(result.diagnostics).toEqual([]);
   });
 
-  it.each(["matrix.map((row) => row).push([])", "matrix.slice().reverse()"])(
-    "still reports when only a derived array is mutated through %s",
-    (mutation) => {
-      const result = run(`
+  it.each([
+    "matrix.map((row) => row).push([])",
+    "matrix.slice().reverse()",
+    "(matrix.slice().push as (value: number[]) => number)([])",
+  ])("still reports when only a derived array is mutated through %s", (mutation) => {
+    const result = run(`
         function Matrix() {
           const matrix = [[], []];
           ${mutation};
           return <Grid matrix={matrix} />;
         }
       `);
-      expect(result.diagnostics).toHaveLength(1);
-    },
-  );
+    expect(result.diagnostics).toHaveLength(1);
+  });
 
   it("still flags a static array built from a pure module-scope helper named `random`", () => {
     const result = run(`

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/prefer-module-scope-static-value.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/prefer-module-scope-static-value.regressions.test.ts
@@ -297,6 +297,53 @@ describe("architecture/prefer-module-scope-static-value — regressions", () => 
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it.each([
+    "matrix[0]!.push(1)",
+    "matrix[0]?.push(1)",
+    "(matrix[0] as number[]).push(1)",
+    "matrix['0']['push'](1)",
+    "matrix[0]!.sort()",
+  ])("recognizes a nested receiver mutation through %s", (mutation) => {
+    const result = run(`
+      function Matrix() {
+        const matrix = [[], []];
+        ${mutation};
+        return <Grid matrix={matrix} />;
+      }
+    `);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it.each([
+    "state.nested.count += 1",
+    "state.nested.count++",
+    "delete state.nested.count",
+    "state['nested']['count'] = 1",
+  ])("recognizes a nested property mutation through %s", (mutation) => {
+    const result = run(`
+      function Counter() {
+        const state = { nested: { count: 0 } };
+        ${mutation};
+        return <Output value={state} />;
+      }
+    `);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it.each(["matrix.map((row) => row).push([])", "matrix.slice().reverse()"])(
+    "still reports when only a derived array is mutated through %s",
+    (mutation) => {
+      const result = run(`
+        function Matrix() {
+          const matrix = [[], []];
+          ${mutation};
+          return <Grid matrix={matrix} />;
+        }
+      `);
+      expect(result.diagnostics).toHaveLength(1);
+    },
+  );
+
   it("still flags a static array built from a pure module-scope helper named `random`", () => {
     const result = run(`
       const random = (seed) => (seed * 9301 + 49297) % 233280;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/prefer-module-scope-static-value.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/prefer-module-scope-static-value.regressions.test.ts
@@ -273,6 +273,30 @@ describe("architecture/prefer-module-scope-static-value — regressions", () => 
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("does not prescribe hoisting a nested array accumulator mutated in a callback", () => {
+    const result = run(`
+      const Tweets = [{ showOnHomepage: true }];
+      function TweetsSection() {
+        const tweetColumns = [[], [], []];
+        Tweets.filter((tweet) => tweet.showOnHomepage).forEach((tweet, index) =>
+          tweetColumns[index % 3]!.push(tweet),
+        );
+        return <div>{tweetColumns.map((column) => column.length)}</div>;
+      }
+    `);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still flags the same nested array when it remains read-only", () => {
+    const result = run(`
+      function TweetsSection() {
+        const tweetColumns = [[], [], []];
+        return <Grid columns={tweetColumns} />;
+      }
+    `);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("still flags a static array built from a pure module-scope helper named `random`", () => {
     const result = run(`
       const random = (seed) => (seed * 9301 + 49297) % 233280;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/prefer-module-scope-static-value.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/prefer-module-scope-static-value.ts
@@ -47,6 +47,7 @@ const MUTATING_RECEIVER_METHOD_NAMES = new Set([
 //   4. Mutating method call: `OPTS.push(...)` / `byId.set(...)`.
 const isMutationContext = (referenceIdentifier: EsTreeNode): boolean => {
   let mutationTarget = referenceIdentifier;
+  let receiverMethodName: string | null = null;
 
   while (mutationTarget.parent) {
     const parent = mutationTarget.parent;
@@ -61,6 +62,7 @@ const isMutationContext = (referenceIdentifier: EsTreeNode): boolean => {
     }
 
     if (isNodeOfType(parent, "MemberExpression") && parent.object === mutationTarget) {
+      receiverMethodName = getStaticPropertyName(parent);
       mutationTarget = parent;
       continue;
     }
@@ -84,8 +86,7 @@ const isMutationContext = (referenceIdentifier: EsTreeNode): boolean => {
     return Boolean(
       isNodeOfType(parent, "CallExpression") &&
       parent.callee === mutationTarget &&
-      isNodeOfType(mutationTarget, "MemberExpression") &&
-      MUTATING_RECEIVER_METHOD_NAMES.has(getStaticPropertyName(mutationTarget) ?? ""),
+      MUTATING_RECEIVER_METHOD_NAMES.has(receiverMethodName ?? ""),
     );
   }
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/prefer-module-scope-static-value.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/prefer-module-scope-static-value.ts
@@ -3,10 +3,14 @@ import { defineRule } from "../../utils/define-rule.js";
 import { enclosingComponentOrHookScope } from "../../utils/enclosing-component-or-hook-scope.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isProvenGlobalNamespaceReference } from "../../utils/is-proven-global-namespace-reference.js";
 import { isProvenNodeCryptoNamespaceReference } from "../../utils/is-proven-node-crypto-namespace-reference.js";
-import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import {
+  stripParenExpression,
+  TRANSPARENT_EXPRESSION_WRAPPER_TYPES,
+} from "../../utils/strip-paren-expression.js";
 import { walkAst } from "../../utils/walk-ast.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import {
@@ -42,56 +46,47 @@ const MUTATING_RECEIVER_METHOD_NAMES = new Set([
 //      completeness).
 //   4. Mutating method call: `OPTS.push(...)` / `byId.set(...)`.
 const isMutationContext = (referenceIdentifier: EsTreeNode): boolean => {
-  const parent = referenceIdentifier.parent;
-  if (!parent) return false;
+  let mutationTarget = referenceIdentifier;
 
-  // Direct rebinding: `OPTS = somethingElse`.
-  if (isNodeOfType(parent, "AssignmentExpression") && parent.left === referenceIdentifier) {
-    return true;
-  }
+  while (mutationTarget.parent) {
+    const parent = mutationTarget.parent;
 
-  // `++OPTS` / `OPTS--` — primitive mutation; rare for array/object
-  // bindings but treated as a mutation for completeness.
-  if (isNodeOfType(parent, "UpdateExpression") && parent.argument === referenceIdentifier) {
-    return true;
-  }
-
-  // Member-expression contexts: `OPTS.foo` / `OPTS[0]`.
-  if (isNodeOfType(parent, "MemberExpression") && parent.object === referenceIdentifier) {
-    const grandparent = parent.parent;
-    if (!grandparent) return false;
-
-    // `OPTS.foo = bar` / `OPTS[0] = x` / compound assignments.
-    if (isNodeOfType(grandparent, "AssignmentExpression") && grandparent.left === parent) {
-      return true;
-    }
-
-    // `OPTS.count++` / `++OPTS.foo`.
-    if (isNodeOfType(grandparent, "UpdateExpression") && grandparent.argument === parent) {
-      return true;
-    }
-
-    // `delete OPTS.foo` / `delete OPTS[0]`.
     if (
-      isNodeOfType(grandparent, "UnaryExpression") &&
-      grandparent.operator === "delete" &&
-      grandparent.argument === parent
+      TRANSPARENT_EXPRESSION_WRAPPER_TYPES.has(parent.type) &&
+      "expression" in parent &&
+      parent.expression === mutationTarget
+    ) {
+      mutationTarget = parent;
+      continue;
+    }
+
+    if (isNodeOfType(parent, "MemberExpression") && parent.object === mutationTarget) {
+      mutationTarget = parent;
+      continue;
+    }
+
+    if (isNodeOfType(parent, "AssignmentExpression") && parent.left === mutationTarget) {
+      return true;
+    }
+
+    if (isNodeOfType(parent, "UpdateExpression") && parent.argument === mutationTarget) {
+      return true;
+    }
+
+    if (
+      isNodeOfType(parent, "UnaryExpression") &&
+      parent.operator === "delete" &&
+      parent.argument === mutationTarget
     ) {
       return true;
     }
 
-    // `OPTS.push(...)` — mutating method call. The MemberExpression
-    // must itself be the callee of a CallExpression and the property
-    // must be a non-computed Identifier in our mutating-names set.
-    if (
-      isNodeOfType(grandparent, "CallExpression") &&
-      grandparent.callee === parent &&
-      !parent.computed &&
-      isNodeOfType(parent.property, "Identifier") &&
-      MUTATING_RECEIVER_METHOD_NAMES.has(parent.property.name)
-    ) {
-      return true;
-    }
+    return Boolean(
+      isNodeOfType(parent, "CallExpression") &&
+      parent.callee === mutationTarget &&
+      isNodeOfType(mutationTarget, "MemberExpression") &&
+      MUTATING_RECEIVER_METHOD_NAMES.has(getStaticPropertyName(mutationTarget) ?? ""),
+    );
   }
 
   return false;


### PR DESCRIPTION
## Grounding

An uncached scan of facebook/docusaurus at `5997f3ab` reproduced a real false positive in `website/src/pages/index.tsx`. `tweetColumns` is rebuilt during each render and mutated through `tweetColumns[index % 3]!.push(tweet)`. Hoisting it would share the accumulator across renders and SSR requests, retaining and duplicating entries.

The same shape appeared independently in PostHog: `optionSections` is rebuilt and conditionally mutated through nested property assignments and `.push()` calls from current render inputs.

## Precision boundary

The rule still reports read-only arrays and objects whose identity can be safely hoisted. It abstains only when the binding is proven to be mutated through its own direct member chain, including transparent TypeScript/parenthesis wrappers, nested assignments, updates, deletes, and statically named mutating receiver methods.

Derived receivers remain reportable: mutating `matrix.map(...)` or `matrix.slice()` does not prove that `matrix` itself is mutated. Opaque aliases are intentionally outside this change.

## Changes

- Follow nested member receivers upward when classifying binding mutations.
- Resolve statically named computed mutators such as `value["push"]()`.
- Add paired regression coverage for the exact Docusaurus accumulator and read-only near-neighbor.
- Add adversarial assignment/update/delete, wrapper, optional-chain, and derived-receiver tests.
- Add a permanent fuzz seed and generated snippet-pool coverage.
- Add a patch changeset for `oxlint-plugin-react-doctor`.

## Validation

- Focused rule tests: 64 passed, including wrapped direct mutator callees and wrapped derived-receiver controls.
- Full repository suite: 14/14 tasks passed; React Doctor 209 files passed, 2 skipped; 2,244 tests passed, 27 skipped.
- `nr typecheck`: 15/15 tasks passed.
- `nr lint`, `nr format:check`, and `git diff --check`: passed.
- Strict generated fuzz: `FUZZ_RULE=prefer-module-scope-static-value FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz` passed with target fire coverage.
- Strict React Bench corpus fuzz: 13 real target files plus the regression corpus passed with target fire coverage.
- React Bench 5 oracle A/B: 17/17 current `fix-react-rdh-*` oracle trees scanned, zero failures or partial scans, exact diagnostic parity, and target count 0 → 0.
- Docusaurus stacked A/B: removes exactly the duplicated `tweetColumns` false positives while preserving both genuine `initialSearchResultState` findings.
- Local RDE first-100 corpus: 98 fully comparable roots across 12 repositories; target findings 133 → 132, with 0 additions and 1 removed confirmed FP (`PostHog/posthog`, `src/scenes/insights/filters/AggregationSelect.tsx:143:11`, `optionSections`). No true positive was removed. One Excalidraw root failed symmetrically after the 10-minute budget and one baseline Excalidraw root was partial, so neither was counted as parity evidence.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted lint-rule precision fix with broad regression and fuzz coverage; no runtime or auth/data-path changes.
> 
> **Overview**
> Fixes **false positives** in `prefer-module-scope-static-value` when per-render arrays/objects are mutated through **nested members** (e.g. `tweetColumns[i].push(...)`), where hoisting would incorrectly share mutable state across renders.
> 
> **`isMutationContext`** now walks the AST upward through member chains and transparent wrappers (parens, TS assertions), using **`getStaticPropertyName`** so computed mutators like `matrix['push']()` count. Mutations on **derived** receivers (`matrix.slice().push`) still do not exempt the original binding.
> 
> Adds regression tests (Docusaurus-style accumulators, nested assign/update/delete, wrapped callees), a fuzz corpus file, and snippet-pool seeds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8141d7af0705faa6f0e4973adc7c8808b096ba27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

