### PR TITLE
fix(effect-needs-cleanup): prove callback-ref replacement

### DIFF
--- a/.changeset/shaggy-hoops-peel.md
+++ b/.changeset/shaggy-hoops-peel.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Avoid `effect-needs-cleanup` false positives for callback refs that release listeners from the previous node before replacing their ownership.

--- a/packages/fuzz/corpus/regressions/effect-needs-cleanup--callback-ref-bare-property.tsx
+++ b/packages/fuzz/corpus/regressions/effect-needs-cleanup--callback-ref-bare-property.tsx
@@ -1,0 +1,15 @@
+import { useCallback, useRef } from "react";
+
+export const useViewport = ({ onWheel }) => {
+  const viewportNodeRef = useRef<HTMLElement | null>(null);
+  const attachViewportListeners = useCallback(
+    (node: HTMLElement | null) => {
+      const previous = viewportNodeRef.current;
+      if (previous) previous.removeEventListener("wheel", onWheel);
+      viewportNodeRef.current = node;
+      if (node) node.addEventListener("wheel", onWheel, { passive: false });
+    },
+    [onWheel],
+  );
+  return { ref: attachViewportListeners };
+};

--- a/packages/fuzz/corpus/regressions/effect-needs-cleanup--callback-ref-listener-replacement.tsx
+++ b/packages/fuzz/corpus/regressions/effect-needs-cleanup--callback-ref-listener-replacement.tsx
@@ -1,0 +1,25 @@
+// rule: effect-needs-cleanup
+// weakness: callback-ref-listener-replacement
+// source: react-bench write-react-pedropalau-react-bnb-gallery zsbYAgG
+
+import { useCallback, useRef } from "react";
+
+export const useViewport = (onWheel: (event: WheelEvent) => void) => {
+  const viewportNodeRef = useRef<HTMLButtonElement | null>(null);
+  const attachViewportListeners = useCallback(
+    (node: HTMLButtonElement | null) => {
+      const previous = viewportNodeRef.current;
+      if (previous) {
+        previous.removeEventListener("wheel", onWheel);
+      }
+
+      viewportNodeRef.current = node;
+      if (node) {
+        node.addEventListener("wheel", onWheel, { passive: false });
+      }
+    },
+    [onWheel],
+  );
+
+  return { viewportRef: attachViewportListeners };
+};

--- a/packages/fuzz/corpus/regressions/effect-needs-cleanup--callback-ref-node-alias.tsx
+++ b/packages/fuzz/corpus/regressions/effect-needs-cleanup--callback-ref-node-alias.tsx
@@ -1,0 +1,16 @@
+import { useCallback, useRef } from "react";
+
+export const Viewport = ({ onWheel }) => {
+  const viewportNodeRef = useRef<HTMLElement | null>(null);
+  const viewportRef = useCallback(
+    (node: HTMLElement | null) => {
+      const currentNode = node;
+      const previous = viewportNodeRef.current;
+      if (previous) previous.removeEventListener("wheel", onWheel);
+      viewportNodeRef.current = currentNode;
+      if (currentNode) currentNode.addEventListener("wheel", onWheel, { passive: false });
+    },
+    [onWheel],
+  );
+  return <button ref={viewportRef} />;
+};

--- a/packages/fuzz/corpus/regressions/effect-needs-cleanup--callback-ref-nullish-guard.tsx
+++ b/packages/fuzz/corpus/regressions/effect-needs-cleanup--callback-ref-nullish-guard.tsx
@@ -1,0 +1,18 @@
+// rule: effect-needs-cleanup
+// weakness: control-flow
+// source: PR #1347 Bugbot review — a non-null guard proves the previous node exists
+import { useCallback, useRef } from "react";
+
+export const Viewport = ({ onViewportEvent }: { onViewportEvent: EventListener }) => {
+  const viewportNodeRef = useRef<HTMLDivElement | null>(null);
+  const viewportRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      const previous = viewportNodeRef.current;
+      if (previous !== null) previous.removeEventListener("viewportchange", onViewportEvent);
+      viewportNodeRef.current = node;
+      if (node) node.addEventListener("viewportchange", onViewportEvent);
+    },
+    [onViewportEvent],
+  );
+  return <div ref={viewportRef} />;
+};

--- a/packages/fuzz/corpus/regressions/effect-needs-cleanup--callback-ref-unreassigned-let-alias.tsx
+++ b/packages/fuzz/corpus/regressions/effect-needs-cleanup--callback-ref-unreassigned-let-alias.tsx
@@ -1,0 +1,19 @@
+// rule: effect-needs-cleanup
+// weakness: callback-ref-unreassigned-let-alias
+// source: Cursor Bugbot review on React Doctor PR 1347
+
+import { useCallback, useRef } from "react";
+
+export const Viewport = ({ onWheel }: { onWheel: (event: WheelEvent) => void }) => {
+  const viewportNodeRef = useRef<HTMLButtonElement | null>(null);
+  const viewportRef = useCallback(
+    (node: HTMLButtonElement | null) => {
+      let previous = viewportNodeRef.current;
+      if (previous) previous.removeEventListener("wheel", onWheel);
+      viewportNodeRef.current = node;
+      if (node) node.addEventListener("wheel", onWheel, { passive: false });
+    },
+    [onWheel],
+  );
+  return <button ref={viewportRef} />;
+};

--- a/packages/fuzz/corpus/true-positives/effect-needs-cleanup--callback-ref-alias-ownership.tsx
+++ b/packages/fuzz/corpus/true-positives/effect-needs-cleanup--callback-ref-alias-ownership.tsx
@@ -1,0 +1,18 @@
+// rule: effect-needs-cleanup
+// weakness: identity-provenance
+// source: PR #1347 Bugbot review — assigning the node to a value alias does not retain ownership
+import { useCallback, useRef } from "react";
+
+export const Viewport = ({ onWheel }: { onWheel: EventListener }) => {
+  const viewportNodeRef = useRef<HTMLButtonElement | null>(null);
+  const viewportRef = useCallback(
+    (node: HTMLButtonElement | null) => {
+      let previous = viewportNodeRef.current;
+      if (previous) previous.removeEventListener("wheel", onWheel);
+      previous = node;
+      if (node) node.addEventListener("wheel", onWheel);
+    },
+    [onWheel],
+  );
+  return <button ref={viewportRef} />;
+};

--- a/packages/fuzz/corpus/true-positives/effect-needs-cleanup--callback-ref-logical-ownership.tsx
+++ b/packages/fuzz/corpus/true-positives/effect-needs-cleanup--callback-ref-logical-ownership.tsx
@@ -1,0 +1,18 @@
+// rule: effect-needs-cleanup
+// weakness: control-flow
+// source: PR #1347 Bugbot review — logical assignment does not transfer ownership on every call
+import { useCallback, useRef } from "react";
+
+export const Viewport = ({ onWheel }: { onWheel: EventListener }) => {
+  const viewportNodeRef = useRef<HTMLButtonElement | null>(null);
+  const viewportRef = useCallback(
+    (node: HTMLButtonElement | null) => {
+      const previous = viewportNodeRef.current;
+      if (previous) previous.removeEventListener("wheel", onWheel);
+      viewportNodeRef.current ||= node;
+      if (node) node.addEventListener("wheel", onWheel);
+    },
+    [onWheel],
+  );
+  return <button ref={viewportRef} />;
+};

--- a/packages/fuzz/corpus/true-positives/effect-needs-cleanup--callback-ref-null-unmount.tsx
+++ b/packages/fuzz/corpus/true-positives/effect-needs-cleanup--callback-ref-null-unmount.tsx
@@ -1,0 +1,17 @@
+import { useCallback, useRef } from "react";
+
+export const Viewport = ({ onWheel }) => {
+  const viewportNodeRef = useRef<HTMLElement | null>(null);
+  const viewportRef = useCallback(
+    (node: HTMLElement | null) => {
+      if (node) {
+        const previous = viewportNodeRef.current;
+        if (previous) previous.removeEventListener("wheel", onWheel);
+        viewportNodeRef.current = node;
+        node.addEventListener("wheel", onWheel, { passive: false });
+      }
+    },
+    [onWheel],
+  );
+  return <button ref={viewportRef} />;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
@@ -7250,6 +7250,25 @@ export const Viewport = ({ onWheel }) => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("accepts an unreassigned let alias for the previous callback-ref node", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useCallback, useRef } from "react";
+export const Viewport = ({ onWheel }) => {
+  const viewportNodeRef = useRef(null);
+  const viewportRef = useCallback((node) => {
+    let previous = viewportNodeRef.current;
+    if (previous) previous.removeEventListener("wheel", onWheel);
+    viewportNodeRef.current = node;
+    if (node) node.addEventListener("wheel", onWheel, { passive: false });
+  }, [onWheel]);
+  return <button ref={viewportRef} />;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("accepts listener replacement exposed as a hook ref property", () => {
     const result = runRule(
       effectNeedsCleanup,
@@ -7389,6 +7408,26 @@ export const Viewport = ({ onWheel }) => {
     let previous = viewportNodeRef.current;
     if (previous) previous.removeEventListener("wheel", onWheel);
     previous = node;
+    if (node) node.addEventListener("wheel", onWheel, { passive: false });
+  }, [onWheel]);
+  return <button ref={viewportRef} />;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("rejects a reassigned let alias for the previous callback-ref node", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useCallback, useRef } from "react";
+export const Viewport = ({ onWheel }) => {
+  const viewportNodeRef = useRef(null);
+  const viewportRef = useCallback((node) => {
+    let previous = viewportNodeRef.current;
+    previous = node;
+    if (previous) previous.removeEventListener("wheel", onWheel);
+    viewportNodeRef.current = node;
     if (node) node.addEventListener("wheel", onWheel, { passive: false });
   }, [onWheel]);
   return <button ref={viewportRef} />;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
@@ -7226,4 +7226,116 @@ export const Component = ({ load }) => {
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toHaveLength(1);
   });
+
+  it("accepts listener replacement owned by a JSX callback ref", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useCallback, useRef } from "react";
+export const Viewport = ({ onWheel }) => {
+  const viewportNodeRef = useRef(null);
+  const viewportRef = useCallback((node) => {
+    const previous = viewportNodeRef.current;
+    if (previous) {
+      previous.removeEventListener("wheel", onWheel);
+    }
+    viewportNodeRef.current = node;
+    if (node) {
+      node.addEventListener("wheel", onWheel, { passive: false });
+    }
+  }, [onWheel]);
+  return <button ref={viewportRef} />;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("accepts listener replacement exposed as a hook ref property", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useCallback, useRef } from "react";
+export const useViewport = ({ onWheel }) => {
+  const viewportNodeRef = useRef(null);
+  const attachViewportListeners = useCallback((node) => {
+    const previous = viewportNodeRef.current;
+    if (previous) previous.removeEventListener("wheel", onWheel);
+    viewportNodeRef.current = node;
+    if (node) node.addEventListener("wheel", onWheel, { passive: false });
+  }, [onWheel]);
+  return { viewportRef: attachViewportListeners };
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it.each([
+    {
+      name: "a different event",
+      release: 'previous.removeEventListener("scroll", onWheel);',
+    },
+    {
+      name: "a different handler",
+      release: 'previous.removeEventListener("wheel", onScroll);',
+    },
+  ])("rejects callback-ref replacement with $name", ({ release }) => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useCallback, useRef } from "react";
+export const Viewport = ({ onWheel, onScroll }) => {
+  const viewportNodeRef = useRef(null);
+  const viewportRef = useCallback((node) => {
+    const previous = viewportNodeRef.current;
+    if (previous) {
+      ${release}
+    }
+    viewportNodeRef.current = node;
+    if (node) {
+      node.addEventListener("wheel", onWheel, { passive: false });
+    }
+  }, [onWheel, onScroll]);
+  return <button ref={viewportRef} />;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("rejects replacement logic that is not used as a JSX callback ref", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useCallback, useRef } from "react";
+export const Viewport = ({ onWheel }) => {
+  const viewportNodeRef = useRef(null);
+  const attachViewport = useCallback((node) => {
+    const previous = viewportNodeRef.current;
+    if (previous) previous.removeEventListener("wheel", onWheel);
+    viewportNodeRef.current = node;
+    node.addEventListener("wheel", onWheel, { passive: false });
+  }, [onWheel]);
+  return <button onClick={() => attachViewport(document.body)} />;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("rejects callback-ref replacement that overwrites ownership before release", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useCallback, useRef } from "react";
+export const Viewport = ({ onWheel }) => {
+  const viewportNodeRef = useRef(null);
+  const viewportRef = useCallback((node) => {
+    viewportNodeRef.current = node;
+    const current = viewportNodeRef.current;
+    if (current) current.removeEventListener("wheel", onWheel);
+    if (node) node.addEventListener("wheel", onWheel, { passive: false });
+  }, [onWheel]);
+  return <button ref={viewportRef} />;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
@@ -7333,6 +7333,25 @@ export const useViewport = ({ onWheel }) => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("accepts listener replacement exposed as a bare hook ref property", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useCallback, useRef } from "react";
+export const useViewport = ({ onWheel }) => {
+  const viewportNodeRef = useRef(null);
+  const attachViewportListeners = useCallback((node) => {
+    const previous = viewportNodeRef.current;
+    if (previous) previous.removeEventListener("wheel", onWheel);
+    viewportNodeRef.current = node;
+    if (node) node.addEventListener("wheel", onWheel, { passive: false });
+  }, [onWheel]);
+  return { ref: attachViewportListeners };
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("rejects listener replacement exposed by a non-hook function", () => {
     const result = runRule(
       effectNeedsCleanup,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
@@ -7269,6 +7269,25 @@ export const useViewport = ({ onWheel }) => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("rejects listener replacement exposed by a non-hook function", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useCallback, useRef } from "react";
+export const userViewport = ({ onWheel }) => {
+  const viewportNodeRef = useRef(null);
+  const attachViewportListeners = useCallback((node) => {
+    const previous = viewportNodeRef.current;
+    if (previous) previous.removeEventListener("wheel", onWheel);
+    viewportNodeRef.current = node;
+    if (node) node.addEventListener("wheel", onWheel, { passive: false });
+  }, [onWheel]);
+  return { viewportRef: attachViewportListeners };
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it.each([
     {
       name: "a different event",
@@ -7332,6 +7351,27 @@ export const Viewport = ({ onWheel }) => {
     if (current) current.removeEventListener("wheel", onWheel);
     if (node) node.addEventListener("wheel", onWheel, { passive: false });
   }, [onWheel]);
+  return <button ref={viewportRef} />;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("rejects callback-ref replacement that conditionally skips release", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useCallback, useRef } from "react";
+export const Viewport = ({ onWheel, shouldRelease }) => {
+  const viewportNodeRef = useRef(null);
+  const viewportRef = useCallback((node) => {
+    const previous = viewportNodeRef.current;
+    if (shouldRelease && previous) {
+      previous.removeEventListener("wheel", onWheel);
+    }
+    viewportNodeRef.current = node;
+    if (node) node.addEventListener("wheel", onWheel, { passive: false });
+  }, [onWheel, shouldRelease]);
   return <button ref={viewportRef} />;
 };`,
     );

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
@@ -7416,4 +7416,26 @@ export const Viewport = ({ onWheel }) => {
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toHaveLength(1);
   });
+
+  it.each([
+    { name: "loose null", guard: "previous != null" },
+    { name: "strict null", guard: "previous !== null" },
+  ])("accepts callback-ref replacement guarded by $name", ({ guard }) => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useCallback, useRef } from "react";
+export const Viewport = ({ onWheel }) => {
+  const viewportNodeRef = useRef(null);
+  const viewportRef = useCallback((node) => {
+    const previous = viewportNodeRef.current;
+    if (${guard}) previous.removeEventListener("wheel", onWheel);
+    viewportNodeRef.current = node;
+    if (node) node.addEventListener("wheel", onWheel, { passive: false });
+  }, [onWheel]);
+  return <button ref={viewportRef} />;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
@@ -859,6 +859,31 @@ export const useWindowPan = () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("rejects a callback ref returned from a non-hook function", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useCallback, useRef } from "react";
+const userPhotoZoom = () => {
+  const detachRef = useRef(null);
+  const setViewportNode = useCallback((node) => {
+    detachRef.current?.();
+    detachRef.current = null;
+    if (!node) return;
+    const handleWheel = () => undefined;
+    node.addEventListener("wheel", handleWheel);
+    detachRef.current = () => node.removeEventListener("wheel", handleWheel);
+  }, []);
+  return { setViewportNode };
+};
+export const Gallery = () => {
+  const zoom = userPhotoZoom();
+  return <button ref={zoom.setViewportNode} />;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it.each([
     {
       name: "cleanup effect calls a different ref",
@@ -7391,6 +7416,27 @@ export const Viewport = ({ onWheel, shouldRelease }) => {
     viewportNodeRef.current = node;
     if (node) node.addEventListener("wheel", onWheel, { passive: false });
   }, [onWheel, shouldRelease]);
+  return <button ref={viewportRef} />;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("rejects callback-ref replacement that skips release on null unmount", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useCallback, useRef } from "react";
+export const Viewport = ({ onWheel }) => {
+  const viewportNodeRef = useRef(null);
+  const viewportRef = useCallback((node) => {
+    if (node) {
+      const previous = viewportNodeRef.current;
+      if (previous) previous.removeEventListener("wheel", onWheel);
+      viewportNodeRef.current = node;
+      node.addEventListener("wheel", onWheel, { passive: false });
+    }
+  }, [onWheel]);
   return <button ref={viewportRef} />;
 };`,
     );

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
@@ -7378,4 +7378,42 @@ export const Viewport = ({ onWheel, shouldRelease }) => {
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toHaveLength(1);
   });
+
+  it("rejects callback-ref ownership assigned only to a value alias", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useCallback, useRef } from "react";
+export const Viewport = ({ onWheel }) => {
+  const viewportNodeRef = useRef(null);
+  const viewportRef = useCallback((node) => {
+    let previous = viewportNodeRef.current;
+    if (previous) previous.removeEventListener("wheel", onWheel);
+    previous = node;
+    if (node) node.addEventListener("wheel", onWheel, { passive: false });
+  }, [onWheel]);
+  return <button ref={viewportRef} />;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("rejects callback-ref ownership through a logical assignment", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useCallback, useRef } from "react";
+export const Viewport = ({ onWheel }) => {
+  const viewportNodeRef = useRef(null);
+  const viewportRef = useCallback((node) => {
+    const previous = viewportNodeRef.current;
+    if (previous) previous.removeEventListener("wheel", onWheel);
+    viewportNodeRef.current ||= node;
+    if (node) node.addEventListener("wheel", onWheel, { passive: false });
+  }, [onWheel]);
+  return <button ref={viewportRef} />;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
@@ -7294,6 +7294,26 @@ export const Viewport = ({ onWheel }) => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("accepts an unreassigned alias for the callback-ref node", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useCallback, useRef } from "react";
+export const Viewport = ({ onWheel }) => {
+  const viewportNodeRef = useRef(null);
+  const viewportRef = useCallback((node) => {
+    const currentNode = node;
+    const previous = viewportNodeRef.current;
+    if (previous) previous.removeEventListener("wheel", onWheel);
+    viewportNodeRef.current = currentNode;
+    if (currentNode) currentNode.addEventListener("wheel", onWheel, { passive: false });
+  }, [onWheel]);
+  return <button ref={viewportRef} />;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("accepts listener replacement exposed as a hook ref property", () => {
     const result = runRule(
       effectNeedsCleanup,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -2483,15 +2483,12 @@ const isReactRefListenerReplacementRelease = (
     return false;
   }
   const registrationReceiver = stripParenExpression(registrationCallee.object);
-  const registrationReceiverSymbol = isNodeOfType(registrationReceiver, "Identifier")
-    ? context.scopes.symbolFor(registrationReceiver)
-    : null;
   const registrationReceiverKey = resolveExpressionKey(registrationReceiver, context);
+  const nodeParameterKey = resolveExpressionKey(usageFunction.params?.[0], context);
   const releaseReceiverKey = resolveExpressionKey(releaseCallee.object, context);
   if (
-    registrationReceiverSymbol?.kind !== "parameter" ||
-    findEnclosingFunction(registrationReceiverSymbol.bindingIdentifier) !== usageFunction ||
     registrationReceiverKey === null ||
+    registrationReceiverKey !== nodeParameterKey ||
     releaseReceiverKey === null ||
     usage.eventKey === null ||
     usage.eventKey !== resolveExpressionKey(releaseCall.arguments?.[0], context) ||

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -1266,19 +1266,18 @@ const doesTestRequireLiveExpressionKey = (
   );
 };
 
-const findDirectHandleGuardForRelease = (
+const findLiveExpressionGuardForRelease = (
   releaseCall: EsTreeNode,
   owner: EsTreeNode,
-  usage: SubscribeLikeUsage,
+  expressionKey: string,
   context: RuleContext,
 ): EsTreeNodeOfType<"IfStatement"> | null => {
-  if (usage.handleKey === null) return null;
   let ancestor = releaseCall.parent;
   while (ancestor && ancestor !== owner) {
     if (isNodeOfType(ancestor, "IfStatement")) {
       if (
         ancestor.alternate !== null ||
-        !doesTestRequireLiveExpressionKey(ancestor.test, usage.handleKey, context) ||
+        !doesTestRequireLiveExpressionKey(ancestor.test, expressionKey, context) ||
         !doMatchingNodesCoverEveryPathAfterUsage(ancestor.consequent, [releaseCall], context)
       ) {
         return null;
@@ -1289,6 +1288,16 @@ const findDirectHandleGuardForRelease = (
   }
   return null;
 };
+
+const findDirectHandleGuardForRelease = (
+  releaseCall: EsTreeNode,
+  owner: EsTreeNode,
+  usage: SubscribeLikeUsage,
+  context: RuleContext,
+): EsTreeNodeOfType<"IfStatement"> | null =>
+  usage.handleKey === null
+    ? null
+    : findLiveExpressionGuardForRelease(releaseCall, owner, usage.handleKey, context);
 
 const hasRerunReleaseBeforeUsage = (
   callback: EsTreeNode,
@@ -2422,29 +2431,6 @@ const isFunctionUsedAsReactRef = (functionNode: EsTreeNode, context: RuleContext
   });
 };
 
-const findRefPresenceGuardForRelease = (
-  releaseCall: EsTreeNode,
-  owner: EsTreeNode,
-  refCurrentKey: string,
-  context: RuleContext,
-): EsTreeNodeOfType<"IfStatement"> | null => {
-  let ancestor = releaseCall.parent;
-  while (ancestor && ancestor !== owner) {
-    if (isNodeOfType(ancestor, "IfStatement")) {
-      if (
-        ancestor.alternate !== null ||
-        !doesTestRequireLiveExpressionKey(ancestor.test, refCurrentKey, context) ||
-        !doMatchingNodesCoverEveryPathAfterUsage(ancestor.consequent, [releaseCall], context)
-      ) {
-        return null;
-      }
-      return ancestor;
-    }
-    ancestor = ancestor.parent;
-  }
-  return null;
-};
-
 const isReactRefListenerReplacementRelease = (
   releaseCall: EsTreeNodeOfType<"CallExpression">,
   usage: SubscribeLikeUsage,
@@ -2528,7 +2514,7 @@ const isReactRefListenerReplacementRelease = (
     }
   });
   const releaseAnchor =
-    findRefPresenceGuardForRelease(releaseCall, usageFunction, releaseReceiverKey, context) ??
+    findLiveExpressionGuardForRelease(releaseCall, usageFunction, releaseReceiverKey, context) ??
     releaseCall;
   const safeOwnershipAssignments = matchingOwnershipAssignments.filter((assignment) =>
     doMatchingNodesCoverEveryPathBeforeUsage(assignment, [releaseAnchor], usageFunction, context),

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -2338,7 +2338,7 @@ const isRetainedAbortControllerRefRelease = (
     !usageFunction ||
     !isFunctionLike(usageFunction) ||
     !isReturnedEffectCleanupFunction(releaseFunction) ||
-    !hasReactRefCurrentOrigin(releaseReceiver, context.scopes)
+    !resolveReactRefCurrentOriginSymbol(releaseReceiver, context.scopes)
   ) {
     return false;
   }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -2389,7 +2389,12 @@ const isRetainedAbortControllerRefRelease = (
   );
 };
 
-const isFunctionUsedAsReactRef = (functionNode: EsTreeNode, context: RuleContext): boolean => {
+const isJsxRefAttribute = (node: EsTreeNode | null | undefined): boolean =>
+  isNodeOfType(node, "JSXAttribute") &&
+  isNodeOfType(node.name, "JSXIdentifier") &&
+  node.name.name === "ref";
+
+const isFunctionForwardedToReactRef = (functionNode: EsTreeNode, context: RuleContext): boolean => {
   const bindingIdentifier = getFunctionBindingIdentifier(functionNode);
   if (!bindingIdentifier) return false;
   const symbol = context.scopes.symbolFor(bindingIdentifier);
@@ -2397,22 +2402,31 @@ const isFunctionUsedAsReactRef = (functionNode: EsTreeNode, context: RuleContext
   return symbol.references.some((reference) => {
     const referenceRoot = findTransparentExpressionRoot(reference.identifier);
     const expressionContainer = referenceRoot.parent;
-    const attribute = expressionContainer?.parent;
-    if (
+    return Boolean(
       isNodeOfType(expressionContainer, "JSXExpressionContainer") &&
       expressionContainer.expression === referenceRoot &&
-      isNodeOfType(attribute, "JSXAttribute") &&
-      isNodeOfType(attribute.name, "JSXIdentifier") &&
-      attribute.name.name === "ref"
-    ) {
-      return true;
-    }
+      isJsxRefAttribute(expressionContainer.parent),
+    );
+  });
+};
+
+const isFunctionReturnedFromReactHook = (
+  functionNode: EsTreeNode,
+  context: RuleContext,
+  requireRefPropertyName: boolean,
+): boolean => {
+  const bindingIdentifier = getFunctionBindingIdentifier(functionNode);
+  if (!bindingIdentifier) return false;
+  const symbol = context.scopes.symbolFor(bindingIdentifier);
+  if (!symbol) return false;
+  return symbol.references.some((reference) => {
+    const referenceRoot = findTransparentExpressionRoot(reference.identifier);
     const property = referenceRoot.parent;
     if (
       !isNodeOfType(property, "Property") ||
       property.value !== referenceRoot ||
       !isNodeOfType(property.parent, "ObjectExpression") ||
-      !getStaticPropertyKeyName(property)?.endsWith("Ref")
+      (requireRefPropertyName && !getStaticPropertyKeyName(property)?.endsWith("Ref"))
     ) {
       return false;
     }
@@ -2430,6 +2444,10 @@ const isFunctionUsedAsReactRef = (functionNode: EsTreeNode, context: RuleContext
     );
   });
 };
+
+const isFunctionUsedAsReactRef = (functionNode: EsTreeNode, context: RuleContext): boolean =>
+  isFunctionForwardedToReactRef(functionNode, context) ||
+  isFunctionReturnedFromReactHook(functionNode, context, true);
 
 const isReactRefListenerReplacementRelease = (
   releaseCall: EsTreeNodeOfType<"CallExpression">,
@@ -2518,11 +2536,14 @@ const isReactRefListenerReplacementRelease = (
   const safeOwnershipAssignments = matchingOwnershipAssignments.filter((assignment) =>
     doMatchingNodesCoverEveryPathBeforeUsage(assignment, [releaseAnchor], usageFunction, context),
   );
-  return doMatchingNodesCoverEveryPathBeforeUsage(
-    usage.node,
-    safeOwnershipAssignments,
-    usageFunction,
-    context,
+  return (
+    doMatchingNodesCoverEveryPathFromFunctionEntry(usageFunction, [releaseAnchor], context) &&
+    doMatchingNodesCoverEveryPathBeforeUsage(
+      usage.node,
+      safeOwnershipAssignments,
+      usageFunction,
+      context,
+    )
   );
 };
 
@@ -2792,27 +2813,6 @@ const isPotentiallyReachableFunction = (
   );
 };
 
-const isJsxRefAttribute = (node: EsTreeNode | null | undefined): boolean =>
-  isNodeOfType(node, "JSXAttribute") &&
-  isNodeOfType(node.name, "JSXIdentifier") &&
-  node.name.name === "ref";
-
-const isFunctionForwardedToReactRef = (functionNode: EsTreeNode, context: RuleContext): boolean => {
-  const bindingIdentifier = getFunctionBindingIdentifier(functionNode);
-  if (!bindingIdentifier) return false;
-  const symbol = context.scopes.symbolFor(bindingIdentifier);
-  if (!symbol) return false;
-  return symbol.references.some((reference) => {
-    const referenceRoot = findTransparentExpressionRoot(reference.identifier);
-    const expressionContainer = referenceRoot.parent;
-    return Boolean(
-      isNodeOfType(expressionContainer, "JSXExpressionContainer") &&
-      expressionContainer.expression === referenceRoot &&
-      isJsxRefAttribute(expressionContainer.parent),
-    );
-  });
-};
-
 const findRetainedDisposerStorages = (
   disposerFunction: EsTreeNode,
   usage: SubscribeLikeUsage,
@@ -3005,34 +3005,7 @@ const hasCallbackRefReplacementInvocation = (
     const nodeParameter = storage.retainedFunction.params?.[0];
     const nodeParameterKey = resolveExpressionKey(nodeParameter, context);
     if (!nodeParameterKey || usage.receiverKey !== nodeParameterKey) return false;
-    const bindingIdentifier = getFunctionBindingIdentifier(storage.retainedFunction);
-    const symbol = bindingIdentifier ? context.scopes.symbolFor(bindingIdentifier) : null;
-    const isReturnedFromHook = Boolean(
-      symbol?.references.some((reference) => {
-        const referenceRoot = findTransparentExpressionRoot(reference.identifier);
-        const property = referenceRoot.parent;
-        if (
-          !isNodeOfType(property, "Property") ||
-          property.value !== referenceRoot ||
-          !isNodeOfType(property.parent, "ObjectExpression")
-        ) {
-          return false;
-        }
-        const returnedObject = findTransparentExpressionRoot(property.parent);
-        const returnStatement = returnedObject.parent;
-        if (
-          !isNodeOfType(returnStatement, "ReturnStatement") ||
-          returnStatement.argument !== returnedObject
-        ) {
-          return false;
-        }
-        const hookFunction = findEnclosingFunction(returnStatement);
-        return Boolean(
-          hookFunction && getFunctionBindingIdentifier(hookFunction)?.name.startsWith("use"),
-        );
-      }),
-    );
-    if (!isReturnedFromHook) return false;
+    if (!isFunctionReturnedFromReactHook(storage.retainedFunction, context, false)) return false;
     const usageStart = getRangeStart(usage.node);
     if (usageStart === null) return false;
     let hasNullExit = false;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -2505,7 +2505,6 @@ const isReactRefListenerReplacementRelease = (
       child.operator === "=" &&
       resolveReactRefSymbol(stripParenExpression(child.left), context.scopes)?.id ===
         releaseRefSymbol.id &&
-      resolveExpressionKey(child.left, context) === releaseReceiverKey &&
       resolveExpressionKey(child.right, context) === registrationReceiverKey &&
       releaseStart !== null &&
       (getRangeStart(child) ?? -1) > releaseStart

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -27,6 +27,7 @@ import { getStaticPropertyKeyName } from "../../utils/get-static-property-key-na
 import { isEventHandlerAttribute } from "../../utils/is-event-handler-attribute.js";
 import { isAstDescendant } from "../../utils/is-ast-descendant.js";
 import { isHookCall } from "../../utils/is-hook-call.js";
+import { isReactHookName } from "../../utils/is-react-hook-name.js";
 import { isReactApiCall } from "../../utils/is-react-api-call.js";
 import { readStaticBoolean } from "../../utils/read-static-boolean.js";
 import { hasReactRefCurrentOrigin, resolveReactRefSymbol } from "../../utils/react-ref-origin.js";
@@ -2408,9 +2409,32 @@ const isFunctionUsedAsReactRef = (functionNode: EsTreeNode, context: RuleContext
     }
     const ownerFunction = findEnclosingFunction(returnStatement);
     return Boolean(
-      ownerFunction && getFunctionBindingIdentifier(ownerFunction)?.name.startsWith("use"),
+      ownerFunction && isReactHookName(getFunctionBindingIdentifier(ownerFunction)?.name ?? ""),
     );
   });
+};
+
+const findRefPresenceGuardForRelease = (
+  releaseCall: EsTreeNode,
+  owner: EsTreeNode,
+  refCurrentKey: string,
+  context: RuleContext,
+): EsTreeNodeOfType<"IfStatement"> | null => {
+  let ancestor = releaseCall.parent;
+  while (ancestor && ancestor !== owner) {
+    if (isNodeOfType(ancestor, "IfStatement")) {
+      if (
+        ancestor.alternate !== null ||
+        resolveExpressionKey(ancestor.test, context) !== refCurrentKey ||
+        !doMatchingNodesCoverEveryPathAfterUsage(ancestor.consequent, [releaseCall], context)
+      ) {
+        return null;
+      }
+      return ancestor;
+    }
+    ancestor = ancestor.parent;
+  }
+  return null;
 };
 
 const isReactRefListenerReplacementRelease = (
@@ -2489,9 +2513,15 @@ const isReactRefListenerReplacementRelease = (
       matchingOwnershipAssignments.push(child);
     }
   });
+  const releaseAnchor =
+    findRefPresenceGuardForRelease(releaseCall, usageFunction, releaseReceiverKey, context) ??
+    releaseCall;
+  const safeOwnershipAssignments = matchingOwnershipAssignments.filter((assignment) =>
+    doMatchingNodesCoverEveryPathBeforeUsage(assignment, [releaseAnchor], usageFunction, context),
+  );
   return doMatchingNodesCoverEveryPathBeforeUsage(
     usage.node,
-    matchingOwnershipAssignments,
+    safeOwnershipAssignments,
     usageFunction,
     context,
   );

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -2422,11 +2422,14 @@ const isFunctionReturnedFromReactHook = (
   return symbol.references.some((reference) => {
     const referenceRoot = findTransparentExpressionRoot(reference.identifier);
     const property = referenceRoot.parent;
+    const propertyName = isNodeOfType(property, "Property")
+      ? getStaticPropertyKeyName(property)
+      : null;
     if (
       !isNodeOfType(property, "Property") ||
       property.value !== referenceRoot ||
       !isNodeOfType(property.parent, "ObjectExpression") ||
-      (requireRefPropertyName && !getStaticPropertyKeyName(property)?.endsWith("Ref"))
+      (requireRefPropertyName && propertyName !== "ref" && !propertyName?.endsWith("Ref"))
     ) {
       return false;
     }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -2371,6 +2371,132 @@ const isRetainedAbortControllerRefRelease = (
   );
 };
 
+const isFunctionUsedAsReactRef = (functionNode: EsTreeNode, context: RuleContext): boolean => {
+  const bindingIdentifier = getFunctionBindingIdentifier(functionNode);
+  if (!bindingIdentifier) return false;
+  const symbol = context.scopes.symbolFor(bindingIdentifier);
+  if (!symbol) return false;
+  return symbol.references.some((reference) => {
+    const referenceRoot = findTransparentExpressionRoot(reference.identifier);
+    const expressionContainer = referenceRoot.parent;
+    const attribute = expressionContainer?.parent;
+    if (
+      isNodeOfType(expressionContainer, "JSXExpressionContainer") &&
+      expressionContainer.expression === referenceRoot &&
+      isNodeOfType(attribute, "JSXAttribute") &&
+      isNodeOfType(attribute.name, "JSXIdentifier") &&
+      attribute.name.name === "ref"
+    ) {
+      return true;
+    }
+    const property = referenceRoot.parent;
+    if (
+      !isNodeOfType(property, "Property") ||
+      property.value !== referenceRoot ||
+      !isNodeOfType(property.parent, "ObjectExpression") ||
+      !getStaticPropertyKeyName(property)?.endsWith("Ref")
+    ) {
+      return false;
+    }
+    const returnedObject = findTransparentExpressionRoot(property.parent);
+    const returnStatement = returnedObject.parent;
+    if (
+      !isNodeOfType(returnStatement, "ReturnStatement") ||
+      returnStatement.argument !== returnedObject
+    ) {
+      return false;
+    }
+    const ownerFunction = findEnclosingFunction(returnStatement);
+    return Boolean(
+      ownerFunction && getFunctionBindingIdentifier(ownerFunction)?.name.startsWith("use"),
+    );
+  });
+};
+
+const isReactRefListenerReplacementRelease = (
+  releaseCall: EsTreeNodeOfType<"CallExpression">,
+  usage: SubscribeLikeUsage,
+  context: RuleContext,
+): boolean => {
+  if (!isNodeOfType(usage.node, "CallExpression")) return false;
+  const usageFunction = findEnclosingFunction(usage.node);
+  if (
+    !usageFunction ||
+    !isFunctionLike(usageFunction) ||
+    usageFunction !== findEnclosingFunction(releaseCall) ||
+    !isFunctionUsedAsReactRef(usageFunction, context)
+  ) {
+    return false;
+  }
+  const registrationCallee = stripParenExpression(usage.node.callee);
+  const releaseCallee = stripParenExpression(releaseCall.callee);
+  if (
+    !isNodeOfType(registrationCallee, "MemberExpression") ||
+    registrationCallee.computed ||
+    !isNodeOfType(registrationCallee.property, "Identifier") ||
+    registrationCallee.property.name !== "addEventListener" ||
+    !isNodeOfType(releaseCallee, "MemberExpression") ||
+    releaseCallee.computed ||
+    !isNodeOfType(releaseCallee.property, "Identifier") ||
+    releaseCallee.property.name !== "removeEventListener" ||
+    !hasReactRefCurrentOrigin(releaseCallee.object, context.scopes)
+  ) {
+    return false;
+  }
+  const registrationReceiver = stripParenExpression(registrationCallee.object);
+  const registrationReceiverSymbol = isNodeOfType(registrationReceiver, "Identifier")
+    ? context.scopes.symbolFor(registrationReceiver)
+    : null;
+  const registrationReceiverKey = resolveExpressionKey(registrationReceiver, context);
+  const releaseReceiverKey = resolveExpressionKey(releaseCallee.object, context);
+  if (
+    registrationReceiverSymbol?.kind !== "parameter" ||
+    findEnclosingFunction(registrationReceiverSymbol.bindingIdentifier) !== usageFunction ||
+    registrationReceiverKey === null ||
+    releaseReceiverKey === null ||
+    usage.eventKey === null ||
+    usage.eventKey !== resolveExpressionKey(releaseCall.arguments?.[0], context) ||
+    usage.handlerKey === null ||
+    usage.handlerKey !== resolveExpressionKey(releaseCall.arguments?.[1], context)
+  ) {
+    return false;
+  }
+  const registrationCapture = resolveEventListenerCapture(usage.node.arguments?.[2], {
+    allowIndeterminateEntries: true,
+  });
+  const releaseCapture = resolveEventListenerCapture(releaseCall.arguments?.[2], {
+    allowIndeterminateEntries: true,
+  });
+  if (
+    registrationCapture === null ||
+    releaseCapture === null ||
+    registrationCapture !== releaseCapture
+  ) {
+    return false;
+  }
+  const releaseStart = getRangeStart(releaseCall);
+  const matchingOwnershipAssignments: EsTreeNode[] = [];
+  const usageFunctionBody = usageFunction.body;
+  walkAst(usageFunctionBody, (child: EsTreeNode) => {
+    if (child !== usageFunctionBody && isFunctionLike(child)) return false;
+    if (
+      isNodeOfType(child, "AssignmentExpression") &&
+      resolveExpressionKey(child.left, context) === releaseReceiverKey &&
+      resolveExpressionKey(child.right, context) === registrationReceiverKey &&
+      releaseStart !== null &&
+      (getRangeStart(child) ?? -1) > releaseStart
+    ) {
+      matchingOwnershipAssignments.push(child);
+    }
+  });
+  return doMatchingNodesCoverEveryPathBeforeUsage(
+    usage.node,
+    matchingOwnershipAssignments,
+    usageFunction,
+    context,
+  );
+};
+
 const doesReleaseCallMatchUsage = (
   node: EsTreeNode,
   usage: SubscribeLikeUsage,
@@ -2426,6 +2552,8 @@ const doesReleaseCallMatchUsage = (
     return false;
   }
   const releaseReceiverKey = resolveExpressionKey(callee.object, context);
+
+  if (isReactRefListenerReplacementRelease(callNode, usage, context)) return true;
 
   if (usage.kind === "socket") {
     return (

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -30,7 +30,10 @@ import { isHookCall } from "../../utils/is-hook-call.js";
 import { isReactHookName } from "../../utils/is-react-hook-name.js";
 import { isReactApiCall } from "../../utils/is-react-api-call.js";
 import { readStaticBoolean } from "../../utils/read-static-boolean.js";
-import { hasReactRefCurrentOrigin, resolveReactRefSymbol } from "../../utils/react-ref-origin.js";
+import {
+  resolveReactRefCurrentOriginSymbol,
+  resolveReactRefSymbol,
+} from "../../utils/react-ref-origin.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import { walkAst } from "../../utils/walk-ast.js";
 import { walkInsideStatementBlocks } from "../../utils/walk-inside-statement-blocks.js";
@@ -2454,6 +2457,9 @@ const isReactRefListenerReplacementRelease = (
   }
   const registrationCallee = stripParenExpression(usage.node.callee);
   const releaseCallee = stripParenExpression(releaseCall.callee);
+  const releaseRefSymbol = isNodeOfType(releaseCallee, "MemberExpression")
+    ? resolveReactRefCurrentOriginSymbol(releaseCallee.object, context.scopes)
+    : null;
   if (
     !isNodeOfType(registrationCallee, "MemberExpression") ||
     registrationCallee.computed ||
@@ -2463,7 +2469,7 @@ const isReactRefListenerReplacementRelease = (
     releaseCallee.computed ||
     !isNodeOfType(releaseCallee.property, "Identifier") ||
     releaseCallee.property.name !== "removeEventListener" ||
-    !hasReactRefCurrentOrigin(releaseCallee.object, context.scopes)
+    !releaseRefSymbol
   ) {
     return false;
   }
@@ -2505,6 +2511,9 @@ const isReactRefListenerReplacementRelease = (
     if (child !== usageFunctionBody && isFunctionLike(child)) return false;
     if (
       isNodeOfType(child, "AssignmentExpression") &&
+      child.operator === "=" &&
+      resolveReactRefSymbol(stripParenExpression(child.left), context.scopes)?.id ===
+        releaseRefSymbol.id &&
       resolveExpressionKey(child.left, context) === releaseReceiverKey &&
       resolveExpressionKey(child.right, context) === registrationReceiverKey &&
       releaseStart !== null &&

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -1236,6 +1236,36 @@ const callbackReturnsCleanupForUsage = (
   return doMatchingNodesCoverEveryPathFromFunctionEntry(callback, matchingCleanupReturns, context);
 };
 
+const doesTestRequireLiveExpressionKey = (
+  test: EsTreeNode,
+  expressionKey: string,
+  context: RuleContext,
+): boolean => {
+  if (resolveExpressionKey(test, context) === expressionKey) return true;
+  const unwrappedTest = stripParenExpression(test);
+  if (
+    !isNodeOfType(unwrappedTest, "BinaryExpression") ||
+    (unwrappedTest.operator !== "!=" && unwrappedTest.operator !== "!==")
+  ) {
+    return false;
+  }
+  const isNullishOperand = (operand: EsTreeNode): boolean => {
+    const unwrappedOperand = stripParenExpression(operand);
+    return (
+      (isNodeOfType(unwrappedOperand, "Literal") && unwrappedOperand.value === null) ||
+      (isNodeOfType(unwrappedOperand, "Identifier") &&
+        unwrappedOperand.name === "undefined" &&
+        context.scopes.isGlobalReference(unwrappedOperand))
+    );
+  };
+  return (
+    (resolveExpressionKey(unwrappedTest.left, context) === expressionKey &&
+      isNullishOperand(unwrappedTest.right)) ||
+    (resolveExpressionKey(unwrappedTest.right, context) === expressionKey &&
+      isNullishOperand(unwrappedTest.left))
+  );
+};
+
 const findDirectHandleGuardForRelease = (
   releaseCall: EsTreeNode,
   owner: EsTreeNode,
@@ -1243,37 +1273,12 @@ const findDirectHandleGuardForRelease = (
   context: RuleContext,
 ): EsTreeNodeOfType<"IfStatement"> | null => {
   if (usage.handleKey === null) return null;
-  const doesTestRequireLiveHandle = (test: EsTreeNode): boolean => {
-    if (resolveExpressionKey(test, context) === usage.handleKey) return true;
-    const unwrappedTest = stripParenExpression(test);
-    if (
-      !isNodeOfType(unwrappedTest, "BinaryExpression") ||
-      (unwrappedTest.operator !== "!=" && unwrappedTest.operator !== "!==")
-    ) {
-      return false;
-    }
-    const isNullishOperand = (operand: EsTreeNode): boolean => {
-      const unwrappedOperand = stripParenExpression(operand);
-      return (
-        (isNodeOfType(unwrappedOperand, "Literal") && unwrappedOperand.value === null) ||
-        (isNodeOfType(unwrappedOperand, "Identifier") &&
-          unwrappedOperand.name === "undefined" &&
-          context.scopes.isGlobalReference(unwrappedOperand))
-      );
-    };
-    return (
-      (resolveExpressionKey(unwrappedTest.left, context) === usage.handleKey &&
-        isNullishOperand(unwrappedTest.right)) ||
-      (resolveExpressionKey(unwrappedTest.right, context) === usage.handleKey &&
-        isNullishOperand(unwrappedTest.left))
-    );
-  };
   let ancestor = releaseCall.parent;
   while (ancestor && ancestor !== owner) {
     if (isNodeOfType(ancestor, "IfStatement")) {
       if (
         ancestor.alternate !== null ||
-        !doesTestRequireLiveHandle(ancestor.test) ||
+        !doesTestRequireLiveExpressionKey(ancestor.test, usage.handleKey, context) ||
         !doMatchingNodesCoverEveryPathAfterUsage(ancestor.consequent, [releaseCall], context)
       ) {
         return null;
@@ -2428,7 +2433,7 @@ const findRefPresenceGuardForRelease = (
     if (isNodeOfType(ancestor, "IfStatement")) {
       if (
         ancestor.alternate !== null ||
-        resolveExpressionKey(ancestor.test, context) !== refCurrentKey ||
+        !doesTestRequireLiveExpressionKey(ancestor.test, refCurrentKey, context) ||
         !doMatchingNodesCoverEveryPathAfterUsage(ancestor.consequent, [releaseCall], context)
       ) {
         return null;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/react-ref-origin.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/react-ref-origin.ts
@@ -1,5 +1,6 @@
 import type { ScopeAnalysis, SymbolDescriptor } from "../semantic/scope-analysis.js";
 import type { EsTreeNode } from "./es-tree-node.js";
+import { getDirectUnreassignedInitializer } from "./get-direct-unreassigned-initializer.js";
 import { getStaticPropertyName } from "./get-static-property-name.js";
 import { isNodeOfType } from "./is-node-of-type.js";
 import { isReactApiCall } from "./is-react-api-call.js";
@@ -40,10 +41,12 @@ export const resolveReactRefCurrentOriginSymbol = (
   const refSymbol = resolveReactRefSymbol(expression, scopes);
   if (refSymbol) return refSymbol;
   if (!isNodeOfType(expression, "Identifier")) return null;
-  const symbol = resolveConstIdentifierAlias(expression, scopes);
-  if (!symbol?.initializer || visitedSymbolIds.has(symbol.id)) return null;
+  const symbol = scopes.symbolFor(expression);
+  if (!symbol || visitedSymbolIds.has(symbol.id)) return null;
+  const initializer = getDirectUnreassignedInitializer(symbol);
+  if (!initializer) return null;
   visitedSymbolIds.add(symbol.id);
-  return resolveReactRefCurrentOriginSymbol(symbol.initializer, scopes, visitedSymbolIds);
+  return resolveReactRefCurrentOriginSymbol(initializer, scopes, visitedSymbolIds);
 };
 
 export const hasReactRefCurrentOrigin = (node: EsTreeNode, scopes: ScopeAnalysis): boolean =>

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/react-ref-origin.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/react-ref-origin.ts
@@ -31,16 +31,20 @@ export const resolveReactRefSymbol = (
     : null;
 };
 
-export const hasReactRefCurrentOrigin = (
+export const resolveReactRefCurrentOriginSymbol = (
   node: EsTreeNode,
   scopes: ScopeAnalysis,
   visitedSymbolIds: Set<number> = new Set(),
-): boolean => {
+): SymbolDescriptor | null => {
   const expression = stripParenExpression(node);
-  if (resolveReactRefSymbol(expression, scopes)) return true;
-  if (!isNodeOfType(expression, "Identifier")) return false;
+  const refSymbol = resolveReactRefSymbol(expression, scopes);
+  if (refSymbol) return refSymbol;
+  if (!isNodeOfType(expression, "Identifier")) return null;
   const symbol = resolveConstIdentifierAlias(expression, scopes);
-  if (!symbol?.initializer || visitedSymbolIds.has(symbol.id)) return false;
+  if (!symbol?.initializer || visitedSymbolIds.has(symbol.id)) return null;
   visitedSymbolIds.add(symbol.id);
-  return hasReactRefCurrentOrigin(symbol.initializer, scopes, visitedSymbolIds);
+  return resolveReactRefCurrentOriginSymbol(symbol.initializer, scopes, visitedSymbolIds);
 };
+
+export const hasReactRefCurrentOrigin = (node: EsTreeNode, scopes: ScopeAnalysis): boolean =>
+  resolveReactRefCurrentOriginSymbol(node, scopes) !== null;


### PR DESCRIPTION
## Summary

- recognize React callback refs that remove the exact listener from their previous ref-owned node before replacing ownership
- support direct JSX ref usage and custom-hook results exposed through a `*Ref` property
- preserve diagnostics for ordinary callbacks, changed events/handlers/capture, and ownership overwritten before release
- add the confirmed BnB false-positive shape to the fuzz regression corpus

## Validation

- `nr format`
- `nr -C packages/oxlint-plugin-react-doctor test` (573 files, 15,185 tests)
- `nr -C packages/oxlint-plugin-react-doctor typecheck`
- `nr -C packages/oxlint-plugin-react-doctor build`
- `nr -C packages/fuzz test` (44 tests)
- six strict 1,000-iteration `effect-needs-cleanup` fuzz runs against BnB jobs `zsbYAgG`, `UdLDmRu`, `7Qo8bmr`, `5CLQhDy`, `ZcizLVA`, and `k93D2oh`
- `nr lint` (existing warnings only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The change expands control-flow and ref-tracking heuristics in a lint rule; incorrect proofs could hide real listener leaks or still flag valid code, though scope is limited to callback-ref patterns with heavy test coverage.
> 
> **Overview**
> **`effect-needs-cleanup`** now treats **callback refs** that detach the same listener from the ref’s previous DOM node, then attach on the new node and update the ref, as sufficient cleanup—fixing false positives on patterns like gallery viewport wheel handlers.
> 
> The rule adds static proof via **`isReactRefListenerReplacementRelease`**: the function must be used as a JSX `ref` or returned from a hook on a `ref`/`*Ref` property; `removeEventListener` must match the paired `addEventListener` (event, handler, capture); release must run before ref ownership is reassigned; and nullish guards on the previous node are accepted. Cases that still warn include non-hook helpers, mismatched event/handler, ownership updated before release, `||=` ownership, reassigned aliases, and null-unmount paths that skip cleanup.
> 
> **`react-ref-origin`** gains **`resolveReactRefCurrentOriginSymbol`** (symbol + unreassigned initializer chains) so `previous`/`let previous = ref.current` aliases resolve correctly. Regression and fuzz corpus fixtures plus extensive rule tests document accepted vs rejected shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e0d62da3e52a8b13f6010eff31d274273ad5e9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->