### PR TITLE
fix(rules): resolve React hook aliases semantically

### DIFF
--- a/.changeset/bright-hooks-listen.md
+++ b/.changeset/bright-hooks-listen.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Resolve React hooks by binding identity across state and effect rules, including named imports, immutable aliases, namespace calls, and isomorphic effect aliases.

--- a/packages/fuzz/corpus/regressions/advanced-event-handler-refs--non-react-effect-event-polyfill.tsx
+++ b/packages/fuzz/corpus/regressions/advanced-event-handler-refs--non-react-effect-event-polyfill.tsx
@@ -1,0 +1,17 @@
+// rule: advanced-event-handler-refs
+// weakness: library-idiom
+// source: PR #1362 Cursor Bugbot review
+
+import { useEffectEvent } from "@rocket.chat/fuselage-hooks";
+import { useEffect } from "react";
+
+export const ScrollListener = () => {
+  const onScroll = useEffectEvent(() => syncState());
+
+  useEffect(() => {
+    window.addEventListener("scroll", onScroll);
+    return () => window.removeEventListener("scroll", onScroll);
+  }, [onScroll]);
+
+  return null;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/activity-wraps-effect-heavy-subtree.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/activity-wraps-effect-heavy-subtree.ts
@@ -1,8 +1,9 @@
 import { defineRule } from "../../utils/define-rule.js";
 import { EFFECT_HOOK_NAMES, UPPERCASE_PATTERN } from "../../constants/react.js";
+import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
 import { findProgramRoot } from "../../utils/find-program-root.js";
 import { getImportedName } from "../../utils/get-imported-name.js";
-import { isHookCall } from "../../utils/is-hook-call.js";
+import { isReactHookCall } from "../../utils/is-react-hook-call.js";
 import { walkAst } from "../../utils/walk-ast.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
@@ -56,12 +57,12 @@ const collectChildComponentNames = (
   });
 };
 
-const countEffectHookCalls = (body: EsTreeNode | null): number => {
+const countEffectHookCalls = (body: EsTreeNode | null, scopes: ScopeAnalysis): number => {
   if (!body) return 0;
   let count = 0;
   walkAst(body, (child: EsTreeNode) => {
     if (!isNodeOfType(child, "CallExpression")) return;
-    if (isHookCall(child, EFFECT_HOOK_NAMES)) count++;
+    if (isReactHookCall(child, EFFECT_HOOK_NAMES, scopes)) count++;
   });
   return count;
 };
@@ -110,11 +111,12 @@ const getComponentEffectIndex = (programRoot: EsTreeNode): ComponentEffectIndex 
 const getSameFileComponentEffectCount = (
   programRoot: EsTreeNode,
   componentName: string,
+  scopes: ScopeAnalysis,
 ): number => {
   const index = getComponentEffectIndex(programRoot);
   const cachedCount = index.effectCountByName.get(componentName);
   if (cachedCount !== undefined) return cachedCount;
-  const count = countEffectHookCalls(index.bodyByName.get(componentName) ?? null);
+  const count = countEffectHookCalls(index.bodyByName.get(componentName) ?? null, scopes);
   index.effectCountByName.set(componentName, count);
   return count;
 };
@@ -216,7 +218,11 @@ export const activityWrapsEffectHeavySubtree = defineRule({
         let totalEffects = 0;
         const effectfulChildren: string[] = [];
         for (const componentName of childComponentNames) {
-          const effectCount = getSameFileComponentEffectCount(programRoot, componentName);
+          const effectCount = getSameFileComponentEffectCount(
+            programRoot,
+            componentName,
+            context.scopes,
+          );
           if (effectCount === 0) continue;
           totalEffects += effectCount;
           effectfulChildren.push(`<${componentName}>`);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/advanced-event-handler-refs.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/advanced-event-handler-refs.regressions.test.ts
@@ -91,6 +91,24 @@ describe("advanced-event-handler-refs — regressions", () => {
     }
   });
 
+  it("stays silent for a non-React useEffectEvent polyfill", () => {
+    const result = runRule(
+      advancedEventHandlerRefs,
+      `import { useEffectEvent } from "@rocket.chat/fuselage-hooks";
+      import { useEffect } from "react";
+      function C() {
+        const onScroll = useEffectEvent(() => syncState());
+        useEffect(() => {
+          window.addEventListener('scroll', onScroll);
+          return () => window.removeEventListener('scroll', onScroll);
+        }, [onScroll]);
+        return null;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   // Docs-validation r2: tracecat use-window-size (useThrottledCallback with
   // internal useMemo) and cloudscape collapsible-flashbar (useThrottleCallback
   // with `.cancel()` cleanup) — throttle/debounce wrapper hooks memoize

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/advanced-event-handler-refs.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/advanced-event-handler-refs.ts
@@ -20,6 +20,7 @@ import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 // they ARE the ref-based pattern this rule recommends.
 const REACT_STABLE_HANDLER_HOOK_NAMES = new Set(["useCallback", "useEffectEvent"]);
 const CUSTOM_STABLE_HANDLER_HOOK_NAMES = new Set([
+  "useEffectEvent",
   "useEvent",
   "useEventCallback",
   "useMemoizedFn",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/advanced-event-handler-refs.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/advanced-event-handler-refs.ts
@@ -1,10 +1,12 @@
 import { EFFECT_HOOK_NAMES, SUBSCRIPTION_METHOD_NAMES } from "../../constants/react.js";
+import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
 import { defineRule } from "../../utils/define-rule.js";
 import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
 import { getCalleeName } from "../../utils/get-callee-name.js";
 import { getEffectCallback } from "../../utils/get-effect-callback.js";
 import { getRootIdentifierName } from "../../utils/get-root-identifier-name.js";
 import { isHookCall } from "../../utils/is-hook-call.js";
+import { isReactHookCall } from "../../utils/is-react-hook-call.js";
 import { walkAst } from "../../utils/walk-ast.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { RuleContext } from "../../utils/rule-context.js";
@@ -16,9 +18,8 @@ import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 // the common userland stable-callback hooks (rc-util/ahooks `useEvent`,
 // MUI `useEventCallback`, ahooks `useMemoizedFn`, `useStableCallback`) —
 // they ARE the ref-based pattern this rule recommends.
-const STABLE_HANDLER_HOOK_NAMES = new Set([
-  "useCallback",
-  "useEffectEvent",
+const REACT_STABLE_HANDLER_HOOK_NAMES = new Set(["useCallback", "useEffectEvent"]);
+const CUSTOM_STABLE_HANDLER_HOOK_NAMES = new Set([
   "useEvent",
   "useEventCallback",
   "useMemoizedFn",
@@ -39,8 +40,11 @@ const isThrottledHandlerHookCall = (callNode: EsTreeNodeOfType<"CallExpression">
   return calleeName !== null && THROTTLED_HANDLER_HOOK_PATTERN.test(calleeName);
 };
 
-const isEmptyDepsUseMemoCall = (callNode: EsTreeNodeOfType<"CallExpression">): boolean => {
-  if (!isHookCall(callNode, "useMemo")) return false;
+const isEmptyDepsUseMemoCall = (
+  callNode: EsTreeNodeOfType<"CallExpression">,
+  scopes: ScopeAnalysis,
+): boolean => {
+  if (!isReactHookCall(callNode, "useMemo", scopes)) return false;
   const memoDepsNode = callNode.arguments?.[1];
   return (
     isNodeOfType(memoDepsNode, "ArrayExpression") && (memoDepsNode.elements?.length ?? 0) === 0
@@ -51,11 +55,12 @@ const isEmptyDepsUseMemoCall = (callNode: EsTreeNodeOfType<"CallExpression">): b
 // `someRef.current` (a `useRef(...).current` read) all keep a stable
 // identity, so listing the handler in the deps does NOT cause real
 // re-subscription churn. `useMemo` with non-empty deps still churns.
-const isStableHandlerInitializer = (initializer: EsTreeNode): boolean => {
+const isStableHandlerInitializer = (initializer: EsTreeNode, scopes: ScopeAnalysis): boolean => {
   if (isNodeOfType(initializer, "CallExpression")) {
     return (
-      isHookCall(initializer, STABLE_HANDLER_HOOK_NAMES) ||
-      isEmptyDepsUseMemoCall(initializer) ||
+      isReactHookCall(initializer, REACT_STABLE_HANDLER_HOOK_NAMES, scopes) ||
+      isHookCall(initializer, CUSTOM_STABLE_HANDLER_HOOK_NAMES) ||
+      isEmptyDepsUseMemoCall(initializer, scopes) ||
       isThrottledHandlerHookCall(initializer)
     );
   }
@@ -69,9 +74,15 @@ const isStableHandlerInitializer = (initializer: EsTreeNode): boolean => {
 // A subscription receiver backed by `useRef(...)` has a stable identity, so
 // its presence in the deps never forces re-subscription on its own — the
 // handler churn is still the only churn.
-const isStableRefReceiverDep = (referenceNode: EsTreeNode, receiverDepName: string): boolean => {
+const isStableRefReceiverDep = (
+  referenceNode: EsTreeNode,
+  receiverDepName: string,
+  scopes: ScopeAnalysis,
+): boolean => {
   const receiverBinding = findVariableInitializer(referenceNode, receiverDepName);
-  return Boolean(receiverBinding?.initializer && isHookCall(receiverBinding.initializer, "useRef"));
+  return Boolean(
+    receiverBinding?.initializer && isReactHookCall(receiverBinding.initializer, "useRef", scopes),
+  );
 };
 
 // HACK: `useEffect(() => { window.addEventListener(name, handler);
@@ -102,7 +113,7 @@ export const advancedEventHandlerRefs = defineRule({
     "Store the handler in a ref and have the listener read `handlerRef.current()`. The subscription stays put while the latest handler still runs.",
   create: (context: RuleContext) => ({
     CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
-      if (!isHookCall(node, EFFECT_HOOK_NAMES)) return;
+      if (!isReactHookCall(node, EFFECT_HOOK_NAMES, context.scopes)) return;
       if ((node.arguments?.length ?? 0) < 2) return;
       const callback = getEffectCallback(node);
       if (
@@ -148,7 +159,10 @@ export const advancedEventHandlerRefs = defineRule({
       // lookup: a prop param shadowing an outer stable binding resolves
       // to the (unstable) param, not the outer const.
       const handlerBinding = findVariableInitializer(node, registeredHandlerName);
-      if (handlerBinding?.initializer && isStableHandlerInitializer(handlerBinding.initializer)) {
+      if (
+        handlerBinding?.initializer &&
+        isStableHandlerInitializer(handlerBinding.initializer, context.scopes)
+      ) {
         return;
       }
 
@@ -162,7 +176,7 @@ export const advancedEventHandlerRefs = defineRule({
         (depName) =>
           depName !== registeredHandlerName &&
           subscriptionReceiverNames.has(depName) &&
-          !isStableRefReceiverDep(node, depName),
+          !isStableRefReceiverDep(node, depName, context.scopes),
       );
       if (hasNonHandlerDepTarget) return;
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -25,8 +25,8 @@ import { getRangeStart } from "../../utils/get-range-start.js";
 import { getStaticPropertyKeyName } from "../../utils/get-static-property-key-name.js";
 import { isEventHandlerAttribute } from "../../utils/is-event-handler-attribute.js";
 import { isAstDescendant } from "../../utils/is-ast-descendant.js";
-import { isHookCall } from "../../utils/is-hook-call.js";
 import { isReactHookName } from "../../utils/is-react-hook-name.js";
+import { isReactHookCall } from "../../utils/is-react-hook-call.js";
 import { isReactApiCall } from "../../utils/is-react-api-call.js";
 import { readStaticBoolean } from "../../utils/read-static-boolean.js";
 import {
@@ -1477,7 +1477,7 @@ const hasStableUnmountCleanupForUsage = (
     ) {
       return;
     }
-    if (!isHookCall(child, CLEANUP_EFFECT_HOOK_NAMES)) return;
+    if (!isReactHookCall(child, CLEANUP_EFFECT_HOOK_NAMES, context.scopes)) return;
     const dependencyList = child.arguments?.[1];
     if (!isNodeOfType(dependencyList, "ArrayExpression") || dependencyList.elements.length > 0) {
       return;
@@ -2448,7 +2448,7 @@ const isRetainedAbortControllerRefRelease = (
     !releaseFunction ||
     !usageFunction ||
     !isFunctionLike(usageFunction) ||
-    !isReturnedEffectCleanupFunction(releaseFunction) ||
+    !isReturnedEffectCleanupFunction(releaseFunction, context) ||
     !resolveReactRefCurrentOriginSymbol(releaseReceiver, context.scopes)
   ) {
     return false;
@@ -2901,7 +2901,10 @@ const matchesPairedReleaseVerb = (
 ): boolean =>
   pairedVerbNames.has(releaseVerbName) || UNIVERSAL_RELEASE_VERB_NAMES.has(releaseVerbName);
 
-const isReturnedEffectCleanupFunction = (functionNode: EsTreeNode): boolean => {
+const isReturnedEffectCleanupFunction = (
+  functionNode: EsTreeNode,
+  context: RuleContext,
+): boolean => {
   let currentNode = functionNode;
   let parentNode = currentNode.parent;
   while (
@@ -2922,7 +2925,7 @@ const isReturnedEffectCleanupFunction = (functionNode: EsTreeNode): boolean => {
   return Boolean(
     effectCallback &&
     isNodeOfType(effectCall, "CallExpression") &&
-    isHookCall(effectCall, CLEANUP_EFFECT_HOOK_NAMES),
+    isReactHookCall(effectCall, CLEANUP_EFFECT_HOOK_NAMES, context.scopes),
   );
 };
 
@@ -2932,7 +2935,7 @@ const isPotentiallyReachableFunction = (
 ): boolean => {
   if (
     isInlineRetainedHandlerFunction(functionNode, context) ||
-    isReturnedEffectCleanupFunction(functionNode)
+    isReturnedEffectCleanupFunction(functionNode, context)
   ) {
     return true;
   }
@@ -4394,7 +4397,7 @@ const isInlineRetainedHandlerFunction = (
   if (
     isNodeOfType(callbackCall, "CallExpression") &&
     callbackCall.arguments?.[0] === functionRoot &&
-    isHookCall(callbackCall, "useCallback") &&
+    isReactHookCall(callbackCall, "useCallback", context.scopes) &&
     isDirectJsxEventHandlerValue(callbackCall)
   ) {
     return true;
@@ -4455,14 +4458,14 @@ export const effectNeedsCleanup = defineRule({
 
     return {
       CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
-        if (isHookCall(node, "useCallback")) {
+        if (isReactHookCall(node, "useCallback", context.scopes)) {
           const retainedCallback = getEffectCallback(node);
           if (retainedCallback && !isInlineRetainedHandlerFunction(retainedCallback, context)) {
             reportRetainedLeak(retainedCallback);
           }
           return;
         }
-        if (!isHookCall(node, CLEANUP_EFFECT_HOOK_NAMES)) return;
+        if (!isReactHookCall(node, CLEANUP_EFFECT_HOOK_NAMES, context.scopes)) return;
         const callback = getEffectCallback(node);
         if (!callback) return;
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/hooks-no-nan-in-deps.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/hooks-no-nan-in-deps.test.ts
@@ -71,6 +71,20 @@ describe("hooks-no-nan-in-deps", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("flags `NaN` in an aliased useImperativeHandle dependency array", () => {
+    const result = runRule(
+      hooksNoNanInDeps,
+      `import { useImperativeHandle as exposeHandle } from "react";
+      const Comp = ({ ref }) => {
+        exposeHandle(ref, () => ({ focus: () => {} }), [NaN]);
+        return null;
+      };`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("does not lint `useSignalEffect` (Preact signals — single-arg API, no deps array)", () => {
     const result = runRule(
       hooksNoNanInDeps,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/hooks-no-nan-in-deps.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/hooks-no-nan-in-deps.ts
@@ -1,6 +1,5 @@
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
-import { getCalleeName } from "../../utils/get-callee-name.js";
 import { isReactHookCall } from "../../utils/is-react-hook-call.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isGlobalNanValue } from "../../utils/is-global-nan-value.js";
@@ -51,8 +50,7 @@ export const hooksNoNanInDeps = defineRule({
   create: (context) => ({
     CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
       if (!isReactHookCall(node, HOOKS_WITH_DEP_ARRAY, context.scopes)) return;
-      const calleeName = getCalleeName(node);
-      const depsIndex = calleeName === "useImperativeHandle" ? 2 : 1;
+      const depsIndex = isReactHookCall(node, "useImperativeHandle", context.scopes) ? 2 : 1;
       const depsArgument = node.arguments[depsIndex];
       if (!depsArgument || !isNodeOfType(depsArgument, "ArrayExpression")) return;
       for (const element of depsArgument.elements) {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/hooks-no-nan-in-deps.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/hooks-no-nan-in-deps.ts
@@ -1,7 +1,7 @@
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { getCalleeName } from "../../utils/get-callee-name.js";
-import { isHookCall } from "../../utils/is-hook-call.js";
+import { isReactHookCall } from "../../utils/is-react-hook-call.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isGlobalNanValue } from "../../utils/is-global-nan-value.js";
 
@@ -50,7 +50,7 @@ export const hooksNoNanInDeps = defineRule({
     "Remove `NaN` (or `Number.NaN`) from the dependency array. If a value can be NaN at runtime, normalise it (`Number.isNaN(x) ? 0 : x`) before passing it.",
   create: (context) => ({
     CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
-      if (!isHookCall(node, HOOKS_WITH_DEP_ARRAY)) return;
+      if (!isReactHookCall(node, HOOKS_WITH_DEP_ARRAY, context.scopes)) return;
       const calleeName = getCalleeName(node);
       const depsIndex = calleeName === "useImperativeHandle" ? 2 : 1;
       const depsArgument = node.arguments[depsIndex];

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-adjust-state-on-prop-change.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-adjust-state-on-prop-change.ts
@@ -1,5 +1,5 @@
 import { defineRule } from "../../utils/define-rule.js";
-import { isReactApiCall } from "../../utils/is-react-api-call.js";
+import { isReactHookCall } from "../../utils/is-react-hook-call.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { collectEffectStateWriteFacts } from "./utils/collect-effect-state-write-facts.js";
@@ -17,16 +17,7 @@ export const noAdjustStateOnPropChange = defineRule({
     "Remove the adjustment effect by deriving values during render, resetting the component with a key, or updating related state in the event that changes the prop. Avoid tracking the previous prop in more state, which preserves the duplication. See https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes",
   create: (context: RuleContext) => ({
     CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
-      if (
-        !isReactApiCall(node, "useEffect", context.scopes, {
-          allowGlobalReactNamespace: true,
-          allowUnboundBareCalls: true,
-          resolveConditionalAliases: true,
-          resolveNamedAliases: true,
-        })
-      ) {
-        return;
-      }
+      if (!isReactHookCall(node, "useEffect", context.scopes)) return;
       const analysis = getProgramAnalysis(node);
       if (!analysis) return;
       const dependencyReferences = getEffectDepsRefs(analysis, node);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-derived-state-effect.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-derived-state-effect.ts
@@ -1,6 +1,6 @@
 import { EFFECT_HOOK_NAMES } from "../../constants/react.js";
 import { defineRule } from "../../utils/define-rule.js";
-import { isReactApiCall } from "../../utils/is-react-api-call.js";
+import { isReactHookCall } from "../../utils/is-react-hook-call.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { collectEffectStateWriteFacts } from "./utils/collect-effect-state-write-facts.js";
@@ -15,16 +15,7 @@ export const noDerivedStateEffect = defineRule({
     "Work out derived values while rendering: `const x = fn(dep)`. To reset a component's state when a prop changes, give it a key prop: `<Component key={prop} />`. See https://react.dev/learn/you-might-not-need-an-effect",
   create: (context: RuleContext) => ({
     CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
-      if (
-        !isReactApiCall(node, EFFECT_HOOK_NAMES, context.scopes, {
-          allowGlobalReactNamespace: true,
-          allowUnboundBareCalls: true,
-          resolveConditionalAliases: true,
-          resolveNamedAliases: true,
-        })
-      ) {
-        return;
-      }
+      if (!isReactHookCall(node, EFFECT_HOOK_NAMES, context.scopes)) return;
       const analysis = getProgramAnalysis(node);
       if (!analysis) return;
       const derivedWrite = collectEffectStateWriteFacts(

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-derived-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-derived-state.ts
@@ -3,7 +3,7 @@ import { createComponentPropStackTracker } from "../../utils/create-component-pr
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
-import { isReactApiCall } from "../../utils/is-react-api-call.js";
+import { isReactHookCall } from "../../utils/is-react-hook-call.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { collectEffectStateWriteFacts } from "./utils/collect-effect-state-write-facts.js";
 import { collectRenderStateWriteFacts } from "./utils/collect-render-state-write-facts.js";
@@ -54,16 +54,7 @@ export const noDerivedState = defineRule({
     return {
       ...componentTracker.visitors,
       CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
-        if (
-          !isReactApiCall(node, "useEffect", context.scopes, {
-            allowGlobalReactNamespace: true,
-            allowUnboundBareCalls: true,
-            resolveConditionalAliases: true,
-            resolveNamedAliases: true,
-          })
-        ) {
-          return;
-        }
+        if (!isReactHookCall(node, "useEffect", context.scopes)) return;
         const analysis = getProgramAnalysis(node);
         if (!analysis) return;
         for (const fact of collectEffectStateWriteFacts(

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-derived-use-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-derived-use-state.ts
@@ -6,7 +6,7 @@ import { findProgramRoot } from "../../utils/find-program-root.js";
 import { getCalleeName } from "../../utils/get-callee-name.js";
 import { getRootIdentifierName } from "../../utils/get-root-identifier-name.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
-import { isHookCall } from "../../utils/is-hook-call.js";
+import { isReactHookCall } from "../../utils/is-react-hook-call.js";
 import { isInitialOnlyPropName } from "../../utils/is-initial-only-prop-name.js";
 import { isReactHookName } from "../../utils/is-react-hook-name.js";
 import { walkAst } from "../../utils/walk-ast.js";
@@ -450,7 +450,7 @@ export const noDerivedUseState = defineRule({
     return {
       ...propStackTracker.visitors,
       CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
-        if (!isHookCall(node, "useState") || !node.arguments?.length) return;
+        if (!isReactHookCall(node, "useState", context.scopes) || !node.arguments?.length) return;
         const seed = unwrapInitializerSeed(node.arguments[0]);
 
         const reportStalePropCopy = (propName: string): void => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-direct-state-mutation.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-direct-state-mutation.ts
@@ -328,7 +328,7 @@ export const noDirectStateMutation = defineRule({
   create: (context: RuleContext) => {
     const checkComponent = (componentBody: EsTreeNode | null | undefined): void => {
       if (!componentBody || !isNodeOfType(componentBody, "BlockStatement")) return;
-      const bindings = collectUseStateBindings(componentBody);
+      const bindings = collectUseStateBindings(componentBody, context.scopes);
       if (bindings.length === 0) return;
 
       const stateValueToSetter = new Map<string, string>(

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.ts
@@ -27,6 +27,7 @@ import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isProvenBrowserApiReceiver } from "../../utils/is-proven-browser-api-receiver.js";
 import { isProvenIntrinsicJsxElement } from "../../utils/is-proven-intrinsic-jsx-element.js";
 import { isReactApiCall } from "../../utils/is-react-api-call.js";
+import { isReactHookCall } from "../../utils/is-react-hook-call.js";
 import { isSetterIdentifier } from "../../utils/is-setter-identifier.js";
 import { isUppercaseName } from "../../utils/is-uppercase-name.js";
 import { resolveExactLocalFunction } from "../../utils/resolve-exact-local-function.js";
@@ -82,16 +83,7 @@ const findTopLevelEffectCalls = (
     if (!isNodeOfType(statement, "ExpressionStatement")) continue;
     const expression = unwrapDiscardedExpression(statement);
     if (!isNodeOfType(expression, "CallExpression")) continue;
-    if (
-      !isReactApiCall(expression, EFFECT_HOOK_NAMES, scopes, {
-        allowGlobalReactNamespace: true,
-        allowUnboundBareCalls: true,
-        resolveConditionalAliases: true,
-        resolveNamedAliases: true,
-      })
-    ) {
-      continue;
-    }
+    if (!isReactHookCall(expression, EFFECT_HOOK_NAMES, scopes)) continue;
     effectCalls.push(expression);
   }
   return effectCalls;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-event-handler.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-event-handler.ts
@@ -3,7 +3,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import { getCallbackStatements } from "../../utils/get-callback-statements.js";
 import { getEffectCallback } from "../../utils/get-effect-callback.js";
 import { getRootIdentifierName } from "../../utils/get-root-identifier-name.js";
-import { isHookCall } from "../../utils/is-hook-call.js";
+import { isReactHookCall } from "../../utils/is-react-hook-call.js";
 import { createComponentPropStackTracker } from "../../utils/create-component-prop-stack-tracker.js";
 import { areExpressionsStructurallyEqual } from "../../utils/are-expressions-structurally-equal.js";
 import { walkAst } from "../../utils/walk-ast.js";
@@ -333,7 +333,12 @@ export const noEffectEventHandler = defineRule({
     return {
       ...propStackTracker.visitors,
       CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
-        if (!isHookCall(node, EFFECT_HOOK_NAMES) || (node.arguments?.length ?? 0) < 2) return;
+        if (
+          !isReactHookCall(node, EFFECT_HOOK_NAMES, context.scopes) ||
+          (node.arguments?.length ?? 0) < 2
+        ) {
+          return;
+        }
 
         const callback = getEffectCallback(node);
         if (!callback) return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-event-in-deps.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-event-in-deps.ts
@@ -4,7 +4,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { isComponentAssignment } from "../../utils/is-component-assignment.js";
-import { isHookCall } from "../../utils/is-hook-call.js";
+import { isReactHookCall } from "../../utils/is-react-hook-call.js";
 import { isNonReactEffectEventCallee } from "../../utils/is-non-react-effect-event-callee.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isUppercaseName } from "../../utils/is-uppercase-name.js";
@@ -103,7 +103,7 @@ export const noEffectEventInDeps = defineRule({
         if (!isNodeOfType(declaratorNode.id, "Identifier")) return;
         const initializer = declaratorNode.init;
         if (!initializer || !isNodeOfType(initializer, "CallExpression")) return;
-        if (!isHookCall(initializer, "useEffectEvent")) return;
+        if (!isReactHookCall(initializer, "useEffectEvent", context.scopes)) return;
         // A same-named `useEffectEvent` imported from a non-React package OR
         // defined in this module (userland polyfill) returns a STABLE
         // callback — listing it in deps is fine, so it must not taint the
@@ -119,7 +119,9 @@ export const noEffectEventInDeps = defineRule({
     return {
       ...componentBindings.visitors,
       CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
-        if (!isHookCall(node, HOOKS_WITH_DEPS) || node.arguments.length < 2) return;
+        if (!isReactHookCall(node, HOOKS_WITH_DEPS, context.scopes) || node.arguments.length < 2) {
+          return;
+        }
         if (!componentBindings.isInsideComponent()) return;
         const depsNode = node.arguments[1];
         if (!isNodeOfType(depsNode, "ArrayExpression")) return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-with-fresh-deps.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-with-fresh-deps.ts
@@ -4,7 +4,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
 import { findForwardedFreshHookDependencies } from "../../utils/find-forwarded-fresh-hook-dependencies.js";
-import { isHookCall } from "../../utils/is-hook-call.js";
+import { isReactHookCall } from "../../utils/is-react-hook-call.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import type { RuleContext } from "../../utils/rule-context.js";
@@ -141,7 +141,7 @@ export const noEffectWithFreshDeps = defineRule({
         });
       }
 
-      if (!isHookCall(node, HOOKS_WITH_DEPS)) return;
+      if (!isReactHookCall(node, HOOKS_WITH_DEPS, context.scopes)) return;
       const args = node.arguments ?? [];
       if (args.length < 2) return;
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-event-handler-contracts.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-event-handler-contracts.test.ts
@@ -158,4 +158,21 @@ describe("no-event-handler event-source contract", () => {
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toHaveLength(1);
   });
+
+  it("keeps no-event-trigger-state through a React effect import alias", () => {
+    const result = runRule(
+      noEventTriggerState,
+      `import { useEffect as useSynchronize, useState } from "react";
+      function Form() {
+        const [payload, setPayload] = useState(null);
+        useSynchronize(() => {
+          if (payload) post("/submit", payload);
+        }, [payload]);
+        return <button onClick={() => setPayload({ ready: true })}>Submit</button>;
+      }`,
+      { forceJsx: true },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-event-handler.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-event-handler.ts
@@ -4,6 +4,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { isReactHookCall } from "../../utils/is-react-hook-call.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { walkAst } from "../../utils/walk-ast.js";
 import { collectBoundedEffectExecutionFrames } from "./utils/collect-effect-state-write-facts.js";
@@ -15,7 +16,6 @@ import {
   isProp,
   isState,
   isStateSetterCall,
-  isUseEffect,
   getUseStateDecl,
 } from "./utils/effect/react.js";
 import { findTriggeredSideEffectCalleeName } from "./utils/find-triggered-side-effect-callee-name.js";
@@ -126,7 +126,7 @@ export const noEventHandler = defineRule({
     "Run the side effect in the event handler that triggers it, instead of watching its state from a useEffect. See https://react.dev/learn/you-might-not-need-an-effect#sharing-logic-between-event-handlers",
   create: (context: RuleContext) => ({
     CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
-      if (!isUseEffect(node)) return;
+      if (!isReactHookCall(node, "useEffect", context.scopes)) return;
       const analysis = getProgramAnalysis(node);
       if (!analysis || hasCleanup(analysis, node)) return;
       const frames = collectBoundedEffectExecutionFrames(analysis, node);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-event-trigger-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-event-trigger-state.ts
@@ -3,7 +3,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import { getCallbackStatements } from "../../utils/get-callback-statements.js";
 import { getEffectCallback } from "../../utils/get-effect-callback.js";
 import { isComponentAssignment } from "../../utils/is-component-assignment.js";
-import { isHookCall } from "../../utils/is-hook-call.js";
+import { isReactHookCall } from "../../utils/is-react-hook-call.js";
 import { isUppercaseName } from "../../utils/is-uppercase-name.js";
 import { walkAst } from "../../utils/walk-ast.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
@@ -100,7 +100,7 @@ export const noEventTriggerState = defineRule({
     const checkComponent = (componentBody: EsTreeNode | null | undefined): void => {
       if (!componentBody || !isNodeOfType(componentBody, "BlockStatement")) return;
 
-      const useStateBindings = collectUseStateBindings(componentBody);
+      const useStateBindings = collectUseStateBindings(componentBody, context.scopes);
       if (useStateBindings.length === 0) return;
       const analysis = getProgramAnalysis(componentBody);
       if (!analysis) return;
@@ -113,17 +113,21 @@ export const noEventTriggerState = defineRule({
       // reachability machinery that `rerenderStateOnlyInHandlers`
       // uses to filter these out (transitive dep graph + walk from
       // render-reachable expressions).
-      const eventHandlerReferenceNames = collectFunctionLikeLocalNames(componentBody);
+      const eventHandlerReferenceNames = collectFunctionLikeLocalNames(
+        componentBody,
+        context.scopes,
+      );
       const dependencyGraph = buildLocalDependencyGraph(componentBody, eventHandlerReferenceNames);
       const directRenderNames = collectRenderReachableNames(
         componentBody,
+        context.scopes,
         eventHandlerReferenceNames,
       );
       const renderReachableNames = expandTransitiveDependencies(directRenderNames, dependencyGraph);
 
       walkAst(componentBody, (effectCall: EsTreeNode) => {
         if (!isNodeOfType(effectCall, "CallExpression")) return;
-        if (!isHookCall(effectCall, EFFECT_HOOK_NAMES)) return;
+        if (!isReactHookCall(effectCall, EFFECT_HOOK_NAMES, context.scopes)) return;
         if ((effectCall.arguments?.length ?? 0) < 2) return;
 
         const depsNode = effectCall.arguments[1];

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-initialize-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-initialize-state.ts
@@ -2,10 +2,10 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { isReactHookCall } from "../../utils/is-react-hook-call.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { collectEffectStateWriteFacts } from "./utils/collect-effect-state-write-facts.js";
 import { getProgramAnalysis } from "./utils/effect/get-program-analysis.js";
-import { isUseEffect } from "./utils/effect/react.js";
 
 const getStateName = (stateDeclarator: EsTreeNode): string => {
   if (!isNodeOfType(stateDeclarator, "VariableDeclarator")) return "<state>";
@@ -23,7 +23,7 @@ export const noInitializeState = defineRule({
     "Pass the initial value directly to useState() instead of setting it from a mount-only useEffect. For SSR hydration, prefer useSyncExternalStore().",
   create: (context: RuleContext) => ({
     CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
-      if (!isUseEffect(node)) return;
+      if (!isReactHookCall(node, "useEffect", context.scopes)) return;
       const dependencies = node.arguments?.[1];
       if (
         !dependencies ||

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-mirror-prop-effect.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-mirror-prop-effect.ts
@@ -5,7 +5,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import { getCallbackStatements } from "../../utils/get-callback-statements.js";
 import { getEffectCallback } from "../../utils/get-effect-callback.js";
 import { getRootIdentifierName } from "../../utils/get-root-identifier-name.js";
-import { isHookCall } from "../../utils/is-hook-call.js";
+import { isReactHookCall } from "../../utils/is-react-hook-call.js";
 import { isInitialOnlyPropName } from "../../utils/is-initial-only-prop-name.js";
 import { isSetterIdentifier } from "../../utils/is-setter-identifier.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
@@ -106,7 +106,7 @@ export const noMirrorPropEffect = defineRule({
             continue;
           }
           if (!isNodeOfType(declarator.init, "CallExpression")) continue;
-          if (!isHookCall(declarator.init, "useState")) continue;
+          if (!isReactHookCall(declarator.init, "useState", context.scopes)) continue;
           const initializer = declarator.init.arguments?.[0];
           if (!initializer) continue;
           const propRootName = getPropRootName(initializer, propNames);
@@ -131,7 +131,7 @@ export const noMirrorPropEffect = defineRule({
         if (!isNodeOfType(statement, "ExpressionStatement")) continue;
         const effectCall = unwrapDiscardedExpression(statement);
         if (!isNodeOfType(effectCall, "CallExpression")) continue;
-        if (!isHookCall(effectCall, EFFECT_HOOK_NAMES)) continue;
+        if (!isReactHookCall(effectCall, EFFECT_HOOK_NAMES, context.scopes)) continue;
         if ((effectCall.arguments?.length ?? 0) < 2) continue;
 
         const depsNode = effectCall.arguments[1];

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-mutable-in-deps.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-mutable-in-deps.ts
@@ -1,10 +1,11 @@
 import { MUTABLE_GLOBAL_ROOTS } from "../../constants/dom.js";
 import { HOOKS_WITH_DEPS } from "../../constants/react.js";
+import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
 import { defineRule } from "../../utils/define-rule.js";
 import { collectPatternNames } from "../../utils/collect-pattern-names.js";
 import { getRootIdentifierName } from "../../utils/get-root-identifier-name.js";
 import { isComponentAssignment } from "../../utils/is-component-assignment.js";
-import { isHookCall } from "../../utils/is-hook-call.js";
+import { isReactHookCall } from "../../utils/is-react-hook-call.js";
 import { isUppercaseName } from "../../utils/is-uppercase-name.js";
 import { walkAst } from "../../utils/walk-ast.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
@@ -30,7 +31,10 @@ import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 // Bare `location` / bare `useRef`-returned identifiers are NOT
 // flagged — those are themselves stable references; only their
 // mutable property reads are the bug.
-const collectUseRefBindingNames = (componentBody: EsTreeNode): Set<string> => {
+const collectUseRefBindingNames = (
+  componentBody: EsTreeNode,
+  scopes: ScopeAnalysis,
+): Set<string> => {
   const useRefBindings = new Set<string>();
   if (!isNodeOfType(componentBody, "BlockStatement")) return useRefBindings;
   for (const statement of componentBody.body ?? []) {
@@ -38,7 +42,7 @@ const collectUseRefBindingNames = (componentBody: EsTreeNode): Set<string> => {
     for (const declarator of statement.declarations ?? []) {
       if (!isNodeOfType(declarator.id, "Identifier")) continue;
       if (!isNodeOfType(declarator.init, "CallExpression")) continue;
-      if (!isHookCall(declarator.init, "useRef")) continue;
+      if (!isReactHookCall(declarator.init, "useRef", scopes)) continue;
       useRefBindings.add(declarator.id.name);
     }
   }
@@ -108,13 +112,13 @@ export const noMutableInDeps = defineRule({
       componentParams: ReadonlyArray<EsTreeNode> = [],
     ): void => {
       if (!componentBody || !isNodeOfType(componentBody, "BlockStatement")) return;
-      const useRefBindingNames = collectUseRefBindingNames(componentBody);
+      const useRefBindingNames = collectUseRefBindingNames(componentBody, context.scopes);
       const localBindingNames = collectLocalBindingNames(componentBody);
       for (const param of componentParams) collectPatternNames(param, localBindingNames);
 
       walkAst(componentBody, (child: EsTreeNode) => {
         if (!isNodeOfType(child, "CallExpression")) return;
-        if (!isHookCall(child, HOOKS_WITH_DEPS)) return;
+        if (!isReactHookCall(child, HOOKS_WITH_DEPS, context.scopes)) return;
         if ((child.arguments?.length ?? 0) < 2) return;
         const depsNode = child.arguments[1];
         if (!isNodeOfType(depsNode, "ArrayExpression")) return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.ts
@@ -7,7 +7,7 @@ import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
 import { findTransparentExpressionRoot } from "../../utils/find-transparent-expression-root.js";
 import { collectFunctionReturnStatements } from "../../utils/collect-function-return-statements.js";
 import { isNamespacedApiCallee } from "../../utils/is-namespaced-api-call.js";
-import { isReactApiCall } from "../../utils/is-react-api-call.js";
+import { isReactHookCall } from "../../utils/is-react-hook-call.js";
 import {
   DATA_SINK_METHOD_NAMES,
   STRING_READ_METHOD_NAMES,
@@ -40,7 +40,6 @@ import {
   isRefCall,
   isRefCurrent,
   isState,
-  isUseEffect,
   isWholePropsObjectReference,
 } from "./utils/effect/react.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
@@ -1152,18 +1151,12 @@ export const noPassDataToParent = defineRule({
     "Fetch the data in the parent and pass it down as a prop (or return it from the hook), instead of handing it back up through a prop callback in a useEffect. See https://react.dev/learn/you-might-not-need-an-effect#passing-data-to-the-parent",
   create: (context: RuleContext) => {
     const isReactUseRefCall = (node: EsTreeNode): boolean =>
-      isReactApiCall(node, "useRef", context.scopes, {
-        allowGlobalReactNamespace: true,
-        allowUnboundBareCalls: true,
-      });
+      isReactHookCall(node, "useRef", context.scopes);
     const isReactUseEffectCall = (node: EsTreeNode): boolean =>
-      isReactApiCall(node, "useEffect", context.scopes, {
-        allowGlobalReactNamespace: true,
-        allowUnboundBareCalls: true,
-      });
+      isReactHookCall(node, "useEffect", context.scopes);
     return {
       CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
-        if (!isUseEffect(node)) return;
+        if (!isReactUseEffectCall(node)) return;
         const analysis = getProgramAnalysis(node);
         if (!analysis) return;
         if (hasCleanup(analysis, node)) return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-live-state-to-parent.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-live-state-to-parent.ts
@@ -6,6 +6,7 @@ import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import { isNamespacedApiCallee } from "../../utils/is-namespaced-api-call.js";
 import { isCallResultConsumedAsArgument } from "../../utils/is-call-result-consumed-as-argument.js";
 import { isReactHookName } from "../../utils/is-react-hook-name.js";
+import { isReactHookCall } from "../../utils/is-react-hook-call.js";
 import {
   DATA_SINK_METHOD_NAMES,
   STRING_READ_METHOD_NAMES,
@@ -33,7 +34,6 @@ import {
   isProp,
   isPropCallbackInvocationRef,
   isState,
-  isUseEffect,
   isWholePropsObjectReference,
 } from "./utils/effect/react.js";
 import { getParentCallbackPropNames } from "./utils/resolve-parent-callback-provenance.js";
@@ -361,7 +361,7 @@ export const noPassLiveStateToParent = defineRule({
     "Move the state up to the parent (or return it from the hook), instead of handing it back up through a prop callback in a useEffect. See https://react.dev/learn/you-might-not-need-an-effect#notifying-parent-components-about-state-changes",
   create: (context: RuleContext) => ({
     CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
-      if (!isUseEffect(node)) return;
+      if (!isReactHookCall(node, "useEffect", context.scopes)) return;
       const analysis = getProgramAnalysis(node);
       if (!analysis) return;
       const effectFnRefs = getEffectFnRefs(analysis, node);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-prop-callback-in-effect.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-prop-callback-in-effect.ts
@@ -7,7 +7,7 @@ import { getCalleeName } from "../../utils/get-callee-name.js";
 import { getEffectCallback } from "../../utils/get-effect-callback.js";
 import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
 import { getTransparentReactCallbackWrapperArgument } from "../../utils/get-transparent-react-callback-wrapper-argument.js";
-import { isHookCall } from "../../utils/is-hook-call.js";
+import { isReactHookCall } from "../../utils/is-react-hook-call.js";
 import { isResultDiscardedCall } from "../../utils/is-result-discarded-call.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import type { Reference } from "eslint-scope";
@@ -172,7 +172,12 @@ export const noPropCallbackInEffect = defineRule({
     return {
       ...propStackTracker.visitors,
       CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
-        if (!isHookCall(node, EFFECT_HOOK_NAMES) || (node.arguments?.length ?? 0) < 2) return;
+        if (
+          !isReactHookCall(node, EFFECT_HOOK_NAMES, context.scopes) ||
+          (node.arguments?.length ?? 0) < 2
+        ) {
+          return;
+        }
         const callback = getEffectCallback(node);
         if (
           !callback ||

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-reset-all-state-on-prop-change.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-reset-all-state-on-prop-change.ts
@@ -12,6 +12,7 @@ import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isNodeReachableWithinFunction } from "../../utils/is-node-reachable-within-function.js";
 import { isOutsideAllFunctions } from "../../utils/is-outside-all-functions.js";
 import { isReactApiCall } from "../../utils/is-react-api-call.js";
+import { isReactHookCall } from "../../utils/is-react-hook-call.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { resolveExactLocalFunction } from "../../utils/resolve-exact-local-function.js";
 import type { RuleContext } from "../../utils/rule-context.js";
@@ -30,7 +31,6 @@ import {
   isRefCurrent,
   isState,
   isSyncStateSetterCall,
-  isUseEffect,
 } from "./utils/effect/react.js";
 import { getStaticMemberPropertyName } from "./utils/static-member-property-name.js";
 
@@ -1303,7 +1303,7 @@ export const noResetAllStateOnPropChange = defineRule({
     "Pass the prop as `key` so React resets the component for you when the prop changes, instead of clearing every state value by hand in a useEffect. See https://react.dev/learn/you-might-not-need-an-effect#resetting-all-state-when-a-prop-changes",
   create: (context: RuleContext) => ({
     CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
-      if (!isUseEffect(node)) return;
+      if (!isReactHookCall(node, "useEffect", context.scopes)) return;
       const analysis = getProgramAnalysis(node);
       if (!analysis) return;
       const effectFnRefs = getEffectFnRefs(analysis, node);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-self-updating-effect.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-self-updating-effect.ts
@@ -3,7 +3,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import { getCallbackStatements } from "../../utils/get-callback-statements.js";
 import { getEffectCallback } from "../../utils/get-effect-callback.js";
 import { isComponentAssignment } from "../../utils/is-component-assignment.js";
-import { isHookCall } from "../../utils/is-hook-call.js";
+import { isReactHookCall } from "../../utils/is-react-hook-call.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isAstNode } from "../../utils/is-ast-node.js";
 import { isReactHookName } from "../../utils/is-react-hook-name.js";
@@ -786,7 +786,7 @@ export const noSelfUpdatingEffect = defineRule({
     const checkFunctionScope = (functionBody: EsTreeNode | null | undefined): void => {
       if (!functionBody || !isNodeOfType(functionBody, "BlockStatement")) return;
 
-      const useStateBindings = collectUseStateBindings(functionBody);
+      const useStateBindings = collectUseStateBindings(functionBody, context.scopes);
       if (useStateBindings.length === 0) return;
 
       const setterNameToStateName = new Map<string, string>();
@@ -799,7 +799,7 @@ export const noSelfUpdatingEffect = defineRule({
         if (!isNodeOfType(statement, "ExpressionStatement")) continue;
         const effectCall = unwrapDiscardedExpression(statement);
         if (!isNodeOfType(effectCall, "CallExpression")) continue;
-        if (!isHookCall(effectCall, EFFECT_HOOK_NAMES)) continue;
+        if (!isReactHookCall(effectCall, EFFECT_HOOK_NAMES, context.scopes)) continue;
         if ((effectCall.arguments?.length ?? 0) < 2) continue;
 
         const dependencyStateNames = collectDependencyStateNames(effectCall.arguments[1]);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-set-state-in-render.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-set-state-in-render.ts
@@ -44,7 +44,7 @@ export const noSetStateInRender = defineRule({
     const checkComponent = (componentBody: EsTreeNode | null | undefined): void => {
       if (!componentBody || !isNodeOfType(componentBody, "BlockStatement")) return;
       const setterNames = new Set(
-        collectUseStateBindings(componentBody).map((binding) => binding.setterName),
+        collectUseStateBindings(componentBody, context.scopes).map((binding) => binding.setterName),
       );
       if (setterNames.size === 0) return;
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-stale-timer-ref.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-stale-timer-ref.ts
@@ -3,6 +3,7 @@ import {
   TIMER_CLEANUP_CALLEE_NAMES,
 } from "../../constants/dom.js";
 import { EFFECT_HOOK_NAMES } from "../../constants/react.js";
+import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
 import { defineRule } from "../../utils/define-rule.js";
 import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
 import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
@@ -10,7 +11,7 @@ import { getEffectCallback } from "../../utils/get-effect-callback.js";
 import { getFunctionBindingName } from "../../utils/get-function-binding-name.js";
 import { getRangeStart } from "../../utils/get-range-start.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
-import { isHookCall } from "../../utils/is-hook-call.js";
+import { isReactHookCall } from "../../utils/is-react-hook-call.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isNullishExpression } from "../../utils/is-nullish-expression.js";
 import {
@@ -220,10 +221,12 @@ const collectTimerRefUsageFacts = (ownerScope: EsTreeNode, refName: string): Tim
   return facts;
 };
 
-const isEffectCallbackFunction = (functionNode: EsTreeNode): boolean => {
+const isEffectCallbackFunction = (functionNode: EsTreeNode, scopes: ScopeAnalysis): boolean => {
   const parent = functionNode.parent;
   if (!parent || !isNodeOfType(parent, "CallExpression")) return false;
-  return isHookCall(parent, EFFECT_HOOK_NAMES) && getEffectCallback(parent) === functionNode;
+  return (
+    isReactHookCall(parent, EFFECT_HOOK_NAMES, scopes) && getEffectCallback(parent) === functionNode
+  );
 };
 
 const doesEffectCallbackReturnName = (effectCallback: EsTreeNode, name: string): boolean => {
@@ -262,13 +265,19 @@ const isFunctionReturnedFromEffectCallback = (
 const isReturnedFromAnyEffectInScope = (
   functionNode: EsTreeNode,
   ownerScope: EsTreeNode,
+  scopes: ScopeAnalysis,
 ): boolean => {
   const cleanupBindingName = getFunctionBindingName(functionNode);
   if (cleanupBindingName === null) return false;
   let isReturnedFromEffect = false;
   walkAst(ownerScope, (child: EsTreeNode) => {
     if (isReturnedFromEffect) return false;
-    if (!isNodeOfType(child, "CallExpression") || !isHookCall(child, EFFECT_HOOK_NAMES)) return;
+    if (
+      !isNodeOfType(child, "CallExpression") ||
+      !isReactHookCall(child, EFFECT_HOOK_NAMES, scopes)
+    ) {
+      return;
+    }
     const effectCallback = getEffectCallback(child);
     if (effectCallback && doesEffectCallbackReturnName(effectCallback, cleanupBindingName)) {
       isReturnedFromEffect = true;
@@ -281,18 +290,22 @@ const isReturnedFromAnyEffectInScope = (
 // window there is unmount / StrictMode remount, and the re-run path
 // immediately re-arms the ref in the effect body, so flagging the ubiquitous
 // `return () => clearTimeout(ref.current)` idiom would be mostly noise.
-const isInsideEffectCleanupReturn = (node: EsTreeNode, ownerScope: EsTreeNode): boolean => {
+const isInsideEffectCleanupReturn = (
+  node: EsTreeNode,
+  ownerScope: EsTreeNode,
+  scopes: ScopeAnalysis,
+): boolean => {
   let functionNode = findEnclosingFunction(node);
   while (functionNode) {
     const outerFunction = findEnclosingFunction(functionNode);
     if (
       outerFunction &&
-      isEffectCallbackFunction(outerFunction) &&
+      isEffectCallbackFunction(outerFunction, scopes) &&
       isFunctionReturnedFromEffectCallback(functionNode, outerFunction)
     ) {
       return true;
     }
-    if (isReturnedFromAnyEffectInScope(functionNode, ownerScope)) return true;
+    if (isReturnedFromAnyEffectInScope(functionNode, ownerScope, scopes)) return true;
     functionNode = outerFunction;
   }
   return false;
@@ -341,12 +354,17 @@ export const noStaleTimerRef = defineRule({
       // Closest-scope binding resolution — a shadowing parameter or local
       // re-declaration of the name wins over an outer `useRef` binding.
       const refBinding = findVariableInitializer(node, refName);
-      if (!refBinding?.initializer || !isHookCall(refBinding.initializer, "useRef")) return;
+      if (
+        !refBinding?.initializer ||
+        !isReactHookCall(refBinding.initializer, "useRef", context.scopes)
+      ) {
+        return;
+      }
 
       const usageFacts = collectTimerRefUsageFacts(refBinding.scopeOwner, refName);
       if (!usageFacts.holdsScheduledTimerId || !usageFacts.hasPendingSignalRead) return;
 
-      if (isInsideEffectCleanupReturn(node, refBinding.scopeOwner)) return;
+      if (isInsideEffectCleanupReturn(node, refBinding.scopeOwner, context.scopes)) return;
       if (hasRefCurrentReassignmentAfterClear(node, refName)) return;
 
       context.report({

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/prefer-use-effect-event.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/prefer-use-effect-event.ts
@@ -11,7 +11,7 @@ import { getCalleeName } from "../../utils/get-callee-name.js";
 import { getEffectCallback } from "../../utils/get-effect-callback.js";
 import { getFunctionBindingIdentifier } from "../../utils/get-function-binding-name.js";
 import { isAstDescendant } from "../../utils/is-ast-descendant.js";
-import { isHookCall } from "../../utils/is-hook-call.js";
+import { isReactHookCall } from "../../utils/is-react-hook-call.js";
 import { isReactApiCall } from "../../utils/is-react-api-call.js";
 import { resolveExpressionKey } from "../../utils/resolve-expression-key.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
@@ -401,7 +401,7 @@ export const preferUseEffectEvent = defineRule({
         if (!isNodeOfType(statement, "ExpressionStatement")) continue;
         const effectCall = statement.expression;
         if (!isNodeOfType(effectCall, "CallExpression")) continue;
-        if (!isHookCall(effectCall, EFFECT_HOOK_NAMES)) continue;
+        if (!isReactHookCall(effectCall, EFFECT_HOOK_NAMES, context.scopes)) continue;
         if ((effectCall.arguments?.length ?? 0) < 2) continue;
 
         const depsNode = effectCall.arguments[1];

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/prefer-use-reducer.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/prefer-use-reducer.ts
@@ -134,7 +134,7 @@ export const preferUseReducer = defineRule({
   create: (context: RuleContext) => {
     const reportCoUpdatedUseState = (body: EsTreeNode, componentName: string): void => {
       if (!isNodeOfType(body, "BlockStatement")) return;
-      const bindings = collectUseStateBindings(body);
+      const bindings = collectUseStateBindings(body, context.scopes);
       const setterNames = new Set(bindings.map((binding) => binding.setterName));
       if (setterNames.size < RELATED_USE_STATE_THRESHOLD) return;
       const initializersBySetterName = new Map<string, EsTreeNode | null>(

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/prefer-use-sync-external-store.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/prefer-use-sync-external-store.ts
@@ -1,4 +1,5 @@
 import { EFFECT_HOOK_NAMES, SUBSCRIPTION_METHOD_NAMES } from "../../constants/react.js";
+import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
 import { areExpressionsStructurallyEqual } from "../../utils/are-expressions-structurally-equal.js";
 import { defineRule } from "../../utils/define-rule.js";
 import { findProgramRoot } from "../../utils/find-program-root.js";
@@ -7,7 +8,7 @@ import { getCallbackStatements } from "../../utils/get-callback-statements.js";
 import { getEffectCallback } from "../../utils/get-effect-callback.js";
 import { isComponentAssignment } from "../../utils/is-component-assignment.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
-import { isHookCall } from "../../utils/is-hook-call.js";
+import { isReactHookCall } from "../../utils/is-react-hook-call.js";
 import { isReactHookName } from "../../utils/is-react-hook-name.js";
 import { isSetterIdentifier } from "../../utils/is-setter-identifier.js";
 import { isUppercaseName } from "../../utils/is-uppercase-name.js";
@@ -41,12 +42,18 @@ import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 //
 // The combined match is so specific that real-world false positives
 // are essentially impossible.
-const findUseEffectsInComponent = (componentBody: EsTreeNode | undefined): EsTreeNode[] => {
+const findUseEffectsInComponent = (
+  componentBody: EsTreeNode | undefined,
+  scopes: ScopeAnalysis,
+): EsTreeNode[] => {
   const effectCalls: EsTreeNode[] = [];
   if (!isNodeOfType(componentBody, "BlockStatement")) return effectCalls;
   for (const statement of componentBody.body ?? []) {
     walkAst(statement, (child: EsTreeNode) => {
-      if (isNodeOfType(child, "CallExpression") && isHookCall(child, EFFECT_HOOK_NAMES)) {
+      if (
+        isNodeOfType(child, "CallExpression") &&
+        isReactHookCall(child, EFFECT_HOOK_NAMES, scopes)
+      ) {
         effectCalls.push(child);
       }
     });
@@ -376,7 +383,7 @@ export const preferUseSyncExternalStore = defineRule({
     const checkComponent = (componentBody: EsTreeNode | null | undefined): void => {
       if (!componentBody || !isNodeOfType(componentBody, "BlockStatement")) return;
 
-      const useStateBindings = collectUseStateBindings(componentBody);
+      const useStateBindings = collectUseStateBindings(componentBody, context.scopes);
       if (useStateBindings.length === 0) return;
 
       const useStateInitializerByValueName = new Map<string, EsTreeNode>();
@@ -404,7 +411,7 @@ export const preferUseSyncExternalStore = defineRule({
         setterNameToValueName.set(binding.setterName, binding.valueName);
       }
 
-      for (const effectCall of findUseEffectsInComponent(componentBody)) {
+      for (const effectCall of findUseEffectsInComponent(componentBody, context.scopes)) {
         if (!isNodeOfType(effectCall, "CallExpression")) continue;
         if ((effectCall.arguments?.length ?? 0) < 2) continue;
         const depsNode = effectCall.arguments[1];
@@ -485,7 +492,7 @@ export const preferUseSyncExternalStore = defineRule({
       if (snapshotBindings.length === 0) return;
 
       const reportedDeclarators = new Set<EsTreeNode>();
-      for (const effectCall of findUseEffectsInComponent(componentBody)) {
+      for (const effectCall of findUseEffectsInComponent(componentBody, context.scopes)) {
         if (!isNodeOfType(effectCall, "CallExpression")) continue;
         if ((effectCall.arguments?.length ?? 0) < 2) continue;
         const depsNode = effectCall.arguments[1];

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/rerender-dependencies.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/rerender-dependencies.ts
@@ -1,6 +1,6 @@
 import { HOOKS_WITH_DEPS } from "../../constants/react.js";
 import { defineRule } from "../../utils/define-rule.js";
-import { isHookCall } from "../../utils/is-hook-call.js";
+import { isReactHookCall } from "../../utils/is-react-hook-call.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
@@ -14,7 +14,9 @@ export const rerenderDependencies = defineRule({
     "Move it into a useMemo, useRef, or a constant outside the component so it stays the same between renders.",
   create: (context: RuleContext) => ({
     CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
-      if (!isHookCall(node, HOOKS_WITH_DEPS) || node.arguments.length < 2) return;
+      if (!isReactHookCall(node, HOOKS_WITH_DEPS, context.scopes) || node.arguments.length < 2) {
+        return;
+      }
       const depsNode = node.arguments[1];
       if (!isNodeOfType(depsNode, "ArrayExpression")) return;
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/rerender-lazy-ref-init.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/rerender-lazy-ref-init.ts
@@ -1,7 +1,7 @@
 import { TRIVIAL_INITIALIZER_NAMES } from "../../constants/react.js";
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
-import { isHookCall } from "../../utils/is-hook-call.js";
+import { isReactHookCall } from "../../utils/is-react-hook-call.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isReactHookName } from "../../utils/is-react-hook-name.js";
 import { isTrivialBuiltInConstruction } from "../../utils/is-trivial-built-in-construction.js";
@@ -50,7 +50,7 @@ export const rerenderLazyRefInit = defineRule({
     "Initialize the ref lazily so expensive values are not rebuilt and discarded on every render.",
   create: (context: RuleContext) => ({
     CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
-      if (!isHookCall(node, "useRef") || !node.arguments?.length) return;
+      if (!isReactHookCall(node, "useRef", context.scopes) || !node.arguments?.length) return;
       const initializer = stripParenExpression(node.arguments[0]);
 
       const isPlainCall = isNodeOfType(initializer, "CallExpression");

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/rerender-lazy-state-init.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/rerender-lazy-state-init.ts
@@ -1,7 +1,7 @@
 import { TRIVIAL_INITIALIZER_NAMES } from "../../constants/react.js";
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
-import { isHookCall } from "../../utils/is-hook-call.js";
+import { isReactHookCall } from "../../utils/is-react-hook-call.js";
 import { isReactHookName } from "../../utils/is-react-hook-name.js";
 import { isTrivialBuiltInConstruction } from "../../utils/is-trivial-built-in-construction.js";
 import type { RuleContext } from "../../utils/rule-context.js";
@@ -88,7 +88,7 @@ export const rerenderLazyStateInit = defineRule({
     "Wrap expensive initial state in an arrow function so the initializer does not rerun and get thrown away on every render.",
   create: (context: RuleContext) => ({
     CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
-      if (!isHookCall(node, "useState") || !node.arguments?.length) return;
+      if (!isReactHookCall(node, "useState", context.scopes) || !node.arguments?.length) return;
       const initializer = findEagerInitializerCall(node.arguments[0] as EsTreeNode);
       if (!initializer) return;
       const isConstructor = isNodeOfType(initializer, "NewExpression");

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/rerender-state-only-in-handlers.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/rerender-state-only-in-handlers.regressions.test.ts
@@ -3,6 +3,20 @@ import { runRule } from "../../../test-utils/run-rule.js";
 import { rerenderStateOnlyInHandlers } from "./rerender-state-only-in-handlers.js";
 
 describe("rerender-state-only-in-handlers — regressions", () => {
+  it("treats a userland same-name hook as render-phase consumption", () => {
+    const result = runRule(
+      rerenderStateOnlyInHandlers,
+      `const useEffect = (value) => useCustomSubscription(value);
+      function Widget() {
+        const [selected, setSelected] = useState(null);
+        useEffect(selected);
+        return <button onClick={() => setSelected("primary")}>select</button>;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("flags self-echo state through a React effect import alias", () => {
     const result = runRule(
       rerenderStateOnlyInHandlers,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/rerender-state-only-in-handlers.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/rerender-state-only-in-handlers.regressions.test.ts
@@ -3,6 +3,23 @@ import { runRule } from "../../../test-utils/run-rule.js";
 import { rerenderStateOnlyInHandlers } from "./rerender-state-only-in-handlers.js";
 
 describe("rerender-state-only-in-handlers — regressions", () => {
+  it("flags self-echo state through a React effect import alias", () => {
+    const result = runRule(
+      rerenderStateOnlyInHandlers,
+      `import { useEffect as useSynchronize, useState } from "react";
+      function Widget({ value }) {
+        const [copied, setCopied] = useState(value);
+        useSynchronize(() => {
+          if (copied !== value) setCopied(value);
+        }, [copied, value]);
+        return <button onClick={() => setCopied(null)}>reset</button>;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("copied");
+  });
+
   it("stays silent when state drives a side-effect-only effect through a one-hop derived local", () => {
     const result = runRule(
       rerenderStateOnlyInHandlers,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/rerender-state-only-in-handlers.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/rerender-state-only-in-handlers.ts
@@ -1,9 +1,10 @@
 import { BUILTIN_HOOK_NAMES, EFFECT_HOOK_NAMES } from "../../constants/react.js";
+import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
 import { defineRule } from "../../utils/define-rule.js";
 import { getRootIdentifierName } from "../../utils/get-root-identifier-name.js";
 import { isComponentAssignment } from "../../utils/is-component-assignment.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
-import { isHookCall } from "../../utils/is-hook-call.js";
+import { isReactHookCall } from "../../utils/is-react-hook-call.js";
 import { isReactHookName } from "../../utils/is-react-hook-name.js";
 import { isUppercaseName } from "../../utils/is-uppercase-name.js";
 import { walkAst } from "../../utils/walk-ast.js";
@@ -61,11 +62,12 @@ const isInsideConditionTest = (identifier: EsTreeNode, stopAt: EsTreeNode): bool
 const collectEffectDependencyInfos = (
   componentBody: EsTreeNode,
   setterNames: ReadonlySet<string>,
+  scopes: ScopeAnalysis,
 ): EffectDependencyInfo[] => {
   const effectInfos: EffectDependencyInfo[] = [];
   walkAst(componentBody, (child: EsTreeNode) => {
     if (!isNodeOfType(child, "CallExpression")) return;
-    if (!isHookCall(child, EFFECT_HOOK_NAMES)) return;
+    if (!isReactHookCall(child, EFFECT_HOOK_NAMES, scopes)) return;
     const dependencyNames = new Set<string>();
     for (const argument of child.arguments ?? []) {
       if (!isNodeOfType(argument, "ArrayExpression")) continue;
@@ -141,13 +143,17 @@ const collectEffectDependencyInfos = (
 // Builtin hooks are excluded: a `useState(other)` initializer reads once,
 // and memo/callback deps only matter if their result is render-reachable
 // (the dependency graph already models that).
-const collectCustomHookArgumentNames = (componentBody: EsTreeNode): Set<string> => {
+const collectCustomHookArgumentNames = (
+  componentBody: EsTreeNode,
+  scopes: ScopeAnalysis,
+): Set<string> => {
   const argumentNames = new Set<string>();
   walkAst(componentBody, (child: EsTreeNode) => {
     if (!isNodeOfType(child, "CallExpression")) return;
     if (!isNodeOfType(child.callee, "Identifier")) return;
     const calleeName = child.callee.name;
     if (!isReactHookName(calleeName)) return;
+    if (isReactHookCall(child, BUILTIN_HOOK_NAMES, scopes)) return;
     if (BUILTIN_HOOK_NAMES.has(calleeName)) return;
     if (EFFECT_HOOK_NAMES.has(calleeName)) return;
     for (const argument of child.arguments ?? []) {
@@ -206,16 +212,20 @@ export const rerenderStateOnlyInHandlers = defineRule({
   create: (context: RuleContext) => {
     const checkComponent = (componentBody: EsTreeNode | null | undefined): void => {
       if (!componentBody || !isNodeOfType(componentBody, "BlockStatement")) return;
-      const bindings = collectUseStateBindings(componentBody);
+      const bindings = collectUseStateBindings(componentBody, context.scopes);
       if (bindings.length === 0) return;
 
       const renderReachableExpressions = collectRenderReachableExpressions(componentBody);
       if (renderReachableExpressions.length === 0) return;
 
-      const eventHandlerReferenceNames = collectFunctionLikeLocalNames(componentBody);
+      const eventHandlerReferenceNames = collectFunctionLikeLocalNames(
+        componentBody,
+        context.scopes,
+      );
       const dependencyGraph = buildLocalDependencyGraph(componentBody, eventHandlerReferenceNames);
       const directRenderNames = collectRenderReachableNames(
         componentBody,
+        context.scopes,
         eventHandlerReferenceNames,
       );
       // A top-level `void someState;` is the deliberate "re-render to
@@ -242,7 +252,7 @@ export const rerenderStateOnlyInHandlers = defineRule({
       // state never leaves the effect as a value, so a ref (or no state at
       // all) would work. An effect that consumes the PAYLOAD (member reads,
       // call arguments) before clearing is a handoff, not an echo.
-      const effectInfos = collectEffectDependencyInfos(componentBody, setterNames);
+      const effectInfos = collectEffectDependencyInfos(componentBody, setterNames, context.scopes);
       const selfEchoValueNames = new Set<string>();
       for (const binding of bindings) {
         // A setter also invoked from a NESTED callback of the same effect
@@ -265,7 +275,10 @@ export const rerenderStateOnlyInHandlers = defineRule({
           if (!selfEchoValueNames.has(dependencyName)) effectConsumedNames.add(dependencyName);
         }
       }
-      for (const hookArgumentName of collectCustomHookArgumentNames(componentBody)) {
+      for (const hookArgumentName of collectCustomHookArgumentNames(
+        componentBody,
+        context.scopes,
+      )) {
         effectConsumedNames.add(hookArgumentName);
       }
       for (const reachableName of expandTransitiveDependencies(

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/collect-function-like-local-names.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/collect-function-like-local-names.ts
@@ -1,7 +1,9 @@
+import type { ScopeAnalysis } from "../../../semantic/scope-analysis.js";
 import type { EsTreeNode } from "../../../utils/es-tree-node.js";
 import { getStaticPropertyKeyName } from "../../../utils/get-static-property-key-name.js";
 import { isInlineFunctionExpression } from "../../../utils/is-inline-function-expression.js";
 import { isNodeOfType } from "../../../utils/is-node-of-type.js";
+import { isReactHookCall } from "../../../utils/is-react-hook-call.js";
 import { getStaticMemberReferenceName } from "./event-handler-reference.js";
 import {
   addPatternBindings,
@@ -11,23 +13,14 @@ import {
   resolveBindingName,
   type BindingScope,
 } from "./scope-aware-reference-names.js";
-import { getStaticMemberPropertyName } from "./static-member-property-name.js";
-
-const isUseCallbackCall = (node: EsTreeNode): boolean =>
-  isNodeOfType(node, "CallExpression") && getCalleeName(node.callee) === "useCallback";
-
-const getCalleeName = (node: EsTreeNode): string | null => {
-  if (isNodeOfType(node, "Identifier")) return node.name;
-  if (isNodeOfType(node, "MemberExpression")) return getStaticMemberPropertyName(node);
-  return null;
-};
 
 const isFunctionLikeReference = (
   node: EsTreeNode,
   functionLikeLocalNames: Set<string>,
   scope: BindingScope,
+  scopes: ScopeAnalysis,
 ): boolean => {
-  if (isInlineFunctionExpression(node) || isUseCallbackCall(node)) return true;
+  if (isInlineFunctionExpression(node) || isReactHookCall(node, "useCallback", scopes)) return true;
   if (isNodeOfType(node, "Identifier"))
     return functionLikeLocalNames.has(resolveBindingName(scope, node.name));
   const memberReferenceName = getStaticMemberReferenceName(node, (name) =>
@@ -41,6 +34,7 @@ const addObjectPropertyFunctionNames = (
   node: EsTreeNode,
   functionLikeLocalNames: Set<string>,
   scope: BindingScope,
+  scopes: ScopeAnalysis,
 ): void => {
   if (!isNodeOfType(node, "ObjectExpression")) return;
   for (const property of node.properties ?? []) {
@@ -49,7 +43,7 @@ const addObjectPropertyFunctionNames = (
       stringifyNonStringLiterals: true,
     });
     if (!propertyName) continue;
-    if (!isFunctionLikeReference(property.value, functionLikeLocalNames, scope)) continue;
+    if (!isFunctionLikeReference(property.value, functionLikeLocalNames, scope, scopes)) continue;
     functionLikeLocalNames.add(`${objectBindingName}.${propertyName}`);
   }
 };
@@ -58,6 +52,7 @@ const addVariableDeclarationFunctionNames = (
   statement: EsTreeNode,
   functionLikeLocalNames: Set<string>,
   scope: BindingScope,
+  scopes: ScopeAnalysis,
 ): void => {
   if (!isNodeOfType(statement, "VariableDeclaration")) return;
   const declarationScope = getVariableDeclarationScope(statement, scope);
@@ -68,6 +63,7 @@ const addVariableDeclarationFunctionNames = (
       declarator.init,
       functionLikeLocalNames,
       scope,
+      scopes,
     );
     for (const declaredBindingName of declaredBindingNames) {
       if (isFunctionReference) {
@@ -78,6 +74,7 @@ const addVariableDeclarationFunctionNames = (
         declarator.init,
         functionLikeLocalNames,
         scope,
+        scopes,
       );
     }
   }
@@ -87,6 +84,7 @@ const collectStatementFunctionNames = (
   statement: EsTreeNode,
   functionLikeLocalNames: Set<string>,
   scope: BindingScope,
+  scopes: ScopeAnalysis,
 ): void => {
   if (isNodeOfType(statement, "FunctionDeclaration")) {
     if (statement.id) {
@@ -99,7 +97,7 @@ const collectStatementFunctionNames = (
   }
 
   if (isNodeOfType(statement, "VariableDeclaration")) {
-    addVariableDeclarationFunctionNames(statement, functionLikeLocalNames, scope);
+    addVariableDeclarationFunctionNames(statement, functionLikeLocalNames, scope, scopes);
     return;
   }
 
@@ -108,14 +106,15 @@ const collectStatementFunctionNames = (
       statement.body,
       functionLikeLocalNames,
       createBlockBindingScope(scope),
+      scopes,
     );
     return;
   }
 
   if (isNodeOfType(statement, "IfStatement")) {
-    collectStatementFunctionNames(statement.consequent, functionLikeLocalNames, scope);
+    collectStatementFunctionNames(statement.consequent, functionLikeLocalNames, scope, scopes);
     if (statement.alternate)
-      collectStatementFunctionNames(statement.alternate, functionLikeLocalNames, scope);
+      collectStatementFunctionNames(statement.alternate, functionLikeLocalNames, scope, scopes);
     return;
   }
 
@@ -125,50 +124,66 @@ const collectStatementFunctionNames = (
         switchCase.consequent,
         functionLikeLocalNames,
         createBlockBindingScope(scope),
+        scopes,
       );
     }
     return;
   }
 
   if (isNodeOfType(statement, "TryStatement")) {
-    collectStatementFunctionNames(statement.block, functionLikeLocalNames, scope);
+    collectStatementFunctionNames(statement.block, functionLikeLocalNames, scope, scopes);
     if (statement.handler) {
       const catchScope = createBlockBindingScope(scope);
       addPatternBindings(statement.handler.param, catchScope);
-      collectStatementFunctionNames(statement.handler.body, functionLikeLocalNames, catchScope);
+      collectStatementFunctionNames(
+        statement.handler.body,
+        functionLikeLocalNames,
+        catchScope,
+        scopes,
+      );
     }
     if (statement.finalizer)
-      collectStatementFunctionNames(statement.finalizer, functionLikeLocalNames, scope);
+      collectStatementFunctionNames(statement.finalizer, functionLikeLocalNames, scope, scopes);
     return;
   }
 
   if (isNodeOfType(statement, "ForStatement")) {
     const loopScope = createBlockBindingScope(scope);
     if (statement.init && isNodeOfType(statement.init, "VariableDeclaration")) {
-      addVariableDeclarationFunctionNames(statement.init, functionLikeLocalNames, loopScope);
+      addVariableDeclarationFunctionNames(
+        statement.init,
+        functionLikeLocalNames,
+        loopScope,
+        scopes,
+      );
     }
-    collectStatementFunctionNames(statement.body, functionLikeLocalNames, loopScope);
+    collectStatementFunctionNames(statement.body, functionLikeLocalNames, loopScope, scopes);
     return;
   }
 
   if (isNodeOfType(statement, "ForInStatement") || isNodeOfType(statement, "ForOfStatement")) {
     const loopScope = createBlockBindingScope(scope);
     if (isNodeOfType(statement.left, "VariableDeclaration")) {
-      addVariableDeclarationFunctionNames(statement.left, functionLikeLocalNames, loopScope);
+      addVariableDeclarationFunctionNames(
+        statement.left,
+        functionLikeLocalNames,
+        loopScope,
+        scopes,
+      );
     } else {
       addPatternBindings(statement.left, loopScope);
     }
-    collectStatementFunctionNames(statement.body, functionLikeLocalNames, loopScope);
+    collectStatementFunctionNames(statement.body, functionLikeLocalNames, loopScope, scopes);
     return;
   }
 
   if (isNodeOfType(statement, "WhileStatement") || isNodeOfType(statement, "DoWhileStatement")) {
-    collectStatementFunctionNames(statement.body, functionLikeLocalNames, scope);
+    collectStatementFunctionNames(statement.body, functionLikeLocalNames, scope, scopes);
     return;
   }
 
   if (isNodeOfType(statement, "LabeledStatement")) {
-    collectStatementFunctionNames(statement.body, functionLikeLocalNames, scope);
+    collectStatementFunctionNames(statement.body, functionLikeLocalNames, scope, scopes);
   }
 };
 
@@ -176,13 +191,17 @@ const collectStatementListFunctionNames = (
   statements: EsTreeNode[] | undefined,
   functionLikeLocalNames: Set<string>,
   scope: BindingScope,
+  scopes: ScopeAnalysis,
 ): void => {
   for (const statement of statements ?? []) {
-    collectStatementFunctionNames(statement, functionLikeLocalNames, scope);
+    collectStatementFunctionNames(statement, functionLikeLocalNames, scope, scopes);
   }
 };
 
-export const collectFunctionLikeLocalNames = (componentBody: EsTreeNode): Set<string> => {
+export const collectFunctionLikeLocalNames = (
+  componentBody: EsTreeNode,
+  scopes: ScopeAnalysis,
+): Set<string> => {
   const functionLikeLocalNames = new Set<string>();
   if (!isNodeOfType(componentBody, "BlockStatement")) return functionLikeLocalNames;
   let previousSize = -1;
@@ -192,6 +211,7 @@ export const collectFunctionLikeLocalNames = (componentBody: EsTreeNode): Set<st
       componentBody.body,
       functionLikeLocalNames,
       createComponentBindingScope(),
+      scopes,
     );
   }
   return functionLikeLocalNames;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/collect-render-reachable-names.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/collect-render-reachable-names.ts
@@ -1,6 +1,8 @@
-import { EFFECT_HOOK_NAMES } from "../../../constants/react.js";
+import { BUILTIN_HOOK_NAMES, EFFECT_HOOK_NAMES } from "../../../constants/react.js";
+import type { ScopeAnalysis } from "../../../semantic/scope-analysis.js";
 import type { EsTreeNode } from "../../../utils/es-tree-node.js";
 import { isNodeOfType } from "../../../utils/is-node-of-type.js";
+import { isReactHookCall } from "../../../utils/is-react-hook-call.js";
 import { isReactHookName } from "../../../utils/is-react-hook-name.js";
 import {
   addPatternBindings,
@@ -32,12 +34,19 @@ const collectRenderReachableNamesFromStatements = (
   statements: EsTreeNode[] | undefined,
   names: Set<string>,
   scope: BindingScope,
+  scopes: ScopeAnalysis,
   eventHandlerReferenceNames: Set<string> = new Set(),
 ): boolean => {
   let hasReturn = false;
   for (const statement of statements ?? []) {
     if (
-      collectRenderReachableNamesFromStatement(statement, names, scope, eventHandlerReferenceNames)
+      collectRenderReachableNamesFromStatement(
+        statement,
+        names,
+        scope,
+        scopes,
+        eventHandlerReferenceNames,
+      )
     ) {
       hasReturn = true;
     } else {
@@ -51,6 +60,7 @@ const collectRenderReachableNamesFromStatement = (
   statement: EsTreeNode,
   names: Set<string>,
   scope: BindingScope,
+  scopes: ScopeAnalysis,
   eventHandlerReferenceNames: Set<string>,
 ): boolean => {
   if (isNodeOfType(statement, "ReturnStatement")) {
@@ -73,9 +83,10 @@ const collectRenderReachableNamesFromStatement = (
   if (
     isNodeOfType(statement, "ExpressionStatement") &&
     isNodeOfType(statement.expression, "CallExpression") &&
-    isNodeOfType(statement.expression.callee, "Identifier") &&
-    isReactHookName(statement.expression.callee.name) &&
-    !EFFECT_HOOK_NAMES.has(statement.expression.callee.name)
+    ((isNodeOfType(statement.expression.callee, "Identifier") &&
+      isReactHookName(statement.expression.callee.name)) ||
+      isReactHookCall(statement.expression, BUILTIN_HOOK_NAMES, scopes)) &&
+    !isReactHookCall(statement.expression, EFFECT_HOOK_NAMES, scopes)
   ) {
     for (const argument of statement.expression.arguments ?? []) {
       addNames(names, collectScopedReferenceNames(argument, scope, eventHandlerReferenceNames));
@@ -88,6 +99,7 @@ const collectRenderReachableNamesFromStatement = (
       statement.body,
       names,
       createBlockBindingScope(scope),
+      scopes,
       eventHandlerReferenceNames,
     );
   }
@@ -97,6 +109,7 @@ const collectRenderReachableNamesFromStatement = (
       statement.consequent,
       names,
       scope,
+      scopes,
       eventHandlerReferenceNames,
     );
     const alternateHasReturn = statement.alternate
@@ -104,6 +117,7 @@ const collectRenderReachableNamesFromStatement = (
           statement.alternate,
           names,
           scope,
+          scopes,
           eventHandlerReferenceNames,
         )
       : false;
@@ -124,6 +138,7 @@ const collectRenderReachableNamesFromStatement = (
         switchCase.consequent,
         names,
         caseScope,
+        scopes,
         eventHandlerReferenceNames,
       );
       if (!caseHasReturn) continue;
@@ -149,6 +164,7 @@ const collectRenderReachableNamesFromStatement = (
       statement.block,
       names,
       scope,
+      scopes,
       eventHandlerReferenceNames,
     );
     const handlerHasReturn = statement.handler
@@ -156,6 +172,7 @@ const collectRenderReachableNamesFromStatement = (
           statement.handler,
           names,
           scope,
+          scopes,
           eventHandlerReferenceNames,
         )
       : false;
@@ -164,6 +181,7 @@ const collectRenderReachableNamesFromStatement = (
           statement.finalizer,
           names,
           scope,
+          scopes,
           eventHandlerReferenceNames,
         )
       : false;
@@ -177,6 +195,7 @@ const collectRenderReachableNamesFromStatement = (
       statement.body,
       names,
       catchScope,
+      scopes,
       eventHandlerReferenceNames,
     );
   }
@@ -186,6 +205,7 @@ const collectRenderReachableNamesFromStatement = (
       statement.body,
       names,
       scope,
+      scopes,
       eventHandlerReferenceNames,
     );
     if (bodyHasReturn) {
@@ -204,6 +224,7 @@ const collectRenderReachableNamesFromStatement = (
       statement.body,
       names,
       loopScope,
+      scopes,
       eventHandlerReferenceNames,
     );
     if (!bodyHasReturn) return false;
@@ -242,6 +263,7 @@ const collectRenderReachableNamesFromStatement = (
       statement.body,
       names,
       loopScope,
+      scopes,
       eventHandlerReferenceNames,
     );
     if (!bodyHasReturn) return false;
@@ -254,6 +276,7 @@ const collectRenderReachableNamesFromStatement = (
       statement.body,
       names,
       scope,
+      scopes,
       eventHandlerReferenceNames,
     );
   }
@@ -263,6 +286,7 @@ const collectRenderReachableNamesFromStatement = (
       statement.body,
       names,
       scope,
+      scopes,
       eventHandlerReferenceNames,
     );
     if (bodyHasReturn) {
@@ -279,6 +303,7 @@ const collectRenderReachableNamesFromStatement = (
 
 export const collectRenderReachableNames = (
   componentBody: EsTreeNode,
+  scopes: ScopeAnalysis,
   eventHandlerReferenceNames: Set<string> = new Set(),
 ): Set<string> => {
   const names = new Set<string>();
@@ -287,6 +312,7 @@ export const collectRenderReachableNames = (
     componentBody.body,
     names,
     createComponentBindingScope(),
+    scopes,
     eventHandlerReferenceNames,
   );
   return names;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/collect-use-state-bindings.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/collect-use-state-bindings.ts
@@ -1,14 +1,13 @@
 import type { EsTreeNode } from "../../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../../utils/es-tree-node-of-type.js";
 import type { ScopeAnalysis } from "../../../semantic/scope-analysis.js";
-import { isHookCall } from "../../../utils/is-hook-call.js";
-import { isReactApiCall } from "../../../utils/is-react-api-call.js";
+import { isReactHookCall } from "../../../utils/is-react-hook-call.js";
 import { isSetterIdentifier } from "../../../utils/is-setter-identifier.js";
 import { isNodeOfType } from "../../../utils/is-node-of-type.js";
 
 export const collectUseStateBindings = (
   componentBody: EsTreeNode,
-  scopes?: ScopeAnalysis,
+  scopes: ScopeAnalysis,
 ): Array<{
   valueName: string;
   setterName: string;
@@ -37,15 +36,7 @@ export const collectUseStateBindings = (
         continue;
       }
       if (!isNodeOfType(declarator.init, "CallExpression")) continue;
-      const isUseStateCall = scopes
-        ? isReactApiCall(declarator.init, "useState", scopes, {
-            allowGlobalReactNamespace: true,
-            allowUnboundBareCalls: true,
-            resolveConditionalAliases: true,
-            resolveNamedAliases: true,
-          })
-        : isHookCall(declarator.init, "useState");
-      if (!isUseStateCall) continue;
+      if (!isReactHookCall(declarator.init, "useState", scopes)) continue;
       bindings.push({
         valueName: valueElement.name,
         setterName: setterElement.name,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/effect/react.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/effect/react.ts
@@ -258,20 +258,6 @@ const isHookCallee = (
   return false;
 };
 
-export const isUseEffect = (node: EsTreeNode | null | undefined): boolean => {
-  if (!node || !isNodeOfType(node, "CallExpression")) return false;
-  const callee = node.callee;
-  if (isNodeOfType(callee, "Identifier") && callee.name === "useEffect") return true;
-  if (!isNodeOfType(callee, "MemberExpression")) return false;
-  const receiver = stripParenExpression(callee.object);
-  return (
-    isNodeOfType(receiver, "Identifier") &&
-    receiver.name === "React" &&
-    isNodeOfType(callee.property, "Identifier") &&
-    callee.property.name === "useEffect"
-  );
-};
-
 export const getEffectFn = (analysis: ProgramAnalysis, node: EsTreeNode): EsTreeNode | null => {
   if (!isNodeOfType(node, "CallExpression")) return null;
   const fn = node.arguments?.[0];

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-react-api-call.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-react-api-call.test.ts
@@ -5,6 +5,7 @@ import { parseFixture } from "../../test-utils/parse-fixture.js";
 import type { EsTreeNode } from "./es-tree-node.js";
 import { isNodeOfType } from "./is-node-of-type.js";
 import { isReactApiCall, type ReactApiCallOptions } from "./is-react-api-call.js";
+import { isReactHookCall } from "./is-react-hook-call.js";
 import { walkAst } from "./walk-ast.js";
 
 interface ReactApiCallTestCase {
@@ -27,6 +28,20 @@ const countReactApiCalls = (code: string, options?: ReactApiCallOptions): number
       isNodeOfType(node, "CallExpression") &&
       isReactApiCall(node, EFFECT_API_NAMES, scopes, options)
     ) {
+      matchingCallCount += 1;
+    }
+  });
+  return matchingCallCount;
+};
+
+const countReactHookCalls = (code: string): number => {
+  const parsed = parseFixture(code);
+  expect(parsed.errors).toEqual([]);
+  attachParentReferences(parsed.program);
+  const scopes = analyzeScopes(parsed.program);
+  let matchingCallCount = 0;
+  walkAst(parsed.program, (node: EsTreeNode) => {
+    if (isNodeOfType(node, "CallExpression") && isReactHookCall(node, EFFECT_API_NAMES, scopes)) {
       matchingCallCount += 1;
     }
   });
@@ -230,4 +245,49 @@ describe("isReactApiCall", () => {
       expect(countReactApiCalls(testCase.code, testCase.options)).toBe(testCase.expectedCount);
     });
   }
+});
+
+describe("isReactHookCall", () => {
+  it.each([
+    [
+      "a named import alias",
+      'import { useEffect as runEffect } from "react"; runEffect(() => {});',
+      1,
+    ],
+    [
+      "an immutable local alias",
+      'import { useEffect } from "react"; const runEffect = useEffect; runEffect(() => {});',
+      1,
+    ],
+    [
+      "an isomorphic alias",
+      `import * as React from "react";
+      const runEffect = typeof window === "undefined" ? React.useEffect : React.useLayoutEffect;
+      runEffect(() => {});`,
+      1,
+    ],
+    ["an unbound fixture hook", "useEffect(() => {});", 1],
+    [
+      "a userland same-name function",
+      "const useEffect = (callback) => callback(); useEffect(() => {});",
+      0,
+    ],
+    [
+      "a mutable alias",
+      `import { useEffect } from "react";
+      let runEffect = useEffect;
+      runEffect = (callback) => callback();
+      runEffect(() => {});`,
+      0,
+    ],
+    [
+      "a shadowed import",
+      `import { useEffect } from "react";
+      const run = (useEffect) => useEffect(() => {});
+      run((callback) => callback());`,
+      0,
+    ],
+  ])("classifies %s", (_name, code, expectedCount) => {
+    expect(countReactHookCalls(code)).toBe(expectedCount);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-react-hook-call.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-react-hook-call.ts
@@ -1,0 +1,15 @@
+import type { ScopeAnalysis } from "../semantic/scope-analysis.js";
+import type { EsTreeNode } from "./es-tree-node.js";
+import { isReactApiCall } from "./is-react-api-call.js";
+
+export const isReactHookCall = (
+  node: EsTreeNode,
+  hookNames: string | ReadonlySet<string>,
+  scopes: ScopeAnalysis,
+): boolean =>
+  isReactApiCall(node, hookNames, scopes, {
+    allowGlobalReactNamespace: true,
+    allowUnboundBareCalls: true,
+    resolveConditionalAliases: true,
+    resolveNamedAliases: true,
+  });


### PR DESCRIPTION
## Summary

- centralize semantic React hook recognition in `isReactHookCall`
- migrate state/effect rules from callee-name matching to binding identity
- cover named import aliases, immutable local aliases, namespace calls, and isomorphic effect aliases
- carry semantic identity through state-binding, render-reachability, and function-like-local helpers

This is stacked on #1358; merge #1358 first.

## Validation

- `nr --filter oxlint-plugin-react-doctor test`: 579 files, 15,254 passed, 188 skipped
- `nr --filter oxlint-plugin-react-doctor typecheck`
- `nr --filter @react-doctor/fuzz test`: 44 passed, 402 skipped
- `nr --filter @react-doctor/fuzz typecheck`
- `nr lint`
- `nr format:check`
- strict fuzz against `/Users/aidenybai/Developer/react-bench-internal/jobs`, 1,000 iterations each:
  - `effect-needs-cleanup` (seed 136200)
  - `no-event-trigger-state` (seed 136201)
  - `rerender-state-only-in-handlers` (seed 136202)
  - `rerender-dependencies` (seed 136203)
  - `advanced-event-handler-refs` (seed 136204)
  - `no-effect-event-in-deps` (seed 136205)
- post-rebase `truffler` searches confirm `isReactHookCall` remains the centralized semantic hook resolver

## Base state

Rebased onto #1358 exact head `978d250cd5b3da93cf0dbb29f14bcca41300c302`. The conflict resolution preserves #1358's merged parent-callback provenance in `no-prop-callback-in-effect` while applying this PR's semantic hook recognition.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide change across many lint rules alters when diagnostics fire (aliases vs shadowed/userland hooks); behavior is test-backed but any missed call site could cause false positives or negatives.
> 
> **Overview**
> Introduces **`isReactHookCall`**, a single scope-aware check that treats a call as a React hook only when binding identity traces back to React (named imports, immutable aliases, `React.*`, and isomorphic effect aliases), instead of matching callee strings.
> 
> **State/effect rules** across the plugin are migrated from `isHookCall`, ad hoc `isReactApiCall` options, and the removed **`isUseEffect`** helper to `isReactHookCall` with `context.scopes`. Shared helpers—**`collectUseStateBindings`**, **`collectRenderReachableNames`**, **`collectFunctionLikeLocalNames`**, and related paths—now take **`ScopeAnalysis`** so `useState`/`useEffect`/`useCallback` detection and render-reachability stay aligned with real imports.
> 
> **`advanced-event-handler-refs`** treats React **`useCallback`** / **`useEffectEvent`** as stable only when resolved as React hooks; third-party **`useEffectEvent`** polyfills stay on name-based stable-handler logic so they are not misclassified as React semantics.
> 
> Regression tests and a fuzz corpus case cover import aliases, non-React `useEffectEvent`, aliased `useImperativeHandle` / `useEffect`, and userland same-name hooks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19c6101f6556d77ff4b210cbb0a80b2b0c1dae72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->