### PR TITLE
fix(rules): ignore FileReader loading lifecycles

### DIFF
--- a/.changeset/bright-views-travel.md
+++ b/.changeset/bright-views-travel.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Avoid false positives from `rendering-usetransition-loading` when FileReader success and error callbacks complete the loading state.

--- a/packages/fuzz/corpus/regressions/rendering-usetransition-loading--file-reader-callbacks.tsx
+++ b/packages/fuzz/corpus/regressions/rendering-usetransition-loading--file-reader-callbacks.tsx
@@ -1,0 +1,27 @@
+// rule: rendering-usetransition-loading
+// weakness: library-idiom
+// source: react-bench trials 2ZDe7cD and 8yX8GyT
+
+import { useState } from "react";
+
+export const FileUpload = ({ file }: { file: File }) => {
+  const [isLoading, setIsLoading] = useState(false);
+
+  const readFile = () => {
+    setIsLoading(true);
+    const reader = new FileReader();
+    reader.onload = () => {
+      setIsLoading(false);
+    };
+    reader.onerror = () => {
+      setIsLoading(false);
+    };
+    reader.readAsText(file);
+  };
+
+  return (
+    <button type="button" onClick={readFile}>
+      {isLoading ? "Reading" : "Upload"}
+    </button>
+  );
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/rendering-usetransition-loading.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/rendering-usetransition-loading.regressions.test.ts
@@ -18,7 +18,92 @@ describe("performance/rendering-usetransition-loading — regressions", () => {
       `function C() { const [isLoading, setIsLoading] = useState(false); const toggle = () => { setIsLoading(true); }; return <button onClick={toggle}>{isLoading ? "..." : "go"}</button>; }`,
     );
     expect(result.parseErrors).toEqual([]);
+    expect(
+      result.diagnostics.some((diagnostic) => diagnostic.message.includes('"isLoading"')),
+    ).toBe(true);
+  });
+
+  it("stays silent when FileReader success and error callbacks finish the loading state", () => {
+    const result = runRule(
+      renderingUsetransitionLoading,
+      `function Upload() { const [isLoading, setIsLoading] = useState(false); const handleFile = (file) => { setIsLoading(true); const reader = new FileReader(); reader.onload = () => { setIsLoading(false); setText(reader.result); }; reader.onerror = () => { setIsLoading(false); setError(reader.error); }; reader.readAsText(file); }; return <button onClick={() => handleFile(file)}>{isLoading ? "Reading" : "Upload"}</button>; }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent for the Tracecat FileReader shape with useCallback completion helpers", () => {
+    const result = runRule(
+      renderingUsetransitionLoading,
+      `import { useCallback, useState } from "react"; function Upload() { const [isLoading, setIsLoading] = useState(false); const clearLoadingStatus = useCallback(() => { setIsLoading(false); setFilename(null); }, []); const failRead = useCallback(() => { setError("read failed"); clearLoadingStatus(); }, [clearLoadingStatus]); const handleFile = useCallback((file) => { setIsLoading(true); let reader; try { reader = new FileReader(); } catch { failRead(); return; } reader.onload = () => { setText(reader.result); clearLoadingStatus(); }; reader.onerror = () => { failRead(); }; reader.readAsText(file); }, [clearLoadingStatus, failRead]); return <button onClick={() => handleFile(file)}>{isLoading ? "Reading" : "Upload"}</button>; }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still flags FileReader loading without an error completion", () => {
+    const result = runRule(
+      renderingUsetransitionLoading,
+      `function Upload() { const [isLoading, setIsLoading] = useState(false); const handleFile = (file) => { setIsLoading(true); const reader = new FileReader(); reader.onload = () => setIsLoading(false); reader.readAsText(file); }; return <button onClick={() => handleFile(file)}>{isLoading ? "Reading" : "Upload"}</button>; }`,
+    );
+    expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("still flags FileReader loading without a success completion", () => {
+    const result = runRule(
+      renderingUsetransitionLoading,
+      `function Upload() { const [isLoading, setIsLoading] = useState(false); const handleFile = (file) => { setIsLoading(true); const reader = new FileReader(); reader.onerror = () => setIsLoading(false); reader.readAsText(file); }; return <button onClick={() => handleFile(file)}>{isLoading ? "Reading" : "Upload"}</button>; }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("still flags callback properties on an unrelated local object", () => {
+    const result = runRule(
+      renderingUsetransitionLoading,
+      `function Upload() { const [isLoading, setIsLoading] = useState(false); const handleFile = (file) => { setIsLoading(true); const reader = createReader(); reader.onload = () => setIsLoading(false); reader.onerror = () => setIsLoading(false); reader.readAsText(file); }; return <button onClick={() => handleFile(file)}>{isLoading ? "Reading" : "Upload"}</button>; }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("still flags a locally shadowed FileReader constructor", () => {
+    const result = runRule(
+      renderingUsetransitionLoading,
+      `function Upload({ FileReader }) { const [isLoading, setIsLoading] = useState(false); const handleFile = (file) => { setIsLoading(true); const reader = new FileReader(); reader.onload = () => setIsLoading(false); reader.onerror = () => setIsLoading(false); reader.readAsText(file); }; return <button onClick={() => handleFile(file)}>{isLoading ? "Reading" : "Upload"}</button>; }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("still flags a FileReader callback overwritten before reading starts", () => {
+    const result = runRule(
+      renderingUsetransitionLoading,
+      `function Upload() { const [isLoading, setIsLoading] = useState(false); const handleFile = (file) => { setIsLoading(true); const reader = new FileReader(); reader.onload = () => setIsLoading(false); reader.onerror = () => setIsLoading(false); reader.onerror = reportError; reader.readAsText(file); }; return <button onClick={() => handleFile(file)}>{isLoading ? "Reading" : "Upload"}</button>; }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("still flags FileReader callbacks installed after reading starts", () => {
+    const result = runRule(
+      renderingUsetransitionLoading,
+      `function Upload() { const [isLoading, setIsLoading] = useState(false); const handleFile = (file) => { setIsLoading(true); const reader = new FileReader(); reader.readAsText(file); reader.onload = () => setIsLoading(false); reader.onerror = () => setIsLoading(false); }; return <button onClick={() => handleFile(file)}>{isLoading ? "Reading" : "Upload"}</button>; }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("still flags FileReader callbacks that clear a different loading state", () => {
+    const result = runRule(
+      renderingUsetransitionLoading,
+      `function Upload() { const [isLoading, setIsLoading] = useState(false); const [isPreviewLoading, setIsPreviewLoading] = useState(false); const handleFile = (file) => { setIsLoading(true); const reader = new FileReader(); reader.onload = () => setIsPreviewLoading(false); reader.onerror = () => setIsPreviewLoading(false); reader.readAsText(file); }; return <button onClick={() => handleFile(file)}>{isLoading ? "Reading" : "Upload"}</button>; }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(
+      result.diagnostics.some((diagnostic) => diagnostic.message.includes('"isLoading"')),
+    ).toBe(true);
   });
 
   // FN-critical anchor (algolia/react-instantsearch useAnswers):

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/rendering-usetransition-loading.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/rendering-usetransition-loading.ts
@@ -1,11 +1,18 @@
 import { LOADING_STATE_PATTERN } from "../../constants/react.js";
+import type { SymbolDescriptor } from "../../semantic/scope-analysis.js";
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
+import { getDirectUnreassignedInitializer } from "../../utils/get-direct-unreassigned-initializer.js";
+import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isHookCall } from "../../utils/is-hook-call.js";
+import { isReactApiCall } from "../../utils/is-react-api-call.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { resolveExactLocalFunction } from "../../utils/resolve-exact-local-function.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import { walkAst } from "../../utils/walk-ast.js";
 
 // Walks up to find the function-like that owns this VariableDeclarator
@@ -90,6 +97,254 @@ const RESOURCE_LOAD_EVENT_ATTRIBUTE_PATTERN =
 const JSX_EVENT_HANDLER_ATTRIBUTE_PATTERN = /^on[A-Z]/;
 
 const REDUX_DISPATCH_HOOK_PATTERN = /^use\w*Dispatch$/;
+
+const FILE_READER_READ_METHOD_NAMES: ReadonlySet<string> = new Set([
+  "readAsArrayBuffer",
+  "readAsBinaryString",
+  "readAsDataURL",
+  "readAsText",
+]);
+
+const isGlobalFileReaderConstruction = (
+  expression: EsTreeNode | null,
+  context: RuleContext,
+): boolean => {
+  if (!expression) return false;
+  const unwrappedExpression = stripParenExpression(expression);
+  if (
+    !isNodeOfType(unwrappedExpression, "NewExpression") ||
+    !isNodeOfType(unwrappedExpression.callee, "Identifier")
+  ) {
+    return false;
+  }
+  return (
+    unwrappedExpression.callee.name === "FileReader" &&
+    context.scopes.isGlobalReference(unwrappedExpression.callee)
+  );
+};
+
+const getFileReaderOriginStartBefore = (
+  readerSymbol: SymbolDescriptor,
+  readCall: EsTreeNode,
+  context: RuleContext,
+): number | null => {
+  const readFunction = findEnclosingFunction(readCall);
+  let latestValue: EsTreeNode | null = null;
+  let latestStart: number | null = null;
+  if (
+    readerSymbol.initializer &&
+    findEnclosingFunction(readerSymbol.declarationNode) === readFunction &&
+    readerSymbol.declarationNode.range[0] < readCall.range[0]
+  ) {
+    latestValue = readerSymbol.initializer;
+    latestStart = readerSymbol.declarationNode.range[0];
+  }
+  for (const reference of readerSymbol.references) {
+    if (
+      reference.flag === "read" ||
+      reference.identifier.range[0] >= readCall.range[0] ||
+      (latestStart !== null && reference.identifier.range[0] <= latestStart) ||
+      findEnclosingFunction(reference.identifier) !== readFunction
+    ) {
+      continue;
+    }
+    const assignment = reference.identifier.parent;
+    if (
+      !assignment ||
+      !isNodeOfType(assignment, "AssignmentExpression") ||
+      assignment.operator !== "=" ||
+      assignment.left !== reference.identifier
+    ) {
+      continue;
+    }
+    latestValue = assignment.right;
+    latestStart = reference.identifier.range[0];
+  }
+  return isGlobalFileReaderConstruction(latestValue, context) ? latestStart : null;
+};
+
+const resolveLoadingCompletionFunction = (
+  expression: EsTreeNode,
+  context: RuleContext,
+): EsTreeNode | null => {
+  const directFunction = resolveExactLocalFunction(expression, context.scopes);
+  if (directFunction) return directFunction;
+  const unwrappedExpression = stripParenExpression(expression);
+  if (!isNodeOfType(unwrappedExpression, "Identifier")) return null;
+  const symbol = context.scopes.symbolFor(unwrappedExpression);
+  const initializer = symbol ? getDirectUnreassignedInitializer(symbol) : null;
+  if (
+    !initializer ||
+    !isNodeOfType(initializer, "CallExpression") ||
+    !isReactApiCall(initializer, "useCallback", context.scopes)
+  ) {
+    return null;
+  }
+  const callback = initializer.arguments?.[0];
+  return callback && isFunctionLike(callback) ? callback : null;
+};
+
+const isSetterBooleanCall = (
+  node: EsTreeNode,
+  setterSymbol: SymbolDescriptor,
+  value: boolean,
+  context: RuleContext,
+): boolean => {
+  if (!isNodeOfType(node, "CallExpression")) return false;
+  const callee = stripParenExpression(node.callee);
+  const argument = node.arguments?.[0];
+  const unwrappedArgument = argument ? stripParenExpression(argument) : null;
+  return Boolean(
+    isNodeOfType(callee, "Identifier") &&
+    context.scopes.symbolFor(callee) === setterSymbol &&
+    unwrappedArgument &&
+    isNodeOfType(unwrappedArgument, "Literal") &&
+    unwrappedArgument.value === value,
+  );
+};
+
+const functionClearsLoadingState = (
+  functionNode: EsTreeNode,
+  setterSymbol: SymbolDescriptor,
+  context: RuleContext,
+  visitedFunctions: Set<EsTreeNode>,
+): boolean => {
+  if (visitedFunctions.has(functionNode) || !isFunctionLike(functionNode)) return false;
+  visitedFunctions.add(functionNode);
+  let didClearLoadingState = false;
+  walkAst(functionNode.body, (child) => {
+    if (didClearLoadingState) return false;
+    if (child !== functionNode.body && isFunctionLike(child)) return false;
+    if (!isNodeOfType(child, "CallExpression")) return;
+    if (isSetterBooleanCall(child, setterSymbol, false, context)) {
+      didClearLoadingState = true;
+      return false;
+    }
+    const helperFunction = resolveLoadingCompletionFunction(child.callee, context);
+    if (
+      helperFunction &&
+      functionClearsLoadingState(helperFunction, setterSymbol, context, visitedFunctions)
+    ) {
+      didClearLoadingState = true;
+      return false;
+    }
+  });
+  return didClearLoadingState;
+};
+
+const getLatestFileReaderCallbackBefore = (
+  readCall: EsTreeNode,
+  readerSymbol: SymbolDescriptor,
+  propertyName: "onerror" | "onload",
+  originStart: number,
+  context: RuleContext,
+): EsTreeNode | null => {
+  const readFunction = findEnclosingFunction(readCall);
+  if (!readFunction || !isFunctionLike(readFunction)) return null;
+  let callback: EsTreeNode | null = null;
+  let callbackStart = originStart;
+  walkAst(readFunction.body, (child) => {
+    if (child !== readFunction.body && isFunctionLike(child)) return false;
+    if (
+      !isNodeOfType(child, "AssignmentExpression") ||
+      child.operator !== "=" ||
+      child.range[0] >= readCall.range[0] ||
+      child.range[0] <= callbackStart ||
+      !isNodeOfType(child.left, "MemberExpression") ||
+      getStaticPropertyName(child.left) !== propertyName
+    ) {
+      return;
+    }
+    const receiver = stripParenExpression(child.left.object);
+    if (
+      !isNodeOfType(receiver, "Identifier") ||
+      context.scopes.symbolFor(receiver) !== readerSymbol
+    ) {
+      return;
+    }
+    callback = child.right;
+    callbackStart = child.range[0];
+  });
+  return callback;
+};
+
+const setterStartsLoadingBefore = (
+  readCall: EsTreeNode,
+  setterSymbol: SymbolDescriptor,
+  context: RuleContext,
+): boolean => {
+  const readFunction = findEnclosingFunction(readCall);
+  if (!readFunction || !isFunctionLike(readFunction)) return false;
+  let didStartLoading = false;
+  walkAst(readFunction.body, (child) => {
+    if (didStartLoading) return false;
+    if (child !== readFunction.body && isFunctionLike(child)) return false;
+    if (!isNodeOfType(child, "CallExpression") || child.range[0] >= readCall.range[0]) {
+      return;
+    }
+    if (isSetterBooleanCall(child, setterSymbol, true, context)) {
+      didStartLoading = true;
+      return false;
+    }
+  });
+  return didStartLoading;
+};
+
+const setterTracksFileReader = (
+  functionBody: EsTreeNode,
+  setterSymbol: SymbolDescriptor,
+  context: RuleContext,
+): boolean => {
+  let didFindFileReaderLifecycle = false;
+  walkAst(functionBody, (child) => {
+    if (didFindFileReaderLifecycle) return false;
+    if (
+      !isNodeOfType(child, "CallExpression") ||
+      !isNodeOfType(child.callee, "MemberExpression") ||
+      !FILE_READER_READ_METHOD_NAMES.has(getStaticPropertyName(child.callee) ?? "")
+    ) {
+      return;
+    }
+    const receiver = stripParenExpression(child.callee.object);
+    if (!isNodeOfType(receiver, "Identifier")) return;
+    const readerSymbol = context.scopes.symbolFor(receiver);
+    if (!readerSymbol) return;
+    const originStart = getFileReaderOriginStartBefore(readerSymbol, child, context);
+    if (originStart === null || !setterStartsLoadingBefore(child, setterSymbol, context)) {
+      return;
+    }
+    const loadCallback = getLatestFileReaderCallbackBefore(
+      child,
+      readerSymbol,
+      "onload",
+      originStart,
+      context,
+    );
+    const errorCallback = getLatestFileReaderCallbackBefore(
+      child,
+      readerSymbol,
+      "onerror",
+      originStart,
+      context,
+    );
+    const loadFunction = loadCallback
+      ? resolveLoadingCompletionFunction(loadCallback, context)
+      : null;
+    const errorFunction = errorCallback
+      ? resolveLoadingCompletionFunction(errorCallback, context)
+      : null;
+    if (
+      loadFunction &&
+      errorFunction &&
+      functionClearsLoadingState(loadFunction, setterSymbol, context, new Set()) &&
+      functionClearsLoadingState(errorFunction, setterSymbol, context, new Set())
+    ) {
+      didFindFileReaderLifecycle = true;
+      return false;
+    }
+  });
+  return didFindFileReaderLifecycle;
+};
 
 // One pass over the component body computes every async-work signal the
 // caller ORs together, short-circuiting on the first hit:
@@ -371,6 +626,10 @@ export const renderingUsetransitionLoading = defineRule({
       if (fnBody && hasAsyncLoadingWork(fnBody, setterName)) return;
 
       if (fnBody && setterName) {
+        const setterSymbol = isNodeOfType(secondBinding, "Identifier")
+          ? context.scopes.symbolFor(secondBinding)
+          : null;
+        if (setterSymbol && setterTracksFileReader(fnBody, setterSymbol, context)) return;
         if (setterEscapes(fnBody, setterName, node as EsTreeNode)) return;
         if (setterCalledAlongsideAsyncSignal(fnBody, setterName)) return;
         if (setterCalledInEventListenerHandler(fnBody, setterName)) return;


### PR DESCRIPTION
## Why

Avoids a `rendering-usetransition-loading` false positive for real callback-based FileReader I/O.

A React transition cannot represent completion of an external file read. When the same loading state starts before `readAsText` and is completed by both `onload` and `onerror`, it is application I/O state rather than transition scheduling state.

Before:

```tsx
setIsLoading(true);
const reader = new FileReader();
reader.onload = () => setIsLoading(false);
reader.onerror = () => setIsLoading(false);
reader.readAsText(file);
```

The rule recommended replacing this state with `useTransition`.

After:

The rule stays quiet only when it proves that a real global FileReader owns both completion callbacks before a read starts. Missing, overwritten, late, unrelated, or wrong-setter callbacks remain reportable.

## What changed

- Proves FileReader identity through semantic bindings, including the `let reader; reader = new FileReader()` shape.
- Connects the loading setter to the read starter and both callback-property completions.
- Resolves direct callbacks, same-file helpers, and React `useCallback` helpers used by the Tracecat regressions.
- Adds exact regressions for react-bench trials `2ZDe7cD` and `8yX8GyT` plus adversarial controls.
- Adds a permanent fuzz regression seed and a patch changeset.

## Eval results

| Check | Result |
| --- | --- |
| React-bench evidence | Tracecat `2ZDe7cD`, `8yX8GyT` |
| Current-main reconstruction | Both shapes reported |
| Fixed reconstruction | Both shapes silent |
| Adversarial controls | Missing success/error, wrong setter, shadowed constructor, overwritten/late callbacks still report |
| Strict fuzz | 1,000 iterations, seed `271828`, passed |
| Direct FP oracle | New seed does not fire its named rule |

## Test plan

- `nr test` in `packages/oxlint-plugin-react-doctor` (573 files, 15,188 tests)
- `nr typecheck` in `packages/oxlint-plugin-react-doctor`
- `nr test` in `packages/fuzz`
- `FUZZ_RULE=rendering-usetransition-loading FUZZ_STRICT=1 FUZZ_ITERATIONS=1000 FUZZ_SEED=271828 nr fuzz`
- `nr lint`
- `nr format:check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-rule heuristic only; behavior is narrowed with broad regression and fuzz coverage, with no runtime product impact.
> 
> **Overview**
> Stops **`rendering-usetransition-loading`** from recommending `useTransition` when a loading flag clearly tracks **global `FileReader` I/O** completed via **`onload` and `onerror`** before `readAs*` runs.
> 
> The rule now walks the enclosing function to prove a real **`new FileReader()`** (including reassigned `let reader`), that **`setLoading(true)`** happens before the read, and that both callback properties clear the **same** loading setter— including via local helpers or **`useCallback`** wrappers. Incomplete, shadowed, late, overwritten, or wrong-setter patterns **still report**.
> 
> Adds regression tests, a fuzz corpus seed, and a patch changeset for **`oxlint-plugin-react-doctor`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e71374e6107155783db954cfeb8ed1ef4024918. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->