### PR TITLE
fix(exhaustive-deps): recognize lazy ref registry aliases

### DIFF
--- a/.changeset/shiny-ducks-smile.md
+++ b/.changeset/shiny-ducks-smile.md
@@ -1,0 +1,6 @@
+---
+"oxlint-plugin-react-doctor": patch
+"eslint-plugin-react-doctor": patch
+---
+
+Recognize stable values initialized once through `ref.current ??=` in `exhaustive-deps`.

--- a/packages/fuzz/corpus/regressions/exhaustive-deps--stable-ref-registry.tsx
+++ b/packages/fuzz/corpus/regressions/exhaustive-deps--stable-ref-registry.tsx
@@ -1,0 +1,12 @@
+// rule: exhaustive-deps
+// weakness: identity-provenance
+// source: react-bench Lobe UI eUrzJHL — registry initialized once through ref.current ??=
+import { useCallback, useRef } from "react";
+
+export const Registry = () => {
+  const registryRef = useRef<Set<string> | undefined>(undefined);
+  const registry = (registryRef.current ??= new Set<string>());
+  const register = useCallback((key: string) => registry.add(key), [registry]);
+  const unregister = useCallback((key: string) => registry.delete(key), [registry]);
+  return { register, unregister };
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps-symbol-stability.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps-symbol-stability.ts
@@ -291,7 +291,8 @@ const symbolHasStableRefLazyInitialization = (
   const refSymbol = resolveReactRefSymbol(unwrapExpression(initializer.left), scopes);
   if (!refSymbol) return false;
   return refSymbol.references.every((reference) => {
-    const memberExpression = reference.identifier.parent;
+    const identifierRoot = findTransparentExpressionRoot(reference.identifier);
+    const memberExpression = identifierRoot.parent;
     if (
       !isNodeOfType(memberExpression, "MemberExpression") ||
       unwrapExpression(memberExpression.object) !== reference.identifier ||

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps-symbol-stability.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps-symbol-stability.ts
@@ -277,6 +277,41 @@ const symbolHasStableImportedAlias = (symbol: SymbolDescriptor, scopes: ScopeAna
   return resolvedSymbol !== null && resolvedSymbol !== symbol && resolvedSymbol.kind === "import";
 };
 
+const isAssignmentTarget = (node: EsTreeNode): boolean => {
+  let currentNode = findTransparentExpressionRoot(node);
+  while (currentNode.parent) {
+    const parentNode = currentNode.parent;
+    if (isNodeOfType(parentNode, "AssignmentExpression")) {
+      return parentNode.left === currentNode;
+    }
+    if (isNodeOfType(parentNode, "UpdateExpression")) {
+      return parentNode.argument === currentNode;
+    }
+    if (isNodeOfType(parentNode, "UnaryExpression")) {
+      return parentNode.operator === "delete" && parentNode.argument === currentNode;
+    }
+    if (isNodeOfType(parentNode, "ForInStatement") || isNodeOfType(parentNode, "ForOfStatement")) {
+      return parentNode.left === currentNode;
+    }
+    if (
+      (isNodeOfType(parentNode, "ArrayPattern") &&
+        parentNode.elements.some((element) => element === currentNode)) ||
+      (isNodeOfType(parentNode, "ObjectPattern") &&
+        parentNode.properties.some((property) => property === currentNode)) ||
+      (isNodeOfType(parentNode, "RestElement") && parentNode.argument === currentNode) ||
+      (isNodeOfType(parentNode, "AssignmentPattern") && parentNode.left === currentNode) ||
+      (isNodeOfType(parentNode, "Property") &&
+        parentNode.value === currentNode &&
+        isNodeOfType(parentNode.parent, "ObjectPattern"))
+    ) {
+      currentNode = parentNode;
+      continue;
+    }
+    return false;
+  }
+  return false;
+};
+
 const symbolHasStableRefLazyInitialization = (
   symbol: SymbolDescriptor,
   scopes: ScopeAnalysis,
@@ -305,12 +340,7 @@ const symbolHasStableRefLazyInitialization = (
     if (isNodeOfType(parentNode, "AssignmentExpression") && parentNode.left === referenceRoot) {
       return parentNode === initializer;
     }
-    return !(
-      (isNodeOfType(parentNode, "UpdateExpression") && parentNode.argument === referenceRoot) ||
-      (isNodeOfType(parentNode, "UnaryExpression") &&
-        parentNode.operator === "delete" &&
-        parentNode.argument === referenceRoot)
-    );
+    return !isAssignmentTarget(referenceRoot);
   });
 };
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps-symbol-stability.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps-symbol-stability.ts
@@ -2,10 +2,13 @@ import { closureCaptures } from "../../semantic/closure-captures.js";
 import type { ScopeAnalysis, SymbolDescriptor } from "../../semantic/scope-analysis.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findTransparentExpressionRoot } from "../../utils/find-transparent-expression-root.js";
+import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
 import { getStaticTemplateLiteralValue } from "../../utils/get-static-template-literal-value.js";
 import { isAstDescendant } from "../../utils/is-ast-descendant.js";
 import { isAstNode } from "../../utils/is-ast-node.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { resolveReactRefSymbol } from "../../utils/react-ref-origin.js";
 import { resolveConstIdentifierAlias } from "../../utils/resolve-const-identifier-alias.js";
 import {
   getHookName,
@@ -274,12 +277,49 @@ const symbolHasStableImportedAlias = (symbol: SymbolDescriptor, scopes: ScopeAna
   return resolvedSymbol !== null && resolvedSymbol !== symbol && resolvedSymbol.kind === "import";
 };
 
+const symbolHasStableRefLazyInitialization = (
+  symbol: SymbolDescriptor,
+  scopes: ScopeAnalysis,
+): boolean => {
+  if (symbol.kind !== "const" || symbol.references.some((reference) => reference.flag !== "read")) {
+    return false;
+  }
+  const initializer = symbol.initializer ? unwrapExpression(symbol.initializer) : null;
+  if (!isNodeOfType(initializer, "AssignmentExpression") || initializer.operator !== "??=") {
+    return false;
+  }
+  const refSymbol = resolveReactRefSymbol(unwrapExpression(initializer.left), scopes);
+  if (!refSymbol) return false;
+  return refSymbol.references.every((reference) => {
+    const memberExpression = reference.identifier.parent;
+    if (
+      !isNodeOfType(memberExpression, "MemberExpression") ||
+      unwrapExpression(memberExpression.object) !== reference.identifier ||
+      getStaticPropertyName(memberExpression) !== "current"
+    ) {
+      return false;
+    }
+    const referenceRoot = findTransparentExpressionRoot(memberExpression);
+    const parentNode = referenceRoot.parent;
+    if (isNodeOfType(parentNode, "AssignmentExpression") && parentNode.left === referenceRoot) {
+      return parentNode === initializer;
+    }
+    return !(
+      (isNodeOfType(parentNode, "UpdateExpression") && parentNode.argument === referenceRoot) ||
+      (isNodeOfType(parentNode, "UnaryExpression") &&
+        parentNode.operator === "delete" &&
+        parentNode.argument === referenceRoot)
+    );
+  });
+};
+
 export const symbolHasStableValue = (
   symbol: SymbolDescriptor,
   scopes: ScopeAnalysis,
   visitedSymbolIds: Set<number> = new Set(),
 ): boolean =>
   symbolHasStableHookOrigin(symbol, scopes) ||
+  symbolHasStableRefLazyInitialization(symbol, scopes) ||
   symbolHasStableImportedAlias(symbol, scopes) ||
   symbolHasStableFunctionOrigin(symbol, scopes, visitedSymbolIds) ||
   symbolHasStableMemoizedOrigin(symbol, scopes, visitedSymbolIds);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.regressions.test.ts
@@ -1671,6 +1671,22 @@ describe("react-builtins/exhaustive-deps — regressions", () => {
         "const registryRef = useRef(); const registry = (registryRef.current ??= new Set()); registryRef.current = new Set();",
       ],
       [
+        "later ref replacement through object destructuring",
+        "const registryRef = useRef(); const registry = (registryRef.current ??= new Set()); ({ value: registryRef.current } = source);",
+      ],
+      [
+        "later ref replacement through array destructuring",
+        "const registryRef = useRef(); const registry = (registryRef.current ??= new Set()); [registryRef.current] = source;",
+      ],
+      [
+        "later ref replacement through a for-of target",
+        "const registryRef = useRef(); const registry = (registryRef.current ??= new Set()); for (registryRef.current of sources) {}",
+      ],
+      [
+        "later ref replacement through a destructured for-in target",
+        "const registryRef = useRef(); const registry = (registryRef.current ??= new Set()); for ({ value: registryRef.current } in sources) {}",
+      ],
+      [
         "an escaped ref",
         "const registryRef = useRef(); const registry = (registryRef.current ??= new Set()); expose(registryRef);",
       ],

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.regressions.test.ts
@@ -1623,6 +1623,50 @@ describe("react-builtins/exhaustive-deps — regressions", () => {
       expect(result.diagnostics).toEqual([]);
     });
 
+    it("accepts a registry initialized once through ref.current nullish assignment", () => {
+      const code = `
+        import { useCallback, useRef } from "react";
+        function Accordion() {
+          const registryRef = useRef();
+          const registry = (registryRef.current ??= new Set());
+          const registerItem = useCallback((key) => registry.add(key), [registry]);
+          const unregisterItem = useCallback((key) => registry.delete(key), [registry]);
+          const toggleItem = useCallback((key) => registry.has(key), [registry]);
+          return { registerItem, unregisterItem, toggleItem };
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it.each([
+      ["a fresh local collection", "const registry = new Set();"],
+      [
+        "plain ref assignment",
+        "const registryRef = useRef(); const registry = (registryRef.current = new Set());",
+      ],
+      [
+        "later ref replacement",
+        "const registryRef = useRef(); const registry = (registryRef.current ??= new Set()); registryRef.current = new Set();",
+      ],
+      [
+        "an escaped ref",
+        "const registryRef = useRef(); const registry = (registryRef.current ??= new Set()); expose(registryRef);",
+      ],
+    ])("keeps %s registry dependencies reportable", (_name, declaration) => {
+      const code = `
+        import { useCallback, useRef } from "react";
+        function Accordion() {
+          ${declaration}
+          return useCallback((key) => registry.add(key), [registry]);
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics.length).toBeGreaterThan(0);
+    });
+
     it("keeps reactive identity sources beside a stable member fallback", () => {
       const code = `
         function EditorSurface({ pendingMappingOperationsRef }) {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.regressions.test.ts
@@ -1641,6 +1641,26 @@ describe("react-builtins/exhaustive-deps — regressions", () => {
     });
 
     it.each([
+      [
+        "an asserted ref",
+        "(registryRef as React.MutableRefObject<Set<string> | undefined>).current",
+      ],
+      ["a non-null ref", "(registryRef!).current"],
+    ])("accepts a registry initialized through %s", (_name, refCurrentExpression) => {
+      const code = `
+        import React, { useCallback, useRef } from "react";
+        function Accordion() {
+          const registryRef = useRef<Set<string>>();
+          const registry = (${refCurrentExpression} ??= new Set<string>());
+          return useCallback((key) => registry.add(key), [registry]);
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it.each([
       ["a fresh local collection", "const registry = new Set();"],
       [
         "plain ref assignment",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.ts
@@ -2086,6 +2086,7 @@ If the missing value is recreated every render, move it inside the hook or stabi
           if (
             !rootSymbol ||
             !hasDirectIdentifierDeclarator(rootSymbol) ||
+            symbolHasStableValue(rootSymbol, context.scopes) ||
             !isUnstableInitializer(rootSymbol.initializer)
           ) {
             continue;


### PR DESCRIPTION
## Summary

- recognize immutable aliases initialized once through React `ref.current ??=` as stable dependencies
- require every use of the backing ref to be the same `.current` member and reject later writes, updates, deletion, or ref escape
- reject indirect `.current` replacements through destructuring and `for-in`/`for-of` assignment targets
- cover the exact Lobe UI `eUrzJHL` registry shape plus adversarial negative controls
- add the confirmed false positive to the evolving fuzz regression corpus

## Evidence

React Bench job `write-react-lobehub-lobe-ui-508__eUrzJHL` initializes a registry with:

```tsx
const registryRef = useRef<Set<Key> | undefined>(undefined);
const registry = (registryRef.current ??= new Set<Key>());
```

Three callbacks list `[registry]`. The collection identity is initialized at most once for the mounted component, but current main reports that `registry` is rebuilt every render three times.

PR #1354 is orthogonal: it recognizes render-derived dependencies in the main rule, while this PR proves one-time `ref.current ??=` aliases stable in symbol analysis. The two commits were rebased patch-identically onto `a6e4fb5000b017e67d8bf7b9760477690b8d898e`.

## Validation

- full plugin suite: 581 files, 15,301 passed, 188 skipped
- plugin and fuzz-package typechecks
- fuzz corpus suite: 44 passed, 403 skipped
- strict fuzz against `~/Developer/react-bench-internal/jobs`: `FUZZ_RULE=exhaustive-deps FUZZ_STRICT=1 FUZZ_ITERATIONS=1000 FUZZ_SEED=135202 nr fuzz`
- direct false-positive oracle: the new stable-ref-registry seed has no named-rule hit
- `nr lint`, `nr format:check`, and `git diff --check`
- pre/post `truffler` duplicate-symbol searches

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes heuristic identity analysis in a heavily used lint rule; incorrect stability could hide real stale-closure bugs, though negatives are explicitly tested.
> 
> **Overview**
> **`exhaustive-deps`** no longer reports “rebuilt every render” for **`const` aliases** whose initializer is **`ref.current ??= …`**, when the backing **`useRef`** is only read via **`.current`**, the nullish assignment is the sole write to that cell, and the ref is not reassigned or escaped later.
> 
> Symbol stability gains **`symbolHasStableRefLazyInitialization`** (plus **`isAssignmentTarget`** for destructuring / loop assignment edges). The unstable-dep path now bails out when **`symbolHasStableValue`** already classifies the binding as stable.
> 
> Adds a **fuzz regression** for the Lobe UI registry pattern and **regression tests** for asserted/non-null ref forms and negative cases (plain `=`, later `.current` writes, destructuring, escaped refs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb80a24b238cc2e3f2d4d818bd12e333f06874ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

