### PR TITLE
feat(action): add comment-on-clean input to suppress success comments

### DIFF
--- a/.changeset/quiet-success-comments.md
+++ b/.changeset/quiet-success-comments.md
@@ -1,5 +1,0 @@
----
-"react-doctor": patch
----
-
-Add `comment-on-clean` input to GitHub Action to suppress success comments. When set to `false`, the action will only post PR comments when issues are found, reducing noise. Existing comments are still updated to reflect the latest scan results.

--- a/.changeset/quiet-success-comments.md
+++ b/.changeset/quiet-success-comments.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Add `comment-on-clean` input to GitHub Action to suppress success comments. When set to `false`, the action will only post PR comments when issues are found, reducing noise. Existing comments are still updated to reflect the latest scan results.

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,9 @@ inputs:
   comment:
     description: "Create or update a sticky pull request summary comment. Automatically skipped when the pull request changes no React-eligible files (`.tsx`/`.jsx` or framework entry files)."
     default: "true"
+  comment-on-clean:
+    description: "When comment is enabled, whether to post a comment when the scan finds no issues. Set to false to only comment when there are issues to fix, reducing PR noise. Existing comments are still updated."
+    default: "true"
   review-comments:
     description: "Post inline review comments on the changed lines that triggered diagnostics (pull requests only)."
     default: "true"
@@ -386,6 +389,8 @@ runs:
       env:
         REACT_DOCTOR_COMMENT_FILE: ${{ steps.render.outputs.comment-file }}
         REACT_DOCTOR_SKIPPED: ${{ steps.render.outputs.skipped }}
+        REACT_DOCTOR_CLEAN: ${{ steps.render.outputs.clean }}
+        REACT_DOCTOR_COMMENT_ON_CLEAN: ${{ inputs.comment-on-clean }}
       with:
         script: |
           const fs = require("fs");
@@ -401,6 +406,12 @@ runs:
           // changes were reverted out of the PR.
           const skipped = process.env.REACT_DOCTOR_SKIPPED === "true";
 
+          // A clean scan (no issues found) can optionally skip creating new
+          // comments via the `comment-on-clean` input, reducing PR noise. Existing
+          // comments are still updated so stale findings don't linger.
+          const clean = process.env.REACT_DOCTOR_CLEAN === "true";
+          const commentOnClean = process.env.REACT_DOCTOR_COMMENT_ON_CLEAN !== "false";
+
           const marker = "<!-- react-doctor:summary -->";
           try {
             const { data: comments } = await github.rest.issues.listComments({
@@ -410,6 +421,7 @@ runs:
             });
             const previous = comments.find((comment) => comment.body?.startsWith(marker));
             if (skipped && !previous) return;
+            if (clean && !commentOnClean && !previous) return;
             if (previous) {
               await github.rest.issues.updateComment({
                 ...context.repo,

--- a/packages/react-doctor/tests/github-action-comment.test.ts
+++ b/packages/react-doctor/tests/github-action-comment.test.ts
@@ -356,6 +356,7 @@ describe("render-github-action-comment", () => {
     expect(comment).not.toContain("No React Doctor issues found");
     expect(comment).not.toContain("found no issues");
     expect(outputs).toContain("skipped=true");
+    expect(outputs).toContain("clean=false");
   });
 
   it("marks a diff scan whose changed files examined zero eligible files as skipped", () => {
@@ -378,6 +379,7 @@ describe("render-github-action-comment", () => {
 
     expect(comment).toContain("React Doctor skipped this pull request");
     expect(outputs).toContain("skipped=true");
+    expect(outputs).toContain("clean=false");
   });
 
   it("does NOT skip a clean scan of real React changes (eligible files examined)", () => {
@@ -401,6 +403,14 @@ describe("render-github-action-comment", () => {
     expect(comment).toContain("**React Doctor** found no issues. 🎉");
     expect(comment).not.toContain("skipped this pull request");
     expect(outputs).toContain("skipped=false");
+    expect(outputs).toContain("clean=true");
+  });
+
+  it("marks a scan with issues as not clean", () => {
+    const { outputs } = runRenderer(buildReport());
+
+    expect(outputs).toContain("skipped=false");
+    expect(outputs).toContain("clean=false");
   });
 
   it("does NOT skip a full-scope scan with no projects (clean success, not a no-op)", () => {

--- a/scripts/render-github-action-comment.mjs
+++ b/scripts/render-github-action-comment.mjs
@@ -401,6 +401,14 @@ const isSkippedScan = (report) => {
   return (report.projects ?? []).every((project) => project.scannedFileCount === 0);
 };
 
+const isCleanScan = (report) => {
+  if (!report.ok) return false;
+  if (isSkippedScan(report)) return false;
+  if ((report.summary?.totalDiagnosticCount ?? 0) > 0) return false;
+  if (hasIncompleteChecks(report)) return false;
+  return true;
+};
+
 // Unified body for every successful scan (baseline, diff, full). The lead line
 // adapts to the mode; the error/warning lists are shared.
 const buildIssuesBody = (report) => {
@@ -434,6 +442,7 @@ if (!report) {
   process.exit(0);
 }
 const skipped = isSkippedScan(report);
+const clean = isCleanScan(report);
 const body = skipped ? buildSingleLineBody(COPY.skipped) : buildCommentBody(report);
 
 if (commentPath) {
@@ -445,6 +454,7 @@ if (commentPath) {
 // The Action reads this to suppress the sticky PR comment (it still mirrors the
 // body into the job summary + commit status, which read "skipped").
 appendOutput("skipped", skipped ? "true" : "false");
+appendOutput("clean", clean ? "true" : "false");
 
 appendOutput(
   "score",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a new `comment-on-clean` input to the GitHub Action that allows users to suppress "no issues found" PR comments while still receiving comments when issues are detected.

## Root Cause

The GitHub Action unconditionally posts a "React Doctor found no new issues. 🎉" comment on clean scans. Users who run the action frequently on repositories with good coverage find these success comments noisy.

## Implementation

- Added `comment-on-clean` input (default: `true` for backward compatibility)
- Updated render script to detect and output a `clean` flag
- Modified comment-posting step to skip creating new comments when:
  - Scan is clean (no issues found)
  - `comment-on-clean` is set to `false`
  - No existing comment exists
- Existing comments are still updated to show the latest scan results

## Scope Decision

This change only affects the **comment posting behavior** - it does not modify:
- Diagnostic detection or reporting
- The commit status
- The job summary
- Review comments

Skipped scans (no React files changed) continue to use their existing logic.

## Testing

- Added tests to verify `clean` output is set correctly
- All existing tests pass
- Lint and typecheck pass

## Backward Compatibility

The new input defaults to `true`, maintaining the existing behavior. Users must explicitly set `comment-on-clean: false` to opt into the quieter mode.

Closes #1385
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a032a428-925b-40ac-bf8d-9a23d6b3fa3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a032a428-925b-40ac-bf8d-9a23d6b3fa3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

