### PR TITLE
fix: exclude test diagnostics from production health

### DIFF
--- a/.changeset/quiet-tests-stay.md
+++ b/.changeset/quiet-tests-stay.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": minor
+---
+
+Keep diagnostics from test and story files visible in raw output while excluding them from the production-health score and CI gate by default. Existing per-surface rule, category, and tag includes can opt individual findings back in.

--- a/packages/core/src/diagnostic-surface.ts
+++ b/packages/core/src/diagnostic-surface.ts
@@ -17,8 +17,10 @@ export const isDiagnosticSurface = (value: unknown): value is DiagnosticSurface 
  * to the local CLI so developers see them while editing, but they're
  * removed from the PR comment surface, the score, and the CI gate so
  * they can't bury real React findings or fail a build over a Tailwind
- * shorthand. Override per-surface via `config.surfaces.<surface>` to
- * promote individual rules back in by tag, category, or rule id.
+ * shorthand. Diagnostics from test and story files likewise remain in
+ * raw output while staying out of the production-health score and CI
+ * gate. Override per-surface via `config.surfaces.<surface>` to promote
+ * individual rules back in by tag, category, or rule id.
  */
 export const DEFAULT_SURFACE_EXCLUDED_TAGS: Record<DiagnosticSurface, ReadonlyArray<string>> = {
   cli: [],

--- a/packages/core/src/filter-for-surface.ts
+++ b/packages/core/src/filter-for-surface.ts
@@ -57,6 +57,10 @@ export const isDiagnosticOnSurface = (
   if (resolved.includeCategories.has(category)) return true;
   if (intersects(tags, resolved.includeTags)) return true;
 
+  if (diagnostic.fileContext !== undefined && (surface === "score" || surface === "ciFailure")) {
+    return false;
+  }
+
   if (resolved.excludeRuleKeys.has(ruleKey)) return false;
   if (resolved.excludeCategories.has(category)) return false;
   if (intersects(tags, resolved.excludeTags)) return false;

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -77,8 +77,10 @@ interface ReactDoctorIgnoreConfig {
  *
  * Defaults: design rules (tag `"design"`) are excluded from `prComment`,
  * `score`, and `ciFailure` so style cleanup doesn't dilute meaningful
- * React findings. They remain in `cli` so locally-running developers
- * still see the suggestion when they touch the file.
+ * React findings. Diagnostics stamped with `fileContext: "test" | "story"`
+ * are excluded from `score` and `ciFailure`. Both remain in `cli`, and an
+ * explicit rule, category, or tag include promotes a diagnostic back onto
+ * the selected surface.
  */
 export type DiagnosticSurface = "cli" | "prComment" | "score" | "ciFailure";
 
@@ -388,6 +390,8 @@ export interface ReactDoctorConfig {
    * - `prComment` excludes tag `"design"`
    * - `score` excludes tag `"design"`
    * - `ciFailure` excludes tag `"design"`
+   * - `score` and `ciFailure` exclude test/story file contexts unless an
+   *   existing include control explicitly promotes the diagnostic
    *
    * Pass any controls block (even an empty `{}`) to keep the default
    * exclusions; the user's include/exclude entries layer on top.

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -379,25 +379,22 @@ export interface ReactDoctorConfig {
    */
   adoptExistingLintConfig?: boolean;
   /**
-   * Per-surface include/exclude controls. Each `DiagnosticSurface` is
-   * resolved independently against rule tags, category, and id so a
-   * single rule can be visible locally yet hidden from PR comments,
-   * neutralized from the score, and excluded from the CI gate — all
-   * without touching the rule's severity or activation.
+   * Per-surface include/exclude controls. Each `DiagnosticSurface` resolves
+   * rule tags, categories, and identifiers independently. This lets you keep a rule
+   * visible locally while hiding it from PR comments, the score, or the CI
+   * gate. These controls don't change rule severity or activation.
    *
    * Defaults (applied before user overrides):
    *
    * - `prComment` excludes tag `"design"`
    * - `score` excludes tag `"design"`
    * - `ciFailure` excludes tag `"design"`
-   * - `score` and `ciFailure` exclude test/story file contexts unless an
-   *   existing include control explicitly promotes the diagnostic
+   * - `score` and `ciFailure` exclude test/story file contexts unless explicitly included
    *
-   * Pass any controls block (even an empty `{}`) to keep the default
-   * exclusions; the user's include/exclude entries layer on top.
-   * Include entries always win over exclude entries — handy for
-   * promoting a single high-signal `design-*` rule back into the
-   * score or PR-comment surface.
+   * Pass any controls block, including an empty `{}`, to keep the defaults.
+   * Your include/exclude entries layer on top. Includes always win over
+   * excludes. For example, you can promote one high-signal `design-*` rule
+   * back into the score or PR-comment surface.
    */
   surfaces?: Partial<Record<DiagnosticSurface, SurfaceControls>>;
   /**

--- a/packages/core/tests/filter-for-surface.test.ts
+++ b/packages/core/tests/filter-for-surface.test.ts
@@ -45,6 +45,45 @@ const externalPluginDiagnostic: Diagnostic = {
   category: "Security",
 };
 
+const docusaurusTestDiagnostic: Diagnostic = {
+  filePath: "packages/docusaurus-theme-classic/src/theme/Tabs/__tests__/index.test.tsx",
+  plugin: "react-compiler",
+  rule: "globals",
+  severity: "error",
+  message: "InvalidReact: Unexpected reassignment of a variable",
+  help: "",
+  line: 32,
+  column: 5,
+  category: "Correctness",
+  fileContext: "test",
+};
+
+const radixTestDiagnostic: Diagnostic = {
+  filePath: "packages/react/context-menu/src/context-menu-controlled.test.tsx",
+  plugin: "eslint",
+  rule: "no-unused-vars",
+  severity: "error",
+  message: "'trigger' is assigned a value but never used.",
+  help: "",
+  line: 48,
+  column: 9,
+  category: "Correctness",
+  fileContext: "test",
+};
+
+const storyDiagnostic: Diagnostic = {
+  filePath: "packages/components/src/Button.stories.tsx",
+  plugin: "react-doctor",
+  rule: "design-no-redundant-size-axes",
+  severity: "warning",
+  message: "w-5 h-5 → use the shorthand size-5 (Tailwind v3.4+)",
+  help: "",
+  line: 12,
+  column: 4,
+  category: "Architecture",
+  fileContext: "story",
+};
+
 describe("filterDiagnosticsForSurface defaults", () => {
   it("strips `design`-tagged rules from PR comment, score, and CI failure surfaces by default", () => {
     const diagnostics = [designDiagnostic, correctnessDiagnostic];
@@ -70,6 +109,14 @@ describe("filterDiagnosticsForSurface defaults", () => {
     for (const surface of DIAGNOSTIC_SURFACES) {
       expect(filterDiagnosticsForSurface(diagnostics, surface, null)).toEqual(diagnostics);
     }
+  });
+
+  it("keeps test and story diagnostics visible on CLI while excluding them from production health", () => {
+    const diagnostics = [docusaurusTestDiagnostic, radixTestDiagnostic, storyDiagnostic];
+
+    expect(filterDiagnosticsForSurface(diagnostics, "cli", null)).toEqual(diagnostics);
+    expect(filterDiagnosticsForSurface(diagnostics, "score", null)).toEqual([]);
+    expect(filterDiagnosticsForSurface(diagnostics, "ciFailure", null)).toEqual([]);
   });
 });
 
@@ -117,6 +164,32 @@ describe("filterDiagnosticsForSurface — user overrides", () => {
       },
     };
     expect(isDiagnosticOnSurface(designDiagnostic, "prComment", config)).toBe(true);
+  });
+
+  it("explicit includes restore non-production diagnostics to production-health surfaces", () => {
+    const ruleConfig: ReactDoctorConfig = {
+      surfaces: { score: { includeRules: ["react-compiler/globals"] } },
+    };
+    const categoryConfig: ReactDoctorConfig = {
+      surfaces: { ciFailure: { includeCategories: ["Correctness"] } },
+    };
+    const tagConfig: ReactDoctorConfig = {
+      surfaces: { score: { includeTags: ["design"] } },
+    };
+
+    expect(filterDiagnosticsForSurface([docusaurusTestDiagnostic], "score", ruleConfig)).toEqual([
+      docusaurusTestDiagnostic,
+    ]);
+    expect(
+      filterDiagnosticsForSurface(
+        [docusaurusTestDiagnostic, radixTestDiagnostic],
+        "ciFailure",
+        categoryConfig,
+      ),
+    ).toEqual([docusaurusTestDiagnostic, radixTestDiagnostic]);
+    expect(filterDiagnosticsForSurface([storyDiagnostic], "score", tagConfig)).toEqual([
+      storyDiagnostic,
+    ]);
   });
 });
 

--- a/packages/core/tests/run-inspect.test.ts
+++ b/packages/core/tests/run-inspect.test.ts
@@ -120,6 +120,8 @@ const layersOf = (config: {
   deadCode?: ReadonlyArray<Diagnostic>;
   supplyChain?: ReadonlyArray<Diagnostic>;
   githubViewerPermission?: string | null;
+  reactDoctorConfig?: ReactDoctorConfig | null;
+  scoreLayer?: Layer.Layer<Score>;
   // Pins the dead-code/lint overlap mode. Defaults to "off" so emit-order
   // assertions stay deterministic regardless of the test box's free memory
   // (the "auto" gate reads `os.freemem()`); overlap tests opt into "on".
@@ -127,7 +129,11 @@ const layersOf = (config: {
 }) =>
   Layer.mergeAll(
     Project.layerOf(sampleProject),
-    Config.layerOf({ config: null, resolvedDirectory: "/repo", configSourceDirectory: null }),
+    Config.layerOf({
+      config: config.reactDoctorConfig ?? null,
+      resolvedDirectory: "/repo",
+      configSourceDirectory: null,
+    }),
     Files.layerInMemory(new Map()),
     config.linter ?? Linter.layerOf(config.diagnostics ?? []),
     LintPartialFailures.layerLive,
@@ -138,7 +144,7 @@ const layersOf = (config: {
       defaultBranch: "main",
       githubViewerPermission: config.githubViewerPermission,
     }),
-    Score.layerOf({ score: 85, label: "Good" }),
+    config.scoreLayer ?? Score.layerOf({ score: 85, label: "Good" }),
     SupplyChain.layerOf(config.supplyChain ?? []),
     Progress.layerNoop,
     Reporter.layerCapture,
@@ -457,6 +463,77 @@ describe("runInspect — deterministic diagnostic ordering", () => {
 
     expect(reverseOrder.score).toEqual(forwardOrder.score);
     expect(reverseOrder.diagnostics).toEqual(forwardOrder.diagnostics);
+  });
+});
+
+describe("runInspect — production-health score scope", () => {
+  const docusaurusTestDiagnostic: Diagnostic = {
+    ...lintDiagnostic,
+    filePath: "packages/docusaurus-theme-classic/src/theme/Tabs/__tests__/context.test.tsx",
+    plugin: "react-compiler",
+    rule: "globals",
+    message: "InvalidReact: Unexpected reassignment of a variable",
+    fileContext: "test",
+  };
+
+  const storyDiagnostic: Diagnostic = {
+    ...lintDiagnostic,
+    filePath: "packages/components/src/Button.stories.tsx",
+    plugin: "eslint",
+    rule: "no-unused-vars",
+    fileContext: "story",
+  };
+
+  const runWithCapturedScore = (reactDoctorConfig: ReactDoctorConfig | null = null) =>
+    Effect.gen(function* () {
+      const capturedScoreDiagnostics = yield* Ref.make<ReadonlyArray<Diagnostic>>([]);
+      const scoreLayer = Layer.succeed(
+        Score,
+        Score.of({
+          compute: (input) =>
+            Ref.set(capturedScoreDiagnostics, input.diagnostics).pipe(
+              Effect.as({ score: 85, label: "Good" }),
+            ),
+        }),
+      );
+      const output = yield* runInspect(baseInput).pipe(
+        Effect.provide(
+          layersOf({
+            diagnostics: [docusaurusTestDiagnostic, storyDiagnostic],
+            deadCode: [],
+            reactDoctorConfig,
+            scoreLayer,
+          }),
+        ),
+      );
+      return {
+        output,
+        scoredDiagnostics: yield* Ref.get(capturedScoreDiagnostics),
+      };
+    });
+
+  it("returns test and story diagnostics through the API without sending them to the score", async () => {
+    const result = await Effect.runPromise(runWithCapturedScore());
+
+    expect(result.output.diagnostics).toHaveLength(2);
+    expect(result.output.diagnostics).toEqual(
+      expect.arrayContaining([docusaurusTestDiagnostic, storyDiagnostic]),
+    );
+    expect(result.scoredDiagnostics).toEqual([]);
+  });
+
+  it("restores an explicitly included test diagnostic to the score", async () => {
+    const result = await Effect.runPromise(
+      runWithCapturedScore({
+        surfaces: { score: { includeRules: ["react-compiler/globals"] } },
+      }),
+    );
+
+    expect(result.output.diagnostics).toHaveLength(2);
+    expect(result.output.diagnostics).toEqual(
+      expect.arrayContaining([docusaurusTestDiagnostic, storyDiagnostic]),
+    );
+    expect(result.scoredDiagnostics).toEqual([docusaurusTestDiagnostic]);
   });
 });
 

--- a/packages/react-doctor/src/cli/utils/build-run-event.ts
+++ b/packages/react-doctor/src/cli/utils/build-run-event.ts
@@ -246,6 +246,7 @@ const buildOutcomeAttributes = (input: RunEventInput): RunEventAttributes => {
     "ciFailure",
     input.userConfig,
   );
+  const gateDiagnosticSet = new Set(gateDiagnostics);
   const complete = isInspectResultComplete(result);
   // `scoreOnly` runs never raise a non-zero exit for ordinary findings, and a
   // degraded baseline run (`gateExempt`) skips the finding gate. A hard lint
@@ -287,6 +288,7 @@ const buildOutcomeAttributes = (input: RunEventInput): RunEventAttributes => {
 
   let diagnosticsInTestFiles = 0;
   let diagnosticsInStoryFiles = 0;
+  let nonProductionGateExcluded = 0;
   const diagnosticSiteCounts = new Map<string, number>();
   // Root-cause grouping rollup: how many distinct fix groups, and how many
   // findings they cover. `fixGroupedFindings - fixGroups` is the number of
@@ -296,6 +298,9 @@ const buildOutcomeAttributes = (input: RunEventInput): RunEventAttributes => {
   for (const diagnostic of result.diagnostics) {
     if (diagnostic.fileContext === "test") diagnosticsInTestFiles += 1;
     if (diagnostic.fileContext === "story") diagnosticsInStoryFiles += 1;
+    if (diagnostic.fileContext !== undefined && !gateDiagnosticSet.has(diagnostic)) {
+      nonProductionGateExcluded += 1;
+    }
     const diagnosticSite = JSON.stringify([
       diagnostic.filePath,
       diagnostic.line,
@@ -362,6 +367,7 @@ const buildOutcomeAttributes = (input: RunEventInput): RunEventAttributes => {
       affectedFiles: summary.affectedFileCount,
       inTestFiles: diagnosticsInTestFiles,
       inStoryFiles: diagnosticsInStoryFiles,
+      nonProductionGateExcluded,
       distinctRules: countByRule.size,
       topRule,
       sameSiteOccurrences,

--- a/packages/react-doctor/src/cli/utils/render-multi-project-summary.ts
+++ b/packages/react-doctor/src/cli/utils/render-multi-project-summary.ts
@@ -99,6 +99,10 @@ export const printMultiProjectSummary = (input: MultiProjectSummaryInput): Effec
 
     const surfaceDiagnostics = filterScansForSurface(completedScans, "cli");
     const displayDiagnostics = filterDiagnosticsByCategories(surfaceDiagnostics, categoryFilters);
+    const displayedScoreDiagnostics = filterDiagnosticsByCategories(
+      filterScansForSurface(completedScans, "score"),
+      categoryFilters,
+    );
 
     // Each diagnostic's `filePath` is relative to its own project root,
     // so the code-frame renderer needs to resolve per-diagnostic rather
@@ -166,8 +170,8 @@ export const printMultiProjectSummary = (input: MultiProjectSummaryInput): Effec
     const potentialScore = lowestScoredScan
       ? yield* Effect.promise(() =>
           computeProjectedScore(
-            displayDiagnostics,
-            filterScansForSurface([lowestScoredScan], "cli"),
+            displayedScoreDiagnostics,
+            filterScansForSurface([lowestScoredScan], "score"),
             lowestScoredScan.result.score,
           ),
         )

--- a/packages/react-doctor/src/cli/utils/render-multi-project-summary.ts
+++ b/packages/react-doctor/src/cli/utils/render-multi-project-summary.ts
@@ -99,9 +99,9 @@ export const printMultiProjectSummary = (input: MultiProjectSummaryInput): Effec
 
     const surfaceDiagnostics = filterScansForSurface(completedScans, "cli");
     const displayDiagnostics = filterDiagnosticsByCategories(surfaceDiagnostics, categoryFilters);
-    const displayedScoreDiagnostics = filterDiagnosticsByCategories(
-      filterScansForSurface(completedScans, "score"),
-      categoryFilters,
+    const scoreDiagnostics = new Set(filterScansForSurface(completedScans, "score"));
+    const displayedScoreDiagnostics = displayDiagnostics.filter((diagnostic) =>
+      scoreDiagnostics.has(diagnostic),
     );
 
     // Each diagnostic's `filePath` is relative to its own project root,

--- a/packages/react-doctor/src/inspect.ts
+++ b/packages/react-doctor/src/inspect.ts
@@ -1183,9 +1183,15 @@ const finalizeAndRender = (input: FinalizeInput): Effect.Effect<InspectResult> =
 
     // Re-score with the displayed top errors removed so the score bar can
     // show the payoff as a ghost gain segment.
+    const scoreDiagnostics = filterDiagnosticsForSurface([...diagnostics], "score", userConfig);
+    const displayedScoreDiagnostics = filterDiagnosticsForSurface(
+      [...printedDiagnostics],
+      "score",
+      userConfig,
+    );
     const potentialScore = score
       ? yield* Effect.promise(() =>
-          computeProjectedScore([...printedDiagnostics], [...surfaceDiagnostics], score),
+          computeProjectedScore(displayedScoreDiagnostics, scoreDiagnostics, score),
         )
       : null;
 

--- a/packages/react-doctor/tests/build-run-event.test.ts
+++ b/packages/react-doctor/tests/build-run-event.test.ts
@@ -352,6 +352,43 @@ describe("buildRunEventAttributes", () => {
     expect(excluded["outcome.exitCode"]).toBe(0);
   });
 
+  it("counts non-production findings excluded from the CI gate", () => {
+    const result = buildResult({
+      diagnostics: [
+        buildDiagnostic({
+          filePath: "src/App.test.tsx",
+          rule: "no-foo",
+          fileContext: "test",
+        }),
+        buildDiagnostic({
+          filePath: "src/App.stories.tsx",
+          rule: "no-bar",
+          fileContext: "story",
+        }),
+        buildDiagnostic({ filePath: "src/App.tsx", rule: "no-baz" }),
+      ],
+    });
+
+    const defaultAttributes = buildRunEventAttributes(baseInput({ result }));
+    expect(defaultAttributes["diag.nonProductionGateExcluded"]).toBe(2);
+
+    const ruleIncludedAttributes = buildRunEventAttributes(
+      baseInput({
+        result,
+        userConfig: { surfaces: { ciFailure: { includeRules: ["react-doctor/no-foo"] } } },
+      }),
+    );
+    expect(ruleIncludedAttributes["diag.nonProductionGateExcluded"]).toBe(1);
+
+    const categoryIncludedAttributes = buildRunEventAttributes(
+      baseInput({
+        result,
+        userConfig: { surfaces: { ciFailure: { includeCategories: ["Correctness"] } } },
+      }),
+    );
+    expect(categoryIncludedAttributes["diag.nonProductionGateExcluded"]).toBe(0);
+  });
+
   it("never reports a blocked run in score-only mode (matches the CLI exit guard)", () => {
     process.env[ACTION_INPUT_ENVIRONMENT_VARIABLES.blocking] = "error";
     const result = buildResult({ diagnostics: [buildDiagnostic({ severity: "error" })] });

--- a/packages/react-doctor/tests/inspect-action-exit-code.test.ts
+++ b/packages/react-doctor/tests/inspect-action-exit-code.test.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs";
 import os from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
-import type { InspectResult } from "@react-doctor/core";
+import type { InspectResult, ReactDoctorConfig } from "@react-doctor/core";
 import { inspectAction } from "../src/cli/commands/inspect.js";
 import type { InspectFlags } from "../src/cli/utils/inspect-flags.js";
 import { buildDiagnostic, buildTestProject } from "./regressions/_helpers.js";
@@ -10,6 +10,7 @@ import { buildDiagnostic, buildTestProject } from "./regressions/_helpers.js";
 const mockState = vi.hoisted(() => ({
   projectDirectories: [] as string[],
   result: undefined as InspectResult | undefined,
+  userConfig: undefined as ReactDoctorConfig | null | undefined,
 }));
 
 vi.mock("ora", () => ({
@@ -33,11 +34,11 @@ vi.mock("@react-doctor/core", async (importOriginal) => {
     resolveScanTarget: vi.fn(async (requestedDirectory: string) => ({
       resolvedDirectory: requestedDirectory,
       requestedDirectory,
-      userConfig: null,
+      userConfig: mockState.userConfig ?? null,
       configSourceDirectory: null,
       didRedirectViaRootDir: false,
     })),
-    filterDiagnosticsForSurface: vi.fn((diagnostics) => diagnostics),
+    filterDiagnosticsForSurface: actual.filterDiagnosticsForSurface,
   };
 });
 
@@ -99,6 +100,7 @@ describe("inspectAction exit-code gate", () => {
     process.exitCode = savedExitCode;
     mockState.result = undefined;
     mockState.projectDirectories = [];
+    mockState.userConfig = undefined;
     fs.rmSync(projectDirectory, { recursive: true, force: true });
     vi.clearAllMocks();
   });
@@ -154,6 +156,43 @@ describe("inspectAction exit-code gate", () => {
 
   it("still exits 1 when a complete scan has a blocking finding", async () => {
     await runInspectAction({ diagnostics: [buildDiagnostic({ severity: "error" })] });
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("does not fail CI for an error in a Radix test file by default", async () => {
+    await runInspectAction({
+      diagnostics: [
+        buildDiagnostic({
+          filePath: "packages/react/context-menu/src/context-menu-controlled.test.tsx",
+          plugin: "eslint",
+          rule: "no-unused-vars",
+          severity: "error",
+          category: "Correctness",
+          fileContext: "test",
+        }),
+      ],
+    });
+
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it("fails CI when the Radix test diagnostic is explicitly included", async () => {
+    mockState.userConfig = {
+      surfaces: { ciFailure: { includeRules: ["eslint/no-unused-vars"] } },
+    };
+    await runInspectAction({
+      diagnostics: [
+        buildDiagnostic({
+          filePath: "packages/react/context-menu/src/context-menu-controlled.test.tsx",
+          plugin: "eslint",
+          rule: "no-unused-vars",
+          severity: "error",
+          category: "Correctness",
+          fileContext: "test",
+        }),
+      ],
+    });
+
     expect(process.exitCode).toBe(1);
   });
 

--- a/packages/react-doctor/tests/inspect-surface-filter.test.ts
+++ b/packages/react-doctor/tests/inspect-surface-filter.test.ts
@@ -1,8 +1,20 @@
-import { afterEach, describe, expect, it, vi } from "vite-plus/test";
-import { inspect } from "../src/inspect.js";
+import * as fs from "node:fs";
+import os from "node:os";
 import * as path from "node:path";
 import { gunzipSync } from "node:zlib";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { filterDiagnosticsForSurface } from "@react-doctor/core";
+import type { ReactDoctorConfig } from "@react-doctor/core";
+import { inspect } from "../src/inspect.js";
+import { computeProjectedScore } from "../src/cli/utils/compute-score-projection.js";
 import reactDoctorPlugin from "oxlint-plugin-react-doctor";
+import { setupReactProject } from "./regressions/_helpers.js";
+
+vi.mock("../src/cli/utils/compute-score-projection.js", () => ({
+  computeProjectedScore: vi.fn(async () => null),
+}));
+
+const mockedComputeProjectedScore = vi.mocked(computeProjectedScore);
 
 vi.mock("ora", () => ({
   default: () => ({
@@ -38,6 +50,11 @@ const DESIGN_RULE_OVERRIDES = {
   "react-doctor/no-dark-mode-glow": "warn",
   "react-doctor/no-side-tab-border": "warn",
 } satisfies Record<string, "error" | "warn" | "off">;
+
+const INDEX_KEY_LIST_SOURCE = `export const List = ({ items }: { items: string[] }) => (
+  <div>{items.map((item, index) => <input key={index} defaultValue={item} />)}</div>
+);
+`;
 
 interface CapturedFetchCall {
   url: string;
@@ -75,6 +92,7 @@ describe("inspect — score surface filter", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
+    mockedComputeProjectedScore.mockClear();
   });
 
   it("strips `design`-tagged diagnostics before they are sent to the score API", async () => {
@@ -113,6 +131,129 @@ describe("inspect — score surface filter", () => {
       consoleSpy.mockRestore();
     }
   });
+
+  it(
+    "projects score gains from production diagnostics while retaining test and story findings",
+    { timeout: 60_000 },
+    async () => {
+      const temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "rd-score-projection-"));
+      const projectDirectory = setupReactProject(temporaryDirectory, "app", {
+        files: {
+          "src/List.tsx": INDEX_KEY_LIST_SOURCE,
+          "packages/docusaurus-theme-classic/src/theme/Tabs/__tests__/index.test.tsx":
+            INDEX_KEY_LIST_SOURCE,
+          "packages/react/context-menu/src/context-menu-controlled.stories.tsx":
+            INDEX_KEY_LIST_SOURCE,
+          "src/Design.tsx": `export const Design = () => (
+  <div style={{ backgroundColor: "#000000", color: "white" }}>content</div>
+);
+`,
+        },
+      });
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+      stubScoreFetchAndCapture();
+      vi.stubEnv("REACT_DOCTOR_NO_CACHE", "1");
+
+      try {
+        const configOverride: ReactDoctorConfig = {
+          rules: { "react-doctor/no-pure-black-background": "warn" },
+        };
+        const result = await inspect(projectDirectory, {
+          lint: true,
+          deadCode: false,
+          noScore: false,
+          warnings: true,
+          configOverride,
+        });
+
+        const indexKeyDiagnostics = result.diagnostics.filter(
+          (diagnostic) => diagnostic.rule === "no-array-index-as-key",
+        );
+        expect(indexKeyDiagnostics).toHaveLength(3);
+        expect(indexKeyDiagnostics.map((diagnostic) => diagnostic.fileContext)).toEqual([
+          "test",
+          "story",
+          undefined,
+        ]);
+        expect(mockedComputeProjectedScore).toHaveBeenCalledTimes(1);
+        const [topErrorSource, rescoreSource] = mockedComputeProjectedScore.mock.calls[0];
+        const scoreDiagnostics = filterDiagnosticsForSurface(
+          result.diagnostics,
+          "score",
+          configOverride,
+        );
+        expect(scoreDiagnostics.length).toBeGreaterThan(0);
+        expect(scoreDiagnostics.every((diagnostic) => diagnostic.fileContext === undefined)).toBe(
+          true,
+        );
+        expect(
+          scoreDiagnostics.some(
+            (diagnostic) =>
+              diagnostic.plugin === "react-doctor" &&
+              (reactDoctorPlugin.rules[diagnostic.rule]?.tags?.includes("design") ?? false),
+          ),
+        ).toBe(false);
+        expect(topErrorSource).toEqual(scoreDiagnostics);
+        expect(rescoreSource).toEqual(scoreDiagnostics);
+      } finally {
+        consoleSpy.mockRestore();
+        fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it(
+    "projects explicitly included test and story diagnostics with their production sibling",
+    { timeout: 60_000 },
+    async () => {
+      const temporaryDirectory = fs.mkdtempSync(
+        path.join(os.tmpdir(), "rd-score-projection-included-"),
+      );
+      const projectDirectory = setupReactProject(temporaryDirectory, "app", {
+        files: {
+          "src/List.tsx": INDEX_KEY_LIST_SOURCE,
+          "packages/docusaurus-theme-classic/src/theme/Tabs/__tests__/index.test.tsx":
+            INDEX_KEY_LIST_SOURCE,
+          "packages/react/context-menu/src/context-menu-controlled.stories.tsx":
+            INDEX_KEY_LIST_SOURCE,
+        },
+      });
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+      stubScoreFetchAndCapture();
+      vi.stubEnv("REACT_DOCTOR_NO_CACHE", "1");
+
+      try {
+        const configOverride: ReactDoctorConfig = {
+          surfaces: {
+            score: { includeRules: ["react-doctor/no-array-index-as-key"] },
+          },
+        };
+        const result = await inspect(projectDirectory, {
+          lint: true,
+          deadCode: false,
+          noScore: false,
+          warnings: true,
+          configOverride,
+        });
+
+        expect(mockedComputeProjectedScore).toHaveBeenCalledTimes(1);
+        const [topErrorSource, rescoreSource] = mockedComputeProjectedScore.mock.calls[0];
+        const scoreDiagnostics = filterDiagnosticsForSurface(
+          result.diagnostics,
+          "score",
+          configOverride,
+        );
+        expect(
+          scoreDiagnostics.filter((diagnostic) => diagnostic.fileContext !== undefined),
+        ).toHaveLength(2);
+        expect(topErrorSource).toEqual(scoreDiagnostics);
+        expect(rescoreSource).toEqual(scoreDiagnostics);
+      } finally {
+        consoleSpy.mockRestore();
+        fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+      }
+    },
+  );
 
   // Regression for the Bugbot finding on #271: the `cli` outputSurface
   // used to short-circuit to the raw diagnostic list, which silently

--- a/packages/react-doctor/tests/inspect-surface-filter.test.ts
+++ b/packages/react-doctor/tests/inspect-surface-filter.test.ts
@@ -255,6 +255,50 @@ describe("inspect — score surface filter", () => {
     },
   );
 
+  it(
+    "does not project a score-eligible rule excluded from the CLI",
+    { timeout: 60_000 },
+    async () => {
+      const temporaryDirectory = fs.mkdtempSync(
+        path.join(os.tmpdir(), "rd-score-projection-cli-excluded-"),
+      );
+      const projectDirectory = setupReactProject(temporaryDirectory, "app", {
+        files: { "src/List.tsx": INDEX_KEY_LIST_SOURCE },
+      });
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+      stubScoreFetchAndCapture();
+      vi.stubEnv("REACT_DOCTOR_NO_CACHE", "1");
+
+      try {
+        const configOverride: ReactDoctorConfig = {
+          surfaces: {
+            cli: { excludeRules: ["react-doctor/no-array-index-as-key"] },
+            score: { includeRules: ["react-doctor/no-array-index-as-key"] },
+          },
+        };
+        await inspect(projectDirectory, {
+          lint: true,
+          deadCode: false,
+          noScore: false,
+          warnings: true,
+          configOverride,
+        });
+
+        expect(mockedComputeProjectedScore).toHaveBeenCalledTimes(1);
+        const [topErrorSource, rescoreSource] = mockedComputeProjectedScore.mock.calls[0];
+        expect(
+          topErrorSource.some((diagnostic) => diagnostic.rule === "no-array-index-as-key"),
+        ).toBe(false);
+        expect(
+          rescoreSource.some((diagnostic) => diagnostic.rule === "no-array-index-as-key"),
+        ).toBe(true);
+      } finally {
+        consoleSpy.mockRestore();
+        fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+      }
+    },
+  );
+
   // Regression for the Bugbot finding on #271: the `cli` outputSurface
   // used to short-circuit to the raw diagnostic list, which silently
   // dropped any user-configured `surfaces.cli.exclude*` controls before

--- a/packages/react-doctor/tests/render-multi-project-summary.test.ts
+++ b/packages/react-doctor/tests/render-multi-project-summary.test.ts
@@ -1,0 +1,176 @@
+import * as Effect from "effect/Effect";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import type { Diagnostic, InspectResult, ProjectInfo, ReactDoctorConfig } from "@react-doctor/core";
+import { computeProjectedScore } from "../src/cli/utils/compute-score-projection.js";
+import { printMultiProjectSummary } from "../src/cli/utils/render-multi-project-summary.js";
+
+vi.mock("../src/cli/utils/compute-score-projection.js", () => ({
+  computeProjectedScore: vi.fn(async () => null),
+}));
+
+const mockedComputeProjectedScore = vi.mocked(computeProjectedScore);
+
+const buildProject = (projectName: string): ProjectInfo => ({
+  rootDirectory: `/repo/${projectName}`,
+  projectName,
+  reactVersion: "19.0.0",
+  reactMajorVersion: 19,
+  tailwindVersion: null,
+  zodVersion: null,
+  zodMajorVersion: null,
+  framework: "vite",
+  hasTypeScript: true,
+  hasReactCompiler: false,
+  hasTanStackQuery: false,
+  nextjsVersion: null,
+  nextjsMajorVersion: null,
+  hasReactNativeWorkspace: false,
+  expoVersion: null,
+  shopifyFlashListVersion: null,
+  shopifyFlashListMajorVersion: null,
+  hasReanimated: false,
+  isPreES2023Target: false,
+  preactVersion: null,
+  preactMajorVersion: null,
+  sourceFileCount: 3,
+});
+
+const buildDiagnostic = (overrides: Partial<Diagnostic>): Diagnostic => ({
+  filePath: "src/App.tsx",
+  plugin: "react-doctor",
+  rule: "no-production-issue",
+  severity: "error",
+  message: "Issue",
+  help: "Fix it",
+  line: 1,
+  column: 1,
+  category: "Correctness",
+  ...overrides,
+});
+
+const buildScan = (
+  projectName: string,
+  score: number,
+  diagnostics: Diagnostic[],
+  config: ReactDoctorConfig | null = null,
+) => ({
+  config,
+  result: {
+    diagnostics,
+    score: { score, label: "Needs work" },
+    skippedChecks: [],
+    project: buildProject(projectName),
+    elapsedMilliseconds: 10,
+    scannedFileCount: 3,
+    analyzedFiles: diagnostics.map((diagnostic) => diagnostic.filePath),
+  } satisfies InspectResult,
+});
+
+const lowProductionDiagnostic = buildDiagnostic({
+  filePath: "src/Low.tsx",
+  rule: "no-low-production",
+});
+const lowTestDiagnostic = buildDiagnostic({
+  filePath: "src/Low.test.tsx",
+  rule: "no-low-test",
+  fileContext: "test",
+});
+const lowStoryDiagnostic = buildDiagnostic({
+  filePath: "src/Low.stories.tsx",
+  rule: "no-low-story",
+  fileContext: "story",
+});
+const lowDesignDiagnostic = buildDiagnostic({
+  filePath: "src/LowDesign.tsx",
+  rule: "design-no-redundant-size-axes",
+  severity: "warning",
+  category: "Architecture",
+});
+const highProductionDiagnostic = buildDiagnostic({
+  filePath: "src/High.tsx",
+  rule: "no-high-production",
+});
+const highTestDiagnostic = buildDiagnostic({
+  filePath: "src/High.test.tsx",
+  rule: "no-high-test",
+  fileContext: "test",
+});
+
+const renderSummary = async (
+  lowConfig: ReactDoctorConfig | null = null,
+  highConfig: ReactDoctorConfig | null = null,
+): Promise<void> => {
+  const completedScans = [
+    buildScan(
+      "low",
+      40,
+      [lowProductionDiagnostic, lowTestDiagnostic, lowStoryDiagnostic, lowDesignDiagnostic],
+      lowConfig,
+    ),
+    buildScan("high", 80, [highProductionDiagnostic, highTestDiagnostic], highConfig),
+  ];
+  await Effect.runPromise(
+    printMultiProjectSummary({
+      completedScans,
+      verbose: true,
+      isOffline: true,
+      projectName: "workspace",
+      totalElapsedMilliseconds: 20,
+    }),
+  );
+};
+
+describe("printMultiProjectSummary score projection", () => {
+  afterEach(() => {
+    mockedComputeProjectedScore.mockClear();
+    vi.restoreAllMocks();
+  });
+
+  it("projects the worst score from production diagnostics across projects", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await renderSummary();
+
+    expect(mockedComputeProjectedScore).toHaveBeenCalledTimes(1);
+    const [topErrorSource, rescoreSource] = mockedComputeProjectedScore.mock.calls[0];
+    expect(topErrorSource).toEqual([lowProductionDiagnostic, highProductionDiagnostic]);
+    expect(rescoreSource).toEqual([lowProductionDiagnostic]);
+  });
+
+  it("honors each project's explicit score-surface includes", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await renderSummary(
+      {
+        surfaces: {
+          score: {
+            includeCategories: ["Correctness"],
+            includeTags: ["design"],
+          },
+        },
+      },
+      {
+        surfaces: {
+          score: { includeRules: ["react-doctor/no-high-test"] },
+        },
+      },
+    );
+
+    expect(mockedComputeProjectedScore).toHaveBeenCalledTimes(1);
+    const [topErrorSource, rescoreSource] = mockedComputeProjectedScore.mock.calls[0];
+    expect(topErrorSource).toEqual([
+      lowProductionDiagnostic,
+      lowTestDiagnostic,
+      lowStoryDiagnostic,
+      lowDesignDiagnostic,
+      highProductionDiagnostic,
+      highTestDiagnostic,
+    ]);
+    expect(rescoreSource).toEqual([
+      lowProductionDiagnostic,
+      lowTestDiagnostic,
+      lowStoryDiagnostic,
+      lowDesignDiagnostic,
+    ]);
+  });
+});

--- a/packages/react-doctor/tests/render-multi-project-summary.test.ts
+++ b/packages/react-doctor/tests/render-multi-project-summary.test.ts
@@ -173,4 +173,20 @@ describe("printMultiProjectSummary score projection", () => {
       lowDesignDiagnostic,
     ]);
   });
+
+  it("does not project a score-eligible rule excluded from the CLI", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await renderSummary({
+      surfaces: {
+        cli: { excludeRules: ["react-doctor/no-low-production"] },
+        score: { includeRules: ["react-doctor/no-low-production"] },
+      },
+    });
+
+    expect(mockedComputeProjectedScore).toHaveBeenCalledTimes(1);
+    const [topErrorSource, rescoreSource] = mockedComputeProjectedScore.mock.calls[0];
+    expect(topErrorSource).toEqual([highProductionDiagnostic]);
+    expect(rescoreSource).toEqual([lowProductionDiagnostic]);
+  });
 });

--- a/packages/react-doctor/tests/to-json-report.test.ts
+++ b/packages/react-doctor/tests/to-json-report.test.ts
@@ -89,4 +89,29 @@ describe("toJsonReport (Node API helper)", () => {
     const report = toJsonReport(buildDiagnoseResult(), { version: "9.9.9" });
     expect(report.version).toBe("9.9.9");
   });
+
+  it("preserves test ownership in raw JSON output", () => {
+    const result = buildDiagnoseResult();
+    result.diagnostics = [
+      {
+        ...result.diagnostics[0],
+        filePath:
+          "/virtual/packages/docusaurus-theme-classic/src/theme/Tabs/__tests__/index.test.tsx",
+        plugin: "react-compiler",
+        rule: "globals",
+        fileContext: "test",
+      },
+    ];
+
+    const report = toJsonReport(result, { version: "1.2.3" });
+
+    expect(report.diagnostics).toHaveLength(1);
+    expect(report.diagnostics[0]).toMatchObject({
+      filePath:
+        "/virtual/packages/docusaurus-theme-classic/src/theme/Tabs/__tests__/index.test.tsx",
+      fileContext: "test",
+      plugin: "react-compiler",
+      rule: "globals",
+    });
+  });
 });

--- a/packages/website/public/schema/config.json
+++ b/packages/website/public/schema/config.json
@@ -158,7 +158,7 @@
             }
           },
           "additionalProperties": false,
-          "description": "Per-surface include/exclude controls. Each `DiagnosticSurface` is resolved independently against rule tags, category, and id so a single rule can be visible locally yet hidden from PR comments, neutralized from the score, and excluded from the CI gate — all without touching the rule's severity or activation.\n\nDefaults (applied before user overrides):\n\n- `prComment` excludes tag `\"design\"`\n- `score` excludes tag `\"design\"`\n- `ciFailure` excludes tag `\"design\"`\n\nPass any controls block (even an empty `{}`) to keep the default exclusions; the user's include/exclude entries layer on top. Include entries always win over exclude entries — handy for promoting a single high-signal `design-*` rule back into the score or PR-comment surface."
+          "description": "Per-surface include/exclude controls. Each `DiagnosticSurface` resolves rule tags, categories, and identifiers independently. This lets you keep a rule visible locally while hiding it from PR comments, the score, or the CI gate. These controls don't change rule severity or activation.\n\nDefaults (applied before user overrides):\n\n- `prComment` excludes tag `\"design\"`\n- `score` excludes tag `\"design\"`\n- `ciFailure` excludes tag `\"design\"`\n- `score` and `ciFailure` exclude test/story file contexts unless explicitly included\n\nPass any controls block, including an empty `{}`, to keep the defaults. Your include/exclude entries layer on top. Includes always win over excludes. For example, you can promote one high-signal `design-*` rule back into the score or PR-comment surface."
         },
         "rules": {
           "type": "object",


### PR DESCRIPTION
## Why

React Doctor already stamps diagnostics from test and story files with `fileContext`, but the score and CI gate counted them like production defects. Functionally green Docusaurus and Radix benchmark jobs lost their health verdict solely to React Compiler `globals` findings under `Tabs/__tests__` and `no-unused-vars` under Radix `*.test.tsx`.

The raw findings remain useful. This change keeps them in CLI output, the programmatic API, and JSON reports while preventing test harness and story diagnostics from changing the production-health score or CI exit code by default.

## Product brief: production-health scope for non-production diagnostics

Job: Developers use React Doctor's score and CI exit code to gate shipped application health; today they must accept test-harness findings as production failures or build path-based filtering outside React Doctor.

Change: Reuse `fileContext` and the existing per-surface filter so test/story findings remain observable but do not affect score or CI by default. No flag, config key, or report field is added.

Reuse: Searched score, CI, diagnostic filtering, and file-context symbols with truffler. `filterDiagnosticsForSurface` is already the shared score/CI policy boundary, and `SurfaceControls` already provides the include-wins override contract.

Metric: The wide event now emits `diag.nonProductionGateExcluded`, the number of test/story diagnostics removed from the `ciFailure` surface. Evaluate it alongside `outcome.wouldBlock` and four-week CI cohort retention. Success is fewer production-health blocks without lower retention.

Compat: Raw CLI/API/JSON output and schema version stay unchanged. Existing `includeRules`, `includeCategories`, and `includeTags` controls promote selected findings back into score or CI. The intentional default score/CI behavior change has a pre-1.0 MINOR changeset for `react-doctor`.

Kill: Revert the default exclusion if, after two releases, the affected CI cohort's four-week retention does not improve or repeated job-grounded audits show production-owned files are being classified as test/story.

## What changed

- Explicit per-surface includes still win first.
- Test/story diagnostics are then excluded only from `score` and `ciFailure`.
- CLI, PR-comment, programmatic API, and raw JSON diagnostic lists are unchanged.
- Added `diag.nonProductionGateExcluded` to the anonymized run wide event.
- Added exact Docusaurus and Radix regressions across the core filter, score orchestration, CLI exit gate, and JSON API helper.
- Added a MINOR `react-doctor` changeset.
- No action, security, runner, grader, React Bench, or publishing changes.

## Test plan

Focused:

- Core surface + score orchestration: 2 files, 56 tests passed.
- React Doctor CI + JSON + wide event: 3 files, 47 tests passed.

Full:

- `packages/core`: 118 files, 1,387 tests passed.
- `packages/react-doctor`: 209 files passed, 2 skipped; 2,249 tests passed, 27 skipped.
- Repository typecheck: 15/15 tasks passed.
- Repository lint: exit 0; warning-only existing corpus output.
- Repository format check: 3,175 files passed.
- `git diff --check`: passed.
- Post-change truffler audit: no duplicate filter or metric helper found.

RDE, fuzzing, and React Bench were not run because this changes the post-scan score/CI surface rather than detector behavior. Package publishing was not performed; both exact-head preview-publish runs were cancelled before their publish steps.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default score and CI exit behavior for repos that relied on test/story errors failing builds, though overrides and full CLI visibility remain; scope is centralized in surface filtering with broad regression coverage.
> 
> **Overview**
> **Production-health surfaces no longer treat test and story findings like app defects by default.** Diagnostics stamped with `fileContext: "test"` or `"story"` still appear in CLI output, API results, and JSON; they are dropped from the **`score`** and **`ciFailure`** surfaces unless an explicit `surfaces.*` include (rule, category, or tag) promotes them—same precedence as design-tag exclusions.
> 
> The change lives in **`isDiagnosticOnSurface`** in `filter-for-surface.ts`: after include-wins, any diagnostic with `fileContext` is excluded from `score` and `ciFailure` only (not `cli` or `prComment`). Config docs and the public schema describe the new default.
> 
> **Downstream behavior** is aligned so projections and telemetry match the gate: single- and multi-project **score projection** uses score-surface diagnostics (not raw CLI lists), **`diag.nonProductionGateExcluded`** counts test/story findings removed from the CI gate in run wide events, and **exit-code tests** use the real surface filter (Radix-style test errors no longer fail CI unless included). A **minor** changeset ships the intentional default behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39411aeb350aa4163edda1cb1d118863ddddf7ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->