### PR TITLE
fix: control-has-associated-label recognizes component-wrapped labels with htmlFor

### DIFF
--- a/.changeset/component-wrapped-labels.md
+++ b/.changeset/component-wrapped-labels.md
@@ -1,0 +1,21 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+fix(control-has-associated-label): recognize component-wrapped labels with htmlFor
+
+Fixes #1314. The rule now recognizes form controls associated through
+component-wrapped labels like shadcn/ui's `<Label htmlFor>` (Radix
+LabelPrimitive.Root), not just native `<label>` elements.
+
+Previously, the rule only collected `htmlFor` associations from native `<label>`
+elements. Now it collects them from ANY element (native or component) that has
+both an `htmlFor` attribute and accessible text content. This handles:
+
+- `<Label htmlFor="id">Text</Label>` (shadcn/Radix pattern)
+- `<FormLabel htmlFor="id">Text</FormLabel>`
+- `<InputLabel htmlFor="id">Text</InputLabel>`
+- Any other capitalized component carrying `htmlFor`
+
+The fix is intentionally broad: a component with `htmlFor` + text is a strong
+association signal even when the rendered tag can't be resolved statically.

--- a/.changeset/component-wrapped-labels.md
+++ b/.changeset/component-wrapped-labels.md
@@ -2,20 +2,5 @@
 "oxlint-plugin-react-doctor": patch
 ---
 
-fix(control-has-associated-label): recognize component-wrapped labels with htmlFor
-
-Fixes #1314. The rule now recognizes form controls associated through
-component-wrapped labels like shadcn/ui's `<Label htmlFor>` (Radix
-LabelPrimitive.Root), not just native `<label>` elements.
-
-Previously, the rule only collected `htmlFor` associations from native `<label>`
-elements. Now it collects them from ANY element (native or component) that has
-both an `htmlFor` attribute and accessible text content. This handles:
-
-- `<Label htmlFor="id">Text</Label>` (shadcn/Radix pattern)
-- `<FormLabel htmlFor="id">Text</FormLabel>`
-- `<InputLabel htmlFor="id">Text</InputLabel>`
-- Any other capitalized component carrying `htmlFor`
-
-The fix is intentionally broad: a component with `htmlFor` + text is a strong
-association signal even when the rendered tag can't be resolved statically.
+Recognize matching `htmlFor` associations from components already treated as label renderers in
+`control-has-associated-label`.

--- a/packages/fuzz/corpus/regressions/control-has-associated-label--shadcn-label-html-for.tsx
+++ b/packages/fuzz/corpus/regressions/control-has-associated-label--shadcn-label-html-for.tsx
@@ -1,0 +1,14 @@
+// rule: control-has-associated-label
+// weakness: library-idiom
+// source: GitHub issue #1314
+
+import { Label } from "@/components/ui/label";
+
+export const DepartmentSelect = () => (
+  <div>
+    <Label htmlFor="departmentId">Department</Label>
+    <select id="departmentId" name="departmentId">
+      <option value="">All</option>
+    </select>
+  </div>
+);

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -468,6 +468,8 @@ export const JSX_LEAF_POOL = [
   `<input value={state} onChange={(event) => setState(event.target.value)} onKeyDown={(event) => { if (event.key === "Enter") handle(); }} />`,
   `<input value="frozen" onChange={handleChange} />`,
   `<input type="checkbox" checked={isChecked} onChange={(event) => setState(event.target.checked)} />`,
+  `<><Label htmlFor="fuzz-department">Department</Label><select id="fuzz-department"><option>All</option></select></>`,
+  `<><FormLabel htmlFor="fuzz-department">Department</FormLabel><select id="fuzz-department"><option>All</option></select></>`,
   `<input type="checkbox" indeterminate />`,
   `<input type="radio" value="a" checked={state === "a"} onChange={() => setState("a")} />`,
   `<input type="radio" name="group" value="b" defaultChecked />`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/control-has-associated-label.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/control-has-associated-label.regressions.test.ts
@@ -1036,11 +1036,11 @@ describe("a11y/control-has-associated-label regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
-  it("accepts FormLabel component with htmlFor matching control id", () => {
+  it("does not trust htmlFor on a component that does not render a label", () => {
     const result = runRule(
       controlHasAssociatedLabel,
       `
-        import { FormLabel } from '@/components/form';
+        const FormLabel = ({ children }) => <span>{children}</span>;
 
         const Demo = () => (
           <div>
@@ -1051,6 +1051,6 @@ describe("a11y/control-has-associated-label regressions", () => {
       `,
     );
 
-    expect(result.diagnostics).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
   });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/control-has-associated-label.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/control-has-associated-label.regressions.test.ts
@@ -995,4 +995,62 @@ describe("a11y/control-has-associated-label regressions", () => {
 
     expect(result.diagnostics).toEqual([]);
   });
+
+  it("accepts component-wrapped Label with static htmlFor matching control id (shadcn/Radix pattern)", () => {
+    const result = runRule(
+      controlHasAssociatedLabel,
+      `
+        import { Label } from '@/components/ui/label';
+
+        const Demo = () => (
+          <div className="space-y-2">
+            <Label htmlFor="departmentId">Department</Label>
+            <select id="departmentId" name="departmentId">
+              <option value="">All</option>
+            </select>
+          </div>
+        );
+      `,
+    );
+
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("accepts component-wrapped Label with dynamic htmlFor matching control id", () => {
+    const result = runRule(
+      controlHasAssociatedLabel,
+      `
+        import { Label } from '@/components/ui/label';
+
+        const Demo = ({ fieldId }) => (
+          <div className="space-y-2">
+            <Label htmlFor={fieldId}>Department</Label>
+            <select id={fieldId} name="department">
+              <option value="">All</option>
+            </select>
+          </div>
+        );
+      `,
+    );
+
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("accepts FormLabel component with htmlFor matching control id", () => {
+    const result = runRule(
+      controlHasAssociatedLabel,
+      `
+        import { FormLabel } from '@/components/form';
+
+        const Demo = () => (
+          <div>
+            <FormLabel htmlFor="email">Email</FormLabel>
+            <input id="email" type="email" name="email" />
+          </div>
+        );
+      `,
+    );
+
+    expect(result.diagnostics).toEqual([]);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/control-has-associated-label.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/control-has-associated-label.ts
@@ -897,15 +897,22 @@ export const controlHasAssociatedLabel = defineRule({
         // all and decide at Program:exit. Labels inside JSX-attribute
         // callbacks (render props) may never render, so they don't
         // register.
+        const htmlForAttribute = hasJsxPropIgnoreCase(opening.attributes, HTML_FOR_ATTRIBUTE);
+        const hasHtmlFor = Boolean(htmlForAttribute);
         if (
-          tagName === LABEL_ELEMENT &&
+          hasHtmlFor &&
           hasAccessibleLabelText(node, checkContext) &&
           !isInsideJsxAttribute(node)
         ) {
-          const htmlForAttribute = hasJsxPropIgnoreCase(opening.attributes, HTML_FOR_ATTRIBUTE);
           for (const htmlForKey of getAttributeMatchKeys(htmlForAttribute)) {
             labelHtmlForKeys.add(htmlForKey);
           }
+        }
+        if (
+          rendersLabelElement(tagName, opening) &&
+          hasAccessibleLabelText(node, checkContext) &&
+          !isInsideJsxAttribute(node)
+        ) {
           collectLabelEmbeddedNames(node, 1, checkContext, labelEmbeddedNames);
         }
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/control-has-associated-label.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/control-has-associated-label.ts
@@ -897,23 +897,18 @@ export const controlHasAssociatedLabel = defineRule({
         // all and decide at Program:exit. Labels inside JSX-attribute
         // callbacks (render props) may never render, so they don't
         // register.
-        const htmlForAttribute = hasJsxPropIgnoreCase(opening.attributes, HTML_FOR_ATTRIBUTE);
-        const hasHtmlFor = Boolean(htmlForAttribute);
-        if (
-          hasHtmlFor &&
-          hasAccessibleLabelText(node, checkContext) &&
-          !isInsideJsxAttribute(node)
-        ) {
-          for (const htmlForKey of getAttributeMatchKeys(htmlForAttribute)) {
-            labelHtmlForKeys.add(htmlForKey);
-          }
-        }
         if (
           rendersLabelElement(tagName, opening) &&
           hasAccessibleLabelText(node, checkContext) &&
           !isInsideJsxAttribute(node)
         ) {
-          collectLabelEmbeddedNames(node, 1, checkContext, labelEmbeddedNames);
+          const htmlForAttribute = hasJsxPropIgnoreCase(opening.attributes, HTML_FOR_ATTRIBUTE);
+          for (const htmlForKey of getAttributeMatchKeys(htmlForAttribute)) {
+            labelHtmlForKeys.add(htmlForKey);
+          }
+          if (tagName === LABEL_ELEMENT) {
+            collectLabelEmbeddedNames(node, 1, checkContext, labelEmbeddedNames);
+          }
         }
 
         if (DEFAULT_IGNORE_ELEMENTS.includes(tagName)) return;


### PR DESCRIPTION
## Why

React Doctor 0.7.8 reports `control-has-associated-label` for the common shadcn/Radix shape `<Label htmlFor="departmentId">…</Label><select id="departmentId">…</select>`. Issue #1314 reports six real occurrences and confirms the rendered DOM passes axe.

## What changed

- Extend explicit `htmlFor`/`id` matching from native `<label>` to components already recognized by this rule as label renderers: `Label` and `component="label"`.
- Preserve the existing conservative boundary for arbitrary wrappers such as `FormLabel`; those still report.
- Preserve native-label-only name projection when no `htmlFor` exists.
- Add static, dynamic-identifier, and invalid lookalike regression cases.
- Add a permanent fuzz regression seed and both valid/invalid generator shapes.
- Add a patch changeset for `oxlint-plugin-react-doctor`.

## Validation

- Focused rule tests: 298 passed, 4 skipped.
- Full oxlint plugin suite: 14,827 passed, 188 skipped.
- Full repository suite: 14 tasks passed.
- `nr typecheck`, `nr lint`, `nr format:check`, `git diff --check`, and `nr smoke:json-report`: passed.
- Strict fuzz: `FUZZ_RULE=control-has-associated-label FUZZ_STRICT=1 FUZZ_ITERATIONS=500` passed with 1/1 fire coverage.
- React Bench fuzz corpus: 35 external files plus 289 built-in seeds, passed with 1/1 fire coverage.
- React Bench parity: all 36 pinned RD-health target files scanned, 0 failures, baseline 1 / candidate 1, no deltas.
- Pinned OSS parity: all 4,870 `htmlFor`-bearing JSX/TSX files across 725 cached revisions scanned, 0 failures. Baseline 660 / candidate 637. All 23 removed diagnostics across 17 files were manually traced to native-label, Radix Label, or the pinned Compound Web Radix wrapper; added false positives 0, removed true positives 0.
- The RDE CLI run was not counted because the local harness only accepts report schema v1/v2 while current React Doctor emits v3; local AST-rule parity above is the valid evidence for this oxlint rule.

Fixes #1314.