### PR TITLE
fix(effect-needs-cleanup): prove collection cleanup

### DIFF
--- a/.changeset/soft-monkeys-see.md
+++ b/.changeset/soft-monkeys-see.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Avoid `effect-needs-cleanup` false positives when locally observed resources are retained and exhaustively disconnected through the same collection.

--- a/packages/fuzz/corpus/regressions/effect-needs-cleanup--multiple-observer-pushes.tsx
+++ b/packages/fuzz/corpus/regressions/effect-needs-cleanup--multiple-observer-pushes.tsx
@@ -1,0 +1,17 @@
+// rule: effect-needs-cleanup
+// weakness: cleanup-provenance
+// source: PR #1346 Bugbot review — multiple resources retained by one collection
+import { useEffect } from "react";
+
+export const ObserverGroup = ({ elements }: { elements: Element[] }) => {
+  useEffect(() => {
+    const observers: ResizeObserver[] = [];
+    for (const element of elements) {
+      const observer = new ResizeObserver(() => updateSize());
+      observer.observe(element);
+      observers.push(observer);
+    }
+    return () => observers.forEach((observer) => observer.disconnect());
+  }, [elements]);
+  return null;
+};

--- a/packages/fuzz/corpus/regressions/effect-needs-cleanup--observer-collection.tsx
+++ b/packages/fuzz/corpus/regressions/effect-needs-cleanup--observer-collection.tsx
@@ -1,0 +1,25 @@
+// rule: effect-needs-cleanup
+// weakness: retained-observer-collection-cleanup
+// source: react-bench write-react-cloudscape-design-components dCFuz44
+
+import { useLayoutEffect, useState } from "react";
+
+export const VisualContext = ({ element }: { element: HTMLElement | null }) => {
+  const [value, setValue] = useState("");
+
+  useLayoutEffect(() => {
+    if (!element) return;
+    const detect = () => setValue(element.className);
+    const observers: MutationObserver[] = [];
+
+    for (let node: HTMLElement | null = element; node; node = node.parentElement) {
+      const observer = new MutationObserver(detect);
+      observer.observe(node, { attributes: true, attributeFilter: ["class"] });
+      observers.push(observer);
+    }
+
+    return () => observers.forEach((observer) => observer.disconnect());
+  }, [element]);
+
+  return <output>{value}</output>;
+};

--- a/packages/fuzz/corpus/true-positives/effect-needs-cleanup--observer-collection-wrong-unobserve-target.tsx
+++ b/packages/fuzz/corpus/true-positives/effect-needs-cleanup--observer-collection-wrong-unobserve-target.tsx
@@ -1,0 +1,16 @@
+// rule: effect-needs-cleanup
+// weakness: cleanup-target-provenance
+// source: PR #1346 Bugbot review — collection unobserve target mismatch
+
+import { useEffect } from "react";
+
+export const ObserverGroup = ({ target, otherTarget }: { target: Node; otherTarget: Node }) => {
+  useEffect(() => {
+    const observers: MutationObserver[] = [];
+    const observer = new MutationObserver(() => update());
+    observer.observe(target, { attributes: true });
+    observers.push(observer);
+    return () => observers.forEach((retainedObserver) => retainedObserver.unobserve(otherTarget));
+  }, [target, otherTarget]);
+  return null;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
@@ -273,6 +273,108 @@ export const Measurer = () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("accepts observers retained and disconnected through the same collection", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useLayoutEffect } from "react";
+export const ContextWatcher = ({ element }) => {
+  useLayoutEffect(() => {
+    const observers = [];
+    for (let node = element; node; node = node.parentElement) {
+      const observer = new MutationObserver(update);
+      observer.observe(node, { attributes: true });
+      observers.push(observer);
+    }
+    return () => observers.forEach((observer) => observer.disconnect());
+  }, [element]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("rejects conditionally retaining an observed resource for collection cleanup", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useLayoutEffect } from "react";
+export const ContextWatcher = ({ element, shouldRetain }) => {
+  useLayoutEffect(() => {
+    const observers = [];
+    const observer = new MutationObserver(update);
+    observer.observe(element, { attributes: true });
+    if (shouldRetain) observers.push(observer);
+    return () => observers.forEach((retainedObserver) => retainedObserver.disconnect());
+  }, [element, shouldRetain]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("rejects disconnecting a different observer collection", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useLayoutEffect } from "react";
+export const ContextWatcher = ({ element, previousObservers }) => {
+  useLayoutEffect(() => {
+    const observers = [];
+    const observer = new MutationObserver(update);
+    observer.observe(element, { attributes: true });
+    observers.push(observer);
+    return () => previousObservers.forEach((retainedObserver) => retainedObserver.disconnect());
+  }, [element, previousObservers]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("rejects conditionally iterating the observer collection during cleanup", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useLayoutEffect } from "react";
+export const ContextWatcher = ({ element, shouldCleanup }) => {
+  useLayoutEffect(() => {
+    const observers = [];
+    const observer = new MutationObserver(update);
+    observer.observe(element, { attributes: true });
+    observers.push(observer);
+    return () => {
+      if (shouldCleanup) {
+        observers.forEach((retainedObserver) => retainedObserver.disconnect());
+      }
+    };
+  }, [element, shouldCleanup]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("rejects mutating an observer collection after retaining the resource", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useLayoutEffect } from "react";
+export const ContextWatcher = ({ element }) => {
+  useLayoutEffect(() => {
+    const observers = [];
+    const observer = new MutationObserver(update);
+    observer.observe(element, { attributes: true });
+    observers.push(observer);
+    observers.pop();
+    return () => observers.forEach((retainedObserver) => retainedObserver.disconnect());
+  }, [element]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("does not flag a MutationObserver cleaned up via unobserve", () => {
     const result = runRule(
       effectNeedsCleanup,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
@@ -294,6 +294,28 @@ export const ContextWatcher = ({ element }) => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("accepts multiple observers pushed into the same cleanup collection", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useLayoutEffect } from "react";
+export const ContextWatcher = ({ element, parentElement }) => {
+  useLayoutEffect(() => {
+    const observers = [];
+    const elementObserver = new MutationObserver(update);
+    elementObserver.observe(element, { attributes: true });
+    observers.push(elementObserver);
+    const parentObserver = new MutationObserver(update);
+    parentObserver.observe(parentElement, { attributes: true });
+    observers.push(parentObserver);
+    return () => observers.forEach((observer) => observer.disconnect());
+  }, [element, parentElement]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("rejects conditionally retaining an observed resource for collection cleanup", () => {
     const result = runRule(
       effectNeedsCleanup,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
@@ -424,6 +424,45 @@ export const ObserverGroup = ({ nodes }) => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("accepts matching unobserve cleanup through an observer collection", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+export const ObserverGroup = ({ target }) => {
+  useEffect(() => {
+    const observers = [];
+    const observer = new MutationObserver(update);
+    observer.observe(target, { attributes: true });
+    observers.push(observer);
+    return () => observers.forEach((retainedObserver) => retainedObserver.unobserve(target));
+  }, [target]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("rejects unobserving a different target through an observer collection", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+export const ObserverGroup = ({ target, otherTarget }) => {
+  useEffect(() => {
+    const observers = [];
+    const observer = new MutationObserver(update);
+    observer.observe(target, { attributes: true });
+    observers.push(observer);
+    return () =>
+      observers.forEach((retainedObserver) => retainedObserver.unobserve(otherTarget));
+  }, [target, otherTarget]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("rejects mutating an observer collection after retaining the resource", () => {
     const result = runRule(
       effectNeedsCleanup,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
@@ -355,6 +355,28 @@ export const ContextWatcher = ({ element, shouldCleanup }) => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("rejects short-circuit iteration of the observer collection during cleanup", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useLayoutEffect } from "react";
+export const ContextWatcher = ({ element }) => {
+  useLayoutEffect(() => {
+    const observers = [];
+    const observer = new MutationObserver(update);
+    observer.observe(element, { attributes: true });
+    observers.push(observer);
+    return () => observers.some((retainedObserver) => {
+      retainedObserver.disconnect();
+      return true;
+    });
+  }, [element]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("rejects mutating an observer collection after retaining the resource", () => {
     const result = runRule(
       effectNeedsCleanup,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
@@ -377,6 +377,31 @@ export const ContextWatcher = ({ element }) => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("accepts observer collection cleanup through a direct for-of loop", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+export const ObserverGroup = ({ nodes }) => {
+  useEffect(() => {
+    const observers = [];
+    for (const node of nodes) {
+      const observer = new ResizeObserver(updateSize);
+      observer.observe(node);
+      observers.push(observer);
+    }
+    return () => {
+      for (const observer of observers) {
+        observer.disconnect();
+      }
+    };
+  }, [nodes]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("rejects mutating an observer collection after retaining the resource", () => {
     const result = runRule(
       effectNeedsCleanup,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -1201,8 +1201,11 @@ const doesCleanupFunctionReleaseUsage = (
       const cleanupReceiverCollectionKey = isNodeOfType(cleanupCallee, "MemberExpression")
         ? resolveIteratorCollectionKey(cleanupCallee.object, context)
         : null;
-      if (cleanupForEachCall && cleanupReceiverCollectionKey !== null) {
-        if (findPushedResourceCollectionKey(usage, context) === cleanupReceiverCollectionKey) {
+      if (cleanupReceiverCollectionKey !== null) {
+        if (
+          cleanupForEachCall &&
+          findPushedResourceCollectionKey(usage, context) === cleanupReceiverCollectionKey
+        ) {
           matchingLoopOrHelperAnchors.push(cleanupForEachCall);
         }
         return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -2555,6 +2555,7 @@ const doesReleaseCallMatchUsage = (
     return false;
   }
   const releaseReceiverKey = resolveExpressionKey(callee.object, context);
+  const releaseEventKey = resolveExpressionKey(callNode.arguments?.[0], context);
   const pairedReleaseVerbNames = usage.registrationVerbName
     ? PAIRED_RELEASE_VERB_NAMES_BY_REGISTRATION_VERB.get(usage.registrationVerbName)
     : null;
@@ -2570,7 +2571,9 @@ const doesReleaseCallMatchUsage = (
     pairedReleaseVerbNames &&
     matchesPairedReleaseVerb(releaseVerbName, pairedReleaseVerbNames) &&
     pushedResourceCollectionKey !== null &&
-    pushedResourceCollectionKey === releaseReceiverCollectionKey
+    pushedResourceCollectionKey === releaseReceiverCollectionKey &&
+    (releaseVerbName !== "unobserve" ||
+      (usage.eventKey !== null && releaseEventKey === usage.eventKey))
   ) {
     return true;
   }
@@ -2622,7 +2625,6 @@ const doesReleaseCallMatchUsage = (
     : null;
   if (!pairedVerbNames || !matchesPairedReleaseVerb(releaseVerbName, pairedVerbNames)) return false;
 
-  const releaseEventKey = resolveExpressionKey(callNode.arguments?.[0], context);
   const usageEventArgument = isNodeOfType(usage.node, "CallExpression")
     ? usage.node.arguments?.[0]
     : null;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -918,6 +918,14 @@ const findPushedResourceCollectionKey = (
   }
   const hasOnlyCollectionRetentionAndIteration = collectionSymbol.references.every((reference) => {
     const referenceRoot = findTransparentExpressionRoot(reference.identifier);
+    const forOfStatement = referenceRoot.parent;
+    if (
+      isNodeOfType(forOfStatement, "ForOfStatement") &&
+      forOfStatement.right === referenceRoot &&
+      forOfStatement.await !== true
+    ) {
+      return true;
+    }
     const memberNode = referenceRoot.parent;
     const callNode = memberNode?.parent;
     if (
@@ -1198,10 +1206,18 @@ const doesCleanupFunctionReleaseUsage = (
       const cleanupCallee = isNodeOfType(cleanupCall, "CallExpression")
         ? stripParenExpression(cleanupCall.callee)
         : null;
-      const cleanupReceiverCollectionKey = isNodeOfType(cleanupCallee, "MemberExpression")
-        ? resolveIteratorCollectionKey(cleanupCallee.object, context)
+      const cleanupReceiverForOfStatement = isNodeOfType(cleanupCallee, "MemberExpression")
+        ? findForOfStatementForIteratorExpression(cleanupCallee.object, context)
         : null;
-      if (cleanupReceiverCollectionKey !== null) {
+      const cleanupReceiverCollectionKey = cleanupReceiverForOfStatement
+        ? resolveExpressionKey(cleanupReceiverForOfStatement.right, context)
+        : isNodeOfType(cleanupCallee, "MemberExpression")
+          ? resolveIteratorCollectionKey(cleanupCallee.object, context)
+          : null;
+      if (
+        cleanupReceiverCollectionKey !== null &&
+        findEnclosingFunction(cleanupChild) !== cleanupFunction
+      ) {
         if (
           cleanupForEachCall &&
           findPushedResourceCollectionKey(usage, context) === cleanupReceiverCollectionKey
@@ -1213,10 +1229,9 @@ const doesCleanupFunctionReleaseUsage = (
       const cleanupEventArgument = isNodeOfType(cleanupCall, "CallExpression")
         ? cleanupCall.arguments?.[0]
         : null;
-      const cleanupForOfStatement = findForOfStatementForIteratorExpression(
-        cleanupEventArgument,
-        context,
-      );
+      const cleanupForOfStatement =
+        findForOfStatementForIteratorExpression(cleanupEventArgument, context) ??
+        cleanupReceiverForOfStatement;
       if (!cleanupForOfStatement) {
         didCleanupFunctionMatch = true;
         return false;
@@ -2544,11 +2559,18 @@ const doesReleaseCallMatchUsage = (
     ? PAIRED_RELEASE_VERB_NAMES_BY_REGISTRATION_VERB.get(usage.registrationVerbName)
     : null;
   const pushedResourceCollectionKey = findPushedResourceCollectionKey(usage, context);
+  const releaseReceiverForOfStatement = findForOfStatementForIteratorExpression(
+    callee.object,
+    context,
+  );
+  const releaseReceiverCollectionKey = releaseReceiverForOfStatement
+    ? resolveExpressionKey(releaseReceiverForOfStatement.right, context)
+    : resolveIteratorCollectionKey(callee.object, context);
   if (
     pairedReleaseVerbNames &&
     matchesPairedReleaseVerb(releaseVerbName, pairedReleaseVerbNames) &&
     pushedResourceCollectionKey !== null &&
-    pushedResourceCollectionKey === resolveIteratorCollectionKey(callee.object, context)
+    pushedResourceCollectionKey === releaseReceiverCollectionKey
   ) {
     return true;
   }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -938,7 +938,7 @@ const findPushedResourceCollectionKey = (
     ) {
       return false;
     }
-    return memberNode.property.name === "forEach" || callNode === pushCall;
+    return memberNode.property.name === "forEach" || memberNode.property.name === "push";
   });
   return hasOnlyCollectionRetentionAndIteration
     ? resolveExpressionKey(pushCallee.object, context)

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -855,6 +855,88 @@ const findContainingCollectionKey = (
   return null;
 };
 
+const findPushedResourceCollectionKey = (
+  usage: SubscribeLikeUsage,
+  context: RuleContext,
+): string | null => {
+  if (!isNodeOfType(usage.node, "CallExpression")) return null;
+  const registrationCallee = stripParenExpression(usage.node.callee);
+  if (!isNodeOfType(registrationCallee, "MemberExpression") || registrationCallee.computed) {
+    return null;
+  }
+  const resourceIdentifier = stripParenExpression(registrationCallee.object);
+  if (!isPrivatePlainConstIdentifier(resourceIdentifier, context)) return null;
+  const resourceSymbol = context.scopes.symbolFor(resourceIdentifier);
+  if (!resourceSymbol) return null;
+
+  const pushCalls = resourceSymbol.references.flatMap((reference) => {
+    const referenceRoot = findTransparentExpressionRoot(reference.identifier);
+    const callNode = referenceRoot.parent;
+    if (
+      !isNodeOfType(callNode, "CallExpression") ||
+      !callNode.arguments?.some((argument) => argument === referenceRoot)
+    ) {
+      return [];
+    }
+    const pushCallee = stripParenExpression(callNode.callee);
+    return isNodeOfType(pushCallee, "MemberExpression") &&
+      !pushCallee.computed &&
+      isNodeOfType(pushCallee.object, "Identifier") &&
+      isNodeOfType(pushCallee.property, "Identifier") &&
+      pushCallee.property.name === "push"
+      ? [callNode]
+      : [];
+  });
+  if (pushCalls.length !== 1) return null;
+  const pushCall = pushCalls[0];
+  if (
+    findEnclosingFunction(pushCall) !== findEnclosingFunction(usage.node) ||
+    !doMatchingNodesCoverEveryPathAfterUsage(usage.node, [pushCall], context)
+  ) {
+    return null;
+  }
+
+  const pushCallee = stripParenExpression(pushCall.callee);
+  if (
+    !isNodeOfType(pushCallee, "MemberExpression") ||
+    !isNodeOfType(pushCallee.object, "Identifier") ||
+    !isPrivatePlainConstIdentifier(pushCallee.object, context)
+  ) {
+    return null;
+  }
+  const collectionSymbol = context.scopes.symbolFor(pushCallee.object);
+  const collectionInitializer = collectionSymbol?.initializer
+    ? stripParenExpression(collectionSymbol.initializer)
+    : null;
+  if (
+    !collectionSymbol ||
+    !isNodeOfType(collectionInitializer, "ArrayExpression") ||
+    (collectionInitializer.elements?.length ?? 0) !== 0 ||
+    findEnclosingFunction(collectionSymbol.declarationNode) !== findEnclosingFunction(usage.node)
+  ) {
+    return null;
+  }
+  const hasOnlyCollectionRetentionAndIteration = collectionSymbol.references.every((reference) => {
+    const referenceRoot = findTransparentExpressionRoot(reference.identifier);
+    const memberNode = referenceRoot.parent;
+    const callNode = memberNode?.parent;
+    if (
+      !isNodeOfType(memberNode, "MemberExpression") ||
+      memberNode.object !== referenceRoot ||
+      memberNode.computed ||
+      !isNodeOfType(memberNode.property, "Identifier") ||
+      !isNodeOfType(callNode, "CallExpression") ||
+      callNode.callee !== memberNode
+    ) {
+      return false;
+    }
+    return memberNode.property.name === "forEach" || callNode === pushCall;
+  });
+  return hasOnlyCollectionRetentionAndIteration
+    ? resolveExpressionKey(pushCallee.object, context)
+    : null;
+};
+
 const isWithinAssignmentTarget = (identifier: EsTreeNode): boolean => {
   let currentNode = identifier;
   let parentNode = currentNode.parent;
@@ -992,6 +1074,22 @@ const isSynchronousIteratorCallback = (functionNode: EsTreeNode): boolean => {
   );
 };
 
+const findEnclosingForEachCall = (node: EsTreeNode): EsTreeNode | null => {
+  const callbackNode = findEnclosingFunction(node);
+  if (!callbackNode) return null;
+  const callNode = callbackNode.parent;
+  if (!isNodeOfType(callNode, "CallExpression") || callNode.arguments?.[0] !== callbackNode) {
+    return null;
+  }
+  const callee = stripParenExpression(callNode.callee);
+  return isNodeOfType(callee, "MemberExpression") &&
+    !callee.computed &&
+    isNodeOfType(callee.property, "Identifier") &&
+    callee.property.name === "forEach"
+    ? callNode
+    : null;
+};
+
 const findDirectCallForReference = (identifier: EsTreeNode): EsTreeNode | null => {
   const expressionRoot = findTransparentExpressionRoot(identifier);
   const callNode = expressionRoot.parent;
@@ -1096,6 +1194,19 @@ const doesCleanupFunctionReleaseUsage = (
       ? cleanupChild.expression
       : cleanupChild;
     if (doesReleaseCallMatchUsage(cleanupChild, usage, context)) {
+      const cleanupForEachCall = findEnclosingForEachCall(cleanupChild);
+      const cleanupCallee = isNodeOfType(cleanupCall, "CallExpression")
+        ? stripParenExpression(cleanupCall.callee)
+        : null;
+      const cleanupReceiverCollectionKey = isNodeOfType(cleanupCallee, "MemberExpression")
+        ? resolveIteratorCollectionKey(cleanupCallee.object, context)
+        : null;
+      if (cleanupForEachCall && cleanupReceiverCollectionKey !== null) {
+        if (findPushedResourceCollectionKey(usage, context) === cleanupReceiverCollectionKey) {
+          matchingLoopOrHelperAnchors.push(cleanupForEachCall);
+        }
+        return;
+      }
       const cleanupEventArgument = isNodeOfType(cleanupCall, "CallExpression")
         ? cleanupCall.arguments?.[0]
         : null;
@@ -2426,6 +2537,18 @@ const doesReleaseCallMatchUsage = (
     return false;
   }
   const releaseReceiverKey = resolveExpressionKey(callee.object, context);
+  const pairedReleaseVerbNames = usage.registrationVerbName
+    ? PAIRED_RELEASE_VERB_NAMES_BY_REGISTRATION_VERB.get(usage.registrationVerbName)
+    : null;
+  const pushedResourceCollectionKey = findPushedResourceCollectionKey(usage, context);
+  if (
+    pairedReleaseVerbNames &&
+    matchesPairedReleaseVerb(releaseVerbName, pairedReleaseVerbNames) &&
+    pushedResourceCollectionKey !== null &&
+    pushedResourceCollectionKey === resolveIteratorCollectionKey(callee.object, context)
+  ) {
+    return true;
+  }
 
   if (usage.kind === "socket") {
     return (


### PR DESCRIPTION
## Summary

- prove observer ownership when every registered resource is retained in a local collection
- require unconditional retention, an untouched collection, and exhaustive `forEach` cleanup of that same collection
- preserve diagnostics for conditional retention/cleanup, collection mutation, and cleanup through a different collection
- add the confirmed Cloudscape false positive to the fuzz regression corpus

## Validation

- `nr format`
- `nr -C packages/oxlint-plugin-react-doctor test` (573 files, 15,184 tests)
- `nr -C packages/oxlint-plugin-react-doctor typecheck`
- `nr -C packages/oxlint-plugin-react-doctor build`
- `nr -C packages/fuzz test` (44 tests)
- three strict 1,000-iteration `effect-needs-cleanup` fuzz runs against react-bench jobs `dCFuz44`, `muvDABi`, and `UhMmCoy`
- `nr lint` (existing warnings only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes static analysis heuristics for a widely used lint rule; incorrect proofs could hide real leaks or reintroduce noise, though scope is limited to collection-retention patterns with extensive regression coverage.
> 
> **Overview**
> The **`effect-needs-cleanup`** rule now treats **push-into-local-array + exhaustive cleanup on that same array** as valid cleanup for subscribe-like resources (e.g. `observe` → `disconnect` / `unobserve`), fixing false positives such as multiple `MutationObserver` / `ResizeObserver` instances cleaned up via `observers.forEach(...)`.
> 
> **`findPushedResourceCollectionKey`** links a registration to a collection when the resource is pushed exactly once into an empty `const` array in the same effect, retention is unconditional, the array is only used for `push` / `forEach` / `for-of`, and cleanup iterates that collection. **`doesReleaseCallMatchUsage`** accepts paired release verbs on collection members when keys match (including **`unobserve`** only when the target matches the original observe target). Cleanup-path analysis also recognizes nested **`forEach`** callbacks that disconnect the retained collection.
> 
> Regression and fuzz corpus cases cover the Cloudscape-style pattern and guardrails: still flags conditional retention, wrong collection, conditional/short-circuit cleanup, collection mutation after push, and **`unobserve(otherTarget)`** mismatches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49bf6119799d58803cac2ca9159ccd1024551649. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->