### PR TITLE
fix(no-jsx-element-type): allow concrete renderer factories

### DIFF
--- a/.changeset/great-cycles-shine.md
+++ b/.changeset/great-cycles-shine.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Fix `no-jsx-element-type` false positives on private renderer factories that accurately return one JSX element.

--- a/packages/fuzz/corpus/regressions/no-jsx-element-type--private-renderer-factory.tsx
+++ b/packages/fuzz/corpus/regressions/no-jsx-element-type--private-renderer-factory.tsx
@@ -1,0 +1,11 @@
+// rule: no-jsx-element-type
+// weakness: name-heuristic
+// source: react-bench TRYL276
+
+import React from "react";
+
+const defaultRenderComponent = (props: React.HTMLProps<HTMLInputElement>): JSX.Element => (
+  <input {...props} />
+);
+
+export const renderInput = defaultRenderComponent;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-jsx-element-type.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-jsx-element-type.test.ts
@@ -93,6 +93,29 @@ describe("no-jsx-element-type", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("flags an anonymous default-exported component", () => {
+    const result = runRule(
+      noJsxElementType,
+      `
+      export default (): JSX.Element => <main />;
+    `,
+    );
+
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a component callback wrapped in memo", () => {
+    const result = runRule(
+      noJsxElementType,
+      `
+      import { memo } from "react";
+      const App = memo((): JSX.Element => <main />);
+    `,
+    );
+
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("flags function with parameters and JSX.Element return type", () => {
     const result = runRule(
       noJsxElementType,
@@ -206,6 +229,70 @@ describe("no-jsx-element-type", () => {
       noJsxElementType,
       `
       const element: JSX.Element = <div />;
+    `,
+    );
+
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not flag a private renderer factory with a concrete element contract", () => {
+    const result = runRule(
+      noJsxElementType,
+      `
+      import React from "react";
+
+      const defaultRenderComponent = (
+        props: React.HTMLProps<HTMLInputElement>,
+      ): JSX.Element => <input {...props} />;
+
+      export const ReactTransliterate = ({
+        renderComponent = defaultRenderComponent,
+      }): JSX.Element => renderComponent({});
+    `,
+    );
+
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag lowercase renderer declarations and expressions", () => {
+    const result = runRule(
+      noJsxElementType,
+      `
+      function renderInput(): JSX.Element {
+        return <input />;
+      }
+
+      const renderButton = function (): JSX.Element {
+        return <button />;
+      };
+    `,
+    );
+
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not flag inline renderer callbacks", () => {
+    const result = runRule(
+      noJsxElementType,
+      `
+      registerRenderer((props): JSX.Element => <input {...props} />);
+
+      const renderers = {
+        input: (props): JSX.Element => <input {...props} />,
+      };
+    `,
+    );
+
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not flag method signatures that promise a concrete element", () => {
+    const result = runRule(
+      noJsxElementType,
+      `
+      interface Renderer {
+        renderInput(props: Record<string, unknown>): JSX.Element;
+      }
     `,
     );
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-jsx-element-type.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-jsx-element-type.ts
@@ -1,7 +1,9 @@
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { isComponentFunction } from "../../utils/is-component-function.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { isReactComponentName } from "../../utils/is-react-component-name.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 
 const MESSAGE =
@@ -59,9 +61,14 @@ export const noJsxElementType = defineRule({
     let isJsxImported = false;
     const flaggedAnnotations: EsTreeNode[] = [];
 
-    const checkReturnType = (
+    const collectComponentReturnType = (
+      functionNode: EsTreeNode,
       returnType: EsTreeNodeOfType<"TSTypeAnnotation"> | undefined,
     ): void => {
+      const isComponent = isNodeOfType(functionNode, "TSDeclareFunction")
+        ? Boolean(functionNode.id && isReactComponentName(functionNode.id.name))
+        : isComponentFunction(functionNode);
+      if (!isComponent) return;
       const typeAnnotation = extractReturnTypeAnnotation(returnType);
       if (!typeAnnotation) return;
       if (isJsxElementTypeReference(typeAnnotation)) {
@@ -74,19 +81,16 @@ export const noJsxElementType = defineRule({
         if (isJsxImportBinding(node)) isJsxImported = true;
       },
       FunctionDeclaration(node: EsTreeNodeOfType<"FunctionDeclaration">) {
-        checkReturnType(node.returnType);
+        collectComponentReturnType(node, node.returnType);
       },
       ArrowFunctionExpression(node: EsTreeNodeOfType<"ArrowFunctionExpression">) {
-        checkReturnType(node.returnType);
+        collectComponentReturnType(node, node.returnType);
       },
       FunctionExpression(node: EsTreeNodeOfType<"FunctionExpression">) {
-        checkReturnType(node.returnType);
+        collectComponentReturnType(node, node.returnType);
       },
       TSDeclareFunction(node: EsTreeNodeOfType<"TSDeclareFunction">) {
-        checkReturnType(node.returnType);
-      },
-      TSMethodSignature(node: EsTreeNodeOfType<"TSMethodSignature">) {
-        checkReturnType(node.returnType);
+        collectComponentReturnType(node, node.returnType);
       },
       "Program:exit"() {
         if (isJsxImported) return;


### PR DESCRIPTION
## Why

Prevents `no-jsx-element-type` from treating every JSX-returning callback as a React component.

A private renderer factory can accurately promise one concrete `JSX.Element`; widening it to `React.ReactNode` weakens its valid local contract. This surfaced in react-bench Burhanuday trial `TRYL276`, where the warning was the sole new gate failure.

Before (incorrectly reported):

```tsx
const defaultRenderComponent = (
  props: React.HTMLProps<HTMLInputElement>,
): JSX.Element => <input {...props} />;
```

After (accepted unchanged):

```tsx
const defaultRenderComponent = (
  props: React.HTMLProps<HTMLInputElement>,
): JSX.Element => <input {...props} />;
```

Genuine component APIs such as `const App = (): JSX.Element => <main />` remain reportable.

## What changed

- Limits return-type diagnostics to React component functions, including PascalCase declarations/bindings, default exports, and component HOC callbacks.
- Allows lowercase private renderer declarations, inline renderer callbacks, and renderer method signatures to retain concrete element contracts.
- Adds adversarial controls for `memo`, anonymous default exports, lowercase declarations, object callbacks, and method signatures.
- Adds the Burhanuday shape to the permanent fuzz regression corpus and a patch changeset.

## Eval results

| Check | Result |
| --- | --- |
| Distinct repos scanned | 12 |
| RootDir scans | 99 completed; one Excalidraw root stopped after 7 minutes CPU-bound |
| Target rule | `no-jsx-element-type` |
| Diagnostics | 4,773 surviving component diagnostics across 4 repos |
| Manually inspected hits | 15 across dominant and smaller roots |
| False positives found | 0 in the inspected surviving sample |
| Output artifact | local RDE digest for `path:/private/tmp/react-doctor-jsx-renderer-PrbMQ9` |

## Test plan

- `nr test` in `packages/oxlint-plugin-react-doctor` — 576 files, 15,111 passed, 188 skipped
- `nr test` in `packages/fuzz` — 44 passed, 402 skipped
- `FUZZ_RULE=no-jsx-element-type FUZZ_STRICT=1 FUZZ_ITERATIONS=1000 FUZZ_SEED=1360001 nr fuzz`
- `FUZZ_RULE=no-jsx-element-type FUZZ_STRICT=1 FUZZ_ITERATIONS=1000 FUZZ_SEED=1360002 FUZZ_CORPUS_DIR=packages/fuzz/tmp/bench-corpus nr fuzz`
- `nr build`
- `nr typecheck`
- `nr lint`
- `nr format:check`
- `nr test` — 13/14 package tasks passed; the sole CLI failure (`untracked-working-tree-scope` staged-range case) reproduces unchanged on `main`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint rule heuristic tightening with broad test coverage; no runtime, auth, or data-path changes.
> 
> **Overview**
> **`no-jsx-element-type`** now reports `JSX.Element` return annotations only on **React component** functions (PascalCase bindings, default exports, `memo`/HOC-wrapped callbacks, etc.), instead of every JSX-returning function.
> 
> **Lowercase renderer helpers**, inline renderer callbacks, and **interface method signatures** that promise a single element are left alone. **`TSMethodSignature`** is no longer visited, so concrete renderer contracts in types are not warned.
> 
> Adds regression tests (including Burhanuday-style private renderer factories), a fuzz corpus case, and a patch changeset for `oxlint-plugin-react-doctor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7b4903458671b1b7207b602ff194234c93126a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->