### PR TITLE
fix(rules): unwrap typed call receivers

### DIFF
--- a/.changeset/slimy-needles-win.md
+++ b/.changeset/slimy-needles-win.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Recognize transparent TypeScript wrappers on React and HTTP client call receivers.

--- a/packages/fuzz/corpus/regressions/no-fetch-in-effect--verdict-drop-seed-3155051234-as-any.tsx
+++ b/packages/fuzz/corpus/regressions/no-fetch-in-effect--verdict-drop-seed-3155051234-as-any.tsx
@@ -1,0 +1,18 @@
+// rule: no-fetch-in-effect
+// kind: verdict-drop
+// seed: 3155051234 (iteration 399)
+// variant: as-any call receivers
+
+import axios from "axios";
+import { useEffect, useState } from "react";
+
+export const AsAnySearch = ({ query }: { query: string }) => {
+  const [selection, setSelection] = useState<string | null>(null);
+
+  useEffect(() => {
+    setSelection(null);
+    void (axios as any).get("/search", { params: { query } });
+  }, [query]);
+
+  return <div>{selection}</div>;
+};

--- a/packages/fuzz/corpus/regressions/no-fetch-in-effect--verdict-drop-seed-3155051234-non-null.tsx
+++ b/packages/fuzz/corpus/regressions/no-fetch-in-effect--verdict-drop-seed-3155051234-non-null.tsx
@@ -1,0 +1,18 @@
+// rule: no-fetch-in-effect
+// kind: verdict-drop
+// seed: 3155051234 (iteration 399)
+// variant: non-null-asserted call receivers
+
+import axios from "axios";
+import { useEffect, useState } from "react";
+
+export const NonNullSearch = ({ query }: { query: string }) => {
+  const [selection, setSelection] = useState<string | null>(null);
+
+  useEffect(() => {
+    setSelection(null);
+    void axios!.get("/search", { params: { query } });
+  }, [query]);
+
+  return <div>{selection}</div>;
+};

--- a/packages/fuzz/corpus/regressions/react-compiler-no-manual-memoization--verdict-drop-seed-3155051075-as-any.tsx
+++ b/packages/fuzz/corpus/regressions/react-compiler-no-manual-memoization--verdict-drop-seed-3155051075-as-any.tsx
@@ -1,0 +1,14 @@
+// rule: react-compiler-no-manual-memoization
+// kind: verdict-drop
+// seed: 3155051075 (iteration 240)
+// variant: as-any call receivers
+
+import React from "react";
+
+const mutateReact = () => {
+  React.memo = (value: unknown) => value;
+};
+const AsAnyMemoPanel = (React as any).memo(() => <div />);
+AsAnyMemoPanel.propTypes = { value: () => true };
+
+void mutateReact;

--- a/packages/fuzz/corpus/regressions/react-compiler-no-manual-memoization--verdict-drop-seed-3155051075-non-null.tsx
+++ b/packages/fuzz/corpus/regressions/react-compiler-no-manual-memoization--verdict-drop-seed-3155051075-non-null.tsx
@@ -1,0 +1,14 @@
+// rule: react-compiler-no-manual-memoization
+// kind: verdict-drop
+// seed: 3155051075 (iteration 240)
+// variant: non-null-asserted call receivers
+
+import React from "react";
+
+const mutateReact = () => {
+  React.memo = (value: unknown) => value;
+};
+const NonNullMemoPanel = React!.memo(() => <div />);
+NonNullMemoPanel.propTypes = { value: () => true };
+
+void mutateReact;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/react-compiler-no-manual-memoization.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/react-compiler-no-manual-memoization.regressions.test.ts
@@ -6,6 +6,47 @@ const run = (code: string) =>
   runRule(reactCompilerNoManualMemoization, code, { filename: "fixture.tsx" });
 
 describe("architecture/react-compiler-no-manual-memoization — regressions", () => {
+  it.each([
+    ["an as assertion", "(React as any).memo"],
+    ["a non-null assertion", "(React!).memo"],
+  ])("flags React.memo through %s on its receiver", (_name, callee) => {
+    const result = run(`import React from "react"; const C = ${callee}(Inner);`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it.each([
+    [
+      "a userland object",
+      `const ReactTools = { memo: (value) => value };
+       const C = (ReactTools as any).memo(Inner);`,
+    ],
+    [
+      "a shadowing parameter",
+      `import * as ReactTools from "react";
+       const wrap = (ReactTools) => (ReactTools as any).memo(Inner);`,
+    ],
+    [
+      "a shadowed named import",
+      `import { memo } from "react";
+       const wrap = (memo) => (memo as any)(Inner);`,
+    ],
+    [
+      "a mutable local",
+      `let ReactTools = { memo: (value) => value };
+       const C = (ReactTools!).memo(Inner);`,
+    ],
+  ])("does not flag a wrapped memo method on %s", (_name, code) => {
+    const result = run(code);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not flag a wrapped React.memo call with a custom comparator", () => {
+    const result = run(
+      `import React from "react"; const C = (React as any).memo(Inner, (a, b) => a.id === b.id);`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("does not flag memo() with a custom comparator", () => {
     const result = run(
       `import { memo } from "react"; const C = memo(Inner, (prev, next) => prev.id === next.id);`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/react-compiler-no-manual-memoization.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/architecture/react-compiler-no-manual-memoization.ts
@@ -10,6 +10,7 @@ import { isCanonicalReactNamespaceName } from "../../utils/is-canonical-react-na
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isReactComponentOrHookName } from "../../utils/is-react-component-or-hook-name.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 
 const REMOVAL_MESSAGE_BY_REACT_API_NAME = new Map<string, string>([
   [
@@ -32,8 +33,12 @@ const REMOVAL_MESSAGE_BY_REACT_API_NAME = new Map<string, string>([
 //   import { memo } from "react"                     → "memo"
 //   import { useMemo as memoize } from "react"       → "useMemo"
 //   import * as ReactNS from "react"; ReactNS.memo() → namespace path
-const resolveReactApiNameForIdentifier = (callee: EsTreeNode): string | null => {
+const resolveReactApiNameForIdentifier = (
+  callee: EsTreeNode,
+  context: RuleContext,
+): string | null => {
   if (!isNodeOfType(callee, "Identifier")) return null;
+  if (context.scopes.symbolFor(callee)?.kind !== "import") return null;
   const importedName = getImportedNameFromModule(callee, callee.name, "react");
   if (importedName && REMOVAL_MESSAGE_BY_REACT_API_NAME.has(importedName)) {
     return importedName;
@@ -41,24 +46,40 @@ const resolveReactApiNameForIdentifier = (callee: EsTreeNode): string | null => 
   return null;
 };
 
-const resolveReactApiNameForMemberExpression = (callee: EsTreeNode): string | null => {
+const resolveReactApiNameForMemberExpression = (
+  callee: EsTreeNode,
+  context: RuleContext,
+): string | null => {
   if (!isNodeOfType(callee, "MemberExpression")) return null;
   if (callee.computed) return null;
-  const namespaceIdentifier = callee.object;
+  const namespaceIdentifier = stripParenExpression(callee.object);
   const propertyIdentifier = callee.property;
   if (!isNodeOfType(namespaceIdentifier, "Identifier")) return null;
   if (!isNodeOfType(propertyIdentifier, "Identifier")) return null;
   if (!REMOVAL_MESSAGE_BY_REACT_API_NAME.has(propertyIdentifier.name)) return null;
   const namespaceName = namespaceIdentifier.name;
-  if (isCanonicalReactNamespaceName(namespaceName)) return propertyIdentifier.name;
-  if (isImportedFromModule(namespaceIdentifier, namespaceName, "react")) {
+  if (
+    context.scopes.symbolFor(namespaceIdentifier)?.kind === "import" &&
+    isImportedFromModule(namespaceIdentifier, namespaceName, "react")
+  ) {
+    return propertyIdentifier.name;
+  }
+  if (
+    isCanonicalReactNamespaceName(namespaceName) &&
+    context.scopes.isGlobalReference(namespaceIdentifier)
+  ) {
     return propertyIdentifier.name;
   }
   return null;
 };
 
-const resolveReactApiNameForCallee = (callee: EsTreeNode): string | null =>
-  resolveReactApiNameForIdentifier(callee) ?? resolveReactApiNameForMemberExpression(callee);
+const resolveReactApiNameForCallee = (callee: EsTreeNode, context: RuleContext): string | null => {
+  const unwrappedCallee = stripParenExpression(callee);
+  return (
+    resolveReactApiNameForIdentifier(unwrappedCallee, context) ??
+    resolveReactApiNameForMemberExpression(unwrappedCallee, context)
+  );
+};
 
 // `memo(Inner, undefined)` / `memo(Inner, null)` make React fall back to
 // the default shallow compare — exactly as redundant under React Compiler
@@ -133,7 +154,7 @@ export const reactCompilerNoManualMemoization = defineRule({
     "Delete the `useMemo` / `useCallback` / `memo` call and use the plain value or component. React Compiler caches it for you.",
   create: (context: RuleContext) => ({
     CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
-      const apiName = resolveReactApiNameForCallee(node.callee);
+      const apiName = resolveReactApiNameForCallee(node.callee, context);
       if (!apiName) return;
       // `memo(Component, areEqual)` with a custom comparator encodes
       // bespoke equality the compiler can't replicate, so it isn't

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-fetch-in-effect.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-fetch-in-effect.regressions.test.ts
@@ -16,6 +16,55 @@ const expectPass = (code: string): void => {
 
 describe("state-and-effects/no-fetch-in-effect — regressions", () => {
   it.each([
+    ["an as assertion", "(axios as any).get"],
+    ["a non-null assertion", "(axios!).get"],
+  ])("flags an imported HTTP client through %s on its receiver", (_name, callee) => {
+    expectFail(`
+      import axios from "axios";
+      import { useEffect } from "react";
+      const Search = () => {
+        useEffect(() => { void ${callee}("/search"); }, []);
+        return null;
+      };
+    `);
+  });
+
+  it.each([
+    ["a local object", "const axios = { get: () => undefined };"],
+    ["a mutable local", "let axios = { get: () => undefined };"],
+  ])("does not flag a wrapped get method on %s", (_name, declaration) => {
+    expectPass(`
+      import { useEffect } from "react";
+      const Search = () => {
+        ${declaration}
+        useEffect(() => { void (axios as any).get("/search"); }, []);
+        return null;
+      };
+    `);
+  });
+
+  it("does not flag a wrapped method on a userland client", () => {
+    expectPass(`
+      import { useEffect } from "react";
+      const Search = (httpClient) => {
+        useEffect(() => { void (httpClient!).get("/search"); }, [httpClient]);
+        return null;
+      };
+    `);
+  });
+
+  it("does not flag an imported client shadowed by a parameter", () => {
+    expectPass(`
+      import axios from "axios";
+      import { useEffect } from "react";
+      const Search = (axios) => {
+        useEffect(() => { void (axios as any).get("/search"); }, [axios]);
+        return null;
+      };
+    `);
+  });
+
+  it.each([
     [
       "a shadowing local",
       `import { useEffect } from "react";

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-fetch-in-effect.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-fetch-in-effect.ts
@@ -42,21 +42,24 @@ const isShadowedByLocalBinding = (identifier: EsTreeNode): boolean => {
 
 const isRealFetchCall = (node: EsTreeNode): boolean => {
   if (!isNodeOfType(node, "CallExpression")) return false;
-  if (isNodeOfType(node.callee, "Identifier") && FETCH_CALLEE_NAMES.has(node.callee.name)) {
-    return !isShadowedByLocalBinding(node.callee);
+  const callee = stripParenExpression(node.callee);
+  if (isNodeOfType(callee, "Identifier") && FETCH_CALLEE_NAMES.has(callee.name)) {
+    return !isShadowedByLocalBinding(callee);
   }
+  if (!isNodeOfType(callee, "MemberExpression")) return false;
+  const receiver = stripParenExpression(callee.object);
   return (
-    isNodeOfType(node.callee, "MemberExpression") &&
-    isNodeOfType(node.callee.object, "Identifier") &&
-    FETCH_MEMBER_OBJECTS.has(node.callee.object.name) &&
-    !isShadowedByLocalBinding(node.callee.object)
+    isNodeOfType(receiver, "Identifier") &&
+    FETCH_MEMBER_OBJECTS.has(receiver.name) &&
+    !isShadowedByLocalBinding(receiver)
   );
 };
 
-const isXmlHttpRequestConstruction = (node: EsTreeNode): boolean =>
-  isNodeOfType(node, "NewExpression") &&
-  isNodeOfType(node.callee, "Identifier") &&
-  node.callee.name === "XMLHttpRequest";
+const isXmlHttpRequestConstruction = (node: EsTreeNode): boolean => {
+  if (!isNodeOfType(node, "NewExpression")) return false;
+  const callee = stripParenExpression(node.callee);
+  return isNodeOfType(callee, "Identifier") && callee.name === "XMLHttpRequest";
+};
 
 const isNetworkRequest = (node: EsTreeNode): boolean =>
   isRealFetchCall(node) || isXmlHttpRequestConstruction(node);


### PR DESCRIPTION
## Summary

- recognize transparent TypeScript wrappers on React memoization and HTTP client receivers
- preserve scoped import provenance for shadowed, userland, and mutable bindings
- add permanent fuzz regressions for all four exact verdict-drop shapes

## Validation

- full plugin suite: 582 files, 15,436 passed, 188 skipped
- full root suite: 14/14 tasks
- typecheck: 15/15 tasks
- lint and format check
- JSON report smoke test
- strict 1,000-iteration fuzz for each affected rule, seed 1326001
- strict 1,000-iteration jobs-corpus fuzz for each affected rule, seed 1326002

## Fuzz evidence

The final PR #1326 all-rule sweep found verdict drops for as-any and non-null asserted receivers in react-compiler-no-manual-memoization (seed 3155051075, iteration 240) and no-fetch-in-effect (seed 3155051234, iteration 399). This PR fixes and permanently records all four cases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted AST unwrapping and stricter import provenance in two lint rules; behavior change is more diagnostics on wrapped receivers with explicit false-positive guards in tests.
> 
> **Overview**
> Fixes **false negatives** where TypeScript wrappers on call receivers hid real `React.memo` / HTTP client usage from the linter.
> 
> **`react-compiler-no-manual-memoization`** and **`no-fetch-in-effect`** now peel transparent wrappers (`as any`, `!`, parens, etc.) via `stripParenExpression` on callees and member **objects** before resolving imports. The memo rule also threads **`RuleContext` scopes** so only true React imports or canonical global `React` count—shadowed parameters, userland objects, and mutable locals stay silent.
> 
> Adds regression tests and four **fuzz corpus** fixtures for the exact verdict-drop seeds (as-any and non-null variants per rule). Patch changeset for `oxlint-plugin-react-doctor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 131527e4c316fad6384cd62af811d6fff5372ffa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->