### PR TITLE
fix(core): exclude untracked TypeScript emit quartets from the product scan surface

### DIFF
--- a/.changeset/spotty-moons-relax.md
+++ b/.changeset/spotty-moons-relax.md
@@ -1,0 +1,6 @@
+---
+"@react-doctor/core": patch
+"react-doctor": patch
+---
+
+Exclude untracked TypeScript emit output from the scan: a .js file is dropped only when a complete untracked emit quartet (.js, .js.map, .d.ts, .d.ts.map) with exact source-map targets and matching sourceMappingURL references proves it duplicates a tracked same-stem .ts/.tsx source. Tracked JavaScript files and incomplete or mismatched output sets are still scanned.

--- a/packages/core/src/utils/collect-typescript-emit-duplicate-js-paths.ts
+++ b/packages/core/src/utils/collect-typescript-emit-duplicate-js-paths.ts
@@ -1,0 +1,86 @@
+import * as path from "node:path";
+
+interface EmitQuartetInput {
+  trackedPaths: ReadonlySet<string>;
+  untrackedPaths: ReadonlyArray<string>;
+  readFileText: (relativePath: string) => string;
+}
+
+interface MapTargetInput {
+  expectedFile: string;
+  mapDirectory: string;
+  sourcePath: string;
+}
+
+const lastSourceMappingUrl = (fileContent: string): string | null => {
+  const references = [...fileContent.matchAll(/\/\/# sourceMappingURL=(\S+)/g)];
+  const lastReference = references.at(-1);
+  return lastReference ? lastReference[1] : null;
+};
+
+const mapTargetsSource = (mapContent: string, input: MapTargetInput): boolean => {
+  const parsedMap: unknown = JSON.parse(mapContent);
+  if (typeof parsedMap !== "object" || parsedMap === null) return false;
+  const { file, sources } = parsedMap as { file?: unknown; sources?: unknown };
+  if (file !== input.expectedFile) return false;
+  if (!Array.isArray(sources) || sources.length !== 1 || typeof sources[0] !== "string") {
+    return false;
+  }
+  return path.posix.normalize(path.posix.join(input.mapDirectory, sources[0])) === input.sourcePath;
+};
+
+const quartetProvesEmit = (
+  stem: string,
+  sourcePath: string,
+  readFileText: EmitQuartetInput["readFileText"],
+): boolean => {
+  try {
+    const emitBaseName = path.posix.basename(stem);
+    const mapDirectory = path.posix.dirname(stem);
+    return (
+      lastSourceMappingUrl(readFileText(`${stem}.js`)) === `${emitBaseName}.js.map` &&
+      lastSourceMappingUrl(readFileText(`${stem}.d.ts`)) === `${emitBaseName}.d.ts.map` &&
+      mapTargetsSource(readFileText(`${stem}.js.map`), {
+        expectedFile: `${emitBaseName}.js`,
+        mapDirectory,
+        sourcePath,
+      }) &&
+      mapTargetsSource(readFileText(`${stem}.d.ts.map`), {
+        expectedFile: `${emitBaseName}.d.ts`,
+        mapDirectory,
+        sourcePath,
+      })
+    );
+  } catch {
+    return false;
+  }
+};
+
+// A `.js` file leaves the product scan surface only when a complete untracked
+// TypeScript emit quartet (`.js`, `.js.map`, `.d.ts`, `.d.ts.map`) proves it
+// duplicates a tracked same-stem `.ts`/`.tsx` source: every quartet member is
+// untracked, each source map's `file` names its emitted sibling, its `sources`
+// resolve to exactly the tracked source, and the `.js`/`.d.ts` carry matching
+// `sourceMappingURL` references. Tracked JavaScript files and incomplete or
+// mismatched output sets are always kept.
+export const collectTypeScriptEmitDuplicateJsPaths = (
+  input: EmitQuartetInput,
+): ReadonlySet<string> => {
+  const untracked = new Set(input.untrackedPaths);
+  const duplicateJsPaths = new Set<string>();
+  for (const jsPath of untracked) {
+    if (!jsPath.endsWith(".js")) continue;
+    const stem = jsPath.slice(0, -".js".length);
+    const quartet = [jsPath, `${stem}.js.map`, `${stem}.d.ts`, `${stem}.d.ts.map`];
+    const isFullyUntracked = quartet.every(
+      (emitPath) => untracked.has(emitPath) && !input.trackedPaths.has(emitPath),
+    );
+    if (!isFullyUntracked) continue;
+    const sourcePath = [`${stem}.ts`, `${stem}.tsx`].find((candidatePath) =>
+      input.trackedPaths.has(candidatePath),
+    );
+    if (!sourcePath) continue;
+    if (quartetProvesEmit(stem, sourcePath, input.readFileText)) duplicateJsPaths.add(jsPath);
+  }
+  return duplicateJsPaths;
+};

--- a/packages/core/src/utils/list-source-files.ts
+++ b/packages/core/src/utils/list-source-files.ts
@@ -1,7 +1,9 @@
 import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
 import * as path from "node:path";
 import type { SourceFileEntry } from "../types/index.js";
 import { GIT_LS_FILES_MAX_BUFFER_BYTES } from "../constants.js";
+import { collectTypeScriptEmitDuplicateJsPaths } from "./collect-typescript-emit-duplicate-js-paths.js";
 import { hasIgnoredPathSegment } from "./has-ignored-path-segment.js";
 import { isLintableSourceFile } from "./is-lintable-source-file.js";
 import { isLargeMinifiedFile, statSourceFileSize } from "./is-large-minified-file.js";
@@ -28,32 +30,41 @@ const collectSizedSourceFiles = (
   return entries;
 };
 
+const gitLsFiles = (rootDirectory: string, flags: ReadonlyArray<string>): string[] | null => {
+  const result = spawnSync("git", ["ls-files", "-z", ...flags], {
+    cwd: rootDirectory,
+    encoding: "utf-8",
+    maxBuffer: GIT_LS_FILES_MAX_BUFFER_BYTES,
+  });
+  if (result.error || result.status !== 0) {
+    return null;
+  }
+  return result.stdout.split("\0").filter((filePath) => filePath.length > 0);
+};
+
 const listSourceFilesViaGit = (rootDirectory: string): string[] | null => {
   // HACK: --recurse-submodules is incompatible with --others /
   // --exclude-standard (git rejects the combination). Without this
   // match, every git-mode call silently exited non-zero and the scan
   // always fell back to the much slower filesystem walk below, also
   // skipping submodule files entirely.
-  const result = spawnSync(
-    "git",
-    ["ls-files", "-z", "--cached", "--others", "--exclude-standard"],
-    {
-      cwd: rootDirectory,
-      encoding: "utf-8",
-      maxBuffer: GIT_LS_FILES_MAX_BUFFER_BYTES,
-    },
-  );
-
-  if (result.error || result.status !== 0) {
+  const trackedPaths = gitLsFiles(rootDirectory, ["--cached"]);
+  const untrackedPaths = gitLsFiles(rootDirectory, ["--others", "--exclude-standard"]);
+  if (trackedPaths === null || untrackedPaths === null) {
     return null;
   }
-
-  return result.stdout
-    .split("\0")
-    .filter(
-      (filePath) =>
-        filePath.length > 0 && isLintableSourceFile(filePath) && !hasIgnoredPathSegment(filePath),
-    );
+  const emitDuplicateJsPaths = collectTypeScriptEmitDuplicateJsPaths({
+    trackedPaths: new Set(trackedPaths),
+    untrackedPaths,
+    readFileText: (relativePath) =>
+      fs.readFileSync(path.resolve(rootDirectory, relativePath), "utf-8"),
+  });
+  return [...trackedPaths, ...untrackedPaths].filter(
+    (filePath) =>
+      isLintableSourceFile(filePath) &&
+      !hasIgnoredPathSegment(filePath) &&
+      !emitDuplicateJsPaths.has(filePath),
+  );
 };
 
 const listSourceFilesViaFilesystem = (rootDirectory: string): string[] => {

--- a/packages/core/tests/collect-typescript-emit-duplicate-js-paths.test.ts
+++ b/packages/core/tests/collect-typescript-emit-duplicate-js-paths.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vite-plus/test";
+import { collectTypeScriptEmitDuplicateJsPaths } from "../src/utils/collect-typescript-emit-duplicate-js-paths.js";
+
+interface EmitWorkspace {
+  files: Map<string, string>;
+  trackedPaths: Set<string>;
+  untrackedPaths: string[];
+  readFileText: (relativePath: string) => string;
+}
+
+const createEmitWorkspace = (): EmitWorkspace => {
+  const files = new Map([
+    ["src/store.ts", "export const store = 1;\n"],
+    ["src/store.js", "export const store = 1;\n//# sourceMappingURL=store.js.map\n"],
+    ["src/store.js.map", JSON.stringify({ file: "store.js", sources: ["store.ts"] })],
+    [
+      "src/store.d.ts",
+      "export declare const store: number;\n//# sourceMappingURL=store.d.ts.map\n",
+    ],
+    ["src/store.d.ts.map", JSON.stringify({ file: "store.d.ts", sources: ["store.ts"] })],
+  ]);
+  return {
+    files,
+    trackedPaths: new Set(["src/store.ts"]),
+    untrackedPaths: ["src/store.js", "src/store.js.map", "src/store.d.ts", "src/store.d.ts.map"],
+    readFileText: (relativePath) => {
+      const contents = files.get(relativePath);
+      if (contents === undefined) throw new Error(`missing ${relativePath}`);
+      return contents;
+    },
+  };
+};
+
+describe("collectTypeScriptEmitDuplicateJsPaths", () => {
+  it("excludes a complete untracked quartet duplicating a tracked same-stem source", () => {
+    const workspace = createEmitWorkspace();
+
+    expect(collectTypeScriptEmitDuplicateJsPaths(workspace)).toEqual(new Set(["src/store.js"]));
+  });
+
+  it("accepts a tracked .tsx source referenced through relative map sources", () => {
+    const workspace = createEmitWorkspace();
+    workspace.trackedPaths = new Set(["src/store.tsx"]);
+    workspace.files.set(
+      "src/store.js.map",
+      JSON.stringify({ file: "store.js", sources: ["../src/store.tsx"] }),
+    );
+    workspace.files.set(
+      "src/store.d.ts.map",
+      JSON.stringify({ file: "store.d.ts", sources: ["../src/store.tsx"] }),
+    );
+
+    expect(collectTypeScriptEmitDuplicateJsPaths(workspace)).toEqual(new Set(["src/store.js"]));
+  });
+
+  it("never excludes a tracked .js file", () => {
+    const workspace = createEmitWorkspace();
+    workspace.trackedPaths.add("src/store.js");
+
+    expect(collectTypeScriptEmitDuplicateJsPaths(workspace)).toEqual(new Set());
+  });
+
+  it("keeps the .js file when the quartet is incomplete", () => {
+    const workspace = createEmitWorkspace();
+    workspace.untrackedPaths = workspace.untrackedPaths.filter(
+      (filePath) => filePath !== "src/store.d.ts.map",
+    );
+
+    expect(collectTypeScriptEmitDuplicateJsPaths(workspace)).toEqual(new Set());
+  });
+
+  it("keeps the .js file when no tracked same-stem source exists", () => {
+    const workspace = createEmitWorkspace();
+    workspace.trackedPaths = new Set();
+
+    expect(collectTypeScriptEmitDuplicateJsPaths(workspace)).toEqual(new Set());
+  });
+
+  it("keeps the .js file on a mismatched sourceMappingURL reference", () => {
+    const workspace = createEmitWorkspace();
+    workspace.files.set(
+      "src/store.js",
+      "export const store = 1;\n//# sourceMappingURL=other.js.map\n",
+    );
+
+    expect(collectTypeScriptEmitDuplicateJsPaths(workspace)).toEqual(new Set());
+  });
+
+  it("keeps the .js file when a map's target file or sources mismatch", () => {
+    const wrongFile = createEmitWorkspace();
+    wrongFile.files.set(
+      "src/store.js.map",
+      JSON.stringify({ file: "other.js", sources: ["store.ts"] }),
+    );
+    expect(collectTypeScriptEmitDuplicateJsPaths(wrongFile)).toEqual(new Set());
+
+    const wrongSource = createEmitWorkspace();
+    wrongSource.files.set(
+      "src/store.d.ts.map",
+      JSON.stringify({ file: "store.d.ts", sources: ["other.ts"] }),
+    );
+    expect(collectTypeScriptEmitDuplicateJsPaths(wrongSource)).toEqual(new Set());
+  });
+
+  it("keeps the .js file when a quartet member is unreadable or malformed", () => {
+    const workspace = createEmitWorkspace();
+    workspace.files.set("src/store.js.map", "{");
+
+    expect(collectTypeScriptEmitDuplicateJsPaths(workspace)).toEqual(new Set());
+  });
+});

--- a/packages/core/tests/list-source-files-with-size.test.ts
+++ b/packages/core/tests/list-source-files-with-size.test.ts
@@ -149,4 +149,62 @@ describe("listSourceFilesWithSize", () => {
     fs.rmSync(path.join(temporaryDirectory, ".git"), { recursive: true, force: true });
     expect(listSourceFiles(temporaryDirectory)).toEqual(gitListing);
   });
+
+  const commitAll = (): void => {
+    runGit("add", "-A");
+    runGit(
+      "-c",
+      "user.email=test@example.com",
+      "-c",
+      "user.name=test",
+      "commit",
+      "--quiet",
+      "-m",
+      "init",
+    );
+  };
+
+  const writeEmitQuartet = (): void => {
+    writeNestedFile("src/store.js", "export const store = 1;\n//# sourceMappingURL=store.js.map\n");
+    writeNestedFile(
+      "src/store.js.map",
+      JSON.stringify({ file: "store.js", sources: ["store.ts"] }),
+    );
+    writeNestedFile(
+      "src/store.d.ts",
+      "export declare const store: number;\n//# sourceMappingURL=store.d.ts.map\n",
+    );
+    writeNestedFile(
+      "src/store.d.ts.map",
+      JSON.stringify({ file: "store.d.ts", sources: ["store.ts"] }),
+    );
+  };
+
+  it("git discovery excludes an untracked TypeScript emit quartet duplicating tracked source", () => {
+    writeNestedFile("src/store.ts", "export const store = 1;\n");
+    writeNestedFile("src/app.tsx", "export const App = () => null;\n");
+    runGit("init", "--quiet");
+    commitAll();
+    writeEmitQuartet();
+
+    const filePaths = listSourceFiles(temporaryDirectory);
+
+    expect(filePaths).toContain("src/store.ts");
+    expect(filePaths).toContain("src/app.tsx");
+    expect(filePaths).not.toContain("src/store.js");
+  });
+
+  it("git discovery keeps a tracked .js file and an incomplete emit set", () => {
+    writeNestedFile("src/store.ts", "export const store = 1;\n");
+    writeEmitQuartet();
+    runGit("init", "--quiet");
+    commitAll();
+    writeNestedFile("src/other.ts", "export const other = 1;\n");
+    writeNestedFile("src/other.js", "export const other = 1;\n//# sourceMappingURL=other.js.map\n");
+
+    const filePaths = listSourceFiles(temporaryDirectory);
+
+    expect(filePaths).toContain("src/store.js");
+    expect(filePaths).toContain("src/other.js");
+  });
 });


### PR DESCRIPTION
## Summary

**Why:** in-place `tsc` emit that isn't gitignored (`src/store.ts` → untracked `src/store.js` + maps + declarations) is scanned as product code, so every diagnostic on the source is double-reported on its compiled duplicate.

**What changed:** git-based file discovery now drops a `.js` file only when a **complete untracked emit quartet proves** it duplicates a tracked same-stem source. New `collectTypeScriptEmitDuplicateJsPaths({ trackedPaths, untrackedPaths, readFileText })` in `packages/core/src/utils/`, wired into `listSourceFilesViaGit` (which now issues `git ls-files --cached` and `--others --exclude-standard` separately so tracked vs untracked is known):

- `foo.js`, `foo.js.map`, `foo.d.ts`, `foo.d.ts.map` all present and all untracked
- a tracked same-stem `foo.ts` / `foo.tsx` exists
- exact source-map targets: each map's `file` is its emitted sibling's basename and its `sources` resolve (relative to the map dir) to exactly the tracked source
- matching `sourceMappingURL` references: `foo.js` → `foo.js.map`, `foo.d.ts` → `foo.d.ts.map`

Every tracked JavaScript file and every incomplete or mismatched output set stays in the product scan surface; any unreadable/malformed quartet member fails closed (file kept). The filesystem-walk fallback (no git) is unchanged — "untracked" has no meaning there.

## Test plan

- 8 unit tests for the quartet proof (`collect-typescript-emit-duplicate-js-paths.test.ts`) + 2 git-integration tests in `list-source-files-with-size.test.ts` (real `git init`/commit trees: quartet excluded; tracked `.js` and incomplete sets kept)
- `@react-doctor/core` suite: 119 files / 1395 tests green; `pnpm lint`, `pnpm typecheck`, `pnpm format:check` clean
- `react-doctor --scope changed --base main` on the branch: no issues
- Changeset: patch for `@react-doctor/core` + `react-doctor`

Link to Devin session: https://app.devin.ai/sessions/535363fbddd841ac99d0ac53b08f192e
Requested by: @aidenybai

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to git-mode file enumeration with conservative fail-closed checks; tracked JS and non-emit files are unchanged, with solid test coverage.
> 
> **Overview**
> Stops **double diagnostics** when in-place `tsc` leaves untracked `.js` (and maps/declarations) next to tracked `.ts`/`.tsx` by narrowing git-based discovery.
> 
> **Git listing** now runs `git ls-files --cached` and `--others --exclude-standard` separately so tracked vs untracked paths are known. New `collectTypeScriptEmitDuplicateJsPaths` drops an untracked `.js` from the scan only when a full emit quartet (`.js`, `.js.map`, `.d.ts`, `.d.ts.map`) is untracked, a same-stem tracked source exists, source maps point at that source, and `sourceMappingURL` lines match. **Tracked `.js`**, incomplete sets, and ambiguous/malformed quartets are still scanned; the no-git filesystem walk is unchanged.
> 
> Unit and git-integration tests cover the proof logic and end-to-end listing behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2091444242942aa42019173f43a006ed93bc0928. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->