### PR TITLE
fix(hook-use-state): allow concise tuple returns

### DIFF
--- a/.changeset/afraid-rats-do.md
+++ b/.changeset/afraid-rats-do.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Allow hook-use-state to recognize concise-arrow returns as returned state tuples.

--- a/packages/fuzz/corpus/regressions/hook-use-state--verdict-drop-seed-3155051008.tsx
+++ b/packages/fuzz/corpus/regressions/hook-use-state--verdict-drop-seed-3155051008.tsx
@@ -1,0 +1,6 @@
+// rule: hook-use-state
+// weakness: control-flow
+// source: strict fuzz seed 1326001, derived seed 3155051008
+import { useState } from "react";
+
+export const useStateTupleSeed3155051008 = () => useState(0);

--- a/packages/fuzz/corpus/regressions/hook-use-state--verdict-drop-seed-3155051082.tsx
+++ b/packages/fuzz/corpus/regressions/hook-use-state--verdict-drop-seed-3155051082.tsx
@@ -1,0 +1,6 @@
+// rule: hook-use-state
+// weakness: control-flow
+// source: strict fuzz seed 1326001, derived seed 3155051082
+import { useState } from "react";
+
+export const useStateTupleSeed3155051082 = () => useState(0);

--- a/packages/fuzz/corpus/regressions/hook-use-state--verdict-drop-seed-3155051332.tsx
+++ b/packages/fuzz/corpus/regressions/hook-use-state--verdict-drop-seed-3155051332.tsx
@@ -1,0 +1,6 @@
+// rule: hook-use-state
+// weakness: control-flow
+// source: strict fuzz seed 1326001, derived seed 3155051332
+import { useState } from "react";
+
+export const useStateTupleSeed3155051332 = () => useState(0);

--- a/packages/fuzz/corpus/regressions/hook-use-state--verdict-drop-seed-3155051565.tsx
+++ b/packages/fuzz/corpus/regressions/hook-use-state--verdict-drop-seed-3155051565.tsx
@@ -1,0 +1,6 @@
+// rule: hook-use-state
+// weakness: control-flow
+// source: strict fuzz seed 1326001, derived seed 3155051565
+import { useState } from "react";
+
+export const useStateTupleSeed3155051565 = () => useState(0);

--- a/packages/fuzz/corpus/regressions/hook-use-state--verdict-drop-seed-3155051623.tsx
+++ b/packages/fuzz/corpus/regressions/hook-use-state--verdict-drop-seed-3155051623.tsx
@@ -1,0 +1,6 @@
+// rule: hook-use-state
+// weakness: control-flow
+// source: strict fuzz seed 1326001, derived seed 3155051623
+import { useState } from "react";
+
+export const useStateTupleSeed3155051623 = () => useState(0);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/hook-use-state.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/hook-use-state.regressions.test.ts
@@ -8,4 +8,24 @@ describe("react-builtins/hook-use-state — regressions", () => {
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toHaveLength(1);
   });
+
+  it.each([
+    `const useStateTuple = () => useState(0);`,
+    `const useStateTuple = () => (useState(0));`,
+    `const useStateTuple = () => (useState(0) as readonly [number, unknown]);`,
+    `const useStateTuple = () => { return useState(0); };`,
+  ])("allows returning a useState tuple without local destructuring", (code) => {
+    const result = runRule(hookUseState, code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it.each([`const state = useState(0);`, `consume(useState(0));`, `useState(0);`])(
+    "still reports a non-returned useState tuple",
+    (code) => {
+      const result = runRule(hookUseState, code);
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    },
+  );
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/hook-use-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/hook-use-state.ts
@@ -1,6 +1,7 @@
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findTransparentExpressionRoot } from "../../utils/find-transparent-expression-root.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isReactFunctionCall } from "../../utils/is-react-function-call.js";
 
@@ -81,9 +82,17 @@ export const hookUseState = defineRule({
       CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
         const callExpressionNode: EsTreeNode = node;
         if (!isReactFunctionCall(callExpressionNode, "useState")) return;
+        const expressionRoot = findTransparentExpressionRoot(callExpressionNode);
+        const expressionParent = expressionRoot.parent;
+        if (isNodeOfType(expressionParent, "ReturnStatement")) return;
+        if (
+          isNodeOfType(expressionParent, "ArrowFunctionExpression") &&
+          expressionParent.body === expressionRoot
+        ) {
+          return;
+        }
         const parent = node.parent;
         if (!parent) return;
-        if (isNodeOfType(parent, "ReturnStatement")) return;
         if (!isNodeOfType(parent, "VariableDeclarator")) {
           context.report({ node, message: REQUIRE_DESTRUCTURE_MESSAGE });
           return;


### PR DESCRIPTION
## Why

`hook-use-state` already allows a custom hook to return a `useState` tuple directly from a block body, but it reported the equivalent concise-arrow form. Strict fuzzing exposed five verdict drops when the concise body was rewritten to `return`.

Before:

```tsx
const useCounterState = () => useState(0);
```

After:

```tsx
const useCounterState = () => useState(0);
```

Both concise and block returns now remain quiet because the tuple is returned to the caller rather than consumed locally.

## What changed

- Reuses `findTransparentExpressionRoot` to recognize concise, parenthesized, and TypeScript-wrapped returned tuples.
- Keeps reporting non-destructured tuples used as local initializers, call arguments, or statements.
- Adds adversarial parity and control tests.
- Preserves all five strict-fuzz findings as minimized permanent corpus seeds.
- Adds a patch changeset for `oxlint-plugin-react-doctor`.

## Test plan

- `nr test` — 14/14 tasks green; plugin 15,411 passed / 188 skipped; React Doctor 2,251 passed / 27 skipped.
- `nr typecheck` — 15/15 tasks green.
- `nr lint`
- `nr format:check`
- `nr smoke:json-report`
- `FUZZ_RULE=hook-use-state FUZZ_STRICT=1 FUZZ_INVARIANTS=1 FUZZ_ITERATIONS=1000 FUZZ_SEED=1326001 nr fuzz`
- `FUZZ_RULE=hook-use-state FUZZ_STRICT=1 FUZZ_INVARIANTS=1 FUZZ_ITERATIONS=1000 FUZZ_SEED=1326002 FUZZ_CORPUS_DIR=/Users/aidenybai/Developer/react-bench-internal/jobs nr fuzz`
- `bun scripts/hunt-false-positives.ts` — no `hook-use-state` named regression.

RDE was skipped because this default-off stylistic rule received a narrow return-position parity fix; direct generated and React Bench jobs-corpus fuzzing exercised the changed surface.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow control-flow change to a default-off stylistic lint rule, with tests and fuzz corpus coverage; no auth, data, or runtime behavior impact.
> 
> **Overview**
> Fixes a **false positive** in the default-off `hook-use-state` rule: custom hooks that **return** a `useState` tuple via a **concise arrow body** (`() => useState(0)`) are no longer reported, matching behavior that already applied to `return useState(0)` in a block body.
> 
> The rule now walks through **parentheses and TypeScript casts** with `findTransparentExpressionRoot`, then skips reporting when the call is the direct body of an arrow function or inside a `return`. **Local misuse** (e.g. `const state = useState(0)`, passing the tuple as an argument, or a bare `useState(0)` statement) is still flagged.
> 
> Adds regression tests, five minimized **fuzz corpus** seeds for the strict-fuzz verdict drops, and a patch **changeset** for `oxlint-plugin-react-doctor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ff630704023b639e2b879a274faa190e0d06ae4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->