### PR TITLE
fix(no-flush-sync): recognize imperative DOM handoffs

### DIFF
--- a/.changeset/strong-kids-take.md
+++ b/.changeset/strong-kids-take.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Avoid `no-flush-sync` false positives when an adjacent imperative DOM selection or focus handoff requires the React commit to finish synchronously.

--- a/packages/fuzz/corpus/regressions/no-flush-sync--selection-restoration.tsx
+++ b/packages/fuzz/corpus/regressions/no-flush-sync--selection-restoration.tsx
@@ -1,0 +1,21 @@
+// rule: no-flush-sync
+// weakness: imperative-post-commit-handoff
+// source: react-bench write-react-softmaple-softmaple gxWkbFm
+
+import { flushSync } from "react-dom";
+
+interface SelectionSync {
+  restoreSelection: (selection: { end: number; start: number }) => void;
+}
+
+export const acceptRemoteText = (
+  selectionSync: SelectionSync,
+  selection: { end: number; start: number } | null,
+): void => {
+  flushSync(() => {
+    setText(readRemoteText());
+  });
+  if (selection) {
+    selectionSync.restoreSelection(selection);
+  }
+};

--- a/packages/fuzz/corpus/targets/no-flush-sync--bare-control-flow-handoff.tsx
+++ b/packages/fuzz/corpus/targets/no-flush-sync--bare-control-flow-handoff.tsx
@@ -1,0 +1,6 @@
+import { flushSync } from "react-dom";
+
+export const updateText = (textarea: HTMLTextAreaElement, shouldUpdate: boolean): void => {
+  if (shouldUpdate) flushSync(() => setText(readRemoteText()));
+  textarea.focus();
+};

--- a/packages/fuzz/corpus/targets/no-flush-sync--generic-select-handoff.tsx
+++ b/packages/fuzz/corpus/targets/no-flush-sync--generic-select-handoff.tsx
@@ -1,0 +1,10 @@
+import { flushSync } from "react-dom";
+
+interface Store {
+  select: (name: string) => void;
+}
+
+export const updateSelection = (store: Store): void => {
+  flushSync(() => setText(readRemoteText()));
+  store.select("activeDocument");
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/view-transitions/no-flush-sync.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/view-transitions/no-flush-sync.regressions.test.ts
@@ -199,4 +199,51 @@ const updateText = (textarea, selection) => {
 };`,
     );
   });
+
+  it("still flags an adjacent imperative function declaration", () => {
+    expectFail(
+      `import { flushSync } from "react-dom";
+const updateText = (textarea) => {
+  flushSync(() => setText(readRemoteText()));
+  function restoreLater() {
+    textarea.focus();
+  }
+  queueMicrotask(restoreLater);
+};`,
+    );
+  });
+
+  it("stays silent on a top-level imperative handoff", () => {
+    expectPass(
+      `import { flushSync } from "react-dom";
+flushSync(() => setText(readRemoteText()));
+textarea.focus();`,
+    );
+  });
+
+  it("stays silent on an imperative handoff in a switch case", () => {
+    expectPass(
+      `import { flushSync } from "react-dom";
+const updateText = (textarea, mode) => {
+  switch (mode) {
+    case "edit":
+      flushSync(() => setText(readRemoteText()));
+      textarea.focus();
+      break;
+  }
+};`,
+    );
+  });
+
+  it("stays silent on an imperative handoff in a static block", () => {
+    expectPass(
+      `import { flushSync } from "react-dom";
+class Editor {
+  static {
+    flushSync(() => setText(readRemoteText()));
+    textarea.focus();
+  }
+}`,
+    );
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/view-transitions/no-flush-sync.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/view-transitions/no-flush-sync.regressions.test.ts
@@ -186,6 +186,26 @@ const updateText = (textarea, selection) => {
     );
   });
 
+  it("still flags an imperative mutation outside a bare control-flow branch", () => {
+    expectFail(
+      `import { flushSync } from "react-dom";
+const updateText = (textarea, shouldUpdate) => {
+  if (shouldUpdate) flushSync(() => setText(readRemoteText()));
+  textarea.focus();
+};`,
+    );
+  });
+
+  it("still flags an adjacent generic select method", () => {
+    expectFail(
+      `import { flushSync } from "react-dom";
+const updateSelection = (store) => {
+  flushSync(() => setText(readRemoteText()));
+  store.select("activeDocument");
+};`,
+    );
+  });
+
   it("still flags a deferred imperative helper call", () => {
     expectFail(
       `import { flushSync } from "react-dom";

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/view-transitions/no-flush-sync.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/view-transitions/no-flush-sync.regressions.test.ts
@@ -123,4 +123,80 @@ function ColumnHeader({ releaseWidth, columnIndex }) {
 }`,
     );
   });
+
+  it("stays silent when selection restoration immediately follows flushSync", () => {
+    expectPass(
+      `import { flushSync } from "react-dom";
+const acceptRemoteEvents = (selectionSync, selection, operations) => {
+  flushSync(() => {
+    setText(readRemoteText());
+  });
+  if (selection && operations.length > 0) {
+    selectionSync.restoreSelection(mapSelection(selection, operations));
+  }
+};`,
+    );
+  });
+
+  it("stays silent on a nested selection restoration member", () => {
+    expectPass(
+      `import { flushSync } from "react-dom";
+const integrateRemoteEvents = (context, selection) => {
+  flushSync(() => {
+    context.setText(readRemoteText());
+  });
+  if (selection) {
+    context.selectionSync.restoreSelection(selection);
+  }
+};`,
+    );
+  });
+
+  it("stays silent when an adjacent local helper mutates the DOM", () => {
+    expectPass(
+      `import { flushSync } from "react-dom";
+const restoreSelection = (textarea, selection) => {
+  textarea.setSelectionRange(selection.start, selection.end);
+};
+const updateText = (textarea, selection) => {
+  flushSync(() => setText(readRemoteText()));
+  restoreSelection(textarea, selection);
+};`,
+    );
+  });
+
+  it("still flags an adjacent unknown helper", () => {
+    expectFail(
+      `import { flushSync } from "react-dom";
+const updateText = () => {
+  flushSync(() => setText(readRemoteText()));
+  notifyTextUpdated();
+};`,
+    );
+  });
+
+  it("still flags a non-adjacent imperative mutation", () => {
+    expectFail(
+      `import { flushSync } from "react-dom";
+const updateText = (textarea, selection) => {
+  flushSync(() => setText(readRemoteText()));
+  notifyTextUpdated();
+  textarea.setSelectionRange(selection.start, selection.end);
+};`,
+    );
+  });
+
+  it("still flags a deferred imperative helper call", () => {
+    expectFail(
+      `import { flushSync } from "react-dom";
+const restoreSelection = (textarea, selection) => {
+  textarea.setSelectionRange(selection.start, selection.end);
+};
+const updateText = (textarea, selection) => {
+  flushSync(() => setText(readRemoteText()));
+  const restoreLater = () => restoreSelection(textarea, selection);
+  queueMicrotask(restoreLater);
+};`,
+    );
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/view-transitions/no-flush-sync.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/view-transitions/no-flush-sync.ts
@@ -109,7 +109,7 @@ const collectMeasuringFunctionNames = (program: EsTreeNode): Set<string> =>
   collectFunctionNamesMatchingBody(program, subtreeReadsDomMeasurement);
 
 const subtreeMutatesDomImperatively = (root: EsTreeNode | null | undefined): boolean => {
-  if (!root) return false;
+  if (!root || isFunctionLike(root)) return false;
   let found = false;
   walkAst(root, (child: EsTreeNode) => {
     if (found) return false;
@@ -135,7 +135,9 @@ const callsAnyName = (
   names: ReadonlySet<string>,
   shouldSkipNestedFunctions = false,
 ): boolean => {
-  if (!root || names.size === 0) return false;
+  if (!root || names.size === 0 || (shouldSkipNestedFunctions && isFunctionLike(root))) {
+    return false;
+  }
   let found = false;
   walkAst(root, (child: EsTreeNode) => {
     if (found) return false;
@@ -157,19 +159,31 @@ const isFollowedByImperativeDomMutation = (
 ): boolean => {
   let statement: EsTreeNode = call;
   let parent = statement.parent;
-  while (parent && !isNodeOfType(parent, "BlockStatement")) {
+  while (parent) {
+    const statements =
+      isNodeOfType(parent, "BlockStatement") ||
+      isNodeOfType(parent, "Program") ||
+      isNodeOfType(parent, "StaticBlock")
+        ? parent.body
+        : isNodeOfType(parent, "SwitchCase")
+          ? parent.consequent
+          : null;
+    if (statements) {
+      const statementIndex = statements.findIndex(
+        (siblingStatement) => siblingStatement === statement,
+      );
+      if (statementIndex >= 0) {
+        const nextStatement = statements[statementIndex + 1];
+        return (
+          subtreeMutatesDomImperatively(nextStatement) ||
+          callsAnyName(nextStatement, imperativeDomFunctionNames, true)
+        );
+      }
+    }
     statement = parent;
     parent = parent.parent;
   }
-  if (!parent) return false;
-  const statements = parent.body;
-  const statementIndex = statements.findIndex((blockStatement) => blockStatement === statement);
-  if (statementIndex < 0) return false;
-  const nextStatement = statements[statementIndex + 1];
-  return (
-    subtreeMutatesDomImperatively(nextStatement) ||
-    callsAnyName(nextStatement, imperativeDomFunctionNames, true)
-  );
+  return false;
 };
 
 const isInsideStartViewTransition = (node: EsTreeNode): boolean => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/view-transitions/no-flush-sync.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/view-transitions/no-flush-sync.ts
@@ -5,6 +5,8 @@ import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { getImportedName } from "../../utils/get-imported-name.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import { walkAst } from "../../utils/walk-ast.js";
 
 // Libraries that position or attach to freshly committed DOM — the
@@ -38,6 +40,19 @@ const DOM_MEASUREMENT_NAMES: ReadonlySet<string> = new Set([
 const MEASUREMENT_HELPER_CALLEE_PATTERN =
   /^(?:get|measure|read)\w*(?:Width|Height|Rect|Rects|Size|Bounds|Position)$/;
 
+const IMPERATIVE_DOM_MUTATION_NAMES: ReadonlySet<string> = new Set([
+  "blur",
+  "focus",
+  "restoreSelection",
+  "scroll",
+  "scrollBy",
+  "scrollIntoView",
+  "scrollTo",
+  "select",
+  "setRangeText",
+  "setSelectionRange",
+]);
+
 const subtreeReadsDomMeasurement = (root: EsTreeNode | null | undefined): boolean => {
   if (!root) return false;
   let found = false;
@@ -61,17 +76,14 @@ const subtreeReadsDomMeasurement = (root: EsTreeNode | null | undefined): boolea
   return found;
 };
 
-// Local function bindings whose body reads DOM measurements, including
-// hook-wrapped ones (`const measure = useCallback(() => el.offsetWidth)`).
-const collectMeasuringFunctionNames = (program: EsTreeNode): Set<string> => {
+const collectFunctionNamesMatchingBody = (
+  program: EsTreeNode,
+  matchesBody: (body: EsTreeNode | null | undefined) => boolean,
+): Set<string> => {
   const names = new Set<string>();
   walkAst(program, (child: EsTreeNode) => {
     if (isNodeOfType(child, "FunctionDeclaration")) {
-      if (
-        child.id &&
-        isNodeOfType(child.id, "Identifier") &&
-        subtreeReadsDomMeasurement(child.body)
-      ) {
+      if (child.id && isNodeOfType(child.id, "Identifier") && matchesBody(child.body)) {
         names.add(child.id.name);
       }
       return;
@@ -86,22 +98,48 @@ const collectMeasuringFunctionNames = (program: EsTreeNode): Set<string> => {
     ) {
       functionValue = functionValue.arguments?.[0];
     }
-    if (
-      functionValue &&
-      isFunctionLike(functionValue) &&
-      subtreeReadsDomMeasurement(functionValue.body)
-    ) {
+    if (functionValue && isFunctionLike(functionValue) && matchesBody(functionValue.body)) {
       names.add(child.id.name);
     }
   });
   return names;
 };
 
-const callsAnyName = (root: EsTreeNode | null | undefined, names: ReadonlySet<string>): boolean => {
+const collectMeasuringFunctionNames = (program: EsTreeNode): Set<string> =>
+  collectFunctionNamesMatchingBody(program, subtreeReadsDomMeasurement);
+
+const subtreeMutatesDomImperatively = (root: EsTreeNode | null | undefined): boolean => {
+  if (!root) return false;
+  let found = false;
+  walkAst(root, (child: EsTreeNode) => {
+    if (found) return false;
+    if (child !== root && isFunctionLike(child)) return false;
+    if (!isNodeOfType(child, "CallExpression")) return;
+    const callee = stripParenExpression(child.callee);
+    const propertyName = isNodeOfType(callee, "MemberExpression")
+      ? getStaticPropertyName(callee)
+      : null;
+    if (propertyName !== null && IMPERATIVE_DOM_MUTATION_NAMES.has(propertyName)) {
+      found = true;
+      return false;
+    }
+  });
+  return found;
+};
+
+const collectImperativeDomFunctionNames = (program: EsTreeNode): Set<string> =>
+  collectFunctionNamesMatchingBody(program, subtreeMutatesDomImperatively);
+
+const callsAnyName = (
+  root: EsTreeNode | null | undefined,
+  names: ReadonlySet<string>,
+  shouldSkipNestedFunctions = false,
+): boolean => {
   if (!root || names.size === 0) return false;
   let found = false;
   walkAst(root, (child: EsTreeNode) => {
     if (found) return false;
+    if (shouldSkipNestedFunctions && child !== root && isFunctionLike(child)) return false;
     if (
       isNodeOfType(child, "CallExpression") &&
       isNodeOfType(child.callee, "Identifier") &&
@@ -111,6 +149,27 @@ const callsAnyName = (root: EsTreeNode | null | undefined, names: ReadonlySet<st
     }
   });
   return found;
+};
+
+const isFollowedByImperativeDomMutation = (
+  call: EsTreeNode,
+  imperativeDomFunctionNames: ReadonlySet<string>,
+): boolean => {
+  let statement: EsTreeNode = call;
+  let parent = statement.parent;
+  while (parent && !isNodeOfType(parent, "BlockStatement")) {
+    statement = parent;
+    parent = parent.parent;
+  }
+  if (!parent) return false;
+  const statements = parent.body;
+  const statementIndex = statements.findIndex((blockStatement) => blockStatement === statement);
+  if (statementIndex < 0) return false;
+  const nextStatement = statements[statementIndex + 1];
+  return (
+    subtreeMutatesDomImperatively(nextStatement) ||
+    callsAnyName(nextStatement, imperativeDomFunctionNames, true)
+  );
 };
 
 const isInsideStartViewTransition = (node: EsTreeNode): boolean => {
@@ -172,6 +231,7 @@ const importsImperativeDomLibrary = (program: EsTreeNode): boolean => {
 // diagnostic.
 const hasExemptFlushSyncCall = (program: EsTreeNode, localName: string): boolean => {
   const measuringFunctionNames = collectMeasuringFunctionNames(program);
+  const imperativeDomFunctionNames = collectImperativeDomFunctionNames(program);
   let exempt = false;
   walkAst(program, (child: EsTreeNode) => {
     if (exempt) return false;
@@ -184,7 +244,8 @@ const hasExemptFlushSyncCall = (program: EsTreeNode, localName: string): boolean
     }
     if (
       isInsideStartViewTransition(child) ||
-      enclosingFunctionChainReadsMeasurement(child, measuringFunctionNames)
+      enclosingFunctionChainReadsMeasurement(child, measuringFunctionNames) ||
+      isFollowedByImperativeDomMutation(child, imperativeDomFunctionNames)
     ) {
       exempt = true;
       return false;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/view-transitions/no-flush-sync.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/view-transitions/no-flush-sync.ts
@@ -48,7 +48,6 @@ const IMPERATIVE_DOM_MUTATION_NAMES: ReadonlySet<string> = new Set([
   "scrollBy",
   "scrollIntoView",
   "scrollTo",
-  "select",
   "setRangeText",
   "setSelectionRange",
 ]);
@@ -179,6 +178,12 @@ const isFollowedByImperativeDomMutation = (
           callsAnyName(nextStatement, imperativeDomFunctionNames, true)
         );
       }
+    }
+    if (
+      isFunctionLike(parent) ||
+      (parent.type.endsWith("Statement") && !isNodeOfType(parent, "ExpressionStatement"))
+    ) {
+      return false;
     }
     statement = parent;
     parent = parent.parent;


### PR DESCRIPTION
## Summary

- exempt `flushSync` when the immediately following statement restores selection, focus, or another imperative DOM state
- resolve adjacent local helpers only when their bodies prove the DOM mutation
- keep reporting unknown, deferred, and non-adjacent handoffs
- add the React Bench false positive to the permanent fuzz regression corpus

## Validation

- oxlint plugin suite: 573 files, 14,997 passed, 188 skipped
- monorepo typecheck
- lint (existing warnings only)
- fuzz regression suite: 44 passed
- strict `no-flush-sync` fuzz: 1,000 iterations against `write-react-softmaple-softmaple__gxWkbFm`

## False-positive evidence

The three React Bench findings call `flushSync` immediately before `selectionSync.restoreSelection(...)`. The synchronous commit is required so selection restoration targets the committed DOM; replacing it with an asynchronous update changes behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to oxlint heuristic logic and tests; no runtime, auth, or data paths are affected.
> 
> **Overview**
> Extends **`no-flush-sync`** so a justified `flushSync` import is not reported when a call is **immediately followed** by an imperative DOM handoff (e.g. `restoreSelection`, `focus`, `setSelectionRange`) that needs the commit to finish first.
> 
> The rule now recognizes a fixed set of imperative mutation member calls, walks to the **next sibling statement** (including in `switch` cases and static blocks), and can treat an adjacent call to a **local helper** as exempt only if that helper’s body actually performs those mutations. **Unknown helpers**, **deferred** mutations (e.g. `queueMicrotask`), **statements in between**, and handoffs that are not the direct next statement (e.g. `focus` after a conditional `flushSync` in another branch) still fail.
> 
> Function-name collection for measuring helpers is generalized via `collectFunctionNamesMatchingBody`. Regression tests and fuzz corpus entries cover the React Bench selection-restoration false positive and cases that must keep reporting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fc207dbe79ace403b2b8a01afb1f25ad4156d99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->