### PR TITLE
fix(exhaustive-deps): recognize render-derived dependencies

### DIFF
--- a/.changeset/quiet-lions-thank.md
+++ b/.changeset/quiet-lions-thank.md
@@ -1,0 +1,6 @@
+---
+"oxlint-plugin-react-doctor": patch
+"eslint-plugin-react-doctor": patch
+---
+
+Recognize bounded render-derived equivalents in `exhaustive-deps` dependency lists.

--- a/packages/fuzz/corpus/regressions/exhaustive-deps--conditionally-assigned-derived-local.tsx
+++ b/packages/fuzz/corpus/regressions/exhaustive-deps--conditionally-assigned-derived-local.tsx
@@ -1,0 +1,14 @@
+// rule: exhaustive-deps
+// weakness: derived-local-equivalence
+// source: react-bench Inrupt EzrRGww — valueError is wholly derived from value
+import { useEffect, useState } from "react";
+
+export const Image = ({ value, thingError }: { value?: string; thingError?: Error }) => {
+  let valueError: Error | undefined;
+  if (!value) valueError = new Error("No value found for property.");
+  const [, setError] = useState<Error>();
+  useEffect(() => {
+    setError(thingError ?? valueError);
+  }, [thingError, value]);
+  return null;
+};

--- a/packages/fuzz/corpus/regressions/exhaustive-deps--pure-called-derived-helper.tsx
+++ b/packages/fuzz/corpus/regressions/exhaustive-deps--pure-called-derived-helper.tsx
@@ -1,0 +1,16 @@
+// rule: exhaustive-deps
+// weakness: derived-local-equivalence
+// source: react-bench Sidebar qhkPS3B — helper output is wholly derived from breakPoint
+import { useMemo } from "react";
+
+const BREAK_POINTS = { md: "768px" };
+
+export const Sidebar = ({ breakPoint }: { breakPoint?: string }) => {
+  const getBreakpointValue = () => {
+    if (!breakPoint) return undefined;
+    if (breakPoint === "all") return "screen";
+    if (breakPoint in BREAK_POINTS) return `(max-width: ${BREAK_POINTS.md})`;
+    return `(max-width: ${breakPoint})`;
+  };
+  return useMemo(() => getBreakpointValue(), [breakPoint]);
+};

--- a/packages/fuzz/corpus/targets/exhaustive-deps--mutated-derived-local-initial-state.tsx
+++ b/packages/fuzz/corpus/targets/exhaustive-deps--mutated-derived-local-initial-state.tsx
@@ -1,0 +1,19 @@
+import { useEffect, useState } from "react";
+
+export const Image = ({
+  value,
+  retryError,
+  setError,
+}: {
+  value?: string;
+  retryError: Error;
+  setError: (error: Error | undefined) => void;
+}) => {
+  let valueError: Error | undefined;
+  if (!value) valueError = new Error("No value found for property.");
+  useState((valueError!.cause = retryError));
+  useEffect(() => {
+    setError(valueError);
+  }, [value]);
+  return null;
+};

--- a/packages/fuzz/corpus/targets/exhaustive-deps--nested-derived-local-escape.tsx
+++ b/packages/fuzz/corpus/targets/exhaustive-deps--nested-derived-local-escape.tsx
@@ -1,0 +1,21 @@
+import { useEffect } from "react";
+
+declare const attachRetryError: (error: Error | undefined, retryError: Error) => void;
+
+export const Image = ({
+  value,
+  retryError,
+  setError,
+}: {
+  value?: string;
+  retryError: Error;
+  setError: (error: Error | undefined) => void;
+}) => {
+  let valueError: Error | undefined;
+  if (!value) valueError = new Error("No value found for property.");
+  (() => attachRetryError(valueError, retryError))();
+  useEffect(() => {
+    setError(valueError);
+  }, [value]);
+  return null;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.regressions.test.ts
@@ -2242,6 +2242,24 @@ describe("react-builtins/exhaustive-deps — upstream disable-comment suppressio
       expect(result.diagnostics[0]?.message).toContain("selectedName");
     });
 
+    it("keeps destructured source bindings reportable", () => {
+      const code = `
+        import { useEffect } from "react";
+        function Picker({ enabled, record, consume }) {
+          const { selectedName } = record;
+          let derivedName;
+          if (enabled) derivedName = selectedName;
+          useEffect(() => {
+            consume(derivedName);
+          }, [enabled, record, consume]);
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+      expect(result.diagnostics[0]?.message).toContain("selectedName");
+    });
+
     it("keeps nested mutable-local writes reportable", () => {
       const code = `
         import { useEffect } from "react";

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.regressions.test.ts
@@ -2295,6 +2295,40 @@ describe("react-builtins/exhaustive-deps — upstream disable-comment suppressio
       expect(result.parseErrors).toEqual([]);
       expect(result.diagnostics.length).toBeGreaterThan(0);
     });
+
+    it("keeps nested render-time mutable-local escapes reportable", () => {
+      const code = `
+        import { useEffect } from "react";
+        function Image({ value, retryError, setError }) {
+          let valueError;
+          if (!value) valueError = new Error("No value found for property.");
+          (() => attachRetryError(valueError, retryError))();
+          useEffect(() => {
+            setError(valueError);
+          }, [value]);
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics.length).toBeGreaterThan(0);
+    });
+
+    it("keeps mutable initial-state expressions reportable", () => {
+      const code = `
+        import { useEffect, useState } from "react";
+        function Image({ value, retryError, setError }) {
+          let valueError;
+          if (!value) valueError = new Error("No value found for property.");
+          useState((valueError.retry = retryError));
+          useEffect(() => {
+            setError(valueError);
+          }, [value]);
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics.length).toBeGreaterThan(0);
+    });
   });
 
   it("does not suppress a report on a different line than the disable comment", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.regressions.test.ts
@@ -2225,6 +2225,23 @@ describe("react-builtins/exhaustive-deps — upstream disable-comment suppressio
       expect(result.diagnostics[0]?.message).toContain("retryError");
     });
 
+    it("keeps nested computed-member inputs reportable", () => {
+      const code = `
+        import { useEffect } from "react";
+        function Picker({ enabled, items, index, consume }) {
+          let selectedName;
+          if (enabled) selectedName = items[index].name;
+          useEffect(() => {
+            consume(selectedName);
+          }, [enabled, items, consume]);
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+      expect(result.diagnostics[0]?.message).toContain("selectedName");
+    });
+
     it("keeps nested mutable-local writes reportable", () => {
       const code = `
         import { useEffect } from "react";

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.regressions.test.ts
@@ -2120,6 +2120,148 @@ describe("react-builtins/exhaustive-deps — upstream disable-comment suppressio
     });
   });
 
+  describe("render-derived dependency equivalence", () => {
+    it("accepts a directly called pure helper derived from the listed dependency", () => {
+      const code = `
+        import { useMemo } from "react";
+        const BREAK_POINTS = { md: "768px" };
+        function Sidebar({ breakPoint }) {
+          const getBreakpointValue = () => {
+            if (!breakPoint) return undefined;
+            if (breakPoint === "all") return "screen";
+            if (breakPoint in BREAK_POINTS) {
+              return \`(max-width: \${BREAK_POINTS[breakPoint]})\`;
+            }
+            return \`(max-width: \${breakPoint})\`;
+          };
+          return useMemo(() => getBreakpointValue(), [breakPoint]);
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it("keeps an independently captured helper input reportable", () => {
+      const code = `
+        import { useMemo } from "react";
+        function Sidebar({ breakPoint, unit }) {
+          const getBreakpointValue = () => \`(max-width: \${breakPoint}\${unit})\`;
+          return useMemo(() => getBreakpointValue(), [breakPoint]);
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+      expect(result.diagnostics[0]?.message).toContain("unit");
+    });
+
+    it("keeps a helper passed by identity reportable", () => {
+      const code = `
+        import { useMemo } from "react";
+        function Sidebar({ breakPoint }) {
+          const getBreakpointValue = () => String(breakPoint);
+          return useMemo(() => register(getBreakpointValue), [breakPoint]);
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+      expect(result.diagnostics[0]?.message).toContain("getBreakpointValue");
+    });
+
+    it("keeps a side-effecting helper reportable", () => {
+      const code = `
+        import { useMemo } from "react";
+        function Sidebar({ breakPoint }) {
+          const getBreakpointValue = () => {
+            analytics.track(breakPoint);
+            return String(breakPoint);
+          };
+          return useMemo(() => getBreakpointValue(), [breakPoint]);
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+      expect(result.diagnostics[0]?.message).toContain("getBreakpointValue");
+    });
+
+    it("accepts a conditionally assigned local derived from the listed dependency", () => {
+      const code = `
+        import { useEffect, useState } from "react";
+        function Image({ value, thingError }) {
+          let valueError;
+          if (!value) {
+            valueError = new Error("No value found for property.");
+          }
+          const [, setError] = useState();
+          useEffect(() => {
+            setError(thingError ?? valueError);
+          }, [thingError, value]);
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it("keeps an independent conditional assignment input reportable", () => {
+      const code = `
+        import { useEffect, useState } from "react";
+        function Image({ value, retryError }) {
+          let valueError;
+          if (!value) valueError = new Error("No value found for property.");
+          if (retryError) valueError = retryError;
+          const [, setError] = useState();
+          useEffect(() => {
+            setError(valueError);
+          }, [value]);
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+      expect(result.diagnostics[0]?.message).toContain("retryError");
+    });
+
+    it("keeps nested mutable-local writes reportable", () => {
+      const code = `
+        import { useEffect } from "react";
+        function Image({ value, setError }) {
+          let valueError;
+          const updateError = () => {
+            if (!value) valueError = new Error("No value found for property.");
+          };
+          useEffect(() => {
+            updateError();
+            setError(valueError);
+          }, [value]);
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics.length).toBeGreaterThan(0);
+    });
+
+    it("keeps render-time mutable-local escapes reportable", () => {
+      const code = `
+        import { useEffect } from "react";
+        function Image({ value, retryError, setError }) {
+          let valueError;
+          if (!value) valueError = new Error("No value found for property.");
+          attachRetryError(valueError, retryError);
+          useEffect(() => {
+            setError(valueError);
+          }, [value]);
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics.length).toBeGreaterThan(0);
+    });
+  });
+
   it("does not suppress a report on a different line than the disable comment", () => {
     const code = [
       "function MyComponent({ autoStart, other }) {",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.ts
@@ -9,6 +9,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { findForwardedFreshHookDependencies } from "../../utils/find-forwarded-fresh-hook-dependencies.js";
+import { findTransparentExpressionRoot } from "../../utils/find-transparent-expression-root.js";
 import { getStaticTemplateLiteralValue } from "../../utils/get-static-template-literal-value.js";
 import { isAstNode } from "../../utils/is-ast-node.js";
 import { isReactComponentOrHookName } from "../../utils/is-react-component-or-hook-name.js";
@@ -396,7 +397,10 @@ const collectCaptureDepKeys = (
         keys.add(depKey);
         continue;
       }
-      const identitySourceKeys = resolveReactiveIdentitySourceKeys(symbol, scopes);
+      const identitySourceKeys =
+        resolvePureCalledFunctionSourceKeys(reference, symbol, scopes) ??
+        resolveRenderDerivedMutableSourceKeys(symbol, scopes) ??
+        resolveReactiveIdentitySourceKeys(symbol, scopes);
       if (identitySourceKeys) {
         if (identitySourceKeys.size === 0) stableCapturedNames.add(depKey);
         for (const identitySourceKey of identitySourceKeys) keys.add(identitySourceKey);
@@ -550,6 +554,318 @@ const resolveReactiveIdentitySourceKeys = (
     return null;
   }
   return resolveIdentitySourceKeysFromExpression(symbol.initializer, scopes, new Set([symbol.id]));
+};
+
+const isPureDerivedExpression = (expression: EsTreeNode): boolean => {
+  const candidate = unwrapExpression(expression);
+  if (isNodeOfType(candidate, "Literal") || isNodeOfType(candidate, "Identifier")) return true;
+  if (isNodeOfType(candidate, "MemberExpression")) {
+    return (
+      isPureDerivedExpression(candidate.object) &&
+      (!candidate.computed || isPureDerivedExpression(candidate.property))
+    );
+  }
+  if (isNodeOfType(candidate, "BinaryExpression") || isNodeOfType(candidate, "LogicalExpression")) {
+    return isPureDerivedExpression(candidate.left) && isPureDerivedExpression(candidate.right);
+  }
+  if (isNodeOfType(candidate, "UnaryExpression")) {
+    return candidate.operator !== "delete" && isPureDerivedExpression(candidate.argument);
+  }
+  if (isNodeOfType(candidate, "ConditionalExpression")) {
+    return (
+      isPureDerivedExpression(candidate.test) &&
+      isPureDerivedExpression(candidate.consequent) &&
+      isPureDerivedExpression(candidate.alternate)
+    );
+  }
+  if (isNodeOfType(candidate, "TemplateLiteral")) {
+    return candidate.expressions.every((nestedExpression) =>
+      isPureDerivedExpression(nestedExpression),
+    );
+  }
+  return false;
+};
+
+const isPureDerivedStatement = (statement: EsTreeNode): boolean => {
+  if (isNodeOfType(statement, "BlockStatement")) {
+    return statement.body.every((nestedStatement) => isPureDerivedStatement(nestedStatement));
+  }
+  if (isNodeOfType(statement, "ReturnStatement")) {
+    return !statement.argument || isPureDerivedExpression(statement.argument);
+  }
+  if (isNodeOfType(statement, "IfStatement")) {
+    return (
+      isPureDerivedExpression(statement.test) &&
+      isPureDerivedStatement(statement.consequent) &&
+      (!statement.alternate || isPureDerivedStatement(statement.alternate))
+    );
+  }
+  return false;
+};
+
+const isPureDerivedFunction = (functionNode: EsTreeNode): boolean => {
+  if (
+    !isNodeOfType(functionNode, "FunctionDeclaration") &&
+    !isNodeOfType(functionNode, "FunctionExpression") &&
+    !isNodeOfType(functionNode, "ArrowFunctionExpression")
+  ) {
+    return false;
+  }
+  if (functionNode.async || functionNode.generator) return false;
+  return isNodeOfType(functionNode.body, "BlockStatement")
+    ? isPureDerivedStatement(functionNode.body)
+    : isPureDerivedExpression(functionNode.body);
+};
+
+const resolvePureCalledFunctionSourceKeys = (
+  reference: ReferenceDescriptor,
+  symbol: SymbolDescriptor,
+  scopes: ScopeAnalysis,
+): Set<string> | null => {
+  if (symbol.references.some((symbolReference) => symbolReference.flag !== "read")) return null;
+  const referenceRoot = findTransparentExpressionRoot(reference.identifier);
+  const callExpression = referenceRoot.parent;
+  if (!isNodeOfType(callExpression, "CallExpression") || callExpression.callee !== referenceRoot) {
+    return null;
+  }
+  const functionNode = getFunctionValueNode(symbol);
+  if (!functionNode || !isPureDerivedFunction(functionNode)) return null;
+  const sourceKeys = new Set<string>();
+  for (const capturedReference of closureCaptures(functionNode, scopes)) {
+    const capturedSymbol = capturedReference.resolvedSymbol;
+    if (!capturedSymbol || capturedSymbol.id === symbol.id) continue;
+    if (isOutsideAllFunctions(capturedSymbol) || symbolHasStableValue(capturedSymbol, scopes)) {
+      continue;
+    }
+    const capturedKey = computeDepKey(capturedReference);
+    if (!capturedKey) return null;
+    if (capturedKey === capturedSymbol.name) {
+      const nestedSourceKeys = resolveReactiveIdentitySourceKeys(capturedSymbol, scopes);
+      if (nestedSourceKeys) {
+        for (const nestedSourceKey of nestedSourceKeys) sourceKeys.add(nestedSourceKey);
+        continue;
+      }
+    }
+    sourceKeys.add(capturedKey);
+  }
+  return sourceKeys.size > 0 ? sourceKeys : null;
+};
+
+const mergeDerivedExpressionSourceKeys = (
+  expressions: ReadonlyArray<EsTreeNode>,
+  scopes: ScopeAnalysis,
+  visitedSymbolIds: Set<number>,
+): Set<string> | null => {
+  const sourceKeys = new Set<string>();
+  for (const expression of expressions) {
+    const expressionSourceKeys = resolveDerivedExpressionSourceKeys(
+      expression,
+      scopes,
+      visitedSymbolIds,
+    );
+    if (!expressionSourceKeys) return null;
+    for (const expressionSourceKey of expressionSourceKeys) sourceKeys.add(expressionSourceKey);
+  }
+  return sourceKeys;
+};
+
+const resolveDerivedExpressionSourceKeys = (
+  expression: EsTreeNode,
+  scopes: ScopeAnalysis,
+  visitedSymbolIds: Set<number>,
+): Set<string> | null => {
+  const candidate = unwrapExpression(expression);
+  if (isNodeOfType(candidate, "Literal")) return new Set();
+  if (isNodeOfType(candidate, "Identifier")) {
+    if (scopes.isGlobalReference(candidate)) return new Set();
+    const sourceSymbol = scopes.symbolFor(candidate);
+    if (!sourceSymbol) return null;
+    if (isOutsideAllFunctions(sourceSymbol) || symbolHasStableValue(sourceSymbol, scopes)) {
+      return new Set();
+    }
+    if (
+      sourceSymbol.kind === "const" &&
+      sourceSymbol.initializer &&
+      sourceSymbol.references.every((sourceReference) => sourceReference.flag === "read") &&
+      !visitedSymbolIds.has(sourceSymbol.id)
+    ) {
+      visitedSymbolIds.add(sourceSymbol.id);
+      const sourceKeys = resolveDerivedExpressionSourceKeys(
+        sourceSymbol.initializer,
+        scopes,
+        visitedSymbolIds,
+      );
+      visitedSymbolIds.delete(sourceSymbol.id);
+      if (sourceKeys) return sourceKeys;
+    }
+    return new Set([sourceSymbol.name]);
+  }
+  if (isNodeOfType(candidate, "MemberExpression")) {
+    if (candidate.computed) return null;
+    const sourceKey = stringifyMemberChain(candidate);
+    const rootIdentifier = getMemberRootIdentifier(candidate);
+    const rootSymbol = rootIdentifier ? scopes.symbolFor(rootIdentifier) : null;
+    if (!sourceKey || !rootSymbol) return null;
+    if (isOutsideAllFunctions(rootSymbol) || symbolHasStableValue(rootSymbol, scopes)) {
+      return new Set();
+    }
+    return new Set([sourceKey]);
+  }
+  if (isNodeOfType(candidate, "BinaryExpression") || isNodeOfType(candidate, "LogicalExpression")) {
+    return mergeDerivedExpressionSourceKeys(
+      [candidate.left, candidate.right],
+      scopes,
+      visitedSymbolIds,
+    );
+  }
+  if (isNodeOfType(candidate, "UnaryExpression") && candidate.operator !== "delete") {
+    return resolveDerivedExpressionSourceKeys(candidate.argument, scopes, visitedSymbolIds);
+  }
+  if (isNodeOfType(candidate, "ConditionalExpression")) {
+    return mergeDerivedExpressionSourceKeys(
+      [candidate.test, candidate.consequent, candidate.alternate],
+      scopes,
+      visitedSymbolIds,
+    );
+  }
+  if (isNodeOfType(candidate, "TemplateLiteral")) {
+    return mergeDerivedExpressionSourceKeys(candidate.expressions, scopes, visitedSymbolIds);
+  }
+  if (isNodeOfType(candidate, "NewExpression")) {
+    const callee = unwrapExpression(candidate.callee);
+    if (
+      !isNodeOfType(callee, "Identifier") ||
+      callee.name !== "Error" ||
+      !scopes.isGlobalReference(callee)
+    ) {
+      return null;
+    }
+    const argumentsToAnalyze: EsTreeNode[] = [];
+    for (const argument of candidate.arguments) {
+      if (!isAstNode(argument) || isNodeOfType(argument, "SpreadElement")) return null;
+      argumentsToAnalyze.push(argument);
+    }
+    return mergeDerivedExpressionSourceKeys(argumentsToAnalyze, scopes, visitedSymbolIds);
+  }
+  return null;
+};
+
+const findNearestFunction = (node: EsTreeNode): EsTreeNode | null => {
+  let currentNode = node.parent;
+  while (currentNode) {
+    if (
+      isNodeOfType(currentNode, "FunctionDeclaration") ||
+      isNodeOfType(currentNode, "FunctionExpression") ||
+      isNodeOfType(currentNode, "ArrowFunctionExpression")
+    ) {
+      return currentNode;
+    }
+    currentNode = currentNode.parent ?? null;
+  }
+  return null;
+};
+
+const resolveWriteControlSourceKeys = (
+  assignment: EsTreeNodeOfType<"AssignmentExpression">,
+  boundaryFunction: EsTreeNode,
+  scopes: ScopeAnalysis,
+): Set<string> | null => {
+  const sourceKeys = new Set<string>();
+  let currentNode: EsTreeNode = assignment;
+  while (currentNode.parent && currentNode.parent !== boundaryFunction) {
+    const parentNode: EsTreeNode = currentNode.parent;
+    if (isNodeOfType(parentNode, "IfStatement")) {
+      if (parentNode.test === currentNode) return null;
+      const testSourceKeys = resolveDerivedExpressionSourceKeys(parentNode.test, scopes, new Set());
+      if (!testSourceKeys) return null;
+      for (const testSourceKey of testSourceKeys) sourceKeys.add(testSourceKey);
+    } else if (
+      !isNodeOfType(parentNode, "ExpressionStatement") &&
+      !isNodeOfType(parentNode, "BlockStatement")
+    ) {
+      return null;
+    }
+    currentNode = parentNode;
+  }
+  return currentNode.parent === boundaryFunction ? sourceKeys : null;
+};
+
+const isReadOnlyInitialStateUse = (
+  referenceNode: EsTreeNode,
+  boundaryFunction: EsTreeNode,
+  scopes: ScopeAnalysis,
+): boolean => {
+  let currentNode = referenceNode.parent;
+  while (currentNode && currentNode !== boundaryFunction) {
+    if (isNodeOfType(currentNode, "CallExpression")) {
+      return isReactApiCall(currentNode, "useState", scopes, {
+        allowGlobalReactNamespace: true,
+        allowUnboundBareCalls: true,
+        resolveNamedAliases: true,
+      });
+    }
+    currentNode = currentNode.parent ?? null;
+  }
+  return false;
+};
+
+const resolveRenderDerivedMutableSourceKeys = (
+  symbol: SymbolDescriptor,
+  scopes: ScopeAnalysis,
+): Set<string> | null => {
+  if (
+    symbol.kind !== "let" ||
+    !isNodeOfType(symbol.declarationNode, "VariableDeclarator") ||
+    symbol.declarationNode.id !== symbol.bindingIdentifier
+  ) {
+    return null;
+  }
+  const boundaryFunction = findNearestFunction(symbol.bindingIdentifier);
+  if (!boundaryFunction) return null;
+  const sourceKeys = new Set<string>();
+  if (symbol.initializer) {
+    const initializerSourceKeys = resolveDerivedExpressionSourceKeys(
+      symbol.initializer,
+      scopes,
+      new Set([symbol.id]),
+    );
+    if (!initializerSourceKeys) return null;
+    for (const initializerSourceKey of initializerSourceKeys) sourceKeys.add(initializerSourceKey);
+  }
+  let writeCount = 0;
+  for (const symbolReference of symbol.references) {
+    if (symbolReference.flag === "read") {
+      if (
+        findNearestFunction(symbolReference.identifier) === boundaryFunction &&
+        !isReadOnlyInitialStateUse(symbolReference.identifier, boundaryFunction, scopes)
+      ) {
+        return null;
+      }
+      continue;
+    }
+    if (symbolReference.flag !== "write") return null;
+    const referenceRoot = findTransparentExpressionRoot(symbolReference.identifier);
+    const assignment = referenceRoot.parent;
+    if (
+      !isNodeOfType(assignment, "AssignmentExpression") ||
+      assignment.operator !== "=" ||
+      assignment.left !== referenceRoot ||
+      findNearestFunction(referenceRoot) !== boundaryFunction
+    ) {
+      return null;
+    }
+    const assignmentSourceKeys = resolveDerivedExpressionSourceKeys(
+      assignment.right,
+      scopes,
+      new Set([symbol.id]),
+    );
+    const controlSourceKeys = resolveWriteControlSourceKeys(assignment, boundaryFunction, scopes);
+    if (!assignmentSourceKeys || !controlSourceKeys) return null;
+    for (const assignmentSourceKey of assignmentSourceKeys) sourceKeys.add(assignmentSourceKey);
+    for (const controlSourceKey of controlSourceKeys) sourceKeys.add(controlSourceKey);
+    writeCount += 1;
+  }
+  return writeCount > 0 && sourceKeys.size > 0 ? sourceKeys : null;
 };
 
 // Extra (unused) deps in effect hooks are allowed as intentional

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.ts
@@ -687,6 +687,8 @@ const resolveDerivedExpressionSourceKeys = (
     if (
       sourceSymbol.kind === "const" &&
       sourceSymbol.initializer &&
+      isNodeOfType(sourceSymbol.declarationNode, "VariableDeclarator") &&
+      sourceSymbol.declarationNode.id === sourceSymbol.bindingIdentifier &&
       sourceSymbol.references.every((sourceReference) => sourceReference.flag === "read") &&
       !visitedSymbolIds.has(sourceSymbol.id)
     ) {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.ts
@@ -400,7 +400,7 @@ const collectCaptureDepKeys = (
       }
       const identitySourceKeys =
         resolvePureCalledFunctionSourceKeys(reference, symbol, scopes) ??
-        resolveRenderDerivedMutableSourceKeys(symbol, scopes) ??
+        resolveRenderDerivedMutableSourceKeys(reference, symbol, scopes) ??
         resolveReactiveIdentitySourceKeys(symbol, scopes);
       if (identitySourceKeys) {
         if (identitySourceKeys.size === 0) stableCapturedNames.add(depKey);
@@ -778,26 +778,22 @@ const resolveWriteControlSourceKeys = (
   return currentNode.parent === boundaryFunction ? sourceKeys : null;
 };
 
-const isReadOnlyInitialStateUse = (
-  referenceNode: EsTreeNode,
-  boundaryFunction: EsTreeNode,
-  scopes: ScopeAnalysis,
-): boolean => {
-  let currentNode = referenceNode.parent;
-  while (currentNode && currentNode !== boundaryFunction) {
-    if (isNodeOfType(currentNode, "CallExpression")) {
-      return isReactApiCall(currentNode, "useState", scopes, {
-        allowGlobalReactNamespace: true,
-        allowUnboundBareCalls: true,
-        resolveNamedAliases: true,
-      });
-    }
-    currentNode = currentNode.parent ?? null;
-  }
-  return false;
+const isReadOnlyInitialStateUse = (referenceNode: EsTreeNode, scopes: ScopeAnalysis): boolean => {
+  const referenceRoot = findTransparentExpressionRoot(referenceNode);
+  const callExpression = referenceRoot.parent;
+  return (
+    isNodeOfType(callExpression, "CallExpression") &&
+    callExpression.arguments.some((argument) => argument === referenceRoot) &&
+    isReactApiCall(callExpression, "useState", scopes, {
+      allowGlobalReactNamespace: true,
+      allowUnboundBareCalls: true,
+      resolveNamedAliases: true,
+    })
+  );
 };
 
 const resolveRenderDerivedMutableSourceKeys = (
+  capturedReference: ReferenceDescriptor,
   symbol: SymbolDescriptor,
   scopes: ScopeAnalysis,
 ): Set<string> | null => {
@@ -810,6 +806,8 @@ const resolveRenderDerivedMutableSourceKeys = (
   }
   const boundaryFunction = findEnclosingFunction(symbol.bindingIdentifier);
   if (!boundaryFunction) return null;
+  const capturingFunction = findEnclosingFunction(capturedReference.identifier);
+  if (!capturingFunction || capturingFunction === boundaryFunction) return null;
   const sourceKeys = new Set<string>();
   if (symbol.initializer) {
     const initializerSourceKeys = resolveDerivedExpressionSourceKeys(
@@ -824,8 +822,8 @@ const resolveRenderDerivedMutableSourceKeys = (
   for (const symbolReference of symbol.references) {
     if (symbolReference.flag === "read") {
       if (
-        findEnclosingFunction(symbolReference.identifier) === boundaryFunction &&
-        !isReadOnlyInitialStateUse(symbolReference.identifier, boundaryFunction, scopes)
+        findEnclosingFunction(symbolReference.identifier) !== capturingFunction &&
+        !isReadOnlyInitialStateUse(symbolReference.identifier, scopes)
       ) {
         return null;
       }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.ts
@@ -9,6 +9,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { findForwardedFreshHookDependencies } from "../../utils/find-forwarded-fresh-hook-dependencies.js";
+import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
 import { findTransparentExpressionRoot } from "../../utils/find-transparent-expression-root.js";
 import { getStaticTemplateLiteralValue } from "../../utils/get-static-template-literal-value.js";
 import { isAstNode } from "../../utils/is-ast-node.js";
@@ -701,7 +702,7 @@ const resolveDerivedExpressionSourceKeys = (
     return new Set([sourceSymbol.name]);
   }
   if (isNodeOfType(candidate, "MemberExpression")) {
-    if (candidate.computed) return null;
+    if (hasComputedMemberExpression(candidate)) return null;
     const sourceKey = stringifyMemberChain(candidate);
     const rootIdentifier = getMemberRootIdentifier(candidate);
     const rootSymbol = rootIdentifier ? scopes.symbolFor(rootIdentifier) : null;
@@ -746,21 +747,6 @@ const resolveDerivedExpressionSourceKeys = (
       argumentsToAnalyze.push(argument);
     }
     return mergeDerivedExpressionSourceKeys(argumentsToAnalyze, scopes, visitedSymbolIds);
-  }
-  return null;
-};
-
-const findNearestFunction = (node: EsTreeNode): EsTreeNode | null => {
-  let currentNode = node.parent;
-  while (currentNode) {
-    if (
-      isNodeOfType(currentNode, "FunctionDeclaration") ||
-      isNodeOfType(currentNode, "FunctionExpression") ||
-      isNodeOfType(currentNode, "ArrowFunctionExpression")
-    ) {
-      return currentNode;
-    }
-    currentNode = currentNode.parent ?? null;
   }
   return null;
 };
@@ -820,7 +806,7 @@ const resolveRenderDerivedMutableSourceKeys = (
   ) {
     return null;
   }
-  const boundaryFunction = findNearestFunction(symbol.bindingIdentifier);
+  const boundaryFunction = findEnclosingFunction(symbol.bindingIdentifier);
   if (!boundaryFunction) return null;
   const sourceKeys = new Set<string>();
   if (symbol.initializer) {
@@ -836,7 +822,7 @@ const resolveRenderDerivedMutableSourceKeys = (
   for (const symbolReference of symbol.references) {
     if (symbolReference.flag === "read") {
       if (
-        findNearestFunction(symbolReference.identifier) === boundaryFunction &&
+        findEnclosingFunction(symbolReference.identifier) === boundaryFunction &&
         !isReadOnlyInitialStateUse(symbolReference.identifier, boundaryFunction, scopes)
       ) {
         return null;
@@ -850,7 +836,7 @@ const resolveRenderDerivedMutableSourceKeys = (
       !isNodeOfType(assignment, "AssignmentExpression") ||
       assignment.operator !== "=" ||
       assignment.left !== referenceRoot ||
-      findNearestFunction(referenceRoot) !== boundaryFunction
+      findEnclosingFunction(referenceRoot) !== boundaryFunction
     ) {
       return null;
     }


### PR DESCRIPTION
## Summary

- replace a directly invoked, side-effect-free local helper capture with the helper's complete reactive input set
- replace a conditionally assigned render local with the complete inputs from its assignments and enclosing guards
- keep helper identity escape, side-effecting helpers, independent inputs, nested writes, and render-time mutable escapes reportable
- add both confirmed React Bench false positives to the evolving fuzz regression corpus

## Exact evidence

- Sidebar `qhkPS3B`: `getBreakpointValue` is a pure local helper wholly derived from `breakPoint`; `useMemo(() => getBreakpointValue(), [breakPoint])` is semantically complete, but current main reports the helper name.
- Inrupt `EzrRGww`: `valueError` is assigned only under `if (!value)` and the effect lists `value`; current main reports `valueError` even though its complete render-time source is already present.

The proof is deliberately bounded. Called helpers must have a pure expression/branch/return body and cannot be passed by identity. Mutable locals must use direct render-phase `=` writes whose right-hand sides and `if` guards are statically derivable; nested writes and other render-time uses are rejected.

## Validation

- full plugin suite: 573 files, 14,999 passed, 188 skipped
- fuzz corpus: 44 passed; direct FP oracle has no hit for either new regression
- strict fuzz: `FUZZ_RULE=exhaustive-deps FUZZ_STRICT=1 FUZZ_ITERATIONS=1000 FUZZ_SEED=7121`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `git diff --check`
- pre/post `truffler` duplicate-symbol search

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds non-trivial static analysis to a widely used hook-deps rule; incorrect equivalence could hide real missing dependencies, though scope is bounded and heavily regression-tested.
> 
> **Overview**
> **`exhaustive-deps`** now treats some render-time locals as equivalent to the reactive inputs already in the dependency array, cutting false positives when authors list the true sources instead of derived names.
> 
> When a hook **directly invokes** a side-effect-free local helper (`useMemo(() => getBreakpointValue(), [breakPoint])`), missing-dep analysis maps the helper capture to the helper’s closure inputs instead of demanding the helper binding. **`let`** locals assigned only during render from static expressions—plus their **`if`** guard inputs—can satisfy captures the same way (e.g. `valueError` under `if (!value)` with `[value]` listed).
> 
> The logic is intentionally narrow: helpers passed by reference, side effects, extra inputs, nested writes, render-time mutation, and mutable `useState` initializers still report. Fuzz **regression** fixtures and a large regression test block document accepted and rejected shapes; both **oxlint** and **eslint** plugins get a patch changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1aed2b464af6420265284eaf9115187ab89651ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->