### PR TITLE
test(rule): pin hydration mount-gate true positives

### DIFF
--- a/packages/fuzz/corpus/true-positives/rendering-hydration-no-flicker--portal-mount-gate.tsx
+++ b/packages/fuzz/corpus/true-positives/rendering-hydration-no-flicker--portal-mount-gate.tsx
@@ -1,0 +1,20 @@
+// rule: rendering-hydration-no-flicker
+// weakness: control-flow
+// source: react-bench trial Hx4pzsa
+
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+
+export const Gallery = ({ show }) => {
+  const [isClient, setIsClient] = useState(false);
+
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
+
+  if (!show || !isClient) {
+    return null;
+  }
+
+  return createPortal(<div role="dialog" />, document.body);
+};

--- a/packages/fuzz/corpus/true-positives/rendering-hydration-no-flicker--video-capability-mount-gate.tsx
+++ b/packages/fuzz/corpus/true-positives/rendering-hydration-no-flicker--video-capability-mount-gate.tsx
@@ -1,0 +1,20 @@
+// rule: rendering-hydration-no-flicker
+// weakness: control-flow
+// source: react-bench trial 9tTzDBK
+
+import { useEffect, useMemo, useState } from "react";
+
+export const Background = ({ mime, src }) => {
+  const [hasMounted, setHasMounted] = useState(false);
+
+  useEffect(() => {
+    setHasMounted(true);
+  }, []);
+
+  const isPlayable = useMemo(
+    () => Boolean(hasMounted && document.createElement("video").canPlayType(mime)),
+    [hasMounted, mime],
+  );
+
+  return isPlayable ? <video src={src} /> : <img src={src} />;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/rendering-hydration-no-flicker.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/rendering-hydration-no-flicker.regressions.test.ts
@@ -57,6 +57,40 @@ describe("performance/rendering-hydration-no-flicker — regressions", () => {
     `);
   });
 
+  it("still flags a portal hidden until the client mount effect runs", () => {
+    expectFail(`
+      import { createPortal } from "react-dom";
+      import { useEffect, useState } from "react";
+      const Gallery = ({ show }) => {
+        const [isClient, setIsClient] = useState(false);
+        useEffect(() => {
+          setIsClient(true);
+        }, []);
+        if (!show || !isClient) {
+          return null;
+        }
+        return createPortal(<div role="dialog" />, document.body);
+      };
+    `);
+  });
+
+  it("still flags a media capability gate deferred until after paint", () => {
+    expectFail(`
+      import { useEffect, useMemo, useState } from "react";
+      const Background = ({ mime, src }) => {
+        const [hasMounted, setHasMounted] = useState(false);
+        useEffect(() => {
+          setHasMounted(true);
+        }, []);
+        const isPlayable = useMemo(
+          () => Boolean(hasMounted && document.createElement("video").canPlayType(mime)),
+          [hasMounted, mime],
+        );
+        return isPlayable ? <video src={src} /> : <img src={src} />;
+      };
+    `);
+  });
+
   it("still flags a setter feeding visible content", () => {
     expectFail(`
       const NoteForm = () => {


### PR DESCRIPTION
## Why

React Bench produced 11 suspected false positives for `rendering-hydration-no-flicker`. The exact portal and video capability patches are genuine post-paint UI changes, and current main correctly reports both. Without pinned regressions, a future broad client-only or capability exemption could silently weaken the rule.

Before: the detector had generic mount-flag coverage but no benchmark-derived portal or media-capability fixtures.

After: both exact failure families are must-report unit cases and true-positive fuzz seeds. Detector behavior is unchanged.

## What changed

- add a portal mount-gate must-report regression from trial `Hx4pzsa`
- add a video capability mount-gate must-report regression from trial `9tTzDBK`
- add both verified shapes to the evolving true-positive fuzz corpus
- retain existing silence controls for `useLayoutEffect`, DOM measurement, locale adoption, ARIA-only state, and effects with real additional work

This is test hardening only, so no changeset is required.

## Test plan

- full oxlint plugin suite: 576 files, 15,107 passed, 188 skipped
- strict targeted fuzz: `FUZZ_RULE=rendering-hydration-no-flicker FUZZ_STRICT=1 FUZZ_ITERATIONS=1000 FUZZ_SEED=17172026`
- `nr typecheck`
- `nr lint`
- `nr format:check`
- post-change truffler deduplication search