### PR TITLE
fix(baseline): match stable diagnostic evidence

### DIFF
--- a/.changeset/stable-diagnostic-evidence.md
+++ b/.changeset/stable-diagnostic-evidence.md
@@ -1,0 +1,6 @@
+---
+"react-doctor": patch
+"@react-doctor/core": patch
+---
+
+Match baseline diagnostics by rule, message, and normalized source evidence so unchanged findings can move across files while changed or additional findings remain reportable.

--- a/.changeset/stable-diagnostic-evidence.md
+++ b/.changeset/stable-diagnostic-evidence.md
@@ -3,4 +3,4 @@
 "@react-doctor/core": patch
 ---
 
-Match baseline diagnostics by rule, message, and normalized source evidence so unchanged findings can move across files while changed or additional findings remain reportable.
+Match baseline diagnostics by rule, message, and normalized source evidence, using side-aware Git snapshots and parser-proven handler forwarding so unchanged findings can move safely while changed or additional findings remain reportable.

--- a/docs/json-report.md
+++ b/docs/json-report.md
@@ -32,3 +32,11 @@ Each project includes:
 uses `mode: "baseline"` and includes the optional `baseline` block. Consumers
 must not infer coverage from an empty `diagnostics` array: use each project's
 `complete` and `analyzedFiles` fields.
+
+Baseline comparison identifies a finding by its plugin/rule, diagnostic
+message, and normalized diagnosed source range. The identity is independent of
+file and line, so unchanged findings remain pre-existing after a rename or
+component extraction. Identical findings are compared as a multiset, so an
+additional occurrence is still reported as introduced. When a handler moves
+behind a component prop, the comparison follows the prop only if every
+discovered callsite resolves to one unambiguous handler.

--- a/docs/json-report.md
+++ b/docs/json-report.md
@@ -39,4 +39,10 @@ file and line, so unchanged findings remain pre-existing after a rename or
 component extraction. Identical findings are compared as a multiset, so an
 additional occurrence is still reported as introduced. When a handler moves
 behind a component prop, the comparison follows the prop only if every
-discovered callsite resolves to one unambiguous handler.
+discovered callsite resolves through the TypeScript syntax tree to one
+unambiguous handler. Git supplies separate base and head path sets with rename
+detection disabled, so pure renames, deletions, copies, case-only path changes,
+and unusual filenames do not depend on heuristic similarity scores. A missing,
+binary, or unsmudged Git LFS base blob, unresolved index conflict, missing head
+file, or partial lint degrades the run to ordinary diff reporting instead of
+assigning unsupported new/fixed results.

--- a/packages/core/src/compute-diagnostic-delta.ts
+++ b/packages/core/src/compute-diagnostic-delta.ts
@@ -106,9 +106,10 @@ const buildMatchCandidates = (
  * files while changed constructs or messages remain new. Cardinality is
  * retained for identical findings. Diagnostics explicitly marked
  * `matchByOccurrence` may fall back to same-file plugin/rule/message matching
- * after strict evidence matching, preserving structural reformatting without
- * letting unrelated findings cancel across files. Unreadable evidence uses the
- * same conservative fallback rather than matching across files without proof.
+ * after same-file strict evidence matching. Cross-file evidence matching runs
+ * last so a copy cannot consume a reformatted local occurrence. Unreadable
+ * evidence uses the same conservative fallback rather than matching across
+ * files without proof.
  */
 export const computeDiagnosticDelta = (input: ComputeDiagnosticDeltaInput): DiagnosticDelta => {
   const baseCandidates = buildMatchCandidates(
@@ -164,6 +165,7 @@ export const computeDiagnosticDelta = (input: ComputeDiagnosticDeltaInput): Diag
   };
 
   matchCandidates(baseBySameFileStableEvidence, (candidate) => candidate.sameFileStableEvidenceKey);
+  matchCandidates(baseBySameFileFallback, (candidate) => candidate.sameFileFallbackKey);
   let crossFileMatchCount = 0;
   matchCandidates(
     baseByStableEvidence,
@@ -174,7 +176,6 @@ export const computeDiagnosticDelta = (input: ComputeDiagnosticDeltaInput): Diag
       }
     },
   );
-  matchCandidates(baseBySameFileFallback, (candidate) => candidate.sameFileFallbackKey);
 
   const newDiagnostics = input.headDiagnostics.filter(
     (_diagnostic, diagnosticIndex) => !matchedHeadDiagnosticIndexes.has(diagnosticIndex),

--- a/packages/core/src/compute-diagnostic-delta.ts
+++ b/packages/core/src/compute-diagnostic-delta.ts
@@ -23,12 +23,12 @@ export interface ComputeDiagnosticDeltaInput {
 
 interface DiagnosticMatchKeys {
   readonly stableEvidenceKey: string | null;
+  readonly sameFileStableEvidenceKey: string | null;
   readonly sameFileFallbackKey: string | null;
 }
 
-interface DiagnosticIndexBucket {
-  readonly diagnosticIndexes: number[];
-  nextCandidateIndex: number;
+interface DiagnosticMatchCandidate extends DiagnosticMatchKeys {
+  readonly diagnosticIndex: number;
 }
 
 const fingerprintText = (text: string): string => createHash("sha256").update(text).digest("hex");
@@ -42,11 +42,14 @@ const getDiagnosticMatchKeys = (
   const ruleKey = `${diagnostic.plugin}/${diagnostic.rule}`;
   const messageFingerprint = fingerprintText(`${diagnostic.title ?? ""}\0${diagnostic.message}`);
   const normalizedEvidence = evidence === null ? "" : normalizeEvidence(evidence);
+  const stableEvidenceKey =
+    normalizedEvidence.length > 0
+      ? `evidence\0${ruleKey}\0${messageFingerprint}\0${fingerprintText(normalizedEvidence)}`
+      : null;
   return {
-    stableEvidenceKey:
-      normalizedEvidence.length > 0
-        ? `evidence\0${ruleKey}\0${messageFingerprint}\0${fingerprintText(normalizedEvidence)}`
-        : null,
+    stableEvidenceKey,
+    sameFileStableEvidenceKey:
+      stableEvidenceKey === null ? null : `${diagnostic.filePath}\0${stableEvidenceKey}`,
     sameFileFallbackKey:
       diagnostic.matchByOccurrence || normalizedEvidence.length === 0
         ? `fallback\0${diagnostic.filePath}\0${ruleKey}\0${messageFingerprint}`
@@ -55,30 +58,24 @@ const getDiagnosticMatchKeys = (
 };
 
 const addDiagnosticIndex = (
-  buckets: Map<string, DiagnosticIndexBucket>,
+  buckets: Map<string, number[]>,
   key: string | null,
   diagnosticIndex: number,
 ): void => {
   if (key === null) return;
-  const bucket = buckets.get(key) ?? { diagnosticIndexes: [], nextCandidateIndex: 0 };
-  bucket.diagnosticIndexes.push(diagnosticIndex);
-  buckets.set(key, bucket);
+  const diagnosticIndexes = buckets.get(key) ?? [];
+  diagnosticIndexes.push(diagnosticIndex);
+  buckets.set(key, diagnosticIndexes);
 };
 
 const takeMatchingDiagnosticIndex = (
-  buckets: Map<string, DiagnosticIndexBucket>,
+  buckets: ReadonlyMap<string, ReadonlyArray<number>>,
   key: string | null,
   matchedDiagnosticIndexes: ReadonlySet<number>,
 ): number | null => {
   if (key === null) return null;
-  const bucket = buckets.get(key);
-  if (bucket === undefined) return null;
-  while (bucket.nextCandidateIndex < bucket.diagnosticIndexes.length) {
-    const diagnosticIndex = bucket.diagnosticIndexes[bucket.nextCandidateIndex];
-    bucket.nextCandidateIndex += 1;
-    if (diagnosticIndex !== undefined && !matchedDiagnosticIndexes.has(diagnosticIndex)) {
-      return diagnosticIndex;
-    }
+  for (const diagnosticIndex of buckets.get(key) ?? []) {
+    if (!matchedDiagnosticIndexes.has(diagnosticIndex)) return diagnosticIndex;
   }
   return null;
 };
@@ -88,6 +85,19 @@ const readDiagnosticEvidence = (
   readEvidence: ComputeDiagnosticDeltaInput["readHeadEvidence"],
   readLine: ComputeDiagnosticDeltaInput["readHeadLine"],
 ): string | null => readEvidence?.(diagnostic) ?? readLine(diagnostic.filePath, diagnostic.line);
+
+const buildMatchCandidates = (
+  diagnostics: ReadonlyArray<Diagnostic>,
+  readEvidence: ComputeDiagnosticDeltaInput["readHeadEvidence"],
+  readLine: ComputeDiagnosticDeltaInput["readHeadLine"],
+): DiagnosticMatchCandidate[] =>
+  diagnostics.map((diagnostic, diagnosticIndex) => ({
+    diagnosticIndex,
+    ...getDiagnosticMatchKeys(
+      diagnostic,
+      readDiagnosticEvidence(diagnostic, readEvidence, readLine),
+    ),
+  }));
 
 /**
  * Diffs a head scan against a base scan using a multiset of construct-level
@@ -101,45 +111,74 @@ const readDiagnosticEvidence = (
  * same conservative fallback rather than matching across files without proof.
  */
 export const computeDiagnosticDelta = (input: ComputeDiagnosticDeltaInput): DiagnosticDelta => {
-  const baseByStableEvidence = new Map<string, DiagnosticIndexBucket>();
-  const baseBySameFileFallback = new Map<string, DiagnosticIndexBucket>();
-  for (const [diagnosticIndex, diagnostic] of input.baseDiagnostics.entries()) {
-    const evidence = readDiagnosticEvidence(diagnostic, input.readBaseEvidence, input.readBaseLine);
-    const matchKeys = getDiagnosticMatchKeys(diagnostic, evidence);
-    addDiagnosticIndex(baseByStableEvidence, matchKeys.stableEvidenceKey, diagnosticIndex);
-    addDiagnosticIndex(baseBySameFileFallback, matchKeys.sameFileFallbackKey, diagnosticIndex);
+  const baseCandidates = buildMatchCandidates(
+    input.baseDiagnostics,
+    input.readBaseEvidence,
+    input.readBaseLine,
+  );
+  const headCandidates = buildMatchCandidates(
+    input.headDiagnostics,
+    input.readHeadEvidence,
+    input.readHeadLine,
+  );
+  const baseByStableEvidence = new Map<string, number[]>();
+  const baseBySameFileStableEvidence = new Map<string, number[]>();
+  const baseBySameFileFallback = new Map<string, number[]>();
+  for (const candidate of baseCandidates) {
+    addDiagnosticIndex(
+      baseByStableEvidence,
+      candidate.stableEvidenceKey,
+      candidate.diagnosticIndex,
+    );
+    addDiagnosticIndex(
+      baseBySameFileStableEvidence,
+      candidate.sameFileStableEvidenceKey,
+      candidate.diagnosticIndex,
+    );
+    addDiagnosticIndex(
+      baseBySameFileFallback,
+      candidate.sameFileFallbackKey,
+      candidate.diagnosticIndex,
+    );
   }
 
-  const newDiagnostics: Diagnostic[] = [];
+  const matchedHeadDiagnosticIndexes = new Set<number>();
   const matchedBaseDiagnosticIndexes = new Set<number>();
-  let crossFileMatchCount = 0;
-  for (const diagnostic of input.headDiagnostics) {
-    const evidence = readDiagnosticEvidence(diagnostic, input.readHeadEvidence, input.readHeadLine);
-    const matchKeys = getDiagnosticMatchKeys(diagnostic, evidence);
-    const stableMatchIndex = takeMatchingDiagnosticIndex(
-      baseByStableEvidence,
-      matchKeys.stableEvidenceKey,
-      matchedBaseDiagnosticIndexes,
-    );
-    const matchingDiagnosticIndex =
-      stableMatchIndex ??
-      takeMatchingDiagnosticIndex(
-        baseBySameFileFallback,
-        matchKeys.sameFileFallbackKey,
+  const matchCandidates = (
+    baseBuckets: ReadonlyMap<string, ReadonlyArray<number>>,
+    getKey: (candidate: DiagnosticMatchCandidate) => string | null,
+    onMatch?: (headDiagnosticIndex: number, baseDiagnosticIndex: number) => void,
+  ): void => {
+    for (const candidate of headCandidates) {
+      if (matchedHeadDiagnosticIndexes.has(candidate.diagnosticIndex)) continue;
+      const baseDiagnosticIndex = takeMatchingDiagnosticIndex(
+        baseBuckets,
+        getKey(candidate),
         matchedBaseDiagnosticIndexes,
       );
-    const matchingBaseDiagnostic =
-      matchingDiagnosticIndex === null ? undefined : input.baseDiagnostics[matchingDiagnosticIndex];
-    if (matchingDiagnosticIndex !== null && matchingBaseDiagnostic !== undefined) {
-      matchedBaseDiagnosticIndexes.add(matchingDiagnosticIndex);
-      if (stableMatchIndex !== null && matchingBaseDiagnostic.filePath !== diagnostic.filePath) {
+      if (baseDiagnosticIndex === null) continue;
+      matchedHeadDiagnosticIndexes.add(candidate.diagnosticIndex);
+      matchedBaseDiagnosticIndexes.add(baseDiagnosticIndex);
+      onMatch?.(candidate.diagnosticIndex, baseDiagnosticIndex);
+    }
+  };
+
+  matchCandidates(baseBySameFileStableEvidence, (candidate) => candidate.sameFileStableEvidenceKey);
+  let crossFileMatchCount = 0;
+  matchCandidates(
+    baseByStableEvidence,
+    (candidate) => candidate.stableEvidenceKey,
+    (head, base) => {
+      if (input.headDiagnostics[head]?.filePath !== input.baseDiagnostics[base]?.filePath) {
         crossFileMatchCount += 1;
       }
-    } else {
-      newDiagnostics.push(diagnostic);
-    }
-  }
+    },
+  );
+  matchCandidates(baseBySameFileFallback, (candidate) => candidate.sameFileFallbackKey);
 
+  const newDiagnostics = input.headDiagnostics.filter(
+    (_diagnostic, diagnosticIndex) => !matchedHeadDiagnosticIndexes.has(diagnosticIndex),
+  );
   const fixedCount = input.baseDiagnostics.length - matchedBaseDiagnosticIndexes.size;
 
   return { newDiagnostics, fixedCount, crossFileMatchCount };

--- a/packages/core/src/compute-diagnostic-delta.ts
+++ b/packages/core/src/compute-diagnostic-delta.ts
@@ -6,85 +6,141 @@ export interface DiagnosticDelta {
   readonly newDiagnostics: Diagnostic[];
   /** Count of base diagnostics with no head match — resolved by the change. */
   readonly fixedCount: number;
+  /** Pre-existing diagnostics matched after moving to a different file. */
+  readonly crossFileMatchCount: number;
 }
 
 export interface ComputeDiagnosticDeltaInput {
   readonly headDiagnostics: ReadonlyArray<Diagnostic>;
   readonly baseDiagnostics: ReadonlyArray<Diagnostic>;
-  /**
-   * Returns the source text of `filePath:line` in the head / base trees. It
-   * fingerprints a diagnostic by the *content* of its flagged line rather than
-   * the absolute line number, so code that merely shifted down (lines inserted
-   * above it) is matched as pre-existing instead of reported as new. Return
-   * `null` when the line can't be read; the fingerprint then falls back to
-   * `(file, rule)` and diagnostics are matched in order.
-   */
   readonly readHeadLine: (filePath: string, line: number) => string | null;
   readonly readBaseLine: (filePath: string, line: number) => string | null;
+  /** Returns the normalized source range diagnosed in the head tree. */
+  readonly readHeadEvidence?: (diagnostic: Diagnostic) => string | null;
+  /** Returns the normalized source range diagnosed in the base tree. */
+  readonly readBaseEvidence?: (diagnostic: Diagnostic) => string | null;
 }
 
-const fingerprintDiagnostic = (diagnostic: Diagnostic, lineText: string | null): string => {
+interface DiagnosticMatchKeys {
+  readonly stableEvidenceKey: string | null;
+  readonly sameFileFallbackKey: string | null;
+}
+
+interface DiagnosticIndexBucket {
+  readonly diagnosticIndexes: number[];
+  nextCandidateIndex: number;
+}
+
+const fingerprintText = (text: string): string => createHash("sha256").update(text).digest("hex");
+
+const normalizeEvidence = (evidence: string): string => evidence.replace(/\s+/g, " ").trim();
+
+const getDiagnosticMatchKeys = (
+  diagnostic: Diagnostic,
+  evidence: string | null,
+): DiagnosticMatchKeys => {
   const ruleKey = `${diagnostic.plugin}/${diagnostic.rule}`;
-  const snippet =
-    lineText === null || diagnostic.matchByOccurrence
-      ? ""
-      : createHash("sha1").update(lineText.trim()).digest("hex");
-  return `${diagnostic.filePath}\u0000${ruleKey}\u0000${snippet}`;
+  const messageFingerprint = fingerprintText(`${diagnostic.title ?? ""}\0${diagnostic.message}`);
+  const normalizedEvidence = evidence === null ? "" : normalizeEvidence(evidence);
+  return {
+    stableEvidenceKey:
+      normalizedEvidence.length > 0
+        ? `evidence\0${ruleKey}\0${messageFingerprint}\0${fingerprintText(normalizedEvidence)}`
+        : null,
+    sameFileFallbackKey:
+      diagnostic.matchByOccurrence || normalizedEvidence.length === 0
+        ? `fallback\0${diagnostic.filePath}\0${ruleKey}\0${messageFingerprint}`
+        : null,
+  };
 };
 
+const addDiagnosticIndex = (
+  buckets: Map<string, DiagnosticIndexBucket>,
+  key: string | null,
+  diagnosticIndex: number,
+): void => {
+  if (key === null) return;
+  const bucket = buckets.get(key) ?? { diagnosticIndexes: [], nextCandidateIndex: 0 };
+  bucket.diagnosticIndexes.push(diagnosticIndex);
+  buckets.set(key, bucket);
+};
+
+const takeMatchingDiagnosticIndex = (
+  buckets: Map<string, DiagnosticIndexBucket>,
+  key: string | null,
+  matchedDiagnosticIndexes: ReadonlySet<number>,
+): number | null => {
+  if (key === null) return null;
+  const bucket = buckets.get(key);
+  if (bucket === undefined) return null;
+  while (bucket.nextCandidateIndex < bucket.diagnosticIndexes.length) {
+    const diagnosticIndex = bucket.diagnosticIndexes[bucket.nextCandidateIndex];
+    bucket.nextCandidateIndex += 1;
+    if (diagnosticIndex !== undefined && !matchedDiagnosticIndexes.has(diagnosticIndex)) {
+      return diagnosticIndex;
+    }
+  }
+  return null;
+};
+
+const readDiagnosticEvidence = (
+  diagnostic: Diagnostic,
+  readEvidence: ComputeDiagnosticDeltaInput["readHeadEvidence"],
+  readLine: ComputeDiagnosticDeltaInput["readHeadLine"],
+): string | null => readEvidence?.(diagnostic) ?? readLine(diagnostic.filePath, diagnostic.line);
+
 /**
- * Diffs a head scan against a base scan to isolate the diagnostics a change
- * introduced (and count the ones it resolved). Matching is a multiset over a
- * position-independent fingerprint — `(filePath, plugin/rule, hash(flagged
- * line text))` — so inserting lines above an existing issue doesn't make it
- * look new, while a genuinely new occurrence (new line text, or one more of
- * the same) surfaces. Identical repeated findings are matched by count.
- *
- * Diagnostics carrying `matchByOccurrence` (resolved at diagnostic creation:
- * every Accessibility-category finding, plus rules opting in via their
- * `matchByOccurrence` metadata flag) drop the line-text snippet and match by
- * `(filePath, plugin/rule)` occurrence count alone. Their identity is the
- * flagged element, not the line's text, so editing the line (reindentation,
- * prettier reflow, collapsing a multi-line JSX element) doesn't reclassify a
- * pre-existing finding as new — while one MORE occurrence of the same rule in
- * the file still surfaces. Expression-level rules keep the line-text snippet:
- * there the flagged expression IS the finding, so changed text means new +
- * fixed.
- *
- * v1 limitation: the fingerprint keys on the head-relative `filePath`, and base
- * content is read at that same path. A file renamed by the change therefore has
- * no base match, so its pre-existing findings are reported as new. This
- * over-reports (never hides a real issue) and is rare; rename-aware base
- * resolution is a follow-up.
+ * Diffs a head scan against a base scan using a multiset of construct-level
+ * evidence. Stable identities combine plugin/rule, the diagnostic message,
+ * and normalized diagnosed source, so unchanged findings can move across
+ * files while changed constructs or messages remain new. Cardinality is
+ * retained for identical findings. Diagnostics explicitly marked
+ * `matchByOccurrence` may fall back to same-file plugin/rule/message matching
+ * after strict evidence matching, preserving structural reformatting without
+ * letting unrelated findings cancel across files. Unreadable evidence uses the
+ * same conservative fallback rather than matching across files without proof.
  */
 export const computeDiagnosticDelta = (input: ComputeDiagnosticDeltaInput): DiagnosticDelta => {
-  const unmatchedBaseByFingerprint = new Map<string, number>();
-  for (const diagnostic of input.baseDiagnostics) {
-    const key = fingerprintDiagnostic(
-      diagnostic,
-      input.readBaseLine(diagnostic.filePath, diagnostic.line),
-    );
-    unmatchedBaseByFingerprint.set(key, (unmatchedBaseByFingerprint.get(key) ?? 0) + 1);
+  const baseByStableEvidence = new Map<string, DiagnosticIndexBucket>();
+  const baseBySameFileFallback = new Map<string, DiagnosticIndexBucket>();
+  for (const [diagnosticIndex, diagnostic] of input.baseDiagnostics.entries()) {
+    const evidence = readDiagnosticEvidence(diagnostic, input.readBaseEvidence, input.readBaseLine);
+    const matchKeys = getDiagnosticMatchKeys(diagnostic, evidence);
+    addDiagnosticIndex(baseByStableEvidence, matchKeys.stableEvidenceKey, diagnosticIndex);
+    addDiagnosticIndex(baseBySameFileFallback, matchKeys.sameFileFallbackKey, diagnosticIndex);
   }
 
   const newDiagnostics: Diagnostic[] = [];
+  const matchedBaseDiagnosticIndexes = new Set<number>();
+  let crossFileMatchCount = 0;
   for (const diagnostic of input.headDiagnostics) {
-    const key = fingerprintDiagnostic(
-      diagnostic,
-      input.readHeadLine(diagnostic.filePath, diagnostic.line),
+    const evidence = readDiagnosticEvidence(diagnostic, input.readHeadEvidence, input.readHeadLine);
+    const matchKeys = getDiagnosticMatchKeys(diagnostic, evidence);
+    const stableMatchIndex = takeMatchingDiagnosticIndex(
+      baseByStableEvidence,
+      matchKeys.stableEvidenceKey,
+      matchedBaseDiagnosticIndexes,
     );
-    const availableMatches = unmatchedBaseByFingerprint.get(key) ?? 0;
-    if (availableMatches > 0) {
-      unmatchedBaseByFingerprint.set(key, availableMatches - 1);
+    const matchingDiagnosticIndex =
+      stableMatchIndex ??
+      takeMatchingDiagnosticIndex(
+        baseBySameFileFallback,
+        matchKeys.sameFileFallbackKey,
+        matchedBaseDiagnosticIndexes,
+      );
+    const matchingBaseDiagnostic =
+      matchingDiagnosticIndex === null ? undefined : input.baseDiagnostics[matchingDiagnosticIndex];
+    if (matchingDiagnosticIndex !== null && matchingBaseDiagnostic !== undefined) {
+      matchedBaseDiagnosticIndexes.add(matchingDiagnosticIndex);
+      if (stableMatchIndex !== null && matchingBaseDiagnostic.filePath !== diagnostic.filePath) {
+        crossFileMatchCount += 1;
+      }
     } else {
       newDiagnostics.push(diagnostic);
     }
   }
 
-  let fixedCount = 0;
-  for (const remaining of unmatchedBaseByFingerprint.values()) {
-    fixedCount += remaining;
-  }
+  const fixedCount = input.baseDiagnostics.length - matchedBaseDiagnosticIndexes.size;
 
-  return { newDiagnostics, fixedCount };
+  return { newDiagnostics, fixedCount, crossFileMatchCount };
 };

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -482,8 +482,8 @@ export const DIAGNOSTIC_CATEGORY_BUCKETS = [
 // Categories whose findings are matched by occurrence in the CI baseline
 // delta — the finding's identity is the flagged element (a missing
 // attribute, a wrong element), not the flagged line's text — so the delta
-// matches them by `(file, rule)` occurrence count instead of a line-text
-// hash. Every Accessibility rule is element-level; rules in other
+// may match them by same-file `(rule, message)` occurrence count after strict
+// evidence matching. Every Accessibility rule is element-level; rules in other
 // categories opt in individually via their per-rule `matchByOccurrence`
 // flag (see `resolveMatchByOccurrence` in `runners/oxlint/parse-output`).
 export const OCCURRENCE_MATCHED_CATEGORIES: ReadonlySet<string> = new Set(["Accessibility"]);

--- a/packages/core/src/get-diff-files.ts
+++ b/packages/core/src/get-diff-files.ts
@@ -1,6 +1,7 @@
 import * as Effect from "effect/Effect";
 import { isLintableSourceFile } from "./utils/is-lintable-source-file.js";
 import { Git } from "./services/git.js";
+import type { GitBaselineDiffPlan } from "./services/git.js";
 import type { ChangedFileLineRanges, DiffInfo } from "./types/index.js";
 
 /**
@@ -40,8 +41,19 @@ export const getDiffInfo = (
     }).pipe(Effect.provide(Git.layerNode)),
   );
 
-export const filterSourceFiles = (filePaths: string[]): string[] =>
+export const filterSourceFiles = (filePaths: ReadonlyArray<string>): string[] =>
   filePaths.filter(isLintableSourceFile);
+
+export const getBaselineDiffPlan = (
+  directory: string,
+  ref: string,
+): Promise<GitBaselineDiffPlan | null> =>
+  Effect.runPromise(
+    Effect.gen(function* () {
+      const git = yield* Git;
+      return yield* git.baselineDiffPlan({ directory, ref });
+    }).pipe(Effect.provide(Git.layerNode)),
+  );
 
 /**
  * Programmatic façade over `Git.changedLineRanges` (the `lines` scope). Diffs

--- a/packages/core/src/materialize-source-tree.ts
+++ b/packages/core/src/materialize-source-tree.ts
@@ -7,6 +7,7 @@ import type { ReactDoctorError } from "./errors.js";
 export interface MaterializedTree {
   readonly tempDirectory: string;
   readonly materializedFiles: ReadonlyArray<string>;
+  readonly unmaterializedFiles: ReadonlyArray<string>;
   readonly cleanup: () => void;
 }
 
@@ -39,12 +40,19 @@ export const materializeSourceTree = (input: {
 }): Effect.Effect<MaterializedTree, ReactDoctorError> =>
   Effect.gen(function* () {
     const materializedFiles: string[] = [];
+    const unmaterializedFiles: string[] = [];
     const resolvedTempDirectory = path.resolve(input.tempDirectory);
     for (const relativePath of input.files) {
       const content = yield* input.readContent(relativePath).pipe(Effect.orElseSucceed(() => null));
-      if (content === null) continue;
+      if (content === null) {
+        unmaterializedFiles.push(relativePath);
+        continue;
+      }
       const candidateTargetPath = path.resolve(resolvedTempDirectory, relativePath);
-      if (!isPathInsideDirectory(candidateTargetPath, resolvedTempDirectory)) continue;
+      if (!isPathInsideDirectory(candidateTargetPath, resolvedTempDirectory)) {
+        unmaterializedFiles.push(relativePath);
+        continue;
+      }
       yield* Effect.sync(() => {
         fs.mkdirSync(path.dirname(candidateTargetPath), { recursive: true });
         fs.writeFileSync(candidateTargetPath, content);
@@ -63,6 +71,7 @@ export const materializeSourceTree = (input: {
     return {
       tempDirectory: input.tempDirectory,
       materializedFiles,
+      unmaterializedFiles,
       cleanup: () => {
         try {
           fs.rmSync(input.tempDirectory, { recursive: true, force: true });

--- a/packages/core/src/runners/oxlint/parse-output.ts
+++ b/packages/core/src/runners/oxlint/parse-output.ts
@@ -227,7 +227,8 @@ const resolveDiagnosticCategory = (plugin: string, rule: string): string => {
 
 // Whether the finding's identity is the flagged element rather than the
 // flagged line's text, so `computeDiagnosticDelta` matches it by
-// `(file, rule)` occurrence count. Resolved here — the one place that
+// same-file `(rule, message)` occurrence count after strict evidence matching.
+// Resolved here — the one place that
 // already consults rule metadata — so the delta stays a pure function of
 // its `Diagnostic` inputs. Every Accessibility-category finding qualifies
 // (element-level by nature, including adopted third-party a11y rules);

--- a/packages/core/src/services/git.ts
+++ b/packages/core/src/services/git.ts
@@ -162,6 +162,37 @@ const parseGithubViewerPermission = (stdout: string): string | null => {
 const splitNullSeparated = (value: string): ReadonlyArray<string> =>
   value.split("\0").filter((entry) => entry.length > 0);
 
+export interface GitBaselineDiffPlan {
+  readonly baseFiles: ReadonlyArray<string>;
+  readonly headFiles: ReadonlyArray<string>;
+}
+
+const parseBaselineDiffPlan = (value: string): GitBaselineDiffPlan | null => {
+  const entries = splitNullSeparated(value);
+  const baseFiles = new Set<string>();
+  const headFiles = new Set<string>();
+  for (let entryIndex = 0; entryIndex < entries.length; entryIndex += 2) {
+    const status = entries[entryIndex];
+    const filePath = entries[entryIndex + 1];
+    if (status === undefined || filePath === undefined || status.length !== 1) return null;
+    if (status === "A") {
+      headFiles.add(filePath);
+      continue;
+    }
+    if (status === "D") {
+      baseFiles.add(filePath);
+      continue;
+    }
+    if (status === "M" || status === "T") {
+      baseFiles.add(filePath);
+      headFiles.add(filePath);
+      continue;
+    }
+    return null;
+  }
+  return { baseFiles: [...baseFiles], headFiles: [...headFiles] };
+};
+
 // An untracked file has no base to diff against, so `--scope lines` treats
 // every line as changed by spanning the whole file (1 → last possible line).
 const UNTRACKED_FILE_LAST_LINE = Number.MAX_SAFE_INTEGER;
@@ -285,6 +316,16 @@ export class Git extends Context.Service<
     readonly diffSelection: (
       input: GitDiffSelectionInput,
     ) => Effect.Effect<GitDiffSelection | null, ReactDoctorError>;
+    /**
+     * Side-aware paths between `ref` and the worktree. Rename and copy
+     * detection is disabled so path identity never depends on Git heuristics:
+     * a rename is represented as one base deletion plus one head addition.
+     * Returns `null` for unmerged or otherwise unsupported diff states.
+     */
+    readonly baselineDiffPlan: (input: {
+      readonly directory: string;
+      readonly ref: string;
+    }) => Effect.Effect<GitBaselineDiffPlan | null, ReactDoctorError>;
     /** Files staged for commit (null-separated, `--diff-filter=ACMR`). */
     readonly stagedFilePaths: (
       directory: string,
@@ -700,6 +741,34 @@ export class Git extends Context.Service<
         githubViewerPermission,
         branchExists,
         mergeBase,
+        baselineDiffPlan: (input) => {
+          if (!isSafeGitRevision(input.ref)) return Effect.succeed(null);
+          return Effect.gen(function* () {
+            const unmerged = yield* runGit(input.directory, [
+              "diff",
+              "--no-ext-diff",
+              "-z",
+              "--name-only",
+              "--diff-filter=U",
+              "--relative",
+            ]);
+            if (unmerged.status !== 0 || unmerged.stdout.length > 0) return null;
+            const result = yield* runGit(input.directory, [
+              "diff",
+              "--no-ext-diff",
+              "--no-textconv",
+              "--no-renames",
+              "-z",
+              "--name-status",
+              "--relative",
+              input.ref,
+            ]);
+            return result.status === 0 ? parseBaselineDiffPlan(result.stdout) : null;
+          }).pipe(
+            Effect.catch(() => Effect.succeed(null)),
+            Effect.withSpan("Git.baselineDiffPlan"),
+          );
+        },
         diffSelection: ({ directory, explicitBaseBranch, includeUntracked = false }) =>
           Effect.gen(function* () {
             if (explicitBaseBranch !== undefined && explicitBaseBranch.trim().length === 0) {
@@ -951,6 +1020,7 @@ export class Git extends Context.Service<
     readonly branchExists?: ReadonlyMap<string, boolean>;
     /** Keyed by the `ref` argument; value is the resolved merge-base SHA. */
     readonly mergeBase?: ReadonlyMap<string, string>;
+    readonly baselineDiffPlan?: GitBaselineDiffPlan | null;
     readonly stagedFiles?: ReadonlyArray<string>;
     readonly stagedContent?: ReadonlyMap<string, string>;
     /** Keyed by `<ref>:<relativePath>`. */
@@ -970,6 +1040,7 @@ export class Git extends Context.Service<
         branchExists: (_directory, branch) =>
           Effect.succeed(snapshot.branchExists?.get(branch) ?? false),
         mergeBase: ({ ref }) => Effect.succeed(snapshot.mergeBase?.get(ref) ?? null),
+        baselineDiffPlan: () => Effect.succeed(snapshot.baselineDiffPlan ?? null),
         diffSelection: () => Effect.succeed(snapshot.diffSelection ?? null),
         stagedFilePaths: () => Effect.succeed(snapshot.stagedFiles ?? []),
         showStagedContent: (_directory, relativePath) =>

--- a/packages/core/src/services/git.ts
+++ b/packages/core/src/services/git.ts
@@ -165,6 +165,7 @@ const splitNullSeparated = (value: string): ReadonlyArray<string> =>
 export interface GitBaselineDiffPlan {
   readonly baseFiles: ReadonlyArray<string>;
   readonly headFiles: ReadonlyArray<string>;
+  readonly untrackedFiles: ReadonlyArray<string>;
 }
 
 const parseBaselineDiffPlan = (value: string): GitBaselineDiffPlan | null => {
@@ -190,7 +191,7 @@ const parseBaselineDiffPlan = (value: string): GitBaselineDiffPlan | null => {
     }
     return null;
   }
-  return { baseFiles: [...baseFiles], headFiles: [...headFiles] };
+  return { baseFiles: [...baseFiles], headFiles: [...headFiles], untrackedFiles: [] };
 };
 
 // An untracked file has no base to diff against, so `--scope lines` treats
@@ -775,7 +776,8 @@ export class Git extends Context.Service<
             if (untracked.status !== 0) return null;
             return {
               baseFiles: plan.baseFiles,
-              headFiles: [...new Set([...plan.headFiles, ...splitNullSeparated(untracked.stdout)])],
+              headFiles: plan.headFiles,
+              untrackedFiles: splitNullSeparated(untracked.stdout),
             } satisfies GitBaselineDiffPlan;
           }).pipe(
             Effect.catch(() => Effect.succeed(null)),

--- a/packages/core/src/services/git.ts
+++ b/packages/core/src/services/git.ts
@@ -763,7 +763,23 @@ export class Git extends Context.Service<
               "--relative",
               input.ref,
             ]);
-            return result.status === 0 ? parseBaselineDiffPlan(result.stdout) : null;
+            if (result.status !== 0) return null;
+            const plan = parseBaselineDiffPlan(result.stdout);
+            if (plan === null) return null;
+            const untracked = yield* runGit(input.directory, [
+              "ls-files",
+              "--others",
+              "--exclude-standard",
+              "-z",
+              "--relative",
+            ]);
+            if (untracked.status !== 0) return null;
+            return {
+              baseFiles: plan.baseFiles,
+              headFiles: [
+                ...new Set([...plan.headFiles, ...splitNullSeparated(untracked.stdout)]),
+              ],
+            } satisfies GitBaselineDiffPlan;
           }).pipe(
             Effect.catch(() => Effect.succeed(null)),
             Effect.withSpan("Git.baselineDiffPlan"),

--- a/packages/core/src/services/git.ts
+++ b/packages/core/src/services/git.ts
@@ -771,14 +771,11 @@ export class Git extends Context.Service<
               "--others",
               "--exclude-standard",
               "-z",
-              "--relative",
             ]);
             if (untracked.status !== 0) return null;
             return {
               baseFiles: plan.baseFiles,
-              headFiles: [
-                ...new Set([...plan.headFiles, ...splitNullSeparated(untracked.stdout)]),
-              ],
+              headFiles: [...new Set([...plan.headFiles, ...splitNullSeparated(untracked.stdout)])],
             } satisfies GitBaselineDiffPlan;
           }).pipe(
             Effect.catch(() => Effect.succeed(null)),

--- a/packages/core/src/types/diagnostic.ts
+++ b/packages/core/src/types/diagnostic.ts
@@ -83,11 +83,12 @@ export interface Diagnostic {
    * Set when the finding's identity is the flagged element itself (a missing
    * attribute, a wrong element) rather than the flagged line's text — every
    * Accessibility-category finding, plus rules that opt in via their
-   * `matchByOccurrence` metadata flag. `computeDiagnosticDelta` matches these
-   * by `(filePath, plugin/rule)` occurrence count, so reformatting the flagged
-   * line doesn't reclassify a pre-existing finding as new. Resolved at
-   * diagnostic creation, where rule metadata is available. Absent means
-   * line-text-sensitive matching (the default).
+   * `matchByOccurrence` metadata flag. After strict evidence matching,
+   * `computeDiagnosticDelta` may match these by same-file `(plugin/rule,
+   * message)` occurrence count, so reformatting the flagged element doesn't
+   * reclassify a pre-existing finding as new. Resolved at diagnostic creation,
+   * where rule metadata is available. Absent means diagnosed-source-sensitive
+   * matching (the default).
    */
   matchByOccurrence?: boolean;
   /**

--- a/packages/core/src/types/inspect.ts
+++ b/packages/core/src/types/inspect.ts
@@ -149,14 +149,20 @@ export interface InspectOptions {
   /**
    * Baseline comparison. When set (only meaningful alongside
    * `includePaths`, i.e. a diff scan), `inspect()` runs a second lint pass
-   * over the same files as they existed at `ref` and reports only the
+   * over the relevant base-side files as they existed at `ref` and reports only the
    * diagnostics the change *introduced* — pre-existing findings that merely
    * shifted lines are matched out. The returned `score` is still the head
    * scan's; `InspectResult.baselineDelta` carries the fixed / base counts.
    * `ref` should be a resolved commit (e.g. the merge-base) whose content
-   * `git show <ref>:<file>` can read.
+   * `git show <ref>:<file>` can read. `baseFiles` / `headFiles` may carry a
+   * side-aware Git diff plan; when omitted, React Doctor derives one from
+   * `ref` and the worktree.
    */
-  baseline?: { ref: string };
+  baseline?: {
+    ref: string;
+    baseFiles?: ReadonlyArray<string>;
+    headFiles?: ReadonlyArray<string>;
+  };
   /**
    * Restrict reported diagnostics to those whose source spans intersect the
    * lines the change touched (`--scope lines`). Each entry is one changed file with the

--- a/packages/core/src/types/inspect.ts
+++ b/packages/core/src/types/inspect.ts
@@ -92,6 +92,8 @@ export interface InspectResult {
     fixedCount: number;
     /** Total findings at base (over the same files), for context. */
     baseTotalCount: number;
+    /** Pre-existing findings matched after moving to a different file. */
+    crossFileMatchCount?: number;
   };
 }
 

--- a/packages/core/tests/compute-diagnostic-delta.test.ts
+++ b/packages/core/tests/compute-diagnostic-delta.test.ts
@@ -255,6 +255,31 @@ describe("computeDiagnosticDelta", () => {
     expect(delta.fixedCount).toBe(0);
   });
 
+  it("reserves a reformatted same-file occurrence before matching a cross-file copy", () => {
+    const occurrenceMatched = (filePath: string): Diagnostic =>
+      makeDiagnostic({
+        filePath,
+        rule: "iframe-has-title",
+        category: "Accessibility",
+        matchByOccurrence: true,
+      });
+    const delta = computeDiagnosticDelta({
+      headDiagnostics: [occurrenceMatched("src/CopiedFrame.tsx"), occurrenceMatched("src/App.tsx")],
+      baseDiagnostics: [occurrenceMatched("src/App.tsx")],
+      readHeadLine: lineReaderFrom({
+        "src/CopiedFrame.tsx:10": "<iframe",
+        "src/App.tsx:10": '<iframe src={url} className="embed" />',
+      }),
+      readBaseLine: lineReaderFrom({ "src/App.tsx:10": "<iframe" }),
+    });
+
+    expect(delta.newDiagnostics.map((diagnostic) => diagnostic.filePath)).toEqual([
+      "src/CopiedFrame.tsx",
+    ]);
+    expect(delta.fixedCount).toBe(0);
+    expect(delta.crossFileMatchCount).toBe(0);
+  });
+
   it("falls back to file, rule, and message matching when source is unreadable", () => {
     const base = [makeDiagnostic({ line: 10 })];
     const head = [makeDiagnostic({ line: 99 })];

--- a/packages/core/tests/compute-diagnostic-delta.test.ts
+++ b/packages/core/tests/compute-diagnostic-delta.test.ts
@@ -106,6 +106,27 @@ describe("computeDiagnosticDelta", () => {
     expect(delta.fixedCount).toBe(0);
   });
 
+  it("prefers the same-file occurrence when identical evidence is copied", () => {
+    const flagged = "items.map((item, index) => <Row key={index} />)";
+    const delta = computeDiagnosticDelta({
+      headDiagnostics: [
+        makeDiagnostic({ filePath: "src/CopiedRows.tsx" }),
+        makeDiagnostic({ filePath: "src/App.tsx" }),
+      ],
+      baseDiagnostics: [makeDiagnostic({ filePath: "src/App.tsx" })],
+      readHeadLine: lineReaderFrom({
+        "src/CopiedRows.tsx:10": flagged,
+        "src/App.tsx:10": flagged,
+      }),
+      readBaseLine: lineReaderFrom({ "src/App.tsx:10": flagged }),
+    });
+
+    expect(delta.newDiagnostics.map((diagnostic) => diagnostic.filePath)).toEqual([
+      "src/CopiedRows.tsx",
+    ]);
+    expect(delta.crossFileMatchCount).toBe(0);
+  });
+
   it("distinguishes the same rule on different line content", () => {
     const base = [makeDiagnostic({ line: 10 })];
     const head = [makeDiagnostic({ line: 10 })];

--- a/packages/core/tests/compute-diagnostic-delta.test.ts
+++ b/packages/core/tests/compute-diagnostic-delta.test.ts
@@ -50,6 +50,35 @@ describe("computeDiagnosticDelta", () => {
     expect(delta.fixedCount).toBe(0);
   });
 
+  it("matches unchanged diagnostic evidence after it moves to another file", () => {
+    const flagged = "items.map((item, index) => <Row key={index} />)";
+    const delta = computeDiagnosticDelta({
+      headDiagnostics: [makeDiagnostic({ filePath: "src/Rows.tsx", line: 4 })],
+      baseDiagnostics: [makeDiagnostic({ filePath: "src/App.tsx", line: 10 })],
+      readHeadLine: lineReaderFrom({ "src/Rows.tsx:4": flagged }),
+      readBaseLine: lineReaderFrom({ "src/App.tsx:10": flagged }),
+    });
+    expect(delta.newDiagnostics).toHaveLength(0);
+    expect(delta.fixedCount).toBe(0);
+    expect(delta.crossFileMatchCount).toBe(1);
+  });
+
+  it("does not match changed evidence after a file move", () => {
+    const delta = computeDiagnosticDelta({
+      headDiagnostics: [makeDiagnostic({ filePath: "src/Rows.tsx", line: 4 })],
+      baseDiagnostics: [makeDiagnostic({ filePath: "src/App.tsx", line: 10 })],
+      readHeadLine: lineReaderFrom({
+        "src/Rows.tsx:4": "rows.map((row, rowIndex) => <Row key={rowIndex} />)",
+      }),
+      readBaseLine: lineReaderFrom({
+        "src/App.tsx:10": "items.map((item, index) => <Row key={index} />)",
+      }),
+    });
+    expect(delta.newDiagnostics).toHaveLength(1);
+    expect(delta.fixedCount).toBe(1);
+    expect(delta.crossFileMatchCount).toBe(0);
+  });
+
   it("counts a base-only diagnostic as fixed", () => {
     const flagged = "items.map((x, i) => <Row key={i} />)";
     const delta = computeDiagnosticDelta({
@@ -86,6 +115,38 @@ describe("computeDiagnosticDelta", () => {
       // The flagged line's content changed, so it's a new instance (+ the old one fixed).
       readHeadLine: lineReaderFrom({ "src/App.tsx:10": "rows.map((x, idx) => <Row key={idx} />)" }),
       readBaseLine: lineReaderFrom({ "src/App.tsx:10": "items.map((x, i) => <Row key={i} />)" }),
+    });
+    expect(delta.newDiagnostics).toHaveLength(1);
+    expect(delta.fixedCount).toBe(1);
+  });
+
+  it("distinguishes a changed message when the diagnosed source is unchanged", () => {
+    const flagged = "}, [selectedIds]);";
+    const delta = computeDiagnosticDelta({
+      headDiagnostics: [
+        makeDiagnostic({
+          rule: "exhaustive-deps",
+          message: "Missing dependencies: select, selectUpwards",
+        }),
+      ],
+      baseDiagnostics: [
+        makeDiagnostic({ rule: "exhaustive-deps", message: "Missing dependency: select" }),
+      ],
+      readHeadLine: lineReaderFrom({ "src/App.tsx:10": flagged }),
+      readBaseLine: lineReaderFrom({ "src/App.tsx:10": flagged }),
+    });
+    expect(delta.newDiagnostics).toHaveLength(1);
+    expect(delta.fixedCount).toBe(1);
+  });
+
+  it("uses the full diagnosed source range when evidence readers are supplied", () => {
+    const delta = computeDiagnosticDelta({
+      headDiagnostics: [makeDiagnostic({ endLine: 12 })],
+      baseDiagnostics: [makeDiagnostic({ endLine: 12 })],
+      readHeadLine: () => "}, [persistKey]);",
+      readBaseLine: () => "}, [persistKey]);",
+      readHeadEvidence: () => "useEffect(() => {\n  setSrc(undefined);\n}, [persistKey]);",
+      readBaseEvidence: () => "useEffect(() => {\n  setOpen(false);\n}, [persistKey]);",
     });
     expect(delta.newDiagnostics).toHaveLength(1);
     expect(delta.fixedCount).toBe(1);
@@ -173,7 +234,7 @@ describe("computeDiagnosticDelta", () => {
     expect(delta.fixedCount).toBe(0);
   });
 
-  it("falls back to (file, rule) order matching when line text is unreadable", () => {
+  it("falls back to file, rule, and message matching when source is unreadable", () => {
     const base = [makeDiagnostic({ line: 10 })];
     const head = [makeDiagnostic({ line: 99 })];
     const delta = computeDiagnosticDelta({
@@ -182,8 +243,18 @@ describe("computeDiagnosticDelta", () => {
       readHeadLine: () => null,
       readBaseLine: () => null,
     });
-    // No snippet on either side -> same (file, rule) fingerprint -> matched.
     expect(delta.newDiagnostics).toHaveLength(0);
     expect(delta.fixedCount).toBe(0);
+  });
+
+  it("does not match unreadable diagnostics across files", () => {
+    const delta = computeDiagnosticDelta({
+      headDiagnostics: [makeDiagnostic({ filePath: "src/New.tsx" })],
+      baseDiagnostics: [makeDiagnostic({ filePath: "src/Old.tsx" })],
+      readHeadLine: () => null,
+      readBaseLine: () => null,
+    });
+    expect(delta.newDiagnostics).toHaveLength(1);
+    expect(delta.fixedCount).toBe(1);
   });
 });

--- a/packages/core/tests/materialize-source-tree.test.ts
+++ b/packages/core/tests/materialize-source-tree.test.ts
@@ -1,0 +1,38 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import * as Effect from "effect/Effect";
+import { materializeSourceTree } from "@react-doctor/core";
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+
+describe("materializeSourceTree", () => {
+  let directory: string;
+  let tempDirectory: string;
+
+  beforeEach(() => {
+    directory = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-source-root-"));
+    tempDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-source-snapshot-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(directory, { recursive: true, force: true });
+    fs.rmSync(tempDirectory, { recursive: true, force: true });
+  });
+
+  it("reports absent and unsafe files instead of silently losing them", async () => {
+    const tree = await Effect.runPromise(
+      materializeSourceTree({
+        directory,
+        files: ["src/present.ts", "src/absent.ts", "../escape.ts"],
+        tempDirectory,
+        readContent: (filePath) =>
+          Effect.succeed(filePath === "src/absent.ts" ? null : "export const value = 1;\n"),
+      }),
+    );
+
+    expect(tree.materializedFiles).toEqual(["src/present.ts"]);
+    expect(tree.unmaterializedFiles).toEqual(["src/absent.ts", "../escape.ts"]);
+    expect(fs.existsSync(path.join(tempDirectory, "src/present.ts"))).toBe(true);
+    expect(fs.existsSync(path.resolve(tempDirectory, "..", "escape.ts"))).toBe(false);
+  });
+});

--- a/packages/core/tests/services/git-baseline-diff-plan.test.ts
+++ b/packages/core/tests/services/git-baseline-diff-plan.test.ts
@@ -55,6 +55,7 @@ describe("Git.baselineDiffPlan", () => {
     await expect(readPlan(directory, baseRef)).resolves.toEqual({
       baseFiles: ["src/old-name.tsx"],
       headFiles: ["src/new-name.tsx"],
+      untrackedFiles: [],
     });
   });
 
@@ -68,7 +69,8 @@ describe("Git.baselineDiffPlan", () => {
 
     await expect(readPlan(directory, baseRef)).resolves.toEqual({
       baseFiles: ["src/old-name.tsx"],
-      headFiles: ["src/new-name.tsx"],
+      headFiles: [],
+      untrackedFiles: ["src/new-name.tsx"],
     });
   });
 
@@ -84,6 +86,7 @@ describe("Git.baselineDiffPlan", () => {
     await expect(readPlan(directory, baseRef)).resolves.toEqual({
       baseFiles: [],
       headFiles: ["src/copied.tsx"],
+      untrackedFiles: [],
     });
   });
 
@@ -96,6 +99,7 @@ describe("Git.baselineDiffPlan", () => {
     await expect(readPlan(directory, baseRef)).resolves.toEqual({
       baseFiles: ["src/deleted.tsx"],
       headFiles: [],
+      untrackedFiles: [],
     });
   });
 
@@ -110,6 +114,7 @@ describe("Git.baselineDiffPlan", () => {
       await expect(readPlan(directory, baseRef)).resolves.toEqual({
         baseFiles: [filePath],
         headFiles: [filePath],
+        untrackedFiles: [],
       });
     },
   );

--- a/packages/core/tests/services/git-baseline-diff-plan.test.ts
+++ b/packages/core/tests/services/git-baseline-diff-plan.test.ts
@@ -85,17 +85,20 @@ describe("Git.baselineDiffPlan", () => {
     });
   });
 
-  it("preserves newline-containing paths through null-delimited parsing", async () => {
-    const filePath = "src/line\nbreak.ts";
-    writeFile(directory, filePath, "export const value = 1;\n");
-    const baseRef = commitAll(directory, "base");
-    writeFile(directory, filePath, "export const value = 2;\n");
+  it.skipIf(process.platform === "win32")(
+    "preserves newline-containing paths through null-delimited parsing",
+    async () => {
+      const filePath = "src/line\nbreak.ts";
+      writeFile(directory, filePath, "export const value = 1;\n");
+      const baseRef = commitAll(directory, "base");
+      writeFile(directory, filePath, "export const value = 2;\n");
 
-    await expect(readPlan(directory, baseRef)).resolves.toEqual({
-      baseFiles: [filePath],
-      headFiles: [filePath],
-    });
-  });
+      await expect(readPlan(directory, baseRef)).resolves.toEqual({
+        baseFiles: [filePath],
+        headFiles: [filePath],
+      });
+    },
+  );
 
   it("degrades when the index contains an unresolved merge", async () => {
     writeFile(directory, "src/conflict.ts", "export const value = 'base';\n");

--- a/packages/core/tests/services/git-baseline-diff-plan.test.ts
+++ b/packages/core/tests/services/git-baseline-diff-plan.test.ts
@@ -1,0 +1,119 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import * as Effect from "effect/Effect";
+import { Git } from "@react-doctor/core";
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+
+const runGit = (directory: string, args: ReadonlyArray<string>): string =>
+  execFileSync("git", args, { cwd: directory, encoding: "utf-8" }).trim();
+
+const writeFile = (directory: string, filePath: string, content: string): void => {
+  const absolutePath = path.join(directory, filePath);
+  fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+  fs.writeFileSync(absolutePath, content);
+};
+
+const commitAll = (directory: string, message: string): string => {
+  runGit(directory, ["add", "-A"]);
+  runGit(directory, ["commit", "-m", message]);
+  return runGit(directory, ["rev-parse", "HEAD"]);
+};
+
+const readPlan = (directory: string, ref: string) =>
+  Effect.runPromise(
+    Effect.gen(function* () {
+      const git = yield* Git;
+      return yield* git.baselineDiffPlan({ directory, ref });
+    }).pipe(Effect.provide(Git.layerNode)),
+  );
+
+describe("Git.baselineDiffPlan", () => {
+  let directory: string;
+
+  beforeEach(() => {
+    directory = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-baseline-plan-"));
+    runGit(directory, ["init", "--quiet"]);
+    runGit(directory, ["config", "user.email", "react-doctor@example.com"]);
+    runGit(directory, ["config", "user.name", "React Doctor"]);
+  });
+
+  afterEach(() => {
+    fs.rmSync(directory, { recursive: true, force: true });
+  });
+
+  it("represents a rename as a base deletion and head addition", async () => {
+    writeFile(directory, "src/old-name.tsx", "export const value = 1;\n");
+    const baseRef = commitAll(directory, "base");
+    fs.renameSync(
+      path.join(directory, "src/old-name.tsx"),
+      path.join(directory, "src/new-name.tsx"),
+    );
+    runGit(directory, ["add", "-A"]);
+
+    await expect(readPlan(directory, baseRef)).resolves.toEqual({
+      baseFiles: ["src/old-name.tsx"],
+      headFiles: ["src/new-name.tsx"],
+    });
+  });
+
+  it("keeps a copied file head-only", async () => {
+    writeFile(directory, "src/original.tsx", "export const value = 1;\n");
+    const baseRef = commitAll(directory, "base");
+    fs.copyFileSync(
+      path.join(directory, "src/original.tsx"),
+      path.join(directory, "src/copied.tsx"),
+    );
+    runGit(directory, ["add", "-A"]);
+
+    await expect(readPlan(directory, baseRef)).resolves.toEqual({
+      baseFiles: [],
+      headFiles: ["src/copied.tsx"],
+    });
+  });
+
+  it("keeps deleted files on the base side", async () => {
+    writeFile(directory, "src/deleted.tsx", "export const value = 1;\n");
+    const baseRef = commitAll(directory, "base");
+    fs.rmSync(path.join(directory, "src/deleted.tsx"));
+    runGit(directory, ["add", "-A"]);
+
+    await expect(readPlan(directory, baseRef)).resolves.toEqual({
+      baseFiles: ["src/deleted.tsx"],
+      headFiles: [],
+    });
+  });
+
+  it("preserves newline-containing paths through null-delimited parsing", async () => {
+    const filePath = "src/line\nbreak.ts";
+    writeFile(directory, filePath, "export const value = 1;\n");
+    const baseRef = commitAll(directory, "base");
+    writeFile(directory, filePath, "export const value = 2;\n");
+
+    await expect(readPlan(directory, baseRef)).resolves.toEqual({
+      baseFiles: [filePath],
+      headFiles: [filePath],
+    });
+  });
+
+  it("degrades when the index contains an unresolved merge", async () => {
+    writeFile(directory, "src/conflict.ts", "export const value = 'base';\n");
+    const baseRef = commitAll(directory, "base");
+    const mainBranch = runGit(directory, ["branch", "--show-current"]);
+    runGit(directory, ["branch", "other"]);
+    writeFile(directory, "src/conflict.ts", "export const value = 'main';\n");
+    commitAll(directory, "main change");
+    runGit(directory, ["switch", "other"]);
+    writeFile(directory, "src/conflict.ts", "export const value = 'other';\n");
+    commitAll(directory, "other change");
+    runGit(directory, ["switch", mainBranch]);
+    expect(() => runGit(directory, ["merge", "other"])).toThrow();
+
+    await expect(readPlan(directory, baseRef)).resolves.toBeNull();
+  });
+
+  it("degrades when the baseline ref is unavailable", async () => {
+    await expect(readPlan(directory, "missing-ref")).resolves.toBeNull();
+  });
+});

--- a/packages/core/tests/services/git-baseline-diff-plan.test.ts
+++ b/packages/core/tests/services/git-baseline-diff-plan.test.ts
@@ -58,6 +58,20 @@ describe("Git.baselineDiffPlan", () => {
     });
   });
 
+  it("keeps an unstaged rename destination on the head side", async () => {
+    writeFile(directory, "src/old-name.tsx", "export const value = 1;\n");
+    const baseRef = commitAll(directory, "base");
+    fs.renameSync(
+      path.join(directory, "src/old-name.tsx"),
+      path.join(directory, "src/new-name.tsx"),
+    );
+
+    await expect(readPlan(directory, baseRef)).resolves.toEqual({
+      baseFiles: ["src/old-name.tsx"],
+      headFiles: ["src/new-name.tsx"],
+    });
+  });
+
   it("keeps a copied file head-only", async () => {
     writeFile(directory, "src/original.tsx", "export const value = 1;\n");
     const baseRef = commitAll(directory, "base");

--- a/packages/react-doctor/src/cli/commands/inspect.ts
+++ b/packages/react-doctor/src/cli/commands/inspect.ts
@@ -6,6 +6,7 @@ import * as fs from "node:fs";
 import {
   buildJsonReport,
   DEFAULT_PROJECT_SCAN_CONCURRENCY,
+  getBaselineDiffPlan,
   getChangedLineRanges,
   getDiffInfo,
   hasReactRuntime,
@@ -68,6 +69,7 @@ import {
   resolveProjectChangedLineRanges,
   resolveProjectDiffIncludePaths,
 } from "../utils/resolve-project-diff-include-paths.js";
+import { resolveProjectSourceFilePaths } from "../utils/resolve-project-source-file-paths.js";
 import { runExplain } from "../utils/run-explain.js";
 import { projectManifestChanged } from "../utils/project-manifest-changed.js";
 import { filterScansForSurface } from "../utils/filter-scans-for-surface.js";
@@ -523,6 +525,8 @@ export const inspectAction = async (directory: string, flags: InspectFlags): Pro
         : null;
     // `changed` subtracts pre-existing findings (baseline); `files` / `lines` do not.
     const baselineRef = scope === "changed" ? comparisonBaseRef : null;
+    const baselineDiffPlan =
+      baselineRef === null ? null : await getBaselineDiffPlan(resolvedDirectory, baselineRef);
 
     // `--scope lines`: per-file changed line ranges (repo-relative). Working-tree
     // vs HEAD for uncommitted changes, vs the merge-base otherwise. When no base
@@ -602,6 +606,22 @@ export const inspectAction = async (directory: string, flags: InspectFlags): Pro
 
       let includePaths: string[] | undefined;
       let supplyChainManifestChanged = false;
+      const projectBaselineBaseFiles =
+        baselineDiffPlan === null
+          ? null
+          : resolveProjectSourceFilePaths(
+              resolvedDirectory,
+              scanDirectory,
+              baselineDiffPlan.baseFiles,
+            );
+      const projectBaselineHeadFiles =
+        baselineDiffPlan === null
+          ? null
+          : resolveProjectSourceFilePaths(
+              resolvedDirectory,
+              scanDirectory,
+              baselineDiffPlan.headFiles,
+            );
       if (isDiffMode) {
         const changedSourceFiles =
           diffInfo === null
@@ -614,7 +634,12 @@ export const inspectAction = async (directory: string, flags: InspectFlags): Pro
           supplyChainEnabled &&
           diffInfo !== null &&
           projectManifestChanged(resolvedDirectory, scanDirectory, diffInfo);
-        if (changedSourceFiles.length === 0 && !supplyChainManifestChanged) {
+        const hasBaselineOnlyFiles = (projectBaselineBaseFiles?.length ?? 0) > 0;
+        if (
+          changedSourceFiles.length === 0 &&
+          !supplyChainManifestChanged &&
+          !hasBaselineOnlyFiles
+        ) {
           if (!isQuiet) {
             logger.dim(`No changed source files in ${scanDirectory}, skipping.`);
             logger.break();
@@ -627,6 +652,9 @@ export const inspectAction = async (directory: string, flags: InspectFlags): Pro
         // materialize the base manifest, so the delta filters out pre-existing
         // low-score dependencies instead of reporting them as newly introduced.
         includePaths = [...changedSourceFiles];
+        if (includePaths.length === 0 && hasBaselineOnlyFiles) {
+          includePaths.push(...(projectBaselineBaseFiles ?? []));
+        }
         if (supplyChainManifestChanged) includePaths.push("package.json");
       }
 
@@ -643,7 +671,16 @@ export const inspectAction = async (directory: string, flags: InspectFlags): Pro
         // Pool members overlap; they must not own the process-global Sentry
         // run state (see `InspectOptions.concurrentScan`).
         concurrentScan: isMultiProject,
-        baseline: baselineRef ? { ref: baselineRef } : undefined,
+        baseline:
+          baselineRef !== null &&
+          projectBaselineBaseFiles !== null &&
+          projectBaselineHeadFiles !== null
+            ? {
+                ref: baselineRef,
+                baseFiles: projectBaselineBaseFiles,
+                headFiles: projectBaselineHeadFiles,
+              }
+            : undefined,
         changedLineRanges:
           scope === "lines" && changedLineRanges !== null
             ? resolveProjectChangedLineRanges(resolvedDirectory, scanDirectory, changedLineRanges)

--- a/packages/react-doctor/src/cli/utils/build-run-event.ts
+++ b/packages/react-doctor/src/cli/utils/build-run-event.ts
@@ -445,6 +445,7 @@ const buildOutcomeAttributes = (input: RunEventInput): RunEventAttributes => {
         new: summary.totalDiagnosticCount,
         fixed: result.baselineDelta.fixedCount,
         baseTotal: result.baselineDelta.baseTotalCount,
+        crossFileMatches: result.baselineDelta.crossFileMatchCount ?? null,
         degraded: false,
       }),
     );

--- a/packages/react-doctor/src/cli/utils/is-materializable-git-source.ts
+++ b/packages/react-doctor/src/cli/utils/is-materializable-git-source.ts
@@ -1,0 +1,4 @@
+const GIT_LFS_POINTER_HEADER = "version https://git-lfs.github.com/spec/v1";
+
+export const isMaterializableGitSource = (content: string): boolean =>
+  !content.includes("\0") && !content.startsWith(GIT_LFS_POINTER_HEADER);

--- a/packages/react-doctor/src/cli/utils/materialize-baseline-files.ts
+++ b/packages/react-doctor/src/cli/utils/materialize-baseline-files.ts
@@ -11,6 +11,7 @@ export interface BaselineMaterializedTree extends MaterializedTree {
   readonly baseFiles: ReadonlyArray<string>;
   readonly headFiles: ReadonlyArray<string>;
   readonly isComplete: boolean;
+  readonly untrackedFiles: ReadonlyArray<string>;
 }
 
 /**
@@ -32,12 +33,13 @@ export const materializeBaselineFiles = (input: {
   Effect.runPromise(
     Effect.gen(function* () {
       const git = yield* Git;
-      const diffPlan =
-        input.baseFiles === undefined || input.headFiles === undefined
-          ? yield* git.baselineDiffPlan({ directory: input.directory, ref: input.ref })
-          : null;
+      const diffPlan = yield* git.baselineDiffPlan({
+        directory: input.directory,
+        ref: input.ref,
+      });
       const baseFiles = input.baseFiles ?? diffPlan?.baseFiles;
       const headFiles = input.headFiles ?? diffPlan?.headFiles;
+      const untrackedFiles = diffPlan?.untrackedFiles ?? [];
       if (baseFiles === undefined || headFiles === undefined) return null;
       const files = [...new Set([...input.files, ...baseFiles])];
       const tree = yield* materializeSourceTree({
@@ -64,6 +66,7 @@ export const materializeBaselineFiles = (input: {
         baseFiles,
         headFiles,
         isComplete: baseFiles.every((filePath) => materializedFiles.has(filePath)),
+        untrackedFiles,
       } satisfies BaselineMaterializedTree;
     }).pipe(Effect.provide(Git.layerNode)),
   );

--- a/packages/react-doctor/src/cli/utils/materialize-baseline-files.ts
+++ b/packages/react-doctor/src/cli/utils/materialize-baseline-files.ts
@@ -5,36 +5,66 @@ import {
   type MaterializedTree,
   materializeSourceTree,
 } from "@react-doctor/core";
+import { isMaterializableGitSource } from "./is-materializable-git-source.js";
+
+export interface BaselineMaterializedTree extends MaterializedTree {
+  readonly baseFiles: ReadonlyArray<string>;
+  readonly headFiles: ReadonlyArray<string>;
+  readonly isComplete: boolean;
+}
 
 /**
- * Materializes the `ref` version of `files` into `tempDirectory` (via
- * `git show <ref>:<path>`), mirroring the project layout + head's config files
- * so the base lints under the same rules as head. Reuses the shared,
- * zip-slip-guarded `materializeSourceTree`. Per-file read misses (e.g. a file
- * the PR added, absent at base) are skipped, which is exactly what we want:
- * a brand-new file has no base counterpart, so all its findings are "new".
+ * Materializes the base side of the `ref` → worktree diff into
+ * `tempDirectory`, mirroring the project layout plus head's config files so
+ * both sides lint under the same rules. Git rename heuristics are disabled by
+ * the diff planner, so an old path is retained as a base deletion while its
+ * new path is a head addition. Missing head-only additions are expected;
+ * missing paths that the plan says must exist at base make `isComplete` false.
  */
 export const materializeBaselineFiles = (input: {
   directory: string;
   ref: string;
   files: ReadonlyArray<string>;
+  baseFiles?: ReadonlyArray<string>;
+  headFiles?: ReadonlyArray<string>;
   tempDirectory: string;
-}): Promise<MaterializedTree> =>
+}): Promise<BaselineMaterializedTree | null> =>
   Effect.runPromise(
     Effect.gen(function* () {
       const git = yield* Git;
-      return yield* materializeSourceTree({
+      const diffPlan =
+        input.baseFiles === undefined || input.headFiles === undefined
+          ? yield* git.baselineDiffPlan({ directory: input.directory, ref: input.ref })
+          : null;
+      const baseFiles = input.baseFiles ?? diffPlan?.baseFiles;
+      const headFiles = input.headFiles ?? diffPlan?.headFiles;
+      if (baseFiles === undefined || headFiles === undefined) return null;
+      const files = [...new Set([...input.files, ...baseFiles])];
+      const tree = yield* materializeSourceTree({
         directory: input.directory,
-        files: input.files,
+        files,
         tempDirectory: input.tempDirectory,
         readContent: (relativePath) =>
-          git.showRefContent({
-            directory: input.directory,
-            ref: input.ref,
-            relativePath,
-            options: { maxBufferBytes: GIT_SHOW_MAX_BUFFER_BYTES },
-          }),
+          git
+            .showRefContent({
+              directory: input.directory,
+              ref: input.ref,
+              relativePath,
+              options: { maxBufferBytes: GIT_SHOW_MAX_BUFFER_BYTES },
+            })
+            .pipe(
+              Effect.map((content) =>
+                content !== null && isMaterializableGitSource(content) ? content : null,
+              ),
+            ),
       });
+      const materializedFiles = new Set(tree.materializedFiles);
+      return {
+        ...tree,
+        baseFiles,
+        headFiles,
+        isComplete: baseFiles.every((filePath) => materializedFiles.has(filePath)),
+      } satisfies BaselineMaterializedTree;
     }).pipe(Effect.provide(Git.layerNode)),
   );
 

--- a/packages/react-doctor/src/cli/utils/read-diagnostic-evidence.ts
+++ b/packages/react-doctor/src/cli/utils/read-diagnostic-evidence.ts
@@ -18,6 +18,7 @@ interface SourceRecord {
 interface ComponentDeclaration {
   readonly isDefaultExport: boolean;
   readonly name: string;
+  readonly node: ts.FunctionLikeDeclaration;
   readonly record: SourceRecord;
 }
 
@@ -174,6 +175,7 @@ const findEnclosingComponent = (
         component = {
           isDefaultExport: isDefaultExportedComponent(record, node, name),
           name,
+          node,
           record,
         };
         componentWidth = width;
@@ -380,6 +382,7 @@ const getForwardedHandlerAliases = (
     const tagNames = getComponentTagNames(record, component);
     if (tagNames.size === 0) continue;
     const visit = (node: ts.Node): void => {
+      if (record === component.record && node === component.node) return;
       if (ts.isJsxOpeningElement(node) || ts.isJsxSelfClosingElement(node)) {
         const tagName = getJsxTagName(node);
         if (tagName !== null && tagNames.has(tagName)) {

--- a/packages/react-doctor/src/cli/utils/read-diagnostic-evidence.ts
+++ b/packages/react-doctor/src/cli/utils/read-diagnostic-evidence.ts
@@ -22,6 +22,11 @@ interface ComponentDeclaration {
   readonly record: SourceRecord;
 }
 
+interface BindingCandidate {
+  readonly declaration: ts.Node;
+  readonly scope: ts.Node;
+}
+
 interface DiagnosticEvidenceReaderState {
   readonly aliasesByComponent: Map<string, ReadonlyMap<string, string>>;
   readonly recordByFilePath: Map<string, SourceRecord | null>;
@@ -30,6 +35,8 @@ interface DiagnosticEvidenceReaderState {
 
 const SOURCE_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx", ".mts", ".cts", ".mjs", ".cjs"];
 
+// Core's equivalent AST helpers compile against TypeScript 6 while this package supports
+// TypeScript 5, so these adapters stay local to avoid crossing incompatible node types.
 const getScriptKind = (filePath: string): ts.ScriptKind => {
   const extension = path.extname(filePath).toLowerCase();
   if (extension === ".tsx") return ts.ScriptKind.TSX;
@@ -313,38 +320,89 @@ const getForwardingFunction = (declaration: ts.Declaration): ts.FunctionLikeDecl
   return null;
 };
 
+const getDeclaredBindingName = (node: ts.Node): string | null => {
+  if (
+    (ts.isVariableDeclaration(node) ||
+      ts.isParameter(node) ||
+      ts.isBindingElement(node) ||
+      ts.isFunctionDeclaration(node)) &&
+    node.name !== undefined &&
+    ts.isIdentifier(node.name)
+  ) {
+    return node.name.text;
+  }
+  if (ts.isImportClause(node)) return node.name?.text ?? null;
+  if (ts.isImportSpecifier(node) || ts.isNamespaceImport(node)) return node.name.text;
+  return null;
+};
+
+const findBindingScope = (node: ts.Node): ts.Node => {
+  let currentNode: ts.Node | undefined = node;
+  while (currentNode !== undefined) {
+    if (ts.isParameter(currentNode) && ts.isFunctionLike(currentNode.parent)) {
+      return currentNode.parent;
+    }
+    if (ts.isBlock(currentNode) || ts.isModuleBlock(currentNode) || ts.isSourceFile(currentNode)) {
+      return currentNode;
+    }
+    currentNode = currentNode.parent;
+  }
+  return node.getSourceFile();
+};
+
 const findBindingDeclaration = (
   record: SourceRecord,
-  bindingName: string,
-  usagePosition: number,
+  binding: ts.Identifier,
 ): ts.Declaration | null => {
-  const declarations: ts.Declaration[] = [];
+  const usagePosition = binding.getStart(record.sourceFile);
+  const candidates: BindingCandidate[] = [];
   const visit = (node: ts.Node): void => {
-    if (node.getStart(record.sourceFile) >= usagePosition) return;
-    if (
-      (ts.isVariableDeclaration(node) || ts.isFunctionDeclaration(node)) &&
-      node.name !== undefined &&
-      ts.isIdentifier(node.name) &&
-      node.name.text === bindingName
-    ) {
-      declarations.push(node);
+    if (getDeclaredBindingName(node) === binding.text) {
+      const scope = findBindingScope(node);
+      const isVisibleScope =
+        usagePosition >= scope.getStart(record.sourceFile) && usagePosition <= scope.end;
+      const isVisibleDeclaration =
+        ts.isFunctionDeclaration(node) ||
+        ts.isParameter(node) ||
+        ts.isBindingElement(node) ||
+        ts.isImportClause(node) ||
+        ts.isImportSpecifier(node) ||
+        ts.isNamespaceImport(node) ||
+        node.getStart(record.sourceFile) < usagePosition;
+      if (isVisibleScope && isVisibleDeclaration) {
+        candidates.push({ declaration: node, scope });
+      }
     }
     ts.forEachChild(node, visit);
   };
   visit(record.sourceFile);
-  return declarations.length === 1 ? (declarations[0] ?? null) : null;
+  let nearestCandidate: BindingCandidate | null = null;
+  let nearestScopeWidth = Number.POSITIVE_INFINITY;
+  let isNearestScopeAmbiguous = false;
+  for (const candidate of candidates) {
+    const scopeWidth = candidate.scope.end - candidate.scope.getStart(record.sourceFile);
+    if (scopeWidth < nearestScopeWidth) {
+      nearestCandidate = candidate;
+      nearestScopeWidth = scopeWidth;
+      isNearestScopeAmbiguous = false;
+    } else if (scopeWidth === nearestScopeWidth) {
+      isNearestScopeAmbiguous = true;
+    }
+  }
+  if (isNearestScopeAmbiguous) return null;
+  const declaration = nearestCandidate?.declaration;
+  return declaration !== undefined &&
+    (ts.isVariableDeclaration(declaration) || ts.isFunctionDeclaration(declaration))
+    ? declaration
+    : null;
 };
 
-const resolveHandlerBinding = (
-  record: SourceRecord,
-  bindingName: string,
-  usagePosition: number,
-): string => {
-  const declaration = findBindingDeclaration(record, bindingName, usagePosition);
-  if (declaration === null) return bindingName;
+const resolveHandlerBinding = (record: SourceRecord, binding: ts.Identifier): string => {
+  const declaration = findBindingDeclaration(record, binding);
+  if (declaration === null) return binding.text;
   const forwardingFunction = getForwardingFunction(declaration);
   const target = forwardingFunction === null ? null : resolveTransparentTarget(forwardingFunction);
-  return target === null || target === bindingName ? bindingName : target;
+  return target === null || target === binding.text ? binding.text : target;
 };
 
 const getJsxTagName = (node: ts.JsxOpeningLikeElement): string | null =>
@@ -394,9 +452,7 @@ const getForwardedHandlerAliases = (
               continue;
             }
             const bindings = bindingsByPropName.get(propName) ?? new Set<string>();
-            bindings.add(
-              resolveHandlerBinding(record, binding.text, binding.getStart(record.sourceFile)),
-            );
+            bindings.add(resolveHandlerBinding(record, binding));
             bindingsByPropName.set(propName, bindings);
           }
         }

--- a/packages/react-doctor/src/cli/utils/read-diagnostic-evidence.ts
+++ b/packages/react-doctor/src/cli/utils/read-diagnostic-evidence.ts
@@ -2,126 +2,405 @@ import fs from "node:fs";
 import path from "node:path";
 import { listSourceFiles } from "@react-doctor/core";
 import type { Diagnostic } from "@react-doctor/core";
+import ts from "typescript";
 
 interface CreateDiagnosticEvidenceReaderOptions {
   readonly resolveForwardedHandlers?: boolean;
 }
 
-interface DiagnosticEvidenceReaderState {
-  readonly sourceByFilePath: Map<string, string | null>;
-  readonly aliasesByComponentName: Map<string, ReadonlyMap<string, string>>;
-  componentCallsitePaths: ReadonlyMap<string, ReadonlySet<string>> | null;
+interface SourceRecord {
+  readonly absolutePath: string;
+  readonly filePath: string;
+  readonly sourceFile: ts.SourceFile;
+  readonly sourceText: string;
 }
 
-const readSource = (
-  rootDirectory: string,
-  filePath: string,
-  sourceByFilePath: Map<string, string | null>,
-): string | null => {
-  if (sourceByFilePath.has(filePath)) return sourceByFilePath.get(filePath) ?? null;
+interface ComponentDeclaration {
+  readonly isDefaultExport: boolean;
+  readonly name: string;
+  readonly record: SourceRecord;
+}
+
+interface DiagnosticEvidenceReaderState {
+  readonly aliasesByComponent: Map<string, ReadonlyMap<string, string>>;
+  readonly recordByFilePath: Map<string, SourceRecord | null>;
+  sourceRecords: ReadonlyArray<SourceRecord> | null;
+}
+
+const SOURCE_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx", ".mts", ".cts", ".mjs", ".cjs"];
+
+const getScriptKind = (filePath: string): ts.ScriptKind => {
+  const extension = path.extname(filePath).toLowerCase();
+  if (extension === ".tsx") return ts.ScriptKind.TSX;
+  if (extension === ".jsx") return ts.ScriptKind.JSX;
+  if (extension === ".js" || extension === ".mjs" || extension === ".cjs") {
+    return ts.ScriptKind.JS;
+  }
+  return ts.ScriptKind.TS;
+};
+
+const resolveSafeSourcePath = (rootDirectory: string, filePath: string): string | null => {
   try {
-    const source = fs.readFileSync(path.resolve(rootDirectory, filePath), "utf-8");
-    sourceByFilePath.set(filePath, source);
-    return source;
+    const resolvedRootDirectory = fs.realpathSync(rootDirectory);
+    const absolutePath = path.resolve(resolvedRootDirectory, filePath);
+    const relativePath = path.relative(resolvedRootDirectory, absolutePath);
+    if (
+      relativePath.length === 0 ||
+      relativePath === ".." ||
+      relativePath.startsWith(`..${path.sep}`) ||
+      path.isAbsolute(relativePath)
+    ) {
+      return null;
+    }
+    const stats = fs.lstatSync(absolutePath);
+    if (!stats.isFile() || stats.isSymbolicLink()) return null;
+    const realPath = fs.realpathSync(absolutePath);
+    const realRelativePath = path.relative(resolvedRootDirectory, realPath);
+    return realRelativePath !== ".." &&
+      !realRelativePath.startsWith(`..${path.sep}`) &&
+      !path.isAbsolute(realRelativePath)
+      ? realPath
+      : null;
   } catch {
-    sourceByFilePath.set(filePath, null);
     return null;
   }
 };
 
-const getEnclosingComponentName = (source: string, diagnostic: Diagnostic): string | null => {
-  const sourceBeforeDiagnostic = source
-    .split(/\r?\n/)
-    .slice(0, diagnostic.line - 1)
-    .join("\n");
-  const componentPattern = /\bfunction\s+([A-Z][\w$]*)\b[^{]*\{/g;
-  let componentName: string | null = null;
-  for (const match of sourceBeforeDiagnostic.matchAll(componentPattern)) {
-    const functionSource = sourceBeforeDiagnostic.slice(match.index);
-    const openingBraceCount = functionSource.match(/\{/g)?.length ?? 0;
-    const closingBraceCount = functionSource.match(/\}/g)?.length ?? 0;
-    if (openingBraceCount > closingBraceCount) componentName = match[1] ?? null;
-  }
-  return componentName;
-};
-
-const resolveForwardingCallback = (source: string, bindingName: string): string => {
-  const callbackPattern = new RegExp(
-    `\\bconst\\s+${bindingName}\\s*=\\s*(?:useCallback\\s*\\()?[^=;]*=>\\s*\\{?\\s*(?:return\\s+|void\\s+)?([A-Za-z_$][\\w$]*)\\s*\\(`,
-  );
-  return source.match(callbackPattern)?.[1] ?? bindingName;
-};
-
-const buildComponentCallsitePaths = (
+const readSourceRecord = (
   rootDirectory: string,
-  sourceByFilePath: Map<string, string | null>,
-): ReadonlyMap<string, ReadonlySet<string>> => {
-  const pathsByComponentName = new Map<string, Set<string>>();
-  for (const filePath of listSourceFiles(rootDirectory)) {
-    const source = readSource(rootDirectory, filePath, sourceByFilePath);
-    if (source === null) continue;
-    for (const match of source.matchAll(/<([A-Z][\w$]*)\b/g)) {
-      const componentName = match[1];
-      if (componentName === undefined) continue;
-      const matchingPaths = pathsByComponentName.get(componentName) ?? new Set<string>();
-      matchingPaths.add(filePath);
-      pathsByComponentName.set(componentName, matchingPaths);
-    }
-  }
-  return pathsByComponentName;
-};
-
-const getForwardedHandlerAliases = (
-  rootDirectory: string,
-  source: string,
-  diagnostic: Diagnostic,
+  filePath: string,
   state: DiagnosticEvidenceReaderState,
-): ReadonlyMap<string, string> => {
-  const componentName = getEnclosingComponentName(source, diagnostic);
-  if (componentName === null) return new Map();
-  const cachedAliases = state.aliasesByComponentName.get(componentName);
-  if (cachedAliases !== undefined) return cachedAliases;
+): SourceRecord | null => {
+  const normalizedFilePath = filePath.replace(/\\/g, "/");
+  if (state.recordByFilePath.has(normalizedFilePath)) {
+    return state.recordByFilePath.get(normalizedFilePath) ?? null;
+  }
+  const absolutePath = resolveSafeSourcePath(rootDirectory, normalizedFilePath);
+  if (absolutePath === null) {
+    state.recordByFilePath.set(normalizedFilePath, null);
+    return null;
+  }
+  try {
+    const sourceText = fs.readFileSync(absolutePath, "utf-8");
+    const record = {
+      absolutePath,
+      filePath: normalizedFilePath,
+      sourceFile: ts.createSourceFile(
+        absolutePath,
+        sourceText,
+        ts.ScriptTarget.Latest,
+        true,
+        getScriptKind(absolutePath),
+      ),
+      sourceText,
+    } satisfies SourceRecord;
+    state.recordByFilePath.set(normalizedFilePath, record);
+    return record;
+  } catch {
+    state.recordByFilePath.set(normalizedFilePath, null);
+    return null;
+  }
+};
 
-  state.componentCallsitePaths ??= buildComponentCallsitePaths(
-    rootDirectory,
-    state.sourceByFilePath,
+const listSourceRecords = (
+  rootDirectory: string,
+  state: DiagnosticEvidenceReaderState,
+): ReadonlyArray<SourceRecord> => {
+  if (state.sourceRecords !== null) return state.sourceRecords;
+  state.sourceRecords = listSourceFiles(rootDirectory).flatMap((filePath) => {
+    const record = readSourceRecord(rootDirectory, filePath, state);
+    return record === null ? [] : [record];
+  });
+  return state.sourceRecords;
+};
+
+const getFunctionName = (node: ts.FunctionLikeDeclaration): string | null => {
+  if (ts.isFunctionDeclaration(node) && node.name !== undefined) return node.name.text;
+  if (
+    (ts.isArrowFunction(node) || ts.isFunctionExpression(node)) &&
+    ts.isVariableDeclaration(node.parent) &&
+    ts.isIdentifier(node.parent.name)
+  ) {
+    return node.parent.name.text;
+  }
+  return null;
+};
+
+const isComponentFunction = (node: ts.Node): node is ts.FunctionLikeDeclaration =>
+  ts.isFunctionDeclaration(node) || ts.isFunctionExpression(node) || ts.isArrowFunction(node);
+
+const isDefaultExportedComponent = (
+  record: SourceRecord,
+  node: ts.FunctionLikeDeclaration,
+  componentName: string,
+): boolean => {
+  if (
+    ts.canHaveModifiers(node) &&
+    ts.getModifiers(node)?.some((modifier) => modifier.kind === ts.SyntaxKind.DefaultKeyword)
+  ) {
+    return true;
+  }
+  return record.sourceFile.statements.some(
+    (statement) =>
+      ts.isExportAssignment(statement) &&
+      ts.isIdentifier(statement.expression) &&
+      statement.expression.text === componentName,
   );
-  const bindingsByPropName = new Map<string, Set<string>>();
-  const unresolvedPropNames = new Set<string>();
-  const componentPattern = new RegExp(`<${componentName}\\b[\\s\\S]*?>`, "g");
-  const propPattern = /\b(on[A-Z]\w*)\s*=\s*\{\s*([A-Za-z_$][\w$]*)\s*\}/g;
-  const propNamePattern = /\b(on[A-Z]\w*)\s*=/g;
-  for (const callsitePath of state.componentCallsitePaths.get(componentName) ?? []) {
-    const callsiteSource = readSource(rootDirectory, callsitePath, state.sourceByFilePath);
-    if (callsiteSource === null) continue;
-    for (const componentMatch of callsiteSource.matchAll(componentPattern)) {
-      const componentCallsite = componentMatch[0];
-      const resolvedPropNames = new Set<string>();
-      for (const propMatch of componentCallsite.matchAll(propPattern)) {
-        const propName = propMatch[1];
-        const bindingName = propMatch[2];
-        if (propName === undefined || bindingName === undefined) continue;
-        resolvedPropNames.add(propName);
-        const bindings = bindingsByPropName.get(propName) ?? new Set<string>();
-        bindings.add(resolveForwardingCallback(callsiteSource, bindingName));
-        bindingsByPropName.set(propName, bindings);
+};
+
+const findEnclosingComponent = (
+  record: SourceRecord,
+  diagnostic: Diagnostic,
+): ComponentDeclaration | null => {
+  if (!Number.isInteger(diagnostic.line) || diagnostic.line < 1) return null;
+  const lineIndex = diagnostic.line - 1;
+  if (lineIndex >= record.sourceFile.getLineStarts().length) return null;
+  const diagnosticPosition = record.sourceFile.getPositionOfLineAndCharacter(lineIndex, 0);
+  let component: ComponentDeclaration | null = null;
+  let componentWidth = Number.POSITIVE_INFINITY;
+  const visit = (node: ts.Node): void => {
+    if (diagnosticPosition < node.getStart(record.sourceFile) || diagnosticPosition > node.end) {
+      return;
+    }
+    if (isComponentFunction(node)) {
+      const name = getFunctionName(node);
+      const width = node.end - node.getStart(record.sourceFile);
+      if (name !== null && /^[A-Z]/.test(name) && width < componentWidth) {
+        component = {
+          isDefaultExport: isDefaultExportedComponent(record, node, name),
+          name,
+          record,
+        };
+        componentWidth = width;
       }
-      for (const propNameMatch of componentCallsite.matchAll(propNamePattern)) {
-        const propName = propNameMatch[1];
-        if (propName !== undefined && !resolvedPropNames.has(propName)) {
-          unresolvedPropNames.add(propName);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(record.sourceFile);
+  return component;
+};
+
+const moduleSpecifierTargetsComponent = (
+  callerRecord: SourceRecord,
+  moduleSpecifier: string,
+  componentRecord: SourceRecord,
+): boolean => {
+  if (!moduleSpecifier.startsWith(".")) return false;
+  const unresolvedPath = path.resolve(path.dirname(callerRecord.absolutePath), moduleSpecifier);
+  const candidatePaths = [
+    unresolvedPath,
+    ...SOURCE_EXTENSIONS.map((extension) => `${unresolvedPath}${extension}`),
+    ...SOURCE_EXTENSIONS.map((extension) => path.join(unresolvedPath, `index${extension}`)),
+  ];
+  return candidatePaths.includes(componentRecord.absolutePath);
+};
+
+const getComponentTagNames = (
+  record: SourceRecord,
+  component: ComponentDeclaration,
+): ReadonlySet<string> => {
+  if (record.absolutePath === component.record.absolutePath) return new Set([component.name]);
+  const tagNames = new Set<string>();
+  for (const statement of record.sourceFile.statements) {
+    if (
+      !ts.isImportDeclaration(statement) ||
+      !ts.isStringLiteral(statement.moduleSpecifier) ||
+      !moduleSpecifierTargetsComponent(record, statement.moduleSpecifier.text, component.record)
+    ) {
+      continue;
+    }
+    const importClause = statement.importClause;
+    if (component.isDefaultExport && importClause?.name !== undefined) {
+      tagNames.add(importClause.name.text);
+    }
+    const namedBindings = importClause?.namedBindings;
+    if (namedBindings !== undefined && ts.isNamedImports(namedBindings)) {
+      for (const element of namedBindings.elements) {
+        if ((element.propertyName?.text ?? element.name.text) === component.name) {
+          tagNames.add(element.name.text);
         }
       }
     }
   }
+  return tagNames;
+};
+
+const unwrapExpression = (expression: ts.Expression): ts.Expression => {
+  let currentExpression = expression;
+  while (
+    ts.isParenthesizedExpression(currentExpression) ||
+    ts.isAsExpression(currentExpression) ||
+    ts.isTypeAssertionExpression(currentExpression) ||
+    ts.isNonNullExpression(currentExpression) ||
+    ts.isSatisfiesExpression(currentExpression)
+  ) {
+    currentExpression = currentExpression.expression;
+  }
+  return currentExpression;
+};
+
+const getTransparentCall = (functionNode: ts.FunctionLikeDeclaration): ts.CallExpression | null => {
+  if (functionNode.body === undefined) return null;
+  if (!ts.isBlock(functionNode.body)) {
+    const expression = unwrapExpression(functionNode.body);
+    return ts.isCallExpression(expression) ? expression : null;
+  }
+  if (functionNode.body.statements.length !== 1) return null;
+  const statement = functionNode.body.statements[0];
+  if (statement === undefined) return null;
+  const expression =
+    ts.isExpressionStatement(statement) || ts.isReturnStatement(statement)
+      ? statement.expression
+      : undefined;
+  if (expression === undefined) return null;
+  const unwrappedExpression = unwrapExpression(expression);
+  return ts.isCallExpression(unwrappedExpression) ? unwrappedExpression : null;
+};
+
+const resolveTransparentTarget = (functionNode: ts.FunctionLikeDeclaration): string | null => {
+  const call = getTransparentCall(functionNode);
+  if (call === null) return null;
+  const target = unwrapExpression(call.expression);
+  if (!ts.isIdentifier(target) || call.arguments.length !== functionNode.parameters.length) {
+    return null;
+  }
+  for (const [parameterIndex, parameter] of functionNode.parameters.entries()) {
+    const argument = call.arguments[parameterIndex];
+    const unwrappedArgument = argument === undefined ? null : unwrapExpression(argument);
+    if (
+      !ts.isIdentifier(parameter.name) ||
+      unwrappedArgument === null ||
+      !ts.isIdentifier(unwrappedArgument) ||
+      unwrappedArgument.text !== parameter.name.text
+    ) {
+      return null;
+    }
+  }
+  return target.text;
+};
+
+const getForwardingFunction = (declaration: ts.Declaration): ts.FunctionLikeDeclaration | null => {
+  if (ts.isFunctionDeclaration(declaration)) return declaration;
+  if (!ts.isVariableDeclaration(declaration) || declaration.initializer === undefined) return null;
+  const initializer = unwrapExpression(declaration.initializer);
+  if (ts.isArrowFunction(initializer) || ts.isFunctionExpression(initializer)) return initializer;
+  if (
+    ts.isCallExpression(initializer) &&
+    ts.isIdentifier(initializer.expression) &&
+    initializer.expression.text === "useCallback"
+  ) {
+    const callback = initializer.arguments[0];
+    if (
+      callback !== undefined &&
+      (ts.isArrowFunction(callback) || ts.isFunctionExpression(callback))
+    ) {
+      return callback;
+    }
+  }
+  return null;
+};
+
+const findBindingDeclaration = (
+  record: SourceRecord,
+  bindingName: string,
+  usagePosition: number,
+): ts.Declaration | null => {
+  const declarations: ts.Declaration[] = [];
+  const visit = (node: ts.Node): void => {
+    if (node.getStart(record.sourceFile) >= usagePosition) return;
+    if (
+      (ts.isVariableDeclaration(node) || ts.isFunctionDeclaration(node)) &&
+      node.name !== undefined &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === bindingName
+    ) {
+      declarations.push(node);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(record.sourceFile);
+  return declarations.length === 1 ? (declarations[0] ?? null) : null;
+};
+
+const resolveHandlerBinding = (
+  record: SourceRecord,
+  bindingName: string,
+  usagePosition: number,
+): string => {
+  const declaration = findBindingDeclaration(record, bindingName, usagePosition);
+  if (declaration === null) return bindingName;
+  const forwardingFunction = getForwardingFunction(declaration);
+  const target = forwardingFunction === null ? null : resolveTransparentTarget(forwardingFunction);
+  return target === null || target === bindingName ? bindingName : target;
+};
+
+const getJsxTagName = (node: ts.JsxOpeningLikeElement): string | null =>
+  ts.isIdentifier(node.tagName) ? node.tagName.text : null;
+
+const getHandlerBinding = (
+  node: ts.JsxOpeningLikeElement,
+  propName: string,
+): ts.Identifier | null => {
+  for (const property of node.attributes.properties) {
+    if (!ts.isJsxAttribute(property) || property.name.getText() !== propName) continue;
+    const initializer = property.initializer;
+    if (initializer === undefined || !ts.isJsxExpression(initializer)) return null;
+    return initializer.expression !== undefined && ts.isIdentifier(initializer.expression)
+      ? initializer.expression
+      : null;
+  }
+  return null;
+};
+
+const getForwardedHandlerAliases = (
+  rootDirectory: string,
+  component: ComponentDeclaration,
+  propNames: ReadonlySet<string>,
+  state: DiagnosticEvidenceReaderState,
+): ReadonlyMap<string, string> => {
+  const cacheKey = `${component.record.filePath}\0${component.name}\0${[...propNames].sort().join("\0")}`;
+  const cachedAliases = state.aliasesByComponent.get(cacheKey);
+  if (cachedAliases !== undefined) return cachedAliases;
+
+  const bindingsByPropName = new Map<string, Set<string>>();
+  const unresolvedPropNames = new Set<string>();
+  let callsiteCount = 0;
+  for (const record of listSourceRecords(rootDirectory, state)) {
+    const tagNames = getComponentTagNames(record, component);
+    if (tagNames.size === 0) continue;
+    const visit = (node: ts.Node): void => {
+      if (ts.isJsxOpeningElement(node) || ts.isJsxSelfClosingElement(node)) {
+        const tagName = getJsxTagName(node);
+        if (tagName !== null && tagNames.has(tagName)) {
+          callsiteCount += 1;
+          for (const propName of propNames) {
+            const binding = getHandlerBinding(node, propName);
+            if (binding === null) {
+              unresolvedPropNames.add(propName);
+              continue;
+            }
+            const bindings = bindingsByPropName.get(propName) ?? new Set<string>();
+            bindings.add(
+              resolveHandlerBinding(record, binding.text, binding.getStart(record.sourceFile)),
+            );
+            bindingsByPropName.set(propName, bindings);
+          }
+        }
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(record.sourceFile);
+  }
 
   const aliases = new Map<string, string>();
-  for (const [propName, bindings] of bindingsByPropName) {
-    if (bindings.size !== 1 || unresolvedPropNames.has(propName)) continue;
-    const [bindingName] = bindings;
-    if (bindingName !== undefined) aliases.set(propName, bindingName);
+  if (callsiteCount > 0) {
+    for (const [propName, bindings] of bindingsByPropName) {
+      if (bindings.size !== 1 || unresolvedPropNames.has(propName)) continue;
+      const [bindingName] = bindings;
+      if (bindingName !== undefined) aliases.set(propName, bindingName);
+    }
   }
-  state.aliasesByComponentName.set(componentName, aliases);
+  state.aliasesByComponent.set(cacheKey, aliases);
   return aliases;
 };
 
@@ -143,22 +422,26 @@ export const createDiagnosticEvidenceReader = (
   options: CreateDiagnosticEvidenceReaderOptions = {},
 ): ((diagnostic: Diagnostic) => string | null) => {
   const state: DiagnosticEvidenceReaderState = {
-    sourceByFilePath: new Map(),
-    aliasesByComponentName: new Map(),
-    componentCallsitePaths: null,
+    aliasesByComponent: new Map(),
+    recordByFilePath: new Map(),
+    sourceRecords: null,
   };
 
   return (diagnostic) => {
-    const source = readSource(rootDirectory, diagnostic.filePath, state.sourceByFilePath);
-    if (source === null || !Number.isInteger(diagnostic.line)) return null;
-    const sourceLines = source.split(/\r?\n/);
+    const record = readSourceRecord(rootDirectory, diagnostic.filePath, state);
+    if (record === null || !Number.isInteger(diagnostic.line)) return null;
+    const sourceLines = record.sourceText.split(/\r?\n/);
     const startLineIndex = Math.max(0, diagnostic.line - 1);
     const endLineIndex = Math.max(startLineIndex, (diagnostic.endLine ?? diagnostic.line) - 1);
     const evidence = sourceLines.slice(startLineIndex, endLineIndex + 1).join("\n");
-    if (!options.resolveForwardedHandlers || !/\bon[A-Z]\w*\b/.test(evidence)) return evidence;
+    if (!options.resolveForwardedHandlers) return evidence;
+    const propNames = new Set(evidence.match(/\bon[A-Z]\w*\b/g) ?? []);
+    if (propNames.size === 0) return evidence;
+    const component = findEnclosingComponent(record, diagnostic);
+    if (component === null) return evidence;
     return normalizeForwardedHandlers(
       evidence,
-      getForwardedHandlerAliases(rootDirectory, source, diagnostic, state),
+      getForwardedHandlerAliases(rootDirectory, component, propNames, state),
     );
   };
 };

--- a/packages/react-doctor/src/cli/utils/read-diagnostic-evidence.ts
+++ b/packages/react-doctor/src/cli/utils/read-diagnostic-evidence.ts
@@ -154,8 +154,13 @@ const findEnclosingComponent = (
 ): ComponentDeclaration | null => {
   if (!Number.isInteger(diagnostic.line) || diagnostic.line < 1) return null;
   const lineIndex = diagnostic.line - 1;
-  if (lineIndex >= record.sourceFile.getLineStarts().length) return null;
-  const diagnosticPosition = record.sourceFile.getPositionOfLineAndCharacter(lineIndex, 0);
+  const lineStarts = record.sourceFile.getLineStarts();
+  const lineStart = lineStarts[lineIndex];
+  if (lineStart === undefined) return null;
+  const nextLineStart = lineStarts[lineIndex + 1] ?? record.sourceFile.end;
+  const lineEnd = Math.max(lineStart, nextLineStart - 1);
+  const columnIndex = Number.isInteger(diagnostic.column) ? Math.max(0, diagnostic.column - 1) : 0;
+  const diagnosticPosition = Math.min(lineStart + columnIndex, lineEnd);
   let component: ComponentDeclaration | null = null;
   let componentWidth = Number.POSITIVE_INFINITY;
   const visit = (node: ts.Node): void => {
@@ -187,10 +192,16 @@ const moduleSpecifierTargetsComponent = (
 ): boolean => {
   if (!moduleSpecifier.startsWith(".")) return false;
   const unresolvedPath = path.resolve(path.dirname(callerRecord.absolutePath), moduleSpecifier);
+  const specifiedExtension = path.extname(unresolvedPath).toLowerCase();
+  const sourcePathWithoutExtension = SOURCE_EXTENSIONS.includes(specifiedExtension)
+    ? unresolvedPath.slice(0, -specifiedExtension.length)
+    : unresolvedPath;
   const candidatePaths = [
     unresolvedPath,
-    ...SOURCE_EXTENSIONS.map((extension) => `${unresolvedPath}${extension}`),
-    ...SOURCE_EXTENSIONS.map((extension) => path.join(unresolvedPath, `index${extension}`)),
+    ...SOURCE_EXTENSIONS.map((extension) => `${sourcePathWithoutExtension}${extension}`),
+    ...(sourcePathWithoutExtension === unresolvedPath
+      ? SOURCE_EXTENSIONS.map((extension) => path.join(unresolvedPath, `index${extension}`))
+      : []),
   ];
   return candidatePaths.includes(componentRecord.absolutePath);
 };

--- a/packages/react-doctor/src/cli/utils/read-diagnostic-evidence.ts
+++ b/packages/react-doctor/src/cli/utils/read-diagnostic-evidence.ts
@@ -137,14 +137,15 @@ const unwrapExpression = (expression: ts.Expression): ts.Expression => {
   return currentExpression;
 };
 
+const getCalleeName = (expression: ts.Expression): string | null => {
+  const unwrappedExpression = unwrapExpression(expression);
+  if (ts.isIdentifier(unwrappedExpression)) return unwrappedExpression.text;
+  if (ts.isPropertyAccessExpression(unwrappedExpression)) return unwrappedExpression.name.text;
+  return null;
+};
+
 const isComponentWrapperCall = (node: ts.CallExpression): boolean => {
-  const expression = unwrapExpression(node.expression);
-  let wrapperName: string | null = null;
-  if (ts.isIdentifier(expression)) {
-    wrapperName = expression.text;
-  } else if (ts.isPropertyAccessExpression(expression)) {
-    wrapperName = expression.name.text;
-  }
+  const wrapperName = getCalleeName(node.expression);
   return wrapperName !== null && COMPONENT_WRAPPER_NAMES.has(wrapperName);
 };
 
@@ -337,11 +338,7 @@ const getForwardingFunction = (declaration: ts.Declaration): ts.FunctionLikeDecl
   if (!ts.isVariableDeclaration(declaration) || declaration.initializer === undefined) return null;
   const initializer = unwrapExpression(declaration.initializer);
   if (ts.isArrowFunction(initializer) || ts.isFunctionExpression(initializer)) return initializer;
-  if (
-    ts.isCallExpression(initializer) &&
-    ts.isIdentifier(initializer.expression) &&
-    initializer.expression.text === "useCallback"
-  ) {
+  if (ts.isCallExpression(initializer) && getCalleeName(initializer.expression) === "useCallback") {
     const callback = initializer.arguments[0];
     if (
       callback !== undefined &&
@@ -449,9 +446,9 @@ const getHandlerBinding = (
     if (!ts.isJsxAttribute(property) || property.name.getText() !== propName) continue;
     const initializer = property.initializer;
     if (initializer === undefined || !ts.isJsxExpression(initializer)) return null;
-    return initializer.expression !== undefined && ts.isIdentifier(initializer.expression)
-      ? initializer.expression
-      : null;
+    if (initializer.expression === undefined) return null;
+    const expression = unwrapExpression(initializer.expression);
+    return ts.isIdentifier(expression) ? expression : null;
   }
   return null;
 };

--- a/packages/react-doctor/src/cli/utils/read-diagnostic-evidence.ts
+++ b/packages/react-doctor/src/cli/utils/read-diagnostic-evidence.ts
@@ -1,0 +1,164 @@
+import fs from "node:fs";
+import path from "node:path";
+import { listSourceFiles } from "@react-doctor/core";
+import type { Diagnostic } from "@react-doctor/core";
+
+interface CreateDiagnosticEvidenceReaderOptions {
+  readonly resolveForwardedHandlers?: boolean;
+}
+
+interface DiagnosticEvidenceReaderState {
+  readonly sourceByFilePath: Map<string, string | null>;
+  readonly aliasesByComponentName: Map<string, ReadonlyMap<string, string>>;
+  componentCallsitePaths: ReadonlyMap<string, ReadonlySet<string>> | null;
+}
+
+const readSource = (
+  rootDirectory: string,
+  filePath: string,
+  sourceByFilePath: Map<string, string | null>,
+): string | null => {
+  if (sourceByFilePath.has(filePath)) return sourceByFilePath.get(filePath) ?? null;
+  try {
+    const source = fs.readFileSync(path.resolve(rootDirectory, filePath), "utf-8");
+    sourceByFilePath.set(filePath, source);
+    return source;
+  } catch {
+    sourceByFilePath.set(filePath, null);
+    return null;
+  }
+};
+
+const getEnclosingComponentName = (source: string, diagnostic: Diagnostic): string | null => {
+  const sourceBeforeDiagnostic = source
+    .split(/\r?\n/)
+    .slice(0, diagnostic.line - 1)
+    .join("\n");
+  const componentPattern = /\bfunction\s+([A-Z][\w$]*)\b[^{]*\{/g;
+  let componentName: string | null = null;
+  for (const match of sourceBeforeDiagnostic.matchAll(componentPattern)) {
+    const functionSource = sourceBeforeDiagnostic.slice(match.index);
+    const openingBraceCount = functionSource.match(/\{/g)?.length ?? 0;
+    const closingBraceCount = functionSource.match(/\}/g)?.length ?? 0;
+    if (openingBraceCount > closingBraceCount) componentName = match[1] ?? null;
+  }
+  return componentName;
+};
+
+const resolveForwardingCallback = (source: string, bindingName: string): string => {
+  const callbackPattern = new RegExp(
+    `\\bconst\\s+${bindingName}\\s*=\\s*(?:useCallback\\s*\\()?[^=;]*=>\\s*\\{?\\s*(?:return\\s+|void\\s+)?([A-Za-z_$][\\w$]*)\\s*\\(`,
+  );
+  return source.match(callbackPattern)?.[1] ?? bindingName;
+};
+
+const buildComponentCallsitePaths = (
+  rootDirectory: string,
+  sourceByFilePath: Map<string, string | null>,
+): ReadonlyMap<string, ReadonlySet<string>> => {
+  const pathsByComponentName = new Map<string, Set<string>>();
+  for (const filePath of listSourceFiles(rootDirectory)) {
+    const source = readSource(rootDirectory, filePath, sourceByFilePath);
+    if (source === null) continue;
+    for (const match of source.matchAll(/<([A-Z][\w$]*)\b/g)) {
+      const componentName = match[1];
+      if (componentName === undefined) continue;
+      const matchingPaths = pathsByComponentName.get(componentName) ?? new Set<string>();
+      matchingPaths.add(filePath);
+      pathsByComponentName.set(componentName, matchingPaths);
+    }
+  }
+  return pathsByComponentName;
+};
+
+const getForwardedHandlerAliases = (
+  rootDirectory: string,
+  source: string,
+  diagnostic: Diagnostic,
+  state: DiagnosticEvidenceReaderState,
+): ReadonlyMap<string, string> => {
+  const componentName = getEnclosingComponentName(source, diagnostic);
+  if (componentName === null) return new Map();
+  const cachedAliases = state.aliasesByComponentName.get(componentName);
+  if (cachedAliases !== undefined) return cachedAliases;
+
+  state.componentCallsitePaths ??= buildComponentCallsitePaths(
+    rootDirectory,
+    state.sourceByFilePath,
+  );
+  const bindingsByPropName = new Map<string, Set<string>>();
+  const unresolvedPropNames = new Set<string>();
+  const componentPattern = new RegExp(`<${componentName}\\b[\\s\\S]*?>`, "g");
+  const propPattern = /\b(on[A-Z]\w*)\s*=\s*\{\s*([A-Za-z_$][\w$]*)\s*\}/g;
+  const propNamePattern = /\b(on[A-Z]\w*)\s*=/g;
+  for (const callsitePath of state.componentCallsitePaths.get(componentName) ?? []) {
+    const callsiteSource = readSource(rootDirectory, callsitePath, state.sourceByFilePath);
+    if (callsiteSource === null) continue;
+    for (const componentMatch of callsiteSource.matchAll(componentPattern)) {
+      const componentCallsite = componentMatch[0];
+      const resolvedPropNames = new Set<string>();
+      for (const propMatch of componentCallsite.matchAll(propPattern)) {
+        const propName = propMatch[1];
+        const bindingName = propMatch[2];
+        if (propName === undefined || bindingName === undefined) continue;
+        resolvedPropNames.add(propName);
+        const bindings = bindingsByPropName.get(propName) ?? new Set<string>();
+        bindings.add(resolveForwardingCallback(callsiteSource, bindingName));
+        bindingsByPropName.set(propName, bindings);
+      }
+      for (const propNameMatch of componentCallsite.matchAll(propNamePattern)) {
+        const propName = propNameMatch[1];
+        if (propName !== undefined && !resolvedPropNames.has(propName)) {
+          unresolvedPropNames.add(propName);
+        }
+      }
+    }
+  }
+
+  const aliases = new Map<string, string>();
+  for (const [propName, bindings] of bindingsByPropName) {
+    if (bindings.size !== 1 || unresolvedPropNames.has(propName)) continue;
+    const [bindingName] = bindings;
+    if (bindingName !== undefined) aliases.set(propName, bindingName);
+  }
+  state.aliasesByComponentName.set(componentName, aliases);
+  return aliases;
+};
+
+const normalizeForwardedHandlers = (
+  evidence: string,
+  aliases: ReadonlyMap<string, string>,
+): string => {
+  let normalizedEvidence = evidence;
+  for (const [propName, bindingName] of aliases) {
+    normalizedEvidence = normalizedEvidence
+      .replace(new RegExp(`\\{\\s*${propName}\\s*\\}`, "g"), `{${bindingName}}`)
+      .replace(new RegExp(`=>\\s*${propName}\\s*\\(`, "g"), `=> ${bindingName}(`);
+  }
+  return normalizedEvidence;
+};
+
+export const createDiagnosticEvidenceReader = (
+  rootDirectory: string,
+  options: CreateDiagnosticEvidenceReaderOptions = {},
+): ((diagnostic: Diagnostic) => string | null) => {
+  const state: DiagnosticEvidenceReaderState = {
+    sourceByFilePath: new Map(),
+    aliasesByComponentName: new Map(),
+    componentCallsitePaths: null,
+  };
+
+  return (diagnostic) => {
+    const source = readSource(rootDirectory, diagnostic.filePath, state.sourceByFilePath);
+    if (source === null || !Number.isInteger(diagnostic.line)) return null;
+    const sourceLines = source.split(/\r?\n/);
+    const startLineIndex = Math.max(0, diagnostic.line - 1);
+    const endLineIndex = Math.max(startLineIndex, (diagnostic.endLine ?? diagnostic.line) - 1);
+    const evidence = sourceLines.slice(startLineIndex, endLineIndex + 1).join("\n");
+    if (!options.resolveForwardedHandlers || !/\bon[A-Z]\w*\b/.test(evidence)) return evidence;
+    return normalizeForwardedHandlers(
+      evidence,
+      getForwardedHandlerAliases(rootDirectory, source, diagnostic, state),
+    );
+  };
+};

--- a/packages/react-doctor/src/cli/utils/read-diagnostic-evidence.ts
+++ b/packages/react-doctor/src/cli/utils/read-diagnostic-evidence.ts
@@ -34,6 +34,7 @@ interface DiagnosticEvidenceReaderState {
 }
 
 const SOURCE_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx", ".mts", ".cts", ".mjs", ".cjs"];
+const COMPONENT_WRAPPER_NAMES = new Set(["memo", "forwardRef"]);
 
 // Core's equivalent AST helpers compile against TypeScript 6 while this package supports
 // TypeScript 5, so these adapters stay local to avoid crossing incompatible node types.
@@ -122,14 +123,60 @@ const listSourceRecords = (
   return state.sourceRecords;
 };
 
+const unwrapExpression = (expression: ts.Expression): ts.Expression => {
+  let currentExpression = expression;
+  while (
+    ts.isParenthesizedExpression(currentExpression) ||
+    ts.isAsExpression(currentExpression) ||
+    ts.isTypeAssertionExpression(currentExpression) ||
+    ts.isNonNullExpression(currentExpression) ||
+    ts.isSatisfiesExpression(currentExpression)
+  ) {
+    currentExpression = currentExpression.expression;
+  }
+  return currentExpression;
+};
+
+const isComponentWrapperCall = (node: ts.CallExpression): boolean => {
+  const expression = unwrapExpression(node.expression);
+  let wrapperName: string | null = null;
+  if (ts.isIdentifier(expression)) {
+    wrapperName = expression.text;
+  } else if (ts.isPropertyAccessExpression(expression)) {
+    wrapperName = expression.name.text;
+  }
+  return wrapperName !== null && COMPONENT_WRAPPER_NAMES.has(wrapperName);
+};
+
 const getFunctionName = (node: ts.FunctionLikeDeclaration): string | null => {
   if (ts.isFunctionDeclaration(node) && node.name !== undefined) return node.name.text;
-  if (
-    (ts.isArrowFunction(node) || ts.isFunctionExpression(node)) &&
-    ts.isVariableDeclaration(node.parent) &&
-    ts.isIdentifier(node.parent.name)
-  ) {
-    return node.parent.name.text;
+  if (ts.isArrowFunction(node) || ts.isFunctionExpression(node)) {
+    let componentExpression: ts.Expression = node;
+    while (true) {
+      const parent = componentExpression.parent;
+      if (
+        ts.isParenthesizedExpression(parent) ||
+        ts.isAsExpression(parent) ||
+        ts.isTypeAssertionExpression(parent) ||
+        ts.isNonNullExpression(parent) ||
+        ts.isSatisfiesExpression(parent)
+      ) {
+        componentExpression = parent;
+        continue;
+      }
+      if (
+        ts.isCallExpression(parent) &&
+        parent.arguments[0] === componentExpression &&
+        isComponentWrapperCall(parent)
+      ) {
+        componentExpression = parent;
+        continue;
+      }
+      if (ts.isVariableDeclaration(parent) && ts.isIdentifier(parent.name)) {
+        return parent.name.text;
+      }
+      return node.name?.text ?? null;
+    }
   }
   return null;
 };
@@ -243,20 +290,6 @@ const getComponentTagNames = (
     }
   }
   return tagNames;
-};
-
-const unwrapExpression = (expression: ts.Expression): ts.Expression => {
-  let currentExpression = expression;
-  while (
-    ts.isParenthesizedExpression(currentExpression) ||
-    ts.isAsExpression(currentExpression) ||
-    ts.isTypeAssertionExpression(currentExpression) ||
-    ts.isNonNullExpression(currentExpression) ||
-    ts.isSatisfiesExpression(currentExpression)
-  ) {
-    currentExpression = currentExpression.expression;
-  }
-  return currentExpression;
 };
 
 const getTransparentCall = (functionNode: ts.FunctionLikeDeclaration): ts.CallExpression | null => {

--- a/packages/react-doctor/src/cli/utils/read-source-line.ts
+++ b/packages/react-doctor/src/cli/utils/read-source-line.ts
@@ -2,8 +2,8 @@ import { createNodeReadFileLinesSync } from "@react-doctor/core";
 
 /**
  * Builds a cached `(filePath, line) -> source text` reader rooted at
- * `rootDirectory`, used to fingerprint a diagnostic by the content of its
- * flagged line (see `computeDiagnosticDelta`). Wraps core's
+ * `rootDirectory`, used as the fallback when construct-level diagnostic
+ * evidence cannot be read. Wraps core's
  * `createNodeReadFileLinesSync` with per-file memoization + 1-indexed line
  * lookup; unreadable files / out-of-range lines return `null`.
  */

--- a/packages/react-doctor/src/cli/utils/resolve-project-diff-include-paths.ts
+++ b/packages/react-doctor/src/cli/utils/resolve-project-diff-include-paths.ts
@@ -1,26 +1,14 @@
-import { filterSourceFiles } from "@react-doctor/core";
 import type { ChangedFileLineRanges, DiffInfo } from "@react-doctor/core";
 import { resolveProjectRelativeDirectory } from "./resolve-project-relative-directory.js";
 import { toForwardSlashes } from "./path-format.js";
+import { resolveProjectSourceFilePaths } from "./resolve-project-source-file-paths.js";
 
 export const resolveProjectDiffIncludePaths = (
   rootDirectory: string,
   projectDirectory: string,
   diffInfo: DiffInfo,
 ): string[] => {
-  const relativeProjectDirectory = resolveProjectRelativeDirectory(rootDirectory, projectDirectory);
-  if (relativeProjectDirectory === null) return [];
-
-  const changedSourceFiles = filterSourceFiles(diffInfo.changedFiles);
-  if (relativeProjectDirectory.length === 0) return changedSourceFiles;
-
-  const projectPrefix = `${relativeProjectDirectory}/`;
-  return changedSourceFiles.flatMap((filePath) => {
-    const normalizedFilePath = toForwardSlashes(filePath);
-    if (!normalizedFilePath.startsWith(projectPrefix)) return [];
-    const projectRelativePath = normalizedFilePath.slice(projectPrefix.length);
-    return projectRelativePath.length > 0 ? [projectRelativePath] : [];
-  });
+  return resolveProjectSourceFilePaths(rootDirectory, projectDirectory, diffInfo.changedFiles);
 };
 
 /**

--- a/packages/react-doctor/src/cli/utils/resolve-project-source-file-paths.ts
+++ b/packages/react-doctor/src/cli/utils/resolve-project-source-file-paths.ts
@@ -1,0 +1,23 @@
+import { filterSourceFiles } from "@react-doctor/core";
+import { toForwardSlashes } from "./path-format.js";
+import { resolveProjectRelativeDirectory } from "./resolve-project-relative-directory.js";
+
+export const resolveProjectSourceFilePaths = (
+  rootDirectory: string,
+  projectDirectory: string,
+  filePaths: ReadonlyArray<string>,
+): string[] => {
+  const relativeProjectDirectory = resolveProjectRelativeDirectory(rootDirectory, projectDirectory);
+  if (relativeProjectDirectory === null) return [];
+
+  const sourceFilePaths = filterSourceFiles([...filePaths]);
+  if (relativeProjectDirectory.length === 0) return sourceFilePaths;
+
+  const projectPrefix = `${relativeProjectDirectory}/`;
+  return sourceFilePaths.flatMap((filePath) => {
+    const normalizedFilePath = toForwardSlashes(filePath);
+    if (!normalizedFilePath.startsWith(projectPrefix)) return [];
+    const projectRelativePath = normalizedFilePath.slice(projectPrefix.length);
+    return projectRelativePath.length > 0 ? [projectRelativePath] : [];
+  });
+};

--- a/packages/react-doctor/src/inspect.ts
+++ b/packages/react-doctor/src/inspect.ts
@@ -47,6 +47,7 @@ import { diagnosticIntersectsLineRanges } from "./cli/utils/diagnostic-intersect
 import { makeNoopConsole } from "./cli/utils/noop-console.js";
 import { materializeBaselineFiles } from "./cli/utils/materialize-baseline-files.js";
 import { createSourceLineReader } from "./cli/utils/read-source-line.js";
+import { createDiagnosticEvidenceReader } from "./cli/utils/read-diagnostic-evidence.js";
 import { buildNoScoreMessage } from "./cli/utils/build-no-score-message.js";
 import { printAgentGuidance } from "./cli/utils/render-agent-guidance.js";
 import {
@@ -513,6 +514,10 @@ const runBaselineComparison = async (
       baseDiagnostics: baseOutput.diagnostics,
       readHeadLine: createSourceLineReader(params.directory),
       readBaseLine: createSourceLineReader(snapshot.tempDirectory),
+      readHeadEvidence: createDiagnosticEvidenceReader(params.directory, {
+        resolveForwardedHandlers: true,
+      }),
+      readBaseEvidence: createDiagnosticEvidenceReader(snapshot.tempDirectory),
     });
     return {
       displayDiagnostics: delta.newDiagnostics,
@@ -520,6 +525,7 @@ const runBaselineComparison = async (
         baseRef: params.baselineRef,
         fixedCount: delta.fixedCount,
         baseTotalCount: baseOutput.diagnostics.length,
+        crossFileMatchCount: delta.crossFileMatchCount,
       },
     };
   } finally {

--- a/packages/react-doctor/src/inspect.ts
+++ b/packages/react-doctor/src/inspect.ts
@@ -9,6 +9,7 @@ import {
   computeDiagnosticDelta,
   DEFAULT_SHOW_WARNINGS,
   filterDiagnosticsForSurface,
+  filterSourceFiles,
   highlighter,
   OXLINT_NODE_REQUIREMENT,
   PerFileLintCacheEnabled,
@@ -182,7 +183,11 @@ export interface ResolvedInspectOptions {
   /** Scan time budget in milliseconds, or `null` for no budget. */
   maxDurationMs: number | null;
   /** Baseline ref to subtract (new-only mode), or `null` for a plain scan. */
-  baseline: { ref: string } | null;
+  baseline: {
+    ref: string;
+    baseFiles?: ReadonlyArray<string>;
+    headFiles?: ReadonlyArray<string>;
+  } | null;
   /**
    * `--scope lines`: changed line ranges to restrict reported diagnostics to,
    * or `null` for any other scope. An empty array still filters (a `lines`
@@ -421,6 +426,9 @@ interface RunBaselineComparisonInput {
   headDiagnostics: ReadonlyArray<Diagnostic>;
   resolvedNodeBinaryPath: string | null;
   baselineRef: string;
+  baseFiles?: ReadonlyArray<string>;
+  headFiles?: ReadonlyArray<string>;
+  headAnalyzedFiles: ReadonlyArray<string>;
   /** Shared invocation deadline; bounds the base-ref lint like the head scan. */
   deadlineEpochMs: number | null;
 }
@@ -442,12 +450,30 @@ const runBaselineComparison = async (
     directory: params.directory,
     ref: params.baselineRef,
     files: params.options.includePaths,
+    baseFiles: params.baseFiles,
+    headFiles: params.headFiles,
     tempDirectory,
   }).catch((error: unknown) => {
     rmSync(tempDirectory, { recursive: true, force: true });
     throw error;
   });
+  if (snapshot === null) {
+    rmSync(tempDirectory, { recursive: true, force: true });
+    return null;
+  }
   try {
+    if (!snapshot.isComplete) return null;
+    const analyzedHeadFiles = new Set(params.headAnalyzedFiles);
+    const baseFiles = new Set(snapshot.baseFiles);
+    const expectedHeadFiles = new Set([
+      ...snapshot.headFiles,
+      ...params.options.includePaths.filter((filePath) => !baseFiles.has(filePath)),
+    ]);
+    if (
+      filterSourceFiles([...expectedHeadFiles]).some((filePath) => !analyzedHeadFiles.has(filePath))
+    ) {
+      return null;
+    }
     const baseLayers = buildRuntimeLayers({
       directory: snapshot.tempDirectory,
       hasConfigOverride: true,
@@ -464,7 +490,7 @@ const runBaselineComparison = async (
     const baseProgram = runInspectEffect(
       {
         directory: snapshot.tempDirectory,
-        includePaths: params.options.includePaths,
+        includePaths: snapshot.materializedFiles,
         customRulesOnly: params.options.customRulesOnly,
         respectInlineDisables: params.options.respectInlineDisables,
         warnings: params.options.warnings,
@@ -741,6 +767,9 @@ const runInspectWithRuntime = async (
       headDiagnostics: output.diagnostics,
       resolvedNodeBinaryPath,
       baselineRef: options.baseline.ref,
+      baseFiles: options.baseline.baseFiles,
+      headFiles: options.baseline.headFiles,
+      headAnalyzedFiles: output.analyzedFiles,
       deadlineEpochMs,
     });
     if (comparison) {

--- a/packages/react-doctor/src/inspect.ts
+++ b/packages/react-doctor/src/inspect.ts
@@ -465,8 +465,9 @@ const runBaselineComparison = async (
     if (!snapshot.isComplete) return null;
     const analyzedHeadFiles = new Set(params.headAnalyzedFiles.map(toForwardSlashes));
     const baseFiles = new Set(snapshot.baseFiles.map(toForwardSlashes));
+    const trackedHeadFiles = new Set(snapshot.headFiles.map(toForwardSlashes));
     const expectedHeadFiles = new Set([
-      ...snapshot.headFiles.map(toForwardSlashes),
+      ...trackedHeadFiles,
       ...params.options.includePaths
         .map(toForwardSlashes)
         .filter((filePath) => !baseFiles.has(filePath)),
@@ -537,6 +538,9 @@ const runBaselineComparison = async (
     if (baseOutput.didLintFail || countIncompleteLintFiles(baseOutput.lintPartialFailures) > 0) {
       return null;
     }
+    const hasUnscannedUntrackedSourceFiles = filterSourceFiles(
+      snapshot.untrackedFiles.map(toForwardSlashes),
+    ).some((filePath) => !analyzedHeadFiles.has(filePath));
     const delta = computeDiagnosticDelta({
       headDiagnostics: params.headDiagnostics,
       baseDiagnostics: baseOutput.diagnostics,
@@ -551,7 +555,7 @@ const runBaselineComparison = async (
       displayDiagnostics: delta.newDiagnostics,
       baselineDelta: {
         baseRef: params.baselineRef,
-        fixedCount: delta.fixedCount,
+        fixedCount: hasUnscannedUntrackedSourceFiles ? 0 : delta.fixedCount,
         baseTotalCount: baseOutput.diagnostics.length,
         crossFileMatchCount: delta.crossFileMatchCount,
       },

--- a/packages/react-doctor/src/inspect.ts
+++ b/packages/react-doctor/src/inspect.ts
@@ -466,12 +466,11 @@ const runBaselineComparison = async (
     const analyzedHeadFiles = new Set(params.headAnalyzedFiles.map(toForwardSlashes));
     const baseFiles = new Set(snapshot.baseFiles.map(toForwardSlashes));
     const trackedHeadFiles = new Set(snapshot.headFiles.map(toForwardSlashes));
-    const expectedHeadFiles = new Set([
-      ...trackedHeadFiles,
-      ...params.options.includePaths
-        .map(toForwardSlashes)
-        .filter((filePath) => !baseFiles.has(filePath)),
-    ]);
+    const expectedHeadFiles = new Set(trackedHeadFiles);
+    for (const filePath of params.options.includePaths) {
+      const normalizedFilePath = toForwardSlashes(filePath);
+      if (!baseFiles.has(normalizedFilePath)) expectedHeadFiles.add(normalizedFilePath);
+    }
     if (
       filterSourceFiles([...expectedHeadFiles]).some((filePath) => !analyzedHeadFiles.has(filePath))
     ) {

--- a/packages/react-doctor/src/inspect.ts
+++ b/packages/react-doctor/src/inspect.ts
@@ -463,11 +463,13 @@ const runBaselineComparison = async (
   }
   try {
     if (!snapshot.isComplete) return null;
-    const analyzedHeadFiles = new Set(params.headAnalyzedFiles);
-    const baseFiles = new Set(snapshot.baseFiles);
+    const analyzedHeadFiles = new Set(params.headAnalyzedFiles.map(toForwardSlashes));
+    const baseFiles = new Set(snapshot.baseFiles.map(toForwardSlashes));
     const expectedHeadFiles = new Set([
-      ...snapshot.headFiles,
-      ...params.options.includePaths.filter((filePath) => !baseFiles.has(filePath)),
+      ...snapshot.headFiles.map(toForwardSlashes),
+      ...params.options.includePaths
+        .map(toForwardSlashes)
+        .filter((filePath) => !baseFiles.has(filePath)),
     ]);
     if (
       filterSourceFiles([...expectedHeadFiles]).some((filePath) => !analyzedHeadFiles.has(filePath))

--- a/packages/react-doctor/tests/build-run-event.test.ts
+++ b/packages/react-doctor/tests/build-run-event.test.ts
@@ -455,12 +455,18 @@ describe("buildRunEventAttributes", () => {
   it("emits the baseline delta on a computed baseline run", () => {
     const result = buildResult({
       diagnostics: [buildDiagnostic(), buildDiagnostic({ filePath: "src/B.tsx" })],
-      baselineDelta: { baseRef: "abc1234", fixedCount: 3, baseTotalCount: 7 },
+      baselineDelta: {
+        baseRef: "abc1234",
+        fixedCount: 3,
+        baseTotalCount: 7,
+        crossFileMatchCount: 2,
+      },
     });
     const attributes = buildRunEventAttributes(baseInput({ result, mode: "baseline" }));
     expect(attributes["baseline.new"]).toBe(2);
     expect(attributes["baseline.fixed"]).toBe(3);
     expect(attributes["baseline.baseTotal"]).toBe(7);
+    expect(attributes["baseline.crossFileMatches"]).toBe(2);
     expect(attributes["baseline.degraded"]).toBe(false);
   });
 

--- a/packages/react-doctor/tests/materialize-baseline-files.test.ts
+++ b/packages/react-doctor/tests/materialize-baseline-files.test.ts
@@ -50,6 +50,7 @@ describe("materializeBaselineFiles", () => {
     expect(snapshot?.isComplete).toBe(true);
     expect(snapshot?.baseFiles).toEqual(["src/old-name.tsx"]);
     expect(snapshot?.headFiles).toEqual(["src/new-name.tsx"]);
+    expect(snapshot?.untrackedFiles).toEqual([]);
     expect(snapshot?.materializedFiles).toEqual(["src/old-name.tsx"]);
     expect(fs.readFileSync(path.join(tempDirectory, "src/old-name.tsx"), "utf-8")).toBe(
       "export const value = 1;\n",
@@ -75,6 +76,7 @@ describe("materializeBaselineFiles", () => {
     expect(snapshot?.isComplete).toBe(true);
     expect(snapshot?.baseFiles).toEqual([]);
     expect(snapshot?.headFiles).toEqual(["src/added.tsx"]);
+    expect(snapshot?.untrackedFiles).toEqual([]);
     expect(snapshot?.materializedFiles).toEqual([]);
     expect(snapshot?.unmaterializedFiles).toEqual(["src/added.tsx"]);
     snapshot?.cleanup();

--- a/packages/react-doctor/tests/materialize-baseline-files.test.ts
+++ b/packages/react-doctor/tests/materialize-baseline-files.test.ts
@@ -1,0 +1,105 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+import { materializeBaselineFiles } from "../src/cli/utils/materialize-baseline-files.js";
+
+const runGit = (directory: string, args: ReadonlyArray<string>): string =>
+  execFileSync("git", args, { cwd: directory, encoding: "utf-8" }).trim();
+
+const commitAll = (directory: string, message: string): string => {
+  runGit(directory, ["add", "-A"]);
+  runGit(directory, ["commit", "-m", message]);
+  return runGit(directory, ["rev-parse", "HEAD"]);
+};
+
+describe("materializeBaselineFiles", () => {
+  let directory: string;
+  let tempDirectory: string;
+
+  beforeEach(() => {
+    directory = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-baseline-repo-"));
+    tempDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-baseline-tree-"));
+    runGit(directory, ["init", "--quiet"]);
+    runGit(directory, ["config", "user.email", "react-doctor@example.com"]);
+    runGit(directory, ["config", "user.name", "React Doctor"]);
+  });
+
+  afterEach(() => {
+    fs.rmSync(directory, { recursive: true, force: true });
+    fs.rmSync(tempDirectory, { recursive: true, force: true });
+  });
+
+  it("materializes the old path for a pure rename", async () => {
+    const oldPath = path.join(directory, "src/old-name.tsx");
+    const newPath = path.join(directory, "src/new-name.tsx");
+    fs.mkdirSync(path.dirname(oldPath), { recursive: true });
+    fs.writeFileSync(oldPath, "export const value = 1;\n");
+    const baseRef = commitAll(directory, "base");
+    fs.renameSync(oldPath, newPath);
+    runGit(directory, ["add", "-A"]);
+
+    const snapshot = await materializeBaselineFiles({
+      directory,
+      ref: baseRef,
+      files: ["src/new-name.tsx"],
+      tempDirectory,
+    });
+
+    expect(snapshot?.isComplete).toBe(true);
+    expect(snapshot?.baseFiles).toEqual(["src/old-name.tsx"]);
+    expect(snapshot?.headFiles).toEqual(["src/new-name.tsx"]);
+    expect(snapshot?.materializedFiles).toEqual(["src/old-name.tsx"]);
+    expect(fs.readFileSync(path.join(tempDirectory, "src/old-name.tsx"), "utf-8")).toBe(
+      "export const value = 1;\n",
+    );
+    snapshot?.cleanup();
+  });
+
+  it("does not treat an added head file as an incomplete base snapshot", async () => {
+    runGit(directory, ["commit", "--allow-empty", "-m", "base"]);
+    const baseRef = runGit(directory, ["rev-parse", "HEAD"]);
+    const addedPath = path.join(directory, "src/added.tsx");
+    fs.mkdirSync(path.dirname(addedPath), { recursive: true });
+    fs.writeFileSync(addedPath, "export const value = 1;\n");
+    runGit(directory, ["add", "-A"]);
+
+    const snapshot = await materializeBaselineFiles({
+      directory,
+      ref: baseRef,
+      files: ["src/added.tsx"],
+      tempDirectory,
+    });
+
+    expect(snapshot?.isComplete).toBe(true);
+    expect(snapshot?.baseFiles).toEqual([]);
+    expect(snapshot?.headFiles).toEqual(["src/added.tsx"]);
+    expect(snapshot?.materializedFiles).toEqual([]);
+    expect(snapshot?.unmaterializedFiles).toEqual(["src/added.tsx"]);
+    snapshot?.cleanup();
+  });
+
+  it("degrades when a required base source is an unsmudged Git LFS pointer", async () => {
+    const filePath = "src/tracked.tsx";
+    const absolutePath = path.join(directory, filePath);
+    fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+    fs.writeFileSync(
+      absolutePath,
+      "version https://git-lfs.github.com/spec/v1\noid sha256:0123456789\nsize 10\n",
+    );
+    const baseRef = commitAll(directory, "base");
+    fs.writeFileSync(absolutePath, "export const value = 1;\n");
+
+    const snapshot = await materializeBaselineFiles({
+      directory,
+      ref: baseRef,
+      files: [filePath],
+      tempDirectory,
+    });
+
+    expect(snapshot?.isComplete).toBe(false);
+    expect(snapshot?.unmaterializedFiles).toEqual([filePath]);
+    snapshot?.cleanup();
+  });
+});

--- a/packages/react-doctor/tests/read-diagnostic-evidence.test.ts
+++ b/packages/react-doctor/tests/read-diagnostic-evidence.test.ts
@@ -73,7 +73,7 @@ describe("createDiagnosticEvidenceReader", () => {
     );
     fs.writeFileSync(
       path.join(rootDirectory, "src/chat-message-bubble.tsx"),
-      "export function ChatMessageBubble({ onSuggestion, nested }) {\n  return <>\n    <span onClick={() => onSuggestion(question)}>\n      {question}\n    </span>\n    {nested && <ChatMessageBubble onSuggestion={onSuggestion} nested={false} />}\n  </>\n}\n",
+      "export function ChatMessageBubble({ onSuggestion, nested }) {\n  const nestedBubble = nested ? <ChatMessageBubble onSuggestion={onSuggestion} nested={false} /> : null;\n  return <span onClick={() => onSuggestion(question)}>\n    {question}\n  </span>\n}\n",
     );
     fs.writeFileSync(
       path.join(rootDirectory, "src/chat-page.tsx"),

--- a/packages/react-doctor/tests/read-diagnostic-evidence.test.ts
+++ b/packages/react-doctor/tests/read-diagnostic-evidence.test.ts
@@ -1,0 +1,131 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { computeDiagnosticDelta } from "@react-doctor/core";
+import type { Diagnostic } from "@react-doctor/core";
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+import { createDiagnosticEvidenceReader } from "../src/cli/utils/read-diagnostic-evidence.js";
+
+const makeDiagnostic = (overrides: Partial<Diagnostic> = {}): Diagnostic => ({
+  filePath: "src/wrapper-before.tsx",
+  plugin: "react-doctor",
+  rule: "click-events-have-key-events",
+  severity: "error",
+  title: "Click handler missing keyboard handler",
+  message: "A click handler needs a keyboard handler.",
+  help: "Add a keyboard handler.",
+  line: 1,
+  column: 1,
+  endLine: 3,
+  category: "Accessibility",
+  matchByOccurrence: true,
+  ...overrides,
+});
+
+describe("createDiagnosticEvidenceReader", () => {
+  let rootDirectory: string;
+
+  beforeEach(() => {
+    rootDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-evidence-"));
+    fs.mkdirSync(path.join(rootDirectory, "src"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(rootDirectory, { recursive: true, force: true });
+  });
+
+  it("matches a handler moved behind one unambiguous forwarded prop", () => {
+    fs.writeFileSync(
+      path.join(rootDirectory, "src/wrapper-before.tsx"),
+      "function WrapperBefore() {\n  return <span onClick={() => handleSendMessage(question)}>\n    {question}\n  </span>\n}\n",
+    );
+    fs.writeFileSync(
+      path.join(rootDirectory, "src/chat-message-bubble.tsx"),
+      "function ChatMessageBubble({ onSuggestion }) {\n  return <span onClick={() => onSuggestion(question)}>\n    {question}\n  </span>\n}\n",
+    );
+    fs.writeFileSync(
+      path.join(rootDirectory, "src/chat-page.tsx"),
+      "const handleSuggestion = useCallback((text) => {\n  handleSendMessage(text);\n}, [handleSendMessage]);\n<ChatMessageBubble onSuggestion={handleSuggestion} />;\n",
+    );
+
+    const delta = computeDiagnosticDelta({
+      headDiagnostics: [
+        makeDiagnostic({ filePath: "src/chat-message-bubble.tsx", line: 2, endLine: 4 }),
+      ],
+      baseDiagnostics: [makeDiagnostic({ line: 2, endLine: 4 })],
+      readHeadLine: () => null,
+      readBaseLine: () => null,
+      readHeadEvidence: createDiagnosticEvidenceReader(rootDirectory, {
+        resolveForwardedHandlers: true,
+      }),
+      readBaseEvidence: createDiagnosticEvidenceReader(rootDirectory),
+    });
+
+    expect(delta.newDiagnostics).toHaveLength(0);
+    expect(delta.fixedCount).toBe(0);
+    expect(delta.crossFileMatchCount).toBe(1);
+  });
+
+  it("refuses to equate a forwarded prop with ambiguous callsite bindings", () => {
+    fs.writeFileSync(
+      path.join(rootDirectory, "src/wrapper-before.tsx"),
+      "function WrapperBefore() {\n  return <span onClick={() => handleSendMessage(question)}>\n    {question}\n  </span>\n}\n",
+    );
+    fs.writeFileSync(
+      path.join(rootDirectory, "src/chat-message-bubble.tsx"),
+      "function ChatMessageBubble({ onSuggestion }) {\n  return <span onClick={() => onSuggestion(question)}>\n    {question}\n  </span>\n}\n",
+    );
+    fs.writeFileSync(
+      path.join(rootDirectory, "src/chat-page.tsx"),
+      "<ChatMessageBubble onSuggestion={handleSendMessage} />;\n<ChatMessageBubble onSuggestion={discardMessage} />;\n",
+    );
+
+    const delta = computeDiagnosticDelta({
+      headDiagnostics: [
+        makeDiagnostic({ filePath: "src/chat-message-bubble.tsx", line: 2, endLine: 4 }),
+      ],
+      baseDiagnostics: [makeDiagnostic({ line: 2, endLine: 4 })],
+      readHeadLine: () => null,
+      readBaseLine: () => null,
+      readHeadEvidence: createDiagnosticEvidenceReader(rootDirectory, {
+        resolveForwardedHandlers: true,
+      }),
+      readBaseEvidence: createDiagnosticEvidenceReader(rootDirectory),
+    });
+
+    expect(delta.newDiagnostics).toHaveLength(1);
+    expect(delta.fixedCount).toBe(1);
+    expect(delta.crossFileMatchCount).toBe(0);
+  });
+
+  it("refuses to equate a forwarded prop when a callsite binding is unresolved", () => {
+    fs.writeFileSync(
+      path.join(rootDirectory, "src/wrapper-before.tsx"),
+      "function WrapperBefore() {\n  return <span onClick={() => handleSendMessage(question)}>\n    {question}\n  </span>\n}\n",
+    );
+    fs.writeFileSync(
+      path.join(rootDirectory, "src/chat-message-bubble.tsx"),
+      "function ChatMessageBubble({ onSuggestion }) {\n  return <span onClick={() => onSuggestion(question)}>\n    {question}\n  </span>\n}\n",
+    );
+    fs.writeFileSync(
+      path.join(rootDirectory, "src/chat-page.tsx"),
+      "<ChatMessageBubble onSuggestion={handleSendMessage} />;\n<ChatMessageBubble onSuggestion={() => discardMessage()} />;\n",
+    );
+
+    const delta = computeDiagnosticDelta({
+      headDiagnostics: [
+        makeDiagnostic({ filePath: "src/chat-message-bubble.tsx", line: 2, endLine: 4 }),
+      ],
+      baseDiagnostics: [makeDiagnostic({ line: 2, endLine: 4 })],
+      readHeadLine: () => null,
+      readBaseLine: () => null,
+      readHeadEvidence: createDiagnosticEvidenceReader(rootDirectory, {
+        resolveForwardedHandlers: true,
+      }),
+      readBaseEvidence: createDiagnosticEvidenceReader(rootDirectory),
+    });
+
+    expect(delta.newDiagnostics).toHaveLength(1);
+    expect(delta.fixedCount).toBe(1);
+  });
+});

--- a/packages/react-doctor/tests/read-diagnostic-evidence.test.ts
+++ b/packages/react-doctor/tests/read-diagnostic-evidence.test.ts
@@ -41,11 +41,11 @@ describe("createDiagnosticEvidenceReader", () => {
     );
     fs.writeFileSync(
       path.join(rootDirectory, "src/chat-message-bubble.tsx"),
-      "function ChatMessageBubble({ onSuggestion }) {\n  return <span onClick={() => onSuggestion(question)}>\n    {question}\n  </span>\n}\n",
+      "export function ChatMessageBubble({ onSuggestion }) {\n  return <span onClick={() => onSuggestion(question)}>\n    {question}\n  </span>\n}\n",
     );
     fs.writeFileSync(
       path.join(rootDirectory, "src/chat-page.tsx"),
-      "const handleSuggestion = useCallback((text) => {\n  handleSendMessage(text);\n}, [handleSendMessage]);\n<ChatMessageBubble onSuggestion={handleSuggestion} />;\n",
+      'import { ChatMessageBubble } from "./chat-message-bubble";\nconst handleSuggestion = useCallback((text) => {\n  handleSendMessage(text);\n}, [handleSendMessage]);\n<ChatMessageBubble onSuggestion={handleSuggestion} />;\n',
     );
 
     const delta = computeDiagnosticDelta({
@@ -66,6 +66,67 @@ describe("createDiagnosticEvidenceReader", () => {
     expect(delta.crossFileMatchCount).toBe(1);
   });
 
+  it("resolves a default-exported arrow component through an aliased import", () => {
+    fs.writeFileSync(
+      path.join(rootDirectory, "src/wrapper-before.tsx"),
+      "function WrapperBefore() {\n  return <span onClick={() => handleSendMessage(question)}>\n    {question}\n  </span>\n}\n",
+    );
+    fs.writeFileSync(
+      path.join(rootDirectory, "src/chat-message-bubble.tsx"),
+      "const ChatMessageBubble = ({ onSuggestion }) => {\n  return <span onClick={() => onSuggestion(question)}>\n    {question}\n  </span>\n};\nexport default ChatMessageBubble;\n",
+    );
+    fs.writeFileSync(
+      path.join(rootDirectory, "src/chat-page.tsx"),
+      'import Bubble from "./chat-message-bubble";\n<Bubble onSuggestion={handleSendMessage} />;\n',
+    );
+
+    const delta = computeDiagnosticDelta({
+      headDiagnostics: [
+        makeDiagnostic({ filePath: "src/chat-message-bubble.tsx", line: 2, endLine: 4 }),
+      ],
+      baseDiagnostics: [makeDiagnostic({ line: 2, endLine: 4 })],
+      readHeadLine: () => null,
+      readBaseLine: () => null,
+      readHeadEvidence: createDiagnosticEvidenceReader(rootDirectory, {
+        resolveForwardedHandlers: true,
+      }),
+      readBaseEvidence: createDiagnosticEvidenceReader(rootDirectory),
+    });
+
+    expect(delta.newDiagnostics).toHaveLength(0);
+    expect(delta.crossFileMatchCount).toBe(1);
+  });
+
+  it("does not treat a default import as a named diagnosed component", () => {
+    fs.writeFileSync(
+      path.join(rootDirectory, "src/wrapper-before.tsx"),
+      "function WrapperBefore() {\n  return <span onClick={() => handleSendMessage(question)}>\n    {question}\n  </span>\n}\n",
+    );
+    fs.writeFileSync(
+      path.join(rootDirectory, "src/chat-message-bubble.tsx"),
+      "export default function OtherBubble() { return null; }\nexport function ChatMessageBubble({ onSuggestion }) {\n  return <span onClick={() => onSuggestion(question)}>\n    {question}\n  </span>\n}\n",
+    );
+    fs.writeFileSync(
+      path.join(rootDirectory, "src/chat-page.tsx"),
+      'import Bubble from "./chat-message-bubble";\n<Bubble onSuggestion={handleSendMessage} />;\n',
+    );
+
+    const delta = computeDiagnosticDelta({
+      headDiagnostics: [
+        makeDiagnostic({ filePath: "src/chat-message-bubble.tsx", line: 3, endLine: 5 }),
+      ],
+      baseDiagnostics: [makeDiagnostic({ line: 2, endLine: 4 })],
+      readHeadLine: () => null,
+      readBaseLine: () => null,
+      readHeadEvidence: createDiagnosticEvidenceReader(rootDirectory, {
+        resolveForwardedHandlers: true,
+      }),
+      readBaseEvidence: createDiagnosticEvidenceReader(rootDirectory),
+    });
+
+    expect(delta.newDiagnostics).toHaveLength(1);
+  });
+
   it("refuses to equate a forwarded prop with ambiguous callsite bindings", () => {
     fs.writeFileSync(
       path.join(rootDirectory, "src/wrapper-before.tsx"),
@@ -73,11 +134,11 @@ describe("createDiagnosticEvidenceReader", () => {
     );
     fs.writeFileSync(
       path.join(rootDirectory, "src/chat-message-bubble.tsx"),
-      "function ChatMessageBubble({ onSuggestion }) {\n  return <span onClick={() => onSuggestion(question)}>\n    {question}\n  </span>\n}\n",
+      "export function ChatMessageBubble({ onSuggestion }) {\n  return <span onClick={() => onSuggestion(question)}>\n    {question}\n  </span>\n}\n",
     );
     fs.writeFileSync(
       path.join(rootDirectory, "src/chat-page.tsx"),
-      "<ChatMessageBubble onSuggestion={handleSendMessage} />;\n<ChatMessageBubble onSuggestion={discardMessage} />;\n",
+      'import { ChatMessageBubble } from "./chat-message-bubble";\n<ChatMessageBubble onSuggestion={handleSendMessage} />;\n<ChatMessageBubble onSuggestion={discardMessage} />;\n',
     );
 
     const delta = computeDiagnosticDelta({
@@ -105,11 +166,11 @@ describe("createDiagnosticEvidenceReader", () => {
     );
     fs.writeFileSync(
       path.join(rootDirectory, "src/chat-message-bubble.tsx"),
-      "function ChatMessageBubble({ onSuggestion }) {\n  return <span onClick={() => onSuggestion(question)}>\n    {question}\n  </span>\n}\n",
+      "export function ChatMessageBubble({ onSuggestion }) {\n  return <span onClick={() => onSuggestion(question)}>\n    {question}\n  </span>\n}\n",
     );
     fs.writeFileSync(
       path.join(rootDirectory, "src/chat-page.tsx"),
-      "<ChatMessageBubble onSuggestion={handleSendMessage} />;\n<ChatMessageBubble onSuggestion={() => discardMessage()} />;\n",
+      'import { ChatMessageBubble } from "./chat-message-bubble";\n<ChatMessageBubble onSuggestion={handleSendMessage} />;\n<ChatMessageBubble onSuggestion={() => discardMessage()} />;\n',
     );
 
     const delta = computeDiagnosticDelta({
@@ -127,5 +188,107 @@ describe("createDiagnosticEvidenceReader", () => {
 
     expect(delta.newDiagnostics).toHaveLength(1);
     expect(delta.fixedCount).toBe(1);
+  });
+
+  it("ignores same-named components that do not import the diagnosed component", () => {
+    fs.writeFileSync(
+      path.join(rootDirectory, "src/wrapper-before.tsx"),
+      "function WrapperBefore() {\n  return <span onClick={() => handleSendMessage(question)}>\n    {question}\n  </span>\n}\n",
+    );
+    fs.writeFileSync(
+      path.join(rootDirectory, "src/chat-message-bubble.tsx"),
+      "export function ChatMessageBubble({ onSuggestion }) {\n  return <span onClick={() => onSuggestion(question)}>\n    {question}\n  </span>\n}\n",
+    );
+    fs.writeFileSync(
+      path.join(rootDirectory, "src/chat-page.tsx"),
+      'import { ChatMessageBubble } from "./chat-message-bubble";\n<ChatMessageBubble onSuggestion={handleSendMessage} />;\n',
+    );
+    fs.writeFileSync(
+      path.join(rootDirectory, "src/unrelated.tsx"),
+      "const ChatMessageBubble = ({ onSuggestion }) => null;\n<ChatMessageBubble onSuggestion={discardMessage} />;\n",
+    );
+
+    const delta = computeDiagnosticDelta({
+      headDiagnostics: [
+        makeDiagnostic({ filePath: "src/chat-message-bubble.tsx", line: 2, endLine: 4 }),
+      ],
+      baseDiagnostics: [makeDiagnostic({ line: 2, endLine: 4 })],
+      readHeadLine: () => null,
+      readBaseLine: () => null,
+      readHeadEvidence: createDiagnosticEvidenceReader(rootDirectory, {
+        resolveForwardedHandlers: true,
+      }),
+      readBaseEvidence: createDiagnosticEvidenceReader(rootDirectory),
+    });
+
+    expect(delta.newDiagnostics).toHaveLength(0);
+    expect(delta.crossFileMatchCount).toBe(1);
+  });
+
+  it("rejects a wrapper that changes forwarded arguments", () => {
+    fs.writeFileSync(
+      path.join(rootDirectory, "src/wrapper-before.tsx"),
+      "function WrapperBefore() {\n  return <span onClick={() => handleSendMessage(question)}>\n    {question}\n  </span>\n}\n",
+    );
+    fs.writeFileSync(
+      path.join(rootDirectory, "src/chat-message-bubble.tsx"),
+      "export function ChatMessageBubble({ onSuggestion }) {\n  return <span onClick={() => onSuggestion(question)}>\n    {question}\n  </span>\n}\n",
+    );
+    fs.writeFileSync(
+      path.join(rootDirectory, "src/chat-page.tsx"),
+      'import { ChatMessageBubble } from "./chat-message-bubble";\nconst handleSuggestion = (text) => handleSendMessage(text.trim());\n<ChatMessageBubble onSuggestion={handleSuggestion} />;\n',
+    );
+
+    const delta = computeDiagnosticDelta({
+      headDiagnostics: [
+        makeDiagnostic({ filePath: "src/chat-message-bubble.tsx", line: 2, endLine: 4 }),
+      ],
+      baseDiagnostics: [makeDiagnostic({ line: 2, endLine: 4 })],
+      readHeadLine: () => null,
+      readBaseLine: () => null,
+      readHeadEvidence: createDiagnosticEvidenceReader(rootDirectory, {
+        resolveForwardedHandlers: true,
+      }),
+      readBaseEvidence: createDiagnosticEvidenceReader(rootDirectory),
+    });
+
+    expect(delta.newDiagnostics).toHaveLength(1);
+  });
+
+  it("does not read diagnostic paths outside the project", () => {
+    const outsideDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-outside-"));
+    const outsidePath = path.join(outsideDirectory, "outside.tsx");
+    fs.writeFileSync(outsidePath, "const secret = 'not evidence';\n");
+    const reader = createDiagnosticEvidenceReader(rootDirectory);
+
+    expect(reader(makeDiagnostic({ filePath: outsidePath }))).toBeNull();
+
+    fs.rmSync(outsideDirectory, { recursive: true, force: true });
+  });
+
+  it("does not follow diagnostic symlinks", () => {
+    const outsideDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-outside-"));
+    const outsidePath = path.join(outsideDirectory, "outside.tsx");
+    fs.writeFileSync(outsidePath, "const secret = 'not evidence';\n");
+    fs.symlinkSync(outsidePath, path.join(rootDirectory, "src/linked.tsx"));
+    const reader = createDiagnosticEvidenceReader(rootDirectory);
+
+    expect(reader(makeDiagnostic({ filePath: "src/linked.tsx" }))).toBeNull();
+
+    fs.rmSync(outsideDirectory, { recursive: true, force: true });
+  });
+
+  it("does not follow ancestor symlinks outside the project", () => {
+    const outsideDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-outside-"));
+    fs.writeFileSync(
+      path.join(outsideDirectory, "outside.tsx"),
+      "const secret = 'not evidence';\n",
+    );
+    fs.symlinkSync(outsideDirectory, path.join(rootDirectory, "src/linked-directory"));
+    const reader = createDiagnosticEvidenceReader(rootDirectory);
+
+    expect(reader(makeDiagnostic({ filePath: "src/linked-directory/outside.tsx" }))).toBeNull();
+
+    fs.rmSync(outsideDirectory, { recursive: true, force: true });
   });
 });

--- a/packages/react-doctor/tests/read-diagnostic-evidence.test.ts
+++ b/packages/react-doctor/tests/read-diagnostic-evidence.test.ts
@@ -97,6 +97,61 @@ describe("createDiagnosticEvidenceReader", () => {
     expect(delta.crossFileMatchCount).toBe(1);
   });
 
+  it("uses the diagnostic column to find a single-line arrow component", () => {
+    const componentSource =
+      "export const ChatMessageBubble = ({ onSuggestion }) => <span onClick={() => onSuggestion(question)}>{question}</span>;\n";
+    fs.writeFileSync(path.join(rootDirectory, "src/chat-message-bubble.tsx"), componentSource);
+    fs.writeFileSync(
+      path.join(rootDirectory, "src/chat-page.tsx"),
+      'import { ChatMessageBubble } from "./chat-message-bubble";\n<ChatMessageBubble onSuggestion={handleSendMessage} />;\n',
+    );
+    const reader = createDiagnosticEvidenceReader(rootDirectory, {
+      resolveForwardedHandlers: true,
+    });
+
+    const evidence = reader(
+      makeDiagnostic({
+        filePath: "src/chat-message-bubble.tsx",
+        line: 1,
+        column: componentSource.indexOf("<span") + 1,
+        endLine: 1,
+      }),
+    );
+
+    expect(evidence).toContain("handleSendMessage(question)");
+  });
+
+  it("resolves a JavaScript import specifier to its TypeScript source", () => {
+    fs.writeFileSync(
+      path.join(rootDirectory, "src/wrapper-before.tsx"),
+      "function WrapperBefore() {\n  return <span onClick={() => handleSendMessage(question)}>\n    {question}\n  </span>\n}\n",
+    );
+    fs.writeFileSync(
+      path.join(rootDirectory, "src/chat-message-bubble.tsx"),
+      "export function ChatMessageBubble({ onSuggestion }) {\n  return <span onClick={() => onSuggestion(question)}>\n    {question}\n  </span>\n}\n",
+    );
+    fs.writeFileSync(
+      path.join(rootDirectory, "src/chat-page.tsx"),
+      'import { ChatMessageBubble } from "./chat-message-bubble.js";\n<ChatMessageBubble onSuggestion={handleSendMessage} />;\n',
+    );
+
+    const delta = computeDiagnosticDelta({
+      headDiagnostics: [
+        makeDiagnostic({ filePath: "src/chat-message-bubble.tsx", line: 2, endLine: 4 }),
+      ],
+      baseDiagnostics: [makeDiagnostic({ line: 2, endLine: 4 })],
+      readHeadLine: () => null,
+      readBaseLine: () => null,
+      readHeadEvidence: createDiagnosticEvidenceReader(rootDirectory, {
+        resolveForwardedHandlers: true,
+      }),
+      readBaseEvidence: createDiagnosticEvidenceReader(rootDirectory),
+    });
+
+    expect(delta.newDiagnostics).toHaveLength(0);
+    expect(delta.crossFileMatchCount).toBe(1);
+  });
+
   it("does not treat a default import as a named diagnosed component", () => {
     fs.writeFileSync(
       path.join(rootDirectory, "src/wrapper-before.tsx"),

--- a/packages/react-doctor/tests/read-diagnostic-evidence.test.ts
+++ b/packages/react-doctor/tests/read-diagnostic-evidence.test.ts
@@ -214,6 +214,93 @@ describe("createDiagnosticEvidenceReader", () => {
     expect(delta.newDiagnostics).toHaveLength(1);
   });
 
+  it("ignores same-named bindings in sibling lexical scopes", () => {
+    fs.writeFileSync(
+      path.join(rootDirectory, "src/wrapper-before.tsx"),
+      "function WrapperBefore() {\n  return <span onClick={() => handleSendMessage(question)}>\n    {question}\n  </span>\n}\n",
+    );
+    fs.writeFileSync(
+      path.join(rootDirectory, "src/chat-message-bubble.tsx"),
+      "export function ChatMessageBubble({ onSuggestion }) {\n  return <span onClick={() => onSuggestion(question)}>\n    {question}\n  </span>\n}\n",
+    );
+    fs.writeFileSync(
+      path.join(rootDirectory, "src/chat-page.tsx"),
+      'import { ChatMessageBubble } from "./chat-message-bubble";\nconst handleSuggestion = (text) => handleSendMessage(text);\nfunction Sibling() {\n  const handleSuggestion = (text) => discardMessage(text);\n  return null;\n}\n<ChatMessageBubble onSuggestion={handleSuggestion} />;\n',
+    );
+
+    const delta = computeDiagnosticDelta({
+      headDiagnostics: [
+        makeDiagnostic({ filePath: "src/chat-message-bubble.tsx", line: 2, endLine: 4 }),
+      ],
+      baseDiagnostics: [makeDiagnostic({ line: 2, endLine: 4 })],
+      readHeadLine: () => null,
+      readBaseLine: () => null,
+      readHeadEvidence: createDiagnosticEvidenceReader(rootDirectory, {
+        resolveForwardedHandlers: true,
+      }),
+      readBaseEvidence: createDiagnosticEvidenceReader(rootDirectory),
+    });
+
+    expect(delta.newDiagnostics).toHaveLength(0);
+    expect(delta.crossFileMatchCount).toBe(1);
+  });
+
+  it("does not resolve through an outer binding shadowed by a parameter", () => {
+    fs.writeFileSync(
+      path.join(rootDirectory, "src/wrapper-before.tsx"),
+      "function WrapperBefore() {\n  return <span onClick={() => handleSendMessage(question)}>\n    {question}\n  </span>\n}\n",
+    );
+    fs.writeFileSync(
+      path.join(rootDirectory, "src/chat-message-bubble.tsx"),
+      "export function ChatMessageBubble({ onSuggestion }) {\n  return <span onClick={() => onSuggestion(question)}>\n    {question}\n  </span>\n}\n",
+    );
+    fs.writeFileSync(
+      path.join(rootDirectory, "src/chat-page.tsx"),
+      'import { ChatMessageBubble } from "./chat-message-bubble";\nconst handleSuggestion = (text) => handleSendMessage(text);\nfunction ChatPage({ handleSuggestion }) {\n  return <ChatMessageBubble onSuggestion={handleSuggestion} />;\n}\n',
+    );
+
+    const delta = computeDiagnosticDelta({
+      headDiagnostics: [
+        makeDiagnostic({ filePath: "src/chat-message-bubble.tsx", line: 2, endLine: 4 }),
+      ],
+      baseDiagnostics: [makeDiagnostic({ line: 2, endLine: 4 })],
+      readHeadLine: () => null,
+      readBaseLine: () => null,
+      readHeadEvidence: createDiagnosticEvidenceReader(rootDirectory, {
+        resolveForwardedHandlers: true,
+      }),
+      readBaseEvidence: createDiagnosticEvidenceReader(rootDirectory),
+    });
+
+    expect(delta.newDiagnostics).toHaveLength(1);
+    expect(delta.fixedCount).toBe(1);
+  });
+
+  it("treats imported handlers as opaque lexical bindings", () => {
+    fs.writeFileSync(
+      path.join(rootDirectory, "src/chat-message-bubble.tsx"),
+      "export function ChatMessageBubble({ onSuggestion }) {\n  return <span onClick={() => onSuggestion(question)}>\n    {question}\n  </span>\n}\n",
+    );
+    fs.writeFileSync(
+      path.join(rootDirectory, "src/handlers.ts"),
+      "export const handleSuggestion = (text) => handleSendMessage(text);\n",
+    );
+    fs.writeFileSync(
+      path.join(rootDirectory, "src/chat-page.tsx"),
+      'import { ChatMessageBubble } from "./chat-message-bubble";\nimport { handleSuggestion } from "./handlers";\nfunction Sibling() {\n  const handleSuggestion = (text) => discardMessage(text);\n  return null;\n}\n<ChatMessageBubble onSuggestion={handleSuggestion} />;\n',
+    );
+    const reader = createDiagnosticEvidenceReader(rootDirectory, {
+      resolveForwardedHandlers: true,
+    });
+
+    const evidence = reader(
+      makeDiagnostic({ filePath: "src/chat-message-bubble.tsx", line: 2, endLine: 4 }),
+    );
+
+    expect(evidence).toContain("handleSuggestion(question)");
+    expect(evidence).not.toContain("discardMessage(question)");
+  });
+
   it("refuses to equate a forwarded prop with ambiguous callsite bindings", () => {
     fs.writeFileSync(
       path.join(rootDirectory, "src/wrapper-before.tsx"),

--- a/packages/react-doctor/tests/read-diagnostic-evidence.test.ts
+++ b/packages/react-doctor/tests/read-diagnostic-evidence.test.ts
@@ -66,6 +66,38 @@ describe("createDiagnosticEvidenceReader", () => {
     expect(delta.crossFileMatchCount).toBe(1);
   });
 
+  it("ignores recursive renders inside the diagnosed component", () => {
+    fs.writeFileSync(
+      path.join(rootDirectory, "src/wrapper-before.tsx"),
+      "function WrapperBefore() {\n  return <span onClick={() => handleSendMessage(question)}>\n    {question}\n  </span>\n}\n",
+    );
+    fs.writeFileSync(
+      path.join(rootDirectory, "src/chat-message-bubble.tsx"),
+      "export function ChatMessageBubble({ onSuggestion, nested }) {\n  return <>\n    <span onClick={() => onSuggestion(question)}>\n      {question}\n    </span>\n    {nested && <ChatMessageBubble onSuggestion={onSuggestion} nested={false} />}\n  </>\n}\n",
+    );
+    fs.writeFileSync(
+      path.join(rootDirectory, "src/chat-page.tsx"),
+      'import { ChatMessageBubble } from "./chat-message-bubble";\n<ChatMessageBubble onSuggestion={handleSendMessage} nested />;\n',
+    );
+
+    const delta = computeDiagnosticDelta({
+      headDiagnostics: [
+        makeDiagnostic({ filePath: "src/chat-message-bubble.tsx", line: 3, endLine: 5 }),
+      ],
+      baseDiagnostics: [makeDiagnostic({ line: 2, endLine: 4 })],
+      readHeadLine: () => null,
+      readBaseLine: () => null,
+      readHeadEvidence: createDiagnosticEvidenceReader(rootDirectory, {
+        resolveForwardedHandlers: true,
+      }),
+      readBaseEvidence: createDiagnosticEvidenceReader(rootDirectory),
+    });
+
+    expect(delta.newDiagnostics).toHaveLength(0);
+    expect(delta.fixedCount).toBe(0);
+    expect(delta.crossFileMatchCount).toBe(1);
+  });
+
   it("resolves a default-exported arrow component through an aliased import", () => {
     fs.writeFileSync(
       path.join(rootDirectory, "src/wrapper-before.tsx"),

--- a/packages/react-doctor/tests/read-diagnostic-evidence.test.ts
+++ b/packages/react-doctor/tests/read-diagnostic-evidence.test.ts
@@ -129,6 +129,38 @@ describe("createDiagnosticEvidenceReader", () => {
     expect(delta.crossFileMatchCount).toBe(1);
   });
 
+  it("matches a handler extracted into a memo and forwardRef wrapped component", () => {
+    fs.writeFileSync(
+      path.join(rootDirectory, "src/wrapper-before.tsx"),
+      "function WrapperBefore() {\n  return <span onClick={() => handleSendMessage(question)}>\n    {question}\n  </span>\n}\n",
+    );
+    fs.writeFileSync(
+      path.join(rootDirectory, "src/chat-message-bubble.tsx"),
+      'import { forwardRef, memo } from "react";\nexport const ChatMessageBubble = memo(forwardRef(({ onSuggestion }, _ref) => {\n  return <span onClick={() => onSuggestion(question)}>\n    {question}\n  </span>\n}));\n',
+    );
+    fs.writeFileSync(
+      path.join(rootDirectory, "src/chat-page.tsx"),
+      'import { ChatMessageBubble } from "./chat-message-bubble";\n<ChatMessageBubble onSuggestion={handleSendMessage} />;\n',
+    );
+
+    const delta = computeDiagnosticDelta({
+      headDiagnostics: [
+        makeDiagnostic({ filePath: "src/chat-message-bubble.tsx", line: 3, endLine: 5 }),
+      ],
+      baseDiagnostics: [makeDiagnostic({ line: 2, endLine: 4 })],
+      readHeadLine: () => null,
+      readBaseLine: () => null,
+      readHeadEvidence: createDiagnosticEvidenceReader(rootDirectory, {
+        resolveForwardedHandlers: true,
+      }),
+      readBaseEvidence: createDiagnosticEvidenceReader(rootDirectory),
+    });
+
+    expect(delta.newDiagnostics).toHaveLength(0);
+    expect(delta.fixedCount).toBe(0);
+    expect(delta.crossFileMatchCount).toBe(1);
+  });
+
   it("uses the diagnostic column to find a single-line arrow component", () => {
     const componentSource =
       "export const ChatMessageBubble = ({ onSuggestion }) => <span onClick={() => onSuggestion(question)}>{question}</span>;\n";

--- a/packages/react-doctor/tests/read-diagnostic-evidence.test.ts
+++ b/packages/react-doctor/tests/read-diagnostic-evidence.test.ts
@@ -66,6 +66,70 @@ describe("createDiagnosticEvidenceReader", () => {
     expect(delta.crossFileMatchCount).toBe(1);
   });
 
+  it("resolves a handler through a qualified React.useCallback call", () => {
+    fs.writeFileSync(
+      path.join(rootDirectory, "src/wrapper-before.tsx"),
+      "function WrapperBefore() {\n  return <span onClick={() => handleSendMessage(question)}>\n    {question}\n  </span>\n}\n",
+    );
+    fs.writeFileSync(
+      path.join(rootDirectory, "src/chat-message-bubble.tsx"),
+      "export function ChatMessageBubble({ onSuggestion }) {\n  return <span onClick={() => onSuggestion(question)}>\n    {question}\n  </span>\n}\n",
+    );
+    fs.writeFileSync(
+      path.join(rootDirectory, "src/chat-page.tsx"),
+      'import { ChatMessageBubble } from "./chat-message-bubble";\nconst handleSuggestion = React.useCallback((text) => {\n  handleSendMessage(text);\n}, [handleSendMessage]);\n<ChatMessageBubble onSuggestion={handleSuggestion} />;\n',
+    );
+
+    const delta = computeDiagnosticDelta({
+      headDiagnostics: [
+        makeDiagnostic({ filePath: "src/chat-message-bubble.tsx", line: 2, endLine: 4 }),
+      ],
+      baseDiagnostics: [makeDiagnostic({ line: 2, endLine: 4 })],
+      readHeadLine: () => null,
+      readBaseLine: () => null,
+      readHeadEvidence: createDiagnosticEvidenceReader(rootDirectory, {
+        resolveForwardedHandlers: true,
+      }),
+      readBaseEvidence: createDiagnosticEvidenceReader(rootDirectory),
+    });
+
+    expect(delta.newDiagnostics).toHaveLength(0);
+    expect(delta.fixedCount).toBe(0);
+    expect(delta.crossFileMatchCount).toBe(1);
+  });
+
+  it("unwraps typed handler bindings at component callsites", () => {
+    fs.writeFileSync(
+      path.join(rootDirectory, "src/wrapper-before.tsx"),
+      "function WrapperBefore() {\n  return <span onClick={() => handleSendMessage(question)}>\n    {question}\n  </span>\n}\n",
+    );
+    fs.writeFileSync(
+      path.join(rootDirectory, "src/chat-message-bubble.tsx"),
+      "export function ChatMessageBubble({ onSuggestion }) {\n  return <span onClick={() => onSuggestion(question)}>\n    {question}\n  </span>\n}\n",
+    );
+    fs.writeFileSync(
+      path.join(rootDirectory, "src/chat-page.tsx"),
+      'import { ChatMessageBubble } from "./chat-message-bubble";\ntype Handler = (text: string) => void;\n<ChatMessageBubble onSuggestion={handleSendMessage as Handler} />;\n',
+    );
+
+    const delta = computeDiagnosticDelta({
+      headDiagnostics: [
+        makeDiagnostic({ filePath: "src/chat-message-bubble.tsx", line: 2, endLine: 4 }),
+      ],
+      baseDiagnostics: [makeDiagnostic({ line: 2, endLine: 4 })],
+      readHeadLine: () => null,
+      readBaseLine: () => null,
+      readHeadEvidence: createDiagnosticEvidenceReader(rootDirectory, {
+        resolveForwardedHandlers: true,
+      }),
+      readBaseEvidence: createDiagnosticEvidenceReader(rootDirectory),
+    });
+
+    expect(delta.newDiagnostics).toHaveLength(0);
+    expect(delta.fixedCount).toBe(0);
+    expect(delta.crossFileMatchCount).toBe(1);
+  });
+
   it("ignores recursive renders inside the diagnosed component", () => {
     fs.writeFileSync(
       path.join(rootDirectory, "src/wrapper-before.tsx"),

--- a/packages/react-doctor/tests/regressions/action-subdirectory-baseline-paths.test.ts
+++ b/packages/react-doctor/tests/regressions/action-subdirectory-baseline-paths.test.ts
@@ -114,11 +114,11 @@ describe("#858: subdirectory baseline resolves changed-file paths against the sc
       // ...but pre-existing ones are subtracted, not re-reported as new.
       expect(findings(fixed)).toBeLessThan(headTotal);
 
-      // The bug: repo-relative paths (the pre-fix action output) double the
-      // prefix, so `git show <base>:./UI/src/widget.tsx` misses and the base
-      // count collapses to 0 — the exact signal in #858 (every finding "new").
+      // A repo-relative path still misses the head scan, but the side-aware
+      // plan now notices that the real changed head file was not analyzed and
+      // degrades instead of claiming that every base finding was fixed or new.
       const buggy = await scanUi([path.join("UI", widgetRelative)], { ref: baseRef });
-      expect(buggy.baselineDelta?.baseTotalCount).toBe(0);
+      expect(buggy.baselineDelta).toBeUndefined();
     } finally {
       consoleSpy.mockRestore();
       fs.rmSync(repoDir, { recursive: true, force: true });

--- a/packages/react-doctor/tests/regressions/action-subdirectory-baseline-paths.test.ts
+++ b/packages/react-doctor/tests/regressions/action-subdirectory-baseline-paths.test.ts
@@ -104,6 +104,11 @@ describe("#858: subdirectory baseline resolves changed-file paths against the sc
       const headTotal = findings(headOnly);
       expect(headTotal).toBeGreaterThan(0);
 
+      writeFile(
+        path.join(uiDir, "src/unrelated-untracked.tsx"),
+        "export const unrelated = true;\n",
+      );
+
       // The fix: scan-relative paths, as the patched action now emits.
       const fixed = await scanUi([widgetRelative], { ref: baseRef });
       expect(fixed.baselineDelta).toBeDefined();
@@ -119,6 +124,12 @@ describe("#858: subdirectory baseline resolves changed-file paths against the sc
       // degrades instead of claiming that every base finding was fixed or new.
       const buggy = await scanUi([path.join("UI", widgetRelative)], { ref: baseRef });
       expect(buggy.baselineDelta).toBeUndefined();
+
+      fs.renameSync(path.join(uiDir, widgetRelative), path.join(uiDir, "src/moved-widget.tsx"));
+      const unstagedRename = await scanUi([widgetRelative], { ref: baseRef });
+      expect(unstagedRename.baselineDelta).toBeDefined();
+      expect(unstagedRename.baselineDelta?.baseTotalCount).toBeGreaterThan(0);
+      expect(unstagedRename.baselineDelta?.fixedCount).toBe(0);
     } finally {
       consoleSpy.mockRestore();
       fs.rmSync(repoDir, { recursive: true, force: true });

--- a/packages/react-doctor/tests/regressions/baseline-pure-rename.test.ts
+++ b/packages/react-doctor/tests/regressions/baseline-pure-rename.test.ts
@@ -1,0 +1,89 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { clearConfigCache } from "@react-doctor/core";
+import type { ReactDoctorConfig } from "@react-doctor/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { inspect } from "../../src/inspect.js";
+import { commitAll, initGitRepo, writeFile, writeJson } from "./_helpers.js";
+
+const RULE = "react-doctor/no-array-index-as-key";
+const CONFIG_OVERRIDE: ReactDoctorConfig = { rules: { [RULE]: "warn" } };
+const SOURCE =
+  "export const Rows = ({ rows }) => <ul>{rows.map((row, index) => <li key={index}>{row}</li>)}</ul>;\n";
+
+describe("baseline pure renames", () => {
+  let directory: string;
+
+  beforeEach(() => {
+    clearConfigCache();
+    directory = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-baseline-rename-"));
+    writeJson(path.join(directory, "package.json"), {
+      name: "baseline-rename",
+      dependencies: { react: "^19.0.0", "react-dom": "^19.0.0" },
+    });
+    writeJson(path.join(directory, "tsconfig.json"), {
+      compilerOptions: { jsx: "preserve", target: "es2022", module: "esnext" },
+    });
+  });
+
+  afterEach(() => {
+    fs.rmSync(directory, { recursive: true, force: true });
+  });
+
+  it("matches an unchanged finding at its old baseline path", async () => {
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      const oldPath = path.join(directory, "src/old-rows.tsx");
+      const newPath = path.join(directory, "src/new-rows.tsx");
+      writeFile(oldPath, SOURCE);
+      initGitRepo(directory);
+      const baseRef = commitAll(directory, "base");
+      fs.renameSync(oldPath, newPath);
+
+      const result = await inspect(directory, {
+        lint: true,
+        deadCode: false,
+        noScore: true,
+        silent: true,
+        includePaths: ["src/new-rows.tsx"],
+        baseline: { ref: baseRef },
+        configOverride: CONFIG_OVERRIDE,
+      });
+
+      expect(result.baselineDelta?.baseTotalCount).toBeGreaterThan(0);
+      expect(result.baselineDelta?.crossFileMatchCount).toBeGreaterThan(0);
+      expect(
+        result.diagnostics.filter((diagnostic) => diagnostic.rule === "no-array-index-as-key"),
+      ).toHaveLength(0);
+    } finally {
+      consoleSpy.mockRestore();
+    }
+  });
+
+  it("counts a deleted finding as fixed without requiring a head file", async () => {
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      const deletedPath = path.join(directory, "src/deleted-rows.tsx");
+      writeFile(deletedPath, SOURCE);
+      initGitRepo(directory);
+      const baseRef = commitAll(directory, "base");
+      fs.rmSync(deletedPath);
+
+      const result = await inspect(directory, {
+        lint: true,
+        deadCode: false,
+        noScore: true,
+        silent: true,
+        includePaths: ["src/deleted-rows.tsx"],
+        baseline: { ref: baseRef },
+        configOverride: CONFIG_OVERRIDE,
+      });
+
+      expect(result.baselineDelta?.fixedCount).toBeGreaterThan(0);
+      expect(result.diagnostics).toHaveLength(0);
+    } finally {
+      consoleSpy.mockRestore();
+    }
+  });
+});

--- a/packages/react-doctor/tests/regressions/baseline-pure-rename.test.ts
+++ b/packages/react-doctor/tests/regressions/baseline-pure-rename.test.ts
@@ -40,6 +40,7 @@ describe("baseline pure renames", () => {
       initGitRepo(directory);
       const baseRef = commitAll(directory, "base");
       fs.renameSync(oldPath, newPath);
+      writeFile(path.join(directory, "src/unrelated-untracked.tsx"), "export const value = 1;\n");
 
       const result = await inspect(directory, {
         lint: true,


### PR DESCRIPTION
## Summary

React Doctor now identifies a baseline diagnostic by the code that caused it, not by the file that currently contains it.

The old comparison was roughly:

```text
rule + file path + flagged line
```

That confused a diagnostic’s location with its identity. It caused two opposite errors:

| Change | Old result | Problem |
| --- | --- | --- |
| Existing bad code moved to another file | Rejected | The new filename looked like a new diagnostic |
| New bad code added inside an existing rule/file bucket | Accepted in some cases | The bucket already existed, so the change could be hidden |

The new identity is conceptually:

```text
plugin/rule
+ diagnostic message fingerprint
+ normalized diagnosed-source fingerprint
```

Diagnostics are still matched as a multiset, so one baseline finding cannot hide two identical findings.

## Examples

### Moving existing code

Before:

```text
base: react-doctor/rule | navigation/index.tsx = 1
head: react-doctor/rule | panel-content.tsx    = 1
```

The old comparison treated the head entry as new because the path changed.

Now the normalized diagnosed source and message remain the same, so the finding stays pre-existing after a rename or component extraction.

### Changing the diagnosed construct

```tsx
useEffect(() => {
  setReady(true);
  setExtraState(true); // newly introduced work
}, []);
```

A rule/file count can miss this when the linter still emits one diagnostic object. The new comparison sees that the diagnosed source changed and reports the head diagnostic as new.

Message identity matters too. For example, an `exhaustive-deps` finding may still point at the same dependency-array line while its message changes from:

```text
Missing dependency: select
```

to:

```text
Missing dependencies: select, selectUpwards
```

Those are different findings even if the reported source line is unchanged.

### Extracting a handler behind a prop

Before extraction:

```tsx
onClick={() => handleSendMessage(question)}
```

After extraction:

```tsx
// Child
onClick={() => onSuggestion(question)}

// Caller
<ChatMessageBubble onSuggestion={handleSuggestion} />

const handleSuggestion = (text) => handleSendMessage(text);
```

These snippets are textually different but perform the same work. React Doctor follows the prop only when every discovered callsite proves one unambiguous binding.

Common wrappers are handled too:

```tsx
const handleSuggestion = React.useCallback(
  (text) => handleSendMessage(text),
  [handleSendMessage],
);

<ChatMessageBubble onSuggestion={handleSuggestion as Handler} />
```

Conflicting callsites, unresolved expressions, changed arguments, shadowed bindings, and unrelated same-named components fail closed.

## Matching order

Matches are consumed in this order:

1. Same-file exact evidence
2. Same-file occurrence fallback for rules that opt in
3. Cross-file exact evidence

This matters when code is copied. A cross-file copy cannot steal the baseline match from a reformatted occurrence that remains in the original file.

## Git behavior

Git decides which files exist on each side; it is not part of diagnostic identity.

The comparison handles:

- staged, unstaged, tracked, untracked, deleted, and base-only paths
- renames and case-only moves without Git similarity heuristics
- repository subdirectories and Windows path separators
- filenames containing tabs, newlines, or other unusual characters via NUL-delimited output
- JavaScript import specifiers that resolve to TypeScript sources, such as `.js` → `.tsx`
- recursive component renders, lexical shadowing, imports, `memo`, and `forwardRef`

When React Doctor cannot prove complete coverage—such as an unresolved conflict, missing baseline blob, LFS pointer, binary file, missing head file, partial lint, or unscanned untracked source—it degrades to ordinary diff reporting instead of making unsafe new/fixed claims.

## Compatibility

- The JSON report schema and `schemaVersion` are unchanged.
- `crossFileMatchCount` is optional so cached and older inspect results remain compatible.
- A patch changeset covers `react-doctor` and `@react-doctor/core`.

## Validation

- Full repository tests, typecheck, lint, and production build
- JSON report smoke test
- Focused diagnostic-delta and handler-forwarding regressions
- React Doctor changed-scope scan: 100/100
- CI on macOS, Windows, and Ubuntu with Node 20, 22, 24, 25, and 26
- CodeQL and Bugbot
