### PR TITLE
fix(security): ignore camelcase storage key names

### DIFF
--- a/.changeset/fuzzy-lions-smile.md
+++ b/.changeset/fuzzy-lions-smile.md
@@ -1,0 +1,6 @@
+---
+"oxlint-plugin-react-doctor": patch
+"eslint-plugin-react-doctor": patch
+---
+
+Avoid treating human-readable storage key names with camelCase segments as hardcoded secrets.

--- a/packages/fuzz/corpus/regressions/no-secrets-in-client-code--camelcase-storage-key.tsx
+++ b/packages/fuzz/corpus/regressions/no-secrets-in-client-code--camelcase-storage-key.tsx
@@ -1,0 +1,7 @@
+// rule: no-secrets-in-client-code
+// weakness: name-heuristic
+// source: react-bench Mailing settings FP (iQEuDwY, h4ZXyip, ExdYhbq,
+// Jj7Kdd8, 5qY4jqu)
+"use client";
+
+export const LOCAL_API_KEYS_STORAGE_KEY = "mailing.settings.localApiKeys";

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/no-secrets-in-client-code.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/no-secrets-in-client-code.regressions.test.ts
@@ -103,6 +103,15 @@ describe("security/no-secrets-in-client-code — regressions", () => {
     ).toHaveLength(0);
   });
 
+  it("stays silent on camelCase segments in storage key names (mailing shape)", () => {
+    expect(
+      runClient(`const LOCAL_API_KEYS_STORAGE_KEY = "mailing.settings.localApiKeys";`),
+    ).toHaveLength(0);
+    expect(
+      runClient(`const LOCAL_API_KEYS_STORAGE_KEY = "mailing:settings:localApiKeys";`),
+    ).toHaveLength(0);
+  });
+
   // …while high-entropy values mixing case, digits, and separators still flag.
   it("still flags separator-joined values with entropy (not key-name-shaped)", () => {
     expect(

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/no-secrets-in-client-code.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/no-secrets-in-client-code.ts
@@ -39,15 +39,15 @@ const isSelfReferentialSentinelValue = (variableName: string, literalValue: stri
 
 // Storage/config KEY NAMES (`"auth_local_email_blocklist"`,
 // `"od:memory:pending-connector-auth"`, `"__webstudio__$__api_token"`) are
-// human-readable lowercase words joined by separators; real leaked secrets
-// are high-entropy strings mixing case and digits.
+// human-readable words joined by separators; real leaked secrets are
+// high-entropy strings mixing case and digits.
 const isIdentifierLikeKeyNameValue = (literalValue: string): boolean => {
   const wordSegments = literalValue
     .replace(/^[_$\s]+|[_$\s]+$/g, "")
     .split(/[_\-:./$]+/)
     .filter((segment) => segment.length > 0);
   if (wordSegments.length < 2) return false;
-  return wordSegments.every((segment) => /^[a-z]+$/.test(segment));
+  return wordSegments.every((segment) => /^[a-z]+(?:[A-Z][a-z]+)*$/.test(segment));
 };
 
 // Frameworks with a documented public-env convention get advice naming
@@ -139,8 +139,6 @@ export const noSecretsInClientCode = defineRule({
           !isUiConstant &&
           !isPublicUrlValue(literalValue) &&
           !isPlaceholderValueForVariableHeuristic &&
-          !isSelfReferentialSentinelValue(variableName, literalValue) &&
-          !isIdentifierLikeKeyNameValue(literalValue) &&
           !isSelfReferentialSentinelValue(variableName, literalValue) &&
           !isIdentifierLikeKeyNameValue(literalValue) &&
           literalValue.length > SECRET_MIN_LENGTH_CHARS


### PR DESCRIPTION
## Summary

- stop `no-secrets-in-client-code` from treating separator-delimited storage key names with camelCase segments as hardcoded secrets
- keep entropy-bearing credential strings and actual `auth-token-in-web-storage` persistence reportable
- add the exact react-bench Mailing shape to unit and evolving fuzz regression coverage
- remove a duplicated pair of existing predicate guards

## Evidence

Five reward-1 Mailing trials (`iQEuDwY`, `h4ZXyip`, `ExdYhbq`, `Jj7Kdd8`, `5qY4jqu`) reported `LOCAL_API_KEYS_STORAGE_KEY = "mailing.settings.localApiKeys"` or the colon-delimited equivalent as a secret. The string is a storage key name, not credential material.

The task's separate `auth-token-in-web-storage` findings remain true positives because `ApiKey.id` is an accepted credential. The minimized corpus seed does not persist a credential, and the direct FP oracle confirms neither security rule fires on it.

## Validation

- oxlint plugin: 573 test files; 14,992 passed, 188 skipped
- fuzz corpus smoke: 44 passed
- strict fuzz: `FUZZ_RULE=no-secrets-in-client-code FUZZ_STRICT=1 FUZZ_ITERATIONS=1000 FUZZ_SEED=6107 nr fuzz`
- direct FP oracle: no target-rule or auth-token hit on the new seed
- `nr typecheck`
- `nr lint` (existing repository warnings only)
- `nr format:check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit be690f30468a1115e2cd687709c54827b6be5419. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->