### PR TITLE
feat: flag React 19-only ref cleanups on React 18

### DIFF
--- a/.changeset/tidy-geckos-smile.md
+++ b/.changeset/tidy-geckos-smile.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Add `no-ref-callback-cleanup-before-react-19` to catch ref cleanup functions that React 18 ignores while keeping React 19-only projects quiet.

--- a/packages/fuzz/corpus/true-positives/no-ref-callback-cleanup-before-react-19--function-declaration.tsx
+++ b/packages/fuzz/corpus/true-positives/no-ref-callback-cleanup-before-react-19--function-declaration.tsx
@@ -1,0 +1,18 @@
+// rule: no-ref-callback-cleanup-before-react-19
+// weakness: local-function-resolution
+// source: PR #1356 Bugbot review
+
+const attach = (element: HTMLDivElement | null): void => {
+  element?.setAttribute("data-attached", "true");
+};
+
+export const FunctionDeclarationRef = () => {
+  function attachWithCleanup(element: HTMLDivElement | null) {
+    attach(element);
+    return () => {
+      element?.removeAttribute("data-attached");
+    };
+  }
+
+  return <div ref={attachWithCleanup} />;
+};

--- a/packages/fuzz/corpus/true-positives/no-ref-callback-cleanup-before-react-19--nteract-tree-item.tsx
+++ b/packages/fuzz/corpus/true-positives/no-ref-callback-cleanup-before-react-19--nteract-tree-item.tsx
@@ -1,0 +1,19 @@
+// rule: no-ref-callback-cleanup-before-react-19
+// weakness: version-sensitive-runtime-contract
+// source: React Bench fix-react-rdh-nteract-semiotic-a__w46E9ox
+
+interface TreeItemProps {
+  itemRefs: { current: Map<string, HTMLLIElement> };
+  nodeId: string;
+}
+
+export const TreeItem = ({ itemRefs, nodeId }: TreeItemProps) => (
+  <li
+    ref={(element) => {
+      if (element) itemRefs.current.set(nodeId, element);
+      return () => {
+        itemRefs.current.delete(nodeId);
+      };
+    }}
+  />
+);

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -452,6 +452,7 @@ export const JSX_ATTRIBUTE_POOL = [
   `onKeyDown={handleKeyDown}`,
   `onChange={handleChange}`,
   `onMouseEnter={() => setIsOpen(true)}`,
+  `ref={(node) => () => handle(node)}`,
   `style="color: red"`,
   `style={{ color: "red" }}`,
   `style={{ width: state }}`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness-fixtures.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness-fixtures.ts
@@ -811,6 +811,10 @@ export const livenessFixtures: Readonly<Record<string, LivenessFixture>> = {
   "no-react-dom-deprecated-apis": {
     code: 'import { render } from "react-dom";\nrender(null, document.getElementById("root"));',
   },
+  "no-ref-callback-cleanup-before-react-19": {
+    code: "const Component = ({ release }) => <div ref={(node) => () => release(node)} />;",
+    forceJsx: true,
+  },
   "no-react19-deprecated-apis": {
     code: 'import * as React from "react";\nconst Button = React.createFactory("button");\nvoid Button;',
   },

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
@@ -241,6 +241,7 @@ import { noReactDomDeprecatedApis } from "./rules/architecture/no-react-dom-depr
 import { noReact19DeprecatedApis } from "./rules/architecture/no-react19-deprecated-apis.js";
 import { noRedundantRoles } from "./rules/a11y/no-redundant-roles.js";
 import { noRedundantShouldComponentUpdate } from "./rules/react-builtins/no-redundant-should-component-update.js";
+import { noRefCallbackCleanupBeforeReact19 } from "./rules/correctness/no-ref-callback-cleanup-before-react-19.js";
 import { noRefCurrentInRender } from "./rules/state-and-effects/no-ref-current-in-render.js";
 import { noRenderInRender } from "./rules/architecture/no-render-in-render.js";
 import { noRenderPropChildren } from "./rules/architecture/no-render-prop-children.js";
@@ -3163,6 +3164,17 @@ export const reactDoctorRules = [
       requires: [
         ...new Set<Capability>(["react", ...(noRedundantShouldComponentUpdate.requires ?? [])]),
       ],
+    },
+  },
+  {
+    key: "react-doctor/no-ref-callback-cleanup-before-react-19",
+    id: "no-ref-callback-cleanup-before-react-19",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noRefCallbackCleanupBeforeReact19,
+      framework: "global",
+      category: "Bugs",
     },
   },
   {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-ref-callback-cleanup-before-react-19.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-ref-callback-cleanup-before-react-19.test.ts
@@ -120,6 +120,22 @@ describe("no-ref-callback-cleanup-before-react-19", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("does not report statically unreachable conditional cleanup branches", () => {
+    const result = runRuleForCode(`
+      const safeRef = (node) => { node?.focus(); };
+      const Component = ({ remove }) => (
+        <>
+          <div ref={false ? ((node) => () => remove(node)) : safeRef} />
+          <span ref={true ? safeRef : ((node) => () => remove(node))} />
+          <button ref={0 ? ((node) => () => remove(node)) : safeRef} />
+        </>
+      );
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("stays silent for unknown, mutable, async, and non-ref callbacks", () => {
     const result = runRuleForCode(`
       import { importedRef } from "./refs";

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-ref-callback-cleanup-before-react-19.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-ref-callback-cleanup-before-react-19.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noRefCallbackCleanupBeforeReact19 } from "./no-ref-callback-cleanup-before-react-19.js";
+
+const runRuleForCode = (code: string) =>
+  runRule(noRefCallbackCleanupBeforeReact19, code, { filename: "src/tree.tsx" });
+
+describe("no-ref-callback-cleanup-before-react-19", () => {
+  it("reports the exact Nteract callback-ref cleanup shape", () => {
+    const result = runRuleForCode(`
+      const TreeItem = ({ itemRefs, node }) => (
+        <li
+          ref={(element) => {
+            if (element) itemRefs.current.set(node.id, element);
+            return () => { itemRefs.current.delete(node.id); };
+          }}
+        />
+      );
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("React 18");
+  });
+
+  it("reports concise and conditionally returned cleanup functions", () => {
+    const result = runRuleForCode(`
+      const Examples = ({ remove }) => (
+        <>
+          <div ref={(node) => () => remove(node)} />
+          <span ref={(node) => node ? () => remove(node) : undefined} />
+          <button ref={(node) => node && (() => remove(node))} />
+        </>
+      );
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(3);
+  });
+
+  it("reports immutable local callbacks and aliases", () => {
+    const result = runRuleForCode(`
+      const Component = ({ remove, condition }) => {
+        const attach = (node) => {
+          return () => remove(node);
+        };
+        const attachAlias = attach;
+        const attachWithoutCleanup = (node) => { remove(node); };
+        return (
+          <>
+            <div ref={attachAlias} />
+            <span ref={condition ? attachWithoutCleanup : attach} />
+          </>
+        );
+      };
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
+  it("reports callbacks stabilized with React useCallback", () => {
+    const result = runRuleForCode(`
+      import React, { useCallback as useStableCallback } from "react";
+      const Component = ({ remove }) => {
+        const firstRef = React.useCallback((node) => () => remove(node), [remove]);
+        const secondRef = useStableCallback((node) => {
+          return () => remove(node);
+        }, [remove]);
+        return <><div ref={firstRef} /><span ref={secondRef} /></>;
+      };
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
+  it("stays silent for React 18-compatible null-detach callbacks", () => {
+    const result = runRuleForCode(`
+      const Component = ({ itemRefs, id }) => (
+        <li ref={(element) => {
+          if (element) itemRefs.current.set(id, element);
+          else itemRefs.current.delete(id);
+        }} />
+      );
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not mistake nested function returns for ref callback returns", () => {
+    const result = runRuleForCode(`
+      const Component = ({ subscribe }) => (
+        <div ref={(node) => {
+          const register = () => {
+            return () => subscribe(node);
+          };
+          register();
+        }} />
+      );
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not report statically unreachable logical cleanup branches", () => {
+    const result = runRuleForCode(`
+      const Component = ({ remove }) => (
+        <>
+          <div ref={(node) => false && (() => remove(node))} />
+          <span ref={(node) => true || (() => remove(node))} />
+          <button ref={(node) => "attached" ?? (() => remove(node))} />
+        </>
+      );
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent for unknown, mutable, async, and non-ref callbacks", () => {
+    const result = runRuleForCode(`
+      import { importedRef } from "./refs";
+      let mutableRef = (node) => () => node.remove();
+      const handlers = { ref: (node) => () => node.remove() };
+      const Component = ({ providedRef }) => (
+        <>
+          <div ref={importedRef} />
+          <div ref={mutableRef} />
+          <div ref={handlers.ref} />
+          <div ref={providedRef} />
+          <div ref={async (node) => () => node.remove()} />
+          <div onClick={(event) => () => event.preventDefault()} />
+        </>
+      );
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-ref-callback-cleanup-before-react-19.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-ref-callback-cleanup-before-react-19.test.ts
@@ -59,6 +59,22 @@ describe("no-ref-callback-cleanup-before-react-19", () => {
     expect(result.diagnostics).toHaveLength(2);
   });
 
+  it("reports immutable function declaration callbacks and aliases", () => {
+    const result = runRuleForCode(`
+      const Component = ({ remove }) => {
+        const attachAlias = attach;
+        return <><div ref={attach} /><span ref={attachAlias} /></>;
+
+        function attach(node) {
+          return () => remove(node);
+        }
+      };
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
   it("reports callbacks stabilized with React useCallback", () => {
     const result = runRuleForCode(`
       import React, { useCallback as useStableCallback } from "react";
@@ -140,11 +156,14 @@ describe("no-ref-callback-cleanup-before-react-19", () => {
     const result = runRuleForCode(`
       import { importedRef } from "./refs";
       let mutableRef = (node) => () => node.remove();
+      function reassignedRef(node) { return () => node.remove(); }
+      reassignedRef = (node) => { node?.focus(); };
       const handlers = { ref: (node) => () => node.remove() };
       const Component = ({ providedRef }) => (
         <>
           <div ref={importedRef} />
           <div ref={mutableRef} />
+          <div ref={reassignedRef} />
           <div ref={handlers.ref} />
           <div ref={providedRef} />
           <div ref={async (node) => () => node.remove()} />

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-ref-callback-cleanup-before-react-19.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-ref-callback-cleanup-before-react-19.ts
@@ -64,6 +64,17 @@ const resolveFunctionExpressions = (
 
   const symbol = scopes.symbolFor(expression);
   if (!symbol || visitedSymbolIds.has(symbol.id)) return [];
+  if (
+    symbol.kind === "function" &&
+    isNodeOfType(symbol.declarationNode, "FunctionDeclaration") &&
+    symbol.references.every((reference) => reference.flag === "read")
+  ) {
+    return resolveFunctionExpressions(
+      symbol.declarationNode,
+      scopes,
+      new Set([...visitedSymbolIds, symbol.id]),
+    );
+  }
   const initializer = getDirectConstInitializer(symbol);
   if (!initializer) return [];
   return resolveFunctionExpressions(initializer, scopes, new Set([...visitedSymbolIds, symbol.id]));

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-ref-callback-cleanup-before-react-19.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-ref-callback-cleanup-before-react-19.ts
@@ -20,6 +20,13 @@ const resolveFunctionExpressions = (
     return expression.async || expression.generator ? [] : [expression];
   }
   if (isNodeOfType(expression, "ConditionalExpression")) {
+    if (isNodeOfType(expression.test, "Literal")) {
+      return resolveFunctionExpressions(
+        expression.test.value ? expression.consequent : expression.alternate,
+        scopes,
+        visitedSymbolIds,
+      );
+    }
     return [
       ...resolveFunctionExpressions(expression.consequent, scopes, visitedSymbolIds),
       ...resolveFunctionExpressions(expression.alternate, scopes, visitedSymbolIds),

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-ref-callback-cleanup-before-react-19.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-ref-callback-cleanup-before-react-19.ts
@@ -1,0 +1,109 @@
+import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
+import { collectFunctionReturnStatements } from "../../utils/collect-function-return-statements.js";
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { getDirectConstInitializer } from "../../utils/get-direct-const-initializer.js";
+import { getJsxAttributeName } from "../../utils/get-jsx-attribute-name.js";
+import { isFunctionLike } from "../../utils/is-function-like.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { isReactApiCall } from "../../utils/is-react-api-call.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+
+const resolveFunctionExpressions = (
+  rawExpression: EsTreeNode,
+  scopes: ScopeAnalysis,
+  visitedSymbolIds: ReadonlySet<number> = new Set(),
+): ReadonlyArray<EsTreeNode> => {
+  const expression = stripParenExpression(rawExpression);
+  if (isFunctionLike(expression)) {
+    return expression.async || expression.generator ? [] : [expression];
+  }
+  if (isNodeOfType(expression, "ConditionalExpression")) {
+    return [
+      ...resolveFunctionExpressions(expression.consequent, scopes, visitedSymbolIds),
+      ...resolveFunctionExpressions(expression.alternate, scopes, visitedSymbolIds),
+    ];
+  }
+  if (isNodeOfType(expression, "LogicalExpression")) {
+    if (isNodeOfType(expression.left, "Literal")) {
+      const isLeftTruthy = Boolean(expression.left.value);
+      if (expression.operator === "&&" && !isLeftTruthy) return [];
+      if (expression.operator === "||" && isLeftTruthy) return [];
+      if (expression.operator === "??" && expression.left.value !== null) return [];
+    }
+    if (expression.operator === "&&") {
+      return resolveFunctionExpressions(expression.right, scopes, visitedSymbolIds);
+    }
+    return [
+      ...resolveFunctionExpressions(expression.left, scopes, visitedSymbolIds),
+      ...resolveFunctionExpressions(expression.right, scopes, visitedSymbolIds),
+    ];
+  }
+  if (isNodeOfType(expression, "SequenceExpression")) {
+    const finalExpression = expression.expressions.at(-1);
+    return finalExpression
+      ? resolveFunctionExpressions(finalExpression, scopes, visitedSymbolIds)
+      : [];
+  }
+  if (isNodeOfType(expression, "CallExpression")) {
+    if (!isReactApiCall(expression, "useCallback", scopes)) return [];
+    const callback = expression.arguments[0];
+    return callback && !isNodeOfType(callback, "SpreadElement")
+      ? resolveFunctionExpressions(callback, scopes, visitedSymbolIds)
+      : [];
+  }
+  if (!isNodeOfType(expression, "Identifier")) return [];
+
+  const symbol = scopes.symbolFor(expression);
+  if (!symbol || visitedSymbolIds.has(symbol.id)) return [];
+  const initializer = getDirectConstInitializer(symbol);
+  if (!initializer) return [];
+  return resolveFunctionExpressions(initializer, scopes, new Set([...visitedSymbolIds, symbol.id]));
+};
+
+const functionReturnsCleanupFunction = (
+  functionExpression: EsTreeNode,
+  scopes: ScopeAnalysis,
+): boolean => {
+  if (!isFunctionLike(functionExpression)) return false;
+  if (!isNodeOfType(functionExpression.body, "BlockStatement")) {
+    return resolveFunctionExpressions(functionExpression.body, scopes).length > 0;
+  }
+  return collectFunctionReturnStatements(functionExpression).some((returnStatement) =>
+    Boolean(
+      returnStatement.argument &&
+      resolveFunctionExpressions(returnStatement.argument, scopes).length > 0,
+    ),
+  );
+};
+
+const callbackReturnsCleanupFunction = (callback: EsTreeNode, scopes: ScopeAnalysis): boolean => {
+  return resolveFunctionExpressions(callback, scopes).some((functionExpression) =>
+    functionReturnsCleanupFunction(functionExpression, scopes),
+  );
+};
+
+export const noRefCallbackCleanupBeforeReact19 = defineRule({
+  id: "no-ref-callback-cleanup-before-react-19",
+  title: "Ref cleanup requires React 19",
+  requires: ["react:18"],
+  disabledWhen: ["react:19"],
+  severity: "warn",
+  recommendation:
+    "React 18 ignores functions returned from ref callbacks. Handle cleanup when React calls the ref with `null`, or require React 19 before returning a cleanup function.",
+  create: (context) => ({
+    JSXAttribute(node: EsTreeNodeOfType<"JSXAttribute">) {
+      if (getJsxAttributeName(node.name) !== "ref") return;
+      if (!isNodeOfType(node.value, "JSXExpressionContainer")) return;
+      const callback = node.value.expression;
+      if (!callback || isNodeOfType(callback, "JSXEmptyExpression")) return;
+      if (!callbackReturnsCleanupFunction(callback, context.scopes)) return;
+      context.report({
+        node,
+        message:
+          "This ref callback returns a cleanup function, but React 18 ignores ref cleanup returns, so the cleanup never runs. Handle detachment when React calls the ref with `null`, or require React 19.",
+      });
+    },
+  }),
+});

--- a/packages/react-doctor/tests/regressions/react-19-migration-rules.test.ts
+++ b/packages/react-doctor/tests/regressions/react-19-migration-rules.test.ts
@@ -87,6 +87,53 @@ void hydrateRoot;
   });
 });
 
+describe("no-ref-callback-cleanup-before-react-19", () => {
+  const source = `
+    export const Component = ({ release }) => (
+      <div ref={(node) => {
+        if (!node) return;
+        return () => release(node);
+      }} />
+    );
+  `;
+
+  it("reports when the supported React range includes 18", async () => {
+    const projectDir = setupReactProject(tempRoot, "ref-cleanup-react-18-range", {
+      reactVersion: "^18.1.0 || ^19.0.0",
+      files: { "src/component.tsx": source },
+    });
+
+    const hits = await collectRuleHits(projectDir, "no-ref-callback-cleanup-before-react-19", {
+      reactMajorVersion: 18,
+    });
+    expect(hits).toHaveLength(1);
+  });
+
+  it("stays silent for React 19-only projects", async () => {
+    const projectDir = setupReactProject(tempRoot, "ref-cleanup-react-19", {
+      reactVersion: "^19.0.0",
+      files: { "src/component.tsx": source },
+    });
+
+    const hits = await collectRuleHits(projectDir, "no-ref-callback-cleanup-before-react-19", {
+      reactMajorVersion: 19,
+    });
+    expect(hits).toEqual([]);
+  });
+
+  it("stays silent outside the narrow React 18 compatibility gate", async () => {
+    const projectDir = setupReactProject(tempRoot, "ref-cleanup-react-17", {
+      reactVersion: "^17.0.0",
+      files: { "src/component.tsx": source },
+    });
+
+    const hits = await collectRuleHits(projectDir, "no-ref-callback-cleanup-before-react-19", {
+      reactMajorVersion: 17,
+    });
+    expect(hits).toEqual([]);
+  });
+});
+
 describe("no-legacy-class-lifecycles", () => {
   it("flags componentWillMount / componentWillReceiveProps / componentWillUpdate", async () => {
     const projectDir = setupReactProject(tempRoot, "no-legacy-class-lifecycles-pos", {


### PR DESCRIPTION
## Why

React 19 added support for cleanup functions returned from ref callbacks. React 18 ignores those returns, so code that relies on cleanup-only deletion can leak stale ref entries.

Two accepted Nteract benchmark trials introduced this exact pattern in Semiotic, whose supported React range is `^18.1.0 || ^19.0.0`. The verifier used React 19, masking the React 18 compatibility break.

Primary references: [React 19 release notes](https://react.dev/blog/2024/12/05/react-19#cleanup-functions-for-refs) and [React common component ref docs](https://react.dev/reference/react-dom/components/common#ref-callback).

## What changed

- add `no-ref-callback-cleanup-before-react-19`
- enable it for effective React 18 and disable it when React 19 capability is present
- resolve inline callbacks, immutable local aliases, React `useCallback`, conditional paths, and function-return expressions
- avoid async callbacks, mutable/imported/member callbacks, nested returns, detach-style `null` handling, and unreachable logical branches
- add exact Nteract regression coverage, adversarial tests, a fuzz true-positive corpus entry, liveness coverage, and a metamorphic snippet
- add a patch changeset for `oxlint-plugin-react-doctor`

## RDE results

Local RDE ran 100 root-directory scans across 12 OSS repositories. The new rule emitted 0 diagnostics and 0 false positives in that React-19-heavy sample.

## Test plan

- focused rule tests: 8/8
- oxlint plugin suite: 15,046 passed, 188 skipped
- React 19 migration integration: 46/46
- fuzz smoke: 44 passed, 403 skipped
- strict fuzz: 1,000 iterations, seed 181919
- full typecheck: 15/15 tasks
- lint: clean exit with existing warnings only
- format check: 3,190 files
- JSON report smoke: schema v3, full mode
- full test suite: 13 cached packages passed; React Doctor package passed 2,247 tests with one local Git-fixture failure caused by global `diff.external=difft`; rerunning that fixture with global Git config isolated passed 4/4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive lint rule with version gating and broad tests; no runtime or auth/data-path changes.
> 
> **Overview**
> Adds **`no-ref-callback-cleanup-before-react-19`** to `oxlint-plugin-react-doctor` so projects that still run on **React 18** get warned when a **`ref` callback returns a cleanup function**—behavior React 19 added and React 18 silently ignores (stale refs / leaks).
> 
> The rule is registered under **Bugs**, gated with **`requires: react:18`** and **`disabledWhen: react:19`**, and walks **`ref`** values through inline callbacks, immutable locals, **`useCallback`**, conditionals, and returns while skipping detach-on-`null` patterns, nested inner returns, and unreachable branches.
> 
> Coverage includes unit tests, React 19 migration integration tests, fuzz corpus entries, a liveness fixture, a fuzz JSX snippet, and a patch changeset for the plugin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cdca513dc2180ed01f9636ededa87b07e55b41f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->