### PR TITLE
fix: match nested listener cleanup

### DIFF
--- a/.changeset/chatty-corners-share.md
+++ b/.changeset/chatty-corners-share.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Recognize matching event listener cleanup across nested collections

--- a/packages/fuzz/corpus/regressions/effect-needs-cleanup--additive-collection-mutation.tsx
+++ b/packages/fuzz/corpus/regressions/effect-needs-cleanup--additive-collection-mutation.tsx
@@ -1,0 +1,22 @@
+// rule: effect-needs-cleanup
+// weakness: control-flow
+// source: PR #1380 Bugbot follow-up — additive mutations preserve every registered entry
+
+import { useEffect } from "react";
+
+export const Subscriptions = ({ emitter, extraHandler, subscriptions }) => {
+  useEffect(() => {
+    subscriptions.forEach(({ event, handler }) => {
+      emitter.on(event, handler);
+    });
+
+    return () => {
+      subscriptions.push({ event: "extra", handler: extraHandler });
+      subscriptions.forEach(({ event, handler }) => {
+        emitter.off(event, handler);
+      });
+    };
+  }, [emitter, extraHandler, subscriptions]);
+
+  return null;
+};

--- a/packages/fuzz/corpus/regressions/effect-needs-cleanup--cleared-projected-collection.tsx
+++ b/packages/fuzz/corpus/regressions/effect-needs-cleanup--cleared-projected-collection.tsx
@@ -1,0 +1,23 @@
+// rule: effect-needs-cleanup
+// weakness: control-flow
+// expect: diagnostic
+// source: PR #1380 adversarial review — clearing the replay collection loses registrations
+
+import { useEffect } from "react";
+
+export const Subscriptions = ({ emitter, subscriptions }) => {
+  useEffect(() => {
+    subscriptions.forEach(({ event, handler }) => {
+      emitter.on(event, handler);
+    });
+
+    return () => {
+      subscriptions.length = 0;
+      subscriptions.forEach(({ event, handler }) => {
+        emitter.off(event, handler);
+      });
+    };
+  }, [emitter, subscriptions]);
+
+  return null;
+};

--- a/packages/fuzz/corpus/regressions/effect-needs-cleanup--inline-capture-options.tsx
+++ b/packages/fuzz/corpus/regressions/effect-needs-cleanup--inline-capture-options.tsx
@@ -1,0 +1,16 @@
+// rule: effect-needs-cleanup
+// weakness: identity-provenance
+// source: PR #1380 Bugbot review — matching inline option bags hid the capture identity
+
+import { useEffect } from "react";
+
+export const OutsideAction = ({ capture, onOutsideAction }) => {
+  useEffect(() => {
+    document.addEventListener("focusin", onOutsideAction, { capture, passive: true });
+    return () => {
+      document.removeEventListener("focusin", onOutsideAction, { capture, passive: false });
+    };
+  }, [capture, onOutsideAction]);
+
+  return null;
+};

--- a/packages/fuzz/corpus/regressions/effect-needs-cleanup--named-projected-cleanup.tsx
+++ b/packages/fuzz/corpus/regressions/effect-needs-cleanup--named-projected-cleanup.tsx
@@ -1,0 +1,23 @@
+// rule: effect-needs-cleanup
+// weakness: cleanup-provenance
+// source: PR #1380 Bugbot follow-up — named cleanup exhaustively replays registrations
+
+import { useEffect } from "react";
+
+export const Subscriptions = ({ emitter, subscriptions }) => {
+  useEffect(() => {
+    function releaseSubscriptions() {
+      subscriptions.forEach(({ event, handler }) => {
+        emitter.off(event, handler);
+      });
+    }
+
+    subscriptions.forEach(({ event, handler }) => {
+      emitter.on(event, handler);
+    });
+
+    return releaseSubscriptions;
+  }, [emitter, subscriptions]);
+
+  return null;
+};

--- a/packages/fuzz/corpus/regressions/effect-needs-cleanup--nested-listener-collections.tsx
+++ b/packages/fuzz/corpus/regressions/effect-needs-cleanup--nested-listener-collections.tsx
@@ -1,0 +1,34 @@
+// rule: effect-needs-cleanup
+// weakness: control-flow
+// source: ASAP_FIX ReactTooltip fix-react-reacttooltip-react-too__GGzpuvK
+
+import { useEffect } from "react";
+
+interface TooltipProps {
+  anchorRefs: ReadonlyArray<{ current: HTMLElement | null }>;
+}
+
+export const Tooltip = ({ anchorRefs }: TooltipProps) => {
+  useEffect(() => {
+    const elementRefs = new Set(anchorRefs);
+    const enabledEvents = [];
+    const handleFocus = () => {};
+    enabledEvents.push({ event: "focus", listener: handleFocus, capture: true });
+
+    enabledEvents.forEach(({ event, listener, capture }) => {
+      elementRefs.forEach((elementRef) => {
+        elementRef.current?.addEventListener(event, listener, capture);
+      });
+    });
+
+    return () => {
+      enabledEvents.forEach(({ event, listener, capture }) => {
+        elementRefs.forEach((elementRef) => {
+          elementRef.current?.removeEventListener(event, listener, capture);
+        });
+      });
+    };
+  }, [anchorRefs]);
+
+  return null;
+};

--- a/packages/fuzz/corpus/regressions/effect-needs-cleanup--overwritten-projected-entry.tsx
+++ b/packages/fuzz/corpus/regressions/effect-needs-cleanup--overwritten-projected-entry.tsx
@@ -1,0 +1,23 @@
+// rule: effect-needs-cleanup
+// weakness: control-flow
+// expect: diagnostic
+// source: PR #1380 Bugbot follow-up — overwriting an entry loses its registration pair
+
+import { useEffect } from "react";
+
+export const Subscriptions = ({ emitter, subscriptions }) => {
+  useEffect(() => {
+    subscriptions.forEach(({ event, handler }) => {
+      emitter.on(event, handler);
+    });
+
+    return () => {
+      subscriptions[0] = subscriptions[1];
+      subscriptions.forEach(({ event, handler }) => {
+        emitter.off(event, handler);
+      });
+    };
+  }, [emitter, subscriptions]);
+
+  return null;
+};

--- a/packages/fuzz/corpus/regressions/effect-needs-cleanup--projected-bulk-cleanup.tsx
+++ b/packages/fuzz/corpus/regressions/effect-needs-cleanup--projected-bulk-cleanup.tsx
@@ -1,0 +1,17 @@
+// rule: effect-needs-cleanup
+// weakness: cleanup-provenance
+// source: PR #1380 Bugbot follow-up — whole-receiver cleanup releases projected registrations
+
+import { useEffect } from "react";
+
+export const Subscriptions = ({ emitter, handlers }) => {
+  useEffect(() => {
+    handlers.forEach((handler) => {
+      emitter.on("update", handler);
+    });
+
+    return () => emitter.off("update");
+  }, [emitter, handlers]);
+
+  return null;
+};

--- a/packages/fuzz/corpus/true-positives/effect-needs-cleanup--capture-options-key-collision.tsx
+++ b/packages/fuzz/corpus/true-positives/effect-needs-cleanup--capture-options-key-collision.tsx
@@ -1,0 +1,18 @@
+// rule: effect-needs-cleanup
+// weakness: identity-provenance
+// source: PR #1380 Bugbot follow-up — opaque options collided with an inline capture value
+
+import { useEffect } from "react";
+
+export const OutsideAction = ({ listenerOptions, onOutsideAction }) => {
+  useEffect(() => {
+    document.addEventListener("focusin", onOutsideAction, listenerOptions);
+    return () => {
+      document.removeEventListener("focusin", onOutsideAction, {
+        capture: listenerOptions,
+      });
+    };
+  }, [listenerOptions, onOutsideAction]);
+
+  return null;
+};

--- a/packages/fuzz/corpus/true-positives/effect-needs-cleanup--cleanup-body-collection-mutation.tsx
+++ b/packages/fuzz/corpus/true-positives/effect-needs-cleanup--cleanup-body-collection-mutation.tsx
@@ -1,0 +1,22 @@
+// rule: effect-needs-cleanup
+// weakness: control-flow
+// source: PR #1380 Bugbot follow-up — cleanup-body mutation dropped registered entries
+
+import { useEffect } from "react";
+
+export const Subscriptions = ({ emitter, subscriptions }) => {
+  useEffect(() => {
+    subscriptions.forEach(({ event, handler }) => {
+      emitter.on(event, handler);
+    });
+
+    return () => {
+      subscriptions.pop();
+      subscriptions.forEach(({ event, handler }) => {
+        emitter.off(event, handler);
+      });
+    };
+  }, [emitter, subscriptions]);
+
+  return null;
+};

--- a/packages/fuzz/corpus/true-positives/effect-needs-cleanup--conditional-projected-capture-options.tsx
+++ b/packages/fuzz/corpus/true-positives/effect-needs-cleanup--conditional-projected-capture-options.tsx
@@ -1,0 +1,23 @@
+// rule: effect-needs-cleanup
+// weakness: control-flow
+// source: PR #1380 Bugbot follow-up — option bags hid projected capture cleanup safety
+
+import { useEffect } from "react";
+
+export const OutsideActions = ({ shouldCleanup, subscriptions }) => {
+  useEffect(() => {
+    subscriptions.forEach(({ event, handler, capture }) => {
+      document.addEventListener(event, handler, { capture });
+    });
+
+    return () => {
+      subscriptions.forEach(({ event, handler, capture }) => {
+        if (shouldCleanup) {
+          document.removeEventListener(event, handler, { capture });
+        }
+      });
+    };
+  }, [shouldCleanup, subscriptions]);
+
+  return null;
+};

--- a/packages/fuzz/corpus/true-positives/effect-needs-cleanup--conditional-projected-emitter-cleanup.tsx
+++ b/packages/fuzz/corpus/true-positives/effect-needs-cleanup--conditional-projected-emitter-cleanup.tsx
@@ -1,0 +1,21 @@
+// rule: effect-needs-cleanup
+// weakness: control-flow
+// source: PR #1380 Bugbot review — projected emitter cleanup was not checked for exhaustiveness
+
+import { useEffect } from "react";
+
+export const Subscriptions = ({ emitter, shouldCleanup, subscriptions }) => {
+  useEffect(() => {
+    subscriptions.forEach(({ event, handler }) => {
+      emitter.on(event, handler);
+    });
+
+    return () => {
+      subscriptions.forEach(({ event, handler }) => {
+        if (shouldCleanup) emitter.off(event, handler);
+      });
+    };
+  }, [emitter, shouldCleanup, subscriptions]);
+
+  return null;
+};

--- a/packages/fuzz/corpus/true-positives/effect-needs-cleanup--earlier-cleanup-mutation.tsx
+++ b/packages/fuzz/corpus/true-positives/effect-needs-cleanup--earlier-cleanup-mutation.tsx
@@ -1,0 +1,24 @@
+// rule: effect-needs-cleanup
+// weakness: control-flow
+// source: PR #1380 Bugbot follow-up — source order hid cleanup-body collection mutation
+
+import { useEffect } from "react";
+
+export const Subscriptions = ({ emitter, subscriptions }) => {
+  useEffect(() => {
+    function releaseSubscriptions() {
+      subscriptions.pop();
+      subscriptions.forEach(({ event, handler }) => {
+        emitter.off(event, handler);
+      });
+    }
+
+    subscriptions.forEach(({ event, handler }) => {
+      emitter.on(event, handler);
+    });
+
+    return releaseSubscriptions;
+  }, [emitter, subscriptions]);
+
+  return null;
+};

--- a/packages/fuzz/corpus/true-positives/effect-needs-cleanup--unrelated-foreach-cleanup-wrapper.tsx
+++ b/packages/fuzz/corpus/true-positives/effect-needs-cleanup--unrelated-foreach-cleanup-wrapper.tsx
@@ -1,0 +1,23 @@
+// rule: effect-needs-cleanup
+// weakness: control-flow
+// source: PR #1380 Bugbot follow-up — unrelated forEach wrappers hid non-exhaustive cleanup
+
+import { useEffect } from "react";
+
+export const Subscriptions = ({ emitter, subscriptions, unrelatedItems }) => {
+  useEffect(() => {
+    subscriptions.forEach(({ event, handler }) => {
+      emitter.on(event, handler);
+    });
+
+    return () => {
+      unrelatedItems.forEach(() => {
+        subscriptions.forEach(({ event, handler }) => {
+          emitter.off(event, handler);
+        });
+      });
+    };
+  }, [emitter, subscriptions, unrelatedItems]);
+
+  return null;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/react.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/react.ts
@@ -44,6 +44,11 @@ export const STABLE_HOOK_WRAPPERS = new Set(["useState", "useMemo", "useRef"]);
 
 export const GENERIC_EVENT_SUFFIXES = new Set(["Click", "Change", "Input", "Blur", "Focus"]);
 
+export const UNARY_LISTENER_ARGUMENT_COUNT = 1;
+export const UNARY_LISTENER_HANDLER_ARGUMENT_INDEX = 0;
+export const EVENT_LISTENER_HANDLER_ARGUMENT_INDEX = 1;
+export const WHOLE_RECEIVER_RELEASE_ARGUMENT_COUNT = 0;
+
 export const TRIVIAL_INITIALIZER_NAMES = new Set([
   "Boolean",
   "String",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
@@ -4757,6 +4757,36 @@ export const MediaQuery = ({ breakpoint }) => {
     },
   );
 
+  it("rejects cleanup-body mutation when the cleanup is declared before registration", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `
+      function Subscriptions({ emitter, subscriptions }) {
+        useEffect(() => {
+          function releaseSubscriptions() {
+            subscriptions.pop();
+            subscriptions.forEach(({ event, handler }) => {
+              emitter.off(event, handler);
+            });
+          }
+
+          subscriptions.forEach(({ event, handler }) => {
+            emitter.on(event, handler);
+          });
+
+          return releaseSubscriptions;
+        }, [emitter, subscriptions]);
+
+        return null;
+      }
+    `,
+      { filename: "Subscriptions.tsx" },
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it.each([
     "subscriptions.push({ event: 'extra', handler: extraHandler });",
     "subscriptions.unshift({ event: 'extra', handler: extraHandler });",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
@@ -4562,6 +4562,74 @@ export const MediaQuery = ({ breakpoint }) => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("does not collide opaque listener options with an inline capture value", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `
+      function OutsideAction({ listenerOptions, onOutsideAction }) {
+        useEffect(() => {
+          document.addEventListener("focusin", onOutsideAction, listenerOptions);
+          return () => {
+            document.removeEventListener("focusin", onOutsideAction, {
+              capture: listenerOptions,
+            });
+          };
+        }, [listenerOptions, onOutsideAction]);
+
+        return null;
+      }
+    `,
+      { filename: "OutsideAction.tsx" },
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it.each([
+    {
+      name: "conditional cleanup",
+      beforeCleanup: "",
+      cleanup: `
+        if (shouldCleanup) {
+          document.removeEventListener(event, handler, { capture });
+        }
+      `,
+    },
+    {
+      name: "post-registration collection mutation",
+      beforeCleanup: "subscriptions.pop();",
+      cleanup: "document.removeEventListener(event, handler, { capture });",
+    },
+  ])("rejects projected option-bag capture with $name", ({ beforeCleanup, cleanup }) => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `
+      function OutsideActions({ shouldCleanup, subscriptions }) {
+        useEffect(() => {
+          subscriptions.forEach(({ event, handler, capture }) => {
+            document.addEventListener(event, handler, { capture });
+          });
+
+          ${beforeCleanup}
+
+          return () => {
+            subscriptions.forEach(({ event, handler, capture }) => {
+              ${cleanup}
+            });
+          };
+        }, [shouldCleanup, subscriptions]);
+
+        return null;
+      }
+    `,
+      { filename: "OutsideActions.tsx" },
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("accepts direct exhaustive emitter cleanup through projected listener tuples", () => {
     const result = runRule(
       effectNeedsCleanup,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
@@ -4846,12 +4846,15 @@ export const MediaQuery = ({ breakpoint }) => {
     expect(result.diagnostics).toEqual([]);
   });
 
-  it.each(["subscriptions = [];", "subscriptions.length = 0;", "delete subscriptions[0];"])(
-    "rejects projected emitter cleanup after structural mutation with %s",
-    (mutation) => {
-      const result = runRule(
-        effectNeedsCleanup,
-        `
+  it.each([
+    "subscriptions = [];",
+    "subscriptions.length = 0;",
+    "subscriptions[0] = subscriptions[1];",
+    "delete subscriptions[0];",
+  ])("rejects projected emitter cleanup after structural mutation with %s", (mutation) => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `
         function Subscriptions({ emitter, subscriptions }) {
           useEffect(() => {
             subscriptions.forEach(({ event, handler }) => {
@@ -4869,13 +4872,12 @@ export const MediaQuery = ({ breakpoint }) => {
           return null;
         }
       `,
-        { filename: "Subscriptions.tsx" },
-      );
+      { filename: "Subscriptions.tsx" },
+    );
 
-      expect(result.parseErrors).toEqual([]);
-      expect(result.diagnostics).toHaveLength(1);
-    },
-  );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
 
   it.each([
     "subscriptions.push({ event: 'extra', handler: extraHandler });",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
@@ -4479,6 +4479,228 @@ export const MediaQuery = ({ breakpoint }) => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("accepts matching listener setup and cleanup through nested ref collections", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `
+      function Tooltip({ anchorRefs }) {
+        const handleFocus = () => {};
+
+        useEffect(() => {
+          const elementRefs = new Set(anchorRefs);
+          const enabledEvents = [];
+          enabledEvents.push({ event: "focus", listener: handleFocus, capture: true });
+
+          enabledEvents.forEach(({ event, listener, capture }) => {
+            elementRefs.forEach((elementRef) => {
+              elementRef.current?.addEventListener(event, listener, capture);
+            });
+          });
+
+          return () => {
+            enabledEvents.forEach(({ event, listener, capture }) => {
+              elementRefs.forEach((elementRef) => {
+                elementRef.current?.removeEventListener(event, listener, capture);
+              });
+            });
+          };
+        }, [anchorRefs]);
+
+        return null;
+      }
+    `,
+      { filename: "Tooltip.tsx" },
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it.each([
+    {
+      name: "a different receiver collection",
+      cleanup:
+        "cleanupRefs.forEach((elementRef) => elementRef.current?.removeEventListener(event, listener, capture));",
+      extra: "const cleanupRefs = new Set(otherAnchorRefs);",
+    },
+    {
+      name: "a different event projection",
+      cleanup:
+        "elementRefs.forEach((elementRef) => elementRef.current?.removeEventListener(cleanupEvent, listener, capture));",
+      extra: "",
+    },
+    {
+      name: "a different capture value",
+      cleanup:
+        "elementRefs.forEach((elementRef) => elementRef.current?.removeEventListener(event, listener, false));",
+      extra: "",
+    },
+    {
+      name: "a different handler projection",
+      cleanup:
+        "elementRefs.forEach((elementRef) => elementRef.current?.removeEventListener(event, cleanupListener, capture));",
+      extra: "",
+    },
+    {
+      name: "swapped event and handler projections",
+      cleanup:
+        "elementRefs.forEach((elementRef) => elementRef.current?.removeEventListener(listener, event, capture));",
+      extra: "",
+    },
+    {
+      name: "a conditional release",
+      cleanup:
+        "elementRefs.forEach((elementRef) => { if (shouldCleanup) elementRef.current?.removeEventListener(event, listener, capture); });",
+      extra: "",
+    },
+  ])("rejects $name in nested listener collections", ({ cleanup, extra }) => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `
+      function Tooltip({ anchorRefs, otherAnchorRefs, shouldCleanup }) {
+        const handleFocus = () => {};
+
+        useEffect(() => {
+          const elementRefs = new Set(anchorRefs);
+          ${extra}
+          const enabledEvents = [
+            {
+              event: "focus",
+              cleanupEvent: "blur",
+              listener: handleFocus,
+              cleanupListener: () => {},
+              capture: true,
+            },
+          ];
+
+          enabledEvents.forEach(({ event, listener, capture }) => {
+            elementRefs.forEach((elementRef) => {
+              elementRef.current?.addEventListener(event, listener, capture);
+            });
+          });
+
+          return () => {
+            enabledEvents.forEach(({ event, cleanupEvent, listener, cleanupListener, capture }) => {
+              ${cleanup}
+            });
+          };
+        }, [anchorRefs, otherAnchorRefs, shouldCleanup]);
+
+        return null;
+      }
+    `,
+      { filename: "Tooltip.tsx" },
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it.each([
+    {
+      name: "a second callback parameter",
+      setupParameters: "event, listener",
+      setupEvent: "event.event",
+      setupListener: "listener.listener",
+      cleanupParameters: "event, listener",
+      cleanupEvent: "event.event",
+      cleanupListener: "listener.listener",
+    },
+    {
+      name: "array destructuring",
+      setupParameters: "[event, listener]",
+      setupEvent: "event",
+      setupListener: "listener",
+      cleanupParameters: "[event, listener]",
+      cleanupEvent: "event",
+      cleanupListener: "listener",
+    },
+    {
+      name: "defaulted object properties",
+      setupParameters: '{ event = "focus", listener = handleFocus }',
+      setupEvent: "event",
+      setupListener: "listener",
+      cleanupParameters: '{ event = "focus", listener = handleFocus }',
+      cleanupEvent: "event",
+      cleanupListener: "listener",
+    },
+  ])("does not infer cleanup identity through $name", (fixture) => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `
+      function Tooltip({ anchorRefs }) {
+        const handleFocus = () => {};
+
+        useEffect(() => {
+          const elementRefs = new Set(anchorRefs);
+          const enabledEvents = [{ event: "focus", listener: handleFocus }];
+
+          enabledEvents.forEach((${fixture.setupParameters}) => {
+            elementRefs.forEach((elementRef) => {
+              elementRef.current?.addEventListener(${fixture.setupEvent}, ${fixture.setupListener});
+            });
+          });
+
+          return () => {
+            enabledEvents.forEach((${fixture.cleanupParameters}) => {
+              elementRefs.forEach((elementRef) => {
+                elementRef.current?.removeEventListener(${fixture.cleanupEvent}, ${fixture.cleanupListener});
+              });
+            });
+          };
+        }, [anchorRefs]);
+
+        return null;
+      }
+    `,
+      { filename: "Tooltip.tsx" },
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it.each(["enabledEvents.pop();", "elementRefs.clear();"])(
+    "rejects replay cleanup after the registered collection mutates with %s",
+    (mutation) => {
+      const result = runRule(
+        effectNeedsCleanup,
+        `
+        function Tooltip({ anchorRefs }) {
+          const handleFocus = () => {};
+
+          useEffect(() => {
+            const elementRefs = new Set(anchorRefs);
+            const enabledEvents = [{ event: "focus", listener: handleFocus }];
+
+            enabledEvents.forEach(({ event, listener }) => {
+              elementRefs.forEach((elementRef) => {
+                elementRef.current?.addEventListener(event, listener);
+              });
+            });
+
+            ${mutation}
+
+            return () => {
+              enabledEvents.forEach(({ event, listener }) => {
+                elementRefs.forEach((elementRef) => {
+                  elementRef.current?.removeEventListener(event, listener);
+                });
+              });
+            };
+          }, [anchorRefs]);
+
+          return null;
+        }
+      `,
+        { filename: "Tooltip.tsx" },
+      );
+
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    },
+  );
+
   it("rejects a legacy media listener cleanup with a changed handler", () => {
     const result = runRule(
       effectNeedsCleanup,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
@@ -4787,6 +4787,96 @@ export const MediaQuery = ({ breakpoint }) => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("accepts exhaustive projected cleanup declared before registration", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `
+      function Subscriptions({ emitter, subscriptions }) {
+        useEffect(() => {
+          function releaseSubscriptions() {
+            subscriptions.forEach(({ event, handler }) => {
+              emitter.off(event, handler);
+            });
+          }
+
+          subscriptions.forEach(({ event, handler }) => {
+            emitter.on(event, handler);
+          });
+
+          return releaseSubscriptions;
+        }, [emitter, subscriptions]);
+
+        return null;
+      }
+    `,
+      { filename: "Subscriptions.tsx" },
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("accepts exhaustive projected cleanup returned through a stable alias", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `
+      function Subscriptions({ emitter, subscriptions }) {
+        useEffect(() => {
+          const releaseSubscriptions = () => {
+            subscriptions.forEach(({ event, handler }) => {
+              emitter.off(event, handler);
+            });
+          };
+          const cleanup = releaseSubscriptions;
+
+          subscriptions.forEach(({ event, handler }) => {
+            emitter.on(event, handler);
+          });
+
+          return cleanup;
+        }, [emitter, subscriptions]);
+
+        return null;
+      }
+    `,
+      { filename: "Subscriptions.tsx" },
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it.each(["subscriptions = [];", "subscriptions.length = 0;", "delete subscriptions[0];"])(
+    "rejects projected emitter cleanup after structural mutation with %s",
+    (mutation) => {
+      const result = runRule(
+        effectNeedsCleanup,
+        `
+        function Subscriptions({ emitter, subscriptions }) {
+          useEffect(() => {
+            subscriptions.forEach(({ event, handler }) => {
+              emitter.on(event, handler);
+            });
+
+            return () => {
+              ${mutation}
+              subscriptions.forEach(({ event, handler }) => {
+                emitter.off(event, handler);
+              });
+            };
+          }, [emitter, subscriptions]);
+
+          return null;
+        }
+      `,
+        { filename: "Subscriptions.tsx" },
+      );
+
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    },
+  );
+
   it.each([
     "subscriptions.push({ event: 'extra', handler: extraHandler });",
     "subscriptions.unshift({ event: 'extra', handler: extraHandler });",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
@@ -4758,6 +4758,43 @@ export const MediaQuery = ({ breakpoint }) => {
   );
 
   it.each([
+    "subscriptions.push({ event: 'extra', handler: extraHandler });",
+    "subscriptions.unshift({ event: 'extra', handler: extraHandler });",
+    "subscriptions.sort();",
+    "subscriptions.reverse();",
+    "subscriptions.add({ event: 'extra', handler: extraHandler });",
+  ])(
+    "accepts exhaustive projected cleanup after additive or order-only mutation with %s",
+    (mutation) => {
+      const result = runRule(
+        effectNeedsCleanup,
+        `
+      function Subscriptions({ emitter, extraHandler, subscriptions }) {
+        useEffect(() => {
+          subscriptions.forEach(({ event, handler }) => {
+            emitter.on(event, handler);
+          });
+
+          return () => {
+            ${mutation}
+            subscriptions.forEach(({ event, handler }) => {
+              emitter.off(event, handler);
+            });
+          };
+        }, [emitter, extraHandler, subscriptions]);
+
+        return null;
+      }
+    `,
+        { filename: "Subscriptions.tsx" },
+      );
+
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    },
+  );
+
+  it.each([
     {
       name: "a different receiver collection",
       cleanup:

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
@@ -4916,6 +4916,143 @@ export const MediaQuery = ({ breakpoint }) => {
     },
   );
 
+  it.each(["emitter.off();", "emitter.dispose();"])(
+    "accepts projected registrations followed by whole-receiver cleanup with %s",
+    (cleanup) => {
+      const result = runRule(
+        effectNeedsCleanup,
+        `
+          function Subscriptions({ emitter, subscriptions }) {
+            useEffect(() => {
+              subscriptions.forEach(({ event, handler }) => {
+                emitter.on(event, handler);
+              });
+
+              return () => {
+                ${cleanup}
+              };
+            }, [emitter, subscriptions]);
+
+            return null;
+          }
+        `,
+        { filename: "Subscriptions.tsx" },
+      );
+
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    },
+  );
+
+  it("accepts projected handlers followed by handlerless event cleanup", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `
+        function Subscriptions({ emitter, handlers }) {
+          useEffect(() => {
+            handlers.forEach((handler) => {
+              emitter.on("update", handler);
+            });
+
+            return () => {
+              emitter.off("update");
+            };
+          }, [emitter, handlers]);
+
+          return null;
+        }
+      `,
+      { filename: "Subscriptions.tsx" },
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it.each([
+    'emitter.off("other");',
+    'emitter.off("update", handlers[0]);',
+    "emitter.off(getEvent());",
+    "emitter.off(null);",
+    'if (shouldCleanup) emitter.off("update");',
+  ])("rejects projected handlers followed by incomplete event cleanup with %s", (cleanup) => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `
+          function Subscriptions({ emitter, handlers }) {
+            useEffect(() => {
+              handlers.forEach((handler) => {
+                emitter.on("update", handler);
+              });
+
+              return () => {
+                ${cleanup}
+              };
+            }, [emitter, handlers]);
+
+            return null;
+          }
+        `,
+      { filename: "Subscriptions.tsx" },
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not mistake a unary addListener release for handlerless cleanup", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `
+        function Subscriptions({ source, handlers }) {
+          useEffect(() => {
+            handlers.forEach((handler) => {
+              source.addListener(handler);
+            });
+
+            return () => {
+              source.off(handlers[0]);
+            };
+          }, [handlers, source]);
+
+          return null;
+        }
+      `,
+      { filename: "Subscriptions.tsx" },
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it.each(["otherEmitter.off();", "otherEmitter.dispose();", 'emitter.off("focus");'])(
+    "rejects projected registrations followed by incomplete whole-receiver cleanup with %s",
+    (cleanup) => {
+      const result = runRule(
+        effectNeedsCleanup,
+        `
+          function Subscriptions({ emitter, otherEmitter, subscriptions }) {
+            useEffect(() => {
+              subscriptions.forEach(({ event, handler }) => {
+                emitter.on(event, handler);
+              });
+
+              return () => {
+                ${cleanup}
+              };
+            }, [emitter, otherEmitter, subscriptions]);
+
+            return null;
+          }
+        `,
+        { filename: "Subscriptions.tsx" },
+      );
+
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    },
+  );
+
   it.each([
     {
       name: "a different receiver collection",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
@@ -4697,6 +4697,66 @@ export const MediaQuery = ({ breakpoint }) => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("rejects projected emitter cleanup wrapped in an unrelated collection", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `
+      function Subscriptions({ emitter, subscriptions, unrelatedItems }) {
+        useEffect(() => {
+          subscriptions.forEach(({ event, handler }) => {
+            emitter.on(event, handler);
+          });
+
+          return () => {
+            unrelatedItems.forEach(() => {
+              subscriptions.forEach(({ event, handler }) => {
+                emitter.off(event, handler);
+              });
+            });
+          };
+        }, [emitter, subscriptions, unrelatedItems]);
+
+        return null;
+      }
+    `,
+      { filename: "Subscriptions.tsx" },
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it.each(["subscriptions.pop();", "subscriptions.clear();"])(
+    "rejects projected emitter cleanup after cleanup-body mutation with %s",
+    (mutation) => {
+      const result = runRule(
+        effectNeedsCleanup,
+        `
+        function Subscriptions({ emitter, subscriptions }) {
+          useEffect(() => {
+            subscriptions.forEach(({ event, handler }) => {
+              emitter.on(event, handler);
+            });
+
+            return () => {
+              ${mutation}
+              subscriptions.forEach(({ event, handler }) => {
+                emitter.off(event, handler);
+              });
+            };
+          }, [emitter, subscriptions]);
+
+          return null;
+        }
+      `,
+        { filename: "Subscriptions.tsx" },
+      );
+
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    },
+  );
+
   it.each([
     {
       name: "a different receiver collection",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
@@ -4516,6 +4516,119 @@ export const MediaQuery = ({ breakpoint }) => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("accepts matching nonliteral capture values in inline option bags", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `
+      function OutsideAction({ capture, onOutsideAction }) {
+        useEffect(() => {
+          document.addEventListener("focusin", onOutsideAction, { capture, passive: true });
+          return () => {
+            document.removeEventListener("focusin", onOutsideAction, { capture, passive: false });
+          };
+        }, [capture, onOutsideAction]);
+
+        return null;
+      }
+    `,
+      { filename: "OutsideAction.tsx" },
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("rejects different nonliteral capture values in inline option bags", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `
+      function OutsideAction({ capture, cleanupCapture, onOutsideAction }) {
+        useEffect(() => {
+          document.addEventListener("focusin", onOutsideAction, { capture });
+          return () => {
+            document.removeEventListener("focusin", onOutsideAction, {
+              capture: cleanupCapture,
+            });
+          };
+        }, [capture, cleanupCapture, onOutsideAction]);
+
+        return null;
+      }
+    `,
+      { filename: "OutsideAction.tsx" },
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("accepts direct exhaustive emitter cleanup through projected listener tuples", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `
+      function Subscriptions({ emitter, subscriptions }) {
+        useEffect(() => {
+          subscriptions.forEach(({ event, handler }) => {
+            emitter.on(event, handler);
+          });
+
+          return () => {
+            subscriptions.forEach(({ event, handler }) => {
+              emitter.off(event, handler);
+            });
+          };
+        }, [emitter, subscriptions]);
+
+        return null;
+      }
+    `,
+      { filename: "Subscriptions.tsx" },
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it.each([
+    {
+      name: "conditional cleanup",
+      beforeCleanup: "",
+      cleanup: "if (shouldCleanup) emitter.off(event, handler);",
+    },
+    {
+      name: "post-registration collection mutation",
+      beforeCleanup: "subscriptions.pop();",
+      cleanup: "emitter.off(event, handler);",
+    },
+  ])("rejects projected emitter $name", ({ beforeCleanup, cleanup }) => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `
+      function Subscriptions({ emitter, shouldCleanup, subscriptions }) {
+        useEffect(() => {
+          subscriptions.forEach(({ event, handler }) => {
+            emitter.on(event, handler);
+          });
+
+          ${beforeCleanup}
+
+          return () => {
+            subscriptions.forEach(({ event, handler }) => {
+              ${cleanup}
+            });
+          };
+        }, [emitter, shouldCleanup, subscriptions]);
+
+        return null;
+      }
+    `,
+      { filename: "Subscriptions.tsx" },
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it.each([
     {
       name: "a different receiver collection",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -2893,6 +2893,40 @@ const hasCollectionMutationBeforeRelease = (
     const isAfterRegistration = setupOwnerFunctions.has(ownerFunction) && childStart > usageStart;
     const isBeforeRelease = cleanupOwnerFunctions.has(ownerFunction) && childStart < releaseStart;
     if (!isAfterRegistration && !isBeforeRelease) return;
+    if (isNodeOfType(child, "AssignmentExpression")) {
+      const assignmentKey = resolveExpressionKey(child.left, context);
+      if (
+        assignmentKey &&
+        [...collectionKeys].some(
+          (collectionKey) =>
+            assignmentKey === collectionKey || assignmentKey === `${collectionKey}.length`,
+        )
+      ) {
+        didFindMutation = true;
+        return false;
+      }
+      return;
+    }
+    if (isNodeOfType(child, "UnaryExpression") && child.operator === "delete") {
+      const deletedMember = stripParenExpression(child.argument);
+      if (!isNodeOfType(deletedMember, "MemberExpression")) return;
+      if (collectionKeys.has(resolveExpressionKey(deletedMember.object, context) ?? "")) {
+        didFindMutation = true;
+        return false;
+      }
+      return;
+    }
+    if (isNodeOfType(child, "UpdateExpression")) {
+      const updatedKey = resolveExpressionKey(child.argument, context);
+      if (
+        updatedKey &&
+        [...collectionKeys].some((collectionKey) => updatedKey === `${collectionKey}.length`)
+      ) {
+        didFindMutation = true;
+        return false;
+      }
+      return;
+    }
     if (!isNodeOfType(child, "CallExpression")) return;
     const callee = stripParenExpression(child.callee);
     if (
@@ -3232,28 +3266,29 @@ const isReturnedEffectCleanupFunction = (
   functionNode: EsTreeNode,
   context: RuleContext,
 ): boolean => {
-  let currentNode = functionNode;
-  let parentNode = currentNode.parent;
-  while (
-    isNodeOfType(parentNode, "ChainExpression") ||
-    isNodeOfType(parentNode, "TSAsExpression") ||
-    isNodeOfType(parentNode, "TSNonNullExpression")
+  const effectCallback = findEnclosingFunction(functionNode);
+  if (!effectCallback || !isFunctionLike(effectCallback)) return false;
+  const effectCall = effectCallback.parent;
+  if (
+    !isNodeOfType(effectCall, "CallExpression") ||
+    !isReactHookCall(effectCall, CLEANUP_EFFECT_HOOK_NAMES, context.scopes)
   ) {
-    currentNode = parentNode;
-    parentNode = currentNode.parent;
+    return false;
   }
-  const effectCallback =
-    isNodeOfType(parentNode, "ReturnStatement") && parentNode.argument === currentNode
-      ? findEnclosingFunction(parentNode)
-      : isNodeOfType(parentNode, "ArrowFunctionExpression") && parentNode.body === currentNode
-        ? parentNode
-        : null;
-  const effectCall = effectCallback?.parent;
-  return Boolean(
-    effectCallback &&
-    isNodeOfType(effectCall, "CallExpression") &&
-    isReactHookCall(effectCall, CLEANUP_EFFECT_HOOK_NAMES, context.scopes),
-  );
+  if (!isNodeOfType(effectCallback.body, "BlockStatement")) {
+    return resolveStableValue(effectCallback.body, context) === functionNode;
+  }
+  let isReturned = false;
+  walkInsideStatementBlocks(effectCallback.body, (child: EsTreeNode) => {
+    if (
+      isNodeOfType(child, "ReturnStatement") &&
+      child.argument &&
+      resolveStableValue(child.argument, context) === functionNode
+    ) {
+      isReturned = true;
+    }
+  });
+  return isReturned;
 };
 
 const isPotentiallyReachableFunction = (

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -3,7 +3,6 @@ import {
   TIMER_CALLEE_NAMES_REQUIRING_CLEANUP,
   TIMER_CLEANUP_CALLEE_NAMES,
 } from "../../constants/dom.js";
-import { MUTATING_ARRAY_METHODS, MUTATING_COLLECTION_METHODS } from "../../constants/js.js";
 import {
   BOUND_RESOURCE_RELEASE_METHOD_NAMES,
   EFFECT_HOOK_NAMES,
@@ -54,6 +53,18 @@ import type { SymbolDescriptor } from "../../semantic/scope-analysis.js";
 
 const CLEANUP_EFFECT_HOOK_NAMES = new Set([...EFFECT_HOOK_NAMES, "useInsertionEffect"]);
 const REPLAYABLE_ITERATOR_COLLECTION_CACHE = new WeakMap<RuleContext, Map<number, string | null>>();
+const REPLAY_ENTRY_DROPPING_ARRAY_METHOD_NAMES: ReadonlySet<string> = new Set([
+  "pop",
+  "shift",
+  "splice",
+  "fill",
+  "copyWithin",
+]);
+const REPLAY_ENTRY_DROPPING_COLLECTION_METHOD_NAMES: ReadonlySet<string> = new Set([
+  "clear",
+  "delete",
+  "set",
+]);
 
 interface SubscribeLikeUsage {
   kind: "subscribe" | "timer" | "socket";
@@ -2898,8 +2909,8 @@ const hasCollectionMutationBeforeRelease = (
       !isNodeOfType(callee, "MemberExpression") ||
       callee.computed ||
       !isNodeOfType(callee.property, "Identifier") ||
-      (!MUTATING_ARRAY_METHODS.has(callee.property.name) &&
-        !MUTATING_COLLECTION_METHODS.has(callee.property.name)) ||
+      (!REPLAY_ENTRY_DROPPING_ARRAY_METHOD_NAMES.has(callee.property.name) &&
+        !REPLAY_ENTRY_DROPPING_COLLECTION_METHOD_NAMES.has(callee.property.name)) ||
       !collectionKeys.has(resolveExpressionKey(callee.object, context) ?? "")
     ) {
       return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -277,6 +277,58 @@ const resolveResourceIdentityKey = (
 ): string | null =>
   resolveForEachProjectionKey(expression, context) ?? resolveExpressionKey(expression, context);
 
+const resolveEventListenerCaptureIdentityKey = (
+  optionsNode: EsTreeNode | null | undefined,
+  context: RuleContext,
+  allowOpaqueOptionsIdentity: boolean,
+): string | null => {
+  const capture = resolveEventListenerCapture(optionsNode, {
+    allowIndeterminateEntries: true,
+  });
+  if (capture !== null) return `capture:${String(capture)}`;
+  if (!optionsNode) return null;
+  const unwrappedOptions = stripParenExpression(optionsNode);
+  if (!isNodeOfType(unwrappedOptions, "ObjectExpression")) {
+    return allowOpaqueOptionsIdentity
+      ? resolveResourceIdentityKey(unwrappedOptions, context)
+      : null;
+  }
+  let captureKey: string | null = "capture:false";
+  for (const property of unwrappedOptions.properties ?? []) {
+    if (!isNodeOfType(property, "Property")) {
+      captureKey = null;
+      continue;
+    }
+    const propertyName = getStaticPropertyKeyName(property);
+    if (propertyName === null || (!property.computed && propertyName === "__proto__")) {
+      captureKey = null;
+      continue;
+    }
+    if (propertyName === "capture") {
+      captureKey = resolveResourceIdentityKey(property.value, context);
+    }
+  }
+  return captureKey;
+};
+
+const doEventListenerCapturesMatch = (
+  registrationOptions: EsTreeNode | null | undefined,
+  releaseOptions: EsTreeNode | null | undefined,
+  context: RuleContext,
+  allowOpaqueOptionsIdentity = false,
+): boolean => {
+  const registrationCaptureKey = resolveEventListenerCaptureIdentityKey(
+    registrationOptions,
+    context,
+    allowOpaqueOptionsIdentity,
+  );
+  return (
+    registrationCaptureKey !== null &&
+    registrationCaptureKey ===
+      resolveEventListenerCaptureIdentityKey(releaseOptions, context, allowOpaqueOptionsIdentity)
+  );
+};
+
 const findAssignedResourceKey = (resourceNode: EsTreeNode, context: RuleContext): string | null => {
   let currentNode = resourceNode;
   let parentNode = currentNode.parent;
@@ -2689,16 +2741,8 @@ const isReactRefListenerReplacementRelease = (
   ) {
     return false;
   }
-  const registrationCapture = resolveEventListenerCapture(usage.node.arguments?.[2], {
-    allowIndeterminateEntries: true,
-  });
-  const releaseCapture = resolveEventListenerCapture(releaseCall.arguments?.[2], {
-    allowIndeterminateEntries: true,
-  });
   if (
-    registrationCapture === null ||
-    releaseCapture === null ||
-    registrationCapture !== releaseCapture
+    !doEventListenerCapturesMatch(usage.node.arguments?.[2], releaseCall.arguments?.[2], context)
   ) {
     return false;
   }
@@ -2824,6 +2868,48 @@ const hasCollectionMutationBeforeCleanup = (
   return didFindMutation;
 };
 
+const hasSafeForEachProjectionCleanup = (
+  registrationCall: EsTreeNodeOfType<"CallExpression">,
+  releaseCall: EsTreeNodeOfType<"CallExpression">,
+  context: RuleContext,
+): boolean => {
+  const registrationCallee = stripParenExpression(registrationCall.callee);
+  const releaseCallee = stripParenExpression(releaseCall.callee);
+  if (
+    !isNodeOfType(registrationCallee, "MemberExpression") ||
+    !isNodeOfType(releaseCallee, "MemberExpression")
+  ) {
+    return true;
+  }
+  const registrationVerbName = getCalleeName(registrationCall);
+  const releaseVerbName = getCalleeName(releaseCall);
+  const projectionExpressions = [
+    registrationCallee.object,
+    registrationCall.arguments?.[0],
+    registrationCall.arguments?.[1],
+    releaseCallee.object,
+    releaseCall.arguments?.[0],
+    releaseCall.arguments?.[1],
+  ];
+  if (registrationVerbName === "addEventListener" && releaseVerbName === "removeEventListener") {
+    projectionExpressions.push(registrationCall.arguments?.[2], releaseCall.arguments?.[2]);
+  }
+  const projections = projectionExpressions.flatMap((expression) => {
+    const projection = resolveForEachProjection(expression, context);
+    return projection ? [projection] : [];
+  });
+  if (projections.length === 0) return true;
+  const cleanupFunction = findDirectExhaustiveForEachCleanupFunction(releaseCall, context);
+  if (!cleanupFunction) return false;
+  const collectionKeys = new Set(projections.map((projection) => projection.collectionKey));
+  return !hasCollectionMutationBeforeCleanup(
+    registrationCall,
+    cleanupFunction,
+    collectionKeys,
+    context,
+  );
+};
+
 const doesReleaseCallMatchUsage = (
   node: EsTreeNode,
   usage: SubscribeLikeUsage,
@@ -2944,44 +3030,21 @@ const doesReleaseCallMatchUsage = (
   ) {
     const registrationCallee = stripParenExpression(usage.node.callee);
     if (!isNodeOfType(registrationCallee, "MemberExpression")) return false;
-    const registrationCapture = resolveEventListenerCapture(usage.node.arguments?.[2], {
-      allowIndeterminateEntries: true,
-    });
-    const releaseCapture = resolveEventListenerCapture(callNode.arguments?.[2], {
-      allowIndeterminateEntries: true,
-    });
-    const registrationCaptureKey = resolveResourceIdentityKey(usage.node.arguments?.[2], context);
-    const releaseCaptureKey = resolveResourceIdentityKey(callNode.arguments?.[2], context);
-    const doCapturesMatch =
-      registrationCapture === null || releaseCapture === null
-        ? registrationCaptureKey !== null && registrationCaptureKey === releaseCaptureKey
-        : registrationCapture === releaseCapture;
-    if (!doCapturesMatch) return false;
-    const projectionExpressions = [
-      registrationCallee.object,
-      usage.node.arguments?.[0],
-      usage.node.arguments?.[1],
-      usage.node.arguments?.[2],
-      callee.object,
-      callNode.arguments?.[0],
-      callNode.arguments?.[1],
-      callNode.arguments?.[2],
-    ];
-    const projections = projectionExpressions.flatMap((expression) => {
-      const projection = resolveForEachProjection(expression, context);
-      return projection ? [projection] : [];
-    });
-    if (projections.length > 0) {
-      const cleanupFunction = findDirectExhaustiveForEachCleanupFunction(callNode, context);
-      if (!cleanupFunction) return false;
-      const collectionKeys = new Set(projections.map((projection) => projection.collectionKey));
-      if (
-        hasCollectionMutationBeforeCleanup(usage.node, cleanupFunction, collectionKeys, context)
-      ) {
-        return false;
-      }
-    }
+    if (
+      !doEventListenerCapturesMatch(
+        usage.node.arguments?.[2],
+        callNode.arguments?.[2],
+        context,
+        true,
+      )
+    )
+      return false;
   }
+  if (
+    isNodeOfType(usage.node, "CallExpression") &&
+    !hasSafeForEachProjectionCleanup(usage.node, callNode, context)
+  )
+    return false;
   if (usage.receiverKey === null || releaseReceiverKey !== usage.receiverKey) return false;
   if (
     usage.registrationVerbName === "subscribe" &&
@@ -3065,16 +3128,8 @@ const doesReleaseCallMatchUsage = (
       ) {
         return false;
       }
-      const registrationCapture = resolveEventListenerCapture(usage.node.arguments?.[2], {
-        allowIndeterminateEntries: true,
-      });
-      const releaseCapture = resolveEventListenerCapture(callNode.arguments?.[2], {
-        allowIndeterminateEntries: true,
-      });
       if (
-        registrationCapture === null ||
-        releaseCapture === null ||
-        registrationCapture !== releaseCapture
+        !doEventListenerCapturesMatch(usage.node.arguments?.[2], callNode.arguments?.[2], context)
       ) {
         return false;
       }
@@ -3452,20 +3507,12 @@ const isSelfReleasingListenerRelease = (
   ) {
     return false;
   }
-  const registrationCapture = resolveEventListenerCapture(usage.node.arguments?.[2], {
-    allowIndeterminateEntries: true,
-  });
   const releaseCall = isNodeOfType(releaseNode, "ChainExpression")
     ? releaseNode.expression
     : releaseNode;
   if (!isNodeOfType(releaseCall, "CallExpression")) return false;
-  const releaseCapture = resolveEventListenerCapture(releaseCall.arguments?.[2], {
-    allowIndeterminateEntries: true,
-  });
   if (
-    registrationCapture === null ||
-    releaseCapture === null ||
-    registrationCapture !== releaseCapture
+    !doEventListenerCapturesMatch(usage.node.arguments?.[2], releaseCall.arguments?.[2], context)
   ) {
     return false;
   }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -5,8 +5,12 @@ import {
 } from "../../constants/dom.js";
 import {
   BOUND_RESOURCE_RELEASE_METHOD_NAMES,
+  EVENT_LISTENER_HANDLER_ARGUMENT_INDEX,
   EFFECT_HOOK_NAMES,
   GLOBAL_RELEASE_METHOD_NAMES,
+  UNARY_LISTENER_ARGUMENT_COUNT,
+  UNARY_LISTENER_HANDLER_ARGUMENT_INDEX,
+  WHOLE_RECEIVER_RELEASE_ARGUMENT_COUNT,
 } from "../../constants/react.js";
 import { defineRule } from "../../utils/define-rule.js";
 import {
@@ -2949,6 +2953,14 @@ const hasCollectionMutationBeforeRelease = (
   return didFindMutation;
 };
 
+const usesUnaryListenerSignature = (
+  registrationCall: EsTreeNodeOfType<"CallExpression">,
+  releaseCall: EsTreeNodeOfType<"CallExpression">,
+): boolean =>
+  getCalleeName(registrationCall) === "addListener" &&
+  registrationCall.arguments?.length === UNARY_LISTENER_ARGUMENT_COUNT &&
+  releaseCall.arguments?.length === UNARY_LISTENER_ARGUMENT_COUNT;
+
 const hasSafeForEachProjectionCleanup = (
   registrationCall: EsTreeNodeOfType<"CallExpression">,
   releaseCall: EsTreeNodeOfType<"CallExpression">,
@@ -2964,6 +2976,33 @@ const hasSafeForEachProjectionCleanup = (
   }
   const registrationVerbName = getCalleeName(registrationCall);
   const releaseVerbName = getCalleeName(releaseCall);
+  const releaseHandler =
+    releaseCall.arguments?.[
+      usesUnaryListenerSignature(registrationCall, releaseCall)
+        ? UNARY_LISTENER_HANDLER_ARGUMENT_INDEX
+        : EVENT_LISTENER_HANDLER_ARGUMENT_INDEX
+    ];
+  const releaseFunction = findEnclosingFunction(releaseCall);
+  const registrationEventKey = resolveResourceIdentityKey(registrationCall.arguments?.[0], context);
+  const releaseEventKey = resolveResourceIdentityKey(releaseCall.arguments?.[0], context);
+  const doesHandlerlessOffReleaseEveryRegistration =
+    releaseVerbName === "off" &&
+    !releaseHandler &&
+    (releaseCall.arguments?.length === WHOLE_RECEIVER_RELEASE_ARGUMENT_COUNT ||
+      (registrationEventKey !== null && registrationEventKey === releaseEventKey));
+  const doesReleaseCoverEveryCleanupPath = Boolean(
+    releaseFunction &&
+    isFunctionLike(releaseFunction) &&
+    isReturnedEffectCleanupFunction(releaseFunction, context) &&
+    doMatchingNodesCoverEveryPathFromFunctionEntry(releaseFunction, [releaseCall], context),
+  );
+  if (
+    doesReleaseCoverEveryCleanupPath &&
+    ((releaseVerbName !== null && UNIVERSAL_RELEASE_VERB_NAMES.has(releaseVerbName)) ||
+      doesHandlerlessOffReleaseEveryRegistration)
+  ) {
+    return true;
+  }
   const projectionExpressions = [
     registrationCallee.object,
     registrationCall.arguments?.[0],
@@ -3233,18 +3272,22 @@ const doesReleaseCallMatchUsage = (
     releaseVerbName === "removeListener" ||
     releaseVerbName === "off"
   ) {
-    const usesUnaryListenerSignature =
-      usage.registrationVerbName === "addListener" &&
+    const usesUnaryListenerSignatureForCalls =
       isNodeOfType(usage.node, "CallExpression") &&
-      usage.node.arguments?.length === 1 &&
-      callNode.arguments?.length === 1;
-    const releaseHandler = usesUnaryListenerSignature
-      ? callNode.arguments?.[0]
-      : callNode.arguments?.[1];
+      usesUnaryListenerSignature(usage.node, callNode);
+    const releaseHandler = usesUnaryListenerSignatureForCalls
+      ? callNode.arguments?.[UNARY_LISTENER_HANDLER_ARGUMENT_INDEX]
+      : callNode.arguments?.[EVENT_LISTENER_HANDLER_ARGUMENT_INDEX];
     if (!releaseHandler) return releaseVerbName === "off";
-    const expectedHandlerKey = usesUnaryListenerSignature ? usage.eventKey : usage.handlerKey;
+    const expectedHandlerKey = usesUnaryListenerSignatureForCalls
+      ? usage.eventKey
+      : usage.handlerKey;
     const registrationHandler = isNodeOfType(usage.node, "CallExpression")
-      ? usage.node.arguments?.[usesUnaryListenerSignature ? 0 : 1]
+      ? usage.node.arguments?.[
+          usesUnaryListenerSignatureForCalls
+            ? UNARY_LISTENER_HANDLER_ARGUMENT_INDEX
+            : EVENT_LISTENER_HANDLER_ARGUMENT_INDEX
+        ]
       : null;
     return (
       (expectedHandlerKey !== null &&

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -2811,10 +2811,12 @@ const isReactRefListenerReplacementRelease = (
 
 const findDirectExhaustiveForEachCleanupFunction = (
   releaseNode: EsTreeNode,
+  requiredCollectionKeys: ReadonlySet<string>,
   context: RuleContext,
 ): EsTreeNode | null => {
   let currentNode = findTransparentExpressionRoot(releaseNode);
   const visitedFunctions = new Set<EsTreeNode>();
+  const replayedCollectionKeys = new Set<string>();
   while (true) {
     const ownerFunction = findEnclosingFunction(currentNode);
     if (!ownerFunction || !isFunctionLike(ownerFunction) || visitedFunctions.has(ownerFunction)) {
@@ -2839,13 +2841,21 @@ const findDirectExhaustiveForEachCleanupFunction = (
     }
     const forEachCall = findForEachCallForCallback(ownerFunction);
     if (!forEachCall) {
-      return isReturnedEffectCleanupFunction(ownerFunction, context) ? ownerFunction : null;
+      return replayedCollectionKeys.size === requiredCollectionKeys.size &&
+        isReturnedEffectCleanupFunction(ownerFunction, context)
+        ? ownerFunction
+        : null;
     }
+    const forEachCallee = stripParenExpression(forEachCall.callee);
+    if (!isNodeOfType(forEachCallee, "MemberExpression")) return null;
+    const collectionKey = resolveExpressionKey(forEachCallee.object, context);
+    if (!collectionKey || !requiredCollectionKeys.has(collectionKey)) return null;
+    replayedCollectionKeys.add(collectionKey);
     currentNode = findTransparentExpressionRoot(forEachCall);
   }
 };
 
-const collectSetupOwnerFunctions = (usageNode: EsTreeNode): Set<EsTreeNode> => {
+const collectReplayOwnerFunctions = (usageNode: EsTreeNode): Set<EsTreeNode> => {
   const ownerFunctions = new Set<EsTreeNode>();
   let currentNode = usageNode;
   while (true) {
@@ -2860,25 +2870,28 @@ const collectSetupOwnerFunctions = (usageNode: EsTreeNode): Set<EsTreeNode> => {
   return ownerFunctions;
 };
 
-const hasCollectionMutationBeforeCleanup = (
+const hasCollectionMutationBeforeRelease = (
   usageNode: EsTreeNode,
-  cleanupFunction: EsTreeNode,
+  releaseNode: EsTreeNode,
   collectionKeys: ReadonlySet<string>,
   context: RuleContext,
 ): boolean => {
   const usageStart = getRangeStart(usageNode);
-  const cleanupStart = getRangeStart(cleanupFunction);
-  if (usageStart === null || cleanupStart === null) return true;
-  const setupOwnerFunctions = collectSetupOwnerFunctions(usageNode);
+  const releaseStart = getRangeStart(releaseNode);
+  if (usageStart === null || releaseStart === null) return true;
+  const replayOwnerFunctions = new Set([
+    ...collectReplayOwnerFunctions(usageNode),
+    ...collectReplayOwnerFunctions(releaseNode),
+  ]);
   let programNode = usageNode;
   while (programNode.parent) programNode = programNode.parent;
   let didFindMutation = false;
   walkAst(programNode, (child: EsTreeNode) => {
     if (didFindMutation) return false;
     const childStart = getRangeStart(child);
-    if (childStart === null || childStart <= usageStart || childStart >= cleanupStart) return;
+    if (childStart === null || childStart <= usageStart || childStart >= releaseStart) return;
     const ownerFunction = context.cfg.enclosingFunction(child);
-    if (!ownerFunction || !setupOwnerFunctions.has(ownerFunction)) return;
+    if (!ownerFunction || !replayOwnerFunctions.has(ownerFunction)) return;
     if (!isNodeOfType(child, "CallExpression")) return;
     const callee = stripParenExpression(child.callee);
     if (
@@ -2931,12 +2944,16 @@ const hasSafeForEachProjectionCleanup = (
     }
   }
   if (projections.length === 0) return true;
-  const cleanupFunction = findDirectExhaustiveForEachCleanupFunction(releaseCall, context);
-  if (!cleanupFunction) return false;
   const collectionKeys = new Set(projections.map((projection) => projection.collectionKey));
-  return !hasCollectionMutationBeforeCleanup(
+  const cleanupFunction = findDirectExhaustiveForEachCleanupFunction(
+    releaseCall,
+    collectionKeys,
+    context,
+  );
+  if (!cleanupFunction) return false;
+  return !hasCollectionMutationBeforeRelease(
     registrationCall,
-    cleanupFunction,
+    releaseCall,
     collectionKeys,
     context,
   );

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -2895,12 +2895,16 @@ const hasCollectionMutationBeforeRelease = (
     if (!isAfterRegistration && !isBeforeRelease) return;
     if (isNodeOfType(child, "AssignmentExpression")) {
       const assignmentKey = resolveExpressionKey(child.left, context);
+      const assignmentTarget = stripParenExpression(child.left);
       if (
-        assignmentKey &&
-        [...collectionKeys].some(
-          (collectionKey) =>
-            assignmentKey === collectionKey || assignmentKey === `${collectionKey}.length`,
-        )
+        (assignmentKey &&
+          [...collectionKeys].some(
+            (collectionKey) =>
+              assignmentKey === collectionKey || assignmentKey === `${collectionKey}.length`,
+          )) ||
+        (isNodeOfType(assignmentTarget, "MemberExpression") &&
+          assignmentTarget.computed &&
+          collectionKeys.has(resolveExpressionKey(assignmentTarget.object, context) ?? ""))
       ) {
         didFindMutation = true;
         return false;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -289,9 +289,10 @@ const resolveEventListenerCaptureIdentityKey = (
   if (!optionsNode) return null;
   const unwrappedOptions = stripParenExpression(optionsNode);
   if (!isNodeOfType(unwrappedOptions, "ObjectExpression")) {
-    return allowOpaqueOptionsIdentity
+    const optionsKey = allowOpaqueOptionsIdentity
       ? resolveResourceIdentityKey(unwrappedOptions, context)
       : null;
+    return optionsKey ? `options:${optionsKey}` : null;
   }
   let captureKey: string | null = "capture:false";
   for (const property of unwrappedOptions.properties ?? []) {
@@ -305,10 +306,38 @@ const resolveEventListenerCaptureIdentityKey = (
       continue;
     }
     if (propertyName === "capture") {
-      captureKey = resolveResourceIdentityKey(property.value, context);
+      const propertyValueKey = resolveResourceIdentityKey(property.value, context);
+      captureKey = propertyValueKey ? `capture-value:${propertyValueKey}` : null;
     }
   }
   return captureKey;
+};
+
+const resolveEventListenerCaptureProjection = (
+  optionsNode: EsTreeNode | null | undefined,
+  context: RuleContext,
+): ForEachProjection | null => {
+  if (!optionsNode) return null;
+  const unwrappedOptions = stripParenExpression(optionsNode);
+  if (!isNodeOfType(unwrappedOptions, "ObjectExpression")) {
+    return resolveForEachProjection(unwrappedOptions, context);
+  }
+  let captureProjection: ForEachProjection | null = null;
+  for (const property of unwrappedOptions.properties ?? []) {
+    if (!isNodeOfType(property, "Property")) {
+      captureProjection = null;
+      continue;
+    }
+    const propertyName = getStaticPropertyKeyName(property);
+    if (propertyName === null || (!property.computed && propertyName === "__proto__")) {
+      captureProjection = null;
+      continue;
+    }
+    if (propertyName === "capture") {
+      captureProjection = resolveForEachProjection(property.value, context);
+    }
+  }
+  return captureProjection;
 };
 
 const doEventListenerCapturesMatch = (
@@ -2891,13 +2920,16 @@ const hasSafeForEachProjectionCleanup = (
     releaseCall.arguments?.[0],
     releaseCall.arguments?.[1],
   ];
-  if (registrationVerbName === "addEventListener" && releaseVerbName === "removeEventListener") {
-    projectionExpressions.push(registrationCall.arguments?.[2], releaseCall.arguments?.[2]);
-  }
   const projections = projectionExpressions.flatMap((expression) => {
     const projection = resolveForEachProjection(expression, context);
     return projection ? [projection] : [];
   });
+  if (registrationVerbName === "addEventListener" && releaseVerbName === "removeEventListener") {
+    for (const optionsNode of [registrationCall.arguments?.[2], releaseCall.arguments?.[2]]) {
+      const captureProjection = resolveEventListenerCaptureProjection(optionsNode, context);
+      if (captureProjection) projections.push(captureProjection);
+    }
+  }
   if (projections.length === 0) return true;
   const cleanupFunction = findDirectExhaustiveForEachCleanupFunction(releaseCall, context);
   if (!cleanupFunction) return false;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -3,6 +3,7 @@ import {
   TIMER_CALLEE_NAMES_REQUIRING_CLEANUP,
   TIMER_CLEANUP_CALLEE_NAMES,
 } from "../../constants/dom.js";
+import { MUTATING_ARRAY_METHODS, MUTATING_COLLECTION_METHODS } from "../../constants/js.js";
 import {
   BOUND_RESOURCE_RELEASE_METHOD_NAMES,
   EFFECT_HOOK_NAMES,
@@ -63,6 +64,11 @@ interface SubscribeLikeUsage {
   registrationVerbName: string | null;
   eventKey: string | null;
   handlerKey: string | null;
+}
+
+interface ForEachProjection {
+  collectionKey: string;
+  projectionKey: string;
 }
 
 interface RefOwnedHandlerStorage {
@@ -199,6 +205,78 @@ const resolveExpressionKey = (
   return null;
 };
 
+const findForEachCallForCallback = (
+  callbackNode: EsTreeNode,
+): EsTreeNodeOfType<"CallExpression"> | null => {
+  if (!isFunctionLike(callbackNode) || callbackNode.async || callbackNode.generator) return null;
+  const callNode = callbackNode.parent;
+  if (!isNodeOfType(callNode, "CallExpression") || callNode.arguments?.[0] !== callbackNode) {
+    return null;
+  }
+  const callee = stripParenExpression(callNode.callee);
+  return isNodeOfType(callee, "MemberExpression") &&
+    !callee.computed &&
+    isNodeOfType(callee.property, "Identifier") &&
+    callee.property.name === "forEach"
+    ? callNode
+    : null;
+};
+
+const resolveForEachProjection = (
+  expression: EsTreeNode | null | undefined,
+  context: RuleContext,
+): ForEachProjection | null => {
+  if (!expression) return null;
+  let currentExpression = stripParenExpression(expression);
+  const memberNames: string[] = [];
+  while (isNodeOfType(currentExpression, "MemberExpression") && !currentExpression.computed) {
+    if (!isNodeOfType(currentExpression.property, "Identifier")) return null;
+    memberNames.unshift(currentExpression.property.name);
+    currentExpression = stripParenExpression(currentExpression.object);
+  }
+  if (!isNodeOfType(currentExpression, "Identifier")) return null;
+  const symbol = context.scopes.symbolFor(currentExpression);
+  if (!symbol || symbol.kind !== "parameter") return null;
+  let callbackNode: EsTreeNode | null | undefined = symbol.bindingIdentifier.parent;
+  while (callbackNode && !isFunctionLike(callbackNode)) callbackNode = callbackNode.parent;
+  if (!callbackNode || !isFunctionLike(callbackNode)) return null;
+  const forEachCall = findForEachCallForCallback(callbackNode);
+  if (!forEachCall) return null;
+  const forEachCallee = stripParenExpression(forEachCall.callee);
+  if (!isNodeOfType(forEachCallee, "MemberExpression")) return null;
+  const collectionKey = resolveExpressionKey(forEachCallee.object, context);
+  if (!collectionKey) return null;
+  const firstParameter = callbackNode.params[0];
+  const bindingProperty = symbol.bindingIdentifier.parent;
+  const propertyName =
+    isNodeOfType(firstParameter, "ObjectPattern") &&
+    isNodeOfType(bindingProperty, "Property") &&
+    bindingProperty.parent === firstParameter &&
+    bindingProperty.value === symbol.bindingIdentifier
+      ? getStaticPropertyKeyName(bindingProperty)
+      : null;
+  const parameterProjection = firstParameter === symbol.bindingIdentifier ? "value" : propertyName;
+  if (!parameterProjection) return null;
+  return {
+    collectionKey,
+    projectionKey: [parameterProjection, ...memberNames].join("."),
+  };
+};
+
+const resolveForEachProjectionKey = (
+  expression: EsTreeNode | null | undefined,
+  context: RuleContext,
+): string | null => {
+  const projection = resolveForEachProjection(expression, context);
+  return projection ? `forEach:${projection.collectionKey}:${projection.projectionKey}` : null;
+};
+
+const resolveResourceIdentityKey = (
+  expression: EsTreeNode | null | undefined,
+  context: RuleContext,
+): string | null =>
+  resolveForEachProjectionKey(expression, context) ?? resolveExpressionKey(expression, context);
+
 const findAssignedResourceKey = (resourceNode: EsTreeNode, context: RuleContext): string | null => {
   let currentNode = resourceNode;
   let parentNode = currentNode.parent;
@@ -233,10 +311,10 @@ const getCallRegistrationDetails = (
     };
   }
   return {
-    receiverKey: resolveExpressionKey(callee.object, context),
+    receiverKey: resolveResourceIdentityKey(callee.object, context),
     registrationVerbName: callee.property.name,
-    eventKey: resolveExpressionKey(callNode.arguments?.[0], context),
-    handlerKey: resolveExpressionKey(callNode.arguments?.[1], context),
+    eventKey: resolveResourceIdentityKey(callNode.arguments?.[0], context),
+    handlerKey: resolveResourceIdentityKey(callNode.arguments?.[1], context),
   };
 };
 
@@ -2658,6 +2736,94 @@ const isReactRefListenerReplacementRelease = (
   );
 };
 
+const findDirectExhaustiveForEachCleanupFunction = (
+  releaseNode: EsTreeNode,
+  context: RuleContext,
+): EsTreeNode | null => {
+  let currentNode = findTransparentExpressionRoot(releaseNode);
+  const visitedFunctions = new Set<EsTreeNode>();
+  while (true) {
+    const ownerFunction = findEnclosingFunction(currentNode);
+    if (!ownerFunction || !isFunctionLike(ownerFunction) || visitedFunctions.has(ownerFunction)) {
+      return null;
+    }
+    visitedFunctions.add(ownerFunction);
+    const isDirectConciseBody = ownerFunction.body === currentNode;
+    const statementNode = currentNode.parent;
+    const isDirectBlockStatement =
+      isNodeOfType(ownerFunction.body, "BlockStatement") &&
+      isNodeOfType(statementNode, "ExpressionStatement") &&
+      statementNode.parent === ownerFunction.body;
+    if (
+      (!isDirectConciseBody && !isDirectBlockStatement) ||
+      !doMatchingNodesCoverEveryPathFromFunctionEntry(
+        ownerFunction,
+        [isDirectBlockStatement ? statementNode : currentNode],
+        context,
+      )
+    ) {
+      return null;
+    }
+    const forEachCall = findForEachCallForCallback(ownerFunction);
+    if (!forEachCall) {
+      return isReturnedEffectCleanupFunction(ownerFunction, context) ? ownerFunction : null;
+    }
+    currentNode = findTransparentExpressionRoot(forEachCall);
+  }
+};
+
+const collectSetupOwnerFunctions = (usageNode: EsTreeNode): Set<EsTreeNode> => {
+  const ownerFunctions = new Set<EsTreeNode>();
+  let currentNode = usageNode;
+  while (true) {
+    const ownerFunction = findEnclosingFunction(currentNode);
+    if (!ownerFunction || !isFunctionLike(ownerFunction) || ownerFunctions.has(ownerFunction))
+      break;
+    ownerFunctions.add(ownerFunction);
+    const forEachCall = findForEachCallForCallback(ownerFunction);
+    if (!forEachCall) break;
+    currentNode = forEachCall;
+  }
+  return ownerFunctions;
+};
+
+const hasCollectionMutationBeforeCleanup = (
+  usageNode: EsTreeNode,
+  cleanupFunction: EsTreeNode,
+  collectionKeys: ReadonlySet<string>,
+  context: RuleContext,
+): boolean => {
+  const usageStart = getRangeStart(usageNode);
+  const cleanupStart = getRangeStart(cleanupFunction);
+  if (usageStart === null || cleanupStart === null) return true;
+  const setupOwnerFunctions = collectSetupOwnerFunctions(usageNode);
+  let programNode = usageNode;
+  while (programNode.parent) programNode = programNode.parent;
+  let didFindMutation = false;
+  walkAst(programNode, (child: EsTreeNode) => {
+    if (didFindMutation) return false;
+    const childStart = getRangeStart(child);
+    if (childStart === null || childStart <= usageStart || childStart >= cleanupStart) return;
+    const ownerFunction = context.cfg.enclosingFunction(child);
+    if (!ownerFunction || !setupOwnerFunctions.has(ownerFunction)) return;
+    if (!isNodeOfType(child, "CallExpression")) return;
+    const callee = stripParenExpression(child.callee);
+    if (
+      !isNodeOfType(callee, "MemberExpression") ||
+      callee.computed ||
+      !isNodeOfType(callee.property, "Identifier") ||
+      (!MUTATING_ARRAY_METHODS.has(callee.property.name) &&
+        !MUTATING_COLLECTION_METHODS.has(callee.property.name)) ||
+      !collectionKeys.has(resolveExpressionKey(callee.object, context) ?? "")
+    ) {
+      return;
+    }
+    didFindMutation = true;
+    return false;
+  });
+  return didFindMutation;
+};
+
 const doesReleaseCallMatchUsage = (
   node: EsTreeNode,
   usage: SubscribeLikeUsage,
@@ -2712,8 +2878,8 @@ const doesReleaseCallMatchUsage = (
   ) {
     return false;
   }
-  const releaseReceiverKey = resolveExpressionKey(callee.object, context);
-  const releaseEventKey = resolveExpressionKey(callNode.arguments?.[0], context);
+  const releaseReceiverKey = resolveResourceIdentityKey(callee.object, context);
+  const releaseEventKey = resolveResourceIdentityKey(callNode.arguments?.[0], context);
   const pairedReleaseVerbNames = usage.registrationVerbName
     ? PAIRED_RELEASE_VERB_NAMES_BY_REGISTRATION_VERB.get(usage.registrationVerbName)
     : null;
@@ -2771,6 +2937,51 @@ const doesReleaseCallMatchUsage = (
   ) {
     return true;
   }
+  if (
+    usage.registrationVerbName === "addEventListener" &&
+    releaseVerbName === "removeEventListener" &&
+    isNodeOfType(usage.node, "CallExpression")
+  ) {
+    const registrationCallee = stripParenExpression(usage.node.callee);
+    if (!isNodeOfType(registrationCallee, "MemberExpression")) return false;
+    const registrationCapture = resolveEventListenerCapture(usage.node.arguments?.[2], {
+      allowIndeterminateEntries: true,
+    });
+    const releaseCapture = resolveEventListenerCapture(callNode.arguments?.[2], {
+      allowIndeterminateEntries: true,
+    });
+    const registrationCaptureKey = resolveResourceIdentityKey(usage.node.arguments?.[2], context);
+    const releaseCaptureKey = resolveResourceIdentityKey(callNode.arguments?.[2], context);
+    const doCapturesMatch =
+      registrationCapture === null || releaseCapture === null
+        ? registrationCaptureKey !== null && registrationCaptureKey === releaseCaptureKey
+        : registrationCapture === releaseCapture;
+    if (!doCapturesMatch) return false;
+    const projectionExpressions = [
+      registrationCallee.object,
+      usage.node.arguments?.[0],
+      usage.node.arguments?.[1],
+      usage.node.arguments?.[2],
+      callee.object,
+      callNode.arguments?.[0],
+      callNode.arguments?.[1],
+      callNode.arguments?.[2],
+    ];
+    const projections = projectionExpressions.flatMap((expression) => {
+      const projection = resolveForEachProjection(expression, context);
+      return projection ? [projection] : [];
+    });
+    if (projections.length > 0) {
+      const cleanupFunction = findDirectExhaustiveForEachCleanupFunction(callNode, context);
+      if (!cleanupFunction) return false;
+      const collectionKeys = new Set(projections.map((projection) => projection.collectionKey));
+      if (
+        hasCollectionMutationBeforeCleanup(usage.node, cleanupFunction, collectionKeys, context)
+      ) {
+        return false;
+      }
+    }
+  }
   if (usage.receiverKey === null || releaseReceiverKey !== usage.receiverKey) return false;
   if (
     usage.registrationVerbName === "subscribe" &&
@@ -2795,6 +3006,17 @@ const doesReleaseCallMatchUsage = (
   if (hasAssignmentFormLoopIterator) return false;
   if (usage.eventKey !== null && releaseEventKey !== null && usage.eventKey !== releaseEventKey) {
     if (!isNodeOfType(usage.node, "CallExpression")) return false;
+    const registrationEventProjectionKey = resolveForEachProjectionKey(
+      usage.node.arguments?.[0],
+      context,
+    );
+    const releaseEventProjectionKey = resolveForEachProjectionKey(callNode.arguments?.[0], context);
+    if (
+      (registrationEventProjectionKey !== null || releaseEventProjectionKey !== null) &&
+      registrationEventProjectionKey !== releaseEventProjectionKey
+    ) {
+      return false;
+    }
     const usageForOfStatement = findForOfStatementForIteratorExpression(
       usageEventArgument,
       context,
@@ -2883,7 +3105,7 @@ const doesReleaseCallMatchUsage = (
       : null;
     return (
       (expectedHandlerKey !== null &&
-        resolveExpressionKey(releaseHandler, context) === expectedHandlerKey) ||
+        resolveResourceIdentityKey(releaseHandler, context) === expectedHandlerKey) ||
       (registrationHandler !== null &&
         resolveStableValue(releaseHandler, context) ===
           resolveStableValue(registrationHandler, context))

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -216,23 +216,6 @@ const resolveExpressionKey = (
   return null;
 };
 
-const findForEachCallForCallback = (
-  callbackNode: EsTreeNode,
-): EsTreeNodeOfType<"CallExpression"> | null => {
-  if (!isFunctionLike(callbackNode) || callbackNode.async || callbackNode.generator) return null;
-  const callNode = callbackNode.parent;
-  if (!isNodeOfType(callNode, "CallExpression") || callNode.arguments?.[0] !== callbackNode) {
-    return null;
-  }
-  const callee = stripParenExpression(callNode.callee);
-  return isNodeOfType(callee, "MemberExpression") &&
-    !callee.computed &&
-    isNodeOfType(callee.property, "Identifier") &&
-    callee.property.name === "forEach"
-    ? callNode
-    : null;
-};
-
 const resolveForEachProjection = (
   expression: EsTreeNode | null | undefined,
   context: RuleContext,
@@ -251,7 +234,7 @@ const resolveForEachProjection = (
   let callbackNode: EsTreeNode | null | undefined = symbol.bindingIdentifier.parent;
   while (callbackNode && !isFunctionLike(callbackNode)) callbackNode = callbackNode.parent;
   if (!callbackNode || !isFunctionLike(callbackNode)) return null;
-  const forEachCall = findForEachCallForCallback(callbackNode);
+  const forEachCall = findEnclosingForEachCall(callbackNode);
   if (!forEachCall) return null;
   const forEachCallee = stripParenExpression(forEachCall.callee);
   if (!isNodeOfType(forEachCallee, "MemberExpression")) return null;
@@ -1238,9 +1221,15 @@ const isSynchronousIteratorCallback = (functionNode: EsTreeNode): boolean => {
   );
 };
 
-const findEnclosingForEachCall = (node: EsTreeNode): EsTreeNode | null => {
-  const callbackNode = findEnclosingFunction(node);
-  if (!callbackNode) return null;
+const findEnclosingForEachCall = (node: EsTreeNode): EsTreeNodeOfType<"CallExpression"> | null => {
+  const callbackNode = isFunctionLike(node) ? node : findEnclosingFunction(node);
+  if (
+    !callbackNode ||
+    !isFunctionLike(callbackNode) ||
+    callbackNode.async ||
+    callbackNode.generator
+  )
+    return null;
   const callNode = callbackNode.parent;
   if (!isNodeOfType(callNode, "CallExpression") || callNode.arguments?.[0] !== callbackNode) {
     return null;
@@ -2850,7 +2839,7 @@ const findDirectExhaustiveForEachCleanupFunction = (
     ) {
       return null;
     }
-    const forEachCall = findForEachCallForCallback(ownerFunction);
+    const forEachCall = findEnclosingForEachCall(ownerFunction);
     if (!forEachCall) {
       return replayedCollectionKeys.size === requiredCollectionKeys.size &&
         isReturnedEffectCleanupFunction(ownerFunction, context)
@@ -2874,7 +2863,7 @@ const collectReplayOwnerFunctions = (usageNode: EsTreeNode): Set<EsTreeNode> => 
     if (!ownerFunction || !isFunctionLike(ownerFunction) || ownerFunctions.has(ownerFunction))
       break;
     ownerFunctions.add(ownerFunction);
-    const forEachCall = findForEachCallForCallback(ownerFunction);
+    const forEachCall = findEnclosingForEachCall(ownerFunction);
     if (!forEachCall) break;
     currentNode = forEachCall;
   }
@@ -2890,19 +2879,20 @@ const hasCollectionMutationBeforeRelease = (
   const usageStart = getRangeStart(usageNode);
   const releaseStart = getRangeStart(releaseNode);
   if (usageStart === null || releaseStart === null) return true;
-  const replayOwnerFunctions = new Set([
-    ...collectReplayOwnerFunctions(usageNode),
-    ...collectReplayOwnerFunctions(releaseNode),
-  ]);
+  const setupOwnerFunctions = collectReplayOwnerFunctions(usageNode);
+  const cleanupOwnerFunctions = collectReplayOwnerFunctions(releaseNode);
   let programNode = usageNode;
   while (programNode.parent) programNode = programNode.parent;
   let didFindMutation = false;
   walkAst(programNode, (child: EsTreeNode) => {
     if (didFindMutation) return false;
     const childStart = getRangeStart(child);
-    if (childStart === null || childStart <= usageStart || childStart >= releaseStart) return;
+    if (childStart === null) return;
     const ownerFunction = context.cfg.enclosingFunction(child);
-    if (!ownerFunction || !replayOwnerFunctions.has(ownerFunction)) return;
+    if (!ownerFunction) return;
+    const isAfterRegistration = setupOwnerFunctions.has(ownerFunction) && childStart > usageStart;
+    const isBeforeRelease = cleanupOwnerFunctions.has(ownerFunction) && childStart < releaseStart;
+    if (!isAfterRegistration && !isBeforeRelease) return;
     if (!isNodeOfType(child, "CallExpression")) return;
     const callee = stripParenExpression(child.callee);
     if (


### PR DESCRIPTION
## Why

Before: `effect-needs-cleanup` could not correlate ReactTooltip listener registration and removal when both were replayed through the same nested `enabledEvents` and `elementRefs` collections.

After: the rule proves matching receiver, event, handler, capture, collection identity, exhaustive cleanup, and collection stability before accepting the cleanup.

## What changed

- Track stable projections from supported `.forEach` callback bindings.
- Require the same nested collection chain and direct exhaustive cleanup.
- Reject handler swaps, event swaps, capture mismatches, unsupported destructuring, conditional removal, and post-registration collection mutation.
- Add the exact ReactTooltip family to the regression corpus.
- Add a patch changeset.

## Eval results

| Validation | Result |
| --- | --- |
| Local RDE | 99 root scans, 38 rule hits across 7 repos |
| Delta audit | No new rule hits and 0 new FPs |
| Strict fuzz | 1,000 iterations requested, 714 executed, 147 fired, 0 findings |

## Test plan

- 454 focused rule tests passed across the two changed-rule suites.
- Full plugin suite passed: 15,453 tests.
- Full workspace test suite passed.
- Root typecheck and lint passed.
- Changed-file formatting passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large, intricate changes to static matching for a core effect rule could shift diagnostics, but scope is limited to cleanup correlation and is heavily covered by tests and fuzz with reported zero new false positives.
> 
> **Overview**
> **`effect-needs-cleanup`** now treats nested **`forEach`**-driven add/remove listener patterns (e.g. ReactTooltip-style **`enabledEvents` × `elementRefs`**) as valid cleanup when setup and teardown share the same projected identities and exhaustive replay.
> 
> The rule adds **`.forEach` projection keys** for receiver/event/handler (and capture inside option bags), compares registrations to releases via **`resolveResourceIdentityKey`**, and runs **`hasSafeForEachProjectionCleanup`** so cleanup must mirror the nested collection chain. It still **flags** conditional removal, unrelated wrapper loops, structural collection mutation between register and cleanup, and capture/options identity mistakes (including opaque options colliding with inline **`capture`**).
> 
> Related tightening: **returned cleanup** detection follows named/aliased functions; **handlerless** **`off(event)`** / whole-receiver release is accepted when it truly covers projected registrations; **unary `addListener`** arity is handled explicitly. Regression/fuzz corpus and a patch changeset document the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 112324e314bba8693fe9dd2b1d72bdf5159f9ed2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->