### PR TITLE
fix(no-pass-data-to-parent): preserve external hook state

### DIFF
--- a/.changeset/soft-worlds-visit.md
+++ b/.changeset/soft-worlds-visit.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Avoid `no-pass-data-to-parent` false positives when destructured media-query hook state is forwarded to a parent after an external subscription update.

--- a/packages/fuzz/corpus/regressions/no-pass-data-to-parent--destructured-media-query-state.tsx
+++ b/packages/fuzz/corpus/regressions/no-pass-data-to-parent--destructured-media-query-state.tsx
@@ -1,0 +1,23 @@
+// rule: no-pass-data-to-parent
+// weakness: external-state-origin-through-object-pattern
+// source: react-bench write-react-azouaoui-med-react-pro-sidebar hEYzUSm
+
+import { useEffect, useRef } from "react";
+
+interface SidebarProps {
+  onBreakPoint?: (broken: boolean) => void;
+}
+
+export const Sidebar = ({ onBreakPoint }: SidebarProps) => {
+  const { matches: broken, resolved } = useMediaQueryState("(max-width: 768px)");
+  const lastReportedBrokenRef = useRef(false);
+
+  useEffect(() => {
+    if (resolved && broken !== lastReportedBrokenRef.current) {
+      onBreakPoint?.(broken);
+      lastReportedBrokenRef.current = broken;
+    }
+  }, [broken, resolved, onBreakPoint]);
+
+  return null;
+};

--- a/packages/fuzz/corpus/regressions/no-pass-data-to-parent--local-use-sync-external-store.tsx
+++ b/packages/fuzz/corpus/regressions/no-pass-data-to-parent--local-use-sync-external-store.tsx
@@ -1,0 +1,30 @@
+// rule: no-pass-data-to-parent
+// weakness: library-idiom
+// source: PR #1342 review
+
+import { useEffect, useSyncExternalStore } from "react";
+
+interface SidebarProps {
+  onBreakPoint: (broken: boolean) => void;
+}
+
+const useMediaQuery = (query: string) =>
+  useSyncExternalStore(
+    (notify) => {
+      const mediaQuery = window.matchMedia(query);
+      mediaQuery.addEventListener("change", notify);
+      return () => mediaQuery.removeEventListener("change", notify);
+    },
+    () => window.matchMedia(query).matches,
+    () => false,
+  );
+
+export const Sidebar = ({ onBreakPoint }: SidebarProps) => {
+  const broken = useMediaQuery("(max-width: 768px)");
+
+  useEffect(() => {
+    onBreakPoint(broken);
+  }, [broken, onBreakPoint]);
+
+  return null;
+};

--- a/packages/fuzz/corpus/true-positives/no-pass-data-to-parent--escaped-external-state-setter.tsx
+++ b/packages/fuzz/corpus/true-positives/no-pass-data-to-parent--escaped-external-state-setter.tsx
@@ -1,0 +1,32 @@
+// rule: no-pass-data-to-parent
+// weakness: other
+// source: PR #1342 review
+
+import { useEffect, useState } from "react";
+
+interface SidebarProps {
+  onBreakPoint: (broken: boolean) => void;
+}
+
+const useSidebarMediaState = () => {
+  const [broken, setBroken] = useState(false);
+
+  useEffect(() => {
+    const query = window.matchMedia("(max-width: 768px)");
+    const update = (event: MediaQueryListEvent) => setBroken(event.matches);
+    query.addEventListener("change", update);
+    return () => query.removeEventListener("change", update);
+  }, []);
+
+  return [broken, setBroken] as const;
+};
+
+export const Sidebar = ({ onBreakPoint }: SidebarProps) => {
+  const [broken, setBroken] = useSidebarMediaState();
+
+  useEffect(() => {
+    onBreakPoint(broken);
+  }, [broken, onBreakPoint]);
+
+  return <button onClick={() => setBroken(false)}>Reset</button>;
+};

--- a/packages/fuzz/corpus/true-positives/no-pass-data-to-parent--mixed-local-hook-return.tsx
+++ b/packages/fuzz/corpus/true-positives/no-pass-data-to-parent--mixed-local-hook-return.tsx
@@ -1,0 +1,33 @@
+// rule: no-pass-data-to-parent
+// weakness: other
+// source: PR #1342 review
+
+import { useEffect, useState } from "react";
+
+interface SidebarProps {
+  onChildValue: (value: string) => void;
+}
+
+const useSidebarMediaState = () => {
+  const [broken, setBroken] = useState(false);
+
+  useEffect(() => {
+    const query = window.matchMedia("(max-width: 768px)");
+    const update = (event: MediaQueryListEvent) => setBroken(event.matches);
+    query.addEventListener("change", update);
+    return () => query.removeEventListener("change", update);
+  }, []);
+
+  const childValue = readChildValue();
+  return { broken, childValue };
+};
+
+export const Sidebar = ({ onChildValue }: SidebarProps) => {
+  const { childValue } = useSidebarMediaState();
+
+  useEffect(() => {
+    onChildValue(childValue);
+  }, [childValue, onChildValue]);
+
+  return null;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.regressions.test.ts
@@ -126,6 +126,56 @@ describe("no-pass-data-to-parent — regressions", () => {
       expect(result.diagnostics).toEqual([]);
     });
 
+    it("stays silent when a local allowlisted hook delegates to useSyncExternalStore", () => {
+      const result = runRule(
+        noPassDataToParent,
+        `const useMediaQuery = (query) =>
+          useSyncExternalStore(
+            (notify) => {
+              const mediaQuery = window.matchMedia(query);
+              mediaQuery.addEventListener("change", notify);
+              return () => mediaQuery.removeEventListener("change", notify);
+            },
+            () => window.matchMedia(query).matches,
+            () => false,
+          );
+        const Sidebar = ({ onBreakPoint }) => {
+          const broken = useMediaQuery("(max-width: 768px)");
+          useEffect(() => {
+            onBreakPoint(broken);
+          }, [broken, onBreakPoint]);
+          return null;
+        };`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it("still flags an unknown local useSyncExternalStore wrapper", () => {
+      const result = runRule(
+        noPassDataToParent,
+        `const useSidebarStatus = (query) =>
+          useSyncExternalStore(
+            (notify) => {
+              const mediaQuery = window.matchMedia(query);
+              mediaQuery.addEventListener("change", notify);
+              return () => mediaQuery.removeEventListener("change", notify);
+            },
+            () => window.matchMedia(query).matches,
+            () => false,
+          );
+        const Sidebar = ({ onBreakPoint }) => {
+          const broken = useSidebarStatus("(max-width: 768px)");
+          useEffect(() => {
+            onBreakPoint(broken);
+          }, [broken, onBreakPoint]);
+          return null;
+        };`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    });
+
     it("still flags media-query state that a user handler can also update", () => {
       const result = runRule(
         noPassDataToParent,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.regressions.test.ts
@@ -61,6 +61,97 @@ describe("no-pass-data-to-parent — regressions", () => {
       expect(result.diagnostics).toEqual([]);
     });
 
+    it("stays silent when notifying through a callback ref of a media-query hook transition", () => {
+      const result = runRule(
+        noPassDataToParent,
+        `const Sidebar = ({ onBreakPoint }) => {
+          const onBreakPointRef = useRef(onBreakPoint);
+          onBreakPointRef.current = onBreakPoint;
+          const broken = useMediaQuery("(max-width: 768px)");
+          const lastReportedBrokenRef = useRef(false);
+          useEffect(() => {
+            if (broken !== lastReportedBrokenRef.current) {
+              lastReportedBrokenRef.current = broken;
+              onBreakPointRef.current?.(broken);
+            }
+          }, [broken]);
+          return null;
+        };`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it("stays silent when destructured media-query state is externally owned", () => {
+      const result = runRule(
+        noPassDataToParent,
+        `const Sidebar = ({ onBreakPoint }) => {
+          const { matches: broken, resolved } = useMediaQueryState("(max-width: 768px)");
+          const lastReportedBrokenRef = useRef(false);
+          useEffect(() => {
+            if (resolved && broken !== lastReportedBrokenRef.current) {
+              onBreakPoint?.(broken);
+              lastReportedBrokenRef.current = broken;
+            }
+          }, [broken, resolved, onBreakPoint]);
+          return null;
+        };`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it("stays silent when a local custom hook returns exclusively external state", () => {
+      const result = runRule(
+        noPassDataToParent,
+        `const useSidebarMediaState = () => {
+          const [broken, setBroken] = useState(false);
+          useEffect(() => {
+            const query = window.matchMedia("(max-width: 768px)");
+            const update = (event) => setBroken(event.matches);
+            query.addEventListener("change", update);
+            return () => query.removeEventListener("change", update);
+          }, []);
+          return { matches: broken };
+        };
+        const Sidebar = ({ onBreakPoint }) => {
+          const { matches: broken } = useSidebarMediaState();
+          useEffect(() => {
+            onBreakPoint(broken);
+          }, [broken, onBreakPoint]);
+          return null;
+        };`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it("still flags media-query state that a user handler can also update", () => {
+      const result = runRule(
+        noPassDataToParent,
+        `const useMediaQueryState = () => {
+          const [broken, setBroken] = useState(false);
+          useEffect(() => {
+            const query = window.matchMedia("(max-width: 768px)");
+            const update = (event) => setBroken(event.matches);
+            query.addEventListener("change", update);
+            return () => query.removeEventListener("change", update);
+          }, []);
+          const reset = () => setBroken(false);
+          return { broken, reset };
+        };
+        const Sidebar = ({ onBreakPoint }) => {
+          const { broken, reset } = useMediaQueryState();
+          useEffect(() => {
+            onBreakPoint(broken);
+          }, [broken, onBreakPoint]);
+          return <button onClick={reset}>Reset</button>;
+        };`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    });
+
     it("still flags ordinary child-owned form state passed to a parent", () => {
       const result = runRule(
         noPassDataToParent,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.regressions.test.ts
@@ -152,6 +152,31 @@ describe("no-pass-data-to-parent — regressions", () => {
       expect(result.diagnostics).toHaveLength(1);
     });
 
+    it("still flags externally updated state when its setter escapes the hook", () => {
+      const result = runRule(
+        noPassDataToParent,
+        `const useSidebarMediaState = () => {
+          const [broken, setBroken] = useState(false);
+          useEffect(() => {
+            const query = window.matchMedia("(max-width: 768px)");
+            const update = (event) => setBroken(event.matches);
+            query.addEventListener("change", update);
+            return () => query.removeEventListener("change", update);
+          }, []);
+          return [broken, setBroken];
+        };
+        const Sidebar = ({ onBreakPoint }) => {
+          const [broken, setBroken] = useSidebarMediaState();
+          useEffect(() => {
+            onBreakPoint(broken);
+          }, [broken, onBreakPoint]);
+          return <button onClick={() => setBroken(false)}>Reset</button>;
+        };`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    });
+
     it("stays silent when a local allowlisted hook delegates to useSyncExternalStore", () => {
       const result = runRule(
         noPassDataToParent,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.regressions.test.ts
@@ -126,6 +126,32 @@ describe("no-pass-data-to-parent — regressions", () => {
       expect(result.diagnostics).toEqual([]);
     });
 
+    it("still flags a non-state value returned beside external hook state", () => {
+      const result = runRule(
+        noPassDataToParent,
+        `const useSidebarMediaState = () => {
+          const [broken, setBroken] = useState(false);
+          useEffect(() => {
+            const query = window.matchMedia("(max-width: 768px)");
+            const update = (event) => setBroken(event.matches);
+            query.addEventListener("change", update);
+            return () => query.removeEventListener("change", update);
+          }, []);
+          const childValue = readChildValue();
+          return { broken, childValue };
+        };
+        const Sidebar = ({ onChildValue }) => {
+          const { childValue } = useSidebarMediaState();
+          useEffect(() => {
+            onChildValue(childValue);
+          }, [childValue, onChildValue]);
+          return null;
+        };`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    });
+
     it("stays silent when a local allowlisted hook delegates to useSyncExternalStore", () => {
       const result = runRule(
         noPassDataToParent,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.ts
@@ -1004,16 +1004,17 @@ const getLocalHookExternalStateProof = (
     }
   }
   if (!hookFunction) return null;
-  const returnedStateReferences = collectFunctionReturnStatements(hookFunction)
-    .flatMap((returnStatement) =>
+  const returnedReferences = collectFunctionReturnStatements(hookFunction).flatMap(
+    (returnStatement) =>
       returnStatement.argument
         ? getDownstreamRefs(analysis, returnStatement.argument as EsTreeNode)
         : [],
-    )
-    .filter(isReactStateReference);
-  if (returnedStateReferences.length === 0) return null;
-  return returnedStateReferences.every((stateReference) =>
-    isExternallyDrivenState(analysis, stateReference),
+  );
+  if (returnedReferences.length === 0) return null;
+  return returnedReferences.every(
+    (returnedReference) =>
+      isReactStateReference(returnedReference) &&
+      isExternallyDrivenState(analysis, returnedReference),
   );
 };
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.ts
@@ -37,12 +37,13 @@ import {
   isProp,
   isRefCall,
   isRefCurrent,
+  isState,
   isUseEffect,
   isWholePropsObjectReference,
 } from "./utils/effect/react.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
-import { isExternallyDrivenState, isReactStateReference } from "./utils/effect/external-state.js";
+import { isExternallyDrivenState } from "./utils/effect/external-state.js";
 import { getStaticMemberPropertyName } from "./utils/static-member-property-name.js";
 
 // 1:1 port of upstream `src/rules/no-pass-data-to-parent.js`, narrowed to
@@ -1013,8 +1014,7 @@ const getLocalHookExternalStateProof = (
   if (returnedReferences.length === 0) return null;
   return returnedReferences.every(
     (returnedReference) =>
-      isReactStateReference(returnedReference) &&
-      isExternallyDrivenState(analysis, returnedReference),
+      isState(analysis, returnedReference) && isExternallyDrivenState(analysis, returnedReference),
   );
 };
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.ts
@@ -1011,11 +1011,9 @@ const getLocalHookExternalStateProof = (
         : [],
     )
     .filter(isReactStateReference);
-  return (
-    returnedStateReferences.length > 0 &&
-    returnedStateReferences.every((stateReference) =>
-      isExternallyDrivenState(analysis, stateReference),
-    )
+  if (returnedStateReferences.length === 0) return null;
+  return returnedStateReferences.every((stateReference) =>
+    isExternallyDrivenState(analysis, stateReference),
   );
 };
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.ts
@@ -4,6 +4,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
 import { findTransparentExpressionRoot } from "../../utils/find-transparent-expression-root.js";
+import { collectFunctionReturnStatements } from "../../utils/collect-function-return-statements.js";
 import { isNamespacedApiCallee } from "../../utils/is-namespaced-api-call.js";
 import { isReactApiCall } from "../../utils/is-react-api-call.js";
 import {
@@ -41,7 +42,7 @@ import {
 } from "./utils/effect/react.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
-import { isExternallyDrivenState } from "./utils/effect/external-state.js";
+import { isExternallyDrivenState, isReactStateReference } from "./utils/effect/external-state.js";
 import { getStaticMemberPropertyName } from "./utils/static-member-property-name.js";
 
 // 1:1 port of upstream `src/rules/no-pass-data-to-parent.js`, narrowed to
@@ -917,6 +918,7 @@ const EXTERNAL_SUBSCRIPTION_HOOK_NAMES: ReadonlySet<string> = new Set([
   "useIntersectionObserver",
   "useMatchMedia",
   "useMediaQuery",
+  "useMediaQueryState",
   "useResizeObserver",
   "useVisibility",
   "useWindowSize",
@@ -982,9 +984,46 @@ const isParentWiredHookCalleeRef = (analysis: ProgramAnalysis, ref: Reference): 
   );
 };
 
-const isExternalSubscriptionHookRef = (ref: Reference): boolean => {
+const getLocalHookExternalStateProof = (
+  analysis: ProgramAnalysis,
+  ref: Reference,
+): boolean | null => {
+  let hookFunction = resolveToFunction(ref);
+  if (!hookFunction) {
+    for (const definition of ref.resolved?.defs ?? []) {
+      const definitionNode = definition.node as unknown as EsTreeNode;
+      if (!isNodeOfType(definitionNode, "VariableDeclarator") || !definitionNode.init) continue;
+      const initializer = stripParenExpression(definitionNode.init as EsTreeNode);
+      if (!isNodeOfType(initializer, "CallExpression")) continue;
+      const callee = stripParenExpression(initializer.callee as EsTreeNode);
+      if (!isNodeOfType(callee, "Identifier")) continue;
+      const calleeReference = getRef(analysis, callee);
+      if (!calleeReference) continue;
+      hookFunction = resolveToFunction(calleeReference);
+      if (hookFunction) break;
+    }
+  }
+  if (!hookFunction) return null;
+  const returnedStateReferences = collectFunctionReturnStatements(hookFunction)
+    .flatMap((returnStatement) =>
+      returnStatement.argument
+        ? getDownstreamRefs(analysis, returnStatement.argument as EsTreeNode)
+        : [],
+    )
+    .filter(isReactStateReference);
+  return (
+    returnedStateReferences.length > 0 &&
+    returnedStateReferences.every((stateReference) =>
+      isExternallyDrivenState(analysis, stateReference),
+    )
+  );
+};
+
+const isExternalSubscriptionHookRef = (analysis: ProgramAnalysis, ref: Reference): boolean => {
   const identifier = ref.identifier as unknown as EsTreeNode;
   if (!isNodeOfType(identifier, "Identifier")) return false;
+  const localHookProof = getLocalHookExternalStateProof(analysis, ref);
+  if (localHookProof !== null) return localHookProof;
   if (EXTERNAL_SUBSCRIPTION_HOOK_NAMES.has(identifier.name) && isCalleePosition(identifier)) {
     return true;
   }
@@ -1162,7 +1201,8 @@ export const noPassDataToParent = defineRule({
               return getDownstreamRefs(analysis, argument as EsTreeNode);
             })
             .flatMap((argumentRef) =>
-              isExternallyDrivenState(analysis, argumentRef)
+              isExternallyDrivenState(analysis, argumentRef) ||
+              isExternalSubscriptionHookRef(analysis, argumentRef)
                 ? []
                 : getUpstreamRefs(analysis, argumentRef),
             )
@@ -1176,7 +1216,7 @@ export const noPassDataToParent = defineRule({
 
           const isSomeArgsData = argsUpstreamRefs.some((argRef) => {
             if (isUseStateIdentifier(argRef.identifier as unknown as EsTreeNode)) return false;
-            if (isExternalSubscriptionHookRef(argRef)) return false;
+            if (isExternalSubscriptionHookRef(analysis, argRef)) return false;
             if (isProp(analysis, argRef)) return false;
             if (isUseRefIdentifier(argRef.identifier as unknown as EsTreeNode)) return false;
             if (isRefCurrent(argRef)) return false;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/effect/external-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/effect/external-state.ts
@@ -164,6 +164,9 @@ const findUseStateDeclarator = (ref: Reference): EsTreeNode | null => {
   return null;
 };
 
+export const isReactStateReference = (ref: Reference): boolean =>
+  findUseStateDeclarator(ref) !== null;
+
 // The answer depends only on the state's declaration, so cache it per
 // declarator — the effect-family rules query the same state from many refs.
 const declaratorToExternallyDriven = new WeakMap<EsTreeNode, boolean>();

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/effect/external-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/effect/external-state.ts
@@ -164,9 +164,6 @@ const findUseStateDeclarator = (ref: Reference): EsTreeNode | null => {
   return null;
 };
 
-export const isReactStateReference = (ref: Reference): boolean =>
-  findUseStateDeclarator(ref) !== null;
-
 // The answer depends only on the state's declaration, so cache it per
 // declarator — the effect-family rules query the same state from many refs.
 const declaratorToExternallyDriven = new WeakMap<EsTreeNode, boolean>();


### PR DESCRIPTION
## Summary

- recognize object-destructured `useMediaQueryState` results as externally owned subscription state
- prove local custom-hook results only when every returned React state binding is exclusively updated by deferred callbacks
- retain diagnostics when the same state also has a synchronous user-update path
- add the React Bench Sidebar case to the permanent fuzz regression corpus

## Validation

- oxlint plugin suite: 573 files, 14,995 passed, 188 skipped
- monorepo typecheck
- lint (existing warnings only)
- fuzz regression suite: 44 passed
- strict `no-pass-data-to-parent` fuzz: 1,000 iterations against `write-react-azouaoui-med-react-p__hEYzUSm`

## False-positive evidence

All eight saved Sidebar trials forward media-query changes owned by an external browser subscription. Seven direct `useMediaQuery` forms were already exempt; the remaining packed-current-main failure destructures `matches` from `useMediaQueryState`, losing that ownership before the reporting effect.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes static-analysis heuristics for a widely used lint rule; incorrect proofs could hide real anti-patterns, though new regression and fuzz cases target the main boundaries.
> 
> **Overview**
> Reduces **false positives** in `no-pass-data-to-parent` when a `useEffect` notifies a parent about values that come from **browser-driven subscriptions** (media queries, observers, etc.) rather than child-owned state.
> 
> The rule now treats **`useMediaQueryState`** like other known external-subscription hooks, including when **`matches` / similar fields are object-destructured** before being passed to a parent callback. For **local custom hooks**, it inspects return values: if **every returned binding is React state updated only via deferred external callbacks**, forwarding that state to a parent is allowed; **mixed returns**, **escaped setters**, **user-updatable reset paths**, and **non-allowlisted `useSyncExternalStore` wrappers** still report.
> 
> Argument tracing also skips upstream analysis when a value is classified as an external-subscription hook ref, not only when `isExternallyDrivenState` already applied. Regression tests and fuzz corpus cases cover the Sidebar/media-query shapes and the remaining true-positive boundaries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a6012d981e8989e2bc4e01d551ace9e43f82c1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->