### PR TITLE
chore: document scrubbed score paths

### DIFF
--- a/.changeset/tame-eagles-enter.md
+++ b/.changeset/tame-eagles-enter.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Preserve scrubbed diagnostic file paths in hosted score requests so scoring can distinguish findings without transmitting home-directory identities or embedded secrets.


### PR DESCRIPTION
## Why

PR #1348 preserved sanitized diagnostic file paths in hosted score requests, but it merged without a changeset. That left the published `react-doctor` behavior absent from the generated release changelog.

Before: the score payload improvement would ship under an unrelated version bump with no direct release note.

After: the next `react-doctor` patch release records that paths remain useful for scoring while home-directory identities and embedded secrets stay redacted.

### Product brief

- **Job:** Release consumers need user-visible score behavior to be traceable through semver and the changelog.
- **Change:** Add the missing patch compatibility artifact; do not change runtime behavior.
- **Reuse:** Use the existing Changesets release pipeline. `@react-doctor/core` is private, so `react-doctor` is the only affected published package.
- **Metric:** Keep using the existing `score.available` wide-event outcome; this metadata-only repair adds no telemetry.
- **Compat:** Patch changeset only; no default, schema, API shape, or GitHub Action changes.
- **Kill:** If `score.available` falls by at least one percentage point for two consecutive release cohorts, revisit the underlying score-payload behavior separately.

## What changed

- Added a `react-doctor` patch changeset documenting scrubbed diagnostic paths in hosted score requests.
- Left runtime code and generated release files unchanged.

## Test plan

- `nr changeset status`
- `nr format:check`
- `nr lint`
- `nr typecheck`
- `nr test` — 14/14 tasks passed; React Doctor 2,251 passed / 27 skipped
- `nr smoke:json-report` — schemaVersion 3 smoke passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 6c7705b775ca87573df3ec0f85c957b67a1312ba. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->