### PR TITLE
fix: preserve production routes in health checks

### DIFF
--- a/.changeset/beige-lamps-relate.md
+++ b/.changeset/beige-lamps-relate.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Preserve production routes named test or tests in scoring and CI, and add file-context controls for restoring test or story diagnostics.

--- a/packages/core/src/classify-file-context.ts
+++ b/packages/core/src/classify-file-context.ts
@@ -23,7 +23,6 @@ const TEST_FILE_SUFFIX_PATTERN = new RegExp(
 const TEST_FILE_DIRECTORY_PATTERN =
   /(?:^|\/)(?:__tests__|__test__|tests|test|__mocks__|cypress|e2e|playwright)\//;
 const AMBIGUOUS_TEST_ROUTE_DIRECTORY_PATTERN = /(?:^|\/)(?:tests|test)\//;
-const NEXT_ROUTE_ROOT_PATTERN = /(?:^|\/)(app|pages)\//;
 const NEXT_APP_ROUTE_FILE_SUFFIX_PATTERN =
   /\/(?:default|error|forbidden|global-error|layout|loading|not-found|page|route|template|unauthorized)\.[cm]?[jt]sx?$/;
 const SCRIPT_FILE_SUFFIX_PATTERN = /\.[cm]?[jt]sx?$/;
@@ -66,9 +65,12 @@ const stripAboveSourceRoot = (relativePath: string): string => {
 const isFrameworkRouteBeforeAmbiguousTestDirectory = (relativePath: string): boolean => {
   const testDirectoryMatch = AMBIGUOUS_TEST_ROUTE_DIRECTORY_PATTERN.exec(relativePath);
   if (testDirectoryMatch === null) return false;
-  const routeRootMatch = NEXT_ROUTE_ROOT_PATTERN.exec(relativePath);
-  if (routeRootMatch === null || routeRootMatch.index >= testDirectoryMatch.index) return false;
-  return routeRootMatch[1] === "pages"
+  let nearestRouteRoot: string | undefined;
+  for (const pathSegment of relativePath.slice(0, testDirectoryMatch.index).split("/")) {
+    if (pathSegment === "app" || pathSegment === "pages") nearestRouteRoot = pathSegment;
+  }
+  if (nearestRouteRoot === undefined) return false;
+  return nearestRouteRoot === "pages"
     ? SCRIPT_FILE_SUFFIX_PATTERN.test(relativePath)
     : NEXT_APP_ROUTE_FILE_SUFFIX_PATTERN.test(relativePath);
 };

--- a/packages/core/src/classify-file-context.ts
+++ b/packages/core/src/classify-file-context.ts
@@ -22,6 +22,11 @@ const TEST_FILE_SUFFIX_PATTERN = new RegExp(
 );
 const TEST_FILE_DIRECTORY_PATTERN =
   /(?:^|\/)(?:__tests__|__test__|tests|test|__mocks__|cypress|e2e|playwright)\//;
+const AMBIGUOUS_TEST_ROUTE_DIRECTORY_PATTERN = /(?:^|\/)(?:tests|test)\//;
+const NEXT_ROUTE_ROOT_PATTERN = /(?:^|\/)(app|pages)\//;
+const NEXT_APP_ROUTE_FILE_SUFFIX_PATTERN =
+  /\/(?:default|error|forbidden|global-error|layout|loading|not-found|page|route|template|unauthorized)\.[cm]?[jt]sx?$/;
+const SCRIPT_FILE_SUFFIX_PATTERN = /\.[cm]?[jt]sx?$/;
 
 // "Source root" markers — once a path contains `/src/`, `/app/`,
 // `/lib/`, `/pages/`, etc., everything BELOW that is production code
@@ -58,6 +63,16 @@ const stripAboveSourceRoot = (relativePath: string): string => {
   return relativePath.slice(fixtureMatch.index + fixtureMatch[0].length - 1);
 };
 
+const isFrameworkRouteBeforeAmbiguousTestDirectory = (relativePath: string): boolean => {
+  const testDirectoryMatch = AMBIGUOUS_TEST_ROUTE_DIRECTORY_PATTERN.exec(relativePath);
+  if (testDirectoryMatch === null) return false;
+  const routeRootMatch = NEXT_ROUTE_ROOT_PATTERN.exec(relativePath);
+  if (routeRootMatch === null || routeRootMatch.index >= testDirectoryMatch.index) return false;
+  return routeRootMatch[1] === "pages"
+    ? SCRIPT_FILE_SUFFIX_PATTERN.test(relativePath)
+    : NEXT_APP_ROUTE_FILE_SUFFIX_PATTERN.test(relativePath);
+};
+
 /**
  * Classifies where a file sits relative to shipped code. A finding in a
  * `.stories.tsx` or `.spec.ts` file never runs in front of users, so
@@ -79,5 +94,6 @@ export const classifyFileContext = (relativePath: string): DiagnosticFileContext
   // scopes to the source-root-below path so that fixture-project
   // source files don't get falsely auto-suppressed.
   const scoped = stripAboveSourceRoot(forwardSlashed);
+  if (isFrameworkRouteBeforeAmbiguousTestDirectory(scoped)) return "production";
   return TEST_FILE_DIRECTORY_PATTERN.test(scoped) ? "test" : "production";
 };

--- a/packages/core/src/filter-for-surface.ts
+++ b/packages/core/src/filter-for-surface.ts
@@ -8,6 +8,7 @@ import { DEFAULT_SURFACE_EXCLUDED_TAGS } from "./diagnostic-surface.js";
 import { getDiagnosticRuleIdentity } from "./get-diagnostic-rule-identity.js";
 
 interface ResolvedSurfaceControls {
+  includeFileContexts: ReadonlySet<string>;
   includeTags: ReadonlySet<string>;
   excludeTags: ReadonlySet<string>;
   includeCategories: ReadonlySet<string>;
@@ -31,6 +32,7 @@ const buildResolvedControls = (
   for (const tag of toStringSet(userControls?.excludeTags)) excludeTags.add(tag);
 
   return {
+    includeFileContexts: toStringSet(userControls?.includeFileContexts),
     includeTags,
     excludeTags,
     includeCategories: toStringSet(userControls?.includeCategories),
@@ -57,7 +59,11 @@ export const isDiagnosticOnSurface = (
   if (resolved.includeCategories.has(category)) return true;
   if (intersects(tags, resolved.includeTags)) return true;
 
-  if (diagnostic.fileContext !== undefined && (surface === "score" || surface === "ciFailure")) {
+  if (
+    diagnostic.fileContext !== undefined &&
+    (surface === "score" || surface === "ciFailure") &&
+    !resolved.includeFileContexts.has(diagnostic.fileContext)
+  ) {
     return false;
   }
 

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -1,3 +1,5 @@
+import type { DiagnosticFileContext } from "./diagnostic.js";
+
 /**
  * Severity threshold at which a scan blocks CI (exits non-zero). Controlled
  * by `blocking` / `--blocking` (default `"error"`):
@@ -78,9 +80,9 @@ interface ReactDoctorIgnoreConfig {
  * Defaults: design rules (tag `"design"`) are excluded from `prComment`,
  * `score`, and `ciFailure` so style cleanup doesn't dilute meaningful
  * React findings. Diagnostics stamped with `fileContext: "test" | "story"`
- * are excluded from `score` and `ciFailure`. Both remain in `cli`, and an
- * explicit rule, category, or tag include promotes a diagnostic back onto
- * the selected surface.
+ * are excluded from `score` and `ciFailure`. Both remain in `cli`. Explicit
+ * rule, category, or tag includes promote matching diagnostics, while
+ * `includeFileContexts` restores a context without bypassing other exclusions.
  */
 export type DiagnosticSurface = "cli" | "prComment" | "score" | "ciFailure";
 
@@ -126,6 +128,11 @@ export interface SeverityBuckets {
 }
 
 export interface SurfaceControls {
+  /**
+   * Non-production file contexts to retain on this surface. This restores
+   * test or story findings without overriding unrelated tag exclusions.
+   */
+  includeFileContexts?: Array<Exclude<DiagnosticFileContext, "production">>;
   /**
    * Tag names whose diagnostics should be force-included on the surface,
    * even if a default or category-level exclusion would otherwise drop
@@ -392,9 +399,9 @@ export interface ReactDoctorConfig {
    * - `score` and `ciFailure` exclude test/story file contexts unless explicitly included
    *
    * Pass any controls block, including an empty `{}`, to keep the defaults.
-   * Your include/exclude entries layer on top. Includes always win over
-   * excludes. For example, you can promote one high-signal `design-*` rule
-   * back into the score or PR-comment surface.
+   * Your include/exclude entries layer on top. Rule, category, and tag includes
+   * win over their exclusions. Included file contexts still respect unrelated
+   * exclusions, so restoring story findings does not restore every design rule.
    */
   surfaces?: Partial<Record<DiagnosticSurface, SurfaceControls>>;
   /**

--- a/packages/core/src/validate-config-types.ts
+++ b/packages/core/src/validate-config-types.ts
@@ -1,4 +1,5 @@
 import type {
+  DiagnosticFileContext,
   DiagnosticSurface,
   ReactDoctorConfig,
   RuleSeverityOverride,
@@ -9,6 +10,10 @@ import { DIAGNOSTIC_CATEGORY_BUCKETS } from "./constants.js";
 import { warnConfigIssue } from "./utils/warn-config-issue.js";
 
 const VALID_RULE_SEVERITIES: ReadonlyArray<RuleSeverityOverride> = ["error", "warn", "off"];
+const VALID_INCLUDED_FILE_CONTEXTS: ReadonlyArray<Exclude<DiagnosticFileContext, "production">> = [
+  "test",
+  "story",
+];
 
 // The pre-collapse category names live on in old configs. They no longer
 // match any diagnostic's `category` (everything now rolls up into the five
@@ -66,6 +71,11 @@ const SURFACE_CONTROL_FIELD_NAMES = [
   "includeRules",
   "excludeRules",
 ] as const satisfies ReadonlyArray<keyof SurfaceControls>;
+
+const isIncludedFileContext = (
+  value: string,
+): value is Exclude<DiagnosticFileContext, "production"> =>
+  VALID_INCLUDED_FILE_CONTEXTS.some((fileContext) => fileContext === value);
 
 const SEVERITY_FIELD_NAMES = ["rules", "categories"] as const satisfies ReadonlyArray<
   keyof ReactDoctorConfig
@@ -130,6 +140,21 @@ const validateSurfaceControls = (
     return undefined;
   }
   const validatedSurfaceControls: SurfaceControls = {};
+  if (rawControls.includeFileContexts !== undefined) {
+    const qualifiedName = `surfaces.${surface}.includeFileContexts`;
+    const result = validateStringArrayField(qualifiedName, rawControls.includeFileContexts);
+    if (result !== undefined) {
+      validatedSurfaceControls.includeFileContexts = result.filter(
+        (fileContext): fileContext is Exclude<DiagnosticFileContext, "production"> => {
+          if (isIncludedFileContext(fileContext)) return true;
+          warnConfigIssue(
+            `config field "${qualifiedName}" lists "${fileContext}", which is not a non-production file context (expected one of: ${VALID_INCLUDED_FILE_CONTEXTS.join(", ")}); ignoring the entry.`,
+          );
+          return false;
+        },
+      );
+    }
+  }
   for (const fieldName of SURFACE_CONTROL_FIELD_NAMES) {
     if (rawControls[fieldName] === undefined) continue;
     const qualifiedName = `surfaces.${surface}.${fieldName}`;

--- a/packages/core/tests/classify-file-context.test.ts
+++ b/packages/core/tests/classify-file-context.test.ts
@@ -38,6 +38,20 @@ describe("classifyFileContext", () => {
     expect(classifyFileContext("app/page.tsx")).toBe("production");
   });
 
+  it("keeps production routes whose URL segments resemble test directories", () => {
+    expect(classifyFileContext("app/test/page.tsx")).toBe("production");
+    expect(classifyFileContext("src/app/tests/route.ts")).toBe("production");
+    expect(classifyFileContext("pages/tests/dashboard.tsx")).toBe("production");
+  });
+
+  it("keeps test projects containing route-shaped files classified as test", () => {
+    expect(classifyFileContext("tests/app/test/page.tsx")).toBe("test");
+    expect(classifyFileContext("e2e/pages/checkout.tsx")).toBe("test");
+    expect(classifyFileContext("app/tests/helper.ts")).toBe("test");
+    expect(classifyFileContext("pages/__tests__/dashboard.tsx")).toBe("test");
+    expect(classifyFileContext("pages/tests/dashboard.test.tsx")).toBe("test");
+  });
+
   it("classifies fixture-project source files under `fixtures/` as production", () => {
     expect(classifyFileContext("tests/fixtures/sample/src/Button.tsx")).toBe("production");
     expect(classifyFileContext("tests/__fixtures__/repo/Component.tsx")).toBe("production");

--- a/packages/core/tests/classify-file-context.test.ts
+++ b/packages/core/tests/classify-file-context.test.ts
@@ -42,6 +42,8 @@ describe("classifyFileContext", () => {
     expect(classifyFileContext("app/test/page.tsx")).toBe("production");
     expect(classifyFileContext("src/app/tests/route.ts")).toBe("production");
     expect(classifyFileContext("pages/tests/dashboard.tsx")).toBe("production");
+    expect(classifyFileContext("packages/app/pages/tests/dashboard.tsx")).toBe("production");
+    expect(classifyFileContext("/workspace/app/pages/tests/dashboard.tsx")).toBe("production");
   });
 
   it("keeps test projects containing route-shaped files classified as test", () => {

--- a/packages/core/tests/filter-for-surface.test.ts
+++ b/packages/core/tests/filter-for-surface.test.ts
@@ -17,7 +17,7 @@ const designDiagnostic: Diagnostic = {
   help: "",
   line: 12,
   column: 4,
-  category: "Architecture",
+  category: "Maintainability",
 };
 
 const correctnessDiagnostic: Diagnostic = {
@@ -29,7 +29,7 @@ const correctnessDiagnostic: Diagnostic = {
   help: "",
   line: 18,
   column: 5,
-  category: "Correctness",
+  category: "Bugs",
 };
 
 const externalPluginDiagnostic: Diagnostic = {
@@ -54,7 +54,7 @@ const docusaurusTestDiagnostic: Diagnostic = {
   help: "",
   line: 32,
   column: 5,
-  category: "Correctness",
+  category: "Bugs",
   fileContext: "test",
 };
 
@@ -67,7 +67,7 @@ const radixTestDiagnostic: Diagnostic = {
   help: "",
   line: 48,
   column: 9,
-  category: "Correctness",
+  category: "Bugs",
   fileContext: "test",
 };
 
@@ -80,7 +80,7 @@ const storyDiagnostic: Diagnostic = {
   help: "",
   line: 12,
   column: 4,
-  category: "Architecture",
+  category: "Maintainability",
   fileContext: "story",
 };
 
@@ -141,7 +141,7 @@ describe("filterDiagnosticsForSurface — user overrides", () => {
 
   it("`excludeCategories` removes everything in a category from a surface", () => {
     const config: ReactDoctorConfig = {
-      surfaces: { ciFailure: { excludeCategories: ["Correctness"] } },
+      surfaces: { ciFailure: { excludeCategories: ["Bugs"] } },
     };
     const diagnostics = [designDiagnostic, correctnessDiagnostic];
     expect(filterDiagnosticsForSurface(diagnostics, "ciFailure", config)).toEqual([]);
@@ -171,7 +171,7 @@ describe("filterDiagnosticsForSurface — user overrides", () => {
       surfaces: { score: { includeRules: ["react-compiler/globals"] } },
     };
     const categoryConfig: ReactDoctorConfig = {
-      surfaces: { ciFailure: { includeCategories: ["Correctness"] } },
+      surfaces: { ciFailure: { includeCategories: ["Bugs"] } },
     };
     const tagConfig: ReactDoctorConfig = {
       surfaces: { score: { includeTags: ["design"] } },
@@ -190,6 +190,20 @@ describe("filterDiagnosticsForSurface — user overrides", () => {
     expect(filterDiagnosticsForSurface([storyDiagnostic], "score", tagConfig)).toEqual([
       storyDiagnostic,
     ]);
+  });
+
+  it("includes requested file contexts without overriding unrelated exclusions", () => {
+    const config: ReactDoctorConfig = {
+      surfaces: { score: { includeFileContexts: ["test", "story"] } },
+    };
+
+    expect(
+      filterDiagnosticsForSurface(
+        [docusaurusTestDiagnostic, radixTestDiagnostic, storyDiagnostic],
+        "score",
+        config,
+      ),
+    ).toEqual([docusaurusTestDiagnostic, radixTestDiagnostic]);
   });
 });
 

--- a/packages/core/tests/validate-config-types.test.ts
+++ b/packages/core/tests/validate-config-types.test.ts
@@ -77,7 +77,11 @@ describe("validateConfigTypes", () => {
     it("passes through a well-formed surfaces config untouched", () => {
       const input: ReactDoctorConfig = {
         surfaces: {
-          prComment: { includeTags: ["design"], excludeCategories: ["Performance"] },
+          prComment: {
+            includeFileContexts: ["story"],
+            includeTags: ["design"],
+            excludeCategories: ["Performance"],
+          },
           ciFailure: { excludeRules: ["react-doctor/no-vague-button-label"] },
         },
       };
@@ -106,6 +110,18 @@ describe("validateConfigTypes", () => {
       });
       expect(result.surfaces).toEqual({ score: { excludeTags: ["design"] } });
       expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("excludeTags"));
+    });
+
+    it("drops unknown included file contexts with a stderr warning", () => {
+      const result = validateConfigTypes({
+        surfaces: {
+          score: {
+            includeFileContexts: ["test", "production"] as unknown as Array<"test">,
+          },
+        },
+      });
+      expect(result.surfaces).toEqual({ score: { includeFileContexts: ["test"] } });
+      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("production"));
     });
 
     it("drops the entire surfaces field if it isn't an object", () => {

--- a/packages/react-doctor/tests/build-run-event.test.ts
+++ b/packages/react-doctor/tests/build-run-event.test.ts
@@ -50,7 +50,7 @@ const buildDiagnostic = (overrides: Partial<Diagnostic> = {}): Diagnostic => ({
   help: "Use a stable id",
   line: 1,
   column: 1,
-  category: "Correctness",
+  category: "Bugs",
   ...overrides,
 });
 
@@ -278,7 +278,7 @@ describe("buildRunEventAttributes", () => {
         buildDiagnostic({
           severity: "warning",
           rule: "no-bar",
-          category: "Correctness",
+          category: "Bugs",
           filePath: "src/B.tsx",
         }),
       ],
@@ -293,7 +293,7 @@ describe("buildRunEventAttributes", () => {
     expect(attributes["diag.distinctRules"]).toBe(2);
     expect(attributes["diag.topRule"]).toBe("react-doctor/no-foo");
     expect(attributes["diag.category.performance"]).toBe(2);
-    expect(attributes["diag.category.correctness"]).toBe(1);
+    expect(attributes["diag.category.bugs"]).toBe(1);
     expect(attributes["score.value"]).toBe(73);
     expect(attributes["score.label"]).toBe("Fair");
     expect(attributes["score.available"]).toBe(true);
@@ -383,10 +383,20 @@ describe("buildRunEventAttributes", () => {
     const categoryIncludedAttributes = buildRunEventAttributes(
       baseInput({
         result,
-        userConfig: { surfaces: { ciFailure: { includeCategories: ["Correctness"] } } },
+        userConfig: { surfaces: { ciFailure: { includeCategories: ["Bugs"] } } },
       }),
     );
     expect(categoryIncludedAttributes["diag.nonProductionGateExcluded"]).toBe(0);
+
+    const fileContextIncludedAttributes = buildRunEventAttributes(
+      baseInput({
+        result,
+        userConfig: {
+          surfaces: { ciFailure: { includeFileContexts: ["test", "story"] } },
+        },
+      }),
+    );
+    expect(fileContextIncludedAttributes["diag.nonProductionGateExcluded"]).toBe(0);
   });
 
   it("never reports a blocked run in score-only mode (matches the CLI exit guard)", () => {

--- a/packages/react-doctor/tests/inspect-action-exit-code.test.ts
+++ b/packages/react-doctor/tests/inspect-action-exit-code.test.ts
@@ -167,7 +167,7 @@ describe("inspectAction exit-code gate", () => {
           plugin: "eslint",
           rule: "no-unused-vars",
           severity: "error",
-          category: "Correctness",
+          category: "Bugs",
           fileContext: "test",
         }),
       ],
@@ -187,7 +187,27 @@ describe("inspectAction exit-code gate", () => {
           plugin: "eslint",
           rule: "no-unused-vars",
           severity: "error",
-          category: "Correctness",
+          category: "Bugs",
+          fileContext: "test",
+        }),
+      ],
+    });
+
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("fails CI when test diagnostics are included by file context", async () => {
+    mockState.userConfig = {
+      surfaces: { ciFailure: { includeFileContexts: ["test"] } },
+    };
+    await runInspectAction({
+      diagnostics: [
+        buildDiagnostic({
+          filePath: "packages/react/context-menu/src/context-menu-controlled.test.tsx",
+          plugin: "eslint",
+          rule: "no-unused-vars",
+          severity: "error",
+          category: "Bugs",
           fileContext: "test",
         }),
       ],

--- a/packages/react-doctor/tests/inspect-surface-filter.test.ts
+++ b/packages/react-doctor/tests/inspect-surface-filter.test.ts
@@ -225,7 +225,7 @@ describe("inspect — score surface filter", () => {
       try {
         const configOverride: ReactDoctorConfig = {
           surfaces: {
-            score: { includeRules: ["react-doctor/no-array-index-as-key"] },
+            score: { includeFileContexts: ["test", "story"] },
           },
         };
         const result = await inspect(projectDirectory, {

--- a/packages/react-doctor/tests/render-multi-project-summary.test.ts
+++ b/packages/react-doctor/tests/render-multi-project-summary.test.ts
@@ -44,7 +44,7 @@ const buildDiagnostic = (overrides: Partial<Diagnostic>): Diagnostic => ({
   help: "Fix it",
   line: 1,
   column: 1,
-  category: "Correctness",
+  category: "Bugs",
   ...overrides,
 });
 
@@ -84,7 +84,7 @@ const lowDesignDiagnostic = buildDiagnostic({
   filePath: "src/LowDesign.tsx",
   rule: "design-no-redundant-size-axes",
   severity: "warning",
-  category: "Architecture",
+  category: "Maintainability",
 });
 const highProductionDiagnostic = buildDiagnostic({
   filePath: "src/High.tsx",
@@ -144,7 +144,7 @@ describe("printMultiProjectSummary score projection", () => {
       {
         surfaces: {
           score: {
-            includeCategories: ["Correctness"],
+            includeCategories: ["Bugs"],
             includeTags: ["design"],
           },
         },

--- a/packages/website/public/schema/config.json
+++ b/packages/website/public/schema/config.json
@@ -158,7 +158,7 @@
             }
           },
           "additionalProperties": false,
-          "description": "Per-surface include/exclude controls. Each `DiagnosticSurface` resolves rule tags, categories, and identifiers independently. This lets you keep a rule visible locally while hiding it from PR comments, the score, or the CI gate. These controls don't change rule severity or activation.\n\nDefaults (applied before user overrides):\n\n- `prComment` excludes tag `\"design\"`\n- `score` excludes tag `\"design\"`\n- `ciFailure` excludes tag `\"design\"`\n- `score` and `ciFailure` exclude test/story file contexts unless explicitly included\n\nPass any controls block, including an empty `{}`, to keep the defaults. Your include/exclude entries layer on top. Includes always win over excludes. For example, you can promote one high-signal `design-*` rule back into the score or PR-comment surface."
+          "description": "Per-surface include/exclude controls. Each `DiagnosticSurface` resolves rule tags, categories, and identifiers independently. This lets you keep a rule visible locally while hiding it from PR comments, the score, or the CI gate. These controls don't change rule severity or activation.\n\nDefaults (applied before user overrides):\n\n- `prComment` excludes tag `\"design\"`\n- `score` excludes tag `\"design\"`\n- `ciFailure` excludes tag `\"design\"`\n- `score` and `ciFailure` exclude test/story file contexts unless explicitly included\n\nPass any controls block, including an empty `{}`, to keep the defaults. Your include/exclude entries layer on top. Rule, category, and tag includes win over their exclusions. Included file contexts still respect unrelated exclusions, so restoring story findings does not restore every design rule."
         },
         "rules": {
           "type": "object",
@@ -260,6 +260,17 @@
     "SurfaceControls": {
       "type": "object",
       "properties": {
+        "includeFileContexts": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "test",
+              "story"
+            ]
+          },
+          "description": "Non-production file contexts to retain on this surface. This restores test or story findings without overriding unrelated tag exclusions."
+        },
         "includeTags": {
           "type": "array",
           "items": {

--- a/skills/react-doctor/references/explain.md
+++ b/skills/react-doctor/references/explain.md
@@ -51,6 +51,7 @@ Match the control to the intent — prefer the narrowest one:
 - **A whole area is unwanted** (e.g. all React Native rules) → `rules category "<Category>" off`.
 - **A behavioral family is noisy** (`design`, `test-noise`, `migration-hint`) → `rules ignore-tag <tag>`.
 - **Keep it locally but hide from PR comment / score / CI gate only** → do NOT disable. Edit `surfaces` in your config (`surfaces.prComment.excludeRules`, `surfaces.score.excludeTags`, `surfaces.ciFailure.excludeCategories`). The rule still shows in local `cli` output.
+- **Restore test or story findings to production health** → set `surfaces.score.includeFileContexts` or `surfaces.ciFailure.includeFileContexts` to `["test"]`, `["story"]`, or both. Other surface exclusions still apply.
 
 How the layers combine: `ignore.tags` disables every rule carrying that tag **before** linting, so a tagged rule stays off even if `rules`/`categories` set it to `warn`/`error` (a rule-level override cannot re-enable a tag-ignored rule). For rules that aren't tag-disabled, `rules` overrides `categories` overrides the rule's default. `surfaces` is visibility-only and never changes whether a rule runs.
 


### PR DESCRIPTION
## Why

React Doctor 0.8.0 excludes test and story diagnostics from the score and CI gate, but the path heuristic also classified valid Next.js routes such as `app/test/page.tsx` and `pages/tests/dashboard.tsx` as tests. Production errors in those routes could no longer affect health or block CI.

Before:

```text
app/test/page.tsx -> fileContext: test -> excluded from score and CI
```

After:

```text
app/test/page.tsx -> fileContext: production -> included in score and CI
```

### Product brief

- **Job:** CI users need production route diagnostics to remain trustworthy even when a URL segment is named `test` or `tests`.
- **Change:** Preserve route-shaped files beneath `app` and `pages`, and add `includeFileContexts` as an exact opt-out from the 0.8 non-production default.
- **Reuse:** Extends the existing file-context classifier, surface controls, config validator, and `diag.nonProductionGateExcluded` wide-event attribute; no parallel classifier or metric was added.
- **Metric:** Continue watching `diag.nonProductionGateExcluded`; production-route reports should stop while intentional test/story exclusions remain measurable.
- **Compat:** Defaults stay unchanged for real tests and stories. `react-doctor` receives a patch changeset. The JSON report schema and GitHub Action are unchanged.
- **Kill:** Revisit the route exception if production-path misclassification persists or strong test directories begin entering health surfaces.

## What changed

- Treat `test` and `tests` URL segments as production only when they occur beneath a route root and the file matches the Next.js App or Pages Router shape.
- Keep strong test conventions such as `__tests__`, `__mocks__`, `e2e`, and test/spec suffixes classified as tests.
- Add `surfaces.<surface>.includeFileContexts` for restoring `test` and/or `story` diagnostics without bypassing unrelated design exclusions.
- Validate the new config values and publish them in the generated config schema and distributed configuration guidance.
- Replace stale `Correctness`/`Architecture` test categories with current buckets so override tests exercise loadable configuration.
- Add regression coverage for classification, score projection, CI blocking, telemetry, config validation, and multi-project summaries.

RDE was not run because this changes diagnostic surface routing rather than a lint rule or detector.

## Test plan

- `nr test`
- `nr lint`
- `nr typecheck`
- `nr format:check <changed files>`
- `nr smoke:json-report`
- `nr check:published-deps`
- `npx react-doctor@latest packages/core --verbose --scope changed`
- `npx react-doctor@latest packages/react-doctor --verbose --scope changed`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI/score routing via file-context heuristics and new surface controls; misclassification could still include or exclude the wrong files, but defaults preserve existing test/story behavior and coverage is broad.
> 
> **Overview**
> Fixes a **0.8.0 regression** where paths like `app/test/page.tsx` or `pages/tests/dashboard.tsx` were labeled `fileContext: test` and dropped from **score** and **CI**, so real production bugs on those routes no longer affected health or blocking.
> 
> **File classification** now treats `test` / `tests` path segments as **production** only when they sit under an `app` or `pages` route root and the file matches App Router route filenames or a generic script under `pages`. Strong test signals (`__tests__`, `.test.*`, files under top-level `tests/`, etc.) are unchanged.
> 
> **Surface config** adds `surfaces.<surface>.includeFileContexts` (`"test"` / `"story"`) so teams can opt test or story diagnostics back onto score or `ciFailure` **without** overriding other exclusions (e.g. design-tagged rules stay excluded). Validation, JSON schema, and configuration docs were updated accordingly.
> 
> Tests and telemetry assertions were extended for classification, filtering, CI exit code, `diag.nonProductionGateExcluded`, and multi-project scoring; stale category names in fixtures were updated to current buckets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c3184012ce4d37248aff5ced3ecb796874891b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->