### PR TITLE
fix: detect imported React 19 context values

### DIFF
--- a/.changeset/three-deserts-arrive.md
+++ b/.changeset/three-deserts-arrive.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Detect constructed values passed through imported React 19 context providers

--- a/packages/fuzz/corpus/true-positives/jsx-no-constructed-context-values--imported-react-19-context.tsx
+++ b/packages/fuzz/corpus/true-positives/jsx-no-constructed-context-values--imported-react-19-context.tsx
@@ -1,0 +1,14 @@
+// rule: jsx-no-constructed-context-values
+// source: ASAP_FIX Lobe UI write-react-lobehub-lobe-ui-508__hddXHTF
+// react-major: 19
+
+import { AccordionExpansionContext } from "./context";
+
+interface AccordionProps {
+  expandedKeys: ReadonlyArray<string>;
+  onToggle: (key: string) => void;
+}
+
+export const Accordion = ({ expandedKeys, onToggle }: AccordionProps) => (
+  <AccordionExpansionContext value={{ expandedKeys, onToggle }} />
+);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-no-constructed-context-values.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-no-constructed-context-values.regressions.test.ts
@@ -95,6 +95,44 @@ describe("react-builtins/jsx-no-constructed-context-values — regressions", () 
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("flags an imported React 19 context shorthand", () => {
+    const result = runRule(
+      jsxNoConstructedContextValues,
+      `
+      import { AccordionExpansionContext } from "./context";
+
+      function Accordion({ expandedKeys, onToggle, registerItemKey }) {
+        return (
+          <AccordionExpansionContext
+            value={{ expandedKeys, onToggle, registerItemKey }}
+          />
+        );
+      }
+    `,
+      { filename: "Accordion.tsx" },
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a renamed imported React 19 context shorthand", () => {
+    const result = runRule(
+      jsxNoConstructedContextValues,
+      `
+      import { AccordionExpansionContext as ExpansionProvider } from "./context";
+
+      function Accordion({ value }) {
+        return <ExpansionProvider value={{ value }} />;
+      }
+    `,
+      { filename: "Accordion.tsx" },
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("does not flag a primitive value on the React 19 shorthand", () => {
     const result = runRule(
       jsxNoConstructedContextValues,
@@ -121,6 +159,54 @@ describe("react-builtins/jsx-no-constructed-context-values — regressions", () 
 
       function App() {
         return <Component value={{ a: 1 }} />;
+      }
+    `,
+      { filename: "fixture.jsx" },
+    );
+
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not flag an ordinary imported component with a value prop", () => {
+    const result = runRule(
+      jsxNoConstructedContextValues,
+      `
+      import { ValuePanel } from "./value-panel";
+
+      function App() {
+        return <ValuePanel value={{ a: 1 }} />;
+      }
+    `,
+      { filename: "fixture.jsx" },
+    );
+
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not infer a context from an imported component name alone", () => {
+    const result = runRule(
+      jsxNoConstructedContextValues,
+      `
+      import { UserContext } from "./components";
+
+      function App() {
+        return <UserContext value={{ a: 1 }} />;
+      }
+    `,
+      { filename: "fixture.jsx" },
+    );
+
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not flag an imported context shadowed by a prop", () => {
+    const result = runRule(
+      jsxNoConstructedContextValues,
+      `
+      import { ThemeContext } from "./context";
+
+      function App({ ThemeContext }) {
+        return <ThemeContext value={{ a: 1 }} />;
       }
     `,
       { filename: "fixture.jsx" },

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-no-constructed-context-values.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-no-constructed-context-values.ts
@@ -1,8 +1,13 @@
 import { defineRule } from "../../utils/define-rule.js";
+import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
-import { getImportedNameFromModule } from "../../utils/find-import-source-for-name.js";
+import {
+  getImportedNameFromModule,
+  getImportSourceForName,
+} from "../../utils/find-import-source-for-name.js";
 import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
+import { getImportedName } from "../../utils/get-imported-name.js";
 import { isAstNode } from "../../utils/is-ast-node.js";
 import { isCanonicalReactNamespaceName } from "../../utils/is-canonical-react-namespace-name.js";
 import { isInsideFunctionScope } from "../../utils/is-inside-function-scope.js";
@@ -112,9 +117,19 @@ const collectContextBindings = (programRoot: EsTreeNode): Set<string> => {
 const isCreateContextBindingJsxName = (
   node: EsTreeNode,
   contextBindings: ReadonlySet<string>,
+  scopes: ScopeAnalysis,
 ): boolean => {
   if (!isNodeOfType(node, "JSXIdentifier")) return false;
-  if (!contextBindings.has(node.name)) return false;
+  if (!contextBindings.has(node.name)) {
+    const symbol = scopes.symbolFor(node);
+    if (!symbol || symbol.kind !== "import") return false;
+    const importedName = getImportedName(symbol.declarationNode);
+    const importSource = getImportSourceForName(node, node.name);
+    return (
+      importSource?.toLowerCase().includes("context") === true &&
+      (node.name.endsWith("Context") || importedName?.endsWith("Context") === true)
+    );
+  }
   const binding = findVariableInitializer(node, node.name);
   if (!binding) return false;
   return binding.scopeOwner.type === "Program";
@@ -151,7 +166,11 @@ export const jsxNoConstructedContextValues = defineRule({
         if (isTestlikeFile) return;
         const nameNode = node.name as EsTreeNode;
         const isLegacyProvider = isProviderMemberName(nameNode);
-        const isReact19Shorthand = isCreateContextBindingJsxName(nameNode, contextBindings);
+        const isReact19Shorthand = isCreateContextBindingJsxName(
+          nameNode,
+          contextBindings,
+          context.scopes,
+        );
         if (!isLegacyProvider && !isReact19Shorthand) return;
         if (!isInsideFunctionScope(node)) return;
         for (const attribute of node.attributes) {


### PR DESCRIPTION
## Why

Before: `jsx-no-constructed-context-values` recognized React 19 shorthand only when the context was created in the same file, so the Lobe `AccordionExpansionContext` job passed an inline object through an imported provider without a finding.

After: imported shorthand providers from context modules are recognized conservatively, while shadowed bindings and ordinary imported components remain quiet.

## What changed

- Resolve imported JSX identifiers through scope analysis and require context-shaped import provenance.
- Add positive fixtures for direct and renamed imports plus negative collision and shadowing fixtures.
- Add the downloaded-job shape to the fuzz true-positive corpus.
- Add a patch changeset.

## Eval results

| Validation | Result |
| --- | --- |
| Local RDE | 99 root scans, 225 rule hits across 5 repos |
| Delta audit | 3 new hits, all manually confirmed true positives, 0 new FPs |
| Strict fuzz | 1,000 iterations requested, 646 executed, 20 fired, 0 findings |

## Test plan

- Focused rule regressions passed.
- Full workspace test suite passed.
- Root typecheck and lint passed.
- Changed-file formatting passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-only heuristic tightening with conservative import-path and naming guards; no runtime or security impact, with explicit negative tests to limit false positives.
> 
> **Overview**
> **`jsx-no-constructed-context-values`** now flags inline constructed `value` props on **imported** React 19 context shorthand (`<SomeContext value={…}>`), not only when `createContext` runs in the same file.
> 
> When the JSX name is not a local `createContext` binding, the rule uses **scope analysis** to treat it as a provider only if the symbol is an import from a module path containing `context` and the local or imported name ends with `Context`. Renamed imports are covered; ordinary components with a `value` prop, `*Context` names imported from non-context modules, and props that shadow an imported context stay **silent**.
> 
> Regression tests and a fuzz true-positive corpus case mirror the Lobe UI accordion pattern; the plugin gets a patch changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10559729cfee5cf8d3450355736a6830fce41318. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->