### PR TITLE
fix(action): improve ensure-json-report error messages

### DIFF
--- a/.changeset/fix-action-error-messages.md
+++ b/.changeset/fix-action-error-messages.md
@@ -1,5 +1,0 @@
----
-"react-doctor": patch
----
-
-fix(action): improve ensure-json-report error messages with specific diagnostics for different failure scenarios

--- a/.changeset/fix-action-error-messages.md
+++ b/.changeset/fix-action-error-messages.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+fix(action): improve ensure-json-report error messages with specific diagnostics for different failure scenarios

--- a/packages/react-doctor/tests/ensure-json-report.test.ts
+++ b/packages/react-doctor/tests/ensure-json-report.test.ts
@@ -1,0 +1,94 @@
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+
+const REPOSITORY_ROOT = path.resolve(import.meta.dirname, "..", "..", "..");
+const ENSURE_REPORT_SCRIPT_PATH = path.join(REPOSITORY_ROOT, "scripts/ensure-json-report.mjs");
+const tempDirectories: string[] = [];
+
+const runEnsureJsonReport = (contents?: string) => {
+  const tempDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-report-"));
+  const reportPath = path.join(tempDirectory, "report.json");
+  tempDirectories.push(tempDirectory);
+
+  if (contents !== undefined) {
+    fs.writeFileSync(reportPath, contents);
+  }
+
+  const result = spawnSync(process.execPath, [ENSURE_REPORT_SCRIPT_PATH, reportPath, "7"], {
+    encoding: "utf8",
+  });
+
+  return {
+    report: JSON.parse(fs.readFileSync(reportPath, "utf8")),
+    status: result.status,
+  };
+};
+
+describe("ensure-json-report", () => {
+  afterEach(() => {
+    for (const directory of tempDirectories.splice(0)) {
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it.each([1, 2, 3])("accepts schema version %s reports", (schemaVersion) => {
+    const contents = JSON.stringify({ schemaVersion, ok: true });
+    const { report, status } = runEnsureJsonReport(contents);
+
+    expect(status).toBe(0);
+    expect(report).toEqual({ schemaVersion, ok: true });
+  });
+
+  it.each([
+    {
+      contents: "",
+      message: "react-doctor exited with status 7 but produced an empty report.",
+    },
+    {
+      contents: "{",
+      message: "react-doctor produced output that is not valid JSON.",
+    },
+    {
+      contents: "null",
+      message: "react-doctor produced JSON that is not a report object.",
+    },
+    {
+      contents: "{}",
+      message:
+        "react-doctor produced a JSON report without a schemaVersion. The installed CLI may be incompatible with this GitHub Action version.",
+    },
+    {
+      contents: '{"schemaVersion":999,"ok":true}',
+      message:
+        "react-doctor produced schema version 999, but this GitHub Action supports 1, 2, 3. Update millionco/react-doctor@v2 or pin the CLI version to match the Action release.",
+    },
+    {
+      contents: '{"schemaVersion":3}',
+      message: "react-doctor produced a schema version 3 report without the required ok field.",
+    },
+  ])("writes a valid fallback report for malformed output", ({ contents, message }) => {
+    const { report, status } = runEnsureJsonReport(contents);
+
+    expect(status).toBe(1);
+    expect(report).toMatchObject({
+      schemaVersion: 3,
+      ok: false,
+      error: {
+        name: "ReactDoctorActionError",
+        message,
+      },
+    });
+  });
+
+  it("reports when the CLI did not create a readable report", () => {
+    const { report, status } = runEnsureJsonReport();
+
+    expect(status).toBe(1);
+    expect(report.error.message).toBe(
+      "react-doctor exited with status 7 without producing a readable JSON report.",
+    );
+  });
+});

--- a/scripts/ensure-json-report.mjs
+++ b/scripts/ensure-json-report.mjs
@@ -32,58 +32,57 @@ const buildFallbackReport = (errorMessage) => ({
   },
 });
 
+const failWithReport = (errorMessage) => {
+  fs.writeFileSync(reportPath, `${JSON.stringify(buildFallbackReport(errorMessage))}\n`);
+  process.exit(1);
+};
+
 const KNOWN_SCHEMA_VERSIONS = new Set([1, 2, 3]);
 
+let raw;
+
 try {
-  const raw = fs.readFileSync(reportPath, "utf8").trim();
-
-  if (!raw) {
-    const fallbackReport = buildFallbackReport(
-      `react-doctor exited with status ${Number.isFinite(status) ? status : 1} but produced an empty report. This may occur when no files were scanned or an unexpected error occurred.`,
-    );
-    fs.writeFileSync(reportPath, `${JSON.stringify(fallbackReport)}\n`);
-    process.exit(1);
-  }
-
-  const parsed = JSON.parse(raw);
-
-  if (!parsed || typeof parsed !== "object") {
-    const fallbackReport = buildFallbackReport(
-      `react-doctor produced invalid JSON output. This may indicate a crash or unexpected error during the scan.`,
-    );
-    fs.writeFileSync(reportPath, `${JSON.stringify(fallbackReport)}\n`);
-    process.exit(1);
-  }
-
-  if (typeof parsed.schemaVersion !== "number") {
-    const fallbackReport = buildFallbackReport(
-      `react-doctor produced a JSON report without a schemaVersion field. The installed react-doctor version may be incompatible with this GitHub Action version.`,
-    );
-    fs.writeFileSync(reportPath, `${JSON.stringify(fallbackReport)}\n`);
-    process.exit(1);
-  }
-
-  if (!KNOWN_SCHEMA_VERSIONS.has(parsed.schemaVersion)) {
-    const fallbackReport = buildFallbackReport(
-      `react-doctor produced a JSON report with schema version ${parsed.schemaVersion}, which is not supported by this GitHub Action version (supports: ${Array.from(KNOWN_SCHEMA_VERSIONS).sort().join(", ")}). Please update the GitHub Action to the latest version (millionco/react-doctor@v2) or pin the react-doctor version to match this Action release.`,
-    );
-    fs.writeFileSync(reportPath, `${JSON.stringify(fallbackReport)}\n`);
-    process.exit(1);
-  }
-
-  if (typeof parsed.ok !== "boolean") {
-    const fallbackReport = buildFallbackReport(
-      `react-doctor produced a JSON report with schema version ${parsed.schemaVersion} but is missing the required 'ok' field. The report may be corrupted.`,
-    );
-    fs.writeFileSync(reportPath, `${JSON.stringify(fallbackReport)}\n`);
-    process.exit(1);
-  }
-
-  process.exit(0);
-} catch (parseError) {
-  const fallbackReport = buildFallbackReport(
-    `react-doctor produced unparseable JSON output. Parse error: ${parseError.message}`,
+  raw = fs.readFileSync(reportPath, "utf8").trim();
+} catch {
+  failWithReport(
+    `react-doctor exited with status ${Number.isFinite(status) ? status : 1} without producing a readable JSON report.`,
   );
-  fs.writeFileSync(reportPath, `${JSON.stringify(fallbackReport)}\n`);
-  process.exit(1);
 }
+
+if (!raw) {
+  failWithReport(
+    `react-doctor exited with status ${Number.isFinite(status) ? status : 1} but produced an empty report.`,
+  );
+}
+
+let parsed;
+
+try {
+  parsed = JSON.parse(raw);
+} catch {
+  failWithReport("react-doctor produced output that is not valid JSON.");
+}
+
+if (!parsed || typeof parsed !== "object") {
+  failWithReport("react-doctor produced JSON that is not a report object.");
+}
+
+if (typeof parsed.schemaVersion !== "number") {
+  failWithReport(
+    "react-doctor produced a JSON report without a schemaVersion. The installed CLI may be incompatible with this GitHub Action version.",
+  );
+}
+
+if (!KNOWN_SCHEMA_VERSIONS.has(parsed.schemaVersion)) {
+  failWithReport(
+    `react-doctor produced schema version ${parsed.schemaVersion}, but this GitHub Action supports ${Array.from(KNOWN_SCHEMA_VERSIONS).sort().join(", ")}. Update millionco/react-doctor@v2 or pin the CLI version to match the Action release.`,
+  );
+}
+
+if (typeof parsed.ok !== "boolean") {
+  failWithReport(
+    `react-doctor produced a schema version ${parsed.schemaVersion} report without the required ok field.`,
+  );
+}
+
+process.exit(0);

--- a/scripts/ensure-json-report.mjs
+++ b/scripts/ensure-json-report.mjs
@@ -7,7 +7,7 @@ if (!reportPath) {
   process.exit(0);
 }
 
-const fallbackReport = {
+const buildFallbackReport = (errorMessage) => ({
   schemaVersion: 3,
   version: "unknown",
   ok: false,
@@ -27,24 +27,63 @@ const fallbackReport = {
   elapsedMilliseconds: 0,
   error: {
     name: "ReactDoctorActionError",
-    message: `react-doctor exited with status ${Number.isFinite(status) ? status : 1} before producing a JSON report.`,
+    message: errorMessage,
     chain: [],
   },
-};
+});
 
-// Known JsonReport schema versions remain valid CLI output; only an
-// unparseable or unrecognized payload is treated as a failed scan.
 const KNOWN_SCHEMA_VERSIONS = new Set([1, 2, 3]);
 
 try {
   const raw = fs.readFileSync(reportPath, "utf8").trim();
-  const parsed = JSON.parse(raw);
-  if (parsed && KNOWN_SCHEMA_VERSIONS.has(parsed.schemaVersion) && typeof parsed.ok === "boolean") {
-    process.exit(0);
+  
+  if (!raw) {
+    const fallbackReport = buildFallbackReport(
+      `react-doctor exited with status ${Number.isFinite(status) ? status : 1} but produced an empty report. This may occur when no files were scanned or an unexpected error occurred.`,
+    );
+    fs.writeFileSync(reportPath, `${JSON.stringify(fallbackReport)}\n`);
+    process.exit(1);
   }
-} catch {
-  // Fall through to the fallback report.
+  
+  const parsed = JSON.parse(raw);
+  
+  if (!parsed || typeof parsed !== "object") {
+    const fallbackReport = buildFallbackReport(
+      `react-doctor produced invalid JSON output. This may indicate a crash or unexpected error during the scan.`,
+    );
+    fs.writeFileSync(reportPath, `${JSON.stringify(fallbackReport)}\n`);
+    process.exit(1);
+  }
+  
+  if (typeof parsed.schemaVersion !== "number") {
+    const fallbackReport = buildFallbackReport(
+      `react-doctor produced a JSON report without a schemaVersion field. The installed react-doctor version may be incompatible with this GitHub Action version.`,
+    );
+    fs.writeFileSync(reportPath, `${JSON.stringify(fallbackReport)}\n`);
+    process.exit(1);
+  }
+  
+  if (!KNOWN_SCHEMA_VERSIONS.has(parsed.schemaVersion)) {
+    const fallbackReport = buildFallbackReport(
+      `react-doctor produced a JSON report with schema version ${parsed.schemaVersion}, which is not supported by this GitHub Action version (supports: ${Array.from(KNOWN_SCHEMA_VERSIONS).sort().join(", ")}). Please update the GitHub Action to the latest version (millionco/react-doctor@v2) or pin the react-doctor version to match this Action release.`,
+    );
+    fs.writeFileSync(reportPath, `${JSON.stringify(fallbackReport)}\n`);
+    process.exit(1);
+  }
+  
+  if (typeof parsed.ok !== "boolean") {
+    const fallbackReport = buildFallbackReport(
+      `react-doctor produced a JSON report with schema version ${parsed.schemaVersion} but is missing the required 'ok' field. The report may be corrupted.`,
+    );
+    fs.writeFileSync(reportPath, `${JSON.stringify(fallbackReport)}\n`);
+    process.exit(1);
+  }
+  
+  process.exit(0);
+} catch (parseError) {
+  const fallbackReport = buildFallbackReport(
+    `react-doctor produced unparseable JSON output. Parse error: ${parseError.message}`,
+  );
+  fs.writeFileSync(reportPath, `${JSON.stringify(fallbackReport)}\n`);
+  process.exit(1);
 }
-
-fs.writeFileSync(reportPath, `${JSON.stringify(fallbackReport)}\n`);
-process.exit(1);

--- a/scripts/ensure-json-report.mjs
+++ b/scripts/ensure-json-report.mjs
@@ -36,7 +36,7 @@ const KNOWN_SCHEMA_VERSIONS = new Set([1, 2, 3]);
 
 try {
   const raw = fs.readFileSync(reportPath, "utf8").trim();
-  
+
   if (!raw) {
     const fallbackReport = buildFallbackReport(
       `react-doctor exited with status ${Number.isFinite(status) ? status : 1} but produced an empty report. This may occur when no files were scanned or an unexpected error occurred.`,
@@ -44,9 +44,9 @@ try {
     fs.writeFileSync(reportPath, `${JSON.stringify(fallbackReport)}\n`);
     process.exit(1);
   }
-  
+
   const parsed = JSON.parse(raw);
-  
+
   if (!parsed || typeof parsed !== "object") {
     const fallbackReport = buildFallbackReport(
       `react-doctor produced invalid JSON output. This may indicate a crash or unexpected error during the scan.`,
@@ -54,7 +54,7 @@ try {
     fs.writeFileSync(reportPath, `${JSON.stringify(fallbackReport)}\n`);
     process.exit(1);
   }
-  
+
   if (typeof parsed.schemaVersion !== "number") {
     const fallbackReport = buildFallbackReport(
       `react-doctor produced a JSON report without a schemaVersion field. The installed react-doctor version may be incompatible with this GitHub Action version.`,
@@ -62,7 +62,7 @@ try {
     fs.writeFileSync(reportPath, `${JSON.stringify(fallbackReport)}\n`);
     process.exit(1);
   }
-  
+
   if (!KNOWN_SCHEMA_VERSIONS.has(parsed.schemaVersion)) {
     const fallbackReport = buildFallbackReport(
       `react-doctor produced a JSON report with schema version ${parsed.schemaVersion}, which is not supported by this GitHub Action version (supports: ${Array.from(KNOWN_SCHEMA_VERSIONS).sort().join(", ")}). Please update the GitHub Action to the latest version (millionco/react-doctor@v2) or pin the react-doctor version to match this Action release.`,
@@ -70,7 +70,7 @@ try {
     fs.writeFileSync(reportPath, `${JSON.stringify(fallbackReport)}\n`);
     process.exit(1);
   }
-  
+
   if (typeof parsed.ok !== "boolean") {
     const fallbackReport = buildFallbackReport(
       `react-doctor produced a JSON report with schema version ${parsed.schemaVersion} but is missing the required 'ok' field. The report may be corrupted.`,
@@ -78,7 +78,7 @@ try {
     fs.writeFileSync(reportPath, `${JSON.stringify(fallbackReport)}\n`);
     process.exit(1);
   }
-  
+
   process.exit(0);
 } catch (parseError) {
   const fallbackReport = buildFallbackReport(


### PR DESCRIPTION
## Problem

When the GitHub Action receives a missing, malformed, or incompatible CLI report, `ensure-json-report.mjs` replaces it with a generic fallback. The fallback hides whether the CLI produced no file, empty output, invalid JSON, an unsupported schema, or an incomplete report.

## Solution

- Emit a specific, actionable fallback for each failure class.
- Keep parser details and filesystem paths out of PR-facing error text.
- Continue accepting report schema versions 1, 2, and 3.
- Always write the existing schema-v3 fallback shape on failure.
- Remove the npm-package Changeset: this changes only the independently versioned GitHub Action.

## Validation

- Added 10 focused tests covering every supported schema plus missing, empty, non-JSON, non-object, unsupported-schema, and missing-`ok` reports.
- Full repository tests, lint, typecheck, formatting, and JSON-report smoke test pass locally.
- React Doctor reports 100/100 on the changed scope.

## Release note

This touches `scripts/ensure-json-report.mjs`, so it needs a patch GitHub Action release after merge. It does not require an npm package release.

Closes #1331