### PR TITLE
fix(effect-needs-cleanup): prove nested ref ownership

### DIFF
--- a/.changeset/pink-wings-bow.md
+++ b/.changeset/pink-wings-bow.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Fix effect-needs-cleanup false positives for generation-guarded nested subscriptions owned by an effect.

--- a/packages/fuzz/corpus/regressions/effect-needs-cleanup--nested-generation-owned-subscription.tsx
+++ b/packages/fuzz/corpus/regressions/effect-needs-cleanup--nested-generation-owned-subscription.tsx
@@ -1,0 +1,47 @@
+// rule: effect-needs-cleanup
+// weakness: control-flow
+// source: react-bench FormidableLabs/victory a2Z2PMc false positive
+import { useEffect, useRef } from "react";
+
+export const Animation = ({ timer, delay }) => {
+  const loopID = useRef<number | undefined>(undefined);
+  const delayID = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const runID = useRef(0);
+
+  useEffect(() => {
+    const cancel = () => {
+      runID.current += 1;
+      if (loopID.current !== undefined) {
+        timer.unsubscribe(loopID.current);
+        loopID.current = undefined;
+      }
+      if (delayID.current !== undefined) {
+        clearTimeout(delayID.current);
+        delayID.current = undefined;
+      }
+    };
+    const startQueue = (run: number) => {
+      const start = () => {
+        if (run !== runID.current) return;
+        delayID.current = undefined;
+        loopID.current = timer.subscribe(() => {
+          if (run !== runID.current) return;
+          if (loopID.current !== undefined) {
+            timer.unsubscribe(loopID.current);
+            loopID.current = undefined;
+          }
+          startQueue(run);
+        }, 1000);
+      };
+      if (delay) {
+        delayID.current = setTimeout(start, delay);
+      } else {
+        start();
+      }
+    };
+    startQueue(runID.current);
+    return cancel;
+  }, [delay, timer]);
+
+  return null;
+};

--- a/packages/fuzz/corpus/regressions/effect-needs-cleanup--nested-queue-owned-subscription.tsx
+++ b/packages/fuzz/corpus/regressions/effect-needs-cleanup--nested-queue-owned-subscription.tsx
@@ -1,0 +1,49 @@
+// rule: effect-needs-cleanup
+// weakness: control-flow
+// source: react-bench FormidableLabs/victory axv5XzX false positive
+import { useEffect, useRef } from "react";
+
+export const Animation = ({ timer, delay }) => {
+  const loopID = useRef<number | undefined>(undefined);
+  const timeoutID = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const runID = useRef(0);
+
+  useEffect(() => {
+    const stopActiveTimer = () => {
+      if (timeoutID.current) {
+        clearTimeout(timeoutID.current);
+        timeoutID.current = undefined;
+      }
+      if (loopID.current) {
+        timer.unsubscribe(loopID.current);
+        loopID.current = undefined;
+      }
+    };
+    const stepFrame = (currentRunID: number) => {
+      if (currentRunID !== runID.current) return;
+      if (loopID.current) {
+        timer.unsubscribe(loopID.current);
+        loopID.current = undefined;
+      }
+      traverseQueue();
+    };
+    const traverseQueue = () => {
+      runID.current += 1;
+      const currentRunID = runID.current;
+      const start = () => {
+        if (runID.current !== currentRunID) return;
+        timeoutID.current = undefined;
+        loopID.current = timer.subscribe(() => stepFrame(currentRunID), 1000);
+      };
+      if (delay) {
+        timeoutID.current = setTimeout(start, delay);
+      } else {
+        start();
+      }
+    };
+    traverseQueue();
+    return stopActiveTimer;
+  }, [delay, timer]);
+
+  return null;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup-victory.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup-victory.test.ts
@@ -191,6 +191,37 @@ export const Component = ({ timer }) => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("reports when a Promise callback can invoke the guarded allocator after cleanup", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import React from "react";
+export const Component = ({ timer }) => {
+  const loopID = React.useRef(undefined);
+  const delayID = React.useRef(undefined);
+  const runID = React.useRef(0);
+  React.useEffect(() => {
+    runID.current += 1;
+    const currentRunID = runID.current;
+    const start = () => {
+      if (currentRunID !== runID.current) return;
+      loopID.current = timer.subscribe(tick, 1000);
+    };
+    start();
+    delayID.current = setTimeout(start, 1000);
+    Promise.resolve().then(() => start());
+    return () => {
+      timer.unsubscribe(loopID.current);
+      clearTimeout(delayID.current);
+    };
+  }, [timer]);
+  return null;
+};`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("reports when cleanup releases a different retained handle", () => {
     const result = runRule(
       effectNeedsCleanup,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup-victory.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup-victory.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { effectNeedsCleanup } from "./effect-needs-cleanup.js";
+
+const runVictoryOwnershipCase = (overrides = "") =>
+  runRule(
+    effectNeedsCleanup,
+    `import React from "react";
+export const Component = ({ timer, delay }) => {
+  const loopID = React.useRef(undefined);
+  const delayID = React.useRef(undefined);
+  const runID = React.useRef(0);
+
+  React.useEffect(() => {
+    const cancel = () => {
+      runID.current += 1;
+      if (loopID.current !== undefined) {
+        timer.unsubscribe(loopID.current);
+        loopID.current = undefined;
+      }
+      if (delayID.current !== undefined) {
+        clearTimeout(delayID.current);
+        delayID.current = undefined;
+      }
+    };
+
+    const startQueue = (run) => {
+      const start = () => {
+        ${overrides || "if (run !== runID.current) return;"}
+        loopID.current = timer.subscribe(() => {
+          if (run !== runID.current) return;
+          if (loopID.current !== undefined) {
+            timer.unsubscribe(loopID.current);
+            loopID.current = undefined;
+          }
+          startQueue(run);
+        }, 1000);
+      };
+
+      if (delay) {
+        delayID.current = setTimeout(start, delay);
+      } else {
+        start();
+      }
+    };
+
+    startQueue(runID.current);
+    return cancel;
+  }, [delay, timer]);
+  return null;
+};`,
+  );
+
+describe("effect-needs-cleanup Victory nested effect ownership", () => {
+  it("accepts a receiver-owned numeric subscription handle", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import React from "react";
+export const Component = ({ timer }) => {
+  const loopID = React.useRef(undefined);
+  React.useEffect(() => {
+    loopID.current = timer.subscribe(tick, 1000);
+    return () => timer.unsubscribe(loopID.current);
+  }, [timer]);
+  return null;
+};`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("reports when another receiver releases the numeric subscription handle", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import React from "react";
+export const Component = ({ timer, otherTimer }) => {
+  const loopID = React.useRef(undefined);
+  React.useEffect(() => {
+    loopID.current = timer.subscribe(tick, 1000);
+    return () => otherTimer.unsubscribe(loopID.current);
+  }, [otherTimer, timer]);
+  return null;
+};`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("accepts a generation-guarded nested subscription owned by the effect", () => {
+    const result = runVictoryOwnershipCase();
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("accepts a nested queue whose generation advances before each scheduled run", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import React from "react";
+export const Component = ({ timer, delay }) => {
+  const loopID = React.useRef(undefined);
+  const timeoutID = React.useRef(undefined);
+  const runID = React.useRef(0);
+  React.useEffect(() => {
+    const stopActiveTimer = () => {
+      if (timeoutID.current) {
+        clearTimeout(timeoutID.current);
+        timeoutID.current = undefined;
+      }
+      if (loopID.current) {
+        timer.unsubscribe(loopID.current);
+        loopID.current = undefined;
+      }
+    };
+    const stepFrame = (currentRunID) => {
+      if (currentRunID !== runID.current) return;
+      if (loopID.current) {
+        timer.unsubscribe(loopID.current);
+        loopID.current = undefined;
+      }
+      traverseQueue();
+    };
+    const traverseQueue = () => {
+      runID.current += 1;
+      const currentRunID = runID.current;
+      const start = () => {
+        if (runID.current !== currentRunID) return;
+        timeoutID.current = undefined;
+        loopID.current = timer.subscribe(() => stepFrame(currentRunID), 1000);
+      };
+      if (delay) {
+        timeoutID.current = setTimeout(start, delay);
+      } else {
+        start();
+      }
+    };
+    traverseQueue();
+    return stopActiveTimer;
+  }, [delay, timer]);
+  return null;
+};`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("reports when the nested allocation can reacquire after cancellation", () => {
+    const result = runVictoryOwnershipCase("void run;");
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports when cleanup advances a different generation", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import React from "react";
+export const Component = ({ timer }) => {
+  const loopID = React.useRef(undefined);
+  const delayID = React.useRef(undefined);
+  const runID = React.useRef(0);
+  const otherRunID = React.useRef(0);
+  React.useEffect(() => {
+    const start = (run) => {
+      if (run !== otherRunID.current) return;
+      loopID.current = timer.subscribe(tick, 1000);
+    };
+    start(otherRunID.current);
+    delayID.current = setTimeout(start, 1000, otherRunID.current);
+    return () => {
+      runID.current += 1;
+      timer.unsubscribe(loopID.current);
+      clearTimeout(delayID.current);
+    };
+  }, [timer]);
+  return null;
+};`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports when a conjunction does not guarantee the stale run returns", () => {
+    const result = runVictoryOwnershipCase("if (run !== runID.current && delay > 0) return;");
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports when cleanup releases a different retained handle", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import React from "react";
+export const Component = ({ timer }) => {
+  const loopID = React.useRef(undefined);
+  const otherLoopID = React.useRef(undefined);
+  const runID = React.useRef(0);
+  React.useEffect(() => {
+    const start = (run) => {
+      if (run !== runID.current) return;
+      loopID.current = timer.subscribe(tick, 1000);
+    };
+    start(runID.current);
+    return () => {
+      runID.current += 1;
+      timer.unsubscribe(otherLoopID.current);
+    };
+  }, [timer]);
+  return null;
+};`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports when the effect omits its returned cleanup", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import React from "react";
+export const Component = ({ timer }) => {
+  const loopID = React.useRef(undefined);
+  const runID = React.useRef(0);
+  React.useEffect(() => {
+    const start = (run) => {
+      if (run !== runID.current) return;
+      loopID.current = timer.subscribe(tick, 1000);
+    };
+    start(runID.current);
+  }, [timer]);
+  return null;
+};`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -12,6 +12,7 @@ import {
 import { defineRule } from "../../utils/define-rule.js";
 import {
   collectEffectInvokedFunctions,
+  collectSynchronouslyEffectInvokedFunctions,
   getPromiseChainCallForCallback,
 } from "../../utils/collect-effect-invoked-functions.js";
 import { enclosingComponentOrHookName } from "../../utils/enclosing-component-or-hook-name.js";
@@ -1789,7 +1790,7 @@ const getOwnedFunctionReference = (
     if (
       referenceOwner &&
       referenceOwner !== usageFunction &&
-      collectEffectInvokedFunctions(callback).has(referenceOwner)
+      collectSynchronouslyEffectInvokedFunctions(callback).has(referenceOwner)
     ) {
       return { generationKey: null };
     }
@@ -1848,7 +1849,7 @@ const hasGuardedRefOwnedNestedCleanup = (
     usageAssignment.operator !== "=" ||
     usageAssignment.right !== usageExpression ||
     !resolveReactRefSymbol(stripParenExpression(usageAssignment.left), context.scopes) ||
-    !collectEffectInvokedFunctions(callback).has(usageFunction) ||
+    !collectSynchronouslyEffectInvokedFunctions(callback).has(usageFunction) ||
     !cleanupReturnsReleaseUsage(cleanupReturns, usage, context) ||
     !doMatchingNodesCoverEveryPathFromFunctionEntry(callback, cleanupReturns, context)
   ) {
@@ -1881,7 +1882,7 @@ const hasGuardedRefOwnedNestedCleanup = (
   if (generationKeys.size !== 1) return false;
   const generationKey = generationKeys.values().next().value;
   if (typeof generationKey !== "string") return false;
-  const invokedFunctions = collectEffectInvokedFunctions(callback);
+  const invokedFunctions = collectSynchronouslyEffectInvokedFunctions(callback);
   return [...invokedFunctions, ...cleanupFunctions].some((owner) =>
     functionAdvancesGeneration(owner, generationKey, context),
   );

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -78,6 +78,10 @@ interface BooleanGuardState {
   value: boolean;
 }
 
+interface OwnedFunctionReference {
+  generationKey: string | null;
+}
+
 interface GlobalReleaseProof {
   anchor: EsTreeNode;
   call: EsTreeNode;
@@ -1001,7 +1005,7 @@ const findSingleDirectInvocation = (
     const callNode = findDirectCallForReference(reference.identifier);
     return callNode ? [callNode] : [];
   });
-  if (invocationCalls.length !== 1) return null;
+  if (invocationCalls.length !== 1 || symbol.references.length !== 1) return null;
   const invocationCall = invocationCalls[0];
   return findEnclosingFunction(invocationCall) === caller &&
     isNodeReachableWithinFunction(invocationCall, context)
@@ -1651,12 +1655,247 @@ const hasPotentialInterruptionAfterGuard = (
   return hasPotentialInterruption;
 };
 
+const getNumericReactRefCurrentKey = (
+  expression: EsTreeNode,
+  context: RuleContext,
+): string | null => {
+  const refSymbol = resolveReactRefSymbol(stripParenExpression(expression), context.scopes);
+  const initializer = refSymbol?.initializer ? stripParenExpression(refSymbol.initializer) : null;
+  if (!isNodeOfType(initializer, "CallExpression")) return null;
+  const initialValue = initializer.arguments?.[0]
+    ? stripParenExpression(initializer.arguments[0])
+    : null;
+  if (!isNodeOfType(initialValue, "Literal") || typeof initialValue.value !== "number") {
+    return null;
+  }
+  return resolveExpressionKey(expression, context);
+};
+
+const getBlockingGenerationKey = (expression: EsTreeNode, context: RuleContext): string | null => {
+  const test = stripParenExpression(expression);
+  if (isNodeOfType(test, "LogicalExpression") && test.operator === "||") {
+    return (
+      getBlockingGenerationKey(test.left, context) ?? getBlockingGenerationKey(test.right, context)
+    );
+  }
+  if (
+    !isNodeOfType(test, "BinaryExpression") ||
+    (test.operator !== "!==" && test.operator !== "!=")
+  ) {
+    return null;
+  }
+  const leftKey = getNumericReactRefCurrentKey(test.left, context);
+  const rightKey = getNumericReactRefCurrentKey(test.right, context);
+  const snapshotExpression = leftKey
+    ? stripParenExpression(test.right)
+    : stripParenExpression(test.left);
+  const key = leftKey ?? rightKey;
+  return key && isNodeOfType(snapshotExpression, "Identifier") ? key : null;
+};
+
+const findGenerationGuardKeyForDeferredUsage = (
+  usageFunction: EsTreeNode,
+  usageNode: EsTreeNode,
+  context: RuleContext,
+): string | null => {
+  if (!isFunctionLike(usageFunction)) return null;
+  let generationKey: string | null = null;
+  walkAst(usageFunction.body, (child: EsTreeNode) => {
+    if (generationKey) return false;
+    if (child !== usageFunction.body && isFunctionLike(child)) return false;
+    if (!isNodeOfType(child, "IfStatement") || child.alternate) {
+      return;
+    }
+    const key = getBlockingGenerationKey(child.test, context);
+    if (
+      !key ||
+      canNodeReachLaterNodeWithinFunction(child.consequent, usageNode, usageFunction, context) ||
+      !doMatchingNodesCoverEveryPathBeforeUsage(usageNode, [child], usageFunction, context)
+    ) {
+      return;
+    }
+    generationKey = key;
+  });
+  return generationKey;
+};
+
+const isGenerationAdvance = (
+  node: EsTreeNode,
+  generationKey: string,
+  context: RuleContext,
+): boolean => {
+  if (
+    isNodeOfType(node, "UpdateExpression") &&
+    resolveExpressionKey(node.argument, context) === generationKey
+  ) {
+    return true;
+  }
+  if (
+    !isNodeOfType(node, "AssignmentExpression") ||
+    resolveExpressionKey(node.left, context) !== generationKey ||
+    (node.operator !== "+=" && node.operator !== "-=")
+  ) {
+    return false;
+  }
+  const amount = stripParenExpression(node.right);
+  return isNodeOfType(amount, "Literal") && typeof amount.value === "number" && amount.value !== 0;
+};
+
+const functionAdvancesGeneration = (
+  owner: EsTreeNode,
+  generationKey: string,
+  context: RuleContext,
+): boolean => {
+  if (!isFunctionLike(owner)) return false;
+  let didAdvanceGeneration = false;
+  walkAst(owner.body, (child: EsTreeNode) => {
+    if (didAdvanceGeneration) return false;
+    if (child !== owner.body && isFunctionLike(child)) return false;
+    if (isGenerationAdvance(child, generationKey, context)) {
+      didAdvanceGeneration = true;
+      return false;
+    }
+  });
+  return didAdvanceGeneration;
+};
+
+const cleanupReturnsReleaseUsage = (
+  cleanupReturns: ReadonlyArray<EsTreeNode>,
+  usage: SubscribeLikeUsage,
+  context: RuleContext,
+): boolean =>
+  cleanupReturns.length > 0 &&
+  cleanupReturns.every((cleanupReturn) => {
+    if (!isNodeOfType(cleanupReturn, "ReturnStatement") || !cleanupReturn.argument) return false;
+    const cleanupFunction = resolveStableValue(cleanupReturn.argument, context);
+    return Boolean(
+      cleanupFunction &&
+      isFunctionLike(cleanupFunction) &&
+      doesCleanupFunctionReleaseUsage(cleanupFunction, usage, context),
+    );
+  });
+
+const getOwnedFunctionReference = (
+  reference: EsTreeNode,
+  usageFunction: EsTreeNode,
+  usageNode: EsTreeNode,
+  callback: EsTreeNode,
+  cleanupReturns: ReadonlyArray<EsTreeNode>,
+  context: RuleContext,
+): OwnedFunctionReference | null => {
+  const directCall = findDirectCallForReference(reference);
+  if (directCall) {
+    const referenceOwner = findEnclosingFunction(directCall);
+    if (
+      referenceOwner &&
+      referenceOwner !== usageFunction &&
+      collectEffectInvokedFunctions(callback).has(referenceOwner)
+    ) {
+      return { generationKey: null };
+    }
+    const generationKey = referenceOwner
+      ? findGenerationGuardKeyForDeferredUsage(referenceOwner, directCall, context)
+      : null;
+    return generationKey ? { generationKey } : null;
+  }
+  const referenceRoot = findTransparentExpressionRoot(reference);
+  const schedulerCall = referenceRoot.parent;
+  if (
+    !isNodeOfType(schedulerCall, "CallExpression") ||
+    !schedulerCall.arguments.some((argument) => argument === referenceRoot) ||
+    !isNodeOfType(schedulerCall.callee, "Identifier") ||
+    schedulerCall.callee.name !== "setTimeout" ||
+    !context.scopes.isGlobalReference(schedulerCall.callee)
+  ) {
+    return null;
+  }
+  const schedulerUsage: SubscribeLikeUsage = {
+    kind: "timer",
+    node: schedulerCall,
+    resourceName: schedulerCall.callee.name,
+    handleKey: findAssignedResourceKey(schedulerCall, context),
+    receiverKey: null,
+    registrationVerbName: schedulerCall.callee.name,
+    eventKey: null,
+    handlerKey: null,
+  };
+  const generationKey = findGenerationGuardKeyForDeferredUsage(usageFunction, usageNode, context);
+  return schedulerUsage.handleKey !== null &&
+    cleanupReturnsReleaseUsage(cleanupReturns, schedulerUsage, context) &&
+    generationKey
+    ? { generationKey }
+    : null;
+};
+
+const hasGuardedRefOwnedNestedCleanup = (
+  callback: EsTreeNode,
+  usage: SubscribeLikeUsage,
+  cleanupReturns: ReadonlyArray<EsTreeNode>,
+  context: RuleContext,
+): boolean => {
+  const usageFunction = findEnclosingFunction(usage.node);
+  const usageExpression = findTransparentExpressionRoot(usage.node);
+  const usageAssignment = usageExpression.parent;
+  if (
+    (usage.kind !== "subscribe" && usage.kind !== "timer") ||
+    usage.handleKey === null ||
+    !usageFunction ||
+    !isFunctionLike(usageFunction) ||
+    usageFunction === callback ||
+    usageFunction.async ||
+    usageFunction.generator ||
+    !isNodeOfType(usageAssignment, "AssignmentExpression") ||
+    usageAssignment.operator !== "=" ||
+    usageAssignment.right !== usageExpression ||
+    !resolveReactRefSymbol(stripParenExpression(usageAssignment.left), context.scopes) ||
+    !collectEffectInvokedFunctions(callback).has(usageFunction) ||
+    !cleanupReturnsReleaseUsage(cleanupReturns, usage, context) ||
+    !doMatchingNodesCoverEveryPathFromFunctionEntry(callback, cleanupReturns, context)
+  ) {
+    return false;
+  }
+  const cleanupFunctions = cleanupReturns.flatMap((cleanupReturn) => {
+    if (!isNodeOfType(cleanupReturn, "ReturnStatement") || !cleanupReturn.argument) return [];
+    const cleanupFunction = resolveStableValue(cleanupReturn.argument, context);
+    return cleanupFunction && isFunctionLike(cleanupFunction) ? [cleanupFunction] : [];
+  });
+  const bindingIdentifier = getFunctionBindingIdentifier(usageFunction);
+  const functionSymbol = bindingIdentifier ? context.scopes.symbolFor(bindingIdentifier) : null;
+  if (!functionSymbol || functionSymbol.references.length === 0) return false;
+  const ownedReferences = functionSymbol.references.map((reference) =>
+    getOwnedFunctionReference(
+      reference.identifier,
+      usageFunction,
+      usage.node,
+      callback,
+      cleanupReturns,
+      context,
+    ),
+  );
+  if (ownedReferences.some((reference) => reference === null)) return false;
+  const generationKeys = new Set(
+    ownedReferences.flatMap((reference) =>
+      reference?.generationKey ? [reference.generationKey] : [],
+    ),
+  );
+  if (generationKeys.size !== 1) return false;
+  const generationKey = generationKeys.values().next().value;
+  if (typeof generationKey !== "string") return false;
+  const invokedFunctions = collectEffectInvokedFunctions(callback);
+  return [...invokedFunctions, ...cleanupFunctions].some((owner) =>
+    functionAdvancesGeneration(owner, generationKey, context),
+  );
+};
+
 const hasGuardedDeferredCleanup = (
   callback: EsTreeNode,
   usage: SubscribeLikeUsage,
   cleanupReturns: ReadonlyArray<EsTreeNode>,
   context: RuleContext,
 ): boolean => {
+  if (hasGuardedRefOwnedNestedCleanup(callback, usage, cleanupReturns, context)) {
+    return true;
+  }
   const usageFunction = findEnclosingFunction(usage.node);
   const promiseChainCall = usageFunction ? getPromiseChainCallForCallback(usageFunction) : null;
   if (
@@ -2212,6 +2451,14 @@ const doesReleaseCallMatchUsage = (
     return true;
   }
   if (usage.receiverKey === null || releaseReceiverKey !== usage.receiverKey) return false;
+  if (
+    usage.registrationVerbName === "subscribe" &&
+    (releaseVerbName === "unsubscribe" || releaseVerbName === "unsub") &&
+    usage.handleKey !== null &&
+    resolveExpressionKey(callNode.arguments?.[0], context) === usage.handleKey
+  ) {
+    return true;
+  }
   const pairedVerbNames = usage.registrationVerbName
     ? PAIRED_RELEASE_VERB_NAMES_BY_REGISTRATION_VERB.get(usage.registrationVerbName)
     : null;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/collect-effect-invoked-functions.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/collect-effect-invoked-functions.ts
@@ -36,7 +36,10 @@ export const getPromiseChainCallForCallback = (candidate: EsTreeNode): EsTreeNod
 // path (transitively), and promise-chain callbacks rooted at calls made on
 // that path — as opposed to handlers merely registered for a later external
 // event (addEventListener / setInterval) or the returned cleanup function.
-export const collectEffectInvokedFunctions = (effectCallback: EsTreeNode): Set<EsTreeNode> => {
+const collectInvokedFunctions = (
+  effectCallback: EsTreeNode,
+  includePromiseCallbacks: boolean,
+): Set<EsTreeNode> => {
   const invokedFunctions = new Set<EsTreeNode>([effectCallback]);
   const localFunctionBindings = new Map<string, EsTreeNode>();
   const calledBindingNames = new Set<string>();
@@ -83,7 +86,7 @@ export const collectEffectInvokedFunctions = (effectCallback: EsTreeNode): Set<E
         return;
       }
 
-      if (isPromiseChainCall(callee)) {
+      if (includePromiseCallbacks && isPromiseChainCall(callee)) {
         for (const callArgument of child.arguments ?? []) {
           enqueue(callArgument);
         }
@@ -97,3 +100,10 @@ export const collectEffectInvokedFunctions = (effectCallback: EsTreeNode): Set<E
 
   return invokedFunctions;
 };
+
+export const collectEffectInvokedFunctions = (effectCallback: EsTreeNode): Set<EsTreeNode> =>
+  collectInvokedFunctions(effectCallback, true);
+
+export const collectSynchronouslyEffectInvokedFunctions = (
+  effectCallback: EsTreeNode,
+): Set<EsTreeNode> => collectInvokedFunctions(effectCallback, false);


### PR DESCRIPTION
## Why

`effect-needs-cleanup` rejected Victory animation loops even though the effect owns both the active subscription ID and delayed start timer. The nested queue uses a numeric generation ref to prevent stale closures from reacquiring after cancellation, and the returned cleanup releases the same receiver-owned handles.

## What changed

- Recognize receiver APIs shaped as `timer.subscribe(...)` / `timer.unsubscribe(subscriptionID)`.
- Prove nested ref ownership only when every function reference is a synchronous call or an owned `setTimeout` callback, every deferred path is generation-guarded, and the effect cleanup releases the matching refs.
- Stop treating a helper as single-invoked when it also escapes as a callback.
- Add adversarial controls for missing cleanup, changed receiver/handle/generation, missing guards, and non-dominating `&&` guards.
- Add both confirmed Victory false positives to the permanent fuzz regression corpus.

## Exact replay

| Trial | Result |
| --- | --- |
| `a2Z2PMc` | 0 `effect-needs-cleanup` diagnostics |
| `axv5XzX` | 0 `effect-needs-cleanup` diagnostics |

Both saved patches were applied to FormidableLabs/victory at `75549cf8c67e3ea220f862eb7f530c36d540d41c` and run through this branch's rule implementation.

## Test plan

- Full oxlint plugin suite: 577 files, 15,115 passed, 188 skipped
- Plugin typecheck
- Repository lint and format check
- Fuzz corpus smoke: 44 passed
- `FUZZ_RULE=effect-needs-cleanup FUZZ_STRICT=1 FUZZ_ITERATIONS=1000 FUZZ_SEED=1368002 nr fuzz`
- Exact saved-patch replays for both trial IDs

RDE was not rerun because these are exact react-bench OSS artifacts and both complete saved rewrites were replayed directly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes static analysis for effect cleanup in a large, control-flow-heavy rule; incorrect proofs could hide real leaks or keep false positives, but scope is limited to the oxlint plugin and is heavily tested.
> 
> **Overview**
> Fixes **false positives** in `effect-needs-cleanup` for animation-style effects (e.g. Victory) where subscriptions and timers live in nested helpers but are still owned by the returned cleanup.
> 
> The rule now treats **`timer.subscribe` / `timer.unsubscribe(handle)`** as a valid release pair when the handle ref matches, and adds **`hasGuardedRefOwnedNestedCleanup`**: it accepts nested ref assignments when helpers are only invoked synchronously from the effect (via **`collectSynchronouslyEffectInvokedFunctions`**, which skips promise-chain callbacks), deferred paths are blocked by a **numeric generation ref** (`run !== runID.current`), cleanup releases the same refs, and generation is advanced on cancel/requeue.
> 
> **`findSingleDirectInvocation`** no longer treats a helper as single-use if it has extra references (e.g. as a `setTimeout` callback). Regression tests and fuzz corpus entries cover the Victory cases and adversarial misses (wrong receiver/handle, weak guards, promise paths, missing cleanup).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe5170eefd88b7c0ff8976b2b8e5d35e5d48a766. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->