### PR TITLE
fix(no-hydration-branch): follow helper provenance

### DIFF
--- a/.changeset/big-wombats-kick.md
+++ b/.changeset/big-wombats-kick.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Detect no-hydration-branch-on-browser-global through local helpers and React useMemo.

--- a/packages/fuzz/corpus/true-positives/no-hydration-branch-on-browser-global--combined-helper-predicates.tsx
+++ b/packages/fuzz/corpus/true-positives/no-hydration-branch-on-browser-global--combined-helper-predicates.tsx
@@ -1,0 +1,14 @@
+// rule: no-hydration-branch-on-browser-global
+// weakness: combined-wrapper-transparency
+// source: PR #1353 Bugbot review — combined local helper predicates
+
+import { useMemo } from "react";
+
+const hasWindow = () => typeof window !== "undefined";
+const hasDocument = () => typeof document !== "undefined";
+
+export const RuntimeBranch = () => {
+  const canUseWindow = useMemo(hasWindow, []);
+  const canUseDocument = useMemo(hasDocument, []);
+  return canUseWindow && canUseDocument ? <Client /> : <Server />;
+};

--- a/packages/fuzz/corpus/true-positives/no-hydration-branch-on-browser-global--helper-usememo.tsx
+++ b/packages/fuzz/corpus/true-positives/no-hydration-branch-on-browser-global--helper-usememo.tsx
@@ -1,0 +1,17 @@
+// rule: no-hydration-branch-on-browser-global
+// weakness: wrapper-transparency
+// source: react-bench trial fT6Z4PE
+
+"use client";
+
+import { useMemo } from "react";
+
+const isPlayableVideo = (mime: string) => {
+  if (typeof document === "undefined") return false;
+  return ["maybe", "probably"].includes(document.createElement("video").canPlayType(mime));
+};
+
+export const Background = ({ mime }: { mime: string }) => {
+  const playable = useMemo(() => mime.startsWith("video/") && isPlayableVideo(mime), [mime]);
+  return playable ? <video /> : <img alt="" />;
+};

--- a/packages/fuzz/corpus/true-positives/no-hydration-branch-on-browser-global--shadowed-helper-returns.tsx
+++ b/packages/fuzz/corpus/true-positives/no-hydration-branch-on-browser-global--shadowed-helper-returns.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+const isClient = () => {
+  if (typeof window !== "undefined") {
+    const available = true;
+    return available;
+  }
+  const available = false;
+  return available;
+};
+
+export const Page = () => (isClient() ? <Client /> : <Server />);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-hydration-branch-on-browser-global.provenance.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-hydration-branch-on-browser-global.provenance.regressions.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noHydrationBranchOnBrowserGlobal } from "./no-hydration-branch-on-browser-global.js";
+
+const run = (code: string) =>
+  runRule(noHydrationBranchOnBrowserGlobal, code, { filename: "app/background.tsx" });
+
+describe("no-hydration-branch-on-browser-global — helper provenance", () => {
+  it("reports the Jumper browser capability helper through useMemo", () => {
+    const result = run(`
+      "use client";
+      import { useMemo, useState } from "react";
+      const VIDEO_MIME_TYPES = new Set(["video/mp4", "video/webm"]);
+      const isVideoCandidateMime = (mime: string) => VIDEO_MIME_TYPES.has(mime);
+      const isPlayableVideo = (mime: string) => {
+        if (typeof document === "undefined") return false;
+        return ["maybe", "probably"].includes(
+          document.createElement("video").canPlayType(mime),
+        );
+      };
+      export const Background = ({ src, mime }) => {
+        const [failed, setFailed] = useState(false);
+        const playable = useMemo(
+          () => isVideoCandidateMime(mime) && isPlayableVideo(mime),
+          [mime],
+        );
+        return Boolean(src) && playable && !failed
+          ? <video src={src} onError={() => setFailed(true)} />
+          : <Image src={src} />;
+      };
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it.each([
+    [
+      "a direct local helper",
+      `
+        "use client";
+        const isBrowser = () => typeof window !== "undefined";
+        export const Page = () => isBrowser() ? <Client /> : <Server />;
+      `,
+    ],
+    [
+      "immutable helper and hook aliases",
+      `
+        "use client";
+        import { useMemo } from "react";
+        const browserCheck = () => typeof document !== "undefined";
+        const browserCheckAlias = browserCheck;
+        const memoize = useMemo;
+        export const Page = () => {
+          const isBrowser = memoize(() => browserCheckAlias(), []);
+          return isBrowser ? <Client /> : <Server />;
+        };
+      `,
+    ],
+    [
+      "a React namespace useMemo callback",
+      `
+        "use client";
+        import * as React from "react";
+        function canUseBrowser() {
+          if (typeof window === "undefined") return false;
+          return supportsRequiredFeature(window);
+        }
+        export const Page = () => {
+          const canRender = React.useMemo(canUseBrowser, []);
+          return canRender ? <Client /> : <Server />;
+        };
+      `,
+    ],
+    [
+      "a rendered attribute branch",
+      `
+        "use client";
+        const isBrowser = () => typeof window !== "undefined";
+        export const Page = () => (
+          <main data-runtime={isBrowser() ? "client" : "server"} />
+        );
+      `,
+    ],
+  ])("reports browser-global provenance through %s", (_name, code) => {
+    const result = run(code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it.each([
+    [
+      "an effect-only helper result",
+      `
+        "use client";
+        import { useEffect } from "react";
+        const isBrowser = () => typeof window !== "undefined";
+        export const Page = () => {
+          useEffect(() => log(isBrowser()), []);
+          return <Server />;
+        };
+      `,
+    ],
+    [
+      "an event-only helper result",
+      `
+        "use client";
+        const isBrowser = () => typeof document !== "undefined";
+        export const Page = () => <button onClick={() => log(isBrowser())}>check</button>;
+      `,
+    ],
+    [
+      "a helper result that does not select output",
+      `
+        "use client";
+        const isBrowser = () => typeof window !== "undefined";
+        export const Page = () => {
+          const browser = isBrowser();
+          log(browser);
+          return <Server />;
+        };
+      `,
+    ],
+    [
+      "structurally equivalent rendered branches",
+      `
+        "use client";
+        const isBrowser = () => typeof window !== "undefined";
+        export const Page = () => isBrowser() ? <Same /> : <Same />;
+      `,
+    ],
+    [
+      "a false-initialized mounted condition gate",
+      `
+        "use client";
+        import { useMemo, useState } from "react";
+        const isBrowser = () => typeof window !== "undefined";
+        export const Page = () => {
+          const [mounted] = useState(false);
+          const browser = useMemo(isBrowser, []);
+          return mounted && browser ? <Client /> : <Server />;
+        };
+      `,
+    ],
+    [
+      "a false-initialized mounted early return",
+      `
+        "use client";
+        import { useMemo, useState } from "react";
+        const isBrowser = () => typeof document !== "undefined";
+        export const Page = () => {
+          const [mounted] = useState(false);
+          const browser = useMemo(isBrowser, []);
+          if (!mounted) return <Server />;
+          return browser ? <Client /> : <Server />;
+        };
+      `,
+    ],
+    [
+      "a browser guard whose return paths are equivalent",
+      `
+        "use client";
+        const isBrowser = () => {
+          if (typeof window === "undefined") return false;
+          return false;
+        };
+        export const Page = () => isBrowser() ? <Client /> : <Server />;
+      `,
+    ],
+    [
+      "a browser check that does not control the helper return",
+      `
+        "use client";
+        const isBrowser = () => {
+          if (typeof document === "undefined") log("server");
+          return false;
+        };
+        export const Page = () => isBrowser() ? <Client /> : <Server />;
+      `,
+    ],
+    [
+      "a statically disabled helper parameter gate",
+      `
+        "use client";
+        const isBrowser = (enabled) => enabled && typeof window !== "undefined";
+        export const Page = () => isBrowser(false) ? <Client /> : <Server />;
+      `,
+    ],
+    [
+      "a shadowed document helper parameter",
+      `
+        "use client";
+        const isBrowser = (document) => typeof document !== "undefined";
+        export const Page = ({ environment }) =>
+          isBrowser(environment) ? <Client /> : <Server />;
+      `,
+    ],
+    [
+      "a userland useMemo lookalike",
+      `
+        "use client";
+        const useMemo = (_callback) => false;
+        export const Page = () => {
+          const browser = useMemo(() => typeof document !== "undefined");
+          return browser ? <Client /> : <Server />;
+        };
+      `,
+    ],
+    [
+      "a lookalike useMemo import",
+      `
+        "use client";
+        import { useMemo } from "not-react";
+        export const Page = () => {
+          const browser = useMemo(() => typeof window !== "undefined", []);
+          return browser ? <Client /> : <Server />;
+        };
+      `,
+    ],
+    [
+      "an imported browser helper",
+      `
+        "use client";
+        import { isBrowser } from "./environment";
+        export const Page = () => isBrowser() ? <Client /> : <Server />;
+      `,
+    ],
+    [
+      "a mutable local result",
+      `
+        "use client";
+        const isBrowser = () => typeof window !== "undefined";
+        export const Page = () => {
+          let browser = isBrowser();
+          browser = false;
+          return browser ? <Client /> : <Server />;
+        };
+      `,
+    ],
+  ])("stays quiet for %s", (_name, code) => {
+    const result = run(code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-hydration-branch-on-browser-global.provenance.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-hydration-branch-on-browser-global.provenance.regressions.test.ts
@@ -96,6 +96,22 @@ describe("no-hydration-branch-on-browser-global — helper provenance", () => {
         };
       `,
     ],
+    [
+      "a client-varying helper beside a direct browser predicate",
+      `
+        "use client";
+        const isClient = () => {
+          if (typeof window === "undefined") {
+            if (false) return true;
+            return false;
+          }
+          if (false) return false;
+          return true;
+        };
+        export const Page = () =>
+          isClient() && typeof document !== "undefined" ? <Client /> : <Server />;
+      `,
+    ],
   ])("reports browser-global provenance through %s", (_name, code) => {
     const result = run(code);
     expect(result.parseErrors).toEqual([]);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-hydration-branch-on-browser-global.provenance.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-hydration-branch-on-browser-global.provenance.regressions.test.ts
@@ -82,6 +82,20 @@ describe("no-hydration-branch-on-browser-global — helper provenance", () => {
         );
       `,
     ],
+    [
+      "combined local helpers and useMemo wrappers",
+      `
+        "use client";
+        import { useMemo } from "react";
+        const hasWindow = () => typeof window !== "undefined";
+        const hasDocument = () => typeof document !== "undefined";
+        export const Page = () => {
+          const canUseWindow = useMemo(hasWindow, []);
+          const canUseDocument = useMemo(hasDocument, []);
+          return canUseWindow && canUseDocument ? <Client /> : <Server />;
+        };
+      `,
+    ],
   ])("reports browser-global provenance through %s", (_name, code) => {
     const result = run(code);
     expect(result.parseErrors).toEqual([]);
@@ -234,6 +248,20 @@ describe("no-hydration-branch-on-browser-global — helper provenance", () => {
           let browser = isBrowser();
           browser = false;
           return browser ? <Client /> : <Server />;
+        };
+      `,
+    ],
+    [
+      "combined complementary helper predicates",
+      `
+        "use client";
+        import { useMemo } from "react";
+        const isBrowser = () => typeof window !== "undefined";
+        const isServer = () => typeof window === "undefined";
+        export const Page = () => {
+          const browser = useMemo(isBrowser, []);
+          const server = useMemo(isServer, []);
+          return browser && server ? <Client /> : <Server />;
         };
       `,
     ],

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-hydration-branch-on-browser-global.provenance.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-hydration-branch-on-browser-global.provenance.regressions.test.ts
@@ -112,6 +112,21 @@ describe("no-hydration-branch-on-browser-global — helper provenance", () => {
           isClient() && typeof document !== "undefined" ? <Client /> : <Server />;
       `,
     ],
+    [
+      "shadowed helper return bindings",
+      `
+        "use client";
+        const isClient = () => {
+          if (typeof window !== "undefined") {
+            const available = true;
+            return available;
+          }
+          const available = false;
+          return available;
+        };
+        export const Page = () => isClient() ? <Client /> : <Server />;
+      `,
+    ],
   ])("reports browser-global provenance through %s", (_name, code) => {
     const result = run(code);
     expect(result.parseErrors).toEqual([]);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-hydration-branch-on-browser-global.provenance.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-hydration-branch-on-browser-global.provenance.regressions.test.ts
@@ -193,6 +193,22 @@ describe("no-hydration-branch-on-browser-global — helper provenance", () => {
       `,
     ],
     [
+      "equivalent multi-return helper branches",
+      `
+        "use client";
+        const canRender = (enabled) => {
+          if (typeof window !== "undefined") {
+            if (enabled) return true;
+            return false;
+          }
+          if (enabled) return true;
+          return false;
+        };
+        export const Page = ({ enabled }) =>
+          canRender(enabled) ? <Client /> : <Server />;
+      `,
+    ],
+    [
       "a statically disabled helper parameter gate",
       `
         "use client";

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-hydration-branch-on-browser-global.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-hydration-branch-on-browser-global.ts
@@ -16,9 +16,11 @@ import { isGatedByFalsyInitialState } from "../../utils/is-gated-by-falsy-initia
 import { isGeneratedImageRenderContext } from "../../utils/is-generated-image-render-context.js";
 import { isEventHandlerAttribute } from "../../utils/is-event-handler-attribute.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { isReactApiCall } from "../../utils/is-react-api-call.js";
 import { classifyReactNativeFileTarget } from "../../utils/is-react-native-file.js";
 import { isTestlikeFilename } from "../../utils/is-testlike-filename.js";
 import { readInitialStateBoolean } from "../../utils/read-initial-state-boolean.js";
+import { resolveExactLocalFunction } from "../../utils/resolve-exact-local-function.js";
 import { statementAlwaysExits } from "../../utils/statement-always-exits.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
@@ -36,6 +38,12 @@ interface BrowserPredicateMatch {
 interface HydrationConditionMatch {
   readonly predicateMatch: BrowserPredicateMatch;
   readonly predicateNode: EsTreeNode;
+}
+
+interface HydrationResolutionState {
+  readonly parameterValuesBySymbolId: Map<number, EsTreeNode>;
+  readonly visitedFunctionNodes: Set<EsTreeNode>;
+  readonly visitedSymbolIds: Set<number>;
 }
 
 const evaluateEquality = (operator: string, left: string, right: string): boolean | null => {
@@ -141,10 +149,20 @@ const readHydrationConditionResult = (
   expression: EsTreeNode,
   context: RuleContext,
   runtime: "client" | "server",
+  state: HydrationResolutionState,
 ): boolean | null => {
   const unwrappedExpression = stripParenExpression(expression);
   const predicateMatch = matchBrowserPredicate(unwrappedExpression, context);
   if (predicateMatch) return predicateMatch[`${runtime}Result`];
+  const expressionSymbol = isNodeOfType(unwrappedExpression, "Identifier")
+    ? context.scopes.symbolFor(unwrappedExpression)
+    : null;
+  const parameterValue = expressionSymbol
+    ? state.parameterValuesBySymbolId.get(expressionSymbol.id)
+    : null;
+  if (parameterValue) {
+    return readHydrationConditionResult(parameterValue, context, runtime, state);
+  }
   const staticResult = readInitialStateBoolean(unwrappedExpression, context.scopes);
   if (staticResult !== null) return staticResult;
   if (
@@ -155,6 +173,7 @@ const readHydrationConditionResult = (
       unwrappedExpression.argument,
       context,
       runtime,
+      state,
     );
     return argumentResult === null ? null : !argumentResult;
   }
@@ -166,23 +185,118 @@ const readHydrationConditionResult = (
   }
   return readLogicalConditionResult(
     unwrappedExpression.operator,
-    readHydrationConditionResult(unwrappedExpression.left, context, runtime),
-    readHydrationConditionResult(unwrappedExpression.right, context, runtime),
+    readHydrationConditionResult(unwrappedExpression.left, context, runtime, state),
+    readHydrationConditionResult(unwrappedExpression.right, context, runtime, state),
   );
 };
 
-const matchHydrationCondition = (
+const areHelperReturnValuesEquivalent = (
+  leftValue: EsTreeNode,
+  rightValue: EsTreeNode,
+  context: RuleContext,
+): boolean => {
+  if (areExpressionsStructurallyEqual(leftValue, rightValue)) return true;
+  const leftBoolean = readInitialStateBoolean(leftValue, context.scopes);
+  const rightBoolean = readInitialStateBoolean(rightValue, context.scopes);
+  return leftBoolean !== null && rightBoolean !== null && leftBoolean === rightBoolean;
+};
+
+const doHelperReturnValuesDiffer = (
+  leftValues: ReadonlyArray<EsTreeNode>,
+  rightValues: ReadonlyArray<EsTreeNode>,
+  context: RuleContext,
+): boolean =>
+  leftValues.some((leftValue) =>
+    rightValues.some(
+      (rightValue) => !areHelperReturnValuesEquivalent(leftValue, rightValue, context),
+    ),
+  );
+
+const matchHydrationConditionInternal = (
   expression: EsTreeNode,
   context: RuleContext,
+  state: HydrationResolutionState,
 ): HydrationConditionMatch | null => {
   const unwrappedExpression = stripParenExpression(expression);
   const predicateMatch = matchBrowserPredicate(unwrappedExpression, context);
   if (predicateMatch) return { predicateMatch, predicateNode: unwrappedExpression };
+  if (isNodeOfType(unwrappedExpression, "Identifier")) {
+    const symbol = context.scopes.symbolFor(unwrappedExpression);
+    const parameterValue = symbol ? state.parameterValuesBySymbolId.get(symbol.id) : null;
+    if (symbol && parameterValue && !state.visitedSymbolIds.has(symbol.id)) {
+      state.visitedSymbolIds.add(symbol.id);
+      const match = matchHydrationConditionInternal(parameterValue, context, state);
+      state.visitedSymbolIds.delete(symbol.id);
+      return match;
+    }
+    if (
+      !symbol ||
+      symbol.kind !== "const" ||
+      !symbol.initializer ||
+      symbol.references.some((reference) => reference.flag !== "read") ||
+      state.visitedSymbolIds.has(symbol.id)
+    ) {
+      return null;
+    }
+    state.visitedSymbolIds.add(symbol.id);
+    const match = matchHydrationConditionInternal(symbol.initializer, context, state);
+    state.visitedSymbolIds.delete(symbol.id);
+    return match;
+  }
+  if (isNodeOfType(unwrappedExpression, "CallExpression")) {
+    const callArguments = unwrappedExpression.arguments ?? [];
+    if (
+      isReactApiCall(unwrappedExpression, "useMemo", context.scopes, {
+        allowGlobalReactNamespace: true,
+        resolveNamedAliases: true,
+      })
+    ) {
+      const callbackArgument = callArguments[0];
+      if (!callbackArgument || isNodeOfType(callbackArgument, "SpreadElement")) return null;
+      const callbackFunction = resolveExactLocalFunction(callbackArgument, context.scopes);
+      return isFunctionLike(callbackFunction) && callbackFunction.params.length === 0
+        ? matchHydrationFunctionResult(callbackFunction, context, state)
+        : null;
+    }
+    const callee = stripParenExpression(unwrappedExpression.callee);
+    if (
+      isNodeOfType(callee, "Identifier") &&
+      callee.name === "Boolean" &&
+      context.scopes.isGlobalReference(callee) &&
+      callArguments.length === 1 &&
+      !isNodeOfType(callArguments[0], "SpreadElement")
+    ) {
+      return matchHydrationConditionInternal(callArguments[0], context, state);
+    }
+    const helperFunction = resolveExactLocalFunction(callee, context.scopes);
+    if (
+      !isFunctionLike(helperFunction) ||
+      helperFunction.async ||
+      (isNodeOfType(helperFunction, "FunctionDeclaration") && helperFunction.generator) ||
+      (isNodeOfType(helperFunction, "FunctionExpression") && helperFunction.generator) ||
+      helperFunction.params.some((parameter) => !isNodeOfType(parameter, "Identifier")) ||
+      callArguments.some((argument) => isNodeOfType(argument, "SpreadElement"))
+    ) {
+      return null;
+    }
+    const parameterValuesBySymbolId = new Map(state.parameterValuesBySymbolId);
+    for (let parameterIndex = 0; parameterIndex < helperFunction.params.length; parameterIndex++) {
+      const parameter = helperFunction.params[parameterIndex];
+      const argument = callArguments[parameterIndex];
+      if (!argument || !isNodeOfType(parameter, "Identifier")) continue;
+      const parameterSymbol = context.scopes.symbolFor(parameter);
+      if (parameterSymbol) parameterValuesBySymbolId.set(parameterSymbol.id, argument);
+    }
+    return matchHydrationFunctionResult(helperFunction, context, {
+      ...state,
+      parameterValuesBySymbolId,
+    });
+  }
   if (
     isNodeOfType(unwrappedExpression, "UnaryExpression") &&
     unwrappedExpression.operator === "!"
   ) {
-    return matchHydrationCondition(unwrappedExpression.argument, context);
+    return matchHydrationConditionInternal(unwrappedExpression.argument, context, state);
   }
   if (
     !isNodeOfType(unwrappedExpression, "LogicalExpression") ||
@@ -190,11 +304,21 @@ const matchHydrationCondition = (
   ) {
     return null;
   }
-  const leftMatch = matchHydrationCondition(unwrappedExpression.left, context);
-  const rightMatch = matchHydrationCondition(unwrappedExpression.right, context);
+  const leftMatch = matchHydrationConditionInternal(unwrappedExpression.left, context, state);
+  const rightMatch = matchHydrationConditionInternal(unwrappedExpression.right, context, state);
   if (leftMatch && rightMatch) {
-    const clientResult = readHydrationConditionResult(unwrappedExpression, context, "client");
-    const serverResult = readHydrationConditionResult(unwrappedExpression, context, "server");
+    const clientResult = readHydrationConditionResult(
+      unwrappedExpression,
+      context,
+      "client",
+      state,
+    );
+    const serverResult = readHydrationConditionResult(
+      unwrappedExpression,
+      context,
+      "server",
+      state,
+    );
     return clientResult !== null && serverResult !== null && clientResult !== serverResult
       ? leftMatch
       : null;
@@ -202,7 +326,7 @@ const matchHydrationCondition = (
   const nestedMatch = leftMatch ?? rightMatch;
   if (!nestedMatch) return null;
   const otherOperand = leftMatch ? unwrappedExpression.right : unwrappedExpression.left;
-  const otherResult = readInitialStateBoolean(otherOperand, context.scopes);
+  const otherResult = readHydrationConditionResult(otherOperand, context, "server", state);
   if (
     (unwrappedExpression.operator === "&&" && otherResult === false) ||
     (unwrappedExpression.operator === "||" && otherResult === true)
@@ -211,6 +335,70 @@ const matchHydrationCondition = (
   }
   return nestedMatch;
 };
+
+const matchHydrationReturningStatement = (
+  statement: EsTreeNode,
+  context: RuleContext,
+  state: HydrationResolutionState,
+): HydrationConditionMatch | null => {
+  if (isNodeOfType(statement, "ReturnStatement")) {
+    return statement.argument
+      ? matchHydrationConditionInternal(statement.argument, context, state)
+      : null;
+  }
+  if (isNodeOfType(statement, "IfStatement")) {
+    const conditionMatch = matchHydrationConditionInternal(statement.test, context, state);
+    const consequentValues = getReturnedValues(statement.consequent);
+    const alternateValues = statement.alternate
+      ? getReturnedValues(statement.alternate)
+      : findFollowingReturnedValues(statement);
+    if (
+      conditionMatch &&
+      consequentValues.length > 0 &&
+      alternateValues.length > 0 &&
+      doHelperReturnValuesDiffer(consequentValues, alternateValues, context)
+    ) {
+      return conditionMatch;
+    }
+    return (
+      matchHydrationReturningStatement(statement.consequent, context, state) ??
+      (statement.alternate
+        ? matchHydrationReturningStatement(statement.alternate, context, state)
+        : null)
+    );
+  }
+  if (!isNodeOfType(statement, "BlockStatement")) return null;
+  for (const childStatement of statement.body) {
+    const match = matchHydrationReturningStatement(childStatement, context, state);
+    if (match) return match;
+    if (statementAlwaysExits(childStatement)) break;
+  }
+  return null;
+};
+
+const matchHydrationFunctionResult = (
+  functionNode: EsTreeNode,
+  context: RuleContext,
+  state: HydrationResolutionState,
+): HydrationConditionMatch | null => {
+  if (!isFunctionLike(functionNode) || state.visitedFunctionNodes.has(functionNode)) return null;
+  state.visitedFunctionNodes.add(functionNode);
+  const match = isNodeOfType(functionNode.body, "BlockStatement")
+    ? matchHydrationReturningStatement(functionNode.body, context, state)
+    : matchHydrationConditionInternal(functionNode.body, context, state);
+  state.visitedFunctionNodes.delete(functionNode);
+  return match;
+};
+
+const matchHydrationCondition = (
+  expression: EsTreeNode,
+  context: RuleContext,
+): HydrationConditionMatch | null =>
+  matchHydrationConditionInternal(expression, context, {
+    parameterValuesBySymbolId: new Map(),
+    visitedFunctionNodes: new Set(),
+    visitedSymbolIds: new Set(),
+  });
 
 const areNodeArraysEquivalent = (
   leftNodes: ReadonlyArray<EsTreeNode>,
@@ -495,23 +683,23 @@ export const noHydrationBranchOnBrowserGlobal = defineRule({
       const { predicateMatch, predicateNode } = conditionMatch;
       if (reportedNodes.has(predicateNode)) return;
       if (rightBranch && areRenderedBranchesEquivalent(leftBranch, rightBranch)) return;
-      const componentOrHookNode = findRenderPhaseComponentOrHook(predicateNode, context.scopes);
+      const componentOrHookNode = findRenderPhaseComponentOrHook(conditionNode, context.scopes);
       if (!componentOrHookNode) return;
       if (!hasClientRenderEvidence(componentOrHookNode, fileHasUseClientDirective)) return;
       if (
         requiresRenderedContext &&
-        !isInRenderedOutput(predicateNode, componentOrHookNode, context.scopes)
+        !isInRenderedOutput(conditionNode, componentOrHookNode, context.scopes)
       )
         return;
       if (!isRenderedValue(leftBranch) && (!rightBranch || !isRenderedValue(rightBranch))) {
-        const attribute = findEnclosingJsxAttribute(predicateNode);
+        const attribute = findEnclosingJsxAttribute(conditionNode);
         if (!attribute || isEventHandlerAttribute(attribute)) return;
       }
-      if (fileIsEmailTemplate || isGatedByFalsyInitialState(predicateNode, context.scopes)) {
+      if (fileIsEmailTemplate || isGatedByFalsyInitialState(conditionNode, context.scopes)) {
         return;
       }
-      if (isAfterClientOnlyEarlyReturn(predicateNode, componentOrHookNode, context.scopes)) return;
-      const openingElement = findEnclosingJsxOpeningElement(predicateNode);
+      if (isAfterClientOnlyEarlyReturn(conditionNode, componentOrHookNode, context.scopes)) return;
+      const openingElement = findEnclosingJsxOpeningElement(conditionNode);
       if (
         hasSuppressHydrationWarningAttribute(openingElement) &&
         !isStructuralRenderedValue(leftBranch) &&

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-hydration-branch-on-browser-global.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-hydration-branch-on-browser-global.ts
@@ -326,12 +326,46 @@ const readHydrationFunctionResult = (
   return result;
 };
 
+const doEquivalentExpressionBindingsMatch = (
+  leftExpression: EsTreeNode,
+  rightExpression: EsTreeNode,
+  scopes: ScopeAnalysis,
+): boolean => {
+  const left = stripParenExpression(leftExpression);
+  const right = stripParenExpression(rightExpression);
+  if (isNodeOfType(left, "Identifier") && isNodeOfType(right, "Identifier")) {
+    const leftSymbol = scopes.symbolFor(left);
+    const rightSymbol = scopes.symbolFor(right);
+    return leftSymbol || rightSymbol ? leftSymbol?.id === rightSymbol?.id : true;
+  }
+  if (isNodeOfType(left, "MemberExpression") && isNodeOfType(right, "MemberExpression")) {
+    return (
+      doEquivalentExpressionBindingsMatch(left.object, right.object, scopes) &&
+      (!left.computed || doEquivalentExpressionBindingsMatch(left.property, right.property, scopes))
+    );
+  }
+  if (isNodeOfType(left, "CallExpression") && isNodeOfType(right, "CallExpression")) {
+    const rightArguments = right.arguments ?? [];
+    return (
+      doEquivalentExpressionBindingsMatch(left.callee, right.callee, scopes) &&
+      (left.arguments ?? []).every((argument, index) => {
+        const rightArgument = rightArguments[index];
+        return Boolean(
+          rightArgument && doEquivalentExpressionBindingsMatch(argument, rightArgument, scopes),
+        );
+      })
+    );
+  }
+  return true;
+};
+
 const areHelperReturnValuesEquivalent = (
   leftValue: EsTreeNode,
   rightValue: EsTreeNode,
   context: RuleContext,
 ): boolean => {
-  if (areExpressionsStructurallyEqual(leftValue, rightValue)) return true;
+  if (areExpressionsStructurallyEqual(leftValue, rightValue))
+    return doEquivalentExpressionBindingsMatch(leftValue, rightValue, context.scopes);
   const leftBoolean = readInitialStateBoolean(leftValue, context.scopes);
   const rightBoolean = readInitialStateBoolean(rightValue, context.scopes);
   return leftBoolean !== null && rightBoolean !== null && leftBoolean === rightBoolean;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-hydration-branch-on-browser-global.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-hydration-branch-on-browser-global.ts
@@ -452,34 +452,13 @@ const matchHydrationConditionInternal = (
   }
   const leftMatch = matchHydrationConditionInternal(unwrappedExpression.left, context, state);
   const rightMatch = matchHydrationConditionInternal(unwrappedExpression.right, context, state);
-  if (leftMatch && rightMatch) {
-    const clientResult = readHydrationConditionResult(
-      unwrappedExpression,
-      context,
-      "client",
-      state,
-    );
-    const serverResult = readHydrationConditionResult(
-      unwrappedExpression,
-      context,
-      "server",
-      state,
-    );
-    return clientResult !== null && serverResult !== null && clientResult === serverResult
-      ? null
-      : leftMatch;
-  }
   const nestedMatch = leftMatch ?? rightMatch;
   if (!nestedMatch) return null;
-  const otherOperand = leftMatch ? unwrappedExpression.right : unwrappedExpression.left;
-  const otherResult = readHydrationConditionResult(otherOperand, context, "server", state);
-  if (
-    (unwrappedExpression.operator === "&&" && otherResult === false) ||
-    (unwrappedExpression.operator === "||" && otherResult === true)
-  ) {
-    return null;
-  }
-  return nestedMatch;
+  const clientResult = readHydrationConditionResult(unwrappedExpression, context, "client", state);
+  const serverResult = readHydrationConditionResult(unwrappedExpression, context, "server", state);
+  return clientResult !== null && serverResult !== null && clientResult === serverResult
+    ? null
+    : nestedMatch;
 };
 
 const matchHydrationReturningStatement = (

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-hydration-branch-on-browser-global.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-hydration-branch-on-browser-global.ts
@@ -341,12 +341,22 @@ const doHelperReturnValuesDiffer = (
   leftValues: ReadonlyArray<EsTreeNode>,
   rightValues: ReadonlyArray<EsTreeNode>,
   context: RuleContext,
-): boolean =>
-  leftValues.some((leftValue) =>
-    rightValues.some(
-      (rightValue) => !areHelperReturnValuesEquivalent(leftValue, rightValue, context),
-    ),
+): boolean => {
+  const everyValueHasEquivalent = (
+    values: ReadonlyArray<EsTreeNode>,
+    candidateValues: ReadonlyArray<EsTreeNode>,
+  ): boolean =>
+    values.every((value) =>
+      candidateValues.some((candidateValue) =>
+        areHelperReturnValuesEquivalent(value, candidateValue, context),
+      ),
+    );
+
+  return (
+    !everyValueHasEquivalent(leftValues, rightValues) ||
+    !everyValueHasEquivalent(rightValues, leftValues)
   );
+};
 
 const matchHydrationConditionInternal = (
   expression: EsTreeNode,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-hydration-branch-on-browser-global.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-hydration-branch-on-browser-global.ts
@@ -46,6 +46,11 @@ interface HydrationResolutionState {
   readonly visitedSymbolIds: Set<number>;
 }
 
+interface HydrationStatementResult {
+  readonly didReturn: boolean;
+  readonly value: boolean | null;
+}
+
 const evaluateEquality = (operator: string, left: string, right: string): boolean | null => {
   if (operator === "===" || operator === "==") return left === right;
   if (operator === "!==" || operator === "!=") return left !== right;
@@ -154,17 +159,86 @@ const readHydrationConditionResult = (
   const unwrappedExpression = stripParenExpression(expression);
   const predicateMatch = matchBrowserPredicate(unwrappedExpression, context);
   if (predicateMatch) return predicateMatch[`${runtime}Result`];
+  const staticResult = readInitialStateBoolean(unwrappedExpression, context.scopes);
+  if (staticResult !== null) return staticResult;
   const expressionSymbol = isNodeOfType(unwrappedExpression, "Identifier")
     ? context.scopes.symbolFor(unwrappedExpression)
     : null;
   const parameterValue = expressionSymbol
     ? state.parameterValuesBySymbolId.get(expressionSymbol.id)
     : null;
-  if (parameterValue) {
-    return readHydrationConditionResult(parameterValue, context, runtime, state);
+  if (expressionSymbol && parameterValue && !state.visitedSymbolIds.has(expressionSymbol.id)) {
+    state.visitedSymbolIds.add(expressionSymbol.id);
+    const result = readHydrationConditionResult(parameterValue, context, runtime, state);
+    state.visitedSymbolIds.delete(expressionSymbol.id);
+    return result;
   }
-  const staticResult = readInitialStateBoolean(unwrappedExpression, context.scopes);
-  if (staticResult !== null) return staticResult;
+  if (
+    expressionSymbol &&
+    expressionSymbol.kind === "const" &&
+    expressionSymbol.initializer &&
+    expressionSymbol.references.every((reference) => reference.flag === "read") &&
+    !state.visitedSymbolIds.has(expressionSymbol.id)
+  ) {
+    state.visitedSymbolIds.add(expressionSymbol.id);
+    const result = readHydrationConditionResult(
+      expressionSymbol.initializer,
+      context,
+      runtime,
+      state,
+    );
+    state.visitedSymbolIds.delete(expressionSymbol.id);
+    return result;
+  }
+  if (isNodeOfType(unwrappedExpression, "CallExpression")) {
+    const callArguments = unwrappedExpression.arguments ?? [];
+    if (
+      isReactApiCall(unwrappedExpression, "useMemo", context.scopes, {
+        allowGlobalReactNamespace: true,
+        resolveNamedAliases: true,
+      })
+    ) {
+      const callbackArgument = callArguments[0];
+      if (!callbackArgument || isNodeOfType(callbackArgument, "SpreadElement")) return null;
+      const callbackFunction = resolveExactLocalFunction(callbackArgument, context.scopes);
+      return isFunctionLike(callbackFunction) && callbackFunction.params.length === 0
+        ? readHydrationFunctionResult(callbackFunction, context, runtime, state)
+        : null;
+    }
+    const callee = stripParenExpression(unwrappedExpression.callee);
+    if (
+      isNodeOfType(callee, "Identifier") &&
+      callee.name === "Boolean" &&
+      context.scopes.isGlobalReference(callee) &&
+      callArguments.length === 1 &&
+      !isNodeOfType(callArguments[0], "SpreadElement")
+    ) {
+      return readHydrationConditionResult(callArguments[0], context, runtime, state);
+    }
+    const helperFunction = resolveExactLocalFunction(callee, context.scopes);
+    if (
+      !isFunctionLike(helperFunction) ||
+      helperFunction.async ||
+      (isNodeOfType(helperFunction, "FunctionDeclaration") && helperFunction.generator) ||
+      (isNodeOfType(helperFunction, "FunctionExpression") && helperFunction.generator) ||
+      helperFunction.params.some((parameter) => !isNodeOfType(parameter, "Identifier")) ||
+      callArguments.some((argument) => isNodeOfType(argument, "SpreadElement"))
+    ) {
+      return null;
+    }
+    const parameterValuesBySymbolId = new Map(state.parameterValuesBySymbolId);
+    for (let parameterIndex = 0; parameterIndex < helperFunction.params.length; parameterIndex++) {
+      const parameter = helperFunction.params[parameterIndex];
+      const argument = callArguments[parameterIndex];
+      if (!argument || !isNodeOfType(parameter, "Identifier")) continue;
+      const parameterSymbol = context.scopes.symbolFor(parameter);
+      if (parameterSymbol) parameterValuesBySymbolId.set(parameterSymbol.id, argument);
+    }
+    return readHydrationFunctionResult(helperFunction, context, runtime, {
+      ...state,
+      parameterValuesBySymbolId,
+    });
+  }
   if (
     isNodeOfType(unwrappedExpression, "UnaryExpression") &&
     unwrappedExpression.operator === "!"
@@ -188,6 +262,68 @@ const readHydrationConditionResult = (
     readHydrationConditionResult(unwrappedExpression.left, context, runtime, state),
     readHydrationConditionResult(unwrappedExpression.right, context, runtime, state),
   );
+};
+
+const readHydrationStatementResult = (
+  statement: EsTreeNode,
+  context: RuleContext,
+  runtime: "client" | "server",
+  state: HydrationResolutionState,
+): HydrationStatementResult => {
+  if (isNodeOfType(statement, "ReturnStatement")) {
+    return {
+      didReturn: true,
+      value: statement.argument
+        ? readHydrationConditionResult(statement.argument, context, runtime, state)
+        : null,
+    };
+  }
+  if (isNodeOfType(statement, "BlockStatement")) {
+    for (const childStatement of statement.body) {
+      const result = readHydrationStatementResult(childStatement, context, runtime, state);
+      if (result.didReturn) return result;
+      if (statementAlwaysExits(childStatement)) break;
+    }
+    return { didReturn: false, value: null };
+  }
+  if (!isNodeOfType(statement, "IfStatement")) return { didReturn: false, value: null };
+  const conditionResult = readHydrationConditionResult(statement.test, context, runtime, state);
+  if (conditionResult !== null) {
+    const selectedBranch = conditionResult ? statement.consequent : statement.alternate;
+    return selectedBranch
+      ? readHydrationStatementResult(selectedBranch, context, runtime, state)
+      : { didReturn: false, value: null };
+  }
+  const consequentResult = readHydrationStatementResult(
+    statement.consequent,
+    context,
+    runtime,
+    state,
+  );
+  const alternateResult = statement.alternate
+    ? readHydrationStatementResult(statement.alternate, context, runtime, state)
+    : { didReturn: false, value: null };
+  return consequentResult.didReturn &&
+    alternateResult.didReturn &&
+    consequentResult.value !== null &&
+    consequentResult.value === alternateResult.value
+    ? consequentResult
+    : { didReturn: consequentResult.didReturn || alternateResult.didReturn, value: null };
+};
+
+const readHydrationFunctionResult = (
+  functionNode: EsTreeNode,
+  context: RuleContext,
+  runtime: "client" | "server",
+  state: HydrationResolutionState,
+): boolean | null => {
+  if (!isFunctionLike(functionNode) || state.visitedFunctionNodes.has(functionNode)) return null;
+  state.visitedFunctionNodes.add(functionNode);
+  const result = isNodeOfType(functionNode.body, "BlockStatement")
+    ? readHydrationStatementResult(functionNode.body, context, runtime, state).value
+    : readHydrationConditionResult(functionNode.body, context, runtime, state);
+  state.visitedFunctionNodes.delete(functionNode);
+  return result;
 };
 
 const areHelperReturnValuesEquivalent = (
@@ -319,9 +455,9 @@ const matchHydrationConditionInternal = (
       "server",
       state,
     );
-    return clientResult !== null && serverResult !== null && clientResult !== serverResult
-      ? leftMatch
-      : null;
+    return clientResult !== null && serverResult !== null && clientResult === serverResult
+      ? null
+      : leftMatch;
   }
   const nestedMatch = leftMatch ?? rightMatch;
   if (!nestedMatch) return null;


### PR DESCRIPTION
## Why

`no-hydration-branch-on-browser-global` missed hydration divergence when a browser-global predicate was hidden behind a local helper and then memoized with React `useMemo`.

Before, the Jumper React Bench case could select `<video>` in the browser and `<Image>` during SSR without a diagnostic:

```tsx
const isPlayableVideo = (mime: string) => {
  if (typeof document === "undefined") return false;
  return document.createElement("video").canPlayType(mime) !== "";
};

const playable = useMemo(
  () => candidate && isPlayableVideo(mime),
  [candidate, mime],
);

return playable ? <video /> : <Image />;
```

After this change, the rule follows the immutable local helper and proven React `useMemo` provenance and reports the underlying browser-global predicate. Stable initial output followed by a mounted-state update, or `useSyncExternalStore` for an external browser capability, avoids the hydration mismatch.

React Bench evidence: trial `fT6Z4PE` in `jumperexchange/jumper`.

## What changed

- Follow immutable local constants, exact local helpers, helper parameters, global `Boolean`, and proven React `useMemo` calls.
- Require helper control flow to return observably different values before propagating a browser predicate.
- Compare structurally equal helper returns by binding identity, avoiding shadowed-name false negatives.
- Preserve render-context, mounted-state, early-return, event-handler, effect-only, shadowing, import, mutation, and structurally-equal-branch safeguards at the call site.
- Add focused provenance regressions and three true-positive fuzz corpus seeds.
- Add a patch changeset for `oxlint-plugin-react-doctor`.

## Eval results

| Corpus | Scans | Distinct repos | Target diagnostics | False positives |
| --- | ---: | ---: | ---: | ---: |
| Local RDE OSS sample | 50 | 9 | 0 | 0 |

The sample covered pierre, react-grab, bippy, react-scan, expect, tldraw, excalidraw, twenty, and plane.

## Test plan

- `nr test` in `packages/oxlint-plugin-react-doctor`: 574 files, 15,015 passing tests (188 skipped)
- `nr typecheck`
- `nr lint`
- `nr build`
- `nr smoke:json-report`
- `nr test:corpus`: 44 corpus cases
- `FUZZ_RULE=no-hydration-branch-on-browser-global FUZZ_STRICT=1 FUZZ_ITERATIONS=1000 FUZZ_SEED=1707 nr fuzz`
- Local RDE: 50 scans across 9 distinct repos, then target-rule digest
- `nr format:check`
- `git diff --check`

The repository-wide test run passed the changed plugin and all other packages except the pre-existing CLI regression `untracked-working-tree-scope.test.ts > preserves staged selection and exact staged line ranges`, which also reproduced in an isolated retry and does not touch this rule path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Larger static-analysis surface in one lint rule may shift diagnostics (more true positives, possible new noise); scope is limited to the plugin rule and tests, not runtime auth or data paths.
> 
> **Overview**
> **`no-hydration-branch-on-browser-global`** now follows browser-global checks when they are wrapped in local helpers, immutable `const` aliases, `Boolean()`, or real React **`useMemo`** (including `React.useMemo` and hook aliases), instead of only flagging inline `typeof window` / `typeof document` predicates.
> 
> The rule walks helper bodies and memo callbacks to see whether control flow returns different values on client vs server before attributing a hydration mismatch. Logical combinations are suppressed when client and server evaluate the same; reporting uses the full branch condition for render-context checks. Existing safeguards (effects/events only, mounted gates, imported helpers, fake `useMemo`, equivalent branches, etc.) stay in place.
> 
> Adds provenance regression tests, fuzz true-positive seeds, and a patch changeset for **`oxlint-plugin-react-doctor`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4f38afb8ccf1950fe1f83409fb7267c34f499d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->