### PR TITLE
fix: skip supabase-client-owned-authz-field on 'use server' files

### DIFF
--- a/.changeset/use-server-directive.md
+++ b/.changeset/use-server-directive.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Skip `supabase-client-owned-authz-field` on files with `'use server'` directive. Server actions with top-level `'use server'` are framework-enforced server-only code, so the rule's client-side threat model does not apply.

--- a/packages/fuzz/corpus/regressions/supabase-client-owned-authz-field--use-server-module.tsx
+++ b/packages/fuzz/corpus/regressions/supabase-client-owned-authz-field--use-server-module.tsx
@@ -1,0 +1,16 @@
+// rule: supabase-client-owned-authz-field
+// weakness: framework-gating
+// source: issue #1312 exact semicolonless server-action report
+
+// prettier-ignore
+"use server"
+
+import { createClient } from "@/lib/supabase/server";
+
+export const createFaqItem = async (tenantId: string, formData: FormData) => {
+  const supabase = await createClient();
+  await supabase.from("faq_items").insert({
+    tenant_id: tenantId,
+    question: String(formData.get("question")),
+  });
+};

--- a/packages/fuzz/corpus/true-positives/supabase-client-owned-authz-field--client-write.tsx
+++ b/packages/fuzz/corpus/true-positives/supabase-client-owned-authz-field--client-write.tsx
@@ -1,0 +1,7 @@
+// rule: supabase-client-owned-authz-field
+// weakness: framework-gating
+// source: issue #1312 paired client-side positive control
+
+export const createTeam = async (ownerId: string) => {
+  await supabase.from("teams").insert({ ownerId, role: "admin" });
+};

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -248,6 +248,7 @@ export const LIBRARY_SNIPPET_POOL = [
 
 // Module scope — SSR hazards, guard aliases, contexts, caches, styled.
 export const MODULE_SCOPE_SNIPPET_POOL = [
+  `export const createFuzzTeam = async (ownerId: string) => { await supabase.from("teams").insert({ ownerId, role: "admin" }); };`,
   `import { ImageResponse as FuzzImageResponse } from "next/og"; export const FuzzPostcardLayout = ({ url }) => <img src={url} alt="" />; export const FuzzPostcardRoute = () => new FuzzImageResponse(FuzzPostcardLayout({ url }));`,
   `import { render as fuzzRender } from "@testing-library/react"; it("mounts a one-shot ref harness", () => { const FuzzOneShotRefTarget = () => { const targetRef = React.createRef(); return <FuzzFocusTrap targetRef={targetRef}><button ref={targetRef}>Target</button></FuzzFocusTrap>; }; fuzzRender(<FuzzOneShotRefTarget />); });`,
   `import { render as fuzzRenderWithTypeWrapper } from "@testing-library/react"; it("mounts a type-wrapped one-shot ref harness", () => { const FuzzTypeWrappedOneShotRefTarget = () => { const targetRef = React.createRef(); return <FuzzFocusTrap targetRef={targetRef}><button ref={targetRef}>Target</button></FuzzFocusTrap>; }; fuzzRenderWithTypeWrapper((<FuzzTypeWrappedOneShotRefTarget />) as React.ReactElement); });`,
@@ -304,6 +305,10 @@ export const MODULE_SCOPE_SNIPPET_POOL = [
 ] as const;
 
 export const SERVER_MODULE_PROGRAM_POOL = [
+  `"use server"
+export const createFuzzTeam = async (ownerId: string) => {
+  await supabase.from("teams").insert({ ownerId, role: "admin" });
+};`,
   `export default async function Page() {
   const response = await fetch("https://api.example.com/feed");
   return Response.json(await response.json());

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/supabase-client-owned-authz-field.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/supabase-client-owned-authz-field.regressions.test.ts
@@ -26,10 +26,10 @@ describe("security-scan/supabase-client-owned-authz-field — regressions", () =
     expect(findings).toHaveLength(0);
   });
 
-  it("stays silent on files with 'use server' directive", () => {
+  it("stays silent on the exact semicolonless server-action report", () => {
     const findings = runScanRule(supabaseClientOwnedAuthzField, {
       relativePath: "app/(admin)/faq/actions.ts",
-      content: `"use server";
+      content: `'use server'
 
 import { createClient } from "@/lib/supabase/server";
 import { requireTenantRole } from "@/lib/auth/require-role";
@@ -49,15 +49,49 @@ export async function createFaqItem(tenantId: string, formData: FormData) {
     expect(findings).toHaveLength(0);
   });
 
-  it("stays silent on files with single-quoted 'use server' directive", () => {
+  it("stays silent on a pinned semicolonless OSS server action", () => {
     const findings = runScanRule(supabaseClientOwnedAuthzField, {
-      relativePath: "src/actions/delete-post.ts",
-      content: `'use server';
+      relativePath: "app/actions/token-trading-actions.ts",
+      content: `"use server"
 
-export async function deletePost(userId: string, postId: string) {
-  await supabase.from("posts").delete().match({ id: postId, ownerId: userId });
+import { createServerSupabaseClient } from "@/lib/supabase/server";
+
+export async function createBuyOffer(formData: { userId: string; poolId: string }) {
+  const supabase = await createServerSupabaseClient();
+  await supabase.from("token_offers").insert({
+    buyer_id: formData.userId,
+    pool_id: formData.poolId,
+  });
 }`,
     });
     expect(findings).toHaveLength(0);
+  });
+
+  it("stays silent when a multiline license precedes a real directive", () => {
+    const findings = runScanRule(supabaseClientOwnedAuthzField, {
+      relativePath: "src/actions/create-team.ts",
+      content: `/**
+ * Copyright Example Corp.
+ */
+'use server'
+
+export async function createTeam(ownerId: string) {
+  await supabase.from("teams").insert({ ownerId, role: "admin" });
+}`,
+    });
+    expect(findings).toHaveLength(0);
+  });
+
+  it("still flags a client write when 'use server' only appears in a block comment", () => {
+    const findings = runScanRule(supabaseClientOwnedAuthzField, {
+      relativePath: "src/lib/create-team.ts",
+      content: `/*
+'use server';
+*/
+export const createTeam = async (ownerId: string) => {
+  await supabase.from("teams").insert({ ownerId, role: "admin" });
+};`,
+    });
+    expect(findings).toHaveLength(1);
   });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/supabase-client-owned-authz-field.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/supabase-client-owned-authz-field.regressions.test.ts
@@ -25,4 +25,39 @@ describe("security-scan/supabase-client-owned-authz-field — regressions", () =
     });
     expect(findings).toHaveLength(0);
   });
+
+  it("stays silent on files with 'use server' directive", () => {
+    const findings = runScanRule(supabaseClientOwnedAuthzField, {
+      relativePath: "app/(admin)/faq/actions.ts",
+      content: `"use server";
+
+import { createClient } from "@/lib/supabase/server";
+import { requireTenantRole } from "@/lib/auth/require-role";
+
+export async function createFaqItem(tenantId: string, formData: FormData) {
+  const auth = await requireTenantRole(tenantId, "admin");
+  if ("error" in auth) return { error: auth.error };
+
+  const supabase = await createClient();
+  const { error } = await supabase.from("faq_items").insert({
+    tenant_id: tenantId,
+    question: String(formData.get("question")),
+  });
+  return error ? { error: error.message } : {};
+}`,
+    });
+    expect(findings).toHaveLength(0);
+  });
+
+  it("stays silent on files with single-quoted 'use server' directive", () => {
+    const findings = runScanRule(supabaseClientOwnedAuthzField, {
+      relativePath: "src/actions/delete-post.ts",
+      content: `'use server';
+
+export async function deletePost(userId: string, postId: string) {
+  await supabase.from("posts").delete().match({ id: postId, ownerId: userId });
+}`,
+    });
+    expect(findings).toHaveLength(0);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/supabase-client-owned-authz-field.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/supabase-client-owned-authz-field.ts
@@ -1,4 +1,5 @@
 import { defineRule } from "../../utils/define-rule.js";
+import { hasUseServerDirectiveInContent } from "./utils/has-use-server-directive-in-content.js";
 import { isClientSourcePath } from "./utils/is-client-source-path.js";
 import { scanByPattern } from "./utils/scan-by-pattern.js";
 
@@ -15,7 +16,8 @@ export const supabaseClientOwnedAuthzField = defineRule({
   recommendation:
     "Use RLS policies based on `auth.uid()` and server-owned membership rows; do not trust client-provided owner, org, or role columns.",
   scan: scanByPattern({
-    shouldScan: (file) => isClientSourcePath(file.relativePath),
+    shouldScan: (file) =>
+      isClientSourcePath(file.relativePath) && !hasUseServerDirectiveInContent(file.content),
     pattern: SENSITIVE_AUTH_FIELD_PATTERN,
     requireAll: [SUPABASE_CLIENT_AUTHZ_WRITE_PATTERN],
     message:

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/supabase-client-owned-authz-field.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/supabase-client-owned-authz-field.ts
@@ -9,18 +9,23 @@ const SENSITIVE_AUTH_FIELD_PATTERN =
 const SUPABASE_CLIENT_AUTHZ_WRITE_PATTERN =
   /\b(?:supabase\b|\.from\s*\(\s*["'][^"']+["']\s*\))[\s\S]{0,700}\b(?:insert|upsert|update)\s*\(\s*(?:\{|\[?\s*\{)[\s\S]{0,700}\b(?:ownerId|creatorId|userId|orgId|tenantId|role|isAdmin)\b/i;
 
+const scanSupabaseClientOwnedAuthzField = scanByPattern({
+  shouldScan: (file) => isClientSourcePath(file.relativePath),
+  pattern: SENSITIVE_AUTH_FIELD_PATTERN,
+  requireAll: [SUPABASE_CLIENT_AUTHZ_WRITE_PATTERN],
+  message:
+    "Client Supabase code appears to write user, tenant, owner, or role fields that should be enforced by RLS.",
+});
+
 export const supabaseClientOwnedAuthzField = defineRule({
   id: "supabase-client-owned-authz-field",
   title: "Client writes Supabase authorization field",
   severity: "error",
   recommendation:
     "Use RLS policies based on `auth.uid()` and server-owned membership rows; do not trust client-provided owner, org, or role columns.",
-  scan: scanByPattern({
-    shouldScan: (file) =>
-      isClientSourcePath(file.relativePath) && !hasUseServerDirectiveInContent(file.content),
-    pattern: SENSITIVE_AUTH_FIELD_PATTERN,
-    requireAll: [SUPABASE_CLIENT_AUTHZ_WRITE_PATTERN],
-    message:
-      "Client Supabase code appears to write user, tenant, owner, or role fields that should be enforced by RLS.",
-  }),
+  scan: (file) => {
+    const findings = scanSupabaseClientOwnedAuthzField(file);
+    if (findings.length === 0) return findings;
+    return hasUseServerDirectiveInContent(file.content, file.relativePath) ? [] : findings;
+  },
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/utils/has-use-server-directive-in-content.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/utils/has-use-server-directive-in-content.test.ts
@@ -10,12 +10,44 @@ describe("security-scan/utils/has-use-server-directive-in-content", () => {
     expect(hasUseServerDirectiveInContent("'use server';\n\nexport const foo = 1;")).toBe(true);
   });
 
+  it("detects semicolonless directives", () => {
+    expect(hasUseServerDirectiveInContent("'use server'\n\nexport const foo = 1;")).toBe(true);
+    expect(hasUseServerDirectiveInContent('"use server"\n\nexport const foo = 1;')).toBe(true);
+  });
+
   it("detects 'use server' after leading whitespace", () => {
     expect(hasUseServerDirectiveInContent('  "use server";\n\nexport const foo = 1;')).toBe(true);
   });
 
   it("detects 'use server' after blank lines", () => {
     expect(hasUseServerDirectiveInContent('\n\n"use server";\n\nexport const foo = 1;')).toBe(true);
+  });
+
+  it("detects a directive after a multiline leading comment", () => {
+    expect(
+      hasUseServerDirectiveInContent(`/**
+ * Copyright Example Corp.
+ */
+"use server"
+
+export const foo = 1;`),
+    ).toBe(true);
+  });
+
+  it("detects a directive with trailing comments and whitespace", () => {
+    expect(
+      hasUseServerDirectiveInContent(`/* server actions */
+  'use server' /* framework boundary */ ; // trailing note
+export const foo = 1;`),
+    ).toBe(true);
+  });
+
+  it("detects 'use server' within the leading directive prologue", () => {
+    expect(
+      hasUseServerDirectiveInContent(`"use strict";
+'use server'
+export const foo = 1;`),
+    ).toBe(true);
   });
 
   it("does not detect 'use server' in the middle of the file", () => {
@@ -26,6 +58,21 @@ describe("security-scan/utils/has-use-server-directive-in-content", () => {
 
   it("does not detect 'use server' in comments", () => {
     expect(hasUseServerDirectiveInContent('// "use server";\n\nexport const foo = 1;')).toBe(false);
+    expect(
+      hasUseServerDirectiveInContent(`/*
+'use server';
+*/
+export const foo = 1;`),
+    ).toBe(false);
+  });
+
+  it("does not detect wrapped or asserted string expressions as directives", () => {
+    expect(hasUseServerDirectiveInContent(`("use server" as const);\nexport const foo = 1;`)).toBe(
+      false,
+    );
+    expect(
+      hasUseServerDirectiveInContent(`"use server" satisfies string;\nexport const foo = 1;`),
+    ).toBe(false);
   });
 
   it("does not detect files without 'use server'", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/utils/has-use-server-directive-in-content.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/utils/has-use-server-directive-in-content.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vite-plus/test";
+import { hasUseServerDirectiveInContent } from "./has-use-server-directive-in-content.js";
+
+describe("security-scan/utils/has-use-server-directive-in-content", () => {
+  it("detects double-quoted 'use server' directive at file start", () => {
+    expect(hasUseServerDirectiveInContent('"use server";\n\nexport const foo = 1;')).toBe(true);
+  });
+
+  it("detects single-quoted 'use server' directive at file start", () => {
+    expect(hasUseServerDirectiveInContent("'use server';\n\nexport const foo = 1;")).toBe(true);
+  });
+
+  it("detects 'use server' after leading whitespace", () => {
+    expect(hasUseServerDirectiveInContent('  "use server";\n\nexport const foo = 1;')).toBe(true);
+  });
+
+  it("detects 'use server' after blank lines", () => {
+    expect(hasUseServerDirectiveInContent('\n\n"use server";\n\nexport const foo = 1;')).toBe(
+      true,
+    );
+  });
+
+  it("does not detect 'use server' in the middle of the file", () => {
+    expect(
+      hasUseServerDirectiveInContent('const foo = 1;\n\n"use server";\n\nexport const bar = 2;'),
+    ).toBe(false);
+  });
+
+  it("does not detect 'use server' in comments", () => {
+    expect(hasUseServerDirectiveInContent('// "use server";\n\nexport const foo = 1;')).toBe(
+      false,
+    );
+  });
+
+  it("does not detect files without 'use server'", () => {
+    expect(hasUseServerDirectiveInContent('export const foo = 1;')).toBe(false);
+  });
+
+  it("does not detect 'use client' as 'use server'", () => {
+    expect(hasUseServerDirectiveInContent('"use client";\n\nexport const foo = 1;')).toBe(false);
+  });
+
+  it("handles empty files", () => {
+    expect(hasUseServerDirectiveInContent("")).toBe(false);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/utils/has-use-server-directive-in-content.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/utils/has-use-server-directive-in-content.test.ts
@@ -15,9 +15,7 @@ describe("security-scan/utils/has-use-server-directive-in-content", () => {
   });
 
   it("detects 'use server' after blank lines", () => {
-    expect(hasUseServerDirectiveInContent('\n\n"use server";\n\nexport const foo = 1;')).toBe(
-      true,
-    );
+    expect(hasUseServerDirectiveInContent('\n\n"use server";\n\nexport const foo = 1;')).toBe(true);
   });
 
   it("does not detect 'use server' in the middle of the file", () => {
@@ -27,13 +25,11 @@ describe("security-scan/utils/has-use-server-directive-in-content", () => {
   });
 
   it("does not detect 'use server' in comments", () => {
-    expect(hasUseServerDirectiveInContent('// "use server";\n\nexport const foo = 1;')).toBe(
-      false,
-    );
+    expect(hasUseServerDirectiveInContent('// "use server";\n\nexport const foo = 1;')).toBe(false);
   });
 
   it("does not detect files without 'use server'", () => {
-    expect(hasUseServerDirectiveInContent('export const foo = 1;')).toBe(false);
+    expect(hasUseServerDirectiveInContent("export const foo = 1;")).toBe(false);
   });
 
   it("does not detect 'use client' as 'use server'", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/utils/has-use-server-directive-in-content.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/utils/has-use-server-directive-in-content.ts
@@ -1,0 +1,13 @@
+export const hasUseServerDirectiveInContent = (content: string): boolean => {
+  const lines = content.split("\n");
+  for (const line of lines) {
+    const trimmedLine = line.trim();
+    if (trimmedLine === "") continue;
+    if (trimmedLine.startsWith("//") || trimmedLine.startsWith("/*")) continue;
+    if (trimmedLine === '"use server";' || trimmedLine === "'use server';") {
+      return true;
+    }
+    return false;
+  }
+  return false;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/utils/has-use-server-directive-in-content.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/utils/has-use-server-directive-in-content.ts
@@ -1,13 +1,14 @@
-export const hasUseServerDirectiveInContent = (content: string): boolean => {
-  const lines = content.split("\n");
-  for (const line of lines) {
-    const trimmedLine = line.trim();
-    if (trimmedLine === "") continue;
-    if (trimmedLine.startsWith("//") || trimmedLine.startsWith("/*")) continue;
-    if (trimmedLine === '"use server";' || trimmedLine === "'use server';") {
-      return true;
-    }
-    return false;
-  }
-  return false;
+import { hasDirective } from "../../../utils/has-directive.js";
+import { parseSourceText } from "../../../utils/parse-source-file.js";
+
+export const hasUseServerDirectiveInContent = (
+  content: string,
+  relativePath = "source.tsx",
+): boolean => {
+  const programNode = parseSourceText({
+    filename: relativePath,
+    sourceText: content,
+    shouldAttachParentReferences: false,
+  });
+  return programNode === null ? false : hasDirective(programNode, "use server");
 };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/has-directive.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/has-directive.ts
@@ -3,12 +3,11 @@ import { isNodeOfType } from "./is-node-of-type.js";
 
 export const hasDirective = (programNode: EsTreeNode, directive: string): boolean => {
   if (!isNodeOfType(programNode, "Program")) return false;
-  return Boolean(
-    programNode.body?.some(
-      (statement) =>
-        isNodeOfType(statement, "ExpressionStatement") &&
-        isNodeOfType(statement.expression, "Literal") &&
-        statement.expression.value === directive,
-    ),
-  );
+  for (const statement of programNode.body) {
+    if (!isNodeOfType(statement, "ExpressionStatement") || statement.directive === undefined) {
+      return false;
+    }
+    if (statement.directive === directive) return true;
+  }
+  return false;
 };


### PR DESCRIPTION
## Summary

Fixes #1312. `supabase-client-owned-authz-field` no longer applies its browser-client threat model to a module whose executable directive prologue proves that it is a server-action file.

## Precision boundary

The original Supabase write scan still runs first. A candidate finding is suppressed only when parsing succeeds and the Program has an exact `"use server"` or `'use server'` directive in its module directive prologue.

This does not trust comments, escaped strings, parenthesized/asserted expressions, later string literals, function-level directives, malformed files, or similarly named text. Parse failures remain conservative and preserve the original finding.

## Regression coverage

- Exact semicolonless server-action report and a pinned OSS server action.
- Single/double quotes, comments/licenses, BOM, hashbang, and a preceding `use strict` directive.
- Paired client-write positives for comment-only, later, escaped, wrapped, function-level, and malformed forms.
- Permanent false-positive and true-positive fuzz seeds.

## Validation

- Full plugin suite: 14,848 passed, 188 skipped.
- Strict generated fuzz: 1,018 executions, target fired 23 times, zero parse skips or findings.
- Strict React Bench corpus fuzz: 506 executions, target fired eight times, zero parse skips or findings.
- Pinned real server action (`yurimatos19/sgvaq@dce34b87`): target `1 -> 0`.
- Pinned React Bench true positive (`chrizzzly87/travelflow@2b40a718`): target `1 -> 1`.
- Typecheck, format check, and `git diff --check` passed.
- Exact-head CI, CodeQL, React Doctor, and Bugbot pass; review-thread audit is empty.

The canceled checks are only the preview-package workflow, intentionally stopped because no package publishing is authorized.
