### PR TITLE
fix(effect-needs-cleanup): accept self-releasing gesture listeners

### DIFF
--- a/.changeset/dry-pans-build.md
+++ b/.changeset/dry-pans-build.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Avoid effect-needs-cleanup false positives for gesture listeners that synchronously remove themselves and their peer listeners.

--- a/packages/fuzz/corpus/regressions/effect-needs-cleanup--self-releasing-gesture-listeners.tsx
+++ b/packages/fuzz/corpus/regressions/effect-needs-cleanup--self-releasing-gesture-listeners.tsx
@@ -1,0 +1,19 @@
+// rule: effect-needs-cleanup
+// weakness: control-flow
+// source: react-bench write-react-pedropalau-react-bnb rGxhkXn
+
+import { useCallback } from "react";
+
+export const useZoomPan = () => {
+  const onMouseDown = useCallback(() => {
+    const handleMouseMove = () => updatePosition();
+    function handleMouseUp() {
+      window.removeEventListener("mousemove", handleMouseMove);
+      window.removeEventListener("mouseup", handleMouseUp);
+    }
+    window.addEventListener("mousemove", handleMouseMove);
+    window.addEventListener("mouseup", handleMouseUp);
+  }, []);
+
+  return { onMouseDown };
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
@@ -751,6 +751,29 @@ export const useDrag = () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("accepts the end listener registered before its peer", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useCallback } from "react";
+export const useDrag = () => {
+  const onMouseDown = useCallback(() => {
+    function handleMouseMove() {
+      updatePosition();
+    }
+    function handleMouseUp() {
+      window.removeEventListener("mousemove", handleMouseMove);
+      window.removeEventListener("mouseup", handleMouseUp);
+    }
+    window.addEventListener("mouseup", handleMouseUp);
+    window.addEventListener("mousemove", handleMouseMove);
+  }, []);
+  return onMouseDown;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it.each([
     {
       name: "a conditionally registered end listener",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
@@ -702,6 +702,119 @@ export const DevServer = ({ app }) => {
   });
 });
 
+describe("effect-needs-cleanup self-releasing gesture listeners", () => {
+  it("accepts the react-bnb mouseup-owned release protocol", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useCallback, useRef } from "react";
+export const useZoomPan = () => {
+  const dragRef = useRef(null);
+  const panBy = useCallback(() => {}, []);
+  const onMouseDown = useCallback((event) => {
+    dragRef.current = { startX: event.clientX, startY: event.clientY };
+    function handleMouseMove(moveEvent) {
+      panBy(moveEvent.clientX, moveEvent.clientY);
+    }
+    function handleMouseUp() {
+      dragRef.current = null;
+      window.removeEventListener("mousemove", handleMouseMove);
+      window.removeEventListener("mouseup", handleMouseUp);
+    }
+    window.addEventListener("mousemove", handleMouseMove);
+    window.addEventListener("mouseup", handleMouseUp);
+  }, [panBy]);
+  return { onMouseDown };
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("accepts a const-bound end listener that releases itself and its peer", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useCallback } from "react";
+export const useDrag = () => {
+  const onMouseDown = useCallback(() => {
+    const handleMouseMove = () => updatePosition();
+    const handleMouseUp = () => {
+      window.removeEventListener("mousemove", handleMouseMove);
+      window.removeEventListener("mouseup", handleMouseUp);
+    };
+    window.addEventListener("mousemove", handleMouseMove);
+    window.addEventListener("mouseup", handleMouseUp);
+  }, []);
+  return onMouseDown;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it.each([
+    {
+      name: "a conditionally registered end listener",
+      moveOptions: "",
+      releaseBody:
+        'window.removeEventListener("mousemove", handleMouseMove); window.removeEventListener("mouseup", handleMouseUp);',
+      endRegistration: 'if (shouldAttachEnd) window.addEventListener("mouseup", handleMouseUp);',
+      endPrefix: "",
+    },
+    {
+      name: "a conditionally executed release",
+      moveOptions: "",
+      releaseBody:
+        'if (shouldRelease) { window.removeEventListener("mousemove", handleMouseMove); window.removeEventListener("mouseup", handleMouseUp); }',
+      endRegistration: 'window.addEventListener("mouseup", handleMouseUp);',
+      endPrefix: "",
+    },
+    {
+      name: "an async end listener",
+      moveOptions: "",
+      releaseBody:
+        'window.removeEventListener("mousemove", handleMouseMove); window.removeEventListener("mouseup", handleMouseUp);',
+      endRegistration: 'window.addEventListener("mouseup", handleMouseUp);',
+      endPrefix: "async ",
+    },
+    {
+      name: "an end listener on a different receiver",
+      moveOptions: "",
+      releaseBody:
+        'window.removeEventListener("mousemove", handleMouseMove); document.removeEventListener("mouseup", handleMouseUp);',
+      endRegistration: 'document.addEventListener("mouseup", handleMouseUp);',
+      endPrefix: "",
+    },
+    {
+      name: "a capture mismatch",
+      moveOptions: ", true",
+      releaseBody:
+        'window.removeEventListener("mousemove", handleMouseMove, false); window.removeEventListener("mouseup", handleMouseUp);',
+      endRegistration: 'window.addEventListener("mouseup", handleMouseUp);',
+      endPrefix: "",
+    },
+  ])("rejects $name", ({ moveOptions, releaseBody, endRegistration, endPrefix }) => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useCallback } from "react";
+export const useDrag = ({ shouldAttachEnd, shouldRelease }) => {
+  const onMouseDown = useCallback(() => {
+    function handleMouseMove() {
+      updatePosition();
+    }
+    ${endPrefix}function handleMouseUp() {
+      ${releaseBody}
+    }
+    window.addEventListener("mousemove", handleMouseMove${moveOptions});
+    ${endRegistration}
+  }, [shouldAttachEnd, shouldRelease]);
+  return onMouseDown;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+});
+
 describe("effect-needs-cleanup — for-of listener pairs", () => {
   it("accepts matching listener setup and cleanup loops over the same event collection", () => {
     const result = runRule(

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -2351,7 +2351,15 @@ const isSelfReleasingListenerRelease = (
   if (triggerRegistrations.some((triggerRegistration) => triggerRegistration === usage.node)) {
     return true;
   }
-  return doMatchingNodesCoverEveryPathAfterUsage(usage.node, triggerRegistrations, context);
+  return (
+    doMatchingNodesCoverEveryPathAfterUsage(usage.node, triggerRegistrations, context) ||
+    doMatchingNodesCoverEveryPathBeforeUsage(
+      usage.node,
+      triggerRegistrations,
+      ownerFunction,
+      context,
+    )
+  );
 };
 
 const isReleaseReachableForUsage = (

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -2235,8 +2235,11 @@ const doesReleaseCallMatchUsage = (
     const releaseHandler = callNode.arguments?.[1];
     if (!releaseHandler) return releaseVerbName === "off";
     return (
-      usage.handlerKey !== null &&
-      resolveExpressionKey(releaseHandler, context) === usage.handlerKey
+      (usage.handlerKey !== null &&
+        resolveExpressionKey(releaseHandler, context) === usage.handlerKey) ||
+      (isNodeOfType(usage.node, "CallExpression") &&
+        resolveStableValue(releaseHandler, context) ===
+          resolveStableValue(usage.node.arguments?.[1], context))
     );
   }
   if (releaseVerbName === "unobserve" && usage.eventKey !== null) {
@@ -2293,6 +2296,64 @@ const isPotentiallyReachableFunction = (
   );
 };
 
+const isSelfReleasingListenerRelease = (
+  releaseNode: EsTreeNode,
+  releaseFunction: EsTreeNode,
+  usage: SubscribeLikeUsage,
+  context: RuleContext,
+): boolean => {
+  if (
+    usage.kind !== "subscribe" ||
+    usage.registrationVerbName !== "addEventListener" ||
+    usage.receiverKey === null ||
+    usage.eventKey === null ||
+    !isNodeOfType(usage.node, "CallExpression") ||
+    !isFunctionLike(releaseFunction) ||
+    releaseFunction.async ||
+    releaseFunction.generator ||
+    !isNodeOfType(releaseFunction.body, "BlockStatement") ||
+    !doMatchingNodesCoverEveryPathFromFunctionEntry(releaseFunction, [releaseNode], context)
+  ) {
+    return false;
+  }
+  const registrationCapture = resolveEventListenerCapture(usage.node.arguments?.[2], {
+    allowIndeterminateEntries: true,
+  });
+  const releaseCall = isNodeOfType(releaseNode, "ChainExpression")
+    ? releaseNode.expression
+    : releaseNode;
+  if (!isNodeOfType(releaseCall, "CallExpression")) return false;
+  const releaseCapture = resolveEventListenerCapture(releaseCall.arguments?.[2], {
+    allowIndeterminateEntries: true,
+  });
+  if (
+    registrationCapture === null ||
+    releaseCapture === null ||
+    registrationCapture !== releaseCapture
+  ) {
+    return false;
+  }
+  const ownerFunction = findEnclosingFunction(releaseFunction);
+  if (!ownerFunction || !isFunctionLike(ownerFunction)) return false;
+  const triggerRegistrations: EsTreeNode[] = [];
+  walkAst(ownerFunction.body, (child: EsTreeNode) => {
+    if (child !== ownerFunction.body && isFunctionLike(child)) return false;
+    if (!isNodeOfType(child, "CallExpression")) return;
+    const registrationDetails = getCallRegistrationDetails(child, context);
+    if (
+      registrationDetails.registrationVerbName === "addEventListener" &&
+      registrationDetails.receiverKey === usage.receiverKey &&
+      resolveStableValue(child.arguments?.[1], context) === releaseFunction
+    ) {
+      triggerRegistrations.push(child);
+    }
+  });
+  if (triggerRegistrations.some((triggerRegistration) => triggerRegistration === usage.node)) {
+    return true;
+  }
+  return doMatchingNodesCoverEveryPathAfterUsage(usage.node, triggerRegistrations, context);
+};
+
 const isReleaseReachableForUsage = (
   releaseNode: EsTreeNode,
   usage: SubscribeLikeUsage,
@@ -2311,6 +2372,7 @@ const isReleaseReachableForUsage = (
   ) {
     return isReactRefCallbackCleanupOwnedByEffect(usageFunction, releaseFunction, usage, context);
   }
+  if (isSelfReleasingListenerRelease(releaseNode, releaseFunction, usage, context)) return true;
   return isPotentiallyReachableFunction(releaseFunction, context);
 };
 


### PR DESCRIPTION
## Why

Avoids an `effect-needs-cleanup` false positive for temporary gesture listeners whose synchronously registered end listener removes itself and every peer listener.

React Bench trial `rGxhkXn` registers `mousemove` and `mouseup` together during a drag. The `mouseup` handler removes both registrations, so the resource has a complete self-release path even though cleanup is not returned from an effect.

Before:

```tsx
function handleMouseUp() {
  window.removeEventListener("mousemove", handleMouseMove);
  window.removeEventListener("mouseup", handleMouseUp);
}
window.addEventListener("mousemove", handleMouseMove);
window.addEventListener("mouseup", handleMouseUp);
```

The `mousemove` registration was reported as leaking.

After, React Doctor proves the end callback is registered on the same target, reaches each matching release on every path, and preserves capture semantics.

## What changed

- Correlates named and const-bound end callbacks with their listener registration.
- Accepts only synchronous, exhaustive self-release protocols on a proven receiver/event identity.
- Keeps diagnostics for conditional registration, conditional release, async callbacks, cross-target triggers, and capture mismatches.
- Adds the exact React Bench family as a permanent fuzz regression seed.
- Adds a patch changeset for `oxlint-plugin-react-doctor`.

## Validation

- Complete plugin suite: 574 files, 15,017 passed, 188 skipped.
- Exact saved `rGxhkXn` source: 0 parse errors, 0 target diagnostics after the fix (1 on current main).
- `FUZZ_RULE=effect-needs-cleanup FUZZ_STRICT=1 FUZZ_ITERATIONS=1000 FUZZ_SEED=1353001 nr fuzz`.
- Fuzz corpus tests: 44 passed; direct false-positive oracle has no hit for the new seed.
- `nr typecheck`.
- `nr lint` (existing warnings only).
- `nr format:check`.

RDE was not rerun because this is an exact React Bench false-positive replay with strict targeted fuzzing and a narrow path/identity proof.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes control-flow and handler-matching logic in a large lint rule; risk is mitigated by broad regression and fuzz coverage, but false negatives on partial release patterns remain possible.
> 
> **Overview**
> Fixes **false positives** in `effect-needs-cleanup` when drag/zoom code registers temporary `mousemove` / `mouseup` listeners whose **end handler synchronously removes itself and every peer**—no effect cleanup return required.
> 
> The rule now recognizes this **self-releasing `addEventListener` protocol**: it ties release callbacks to their registration (including stable handler identity), checks that the trigger listener is registered on the same receiver with matching capture, and uses existing CFG path coverage so releases are proven on every path. **Conditional registration, conditional release, async end handlers, cross-target listeners, and capture mismatches** still diagnose.
> 
> Adds regression tests for the React Bench shape, negative cases, a fuzz corpus seed, and a patch changeset for `oxlint-plugin-react-doctor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 219fc0c0b895233a4bd78be30bbfc2fe2f6b78f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->