### PR TITLE
fix(rule): preserve createRef stored in state

### DIFF
--- a/.changeset/bumpy-pets-yawn.md
+++ b/.changeset/bumpy-pets-yawn.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Stop no-create-ref-in-function-component from warning on createRef values stored as initial React state.

--- a/packages/fuzz/corpus/regressions/no-create-ref-in-function-component--named-lazy-state-initializer.tsx
+++ b/packages/fuzz/corpus/regressions/no-create-ref-in-function-component--named-lazy-state-initializer.tsx
@@ -1,0 +1,17 @@
+// rule: no-create-ref-in-function-component
+// weakness: name-heuristic
+// source: PR #1309 adversarial review
+
+import { createRef, useState } from "react";
+
+const useInitialAnchorRef = () => createRef<HTMLAnchorElement>();
+
+export const RedirectToApp = () => {
+  const [anchorRef] = useState(useInitialAnchorRef);
+
+  return (
+    <a ref={anchorRef} href="inxt://app">
+      Open app
+    </a>
+  );
+};

--- a/packages/fuzz/corpus/regressions/no-create-ref-in-function-component--stable-state-initializer.tsx
+++ b/packages/fuzz/corpus/regressions/no-create-ref-in-function-component--stable-state-initializer.tsx
@@ -1,0 +1,19 @@
+// rule: no-create-ref-in-function-component
+// weakness: library-idiom
+// source: internxt/drive-web@3f96ab42f727083a04cbb1e2aef39d232ca730cc
+
+import { createRef, useEffect, useState } from "react";
+
+export const RedirectToApp = () => {
+  const [anchorRef] = useState(createRef<HTMLAnchorElement>());
+
+  useEffect(() => {
+    anchorRef.current?.click();
+  }, [anchorRef]);
+
+  return (
+    <a ref={anchorRef} href="inxt://app">
+      Open app
+    </a>
+  );
+};

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -101,6 +101,7 @@ export const STATE_SNIPPET_POOL = [
   `const FuzzNestedPanel = () => <div>nested</div>; const fuzzNestedPanelNode = <FuzzNestedPanel />;`,
   `const [state, setState] = useState(0);`,
   `const [fuzzStableStateRef] = useState(createRef()); const fuzzStableStateRefNode = <button ref={fuzzStableStateRef}>Open</button>;`,
+  `const useFuzzInitialRef = () => createRef(); const [fuzzStableLazyStateRef] = useState(useFuzzInitialRef); const fuzzStableLazyStateRefNode = <button ref={fuzzStableLazyStateRef}>Open</button>;`,
   `const [state, setState] = useState(() => Number(localStorage.getItem("count") ?? 0));`,
   `const [theme, setTheme] = useState(() => (typeof window === "undefined" ? "light" : (localStorage.getItem("theme") ?? "light")));`,
   `const [isDark, setIsDark] = useState(() => window.matchMedia("(prefers-color-scheme: dark)").matches);`,

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -100,6 +100,7 @@ export const STATE_SNIPPET_POOL = [
   `const fuzzReadOnlyColumns = [["first"], ["second"]]; const fuzzReadOnlyColumnsNode = <Grid columns={fuzzReadOnlyColumns} />;`,
   `const FuzzNestedPanel = () => <div>nested</div>; const fuzzNestedPanelNode = <FuzzNestedPanel />;`,
   `const [state, setState] = useState(0);`,
+  `const [fuzzStableStateRef] = useState(createRef()); const fuzzStableStateRefNode = <button ref={fuzzStableStateRef}>Open</button>;`,
   `const [state, setState] = useState(() => Number(localStorage.getItem("count") ?? 0));`,
   `const [theme, setTheme] = useState(() => (typeof window === "undefined" ? "light" : (localStorage.getItem("theme") ?? "light")));`,
   `const [isDark, setIsDark] = useState(() => window.matchMedia("(prefers-color-scheme: dark)").matches);`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-create-ref-in-function-component.state-initializer.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-create-ref-in-function-component.state-initializer.regressions.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noCreateRefInFunctionComponent } from "./no-create-ref-in-function-component.js";
+
+const runCreateRefRule = (source: string) => runRule(noCreateRefInFunctionComponent, source);
+
+describe("no-create-ref-in-function-component — stable state initializers", () => {
+  it("stays silent for the four authentic Internxt useState forms", () => {
+    const sources = [
+      `import React, { useState } from "react";
+export const Redirect = () => {
+  const [anchorRef] = useState(React.createRef<HTMLAnchorElement>());
+  return <a ref={anchorRef}>Open</a>;
+};`,
+      `import { createRef, useState } from "react";
+export const GridItem = () => {
+  const [itemRef] = useState(createRef<HTMLDivElement>());
+  return <div ref={itemRef} />;
+};`,
+      `import { createRef, useState, type RefObject } from "react";
+export const ChangePassword = () => {
+  const [backupKeyInputRef] = useState<RefObject<HTMLInputElement>>(createRef());
+  return <input ref={backupKeyInputRef} />;
+};`,
+      `import * as ReactRuntime from "react";
+export const Skeleton = () => {
+  const [itemRef] = ReactRuntime.useState(ReactRuntime.createRef<HTMLDivElement>());
+  return <div ref={itemRef} />;
+};`,
+    ];
+    for (const source of sources) {
+      const result = runCreateRefRule(source);
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    }
+  });
+
+  it("stays silent for eager, lazy, and StrictMode state initialization", () => {
+    const result = runCreateRefRule(`import React, { StrictMode, createRef, useState } from "react";
+const EagerTarget = () => {
+  const [target] = useState(createRef<HTMLButtonElement>());
+  return <button ref={target}>Eager</button>;
+};
+const LazyTarget = () => {
+  const [target] = useState(() => createRef<HTMLButtonElement>());
+  return <button ref={target}>Lazy</button>;
+};
+export const App = () => <StrictMode><EagerTarget /><LazyTarget /></StrictMode>;`);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("resolves React import, namespace, const, computed, and transparent aliases", () => {
+    const result = runCreateRefRule(`import * as Runtime from "react";
+import { createRef as makeRef, useState as preserveState } from "react";
+const keep = preserveState;
+export const NamedAlias = () => {
+  const [target] = keep((makeRef<HTMLButtonElement>() as React.RefObject<HTMLButtonElement>));
+  return <button ref={target}>Named</button>;
+};
+export const NamespaceAlias = () => {
+  const [target] = Runtime["useState"]((Runtime["createRef"]<HTMLButtonElement>()));
+  return <button ref={target}>Namespace</button>;
+};`);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("reports direct createRef and non-state Hook initializers", () => {
+    const sources = [
+      `import { createRef } from "react";
+export const Direct = ({ observe }) => {
+  const target = createRef();
+  observe(target);
+  return <input ref={target} />;
+};`,
+      `import { createRef, useReducer } from "react";
+export const Reduced = () => {
+  const [target] = useReducer((state) => state, createRef());
+  return <input ref={target} />;
+};`,
+    ];
+    for (const source of sources) {
+      const result = runCreateRefRule(source);
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    }
+  });
+
+  it("keeps useMemo reportable for empty, changing, omitted, and mutable dependencies", () => {
+    const sources = [
+      `import React from "react"; const Target = () => { const target = React.useMemo(() => React.createRef(), []); return <input ref={target} />; };`,
+      `import React from "react"; const Target = ({ value }) => { const target = React.useMemo(() => React.createRef(), [value]); return <input ref={target} />; };`,
+      `import React from "react"; const Target = () => { const target = React.useMemo(() => React.createRef()); return <input ref={target} />; };`,
+      `import React from "react"; const Target = ({ value }) => { const dependencies = [value]; dependencies.push(value); const target = React.useMemo(() => React.createRef(), dependencies); return <input ref={target} />; };`,
+    ];
+    for (const source of sources) {
+      const result = runCreateRefRule(source);
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    }
+  });
+
+  it("does not trust shadowed or similarly named state functions", () => {
+    const localStateResult = runCreateRefRule(`import { createRef } from "react";
+const useState = (value) => [value];
+export const Target = () => {
+  const [target] = useState(createRef());
+  return <input ref={target} />;
+};`);
+    const shadowedNamespaceResult = runCreateRefRule(`import { createRef } from "react";
+const Runtime = { useState: (value) => [value] };
+export const Target = () => {
+  const [target] = Runtime.useState(createRef());
+  return <input ref={target} />;
+};`);
+    const localCreateRefResult = runCreateRefRule(`import { useState } from "react";
+const createRef = () => ({ current: null });
+export const Target = () => {
+  const [target] = useState(createRef());
+  return <input ref={target} />;
+};`);
+    expect(localStateResult.diagnostics).toHaveLength(1);
+    expect(shadowedNamespaceResult.diagnostics).toHaveLength(1);
+    expect(localCreateRefResult.diagnostics).toEqual([]);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-create-ref-in-function-component.state-initializer.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-create-ref-in-function-component.state-initializer.regressions.test.ts
@@ -35,17 +35,56 @@ export const Skeleton = () => {
     }
   });
 
-  it("stays silent for eager, lazy, and StrictMode state initialization", () => {
+  it("stays silent for eager and inline lazy state initialization under StrictMode", () => {
     const result = runCreateRefRule(`import React, { StrictMode, createRef, useState } from "react";
 const EagerTarget = () => {
   const [target] = useState(createRef<HTMLButtonElement>());
   return <button ref={target}>Eager</button>;
 };
 const LazyTarget = () => {
-  const [target] = useState(() => createRef<HTMLButtonElement>());
+  const [target] = useState(function useInitialTargetRef() {
+    return createRef<HTMLButtonElement>();
+  });
   return <button ref={target}>Lazy</button>;
 };
 export const App = () => <StrictMode><EagerTarget /><LazyTarget /></StrictMode>;`);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent when every reference to a local initializer is a useState initializer", () => {
+    const result = runCreateRefRule(`import React, { createRef, useState } from "react";
+const useModuleInitialRef = () => createRef<HTMLDivElement>();
+function useDeclaredInitialRef() {
+  return createRef<HTMLDivElement>();
+}
+const ModuleTarget = () => {
+  const [target] = useState(useModuleInitialRef);
+  const [declaredTarget] = useState(useDeclaredInitialRef);
+  return <><div ref={target} /><div ref={declaredTarget} /></>;
+};
+export const LocalTarget = () => {
+  const useLocalInitialRef = () => createRef<HTMLButtonElement>();
+  const [firstTarget] = useState(useLocalInitialRef);
+  const [secondTarget] = React.useState(useLocalInitialRef);
+  return <><button ref={firstTarget}>First</button><button ref={secondTarget}>Second</button></>;
+};`);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("resolves transparent wrappers around named lazy initializer functions and references", () => {
+    const result =
+      runCreateRefRule(`import React, { createRef, useState, type RefObject } from "react";
+const useNamedInitialRef = ((function useWrappedInitialRef() {
+  return createRef<HTMLButtonElement>();
+}) as () => RefObject<HTMLButtonElement>);
+const useArrowInitialRef = ((() => createRef<HTMLButtonElement>()) satisfies () => RefObject<HTMLButtonElement>);
+export const Target = () => {
+  const [namedTarget] = useState((useNamedInitialRef as () => RefObject<HTMLButtonElement>));
+  const [arrowTarget] = useState(useArrowInitialRef satisfies () => RefObject<HTMLButtonElement>);
+  return <><button ref={namedTarget}>Named</button><button ref={arrowTarget}>Arrow</button></>;
+};`);
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toEqual([]);
   });
@@ -123,5 +162,73 @@ export const Target = () => {
     expect(localStateResult.diagnostics).toHaveLength(1);
     expect(shadowedNamespaceResult.diagnostics).toHaveLength(1);
     expect(localCreateRefResult.diagnostics).toEqual([]);
+  });
+
+  it("reports named initializers with non-state, mutable, or ambiguous uses", () => {
+    const sources = [
+      `import { createRef, useState } from "react";
+export const Target = () => {
+  const useInitialRef = () => createRef();
+  const [target] = useState(useInitialRef);
+  const unstableTarget = useInitialRef();
+  return <><input ref={target} /><input ref={unstableTarget} /></>;
+};`,
+      `import { createRef, useState } from "react";
+export const Target = () => {
+  let useInitialRef = () => createRef();
+  const [target] = useState(useInitialRef);
+  useInitialRef = () => ({ current: null });
+  return <input ref={target} />;
+};`,
+      `import { createRef, useState } from "react";
+export const Target = () => {
+  const useInitialRef = () => createRef();
+  observe(useInitialRef);
+  const [target] = useState(useInitialRef);
+  return <input ref={target} />;
+};`,
+      `import { createRef } from "react";
+const useState = (initializer) => [initializer()];
+export const Target = () => {
+  const useInitialRef = () => createRef();
+  const [target] = useState(useInitialRef);
+  return <input ref={target} />;
+};`,
+      `import { createRef } from "react";
+export const Target = () => run(function useInitialRef() {
+  return createRef();
+});`,
+      `import { createRef, useState } from "react";
+export const useInitialRef = () => createRef();
+export const Target = () => {
+  const [target] = useState(useInitialRef);
+  return <input ref={target} />;
+};`,
+      `import { createRef, useState } from "react";
+export function useInitialRef() { return createRef(); }
+export const Target = () => {
+  const [target] = useState(useInitialRef);
+  return <input ref={target} />;
+};`,
+      `import { createRef, useState } from "react";
+const useInitialRef = () => createRef();
+export { useInitialRef };
+export const Target = () => {
+  const [target] = useState(useInitialRef);
+  return <input ref={target} />;
+};`,
+      `import { createRef, useState } from "react";
+const useInitialRef = () => createRef();
+export default useInitialRef;
+export const Target = () => {
+  const [target] = useState(useInitialRef);
+  return <input ref={target} />;
+};`,
+    ];
+    for (const source of sources) {
+      const result = runCreateRefRule(source);
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    }
   });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-create-ref-in-function-component.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-create-ref-in-function-component.ts
@@ -3,6 +3,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
 import { findTransparentExpressionRoot } from "../../utils/find-transparent-expression-root.js";
 import { functionContainsReactRenderOutput } from "../../utils/function-contains-react-render-output.js";
+import { getFunctionBindingIdentifier } from "../../utils/get-function-binding-name.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isReactApiCall } from "../../utils/is-react-api-call.js";
 import { isReactHookName } from "../../utils/is-react-hook-name.js";
@@ -36,7 +37,7 @@ const findEnclosingRenderFunction = (
   return enclosingFunction;
 };
 
-const isCreateRefStoredAsInitialReactState = (node: EsTreeNode, scopes: ScopeAnalysis): boolean => {
+const isReactUseStateInitialState = (node: EsTreeNode, scopes: ScopeAnalysis): boolean => {
   const initialState = findTransparentExpressionRoot(node);
   const stateCall = initialState.parent;
   return Boolean(
@@ -47,6 +48,47 @@ const isCreateRefStoredAsInitialReactState = (node: EsTreeNode, scopes: ScopeAna
       allowGlobalReactNamespace: true,
       resolveNamedAliases: true,
     }),
+  );
+};
+
+const hasDirectExportWrapper = (declarationNode: EsTreeNode): boolean => {
+  const parent = declarationNode.parent;
+  if (
+    isNodeOfType(parent, "ExportNamedDeclaration") ||
+    isNodeOfType(parent, "ExportDefaultDeclaration")
+  ) {
+    return true;
+  }
+  return Boolean(
+    isNodeOfType(declarationNode, "VariableDeclarator") &&
+    (isNodeOfType(parent?.parent, "ExportNamedDeclaration") ||
+      isNodeOfType(parent?.parent, "ExportDefaultDeclaration")),
+  );
+};
+
+const isFunctionExclusivelyUsedAsReactStateInitializer = (
+  functionNode: EsTreeNode,
+  scopes: ScopeAnalysis,
+): boolean => {
+  if (isReactUseStateInitialState(functionNode, scopes)) return true;
+  const bindingIdentifier = getFunctionBindingIdentifier(
+    findTransparentExpressionRoot(functionNode),
+  );
+  if (!bindingIdentifier) return false;
+  const bindingSymbol = isNodeOfType(functionNode, "FunctionDeclaration")
+    ? scopes.scopeFor(functionNode).symbolsByName.get(bindingIdentifier.name)
+    : scopes.symbolFor(bindingIdentifier);
+  if (
+    !bindingSymbol ||
+    (bindingSymbol.kind !== "const" && bindingSymbol.kind !== "function") ||
+    hasDirectExportWrapper(bindingSymbol.declarationNode) ||
+    bindingSymbol.references.length === 0
+  ) {
+    return false;
+  }
+  return bindingSymbol.references.every(
+    (reference) =>
+      reference.flag === "read" && isReactUseStateInitialState(reference.identifier, scopes),
   );
 };
 
@@ -87,7 +129,12 @@ export const noCreateRefInFunctionComponent = defineRule({
         isReactHookName(displayName) ||
         functionContainsReactRenderOutput(enclosingFunction, context.scopes, context.cfg);
       if (!isComponentOrHook) return;
-      if (isCreateRefStoredAsInitialReactState(node, context.scopes)) return;
+      if (
+        isReactUseStateInitialState(node, context.scopes) ||
+        isFunctionExclusivelyUsedAsReactStateInitializer(enclosingFunction, context.scopes)
+      ) {
+        return;
+      }
       if (
         isProvenOneShotTestingLibraryComponent(enclosingFunction, context.filename, context.scopes)
       ) {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-create-ref-in-function-component.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-create-ref-in-function-component.ts
@@ -1,6 +1,7 @@
 import { componentOrHookDisplayNameForFunction } from "../../utils/component-or-hook-display-name.js";
 import { defineRule } from "../../utils/define-rule.js";
 import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
+import { findTransparentExpressionRoot } from "../../utils/find-transparent-expression-root.js";
 import { functionContainsReactRenderOutput } from "../../utils/function-contains-react-render-output.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isReactApiCall } from "../../utils/is-react-api-call.js";
@@ -33,6 +34,20 @@ const findEnclosingRenderFunction = (
     enclosingFunction = findEnclosingFunction(enclosingFunction);
   }
   return enclosingFunction;
+};
+
+const isCreateRefStoredAsInitialReactState = (node: EsTreeNode, scopes: ScopeAnalysis): boolean => {
+  const initialState = findTransparentExpressionRoot(node);
+  const stateCall = initialState.parent;
+  return Boolean(
+    stateCall &&
+    isNodeOfType(stateCall, "CallExpression") &&
+    stateCall.arguments[0] === initialState &&
+    isReactApiCall(stateCall, "useState", scopes, {
+      allowGlobalReactNamespace: true,
+      resolveNamedAliases: true,
+    }),
+  );
 };
 
 // `createRef` is the class-component ref API. Inside a function component or a
@@ -72,6 +87,7 @@ export const noCreateRefInFunctionComponent = defineRule({
         isReactHookName(displayName) ||
         functionContainsReactRenderOutput(enclosingFunction, context.scopes, context.cfg);
       if (!isComponentOrHook) return;
+      if (isCreateRefStoredAsInitialReactState(node, context.scopes)) return;
       if (
         isProvenOneShotTestingLibraryComponent(enclosingFunction, context.filename, context.scopes)
       ) {


### PR DESCRIPTION
## Why

At `internxt/drive-web@3f96ab42f727083a04cbb1e2aef39d232ca730cc`, React Doctor reports five `no-create-ref-in-function-component` findings. Four pass `createRef()` as the initial value of `useState`; React retains that committed state value across rerenders, so the rule's definite claim that a later render replaces the ref is false.

The fifth Internxt finding uses `useMemo(() => createRef(), [])`. It remains reportable because `useMemo` is not a semantic identity guarantee.

## What changed

- Suppress a proven React `createRef()` call used as the first `useState` argument.
- Handle inline and locally bound named lazy initializers only when every reference is an immutable, non-exported, proven React `useState` initializer.
- Preserve the merged one-shot Testing Library exemption from #1303.
- Preserve reports for direct render-time creation, `useReducer`, `useMemo`, exports, writes, direct calls, ambiguous escapes, shadowed state functions, and similarly named userland APIs.
- Add paired regression tests, two permanent fuzz seeds, generator shapes, and a patch changeset.

## Validation

Validated candidate `4a7f748006aeaa479f30354871d41d05c23ce2c7` against exact main `174955c25558a45dc3c8667c6efebb1af16ba8b4`.

### Exact repositories

- Internxt: 853 files per version, 5 → 1 diagnostics. Only the four `useState(createRef())` false positives were removed; `useMemo(() => createRef(), [])` remains.
- Suomi UI: parity 1 → 1. The #1303 one-shot Modal test remains quiet and the real Table finding at `src/core/Table/Table.tsx:195:22` remains.

### React Bench and oracles

- 61/61 states valid; no scan failures or partial scans.
- Base: 31/31 repositories, 14,538 files per version, 6 → 2 diagnostics.
- Oracles: 30/30 repositories, 14,422 files per version, 6 → 2 diagnostics.
- Added diagnostics: 0.
- Removed diagnostics: only the same four confirmed Internxt false positives in base and oracle.
- Retained findings: Catho direct inline ref creation and Internxt `useMemo`.

### OSS / RDE corpus

- 100/100 frozen roots valid.
- 25,758 files per version.
- 3 → 3 target-rule diagnostics.
- Added: 0; removed: 0; scan failures: 0.

### Fuzzing

Strict 2,000-iteration runs passed with target fire coverage:

- Generated: 2,000 iterations, fire coverage 1/1.
- `react-bench-5`: 400 corpus files plus built-in regression seeds, 2,000 iterations, fire coverage 1/1.

### Repository gates

- Combined focused suites: 31/31 passed at the final head.
- Full plugin suite: 569 files, 14,824 tests passed.
- Full `nr test`: 14/14 tasks passed.
- `nr lint`
- `nr typecheck`
- `nr format:check`
- `git diff --check`
- Pre/post truffler duplicate search.

Both preview publishing workflows were cancelled before their publish steps.
