### PR TITLE
fix: make set-state-in-effect advisory

### DIFF
--- a/.changeset/silent-news-melt.md
+++ b/.changeset/silent-news-melt.md
@@ -1,0 +1,6 @@
+---
+"oxlint-plugin-react-doctor": patch
+"react-doctor": patch
+---
+
+Treat set-state-in-effect as advisory render guidance instead of a compiler bailout

--- a/packages/core/src/runners/oxlint/parse-output.ts
+++ b/packages/core/src/runners/oxlint/parse-output.ts
@@ -49,6 +49,8 @@ const REACT_COMPILER_ACTION = "Rewrite the flagged code so the compiler can opti
 // users off mature libraries (#950), so this rule names the real fix instead.
 const REACT_COMPILER_INCOMPATIBLE_LIBRARY_ACTION =
   "It's how the library works, not a bug in your code. Memoize values you pass from it into other memoized components, or suppress it with `// react-doctor-disable-next-line react-hooks-js/incompatible-library`.";
+const SET_STATE_IN_EFFECT_ACTION =
+  "Prefer deriving or initializing the value before render. If the effect must read a browser API after mount, treat this as advisory or suppress it with `// react-doctor-disable-next-line react-hooks-js/set-state-in-effect`.";
 const REACT_COMPILER_GENERIC_MESSAGE = `${REACT_COMPILER_IMPACT}. ${REACT_COMPILER_ACTION}`;
 
 const buildReactCompilerMessage = (
@@ -58,6 +60,12 @@ const buildReactCompilerMessage = (
   const normalizedSummary = reasonSummary.replace(TRAILING_PERIOD_PATTERN, "");
   if (!normalizedSummary) return `${REACT_COMPILER_IMPACT}. ${action}`;
   return `${REACT_COMPILER_IMPACT}: ${normalizedSummary}. ${action}`;
+};
+
+const buildSetStateInEffectMessage = (reasonSummary: string): string => {
+  const normalizedSummary = reasonSummary.replace(TRAILING_PERIOD_PATTERN, "");
+  const reason = normalizedSummary ? `: ${normalizedSummary}` : "";
+  return `This synchronous effect update causes an extra render${reason}. ${SET_STATE_IN_EFFECT_ACTION}`;
 };
 
 // Adopted third-party plugins (not in the react-doctor registry) → the
@@ -194,6 +202,12 @@ const resolveCleanedDiagnostic = (
     if (rule === "error-boundaries") {
       return {
         message: REACT_ERROR_BOUNDARY_MESSAGE,
+        help: reasonDetail || help,
+      };
+    }
+    if (rule === "set-state-in-effect") {
+      return {
+        message: buildSetStateInEffectMessage(reasonSummary.trim()),
         help: reasonDetail || help,
       };
     }

--- a/packages/core/tests/react-compiler-bailout-message.test.ts
+++ b/packages/core/tests/react-compiler-bailout-message.test.ts
@@ -88,4 +88,16 @@ describe("parseOxlintOutput react-hooks-js bail-out reason in primary message", 
     );
     expect(diagnostic.message).not.toContain("Rewrite the flagged code");
   });
+
+  it("describes set-state-in-effect as render advice instead of a compiler bailout", () => {
+    const reason = "Calling setState synchronously within an effect can trigger cascading renders";
+    const stdout = buildOxlintStdout("react-hooks-js(set-state-in-effect)", reason);
+    const [diagnostic] = parseOxlintOutput(stdout, buildProject(), TEST_ROOT_DIRECTORY);
+
+    expect(diagnostic.message).toContain(reason);
+    expect(diagnostic.message).toContain("extra render");
+    expect(diagnostic.message).toContain("browser API");
+    expect(diagnostic.message).not.toContain("React Compiler's automatic memoization");
+    expect(diagnostic.message).not.toContain("Rewrite the flagged code");
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/rules.ts
+++ b/packages/oxlint-plugin-react-doctor/src/rules.ts
@@ -60,7 +60,7 @@ export const EXTERNAL_RULES = [
   { key: "react-hooks-js/refs", source: "react-compiler", severity: "error" },
   { key: "react-hooks-js/purity", source: "react-compiler", severity: "error" },
   { key: "react-hooks-js/hooks", source: "react-compiler", severity: "error" },
-  { key: "react-hooks-js/set-state-in-effect", source: "react-compiler", severity: "error" },
+  { key: "react-hooks-js/set-state-in-effect", source: "react-compiler", severity: "warn" },
   { key: "react-hooks-js/globals", source: "react-compiler", severity: "error" },
   { key: "react-hooks-js/error-boundaries", source: "react-compiler", severity: "error" },
   {

--- a/packages/react-doctor/tests/regressions/scan-resilience.test.ts
+++ b/packages/react-doctor/tests/regressions/scan-resilience.test.ts
@@ -424,7 +424,6 @@ describe("issue #141: oxlint config must not reference unloaded plugins", () => 
 
     expect(hasReactHooksJsPluginEntry).toBe(true);
     expect(reactHooksJsRuleKeys.length).toBeGreaterThan(0);
-    expect(reactHooksJsRuleKeys.every((ruleKey) => config.rules[ruleKey] === "error")).toBe(true);
   });
 
   it("emits no react-hooks-js rules when customRulesOnly skips the plugin", () => {
@@ -463,15 +462,7 @@ describe("issue #141: oxlint config must not reference unloaded plugins", () => 
     );
   });
 
-  it("emits every react-hooks-js rule at error severity (so they block CI by default)", () => {
-    // Regression for the silent severity downgrade introduced in PR
-    // #140: every `react-hooks-js/*` entry got mass-converted from
-    // `"error"` to `"warn"`, which made "React Compiler can't optimize
-    // this code" diagnostics stop counting toward `errorCount` and
-    // stop blocking CI (react-doctor blocks on error-severity diagnostics
-    // by default unless `--blocking none` is set). Each compiler diagnostic
-    // represents an unoptimizable component shape — surfacing as warnings
-    // hid real perf regressions.
+  it("keeps compiler bailouts blocking while set-state-in-effect remains advisory", () => {
     const config = createOxlintConfig({
       pluginPath: "/tmp/react-doctor-plugin.js",
       project: buildTestProject({ rootDirectory: "/tmp/test", hasReactCompiler: true }),
@@ -482,7 +473,14 @@ describe("issue #141: oxlint config must not reference unloaded plugins", () => 
       .map(([ruleKey, severity]) => ({ ruleKey, severity }));
 
     expect(compilerSeverities.length).toBeGreaterThan(0);
-    const nonErrorEntries = compilerSeverities.filter((entry) => entry.severity !== "error");
+    const setStateInEffectEntry = compilerSeverities.find(
+      (entry) => entry.ruleKey === "react-hooks-js/set-state-in-effect",
+    );
+    const nonErrorEntries = compilerSeverities.filter(
+      (entry) =>
+        entry.ruleKey !== "react-hooks-js/set-state-in-effect" && entry.severity !== "error",
+    );
+    expect(setStateInEffectEntry?.severity).toBe("warn");
     expect(nonErrorEntries).toEqual([]);
   });
 


### PR DESCRIPTION
## Why

Before: every `react-hooks-js/set-state-in-effect` finding was an error and React Doctor rewrote it as a React Compiler bailout, rejecting valid client capability checks such as Jumper `HTMLMediaElement.canPlayType`.

After: the finding remains visible as advisory extra-render guidance, while actual React Compiler bailout rules remain blocking errors.

## What changed

- Change only `set-state-in-effect` from error to warning.
- Give it a dedicated message focused on the synchronous extra render and post-mount browser API exception.
- Preserve error severity for every other `react-hooks-js` compiler rule.
- Add focused severity and message regressions.
- Add patch changesets for `oxlint-plugin-react-doctor` and `react-doctor`.

## Product brief

Job: CI users need valid post-mount browser capability checks to remain visible without being rejected as compiler failures.
Change: reuse the existing rule and severity surface; no new flag, config, schema, or action input.
Metric: reuse the existing `rule.fired` metric and wide-event severity dimension to watch advisory volume and CI cohort retention.
Compat: default severity changes only for this rule and is versioned by patch changesets; explicit user overrides continue to win.
Kill: reconsider the advisory default if two release audits find confirmed correctness regressions attributable to this downgrade.

## Test plan

- Core message regressions passed: 9 tests.
- CLI severity regressions passed: 39 tests.
- Full workspace test suite passed.
- Root typecheck and lint passed.
- Changed-file formatting passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default CI blocking behavior changes for one compiler-adjacent rule (error → warn), which can let synchronous setState-in-effect patterns pass gates unless users override severity; scope is narrow and other bailouts remain errors.
> 
> **Overview**
> **`react-hooks-js/set-state-in-effect` is no longer a blocking CI failure** — default severity moves from **error** to **warn**, while every other React Compiler (`react-hooks-js/*`) rule stays at **error**.
> 
> Oxlint output for that rule is **rewritten** so it reads as **extra-render guidance** (derive or initialize before render; post-mount browser API checks can stay advisory) instead of the generic **“React Compiler can't optimize / rewrite it”** bailout copy, including a dedicated disable comment.
> 
> Regressions cover the new message shape and the **warn-only** exception in oxlint config; patch changesets version **`oxlint-plugin-react-doctor`** and **`react-doctor`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8289ac6835b7fc1f6020dd58ef23d787ae055f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->