### PR TITLE
fix(git): ignore external diff renderers

### DIFF
--- a/.changeset/quiet-git-diffs.md
+++ b/.changeset/quiet-git-diffs.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Ignore user-configured external Git diff renderers when computing changed files and line ranges.

--- a/packages/core/src/services/git.ts
+++ b/packages/core/src/services/git.ts
@@ -669,6 +669,7 @@ export class Git extends Context.Service<
 
           const diff = yield* runGit(input.directory, [
             "diff",
+            "--no-ext-diff",
             "-z",
             "--name-only",
             "--diff-filter=ACMR",
@@ -760,6 +761,7 @@ export class Git extends Context.Service<
             if (resolvedCurrentBranch !== null && resolvedCurrentBranch === baseBranch) {
               const uncommitted = yield* runGit(directory, [
                 "diff",
+                "--no-ext-diff",
                 "-z",
                 "--name-only",
                 "--diff-filter=ACMR",
@@ -788,6 +790,7 @@ export class Git extends Context.Service<
 
             const diff = yield* runGit(directory, [
               "diff",
+              "--no-ext-diff",
               "-z",
               "--name-only",
               "--diff-filter=ACMR",
@@ -811,6 +814,7 @@ export class Git extends Context.Service<
         stagedFilePaths: (directory) =>
           runGit(directory, [
             "diff",
+            "--no-ext-diff",
             "--cached",
             "-z",
             "--name-only",
@@ -884,6 +888,7 @@ export class Git extends Context.Service<
             if (baseRef !== undefined && !isSafeGitRevision(baseRef)) return null;
             const result = yield* runGit(directory, [
               "diff",
+              "--no-ext-diff",
               "--unified=0",
               "--diff-filter=ACMR",
               "--relative",

--- a/packages/react-doctor/tests/regressions/untracked-working-tree-scope.test.ts
+++ b/packages/react-doctor/tests/regressions/untracked-working-tree-scope.test.ts
@@ -109,6 +109,9 @@ describe("--include-untracked folds untracked files into working-tree scopes", (
       "export const Staged = () => <button>Save</button>;\n",
     );
     execFileSync("git", ["add", "src/staged.tsx"], { cwd: repositoryDirectory });
+    execFileSync("git", ["config", "diff.external", "false"], {
+      cwd: repositoryDirectory,
+    });
 
     const lineRanges = await getChangedLineRanges({
       directory: repositoryDirectory,


### PR DESCRIPTION
## Summary

- pass Git's no-ext-diff option to every machine-readable diff invocation
- preserve staged changed-line and changed-file detection when a user configures an external renderer
- add a regression that enables a repository-local external diff command

## Validation

- full monorepo test: 14/14 tasks
- React Doctor: 2,251 passed, 27 skipped
- fuzz: 403/403
- typecheck: 15/15
- lint and format check
- core Git service tests: 35/35

## Product compatibility

This hardens an existing internal Git integration without adding a new CLI, API, schema, configuration, or output surface. A patch changeset is included.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow hardening of internal git subprocess flags with no new API or config; behavior only changes when external diff renderers were previously breaking scope detection.
> 
> **Overview**
> Adds **`--no-ext-diff`** to every **`git diff`** call in the core Git service that feeds **changed-file lists** and **`--scope lines`** parsing, so user **`diff.external`** / GUI diff tools cannot replace stdout with non-parseable output.
> 
> Coverage includes **explicit range** diffs, **working-tree** and **merge-base** selections, **staged** file paths, and **`changedLineRanges`** (`--unified=0`). A **patch changeset** documents the behavior; a regression test stages a file with **`diff.external`** set locally and asserts staged line ranges stay exact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04bff653d15cc9a57ca1a2f70be08f4e92622b2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->