### PR TITLE
fix(no-adjust-state): align the published contract

### DIFF
--- a/.changeset/wise-apes-adjust.md
+++ b/.changeset/wise-apes-adjust.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Align `no-adjust-state-on-prop-change` with its published contract by reporting prop-triggered resets instead of direct prop mirrors.

--- a/packages/fuzz/corpus/regressions/no-adjust-state-on-prop-change--direct-prop-mirror.tsx
+++ b/packages/fuzz/corpus/regressions/no-adjust-state-on-prop-change--direct-prop-mirror.tsx
@@ -1,0 +1,15 @@
+// rule: no-adjust-state-on-prop-change
+// weakness: contract-inversion
+// source: published React Doctor rule contract
+
+import { useEffect, useState } from "react";
+
+export const MirroredValue = ({ value }: { value: string }) => {
+  const [mirror, setMirror] = useState(value);
+
+  useEffect(() => {
+    setMirror(value);
+  }, [value]);
+
+  return <div>{mirror}</div>;
+};

--- a/packages/fuzz/corpus/regressions/no-adjust-state-on-prop-change--member-http-reset.tsx
+++ b/packages/fuzz/corpus/regressions/no-adjust-state-on-prop-change--member-http-reset.tsx
@@ -1,0 +1,17 @@
+// rule: no-adjust-state-on-prop-change
+// weakness: member-style-http-effect
+// source: PR #1361 review
+
+import axios from "axios";
+import { useEffect, useState } from "react";
+
+export const Search = ({ query }: { query: string }) => {
+  const [selection, setSelection] = useState<string | null>(null);
+
+  useEffect(() => {
+    setSelection(null);
+    void axios.get("/search", { params: { query } });
+  }, [query]);
+
+  return <div>{selection}</div>;
+};

--- a/packages/fuzz/corpus/regressions/no-adjust-state-on-prop-change--observer-registration.tsx
+++ b/packages/fuzz/corpus/regressions/no-adjust-state-on-prop-change--observer-registration.tsx
@@ -1,0 +1,17 @@
+// rule: no-adjust-state-on-prop-change
+// weakness: observer-registration-effect
+// source: PR #1361 review
+
+import { useEffect, useState } from "react";
+
+export const Feed = ({ source }: { source: Element }) => {
+  const [selection, setSelection] = useState<string | null>(null);
+
+  useEffect(() => {
+    setSelection(null);
+    const observer = new ResizeObserver(() => setSelection("updated"));
+    observer.observe(source);
+  }, [source]);
+
+  return <div>{selection}</div>;
+};

--- a/packages/fuzz/corpus/regressions/no-adjust-state-on-prop-change--subscription-reset.tsx
+++ b/packages/fuzz/corpus/regressions/no-adjust-state-on-prop-change--subscription-reset.tsx
@@ -1,0 +1,20 @@
+// rule: no-adjust-state-on-prop-change
+// weakness: subscription-driven-effect
+// source: PR #1361 review
+
+import { useEffect, useState } from "react";
+
+interface FeedSource {
+  subscribe: (listener: () => void) => () => void;
+}
+
+export const Feed = ({ source }: { source: FeedSource }) => {
+  const [selection, setSelection] = useState<string | null>(null);
+
+  useEffect(() => {
+    setSelection(null);
+    source.subscribe(() => setSelection("updated"));
+  }, [source]);
+
+  return <div>{selection}</div>;
+};

--- a/packages/fuzz/corpus/true-positives/effect-needs-cleanup--computed-subscribe-identifier.tsx
+++ b/packages/fuzz/corpus/true-positives/effect-needs-cleanup--computed-subscribe-identifier.tsx
@@ -1,0 +1,22 @@
+// rule: effect-needs-cleanup
+// weakness: computed-subscription-method
+// source: PR #1361 review
+
+import { useEffect } from "react";
+
+interface SubscriptionSource {
+  [methodName: string]: (listener: () => void) => void;
+}
+
+interface ExampleProps {
+  source: SubscriptionSource;
+  subscribe: string;
+}
+
+export const Example = ({ source, subscribe }: ExampleProps) => {
+  useEffect(() => {
+    source[subscribe](() => refresh());
+  }, [source, subscribe]);
+
+  return null;
+};

--- a/packages/fuzz/corpus/true-positives/no-adjust-state-on-prop-change--prop-keyed-reset.tsx
+++ b/packages/fuzz/corpus/true-positives/no-adjust-state-on-prop-change--prop-keyed-reset.tsx
@@ -1,0 +1,15 @@
+// rule: no-adjust-state-on-prop-change
+// weakness: contract-inversion
+// source: published React Doctor rule contract
+
+import { useEffect, useState } from "react";
+
+export const SelectableList = ({ items }: { items: string[] }) => {
+  const [selection, setSelection] = useState<string | null>(null);
+
+  useEffect(() => {
+    setSelection(null);
+  }, [items]);
+
+  return <div>{selection}</div>;
+};

--- a/packages/fuzz/corpus/true-positives/no-adjust-state-on-prop-change--uninvoked-subscription-helper.tsx
+++ b/packages/fuzz/corpus/true-positives/no-adjust-state-on-prop-change--uninvoked-subscription-helper.tsx
@@ -1,0 +1,20 @@
+// rule: no-adjust-state-on-prop-change
+// weakness: uninvoked-nested-external-work
+// source: PR #1361 review
+
+import { useEffect, useState } from "react";
+
+interface FeedSource {
+  subscribe: (listener: () => void) => () => void;
+}
+
+export const Feed = ({ itemId, source }: { itemId: string; source: FeedSource }) => {
+  const [selection, setSelection] = useState<string | null>(null);
+
+  useEffect(() => {
+    setSelection(null);
+    const _subscribeLater = () => source.subscribe(() => setSelection("updated"));
+  }, [itemId, source]);
+
+  return <div>{selection}</div>;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness-fixtures.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness-fixtures.ts
@@ -511,7 +511,7 @@ export const livenessFixtures: Readonly<Record<string, LivenessFixture>> = {
     filePath: "src/components/save-button.tsx",
   },
   "no-adjust-state-on-prop-change": {
-    code: 'function Field({ value }) {\n        const [draft, setDraft] = useState("");\n        useEffect(() => {\n          setDraft(value);\n        }, [value]);\n        return <input value={draft} />;\n      }',
+    code: "function List({ items }) {\n        const [selection, setSelection] = useState(null);\n        useEffect(() => {\n          setSelection(null);\n        }, [items]);\n        return <div>{selection}</div>;\n      }",
   },
   "no-aria-hidden-on-focusable": {
     code: 'export const A = () => <button aria-hidden={true} type="button">x</button>;',

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
@@ -3477,6 +3477,19 @@ export const Computed = ({ el }) => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("preserves identifier-computed subscribe detection", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `function Example({ source, subscribe }) {
+        useEffect(() => {
+          source[subscribe](() => refresh());
+        }, [source, subscribe]);
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("flags a retained function whose setInterval id is captured but never cleared", () => {
     const result = runRule(
       effectNeedsCleanup,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -39,6 +39,7 @@ import { walkInsideStatementBlocks } from "../../utils/walk-inside-statement-blo
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import {
+  getSubscribeOrObserveMethodName,
   isCleanupReturningSubscribeLikeCallExpression,
   isSubscribeOrObserveCallExpression,
   OBSERVER_REGISTRATION_METHOD_NAME,
@@ -299,13 +300,13 @@ const findSubscribeLikeUsages = (
       return;
     }
 
-    if (isSubscribeOrObserveCallExpression(child)) {
+    const subscribeOrObserveMethodName = getSubscribeOrObserveMethodName(child);
+    if (subscribeOrObserveMethodName !== null) {
       const registrationDetails = getCallRegistrationDetails(child, context);
-      if (registrationDetails.registrationVerbName === null) return;
       usages.push({
         kind: "subscribe",
         node: child,
-        resourceName: registrationDetails.registrationVerbName,
+        resourceName: subscribeOrObserveMethodName,
         handleKey: findAssignedResourceKey(child, context),
         ...registrationDetails,
       });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -7,7 +7,6 @@ import {
   BOUND_RESOURCE_RELEASE_METHOD_NAMES,
   EFFECT_HOOK_NAMES,
   GLOBAL_RELEASE_METHOD_NAMES,
-  SUBSCRIPTION_METHOD_NAMES,
 } from "../../constants/react.js";
 import { defineRule } from "../../utils/define-rule.js";
 import {
@@ -41,7 +40,8 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import {
   isCleanupReturningSubscribeLikeCallExpression,
-  isSubscribeLikeCallExpression,
+  isSubscribeOrObserveCallExpression,
+  OBSERVER_REGISTRATION_METHOD_NAME,
 } from "./utils/is-subscribe-like-call-expression.js";
 import { resolveEventListenerCapture } from "./utils/resolve-event-listener-capture.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
@@ -50,11 +50,6 @@ import { isNodeReachableWithinFunction } from "../../utils/is-node-reachable-wit
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import type { SymbolDescriptor } from "../../semantic/scope-analysis.js";
 
-// `observer.observe(el)` is the registration moment for ResizeObserver /
-// MutationObserver / IntersectionObserver et al. — subscription-shaped,
-// but not in `SUBSCRIPTION_METHOD_NAMES` (other consumers of that set
-// treat subscriptions as store-like).
-const OBSERVER_REGISTRATION_METHOD_NAME = "observe";
 const CLEANUP_EFFECT_HOOK_NAMES = new Set([...EFFECT_HOOK_NAMES, "useInsertionEffect"]);
 const REPLAYABLE_ITERATOR_COLLECTION_CACHE = new WeakMap<RuleContext, Map<number, string | null>>();
 
@@ -142,16 +137,6 @@ const isSocketConstruction = (node: EsTreeNode): node is EsTreeNodeOfType<"NewEx
   isNodeOfType(node, "NewExpression") &&
   isNodeOfType(node.callee, "Identifier") &&
   SOCKET_CONSTRUCTOR_NAMES_REQUIRING_CLEANUP.has(node.callee.name);
-
-const isSubscribeOrObserveCall = (node: EsTreeNode): boolean => {
-  if (isSubscribeLikeCallExpression(node)) return true;
-  return (
-    isNodeOfType(node, "CallExpression") &&
-    isNodeOfType(node.callee, "MemberExpression") &&
-    isNodeOfType(node.callee.property, "Identifier") &&
-    node.callee.property.name === OBSERVER_REGISTRATION_METHOD_NAME
-  );
-};
 
 const resolveExpressionKey = (
   expression: EsTreeNode | null | undefined,
@@ -314,17 +299,13 @@ const findSubscribeLikeUsages = (
       return;
     }
 
-    if (
-      isNodeOfType(child.callee, "MemberExpression") &&
-      isNodeOfType(child.callee.property, "Identifier") &&
-      (SUBSCRIPTION_METHOD_NAMES.has(child.callee.property.name) ||
-        child.callee.property.name === OBSERVER_REGISTRATION_METHOD_NAME)
-    ) {
+    if (isSubscribeOrObserveCallExpression(child)) {
       const registrationDetails = getCallRegistrationDetails(child, context);
+      if (registrationDetails.registrationVerbName === null) return;
       usages.push({
         kind: "subscribe",
         node: child,
-        resourceName: child.callee.property.name,
+        resourceName: registrationDetails.registrationVerbName,
         handleKey: findAssignedResourceKey(child, context),
         ...registrationDetails,
       });
@@ -3990,7 +3971,7 @@ const findRetainedFunctionLeak = (
     }
 
     if (
-      isSubscribeOrObserveCall(child) &&
+      isSubscribeOrObserveCallExpression(child) &&
       (!doesResourceResultEscape(
         child,
         allowReturnedResourceEscape,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-state-write-contracts.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-state-write-contracts.test.ts
@@ -393,11 +393,17 @@ describe("derived-state family contracts", () => {
       };`,
     ],
   ])("recognizes %s by React binding identity", (_name, aliasCode) => {
-    for (const rule of [noDerivedState, noDerivedStateEffect, noAdjustStateOnPropChange]) {
+    for (const rule of [noDerivedState, noDerivedStateEffect]) {
       const result = runRule(rule, aliasCode);
       expect(result.parseErrors).toEqual([]);
       expect(result.diagnostics).toHaveLength(1);
     }
+    const adjustmentResult = runRule(
+      noAdjustStateOnPropChange,
+      aliasCode.replace("setMirror(value)", "setMirror(null)"),
+    );
+    expect(adjustmentResult.parseErrors).toEqual([]);
+    expect(adjustmentResult.diagnostics).toHaveLength(1);
   });
 
   it.each([

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-state-write-contracts.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-state-write-contracts.test.ts
@@ -551,7 +551,7 @@ describe("derived-state family contracts", () => {
       }, [value]);
       return <div>{String(mirror)}</div>;
     }`;
-    for (const rule of [noDerivedState, noDerivedStateEffect, noAdjustStateOnPropChange]) {
+    for (const rule of [noDerivedState, noDerivedStateEffect]) {
       const result = runRule(rule, transformCode, { forceJsx: true });
       expect(result.parseErrors).toEqual([]);
       expect(result.diagnostics).toHaveLength(1);
@@ -602,15 +602,14 @@ describe("derived-state family contracts", () => {
     }
   });
 
-  it("requires a copied render source for prop-change adjustment", () => {
-    const copiedResult = runRule(
-      noAdjustStateOnPropChange,
-      `function Example({ value }) {
+  it("assigns prop copies to the derived-state rules and unrelated resets to this rule", () => {
+    const propMirrorCode = `function Example({ value }) {
         const [mirror, setMirror] = useState(null);
         useEffect(() => setMirror(value), [value]);
         return mirror;
-      }`,
-    );
+      }`;
+    const copiedResult = runRule(noAdjustStateOnPropChange, propMirrorCode);
+    const owningSiblingResult = runRule(noDerivedStateEffect, propMirrorCode);
     const constantResult = runRule(
       noAdjustStateOnPropChange,
       `function Example({ value }) {
@@ -620,8 +619,10 @@ describe("derived-state family contracts", () => {
       }`,
     );
     expect(copiedResult.parseErrors).toEqual([]);
-    expect(copiedResult.diagnostics).toHaveLength(1);
+    expect(copiedResult.diagnostics).toEqual([]);
+    expect(owningSiblingResult.parseErrors).toEqual([]);
+    expect(owningSiblingResult.diagnostics).toHaveLength(1);
     expect(constantResult.parseErrors).toEqual([]);
-    expect(constantResult.diagnostics).toEqual([]);
+    expect(constantResult.diagnostics).toHaveLength(1);
   });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-adjust-state-on-prop-change.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-adjust-state-on-prop-change.regressions.test.ts
@@ -101,6 +101,23 @@ describe("no-adjust-state-on-prop-change — regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("stays silent on a synchronous reset beside observer registration", () => {
+    const result = runRule(
+      noAdjustStateOnPropChange,
+      `function Feed({ source }) {
+        const [selection, setSelection] = useState(null);
+        useEffect(() => {
+          setSelection(null);
+          const observer = new ResizeObserver(() => refresh());
+          observer.observe(source);
+        }, [source]);
+        return selection;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("stays silent on a synchronous reset beside a member-style HTTP request", () => {
     const result = runRule(
       noAdjustStateOnPropChange,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-adjust-state-on-prop-change.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-adjust-state-on-prop-change.regressions.test.ts
@@ -5,6 +5,45 @@ import { noAdjustStateOnPropChange } from "./no-adjust-state-on-prop-change.js";
 describe("no-adjust-state-on-prop-change — regressions", () => {
   it("ships at warn severity, matching the derived-state family", () => {
     expect(noAdjustStateOnPropChange.severity).toBe("warn");
+    expect(noAdjustStateOnPropChange.recommendation).toContain(
+      "Avoid tracking the previous prop in more state",
+    );
+  });
+
+  it("leaves the exact Brainly guarded prop mirror outside this effect rule", () => {
+    const result = runRule(
+      noAdjustStateOnPropChange,
+      `function RadioGroup({ value }) {
+        const [selectedValue, setSelectedValue] = useState(value ?? null);
+        const [prevValue, setPrevValue] = useState(value);
+        if (value !== prevValue) {
+          setPrevValue(value);
+          setSelectedValue(value ?? null);
+        }
+        return selectedValue;
+      }`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("leaves a guarded previous-render trend tracker outside this effect rule", () => {
+    const result = runRule(
+      noAdjustStateOnPropChange,
+      `function Counter({ count }) {
+        const [previousCount, setPreviousCount] = useState(count);
+        const [trend, setTrend] = useState(null);
+        if (count !== previousCount) {
+          setPreviousCount(count);
+          setTrend(count > previousCount ? "increasing" : "decreasing");
+        }
+        return trend;
+      }`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
   });
 
   it("stays silent on constant transition flags with a setTimeout sibling", () => {
@@ -60,7 +99,7 @@ describe("no-adjust-state-on-prop-change — regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
-  it("stays silent on a constant setter with no copied render source", () => {
+  it("reports the published prop-keyed constant reset", () => {
     const result = runRule(
       noAdjustStateOnPropChange,
       `function List({ items }) {
@@ -71,7 +110,7 @@ describe("no-adjust-state-on-prop-change — regressions", () => {
       }`,
     );
     expect(result.parseErrors).toEqual([]);
-    expect(result.diagnostics).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
   });
 
   it("stays silent on an opaque hook result member read", () => {
@@ -258,7 +297,7 @@ describe("no-adjust-state-on-prop-change — regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
-  it("stays silent on a module-constant reset with no copied render source", () => {
+  it("reports an immutable module-constant reset with no external work", () => {
     const result = runRule(
       noAdjustStateOnPropChange,
       `const EMPTY = { items: [] };
@@ -271,10 +310,10 @@ describe("no-adjust-state-on-prop-change — regressions", () => {
       }`,
     );
     expect(result.parseErrors).toEqual([]);
-    expect(result.diagnostics).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
   });
 
-  it("stays silent on a prop-keyed constant reset inside memo and forwardRef", () => {
+  it("reports a prop-keyed constant reset inside memo and forwardRef", () => {
     const result = runRule(
       noAdjustStateOnPropChange,
       `const VideoBlock = memo(forwardRef(({ url }, ref) => {
@@ -286,7 +325,7 @@ describe("no-adjust-state-on-prop-change — regressions", () => {
       }));`,
     );
     expect(result.parseErrors).toEqual([]);
-    expect(result.diagnostics).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
   });
 
   it("stays silent on a timer-driven two-phase transition", () => {
@@ -426,7 +465,7 @@ describe("no-adjust-state-on-prop-change — regressions", () => {
       expect(result.diagnostics).toEqual([]);
     });
 
-    it("stays silent on a constant reset keyed on a prop dependency", () => {
+    it("reports a constant reset keyed on a prop dependency", () => {
       const result = runRule(
         noAdjustStateOnPropChange,
         `function List({ items }) {
@@ -438,7 +477,7 @@ describe("no-adjust-state-on-prop-change — regressions", () => {
         }`,
       );
       expect(result.parseErrors).toEqual([]);
-      expect(result.diagnostics).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
     });
 
     it("stays silent on a nested two-phase timer toggle", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-adjust-state-on-prop-change.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-adjust-state-on-prop-change.regressions.test.ts
@@ -83,6 +83,56 @@ describe("no-adjust-state-on-prop-change — regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("stays silent on synchronous resets beside subscription setup", () => {
+    const result = runRule(
+      noAdjustStateOnPropChange,
+      `function Feed({ source }) {
+        const [selection, setSelection] = useState(null);
+        useEffect(() => {
+          setSelection(null);
+          source.subscribe(() => refresh());
+          window.addEventListener("focus", refresh);
+          source.events.on("change", refresh);
+        }, [source]);
+        return selection;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent on a synchronous reset beside a member-style HTTP request", () => {
+    const result = runRule(
+      noAdjustStateOnPropChange,
+      `function Search({ query }) {
+        const [selection, setSelection] = useState(null);
+        useEffect(() => {
+          setSelection(null);
+          void axios.get("/search", { params: { query } });
+        }, [query]);
+        return selection;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still reports a synchronous reset beside an unrelated get method", () => {
+    const result = runRule(
+      noAdjustStateOnPropChange,
+      `function Selection({ itemId, cache }) {
+        const [selection, setSelection] = useState(null);
+        useEffect(() => {
+          setSelection(null);
+          cache.get(itemId);
+        }, [itemId, cache]);
+        return selection;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("stays silent on a literal reset beside a timer callback", () => {
     const result = runRule(
       noAdjustStateOnPropChange,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-adjust-state-on-prop-change.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-adjust-state-on-prop-change.regressions.test.ts
@@ -133,6 +133,39 @@ describe("no-adjust-state-on-prop-change — regressions", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("still reports when external work only exists in an uninvoked nested function", () => {
+    const result = runRule(
+      noAdjustStateOnPropChange,
+      `function Selection({ itemId, source }) {
+        const [selection, setSelection] = useState(null);
+        useEffect(() => {
+          setSelection(null);
+          const subscribeLater = () => source.subscribe(refresh);
+        }, [itemId, source]);
+        return selection;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays silent when a nested subscription helper is invoked by the effect", () => {
+    const result = runRule(
+      noAdjustStateOnPropChange,
+      `function Selection({ itemId, source }) {
+        const [selection, setSelection] = useState(null);
+        useEffect(() => {
+          setSelection(null);
+          const subscribe = () => source.subscribe(refresh);
+          subscribe();
+        }, [itemId, source]);
+        return selection;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("stays silent on a literal reset beside a timer callback", () => {
     const result = runRule(
       noAdjustStateOnPropChange,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-adjust-state-on-prop-change.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-adjust-state-on-prop-change.ts
@@ -5,15 +5,21 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { collectEffectStateWriteFacts } from "./utils/collect-effect-state-write-facts.js";
 import { getUpstreamRefs } from "./utils/effect/ast.js";
 import { getProgramAnalysis } from "./utils/effect/get-program-analysis.js";
-import { getEffectDepsRefs, isProp, isState } from "./utils/effect/react.js";
+import {
+  getEffectDepsRefs,
+  hasCleanup,
+  isProp,
+  isState,
+} from "./utils/effect/react.js";
+import { hasDeferredOrExternalEffectWork } from "./utils/has-deferred-or-external-effect-work.js";
 
 export const noAdjustStateOnPropChange = defineRule({
   id: "no-adjust-state-on-prop-change",
-  title: "State synced to a prop inside an effect",
+  title: "State adjusted after a prop changes",
   severity: "warn",
   tags: ["test-noise"],
   recommendation:
-    "Adjust the state inline during render with a `prev`-prop comparison (`if (prop !== prevProp) { setPrevProp(prop); setX(...); }`), or refactor to remove the duplicated state. Routing the adjustment through a useEffect forces an extra render with a stale UI between the two commits. See https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes",
+    "Remove the adjustment effect by deriving values during render, resetting the component with a key, or updating related state in the event that changes the prop. Avoid tracking the previous prop in more state, which preserves the duplication. See https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes",
   create: (context: RuleContext) => ({
     CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
       if (
@@ -36,8 +42,20 @@ export const noAdjustStateOnPropChange = defineRule({
         )
         .some((reference) => isProp(analysis, reference));
       if (!hasPropDependency) return;
-      for (const fact of collectEffectStateWriteFacts(analysis, context, node, context.filename)) {
-        if (!fact.isRenderKnownCopy || fact.resetsSourceState) continue;
+      const facts = collectEffectStateWriteFacts(analysis, context, node, context.filename);
+      if (
+        hasCleanup(analysis, node) ||
+        hasDeferredOrExternalEffectWork(analysis, node, context.scopes) ||
+        facts.some((fact) => fact.isDeferred)
+      ) {
+        return;
+      }
+      for (const fact of facts) {
+        if (!fact.isSynchronousRenderValue || fact.resetsSourceState) continue;
+        const writtenValueHasPropSource = fact.sourceReferences
+          .flatMap((reference) => getUpstreamRefs(analysis, reference))
+          .some((reference) => isProp(analysis, reference));
+        if (writtenValueHasPropSource) continue;
         context.report({
           node: fact.callExpression,
           message:

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-adjust-state-on-prop-change.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-adjust-state-on-prop-change.ts
@@ -5,12 +5,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { collectEffectStateWriteFacts } from "./utils/collect-effect-state-write-facts.js";
 import { getUpstreamRefs } from "./utils/effect/ast.js";
 import { getProgramAnalysis } from "./utils/effect/get-program-analysis.js";
-import {
-  getEffectDepsRefs,
-  hasCleanup,
-  isProp,
-  isState,
-} from "./utils/effect/react.js";
+import { getEffectDepsRefs, hasCleanup, isProp, isState } from "./utils/effect/react.js";
 import { hasDeferredOrExternalEffectWork } from "./utils/has-deferred-or-external-effect-work.js";
 
 export const noAdjustStateOnPropChange = defineRule({

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-derived-state.cross-file.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-derived-state.cross-file.test.ts
@@ -82,13 +82,29 @@ function List({ items }) {
   it.each([
     {
       dependencies: "[value]",
+      diagnosticCount: 0,
       name: "no-adjust-state-on-prop-change",
       rule: noAdjustStateOnPropChange,
     },
-    { dependencies: "[value]", name: "no-derived-state", rule: noDerivedState },
-    { dependencies: "[value]", name: "no-derived-state-effect", rule: noDerivedStateEffect },
-    { dependencies: "[]", name: "no-initialize-state", rule: noInitializeState },
-  ])("shares imported helper provenance with $name", ({ dependencies, rule }) => {
+    {
+      dependencies: "[value]",
+      diagnosticCount: 1,
+      name: "no-derived-state",
+      rule: noDerivedState,
+    },
+    {
+      dependencies: "[value]",
+      diagnosticCount: 1,
+      name: "no-derived-state-effect",
+      rule: noDerivedStateEffect,
+    },
+    {
+      dependencies: "[]",
+      diagnosticCount: 1,
+      name: "no-initialize-state",
+      rule: noInitializeState,
+    },
+  ])("shares imported helper provenance with $name", ({ dependencies, diagnosticCount, rule }) => {
     writeFile("src/derive-label.ts", `export const deriveLabel = (value) => value.trim();\n`);
     const result = runConsumer(
       `
@@ -104,7 +120,7 @@ function Field({ value }) {
       rule,
     );
     expect(result.parseErrors).toEqual([]);
-    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics).toHaveLength(diagnosticCount);
   });
 
   it.each([

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/collect-effect-state-write-facts.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/collect-effect-state-write-facts.ts
@@ -77,6 +77,7 @@ export interface EffectStateWriteFact {
   sourceReferences: ReadonlyArray<Reference>;
   isDeferred: boolean;
   isRenderKnownCopy: boolean;
+  isSynchronousRenderValue: boolean;
   matchesStateInitializer: boolean;
   resetsSourceState: boolean;
 }
@@ -1684,6 +1685,11 @@ export const collectEffectStateWriteFacts = (
         sourceReferences,
         isDeferred: frame.isDeferred,
         isRenderKnownCopy,
+        isSynchronousRenderValue:
+          !frame.isDeferred &&
+          !valueEvidence.hasUnknownSource &&
+          !valueEvidence.hasDeferredIntroducedValue &&
+          !valueEvidence.readsExternalValue,
         matchesStateInitializer: doesMatchStateInitializer,
         resetsSourceState: false,
       });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/has-deferred-or-external-effect-work.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/has-deferred-or-external-effect-work.ts
@@ -1,6 +1,6 @@
 import { TIMER_AND_SCHEDULER_DIRECT_CALLEE_NAMES } from "../../../constants/dom.js";
-import { FETCH_CALLEE_NAMES } from "../../../constants/library.js";
 import type { ScopeAnalysis } from "../../../semantic/scope-analysis.js";
+import { containsFetchCall } from "../../../utils/contains-fetch-call.js";
 import type { EsTreeNode } from "../../../utils/es-tree-node.js";
 import { getStaticPropertyName } from "../../../utils/get-static-property-name.js";
 import { isFunctionLike } from "../../../utils/is-function-like.js";
@@ -9,6 +9,7 @@ import { resolveExactLocalFunction } from "../../../utils/resolve-exact-local-fu
 import { walkAst } from "../../../utils/walk-ast.js";
 import type { ProgramAnalysis } from "./effect/get-program-analysis.js";
 import { getEffectFn } from "./effect/react.js";
+import { isSubscribeLikeCallExpression } from "./is-subscribe-like-call-expression.js";
 
 const DEFERRED_MEMBER_NAMES: ReadonlySet<string> = new Set(["catch", "finally", "then"]);
 
@@ -19,6 +20,7 @@ export const hasDeferredOrExternalEffectWork = (
 ): boolean => {
   const effectFunction = getEffectFn(analysis, effectNode);
   if (!effectFunction) return false;
+  if (containsFetchCall(effectFunction, { stopAtFunctionBoundary: true })) return true;
   let didFindDeferredOrExternalWork = false;
   walkAst(effectFunction, (child) => {
     if (didFindDeferredOrExternalWork) return false;
@@ -33,6 +35,10 @@ export const hasDeferredOrExternalEffectWork = (
       }
     }
     if (!isNodeOfType(child, "CallExpression")) return;
+    if (isSubscribeLikeCallExpression(child)) {
+      didFindDeferredOrExternalWork = true;
+      return false;
+    }
     const localFunction = resolveExactLocalFunction(child.callee, scopes);
     if (isFunctionLike(localFunction) && localFunction.async) {
       didFindDeferredOrExternalWork = true;
@@ -41,8 +47,7 @@ export const hasDeferredOrExternalEffectWork = (
     const callee = child.callee;
     if (
       isNodeOfType(callee, "Identifier") &&
-      (FETCH_CALLEE_NAMES.has(callee.name) ||
-        TIMER_AND_SCHEDULER_DIRECT_CALLEE_NAMES.has(callee.name))
+      TIMER_AND_SCHEDULER_DIRECT_CALLEE_NAMES.has(callee.name)
     ) {
       didFindDeferredOrExternalWork = true;
       return false;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/has-deferred-or-external-effect-work.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/has-deferred-or-external-effect-work.ts
@@ -1,5 +1,6 @@
 import { TIMER_AND_SCHEDULER_DIRECT_CALLEE_NAMES } from "../../../constants/dom.js";
 import type { ScopeAnalysis } from "../../../semantic/scope-analysis.js";
+import { collectEffectInvokedFunctions } from "../../../utils/collect-effect-invoked-functions.js";
 import { containsFetchCall } from "../../../utils/contains-fetch-call.js";
 import type { EsTreeNode } from "../../../utils/es-tree-node.js";
 import { getStaticPropertyName } from "../../../utils/get-static-property-name.js";
@@ -21,9 +22,13 @@ export const hasDeferredOrExternalEffectWork = (
   const effectFunction = getEffectFn(analysis, effectNode);
   if (!effectFunction) return false;
   if (containsFetchCall(effectFunction, { stopAtFunctionBoundary: true })) return true;
+  const effectInvokedFunctions = collectEffectInvokedFunctions(effectFunction);
   let didFindDeferredOrExternalWork = false;
   walkAst(effectFunction, (child) => {
     if (didFindDeferredOrExternalWork) return false;
+    if (child !== effectFunction && isFunctionLike(child) && !effectInvokedFunctions.has(child)) {
+      return false;
+    }
     if (isNodeOfType(child, "AssignmentExpression")) {
       const assignmentTarget = child.left;
       const handlerName = isNodeOfType(assignmentTarget, "MemberExpression")

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/has-deferred-or-external-effect-work.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/has-deferred-or-external-effect-work.ts
@@ -10,7 +10,7 @@ import { resolveExactLocalFunction } from "../../../utils/resolve-exact-local-fu
 import { walkAst } from "../../../utils/walk-ast.js";
 import type { ProgramAnalysis } from "./effect/get-program-analysis.js";
 import { getEffectFn } from "./effect/react.js";
-import { isSubscribeLikeCallExpression } from "./is-subscribe-like-call-expression.js";
+import { isSubscribeOrObserveCallExpression } from "./is-subscribe-like-call-expression.js";
 
 const DEFERRED_MEMBER_NAMES: ReadonlySet<string> = new Set(["catch", "finally", "then"]);
 
@@ -40,7 +40,7 @@ export const hasDeferredOrExternalEffectWork = (
       }
     }
     if (!isNodeOfType(child, "CallExpression")) return;
-    if (isSubscribeLikeCallExpression(child)) {
+    if (isSubscribeOrObserveCallExpression(child)) {
       didFindDeferredOrExternalWork = true;
       return false;
     }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/has-deferred-or-external-effect-work.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/has-deferred-or-external-effect-work.ts
@@ -1,0 +1,59 @@
+import { TIMER_AND_SCHEDULER_DIRECT_CALLEE_NAMES } from "../../../constants/dom.js";
+import { FETCH_CALLEE_NAMES } from "../../../constants/library.js";
+import type { ScopeAnalysis } from "../../../semantic/scope-analysis.js";
+import type { EsTreeNode } from "../../../utils/es-tree-node.js";
+import { getStaticPropertyName } from "../../../utils/get-static-property-name.js";
+import { isFunctionLike } from "../../../utils/is-function-like.js";
+import { isNodeOfType } from "../../../utils/is-node-of-type.js";
+import { resolveExactLocalFunction } from "../../../utils/resolve-exact-local-function.js";
+import { walkAst } from "../../../utils/walk-ast.js";
+import type { ProgramAnalysis } from "./effect/get-program-analysis.js";
+import { getEffectFn } from "./effect/react.js";
+
+const DEFERRED_MEMBER_NAMES: ReadonlySet<string> = new Set(["catch", "finally", "then"]);
+
+export const hasDeferredOrExternalEffectWork = (
+  analysis: ProgramAnalysis,
+  effectNode: EsTreeNode,
+  scopes: ScopeAnalysis,
+): boolean => {
+  const effectFunction = getEffectFn(analysis, effectNode);
+  if (!effectFunction) return false;
+  let didFindDeferredOrExternalWork = false;
+  walkAst(effectFunction, (child) => {
+    if (didFindDeferredOrExternalWork) return false;
+    if (isNodeOfType(child, "AssignmentExpression")) {
+      const assignmentTarget = child.left;
+      const handlerName = isNodeOfType(assignmentTarget, "MemberExpression")
+        ? getStaticPropertyName(assignmentTarget)
+        : null;
+      if (handlerName?.startsWith("on") && isFunctionLike(child.right)) {
+        didFindDeferredOrExternalWork = true;
+        return false;
+      }
+    }
+    if (!isNodeOfType(child, "CallExpression")) return;
+    const localFunction = resolveExactLocalFunction(child.callee, scopes);
+    if (isFunctionLike(localFunction) && localFunction.async) {
+      didFindDeferredOrExternalWork = true;
+      return false;
+    }
+    const callee = child.callee;
+    if (
+      isNodeOfType(callee, "Identifier") &&
+      (FETCH_CALLEE_NAMES.has(callee.name) ||
+        TIMER_AND_SCHEDULER_DIRECT_CALLEE_NAMES.has(callee.name))
+    ) {
+      didFindDeferredOrExternalWork = true;
+      return false;
+    }
+    const memberName = isNodeOfType(callee, "MemberExpression")
+      ? getStaticPropertyName(callee)
+      : null;
+    if (memberName && DEFERRED_MEMBER_NAMES.has(memberName)) {
+      didFindDeferredOrExternalWork = true;
+      return false;
+    }
+  });
+  return didFindDeferredOrExternalWork;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/is-subscribe-like-call-expression.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/is-subscribe-like-call-expression.ts
@@ -19,13 +19,16 @@ export const isSubscribeLikeCallExpression = (node: EsTreeNode): boolean => {
   return methodName !== null && SUBSCRIPTION_METHOD_NAMES.has(methodName);
 };
 
-export const isSubscribeOrObserveCallExpression = (node: EsTreeNode): boolean => {
+export const getSubscribeOrObserveMethodName = (node: EsTreeNode): string | null => {
   const methodName = getSubscribeLikeMethodName(node);
-  return (
+  const isSubscribeOrObserve =
     methodName !== null &&
-    (SUBSCRIPTION_METHOD_NAMES.has(methodName) || methodName === OBSERVER_REGISTRATION_METHOD_NAME)
-  );
+    (SUBSCRIPTION_METHOD_NAMES.has(methodName) || methodName === OBSERVER_REGISTRATION_METHOD_NAME);
+  return isSubscribeOrObserve ? methodName : null;
 };
+
+export const isSubscribeOrObserveCallExpression = (node: EsTreeNode): boolean =>
+  getSubscribeOrObserveMethodName(node) !== null;
 
 export const isCleanupReturningSubscribeLikeCallExpression = (node: EsTreeNode): boolean => {
   const methodName = getSubscribeLikeMethodName(node);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/is-subscribe-like-call-expression.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/is-subscribe-like-call-expression.ts
@@ -5,6 +5,8 @@ import {
 import type { EsTreeNode } from "../../../utils/es-tree-node.js";
 import { isNodeOfType } from "../../../utils/is-node-of-type.js";
 
+export const OBSERVER_REGISTRATION_METHOD_NAME = "observe";
+
 const getSubscribeLikeMethodName = (node: EsTreeNode): string | null => {
   if (!isNodeOfType(node, "CallExpression")) return null;
   if (!isNodeOfType(node.callee, "MemberExpression")) return null;
@@ -15,6 +17,14 @@ const getSubscribeLikeMethodName = (node: EsTreeNode): string | null => {
 export const isSubscribeLikeCallExpression = (node: EsTreeNode): boolean => {
   const methodName = getSubscribeLikeMethodName(node);
   return methodName !== null && SUBSCRIPTION_METHOD_NAMES.has(methodName);
+};
+
+export const isSubscribeOrObserveCallExpression = (node: EsTreeNode): boolean => {
+  const methodName = getSubscribeLikeMethodName(node);
+  return (
+    methodName !== null &&
+    (SUBSCRIPTION_METHOD_NAMES.has(methodName) || methodName === OBSERVER_REGISTRATION_METHOD_NAME)
+  );
 };
 
 export const isCleanupReturningSubscribeLikeCallExpression = (node: EsTreeNode): boolean => {

--- a/packages/react-doctor/tests/regressions/state-rules/effect-fixtures/no-adjust-state-on-prop-change.json
+++ b/packages/react-doctor/tests/regressions/state-rules/effect-fixtures/no-adjust-state-on-prop-change.json
@@ -14,24 +14,18 @@
     },
     {
       "idx": 2,
-      "name": "Set state to literal when prop changes",
-      "code": "\n        function List({ items }) {\n          const [selection, setSelection] = useState();\n\n          useEffect(() => {\n            setSelection(null);\n          }, [items]);\n        }\n      ",
-      "todo": false
-    },
-    {
-      "idx": 3,
       "name": "Set state to external state when prop changes",
       "code": "\n        function List({ items }) {\n          const [selection, setSelection] = useState();\n          const { data: externalData } = useDataSource();\n\n          useEffect(() => {\n            setSelection(externalData);\n          }, [items]);\n        }\n      ",
       "todo": false
     },
     {
-      "idx": 4,
-      "name": "Conditionally set state to literal when prop changes",
-      "code": "\n        function Form({ result }) {\n          const [error, setError] = useState();\n\n          useEffect(() => {\n            if (result.data) {\n              setError(null);\n            }\n          }, [result]);\n        }\n      ",
+      "idx": 3,
+      "name": "Set state to a value derived from props",
+      "code": "\n        function Counter({ count }) {\n          const [doubleCount, setDoubleCount] = useState(0);\n\n          useEffect(() => {\n            setDoubleCount(count * 2);\n          }, [count]);\n        }\n      ",
       "todo": false
     },
     {
-      "idx": 5,
+      "idx": 4,
       "name": "Setter inside named async function called from effect",
       "code": "\n        function Profile({ userId }) {\n          const [data, setData] = useState(null);\n\n          useEffect(() => {\n            const sync = async () => {\n              await refresh(userId);\n              setData(true);\n            };\n            sync();\n          }, [userId]);\n        }\n      ",
       "todo": false
@@ -40,13 +34,20 @@
   "invalid": [
     {
       "idx": 0,
-      "name": "Set state to a value derived from props",
-      "code": "\n        function Counter({ count }) {\n          const [doubleCount, setDoubleCount] = useState(0);\n\n          useEffect(() => {\n            setDoubleCount(count * 2);\n          }, [count]);\n        }\n      ",
+      "name": "Set state to literal when prop changes",
+      "code": "\n        function List({ items }) {\n          const [selection, setSelection] = useState();\n\n          useEffect(() => {\n            setSelection(null);\n          }, [items]);\n        }\n      ",
       "todo": false,
       "errors": 1
     },
     {
       "idx": 1,
+      "name": "Conditionally set state to literal when prop changes",
+      "code": "\n        function Form({ result }) {\n          const [error, setError] = useState();\n\n          useEffect(() => {\n            if (result.data) {\n              setError(null);\n            }\n          }, [result]);\n        }\n      ",
+      "todo": false,
+      "errors": 1
+    },
+    {
+      "idx": 2,
       "name": "Set state to internal state when prop changes",
       "code": "\n        function List({ items }) {\n          const [selection, setSelection] = useState();\n          const [internalData, setInternalData] = useState();\n\n          useEffect(() => {\n            setSelection(internalData);\n          }, [items, internalData]);\n        }\n      ",
       "todo": false,


### PR DESCRIPTION
## Summary

- align `no-adjust-state-on-prop-change` with the published reset/adjustment contract
- report synchronous non-prop-derived state writes caused by prop dependencies
- leave direct prop mirrors to the derived-state sibling rules
- exclude cleanup, async, timer, subscription, external-callback, and externally-derived writes
- replace the previous-prop recommendation with derive/key/event guidance
- add contract, sibling-ownership, liveness, and fuzz regressions plus a patch changeset

The Brainly benchmark baseline is intentionally silent because it is a direct prop mirror and belongs to the derived-state family. The benchmark should remain excluded until its target and prompt are redesigned around one contract.

## Validation

- focused contract suites: 65 passing
- full plugin suite: 15,107 passing, 188 skipped
- plugin typecheck and build
- monorepo build, lint, and format check
- fuzz corpus: 44 passing, 402 skipped
- strict fuzz: 1,000 iterations, seed 1359001
- uncached local RDE: 100 roots, 123 matching findings across 7 repositories; sampled findings matched the published synchronous prop-triggered adjustment condition, with direct mirrors and deferred/external work excluded

RDE was run with `REACT_DOCTOR_NO_CACHE=1`; the initial cached partial output was discarded from the validation evidence.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes lint behavior for a widely used derived-state rule family—some patterns will newly report or stop reporting—though scope is limited to effect analysis heuristics with extensive regression coverage.
> 
> **Overview**
> **`no-adjust-state-on-prop-change`** now matches its published contract: it flags **synchronous state resets/adjustments** in `useEffect` when a **prop** is in the dependency array, and it **stops** treating direct prop mirrors (`setState(prop)`) as this rule’s job—those stay with **`no-derived-state` / `no-derived-state-effect`**.
> 
> Detection now requires **`isSynchronousRenderValue`** writes whose value is **not** derived from props, and it **bails out** when the effect has cleanup, deferred work, or **external side work** (subscriptions, `observe`, fetch/HTTP, timers, promise chains, async invokes, etc.) via new **`hasDeferredOrExternalEffectWork`** and **`isSynchronousRenderValue`** on effect state-write facts.
> 
> **`effect-needs-cleanup`** shares refactored subscribe/observe helpers (`getSubscribeOrObserveMethodName`, computed `source[subscribe](…)` coverage). Messaging, liveness fixture, fuzz corpus, and contract tests are updated accordingly (patch changeset).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9a803c9e4fc4b054db8bce4a5e535a2a6de6f28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->