### PR TITLE
NEW_RULES: Add security resource safety diagnostics

### DIFF
--- a/.changeset/rd-new-rules-nextjs.md
+++ b/.changeset/rd-new-rules-nextjs.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Add `nextjs-async-dynamic-api-not-awaited` to catch synchronous property access on Next.js 15+ async request APIs while respecting official migration casts and same-path promise unwrapping.

--- a/.changeset/rd-new-rules-security.md
+++ b/.changeset/rd-new-rules-security.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": minor
+---
+
+feat(rules): add 1 new security rules, corpus-validated and FP-hardened

--- a/.changeset/rd-new-rules-security.md
+++ b/.changeset/rd-new-rules-security.md
@@ -2,4 +2,4 @@
 "oxlint-plugin-react-doctor": minor
 ---
 
-feat(rules): add 1 new security rules, corpus-validated and FP-hardened
+feat(rules): add the window-open-without-noopener security rule, corpus-validated and FP-hardened

--- a/packages/core/src/project-info/capabilities.ts
+++ b/packages/core/src/project-info/capabilities.ts
@@ -98,6 +98,9 @@ export const buildCapabilities = (project: ProjectInfo): ReadonlySet<Capability>
   if (project.nextjsMajorVersion !== null && project.nextjsMajorVersion >= 15) {
     capabilities.add("nextjs:15");
   }
+  if (project.nextjsMajorVersion !== null && project.nextjsMajorVersion >= 16) {
+    capabilities.add("nextjs:16");
+  }
   addMajorLadder(
     capabilities,
     "react",

--- a/packages/core/tests/build-capabilities.test.ts
+++ b/packages/core/tests/build-capabilities.test.ts
@@ -329,6 +329,24 @@ describe("buildCapabilities", () => {
     expect(capabilities.has("nextjs:15")).toBe(false);
   });
 
+  it("emits `nextjs:16` capability only for Next.js 16+ projects", () => {
+    const nextjs15Capabilities = buildCapabilities({
+      ...baseProject,
+      framework: "nextjs",
+      nextjsVersion: "^15.3.0",
+      nextjsMajorVersion: 15,
+    });
+    const nextjs16Capabilities = buildCapabilities({
+      ...baseProject,
+      framework: "nextjs",
+      nextjsVersion: "^16.0.0",
+      nextjsMajorVersion: 16,
+    });
+    expect(nextjs15Capabilities.has("nextjs:16")).toBe(false);
+    expect(nextjs16Capabilities.has("nextjs:15")).toBe(true);
+    expect(nextjs16Capabilities.has("nextjs:16")).toBe(true);
+  });
+
   it("emits `server-actions` for server-capable frameworks only", () => {
     for (const framework of ["nextjs", "tanstack-start", "remix"] as const) {
       expect(buildCapabilities({ ...baseProject, framework }).has("server-actions")).toBe(true);

--- a/packages/core/tests/cross-file-rule-ids.test.ts
+++ b/packages/core/tests/cross-file-rule-ids.test.ts
@@ -168,6 +168,7 @@ describe("CROSS_FILE_RULE_IDS", () => {
       "rn-no-raw-text",
       "rn-prefer-expo-image",
       "rn-style-prefer-boxshadow",
+      "window-open-without-noopener",
     ]);
   });
 

--- a/packages/fuzz/corpus/regressions/nextjs-async-dynamic-api-not-awaited--aliased-unsafe-unwrapped-type.tsx
+++ b/packages/fuzz/corpus/regressions/nextjs-async-dynamic-api-not-awaited--aliased-unsafe-unwrapped-type.tsx
@@ -1,0 +1,7 @@
+// rule: nextjs-async-dynamic-api-not-awaited
+// weakness: wrapper-transparency
+// source: PR #1000 deep audit
+
+import { cookies, type UnsafeUnwrappedCookies as LegacyCookieStore } from "next/headers";
+
+export const readSession = () => (cookies() as unknown as LegacyCookieStore).get("session");

--- a/packages/fuzz/corpus/regressions/nextjs-async-dynamic-api-not-awaited--arbitrary-map-callback.tsx
+++ b/packages/fuzz/corpus/regressions/nextjs-async-dynamic-api-not-awaited--arbitrary-map-callback.tsx
@@ -1,0 +1,15 @@
+// rule: nextjs-async-dynamic-api-not-awaited
+// weakness: library-idiom
+// source: PR #1000 independent audit
+
+import { cookies } from "next/headers";
+
+export const scheduleRead = async (scheduler: {
+  flush: () => void;
+  map: (callback: () => unknown) => void;
+}) => {
+  let pendingCookies = cookies();
+  scheduler.map(() => pendingCookies.get("session"));
+  pendingCookies = await pendingCookies;
+  scheduler.flush();
+};

--- a/packages/fuzz/corpus/regressions/nextjs-async-dynamic-api-not-awaited--computed-promise-settle.tsx
+++ b/packages/fuzz/corpus/regressions/nextjs-async-dynamic-api-not-awaited--computed-promise-settle.tsx
@@ -1,0 +1,10 @@
+// rule: nextjs-async-dynamic-api-not-awaited
+// weakness: library-idiom
+// source: PR #1000 deep audit
+
+import { cookies } from "next/headers";
+
+export const readSession = () => {
+  const pendingCookies = cookies();
+  return pendingCookies["then"]((cookieStore) => cookieStore.get("session"));
+};

--- a/packages/fuzz/corpus/regressions/nextjs-async-dynamic-api-not-awaited--const-promise-settle.tsx
+++ b/packages/fuzz/corpus/regressions/nextjs-async-dynamic-api-not-awaited--const-promise-settle.tsx
@@ -1,0 +1,9 @@
+// rule: nextjs-async-dynamic-api-not-awaited
+// weakness: alias-guard
+// source: PR #1000 independent audit
+
+import { cookies } from "next/headers";
+
+const settleMethod = "then";
+
+export const readSession = () => cookies()[settleMethod]((store) => store.get("session"));

--- a/packages/fuzz/corpus/regressions/nextjs-async-dynamic-api-not-awaited--destructured-clearing-write.tsx
+++ b/packages/fuzz/corpus/regressions/nextjs-async-dynamic-api-not-awaited--destructured-clearing-write.tsx
@@ -1,0 +1,17 @@
+// rule: nextjs-async-dynamic-api-not-awaited
+// weakness: control-flow
+// source: PR #1000 deep audit
+
+import { cookies } from "next/headers";
+
+export const readSession = async () => {
+  let pendingCookies = cookies();
+  ({ pendingCookies } = { pendingCookies: await pendingCookies });
+  return pendingCookies.get("session");
+};
+
+export const readMissingSession = async () => {
+  let pendingCookies = cookies();
+  ({ pendingCookies = await pendingCookies } = {});
+  return pendingCookies.get("session");
+};

--- a/packages/fuzz/corpus/regressions/nextjs-async-dynamic-api-not-awaited--exiting-catch.tsx
+++ b/packages/fuzz/corpus/regressions/nextjs-async-dynamic-api-not-awaited--exiting-catch.tsx
@@ -1,0 +1,15 @@
+// rule: nextjs-async-dynamic-api-not-awaited
+// weakness: control-flow
+// source: PR #1000 deep audit
+
+import { cookies } from "next/headers";
+
+export const readSession = async () => {
+  let pendingCookies = cookies();
+  try {
+    pendingCookies = await pendingCookies;
+  } catch {
+    return null;
+  }
+  return pendingCookies.get("session");
+};

--- a/packages/fuzz/corpus/regressions/nextjs-async-dynamic-api-not-awaited--invocation-boundaries.tsx
+++ b/packages/fuzz/corpus/regressions/nextjs-async-dynamic-api-not-awaited--invocation-boundaries.tsx
@@ -1,0 +1,28 @@
+// rule: nextjs-async-dynamic-api-not-awaited
+// weakness: control-flow
+// source: PR #1000 exact-head audit
+
+import { cookies } from "next/headers";
+
+export const readAfterUnawaitedTaint = () => {
+  let cookieStore = { get: (name: string) => name };
+  const taint = async () => {
+    await 0;
+    cookieStore = cookies();
+  };
+  taint();
+  return cookieStore.get("session");
+};
+
+export const readAfterNestedReplacement = () => {
+  let cookieStore = { get: (name: string) => name };
+  const update = () => {
+    const taint = () => {
+      cookieStore = cookies();
+    };
+    taint();
+    cookieStore = { get: (name: string) => name };
+  };
+  update();
+  return cookieStore.get("session");
+};

--- a/packages/fuzz/corpus/regressions/nextjs-async-dynamic-api-not-awaited--invocation-completion-paths.tsx
+++ b/packages/fuzz/corpus/regressions/nextjs-async-dynamic-api-not-awaited--invocation-completion-paths.tsx
@@ -1,0 +1,140 @@
+// rule: nextjs-async-dynamic-api-not-awaited
+// weakness: control-flow
+// source: PR #1000 final audit
+
+import { cookies } from "next/headers";
+
+export const readAfterBranchClear = (condition: boolean) => {
+  let cookieStore = cookies();
+  const clear = () => {
+    if (condition) cookieStore = { get: (name: string) => name };
+    else cookieStore = { get: (name: string) => name };
+  };
+  clear();
+  return cookieStore.get("session");
+};
+
+export const readAfterCaughtClear = (condition: boolean) => {
+  let cookieStore = { get: (name: string) => name };
+  const update = () => {
+    cookieStore = cookies();
+    if (condition) throw new Error();
+    cookieStore = { get: (name: string) => name };
+  };
+  try {
+    update();
+  } catch {
+    cookieStore = { get: (name: string) => name };
+  }
+  return cookieStore.get("session");
+};
+
+export const readAfterStaticLoopAwait = () => {
+  let cookieStore = cookies();
+  const clear = async () => {
+    while (false) await 0;
+    cookieStore = { get: (name: string) => name };
+  };
+  clear();
+  return cookieStore.get("session");
+};
+
+export const readAfterEmptyCallbacks = () => {
+  let cookieStore = { get: (name: string) => name };
+  [...[]].map(() => {
+    cookieStore = cookies();
+  });
+  [0].reduce(() => {
+    cookieStore = cookies();
+    return 0;
+  });
+  [0].sort(() => {
+    cookieStore = cookies();
+    return 0;
+  });
+  return cookieStore.get("session");
+};
+
+export const readAfterEquivalentEmptyCallbacks = () => {
+  let cookieStore = { get: (name: string) => name };
+  const emptyValues: number[] = [];
+  emptyValues.map(() => {
+    cookieStore = cookies();
+  });
+  Array.of().map(() => {
+    cookieStore = cookies();
+  });
+  Array.from([], () => {
+    cookieStore = cookies();
+  });
+  return cookieStore.get("session");
+};
+
+export const readAfterEquivalentDenseClears = () => {
+  let cookieStore = cookies();
+  const values = [0];
+  values.map(() => {
+    cookieStore = { get: (name: string) => name };
+  });
+  Array.of(0).map(() => {
+    cookieStore = { get: (name: string) => name };
+  });
+  Array.from([0], () => {
+    cookieStore = { get: (name: string) => name };
+  });
+  return cookieStore.get("session");
+};
+
+export const readAfterNestedBranchClear = (first: boolean, second: boolean) => {
+  let cookieStore = cookies();
+  const clear = () => {
+    if (first) {
+      if (second) cookieStore = { get: (name: string) => name };
+      else cookieStore = { get: (name: string) => name };
+    } else cookieStore = { get: (name: string) => name };
+  };
+  clear();
+  return cookieStore.get("session");
+};
+
+export const readAfterSingleCodePointCallbacks = () => {
+  let cookieStore = { get: (name: string) => name };
+  [..."💩"].reduce(() => {
+    cookieStore = cookies();
+    return "";
+  });
+  return cookieStore.get("session");
+};
+
+export const readAfterDeadMutation = () => {
+  let cookieStore = cookies();
+  const values = [0];
+  if (false) values.pop();
+  values.map(() => {
+    cookieStore = { get: (name: string) => name };
+  });
+  return cookieStore.get("session");
+};
+
+export const readAfterKnownNoop = () => {
+  let cookieStore = cookies();
+  const noop = () => {};
+  const clear = () => {
+    noop();
+    cookieStore = { get: (name: string) => name };
+  };
+  try {
+    clear();
+  } catch {}
+  return cookieStore.get("session");
+};
+
+export const readAfterSparseLengthGrowth = () => {
+  let cookieStore = { get: (name: string) => name };
+  const values: number[] = [];
+  values.length = 1;
+  values.map(() => {
+    cookieStore = cookies();
+  });
+  return cookieStore.get("session");
+};

--- a/packages/fuzz/corpus/regressions/nextjs-async-dynamic-api-not-awaited--invoked-official-prop-clear/app/[slug]/page.tsx
+++ b/packages/fuzz/corpus/regressions/nextjs-async-dynamic-api-not-awaited--invoked-official-prop-clear/app/[slug]/page.tsx
@@ -1,0 +1,17 @@
+// rule: nextjs-async-dynamic-api-not-awaited
+// weakness: control-flow
+// source: PR #1000 exact-head audit
+
+interface PageProps {
+  params: Promise<{ slug: string }> | { slug: string };
+}
+
+const Page = (props: PageProps) => {
+  const read = () => {
+    props.params = { slug: "safe" };
+    return props.params.slug;
+  };
+  return read();
+};
+
+export default Page;

--- a/packages/fuzz/corpus/regressions/nextjs-async-dynamic-api-not-awaited--local-official-type-alias.tsx
+++ b/packages/fuzz/corpus/regressions/nextjs-async-dynamic-api-not-awaited--local-official-type-alias.tsx
@@ -1,0 +1,9 @@
+// rule: nextjs-async-dynamic-api-not-awaited
+// weakness: alias-guard
+// source: PR #1000 deep audit
+
+import { cookies, type UnsafeUnwrappedCookies } from "next/headers";
+
+type LegacyCookieStore = UnsafeUnwrappedCookies;
+
+export const readSession = () => (cookies() as unknown as LegacyCookieStore).get("session");

--- a/packages/fuzz/corpus/regressions/nextjs-async-dynamic-api-not-awaited--non-consuming-reflection-and-unary.tsx
+++ b/packages/fuzz/corpus/regressions/nextjs-async-dynamic-api-not-awaited--non-consuming-reflection-and-unary.tsx
@@ -1,0 +1,16 @@
+// rule: nextjs-async-dynamic-api-not-awaited
+// weakness: library-idiom
+// source: PR #1393 Bugbot
+
+import { cookies } from "next/headers";
+
+export const inspectPendingCookies = () => {
+  const pendingCookies = cookies();
+  return [
+    Reflect.getOwnPropertyDescriptor(pendingCookies, "then"),
+    Reflect.has(pendingCookies, "catch"),
+    Object.getOwnPropertyDescriptor(pendingCookies, "finally"),
+    !pendingCookies,
+    typeof pendingCookies,
+  ];
+};

--- a/packages/fuzz/corpus/regressions/nextjs-async-dynamic-api-not-awaited--object-member-fallback-replacement/app/[slug]/page.tsx
+++ b/packages/fuzz/corpus/regressions/nextjs-async-dynamic-api-not-awaited--object-member-fallback-replacement/app/[slug]/page.tsx
@@ -1,0 +1,12 @@
+// rule: nextjs-async-dynamic-api-not-awaited
+// weakness: control-flow
+// source: PR #1000 independent audit
+
+export default async function Page(props) {
+  try {
+    props.params = await props.params;
+  } catch {
+    props.params = { slug: "fallback" };
+  }
+  return props.params.slug;
+}

--- a/packages/fuzz/corpus/regressions/nextjs-async-dynamic-api-not-awaited--object-member-self-unwrapping/app/[slug]/page.tsx
+++ b/packages/fuzz/corpus/regressions/nextjs-async-dynamic-api-not-awaited--object-member-self-unwrapping/app/[slug]/page.tsx
@@ -1,0 +1,9 @@
+// rule: nextjs-async-dynamic-api-not-awaited
+// weakness: control-flow
+// source: PR #1000 independent audit
+
+export default async function Page(props) {
+  const alias = props;
+  alias.params = await alias.params;
+  return props.params.slug;
+}

--- a/packages/fuzz/corpus/regressions/nextjs-async-dynamic-api-not-awaited--object-rest-subtraction/app/[slug]/page.tsx
+++ b/packages/fuzz/corpus/regressions/nextjs-async-dynamic-api-not-awaited--object-rest-subtraction/app/[slug]/page.tsx
@@ -1,0 +1,7 @@
+// rule: nextjs-async-dynamic-api-not-awaited
+// weakness: copy-tracking
+// source: PR #1000 independent audit
+
+export default function Page({ params, ...props }) {
+  return props.params.slug;
+}

--- a/packages/fuzz/corpus/regressions/nextjs-async-dynamic-api-not-awaited--promise-method-destructure.tsx
+++ b/packages/fuzz/corpus/regressions/nextjs-async-dynamic-api-not-awaited--promise-method-destructure.tsx
@@ -1,0 +1,10 @@
+// rule: nextjs-async-dynamic-api-not-awaited
+// weakness: library-idiom
+// source: PR #1000 deep audit
+
+import { cookies } from "next/headers";
+
+export const readSession = () => {
+  const { then } = cookies();
+  return then;
+};

--- a/packages/fuzz/corpus/regressions/nextjs-async-dynamic-api-not-awaited--same-branch-callback-overwrite.tsx
+++ b/packages/fuzz/corpus/regressions/nextjs-async-dynamic-api-not-awaited--same-branch-callback-overwrite.tsx
@@ -1,0 +1,16 @@
+// rule: nextjs-async-dynamic-api-not-awaited
+// weakness: control-flow
+// source: PR #1000 independent audit
+
+import { cookies } from "next/headers";
+
+export const readSession = async (shouldCall: boolean) => {
+  let pendingCookies = cookies();
+  const readPendingCookies = () => pendingCookies.get("session");
+  let readAlias = readPendingCookies;
+  if (shouldCall) {
+    readAlias = () => null;
+    readAlias();
+  }
+  pendingCookies = await pendingCookies;
+};

--- a/packages/fuzz/corpus/regressions/nextjs-async-dynamic-api-not-awaited--static-loop-clearing.tsx
+++ b/packages/fuzz/corpus/regressions/nextjs-async-dynamic-api-not-awaited--static-loop-clearing.tsx
@@ -1,0 +1,14 @@
+// rule: nextjs-async-dynamic-api-not-awaited
+// weakness: control-flow
+// source: PR #1000 independent audit
+
+import { cookies } from "next/headers";
+
+export const readSession = async () => {
+  let pendingCookies = cookies();
+  while (1) {
+    pendingCookies = await pendingCookies;
+    break;
+  }
+  return pendingCookies.get("session");
+};

--- a/packages/fuzz/corpus/regressions/nextjs-async-dynamic-api-not-awaited--statically-unreachable-logical-source.tsx
+++ b/packages/fuzz/corpus/regressions/nextjs-async-dynamic-api-not-awaited--statically-unreachable-logical-source.tsx
@@ -1,0 +1,15 @@
+// rule: nextjs-async-dynamic-api-not-awaited
+// weakness: control-flow
+// source: PR #1000 deep audit
+
+import { cookies } from "next/headers";
+
+export const readSession = () => {
+  const cookieStore = { get: (name: string) => name } || cookies();
+  return cookieStore.get("session");
+};
+
+export const readCookieLabel = (suffix: string) => {
+  const label = `cookie-${suffix}` || cookies();
+  return label.length;
+};

--- a/packages/fuzz/corpus/regressions/nextjs-async-dynamic-api-not-awaited--ternary-all-branches-clear.tsx
+++ b/packages/fuzz/corpus/regressions/nextjs-async-dynamic-api-not-awaited--ternary-all-branches-clear.tsx
@@ -1,0 +1,16 @@
+// rule: nextjs-async-dynamic-api-not-awaited
+// weakness: control-flow
+// source: PR #1000 deep audit
+
+import { cookies } from "next/headers";
+
+export const readSession = async (useRequestCookies: boolean) => {
+  let pendingCookies = cookies();
+  const selectedCookies = useRequestCookies
+    ? (pendingCookies = await pendingCookies)
+    : (pendingCookies = getFallbackCookieStore());
+  return {
+    selectedCookies,
+    session: pendingCookies.get("session"),
+  };
+};

--- a/packages/fuzz/corpus/regressions/nextjs-async-dynamic-api-not-awaited--truthy-promise-and-fallback.tsx
+++ b/packages/fuzz/corpus/regressions/nextjs-async-dynamic-api-not-awaited--truthy-promise-and-fallback.tsx
@@ -1,0 +1,12 @@
+// rule: nextjs-async-dynamic-api-not-awaited
+// weakness: control-flow
+// source: PR #1000 deep audit
+
+import { cookies } from "next/headers";
+
+const fallbackCookieStore = { get: (name: string) => name };
+
+export const readSession = () => {
+  const cookieStore = cookies() && fallbackCookieStore;
+  return cookieStore.get("session");
+};

--- a/packages/fuzz/corpus/regressions/nextjs-async-dynamic-api-not-awaited--try-catch-all-clear.tsx
+++ b/packages/fuzz/corpus/regressions/nextjs-async-dynamic-api-not-awaited--try-catch-all-clear.tsx
@@ -1,0 +1,19 @@
+// rule: nextjs-async-dynamic-api-not-awaited
+// weakness: control-flow
+// source: PR #1000 deep audit
+
+import { cookies } from "next/headers";
+
+declare const getFallbackCookieStore: () => {
+  get: (name: string) => string;
+};
+
+export const readSession = async () => {
+  let pendingCookies = cookies();
+  try {
+    pendingCookies = await pendingCookies;
+  } catch {
+    pendingCookies = getFallbackCookieStore();
+  }
+  return pendingCookies.get("session");
+};

--- a/packages/fuzz/corpus/regressions/window-open-without-noopener--anchor-href-trusted-link.tsx
+++ b/packages/fuzz/corpus/regressions/window-open-without-noopener--anchor-href-trusted-link.tsx
@@ -1,0 +1,34 @@
+// rule: window-open-without-noopener
+// weakness: wrapper-transparency
+// source: react-bench corpus audit 2026-07 (anchorEl.href helper fed e.currentTarget from a locally proven relative URL getter)
+const createRelativePlaygroundUrl = ({ fixture }: { fixture: string }) => `/playground/${fixture}`;
+
+const openAnchorInNewTab = (anchorEl: HTMLAnchorElement) => {
+  window.open(anchorEl.href, "_blank");
+};
+
+export function FixtureLink({
+  children,
+  fixtureId,
+  onFixtureSelect,
+}: {
+  children: string;
+  fixtureId: string;
+  onFixtureSelect: (fixtureId: string) => void;
+}) {
+  return (
+    <a
+      href={createRelativePlaygroundUrl({ fixture: fixtureId })}
+      onClick={(event) => {
+        event.preventDefault();
+        if (event.metaKey) {
+          openAnchorInNewTab(event.currentTarget);
+        } else {
+          onFixtureSelect(fixtureId);
+        }
+      }}
+    >
+      {children}
+    </a>
+  );
+}

--- a/packages/fuzz/corpus/regressions/window-open-without-noopener--blob-object-url.tsx
+++ b/packages/fuzz/corpus/regressions/window-open-without-noopener--blob-object-url.tsx
@@ -1,0 +1,18 @@
+// rule: window-open-without-noopener
+// weakness: library-idiom
+// source: react-bench corpus audit 2026-07 (attachment preview: blob: URL of the user's own uploaded content, no opener hazard)
+export const ExportPreviewButton = ({ svgRef }: { svgRef: { current: SVGSVGElement | null } }) => {
+  const handleExport = () => {
+    if (!svgRef.current) return;
+    const svgMarkup = new XMLSerializer().serializeToString(svgRef.current);
+    const blob = new Blob([svgMarkup], { type: "image/svg+xml" });
+    const objectUrl = URL.createObjectURL(blob);
+    window.open(objectUrl, "_blank");
+    setTimeout(() => URL.revokeObjectURL(objectUrl), 60_000);
+  };
+  return (
+    <button type="button" onClick={handleExport}>
+      Preview export
+    </button>
+  );
+};

--- a/packages/fuzz/corpus/regressions/window-open-without-noopener--const-concat-prefix.tsx
+++ b/packages/fuzz/corpus/regressions/window-open-without-noopener--const-concat-prefix.tsx
@@ -1,0 +1,9 @@
+// rule: window-open-without-noopener
+// weakness: alias-guard
+// source: Cursor Bugbot review on PR #1392
+const rootPrefix = "https://example.com/" as const;
+const destinationPrefix = rootPrefix satisfies string;
+
+export const openDestination = (slug: string) => {
+  window.open(destinationPrefix + slug, "_blank");
+};

--- a/packages/fuzz/corpus/regressions/window-open-without-noopener--custom-jsx-return.tsx
+++ b/packages/fuzz/corpus/regressions/window-open-without-noopener--custom-jsx-return.tsx
@@ -1,0 +1,11 @@
+// rule: window-open-without-noopener
+// weakness: custom-callback-return
+interface ConsumerProps {
+  onClick: () => Window | null;
+}
+
+const Consumer = ({ onClick }: ConsumerProps) => onClick();
+
+export const App = (userControlledUrl: string) => (
+  <Consumer onClick={() => window.open(userControlledUrl)} />
+);

--- a/packages/fuzz/corpus/regressions/window-open-without-noopener--custom-jsx-return.tsx
+++ b/packages/fuzz/corpus/regressions/window-open-without-noopener--custom-jsx-return.tsx
@@ -1,5 +1,7 @@
 // rule: window-open-without-noopener
 // weakness: custom-callback-return
+import * as React from "react";
+
 interface ConsumerProps {
   onClick: () => Window | null;
 }
@@ -9,3 +11,8 @@ const Consumer = ({ onClick }: ConsumerProps) => onClick();
 export const App = (userControlledUrl: string) => (
   <Consumer onClick={() => window.open(userControlledUrl)} />
 );
+
+export const CreateElementApp = (userControlledUrl: string) =>
+  React.createElement(Consumer, {
+    onClick: () => window.open(userControlledUrl),
+  });

--- a/packages/fuzz/corpus/regressions/window-open-without-noopener--local-wrapper-literal-args.tsx
+++ b/packages/fuzz/corpus/regressions/window-open-without-noopener--local-wrapper-literal-args.tsx
@@ -1,0 +1,23 @@
+// rule: window-open-without-noopener
+// weakness: wrapper-transparency
+// source: react-bench corpus audit 2026-07 (rad-ui NavBar: local wrapper only ever called with hardcoded literal URLs)
+import { useCallback } from "react";
+
+export const NavBar = () => {
+  const openLink = useCallback(
+    (url: string) => () => {
+      window.open(url, "_blank");
+    },
+    [],
+  );
+  return (
+    <div>
+      <button type="button" onClick={openLink("https://discord.gg/nMaQfeEPNp")}>
+        Discord
+      </button>
+      <button type="button" onClick={openLink("https://github.com/rad-ui/ui")}>
+        Star on GitHub
+      </button>
+    </div>
+  );
+};

--- a/packages/fuzz/corpus/regressions/window-open-without-noopener--opaque-template-features.tsx
+++ b/packages/fuzz/corpus/regressions/window-open-without-noopener--opaque-template-features.tsx
@@ -1,0 +1,8 @@
+// rule: window-open-without-noopener
+// weakness: wrapper-transparency
+// source: Cursor Bugbot review on PR #1392
+import { POPUP_FEATURES } from "./popup-features";
+
+export const openPopup = (destination: string) => {
+  window.open(destination, "_blank", `${POPUP_FEATURES}`);
+};

--- a/packages/fuzz/corpus/regressions/window-open-without-noopener--parenthesized-url-serialization.tsx
+++ b/packages/fuzz/corpus/regressions/window-open-without-noopener--parenthesized-url-serialization.tsx
@@ -1,0 +1,7 @@
+// rule: window-open-without-noopener
+// weakness: wrapper-transparency
+// source: Bugbot review on PR #1392
+export const openParenthesizedUrl = () => {
+  // prettier-ignore
+  window.open((new URL("/store", window.location.origin)).toString(), "_blank");
+};

--- a/packages/fuzz/corpus/regressions/window-open-without-noopener--replaced-array-foreach.tsx
+++ b/packages/fuzz/corpus/regressions/window-open-without-noopener--replaced-array-foreach.tsx
@@ -1,0 +1,7 @@
+// rule: window-open-without-noopener
+// weakness: replaced-array-method
+export const capturePopup = (userControlledUrl: string) => {
+  const links = [userControlledUrl];
+  links.forEach = (callback) => callback(links[0]);
+  return links.forEach((href) => window.open(href));
+};

--- a/packages/fuzz/corpus/regressions/window-open-without-noopener--router-push-co-navigation.tsx
+++ b/packages/fuzz/corpus/regressions/window-open-without-noopener--router-push-co-navigation.tsx
@@ -1,0 +1,26 @@
+// rule: window-open-without-noopener
+// weakness: control-flow
+// source: react-bench corpus audit 2026-07 (hyperdx cmd+click row: Router.push in the sibling branch witnesses an internal route)
+import Router from "next/router";
+
+export function ListingRow({ href, name }: { href: string; name: string }) {
+  return (
+    <button
+      type="button"
+      onClick={(event) => {
+        if (event.metaKey || event.ctrlKey) {
+          window.open(href, "_blank");
+        } else {
+          Router.push(href);
+        }
+      }}
+      onAuxClick={(event) => {
+        if (event.button === 1) {
+          window.open(href, "_blank");
+        }
+      }}
+    >
+      {name}
+    </button>
+  );
+}

--- a/packages/fuzz/corpus/regressions/window-open-without-noopener--same-origin-builders.tsx
+++ b/packages/fuzz/corpus/regressions/window-open-without-noopener--same-origin-builders.tsx
@@ -1,7 +1,9 @@
 // rule: window-open-without-noopener
 // weakness: control-flow
-// source: PR #1000 corpus sweep (dtale same-origin popups; opener is wanted for app windows)
-import { fullPath, buildURL, getLocation } from "./menu-utils";
+// source: PR #1000 corpus sweep (locally proven same-origin popup builders)
+const fullPath = (path: string, dataId: string) => `${path}/${dataId}`;
+const buildURL = (path: string, _options: object) => path;
+const getLocation = () => window.location;
 
 export const openExport = (dataId: string, exportType: string) => {
   window.open(`${fullPath("/dtale/data-export", dataId)}?type=${exportType}`, "_blank");

--- a/packages/fuzz/corpus/regressions/window-open-without-noopener--same-origin-builders.tsx
+++ b/packages/fuzz/corpus/regressions/window-open-without-noopener--same-origin-builders.tsx
@@ -3,14 +3,9 @@
 // source: PR #1000 corpus sweep (locally proven same-origin popup builders)
 const fullPath = (path: string, dataId: string) => `${path}/${dataId}`;
 const buildURL = (path: string, _options: object) => path;
-const getLocation = () => window.location;
 
 export const openExport = (dataId: string, exportType: string) => {
   window.open(`${fullPath("/dtale/data-export", dataId)}?type=${exportType}`, "_blank");
-};
-
-export const openInNewTab = () => {
-  window.open(getLocation().pathname?.replace("/iframe/", "/main/") ?? "", "_blank");
 };
 
 export const openHtmlExport = (dataId: string) => {

--- a/packages/fuzz/corpus/regressions/window-open-without-noopener--shadowed-window.tsx
+++ b/packages/fuzz/corpus/regressions/window-open-without-noopener--shadowed-window.tsx
@@ -1,0 +1,10 @@
+// rule: window-open-without-noopener
+// weakness: name-heuristic
+// source: PR #1000 split deep audit
+interface PopupApi {
+  open: (url: string) => void;
+}
+
+export const openEmbeddedPopup = (window: PopupApi, url: string) => {
+  window.open(url);
+};

--- a/packages/fuzz/corpus/regressions/window-open-without-noopener--slash-joined-nested-base.tsx
+++ b/packages/fuzz/corpus/regressions/window-open-without-noopener--slash-joined-nested-base.tsx
@@ -1,0 +1,7 @@
+// rule: window-open-without-noopener
+// weakness: control-flow
+// source: Bugbot review on PR #1392
+export const openNestedApiPath = () => {
+  const basePath = "/api/v1/";
+  window.open(`${basePath}/users`, "_blank");
+};

--- a/packages/fuzz/corpus/regressions/window-open-without-noopener--url-getter-helper.tsx
+++ b/packages/fuzz/corpus/regressions/window-open-without-noopener--url-getter-helper.tsx
@@ -1,0 +1,24 @@
+// rule: window-open-without-noopener
+// weakness: cross-file
+// source: react-bench corpus audit 2026-07 (a locally proven URL getter returns a same-origin path)
+const getViewUrl = (view: { view_id: string }, currentWorkspaceId: string) =>
+  `/workspace/${currentWorkspaceId}/view/${view.view_id}`;
+
+export const OpenInNewTab = ({
+  view,
+  currentWorkspaceId,
+}: {
+  view: { view_id: string };
+  currentWorkspaceId: string;
+}) => {
+  const onSelect = () => {
+    const url = getViewUrl(view, currentWorkspaceId);
+    if (!url) return;
+    window.open(url, "_blank");
+  };
+  return (
+    <button type="button" onClick={onSelect}>
+      Open in new tab
+    </button>
+  );
+};

--- a/packages/fuzz/corpus/regressions/window-open-without-noopener--url-instance-href.tsx
+++ b/packages/fuzz/corpus/regressions/window-open-without-noopener--url-instance-href.tsx
@@ -1,0 +1,6 @@
+// rule: window-open-without-noopener
+// weakness: url-instance-href
+export const openSafeUrl = () => {
+  const popupUrl = new URL("/safe", window.origin);
+  window.open(popupUrl.href);
+};

--- a/packages/fuzz/corpus/regressions/window-open-without-noopener--window-origin-template.tsx
+++ b/packages/fuzz/corpus/regressions/window-open-without-noopener--window-origin-template.tsx
@@ -1,0 +1,13 @@
+// rule: window-open-without-noopener
+// weakness: library-idiom
+// source: react-bench corpus audit 2026-07 (AppFlowy as-template: `${window.origin}/…` template is same-origin by construction)
+export const AsTemplateButton = ({ publishUrl }: { publishUrl: string }) => {
+  const handleClick = () => {
+    window.open(`${window.origin}/as-template?viewUrl=${encodeURIComponent(publishUrl)}`, "_blank");
+  };
+  return (
+    <button type="button" onClick={handleClick}>
+      Use as template
+    </button>
+  );
+};

--- a/packages/fuzz/corpus/true-positives/nextjs-async-dynamic-api-not-awaited--callback-cardinality-and-caught-clear.tsx
+++ b/packages/fuzz/corpus/true-positives/nextjs-async-dynamic-api-not-awaited--callback-cardinality-and-caught-clear.tsx
@@ -1,0 +1,78 @@
+// rule: nextjs-async-dynamic-api-not-awaited
+// weakness: control-flow
+// source: PR #1000 final audit
+
+import { cookies } from "next/headers";
+import { useMemo, useState } from "react";
+
+export const readAfterEmptyMap = () => {
+  let cookieStore = cookies();
+  [...[]].map(() => {
+    cookieStore = { get: (name: string) => name };
+  });
+  return cookieStore.get("session");
+};
+
+export const readAfterSingleElementReduce = () => {
+  let cookieStore = cookies();
+  [0].reduce(() => {
+    cookieStore = { get: (name: string) => name };
+    return 0;
+  });
+  return cookieStore.get("session");
+};
+
+export const readAfterCaughtThrow = (condition: boolean) => {
+  let cookieStore = { get: (name: string) => name };
+  const update = () => {
+    cookieStore = cookies();
+    if (condition) throw new Error();
+    cookieStore = { get: (name: string) => name };
+  };
+  try {
+    update();
+  } catch {}
+  return cookieStore.get("session");
+};
+
+export const readAfterSparseClear = () => {
+  let cookieStore = cookies();
+  Array(1).map(() => {
+    cookieStore = { get: (name: string) => name };
+  });
+  return cookieStore.get("session");
+};
+
+export const readAfterNamedHookTaint = () => {
+  let cookieStore = { get: (name: string) => name };
+  useMemo(() => {
+    cookieStore = cookies();
+  }, []);
+  useState(() => {
+    cookieStore = cookies();
+    return 0;
+  });
+  return cookieStore.get("session");
+};
+
+export const readAfterMutatedArrayTaint = () => {
+  let cookieStore = { get: (name: string) => name };
+  const values: number[] = [];
+  values.push(0);
+  values.map(() => {
+    cookieStore = cookies();
+  });
+  return cookieStore.get("session");
+};
+
+export const readAfterCaughtUnknownCall = () => {
+  let cookieStore = cookies();
+  const clear = () => {
+    mayThrow();
+    cookieStore = { get: (name: string) => name };
+  };
+  try {
+    clear();
+  } catch {}
+  return cookieStore.get("session");
+};

--- a/packages/fuzz/corpus/true-positives/nextjs-async-dynamic-api-not-awaited--catch-read-after-throw.tsx
+++ b/packages/fuzz/corpus/true-positives/nextjs-async-dynamic-api-not-awaited--catch-read-after-throw.tsx
@@ -1,0 +1,19 @@
+// rule: nextjs-async-dynamic-api-not-awaited
+// weakness: control-flow
+// source: PR #1000 deep audit
+
+import { cookies } from "next/headers";
+
+declare const getCookieStoreOrThrow: () => {
+  get: (name: string) => string;
+};
+
+export const readSession = () => {
+  let pendingCookies = cookies();
+  try {
+    pendingCookies = getCookieStoreOrThrow();
+  } catch {
+    return pendingCookies.get("session");
+  }
+  return null;
+};

--- a/packages/fuzz/corpus/true-positives/nextjs-async-dynamic-api-not-awaited--caught-official-prop-assignment/app/[slug]/page.tsx
+++ b/packages/fuzz/corpus/true-positives/nextjs-async-dynamic-api-not-awaited--caught-official-prop-assignment/app/[slug]/page.tsx
@@ -1,0 +1,15 @@
+// rule: nextjs-async-dynamic-api-not-awaited
+// weakness: control-flow
+// source: PR #1000 final audit
+
+declare const getSafeOrThrow: () => { slug: string };
+
+export default function Page(props: { params: Promise<{ slug: string }> }) {
+  const read = () => {
+    try {
+      props.params = getSafeOrThrow();
+    } catch {}
+    return props.params.slug;
+  };
+  return read();
+}

--- a/packages/fuzz/corpus/true-positives/nextjs-async-dynamic-api-not-awaited--conditional-member-retention/app/[slug]/page.tsx
+++ b/packages/fuzz/corpus/true-positives/nextjs-async-dynamic-api-not-awaited--conditional-member-retention/app/[slug]/page.tsx
@@ -1,0 +1,7 @@
+// rule: nextjs-async-dynamic-api-not-awaited
+// source: PR #1000 independent audit
+
+export default function Page(props, condition) {
+  props.params = condition ? props.params : { slug: "fallback" };
+  return props.params.slug;
+}

--- a/packages/fuzz/corpus/true-positives/nextjs-async-dynamic-api-not-awaited--conditional-self-reassignment.tsx
+++ b/packages/fuzz/corpus/true-positives/nextjs-async-dynamic-api-not-awaited--conditional-self-reassignment.tsx
@@ -1,0 +1,11 @@
+// rule: nextjs-async-dynamic-api-not-awaited
+// weakness: control-flow
+// source: PR #1000 deep audit
+
+import { cookies } from "next/headers";
+
+export const readSession = async (shouldAwait: boolean) => {
+  let pendingCookies = cookies();
+  pendingCookies = shouldAwait ? await pendingCookies : pendingCookies;
+  return pendingCookies.get("session");
+};

--- a/packages/fuzz/corpus/true-positives/nextjs-async-dynamic-api-not-awaited--deferred-binding-read.tsx
+++ b/packages/fuzz/corpus/true-positives/nextjs-async-dynamic-api-not-awaited--deferred-binding-read.tsx
@@ -1,0 +1,10 @@
+// rule: nextjs-async-dynamic-api-not-awaited
+// weakness: control-flow
+// source: PR #1000 deep audit
+
+import { cookies } from "next/headers";
+
+export const makeSessionReader = () => {
+  const pendingCookies = cookies();
+  return () => pendingCookies.get("session");
+};

--- a/packages/fuzz/corpus/true-positives/nextjs-async-dynamic-api-not-awaited--immediate-mutable-closure.tsx
+++ b/packages/fuzz/corpus/true-positives/nextjs-async-dynamic-api-not-awaited--immediate-mutable-closure.tsx
@@ -1,0 +1,12 @@
+// rule: nextjs-async-dynamic-api-not-awaited
+// weakness: control-flow
+// source: PR #1000 deep audit
+
+import { cookies } from "next/headers";
+
+export const readSession = async () => {
+  let pendingCookies = cookies();
+  const session = (() => pendingCookies.get("session"))();
+  pendingCookies = await pendingCookies;
+  return session;
+};

--- a/packages/fuzz/corpus/true-positives/nextjs-async-dynamic-api-not-awaited--logical-pending-write.tsx
+++ b/packages/fuzz/corpus/true-positives/nextjs-async-dynamic-api-not-awaited--logical-pending-write.tsx
@@ -1,0 +1,11 @@
+// rule: nextjs-async-dynamic-api-not-awaited
+// weakness: copy-tracking
+// source: PR #1000 independent audit
+
+import { cookies } from "next/headers";
+
+export const readSession = () => {
+  let pendingCookies;
+  pendingCookies ??= cookies();
+  return pendingCookies.get("session");
+};

--- a/packages/fuzz/corpus/true-positives/nextjs-async-dynamic-api-not-awaited--named-synchronous-callback.tsx
+++ b/packages/fuzz/corpus/true-positives/nextjs-async-dynamic-api-not-awaited--named-synchronous-callback.tsx
@@ -1,0 +1,14 @@
+// rule: nextjs-async-dynamic-api-not-awaited
+// weakness: control-flow
+// source: PR #1000 independent audit
+
+import { cookies } from "next/headers";
+
+export const readSession = async () => {
+  let pendingCookies = cookies();
+  const values = [0];
+  const readPendingCookies = () => pendingCookies.get("session");
+  const sessions = values.map(readPendingCookies);
+  pendingCookies = await pendingCookies;
+  return sessions;
+};

--- a/packages/fuzz/corpus/true-positives/nextjs-async-dynamic-api-not-awaited--promise-settlement-chain.tsx
+++ b/packages/fuzz/corpus/true-positives/nextjs-async-dynamic-api-not-awaited--promise-settlement-chain.tsx
@@ -1,0 +1,10 @@
+// rule: nextjs-async-dynamic-api-not-awaited
+// weakness: copy-tracking
+// source: PR #1000 deep audit
+
+import { cookies } from "next/headers";
+
+export const readSession = () =>
+  cookies()
+    .catch(() => cookies())
+    .get("session");

--- a/packages/fuzz/corpus/true-positives/nextjs-async-dynamic-api-not-awaited--reflective-property-read.tsx
+++ b/packages/fuzz/corpus/true-positives/nextjs-async-dynamic-api-not-awaited--reflective-property-read.tsx
@@ -1,0 +1,14 @@
+// rule: nextjs-async-dynamic-api-not-awaited
+// weakness: library-idiom
+// source: PR #1000 independent audit
+
+import { cookies } from "next/headers";
+
+export const readSession = () => {
+  const pendingCookies = cookies();
+  return [
+    Reflect.get(pendingCookies, "get"),
+    Reflect.getOwnPropertyDescriptor(pendingCookies, "get"),
+    Reflect.has(pendingCookies, "get"),
+  ];
+};

--- a/packages/fuzz/corpus/true-positives/nextjs-async-dynamic-api-not-awaited--request-api-alias-wrapper.tsx
+++ b/packages/fuzz/corpus/true-positives/nextjs-async-dynamic-api-not-awaited--request-api-alias-wrapper.tsx
@@ -1,0 +1,14 @@
+// rule: nextjs-async-dynamic-api-not-awaited
+// weakness: wrapper-transparency
+// source: PR #1000 independent audit
+
+import { cookies, draftMode } from "next/headers";
+import * as nextHeaders from "next/headers";
+
+const readCookies = cookies;
+const readHeaders = nextHeaders.headers;
+const readDraftMode = () => draftMode();
+
+export const readSession = () => readCookies().get("session");
+export const readRequestId = () => readHeaders().get("x-request-id");
+export const readDraftStatus = () => readDraftMode().isEnabled;

--- a/packages/fuzz/corpus/true-positives/nextjs-async-dynamic-api-not-awaited--synchronous-callback-alias.tsx
+++ b/packages/fuzz/corpus/true-positives/nextjs-async-dynamic-api-not-awaited--synchronous-callback-alias.tsx
@@ -1,0 +1,14 @@
+// rule: nextjs-async-dynamic-api-not-awaited
+// weakness: control-flow
+// source: PR #1000 deep audit
+
+import { cookies } from "next/headers";
+
+export const readSession = async () => {
+  let pendingCookies = cookies();
+  const readPendingCookies = () => pendingCookies.get("session");
+  const readPendingCookiesAlias = readPendingCookies;
+  const sessions = [0].map(() => readPendingCookiesAlias());
+  pendingCookies = await pendingCookies;
+  return sessions[0];
+};

--- a/packages/fuzz/corpus/true-positives/nextjs-async-dynamic-api-not-awaited--synchronous-enumeration.tsx
+++ b/packages/fuzz/corpus/true-positives/nextjs-async-dynamic-api-not-awaited--synchronous-enumeration.tsx
@@ -1,0 +1,7 @@
+// rule: nextjs-async-dynamic-api-not-awaited
+// weakness: wrapper-transparency
+// source: PR #1000 deep audit
+
+import { cookies } from "next/headers";
+
+export const listCookieProperties = () => Object.keys(cookies());

--- a/packages/fuzz/corpus/true-positives/window-open-without-noopener--authoritative-properties.tsx
+++ b/packages/fuzz/corpus/true-positives/window-open-without-noopener--authoritative-properties.tsx
@@ -1,0 +1,15 @@
+// rule: window-open-without-noopener
+// weakness: override-order
+export const UnsafeLink = ({ dynamicHref }: { dynamicHref: string }) => {
+  const links = { docs: "/safe", docs: dynamicHref };
+  return (
+    <a
+      href="/safe"
+      href={dynamicHref}
+      onClick={(event) => {
+        window.open(event.currentTarget.href);
+        window.open(links.docs);
+      }}
+    />
+  );
+};

--- a/packages/fuzz/corpus/true-positives/window-open-without-noopener--computed-global-call.tsx
+++ b/packages/fuzz/corpus/true-positives/window-open-without-noopener--computed-global-call.tsx
@@ -1,0 +1,6 @@
+// rule: window-open-without-noopener
+// weakness: wrapper-transparency
+// source: PR #1000 split deep audit
+export const openUntrustedPopup = (url: string) => {
+  window["open"](url);
+};

--- a/packages/fuzz/corpus/true-positives/window-open-without-noopener--conditional-router-witness.tsx
+++ b/packages/fuzz/corpus/true-positives/window-open-without-noopener--conditional-router-witness.tsx
@@ -1,0 +1,8 @@
+// rule: window-open-without-noopener
+// weakness: control-flow
+import Router from "next/router";
+
+export const openDestination = (destination: string, shouldNavigate: boolean) => {
+  if (shouldNavigate) Router.push(destination);
+  window.open(destination);
+};

--- a/packages/fuzz/corpus/true-positives/window-open-without-noopener--global-method-aliases.tsx
+++ b/packages/fuzz/corpus/true-positives/window-open-without-noopener--global-method-aliases.tsx
@@ -1,0 +1,10 @@
+// rule: window-open-without-noopener
+// weakness: alias-guard
+// source: PR #1000 deep audit 2026-07 (Window.open aliases retain the global security semantics)
+const openPopup = globalThis.open;
+const { open: openFromWindow } = window;
+
+export const openDestinations = (firstDestination: string, secondDestination: string) => {
+  openPopup(firstDestination);
+  openFromWindow(secondDestination);
+};

--- a/packages/fuzz/corpus/true-positives/window-open-without-noopener--global-method-aliases.tsx
+++ b/packages/fuzz/corpus/true-positives/window-open-without-noopener--global-method-aliases.tsx
@@ -3,8 +3,14 @@
 // source: PR #1000 deep audit 2026-07 (Window.open aliases retain the global security semantics)
 const openPopup = globalThis.open;
 const { open: openFromWindow } = window;
+const popupHost = top;
+const { open: openFromFrames } = frames;
 
 export const openDestinations = (firstDestination: string, secondDestination: string) => {
   openPopup(firstDestination);
   openFromWindow(secondDestination);
+  globalThis.open(firstDestination);
+  self.open(secondDestination);
+  popupHost.open(firstDestination);
+  openFromFrames(secondDestination);
 };

--- a/packages/fuzz/corpus/true-positives/window-open-without-noopener--mutated-array-config.tsx
+++ b/packages/fuzz/corpus/true-positives/window-open-without-noopener--mutated-array-config.tsx
@@ -8,4 +8,9 @@ export const openMutatedConfig = (userControlledUrl: string) => {
   const extendedLinks = [{ href: "/safe" }];
   extendedLinks.push({ href: userControlledUrl });
   extendedLinks.forEach((item) => window.open(item.href));
+
+  const destructuredLinks = [{ href: "/safe" }];
+  const destructuredLinksAlias = destructuredLinks;
+  destructuredLinksAlias[0].href = userControlledUrl;
+  destructuredLinks.forEach(({ href }) => window.open(href));
 };

--- a/packages/fuzz/corpus/true-positives/window-open-without-noopener--mutated-array-config.tsx
+++ b/packages/fuzz/corpus/true-positives/window-open-without-noopener--mutated-array-config.tsx
@@ -1,0 +1,11 @@
+// rule: window-open-without-noopener
+// weakness: mutation
+export const openMutatedConfig = (userControlledUrl: string) => {
+  const links = [{ href: "/safe" }];
+  links[0].href = userControlledUrl;
+  links.forEach((item) => window.open(item.href));
+
+  const extendedLinks = [{ href: "/safe" }];
+  extendedLinks.push({ href: userControlledUrl });
+  extendedLinks.forEach((item) => window.open(item.href));
+};

--- a/packages/fuzz/corpus/true-positives/window-open-without-noopener--mutated-helper-parameter.tsx
+++ b/packages/fuzz/corpus/true-positives/window-open-without-noopener--mutated-helper-parameter.tsx
@@ -1,0 +1,9 @@
+// rule: window-open-without-noopener
+// weakness: helper-parameter-write
+export const openMutatedHelperResult = (userControlledUrl: string) => {
+  const buildPath = (path: string) => {
+    path = userControlledUrl;
+    return path;
+  };
+  window.open(buildPath("/safe"));
+};

--- a/packages/fuzz/corpus/true-positives/window-open-without-noopener--mutated-url-proofs.tsx
+++ b/packages/fuzz/corpus/true-positives/window-open-without-noopener--mutated-url-proofs.tsx
@@ -29,4 +29,20 @@ export const openMutatedUrl = (blob: Blob, userControlledUrl: string) => {
   const popupUrlAlias = aliasedPopupUrl;
   URL.prototype.toString = () => userControlledUrl;
   window.open(popupUrlAlias);
+
+  const nestedHrefPopupUrl = new URL("/safe", window.origin);
+  const getNestedPopupHref = () => nestedHrefPopupUrl.href;
+  const openNestedPopupHref = () => {
+    nestedHrefPopupUrl.href = userControlledUrl;
+    window.open(getNestedPopupHref());
+  };
+  openNestedPopupHref();
+
+  const nestedInstancePopupUrl = new URL("/safe", window.origin);
+  const getNestedPopupUrl = () => nestedInstancePopupUrl;
+  const openNestedPopupUrl = () => {
+    nestedInstancePopupUrl.href = userControlledUrl;
+    window.open(getNestedPopupUrl());
+  };
+  openNestedPopupUrl();
 };

--- a/packages/fuzz/corpus/true-positives/window-open-without-noopener--mutated-url-proofs.tsx
+++ b/packages/fuzz/corpus/true-positives/window-open-without-noopener--mutated-url-proofs.tsx
@@ -1,0 +1,19 @@
+// rule: window-open-without-noopener
+// weakness: mutation
+export const openMutatedUrl = (blob: Blob, userControlledUrl: string) => {
+  URL.createObjectURL = () => userControlledUrl;
+  window.open(URL.createObjectURL(blob));
+
+  globalThis.URL = class UnsafeUrl extends URL {
+    static createObjectURL = () => userControlledUrl;
+  };
+  window.open(URL.createObjectURL(blob));
+
+  const popupUrl = new URL("/safe", window.origin);
+  popupUrl.href = userControlledUrl;
+  window.open(popupUrl.toString());
+
+  URL.prototype.toString = () => userControlledUrl;
+  const serializedPopupUrl = new URL("/safe", window.origin);
+  window.open(serializedPopupUrl.toString());
+};

--- a/packages/fuzz/corpus/true-positives/window-open-without-noopener--mutated-url-proofs.tsx
+++ b/packages/fuzz/corpus/true-positives/window-open-without-noopener--mutated-url-proofs.tsx
@@ -16,4 +16,17 @@ export const openMutatedUrl = (blob: Blob, userControlledUrl: string) => {
   URL.prototype.toString = () => userControlledUrl;
   const serializedPopupUrl = new URL("/safe", window.origin);
   window.open(serializedPopupUrl.toString());
+
+  const lateMutatedPopupUrl = new URL("/safe", window.origin);
+  URL.prototype.toJSON = () => userControlledUrl;
+  window.open(lateMutatedPopupUrl.toJSON());
+
+  const implicitlySerializedPopupUrl = new URL("/safe", window.origin);
+  URL.prototype.toString = () => userControlledUrl;
+  window.open(`${implicitlySerializedPopupUrl}`);
+
+  const aliasedPopupUrl = new URL("/safe", window.origin);
+  const popupUrlAlias = aliasedPopupUrl;
+  URL.prototype.toString = () => userControlledUrl;
+  window.open(popupUrlAlias);
 };

--- a/packages/fuzz/corpus/true-positives/window-open-without-noopener--opaque-feature-interpolation.tsx
+++ b/packages/fuzz/corpus/true-positives/window-open-without-noopener--opaque-feature-interpolation.tsx
@@ -1,0 +1,5 @@
+// rule: window-open-without-noopener
+// weakness: opaque-feature-interpolation
+export const openWithAmbiguousFeatures = (destination: string, middle: string) => {
+  window.open(destination, "_blank", `no${middle}opener`);
+};

--- a/packages/fuzz/corpus/true-positives/window-open-without-noopener--parameter-write.tsx
+++ b/packages/fuzz/corpus/true-positives/window-open-without-noopener--parameter-write.tsx
@@ -1,0 +1,10 @@
+// rule: window-open-without-noopener
+// weakness: parameter-write
+interface LinkProps {
+  href: string;
+}
+
+export const MutatedLink = ({ href }: LinkProps) => {
+  href = `https://example.com/${href}`;
+  return <button onClick={() => window.open(href)}>Open</button>;
+};

--- a/packages/fuzz/corpus/true-positives/window-open-without-noopener--unreachable-router-witness.tsx
+++ b/packages/fuzz/corpus/true-positives/window-open-without-noopener--unreachable-router-witness.tsx
@@ -1,0 +1,9 @@
+// rule: window-open-without-noopener
+// weakness: control-flow
+// source: PR #1000 deep audit 2026-07 (dead router calls cannot prove a destination is same-origin)
+import Router from "next/router";
+
+export const openDestination = (destination: string) => {
+  if (false) Router.push(destination);
+  window.open(destination);
+};

--- a/packages/fuzz/corpus/true-positives/window-open-without-noopener--unresolved-import.tsx
+++ b/packages/fuzz/corpus/true-positives/window-open-without-noopener--unresolved-import.tsx
@@ -1,0 +1,7 @@
+// rule: window-open-without-noopener
+// weakness: unresolved-import
+import { documentationUrl } from "./missing-links";
+
+export const openImportedDestination = () => {
+  window.open(documentationUrl);
+};

--- a/packages/fuzz/corpus/true-positives/window-open-without-noopener--unsafe-concat-prefix.tsx
+++ b/packages/fuzz/corpus/true-positives/window-open-without-noopener--unsafe-concat-prefix.tsx
@@ -1,0 +1,7 @@
+// rule: window-open-without-noopener
+// weakness: concat-prefix
+export const openHost = (userControlledHost: string) => {
+  window.open("https://" + userControlledHost);
+  window.open("//" + userControlledHost);
+  window.open("" + userControlledHost);
+};

--- a/packages/fuzz/corpus/true-positives/window-open-without-noopener--unsafe-origin-template.tsx
+++ b/packages/fuzz/corpus/true-positives/window-open-without-noopener--unsafe-origin-template.tsx
@@ -1,0 +1,10 @@
+// rule: window-open-without-noopener
+// weakness: origin-boundary
+export const openUnsafeOriginTemplate = () => {
+  window.open(`${window.origin}.evil.com`);
+};
+
+export const openSlashJoinedTemplate = () => {
+  const prefix = "/";
+  window.open(`${prefix}/evil.com`);
+};

--- a/packages/fuzz/corpus/true-positives/window-open-without-noopener--unsafe-path-transforms.tsx
+++ b/packages/fuzz/corpus/true-positives/window-open-without-noopener--unsafe-path-transforms.tsx
@@ -1,0 +1,5 @@
+// rule: window-open-without-noopener
+// weakness: path-normalization
+export const openUnsafePath = () => {
+  window.open(window.location.pathname.slice(1));
+};

--- a/packages/fuzz/corpus/true-positives/window-open-without-noopener--unsafe-path-transforms.tsx
+++ b/packages/fuzz/corpus/true-positives/window-open-without-noopener--unsafe-path-transforms.tsx
@@ -2,4 +2,5 @@
 // weakness: path-normalization
 export const openUnsafePath = () => {
   window.open(window.location.pathname.slice(1));
+  window.open(window.location.pathname.replace("safe", "/"));
 };

--- a/packages/fuzz/corpus/true-positives/window-open-without-noopener--unsafe-path-transforms.tsx
+++ b/packages/fuzz/corpus/true-positives/window-open-without-noopener--unsafe-path-transforms.tsx
@@ -1,6 +1,7 @@
 // rule: window-open-without-noopener
 // weakness: path-normalization
-export const openUnsafePath = () => {
+export const openUnsafePath = (userControlledSuffix: string) => {
   window.open(window.location.pathname.slice(1));
   window.open(window.location.pathname.replace("safe", "/"));
+  window.open(`${window.origin}${userControlledSuffix}`);
 };

--- a/packages/fuzz/corpus/true-positives/window-open-without-noopener--unsafe-path-transforms.tsx
+++ b/packages/fuzz/corpus/true-positives/window-open-without-noopener--unsafe-path-transforms.tsx
@@ -1,7 +1,10 @@
 // rule: window-open-without-noopener
 // weakness: path-normalization
+const getLocation = () => window.location;
+
 export const openUnsafePath = (userControlledSuffix: string) => {
   window.open(window.location.pathname.slice(1));
   window.open(window.location.pathname.replace("safe", "/"));
+  window.open(getLocation().pathname?.replace("/iframe/", "/main/") ?? "", "_blank");
   window.open(`${window.origin}${userControlledSuffix}`);
 };

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -314,6 +314,20 @@ export const MODULE_SCOPE_SNIPPET_POOL = [
 ] as const;
 
 export const SERVER_MODULE_PROGRAM_POOL = [
+  `import { headers } from "next/headers";
+export const readFuzzRequestId = () => headers().get("x-request-id");`,
+  `import { cookies as readFuzzCookies } from "next/headers";
+export const readFuzzFallbackCookie = () => {
+  const cookieStore = { get: (name) => name } || readFuzzCookies();
+  return cookieStore.get("session");
+};`,
+  `import { cookies as readFuzzCallbackCookies } from "next/headers";
+export const readFuzzCallbackCookie = async () => {
+  let pendingCookies = readFuzzCallbackCookies();
+  const sessions = [0].map(() => pendingCookies.get("session"));
+  pendingCookies = await pendingCookies;
+  return sessions[0];
+};`,
   `export default async function Page() {
   const response = await fetch("https://api.example.com/feed");
   return Response.json(await response.json());

--- a/packages/fuzz/tests/verdict-robustness.test.ts
+++ b/packages/fuzz/tests/verdict-robustness.test.ts
@@ -97,6 +97,7 @@ const AUDITED_RULE_IDS = [
   "rn-detox-missing-await",
   "rules-of-hooks",
   "styled-components-non-transient-custom-prop-on-intrinsic-element",
+  "window-open-without-noopener",
 ] as const;
 
 // Rule × variant pairs where losing the diagnostic is the rule's DOCUMENTED

--- a/packages/fuzz/tests/verdict-robustness.test.ts
+++ b/packages/fuzz/tests/verdict-robustness.test.ts
@@ -33,6 +33,7 @@ const AUDITED_RULE_IDS = [
   "js-hoist-regexp",
   "jsx-numeric-and-leaked-render",
   "mobx-reaction-disposer-discarded",
+  "nextjs-async-dynamic-api-not-awaited",
   "nextjs-no-polyfill-script",
   "no-adjust-state-on-prop-change",
   "no-aria-hidden-on-focusable",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/cross-file-rule-ids.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/cross-file-rule-ids.ts
@@ -58,6 +58,7 @@ export const CROSS_FILE_RULE_IDS: ReadonlySet<string> = new Set([
   "only-export-components",
   "no-unguarded-browser-global-at-module-scope",
   "no-unguarded-browser-global-in-render-or-hook-init",
+  "window-open-without-noopener",
   "prefer-dynamic-import",
   "rendering-hydration-mismatch-time",
   "rerender-memo-with-default-value",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/js.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/js.ts
@@ -61,6 +61,8 @@ export const MUTATING_COLLECTION_METHODS = new Set(["add", "clear", "delete", "s
 
 export const CHAINABLE_ITERATION_METHODS = new Set(["map", "filter", "forEach", "flatMap"]);
 
+export const PROMISE_SETTLE_METHODS = new Set(["then", "catch", "finally"]);
+
 // Method names that, when invoked on a non-`Object` receiver, yield a
 // lazy iterator instead of an array. `arr.values()`, `map.entries()`,
 // `set.keys()`, `urlSearchParams.values()`, etc. all surface as

--- a/packages/oxlint-plugin-react-doctor/src/plugin/cross-file-dependencies.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/cross-file-dependencies.ts
@@ -486,6 +486,7 @@ export const UNBOUNDED_CROSS_FILE_RULE_IDS: ReadonlySet<string> = new Set([
   "nextjs-no-img-element",
   "no-loading-flag-reset-outside-finally",
   "only-export-components",
+  "window-open-without-noopener",
 ]);
 
 /**

--- a/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness-fixtures.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness-fixtures.ts
@@ -459,6 +459,10 @@ export const livenessFixtures: Readonly<Record<string, LivenessFixture>> = {
   "nextjs-async-client-component": {
     code: '"use client";\nexport default async function Profile() {\n  const data = await loadProfile();\n  return <div>{data.name}</div>;\n}',
   },
+  "nextjs-async-dynamic-api-not-awaited": {
+    code: 'import { headers } from "next/headers";\nexport const read = () => headers().get("x-request-id");',
+    filePath: "app/page.tsx",
+  },
   "nextjs-error-boundary-missing-use-client": {
     code: "export default function ErrorBoundary({ error, reset }) {\n  return <div>{error.message}</div>;\n}",
     filePath: "/app/app/error.tsx",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness-fixtures.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness-fixtures.ts
@@ -1541,6 +1541,9 @@ export const livenessFixtures: Readonly<Record<string, LivenessFixture>> = {
     code: "export async function POST(request: Request) {\n  const event = await request.json();\n  await applyEvent(event);\n  return Response.json({ ok: true });\n}\n",
     filePath: "src/app/api/webhooks/github/route.ts",
   },
+  "window-open-without-noopener": {
+    code: "window.open(url);",
+  },
   "zod-v4-no-deprecated-error-apis": {
     code: '\n      import { z } from "zod";\n      const error = z.ZodError.create([]);\n    ',
   },

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
@@ -461,6 +461,7 @@ import { urlPrefilledPrivilegedAction } from "./rules/security-scan/url-prefille
 import { useLazyMotion } from "./rules/bundle-size/use-lazy-motion.js";
 import { voidDomElementsNoChildren } from "./rules/react-builtins/void-dom-elements-no-children.js";
 import { webhookSignatureRisk } from "./rules/security-scan/webhook-signature-risk.js";
+import { windowOpenWithoutNoopener } from "./rules/security/window-open-without-noopener.js";
 import { zodV4NoDeprecatedErrorApis } from "./rules/zod/zod-v4-no-deprecated-error-apis.js";
 import { zodV4NoDeprecatedErrorCustomization } from "./rules/zod/zod-v4-no-deprecated-error-customization.js";
 import { zodV4NoDeprecatedSchemaApis } from "./rules/zod/zod-v4-no-deprecated-schema-apis.js";
@@ -5867,6 +5868,17 @@ export const reactDoctorRules = [
       framework: "global",
       category: "Security",
       tags: [...new Set(["security-scan", ...(webhookSignatureRisk.tags ?? [])])],
+    },
+  },
+  {
+    key: "react-doctor/window-open-without-noopener",
+    id: "window-open-without-noopener",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...windowOpenWithoutNoopener,
+      framework: "global",
+      category: "Security",
     },
   },
   {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
@@ -133,6 +133,7 @@ import { mediaHasCaption } from "./rules/a11y/media-has-caption.js";
 import { mobxReactionDisposerDiscarded } from "./rules/state-and-effects/mobx-reaction-disposer-discarded.js";
 import { mouseEventsHaveKeyEvents } from "./rules/a11y/mouse-events-have-key-events.js";
 import { nextjsAsyncClientComponent } from "./rules/nextjs/nextjs-async-client-component.js";
+import { nextjsAsyncDynamicApiNotAwaited } from "./rules/nextjs/nextjs-async-dynamic-api-not-awaited.js";
 import { nextjsErrorBoundaryMissingUseClient } from "./rules/nextjs/nextjs-error-boundary-missing-use-client.js";
 import { nextjsGlobalErrorMissingHtmlBody } from "./rules/nextjs/nextjs-global-error-missing-html-body.js";
 import { nextjsImageMissingSizes } from "./rules/nextjs/nextjs-image-missing-sizes.js";
@@ -1971,6 +1972,17 @@ export const reactDoctorRules = [
     originallyExternal: false,
     rule: {
       ...nextjsAsyncClientComponent,
+      framework: "nextjs",
+      category: "Bugs",
+    },
+  },
+  {
+    key: "react-doctor/nextjs-async-dynamic-api-not-awaited",
+    id: "nextjs-async-dynamic-api-not-awaited",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...nextjsAsyncDynamicApiNotAwaited,
       framework: "nextjs",
       category: "Bugs",
     },

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-deprecated-keyboard-event-keycode-which.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-deprecated-keyboard-event-keycode-which.ts
@@ -4,6 +4,7 @@ import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { getJsxAttributeName } from "../../utils/get-jsx-attribute-name.js";
 import { findTransparentExpressionRoot } from "../../utils/find-transparent-expression-root.js";
 import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
+import { isAstDescendant } from "../../utils/is-ast-descendant.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isNonSourceFilename } from "../../utils/is-non-source-filename.js";
@@ -286,37 +287,29 @@ const functionIsKeyboardHandler = (fnNode: EsTreeNode): boolean => {
   return false;
 };
 
-const isDescendantOf = (node: EsTreeNode, ancestor: EsTreeNode): boolean => {
-  let current: EsTreeNode | null | undefined = node;
-  while (current) {
-    if (current === ancestor) return true;
-    current = current.parent;
-  }
-  return false;
-};
-
 const directLogicControlsFallback = (
   signalNode: EsTreeNode,
   fallbackConditionRoot: EsTreeNode,
 ): boolean => {
-  if (isDescendantOf(signalNode, fallbackConditionRoot)) return true;
+  if (isAstDescendant(signalNode, fallbackConditionRoot)) return true;
   let ancestor = signalNode.parent ?? null;
   while (ancestor && !isFunctionLike(ancestor)) {
     if (
       isNodeOfType(ancestor, "LogicalExpression") &&
-      isDescendantOf(fallbackConditionRoot, ancestor)
+      isAstDescendant(fallbackConditionRoot, ancestor)
     ) {
       return true;
     }
     if (
       isNodeOfType(ancestor, "ConditionalExpression") &&
-      isDescendantOf(fallbackConditionRoot, ancestor) &&
-      (isDescendantOf(signalNode, ancestor.test) || isDescendantOf(signalNode, ancestor.consequent))
+      isAstDescendant(fallbackConditionRoot, ancestor) &&
+      (isAstDescendant(signalNode, ancestor.test) ||
+        isAstDescendant(signalNode, ancestor.consequent))
     ) {
       return true;
     }
-    if (isNodeOfType(ancestor, "IfStatement") && isDescendantOf(signalNode, ancestor.test)) {
-      if (ancestor.alternate && isDescendantOf(fallbackConditionRoot, ancestor.alternate)) {
+    if (isNodeOfType(ancestor, "IfStatement") && isAstDescendant(signalNode, ancestor.test)) {
+      if (ancestor.alternate && isAstDescendant(fallbackConditionRoot, ancestor.alternate)) {
         return true;
       }
       const block = ancestor.parent;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-unguarded-numeric-input-parse.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-unguarded-numeric-input-parse.ts
@@ -6,6 +6,7 @@ import { findJsxAttribute } from "../../utils/find-jsx-attribute.js";
 import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
 import { getJsxPropStringValue } from "../../utils/get-jsx-prop-string-value.js";
 import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
+import { isAstDescendant } from "../../utils/is-ast-descendant.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
@@ -99,15 +100,6 @@ const isNanGuardCall = (
   );
 };
 
-const isDescendantOf = (node: EsTreeNode, ancestor: EsTreeNode): boolean => {
-  let cursor: EsTreeNode | null | undefined = node;
-  while (cursor) {
-    if (cursor === ancestor) return true;
-    cursor = cursor.parent;
-  }
-  return false;
-};
-
 const directlyExits = (statement: EsTreeNode): boolean => {
   if (isNodeOfType(statement, "ReturnStatement") || isNodeOfType(statement, "ThrowStatement")) {
     return true;
@@ -178,13 +170,13 @@ const guardProtectsEveryUse = (
     (reference) =>
       reference.flag === "read" &&
       reference.identifier.range[0] > bindingIdentifier.range[1] &&
-      !isDescendantOf(reference.identifier, testExpression),
+      !isAstDescendant(reference.identifier, testExpression),
   );
   if (validWhenTestTruthy) {
     return (
       valueReferences.length > 0 &&
       valueReferences.every((reference) =>
-        isDescendantOf(reference.identifier, guardParent.consequent),
+        isAstDescendant(reference.identifier, guardParent.consequent),
       )
     );
   }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-async-dynamic-api-not-awaited.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-async-dynamic-api-not-awaited.test.ts
@@ -1,0 +1,2328 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { nextjsAsyncDynamicApiNotAwaited } from "./nextjs-async-dynamic-api-not-awaited.js";
+
+const run = (code: string, filename = "app/page.tsx") =>
+  runRule(nextjsAsyncDynamicApiNotAwaited, code, { filename });
+
+const expectDiagnosticCount = (code: string, count: number, filename?: string): void => {
+  const result = run(code, filename);
+  expect(result.parseErrors).toEqual([]);
+  expect(result.diagnostics).toHaveLength(count);
+};
+
+describe("nextjs-async-dynamic-api-not-awaited", () => {
+  it.each(["cookies", "headers", "draftMode"])(
+    "reports immediate property access on %s()",
+    (apiName) => {
+      expectDiagnosticCount(
+        `import { ${apiName} } from "next/headers";
+         export const read = () => ${apiName}().value;`,
+        1,
+      );
+    },
+  );
+
+  it("reports named-import aliases", () => {
+    expectDiagnosticCount(
+      `import { headers as requestHeaders } from "next/headers";
+       export const read = () => requestHeaders().get("x-request-id");`,
+      1,
+    );
+  });
+
+  it.each(["nextHeaders.headers()", 'nextHeaders["headers"]()'])(
+    "reports namespace access through %s",
+    (callExpression) => {
+      expectDiagnosticCount(
+        `import * as nextHeaders from "next/headers";
+         export const read = () => ${callExpression}.get("x-request-id");`,
+        1,
+      );
+    },
+  );
+
+  it("reports namespace access through a const property alias", () => {
+    expectDiagnosticCount(
+      `import * as nextHeaders from "next/headers";
+       const apiName = "cookies";
+       export const read = () => nextHeaders[apiName]().get("session");`,
+      1,
+    );
+  });
+
+  it("reports optional member access", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = () => cookies()?.get("session")?.value;`,
+      1,
+    );
+  });
+
+  it("reports member access through a local binding", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = () => { const pendingCookies = cookies(); return pendingCookies.get("session"); };`,
+      1,
+    );
+  });
+
+  it("reports wrapped member access through a local binding", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = () => { const pendingCookies = cookies(); return (pendingCookies as any)!.get("session"); };`,
+      1,
+    );
+  });
+
+  it("reports member access through const aliases", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = () => {
+         const pendingCookies = cookies();
+         const samePendingCookies = pendingCookies;
+         const finalAlias = samePendingCookies as Promise<unknown>;
+         return finalAlias.get("session");
+       };`,
+      1,
+    );
+  });
+
+  it("reports direct object destructuring", () => {
+    expectDiagnosticCount(
+      `import { draftMode } from "next/headers";
+       export const read = () => { const { isEnabled } = draftMode(); return isEnabled; };`,
+      1,
+    );
+  });
+
+  it("reports object destructuring through a binding", () => {
+    expectDiagnosticCount(
+      `import { draftMode } from "next/headers";
+       export const read = () => { const pending = draftMode(); const { isEnabled } = pending; return isEnabled; };`,
+      1,
+    );
+  });
+
+  it("reports destructuring assignment from a direct call", () => {
+    expectDiagnosticCount(
+      `import { draftMode } from "next/headers";
+       let isEnabled;
+       export const read = () => ({ isEnabled } = draftMode());`,
+      1,
+    );
+  });
+
+  it("does not report destructuring only Promise settlement methods", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = () => { const { then } = cookies(); return then; };`,
+      0,
+    );
+  });
+
+  it("does not report Promise-method destructuring through a binding", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = () => { const pending = cookies(); const { ["catch"]: catchPromise } = pending; return catchPromise; };`,
+      0,
+    );
+  });
+
+  it("reports a rest-only Promise destructure", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = () => { const pending = cookies(); const { ...ownProperties } = pending; return ownProperties; };`,
+      1,
+    );
+  });
+
+  it("does not report an empty object destructure", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = () => { const {} = cookies(); };`,
+      0,
+    );
+  });
+
+  it.each([
+    "const [firstCookie] = cookies(); return firstCookie;",
+    "const pending = cookies(); const [] = pending;",
+  ])("reports iterable destructuring through %s", (statement) => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = () => { ${statement} };`,
+      1,
+    );
+  });
+
+  it.each([
+    "return [...headers()];",
+    "return { ...headers() };",
+    "const pending = headers(); return consume(...pending);",
+  ])("reports synchronous spread through %s", (statement) => {
+    expectDiagnosticCount(
+      `import { headers } from "next/headers";
+       export const read = () => { ${statement} };`,
+      1,
+    );
+  });
+
+  it.each([
+    "for (const header of headers()) consume(header);",
+    "const pending = headers(); for (const key in pending) consume(key);",
+    "const pending = headers(); yield* pending;",
+  ])("reports synchronous iteration through %s", (statement) => {
+    expectDiagnosticCount(
+      `import { headers } from "next/headers";
+       export function* read() { ${statement} }`,
+      1,
+    );
+  });
+
+  it.each([
+    "Object.keys(cookies())",
+    "Object.values(cookies())",
+    "Object.entries(cookies())",
+    "Object.getOwnPropertyNames(cookies())",
+    "Reflect.ownKeys(cookies())",
+    "Object.fromEntries(cookies())",
+    "Object.assign({}, cookies())",
+    "Array.from(cookies())",
+  ])("reports synchronous enumeration through %s", (expression) => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = () => ${expression};`,
+      1,
+    );
+  });
+
+  it.each(["new Map(headers())", "const pending = headers(); return new Set(pending);"])(
+    "reports synchronous iterable construction through %s",
+    (statement) => {
+      expectDiagnosticCount(
+        `import { headers } from "next/headers";
+         export const read = () => { ${statement} };`,
+        1,
+      );
+    },
+  );
+
+  it("does not treat a shadowed iterable constructor as built-in consumption", () => {
+    expectDiagnosticCount(
+      `import { headers } from "next/headers";
+       export const read = (Map) => new Map(headers());`,
+      0,
+    );
+  });
+
+  it("reports synchronous enumeration through a binding", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = () => { const pending = cookies(); return Object.keys(pending); };`,
+      1,
+    );
+  });
+
+  it("does not treat a shadowed Object helper as built-in enumeration", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = (Object) => Object.keys(cookies());`,
+      0,
+    );
+  });
+
+  it("reports mixed Promise and dynamic-API destructuring", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = () => { const { then, get } = cookies(); return { then, get }; };`,
+      1,
+    );
+  });
+
+  it("reports access before an unconditional reassignment", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = async () => {
+         let pending = cookies();
+         const value = pending.get("session");
+         pending = await pending;
+         return value;
+       };`,
+      1,
+    );
+  });
+
+  it("reports access after a conditional awaited reassignment", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = async (shouldAwait) => {
+         let pending = cookies();
+         if (shouldAwait) pending = await pending;
+         return pending.get("session");
+       };`,
+      1,
+    );
+  });
+
+  it("does not let a deferred nested write hide an outer access", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = () => {
+         let pending = cookies();
+         const replaceLater = () => { pending = getFallback(); };
+         const value = pending.get("session");
+         return { replaceLater, value };
+       };`,
+      1,
+    );
+  });
+
+  it("reports access after an unconditional same-API reassignment", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = () => { let pending = cookies(); pending = cookies(); return pending.get("session"); };`,
+      1,
+    );
+  });
+
+  it("reports independent pending phases of the same binding", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = async () => {
+         let pending = cookies();
+         const first = pending.get("first");
+         pending = await pending;
+         pending = cookies();
+         const second = pending.get("second");
+         return { first, second };
+       };`,
+      2,
+    );
+  });
+
+  it("reports access when an unconditional assignment can preserve the pending value", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = async (shouldAwait) => {
+         let pending = cookies();
+         pending = shouldAwait ? await pending : pending;
+         return pending.get("session");
+       };`,
+      1,
+    );
+  });
+
+  it("does not report an awaited direct call", () => {
+    expectDiagnosticCount(
+      `import { headers } from "next/headers";
+       export const read = async () => (await headers()).get("x-request-id");`,
+      0,
+    );
+  });
+
+  it("does not report an awaited binding", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = async () => { const pending = cookies(); const store = await pending; return store.get("session"); };`,
+      0,
+    );
+  });
+
+  it("does not report access after an unconditional awaited self-reassignment", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = async () => { let pending = cookies(); pending = await pending; return pending.get("session"); };`,
+      0,
+    );
+  });
+
+  it("does not report module access after an awaited self-reassignment", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       let pending = cookies();
+       pending = await pending;
+       export const session = pending.get("session");`,
+      0,
+    );
+  });
+
+  it("reports module access after a conditional awaited reassignment", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       let pending = cookies();
+       if (shouldAwait) pending = await pending;
+       export const session = pending.get("session");`,
+      1,
+    );
+  });
+
+  it("does not report access after an unconditional unknown reassignment", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = () => { let pending = cookies(); pending = getCookieStore(); return pending.get("session"); };`,
+      0,
+    );
+  });
+
+  it("does not report when every branch clears the pending provenance", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = async (useRequestCookies) => {
+         let pending = cookies();
+         if (useRequestCookies) pending = await pending;
+         else pending = getFallbackCookieStore();
+         return pending.get("session");
+       };`,
+      0,
+    );
+  });
+
+  it("does not report when every conditional-expression branch clears pending provenance", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = async (useRequestCookies) => {
+         let pending = cookies();
+         useRequestCookies ? (pending = await pending) : (pending = getFallbackCookieStore());
+         return pending.get("session");
+       };`,
+      0,
+    );
+  });
+
+  it("reports when only one conditional-expression branch clears pending provenance", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = async (useRequestCookies) => {
+         let pending = cookies();
+         useRequestCookies ? (pending = await pending) : observe();
+         return pending.get("session");
+       };`,
+      1,
+    );
+  });
+
+  it("reports on an exceptional path through conditional-expression clearing writes", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = () => {
+         let pending = cookies();
+         try {
+           shouldUseRequestCookies() ? (pending = getRequestCookies()) : (pending = getFallbackCookieStore());
+         } catch {}
+         return pending.get("session");
+       };`,
+      1,
+    );
+  });
+
+  it("reports after a possibly skipped clearing loop", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = async (shouldAwait) => {
+         let pending = cookies();
+         while (shouldAwait) { pending = await pending; shouldAwait = false; }
+         return pending.get("session");
+       };`,
+      1,
+    );
+  });
+
+  it("does not report after a clearing loop that runs at least once", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = async (shouldRepeat) => {
+         let pending = cookies();
+         do { pending = await pending; shouldRepeat = false; } while (shouldRepeat);
+         return pending.get("session");
+       };`,
+      0,
+    );
+  });
+
+  it("does not report after a clearing write on every path that reaches the access", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = async (shouldRead) => {
+         let pending = cookies();
+         if (!shouldRead) return null;
+         pending = await pending;
+         return pending.get("session");
+       };`,
+      0,
+    );
+  });
+
+  it.each(["({ pending } = { pending: await pending });", "[pending] = [await pending];"])(
+    "does not report after the destructured clearing write in %s",
+    (assignment) => {
+      expectDiagnosticCount(
+        `import { cookies } from "next/headers";
+       export const read = async () => {
+         let pending = cookies();
+         ${assignment}
+         return pending.get("session");
+       };`,
+        0,
+      );
+    },
+  );
+
+  it.each([
+    "({ pending } = {});",
+    "[pending] = [];",
+    "({ pending = await pending } = {});",
+    "[pending = await pending] = [];",
+  ])("does not report after an absent destructured value clears pending in %s", (assignment) => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = async () => {
+         let pending = cookies();
+         ${assignment}
+         return pending?.get("session");
+       };`,
+      0,
+    );
+  });
+
+  it("reports when an absent destructured value defaults to the pending promise", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = () => {
+         let pending = cookies();
+         ({ pending = pending } = {});
+         return pending.get("session");
+       };`,
+      1,
+    );
+  });
+
+  it("reports after a conditional destructured clearing write", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = async (shouldAwait) => {
+         let pending = cookies();
+         if (shouldAwait) ({ pending } = { pending: await pending });
+         return pending.get("session");
+       };`,
+      1,
+    );
+  });
+
+  it("reports after a destructured write that retains the pending value", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = () => {
+         let pending = cookies();
+         ({ pending } = { pending });
+         return pending.get("session");
+       };`,
+      1,
+    );
+  });
+
+  it("does not preserve request-API provenance through a fresh object assignment", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = () => {
+         let pending = cookies();
+         pending = { original: pending };
+         return pending.get("session");
+       };`,
+      0,
+    );
+  });
+
+  it.each(["use(cookies())", "React.use(cookies())"])(
+    "does not report React promise unwrapping through %s",
+    (expression) => {
+      expectDiagnosticCount(
+        `import React, { use } from "react";
+         import { cookies } from "next/headers";
+         export const read = () => ${expression}.get("session");`,
+        0,
+      );
+    },
+  );
+
+  it("does not report React promise unwrapping through a binding", () => {
+    expectDiagnosticCount(
+      `import { use } from "react";
+       import { cookies } from "next/headers";
+       export const read = () => { const pending = cookies(); return use(pending).get("session"); };`,
+      0,
+    );
+  });
+
+  it.each(["then", "catch", "finally"])(
+    "does not report direct .%s() promise handling",
+    (methodName) => {
+      expectDiagnosticCount(
+        `import { cookies } from "next/headers";
+         export const read = () => cookies().${methodName}(handle);`,
+        0,
+      );
+    },
+  );
+
+  it.each([
+    'cookies().catch(handle).get("session")',
+    'cookies().then(handle).finally(cleanup).get("session")',
+  ])("reports synchronous access after Promise settlement chaining through %s", (expression) => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = () => ${expression};`,
+      1,
+    );
+  });
+
+  it("reports synchronous access through a Promise settlement-chain binding", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = () => {
+         const pending = cookies().catch(handle);
+         return pending.get("session");
+       };`,
+      1,
+    );
+  });
+
+  it.each([
+    'const alias = shouldRead ? pending : getFallback(); return alias.get("session");',
+    'const alias = pending ?? getFallback(); return alias.get("session");',
+    'let alias; alias = pending; return alias.get("session");',
+    'return (shouldRead ? pending : getFallback()).get("session");',
+  ])("reports retained pending provenance through %s", (statement) => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = (shouldRead) => {
+         const pending = cookies();
+         ${statement}
+       };`,
+      1,
+    );
+  });
+
+  it("does not retain provenance from a non-final sequence expression", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = () => { const store = (cookies(), getFallback()); return store.get("session"); };`,
+      0,
+    );
+  });
+
+  it.each([
+    'const store = false && cookies(); return store.get("session");',
+    'const store = true || cookies(); return store.get("session");',
+    'const store = true ? getFallback() : cookies(); return store.get("session");',
+    'const store = cookies() && getFallback(); return store.get("session");',
+    'const pending = cookies(); const store = pending && getFallback(); return store.get("session");',
+  ])("does not retain unreachable or short-circuited provenance through %s", (statement) => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = () => { ${statement} };`,
+      0,
+    );
+  });
+
+  it.each([
+    'const store = cookies() || getFallback(); return store.get("session");',
+    'const store = cookies() ?? getFallback(); return store.get("session");',
+  ])("retains truthy Promise provenance through %s", (statement) => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = () => { ${statement} };`,
+      1,
+    );
+  });
+
+  it.each(["then", "catch", "finally"])(
+    "does not report computed binding access to %s",
+    (methodName) => {
+      expectDiagnosticCount(
+        `import { cookies } from "next/headers";
+         export const read = () => { const pending = cookies(); return pending["${methodName}"](handle); };`,
+        0,
+      );
+    },
+  );
+
+  it("does not report a promise passed through an unknown function", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = () => consumePromise(cookies());`,
+      0,
+    );
+  });
+
+  it("does not report Promise.all unwrapping", () => {
+    expectDiagnosticCount(
+      `import { cookies, headers } from "next/headers";
+       export const read = async () => {
+         const [cookieStore, headerList] = await Promise.all([cookies(), headers()]);
+         return cookieStore.get("session") ?? headerList.get("x-request-id");
+       };`,
+      0,
+    );
+  });
+
+  it("does not report unrelated modules or request properties", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "./local-headers";
+       export const read = (request) => cookies().get("session") ?? request.cookies.get("session");`,
+      0,
+    );
+  });
+
+  it("does not report a local binding that shadows a named import", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = () => { const cookies = () => ({ get: () => "stub" }); return cookies().get("session"); };`,
+      0,
+    );
+  });
+
+  it("does not report a parameter that shadows a namespace import", () => {
+    expectDiagnosticCount(
+      `import * as nextHeaders from "next/headers";
+       export const read = (nextHeaders) => nextHeaders.headers().get("x-request-id");`,
+      0,
+    );
+  });
+
+  it("does not report a dynamic namespace property", () => {
+    expectDiagnosticCount(
+      `import * as nextHeaders from "next/headers";
+       export const read = (apiName) => nextHeaders[apiName]().get("value");`,
+      0,
+    );
+  });
+
+  it("does not report testlike files", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = () => cookies().get("session");`,
+      0,
+      "app/page.test.tsx",
+    );
+  });
+
+  it.each(["UnsafeUnwrappedCookies", "UnsafeUnwrappedHeaders", "UnsafeUnwrappedDraftMode"])(
+    "does not report the official %s compatibility cast",
+    (typeName) => {
+      const apiName = typeName
+        .replace("UnsafeUnwrapped", "")
+        .replace("Cookies", "cookies")
+        .replace("Headers", "headers")
+        .replace("DraftMode", "draftMode");
+      expectDiagnosticCount(
+        `import { ${apiName}, type ${typeName} } from "next/headers";
+       export const read = () => (${apiName}() as unknown as ${typeName}).value;`,
+        0,
+      );
+    },
+  );
+
+  it("does not report an aliased official compatibility type", () => {
+    expectDiagnosticCount(
+      `import { cookies, type UnsafeUnwrappedCookies as LegacyCookies } from "next/headers";
+       export const read = () => (cookies() as unknown as LegacyCookies).get("session");`,
+      0,
+    );
+  });
+
+  it("does not report a namespace compatibility type", () => {
+    expectDiagnosticCount(
+      `import * as nextHeaders from "next/headers";
+       export const read = () => (nextHeaders.cookies() as unknown as nextHeaders.UnsafeUnwrappedCookies).get("session");`,
+      0,
+    );
+  });
+
+  it("reports compatibility casts when Next.js 16 removes synchronous access", () => {
+    const result = runRule(
+      nextjsAsyncDynamicApiNotAwaited,
+      `import { cookies, type UnsafeUnwrappedCookies } from "next/headers";
+       export const read = () => (cookies() as unknown as UnsafeUnwrappedCookies).get("session");`,
+      {
+        filename: "app/page.tsx",
+        settings: { "react-doctor": { capabilities: ["nextjs:15", "nextjs:16"] } },
+      },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not report an angle-bracket compatibility cast", () => {
+    expectDiagnosticCount(
+      `import { headers, type UnsafeUnwrappedHeaders } from "next/headers";
+       export const read = () => (<UnsafeUnwrappedHeaders><unknown>headers()).get("x-request-id");`,
+      0,
+      "app/request.ts",
+    );
+  });
+
+  it("does not report an alias created through the compatibility cast", () => {
+    expectDiagnosticCount(
+      `import { cookies, type UnsafeUnwrappedCookies } from "next/headers";
+       export const read = () => {
+         const pending = cookies();
+         const store = pending as unknown as UnsafeUnwrappedCookies;
+         return store.get("session");
+       };`,
+      0,
+    );
+  });
+
+  it("does not report access after assigning a compatibility-cast call", () => {
+    expectDiagnosticCount(
+      `import { cookies, type UnsafeUnwrappedCookies } from "next/headers";
+       export const read = () => {
+         let pending = cookies();
+         pending = cookies() as unknown as UnsafeUnwrappedCookies;
+         return pending.get("session");
+       };`,
+      0,
+    );
+  });
+
+  it("does not report access after compatibility-casting the pending binding", () => {
+    expectDiagnosticCount(
+      `import { cookies, type UnsafeUnwrappedCookies } from "next/headers";
+       export const read = () => {
+         let pending = cookies();
+         pending = pending as unknown as UnsafeUnwrappedCookies;
+         return pending.get("session");
+       };`,
+      0,
+    );
+  });
+
+  it("reports a same-named local type used as a cast", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       interface UnsafeUnwrappedCookies { get(name: string): string }
+       export const read = () => (cookies() as unknown as UnsafeUnwrappedCookies).get("session");`,
+      1,
+    );
+  });
+
+  it("reports a nested type alias that shadows an imported compatibility type", () => {
+    expectDiagnosticCount(
+      `import { cookies, type UnsafeUnwrappedCookies as LegacyCookies } from "next/headers";
+       export const read = () => {
+         interface LegacyCookies { get(name: string): string }
+         return (cookies() as unknown as LegacyCookies).get("session");
+       };`,
+      1,
+    );
+  });
+
+  it("does not let an optional call conditionally clear pending provenance", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = async (maybeConsume) => {
+         let pending = cookies();
+         maybeConsume?.(pending = await pending);
+         return pending.get("session");
+       };`,
+      1,
+    );
+  });
+
+  it("does not let a logical assignment conditionally clear pending provenance", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = async (state) => {
+         let pending = cookies();
+         state.store ||= (pending = await pending);
+         return pending.get("session");
+       };`,
+      1,
+    );
+  });
+
+  it("reports when a catch path can reach access without clearing provenance", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = async () => {
+         let pending = cookies();
+         try { mayThrow(); pending = await pending; } catch {}
+         return pending.get("session");
+       };`,
+      1,
+    );
+  });
+
+  it("does not report when a finally block clears provenance", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = async () => {
+         let pending = cookies();
+         try { mayThrow(); } finally { pending = await pending; }
+         return pending.get("session");
+       };`,
+      0,
+    );
+  });
+
+  it("does not report when a catch path always exits", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = async () => {
+         let pending = cookies();
+         try { mayThrow(); pending = await pending; } catch { return null; }
+         return pending.get("session");
+       };`,
+      0,
+    );
+  });
+
+  it("reports a generic cast that does not use the official escape hatch", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = () => (cookies() as any).get("session");`,
+      1,
+    );
+  });
+
+  it("reports through a satisfies wrapper", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = () => (cookies() satisfies Promise<unknown>).get("session");`,
+      1,
+    );
+  });
+
+  it("reports deferred nested reads of a stable pending binding", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const makeReader = () => { const pending = cookies(); return () => pending.get("session"); };`,
+      1,
+    );
+  });
+
+  it("handles a long alias chain without recursive traversal", () => {
+    const aliasCount = 1_500;
+    const aliasDeclarations = Array.from(
+      { length: aliasCount },
+      (_, aliasIndex) => `const pending${aliasIndex + 1} = pending${aliasIndex};`,
+    ).join("\n");
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = () => {
+         const pending0 = cookies();
+         ${aliasDeclarations}
+         return pending${aliasCount}.get("session");
+       };`,
+      1,
+    );
+  });
+
+  it("does not attribute an earlier read to a later request API source", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = async () => {
+         let pending = cookies();
+         const first = pending.get("first");
+         pending = cookies();
+         pending = await pending;
+         return first;
+       };`,
+      1,
+    );
+  });
+
+  it("accepts a local alias of an official compatibility type", () => {
+    expectDiagnosticCount(
+      `import { cookies, type UnsafeUnwrappedCookies } from "next/headers";
+       type LegacyCookieStore = UnsafeUnwrappedCookies;
+       export const read = () => (cookies() as unknown as LegacyCookieStore).get("session");`,
+      0,
+    );
+  });
+
+  it("accepts a local alias of a namespace compatibility type", () => {
+    expectDiagnosticCount(
+      `import * as nextHeaders from "next/headers";
+       type LegacyHeaderStore = nextHeaders.UnsafeUnwrappedHeaders;
+       export const read = () => (nextHeaders.headers() as unknown as LegacyHeaderStore).get("x-request-id");`,
+      0,
+    );
+  });
+
+  it("does not trust a local type alias with an official-looking name", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       type UnsafeUnwrappedCookies = { get(name: string): string };
+       export const read = () => (cookies() as unknown as UnsafeUnwrappedCookies).get("session");`,
+      1,
+    );
+  });
+
+  it("does not report when both the try and continuing catch paths clear provenance", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = async () => {
+         let pending = cookies();
+         try { pending = await pending; }
+         catch { pending = getFallbackCookieStore(); }
+         return pending.get("session");
+       };`,
+      0,
+    );
+  });
+
+  it("does not report when every continuing catch branch clears provenance", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = async (usePrimaryFallback) => {
+         let pending = cookies();
+         try { pending = await pending; }
+         catch {
+           if (usePrimaryFallback) pending = getPrimaryCookieStore();
+           else pending = getSecondaryCookieStore();
+         }
+         return pending.get("session");
+       };`,
+      0,
+    );
+  });
+
+  it("reports a catch read when the clearing assignment right side throws", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = () => {
+         let pending = cookies();
+         try { pending = getCookieStoreOrThrow(); }
+         catch { return pending.get("session"); }
+       };`,
+      1,
+    );
+  });
+
+  it("reports a mutable pending binding read by an immediately invoked closure", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = async () => {
+         let pending = cookies();
+         const value = (() => pending.get("session"))();
+         pending = await pending;
+         return value;
+       };`,
+      1,
+    );
+  });
+
+  it("reports a mutable pending binding read by a directly called local closure", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = async () => {
+         let pending = cookies();
+         const readPending = () => pending.get("session");
+         const value = readPending();
+         pending = await pending;
+         return value;
+       };`,
+      1,
+    );
+  });
+
+  it("does not report a mutable closure that is called only after provenance clears", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = async () => {
+         let pending = cookies();
+         const readPending = () => pending.get("session");
+         pending = await pending;
+         return readPending();
+       };`,
+      0,
+    );
+  });
+
+  it("does not report after nested branches all clear provenance", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = async (useRequestCookies, usePrimaryFallback) => {
+         let pending = cookies();
+         if (useRequestCookies) pending = await pending;
+         else if (usePrimaryFallback) pending = getPrimaryCookieStore();
+         else pending = getSecondaryCookieStore();
+         return pending.get("session");
+       };`,
+      0,
+    );
+  });
+
+  it("does not report after a do-while body clears provenance on every branch", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = async (useRequestCookies) => {
+         let pending = cookies();
+         do {
+           if (useRequestCookies) pending = await pending;
+           else pending = getFallbackCookieStore();
+         } while (false);
+         return pending.get("session");
+       };`,
+      0,
+    );
+  });
+
+  it("does not report after a do-while body clears before a possible continue", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = async (shouldContinue) => {
+         let pending = cookies();
+         do {
+           pending = await pending;
+           if (shouldContinue) continue;
+         } while (false);
+         return pending.get("session");
+       };`,
+      0,
+    );
+  });
+
+  it.each([
+    'const store = ({ get: (name) => name }) || cookies(); return store.get("session");',
+    "const store = [] || cookies(); return store.length;",
+    "const store = `ready` || cookies(); return store.length;",
+    "const store = `ready-${value}` || cookies(); return store.length;",
+    "const store = !1 && cookies(); return store.valueOf();",
+    "const store = !!null ?? cookies(); return store.valueOf();",
+    "const store = Infinity || cookies(); return store.valueOf();",
+  ])("does not retain a request API from a statically unreachable branch in %s", (statement) => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = () => { ${statement} };`,
+      0,
+    );
+  });
+
+  it.each(["new Headers(headers())", "new URLSearchParams(headers())"])(
+    "reports synchronous iterable construction through %s",
+    (expression) => {
+      expectDiagnosticCount(
+        `import { headers } from "next/headers";
+         export const read = () => ${expression};`,
+        1,
+      );
+    },
+  );
+
+  it("reports a mutable pending binding read by a directly invoked closure alias", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = async () => {
+         let pending = cookies();
+         const readPending = () => pending.get("session");
+         const readAlias = readPending;
+         const value = readAlias();
+         pending = await pending;
+         return value;
+       };`,
+      1,
+    );
+  });
+
+  it("does not report a closure alias invoked only after provenance clears", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = async () => {
+         let pending = cookies();
+         const readPending = () => pending.get("session");
+         const readAlias = readPending;
+         pending = await pending;
+         return readAlias();
+       };`,
+      0,
+    );
+  });
+
+  it("does not report a closure alias overwritten before invocation", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = async () => {
+         let pending = cookies();
+         const readPending = () => pending.get("session");
+         let readAlias = readPending;
+         readAlias = () => null;
+         readAlias();
+         pending = await pending;
+       };`,
+      0,
+    );
+  });
+
+  it("reports a closure alias invoked before it is overwritten", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = async () => {
+         let pending = cookies();
+         const readPending = () => pending.get("session");
+         let readAlias = readPending;
+         readAlias();
+         readAlias = () => null;
+         pending = await pending;
+       };`,
+      1,
+    );
+  });
+
+  it("reports a closure alias that is only conditionally overwritten before invocation", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = async (shouldReplace) => {
+         let pending = cookies();
+         const readPending = () => pending.get("session");
+         let readAlias = readPending;
+         if (shouldReplace) readAlias = () => null;
+         readAlias();
+         pending = await pending;
+       };`,
+      1,
+    );
+  });
+
+  it("does not report a closure alias overwritten on the only branch that invokes it", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = async (shouldCall) => {
+         let pending = cookies();
+         const readPending = () => pending.get("session");
+         let readAlias = readPending;
+         if (shouldCall) {
+           readAlias = () => null;
+           readAlias();
+         }
+         pending = await pending;
+       };`,
+      0,
+    );
+  });
+
+  it.each(["[0].map(() => pending.get('session'))", "new Promise(() => pending.get('session'))"])(
+    "reports a mutable pending binding read by the synchronous callback in %s",
+    (expression) => {
+      expectDiagnosticCount(
+        `import { cookies } from "next/headers";
+       export const read = async () => {
+         let pending = cookies();
+         const value = ${expression};
+         pending = await pending;
+         return value;
+       };`,
+        1,
+      );
+    },
+  );
+
+  it.each([
+    "[0].map(readPending)",
+    "Array.of(0).map(readPending)",
+    "new Array(0, 1).map(readPending)",
+    "new Promise(readPending)",
+  ])("reports a named synchronous callback passed through %s", (expression) => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+         export const read = async () => {
+           let pending = cookies();
+           const readPending = () => pending.get("session");
+           const value = ${expression};
+           pending = await pending;
+           return value;
+         };`,
+      1,
+    );
+  });
+
+  it("reports a named callback on an immutable array alias", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = async () => {
+         let pending = cookies();
+         const values = [0];
+         const readPending = () => pending.get("session");
+         const result = values.map(readPending);
+         pending = await pending;
+         return result;
+       };`,
+      1,
+    );
+  });
+
+  it("reports a named callback on an immutable global Array call alias", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = async () => {
+         let pending = cookies();
+         const values = Array.of(0);
+         const readPending = () => pending.get("session");
+         const result = values.map(readPending);
+         pending = await pending;
+         return result;
+       };`,
+      1,
+    );
+  });
+
+  it.each(["A(1).map(readPending)", "new A(1).map(readPending)"])(
+    "reports a named callback through an immutable global Array constructor alias in %s",
+    (invocation) => {
+      expectDiagnosticCount(
+        `import { cookies } from "next/headers";
+         export const read = async () => {
+           let pending = cookies();
+           const A = Array;
+           const readPending = () => pending.get("session");
+           const result = ${invocation};
+           pending = await pending;
+           return result;
+         };`,
+        1,
+      );
+    },
+  );
+
+  it.each([
+    "let values = [0]; values.map(readPending);",
+    "const values = scheduler.values; values.map(readPending);",
+    "const values = [0]; values.map = scheduler.map; values.map(readPending);",
+    "const Array = scheduler.Array; Array.of(0).map(readPending);",
+    "const Array = scheduler.Array; Array(1).map(readPending);",
+    "const Array = scheduler.Array; new Array(1).map(readPending);",
+    "const A = scheduler.Array; A(1).map(readPending);",
+    "let A = Array; A(1).map(readPending);",
+  ])("fails closed for an unproven synchronous callback host through %s", (invocation) => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = async (scheduler) => {
+         let pending = cookies();
+         const readPending = () => pending.get("session");
+         ${invocation}
+         pending = await pending;
+       };`,
+      0,
+    );
+  });
+
+  it("does not treat an arbitrary receiver's map callback as synchronously invoked", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = async (scheduler) => {
+         let pending = cookies();
+         scheduler.map(() => pending.get("session"));
+         pending = await pending;
+         scheduler.flush();
+       };`,
+      0,
+    );
+  });
+
+  it.each([
+    "while (true)",
+    "while (1)",
+    'while ("run")',
+    "while (1n)",
+    "while (!false)",
+    "for (;;)",
+  ])("recognizes provenance clearing before a break from %s", (loopHeader) => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+         export const read = async () => {
+           let pending = cookies();
+           ${loopHeader} {
+             pending = await pending;
+             break;
+           }
+           return pending.get("session");
+         };`,
+      0,
+    );
+  });
+
+  it.each(["then", "catch", "finally"])(
+    "does not report a Promise settlement method selected through const %s",
+    (methodName) => {
+      expectDiagnosticCount(
+        `import { cookies } from "next/headers";
+         const settleMethod = "${methodName}";
+         export const read = () => cookies()[settleMethod](handle);`,
+        0,
+      );
+    },
+  );
+
+  it.each([
+    'Reflect.get(pending, "get")',
+    'Reflect.getOwnPropertyDescriptor(pending, "get")',
+    'Reflect.has(pending, "get")',
+    'Object.getOwnPropertyDescriptor(pending, "get")',
+    '"get" in pending',
+  ])("reports reflective property access through %s", (expression) => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = () => {
+         const pending = cookies();
+         return ${expression};
+       };`,
+      1,
+    );
+  });
+
+  it.each([
+    'Reflect.get(pending, "then")',
+    'Reflect.getOwnPropertyDescriptor(pending, "catch")',
+    'Reflect.has(pending, "finally")',
+    'Object.getOwnPropertyDescriptor(pending, "then")',
+  ])("does not report reflective Promise settlement access through %s", (expression) => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = () => { const pending = cookies(); return ${expression}; };`,
+      0,
+    );
+  });
+
+  it.each(["!pending", "typeof pending"])(
+    "does not report non-consuming unary access through %s",
+    (expression) => {
+      expectDiagnosticCount(
+        `import { cookies } from "next/headers";
+         export const read = () => { const pending = cookies(); return ${expression}; };`,
+        0,
+      );
+    },
+  );
+
+  it.each([
+    `import { cookies } from "next/headers";
+     const readCookies = cookies;
+     export const read = () => readCookies().get("session");`,
+    `import * as nextHeaders from "next/headers";
+     const requestHeaders = nextHeaders;
+     export const read = () => requestHeaders.headers().get("x-request-id");`,
+    `import * as nextHeaders from "next/headers";
+     const readCookies = nextHeaders.cookies;
+     export const read = () => readCookies().get("session");`,
+    `import * as nextHeaders from "next/headers";
+     const key = "cookies";
+     const readCookies = nextHeaders[key];
+     export const read = () => readCookies().get("session");`,
+    `import * as nextHeaders from "next/headers";
+     const { headers: readHeaders } = nextHeaders;
+     export const read = () => readHeaders().get("x-request-id");`,
+    `import { draftMode } from "next/headers";
+     const readDraftMode = () => draftMode();
+     export const read = () => readDraftMode().isEnabled;`,
+  ])("reports bounded aliases and wrappers of next/headers APIs", (code) => {
+    expectDiagnosticCount(code, 1);
+  });
+
+  it.each(["let pending; pending ??= cookies();", "const { pending } = { pending: cookies() };"])(
+    "reports pending values introduced through %s",
+    (declaration) => {
+      expectDiagnosticCount(
+        `import { cookies } from "next/headers";
+       export const read = () => {
+         ${declaration}
+         return pending.get("session");
+       };`,
+        1,
+      );
+    },
+  );
+
+  it.each([
+    {
+      code: `export default function Page({ params }) { return params.slug; }`,
+      filename: "app/blog/[slug]/page.tsx",
+    },
+    {
+      code: `export default function Page(props) { return props.searchParams.query; }`,
+      filename: "src/app/search/page.tsx",
+    },
+    {
+      code: `export default function Page(props) { const routeProps = props; return routeProps.params.slug; }`,
+      filename: "app/blog/[slug]/page.tsx",
+    },
+    {
+      code: `export default function Page(props) { const { params: routeParams } = props; return routeParams.slug; }`,
+      filename: "app/blog/[slug]/page.tsx",
+    },
+    {
+      code: `export default function Page({ params: { slug } }) { return slug; }`,
+      filename: "app/blog/[slug]/page.tsx",
+    },
+    {
+      code: `export default function Layout({ params: routeParams }) { return routeParams.team; }`,
+      filename: "app/[team]/layout.tsx",
+    },
+    {
+      code: `export const GET = (request, { params }) => Response.json({ slug: params.slug });`,
+      filename: "app/api/[slug]/route.ts",
+    },
+    {
+      code: `export const generateMetadata = ({ searchParams }) => ({ title: searchParams.query });`,
+      filename: "app/search/page.tsx",
+    },
+    {
+      code: `export const generateViewport = ({ params }) => ({ themeColor: params.theme });`,
+      filename: "app/[theme]/layout.tsx",
+    },
+    {
+      code: `export default function Default({ params }) { return params.slug; }`,
+      filename: "app/blog/[slug]/default.tsx",
+    },
+  ])("reports synchronous official async request props in $filename", ({ code, filename }) => {
+    expectDiagnosticCount(code, 1, filename);
+  });
+
+  it.each(["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"])(
+    "reports route params in the %s handler context",
+    (methodName) => {
+      expectDiagnosticCount(
+        `export const ${methodName} = (request, context) => Response.json(context.params.slug);`,
+        1,
+        "app/api/[slug]/route.ts",
+      );
+    },
+  );
+
+  it.each([
+    `const Page = ({ params }) => params.slug; export { Page as default };`,
+    `const Page = ({ params }) => params.slug; const Exported = Page; export default Exported;`,
+    `export default function Page({ ["params"]: routeParams }) { return routeParams.slug; }`,
+    `export const generateMetadata = ({ params }) => ({ title: params.slug });`,
+    `export const generateViewport = ({ searchParams }) => ({ colorScheme: searchParams.scheme });`,
+  ])("reports official async props through supported export and pattern forms", (code) => {
+    expectDiagnosticCount(code, 1, "app/[slug]/page.tsx");
+  });
+
+  it.each([
+    `export default function Page({ params }) { return { ...params }; }`,
+    `export default function Page({ params }) { return Object.keys(params); }`,
+    `export default function Page({ params }) { const { slug } = params; return slug; }`,
+    `export default function Page({ ...props }) { return props.params.slug; }`,
+    `export default function Page(props) { const { ...routeProps } = props; return routeProps.params.slug; }`,
+  ])("reports official async props through synchronous consumption forms", (code) => {
+    expectDiagnosticCount(code, 1, "app/[slug]/page.tsx");
+  });
+
+  it.each([
+    `export default function Page({ params, ...props }) { return props.searchParams.query; }`,
+    `export default function Page({ searchParams, ...props }) { return props.params.slug; }`,
+    `export default function Page(props) { const { params, ...rest } = props; return rest.searchParams.query; }`,
+    `export default function Page(props) { let rest; ({ params, ...rest } = props); return rest.searchParams.query; }`,
+  ])("reports official props that remain in an object rest binding", (code) => {
+    expectDiagnosticCount(code, 1, "app/[slug]/page.tsx");
+  });
+
+  it("reports a nested consumed prop and a separate prop retained by object rest", () => {
+    expectDiagnosticCount(
+      `export default function Page(props) { const { params: { slug }, ...rest } = props; return slug + rest.searchParams.query; }`,
+      2,
+      "app/[slug]/page.tsx",
+    );
+  });
+
+  it.each([
+    {
+      code: `export default function Page({ params, ...props }) { return props.params.slug; }`,
+      filename: "app/[slug]/page.tsx",
+    },
+    {
+      code: `export default function Page({ params, searchParams, ...props }) { return props.params?.slug ?? props.searchParams?.query; }`,
+      filename: "app/[slug]/page.tsx",
+    },
+    {
+      code: `export default function Page(props) { const { params, ...rest } = props; return rest.params.slug; }`,
+      filename: "app/[slug]/page.tsx",
+    },
+    {
+      code: `export default function Page(props) { let rest; ({ params, ...rest } = props); return rest.params.slug; }`,
+      filename: "app/[slug]/page.tsx",
+    },
+    {
+      code: `export default function Page(props) { const { params: routeParams = fallback, ...rest } = props; return rest.params.slug; }`,
+      filename: "app/[slug]/page.tsx",
+    },
+    {
+      code: `export default function Page(props) { const { ["params"]: routeParams, ...rest } = props; return rest.params.slug; }`,
+      filename: "app/[slug]/page.tsx",
+    },
+    {
+      code: `export default function Page(props) { const { [propertyName]: consumed, ...rest } = props; return rest.params.slug; }`,
+      filename: "app/[slug]/page.tsx",
+    },
+    {
+      code: `export default function Layout({ params, ...props }) { return props.params.slug; }`,
+      filename: "app/[slug]/layout.tsx",
+    },
+    {
+      code: `export default function Default({ params, ...props }) { return props.params.slug; }`,
+      filename: "app/[slug]/default.tsx",
+    },
+    {
+      code: `export const GET = (request, { params, ...context }) => Response.json(context.params.slug);`,
+      filename: "app/api/[slug]/route.ts",
+    },
+  ])(
+    "does not report official props removed from an object rest binding in $filename",
+    ({ code, filename }) => {
+      expectDiagnosticCount(code, 0, filename);
+    },
+  );
+
+  it("does not add a rest diagnostic for a nested prop removed from object rest", () => {
+    expectDiagnosticCount(
+      `export default function Page(props) { const { params: { slug }, ...rest } = props; return slug + rest.params.slug; }`,
+      1,
+      "app/[slug]/page.tsx",
+    );
+  });
+
+  it.each(["params", "id"])("reports metadata image %s in Next.js 16", (propertyName) => {
+    const result = runRule(
+      nextjsAsyncDynamicApiNotAwaited,
+      `export default function Image({ ${propertyName} }) { return new ImageResponse(${propertyName}.value); }`,
+      {
+        filename: "app/blog/[slug]/opengraph-image.tsx",
+        settings: { "react-doctor": { capabilities: ["nextjs:15", "nextjs:16"] } },
+      },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it.each([
+    {
+      code: `export default function Image({ id }) { return new ImageResponse(String(id * 50000)); }`,
+      filename: "app/blog/[slug]/opengraph-image.tsx",
+    },
+    {
+      code: `export default function Image({ id }) { return <div>{id}</div>; }`,
+      filename: "app/blog/[slug]/opengraph-image.tsx",
+    },
+    {
+      code: `export default function Image({ id }) { return new ImageResponse(String(id)); }`,
+      filename: "app/blog/[slug]/opengraph-image.tsx",
+    },
+    {
+      code: `export default function Image({ id }) { const imageId = id; return new ImageResponse(String(imageId * 50000)); }`,
+      filename: "app/blog/[slug]/opengraph-image.tsx",
+    },
+    {
+      code: `export default function Image({ id }) { return id ? 1 : 0; }`,
+      filename: "app/blog/[slug]/opengraph-image.tsx",
+    },
+    {
+      code: `export default function Image({ id }) { if (id) return 1; return 0; }`,
+      filename: "app/blog/[slug]/opengraph-image.tsx",
+    },
+    {
+      code: `export default function Image({ id }) { while (id) break; return 0; }`,
+      filename: "app/blog/[slug]/opengraph-image.tsx",
+    },
+    {
+      code: `export default function Image({ id }) { return id && 1; }`,
+      filename: "app/blog/[slug]/opengraph-image.tsx",
+    },
+    {
+      code: `export default function Image({ id }) { switch (id) { case 1: return 1; default: return 0; } }`,
+      filename: "app/blog/[slug]/opengraph-image.tsx",
+    },
+    {
+      code: `export default function Image({ id }) { return values[id]; }`,
+      filename: "app/blog/[slug]/opengraph-image.tsx",
+    },
+    {
+      code: `export default function Image({ id }) { return (null?.foo)[id]; }`,
+      filename: "app/blog/[slug]/opengraph-image.tsx",
+    },
+    {
+      code: `export default function Image({ id }) { return (undefined?.foo)[id]; }`,
+      filename: "app/blog/[slug]/opengraph-image.tsx",
+    },
+    {
+      code: `export default function Image({ id }) { return (null?.foo).bar[id]; }`,
+      filename: "app/blog/[slug]/opengraph-image.tsx",
+    },
+    {
+      code: `export default function Image({ id }) { return (false && {})?.[id]; }`,
+      filename: "app/blog/[slug]/opengraph-image.tsx",
+    },
+    {
+      code: `export default function Image({ id }) { return (null?.foo)(id + 1); }`,
+      filename: "app/blog/[slug]/opengraph-image.tsx",
+    },
+    {
+      code: `export default function Image({ id }) { return { [id]: true }; }`,
+      filename: "app/blog/[slug]/opengraph-image.tsx",
+    },
+    {
+      code: `export default function Image({ id }) { return "value" in id; }`,
+      filename: "app/blog/[slug]/opengraph-image.tsx",
+    },
+    {
+      code: `export default function Image({ id }) { return parseInt(id, 10); }`,
+      filename: "app/blog/[slug]/opengraph-image.tsx",
+    },
+    {
+      code: `export default function Image({ id }) { return parseFloat(id); }`,
+      filename: "app/blog/[slug]/opengraph-image.tsx",
+    },
+    {
+      code: `export default function Image({ id }) { return isNaN(id); }`,
+      filename: "app/blog/[slug]/opengraph-image.tsx",
+    },
+    {
+      code: `export default function Image({ id }) { return isFinite(id); }`,
+      filename: "app/blog/[slug]/opengraph-image.tsx",
+    },
+    {
+      code: `export default function Image({ id }) { return encodeURIComponent(id); }`,
+      filename: "app/blog/[slug]/opengraph-image.tsx",
+    },
+    {
+      code: `export default function Image({ id }) { return JSON.stringify(id); }`,
+      filename: "app/blog/[slug]/opengraph-image.tsx",
+    },
+    {
+      code: "export default function Image({ id }) { return String.raw`/${id}`; }",
+      filename: "app/blog/[slug]/opengraph-image.tsx",
+    },
+    {
+      code: "const raw = String.raw; export default function Image({ id }) { return raw`/${id}`; }",
+      filename: "app/blog/[slug]/opengraph-image.tsx",
+    },
+    {
+      code: `export default function Image({ id }) { id++; return null; }`,
+      filename: "app/blog/[slug]/opengraph-image.tsx",
+    },
+    {
+      code: `export default function Image({ id }) { id += 1; return null; }`,
+      filename: "app/blog/[slug]/opengraph-image.tsx",
+    },
+    {
+      code: `export default function Sitemap({ id }) { return [{ url: String(id * 50000) }]; }`,
+      filename: "app/sitemap.ts",
+    },
+    {
+      code: "export default function Sitemap({ id }) { return [{ url: `/product/${id}` }]; }",
+      filename: "app/sitemap.ts",
+    },
+  ])("reports direct Next.js 16 id consumption in $filename", ({ code, filename }) => {
+    const result = runRule(nextjsAsyncDynamicApiNotAwaited, code, {
+      filename,
+      settings: { "react-doctor": { capabilities: ["nextjs:15", "nextjs:16"] } },
+    });
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it.each([
+    `export default async function Image({ id }) { const imageId = await id; return new ImageResponse(String(imageId * 50000)); }`,
+    `import { use } from "react"; export default function Image({ id }) { const imageId = use(id); return new ImageResponse(String(imageId * 50000)); }`,
+    `export default function Image({ id }) { return id; }`,
+    `export default function Image({ id }) { return { id }; }`,
+    `export default function Image({ id }) { return [id]; }`,
+    `export default function Image({ id }) { return consume(id); }`,
+    `export default function Image({ id }) { return Promise.resolve(id); }`,
+    "export default function Image({ id }) { return consume`/${id}`; }",
+    `export default function Image({ id }) { return null?.[id]; }`,
+    `export default function Image({ id }) { return undefined?.[id]; }`,
+    `export default function Image({ id }) { return (void 0)?.[id]; }`,
+    `export default function Image({ id }) { return null?.foo[id]; }`,
+    `export default function Image({ id }) { return null?.foo.bar[id]; }`,
+    `export default function Image({ id }) { return null?.foo?.[id]; }`,
+    `export default function Image({ id }) { return undefined?.foo?.[id]; }`,
+    `export default function Image({ id }) { return (null?.foo)?.[id]; }`,
+    `export default function Image({ id }) { return (null?.foo)?.bar[id]; }`,
+    `export default function Image({ id }) { return (true ? null : {})?.[id]; }`,
+    `export default function Image({ id }) { return (false ? {} : undefined)?.[id]; }`,
+    `export default function Image({ id }) { return (null ?? undefined)?.[id]; }`,
+    `export default function Image({ id }) { return (null || undefined)?.[id]; }`,
+    `export default function Image({ id }) { return (0, null)?.[id]; }`,
+    `export default function Image({ id }) { let value; return (value = null)?.[id]; }`,
+    `export default function Image({ id }) { return null?.(id + 1); }`,
+    `export default function Image({ id }) { return null?.foo(id + 1); }`,
+    `export default function Image({ id }) { return null?.foo?.(id + 1); }`,
+    `export default function Image({ id }) { return (null?.foo)?.(id + 1); }`,
+    `export default function Image({ id }) { return false && values[id]; }`,
+    `export default function Image({ id }) { return true ? null : values[id]; }`,
+    `export default function Image({ id }) { const parseInt = consume; return parseInt(id); }`,
+    "export default function Image({ id }) { const String = consume; return String.raw`/${id}`; }",
+    "let raw = String.raw; export default function Image({ id }) { return raw`/${id}`; }",
+    `export default function Image({ id }) { return id.then((imageId) => imageId * 50000); }`,
+  ])("does not report safe or propagating Next.js 16 id usage", (code) => {
+    const result = runRule(nextjsAsyncDynamicApiNotAwaited, code, {
+      filename: "app/blog/[slug]/opengraph-image.tsx",
+      settings: { "react-doctor": { capabilities: ["nextjs:15", "nextjs:16"] } },
+    });
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it.each([
+    {
+      code: `export default async function Page(props) { props.params = await props.params; return props.params.slug; }`,
+      filename: "app/[slug]/page.tsx",
+      capabilities: ["nextjs:15"],
+    },
+    {
+      code: `export default async function Page({ ...props }) { props.params = await props.params; return props.params.slug; }`,
+      filename: "app/[slug]/page.tsx",
+      capabilities: ["nextjs:15"],
+    },
+    {
+      code: `export default async function Page(props) { const alias = props; alias.params = await alias.params; return props.params.slug; }`,
+      filename: "app/[slug]/page.tsx",
+      capabilities: ["nextjs:15"],
+    },
+    {
+      code: `export default async function Page(props) { const alias = props; alias.params = await alias.params; return alias.params.slug; }`,
+      filename: "app/[slug]/page.tsx",
+      capabilities: ["nextjs:15"],
+    },
+    {
+      code: `export default async function Page(props, other) { props.params = await other.params; return props.params.slug; }`,
+      filename: "app/[slug]/page.tsx",
+      capabilities: ["nextjs:15"],
+    },
+    {
+      code: `import { use } from "react"; export default function Page(props, other) { props.params = use(other.params); return props.params.slug; }`,
+      filename: "app/[slug]/page.tsx",
+      capabilities: ["nextjs:15"],
+    },
+    {
+      code: `export default function Page(props) { props.params = { slug: "local" }; return props.params.slug; }`,
+      filename: "app/[slug]/page.tsx",
+      capabilities: ["nextjs:15"],
+    },
+    {
+      code: `export default async function Page(props) { try { props.params = await props.params; } catch { props.params = { slug: "fallback" }; } return props.params.slug; }`,
+      filename: "app/[slug]/page.tsx",
+      capabilities: ["nextjs:15"],
+    },
+    {
+      code: `export default async function Page(props) { props.searchParams = await props.searchParams; return props.searchParams.query; }`,
+      filename: "app/[slug]/page.tsx",
+      capabilities: ["nextjs:15"],
+    },
+    {
+      code: `import { cookies } from "next/headers"; export default async function Page(props) { let pending = cookies(); pending = await pending; props.params = pending; return props.params.slug; }`,
+      filename: "app/[slug]/page.tsx",
+      capabilities: ["nextjs:15"],
+    },
+    {
+      code: `export default async function Page(props) { let pending = props.params; pending = await pending; props.params = pending; return props.params.slug; }`,
+      filename: "app/[slug]/page.tsx",
+      capabilities: ["nextjs:15"],
+    },
+    {
+      code: `import { cookies } from "next/headers"; export default function Page(props) { let pending = cookies(); pending = { slug: "safe" }; props.params = pending; return props.params.slug; }`,
+      filename: "app/[slug]/page.tsx",
+      capabilities: ["nextjs:15"],
+    },
+    {
+      code: `import { cookies } from "next/headers"; export default async function Page(props) { let pending = { slug: "safe" }; pending = cookies(); pending = await pending; props.params = pending; return props.params.slug; }`,
+      filename: "app/[slug]/page.tsx",
+      capabilities: ["nextjs:15"],
+    },
+    {
+      code: `import { cookies } from "next/headers"; export default function Page(props) { let other = { slug: "safe" }; let pending = other; other = cookies(); props.params = pending; return props.params.slug; }`,
+      filename: "app/[slug]/page.tsx",
+      capabilities: ["nextjs:15"],
+    },
+    {
+      code: `import { use } from "react"; export default function Page(props) { props.params = use(props.params); return props.params.slug; }`,
+      filename: "app/[slug]/page.tsx",
+      capabilities: ["nextjs:15"],
+    },
+    {
+      code: `export default async function Image(props) { props.id = await props.id; return new ImageResponse(String(props.id * 50000)); }`,
+      filename: "app/[slug]/opengraph-image.tsx",
+      capabilities: ["nextjs:15", "nextjs:16"],
+    },
+  ])(
+    "does not report an official prop after unconditional self-unwrapping",
+    ({ code, filename, capabilities }) => {
+      const result = runRule(nextjsAsyncDynamicApiNotAwaited, code, {
+        filename,
+        settings: { "react-doctor": { capabilities } },
+      });
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(0);
+    },
+  );
+
+  it.each([
+    `export default async function Page(props, shouldAwait) { if (shouldAwait) props.params = await props.params; return props.params.slug; }`,
+    `export default async function Page(props) { props.searchParams = await props.searchParams; return props.params.slug; }`,
+    `export default function Page(props, condition) { props.params = condition ? props.params : { slug: "fallback" }; return props.params.slug; }`,
+    `export default function Page(props) { props.params = props.params || fallback; return props.params.slug; }`,
+    `export default function Page(props) { props.params = props.params ?? fallback; return props.params.slug; }`,
+    `export default function Page(props) { props.params = (observe(), props.params); return props.params.slug; }`,
+    `export default function Page(props) { const pending = props.params; props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { const pending = cookies(); props.params = pending; return props.params.slug; }`,
+    `export default function Page(props) { let pending = props.params; props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = cookies(); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props, condition) { let pending = cookies(); if (condition) pending = { slug: "fallback" }; props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default async function Page(props) { let pending = cookies(); pending = await pending; pending = cookies(); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = { slug: "safe" }; pending = cookies(); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default async function Page(props, condition) { let pending = cookies(); pending = await pending; if (condition) pending = cookies(); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default async function Page(props) { let { params: pending } = props; pending = await pending; pending = cookies(); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending; pending ??= cookies(); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = null; pending ||= cookies(); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = { slug: "safe" }; pending &&= cookies(); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let other = { slug: "safe" }; let pending = other; other = cookies(); pending = other; props.params = pending; return props.params.slug; }`,
+    `export default function Page(props) { const { params: pending } = props; props.params = pending; return props.params.slug; }`,
+    `export default function Page(props) { const alias = props; const { params: pending } = alias; props.params = pending; return props.params.slug; }`,
+    `export default function Page(props) { props.params = props.searchParams; return props.params.slug; }`,
+    `export default async function Page(props) { try { props.params = await props.params; } catch {} return props.params.slug; }`,
+    `export default async function Page(props, shouldFallback) { try { props.params = await props.params; } catch { if (shouldFallback) props.params = { slug: "fallback" }; } return props.params.slug; }`,
+  ])("reports an official prop without unconditional matching self-unwrapping %#", (code) => {
+    expectDiagnosticCount(code, 1, "app/[slug]/page.tsx");
+  });
+
+  it("reports a compound official prop write and clears the following read", () => {
+    expectDiagnosticCount(
+      `export default function Page(props) { props.params += fallback; return props.params.slug; }`,
+      1,
+      "app/[slug]/page.tsx",
+    );
+  });
+
+  it.each(["||=", "??="])(
+    "reports a retaining %s official prop write and the following read",
+    (operator) => {
+      expectDiagnosticCount(
+        `export default function Page(props) { props.params ${operator} fallback; return props.params.slug; }`,
+        2,
+        "app/[slug]/page.tsx",
+      );
+    },
+  );
+
+  it("reports an &&= official prop write and clears the following read", () => {
+    expectDiagnosticCount(
+      `export default function Page(props) { props.params &&= fallback; return props.params.slug; }`,
+      1,
+      "app/[slug]/page.tsx",
+    );
+  });
+
+  it.each([
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = {}; if (false) pending = cookies(); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = {}; false && (pending = cookies()); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = {}; true || (pending = cookies()); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = {}; false ? (pending = cookies()) : 0; props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = {}; pending ||= cookies(); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = { slug: "safe" }; pending ??= cookies(); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = null; pending &&= cookies(); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = {}; const taint = () => { pending = cookies(); }; props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default async function Page(props) { let pending = cookies(); const clear = async () => { pending = await pending; }; await clear(); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default async function Page(props) { let pending = cookies(); await (async () => { pending = await pending; })(); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = {}; const update = () => { pending = cookies(); pending = {}; }; update(); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = {}; const taint = () => { return; pending = cookies(); }; taint(); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = {}; const taint = async () => { await 0; pending = cookies(); }; taint(); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = {}; const taint = () => { pending = cookies(); }; if (false) taint(); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = cookies(); const clear = async () => { if (false) await 0; pending = {}; }; clear(); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = {}; const taint = async () => { if (true) await 0; pending = cookies(); }; taint(); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = cookies(); const clear = () => { pending = {}; throw new Error(); }; try { clear(); } catch {} props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = cookies(); [0].map(() => { pending = {}; }); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = cookies(); new Promise(() => { pending = {}; }); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props, shouldThrow) { let pending = cookies(); const clear = () => { if (shouldThrow) throw new Error(); pending = {}; }; clear(); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = cookies(); const clear = () => { try { throw new Error(); } catch {} pending = {}; }; clear(); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = cookies(); const clear = () => { try { throw new Error(); } finally { pending = {}; } }; try { clear(); } catch {} props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props, condition) { let pending = cookies(); const clear = () => { if (condition) pending = {}; else pending = {}; }; clear(); props.params = pending; return props.params.slug; }`,
+    `export default function Page(props, condition) { const clear = () => { if (condition) props.params = {}; else props.params = {}; }; clear(); return props.params.slug; }`,
+    `export default function Page(props, condition) { const read = () => { if (condition) props.params = { slug: "first" }; else props.params = { slug: "second" }; return props.params.slug; }; return read(); }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = cookies(); const clear = async () => { while (false) await 0; pending = {}; }; clear(); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = cookies(); const clear = async () => { for (; false; ) await 0; pending = {}; }; clear(); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = {}; [...[]].map(() => { pending = cookies(); }); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = {}; [0].reduce(() => { pending = cookies(); }); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = {}; [0].sort(() => { pending = cookies(); return 0; }); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = {}; const values = []; values.map(() => { pending = cookies(); }); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = {}; Array.of().map(() => { pending = cookies(); }); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = {}; Array.from([], () => { pending = cookies(); }); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = cookies(); const values = [0]; values.map(() => { pending = {}; }); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = cookies(); Array.of(0).map(() => { pending = {}; }); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = cookies(); Array.from([0], () => { pending = {}; }); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = cookies(); [undefined].map(() => { pending = {}; }); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = cookies(); Array.of(undefined).map(() => { pending = {}; }); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = cookies(); [0].reduce(() => { pending = {}; return 0; }, 0); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = cookies(); [0, 1].reduce(() => { pending = {}; return 0; }); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = cookies(); [0, 1].sort(() => { pending = {}; return 0; }); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = cookies(); [0, 1].toSorted(() => { pending = {}; return 0; }); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = cookies(); Array.from([,], () => { pending = {}; }); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props, first, second) { let pending = cookies(); const clear = () => { if (first) { if (second) pending = {}; else pending = {}; } else pending = {}; }; clear(); props.params = pending; return props.params.slug; }`,
+    `export default function Page(props, first, second) { const read = () => { if (first) { if (second) props.params = {}; else props.params = {}; } else props.params = {}; return props.params.slug; }; return read(); }`,
+    `import { cookies } from "next/headers"; export default function Page(props, condition) { let pending = cookies(); try { throw new Error(); } catch { if (condition) pending = {}; else pending = {}; } props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props, condition) { let pending = {}; const update = () => { pending = cookies(); throw new Error(); }; try { update(); } catch { if (condition) pending = {}; else pending = {}; } props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = {}; [..."💩"].reduce(() => { pending = cookies(); }); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = {}; Array.from("💩").reduce(() => { pending = cookies(); }); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = cookies(); [..."ab"].reduce(() => { pending = {}; return ""; }); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = cookies(); const values = [0]; if (false) values.pop(); values.map(() => { pending = {}; }); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = cookies(); const values = [0]; false && values.pop(); values.map(() => { pending = {}; }); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = cookies(); const values = [0]; const mutate = () => values.pop(); values.map(() => { pending = {}; }); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = {}; const values = []; if (false) values.push(0); values.map(() => { pending = cookies(); }); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = {}; const values = [0]; values.pop(); values.map(() => { pending = cookies(); }); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = {}; const values = []; values.length = 1; values.map(() => { pending = cookies(); }); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = cookies(); const values = []; values.push(0); values.map(() => { pending = {}; }); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = cookies(); const noop = () => {}; const clear = () => { noop(); pending = {}; }; try { clear(); } catch {} props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = {}; const update = () => { pending = cookies(); pending = {}; throw new Error(); }; try { update(); } catch {} props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = {}; const update = () => { pending = cookies(); pending = {}; }; if (false) { try { update(); } catch {} } update(); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props, shouldThrow) { let pending = {}; const update = () => { pending = cookies(); if (shouldThrow) throw new Error(); pending = {}; }; try { update(); } catch { return null; } props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props, shouldThrow) { let pending = {}; const update = () => { pending = cookies(); if (shouldThrow) throw new Error(); pending = {}; }; try { update(); } catch { throw new Error(); } props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props, shouldThrow) { let pending = {}; const update = () => { pending = cookies(); if (shouldThrow) throw new Error(); pending = {}; }; try { update(); } catch { pending = {}; } props.params = pending; return props.params.slug; }`,
+  ])("ignores unreachable taint and honors invoked clearing %#", (code) => {
+    expectDiagnosticCount(code, 0, "app/[slug]/page.tsx");
+  });
+
+  it.each([
+    `import { cookies } from "next/headers"; export default function Page(props) { let first = cookies(); let second = first; first = second; props.params = first; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = {}; const taint = () => { pending = cookies(); }; taint(); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = {}; (() => { pending = cookies(); })(); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = {}; const update = () => { pending = {}; pending = cookies(); }; update(); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = {}; const taint = async () => { pending = cookies(); await 0; }; taint(); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default async function Page(props) { let pending = {}; const taint = async () => { await 0; pending = cookies(); }; await taint(); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props, shouldWait) { let pending = {}; const taint = async () => { if (shouldWait) await 0; pending = cookies(); }; taint(); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props, shouldThrow) { let pending = {}; const update = () => { pending = cookies(); if (shouldThrow) throw new Error(); pending = {}; }; try { update(); } catch {} props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = {}; [0].map(() => { pending = cookies(); }); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = {}; new Promise(() => { pending = cookies(); }); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = cookies(); [...[]].map(() => { pending = {}; }); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = cookies(); [0].reduce(() => { pending = {}; }); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = cookies(); [0].sort(() => { pending = {}; return 0; }); props.params = pending; return props.params.slug; }`,
+    `export default function Page(props) { const read = () => { try { props.params = getSafeOrThrow(); } catch {} return props.params.slug; }; return read(); }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = cookies(); const values = []; values.map(() => { pending = {}; }); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = cookies(); Array.of().map(() => { pending = {}; }); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = cookies(); Array.from([], () => { pending = {}; }); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = {}; const values = [0]; values.map(() => { pending = cookies(); }); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = {}; Array.of(0).map(() => { pending = cookies(); }); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = {}; Array.from([0], () => { pending = cookies(); }); props.params = pending; return props.params.slug; }`,
+    `import { useMemo } from "react"; import { cookies } from "next/headers"; export default function Page(props) { let pending = {}; useMemo(() => { pending = cookies(); }, []); props.params = pending; return props.params.slug; }`,
+    `import { useState } from "react"; import { cookies } from "next/headers"; export default function Page(props) { let pending = {}; useState(() => { pending = cookies(); return 0; }); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = cookies(); [,].map(() => { pending = {}; }); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = cookies(); Array(1).map(() => { pending = {}; }); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = {}; [undefined].map(() => { pending = cookies(); }); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = {}; Array.of(undefined).map(() => { pending = cookies(); }); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = cookies(); [].reduce(() => { pending = {}; return 0; }, 0); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = cookies(); [0, undefined].sort(() => { pending = {}; return 0; }); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = cookies(); [0, undefined].toSorted(() => { pending = {}; return 0; }); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = {}; Array.from([,], () => { pending = cookies(); }); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = {}; const values = []; values.push(0); values.map(() => { pending = cookies(); }); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = cookies(); const values = [0]; values.pop(); values.map(() => { pending = {}; }); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = cookies(); const values = [0]; values.length = 0; values.map(() => { pending = {}; }); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = {}; const values = []; values[0] = 0; values.map(() => { pending = cookies(); }); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = cookies(); const clear = () => { mayThrow(); pending = {}; }; try { clear(); } catch {} props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = {}; const update = () => { pending = cookies(); mayThrow(); pending = {}; }; try { update(); } catch {} props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = cookies(); [..."💩"].reduce(() => { pending = {}; }); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = cookies(); [..."💩"].sort(() => { pending = {}; return 0; }); props.params = pending; return props.params.slug; }`,
+  ])("retains reachable aliases and invoked taint %#", (code) => {
+    expectDiagnosticCount(code, 1, "app/[slug]/page.tsx");
+  });
+
+  it.each(["||=", "??="])("reports pending local %s retention and the later read", (operator) => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers"; export const read = () => { let pending = cookies(); pending ${operator} { get: () => "safe" }; return pending.get("x"); };`,
+      2,
+    );
+  });
+
+  it("reports pending local &&= consumption and clears the later read", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers"; export const read = () => { let pending = cookies(); pending &&= { get: () => "safe" }; return pending.get("x"); };`,
+      1,
+    );
+  });
+
+  it("reports pending local &&= unwrapping and clears the later read", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers"; export const read = async () => { let pending = cookies(); pending &&= await pending; return pending.get("x"); };`,
+      1,
+    );
+  });
+
+  it.each([
+    `import { cookies } from "next/headers"; export const read = () => { let pending = { get: () => "safe" }; if (false) pending = cookies(); return pending.get("x"); };`,
+    `import { cookies } from "next/headers"; export const read = () => { let pending = { get: () => "safe" }; false && (pending = cookies()); return pending.get("x"); };`,
+    `import { cookies } from "next/headers"; export const read = () => { let pending = { get: () => "safe" }; pending ||= cookies(); return pending.get("x"); };`,
+    `import { cookies } from "next/headers"; export const read = () => { let pending = { get: () => "safe" }; pending ??= cookies(); return pending.get("x"); };`,
+    `import { cookies } from "next/headers"; export const read = () => { let pending = null; pending &&= cookies(); return pending?.get("x"); };`,
+  ])("ignores a statically skipped local taint", (code) => {
+    expectDiagnosticCount(code, 0);
+  });
+
+  it.each([
+    `import { cookies } from "next/headers"; export default function Page(props, shouldClear) { let pending = cookies(); const clear = () => { if (shouldClear) pending = {}; }; clear(); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = cookies(); const clear = () => { return; pending = {}; }; clear(); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = cookies(); const clear = async () => { await 0; pending = {}; }; clear(); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props, shouldWait) { let pending = cookies(); const clear = async () => { if (shouldWait) await 0; pending = {}; }; clear(); props.params = pending; return props.params.slug; }`,
+  ])("retains pending state when an invoked clear is not guaranteed before return %#", (code) => {
+    expectDiagnosticCount(code, 1, "app/[slug]/page.tsx");
+  });
+
+  it("accepts an official prop cleared by a directly invoked closure", () => {
+    expectDiagnosticCount(
+      `export default function Page(props) { const read = () => { props.params = { slug: "safe" }; return props.params.slug; }; return read(); }`,
+      0,
+      "app/[slug]/page.tsx",
+    );
+  });
+
+  it.each([
+    `import { cookies } from "next/headers"; export default function Page(props) { let pending = {}; const outer = () => { const taint = () => { pending = cookies(); }; taint(); pending = {}; }; outer(); props.params = pending; return props.params.slug; }`,
+    `import { cookies } from "next/headers"; export default function Page(props, shouldThrow) { let pending = {}; const update = () => { pending = cookies(); if (shouldThrow) throw new Error(); pending = {}; }; update(); props.params = pending; return props.params.slug; }`,
+  ])("tracks ordered effects through directly invoked closures %#", (code) => {
+    expectDiagnosticCount(code, 0, "app/[slug]/page.tsx");
+  });
+
+  it("uses the call-site value for a captured logical assignment", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers"; export default function Page(props) { let pending = null; pending = {}; const taint = () => { pending ??= cookies(); }; taint(); props.params = pending; return props.params.slug; }`,
+      0,
+      "app/[slug]/page.tsx",
+    );
+  });
+
+  it("taints from a captured logical assignment enabled at the call site", () => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers"; export default function Page(props) { let pending = {}; pending = null; const taint = () => { pending ??= cookies(); }; taint(); props.params = pending; return props.params.slug; }`,
+      1,
+      "app/[slug]/page.tsx",
+    );
+  });
+
+  it.each([
+    [`&&=`, 1],
+    [`||=`, 2],
+  ])("reports invoked pending local %s consumption", (operator, count) => {
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers"; export const read = () => { let pending = cookies(); const update = () => { pending ${operator} { get: () => "safe" }; }; update(); return pending.get("x"); };`,
+      count,
+    );
+  });
+
+  it.each([
+    [
+      `import { cookies } from "next/headers"; export default function Page(props) { let pending = cookies(); [].map(() => { pending = {}; }); props.params = pending; return props.params.slug; }`,
+      1,
+    ],
+    [
+      `import { cookies } from "next/headers"; export default function Page(props) { let pending = {}; [].map(() => { pending = cookies(); }); props.params = pending; return props.params.slug; }`,
+      0,
+    ],
+  ])("does not project effects from a callback that may never run", (code, count) => {
+    expectDiagnosticCount(code, count, "app/[slug]/page.tsx");
+  });
+
+  it("accepts self-unwrapping in a try when the catch cannot reach the read", () => {
+    expectDiagnosticCount(
+      `export default async function Page(props) { try { props.params = await props.params; } catch { throw new Error("failed"); } return props.params.slug; }`,
+      0,
+      "app/[slug]/page.tsx",
+    );
+  });
+
+  it("reports sitemap id in Next.js 16", () => {
+    const result = runRule(
+      nextjsAsyncDynamicApiNotAwaited,
+      `export default function Sitemap({ id }) { return [{ url: id.value }]; }`,
+      {
+        filename: "app/sitemap.ts",
+        settings: { "react-doctor": { capabilities: ["nextjs:15", "nextjs:16"] } },
+      },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it.each([
+    {
+      code: `export default function Sitemap({ id }) { return [{ url: id.value }]; }`,
+      capabilities: ["nextjs:15"],
+    },
+    {
+      code: `export const generateSitemaps = ({ id }) => [{ id: id.value }];`,
+      capabilities: ["nextjs:15", "nextjs:16"],
+    },
+  ])("does not report a synchronous sitemap producer", ({ code, capabilities }) => {
+    const result = runRule(nextjsAsyncDynamicApiNotAwaited, code, {
+      filename: "app/sitemap.ts",
+      settings: { "react-doctor": { capabilities } },
+    });
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not report generateImageMetadata in Next.js 16", () => {
+    const result = runRule(
+      nextjsAsyncDynamicApiNotAwaited,
+      `export const generateImageMetadata = ({ params, id }) => [{ id: params.slug + id.value }];`,
+      {
+        filename: "app/blog/[slug]/opengraph-image.tsx",
+        settings: { "react-doctor": { capabilities: ["nextjs:15", "nextjs:16"] } },
+      },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it.each([
+    {
+      code: `export default async function Page({ params }) { const route = await params; return route.slug; }`,
+      filename: "app/blog/[slug]/page.tsx",
+    },
+    {
+      code: `import { use } from "react"; export default function Page({ searchParams }) { return use(searchParams).query; }`,
+      filename: "app/search/page.tsx",
+    },
+    {
+      code: `import { use as unwrap } from "react"; export default function Page({ params }) { return unwrap(params).slug; }`,
+      filename: "app/[slug]/page.tsx",
+    },
+    {
+      code: `export default function Page({ params }) { return params.then((route) => route.slug); }`,
+      filename: "app/[slug]/page.tsx",
+    },
+    {
+      code: `export const helper = ({ params }) => params.slug;`,
+      filename: "app/blog/[slug]/page.tsx",
+    },
+    {
+      code: `function Page({ params }) { return params.slug; } export { Page };`,
+      filename: "app/blog/[slug]/page.tsx",
+    },
+    {
+      code: `export default function Card({ params }) { return params.slug; }`,
+      filename: "src/components/page.tsx",
+    },
+    {
+      code: `export default function Layout({ searchParams }) { return searchParams.query; }`,
+      filename: "app/layout.tsx",
+    },
+    {
+      code: `export default function Loading({ params }) { return params.slug; }`,
+      filename: "app/loading.tsx",
+    },
+    {
+      code: `export default function Template({ params }) { return params.slug; }`,
+      filename: "app/template.tsx",
+    },
+    {
+      code: `export default function LegacyPage({ params }) { return params.slug; }`,
+      filename: "pages/page.tsx",
+    },
+    {
+      code: `export default withPage(function Page({ params }) { return params.slug; });`,
+      filename: "app/blog/[slug]/page.tsx",
+    },
+    {
+      code: `export default function Page(props) { return props[propertyName].slug; }`,
+      filename: "app/blog/[slug]/page.tsx",
+    },
+    {
+      code: `export default function Route(request) { return request.params.slug; }`,
+      filename: "app/api/[slug]/route.ts",
+    },
+    {
+      code: `export const handler = (request, { params }) => params.slug;`,
+      filename: "app/api/[slug]/route.ts",
+    },
+    {
+      code: `export default function Route(request, { params }) { return params.slug; }`,
+      filename: "app/api/[slug]/route.ts",
+    },
+    {
+      code: `export const generateStaticParams = ({ params }) => [{ slug: params.slug }];`,
+      filename: "app/[slug]/page.tsx",
+    },
+    {
+      code: `export default function Page({ [propertyName]: routeParams }) { return routeParams.slug; }`,
+      filename: "app/[slug]/page.tsx",
+    },
+    {
+      code: `export default function Page({ params }) { return <div />; }`,
+      filename: "app/[slug]/page.tsx",
+    },
+    {
+      code: `export default function Image({ params }) { return new ImageResponse(params.slug); }`,
+      filename: "app/blog/[slug]/opengraph-image.tsx",
+    },
+    {
+      code: `export const generateImageMetadata = ({ params }) => [{ id: params.slug }];`,
+      filename: "app/blog/[slug]/opengraph-image.tsx",
+    },
+    {
+      code: `export async function Page({ params }) { params = await params; return params.slug; } export default Page;`,
+      filename: "app/blog/[slug]/page.tsx",
+    },
+  ])("does not report safe or non-contract request props in $filename", ({ code, filename }) => {
+    expectDiagnosticCount(code, 0, filename);
+  });
+
+  it("reports request props after only a conditional await", () => {
+    expectDiagnosticCount(
+      `export async function Page({ params }, shouldAwait) {
+         if (shouldAwait) params = await params;
+         return params.slug;
+       }
+       export default Page;`,
+      1,
+      "app/blog/[slug]/page.tsx",
+    );
+  });
+
+  it("handles a deeply nested logical source without recursive traversal", () => {
+    const logicalBranchCount = 1_200;
+    const pendingExpression = `cookies()${" || getFallbackCookieStore()".repeat(logicalBranchCount)}`;
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = () => {
+         const pending = ${pendingExpression};
+         return pending.get("session");
+       };`,
+      1,
+    );
+  });
+
+  it("handles a deeply nested logical alias without recursive traversal", () => {
+    const logicalBranchCount = 1_200;
+    const pendingExpression = `pending${" || getFallbackCookieStore()".repeat(logicalBranchCount)}`;
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = () => {
+         const pending = cookies();
+         const alias = ${pendingExpression};
+         return alias.get("session");
+       };`,
+      1,
+    );
+  });
+
+  it("analyzes many reconverging branches without path explosion", () => {
+    const branchCount = 40;
+    const reconvergingBranches = Array.from(
+      { length: branchCount },
+      (_, branchIndex) =>
+        `if (flags[${branchIndex}]) observe(${branchIndex}); else observe(-${branchIndex});`,
+    ).join("\n");
+    expectDiagnosticCount(
+      `import { cookies } from "next/headers";
+       export const read = async (flags) => {
+         let pending = cookies();
+         pending = await pending;
+         ${reconvergingBranches}
+         return pending.get("session");
+       };`,
+      0,
+    );
+  });
+
+  it("declares the Next.js 15 capability gate", () => {
+    expect(nextjsAsyncDynamicApiNotAwaited.requires).toEqual(["nextjs:15"]);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-async-dynamic-api-not-awaited.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-async-dynamic-api-not-awaited.ts
@@ -1,0 +1,3264 @@
+import * as path from "node:path";
+import {
+  NEXTJS_SOURCE_FILE_EXTENSION_GROUP,
+  ROUTE_HANDLER_HTTP_METHODS,
+} from "../../constants/nextjs.js";
+import { PROMISE_SETTLE_METHODS } from "../../constants/js.js";
+import type { BasicBlock } from "../../semantic/control-flow-graph.js";
+import type { SymbolDescriptor } from "../../semantic/scope-analysis.js";
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { executesDuringRender } from "../../utils/executes-during-render.js";
+import {
+  getImportedNameFromModule,
+  isNamespaceImportFromModule,
+} from "../../utils/find-import-source-for-name.js";
+import { findTransparentExpressionRoot } from "../../utils/find-transparent-expression-root.js";
+import { findExportedValue } from "../../utils/find-exported-value.js";
+import { findProgramRoot } from "../../utils/find-program-root.js";
+import { findVisibleSymbol } from "../../utils/find-visible-symbol.js";
+import { hasCapability } from "../../utils/get-react-doctor-setting.js";
+import { getSingleReturnExpression } from "../../utils/get-single-return-expression.js";
+import { getNodeStartIndex } from "../../utils/get-node-start-index.js";
+import { getStaticPropertyKeyName } from "../../utils/get-static-property-key-name.js";
+import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
+import { isAstNode } from "../../utils/is-ast-node.js";
+import { isAstDescendant } from "../../utils/is-ast-descendant.js";
+import { isFunctionLike } from "../../utils/is-function-like.js";
+import { isFrameworkRouteOrSpecialFilename } from "../../utils/is-framework-route-or-special-filename.js";
+import { isInProjectDirectory } from "../../utils/is-in-project-directory.js";
+import { isNextjsMetadataImageRouteFilename } from "../../utils/is-nextjs-metadata-image-route-filename.js";
+import { isNodeReachableWithinFunction } from "../../utils/is-node-reachable-within-function.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { isReactApiCall } from "../../utils/is-react-api-call.js";
+import { nodeDominatesNode } from "../../utils/node-dominates-node.js";
+import { normalizeFilename } from "../../utils/normalize-filename.js";
+import { resolveConstIdentifierAlias } from "../../utils/resolve-const-identifier-alias.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+import { statementAlwaysExits } from "../../utils/statement-always-exits.js";
+import {
+  stripParenExpression,
+  TRANSPARENT_EXPRESSION_WRAPPER_TYPES,
+} from "../../utils/strip-paren-expression.js";
+import { walkAst } from "../../utils/walk-ast.js";
+
+const DYNAMIC_API_NAMES: ReadonlySet<string> = new Set(["cookies", "headers", "draftMode"]);
+const UNSAFE_UNWRAPPED_TYPE_NAMES: ReadonlySet<string> = new Set([
+  "UnsafeUnwrappedCookies",
+  "UnsafeUnwrappedHeaders",
+  "UnsafeUnwrappedDraftMode",
+]);
+const OBJECT_ENUMERATION_METHOD_NAMES: ReadonlySet<string> = new Set([
+  "entries",
+  "getOwnPropertyDescriptor",
+  "getOwnPropertyDescriptors",
+  "getOwnPropertyNames",
+  "getOwnPropertySymbols",
+  "keys",
+  "values",
+]);
+const ITERABLE_CONSTRUCTOR_NAMES: ReadonlySet<string> = new Set([
+  "Headers",
+  "Map",
+  "Set",
+  "URLSearchParams",
+  "WeakMap",
+  "WeakSet",
+]);
+const COERCIVE_GLOBAL_NAMES: ReadonlySet<string> = new Set([
+  "BigInt",
+  "Boolean",
+  "decodeURI",
+  "decodeURIComponent",
+  "Number",
+  "String",
+  "encodeURI",
+  "encodeURIComponent",
+  "isFinite",
+  "isNaN",
+  "parseFloat",
+  "parseInt",
+]);
+const NON_CONSUMING_UNARY_OPERATORS: ReadonlySet<string> = new Set(["!", "typeof", "void"]);
+const SITEMAP_FILE_PATTERN = new RegExp(`^sitemap\\.${NEXTJS_SOURCE_FILE_EXTENSION_GROUP}$`);
+const ARRAY_CARDINALITY_MUTATION_METHOD_NAMES: ReadonlySet<string> = new Set([
+  "copyWithin",
+  "fill",
+  "pop",
+  "push",
+  "reverse",
+  "shift",
+  "sort",
+  "splice",
+  "unshift",
+]);
+
+const MESSAGE =
+  "This Next.js request API returns a Promise. Synchronous property access warns in Next.js 15 and is removed in Next.js 16; await it or unwrap it with React `use()`.";
+
+interface PendingSymbolCandidate {
+  sourceExpression: EsTreeNode;
+  symbol: SymbolDescriptor;
+}
+
+interface PendingSymbolFlow {
+  isClearedAtExit: boolean;
+  isClearedBefore: (referenceIdentifier: EsTreeNode) => boolean;
+}
+
+interface ExitingCatchClearing {
+  clearingNode: EsTreeNode;
+  tryStatement: EsTreeNode;
+}
+
+interface ConditionalClearingBranches {
+  hasAlternate: boolean;
+  hasConsequent: boolean;
+}
+
+interface ExecutionProjectionOptions {
+  requiresGuaranteedExecution: boolean;
+}
+
+interface AsyncExecutionPhase {
+  mayExecuteBeforeSuspension: boolean;
+  mustExecuteBeforeSuspension: boolean;
+}
+
+interface DirectInvocationSiteOptions {
+  includeCallbackExecutionSites: boolean;
+  requireGuaranteedCallbackExecution?: boolean;
+}
+
+interface KnownArrayCardinality {
+  comparableElementCount: number;
+  length: number;
+  presentElementCount: number;
+}
+
+interface ProjectedClearingSitesInput {
+  afterStart: number;
+  context: RuleContext;
+  symbol: SymbolDescriptor;
+  targetOwner: EsTreeNode | null;
+}
+
+const resolvesToImportBinding = (context: RuleContext, identifier: EsTreeNode): boolean =>
+  findVisibleSymbol(identifier, context.scopes)?.kind === "import";
+
+const getStaticStringValue = (context: RuleContext, expression: EsTreeNode): string | null => {
+  const node = stripParenExpression(expression);
+  if (isNodeOfType(node, "Literal") && typeof node.value === "string") return node.value;
+  if (!isNodeOfType(node, "Identifier")) return null;
+  const symbol = resolveConstIdentifierAlias(node, context.scopes);
+  return symbol?.initializer ? getStaticStringValue(context, symbol.initializer) : null;
+};
+
+const getResolvedStaticPropertyName = (
+  context: RuleContext,
+  memberExpression: EsTreeNodeOfType<"MemberExpression">,
+): string | null =>
+  getStaticPropertyName(memberExpression) ??
+  (memberExpression.computed ? getStaticStringValue(context, memberExpression.property) : null);
+
+const isNextHeadersDynamicCall = (
+  context: RuleContext,
+  expression: EsTreeNode,
+  visitedWrapperSymbolIds: Set<number> = new Set(),
+): boolean => {
+  const node = stripParenExpression(expression);
+  if (!isNodeOfType(node, "CallExpression")) return false;
+  const callee = stripParenExpression(node.callee);
+  if (isNodeOfType(callee, "Identifier")) {
+    const symbol = resolveConstIdentifierAlias(callee, context.scopes);
+    if (symbol?.kind === "import" && isNodeOfType(symbol.bindingIdentifier, "Identifier")) {
+      const importedName = getImportedNameFromModule(
+        node,
+        symbol.bindingIdentifier.name,
+        "next/headers",
+      );
+      if (importedName !== null && DYNAMIC_API_NAMES.has(importedName)) return true;
+    }
+    const localSymbol = context.scopes.symbolFor(callee);
+    if (localSymbol?.kind === "const" && localSymbol.initializer) {
+      const initializer = stripParenExpression(localSymbol.initializer);
+      if (isNodeOfType(initializer, "MemberExpression")) {
+        const namespaceExpression = stripParenExpression(initializer.object);
+        const importedName = getResolvedStaticPropertyName(context, initializer);
+        if (
+          isNodeOfType(namespaceExpression, "Identifier") &&
+          importedName !== null &&
+          DYNAMIC_API_NAMES.has(importedName)
+        ) {
+          const namespaceSymbol = resolveConstIdentifierAlias(namespaceExpression, context.scopes);
+          if (
+            namespaceSymbol?.kind === "import" &&
+            isNodeOfType(namespaceSymbol.bindingIdentifier, "Identifier") &&
+            isNamespaceImportFromModule(
+              node,
+              namespaceSymbol.bindingIdentifier.name,
+              "next/headers",
+            )
+          ) {
+            return true;
+          }
+        }
+      }
+    }
+    if (
+      node.arguments.length === 0 &&
+      localSymbol?.initializer &&
+      isFunctionLike(localSymbol.initializer) &&
+      !visitedWrapperSymbolIds.has(localSymbol.id) &&
+      localSymbol.initializer.params.length === 0
+    ) {
+      const returnedExpression = getSingleReturnExpression(localSymbol.initializer);
+      if (returnedExpression) {
+        visitedWrapperSymbolIds.add(localSymbol.id);
+        if (isNextHeadersDynamicCall(context, returnedExpression, visitedWrapperSymbolIds)) {
+          return true;
+        }
+      }
+    }
+    if (
+      localSymbol?.kind !== "const" ||
+      !isNodeOfType(localSymbol.declarationNode, "VariableDeclarator") ||
+      !isNodeOfType(localSymbol.declarationNode.id, "ObjectPattern") ||
+      !localSymbol.initializer
+    ) {
+      return false;
+    }
+    const property = localSymbol.declarationNode.id.properties.find(
+      (candidateProperty) =>
+        isNodeOfType(candidateProperty, "Property") &&
+        candidateProperty.value === localSymbol.bindingIdentifier,
+    );
+    if (!isNodeOfType(property, "Property")) return false;
+    const importedName = getStaticPropertyKeyName(property, { allowComputedString: true });
+    const namespaceExpression = stripParenExpression(localSymbol.initializer);
+    if (
+      importedName === null ||
+      !DYNAMIC_API_NAMES.has(importedName) ||
+      !isNodeOfType(namespaceExpression, "Identifier")
+    ) {
+      return false;
+    }
+    const namespaceSymbol = resolveConstIdentifierAlias(namespaceExpression, context.scopes);
+    return Boolean(
+      namespaceSymbol?.kind === "import" &&
+      isNodeOfType(namespaceSymbol.bindingIdentifier, "Identifier") &&
+      isNamespaceImportFromModule(node, namespaceSymbol.bindingIdentifier.name, "next/headers"),
+    );
+  }
+  if (!isNodeOfType(callee, "MemberExpression")) return false;
+  const namespaceObject = stripParenExpression(callee.object);
+  const memberName = getResolvedStaticPropertyName(context, callee);
+  if (
+    !isNodeOfType(namespaceObject, "Identifier") ||
+    memberName === null ||
+    !DYNAMIC_API_NAMES.has(memberName) ||
+    !resolveConstIdentifierAlias(namespaceObject, context.scopes)
+  ) {
+    return false;
+  }
+  const namespaceSymbol = resolveConstIdentifierAlias(namespaceObject, context.scopes);
+  return Boolean(
+    namespaceSymbol?.kind === "import" &&
+    isNodeOfType(namespaceSymbol.bindingIdentifier, "Identifier") &&
+    isNamespaceImportFromModule(node, namespaceSymbol.bindingIdentifier.name, "next/headers"),
+  );
+};
+
+const isUnsafeUnwrappedType = (
+  context: RuleContext,
+  typeNode: EsTreeNode,
+  visitedSymbolIds: Set<number> = new Set(),
+): boolean => {
+  if (!isNodeOfType(typeNode, "TSTypeReference")) return false;
+  const typeName = typeNode.typeName;
+  if (isNodeOfType(typeName, "Identifier")) {
+    const symbol = findVisibleSymbol(typeName, context.scopes);
+    if (!symbol || visitedSymbolIds.has(symbol.id)) return false;
+    if (symbol.kind === "import") {
+      const importedName = getImportedNameFromModule(typeNode, typeName.name, "next/headers");
+      return importedName !== null && UNSAFE_UNWRAPPED_TYPE_NAMES.has(importedName);
+    }
+    if (!isNodeOfType(symbol.declarationNode, "TSTypeAliasDeclaration")) return false;
+    visitedSymbolIds.add(symbol.id);
+    return isUnsafeUnwrappedType(context, symbol.declarationNode.typeAnnotation, visitedSymbolIds);
+  }
+  if (
+    !isNodeOfType(typeName, "TSQualifiedName") ||
+    !isNodeOfType(typeName.left, "Identifier") ||
+    !isNodeOfType(typeName.right, "Identifier") ||
+    !UNSAFE_UNWRAPPED_TYPE_NAMES.has(typeName.right.name) ||
+    !resolvesToImportBinding(context, typeName.left)
+  ) {
+    return false;
+  }
+  return isNamespaceImportFromModule(typeNode, typeName.left.name, "next/headers");
+};
+
+const castChainAssertsUnsafeUnwrapped = (context: RuleContext, expression: EsTreeNode): boolean => {
+  if (hasCapability(context.settings, "nextjs:16")) return false;
+  let current: EsTreeNode | null = expression;
+  while (current) {
+    if (
+      (isNodeOfType(current, "TSAsExpression") || isNodeOfType(current, "TSTypeAssertion")) &&
+      isUnsafeUnwrappedType(context, current.typeAnnotation)
+    ) {
+      return true;
+    }
+    if (
+      !TRANSPARENT_EXPRESSION_WRAPPER_TYPES.has(current.type) ||
+      !("expression" in current) ||
+      !isAstNode(current.expression)
+    ) {
+      return false;
+    }
+    current = current.expression;
+  }
+  return false;
+};
+
+const isPromiseSettleAccess = (
+  context: RuleContext,
+  memberExpression: EsTreeNodeOfType<"MemberExpression">,
+): boolean => {
+  const propertyName = getResolvedStaticPropertyName(context, memberExpression);
+  return propertyName !== null && PROMISE_SETTLE_METHODS.has(propertyName);
+};
+
+interface StaticLogicalValue {
+  isNullish: boolean;
+  isTruthy: boolean;
+}
+
+interface RetainedExpressionFrame {
+  expression: EsTreeNode;
+  isExpanded: boolean;
+}
+
+interface RetainedSourceMatcher {
+  (expression: EsTreeNode): EsTreeNode | null;
+}
+
+interface PatternAssignedValue {
+  expression: EsTreeNode | null;
+}
+
+interface FunctionAliasCandidate {
+  sourceNode: EsTreeNode;
+  symbol: SymbolDescriptor;
+}
+
+interface OfficialAsyncPropContract {
+  directConsumptionPropertyNames?: ReadonlySet<string>;
+  parameterIndex: number;
+  propertyNames: ReadonlySet<string>;
+}
+
+interface OfficialAsyncPropReference {
+  contract: OfficialAsyncPropContract;
+  propertyName: string;
+}
+
+interface OfficialPropsObjectSource {
+  contract: OfficialAsyncPropContract;
+  sourceExpression: EsTreeNode;
+  symbol: SymbolDescriptor;
+}
+
+const getOfficialAsyncPropContract = (
+  context: RuleContext,
+  functionNode: EsTreeNode,
+): OfficialAsyncPropContract | null => {
+  const basename = path.basename(context.filename ?? "");
+  const normalizedFilename = normalizeFilename(context.filename ?? "");
+  const isSitemapFile =
+    (isInProjectDirectory(context, "app") || normalizedFilename.startsWith("app/")) &&
+    SITEMAP_FILE_PATTERN.test(basename);
+  if (!isSitemapFile && !isFrameworkRouteOrSpecialFilename(context, "next")) return null;
+  const program = findProgramRoot(functionNode);
+  if (!program) return null;
+  const routeKind = basename.split(".")[0] ?? "";
+  const exportedValueMatchesFunction = (exportedValue: EsTreeNode | null): boolean => {
+    if (exportedValue === functionNode) return true;
+    if (!exportedValue || !isNodeOfType(exportedValue, "Identifier")) return false;
+    const symbol = resolveConstIdentifierAlias(exportedValue, context.scopes);
+    return Boolean(
+      symbol && (symbol.initializer === functionNode || symbol.declarationNode === functionNode),
+    );
+  };
+  const isDefaultExport = exportedValueMatchesFunction(findExportedValue(program, "default"));
+  const isPage = routeKind === "page";
+  if (isDefaultExport) {
+    if (isPage) {
+      return { parameterIndex: 0, propertyNames: new Set(["params", "searchParams"]) };
+    }
+    if (
+      routeKind === "layout" ||
+      routeKind === "default" ||
+      (isNextjsMetadataImageRouteFilename(context.filename) &&
+        hasCapability(context.settings, "nextjs:16"))
+    ) {
+      return {
+        directConsumptionPropertyNames: isNextjsMetadataImageRouteFilename(context.filename)
+          ? new Set(["id"])
+          : undefined,
+        parameterIndex: 0,
+        propertyNames: isNextjsMetadataImageRouteFilename(context.filename)
+          ? new Set(["id", "params"])
+          : new Set(["params"]),
+      };
+    }
+    if (isSitemapFile && hasCapability(context.settings, "nextjs:16")) {
+      return {
+        directConsumptionPropertyNames: new Set(["id"]),
+        parameterIndex: 0,
+        propertyNames: new Set(["id"]),
+      };
+    }
+  }
+  if (routeKind === "route") {
+    for (const methodName of ROUTE_HANDLER_HTTP_METHODS) {
+      if (exportedValueMatchesFunction(findExportedValue(program, methodName))) {
+        return { parameterIndex: 1, propertyNames: new Set(["params"]) };
+      }
+    }
+    return null;
+  }
+  if (routeKind !== "page" && routeKind !== "layout") return null;
+  if (
+    !exportedValueMatchesFunction(findExportedValue(program, "generateMetadata")) &&
+    !exportedValueMatchesFunction(findExportedValue(program, "generateViewport"))
+  ) {
+    return null;
+  }
+  return {
+    parameterIndex: 0,
+    propertyNames: isPage ? new Set(["params", "searchParams"]) : new Set(["params"]),
+  };
+};
+
+const findParameterPropertyName = (
+  parameter: EsTreeNode,
+  bindingIdentifier: EsTreeNode,
+): string | null => {
+  const pattern = isNodeOfType(parameter, "AssignmentPattern") ? parameter.left : parameter;
+  if (!isNodeOfType(pattern, "ObjectPattern")) return null;
+  for (const property of pattern.properties) {
+    if (!isNodeOfType(property, "Property")) continue;
+    let propertyBinding = property.value;
+    if (isNodeOfType(propertyBinding, "AssignmentPattern")) {
+      propertyBinding = propertyBinding.left;
+    }
+    if (propertyBinding !== bindingIdentifier) continue;
+    return getStaticPropertyKeyName(property, { allowComputedString: true });
+  }
+  return null;
+};
+
+const findObjectRestElementForSymbol = (
+  context: RuleContext,
+  pattern: EsTreeNode,
+  symbol: SymbolDescriptor,
+): EsTreeNode | null => {
+  if (!isNodeOfType(pattern, "ObjectPattern")) return null;
+  return (
+    pattern.properties.find(
+      (property) =>
+        isNodeOfType(property, "RestElement") &&
+        context.scopes.symbolFor(property.argument)?.id === symbol.id,
+    ) ?? null
+  );
+};
+
+const narrowContractForObjectRest = (
+  pattern: EsTreeNode,
+  contract: OfficialAsyncPropContract,
+): OfficialAsyncPropContract | null => {
+  if (!isNodeOfType(pattern, "ObjectPattern")) return null;
+  const propertyNames = new Set(contract.propertyNames);
+  for (const property of pattern.properties) {
+    if (!isNodeOfType(property, "Property")) continue;
+    const propertyName = getStaticPropertyKeyName(property, { allowComputedString: true });
+    if (propertyName === null) return null;
+    propertyNames.delete(propertyName);
+  }
+  const directConsumptionPropertyNames = contract.directConsumptionPropertyNames
+    ? new Set(contract.directConsumptionPropertyNames)
+    : undefined;
+  if (directConsumptionPropertyNames) {
+    for (const propertyName of contract.propertyNames) {
+      if (!propertyNames.has(propertyName)) directConsumptionPropertyNames.delete(propertyName);
+    }
+  }
+  return { directConsumptionPropertyNames, parameterIndex: contract.parameterIndex, propertyNames };
+};
+
+const findOfficialPropsObjectSource = (
+  context: RuleContext,
+  expression: EsTreeNode,
+  visitedSymbolIds: Set<number> = new Set(),
+): OfficialPropsObjectSource | null => {
+  const node = stripParenExpression(expression);
+  if (!isNodeOfType(node, "Identifier")) return null;
+  const directSymbol = context.scopes.symbolFor(node);
+  if (!directSymbol || visitedSymbolIds.has(directSymbol.id)) return null;
+  visitedSymbolIds.add(directSymbol.id);
+  const symbol = resolveConstIdentifierAlias(node, context.scopes) ?? directSymbol;
+  if (!symbol) return null;
+  const functionNode = context.cfg.enclosingFunction(symbol.bindingIdentifier);
+  if (functionNode && isFunctionLike(functionNode)) {
+    const contract = getOfficialAsyncPropContract(context, functionNode);
+    const parameter = contract ? functionNode.params[contract.parameterIndex] : null;
+    const parameterPattern =
+      parameter && isNodeOfType(parameter, "AssignmentPattern") ? parameter.left : parameter;
+    const isDirectParameter = parameterPattern === symbol.bindingIdentifier;
+    const restElement =
+      contract && parameterPattern
+        ? findObjectRestElementForSymbol(context, parameterPattern, symbol)
+        : null;
+    if (contract && isDirectParameter) {
+      return { contract, sourceExpression: symbol.bindingIdentifier, symbol };
+    }
+    if (contract && parameterPattern && restElement) {
+      const narrowedContract = narrowContractForObjectRest(parameterPattern, contract);
+      return narrowedContract
+        ? { contract: narrowedContract, sourceExpression: restElement, symbol }
+        : null;
+    }
+  }
+  if (
+    directSymbol.kind === "const" &&
+    directSymbol.initializer &&
+    isNodeOfType(directSymbol.declarationNode, "VariableDeclarator")
+  ) {
+    const declarationPattern = directSymbol.declarationNode.id;
+    const restElement = findObjectRestElementForSymbol(context, declarationPattern, directSymbol);
+    if (restElement) {
+      const source = findOfficialPropsObjectSource(
+        context,
+        directSymbol.initializer,
+        new Set(visitedSymbolIds),
+      );
+      const narrowedContract = source
+        ? narrowContractForObjectRest(declarationPattern, source.contract)
+        : null;
+      return source && narrowedContract
+        ? { contract: narrowedContract, sourceExpression: restElement, symbol: directSymbol }
+        : null;
+    }
+  }
+  const assignmentCandidates = directSymbol.references
+    .map((reference) => findPatternAssignmentForIdentifier(reference.identifier))
+    .filter((assignment): assignment is EsTreeNodeOfType<"AssignmentExpression"> =>
+      Boolean(
+        assignment &&
+        assignment.operator === "=" &&
+        findObjectRestElementForSymbol(context, assignment.left, directSymbol) &&
+        nodeDominatesNode(assignment, expression, context),
+      ),
+    )
+    .sort((left, right) => getNodeStartIndex(right) - getNodeStartIndex(left));
+  for (const assignment of assignmentCandidates) {
+    const source = findOfficialPropsObjectSource(
+      context,
+      assignment.right,
+      new Set(visitedSymbolIds),
+    );
+    const narrowedContract = source
+      ? narrowContractForObjectRest(assignment.left, source.contract)
+      : null;
+    if (source && narrowedContract) {
+      return { contract: narrowedContract, sourceExpression: assignment, symbol: directSymbol };
+    }
+  }
+  return null;
+};
+
+const memberExpressionMatchesOfficialProperty = (
+  context: RuleContext,
+  expression: EsTreeNode,
+  sourceSymbol: SymbolDescriptor,
+  propertyName: string,
+): boolean => {
+  const node = stripParenExpression(expression);
+  if (
+    !isNodeOfType(node, "MemberExpression") ||
+    getResolvedStaticPropertyName(context, node) !== propertyName
+  ) {
+    return false;
+  }
+  const receiver = stripParenExpression(node.object);
+  if (!isNodeOfType(receiver, "Identifier")) return false;
+  const receiverSymbol =
+    resolveConstIdentifierAlias(receiver, context.scopes) ?? context.scopes.symbolFor(receiver);
+  return receiverSymbol?.id === sourceSymbol.id;
+};
+
+const assignmentUnwrapsOfficialProperty = (
+  context: RuleContext,
+  assignment: EsTreeNodeOfType<"AssignmentExpression">,
+  sourceSymbol: SymbolDescriptor,
+  propertyName: string,
+): boolean => {
+  if (
+    assignment.operator !== "=" ||
+    !memberExpressionMatchesOfficialProperty(context, assignment.left, sourceSymbol, propertyName)
+  ) {
+    return false;
+  }
+  const right = stripParenExpression(assignment.right);
+  if (isNodeOfType(right, "AwaitExpression")) {
+    return true;
+  }
+  if (
+    isNodeOfType(right, "CallExpression") &&
+    isReactApiCall(right, "use", context.scopes, { resolveNamedAliases: true }) &&
+    right.arguments[0] &&
+    !isNodeOfType(right.arguments[0], "SpreadElement")
+  ) {
+    return true;
+  }
+  return !expressionMayRetainOfficialPendingValue(context, right);
+};
+
+const collectOfficialPropertyClearingNodes = (
+  context: RuleContext,
+  source: OfficialPropsObjectSource,
+  propertyName: string,
+): EsTreeNode[] => {
+  const owner = context.cfg.enclosingFunction(source.sourceExpression);
+  if (!owner) return [];
+  const clearingNodes: EsTreeNode[] = [];
+  walkAst(owner, (node) => {
+    if (isNodeOfType(node, "AssignmentExpression")) {
+      if (
+        node.operator === "="
+          ? assignmentUnwrapsOfficialProperty(context, node, source.symbol, propertyName)
+          : node.operator !== "||=" &&
+            node.operator !== "??=" &&
+            memberExpressionMatchesOfficialProperty(context, node.left, source.symbol, propertyName)
+      ) {
+        clearingNodes.push(node);
+      }
+      return;
+    }
+    if (
+      isNodeOfType(node, "UpdateExpression") &&
+      memberExpressionMatchesOfficialProperty(context, node.argument, source.symbol, propertyName)
+    ) {
+      clearingNodes.push(node);
+    }
+  });
+  return projectGuaranteedClearingNodes(context, clearingNodes, owner);
+};
+
+const officialPropertyIsClearedBeforeReferenceInOwner = (
+  context: RuleContext,
+  source: OfficialPropsObjectSource,
+  propertyName: string,
+  reference: EsTreeNode,
+): boolean => {
+  const referenceOwner = context.cfg.enclosingFunction(reference);
+  if (
+    !referenceOwner ||
+    referenceOwner === context.cfg.enclosingFunction(source.sourceExpression)
+  ) {
+    return false;
+  }
+  const clearingNodes: EsTreeNode[] = [];
+  walkAst(referenceOwner, (node) => {
+    if (node !== referenceOwner && isFunctionLike(node)) return false;
+    if (
+      isNodeOfType(node, "AssignmentExpression") &&
+      !findCaughtTryStatement(node) &&
+      (node.operator === "="
+        ? assignmentUnwrapsOfficialProperty(context, node, source.symbol, propertyName)
+        : node.operator !== "||=" &&
+          node.operator !== "??=" &&
+          memberExpressionMatchesOfficialProperty(context, node.left, source.symbol, propertyName))
+    ) {
+      clearingNodes.push(node);
+    }
+  });
+  return projectGuaranteedClearingNodes(context, clearingNodes, referenceOwner).some(
+    (executionSite) => nodeDominatesNode(executionSite, reference, context),
+  );
+};
+
+const findOfficialAsyncRequestPropReference = (
+  context: RuleContext,
+  expression: EsTreeNode,
+): OfficialAsyncPropReference | null => {
+  const node = stripParenExpression(expression);
+  let bindingIdentifier: EsTreeNode | null = null;
+  let propertyName: string | null = null;
+  if (isNodeOfType(node, "Identifier")) {
+    const symbol = context.scopes.symbolFor(node);
+    if (!symbol) return null;
+    bindingIdentifier = symbol.bindingIdentifier;
+  } else if (isNodeOfType(node, "MemberExpression")) {
+    const receiver = stripParenExpression(node.object);
+    if (!isNodeOfType(receiver, "Identifier")) return null;
+    propertyName = getStaticPropertyName(node);
+    const propsSource = findOfficialPropsObjectSource(context, receiver);
+    if (
+      !propsSource ||
+      propertyName === null ||
+      !propsSource.contract.propertyNames.has(propertyName) ||
+      officialPropertyIsClearedBeforeReferenceInOwner(context, propsSource, propertyName, node) ||
+      createPendingSymbolFlow(
+        context,
+        propsSource.symbol,
+        propsSource.sourceExpression,
+        collectOfficialPropertyClearingNodes(context, propsSource, propertyName),
+      ).isClearedBefore(node)
+    ) {
+      return null;
+    }
+    return { contract: propsSource.contract, propertyName };
+  } else {
+    return null;
+  }
+  const functionNode = context.cfg.enclosingFunction(bindingIdentifier);
+  if (!functionNode || !isFunctionLike(functionNode)) return null;
+  const bindingSymbol = context.scopes.symbolFor(bindingIdentifier);
+  if (!bindingSymbol) return null;
+  const contract = getOfficialAsyncPropContract(context, functionNode);
+  if (!contract) return null;
+  const parameter = functionNode.params[contract.parameterIndex];
+  if (!parameter) return null;
+  const destructuredPropertyName = findParameterPropertyName(parameter, bindingIdentifier);
+  if (
+    !destructuredPropertyName ||
+    !contract.propertyNames.has(destructuredPropertyName) ||
+    createPendingSymbolFlow(context, bindingSymbol, bindingIdentifier).isClearedBefore(node)
+  ) {
+    return null;
+  }
+  return { contract, propertyName: destructuredPropertyName };
+};
+
+const isOfficialAsyncRequestPropSource = (context: RuleContext, expression: EsTreeNode): boolean =>
+  Boolean(findOfficialAsyncRequestPropReference(context, expression));
+
+const isOfficialDirectValueSource = (context: RuleContext, expression: EsTreeNode): boolean => {
+  const reference = findOfficialAsyncRequestPropReference(context, expression);
+  return Boolean(reference?.contract.directConsumptionPropertyNames?.has(reference.propertyName));
+};
+
+const getStaticLogicalValue = (
+  context: RuleContext,
+  expression: EsTreeNode,
+): StaticLogicalValue | null => {
+  let node = stripParenExpression(expression);
+  let hasBooleanNegation = false;
+  let shouldInvertTruthy = false;
+  while (isNodeOfType(node, "UnaryExpression") && node.operator === "!") {
+    hasBooleanNegation = true;
+    shouldInvertTruthy = !shouldInvertTruthy;
+    node = stripParenExpression(node.argument);
+  }
+
+  let value: StaticLogicalValue | null = null;
+  if (isNodeOfType(node, "Literal")) {
+    value = { isNullish: node.value === null, isTruthy: Boolean(node.value) };
+  } else if (
+    isNodeOfType(node, "ArrayExpression") ||
+    isNodeOfType(node, "ObjectExpression") ||
+    isNodeOfType(node, "ArrowFunctionExpression") ||
+    isNodeOfType(node, "FunctionExpression") ||
+    isNodeOfType(node, "ClassExpression") ||
+    isNodeOfType(node, "NewExpression")
+  ) {
+    value = { isNullish: false, isTruthy: true };
+  } else if (isNodeOfType(node, "TemplateLiteral")) {
+    const hasStaticContent = node.quasis.some(
+      (quasi) => (quasi.value.cooked ?? quasi.value.raw).length > 0,
+    );
+    if (hasStaticContent || node.expressions.length === 0) {
+      value = { isNullish: false, isTruthy: hasStaticContent };
+    }
+  } else if (isNodeOfType(node, "UnaryExpression") && node.operator === "void") {
+    value = { isNullish: true, isTruthy: false };
+  } else if (isNodeOfType(node, "UnaryExpression") && node.operator === "typeof") {
+    value = { isNullish: false, isTruthy: true };
+  } else if (
+    isNodeOfType(node, "Identifier") &&
+    context.scopes.isGlobalReference(node) &&
+    (node.name === "undefined" || node.name === "NaN" || node.name === "Infinity")
+  ) {
+    value = {
+      isNullish: node.name === "undefined",
+      isTruthy: node.name === "Infinity",
+    };
+  }
+  if (!value || !hasBooleanNegation) return value;
+  return {
+    isNullish: false,
+    isTruthy: shouldInvertTruthy ? !value.isTruthy : value.isTruthy,
+  };
+};
+
+const logicalRightCanBecomeResult = (
+  operator: EsTreeNodeOfType<"LogicalExpression">["operator"],
+  leftValue: StaticLogicalValue,
+): boolean => {
+  if (operator === "&&") return leftValue.isTruthy;
+  if (operator === "||") return !leftValue.isTruthy;
+  return leftValue.isNullish;
+};
+
+const expressionIsGuaranteedNullish = (context: RuleContext, expression: EsTreeNode): boolean => {
+  const staticValue = getStaticLogicalValue(context, expression);
+  if (staticValue) return staticValue.isNullish;
+  if (isNodeOfType(expression, "ConditionalExpression")) {
+    const testValue = getStaticLogicalValue(context, expression.test);
+    return Boolean(
+      testValue &&
+      expressionIsGuaranteedNullish(
+        context,
+        testValue.isTruthy ? expression.consequent : expression.alternate,
+      ),
+    );
+  }
+  if (isNodeOfType(expression, "LogicalExpression")) {
+    const leftValue = getStaticLogicalValue(context, expression.left);
+    if (!leftValue) return false;
+    return logicalRightCanBecomeResult(expression.operator, leftValue)
+      ? expressionIsGuaranteedNullish(context, expression.right)
+      : leftValue.isNullish;
+  }
+  if (isNodeOfType(expression, "SequenceExpression")) {
+    const finalExpression = expression.expressions.at(-1);
+    return Boolean(finalExpression && expressionIsGuaranteedNullish(context, finalExpression));
+  }
+  if (isNodeOfType(expression, "AssignmentExpression")) {
+    return expressionIsGuaranteedNullish(context, expression.right);
+  }
+  if (isNodeOfType(expression, "ChainExpression")) {
+    return optionalChainStaticallyShortCircuits(context, expression.expression);
+  }
+  return (
+    (isNodeOfType(expression, "MemberExpression") || isNodeOfType(expression, "CallExpression")) &&
+    optionalChainStaticallyShortCircuits(context, expression)
+  );
+};
+
+const optionalChainStaticallyShortCircuits = (
+  context: RuleContext,
+  expression: EsTreeNode,
+): boolean => {
+  let current = expression;
+  while (true) {
+    if (isNodeOfType(current, "MemberExpression")) {
+      if (current.optional && expressionIsGuaranteedNullish(context, current.object)) return true;
+      current = current.object;
+      continue;
+    }
+    if (isNodeOfType(current, "CallExpression")) {
+      if (current.optional && expressionIsGuaranteedNullish(context, current.callee)) return true;
+      current = current.callee;
+      continue;
+    }
+    return false;
+  }
+};
+
+const getStaticSymbolValueBefore = (
+  context: RuleContext,
+  identifier: EsTreeNode,
+  referenceNode: EsTreeNode,
+): StaticLogicalValue | null => {
+  const symbol = context.scopes.symbolFor(identifier);
+  if (!symbol) return null;
+  let valueExpression = symbol.initializer;
+  let valueStart = valueExpression ? getNodeStartIndex(valueExpression) : -1;
+  for (const reference of symbol.references) {
+    if (reference.flag === "read") continue;
+    const assignment = findPatternAssignmentForIdentifier(reference.identifier);
+    if (
+      !assignment ||
+      assignment.operator !== "=" ||
+      context.cfg.enclosingFunction(assignment) !== context.cfg.enclosingFunction(referenceNode) ||
+      !nodeDominatesNode(assignment, referenceNode, context)
+    ) {
+      continue;
+    }
+    const assignmentStart = getNodeStartIndex(assignment);
+    if (assignmentStart <= valueStart || assignmentStart >= getNodeStartIndex(referenceNode)) {
+      continue;
+    }
+    const assignedValue = findPatternAssignedValue(
+      context,
+      assignment.left,
+      assignment.right,
+      symbol,
+    );
+    if (!assignedValue) continue;
+    valueExpression = assignedValue.expression;
+    valueStart = assignmentStart;
+  }
+  if (valueExpression) return getStaticLogicalValue(context, valueExpression);
+  return isNodeOfType(symbol.declarationNode, "VariableDeclarator")
+    ? { isNullish: true, isTruthy: false }
+    : null;
+};
+
+const expressionIsStaticallySkipped = (
+  context: RuleContext,
+  expression: EsTreeNode,
+  logicalAssignmentReference: EsTreeNode | null = null,
+): boolean => {
+  let current = expression;
+  while (current.parent) {
+    const parent = current.parent;
+    if (isFunctionLike(parent)) return false;
+    if (isNodeOfType(parent, "LogicalExpression") && parent.right === current) {
+      const leftValue = getStaticLogicalValue(context, parent.left);
+      if (leftValue && !logicalRightCanBecomeResult(parent.operator, leftValue)) return true;
+    } else if (isNodeOfType(parent, "ConditionalExpression") && parent.test !== current) {
+      const testValue = getStaticLogicalValue(context, parent.test);
+      if (
+        testValue &&
+        ((parent.consequent === current && !testValue.isTruthy) ||
+          (parent.alternate === current && testValue.isTruthy))
+      ) {
+        return true;
+      }
+    } else if (isNodeOfType(parent, "IfStatement") && parent.test !== current) {
+      const testValue = getStaticLogicalValue(context, parent.test);
+      if (
+        testValue &&
+        ((parent.consequent === current && !testValue.isTruthy) ||
+          (parent.alternate === current && testValue.isTruthy))
+      ) {
+        return true;
+      }
+    } else if (
+      isNodeOfType(parent, "WhileStatement") &&
+      parent.body === current &&
+      getStaticLogicalValue(context, parent.test)?.isTruthy === false
+    ) {
+      return true;
+    } else if (
+      isNodeOfType(parent, "ForStatement") &&
+      (parent.body === current || parent.update === current) &&
+      parent.test &&
+      getStaticLogicalValue(context, parent.test)?.isTruthy === false
+    ) {
+      return true;
+    } else if (
+      isNodeOfType(parent, "AssignmentExpression") &&
+      parent.right === current &&
+      (parent.operator === "&&=" || parent.operator === "||=" || parent.operator === "??=")
+    ) {
+      const target = stripParenExpression(parent.left);
+      const leftValue = isNodeOfType(target, "Identifier")
+        ? getStaticSymbolValueBefore(context, target, logicalAssignmentReference ?? parent)
+        : null;
+      if (
+        leftValue &&
+        ((parent.operator === "&&=" && !leftValue.isTruthy) ||
+          (parent.operator === "||=" && leftValue.isTruthy) ||
+          (parent.operator === "??=" && !leftValue.isNullish))
+      ) {
+        return true;
+      }
+    } else if (
+      isNodeOfType(parent, "MemberExpression") &&
+      parent.computed &&
+      parent.property === current &&
+      optionalChainStaticallyShortCircuits(context, parent)
+    ) {
+      return true;
+    } else if (
+      isNodeOfType(parent, "CallExpression") &&
+      parent.arguments.some((argument) => argument === current) &&
+      optionalChainStaticallyShortCircuits(context, parent)
+    ) {
+      return true;
+    }
+    current = parent;
+  }
+  return false;
+};
+
+const findRetainedExpressionSource = (
+  context: RuleContext,
+  expression: EsTreeNode,
+  matchSource: RetainedSourceMatcher,
+): EsTreeNode | null => {
+  const sourceByExpression = new Map<EsTreeNode, EsTreeNode | null>();
+  const pendingFrames: RetainedExpressionFrame[] = [{ expression, isExpanded: false }];
+
+  while (pendingFrames.length > 0) {
+    const frame = pendingFrames.pop();
+    if (!frame) continue;
+    if (castChainAssertsUnsafeUnwrapped(context, frame.expression)) {
+      sourceByExpression.set(frame.expression, null);
+      continue;
+    }
+    const node = stripParenExpression(frame.expression);
+    if (!frame.isExpanded) {
+      pendingFrames.push({ expression: frame.expression, isExpanded: true });
+      if (isNodeOfType(node, "ConditionalExpression")) {
+        const staticTestValue = getStaticLogicalValue(context, node.test);
+        if (staticTestValue) {
+          pendingFrames.push({
+            expression: staticTestValue.isTruthy ? node.consequent : node.alternate,
+            isExpanded: false,
+          });
+        } else {
+          pendingFrames.push({ expression: node.consequent, isExpanded: false });
+          pendingFrames.push({ expression: node.alternate, isExpanded: false });
+        }
+      } else if (isNodeOfType(node, "LogicalExpression")) {
+        pendingFrames.push({ expression: node.left, isExpanded: false });
+        pendingFrames.push({ expression: node.right, isExpanded: false });
+      } else if (isNodeOfType(node, "SequenceExpression")) {
+        const finalExpression = node.expressions.at(-1);
+        if (finalExpression) {
+          pendingFrames.push({ expression: finalExpression, isExpanded: false });
+        }
+      } else if (isNodeOfType(node, "AssignmentExpression")) {
+        pendingFrames.push({ expression: node.right, isExpanded: false });
+      } else if (isNodeOfType(node, "CallExpression")) {
+        const callee = stripParenExpression(node.callee);
+        if (isNodeOfType(callee, "MemberExpression") && isPromiseSettleAccess(context, callee)) {
+          pendingFrames.push({ expression: callee.object, isExpanded: false });
+        }
+      }
+      continue;
+    }
+
+    const directSource = matchSource(node);
+    if (directSource) {
+      sourceByExpression.set(frame.expression, directSource);
+      continue;
+    }
+
+    let retainedSource: EsTreeNode | null = null;
+    if (isNodeOfType(node, "ConditionalExpression")) {
+      const staticTestValue = getStaticLogicalValue(context, node.test);
+      if (staticTestValue) {
+        retainedSource =
+          sourceByExpression.get(staticTestValue.isTruthy ? node.consequent : node.alternate) ??
+          null;
+      } else {
+        retainedSource =
+          sourceByExpression.get(node.alternate) ?? sourceByExpression.get(node.consequent) ?? null;
+      }
+    } else if (isNodeOfType(node, "LogicalExpression")) {
+      const leftSource = sourceByExpression.get(node.left) ?? null;
+      const rightSource = sourceByExpression.get(node.right) ?? null;
+      if (leftSource) {
+        retainedSource = node.operator === "&&" ? rightSource : leftSource;
+      } else {
+        const staticLeftValue = getStaticLogicalValue(context, node.left);
+        retainedSource =
+          !staticLeftValue || logicalRightCanBecomeResult(node.operator, staticLeftValue)
+            ? rightSource
+            : null;
+      }
+    } else if (isNodeOfType(node, "SequenceExpression")) {
+      const finalExpression = node.expressions.at(-1);
+      retainedSource = finalExpression ? (sourceByExpression.get(finalExpression) ?? null) : null;
+    } else if (isNodeOfType(node, "AssignmentExpression")) {
+      retainedSource = sourceByExpression.get(node.right) ?? null;
+    } else if (isNodeOfType(node, "CallExpression")) {
+      const callee = stripParenExpression(node.callee);
+      if (isNodeOfType(callee, "MemberExpression") && isPromiseSettleAccess(context, callee)) {
+        retainedSource = sourceByExpression.get(callee.object) ?? null;
+      }
+    }
+    sourceByExpression.set(frame.expression, retainedSource);
+  }
+  return sourceByExpression.get(expression) ?? null;
+};
+
+const expressionMayRetainOfficialPendingValue = (
+  context: RuleContext,
+  expression: EsTreeNode,
+): boolean => {
+  const activeSymbolReferences = new Set<string>();
+  const findSource = (candidate: EsTreeNode): EsTreeNode | null =>
+    findRetainedExpressionSource(context, candidate, (nestedCandidate) => {
+      if (isNextHeadersDynamicCall(context, nestedCandidate)) return nestedCandidate;
+      if (isNodeOfType(nestedCandidate, "MemberExpression")) {
+        const receiver = stripParenExpression(nestedCandidate.object);
+        const propertyName = getResolvedStaticPropertyName(context, nestedCandidate);
+        const propsSource = isNodeOfType(receiver, "Identifier")
+          ? findOfficialPropsObjectSource(context, receiver)
+          : null;
+        return propsSource && propertyName && propsSource.contract.propertyNames.has(propertyName)
+          ? nestedCandidate
+          : null;
+      }
+      if (!isNodeOfType(nestedCandidate, "Identifier")) return null;
+      if (findOfficialAsyncRequestPropReference(context, nestedCandidate)) return nestedCandidate;
+      const symbol = context.scopes.symbolFor(nestedCandidate);
+      if (symbol && isNodeOfType(symbol.declarationNode, "VariableDeclarator")) {
+        const declaration = symbol.declarationNode;
+        const propertyName = findParameterPropertyName(declaration.id, symbol.bindingIdentifier);
+        const propsSource = declaration.init
+          ? findOfficialPropsObjectSource(context, declaration.init)
+          : null;
+        if (
+          propertyName &&
+          propsSource?.contract.propertyNames.has(propertyName) &&
+          !createPendingSymbolFlow(context, symbol, symbol.bindingIdentifier).isClearedBefore(
+            nestedCandidate,
+          )
+        ) {
+          return nestedCandidate;
+        }
+      }
+      if (!symbol) return null;
+      const candidateStart = getNodeStartIndex(nestedCandidate);
+      const activeReferenceKey = `${symbol.id}:${candidateStart}`;
+      if (activeSymbolReferences.has(activeReferenceKey)) return null;
+      activeSymbolReferences.add(activeReferenceKey);
+      const candidateSources: EsTreeNode[] = symbol.initializer ? [symbol.initializer] : [];
+      for (const reference of symbol.references) {
+        if (reference.flag === "read") continue;
+        const assignment = findPatternAssignmentForIdentifier(reference.identifier);
+        if (
+          !assignment ||
+          (assignment.operator !== "=" &&
+            assignment.operator !== "&&=" &&
+            assignment.operator !== "||=" &&
+            assignment.operator !== "??=")
+        ) {
+          continue;
+        }
+        const assignedValue = findPatternAssignedValue(
+          context,
+          assignment.left,
+          assignment.right,
+          symbol,
+        );
+        if (assignedValue?.expression) candidateSources.push(assignedValue.expression);
+      }
+      const candidateOwner = context.cfg.enclosingFunction(nestedCandidate);
+      for (const sourceExpression of candidateSources) {
+        if (
+          context.cfg.enclosingFunction(sourceExpression) === candidateOwner &&
+          expressionIsStaticallySkipped(context, sourceExpression)
+        ) {
+          continue;
+        }
+        const source = findSource(sourceExpression);
+        if (!source) continue;
+        const sourceOwner = context.cfg.enclosingFunction(sourceExpression);
+        const sourceMayEscapeWithPending = Boolean(
+          sourceOwner &&
+          isFunctionLike(sourceOwner) &&
+          sourceOwnerMayEscapeWithPending(context, symbol, sourceExpression),
+        );
+        const liveCaughtInvocations =
+          sourceOwner && isFunctionLike(sourceOwner)
+            ? getDirectInvocationSites(context, sourceOwner).filter(
+                (invocationSite) =>
+                  isNodeReachableWithinFunction(invocationSite, context) &&
+                  !expressionIsStaticallySkipped(context, invocationSite) &&
+                  caughtInvocationMayContinue(invocationSite),
+              )
+            : [];
+        const allCaughtInvocationsClear =
+          liveCaughtInvocations.length > 0 &&
+          liveCaughtInvocations.every((invocationSite) =>
+            caughtHandlerDefinitelyClearsSymbol(context, symbol, invocationSite),
+          );
+        const hasCaughtInvocation =
+          liveCaughtInvocations.length > 0 &&
+          sourceMayEscapeWithPending &&
+          !allCaughtInvocationsClear;
+        const sourceFlow = createPendingSymbolFlow(context, symbol, sourceExpression);
+        if (
+          sourceOwner !== candidateOwner &&
+          !hasCaughtInvocation &&
+          (sourceFlow.isClearedAtExit ||
+            (liveCaughtInvocations.length > 0 &&
+              (!sourceMayEscapeWithPending || allCaughtInvocationsClear)))
+        ) {
+          continue;
+        }
+        const sourceExecutionSites = getRetainedSourceExecutionSites(
+          context,
+          symbol,
+          sourceExpression,
+          candidateOwner,
+        );
+        for (const sourceExecutionSite of sourceExecutionSites) {
+          const sourceExecutionStart = getNodeStartIndex(sourceExecutionSite);
+          if (
+            sourceExecutionStart >= candidateStart ||
+            !isNodeReachableWithinFunction(sourceExecutionSite, context) ||
+            expressionIsStaticallySkipped(context, sourceExecutionSite) ||
+            expressionIsStaticallySkipped(context, sourceExpression, sourceExecutionSite)
+          ) {
+            continue;
+          }
+          const clearingExecutionSites = getProjectedProvenanceClearingSites({
+            afterStart: sourceExecutionStart,
+            context,
+            symbol,
+            targetOwner: candidateOwner,
+          });
+          if (
+            !createPendingSymbolFlow(
+              context,
+              symbol,
+              sourceExecutionSite,
+              clearingExecutionSites,
+            ).isClearedBefore(nestedCandidate)
+          ) {
+            activeSymbolReferences.delete(activeReferenceKey);
+            return source;
+          }
+        }
+      }
+      activeSymbolReferences.delete(activeReferenceKey);
+      return null;
+    });
+  return Boolean(findSource(expression));
+};
+
+const symbolMayHoldOfficialPendingValueBefore = (
+  context: RuleContext,
+  symbol: SymbolDescriptor,
+  reference: EsTreeNode,
+): boolean => {
+  const referenceOwner = context.cfg.enclosingFunction(reference);
+  const referenceStart = getNodeStartIndex(reference);
+  const candidateSources: EsTreeNode[] = symbol.initializer ? [symbol.initializer] : [];
+  for (const symbolReference of symbol.references) {
+    if (symbolReference.flag === "read") continue;
+    const assignment = findPatternAssignmentForIdentifier(symbolReference.identifier);
+    if (!assignment || assignment.operator !== "=") continue;
+    const assignedValue = findPatternAssignedValue(
+      context,
+      assignment.left,
+      assignment.right,
+      symbol,
+    );
+    if (assignedValue?.expression) candidateSources.push(assignedValue.expression);
+  }
+  return candidateSources.some(
+    (sourceExpression) =>
+      context.cfg.enclosingFunction(sourceExpression) === referenceOwner &&
+      getNodeStartIndex(sourceExpression) < referenceStart &&
+      !expressionIsStaticallySkipped(context, sourceExpression) &&
+      expressionMayRetainOfficialPendingValue(context, sourceExpression) &&
+      !createPendingSymbolFlow(context, symbol, sourceExpression).isClearedBefore(reference),
+  );
+};
+
+const capturedSymbolMayBePendingAtInvocation = (
+  context: RuleContext,
+  identifier: EsTreeNode,
+): boolean => {
+  const symbol = context.scopes.symbolFor(identifier);
+  const referenceOwner = context.cfg.enclosingFunction(identifier);
+  if (
+    !symbol ||
+    !referenceOwner ||
+    !isFunctionLike(referenceOwner) ||
+    context.cfg.enclosingFunction(symbol.bindingIdentifier) === referenceOwner
+  ) {
+    return false;
+  }
+  return getDirectInvocationSites(context, referenceOwner, {
+    includeCallbackExecutionSites: false,
+  }).some((invocationSite) =>
+    symbolMayHoldOfficialPendingValueBefore(context, symbol, invocationSite),
+  );
+};
+
+const findPendingDynamicApiSource = (
+  context: RuleContext,
+  expression: EsTreeNode,
+): EsTreeNode | null =>
+  findRetainedExpressionSource(context, expression, (candidateExpression) =>
+    isNextHeadersDynamicCall(context, candidateExpression) ||
+    isOfficialAsyncRequestPropSource(context, candidateExpression)
+      ? candidateExpression
+      : null,
+  );
+
+const patternReadsDynamicApiValue = (pattern: EsTreeNode): boolean => {
+  if (isNodeOfType(pattern, "ArrayPattern")) return true;
+  if (!isNodeOfType(pattern, "ObjectPattern")) return false;
+  return pattern.properties.some(
+    (property) =>
+      isNodeOfType(property, "RestElement") ||
+      (isNodeOfType(property, "Property") &&
+        !PROMISE_SETTLE_METHODS.has(
+          getStaticPropertyKeyName(property, { allowComputedString: true }) ?? "",
+        )),
+  );
+};
+
+const isObjectDestructureOfExpression = (parent: EsTreeNode, expression: EsTreeNode): boolean => {
+  if (
+    isNodeOfType(parent, "VariableDeclarator") &&
+    parent.init === expression &&
+    (isNodeOfType(parent.id, "ObjectPattern") || isNodeOfType(parent.id, "ArrayPattern"))
+  ) {
+    return patternReadsDynamicApiValue(parent.id);
+  }
+  return (
+    isNodeOfType(parent, "AssignmentExpression") &&
+    parent.right === expression &&
+    (isNodeOfType(parent.left, "ObjectPattern") || isNodeOfType(parent.left, "ArrayPattern")) &&
+    patternReadsDynamicApiValue(parent.left)
+  );
+};
+
+const expressionMayRetainPendingSymbol = (
+  context: RuleContext,
+  expression: EsTreeNode,
+  symbol: SymbolDescriptor,
+): boolean =>
+  Boolean(
+    findRetainedExpressionSource(context, expression, (candidateExpression) =>
+      isNodeOfType(candidateExpression, "Identifier") &&
+      context.scopes.symbolFor(candidateExpression)?.id === symbol.id
+        ? candidateExpression
+        : null,
+    ),
+  );
+
+const isGlobalEnumerationCallForArgument = (
+  context: RuleContext,
+  callExpression: EsTreeNodeOfType<"CallExpression">,
+  argumentExpression: EsTreeNode,
+): boolean => {
+  const callee = stripParenExpression(callExpression.callee);
+  if (!isNodeOfType(callee, "MemberExpression")) return false;
+  const receiver = stripParenExpression(callee.object);
+  if (!isNodeOfType(receiver, "Identifier") || !context.scopes.isGlobalReference(receiver)) {
+    return false;
+  }
+  const methodName = getStaticPropertyName(callee);
+  const reflectedPropertyName = callExpression.arguments[1]
+    ? getStaticStringValue(context, callExpression.arguments[1])
+    : null;
+  const accessesPromiseSettleProperty = Boolean(
+    reflectedPropertyName && PROMISE_SETTLE_METHODS.has(reflectedPropertyName),
+  );
+  if (receiver.name === "Array") {
+    return methodName === "from" && callExpression.arguments[0] === argumentExpression;
+  }
+  if (receiver.name === "Reflect") {
+    if (
+      accessesPromiseSettleProperty &&
+      (methodName === "get" || methodName === "getOwnPropertyDescriptor" || methodName === "has")
+    ) {
+      return false;
+    }
+    return (
+      (methodName === "get" ||
+        methodName === "getOwnPropertyDescriptor" ||
+        methodName === "has" ||
+        methodName === "ownKeys") &&
+      callExpression.arguments[0] === argumentExpression
+    );
+  }
+  if (
+    receiver.name === "Object" &&
+    methodName === "getOwnPropertyDescriptor" &&
+    accessesPromiseSettleProperty
+  ) {
+    return false;
+  }
+  return (
+    receiver.name === "Object" &&
+    methodName !== null &&
+    ((OBJECT_ENUMERATION_METHOD_NAMES.has(methodName) &&
+      callExpression.arguments[0] === argumentExpression) ||
+      (methodName === "fromEntries" && callExpression.arguments[0] === argumentExpression) ||
+      (methodName === "assign" &&
+        callExpression.arguments.slice(1).some((argument) => argument === argumentExpression)))
+  );
+};
+
+const isGlobalIterableConstructorForArgument = (
+  context: RuleContext,
+  newExpression: EsTreeNodeOfType<"NewExpression">,
+  argumentExpression: EsTreeNode,
+): boolean => {
+  const callee = stripParenExpression(newExpression.callee);
+  return (
+    isNodeOfType(callee, "Identifier") &&
+    ITERABLE_CONSTRUCTOR_NAMES.has(callee.name) &&
+    context.scopes.isGlobalReference(callee) &&
+    newExpression.arguments[0] === argumentExpression
+  );
+};
+
+const isGlobalCoercionCallForArgument = (
+  context: RuleContext,
+  callExpression: EsTreeNodeOfType<"CallExpression">,
+  argumentExpression: EsTreeNode,
+): boolean => {
+  const callee = stripParenExpression(callExpression.callee);
+  if (
+    isNodeOfType(callee, "Identifier") &&
+    COERCIVE_GLOBAL_NAMES.has(callee.name) &&
+    context.scopes.isGlobalReference(callee) &&
+    callExpression.arguments[0] === argumentExpression
+  ) {
+    return true;
+  }
+  if (!isNodeOfType(callee, "MemberExpression")) return false;
+  const receiver = stripParenExpression(callee.object);
+  return Boolean(
+    isNodeOfType(receiver, "Identifier") &&
+    receiver.name === "JSON" &&
+    context.scopes.isGlobalReference(receiver) &&
+    getResolvedStaticPropertyName(context, callee) === "stringify" &&
+    callExpression.arguments[0] === argumentExpression,
+  );
+};
+
+const isPromiseSettlementCall = (
+  context: RuleContext,
+  callExpression: EsTreeNodeOfType<"CallExpression">,
+  calleeRoot: EsTreeNode,
+  memberExpression: EsTreeNodeOfType<"MemberExpression">,
+): boolean =>
+  callExpression.callee === calleeRoot && isPromiseSettleAccess(context, memberExpression);
+
+const expressionIsSynchronouslyConsumed = (
+  context: RuleContext,
+  expression: EsTreeNode,
+): boolean => {
+  let current = findTransparentExpressionRoot(expression);
+  while (current.parent) {
+    const parent = current.parent;
+    if (isNodeOfType(parent, "MemberExpression") && parent.object === current) {
+      if (!isPromiseSettleAccess(context, parent)) return true;
+      const memberRoot = findTransparentExpressionRoot(parent);
+      const call = memberRoot.parent;
+      if (
+        !call ||
+        !isNodeOfType(call, "CallExpression") ||
+        !isPromiseSettlementCall(context, call, memberRoot, parent)
+      ) {
+        return false;
+      }
+      current = findTransparentExpressionRoot(call);
+      continue;
+    }
+    if (isNodeOfType(parent, "SpreadElement") && parent.argument === current) return true;
+    if (
+      (isNodeOfType(parent, "ForOfStatement") || isNodeOfType(parent, "ForInStatement")) &&
+      parent.right === current
+    ) {
+      return true;
+    }
+    if (isNodeOfType(parent, "YieldExpression") && parent.delegate && parent.argument === current) {
+      return true;
+    }
+    if (
+      isNodeOfType(parent, "BinaryExpression") &&
+      (parent.operator !== "in" || parent.right === current)
+    ) {
+      return true;
+    }
+    if (
+      isNodeOfType(parent, "UnaryExpression") &&
+      parent.argument === current &&
+      !NON_CONSUMING_UNARY_OPERATORS.has(parent.operator)
+    ) {
+      return true;
+    }
+    if (
+      isNodeOfType(parent, "TemplateLiteral") &&
+      parent.expressions.some((expression) => expression === current)
+    ) {
+      if (
+        parent.parent &&
+        isNodeOfType(parent.parent, "TaggedTemplateExpression") &&
+        parent.parent.quasi === parent
+      ) {
+        return false;
+      }
+      return true;
+    }
+    if (isNodeOfType(parent, "JSXExpressionContainer") && parent.expression === current) {
+      return true;
+    }
+    if (isObjectDestructureOfExpression(parent, current)) return true;
+    if (isNodeOfType(parent, "CallExpression")) {
+      return (
+        isGlobalEnumerationCallForArgument(context, parent, current) ||
+        isGlobalCoercionCallForArgument(context, parent, current)
+      );
+    }
+    if (isNodeOfType(parent, "NewExpression")) {
+      return isGlobalIterableConstructorForArgument(context, parent, current);
+    }
+    if (isNodeOfType(parent, "ConditionalExpression")) {
+      if (parent.test === current) return false;
+      current = findTransparentExpressionRoot(parent);
+      continue;
+    }
+    if (isNodeOfType(parent, "LogicalExpression")) {
+      current = findTransparentExpressionRoot(parent);
+      continue;
+    }
+    if (
+      (isNodeOfType(parent, "MemberExpression") &&
+        parent.computed &&
+        parent.property === current) ||
+      (isNodeOfType(parent, "Property") && parent.computed && parent.key === current) ||
+      (isNodeOfType(parent, "UpdateExpression") && parent.argument === current) ||
+      (isNodeOfType(parent, "AssignmentExpression") &&
+        parent.operator !== "=" &&
+        parent.left === current)
+    ) {
+      return true;
+    }
+    if (isNodeOfType(parent, "SequenceExpression")) {
+      if (parent.expressions.at(-1) !== current) return false;
+      current = findTransparentExpressionRoot(parent);
+      continue;
+    }
+    if (isNodeOfType(parent, "AssignmentExpression") && parent.right === current) {
+      current = findTransparentExpressionRoot(parent);
+      continue;
+    }
+    return false;
+  }
+  return false;
+};
+
+const findRetainingAliasCandidate = (
+  context: RuleContext,
+  referenceIdentifier: EsTreeNode,
+  sourceSymbol: SymbolDescriptor,
+): PendingSymbolCandidate | null => {
+  let current = findTransparentExpressionRoot(referenceIdentifier);
+  while (current.parent) {
+    const parent = current.parent;
+    if (
+      isNodeOfType(parent, "VariableDeclarator") &&
+      parent.init === current &&
+      isNodeOfType(parent.id, "Identifier")
+    ) {
+      if (!expressionMayRetainPendingSymbol(context, parent.init, sourceSymbol)) return null;
+      const symbol = context.scopes.symbolFor(parent.id);
+      return symbol ? { sourceExpression: parent.init, symbol } : null;
+    }
+    if (
+      isNodeOfType(parent, "AssignmentExpression") &&
+      parent.operator === "=" &&
+      parent.right === current &&
+      isNodeOfType(stripParenExpression(parent.left), "Identifier")
+    ) {
+      if (!expressionMayRetainPendingSymbol(context, parent.right, sourceSymbol)) return null;
+      const symbol = context.scopes.symbolFor(stripParenExpression(parent.left));
+      return symbol ? { sourceExpression: parent.right, symbol } : null;
+    }
+    if (
+      parent.type.endsWith("Statement") ||
+      isNodeOfType(parent, "AwaitExpression") ||
+      isNodeOfType(parent, "ArrowFunctionExpression") ||
+      isNodeOfType(parent, "FunctionExpression")
+    ) {
+      return null;
+    }
+    current = findTransparentExpressionRoot(parent);
+  }
+  return null;
+};
+
+const isDefinitelyUndefinedExpression = (context: RuleContext, expression: EsTreeNode): boolean => {
+  const node = stripParenExpression(expression);
+  return (
+    (isNodeOfType(node, "Identifier") &&
+      node.name === "undefined" &&
+      context.scopes.isGlobalReference(node)) ||
+    (isNodeOfType(node, "UnaryExpression") && node.operator === "void")
+  );
+};
+
+const findPatternAssignedValue = (
+  context: RuleContext,
+  pattern: EsTreeNode,
+  sourceExpression: EsTreeNode | null,
+  targetSymbol: SymbolDescriptor,
+): PatternAssignedValue | null => {
+  if (isNodeOfType(pattern, "Identifier")) {
+    return context.scopes.symbolFor(pattern)?.id === targetSymbol.id
+      ? { expression: sourceExpression }
+      : null;
+  }
+  if (isNodeOfType(pattern, "AssignmentPattern")) {
+    const assignedExpression =
+      sourceExpression === null || isDefinitelyUndefinedExpression(context, sourceExpression)
+        ? pattern.right
+        : sourceExpression;
+    return findPatternAssignedValue(context, pattern.left, assignedExpression, targetSymbol);
+  }
+  if (isNodeOfType(pattern, "ObjectPattern")) {
+    if (sourceExpression === null) return null;
+    const source = stripParenExpression(sourceExpression);
+    if (!isNodeOfType(source, "ObjectExpression")) return null;
+    const hasUnknownSourceProperties = source.properties.some(
+      (property) =>
+        isNodeOfType(property, "SpreadElement") ||
+        (isNodeOfType(property, "Property") &&
+          getStaticPropertyKeyName(property, { allowComputedString: true }) === null),
+    );
+    for (const patternProperty of pattern.properties) {
+      if (!isNodeOfType(patternProperty, "Property")) continue;
+      const propertyName = getStaticPropertyKeyName(patternProperty, { allowComputedString: true });
+      if (propertyName === null) continue;
+      const sourceProperty = source.properties.find(
+        (property) =>
+          isNodeOfType(property, "Property") &&
+          getStaticPropertyKeyName(property, { allowComputedString: true }) === propertyName,
+      );
+      if (!isNodeOfType(sourceProperty, "Property") && hasUnknownSourceProperties) continue;
+      const assignedValue = findPatternAssignedValue(
+        context,
+        patternProperty.value,
+        isNodeOfType(sourceProperty, "Property") ? sourceProperty.value : null,
+        targetSymbol,
+      );
+      if (assignedValue) return assignedValue;
+    }
+    return null;
+  }
+  if (isNodeOfType(pattern, "ArrayPattern")) {
+    if (sourceExpression === null) return null;
+    const source = stripParenExpression(sourceExpression);
+    if (!isNodeOfType(source, "ArrayExpression")) return null;
+    for (const [elementIndex, patternElement] of pattern.elements.entries()) {
+      const sourceElement = source.elements[elementIndex];
+      if (!patternElement) continue;
+      if (
+        source.elements
+          .slice(0, elementIndex + 1)
+          .some((element) => isNodeOfType(element, "SpreadElement"))
+      )
+        continue;
+      const assignedValue = findPatternAssignedValue(
+        context,
+        patternElement,
+        sourceElement && !isNodeOfType(sourceElement, "SpreadElement") ? sourceElement : null,
+        targetSymbol,
+      );
+      if (assignedValue) return assignedValue;
+    }
+  }
+  return null;
+};
+
+const findPatternAssignmentForIdentifier = (
+  identifier: EsTreeNode,
+): EsTreeNodeOfType<"AssignmentExpression"> | null => {
+  let assignmentTarget = findTransparentExpressionRoot(identifier);
+  while (
+    assignmentTarget.parent &&
+    (isNodeOfType(assignmentTarget.parent, "Property") ||
+      isNodeOfType(assignmentTarget.parent, "ObjectPattern") ||
+      isNodeOfType(assignmentTarget.parent, "ArrayPattern") ||
+      isNodeOfType(assignmentTarget.parent, "AssignmentPattern") ||
+      isNodeOfType(assignmentTarget.parent, "RestElement"))
+  ) {
+    assignmentTarget = assignmentTarget.parent;
+  }
+  const assignment = assignmentTarget.parent;
+  return assignment &&
+    isNodeOfType(assignment, "AssignmentExpression") &&
+    assignment.left === assignmentTarget
+    ? assignment
+    : null;
+};
+
+const getProvenanceClearingAssignment = (
+  context: RuleContext,
+  symbol: SymbolDescriptor,
+  writeIdentifier: EsTreeNode,
+): EsTreeNodeOfType<"AssignmentExpression"> | null => {
+  const assignment = findPatternAssignmentForIdentifier(writeIdentifier);
+  if (
+    !assignment ||
+    assignment.operator === "||=" ||
+    assignment.operator === "??=" ||
+    expressionIsStaticallySkipped(context, assignment)
+  ) {
+    return null;
+  }
+  if (assignment.operator !== "=" && assignment.operator !== "&&=") return assignment;
+  const assignedValue = findPatternAssignedValue(
+    context,
+    assignment.left,
+    assignment.right,
+    symbol,
+  );
+  if (
+    !assignedValue ||
+    (assignedValue.expression &&
+      expressionMayRetainPendingSymbol(context, assignedValue.expression, symbol))
+  ) {
+    return null;
+  }
+  return assignment;
+};
+
+const isConditionallyExecutedWithinExpression = (node: EsTreeNode): boolean => {
+  let current = node;
+  while (current.parent) {
+    const parent = current.parent;
+    if (isNodeOfType(parent, "LogicalExpression") && parent.right === current) return true;
+    if (isNodeOfType(parent, "ConditionalExpression") && parent.test !== current) return true;
+    if (
+      isNodeOfType(parent, "AssignmentExpression") &&
+      (parent.operator === "&&=" || parent.operator === "||=" || parent.operator === "??=") &&
+      parent.right === current
+    ) {
+      return true;
+    }
+    if (
+      isNodeOfType(parent, "CallExpression") &&
+      parent.optional &&
+      parent.arguments.some((argument) => argument === current)
+    ) {
+      return true;
+    }
+    if (
+      isNodeOfType(parent, "MemberExpression") &&
+      parent.optional &&
+      parent.computed &&
+      parent.property === current
+    ) {
+      return true;
+    }
+    if (parent.type.endsWith("Statement") || isNodeOfType(parent, "VariableDeclarator")) {
+      return false;
+    }
+    current = parent;
+  }
+  return false;
+};
+
+const findDirectConditionalBranch = (
+  assignment: EsTreeNode,
+): { conditionalExpression: EsTreeNode; isConsequent: boolean } | null => {
+  const assignmentRoot = findTransparentExpressionRoot(assignment);
+  const parent = assignmentRoot.parent;
+  if (!parent || !isNodeOfType(parent, "ConditionalExpression")) return null;
+  if (parent.consequent === assignmentRoot) {
+    return { conditionalExpression: parent, isConsequent: true };
+  }
+  return parent.alternate === assignmentRoot
+    ? { conditionalExpression: parent, isConsequent: false }
+    : null;
+};
+
+const findCaughtTryStatement = (node: EsTreeNode): EsTreeNode | null => {
+  let current = node;
+  while (current.parent) {
+    const parent = current.parent;
+    if (isNodeOfType(parent, "TryStatement") && parent.block === current && parent.handler) {
+      return parent;
+    }
+    if (
+      isNodeOfType(parent, "ArrowFunctionExpression") ||
+      isNodeOfType(parent, "FunctionExpression") ||
+      isNodeOfType(parent, "FunctionDeclaration")
+    ) {
+      return null;
+    }
+    current = parent;
+  }
+  return null;
+};
+
+const aliasIsOverwrittenBeforeInvocation = (
+  context: RuleContext,
+  candidate: FunctionAliasCandidate,
+  invocation: EsTreeNode,
+): boolean => {
+  const sourceStart = getNodeStartIndex(candidate.sourceNode);
+  const invocationStart = getNodeStartIndex(invocation);
+  const invocationOwner = context.cfg.enclosingFunction(invocation);
+  return candidate.symbol.references.some((reference) => {
+    if (reference.flag === "read") return false;
+    const patternAssignment = findPatternAssignmentForIdentifier(reference.identifier);
+    const referenceRoot = findTransparentExpressionRoot(reference.identifier);
+    const directAssignment = referenceRoot.parent;
+    let writeNode = reference.identifier;
+    if (patternAssignment) {
+      writeNode = patternAssignment;
+    } else if (
+      directAssignment &&
+      isNodeOfType(directAssignment, "AssignmentExpression") &&
+      directAssignment.left === referenceRoot
+    ) {
+      writeNode = directAssignment;
+    }
+    const writeStart = getNodeStartIndex(writeNode);
+    return (
+      writeNode !== candidate.sourceNode &&
+      writeStart > sourceStart &&
+      writeStart < invocationStart &&
+      context.cfg.enclosingFunction(writeNode) === invocationOwner &&
+      nodeDominatesNode(writeNode, invocation, context)
+    );
+  });
+};
+
+const edgeKey = (from: BasicBlock, to: BasicBlock): string => `${from.id}:${to.id}`;
+
+const createPendingSymbolFlow = (
+  context: RuleContext,
+  symbol: SymbolDescriptor,
+  sourceExpression: EsTreeNode,
+  additionalClearingNodes: ReadonlyArray<EsTreeNode> = [],
+): PendingSymbolFlow => {
+  const owner = context.cfg.enclosingFunction(sourceExpression);
+  const sourceStart = getNodeStartIndex(sourceExpression);
+  if (sourceStart < 0) return { isClearedAtExit: false, isClearedBefore: () => false };
+
+  const projectedClearingNodes = new Set<EsTreeNode>(
+    additionalClearingNodes.filter(
+      (clearingNode) =>
+        isNodeOfType(clearingNode, "CallExpression") || isNodeOfType(clearingNode, "NewExpression"),
+    ),
+  );
+  const clearingAssignmentSet = new Set<EsTreeNode>(additionalClearingNodes);
+  for (const reference of symbol.references) {
+    if (context.cfg.enclosingFunction(reference.identifier) !== owner) continue;
+    const assignment = getProvenanceClearingAssignment(context, symbol, reference.identifier);
+    if (!assignment) continue;
+    const assignmentStart = getNodeStartIndex(assignment);
+    if (assignmentStart <= sourceStart) continue;
+    clearingAssignmentSet.add(assignment);
+  }
+  const clearingNodes = new Set<EsTreeNode>();
+  const conditionalClearingBranches = new Map<EsTreeNode, ConditionalClearingBranches>();
+  for (const assignment of clearingAssignmentSet) {
+    if (!isConditionallyExecutedWithinExpression(assignment)) {
+      clearingNodes.add(assignment);
+      continue;
+    }
+    const conditionalBranch = findDirectConditionalBranch(assignment);
+    if (!conditionalBranch) continue;
+    const branches = conditionalClearingBranches.get(conditionalBranch.conditionalExpression) ?? {
+      hasAlternate: false,
+      hasConsequent: false,
+    };
+    if (conditionalBranch.isConsequent) branches.hasConsequent = true;
+    else branches.hasAlternate = true;
+    conditionalClearingBranches.set(conditionalBranch.conditionalExpression, branches);
+  }
+  for (const [conditionalExpression, branches] of conditionalClearingBranches) {
+    if (branches.hasConsequent && branches.hasAlternate) clearingNodes.add(conditionalExpression);
+  }
+  if (clearingNodes.size === 0) {
+    return { isClearedAtExit: false, isClearedBefore: () => false };
+  }
+
+  if (!owner) {
+    const unconditionalAssignmentStarts: number[] = [];
+    for (const clearingNode of clearingNodes) {
+      if (context.cfg.isUnconditionalFromEntry(clearingNode)) {
+        unconditionalAssignmentStarts.push(getNodeStartIndex(clearingNode));
+      }
+    }
+    return {
+      isClearedAtExit: false,
+      isClearedBefore: (referenceIdentifier) => {
+        const referenceStart = getNodeStartIndex(referenceIdentifier);
+        return unconditionalAssignmentStarts.some((start) => start < referenceStart);
+      },
+    };
+  }
+  const functionCfg = context.cfg.cfgFor(owner);
+  const isParameterSource =
+    isFunctionLike(owner) &&
+    owner.params.some(
+      (parameter) => parameter === sourceExpression || isAstDescendant(sourceExpression, parameter),
+    );
+  const sourceBlock =
+    functionCfg?.blockOf(sourceExpression) ?? (isParameterSource ? functionCfg?.entry : null);
+  if (!functionCfg || !sourceBlock) {
+    return { isClearedAtExit: false, isClearedBefore: () => false };
+  }
+
+  const clearingStartsByBlock = new Map<BasicBlock, number[]>();
+  const exceptionalCatchEdgeKeys = new Set<string>();
+  const exitingCatchClearings: ExitingCatchClearing[] = [];
+  for (const clearingNode of clearingNodes) {
+    const clearingBlock = functionCfg.blockOf(clearingNode);
+    if (!clearingBlock) continue;
+    const starts = clearingStartsByBlock.get(clearingBlock) ?? [];
+    starts.push(getNodeStartIndex(clearingNode));
+    clearingStartsByBlock.set(clearingBlock, starts);
+
+    const caughtTryStatement = findCaughtTryStatement(clearingNode);
+    if (
+      projectedClearingNodes.has(clearingNode) ||
+      !caughtTryStatement ||
+      !isNodeOfType(caughtTryStatement, "TryStatement")
+    ) {
+      continue;
+    }
+    const catchBlock = functionCfg.blockOf(caughtTryStatement.handler?.body ?? caughtTryStatement);
+    if (catchBlock) {
+      for (const predecessor of catchBlock.predecessors) {
+        if (predecessor.kind === "cond") {
+          exceptionalCatchEdgeKeys.add(edgeKey(predecessor.from, predecessor.to));
+        }
+      }
+    }
+    if (caughtTryStatement.handler && statementAlwaysExits(caughtTryStatement.handler.body)) {
+      exitingCatchClearings.push({ clearingNode, tryStatement: caughtTryStatement });
+    }
+  }
+
+  const reachableBlocks = new Set<BasicBlock>([sourceBlock]);
+  const pendingBlocks = [sourceBlock];
+  while (pendingBlocks.length > 0) {
+    const block = pendingBlocks.pop();
+    if (!block) continue;
+    for (const successor of block.successors) {
+      if (reachableBlocks.has(successor.to)) continue;
+      reachableBlocks.add(successor.to);
+      pendingBlocks.push(successor.to);
+    }
+  }
+
+  const incomingClearedByBlock = new Map<BasicBlock, boolean>();
+  const outgoingClearedByBlock = new Map<BasicBlock, boolean>();
+  for (const block of reachableBlocks) {
+    incomingClearedByBlock.set(block, true);
+    outgoingClearedByBlock.set(block, true);
+  }
+  const sourceHasClearingWrite = (clearingStartsByBlock.get(sourceBlock) ?? []).some(
+    (start) => start > sourceStart,
+  );
+  incomingClearedByBlock.set(sourceBlock, false);
+  outgoingClearedByBlock.set(sourceBlock, sourceHasClearingWrite);
+
+  const pendingFlowBlocks = sourceBlock.successors.map((successor) => successor.to);
+  const queuedFlowBlocks = new Set(pendingFlowBlocks);
+  for (let flowBlockIndex = 0; flowBlockIndex < pendingFlowBlocks.length; flowBlockIndex += 1) {
+    const block = pendingFlowBlocks[flowBlockIndex];
+    if (!block) continue;
+    queuedFlowBlocks.delete(block);
+    if (block === sourceBlock) continue;
+    const reachablePredecessors = block.predecessors.filter((predecessor) =>
+      reachableBlocks.has(predecessor.from),
+    );
+    const isClearedOnEntry =
+      reachablePredecessors.length > 0 &&
+      reachablePredecessors.every((predecessor) => {
+        if (exceptionalCatchEdgeKeys.has(edgeKey(predecessor.from, predecessor.to))) {
+          return Boolean(incomingClearedByBlock.get(predecessor.from));
+        }
+        return Boolean(outgoingClearedByBlock.get(predecessor.from));
+      });
+    const isClearedOnExit = isClearedOnEntry || (clearingStartsByBlock.get(block)?.length ?? 0) > 0;
+    if (
+      incomingClearedByBlock.get(block) === isClearedOnEntry &&
+      outgoingClearedByBlock.get(block) === isClearedOnExit
+    ) {
+      continue;
+    }
+    incomingClearedByBlock.set(block, isClearedOnEntry);
+    outgoingClearedByBlock.set(block, isClearedOnExit);
+    for (const successor of block.successors) {
+      if (!reachableBlocks.has(successor.to) || queuedFlowBlocks.has(successor.to)) continue;
+      queuedFlowBlocks.add(successor.to);
+      pendingFlowBlocks.push(successor.to);
+    }
+  }
+
+  const normalExitPredecessors = functionCfg.exit.predecessors.filter(
+    (predecessor) => predecessor.kind !== "throw",
+  );
+  return {
+    isClearedAtExit:
+      normalExitPredecessors.length > 0 &&
+      normalExitPredecessors.every((predecessor) =>
+        Boolean(outgoingClearedByBlock.get(predecessor.from)),
+      ),
+    isClearedBefore: (referenceIdentifier) => {
+      if (context.cfg.enclosingFunction(referenceIdentifier) !== owner) return false;
+      const referenceStart = getNodeStartIndex(referenceIdentifier);
+      const referenceBlock = functionCfg.blockOf(referenceIdentifier);
+      if (referenceStart <= sourceStart || !referenceBlock) return false;
+      if (
+        exitingCatchClearings.some(
+          ({ clearingNode, tryStatement }) =>
+            getNodeStartIndex(clearingNode) < referenceStart &&
+            !isAstDescendant(referenceIdentifier, tryStatement) &&
+            context.cfg.isUnconditionalFromEntry(clearingNode),
+        )
+      ) {
+        return true;
+      }
+      const enclosingClearingStart = Array.from(clearingNodes)
+        .filter((clearingNode) => isAstDescendant(referenceIdentifier, clearingNode))
+        .map(getNodeStartIndex)
+        .at(-1);
+      const startsInReferenceBlock = clearingStartsByBlock.get(referenceBlock) ?? [];
+      const hasClearingWriteBeforeReference = startsInReferenceBlock.some(
+        (start) =>
+          start !== enclosingClearingStart &&
+          start < referenceStart &&
+          (referenceBlock !== sourceBlock || start > sourceStart),
+      );
+      if (hasClearingWriteBeforeReference) return true;
+      if (referenceBlock === sourceBlock) return false;
+      return Boolean(incomingClearedByBlock.get(referenceBlock));
+    },
+  };
+};
+
+const getDirectInvocationSites = (
+  context: RuleContext,
+  functionNode: EsTreeNode,
+  options: DirectInvocationSiteOptions = { includeCallbackExecutionSites: true },
+): EsTreeNode[] => {
+  const expressionIsGuaranteedUndefined = (expression: EsTreeNode): boolean => {
+    const node = stripParenExpression(expression);
+    return (
+      (isNodeOfType(node, "UnaryExpression") && node.operator === "void") ||
+      (isNodeOfType(node, "Identifier") &&
+        node.name === "undefined" &&
+        context.scopes.isGlobalReference(node))
+    );
+  };
+  const applyKnownCardinalityMutations = (
+    symbol: SymbolDescriptor,
+    initialCardinality: KnownArrayCardinality,
+    referenceNode: EsTreeNode,
+  ): KnownArrayCardinality | null => {
+    const referenceStart = getNodeStartIndex(referenceNode);
+    const referenceOwner = context.cfg.enclosingFunction(referenceNode);
+    const cardinality = { ...initialCardinality };
+    const mutationReferences = symbol.references
+      .filter(
+        (reference) =>
+          getNodeStartIndex(reference.identifier) < referenceStart &&
+          context.cfg.enclosingFunction(reference.identifier) === referenceOwner &&
+          isNodeReachableWithinFunction(reference.identifier, context) &&
+          !expressionIsStaticallySkipped(context, reference.identifier),
+      )
+      .toSorted(
+        (first, second) =>
+          getNodeStartIndex(first.identifier) - getNodeStartIndex(second.identifier),
+      );
+    for (const reference of mutationReferences) {
+      const referenceRoot = findTransparentExpressionRoot(reference.identifier);
+      const memberExpression = referenceRoot.parent;
+      if (
+        !memberExpression ||
+        !isNodeOfType(memberExpression, "MemberExpression") ||
+        memberExpression.object !== referenceRoot
+      ) {
+        continue;
+      }
+      const parent = memberExpression.parent;
+      if (parent && isNodeOfType(parent, "CallExpression") && parent.callee === memberExpression) {
+        const methodName = getResolvedStaticPropertyName(context, memberExpression);
+        if (!methodName || !ARRAY_CARDINALITY_MUTATION_METHOD_NAMES.has(methodName)) continue;
+        if (methodName === "push" || methodName === "unshift") {
+          if (parent.arguments.some((argument) => isNodeOfType(argument, "SpreadElement"))) {
+            return null;
+          }
+          cardinality.length += parent.arguments.length;
+          cardinality.presentElementCount += parent.arguments.length;
+          cardinality.comparableElementCount += parent.arguments.filter(
+            (argument) => !expressionIsGuaranteedUndefined(argument),
+          ).length;
+          continue;
+        }
+        if (methodName === "pop" || methodName === "shift") {
+          if (cardinality.length === 0) continue;
+          if (
+            cardinality.presentElementCount !== cardinality.length ||
+            cardinality.comparableElementCount !== cardinality.presentElementCount
+          ) {
+            return null;
+          }
+          cardinality.length -= 1;
+          cardinality.presentElementCount -= 1;
+          cardinality.comparableElementCount -= 1;
+          continue;
+        }
+        return null;
+      }
+      if (
+        !parent ||
+        !isNodeOfType(parent, "AssignmentExpression") ||
+        parent.left !== memberExpression ||
+        parent.operator !== "="
+      ) {
+        continue;
+      }
+      const propertyName = getResolvedStaticPropertyName(context, memberExpression);
+      if (propertyName === "length" && isNodeOfType(parent.right, "Literal")) {
+        const nextLength = parent.right.value;
+        if (typeof nextLength !== "number" || !Number.isInteger(nextLength) || nextLength < 0) {
+          return null;
+        }
+        if (nextLength >= cardinality.length) {
+          cardinality.length = nextLength;
+          continue;
+        }
+        if (
+          nextLength === 0 ||
+          (cardinality.presentElementCount === cardinality.length &&
+            cardinality.comparableElementCount === cardinality.presentElementCount)
+        ) {
+          cardinality.length = nextLength;
+          cardinality.presentElementCount = nextLength;
+          cardinality.comparableElementCount = nextLength;
+          continue;
+        }
+        return null;
+      }
+      const property = stripParenExpression(memberExpression.property);
+      if (
+        memberExpression.computed &&
+        isNodeOfType(property, "Literal") &&
+        typeof property.value === "number" &&
+        Number.isInteger(property.value) &&
+        property.value >= cardinality.length
+      ) {
+        cardinality.length = property.value + 1;
+        cardinality.presentElementCount += 1;
+        if (!expressionIsGuaranteedUndefined(parent.right)) {
+          cardinality.comparableElementCount += 1;
+        }
+        continue;
+      }
+      return null;
+    }
+    return cardinality;
+  };
+  const getKnownArrayCardinality = (
+    expression: EsTreeNode,
+    referenceNode: EsTreeNode,
+    visitedSymbolIds: ReadonlySet<number> = new Set(),
+  ): KnownArrayCardinality | null => {
+    const node = stripParenExpression(expression);
+    if (isNodeOfType(node, "Identifier")) {
+      const symbol = resolveConstIdentifierAlias(node, context.scopes);
+      if (!symbol?.initializer || visitedSymbolIds.has(symbol.id)) {
+        return null;
+      }
+      const nextVisitedSymbolIds = new Set(visitedSymbolIds);
+      nextVisitedSymbolIds.add(symbol.id);
+      const initialCardinality = getKnownArrayCardinality(
+        symbol.initializer,
+        referenceNode,
+        nextVisitedSymbolIds,
+      );
+      return initialCardinality
+        ? applyKnownCardinalityMutations(symbol, initialCardinality, referenceNode)
+        : null;
+    }
+    if (isNodeOfType(node, "Literal") && typeof node.value === "string") {
+      const codePointCount = Array.from(node.value).length;
+      return {
+        comparableElementCount: codePointCount,
+        length: codePointCount,
+        presentElementCount: codePointCount,
+      };
+    }
+    if (isNodeOfType(node, "ArrayExpression")) {
+      const cardinality: KnownArrayCardinality = {
+        comparableElementCount: 0,
+        length: 0,
+        presentElementCount: 0,
+      };
+      for (const element of node.elements) {
+        if (!element) {
+          cardinality.length += 1;
+          continue;
+        }
+        if (isNodeOfType(element, "SpreadElement")) {
+          const spreadCardinality = getKnownArrayCardinality(
+            element.argument,
+            referenceNode,
+            visitedSymbolIds,
+          );
+          if (!spreadCardinality) return null;
+          cardinality.length += spreadCardinality.length;
+          cardinality.presentElementCount += spreadCardinality.length;
+          cardinality.comparableElementCount += spreadCardinality.comparableElementCount;
+          continue;
+        }
+        cardinality.length += 1;
+        cardinality.presentElementCount += 1;
+        if (!expressionIsGuaranteedUndefined(element)) cardinality.comparableElementCount += 1;
+      }
+      return cardinality;
+    }
+    if (!isNodeOfType(node, "CallExpression") && !isNodeOfType(node, "NewExpression")) {
+      return null;
+    }
+    const callee = stripParenExpression(node.callee);
+    if (
+      isNodeOfType(callee, "Identifier") &&
+      callee.name === "Array" &&
+      context.scopes.isGlobalReference(callee)
+    ) {
+      const argumentsList = node.arguments ?? [];
+      const onlyArgument = argumentsList.length === 1 ? argumentsList[0] : null;
+      if (
+        onlyArgument &&
+        !isNodeOfType(onlyArgument, "SpreadElement") &&
+        isNodeOfType(onlyArgument, "Literal") &&
+        typeof onlyArgument.value === "number" &&
+        Number.isInteger(onlyArgument.value) &&
+        onlyArgument.value >= 0
+      ) {
+        return {
+          comparableElementCount: 0,
+          length: onlyArgument.value,
+          presentElementCount: 0,
+        };
+      }
+      if (argumentsList.some((argument) => isNodeOfType(argument, "SpreadElement"))) return null;
+      const comparableElementCount = argumentsList.filter(
+        (argument) => !expressionIsGuaranteedUndefined(argument),
+      ).length;
+      return {
+        comparableElementCount,
+        length: argumentsList.length,
+        presentElementCount: argumentsList.length,
+      };
+    }
+    if (
+      !isNodeOfType(callee, "MemberExpression") ||
+      !isNodeOfType(callee.object, "Identifier") ||
+      callee.object.name !== "Array" ||
+      !context.scopes.isGlobalReference(callee.object)
+    ) {
+      return null;
+    }
+    const methodName = getResolvedStaticPropertyName(context, callee);
+    if (methodName === "from") {
+      const sourceArgument = node.arguments?.[0];
+      if (!sourceArgument || isNodeOfType(sourceArgument, "SpreadElement")) return null;
+      const sourceCardinality = getKnownArrayCardinality(
+        sourceArgument,
+        referenceNode,
+        visitedSymbolIds,
+      );
+      return sourceCardinality
+        ? {
+            comparableElementCount: sourceCardinality.comparableElementCount,
+            length: sourceCardinality.length,
+            presentElementCount: sourceCardinality.length,
+          }
+        : null;
+    }
+    if (methodName !== "of") return null;
+    const argumentsList = node.arguments ?? [];
+    if (argumentsList.some((argument) => isNodeOfType(argument, "SpreadElement"))) return null;
+    return {
+      comparableElementCount: argumentsList.filter(
+        (argument) => !expressionIsGuaranteedUndefined(argument),
+      ).length,
+      length: argumentsList.length,
+      presentElementCount: argumentsList.length,
+    };
+  };
+  const callbackExecutionMatches = (invocationSite: EsTreeNode): boolean => {
+    if (isNodeOfType(invocationSite, "NewExpression")) return true;
+    if (!isNodeOfType(invocationSite, "CallExpression")) return false;
+    const callee = stripParenExpression(invocationSite.callee);
+    if (!isNodeOfType(callee, "MemberExpression")) {
+      return !options.requireGuaranteedCallbackExecution;
+    }
+    const methodName = getResolvedStaticPropertyName(context, callee);
+    if (
+      methodName === "from" &&
+      isNodeOfType(callee.object, "Identifier") &&
+      callee.object.name === "Array" &&
+      context.scopes.isGlobalReference(callee.object)
+    ) {
+      const sourceArgument = invocationSite.arguments[0];
+      const sourceCardinality =
+        sourceArgument && !isNodeOfType(sourceArgument, "SpreadElement")
+          ? getKnownArrayCardinality(sourceArgument, invocationSite)
+          : null;
+      return sourceCardinality
+        ? sourceCardinality.length > 0
+        : !options.requireGuaranteedCallbackExecution;
+    }
+    const receiver = stripParenExpression(callee.object);
+    const cardinality = getKnownArrayCardinality(receiver, invocationSite);
+    if (cardinality) {
+      if (methodName === "reduce" || methodName === "reduceRight") {
+        return invocationSite.arguments.slice(1).length > 0
+          ? cardinality.presentElementCount > 0
+          : cardinality.presentElementCount > 1;
+      }
+      if (methodName === "sort" || methodName === "toSorted") {
+        return cardinality.comparableElementCount > 1;
+      }
+      return cardinality.presentElementCount > 0;
+    }
+    return !options.requireGuaranteedCallbackExecution;
+  };
+  const functionRoot = findTransparentExpressionRoot(functionNode);
+  const directParent = functionRoot.parent;
+  if (
+    directParent &&
+    isNodeOfType(directParent, "CallExpression") &&
+    directParent.callee === functionRoot
+  ) {
+    return [directParent];
+  }
+  if (
+    options.includeCallbackExecutionSites &&
+    directParent &&
+    callbackExecutionMatches(directParent) &&
+    executesDuringRender(functionRoot, context.scopes, {
+      requireProvenSynchronousCallbackReceiver: true,
+    })
+  ) {
+    return [directParent];
+  }
+
+  let functionSymbol: SymbolDescriptor | null = null;
+  if (isNodeOfType(functionNode, "FunctionDeclaration") && functionNode.id) {
+    functionSymbol = context.scopes.symbolFor(functionNode.id);
+  } else {
+    const declarationParent = functionRoot.parent;
+    if (
+      declarationParent &&
+      isNodeOfType(declarationParent, "VariableDeclarator") &&
+      declarationParent.init === functionRoot &&
+      isNodeOfType(declarationParent.id, "Identifier")
+    ) {
+      functionSymbol = context.scopes.symbolFor(declarationParent.id);
+    }
+  }
+  if (!functionSymbol) return [];
+
+  const invocationSites: EsTreeNode[] = [];
+  const pendingFunctionAliases: FunctionAliasCandidate[] = [
+    { sourceNode: functionNode, symbol: functionSymbol },
+  ];
+  const visitedFunctionSymbolIds = new Set<number>();
+  while (pendingFunctionAliases.length > 0) {
+    const candidate = pendingFunctionAliases.pop();
+    if (!candidate || visitedFunctionSymbolIds.has(candidate.symbol.id)) continue;
+    visitedFunctionSymbolIds.add(candidate.symbol.id);
+    for (const reference of candidate.symbol.references) {
+      if (reference.flag === "write") continue;
+      const referenceRoot = findTransparentExpressionRoot(reference.identifier);
+      const parent = referenceRoot.parent;
+      if (parent && isNodeOfType(parent, "CallExpression") && parent.callee === referenceRoot) {
+        if (!aliasIsOverwrittenBeforeInvocation(context, candidate, parent)) {
+          invocationSites.push(parent);
+        }
+        continue;
+      }
+      if (
+        options.includeCallbackExecutionSites &&
+        parent &&
+        callbackExecutionMatches(parent) &&
+        (isNodeOfType(parent, "CallExpression") || isNodeOfType(parent, "NewExpression")) &&
+        executesDuringRender(referenceRoot, context.scopes, {
+          requireProvenSynchronousCallbackReceiver: true,
+        })
+      ) {
+        if (!aliasIsOverwrittenBeforeInvocation(context, candidate, parent)) {
+          invocationSites.push(parent);
+        }
+        continue;
+      }
+      if (
+        parent &&
+        isNodeOfType(parent, "VariableDeclarator") &&
+        parent.init === referenceRoot &&
+        isNodeOfType(parent.id, "Identifier")
+      ) {
+        const aliasSymbol = context.scopes.symbolFor(parent.id);
+        if (aliasSymbol) pendingFunctionAliases.push({ sourceNode: parent, symbol: aliasSymbol });
+        continue;
+      }
+      if (
+        parent &&
+        isNodeOfType(parent, "AssignmentExpression") &&
+        parent.operator === "=" &&
+        parent.right === referenceRoot
+      ) {
+        const assignmentTarget = stripParenExpression(parent.left);
+        if (!isNodeOfType(assignmentTarget, "Identifier")) continue;
+        const aliasSymbol = context.scopes.symbolFor(assignmentTarget);
+        if (aliasSymbol) pendingFunctionAliases.push({ sourceNode: parent, symbol: aliasSymbol });
+      }
+    }
+  }
+  return invocationSites;
+};
+
+const invocationWaitsForCompletion = (invocationSite: EsTreeNode): boolean => {
+  const invocationRoot = findTransparentExpressionRoot(invocationSite);
+  const parent = invocationRoot.parent;
+  return Boolean(
+    parent && isNodeOfType(parent, "AwaitExpression") && parent.argument === invocationRoot,
+  );
+};
+
+const getStaticallySelectedExecutionRoot = (context: RuleContext, node: EsTreeNode): EsTreeNode => {
+  let current = node;
+  let selectedRoot = node;
+  while (current.parent && !isFunctionLike(current.parent)) {
+    const parent = current.parent;
+    if (isNodeOfType(parent, "IfStatement") && parent.test !== current) {
+      const testValue = getStaticLogicalValue(context, parent.test);
+      const isSelectedBranch = Boolean(
+        testValue &&
+        ((parent.consequent === current && testValue.isTruthy) ||
+          (parent.alternate === current && !testValue.isTruthy)),
+      );
+      if (!isSelectedBranch) break;
+      selectedRoot = parent;
+    }
+    current = parent;
+  }
+  return selectedRoot;
+};
+
+const getAsyncExecutionPhase = (context: RuleContext, node: EsTreeNode): AsyncExecutionPhase => {
+  const owner = context.cfg.enclosingFunction(node);
+  if (!owner || !isFunctionLike(owner) || !owner.async) {
+    return { mayExecuteBeforeSuspension: true, mustExecuteBeforeSuspension: true };
+  }
+  const nodeStart = getNodeStartIndex(node);
+  let hasPossiblePriorSuspension = false;
+  let hasGuaranteedPriorSuspension = false;
+  walkAst(owner, (candidate) => {
+    if (candidate !== owner && isFunctionLike(candidate)) return false;
+    if (!isNodeOfType(candidate, "AwaitExpression")) return;
+    if (
+      !isNodeReachableWithinFunction(candidate, context) ||
+      expressionIsStaticallySkipped(context, candidate)
+    ) {
+      return;
+    }
+    const isInsideEffect = isAstDescendant(candidate, node);
+    if (!isInsideEffect && getNodeStartIndex(candidate) >= nodeStart) return;
+    hasPossiblePriorSuspension = true;
+    if (
+      isInsideEffect ||
+      nodeDominatesNode(getStaticallySelectedExecutionRoot(context, candidate), node, context)
+    ) {
+      hasGuaranteedPriorSuspension = true;
+    }
+  });
+  return {
+    mayExecuteBeforeSuspension: !hasGuaranteedPriorSuspension,
+    mustExecuteBeforeSuspension: !hasPossiblePriorSuspension,
+  };
+};
+
+const caughtInvocationMayContinue = (invocationSite: EsTreeNode): boolean => {
+  const caughtTryStatement = findCaughtTryStatement(invocationSite);
+  return Boolean(
+    caughtTryStatement &&
+    isNodeOfType(caughtTryStatement, "TryStatement") &&
+    caughtTryStatement.handler &&
+    !statementAlwaysExits(caughtTryStatement.handler.body),
+  );
+};
+
+const caughtHandlerDefinitelyClearsSymbol = (
+  context: RuleContext,
+  symbol: SymbolDescriptor,
+  invocationSite: EsTreeNode,
+): boolean => {
+  const caughtTryStatement = findCaughtTryStatement(invocationSite);
+  if (
+    !caughtTryStatement ||
+    !isNodeOfType(caughtTryStatement, "TryStatement") ||
+    !caughtTryStatement.handler
+  ) {
+    return false;
+  }
+  const handlerBody = caughtTryStatement.handler.body;
+  const clearingAssignments = symbol.references.flatMap((reference) => {
+    if (reference.flag === "read") return [];
+    const assignment = getProvenanceClearingAssignment(context, symbol, reference.identifier);
+    return assignment && isAstDescendant(assignment, handlerBody) ? [assignment] : [];
+  });
+  const handlerOwner = context.cfg.enclosingFunction(handlerBody);
+  return projectGuaranteedClearingNodes(context, clearingAssignments, handlerOwner).some(
+    (clearingNode) => {
+      let current = findTransparentExpressionRoot(clearingNode);
+      while (current.parent && current.parent !== handlerBody) {
+        const parent = current.parent;
+        if (
+          isNodeOfType(parent, "IfStatement") ||
+          isNodeOfType(parent, "ConditionalExpression") ||
+          isNodeOfType(parent, "SwitchStatement") ||
+          isNodeOfType(parent, "WhileStatement") ||
+          isNodeOfType(parent, "DoWhileStatement") ||
+          isNodeOfType(parent, "ForStatement") ||
+          isNodeOfType(parent, "ForInStatement") ||
+          isNodeOfType(parent, "ForOfStatement")
+        ) {
+          return false;
+        }
+        current = parent;
+      }
+      return current.parent === handlerBody;
+    },
+  );
+};
+
+const throwEscapesBeforeNode = (throwNode: EsTreeNode, node: EsTreeNode): boolean => {
+  let current = throwNode;
+  while (current.parent && !isFunctionLike(current.parent)) {
+    const parent = current.parent;
+    if (isNodeOfType(parent, "TryStatement")) {
+      if (parent.finalizer && isAstDescendant(node, parent.finalizer)) return false;
+      if (parent.block === current && parent.handler) return false;
+    }
+    current = parent;
+  }
+  return true;
+};
+
+const hasEscapingThrowBeforeNode = (context: RuleContext, node: EsTreeNode): boolean => {
+  const owner = context.cfg.enclosingFunction(node);
+  if (!owner) return false;
+  const nodeStart = getNodeStartIndex(node);
+  let hasPriorThrow = false;
+  walkAst(owner, (candidate) => {
+    if (candidate !== owner && isFunctionLike(candidate)) return false;
+    if (
+      isNodeOfType(candidate, "ThrowStatement") &&
+      getNodeStartIndex(candidate) < nodeStart &&
+      isNodeReachableWithinFunction(candidate, context) &&
+      !expressionIsStaticallySkipped(context, candidate) &&
+      throwEscapesBeforeNode(candidate, node)
+    ) {
+      hasPriorThrow = true;
+    }
+  });
+  return hasPriorThrow;
+};
+
+const callIsKnownNoop = (context: RuleContext, node: EsTreeNode): boolean => {
+  if (!isNodeOfType(node, "CallExpression")) return false;
+  const callee = stripParenExpression(node.callee);
+  if (!isNodeOfType(callee, "Identifier")) return false;
+  const symbol = context.scopes.symbolFor(callee);
+  const functionNode = symbol?.initializer ?? symbol?.declarationNode;
+  return Boolean(
+    functionNode &&
+    isFunctionLike(functionNode) &&
+    isNodeOfType(functionNode.body, "BlockStatement") &&
+    functionNode.body.body.length === 0,
+  );
+};
+
+const hasEscapingCallBeforeNode = (context: RuleContext, node: EsTreeNode): boolean => {
+  const owner = context.cfg.enclosingFunction(node);
+  if (!owner) return false;
+  const nodeStart = getNodeStartIndex(node);
+  let hasPriorCall = false;
+  walkAst(owner, (candidate) => {
+    if (candidate !== owner && isFunctionLike(candidate)) return false;
+    if (
+      (isNodeOfType(candidate, "CallExpression") || isNodeOfType(candidate, "NewExpression")) &&
+      getNodeStartIndex(candidate) < nodeStart &&
+      isNodeReachableWithinFunction(candidate, context) &&
+      !expressionIsStaticallySkipped(context, candidate) &&
+      !findCaughtTryStatement(candidate) &&
+      !isNextHeadersDynamicCall(context, candidate) &&
+      !callIsKnownNoop(context, candidate) &&
+      throwEscapesBeforeNode(candidate, node)
+    ) {
+      hasPriorCall = true;
+    }
+  });
+  return hasPriorCall;
+};
+
+const sourceOwnerMayEscapeWithPending = (
+  context: RuleContext,
+  symbol: SymbolDescriptor,
+  sourceExpression: EsTreeNode,
+): boolean => {
+  const owner = context.cfg.enclosingFunction(sourceExpression);
+  if (!owner) return false;
+  const sourceStart = getNodeStartIndex(sourceExpression);
+  const flow = createPendingSymbolFlow(context, symbol, sourceExpression);
+  let mayEscapeWithPending = false;
+  walkAst(owner, (candidate) => {
+    if (candidate !== owner && isFunctionLike(candidate)) return false;
+    if (
+      isNodeOfType(candidate, "ThrowStatement") &&
+      getNodeStartIndex(candidate) > sourceStart &&
+      isNodeReachableWithinFunction(candidate, context) &&
+      !expressionIsStaticallySkipped(context, candidate) &&
+      throwEscapesBeforeNode(candidate, owner) &&
+      !flow.isClearedBefore(candidate)
+    ) {
+      mayEscapeWithPending = true;
+    }
+    if (
+      (isNodeOfType(candidate, "CallExpression") || isNodeOfType(candidate, "NewExpression")) &&
+      getNodeStartIndex(candidate) > sourceStart &&
+      isNodeReachableWithinFunction(candidate, context) &&
+      !expressionIsStaticallySkipped(context, candidate) &&
+      !findCaughtTryStatement(candidate) &&
+      !isNextHeadersDynamicCall(context, candidate) &&
+      !callIsKnownNoop(context, candidate) &&
+      throwEscapesBeforeNode(candidate, owner) &&
+      !flow.isClearedBefore(candidate)
+    ) {
+      mayEscapeWithPending = true;
+    }
+  });
+  return mayEscapeWithPending;
+};
+
+const getExecutionSitesInOwner = (
+  context: RuleContext,
+  node: EsTreeNode,
+  targetOwner: EsTreeNode | null,
+  options: ExecutionProjectionOptions,
+  visitedFunctionNodes: ReadonlySet<EsTreeNode> = new Set(),
+): EsTreeNode[] => {
+  const nodeOwner = context.cfg.enclosingFunction(node);
+  if (nodeOwner === targetOwner) return [node];
+  if (
+    !nodeOwner ||
+    !isFunctionLike(nodeOwner) ||
+    visitedFunctionNodes.has(nodeOwner) ||
+    !isNodeReachableWithinFunction(node, context) ||
+    (options.requiresGuaranteedExecution && !context.cfg.isUnconditionalFromEntry(node))
+  ) {
+    return [];
+  }
+  const nextVisitedFunctionNodes = new Set(visitedFunctionNodes);
+  nextVisitedFunctionNodes.add(nodeOwner);
+  const executionPhase = getAsyncExecutionPhase(context, node);
+  const hasPriorEscapingInterruption =
+    options.requiresGuaranteedExecution &&
+    (hasEscapingThrowBeforeNode(context, node) || hasEscapingCallBeforeNode(context, node));
+  return getDirectInvocationSites(context, nodeOwner, {
+    includeCallbackExecutionSites: true,
+    requireGuaranteedCallbackExecution: options.requiresGuaranteedExecution,
+  }).flatMap((invocationSite) => {
+    if (hasPriorEscapingInterruption && caughtInvocationMayContinue(invocationSite)) return [];
+    if (
+      !invocationWaitsForCompletion(invocationSite) &&
+      (options.requiresGuaranteedExecution
+        ? !executionPhase.mustExecuteBeforeSuspension
+        : !executionPhase.mayExecuteBeforeSuspension)
+    ) {
+      return [];
+    }
+    return getExecutionSitesInOwner(
+      context,
+      invocationSite,
+      targetOwner,
+      options,
+      nextVisitedFunctionNodes,
+    );
+  });
+};
+
+const findConditionalClearingBranch = (
+  node: EsTreeNode,
+): { conditionalRoot: EsTreeNode; isConsequent: boolean } | null => {
+  let current = findTransparentExpressionRoot(node);
+  while (current.parent && !isFunctionLike(current.parent)) {
+    const parent = current.parent;
+    if (isNodeOfType(parent, "IfStatement")) {
+      if (parent.consequent === current) {
+        return { conditionalRoot: parent, isConsequent: true };
+      }
+      if (parent.alternate === current) {
+        return { conditionalRoot: parent, isConsequent: false };
+      }
+      return null;
+    }
+    if (isNodeOfType(parent, "ConditionalExpression")) {
+      if (parent.consequent === current) {
+        return { conditionalRoot: parent, isConsequent: true };
+      }
+      if (parent.alternate === current) {
+        return { conditionalRoot: parent, isConsequent: false };
+      }
+      return null;
+    }
+    if (!isNodeOfType(parent, "ExpressionStatement") && !isNodeOfType(parent, "BlockStatement")) {
+      return null;
+    }
+    current = parent;
+  }
+  return null;
+};
+
+const projectGuaranteedClearingNodes = (
+  context: RuleContext,
+  clearingNodes: ReadonlyArray<EsTreeNode>,
+  targetOwner: EsTreeNode | null,
+): EsTreeNode[] => {
+  const reachableClearingNodes = clearingNodes.filter(
+    (clearingNode) =>
+      isNodeReachableWithinFunction(clearingNode, context) &&
+      !expressionIsStaticallySkipped(context, clearingNode),
+  );
+  const combinedClearingNodes = [...reachableClearingNodes];
+  const combinedClearingNodeSet = new Set(combinedClearingNodes);
+  let didCombineBranch = true;
+  while (didCombineBranch) {
+    didCombineBranch = false;
+    const conditionalBranches = new Map<
+      EsTreeNode,
+      { hasAlternate: boolean; hasConsequent: boolean }
+    >();
+    for (const clearingNode of combinedClearingNodes) {
+      const branch = findConditionalClearingBranch(clearingNode);
+      if (!branch) continue;
+      const branches = conditionalBranches.get(branch.conditionalRoot) ?? {
+        hasAlternate: false,
+        hasConsequent: false,
+      };
+      if (branch.isConsequent) branches.hasConsequent = true;
+      else branches.hasAlternate = true;
+      conditionalBranches.set(branch.conditionalRoot, branches);
+    }
+    for (const [conditionalRoot, branches] of conditionalBranches) {
+      if (
+        !branches.hasConsequent ||
+        !branches.hasAlternate ||
+        combinedClearingNodeSet.has(conditionalRoot)
+      ) {
+        continue;
+      }
+      combinedClearingNodeSet.add(conditionalRoot);
+      combinedClearingNodes.push(conditionalRoot);
+      didCombineBranch = true;
+    }
+  }
+  return combinedClearingNodes.flatMap((clearingNode) =>
+    getExecutionSitesInOwner(context, clearingNode, targetOwner, {
+      requiresGuaranteedExecution: true,
+    }),
+  );
+};
+
+const getProjectedProvenanceClearingSites = ({
+  afterStart,
+  context,
+  symbol,
+  targetOwner,
+}: ProjectedClearingSitesInput): EsTreeNode[] => {
+  const clearingAssignments = symbol.references.flatMap((reference) => {
+    const assignment = getProvenanceClearingAssignment(context, symbol, reference.identifier);
+    return assignment ? [assignment] : [];
+  });
+  return projectGuaranteedClearingNodes(context, clearingAssignments, targetOwner).filter(
+    (clearingExecutionSite) => getNodeStartIndex(clearingExecutionSite) > afterStart,
+  );
+};
+
+const getRetainedSourceExecutionSites = (
+  context: RuleContext,
+  symbol: SymbolDescriptor,
+  node: EsTreeNode,
+  targetOwner: EsTreeNode | null,
+  visitedFunctionNodes: ReadonlySet<EsTreeNode> = new Set(),
+): EsTreeNode[] => {
+  const nodeOwner = context.cfg.enclosingFunction(node);
+  if (nodeOwner === targetOwner) return [node];
+  if (
+    !nodeOwner ||
+    !isFunctionLike(nodeOwner) ||
+    visitedFunctionNodes.has(nodeOwner) ||
+    !isNodeReachableWithinFunction(node, context)
+  ) {
+    return [];
+  }
+  const nextVisitedFunctionNodes = new Set(visitedFunctionNodes);
+  nextVisitedFunctionNodes.add(nodeOwner);
+  const executionPhase = getAsyncExecutionPhase(context, node);
+  return getDirectInvocationSites(context, nodeOwner, {
+    includeCallbackExecutionSites: true,
+    requireGuaranteedCallbackExecution: false,
+  }).flatMap((invocationSite) => {
+    if (
+      !invocationWaitsForCompletion(invocationSite) &&
+      !executionPhase.mayExecuteBeforeSuspension
+    ) {
+      return [];
+    }
+    const invocationOwner = context.cfg.enclosingFunction(invocationSite);
+    if (!invocationOwner) return [];
+    if (invocationOwner !== targetOwner) {
+      const invocationStart = getNodeStartIndex(invocationSite);
+      const clearingExecutionSites = getProjectedProvenanceClearingSites({
+        afterStart: invocationStart,
+        context,
+        symbol,
+        targetOwner: invocationOwner,
+      });
+      if (
+        createPendingSymbolFlow(context, symbol, invocationSite, clearingExecutionSites)
+          .isClearedAtExit
+      ) {
+        return [];
+      }
+    }
+    return getRetainedSourceExecutionSites(
+      context,
+      symbol,
+      invocationSite,
+      targetOwner,
+      nextVisitedFunctionNodes,
+    );
+  });
+};
+
+const symbolHasSynchronousAccess = (
+  context: RuleContext,
+  initialSymbol: SymbolDescriptor,
+  initialSourceExpression: EsTreeNode,
+): boolean => {
+  const pendingCandidates: PendingSymbolCandidate[] = [
+    { sourceExpression: initialSourceExpression, symbol: initialSymbol },
+  ];
+  const visitedSymbolIds = new Set<number>();
+
+  while (pendingCandidates.length > 0) {
+    const candidate = pendingCandidates.pop();
+    if (!candidate || visitedSymbolIds.has(candidate.symbol.id)) continue;
+    visitedSymbolIds.add(candidate.symbol.id);
+    const owner = context.cfg.enclosingFunction(candidate.sourceExpression);
+    const hasAnyWrite = candidate.symbol.references.some(
+      (reference) =>
+        reference.flag !== "read" ||
+        Boolean(findPatternAssignmentForIdentifier(reference.identifier)),
+    );
+    const sourceStart = getNodeStartIndex(candidate.sourceExpression);
+    const projectedClearingSites = getProjectedProvenanceClearingSites({
+      afterStart: sourceStart,
+      context,
+      symbol: candidate.symbol,
+      targetOwner: owner,
+    });
+    const flow = createPendingSymbolFlow(
+      context,
+      candidate.symbol,
+      candidate.sourceExpression,
+      projectedClearingSites,
+    );
+
+    for (const reference of candidate.symbol.references) {
+      if (reference.flag === "write" || findPatternAssignmentForIdentifier(reference.identifier)) {
+        continue;
+      }
+      const referenceStart = getNodeStartIndex(reference.identifier);
+      if (referenceStart <= sourceStart) continue;
+      const referenceOwner = context.cfg.enclosingFunction(reference.identifier);
+      if (referenceOwner !== owner && hasAnyWrite) {
+        if (!referenceOwner) continue;
+        const hasWriteInReferenceOwner = candidate.symbol.references.some(
+          (innerReference) =>
+            (innerReference.flag !== "read" ||
+              Boolean(findPatternAssignmentForIdentifier(innerReference.identifier))) &&
+            context.cfg.enclosingFunction(innerReference.identifier) === referenceOwner,
+        );
+        if (hasWriteInReferenceOwner) continue;
+        const hasUnclearedDirectInvocation = getDirectInvocationSites(context, referenceOwner).some(
+          (invocation) =>
+            context.cfg.enclosingFunction(invocation) === owner &&
+            getNodeStartIndex(invocation) > sourceStart &&
+            !flow.isClearedBefore(invocation),
+        );
+        if (!hasUnclearedDirectInvocation) continue;
+      }
+      if (flow.isClearedBefore(reference.identifier)) continue;
+      const referenceRoot = findTransparentExpressionRoot(reference.identifier);
+      if (expressionIsSynchronouslyConsumed(context, referenceRoot)) return true;
+      const aliasCandidate = findRetainingAliasCandidate(
+        context,
+        reference.identifier,
+        candidate.symbol,
+      );
+      if (aliasCandidate) pendingCandidates.push(aliasCandidate);
+    }
+  }
+  return false;
+};
+
+const reportDirectDestructure = (
+  context: RuleContext,
+  expression: EsTreeNode,
+  pattern: EsTreeNode,
+): void => {
+  if (!patternReadsDynamicApiValue(pattern)) return;
+  const source = findPendingDynamicApiSource(context, expression);
+  if (!source) return;
+  context.report({ node: source, message: MESSAGE });
+};
+
+const reportAssignedPendingExpression = (
+  context: RuleContext,
+  expression: EsTreeNode,
+  identifier: EsTreeNode,
+): void => {
+  const symbol = context.scopes.symbolFor(identifier);
+  if (!symbol) return;
+  const expressionOwner = context.cfg.enclosingFunction(expression);
+  const bindingOwner = context.cfg.enclosingFunction(symbol.bindingIdentifier);
+  if (expressionOwner === bindingOwner) {
+    if (expressionIsStaticallySkipped(context, expression)) return;
+  } else {
+    if (!expressionOwner || !isFunctionLike(expressionOwner)) return;
+    const invocationSites = getDirectInvocationSites(context, expressionOwner, {
+      includeCallbackExecutionSites: false,
+    });
+    if (
+      invocationSites.length === 0 ||
+      invocationSites.every((invocationSite) =>
+        expressionIsStaticallySkipped(context, expression, invocationSite),
+      )
+    ) {
+      return;
+    }
+  }
+  const source = findPendingDynamicApiSource(context, expression);
+  if (!source) return;
+  if (!symbolHasSynchronousAccess(context, symbol, expression)) return;
+  context.report({ node: source, message: MESSAGE });
+};
+
+const collectPatternBindingIdentifiers = (
+  pattern: EsTreeNode,
+  identifiers: EsTreeNode[] = [],
+): EsTreeNode[] => {
+  if (isNodeOfType(pattern, "Identifier")) {
+    identifiers.push(pattern);
+  } else if (isNodeOfType(pattern, "AssignmentPattern")) {
+    collectPatternBindingIdentifiers(pattern.left, identifiers);
+  } else if (isNodeOfType(pattern, "RestElement")) {
+    collectPatternBindingIdentifiers(pattern.argument, identifiers);
+  } else if (isNodeOfType(pattern, "ObjectPattern")) {
+    for (const property of pattern.properties) {
+      if (isNodeOfType(property, "Property")) {
+        collectPatternBindingIdentifiers(property.value, identifiers);
+      } else if (isNodeOfType(property, "RestElement")) {
+        collectPatternBindingIdentifiers(property.argument, identifiers);
+      }
+    }
+  } else if (isNodeOfType(pattern, "ArrayPattern")) {
+    for (const element of pattern.elements) {
+      if (element) collectPatternBindingIdentifiers(element, identifiers);
+    }
+  }
+  return identifiers;
+};
+
+const reportPatternAssignedPendingExpressions = (
+  context: RuleContext,
+  pattern: EsTreeNode,
+  expression: EsTreeNode,
+): void => {
+  for (const bindingIdentifier of collectPatternBindingIdentifiers(pattern)) {
+    const symbol = context.scopes.symbolFor(bindingIdentifier);
+    if (!symbol) continue;
+    const assignedValue = findPatternAssignedValue(context, pattern, expression, symbol);
+    if (!assignedValue?.expression) continue;
+    reportAssignedPendingExpression(context, assignedValue.expression, bindingIdentifier);
+  }
+};
+
+const getDirectPatternBindingIdentifier = (pattern: EsTreeNode): EsTreeNode | null => {
+  if (isNodeOfType(pattern, "Identifier")) return pattern;
+  if (isNodeOfType(pattern, "AssignmentPattern") && isNodeOfType(pattern.left, "Identifier")) {
+    return pattern.left;
+  }
+  return null;
+};
+
+const reportOfficialPropsPatternAliases = (
+  context: RuleContext,
+  pattern: EsTreeNode,
+  expression: EsTreeNode,
+): void => {
+  if (!isNodeOfType(pattern, "ObjectPattern")) return;
+  const propsSource = findOfficialPropsObjectSource(context, expression);
+  if (!propsSource) return;
+  for (const property of pattern.properties) {
+    if (!isNodeOfType(property, "Property")) continue;
+    const propertyName = getStaticPropertyKeyName(property, { allowComputedString: true });
+    if (!propertyName || !propsSource.contract.propertyNames.has(propertyName)) continue;
+    const bindingIdentifier = getDirectPatternBindingIdentifier(property.value);
+    if (!bindingIdentifier) {
+      context.report({ node: property, message: MESSAGE });
+      continue;
+    }
+    const symbol = context.scopes.symbolFor(bindingIdentifier);
+    if (!symbol || !symbolHasSynchronousAccess(context, symbol, property.value)) continue;
+    context.report({ node: property, message: MESSAGE });
+  }
+};
+
+const reportNestedOfficialParameterDestructure = (
+  context: RuleContext,
+  functionNode: EsTreeNode,
+): void => {
+  if (!isFunctionLike(functionNode)) return;
+  const contract = getOfficialAsyncPropContract(context, functionNode);
+  if (!contract) return;
+  const parameter = functionNode.params[contract.parameterIndex];
+  const pattern =
+    parameter && isNodeOfType(parameter, "AssignmentPattern") ? parameter.left : parameter;
+  if (!pattern || !isNodeOfType(pattern, "ObjectPattern")) return;
+  for (const property of pattern.properties) {
+    if (!isNodeOfType(property, "Property")) continue;
+    const propertyName = getStaticPropertyKeyName(property, { allowComputedString: true });
+    if (!propertyName || !contract.propertyNames.has(propertyName)) continue;
+    if (!getDirectPatternBindingIdentifier(property.value)) {
+      context.report({ node: property, message: MESSAGE });
+    }
+  }
+};
+
+const reportDirectSynchronousConsumption = (context: RuleContext, expression: EsTreeNode): void => {
+  const source = findPendingDynamicApiSource(context, expression);
+  if (source) context.report({ node: source, message: MESSAGE });
+};
+
+const reportOfficialDirectValueConsumption = (
+  context: RuleContext,
+  expression: EsTreeNode,
+): void => {
+  if (expressionIsStaticallySkipped(context, expression)) return;
+  if (isOfficialDirectValueSource(context, expression)) {
+    context.report({ node: expression, message: MESSAGE });
+  }
+};
+
+const memberExpressionIsAssignmentTarget = (expression: EsTreeNode): boolean => {
+  const root = findTransparentExpressionRoot(expression);
+  const parent = root.parent;
+  return Boolean(parent && isNodeOfType(parent, "AssignmentExpression") && parent.left === root);
+};
+
+const memberExpressionIsDirectlyUnwrapped = (
+  context: RuleContext,
+  expression: EsTreeNode,
+): boolean => {
+  const root = findTransparentExpressionRoot(expression);
+  const parent = root.parent;
+  if (parent && isNodeOfType(parent, "AwaitExpression") && parent.argument === root) return true;
+  return Boolean(
+    parent &&
+    isNodeOfType(parent, "CallExpression") &&
+    parent.arguments[0] === root &&
+    isReactApiCall(parent, "use", context.scopes, { resolveNamedAliases: true }),
+  );
+};
+
+export const nextjsAsyncDynamicApiNotAwaited = defineRule({
+  id: "nextjs-async-dynamic-api-not-awaited",
+  title: "Synchronous Next.js request API access",
+  tags: ["test-noise"],
+  requires: ["nextjs:15"],
+  severity: "error",
+  recommendation:
+    "Await `cookies()`, `headers()`, `draftMode()`, and async route `params` or `searchParams`, or unwrap their promises with React `use()`, before reading properties.",
+  create: (context: RuleContext) => ({
+    FunctionDeclaration(node: EsTreeNodeOfType<"FunctionDeclaration">) {
+      reportNestedOfficialParameterDestructure(context, node);
+    },
+    FunctionExpression(node: EsTreeNodeOfType<"FunctionExpression">) {
+      reportNestedOfficialParameterDestructure(context, node);
+    },
+    ArrowFunctionExpression(node: EsTreeNodeOfType<"ArrowFunctionExpression">) {
+      reportNestedOfficialParameterDestructure(context, node);
+    },
+    MemberExpression(node: EsTreeNodeOfType<"MemberExpression">) {
+      if (node.computed) reportOfficialDirectValueConsumption(context, node.property);
+      if (memberExpressionIsAssignmentTarget(node)) {
+        const assignment = findTransparentExpressionRoot(node).parent;
+        if (
+          assignment &&
+          isNodeOfType(assignment, "AssignmentExpression") &&
+          assignment.operator !== "="
+        ) {
+          reportDirectSynchronousConsumption(context, node);
+        }
+        return;
+      }
+      if (memberExpressionIsDirectlyUnwrapped(context, node)) {
+        return;
+      }
+      const source = findPendingDynamicApiSource(context, node.object);
+      if (!source) return;
+      if (isPromiseSettleAccess(context, node)) return;
+      context.report({ node: source, message: MESSAGE });
+    },
+    VariableDeclarator(node: EsTreeNodeOfType<"VariableDeclarator">) {
+      if (!node.init) return;
+      reportDirectDestructure(context, node.init, node.id);
+      if (isNodeOfType(node.id, "Identifier")) {
+        reportAssignedPendingExpression(context, node.init, node.id);
+      } else {
+        reportPatternAssignedPendingExpressions(context, node.id, node.init);
+        reportOfficialPropsPatternAliases(context, node.id, node.init);
+      }
+    },
+    AssignmentExpression(node: EsTreeNodeOfType<"AssignmentExpression">) {
+      if (node.operator === "=") {
+        reportDirectDestructure(context, node.right, node.left);
+        if (!isNodeOfType(stripParenExpression(node.left), "Identifier")) {
+          reportPatternAssignedPendingExpressions(context, node.left, node.right);
+          reportOfficialPropsPatternAliases(context, node.left, node.right);
+        }
+      } else if (node.operator !== "&&=" && node.operator !== "||=" && node.operator !== "??=") {
+        if (!isNodeOfType(stripParenExpression(node.left), "MemberExpression")) {
+          reportDirectSynchronousConsumption(context, node.left);
+        }
+        return;
+      }
+      const assignmentTarget = stripParenExpression(node.left);
+      if (!isNodeOfType(assignmentTarget, "Identifier")) return;
+      if (node.operator === "&&=" || node.operator === "||=" || node.operator === "??=") {
+        if (
+          expressionMayRetainOfficialPendingValue(context, assignmentTarget) ||
+          capturedSymbolMayBePendingAtInvocation(context, assignmentTarget)
+        ) {
+          context.report({ node: assignmentTarget, message: MESSAGE });
+        }
+      }
+      reportAssignedPendingExpression(context, node.right, assignmentTarget);
+    },
+    UpdateExpression(node: EsTreeNodeOfType<"UpdateExpression">) {
+      reportDirectSynchronousConsumption(context, node.argument);
+    },
+    Property(node: EsTreeNodeOfType<"Property">) {
+      if (node.computed) reportOfficialDirectValueConsumption(context, node.key);
+    },
+    ConditionalExpression(node: EsTreeNodeOfType<"ConditionalExpression">) {
+      reportOfficialDirectValueConsumption(context, node.test);
+    },
+    LogicalExpression(node: EsTreeNodeOfType<"LogicalExpression">) {
+      reportOfficialDirectValueConsumption(context, node.left);
+    },
+    IfStatement(node: EsTreeNodeOfType<"IfStatement">) {
+      reportOfficialDirectValueConsumption(context, node.test);
+    },
+    WhileStatement(node: EsTreeNodeOfType<"WhileStatement">) {
+      reportOfficialDirectValueConsumption(context, node.test);
+    },
+    DoWhileStatement(node: EsTreeNodeOfType<"DoWhileStatement">) {
+      reportOfficialDirectValueConsumption(context, node.test);
+    },
+    ForStatement(node: EsTreeNodeOfType<"ForStatement">) {
+      if (node.test) reportOfficialDirectValueConsumption(context, node.test);
+    },
+    SwitchStatement(node: EsTreeNodeOfType<"SwitchStatement">) {
+      reportOfficialDirectValueConsumption(context, node.discriminant);
+    },
+    SpreadElement(node: EsTreeNodeOfType<"SpreadElement">) {
+      reportDirectSynchronousConsumption(context, node.argument);
+    },
+    ForInStatement(node: EsTreeNodeOfType<"ForInStatement">) {
+      reportDirectSynchronousConsumption(context, node.right);
+    },
+    ForOfStatement(node: EsTreeNodeOfType<"ForOfStatement">) {
+      reportDirectSynchronousConsumption(context, node.right);
+    },
+    YieldExpression(node: EsTreeNodeOfType<"YieldExpression">) {
+      if (!node.delegate || !node.argument) return;
+      reportDirectSynchronousConsumption(context, node.argument);
+    },
+    BinaryExpression(node: EsTreeNodeOfType<"BinaryExpression">) {
+      if (node.operator === "in") {
+        reportDirectSynchronousConsumption(context, node.right);
+        reportOfficialDirectValueConsumption(context, node.left);
+        return;
+      }
+      reportOfficialDirectValueConsumption(context, node.left);
+      reportOfficialDirectValueConsumption(context, node.right);
+    },
+    UnaryExpression(node: EsTreeNodeOfType<"UnaryExpression">) {
+      if (node.operator !== "void") reportOfficialDirectValueConsumption(context, node.argument);
+    },
+    TemplateLiteral(node: EsTreeNodeOfType<"TemplateLiteral">) {
+      if (
+        node.parent &&
+        isNodeOfType(node.parent, "TaggedTemplateExpression") &&
+        node.parent.quasi === node
+      ) {
+        const directTag = stripParenExpression(node.parent.tag);
+        const aliasSymbol = isNodeOfType(directTag, "Identifier")
+          ? resolveConstIdentifierAlias(directTag, context.scopes)
+          : null;
+        const tag = stripParenExpression(
+          aliasSymbol?.kind === "const" && aliasSymbol.initializer
+            ? aliasSymbol.initializer
+            : directTag,
+        );
+        if (!isNodeOfType(tag, "MemberExpression")) return;
+        const receiver = stripParenExpression(tag.object);
+        if (
+          !isNodeOfType(receiver, "Identifier") ||
+          receiver.name !== "String" ||
+          !context.scopes.isGlobalReference(receiver) ||
+          getResolvedStaticPropertyName(context, tag) !== "raw"
+        ) {
+          return;
+        }
+      }
+      for (const expression of node.expressions) {
+        reportOfficialDirectValueConsumption(context, expression);
+      }
+    },
+    JSXExpressionContainer(node: EsTreeNodeOfType<"JSXExpressionContainer">) {
+      if (isAstNode(node.expression)) {
+        reportOfficialDirectValueConsumption(context, node.expression);
+      }
+    },
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+      for (const argument of node.arguments) {
+        if (isNodeOfType(argument, "SpreadElement")) continue;
+        if (isGlobalEnumerationCallForArgument(context, node, argument)) {
+          reportDirectSynchronousConsumption(context, argument);
+        }
+        if (isGlobalCoercionCallForArgument(context, node, argument)) {
+          reportOfficialDirectValueConsumption(context, argument);
+        }
+      }
+    },
+    NewExpression(node: EsTreeNodeOfType<"NewExpression">) {
+      for (const argument of node.arguments) {
+        if (isNodeOfType(argument, "SpreadElement")) continue;
+        if (!isGlobalIterableConstructorForArgument(context, node, argument)) continue;
+        reportDirectSynchronousConsumption(context, argument);
+      }
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-async-dynamic-api-not-awaited.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-async-dynamic-api-not-awaited.ts
@@ -3,7 +3,7 @@ import {
   NEXTJS_SOURCE_FILE_EXTENSION_GROUP,
   ROUTE_HANDLER_HTTP_METHODS,
 } from "../../constants/nextjs.js";
-import { PROMISE_SETTLE_METHODS } from "../../constants/js.js";
+import { MUTATING_ARRAY_METHODS, PROMISE_SETTLE_METHODS } from "../../constants/js.js";
 import type { BasicBlock } from "../../semantic/control-flow-graph.js";
 import type { SymbolDescriptor } from "../../semantic/scope-analysis.js";
 import { defineRule } from "../../utils/define-rule.js";
@@ -82,18 +82,6 @@ const COERCIVE_GLOBAL_NAMES: ReadonlySet<string> = new Set([
 ]);
 const NON_CONSUMING_UNARY_OPERATORS: ReadonlySet<string> = new Set(["!", "typeof", "void"]);
 const SITEMAP_FILE_PATTERN = new RegExp(`^sitemap\\.${NEXTJS_SOURCE_FILE_EXTENSION_GROUP}$`);
-const ARRAY_CARDINALITY_MUTATION_METHOD_NAMES: ReadonlySet<string> = new Set([
-  "copyWithin",
-  "fill",
-  "pop",
-  "push",
-  "reverse",
-  "shift",
-  "sort",
-  "splice",
-  "unshift",
-]);
-
 const MESSAGE =
   "This Next.js request API returns a Promise. Synchronous property access warns in Next.js 15 and is removed in Next.js 16; await it or unwrap it with React `use()`.";
 
@@ -2075,7 +2063,7 @@ const getDirectInvocationSites = (
       const parent = memberExpression.parent;
       if (parent && isNodeOfType(parent, "CallExpression") && parent.callee === memberExpression) {
         const methodName = getResolvedStaticPropertyName(context, memberExpression);
-        if (!methodName || !ARRAY_CARDINALITY_MUTATION_METHOD_NAMES.has(methodName)) continue;
+        if (!methodName || !MUTATING_ARRAY_METHODS.has(methodName)) continue;
         if (methodName === "push" || methodName === "unshift") {
           if (parent.arguments.some((argument) => isNodeOfType(argument, "SpreadElement"))) {
             return null;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-detox-missing-await.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-detox-missing-await.ts
@@ -1,3 +1,4 @@
+import { PROMISE_SETTLE_METHODS } from "../../constants/js.js";
 import { defineRule } from "../../utils/define-rule.js";
 import { getImportSourceForName } from "../../utils/find-import-source-for-name.js";
 import { normalizeFilename } from "../../utils/normalize-filename.js";
@@ -123,12 +124,11 @@ const getDetoxOperationMethodName = (
   while (true) {
     const methodName = getTerminalMethodName(currentCall);
     if (methodName === null) return null;
+    if (!PROMISE_SETTLE_METHODS.has(methodName)) return methodName;
     if (methodName === "catch") {
       if (isCallableHandler(currentCall.arguments[0] as EsTreeNode | undefined)) return null;
     } else if (methodName === "then") {
       if (isCallableHandler(currentCall.arguments[1] as EsTreeNode | undefined)) return null;
-    } else if (methodName !== "finally") {
-      return methodName;
     }
     const callee = currentCall.callee;
     if (!isNodeOfType(callee, "MemberExpression")) return null;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.performance.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.performance.test.ts
@@ -1,0 +1,49 @@
+import { expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { windowOpenWithoutNoopener } from "./window-open-without-noopener.js";
+
+const REPEATED_POPUP_CALL_COUNT = 2_000;
+const DISTINCT_WRAPPER_COUNT = 500;
+const DISTINCT_ROUTER_DESTINATION_COUNT = 1_000;
+const REPEATED_BLOB_POPUP_COUNT = 2_000;
+
+it("audits repeated dynamic popup calls without pathological rescans", () => {
+  const popupCalls = Array.from(
+    { length: REPEATED_POPUP_CALL_COUNT },
+    () => "window.open(url);",
+  ).join("\n");
+  const result = runRule(windowOpenWithoutNoopener, `const openAll = (url) => { ${popupCalls} };`);
+  expect(result.diagnostics).toHaveLength(REPEATED_POPUP_CALL_COUNT);
+});
+
+it("proves many distinct local wrappers without rescanning the program per wrapper", () => {
+  const wrappers = Array.from(
+    { length: DISTINCT_WRAPPER_COUNT },
+    (_, wrapperIndex) =>
+      `const openLink${wrapperIndex} = (url) => window.open(url); openLink${wrapperIndex}("/safe");`,
+  ).join("\n");
+  const result = runRule(windowOpenWithoutNoopener, wrappers);
+  expect(result.diagnostics).toHaveLength(0);
+});
+
+it("keeps router reachability analysis bounded for many destination bindings", () => {
+  const destinations = Array.from(
+    { length: DISTINCT_ROUTER_DESTINATION_COUNT },
+    (_, destinationIndex) =>
+      `const destination${destinationIndex} = getDestination(${destinationIndex}); Router.push(destination${destinationIndex}); window.open(destination${destinationIndex});`,
+  ).join("\n");
+  const result = runRule(
+    windowOpenWithoutNoopener,
+    `import Router from "next/router"; const openAll = () => { ${destinations} };`,
+  );
+  expect(result.diagnostics).toHaveLength(DISTINCT_ROUTER_DESTINATION_COUNT);
+});
+
+it("proves repeated blob URLs without rescanning global mutations", () => {
+  const popupCalls = Array.from(
+    { length: REPEATED_BLOB_POPUP_COUNT },
+    () => "window.open(URL.createObjectURL(blob));",
+  ).join("\n");
+  const result = runRule(windowOpenWithoutNoopener, `const openAll = (blob) => { ${popupCalls} };`);
+  expect(result.diagnostics).toHaveLength(0);
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.test.ts
@@ -3014,6 +3014,20 @@ window.open(deltaPage, '_blank');
        const openPopup = () => window.open(popupUrl.toString());
        popupUrl.toString = () => userControlledUrl;
        openPopup();`,
+      `const popupUrl = new URL("/safe", window.origin);
+       const getPopupHref = () => popupUrl.href;
+       const openPopup = () => {
+         popupUrl.href = userControlledUrl;
+         window.open(getPopupHref());
+       };
+       openPopup();`,
+      `const popupUrl = new URL("/safe", window.origin);
+       const getPopupUrl = () => popupUrl;
+       const openPopup = () => {
+         popupUrl.href = userControlledUrl;
+         window.open(getPopupUrl());
+       };
+       openPopup();`,
     ]) {
       const result = runRule(windowOpenWithoutNoopener, code);
       expect(result.diagnostics, code).toHaveLength(1);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.test.ts
@@ -104,6 +104,14 @@ describe("window-open-without-noopener", () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("does not flag a mailto: template behind a const binding like the inline form", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      "const mailtoUrl = `mailto:${email}?subject=hi`;\nwindow.open(mailtoUrl, '_blank');",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("does not flag a hardcoded literal destination (Star-on-GitHub button idiom)", () => {
     const result = runRule(
       windowOpenWithoutNoopener,
@@ -181,6 +189,22 @@ describe("window-open-without-noopener", () => {
     const result = runRule(
       windowOpenWithoutNoopener,
       `const url = useMirror ? mirrorUrl : 'https://example.com/download';\nwindow.open(url, '_blank');`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a const && URL whose left operand is statically nullish", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const url = null && dynamicUrl;\nwindow.open(url, '_blank');`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags a const && URL with a dynamic right operand", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const url = useMirror && mirrorUrl;\nwindow.open(url, '_blank');`,
     );
     expect(result.diagnostics).toHaveLength(1);
   });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.test.ts
@@ -242,6 +242,27 @@ describe("window-open-without-noopener", () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("does not flag a noopener=value feature entry", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `window.open(url, '_blank', 'noopener=1,width=500');`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags a feature entry that merely contains noopener as a substring", () => {
+    const result = runRule(windowOpenWithoutNoopener, `window.open(url, '_blank', 'notnoopener');`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag features behind a reassignable let binding (opaque at lint time)", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `let features = 'width=500';\nfeatures = POPUP_FEATURES;\nwindow.open(url, '_blank', features);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("flags when a resolvable features constant lacks noopener", () => {
     const result = runRule(
       windowOpenWithoutNoopener,
@@ -261,6 +282,16 @@ describe("window-open-without-noopener", () => {
       `const x = <a onClick={(e) => e.metaKey ? window.open(href, '_blank') : navigate(href)} />;`,
     );
     expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a window.open in a non-final comma-sequence position", () => {
+    const result = runRule(windowOpenWithoutNoopener, `(window.open(url, '_blank'), undefined);`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a comma sequence whose final window.open result is captured", () => {
+    const result = runRule(windowOpenWithoutNoopener, `const win = (log(), window.open(url));`);
+    expect(result.diagnostics).toHaveLength(0);
   });
 
   it("does not flag a logical guard whose result is captured", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.test.ts
@@ -321,6 +321,61 @@ describe("window-open-without-noopener", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("flags adjacent interpolation after a trusted origin", () => {
+    for (const code of [
+      "window.open(`${window.origin}${suffix}`, '_blank');",
+      `const buildDestination = (base, suffix) => \`\${base}\${suffix}\`;
+       window.open(buildDestination(window.origin, userControlledSuffix), '_blank');`,
+    ]) {
+      const result = runRule(windowOpenWithoutNoopener, code);
+      expect(result.diagnostics).toHaveLength(1);
+    }
+  });
+
+  it("keeps later interpolations safe after a path delimiter", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      "window.open(`${window.origin}/preview/${assetId}`, '_blank');",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("resolves stable const concatenation prefixes", () => {
+    for (const code of [
+      `const destinationPrefix = "https://example.com/";
+       window.open(destinationPrefix + slug, "_blank");`,
+      `const destinationPrefix = "/safe/";
+       window.open(destinationPrefix + slug, "_blank");`,
+      `const rootPrefix = "https://example.com/" as const;
+       const destinationPrefix = rootPrefix;
+       window.open(destinationPrefix + slug, "_blank");`,
+      `const rootPrefix = "https://example.com/" satisfies string;
+       const destinationPrefix = rootPrefix;
+       window.open(destinationPrefix + slug, "_blank");`,
+    ]) {
+      const result = runRule(windowOpenWithoutNoopener, code);
+      expect(result.diagnostics).toHaveLength(0);
+    }
+  });
+
+  it("does not trust opaque or origin-incomplete concatenation prefixes", () => {
+    for (const code of [
+      `import { destinationPrefix } from "./config";
+       window.open(destinationPrefix + slug, "_blank");`,
+      `let destinationPrefix = "/safe/";
+       window.open(destinationPrefix + slug, "_blank");`,
+      `const destinationPrefix = "https://example.com";
+       window.open(destinationPrefix + slug, "_blank");`,
+      `const destinationPrefix = userControlledPrefix;
+       window.open(destinationPrefix + slug, "_blank");`,
+      `const destinationPrefix = "//";
+       window.open(destinationPrefix + slug, "_blank");`,
+    ]) {
+      const result = runRule(windowOpenWithoutNoopener, code);
+      expect(result.diagnostics).toHaveLength(1);
+    }
+  });
+
   it("does not flag when features come from a shared constant (popup-helper idiom)", () => {
     const result = runRule(
       windowOpenWithoutNoopener,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.test.ts
@@ -328,7 +328,7 @@ describe("window-open-without-noopener", () => {
        window.open(buildDestination(window.origin, userControlledSuffix), '_blank');`,
     ]) {
       const result = runRule(windowOpenWithoutNoopener, code);
-      expect(result.diagnostics).toHaveLength(1);
+      expect(result.diagnostics, code).toHaveLength(1);
     }
   });
 
@@ -2054,6 +2054,210 @@ window.open(deltaPage, '_blank');
        links.forEach((item) => window.open(item.href));`,
     );
     expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("rejects nested writes before destructured config iteration", () => {
+    for (const code of [
+      `const links = [{ href: "/safe" }];
+       links[0].href = userControlledUrl;
+       links.forEach(({ href }) => window.open(href));`,
+      `const links = [{ href: "/safe" }];
+       links[index].href = userControlledUrl;
+       links.forEach(({ href }) => window.open(href));`,
+      `const links = [{ href: "/safe" }];
+       const linksAlias = links;
+       linksAlias[0].href = userControlledUrl;
+       links.forEach(({ href }) => window.open(href));`,
+      `const links = [{ href: "/safe" }];
+       const entry = links[0];
+       entry.href = userControlledUrl;
+       links.forEach(({ href }) => window.open(href));`,
+      `const links = [{ href: "/safe" }];
+       const entry = links[0];
+       const entryAlias = entry;
+       entryAlias.href = userControlledUrl;
+       links.forEach(({ href }) => window.open(href));`,
+      `const links = [{ href: "/safe" }];
+       const [entry] = links;
+       entry.href = userControlledUrl;
+       links.forEach(({ href }) => window.open(href));`,
+      `const links = [{ href: "/safe" }];
+       const linksAlias = links;
+       linksAlias.push({ href: userControlledUrl });
+       links.forEach(({ href }) => window.open(href));`,
+      `const links = [{ href: "/safe" }];
+       links[0] = { href: userControlledUrl };
+       links.forEach(({ href }) => window.open(href));`,
+      `const links = [{ href: "/safe" }];
+       const linksAlias = links;
+       linksAlias[0] = { href: userControlledUrl };
+       links.forEach(({ href }) => window.open(href));`,
+      `const links = [{ href: "/safe" }];
+       const linksAlias = links;
+       linksAlias.splice(0, 1, { href: userControlledUrl });
+       links.forEach(({ href }) => window.open(href));`,
+      `const links = [{ href: "/safe" }];
+       Object.assign(links[0], { href: userControlledUrl });
+       links.forEach(({ href }) => window.open(href));`,
+      `const links = [{ href: "/safe" }];
+       Object.defineProperty(links[0], "href", { value: userControlledUrl });
+       links.forEach(({ href }) => window.open(href));`,
+      `const links = [{ href: "/safe" }];
+       Reflect.set(links[0], "href", userControlledUrl);
+       links.forEach(({ href }) => window.open(href));`,
+      `const links = [{ href: "/safe" }, { href: "/other" }];
+       const [, ...remainingLinks] = links;
+       remainingLinks[0].href = userControlledUrl;
+       links.forEach(({ href }) => window.open(href));`,
+      `const links = [{ href: "/safe" }];
+       const alias1 = links;
+       const alias2 = alias1;
+       const alias3 = alias2;
+       const alias4 = alias3;
+       const alias5 = alias4;
+       const alias6 = alias5;
+       const alias7 = alias6;
+       const alias8 = alias7;
+       const alias9 = alias8;
+       const alias10 = alias9;
+       alias10[0].href = userControlledUrl;
+       links.forEach(({ href }) => window.open(href));`,
+      `const links = [{ href: "/one" }, { href: "/two" }];
+       links.forEach(({ href }, index) => {
+         window.open(href);
+         if (index === 0) links[1].href = userControlledUrl;
+       });`,
+      `const links = [{ href: "/one" }, { href: "/two" }];
+       links.forEach((_, index) => {
+         const currentEntry = links[index];
+         currentEntry.href = userControlledUrl;
+         window.open(currentEntry.href);
+       });`,
+      `const links = [{ href: "/one" }, { href: "/two" }];
+       links.forEach((_, index) => {
+         const currentEntry = links[index];
+         window.open(currentEntry.href);
+         links[index + 1].href = userControlledUrl;
+       });`,
+      `const links = [{ href: "/one" }, { href: "/two" }];
+       links.forEach((_, index) => {
+         const currentEntry = links[index];
+         const openCurrentEntry = () => window.open(currentEntry.href);
+         currentEntry.href = userControlledUrl;
+         openCurrentEntry();
+       });`,
+      `const links = [{ href: "/one" }, { href: "/two" }];
+       links.forEach((_, index) => {
+         const currentEntry = links[index];
+         const openCurrentEntry = () => window.open(currentEntry.href);
+         const openCurrentEntryAlias = openCurrentEntry;
+         currentEntry.href = userControlledUrl;
+         openCurrentEntryAlias();
+       });`,
+      `const links = [{ href: "/one" }, { href: "/two" }];
+       links.forEach((_, index) => {
+         const currentEntry = links[index];
+         const openCurrentEntry = () => { window.open(currentEntry.href); };
+         consume(openCurrentEntry);
+         currentEntry.href = userControlledUrl;
+       });`,
+    ]) {
+      const result = runRule(windowOpenWithoutNoopener, code);
+      expect(result.diagnostics, code).toHaveLength(1);
+    }
+  });
+
+  it("keeps destructured config iteration safe from irrelevant or later writes", () => {
+    for (const code of [
+      `const links = [{ href: "/safe", label: "Safe" }];
+       links[0].label = userControlledLabel;
+       links.forEach(({ href }) => window.open(href));`,
+      `const links = [{ href: "/safe" }];
+       links.forEach(({ href }) => window.open(href));
+       links[0].href = userControlledUrl;`,
+      `const links = [{ href: "/safe" }];
+       let linksAlias = links;
+       linksAlias = [{ href: "/other" }];
+       linksAlias[0].href = userControlledUrl;
+       links.forEach(({ href }) => window.open(href));`,
+      `const links = [{ href: "/one" }, { href: "/two" }];
+       links.forEach(({ href }, index) => {
+         const currentEntry = links[index];
+         window.open(href);
+         currentEntry.href = userControlledUrl;
+       });`,
+      `const links = [{ href: "/one" }, { href: "/two" }];
+       links.forEach((_, index) => {
+         const currentEntry = links[index];
+         window.open(currentEntry.href);
+         currentEntry.href = userControlledUrl;
+       });`,
+      `const links = [{ href: "/one" }, { href: "/two" }];
+       links.forEach(({ href }, index) => {
+         window.open(href);
+         links[index] = { href: userControlledUrl };
+       });`,
+      `const links = [{ href: "/one" }, { href: "/two" }];
+       links.forEach((_, index) => {
+         const currentEntry = links[index];
+         const currentEntryAlias = currentEntry;
+         window.open(currentEntryAlias.href);
+       });`,
+      `const links = [{ href: "/one" }, { href: "/two" }];
+       links.forEach((_, index) => {
+         const currentEntry = links[index];
+         const openCurrentEntry = () => window.open(currentEntry.href);
+         openCurrentEntry();
+         currentEntry.href = userControlledUrl;
+       });`,
+      `const links = [{ href: "/one" }, { href: "/two" }];
+       links.forEach((_, index) => {
+         const currentEntry = links[index];
+         const openCurrentEntry = () => window.open(currentEntry.href);
+         openCurrentEntry();
+         openCurrentEntry();
+         currentEntry.href = userControlledUrl;
+       });`,
+      `const links = [{ href: "/safe", label: "Safe" }];
+       Object.assign(links[0], { label: userControlledLabel });
+       links.forEach(({ href }) => window.open(href));`,
+      `const links = [{ href: "/safe", label: "Safe" }];
+       Object.defineProperty(links[0], "label", { value: userControlledLabel });
+       links.forEach(({ href }) => window.open(href));`,
+      `const links = [{ href: "/safe", label: "Safe" }];
+       Reflect.set(links[0], "label", userControlledLabel);
+       links.forEach(({ href }) => window.open(href));`,
+      `const links = [{ href: "/safe" }];
+       links.forEach(({ href }) => window.open(href));
+       Object.assign(links[0], { href: userControlledUrl });`,
+    ]) {
+      const result = runRule(windowOpenWithoutNoopener, code);
+      expect(result.diagnostics, code).toHaveLength(0);
+    }
+  });
+
+  it("fails closed when indexed-entry opener helpers escape exact direct calls", () => {
+    for (const code of [
+      `const links=[{href:"/a"}];links.forEach((_,i)=>{const e=links[i];e.href=user;(()=>window.open(e.href))();});`,
+      `const links=[{href:"/a"}];links.forEach((_,i)=>{const e=links[i];const f=()=>window.open(e.href);const handlers=[f];e.href=user;consume(handlers);});`,
+      `const links=[{href:"/a"}];links.forEach((_,i)=>{const e=links[i];const f=()=>window.open(e.href);const handlers={f};e.href=user;consume(handlers);});`,
+      `const links=[{href:"/a"}];links.forEach((_,i)=>{const e=links[i];const f=()=>window.open(e.href);return f;});`,
+      `const links=[{href:"/a"}];links.forEach((_,i)=>{const e=links[i];const f=()=>window.open(e.href);setTimeout(f,0);e.href=user;});`,
+      `const links=[{href:"/a"}];links.forEach((_,i)=>{const e=links[i];const f=()=>window.open(e.href);e.href=user;setTimeout(f,0);});`,
+      `const links=[{href:"/a"}];links.forEach((_,i)=>{const e=links[i];const f=()=>window.open(e.href);let a=f;e.href=user;a();});`,
+      `const links=[{href:"/a"}];links.forEach((_,i)=>{const e=links[i];const f=()=>window.open(e.href);const bound=f.bind(null);e.href=user;bound();});`,
+    ]) {
+      const result = runRule(windowOpenWithoutNoopener, code);
+      expect(result.diagnostics, code).toHaveLength(1);
+    }
+  });
+
+  it("trusts an indexed-entry IIFE that runs before the current entry changes", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const links=[{href:"/a"}];links.forEach((_,i)=>{const e=links[i];(()=>window.open(e.href))();e.href=user;});`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
   });
 
   it("rejects leading template bases that can end in a slash", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.test.ts
@@ -1341,6 +1341,18 @@ describe("window-open-without-noopener — cross-file imported destinations", ()
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("stays quiet: parenthesized foreign URL serialization remains transparent", () => {
+    writeFile(
+      "src/config.ts",
+      "export const storeUrl = (new URL('/store', window.location.origin)).toString();\n",
+    );
+    const result = runRuleAt(
+      "src/App.tsx",
+      "import { storeUrl } from './config';\nwindow.open(storeUrl, '_blank');\n",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("fails closed for a foreign raw URL object coerced in the consumer", () => {
     writeFile(
       "src/config.ts",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.test.ts
@@ -924,7 +924,7 @@ const MissingNoCharts = ({ dataId, chartType }) => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
-  it("stays quiet: anchorEl.href helper fed e.currentTarget from an inline handler on a trusted-href link (react-cosmos idiom)", () => {
+  it("flags an anchor helper wired through a custom Link with an unresolved href helper", () => {
     const result = runRule(
       windowOpenWithoutNoopener,
       `export function FixtureLink({ children, fixtureId }) {
@@ -948,7 +948,7 @@ function openAnchorInNewTab(anchorEl) {
     expect(result.diagnostics).toHaveLength(1);
   });
 
-  it("stays quiet: anchorEl.href helper reached through a named handler wired to a trusted-href link (react-cosmos bookmarks idiom)", () => {
+  it("flags an anchor helper wired through a custom FixtureLink component", () => {
     const result = runRule(
       windowOpenWithoutNoopener,
       `export function FixtureBookmarks({ bookmarks, onFixtureSelect }) {
@@ -980,6 +980,26 @@ function openAnchorInNewTab(anchorEl) {
 }`,
     );
     expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays quiet: anchorEl.href helper fed currentTarget from an intrinsic anchor with a proven href", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const createRelativePlaygroundUrl = ({ fixture }) => "/playground/" + fixture;
+       const openAnchorInNewTab = (anchorEl) => {
+         window.open(anchorEl.href, "_blank");
+       };
+       const FixtureLink = ({ fixtureId }) => (
+         <a
+           href={createRelativePlaygroundUrl({ fixture: fixtureId })}
+           onClick={(event) => {
+             event.preventDefault();
+             if (event.metaKey) openAnchorInNewTab(event.currentTarget);
+           }}
+         />
+       );`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
   });
 
   it("still flags an anchorEl.href helper when the wired element's href is dynamic", () => {
@@ -1291,6 +1311,188 @@ window.open(buildCorrelationsUrl(dataId, encodeStrings, isPPS, true), '_blank');
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("rejects writes inside a foreign helper using foreign source offsets", () => {
+    writeFile(
+      "src/share-url.ts",
+      `export const buildShareUrl = (userControlledUrl: string) => {
+  const buildPath = (path: string) => {
+    path = userControlledUrl;
+    return path;
+  };
+  return buildPath('/safe');
+};
+`,
+    );
+    const result = runRuleAt(
+      "src/App.tsx",
+      "import { buildShareUrl } from './share-url';\nwindow.open(buildShareUrl(userControlledUrl), '_blank');\n",
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays quiet when a foreign initializer snapshots a trusted let before a later write", () => {
+    writeFile(
+      "src/share-url.ts",
+      `let popupPath = '/safe';
+export const popupTarget = popupPath;
+popupPath = userControlledUrl;
+`,
+    );
+    const result = runRuleAt(
+      "src/App.tsx",
+      "import { popupTarget } from './share-url';\nwindow.open(popupTarget, '_blank');\n",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when a foreign initializer has an uncalled nested mutator", () => {
+    writeFile(
+      "src/share-url.ts",
+      `let popupPath = '/safe';
+const mutatePopupPath = () => {
+  popupPath = userControlledUrl;
+};
+void mutatePopupPath;
+export const popupTarget = popupPath;
+`,
+    );
+    const result = runRuleAt(
+      "src/App.tsx",
+      "import { popupTarget } from './share-url';\nwindow.open(popupTarget, '_blank');\n",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("rejects a module write that completes before an imported helper is called", () => {
+    writeFile(
+      "src/share-url.ts",
+      `let popupPath = '/safe';
+export const buildShareUrl = () => popupPath;
+popupPath = userControlledUrl;
+`,
+    );
+    const result = runRuleAt(
+      "src/App.tsx",
+      "import { buildShareUrl } from './share-url';\nwindow.open(buildShareUrl(), '_blank');\n",
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays quiet when an imported helper has an uncalled nested mutator", () => {
+    writeFile(
+      "src/share-url.ts",
+      `let popupPath = '/safe';
+const mutatePopupPath = () => {
+  popupPath = userControlledUrl;
+};
+void mutatePopupPath;
+export const buildShareUrl = () => popupPath;
+`,
+    );
+    const result = runRuleAt(
+      "src/App.tsx",
+      "import { buildShareUrl } from './share-url';\nwindow.open(buildShareUrl(), '_blank');\n",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("rejects a foreign helper mutated by a function called during module initialization", () => {
+    writeFile(
+      "src/share-url.ts",
+      `let popupPath = '/safe';
+mutatePopupPath();
+export const buildShareUrl = () => popupPath;
+function mutatePopupPath() {
+  popupPath = userControlledUrl;
+}
+`,
+    );
+    const result = runRuleAt(
+      "src/App.tsx",
+      "import { buildShareUrl } from './share-url';\nwindow.open(buildShareUrl(), '_blank');\n",
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays quiet when a write after a foreign helper return is unreachable", () => {
+    writeFile(
+      "src/share-url.ts",
+      `export const buildShareUrl = () => {
+  let popupPath = '/safe';
+  return popupPath;
+  popupPath = userControlledUrl;
+};
+`,
+    );
+    const result = runRuleAt(
+      "src/App.tsx",
+      "import { buildShareUrl } from './share-url';\nwindow.open(buildShareUrl(), '_blank');\n",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("rejects a write before a foreign helper return", () => {
+    writeFile(
+      "src/share-url.ts",
+      `export const buildShareUrl = () => {
+  let popupPath = '/safe';
+  popupPath = userControlledUrl;
+  return popupPath;
+};
+`,
+    );
+    const result = runRuleAt(
+      "src/App.tsx",
+      "import { buildShareUrl } from './share-url';\nwindow.open(buildShareUrl(), '_blank');\n",
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays quiet when a foreign URL initializer precedes a global replacement", () => {
+    writeFile(
+      "src/share-url.ts",
+      `export const storeUrl = new URL('/store', location.origin).toString();
+URL = EvilURL;
+`,
+    );
+    const result = runRuleAt(
+      "src/App.tsx",
+      "import { storeUrl } from './share-url';\nwindow.open(storeUrl, '_blank');\n",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("rejects a global replacement that completes before an imported URL helper is called", () => {
+    writeFile(
+      "src/share-url.ts",
+      `export const buildShareUrl = () => new URL('/store', location.origin).toString();
+URL = EvilURL;
+`,
+    );
+    const result = runRuleAt(
+      "src/App.tsx",
+      "import { buildShareUrl } from './share-url';\nwindow.open(buildShareUrl(), '_blank');\n",
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("rejects a global replacement called during module initialization", () => {
+    writeFile(
+      "src/share-url.ts",
+      `const replaceUrl = () => {
+  URL = EvilURL;
+};
+replaceUrl();
+export const buildShareUrl = () => new URL('/store', location.origin).toString();
+`,
+    );
+    const result = runRuleAt(
+      "src/App.tsx",
+      "import { buildShareUrl } from './share-url';\nwindow.open(buildShareUrl(), '_blank');\n",
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("flags when the imported helper delegates to another imported helper (no transitive cross-file hops)", () => {
     writeFile("src/deep.ts", "export const buildDeepUrl = () => '/deep';\n");
     writeFile(
@@ -1551,20 +1753,33 @@ window.open(deltaPage, '_blank');
 
   it("uses only authoritative intrinsic anchor href attributes", () => {
     for (const code of [
-      `const C = ({ dynamicHref }) => <a href="/safe" {...props} onClick={(event) =>
-         window.open(event.currentTarget.href)} />;`,
-      `const C = ({ dynamicHref }) => <a href="/safe" href={dynamicHref} onClick={(event) =>
-         window.open(event.currentTarget.href)} />;`,
+      `const C = ({ dynamicHref }) => <a href="/safe" {...props} onClick={(event) => {
+         window.open(event.currentTarget.href);
+       }} />;`,
+      `const C = ({ dynamicHref }) => <a href="/safe" href={dynamicHref} onClick={(event) => {
+         window.open(event.currentTarget.href);
+       }} />;`,
     ]) {
       const result = runRule(windowOpenWithoutNoopener, code);
       expect(result.diagnostics).toHaveLength(1);
     }
     const customElement = runRule(
       windowOpenWithoutNoopener,
-      `const C = () => <Link href="/safe" onClick={(event) =>
-         window.open(event.currentTarget.href)} />;`,
+      `const C = () => <Link href="/safe" onClick={(event) => {
+         window.open(event.currentTarget.href);
+       }} />;`,
     );
-    expect(customElement.diagnostics).toHaveLength(0);
+    expect(customElement.diagnostics).toHaveLength(1);
+    const authoritativeHref = runRule(
+      windowOpenWithoutNoopener,
+      `const openAnchor = (anchor) => {
+         window.open(anchor.href);
+       };
+       const C = () => <a {...props} href="/safe" onClick={(event) => {
+         openAnchor(event.currentTarget);
+       }} />;`,
+    );
+    expect(authoritativeHref.diagnostics).toHaveLength(0);
   });
 
   it("uses the authoritative object property and rejects later mutation", () => {
@@ -1858,6 +2073,43 @@ window.open(deltaPage, '_blank');
     ]) {
       const result = runRule(windowOpenWithoutNoopener, code);
       expect(result.diagnostics).toHaveLength(1);
+    }
+  });
+
+  it("stays quiet when a nested opener is synchronously called before an outer write", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const openDestination = (destination) => {
+         const run = () => {
+           window.open(destination);
+         };
+         run();
+         destination = userControlledUrl;
+       };
+       openDestination('/safe');`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when an inline synchronous opener runs before an outer write", () => {
+    for (const code of [
+      `const openDestination = (destination) => {
+         (() => {
+           window.open(destination);
+         })();
+         destination = userControlledUrl;
+       };
+       openDestination('/safe');`,
+      `const openDestination = (destination) => {
+         [1].forEach(() => {
+           window.open(destination);
+         });
+         destination = userControlledUrl;
+       };
+       openDestination('/safe');`,
+    ]) {
+      const result = runRule(windowOpenWithoutNoopener, code);
+      expect(result.diagnostics).toHaveLength(0);
     }
   });
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.test.ts
@@ -345,6 +345,37 @@ describe("window-open-without-noopener", () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("does not flag templates with opaque feature interpolations", () => {
+    for (const features of [
+      `\`\${POPUP_FEATURES}\``,
+      `\`width=500,\${POPUP_FEATURES}\``,
+      `\`\${POPUP_FEATURES},height=400\``,
+      `\`width=500 \${POPUP_FEATURES}\``,
+      `\`noopener=false,\${POPUP_FEATURES}\``,
+      `\`\${dynamicName}=true\``,
+      `\`noopener=\${dynamicValue}\``,
+      `\`noreferrer=\${dynamicValue}\``,
+      `\`\${dynamicPrefix}\${dynamicName}\``,
+      `\`noopener=\${dynamicPrefix}\${dynamicValue}\``,
+    ]) {
+      const result = runRule(
+        windowOpenWithoutNoopener,
+        `import { POPUP_FEATURES } from './popup';
+         window.open(url, '_blank', ${features});`,
+      );
+      expect(result.diagnostics).toHaveLength(0);
+    }
+  });
+
+  it("still resolves a wholly interpolated local features constant", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const POPUP_FEATURES = 'width=500,height=400';
+       window.open(url, '_blank', \`\${POPUP_FEATURES}\`);`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("flags an explicitly nullish features argument like an omitted one", () => {
     for (const features of ["undefined", "null", "void 0"]) {
       const result = runRule(windowOpenWithoutNoopener, `window.open(url, '_blank', ${features});`);
@@ -711,7 +742,7 @@ window.open(downloadPage);`,
       windowOpenWithoutNoopener,
       `const openTab = (path) => {
   const url = fullPath(path, dataId);
-  window.open(url, '_blank', \`titlebar=1,location=1,status=1,width=\${width},height=\${height}\`);
+  window.open(url, '_blank', 'titlebar=1,location=1,status=1,width=500,height=400');
 };`,
     );
     expect(result.diagnostics).toHaveLength(1);
@@ -1594,6 +1625,11 @@ window.open(deltaPage, '_blank');
     for (const code of [
       `const window = { open() {} }; window.open(url);`,
       `const globalThis = { window: { open() {} } }; globalThis.window.open(url);`,
+      `const globalThis = { open() {} }; globalThis.open(url);`,
+      `const self = { open() {} }; self.open(url);`,
+      `const top = { open() {} }; top.open(url);`,
+      `const parent = { open() {} }; parent.open(url);`,
+      `const frames = { open() {} }; frames.open(url);`,
       `function render(window) { window.open(url); }`,
     ]) {
       const result = runRule(windowOpenWithoutNoopener, code);
@@ -1606,6 +1642,15 @@ window.open(deltaPage, '_blank');
     for (const code of [
       `window["open"](url);`,
       "window[`open`](url);",
+      `globalThis.open(url);`,
+      `self.open(url);`,
+      `top.open(url);`,
+      `parent.open(url);`,
+      `frames.open(url);`,
+      `window.top.open(url);`,
+      `window.parent.open(url);`,
+      `window.frames.open(url);`,
+      `globalThis["open"](url);`,
       `(window.open as typeof window.open)(url);`,
       `(window.open(url) as Window | null);`,
     ]) {
@@ -1619,6 +1664,9 @@ window.open(deltaPage, '_blank');
     for (const code of [
       `const openPopup = globalThis.open; openPopup(url);`,
       `const { open: openPopup } = window; openPopup(url);`,
+      `const popupHost = top; popupHost.open(url);`,
+      `const openPopup = parent.open; openPopup(url);`,
+      `const { open: openPopup } = frames; openPopup(url);`,
     ]) {
       const result = runRule(windowOpenWithoutNoopener, code);
       expect(result.diagnostics).toHaveLength(1);
@@ -2015,12 +2063,18 @@ window.open(deltaPage, '_blank');
     expect(result.diagnostics).toHaveLength(1);
   });
 
-  it("does not synthesize noopener across opaque feature interpolation", () => {
-    const unsafe = runRule(
-      windowOpenWithoutNoopener,
-      'window.open(url, "_blank", `no${dynamicText}opener`);',
-    );
-    expect(unsafe.diagnostics).toHaveLength(1);
+  it("does not treat partial opaque feature entries as opener protection", () => {
+    for (const features of [
+      `\`no\${dynamicText}opener\``,
+      `\`width=\${dynamicWidth}\``,
+      `\`width=5\${dynamicWidth}\``,
+      `\`\${dynamicPrefix}width=500\``,
+      `\`\${dynamicName}=false\``,
+      `\`noopener=false,width=\${dynamicWidth}\``,
+    ]) {
+      const unsafe = runRule(windowOpenWithoutNoopener, `window.open(url, "_blank", ${features});`);
+      expect(unsafe.diagnostics).toHaveLength(1);
+    }
     const safe = runRule(
       windowOpenWithoutNoopener,
       'window.open(url, "_blank", `noopener,width=${dynamicWidth}`);',

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.test.ts
@@ -252,13 +252,13 @@ describe("window-open-without-noopener", () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
-  it("does not flag a location.pathname-derived URL (open-in-new-tab idiom)", () => {
+  it("flags a pathname replacement that can remain protocol-relative", () => {
     const result = runRule(
       windowOpenWithoutNoopener,
       `const getLocation = () => window.location;
        window.open(getLocation().pathname?.replace('/iframe/', '/main/') ?? '', '_blank');`,
     );
-    expect(result.diagnostics).toHaveLength(0);
+    expect(result.diagnostics).toHaveLength(1);
   });
 
   it("does not flag a template led by window.location.origin", () => {
@@ -1255,6 +1255,36 @@ describe("window-open-without-noopener — cross-file imported destinations", ()
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("fails closed for a foreign raw URL object coerced in the consumer", () => {
+    writeFile(
+      "src/config.ts",
+      "export const storeUrl = new URL('/store', window.location.origin);\n",
+    );
+    const result = runRuleAt(
+      "src/App.tsx",
+      `import { storeUrl } from './config';
+URL.prototype.toString = () => userControlledUrl;
+window.open(storeUrl, '_blank');
+`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("preserves a foreign URL template snapshot made before consumer mutations", () => {
+    writeFile(
+      "src/config.ts",
+      "export const storeUrl = `${new URL('/store', window.location.origin)}`;\n",
+    );
+    const result = runRuleAt(
+      "src/App.tsx",
+      `import { storeUrl } from './config';
+URL.prototype.toString = () => userControlledUrl;
+window.open(storeUrl, '_blank');
+`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("still flags when a barrel hides a re-export behind a same-named local decoy helper", () => {
     writeFile(
       "src/impl.ts",
@@ -1822,6 +1852,8 @@ window.open(deltaPage, '_blank');
       `window.open(window.location.pathname.substring(1));`,
       `window.open(window.location.pathname.substr(1));`,
       `window.open(window.location.pathname.replace("/safe", "https://evil.com"));`,
+      `window.open(window.location.pathname.replace("safe", "/"));`,
+      `window.open(window.location.pathname.replace("/iframe/", "/main/"));`,
     ]) {
       const result = runRule(windowOpenWithoutNoopener, code);
       expect(result.diagnostics).toHaveLength(1);
@@ -2152,13 +2184,198 @@ window.open(deltaPage, '_blank');
   });
 
   it("rejects URL prototype serializer mutations", () => {
-    const result = runRule(
-      windowOpenWithoutNoopener,
+    for (const code of [
       `URL.prototype.toString = () => userControlledUrl;
        const popupUrl = new URL("/safe", window.origin);
        window.open(popupUrl.toString());`,
+      `const popupUrl = new URL("/safe", window.origin);
+       URL.prototype.toString = () => userControlledUrl;
+       window.open(popupUrl.toString());`,
+      `const popupUrl = new URL("/safe", window.origin);
+       URL.prototype.toJSON = () => userControlledUrl;
+       window.open(popupUrl.toJSON());`,
+      `const popupUrl = new URL("/safe", window.origin);
+       URL.prototype.href = userControlledUrl;
+       window.open(popupUrl.href);`,
+      `const popupUrl = new URL("/safe", window.origin);
+       URL.prototype.toString = () => userControlledUrl;
+       window.open(popupUrl);`,
+      `const popupUrl = new URL("/safe", window.origin);
+       URL.prototype.toString = () => userControlledUrl;
+       window.open(\`\${popupUrl}\`);`,
+      `const popupUrl = new URL("/safe", window.origin);
+       const popupAlias = popupUrl;
+       URL.prototype.toString = () => userControlledUrl;
+       window.open(popupAlias);`,
+      `const popupUrl = new URL("/safe", window.origin);
+       const popupAlias = popupUrl;
+       URL.prototype.toString = () => userControlledUrl;
+       window.open(\`\${popupAlias}\`);`,
+      `const popupUrl = new URL("/safe", window.origin);
+       const popupAlias = condition ? popupUrl : null;
+       URL.prototype.toString = () => userControlledUrl;
+       window.open(popupAlias);`,
+      `const popupUrl = new URL("/safe", window.origin);
+       const popupUrls = [popupUrl];
+       URL.prototype.toString = () => userControlledUrl;
+       window.open(popupUrls[0]);`,
+      `const popupUrl = new URL("/safe", window.origin);
+       const popupUrls = { safe: popupUrl };
+       URL.prototype.toString = () => userControlledUrl;
+       window.open(popupUrls.safe);`,
+      `const popupUrl = new URL("/safe", window.origin);
+       const getShareUrl = () => popupUrl;
+       URL.prototype.toString = () => userControlledUrl;
+       window.open(getShareUrl());`,
+      `const popupUrl = new URL("/safe", window.origin);
+       const getShareUrl = () => popupUrl.toString();
+       URL.prototype.toString = () => userControlledUrl;
+       window.open(getShareUrl());`,
+      `const popupUrl = new URL("/safe", window.origin);
+       const getShareUrl = () => popupUrl.toJSON();
+       URL.prototype.toJSON = () => userControlledUrl;
+       window.open(getShareUrl());`,
+      `const popupUrl = new URL("/safe", window.origin);
+       const getShareUrl = () => popupUrl.href;
+       URL.prototype.href = userControlledUrl;
+       window.open(getShareUrl());`,
+      `const popupUrl = new URL("/safe", window.origin);
+       const getShareUrl = () => \`\${popupUrl}\`;
+       URL.prototype.toString = () => userControlledUrl;
+       window.open(getShareUrl());`,
+      `const popupUrl = new URL("/safe", window.origin);
+       const popupAlias = popupUrl;
+       popupUrl.href = userControlledUrl;
+       window.open(popupAlias);`,
+    ]) {
+      const result = runRule(windowOpenWithoutNoopener, code);
+      expect(result.diagnostics).toHaveLength(1);
+    }
+  });
+
+  it("preserves URL serialization snapshots made before prototype mutations", () => {
+    for (const code of [
+      `const popupUrl = new URL("/safe", window.origin);
+       const serializedPopupUrl = popupUrl.toString();
+       URL.prototype.toString = () => userControlledUrl;
+       window.open(serializedPopupUrl);`,
+      `const popupUrl = new URL("/safe", window.origin);
+       const popupHref = popupUrl.href;
+       URL.prototype.href = userControlledUrl;
+       window.open(popupHref);`,
+      `const popupUrl = new URL("/safe", window.origin);
+       const serializedPopupUrl = \`\${popupUrl}\`;
+       URL.prototype.toString = () => userControlledUrl;
+       window.open(serializedPopupUrl);`,
+      `const popupUrl = new URL("/safe", window.origin);
+       const getShareUrl = () => popupUrl.toString();
+       const serializedPopupUrl = getShareUrl();
+       URL.prototype.toString = () => userControlledUrl;
+       window.open(serializedPopupUrl);`,
+      `const popupUrl = new URL("/safe", window.origin);
+       const getShareUrl = () => popupUrl.toJSON();
+       const serializedPopupUrl = getShareUrl();
+       URL.prototype.toJSON = () => userControlledUrl;
+       window.open(serializedPopupUrl);`,
+      `const popupUrl = new URL("/safe", window.origin);
+       const getShareUrl = () => popupUrl.href;
+       const popupHref = getShareUrl();
+       URL.prototype.href = userControlledUrl;
+       window.open(popupHref);`,
+      `const popupUrl = new URL("/safe", window.origin);
+       const getShareUrl = () => \`\${popupUrl}\`;
+       const serializedPopupUrl = getShareUrl();
+       URL.prototype.toString = () => userControlledUrl;
+       window.open(serializedPopupUrl);`,
+      `const popupUrl = new URL("/safe", window.origin);
+       const serializePopupUrl = () => popupUrl.toString();
+       const getShareUrl = () => serializePopupUrl();
+       const serializedPopupUrl = getShareUrl();
+       window.open(serializedPopupUrl);`,
+      `const popupUrl = new URL("/safe", window.origin);
+       const serializedPopupUrl = getShareUrl();
+       URL.prototype.toString = () => userControlledUrl;
+       function getShareUrl() {
+         return popupUrl.toString();
+       }
+       window.open(serializedPopupUrl);`,
+    ]) {
+      const result = runRule(windowOpenWithoutNoopener, code);
+      expect(result.diagnostics).toHaveLength(0);
+    }
+  });
+
+  it("does not let URL prototype writes invalidate unrelated string serialization", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const popupPath = "/safe";
+       URL.prototype.toString = () => userControlledUrl;
+       window.open(popupPath.toString());`,
     );
-    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not treat mutations on unrelated destructured URL members as prototype writes", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const popupUrl = new URL("/safe", window.origin);
+       const { canParse } = URL;
+       canParse.metadata = userControlledValue;
+       window.open(popupUrl);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("rejects indirect URL prototype and instance mutation APIs", () => {
+    for (const code of [
+      `const popupUrl = new URL("/safe", window.origin);
+       Object.defineProperty(URL.prototype, "toString", { value: () => userControlledUrl });
+       window.open(popupUrl);`,
+      `const popupUrl = new URL("/safe", window.origin);
+       Object.defineProperties(URL.prototype, {
+         toString: { value: () => userControlledUrl },
+       });
+       window.open(popupUrl);`,
+      `const popupUrl = new URL("/safe", window.origin);
+       Reflect.defineProperty(URL.prototype, "toJSON", { value: () => userControlledUrl });
+       window.open(popupUrl);`,
+      `const popupUrl = new URL("/safe", window.origin);
+       Object.assign(URL.prototype, { toString: () => userControlledUrl });
+       window.open(popupUrl);`,
+      `const popupUrl = new URL("/safe", window.origin);
+       Object.setPrototypeOf(popupUrl, { toString: () => userControlledUrl });
+       window.open(popupUrl);`,
+      `const popupUrl = new URL("/safe", window.origin);
+       Object.assign(popupUrl, { href: userControlledUrl });
+       window.open(popupUrl);`,
+      `const popupUrl = new URL("/safe", window.origin);
+       const popupAlias = popupUrl;
+       Object.defineProperty(popupAlias, "toString", { value: () => userControlledUrl });
+       window.open(popupUrl);`,
+      `const popupUrl = new URL("/safe", window.origin);
+       const popupAlias = popupUrl;
+       Reflect.setPrototypeOf(popupAlias, { toString: () => userControlledUrl });
+       window.open(popupUrl);`,
+      `const popupUrl = new URL("/safe", window.origin);
+       const urlPrototype = URL.prototype;
+       urlPrototype.toString = () => userControlledUrl;
+       window.open(popupUrl);`,
+      `const popupUrl = new URL("/safe", window.origin);
+       const { prototype: urlPrototype } = URL;
+       urlPrototype.toString = () => userControlledUrl;
+       window.open(popupUrl);`,
+      `const popupUrl = new URL("/safe", window.origin);
+       const defineProperty = Object.defineProperty;
+       defineProperty(URL.prototype, "toString", { value: () => userControlledUrl });
+       window.open(popupUrl);`,
+      `const popupUrl = new URL("/safe", window.origin);
+       const { defineProperty } = Object;
+       defineProperty(URL.prototype, "toString", { value: () => userControlledUrl });
+       window.open(popupUrl);`,
+    ]) {
+      const result = runRule(windowOpenWithoutNoopener, code);
+      expect(result.diagnostics).toHaveLength(1);
+    }
   });
 
   it("does not assume custom JSX handlers discard callback returns", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.test.ts
@@ -372,7 +372,7 @@ describe("window-open-without-noopener", () => {
        window.open(destinationPrefix + slug, "_blank");`,
     ]) {
       const result = runRule(windowOpenWithoutNoopener, code);
-      expect(result.diagnostics).toHaveLength(1);
+      expect(result.diagnostics, code).toHaveLength(1);
     }
   });
 
@@ -418,7 +418,7 @@ describe("window-open-without-noopener", () => {
         `import { POPUP_FEATURES } from './popup';
          window.open(url, '_blank', ${features});`,
       );
-      expect(result.diagnostics).toHaveLength(0);
+      expect(result.diagnostics, features).toHaveLength(0);
     }
   });
 
@@ -1383,6 +1383,40 @@ window.open(storeUrl, '_blank');
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("does not reuse a local opener invocation while analyzing imported URL values", () => {
+    writeFile(
+      "src/config.ts",
+      "export const storeUrl = new URL('/store', window.location.origin);\n",
+    );
+    const unsafeResult = runRuleAt(
+      "src/App.tsx",
+      `import { storeUrl } from './config';
+const openFirst = () => window.open('/safe');
+openFirst();
+URL.prototype.toString = () => userControlledUrl;
+const openStore = () => window.open(storeUrl);
+openStore();
+`,
+    );
+    expect(unsafeResult.diagnostics).toHaveLength(1);
+
+    writeFile(
+      "src/config.ts",
+      "export const storeUrl = `${new URL('/store', window.location.origin)}`;\n",
+    );
+    const safeResult = runRuleAt(
+      "src/Other.tsx",
+      `import { storeUrl } from './config';
+URL.prototype.toString = () => userControlledUrl;
+const openFirst = () => window.open('/safe');
+openFirst();
+const openStore = () => window.open(storeUrl);
+openStore();
+`,
+    );
+    expect(safeResult.diagnostics).toHaveLength(0);
+  });
+
   it("still flags when a barrel hides a re-export behind a same-named local decoy helper", () => {
     writeFile(
       "src/impl.ts",
@@ -2177,6 +2211,40 @@ window.open(deltaPage, '_blank');
       const result = runRule(windowOpenWithoutNoopener, code);
       expect(result.diagnostics, code).toHaveLength(1);
     }
+
+    for (const code of [
+      `const popupUrl = new URL("/safe", window.origin);
+       const openPopup = () => { window.open(popupUrl.toString()); };
+       openPopup();
+       URL.prototype.toString = () => userControlledUrl;
+       openPopup();`,
+      `const popupUrl = new URL("/safe", window.origin);
+       const openPopup = () => { window.open(popupUrl.toString()); };
+       URL.prototype.toString = () => userControlledUrl;
+       openPopup();
+       openPopup();`,
+      `const popupUrl = new URL("/safe", window.origin);
+       const openPopup = () => { window.open(popupUrl.toString()); };
+       consume(openPopup);
+       URL.prototype.toString = () => userControlledUrl;`,
+    ]) {
+      const result = runRule(windowOpenWithoutNoopener, code);
+      expect(result.diagnostics, code).toHaveLength(1);
+    }
+
+    for (const code of [
+      `const popupUrl = new URL("/safe", window.origin);
+       const openPopup = () => { window.open(popupUrl.toString()); };
+       openPopup();
+       openPopup();
+       URL.prototype.toString = () => userControlledUrl;`,
+      `const popupUrl = new URL("/safe", window.origin);
+       const openPopup = () => { window.open(popupUrl.toString()); };
+       consume(openPopup);`,
+    ]) {
+      const result = runRule(windowOpenWithoutNoopener, code);
+      expect(result.diagnostics, code).toHaveLength(0);
+    }
   });
 
   it("keeps destructured config iteration safe from irrelevant or later writes", () => {
@@ -2612,7 +2680,7 @@ window.open(deltaPage, '_blank');
        window.open(popupAlias);`,
     ]) {
       const result = runRule(windowOpenWithoutNoopener, code);
-      expect(result.diagnostics).toHaveLength(1);
+      expect(result.diagnostics, code).toHaveLength(1);
     }
   });
 
@@ -2664,7 +2732,157 @@ window.open(deltaPage, '_blank');
        window.open(serializedPopupUrl);`,
     ]) {
       const result = runRule(windowOpenWithoutNoopener, code);
-      expect(result.diagnostics).toHaveLength(0);
+      expect(result.diagnostics, code).toHaveLength(0);
+    }
+  });
+
+  it("scopes local invocation references to one opener analysis", () => {
+    for (const code of [
+      `const popupUrl = new URL("/safe", window.origin);
+       const openFirst = () => window.open("/safe");
+       openFirst();
+       URL.prototype.toString = () => userControlledUrl;
+       window.open(popupUrl);`,
+      `const popupUrl = new URL("/safe", window.origin);
+       (() => window.open("/safe"))();
+       URL.prototype.href = userControlledUrl;
+       window.open(popupUrl.href);`,
+    ]) {
+      const result = runRule(windowOpenWithoutNoopener, code);
+      expect(result.diagnostics, code).toHaveLength(1);
+    }
+
+    for (const code of [
+      `const popupUrl = new URL("/safe", window.origin);
+       const serializedPopupUrl = popupUrl.toString();
+       URL.prototype.toString = () => userControlledUrl;
+       const openFirst = () => window.open("/safe");
+       openFirst();
+       window.open(serializedPopupUrl);`,
+      `const popupUrl = new URL("/safe", window.origin);
+       const popupHref = popupUrl.href;
+       URL.prototype.href = userControlledUrl;
+       (() => window.open("/safe"))();
+       window.open(popupHref);`,
+      `const popupUrl = new URL("/safe", window.origin);
+       const serializedPopupUrl = popupUrl.toString();
+       URL.prototype.toString = () => userControlledUrl;
+       const openSnapshot = () => window.open(serializedPopupUrl);
+       openSnapshot();`,
+      `const popupUrl = new URL("/safe", window.origin);
+       const popupHref = popupUrl.href;
+       URL.prototype.href = userControlledUrl;
+       const openSnapshot = () => window.open(popupHref);
+       openSnapshot();`,
+      `const popupUrl = new URL("/safe", window.origin);
+       const serializedPopupUrl = popupUrl.toJSON();
+       URL.prototype.toJSON = () => userControlledUrl;
+       const openSnapshot = () => window.open(serializedPopupUrl);
+       openSnapshot();`,
+      `const popupUrl = new URL("/safe", window.origin);
+       const serializedPopupUrl = \`\${popupUrl}\`;
+       URL.prototype.toString = () => userControlledUrl;
+       const openSnapshot = () => window.open(serializedPopupUrl);
+       openSnapshot();`,
+      `const run = () => {
+         const popupUrl = new URL("/safe", window.origin);
+         const serializedPopupUrl = popupUrl.toString();
+         URL.prototype.toString = () => userControlledUrl;
+         const openSnapshot = () => window.open(serializedPopupUrl);
+         openSnapshot();
+       };
+       run();`,
+      `const popupUrl = new URL("/safe", window.origin);
+       const serializedPopupUrl = popupUrl.toString();
+       const firstAlias = serializedPopupUrl;
+       const secondAlias = firstAlias;
+       URL.prototype.toString = () => userControlledUrl;
+       const openSnapshot = () => window.open(secondAlias);
+       openSnapshot();`,
+      `const popupUrl = new URL("/safe", window.origin);
+       const outer = () => {
+         const serializedPopupUrl = popupUrl.toString();
+         const inner = () => window.open(serializedPopupUrl);
+         inner();
+       };
+       outer();
+       URL.prototype.toString = () => userControlledUrl;`,
+      `const popupUrl = new URL("/safe", window.origin);
+       [1].forEach(() => window.open(popupUrl.toString()));
+       URL.prototype.toString = () => userControlledUrl;`,
+      `const popupUrl = new URL("/safe", window.origin);
+       const openPopup = () => window.open(popupUrl.toString());
+       openPopup();
+       popupUrl.toString = () => userControlledUrl;`,
+      `const popupUrl = new URL("/safe", window.origin);
+       const openPopup = () => window.open(popupUrl.toJSON());
+       openPopup();
+       popupUrl.toJSON = () => userControlledUrl;`,
+      `const popupUrl = new URL("/safe", window.origin);
+       const openPopup = () => window.open(popupUrl.href);
+       openPopup();
+       popupUrl.href = userControlledUrl;`,
+      `const popupUrl = new URL("/safe", window.origin);
+       const openPopup = () => window.open(popupUrl.toString());
+       openPopup();
+       Object.defineProperty(popupUrl, "toString", { value: () => userControlledUrl });`,
+    ]) {
+      const result = runRule(windowOpenWithoutNoopener, code);
+      expect(result.diagnostics, code).toHaveLength(0);
+    }
+
+    for (const code of [
+      `const popupUrl = new URL("/safe", window.origin);
+       const openPopup = () => window.open(popupUrl.toString());
+       URL.prototype.toString = () => userControlledUrl;
+       openPopup();`,
+      `const popupUrl = new URL("/safe", window.origin);
+       const serializePopupUrl = () => popupUrl.toJSON();
+       const openPopup = () => window.open(serializePopupUrl());
+       URL.prototype.toJSON = () => userControlledUrl;
+       openPopup();`,
+      `const popupUrl = new URL("/safe", window.origin);
+       const openPopup = () => {
+         const serializedPopupUrl = popupUrl.toString();
+         window.open(serializedPopupUrl);
+       };
+       URL.prototype.toString = () => userControlledUrl;
+       openPopup();`,
+      `const popupUrl = new URL("/safe", window.origin);
+       const outer = () => {
+         const serializedPopupUrl = popupUrl.toString();
+         const inner = () => window.open(serializedPopupUrl);
+         inner();
+       };
+       URL.prototype.toString = () => userControlledUrl;
+       outer();`,
+      `const popupUrl = new URL("/safe", window.origin);
+       const outer = () => {
+         const popupHref = popupUrl.href;
+         const inner = () => window.open(popupHref);
+         inner();
+       };
+       popupUrl.href = userControlledUrl;
+       outer();`,
+      `const popupUrl = new URL("/safe", window.origin);
+       const outer = () => {
+         const serializedPopupUrl = popupUrl.toString();
+         const inner = () => window.open(serializedPopupUrl);
+         inner();
+       };
+       outer();
+       URL.prototype.toString = () => userControlledUrl;
+       outer();`,
+      `const popupUrl = new URL("/safe", window.origin);
+       URL.prototype.toString = () => userControlledUrl;
+       [1].forEach(() => window.open(popupUrl.toString()));`,
+      `const popupUrl = new URL("/safe", window.origin);
+       const openPopup = () => window.open(popupUrl.toString());
+       popupUrl.toString = () => userControlledUrl;
+       openPopup();`,
+    ]) {
+      const result = runRule(windowOpenWithoutNoopener, code);
+      expect(result.diagnostics, code).toHaveLength(1);
     }
   });
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.test.ts
@@ -1,5 +1,13 @@
-import { describe, expect, it } from "vite-plus/test";
+import * as fs from "node:fs";
+import os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+import { attachParentReferences } from "../../../test-utils/attach-parent-references.js";
+import { parseFixture } from "../../../test-utils/parse-fixture.js";
 import { runRule } from "../../../test-utils/run-rule.js";
+import { walkAst } from "../../utils/walk-ast.js";
+import { wrapWithSemanticContext } from "../../utils/wrap-with-semantic-context.js";
+import { __clearParseSourceFileCacheForTests } from "../../utils/parse-source-file.js";
 import { windowOpenWithoutNoopener } from "./window-open-without-noopener.js";
 
 describe("window-open-without-noopener", () => {
@@ -28,7 +36,10 @@ describe("window-open-without-noopener", () => {
   });
 
   it("flags a concise arrow used as a forEach callback", () => {
-    const result = runRule(windowOpenWithoutNoopener, `list.forEach((link) => window.open(link));`);
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `[link].forEach((link) => window.open(link));`,
+    );
     expect(result.diagnostics).toHaveLength(1);
   });
 
@@ -229,6 +240,54 @@ describe("window-open-without-noopener", () => {
     const result = runRule(
       windowOpenWithoutNoopener,
       `const { releaseUrl } = useUpdateChecker();\nconst x = <button onClick={() => releaseUrl && window.open(releaseUrl, '_blank')} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a template led by a path-builder helper pinned to an app route (dtale export idiom)", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      "const fullPath = (path, dataId) => `${path}/${dataId}`;\nwindow.open(`${fullPath('/dtale/data-export', dataId)}?type=${exportType}`, '_blank');",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a location.pathname-derived URL (open-in-new-tab idiom)", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const getLocation = () => window.location;
+       window.open(getLocation().pathname?.replace('/iframe/', '/main/') ?? '', '_blank');`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a template led by window.location.origin", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      "window.open(`${window.location.origin}/${path}`, '_blank', 'width=700,height=450');",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a helper fed getLocation().href (forward-URL idiom)", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const getLocation = () => window.location;
+       const buildForwardURL = (href) => href;
+       window.open(buildForwardURL(getLocation().href, dataId), '_blank');`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still flags an origin read off a non-location receiver (postMessage event)", () => {
+    const result = runRule(windowOpenWithoutNoopener, "window.open(event.origin, '_blank');");
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a helper-built URL whose first argument is not a same-origin path", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      "window.open(buildUrl(externalHost, path), '_blank');",
     );
     expect(result.diagnostics).toHaveLength(1);
   });
@@ -440,13 +499,1452 @@ describe("window-open-without-noopener", () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
-  it("does not flag a bare open() that is not the window global", () => {
+  it("flags a bare global open() call", () => {
     const result = runRule(windowOpenWithoutNoopener, `open(url, '_blank');`);
-    expect(result.diagnostics).toHaveLength(0);
+    expect(result.diagnostics).toHaveLength(1);
   });
 
   it("does not flag a non-window object's open method", () => {
     const result = runRule(windowOpenWithoutNoopener, `db.open(url);`);
     expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet: Hardcoded link map: member access on a same-file const object of literal URLs", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const EXTERNAL_LINKS = {
+  docs: 'https://docs.example.com/',
+  github: 'https://github.com/acme/widget',
+};
+const HelpMenu = () => (
+  <button onClick={() => window.open(EXTERNAL_LINKS.docs, '_blank')}>Docs</button>
+);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet: Nav config array with hardcoded hrefs: item.external ? window.open(item.href) : navigate(item.href)", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const NAV_ITEMS = [
+  { label: 'Docs', href: 'https://docs.example.com/', external: true },
+  { label: 'Settings', href: '/settings', external: false },
+];
+const Sidebar = ({ navigate }) => (
+  <ul>
+    {NAV_ITEMS.map((item) => (
+      <li key={item.label}>
+        <button
+          onClick={() => {
+            item.external ? window.open(item.href, '_blank') : navigate(item.href);
+          }}
+        >
+          {item.label}
+        </button>
+      </li>
+    ))}
+  </ul>
+);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet: String concatenation with a pinned https origin — the exempt template's exact + equivalent", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `window.open('https://github.com/' + owner + '/' + repo, '_blank');`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet: String concatenation with a same-origin path prefix (drawdb wild shape)", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `window.open('/editor/templates/' + selectedTemplateId, '_blank');`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet: Same-origin absolute URL via ${window.location.origin} in the host position", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `window.open(\`\${window.location.origin}/preview?id=\${documentId}\`, '_blank');`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet: URL API builder: new URL literal origin + searchParams.set + toString()", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const shareUrl = new URL('https://twitter.com/intent/tweet');
+shareUrl.searchParams.set('text', message);
+window.open(shareUrl.toString(), '_blank');`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags an unresolved imported URL constant", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `import { CHANGELOG_URL } from './constants';
+const openChangelog = () => {
+  window.open(CHANGELOG_URL, '_blank');
+};`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays quiet: Template interpolating a same-file trusted const base URL", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const API_BASE = 'https://api.example.com';
+window.open(\`\${API_BASE}/docs/getting-started\`, '_blank');`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet: OAuth popup that must keep window.opener for the postMessage handshake", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const API_BASE = 'https://api.example.com';
+function ConnectButton({ onToken }) {
+  const startOAuth = () => {
+    window.open(\`\${API_BASE}/oauth/google/start\`, 'oauth-popup', 'width=500,height=650');
+  };
+  React.useEffect(() => {
+    const onMessage = (event) => {
+      if (event.origin !== window.location.origin) return;
+      if (event.data?.type === 'oauth-token') onToken(event.data.token);
+    };
+    window.addEventListener('message', onMessage);
+    return () => window.removeEventListener('message', onMessage);
+  }, [onToken]);
+  return <button onClick={startOAuth}>Connect Google</button>;
+}`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet: Blob object URL of app-generated content (SVG/PDF export preview)", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const handleExport = () => {
+  const svgMarkup = new XMLSerializer().serializeToString(svgRef.current);
+  const blob = new Blob([svgMarkup], { type: 'image/svg+xml' });
+  const objectUrl = URL.createObjectURL(blob);
+  window.open(objectUrl, '_blank');
+};`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet: as-const literal URL binding (TSAsExpression not unwrapped)", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const DOCS_URL = 'https://docs.example.com/guide' as const;
+window.open(DOCS_URL, '_blank');`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet: let assigned only hardcoded literals across switch branches", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `function openHelp(kind) {
+  let url;
+  switch (kind) {
+    case 'docs':
+      url = 'https://docs.example.com/';
+      break;
+    default:
+      url = 'https://support.example.com/';
+  }
+  window.open(url, '_blank');
+}`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet: Const search base + encodeURIComponent query (freeCodeCamp shape)", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const SEARCH_URL = 'https://www.freecodecamp.org/news/search/';
+window.open(\`\${SEARCH_URL}?query=\${encodeURIComponent(value)}\`, '_blank');`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet: Template led by window.origin (AppFlowy as-template idiom)", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      "window.open(`${window.origin}/as-template?viewUrl=${encodeURIComponent(publishUrl)}`, '_blank');",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("resolves global destination proofs after the production host captures Program", () => {
+    const parsed = parseFixture(
+      `const blobUrl = URL.createObjectURL(blob);
+window.open(blobUrl);
+window.open(\`\${window.origin}/preview\`);`,
+    );
+    attachParentReferences(parsed.program);
+    const diagnostics: unknown[] = [];
+    const visitors = wrapWithSemanticContext(windowOpenWithoutNoopener).create({
+      report: (diagnostic) => diagnostics.push(diagnostic),
+    });
+    walkAst(parsed.program, (node) => visitors[node.type]?.(node));
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it("flags an unresolved imported camelCase URL constant", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `import { downloadPage } from '@/utils/url';
+window.open(downloadPage);`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags an unresolved path-builder called with a dynamic path", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const openTab = (path) => {
+  const url = fullPath(path, dataId);
+  window.open(url, '_blank', \`titlebar=1,location=1,status=1,width=\${width},height=\${height}\`);
+};`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags unresolved nested URL builders", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const exportHTML = () => {
+  const url = buildURL(fullPath(DATA_ENDPOINT, dataId), { export: true });
+  window.open(url, '_blank');
+};`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays quiet: Sync get…Url route-builder helper (AppFlowy open-in-new-tab idiom)", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const getViewUrl = (view, currentWorkspaceId) =>
+  "/workspace/" + currentWorkspaceId + "/view/" + view.view_id;
+const onSelect = () => {
+  const url = getViewUrl(view, currentWorkspaceId);
+  if (!url) return;
+  window.open(url, '_blank');
+};`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags an unresolved get…Url helper", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `function viewAllDep({ ctrlKey, metaKey }) {
+  window.open(getUrl({ density, operation }), ctrlKey || metaKey ? '_blank' : '_self');
+}`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays quiet: Bare relative template path (glific chat route idiom)", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      "window.open(`chat/${contact.id}?search=${item.messageNumber}`);",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet: file: URL template of an app-written log file (Tauri debug idiom)", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      "window.open(`file://${rustStore.debugLogPath}`, '_blank');",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet: Prop of a local non-exported component whose every usage is a literal path (rad-ui card idiom)", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const IntegrationCard = ({ title, cta = "", ctaLink }) => {
+  const onClickHandler = () => {
+    window.open(ctaLink, '_blank');
+  };
+  return <button onClick={onClickHandler}>{cta}</button>;
+};
+const Page = () => (
+  <div>
+    <IntegrationCard ctaLink="/docs/first-steps/installation" cta="Install" title="Install" />
+    <IntegrationCard ctaLink="/docs/first-steps/introduction" cta="View Docs" title="Docs" />
+  </div>
+);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still flags a prop of an exported component (unknowable call sites)", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `export const PopoverPanel = ({ url }) => (
+  <div onClick={() => window.open(url, '_blank')} />
+);
+const Demo = () => <PopoverPanel url="/docs" />;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a local component prop when one usage passes a dynamic value", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const Card = ({ ctaLink }) => (
+  <button onClick={() => window.open(ctaLink, '_blank')}>Go</button>
+);
+const Page = ({ items }) => (
+  <div>
+    <Card ctaLink="/docs" />
+    <Card ctaLink={items[0].url} />
+  </div>
+);`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a build…Url helper result (composable-origin builder stays opaque)", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      "window.open(buildCorrelationsUrl(dataId, encodeStrings), '_blank');",
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a process…Url transformer of user-entered links (AppFlowy openUrl idiom)", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const newUrl = processUrl(url);
+window.open(newUrl, '_blank');`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a config-supplied help link behind a truthiness guard (jaeger trace-diff idiom)", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const onClick = () => {
+  const helpLink = getConfig().traceDiff?.helpLink;
+  if (helpLink) {
+    window.open(helpLink, '_blank');
+  }
+};`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags an untrusted dynamic destination", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const OpenLink = ({ url }) => (
+         <button onClick={() => window.open(url, "_blank")}>Open</button>
+       );`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a let reassigned from a prop across branches", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `function openTarget(kind, external) {
+         let url;
+         switch (kind) {
+           case "docs":
+             url = "https://docs.example.com/";
+             break;
+           default:
+             url = external;
+         }
+         window.open(url, "_blank");
+       }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a const object map whose accessed value is dynamic", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const LINKS = { docs: buildUrl() };
+       const Help = () => (
+         <button onClick={() => window.open(LINKS.docs, "_blank")}>Docs</button>
+       );`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags useState setters fed by unresolved member builders", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const buildUrls = (dataId, chartType) => {
+  const imageUrl = buildURLString(menuFuncs.fullPath(\`/dtale/missingno/\${chartType}\`, dataId), { id: '1' });
+  const fileUrl = buildURLString(menuFuncs.fullPath(\`/dtale/missingno/\${chartType}\`, dataId), { file: 'true' });
+  return [imageUrl, fileUrl];
+};
+const MissingNoCharts = ({ dataId, chartType }) => {
+  const [imageUrl, setImageUrl] = React.useState();
+  const [fileUrl, setFileUrl] = React.useState();
+  React.useEffect(() => {
+    const urls = buildUrls(dataId, chartType);
+    setImageUrl(urls[0]);
+    setFileUrl(urls[1]);
+  }, [dataId, chartType]);
+  return (
+    <>
+      <button onClick={() => window.open(imageUrl ?? '', '_blank')} />
+      <button onClick={() => window.open(fileUrl ?? '', '_blank')} />
+    </>
+  );
+};`,
+    );
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
+  it("still flags a useState URL whose setter receives server data", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const Portal = () => {
+  const [portalUrl, setPortalUrl] = React.useState();
+  React.useEffect(() => {
+    api.fetchPortal().then((response) => setPortalUrl(response.url));
+  }, []);
+  return <button onClick={() => window.open(portalUrl ?? '', '_blank')} />;
+};`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays quiet: anchorEl.href helper fed e.currentTarget from an inline handler on a trusted-href link (react-cosmos idiom)", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `export function FixtureLink({ children, fixtureId }) {
+  return (
+    <Link
+      href={createRelativePlaygroundUrl({ fixture: fixtureId })}
+      onClick={e => {
+        e.preventDefault();
+        if (e.metaKey) openAnchorInNewTab(e.currentTarget);
+        else selectFixture(fixtureId);
+      }}
+    >
+      {children}
+    </Link>
+  );
+}
+function openAnchorInNewTab(anchorEl) {
+  window.open(anchorEl.href, '_blank');
+}`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays quiet: anchorEl.href helper reached through a named handler wired to a trusted-href link (react-cosmos bookmarks idiom)", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `export function FixtureBookmarks({ bookmarks, onFixtureSelect }) {
+  return (
+    <ul>
+      {bookmarks.map(fixtureItem => {
+        const { fixtureId } = fixtureItem;
+        function handleClick(e) {
+          e.preventDefault();
+          if (e.metaKey) {
+            openAnchorInNewTab(e.currentTarget);
+          } else {
+            onFixtureSelect(fixtureId);
+          }
+        }
+        return (
+          <li key={fixtureId}>
+            <FixtureLink href={createRelativePlaygroundUrl({ fixture: fixtureId })} onClick={handleClick}>
+              {fixtureId}
+            </FixtureLink>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+function openAnchorInNewTab(anchorEl) {
+  window.open(anchorEl.href, '_blank');
+}`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags an anchorEl.href helper when the wired element's href is dynamic", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const ArticleLink = ({ article }) => (
+  <a
+    href={article.url}
+    onClick={e => {
+      if (e.metaKey) openAnchorInNewTab(e.currentTarget);
+    }}
+  >
+    {article.title}
+  </a>
+);
+function openAnchorInNewTab(anchorEl) {
+  window.open(anchorEl.href, '_blank');
+}`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays quiet: local useCallback wrapper only ever called with hardcoded literals (rad-ui NavBar idiom)", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const NavBar = () => {
+  const openLink = useCallback(
+    (url) => () => {
+      window.open(url, "_blank");
+    },
+    []
+  );
+  return (
+    <div>
+      <button onClick={openLink("https://discord.gg/nMaQfeEPNp")}>Discord</button>
+      <button onClick={openLink("https://github.com/rad-ui/ui")}>GitHub</button>
+    </div>
+  );
+};`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still flags a local wrapper when any call site passes a dynamic value", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const Menu = ({ item }) => {
+  const openLink = (url) => {
+    window.open(url, "_blank");
+  };
+  return (
+    <div>
+      <button onClick={() => openLink("https://github.com/rad-ui/ui")}>GitHub</button>
+      <button onClick={() => openLink(item.url)}>Item</button>
+    </div>
+  );
+};`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags an exported helper whose URL parameter has unknowable callers (ant-design openUrl idiom)", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `export const openUrl = ({ href, target }) => {
+  switch (target) {
+    case '_blank':
+      window.open(href, target);
+      break;
+    default:
+      window.location.href = href;
+  }
+};`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays quiet: destructured href from a map over an inline array of hardcoded links (pwa-kit social-icons idiom)", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const SocialIcons = () => (
+  <div>
+    {[
+      { href: 'https://www.youtube.com/channel/UCSTGHqzR1Q9yAVbiS3dAFHg', ariaLabel: 'YouTube' },
+      { href: '/', ariaLabel: 'Pinterest' },
+      { href: 'https://twitter.com/CommerceCloud', ariaLabel: 'Twitter' },
+    ].map(({ href, ariaLabel }) => (
+      <button
+        key={href}
+        onClick={() => {
+          window.open(href);
+        }}
+        aria-label={ariaLabel}
+      />
+    ))}
+  </div>
+);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still flags a destructured value from a map over dynamic template data (glific template-buttons idiom)", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `export const TemplateButtons = ({ template }) => {
+  const handleButtonClick = (type, value) => {
+    if (type === 'call-to-action') {
+      if (value) window.open(value, '_blank');
+    }
+  };
+  return (
+    <div>
+      {template?.map(({ title, value, type }) => (
+        <button key={title} onClick={() => handleButtonClick(type, value)}>
+          {title}
+        </button>
+      ))}
+    </div>
+  );
+};`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays quiet: binding co-navigated through Router.push in a sibling branch (hyperdx cmd+click-row idiom)", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `import Router from "next/router";
+export function ListingRow({ href, name }) {
+  return (
+    <tr
+      onClick={e => {
+        if (e.metaKey || e.ctrlKey) {
+          window.open(href, '_blank');
+        } else {
+          Router.push(href);
+        }
+      }}
+      onAuxClick={e => {
+        if (e.button === 1) {
+          window.open(href, '_blank');
+        }
+      }}
+    >
+      {name}
+    </tr>
+  );
+}`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still flags a host-pinned protocol//hostname template with a config port (PortOS launch idiom)", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      "window.open(`${window.location.protocol}//${window.location.hostname}:${app.uiPort}`, '_blank');",
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a URL destructured from a plural get…Urls getter (PortOS launch-URLs idiom)", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const { https, http } = getLaunchUrls(app);
+window.open(https, '_blank');`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a URL destructured from an awaited API .then callback (PortOS OAuth idiom)", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `api.getGoogleAuthUrl().then(({ url }) => {
+  window.open(url, '_blank');
+});`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+});
+
+// Cross-file verification needs actual files on disk so the rule's
+// resolveCrossFileExport plumbing can resolve and parse the imported
+// modules. Each test writes a temp project and lints the consumer file
+// under its absolute path.
+describe("window-open-without-noopener — cross-file imported destinations", () => {
+  let temporaryDirectory = "";
+
+  beforeEach(() => {
+    temporaryDirectory = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), "rd-window-open-xfile-")),
+    );
+    __clearParseSourceFileCacheForTests();
+    writeFile("package.json", JSON.stringify({ name: "fixture", type: "module" }));
+  });
+
+  afterEach(() => {
+    fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+  });
+
+  const writeFile = (relativePath: string, contents: string): string => {
+    const absolutePath = path.join(temporaryDirectory, relativePath);
+    fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+    fs.writeFileSync(absolutePath, contents, "utf8");
+    return absolutePath;
+  };
+
+  const runRuleAt = (relativePath: string, code: string) =>
+    runRule(windowOpenWithoutNoopener, code, { filename: writeFile(relativePath, code) });
+
+  it("stays quiet: imported const verified cross-file as a relative path literal", () => {
+    writeFile("src/config.ts", "export const downloadTarget = '/downloads/latest';\n");
+    const result = runRuleAt(
+      "src/App.tsx",
+      "import { downloadTarget } from './config';\nwindow.open(downloadTarget, '_blank');\n",
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still flags a URL-named imported const verified cross-file as an external https literal (name-heuristic override)", () => {
+    writeFile(
+      "src/config.ts",
+      "export const downloadPage = 'https://downloads.example.com/latest';\n",
+    );
+    const result = runRuleAt(
+      "src/App.tsx",
+      "import { downloadPage } from './config';\nwindow.open(downloadPage, '_blank');\n",
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a foreign initializer whose new URL() base is an external origin", () => {
+    writeFile(
+      "src/config.ts",
+      "const externalBase = 'https://evil.example.com';\nexport const storeUrl = new URL('/store', externalBase).toString();\n",
+    );
+    const result = runRuleAt(
+      "src/App.tsx",
+      "import { storeUrl } from './config';\nwindow.open(storeUrl, '_blank');\n",
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays quiet: foreign initializer building new URL() against the page's own origin", () => {
+    writeFile(
+      "src/config.ts",
+      "export const storeUrl = new URL('/store', window.location.origin).toString();\n",
+    );
+    const result = runRuleAt(
+      "src/App.tsx",
+      "import { storeUrl } from './config';\nwindow.open(storeUrl, '_blank');\n",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still flags when a barrel hides a re-export behind a same-named local decoy helper", () => {
+    writeFile(
+      "src/impl.ts",
+      "export const buildShareUrl = () => 'https://evil.example.com/share';\n",
+    );
+    writeFile(
+      "src/barrel.ts",
+      "const buildShareUrl = () => '/local-decoy';\nvoid buildShareUrl;\nexport { buildShareUrl } from './impl';\n",
+    );
+    const result = runRuleAt(
+      "src/App.tsx",
+      "import { buildShareUrl } from './barrel';\nwindow.open(buildShareUrl(), '_blank');\n",
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("rejects an imported builder that delegates to an unresolved buildURLString helper", () => {
+    writeFile(
+      "src/correlations-repository.ts",
+      `import { buildURLString } from './url-utils';
+export const buildCorrelationsUrl = (dataId: string, encodeStrings: boolean, pps = false, image = false): string =>
+  buildURLString(\`/dtale/correlations/\${dataId}\`, {
+    encodeStrings: \`\${encodeStrings}\`,
+    pps: \`\${pps}\`,
+    image: \`\${image}\`,
+  });
+`,
+    );
+    const result = runRuleAt(
+      "src/App.tsx",
+      `import { buildCorrelationsUrl } from './correlations-repository';
+window.open(buildCorrelationsUrl(dataId, encodeStrings, isPPS, true), '_blank');
+`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags an imported build…Url helper with one opaque return", () => {
+    writeFile(
+      "src/share-url.ts",
+      `export const buildShareUrl = (target: string | undefined) => {
+  if (target) {
+    return target;
+  }
+  return '/share';
+};
+`,
+    );
+    const result = runRuleAt(
+      "src/App.tsx",
+      "import { buildShareUrl } from './share-url';\nwindow.open(buildShareUrl(candidate), '_blank');\n",
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags when the imported helper delegates to another imported helper (no transitive cross-file hops)", () => {
+    writeFile("src/deep.ts", "export const buildDeepUrl = () => '/deep';\n");
+    writeFile(
+      "src/urls.ts",
+      "import { buildDeepUrl } from './deep';\nexport const buildOuterUrl = () => buildDeepUrl();\n",
+    );
+    const result = runRuleAt(
+      "src/App.tsx",
+      "import { buildOuterUrl } from './urls';\nwindow.open(buildOuterUrl(), '_blank');\n",
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags an unresolvable import with a URL-suffixed name", () => {
+    const result = runRuleAt(
+      "src/App.tsx",
+      "import { downloadPage } from './missing-config';\nwindow.open(downloadPage, '_blank');\n",
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("fails closed when the host provides no filename", () => {
+    writeFile(
+      "src/config.ts",
+      "export const downloadPage = 'https://downloads.example.com/latest';\n",
+    );
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      "import { downloadPage } from './config';\nwindow.open(downloadPage, '_blank');\n",
+      { filename: undefined },
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays quiet: renamed import resolved through a barrel re-export hop to a same-origin path", () => {
+    writeFile("src/paths.ts", "export const internalDownloadPath = '/downloads/latest';\n");
+    writeFile("src/index.ts", "export { internalDownloadPath as downloadPage } from './paths';\n");
+    const result = runRuleAt(
+      "src/App.tsx",
+      "import { downloadPage as appDownloadTarget } from './index';\nwindow.open(appDownloadTarget, '_blank');\n",
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("caps cross-file resolutions per linted file and fails closed past the cap", () => {
+    writeFile(
+      "src/config.ts",
+      [
+        "export const alphaPage = 'https://external.example.com/alpha';",
+        "export const betaPage = 'https://external.example.com/beta';",
+        "export const gammaPage = 'https://external.example.com/gamma';",
+        "export const deltaPage = 'https://external.example.com/delta';",
+      ].join("\n"),
+    );
+    const result = runRuleAt(
+      "src/App.tsx",
+      `import { alphaPage, betaPage, gammaPage, deltaPage } from './config';
+window.open(alphaPage, '_blank');
+window.open(betaPage, '_blank');
+window.open(gammaPage, '_blank');
+window.open(deltaPage, '_blank');
+`,
+    );
+    expect(result.diagnostics).toHaveLength(4);
+  });
+
+  it("ignores shadowed window and globalThis bindings", () => {
+    for (const code of [
+      `const window = { open() {} }; window.open(url);`,
+      `const globalThis = { window: { open() {} } }; globalThis.window.open(url);`,
+      `function render(window) { window.open(url); }`,
+    ]) {
+      const result = runRule(windowOpenWithoutNoopener, code);
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(0);
+    }
+  });
+
+  it("flags statically computed and transparently wrapped global calls", () => {
+    for (const code of [
+      `window["open"](url);`,
+      "window[`open`](url);",
+      `(window.open as typeof window.open)(url);`,
+      `(window.open(url) as Window | null);`,
+    ]) {
+      const result = runRule(windowOpenWithoutNoopener, code);
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    }
+  });
+
+  it("flags aliases of the global open method", () => {
+    for (const code of [
+      `const openPopup = globalThis.open; openPopup(url);`,
+      `const { open: openPopup } = window; openPopup(url);`,
+    ]) {
+      const result = runRule(windowOpenWithoutNoopener, code);
+      expect(result.diagnostics).toHaveLength(1);
+    }
+  });
+
+  it("does not use an unreachable router call as same-origin proof", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `import Router from "next/router";
+       const openDestination = (destination) => {
+         if (false) Router.push(destination);
+         window.open(destination);
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not treat a local Router-shaped object as same-origin proof", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const Router = { push() {} };
+       const openDestination = (destination) => {
+         Router.push(destination);
+         window.open(destination);
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags explicitly disabled opener protections", () => {
+    for (const features of ["noopener=false", "noopener=0", "noopener=no", "noreferrer=false"]) {
+      const result = runRule(
+        windowOpenWithoutNoopener,
+        `window.open(url, "_blank", "${features}");`,
+      );
+      expect(result.diagnostics).toHaveLength(1);
+    }
+  });
+
+  it("accepts explicitly enabled opener protections", () => {
+    for (const features of ["noopener", "noopener=true", "noopener=1", "noopener=yes"]) {
+      const result = runRule(
+        windowOpenWithoutNoopener,
+        `window.open(url, "_blank", "${features}");`,
+      );
+      expect(result.diagnostics).toHaveLength(0);
+    }
+  });
+
+  it("does not trust arbitrary pathname-shaped member reads", () => {
+    for (const code of [
+      `window.open(event.pathname);`,
+      `window.open(payload.location.pathname);`,
+      `window.open(userLocation.href);`,
+    ]) {
+      const result = runRule(windowOpenWithoutNoopener, code);
+      expect(result.diagnostics).toHaveLength(1);
+    }
+  });
+
+  it("does not trust an unknown helper merely because its first argument is safe", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `window.open(selectDestination("/safe", userControlledUrl));`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("inspects local URL getter returns instead of trusting their names", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const getExternalUrl = () => userControlledUrl; window.open(getExternalUrl());`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not trust arbitrary methods called on a trusted path", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const route = "/safe"; window.open(route.resolveRedirect(userControlledUrl));`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not treat a shadowed URL.createObjectURL call as a trusted blob URL", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const URL = { createObjectURL: () => userControlledUrl }; window.open(URL.createObjectURL());`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not let a dynamic replacement change a trusted path into an opaque URL", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `window.open(window.location.pathname.replace("/safe", userControlledUrl));`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not let shadowed wrapper calls poison a locally proven wrapper", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const openLink = (url) => window.open(url);
+       openLink("/safe");
+       function unrelated(openLink) { openLink(userControlledUrl); }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not use a shadowed router argument as proof for an untrusted destination", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const openLink = (url) => {
+         function navigateAnother(url) { router.push(url); }
+         void navigateAnother;
+         window.open(url);
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not let a shadowed assignment invalidate a trusted local URL", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `let url;
+       url = "/safe";
+       function assignOther(url) { url = userControlledUrl; }
+       window.open(url);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("rejects origin templates whose interpolation can extend or replace the host", () => {
+    for (const code of [
+      "window.open(`${window.origin}.evil.com`);",
+      "window.open(`${window.origin}//evil.com`);",
+      'const prefix = ""; window.open(`${prefix}//evil.com`);',
+      "window.open(`/\\\\${host}`);",
+    ]) {
+      const result = runRule(windowOpenWithoutNoopener, code);
+      expect(result.diagnostics).toHaveLength(1);
+    }
+  });
+
+  it("rejects mutable blob and URL proofs", () => {
+    for (const code of [
+      `URL.createObjectURL = () => userControlledUrl;
+       window.open(URL.createObjectURL(blob));`,
+      `const popupUrl = new URL("/safe", window.origin);
+       popupUrl.href = userControlledUrl;
+       window.open(popupUrl.toString());`,
+      `const URL = class { toString() { return userControlledUrl; } };
+       const popupUrl = new URL("/safe");
+       window.open(popupUrl.toString());`,
+    ]) {
+      const result = runRule(windowOpenWithoutNoopener, code);
+      expect(result.diagnostics).toHaveLength(1);
+    }
+  });
+
+  it("uses only authoritative intrinsic anchor href attributes", () => {
+    for (const code of [
+      `const C = ({ dynamicHref }) => <a href="/safe" {...props} onClick={(event) =>
+         window.open(event.currentTarget.href)} />;`,
+      `const C = ({ dynamicHref }) => <a href="/safe" href={dynamicHref} onClick={(event) =>
+         window.open(event.currentTarget.href)} />;`,
+    ]) {
+      const result = runRule(windowOpenWithoutNoopener, code);
+      expect(result.diagnostics).toHaveLength(1);
+    }
+    const customElement = runRule(
+      windowOpenWithoutNoopener,
+      `const C = () => <Link href="/safe" onClick={(event) =>
+         window.open(event.currentTarget.href)} />;`,
+    );
+    expect(customElement.diagnostics).toHaveLength(0);
+  });
+
+  it("uses the authoritative object property and rejects later mutation", () => {
+    for (const code of [
+      `const links = { docs: "/safe", docs: userControlledUrl };
+       window.open(links.docs);`,
+      `const links = { docs: "/safe" };
+       links.docs = userControlledUrl;
+       window.open(links.docs);`,
+      `const links = { docs: "/safe", ...dynamicLinks };
+       window.open(links.docs);`,
+    ]) {
+      const result = runRule(windowOpenWithoutNoopener, code);
+      expect(result.diagnostics).toHaveLength(1);
+    }
+  });
+
+  it("rejects compound writes to a let destination", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `let popupUrl = "/safe";
+       popupUrl += userControlledUrl;
+       window.open(popupUrl);`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("rejects a shadowed getLocation helper", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const getLocation = () => ({ href: userControlledUrl });
+       window.open(getLocation().href);`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("rejects origin-changing pathname transforms", () => {
+    for (const code of [
+      `window.open(window.location.pathname.slice(1));`,
+      `window.open(window.location.pathname.substring(1));`,
+      `window.open(window.location.pathname.substr(1));`,
+      `window.open(window.location.pathname.replace("/safe", "https://evil.com"));`,
+    ]) {
+      const result = runRule(windowOpenWithoutNoopener, code);
+      expect(result.diagnostics).toHaveLength(1);
+    }
+  });
+
+  it("does not treat a reduce callback accumulator as an iterated config item", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const links = [{ href: "/safe" }];
+       links.reduce((item) => {
+         window.open(item.href);
+         return item;
+       }, { href: userControlledUrl });`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("requires a Router witness in the opposite controlling branch", () => {
+    for (const code of [
+      `import Router from "next/router";
+       const openDestination = (destination, shouldNavigate) => {
+         if (shouldNavigate) Router.push(destination);
+         window.open(destination);
+       };`,
+      `import Router from "next/router";
+       const openDestination = (destination) => {
+         const neverCalled = () => Router.push(destination);
+         void neverCalled;
+         window.open(destination);
+       };`,
+    ]) {
+      const result = runRule(windowOpenWithoutNoopener, code);
+      expect(result.diagnostics).toHaveLength(1);
+    }
+  });
+
+  it("accepts exact Next Router aliases in opposite branches", () => {
+    for (const code of [
+      `import NextRouter from "next/router";
+       const openDestination = (destination, newTab) => {
+         if (newTab) window.open(destination);
+         else NextRouter.push(destination);
+       };`,
+      `import { useRouter as useNextRouter } from "next/navigation";
+       const C = ({ destination, newTab }) => {
+         const navigation = useNextRouter();
+         if (newTab) window.open(destination);
+         else navigation.push(destination);
+       };`,
+    ]) {
+      const result = runRule(windowOpenWithoutNoopener, code);
+      expect(result.diagnostics).toHaveLength(0);
+    }
+  });
+
+  it("reports only callback returns whose consumers discard the handle", () => {
+    for (const code of [
+      `const handles = items.map(() => window.open(url));`,
+      `const popupPromise = promise.then(() => window.open(url));`,
+    ]) {
+      const result = runRule(windowOpenWithoutNoopener, code);
+      expect(result.diagnostics).toHaveLength(0);
+    }
+    for (const code of [`[url].forEach(() => window.open(url));`]) {
+      const result = runRule(windowOpenWithoutNoopener, code);
+      expect(result.diagnostics).toHaveLength(1);
+    }
+    const logicalLeft = runRule(windowOpenWithoutNoopener, `window.open(url) || reportFailure();`);
+    expect(logicalLeft.diagnostics).toHaveLength(0);
+  });
+
+  it("distinguishes the global open method from a local shadow", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `function open(value) { return value; }
+       open(userControlledUrl);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("rejects name-only member path helpers", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `window.open(attacker.path(userControlledUrl));`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("rejects a nested write to an iterated config entry", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const links = [{ href: "/safe" }];
+       links[0].href = userControlledUrl;
+       links.forEach((item) => window.open(item.href));`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("rejects leading template bases that can end in a slash", () => {
+    for (const code of [
+      'const prefix = "/"; window.open(`${prefix}/evil.com`);',
+      'const getPrefix = () => "/"; window.open(`${getPrefix()}/evil.com`);',
+    ]) {
+      const result = runRule(windowOpenWithoutNoopener, code);
+      expect(result.diagnostics).toHaveLength(1);
+    }
+  });
+
+  it("rejects replaced URL globals and URL serialization methods", () => {
+    for (const code of [
+      `globalThis.URL = FakeURL;
+       window.open(URL.createObjectURL(blob));`,
+      `const popupUrl = new URL("/safe", window.origin);
+       popupUrl.toString = () => userControlledUrl;
+       window.open(popupUrl.toString());`,
+      `const popupUrl = new URL("/safe", window.origin);
+       popupUrl.toJSON = () => userControlledUrl;
+       window.open(popupUrl.toJSON());`,
+    ]) {
+      const result = runRule(windowOpenWithoutNoopener, code);
+      expect(result.diagnostics).toHaveLength(1);
+    }
+  });
+
+  it("rejects destructuring and iteration writes to a let destination", () => {
+    for (const code of [
+      `let popupUrl = "/safe";
+       [popupUrl] = [userControlledUrl];
+       window.open(popupUrl);`,
+      `let popupUrl = "/safe";
+       for (popupUrl of userControlledUrls) break;
+       window.open(popupUrl);`,
+    ]) {
+      const result = runRule(windowOpenWithoutNoopener, code);
+      expect(result.diagnostics).toHaveLength(1);
+    }
+  });
+
+  it("does not trust builder names or safe-looking first arguments", () => {
+    for (const code of [
+      `window.open(attacker.buildURL("/safe", userControlledUrl));`,
+      `window.open(attacker.fullPath("/safe", userControlledUrl));`,
+      `const fullPath = () => userControlledUrl;
+       window.open(fullPath("/safe"));`,
+    ]) {
+      const result = runRule(windowOpenWithoutNoopener, code);
+      expect(result.diagnostics).toHaveLength(1);
+    }
+  });
+
+  it("rejects a reassigned getLocation function", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `function getLocation() { return window.location; }
+       getLocation = () => ({ href: userControlledUrl });
+       window.open(getLocation().href);`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not synthesize noopener across opaque feature interpolation", () => {
+    const unsafe = runRule(
+      windowOpenWithoutNoopener,
+      'window.open(url, "_blank", `no${dynamicText}opener`);',
+    );
+    expect(unsafe.diagnostics).toHaveLength(1);
+    const safe = runRule(
+      windowOpenWithoutNoopener,
+      'window.open(url, "_blank", `noopener,width=${dynamicWidth}`);',
+    );
+    expect(safe.diagnostics).toHaveLength(0);
+  });
+
+  it("accepts only the default Router export or useRouter hook", () => {
+    for (const code of [
+      `import { useParams as Router } from "next/navigation";
+       const openDestination = (destination, newTab) => {
+         if (newTab) window.open(destination);
+         else Router.push(destination);
+       };`,
+      `import { withRouter as Router } from "next/router";
+       const openDestination = (destination, newTab) => {
+         if (newTab) window.open(destination);
+         else Router.push(destination);
+       };`,
+    ]) {
+      const result = runRule(windowOpenWithoutNoopener, code);
+      expect(result.diagnostics).toHaveLength(1);
+    }
+  });
+
+  it("requires proven built-ins to discard callback returns", () => {
+    for (const code of [
+      `const items = { forEach(callback) { return callback(); } };
+       const popup = items.forEach(() => window.open(url));`,
+      `const setTimeout = (callback) => callback();
+       const popup = setTimeout(() => window.open(url));`,
+      `const handlers = { onClick: () => window.open(url) };
+       const popup = handlers.onClick();`,
+    ]) {
+      const result = runRule(windowOpenWithoutNoopener, code);
+      expect(result.diagnostics).toHaveLength(0);
+    }
+  });
+
+  it("rejects imported URL names when their values cannot be resolved", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `import { CHANGELOG_URL } from "./missing";
+       window.open(CHANGELOG_URL);`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("rejects writes to parameter-derived destination proofs", () => {
+    for (const code of [
+      `const openLink = (url) => {
+         url = userControlledUrl;
+         window.open(url);
+       };
+       openLink("/safe");`,
+      `const C = ({ href }) => {
+         href = userControlledUrl;
+         return <button onClick={() => window.open(href)} />;
+       };
+       const App = () => <C href="/safe" />;`,
+      `const links = [{ href: "/safe" }];
+       links.forEach((item) => {
+         item = { href: userControlledUrl };
+         window.open(item.href);
+       });`,
+      `const links = [{ href: "/safe" }];
+       links.forEach(({ href }) => {
+         href = userControlledUrl;
+         window.open(href);
+       });`,
+      `const openAnchor = (anchor) => {
+         anchor = { href: userControlledUrl };
+         window.open(anchor.href);
+       };
+       const C = () => <a href="/safe" onClick={(event) => openAnchor(event.currentTarget)} />;`,
+      `import Router from "next/router";
+       const openDestination = (destination, newTab) => {
+         destination = userControlledUrl;
+         if (newTab) window.open(destination);
+         else Router.push(destination);
+       };`,
+    ]) {
+      const result = runRule(windowOpenWithoutNoopener, code);
+      expect(result.diagnostics).toHaveLength(1);
+    }
+  });
+
+  it("rejects structural mutations to trusted array configs", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const links = [{ href: "/safe" }];
+       links.push({ href: userControlledUrl });
+       links.forEach((item) => window.open(item.href));`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("rejects destructuring writes after trusted let assignments", () => {
+    for (const code of [
+      `let popupUrl;
+       popupUrl = "/safe";
+       [popupUrl] = [userControlledUrl];
+       window.open(popupUrl);`,
+      `let popupUrl;
+       popupUrl = "/safe";
+       ({ popupUrl } = { popupUrl: userControlledUrl });
+       window.open(popupUrl);`,
+    ]) {
+      const result = runRule(windowOpenWithoutNoopener, code);
+      expect(result.diagnostics).toHaveLength(1);
+    }
+  });
+
+  it("rejects local helper parameters reassigned before return", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const buildPath = (path) => {
+         path = userControlledUrl;
+         return path;
+       };
+       window.open(buildPath("/safe"));`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("rejects URL prototype serializer mutations", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `URL.prototype.toString = () => userControlledUrl;
+       const popupUrl = new URL("/safe", window.origin);
+       window.open(popupUrl.toString());`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not assume custom JSX handlers discard callback returns", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const Consumer = ({ onClick }) => onClick();
+       const App = () => <Consumer onClick={() => window.open(userControlledUrl)} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not assume a replaced array forEach method discards callback returns", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const links = [userControlledUrl];
+       links.forEach = (callback) => callback(links[0]);
+       const popup = links.forEach((href) => window.open(href));`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("reports discarded handles only for proven built-in array receivers", () => {
+    for (const code of [
+      `const links: string[] = getLinks();
+       links.forEach((href) => window.open(href));`,
+      `const links = Array.from(getLinks());
+       links.forEach((href) => window.open(href));`,
+      `const links = new Array(userControlledUrl);
+       links.forEach((href) => window.open(href));`,
+    ]) {
+      const result = runRule(windowOpenWithoutNoopener, code);
+      expect(result.diagnostics).toHaveLength(1);
+    }
+    const opaqueReceiver = runRule(
+      windowOpenWithoutNoopener,
+      `const links = getLinks();
+       const popup = links.forEach((href) => window.open(href));`,
+    );
+    expect(opaqueReceiver.diagnostics).toHaveLength(0);
   });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.test.ts
@@ -319,6 +319,22 @@ describe("window-open-without-noopener", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("flags a bare awaited window.open in an async handler", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `async function openIt() { await window.open(url, '_blank'); }`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag an awaited window.open whose handle is captured", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `async function openIt() { const win = await window.open(url, '_blank'); win?.focus(); }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("flags a void-discarded window.open", () => {
     const result = runRule(windowOpenWithoutNoopener, `void window.open(url, '_blank');`);
     expect(result.diagnostics).toHaveLength(1);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.test.ts
@@ -1947,4 +1947,51 @@ window.open(deltaPage, '_blank');
     );
     expect(opaqueReceiver.diagnostics).toHaveLength(0);
   });
+
+  it("rejects concatenations whose static prefix does not pin the destination", () => {
+    for (const code of [
+      `window.open("https://" + userControlledHost);`,
+      `window.open("//" + userControlledHost);`,
+      `window.open("" + userControlledUrl);`,
+      `window.open("https://example.com" + userControlledSuffix);`,
+      `window.open("/" + userControlledPath);`,
+    ]) {
+      const result = runRule(windowOpenWithoutNoopener, code);
+      expect(result.diagnostics).toHaveLength(1);
+    }
+    for (const code of [
+      `window.open("https://example.com/" + userControlledPath);`,
+      `window.open("/safe/" + userControlledPath);`,
+      `window.open("./" + userControlledPath);`,
+      `window.open("mailto:" + userControlledAddress);`,
+    ]) {
+      const result = runRule(windowOpenWithoutNoopener, code);
+      expect(result.diagnostics).toHaveLength(0);
+    }
+  });
+
+  it("trusts href reads from unmodified URL instances", () => {
+    const trusted = runRule(
+      windowOpenWithoutNoopener,
+      `const popupUrl = new URL("/safe", window.origin);
+       window.open(popupUrl.href);`,
+    );
+    expect(trusted.diagnostics).toHaveLength(0);
+    for (const code of [
+      `const popupUrl = new URL("/safe", window.origin);
+       popupUrl.href = userControlledUrl;
+       window.open(popupUrl.href);`,
+      `const URL = FakeURL;
+       const popupUrl = new URL("/safe", window.origin);
+       window.open(popupUrl.href);`,
+    ]) {
+      const result = runRule(windowOpenWithoutNoopener, code);
+      expect(result.diagnostics).toHaveLength(1);
+    }
+  });
+
+  it("keeps bare pathname reads diagnostic because they can be protocol-relative", () => {
+    const result = runRule(windowOpenWithoutNoopener, `window.open(window.location.pathname);`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.test.ts
@@ -2350,6 +2350,13 @@ window.open(deltaPage, '_blank');
       'const getPrefix = () => condition ? "/api/v1/" : "/"; window.open(`${getPrefix()}/users`);',
       'const prefix = "https://"; window.open(`${prefix}/users`);',
       'const prefix = "  WSS:\\\\  "; window.open(`${prefix}/users`);',
+      'const prefix = ""; window.open(`${prefix}/${userControlledPath}`);',
+      'const prefix = "   "; window.open(`${prefix}/${userControlledPath}`);',
+      'const prefix = "h\\nttps:"; window.open(`${prefix}/${userControlledPath}`);',
+      'const prefix = "ht\\ttps:"; window.open(`${prefix}/${userControlledPath}`);',
+      'const prefix = "http:\\n\\\\"; window.open(`${prefix}/${userControlledPath}`);',
+      'const prefix = "\\u0000"; window.open(`${prefix}/${userControlledPath}`);',
+      'const prefix = "\\u001f"; window.open(`${prefix}/${userControlledPath}`);',
       "const prefix = /\\//; window.open(`${prefix}/evil.com`);",
       "const prefix = /\\\\/; window.open(`${prefix}/evil.com`);",
       'const prefix = ["/"]; window.open(`${prefix}/evil.com`);',
@@ -2380,6 +2387,8 @@ window.open(deltaPage, '_blank');
       "const prefix = false; window.open(`${prefix}/users`);",
       "const prefix = 0; window.open(`${prefix}/users`);",
       "const prefix = null; window.open(`${prefix}/users`);",
+      'const prefix = "h\\vttps:"; window.open(`${prefix}/${userControlledPath}`);',
+      'const prefix = "h\\fttps:"; window.open(`${prefix}/${userControlledPath}`);',
       'const prefix = true ? "/api/v1/" : "/"; window.open(`${prefix}/users`);',
       'const root = "/api/v1/"; const a1 = root; const a2 = a1; const a3 = a2; const a4 = a3; const a5 = a4; const a6 = a5; const a7 = a6; const a8 = a7; const a9 = a8; window.open(`${a9}/users`);',
     ]) {
@@ -2602,16 +2611,141 @@ window.open(deltaPage, '_blank');
     }
   });
 
+  it("accepts parameter-led local helper concatenations with pinned destinations", () => {
+    for (const code of [
+      `const buildPath = (path, dataId) => path + "/" + dataId;
+       window.open(buildPath("/safe", userControlledId));`,
+      `const buildPath = (path, dataId) => path + "" + "/" + dataId;
+       window.open(buildPath("/safe", userControlledId));`,
+      `const buildPath = (path, dataId) => path + \`/item/\` + dataId;
+       window.open(buildPath("/safe", userControlledId));`,
+      `const buildQuery = (path, query) => path + "?q=" + query;
+       window.open(buildQuery("/safe", userControlledQuery));`,
+      `const buildHash = (path, hash) => path + "#" + hash;
+       const safePath = "/safe";
+       window.open(buildHash(safePath, userControlledHash));`,
+      `const buildPath = (path, hostname) => path + "/" + hostname;
+       window.open(buildPath("h\\vttps:", "/evil.example"));`,
+      `const buildPath = (path, hostname) => path + "/" + hostname;
+       window.open(buildPath("h\\fttps:", "/evil.example"));`,
+    ]) {
+      const result = runRule(windowOpenWithoutNoopener, code);
+      expect(result.diagnostics, code).toHaveLength(0);
+    }
+  });
+
+  it("rejects local helper concatenations without a pinned destination boundary", () => {
+    for (const code of [
+      `const buildPath = (path, dataId) => path + dataId;
+       window.open(buildPath("/safe", userControlledId));`,
+      `const buildPath = (path, dataId) => path + dynamicSeparator + dataId;
+       window.open(buildPath("/safe", userControlledId));`,
+      `const buildPath = (path, hostname) => path + "/" + hostname;
+       window.open(buildPath("/", "evil.example.com"));`,
+      `const buildPath = (path, hostname) => path + "/" + hostname;
+       window.open(buildPath("https://", "evil.example.com"));`,
+      `const buildPath = (path, dataId) => path + "//" + dataId;
+       window.open(buildPath("/safe", userControlledId));`,
+      `const buildPath = (path, dataId) => path + "/" + dataId;
+       window.open(buildPath("", userControlledId));`,
+      `const buildPath = (path, dataId) => path + "/" + dataId;
+       window.open(buildPath("   ", userControlledId));`,
+      `const buildPath = (path, dataId) => path + ("/" + dataId);
+       window.open(buildPath("", userControlledId));`,
+      `const buildPath = (path, dataId) => path + "/" + dataId;
+       window.open(buildPath("h\\nttps:", "/evil.example"));`,
+      `const buildPath = (path, dataId) => path + "/" + dataId;
+       window.open(buildPath("h\\rttps:", "/evil.example"));`,
+      `const buildPath = (path, dataId) => path + "/" + dataId;
+       window.open(buildPath("ht\\ttps:", "/evil.example"));`,
+      `const buildPath = (path, dataId) => path + "/" + dataId;
+       window.open(buildPath("ht\\ntp:", "/evil.example"));`,
+      `const buildPath = (path, dataId) => path + "/" + dataId;
+       window.open(buildPath("f\\ntp:", "/evil.example"));`,
+      `const buildPath = (path, dataId) => path + "/" + dataId;
+       window.open(buildPath("http:\\n\\\\", "evil.example"));`,
+      `const buildPath = (path, dataId) => path + "/" + dataId;
+       window.open(buildPath("\\u0000", "/evil.example"));`,
+      `const buildPath = (path, dataId) => path + "/" + dataId;
+       window.open(buildPath("\\u0001", "/evil.example"));`,
+      `const buildPath = (path, dataId) => path + "/" + dataId;
+       window.open(buildPath("\\b", "/evil.example"));`,
+      `const buildPath = (path, dataId) => path + "/" + dataId;
+       window.open(buildPath("\\u001f", "/evil.example"));`,
+      `const buildPath = (path, dataId) => path + "/" + dataId;
+       window.open(buildPath(userControlledUrl, dataId));`,
+      `const buildPath = (path, dataId) => {
+         path = userControlledUrl;
+         return path + "/" + dataId;
+       };
+       window.open(buildPath("/safe", dataId));`,
+      `const buildPath = (path, dataId) => {
+         [path] = [userControlledUrl];
+         return path + "/" + dataId;
+       };
+       window.open(buildPath("/safe", dataId));`,
+      `const buildPath = (path, dataId) => {
+         ({ path } = { path: userControlledUrl });
+         return path + "/" + dataId;
+       };
+       window.open(buildPath("/safe", dataId));`,
+      `const buildPath = (path, dataId) => {
+         [[path]] = [[userControlledUrl]];
+         return path + "/" + dataId;
+       };
+       window.open(buildPath("/safe", dataId));`,
+      `const buildPath = (path, dataId) => {
+         [path = userControlledUrl] = [];
+         return path + "/" + dataId;
+       };
+       window.open(buildPath("/safe", dataId));`,
+      `const buildPath = (path, dataId) => {
+         [...path] = [userControlledUrl];
+         return path + "/" + dataId;
+       };
+       window.open(buildPath("/safe", dataId));`,
+      `const buildPath = (path, dataId) => {
+         ({ value: { path } } = { value: { path: userControlledUrl } });
+         return path + "/" + dataId;
+       };
+       window.open(buildPath("/safe", dataId));`,
+      `const buildPath = (path, dataId) => {
+         ({ value: path = userControlledUrl } = {});
+         return path + "/" + dataId;
+       };
+       window.open(buildPath("/safe", dataId));`,
+      `const buildPath = (path, dataId) => {
+         if (condition) return path + "/" + dataId;
+         return userControlledUrl;
+       };
+       window.open(buildPath("/safe", dataId));`,
+    ]) {
+      const result = runRule(windowOpenWithoutNoopener, code);
+      expect(result.diagnostics, code).toHaveLength(1);
+    }
+  });
+
   it("rejects local helper parameters reassigned before return", () => {
-    const result = runRule(
-      windowOpenWithoutNoopener,
+    for (const code of [
       `const buildPath = (path) => {
          path = userControlledUrl;
          return path;
        };
        window.open(buildPath("/safe"));`,
-    );
-    expect(result.diagnostics).toHaveLength(1);
+      `const buildPath = (path, dataId) => {
+         [path] = [userControlledUrl];
+         return \`${"${path}"}/${"${dataId}"}\`;
+       };
+       window.open(buildPath("/safe", dataId));`,
+      `const buildPath = (path, dataId) => {
+         ({ path } = { path: userControlledUrl });
+         return \`${"${path}"}/${"${dataId}"}\`;
+       };
+       window.open(buildPath("/safe", dataId));`,
+    ]) {
+      const result = runRule(windowOpenWithoutNoopener, code);
+      expect(result.diagnostics, code).toHaveLength(1);
+    }
   });
 
   it("rejects URL prototype serializer mutations", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.test.ts
@@ -1,0 +1,304 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { windowOpenWithoutNoopener } from "./window-open-without-noopener.js";
+
+describe("window-open-without-noopener", () => {
+  it("flags a bare window.open statement with _blank", () => {
+    const result = runRule(windowOpenWithoutNoopener, `window.open(url, '_blank');`);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags window.open with a discarded return", () => {
+    const result = runRule(windowOpenWithoutNoopener, `window.open(url);`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags globalThis.window.open", () => {
+    const result = runRule(windowOpenWithoutNoopener, `globalThis.window.open(url, '_blank');`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a concise arrow inside an onClick handler", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const x = <button onClick={() => window.open(externalUrl, '_blank')} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a concise arrow used as a forEach callback", () => {
+    const result = runRule(windowOpenWithoutNoopener, `list.forEach((link) => window.open(link));`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag when the handle is bound to a variable", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const win = window.open(url, '_blank'); win?.focus();`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when the handle is assigned", () => {
+    const result = runRule(windowOpenWithoutNoopener, `let w; w = window.open(url);`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when the handle is returned", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `function openIt() { return window.open(url); }`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when the handle is immediately used", () => {
+    const result = runRule(windowOpenWithoutNoopener, `window.open(url).focus();`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a concise arrow stored in a variable", () => {
+    const result = runRule(windowOpenWithoutNoopener, `const openPopup = () => window.open(url);`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag navigating targets", () => {
+    for (const target of ["_self", "_top", "_parent"]) {
+      const result = runRule(windowOpenWithoutNoopener, `window.open(url, '${target}');`);
+      expect(result.diagnostics).toHaveLength(0);
+    }
+  });
+
+  it("does not flag when features already contain noopener", () => {
+    const result = runRule(windowOpenWithoutNoopener, `window.open(url, '_blank', 'noopener');`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when features contain noreferrer", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `window.open(url, '_blank', 'noopener,noreferrer');`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a mailto: protocol-handler URL", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `window.open('mailto:support@appflowy.io', '_blank');`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a tel: protocol-handler URL", () => {
+    const result = runRule(windowOpenWithoutNoopener, `window.open('tel:+15551234567');`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a mailto: URL built from a template literal", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      "window.open(`mailto:${email}?subject=hi`, '_blank');",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a hardcoded literal destination (Star-on-GitHub button idiom)", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `window.open('https://github.com/millionco/react-doctor', '_blank');`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a same-origin relative URL (print/report route idiom)", () => {
+    const result = runRule(windowOpenWithoutNoopener, `window.open('/reports/print', '_blank');`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a template with a fixed trusted origin and path-only interpolation", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      "window.open(`https://github.com/${owner}/${repo}`, '_blank');",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a same-origin template URL (app preview route idiom)", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      "window.open(`/preview?id=${documentId}`, '_blank');",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a const identifier bound to a hardcoded literal URL", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const docsUrl = 'https://docs.example.com/guide';\nwindow.open(docsUrl, '_blank');`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a const ternary over an origin-pinned template (release-page dialog idiom)", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      "const releaseUrl = availableVersion ? `https://github.com/owner/repo/releases/tag/v${availableVersion}` : null;\nconst x = <button onClick={() => window.open(releaseUrl, '_blank')} />;",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a const chained through another trusted const binding", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const baseUrl = 'https://github.com/owner/repo';\nconst releaseUrl = baseUrl;\nwindow.open(releaseUrl, '_blank');`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags a const ternary with one untrusted branch", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const url = useMirror ? mirrorUrl : 'https://example.com/download';\nwindow.open(url, '_blank');`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a let binding even when its initializer is trusted", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `let url = '/safe/route';\nurl = userInput;\nwindow.open(url, '_blank');`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a const holding an awaited API-returned URL (billing-link idiom)", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `async function upgrade() {\n  const link = await BillingService.getSubscriptionLink(workspaceId);\n  window.open(link, '_blank');\n}`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a hook-destructured URL behind a logical guard (update-checker idiom)", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const { releaseUrl } = useUpdateChecker();\nconst x = <button onClick={() => releaseUrl && window.open(releaseUrl, '_blank')} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a member-expression URL from server data (upload-list download idiom)", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const onInternalDownload = (file) => {\n  if (file.url) window.open(file.url);\n};`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a template whose interpolation sits in the scheme/host position", () => {
+    const result = runRule(windowOpenWithoutNoopener, "window.open(`${baseUrl}/path`, '_blank');");
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a template whose fixed prefix does not terminate the host", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      "window.open(`https://github.com${suffix}`, '_blank');",
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a protocol-relative template URL", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      "window.open(`//cdn.example.com/${asset}`, '_blank');",
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag when features come from a shared constant (popup-helper idiom)", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const POPUP_FEATURES = 'noopener,noreferrer';\nwindow.open(url, '_blank', POPUP_FEATURES);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a template features string containing noopener (computed popup size idiom)", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      "window.open(url, '_blank', `noopener,noreferrer,width=${width},height=${height}`);",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag when features are opaque at lint time (imported constant idiom)", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `import { POPUP_FEATURES } from './popup';\nwindow.open(url, '_blank', POPUP_FEATURES);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags when a resolvable features constant lacks noopener", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const POPUP_FEATURES = 'width=500,height=400';\nwindow.open(url, '_blank', POPUP_FEATURES);`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a discarded window.open behind a logical guard", () => {
+    const result = runRule(windowOpenWithoutNoopener, `isExternal && window.open(url, '_blank');`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a discarded window.open in a ternary onClick", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const x = <a onClick={(e) => e.metaKey ? window.open(href, '_blank') : navigate(href)} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a logical guard whose result is captured", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const win = canOpen && window.open(url, '_blank');`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags a createElement onClick handler like the JSX equivalent", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `React.createElement('button', { onClick: () => window.open(url, '_blank') });`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag an arrow under a non-handler object property whose handle may be consumed", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `registerFactory({ createWindow: () => window.open(url, '_blank') });`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag other postMessage-style calls", () => {
+    const result = runRule(windowOpenWithoutNoopener, `webview.postMessage(data);`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a bare open() that is not the window global", () => {
+    const result = runRule(windowOpenWithoutNoopener, `open(url, '_blank');`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a non-window object's open method", () => {
+    const result = runRule(windowOpenWithoutNoopener, `db.open(url);`);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.test.ts
@@ -2276,9 +2276,47 @@ window.open(deltaPage, '_blank');
     for (const code of [
       'const prefix = "/"; window.open(`${prefix}/evil.com`);',
       'const getPrefix = () => "/"; window.open(`${getPrefix()}/evil.com`);',
+      'const prefix = "  /  "; window.open(`${prefix}/evil.com`);',
+      'const prefix = "\\\\"; window.open(`${prefix}/evil.com`);',
+      'const prefix = condition ? "/api/v1/" : "/"; window.open(`${prefix}/users`);',
+      'const getPrefix = () => condition ? "/api/v1/" : "/"; window.open(`${getPrefix()}/users`);',
+      'const prefix = "https://"; window.open(`${prefix}/users`);',
+      'const prefix = "  WSS:\\\\  "; window.open(`${prefix}/users`);',
+      "const prefix = /\\//; window.open(`${prefix}/evil.com`);",
+      "const prefix = /\\\\/; window.open(`${prefix}/evil.com`);",
+      'const prefix = ["/"]; window.open(`${prefix}/evil.com`);',
+      'const prefix = { toString: () => "/" }; window.open(`${prefix}/evil.com`);',
+      'const prefix = dynamicPrefix || "/api/v1/"; window.open(`${prefix}/users`);',
+      'const prefix = dynamicPrefix ?? "/api/v1/"; window.open(`${prefix}/users`);',
+      "window.open(`${dynamicPrefix}/users`);",
     ]) {
       const result = runRule(windowOpenWithoutNoopener, code);
       expect(result.diagnostics).toHaveLength(1);
+    }
+  });
+
+  it("accepts slash-joined bases that cannot collapse to a protocol-relative URL", () => {
+    for (const code of [
+      'const prefix = "/api/v1/"; window.open(`${prefix}/users`);',
+      'const getPrefix = () => "/api/v1/"; window.open(`${getPrefix()}/users`);',
+      'const prefix = "/api/v1/" as const; window.open(`${prefix}/users`);',
+      'const prefix = condition ? "/api/v1/" : "/api/v2/"; window.open(`${prefix}/users`);',
+      'const getPrefix = () => condition ? "/api/v1/" : "/api/v2/"; window.open(`${getPrefix()}/users`);',
+      'const prefix = "https://example.com/"; window.open(`${prefix}/users`);',
+      'const prefix = condition && "/api/v1/"; window.open(`${prefix}/users`);',
+      'const prefix = false && "/"; window.open(`${prefix}/users`);',
+      'const prefix = null ?? "/api/v1/"; window.open(`${prefix}/users`);',
+      'const prefix = true || "/"; window.open(`${prefix}/users`);',
+      'const prefix = false ?? "/"; window.open(`${prefix}/users`);',
+      'const prefix = 0 ?? "/"; window.open(`${prefix}/users`);',
+      "const prefix = false; window.open(`${prefix}/users`);",
+      "const prefix = 0; window.open(`${prefix}/users`);",
+      "const prefix = null; window.open(`${prefix}/users`);",
+      'const prefix = true ? "/api/v1/" : "/"; window.open(`${prefix}/users`);',
+      'const root = "/api/v1/"; const a1 = root; const a2 = a1; const a3 = a2; const a4 = a3; const a5 = a4; const a6 = a5; const a7 = a6; const a8 = a7; const a9 = a8; window.open(`${a9}/users`);',
+    ]) {
+      const result = runRule(windowOpenWithoutNoopener, code);
+      expect(result.diagnostics, code).toHaveLength(0);
     }
   });
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.test.ts
@@ -3102,6 +3102,17 @@ window.open(deltaPage, '_blank');
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("does not assume custom createElement handlers discard callback returns", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const Consumer = ({ onClick }) => onClick();
+       const App = () => React.createElement(Consumer, {
+         onClick: () => window.open(userControlledUrl),
+       });`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("does not assume a replaced array forEach method discards callback returns", () => {
     const result = runRule(
       windowOpenWithoutNoopener,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.test.ts
@@ -133,6 +133,26 @@ describe("window-open-without-noopener", () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("does not flag a nullish URL argument (about:blank stays opener-controlled)", () => {
+    for (const call of [
+      "window.open();",
+      "window.open(null, '_blank');",
+      "window.open(undefined, '_blank');",
+      "window.open(void 0, '_blank');",
+    ]) {
+      const result = runRule(windowOpenWithoutNoopener, call);
+      expect(result.diagnostics).toHaveLength(0);
+    }
+  });
+
+  it("does not flag a const URL bound to null", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const fallbackUrl = null;\nwindow.open(fallbackUrl, '_blank');`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("does not flag a const identifier bound to a hardcoded literal URL", () => {
     const result = runRule(
       windowOpenWithoutNoopener,
@@ -296,6 +316,11 @@ describe("window-open-without-noopener", () => {
       windowOpenWithoutNoopener,
       `const x = <a onClick={(e) => e.metaKey ? window.open(href, '_blank') : navigate(href)} />;`,
     );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a void-discarded window.open", () => {
+    const result = runRule(windowOpenWithoutNoopener, `void window.open(url, '_blank');`);
     expect(result.diagnostics).toHaveLength(1);
   });
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.test.ts
@@ -390,6 +390,43 @@ describe("window-open-without-noopener", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("flags a createElement handler under a string-literal onClick key", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `React.createElement('button', { 'onClick': () => window.open(url, '_blank') });`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag an || URL whose left operand is a truthy trusted literal", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `window.open('https://example.com/download' || dynamicUrl, '_blank');`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag a const || URL with a truthy trusted literal left and dynamic fallback", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `const url = 'https://example.com/download' || mirrorUrl;\nwindow.open(url, '_blank');`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags an || URL whose falsy empty-string left falls through to a dynamic operand", () => {
+    const result = runRule(windowOpenWithoutNoopener, `window.open('' || dynamicUrl, '_blank');`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags an || URL whose trusted left is behind a reassignable let binding", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      `let primaryUrl = 'https://example.com/download';\nprimaryUrl = userInput;\nwindow.open(primaryUrl || fallbackUrl, '_blank');`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("does not flag an arrow under a non-handler object property whose handle may be consumed", () => {
     const result = runRule(
       windowOpenWithoutNoopener,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.test.ts
@@ -242,6 +242,21 @@ describe("window-open-without-noopener", () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("flags an explicitly nullish features argument like an omitted one", () => {
+    for (const features of ["undefined", "null", "void 0"]) {
+      const result = runRule(windowOpenWithoutNoopener, `window.open(url, '_blank', ${features});`);
+      expect(result.diagnostics).toHaveLength(1);
+    }
+  });
+
+  it("does not flag a const ternary URL with a void-0 fallback branch", () => {
+    const result = runRule(
+      windowOpenWithoutNoopener,
+      "const releaseUrl = version ? 'https://github.com/owner/repo' : void 0;\nwindow.open(releaseUrl, '_blank');",
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("does not flag a noopener=value feature entry", () => {
     const result = runRule(
       windowOpenWithoutNoopener,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.ts
@@ -5,6 +5,8 @@ import {
   type SymbolDescriptor,
 } from "../../semantic/scope-analysis.js";
 import { getAuthoritativeJsxAttribute } from "../../utils/get-authoritative-jsx-attribute.js";
+import { collectConstAliasSymbols } from "../../utils/collect-const-alias-symbols.js";
+import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
 import { findTransparentExpressionRoot } from "../../utils/find-transparent-expression-root.js";
 import { getStaticPropertyKeyName } from "../../utils/get-static-property-key-name.js";
 import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
@@ -13,6 +15,7 @@ import { isSymbolWriteBefore } from "../../utils/has-symbol-write-before.js";
 import { isProvenGlobalNamespaceReference } from "../../utils/is-proven-global-namespace-reference.js";
 import { isProvenUnmodifiedGlobalNamespaceReference } from "../../utils/is-proven-unmodified-global-namespace-reference.js";
 import { isReactApiCall } from "../../utils/is-react-api-call.js";
+import { resolveConstIdentifierAlias } from "../../utils/resolve-const-identifier-alias.js";
 import { walkAst } from "../../utils/walk-ast.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isNodeReachableWithinFunction } from "../../utils/is-node-reachable-within-function.js";
@@ -361,44 +364,284 @@ const resolveIteratedConstArrayLiteral = (
   return null;
 };
 
+const isRepeatedArrayIterationCallback = (functionNode: EsTreeNode): boolean => {
+  const callExpression = functionNode.parent;
+  if (
+    !callExpression ||
+    !isNodeOfType(callExpression, "CallExpression") ||
+    !(callExpression.arguments ?? []).includes(functionNode as never) ||
+    !isNodeOfType(callExpression.callee, "MemberExpression")
+  ) {
+    return false;
+  }
+  const methodName = getStaticPropertyName(callExpression.callee);
+  return methodName === "map" || methodName === "forEach";
+};
+
+const collectDirectLocalFunctionCalls = (
+  functionNode: EsTreeNode,
+): Array<EsTreeNodeOfType<"CallExpression">> | null => {
+  const nameIdentifier = resolveLocalFunctionNameIdentifier(functionNode);
+  const scopes = currentScopes;
+  const symbol = nameIdentifier ? scopes?.symbolFor(nameIdentifier) : null;
+  if (!scopes || !symbol) return null;
+  const calls: Array<EsTreeNodeOfType<"CallExpression">> = [];
+  for (const aliasSymbol of collectConstAliasSymbols(symbol, scopes)) {
+    for (const reference of aliasSymbol.references) {
+      const referenceRoot = findTransparentExpressionRoot(reference.identifier);
+      const parent = referenceRoot.parent;
+      if (
+        parent &&
+        isNodeOfType(parent, "VariableDeclarator") &&
+        parent.init === referenceRoot &&
+        isNodeOfType(parent.id, "Identifier") &&
+        scopes.symbolFor(parent.id)?.kind === "const"
+      ) {
+        continue;
+      }
+      if (!parent || !isNodeOfType(parent, "CallExpression") || parent.callee !== referenceRoot) {
+        return [];
+      }
+      calls.push(parent);
+    }
+  }
+  return calls.length > 0 ? calls : null;
+};
+
+const mutationMayAffectConfigRead = (
+  mutationNode: EsTreeNode,
+  referenceNode: EsTreeNode,
+  isCurrentIterationElement = false,
+): boolean => {
+  const referenceFunction = findEnclosingFunction(referenceNode);
+  const mutationFunction = findEnclosingFunction(mutationNode);
+  if (
+    referenceFunction &&
+    mutationFunction !== referenceFunction &&
+    resolveLocalFunctionNameIdentifier(referenceFunction)
+  ) {
+    const invocationReferences = collectDirectLocalFunctionCalls(referenceFunction);
+    if (!invocationReferences || invocationReferences.length === 0) return true;
+    return invocationReferences.some((invocationReference) =>
+      mutationMayAffectConfigRead(
+        mutationNode,
+        currentLocalFunctionInvocationReference ?? invocationReference,
+        isCurrentIterationElement,
+      ),
+    );
+  }
+  if (mutationNode.range == null || referenceNode.range == null) return true;
+  if (mutationNode.range[0] < referenceNode.range[0]) return true;
+  return Boolean(
+    !isCurrentIterationElement &&
+    referenceFunction &&
+    mutationFunction === referenceFunction &&
+    isRepeatedArrayIterationCallback(referenceFunction),
+  );
+};
+
+const isCurrentIterationIndex = (indexNode: EsTreeNode, referenceNode: EsTreeNode): boolean => {
+  const lexicalReferenceFunction = findEnclosingFunction(referenceNode);
+  const directCalls = lexicalReferenceFunction
+    ? collectDirectLocalFunctionCalls(lexicalReferenceFunction)
+    : null;
+  const referenceFunction = findEnclosingFunction(
+    currentLocalFunctionInvocationReference ?? directCalls?.[0] ?? referenceNode,
+  );
+  if (!referenceFunction || !isRepeatedArrayIterationCallback(referenceFunction)) return false;
+  const indexParameter =
+    isNodeOfType(referenceFunction, "FunctionDeclaration") ||
+    isNodeOfType(referenceFunction, "FunctionExpression") ||
+    isNodeOfType(referenceFunction, "ArrowFunctionExpression")
+      ? referenceFunction.params?.[1]
+      : null;
+  const indexIdentifier = stripParenExpression(indexNode);
+  return Boolean(
+    indexParameter &&
+    isNodeOfType(indexParameter, "Identifier") &&
+    isNodeOfType(indexIdentifier, "Identifier") &&
+    currentScopes?.symbolFor(indexParameter) === currentScopes?.symbolFor(indexIdentifier),
+  );
+};
+
+const isMutationTarget = (targetNode: EsTreeNode): boolean => {
+  const targetRoot = findTransparentExpressionRoot(targetNode);
+  const parent = targetRoot.parent;
+  return Boolean(
+    parent &&
+    ((isNodeOfType(parent, "AssignmentExpression") && parent.left === targetRoot) ||
+      (isNodeOfType(parent, "UpdateExpression") && parent.argument === targetRoot) ||
+      (isNodeOfType(parent, "UnaryExpression") &&
+        parent.operator === "delete" &&
+        parent.argument === targetRoot)),
+  );
+};
+
+const collectPatternSymbols = (
+  pattern: EsTreeNode,
+  scopes: ScopeAnalysis,
+  symbols: Set<SymbolDescriptor>,
+): void => {
+  if (isNodeOfType(pattern, "Identifier")) {
+    const symbol = scopes.symbolFor(pattern);
+    if (symbol?.kind === "const") symbols.add(symbol);
+    return;
+  }
+  if (isNodeOfType(pattern, "AssignmentPattern")) {
+    collectPatternSymbols(pattern.left as EsTreeNode, scopes, symbols);
+    return;
+  }
+  if (isNodeOfType(pattern, "ArrayPattern")) {
+    for (const element of pattern.elements ?? []) {
+      if (element) collectPatternSymbols(element as EsTreeNode, scopes, symbols);
+    }
+  }
+};
+
+const expressionHasPropertyMutationBefore = (
+  expression: EsTreeNode,
+  propertyName: string,
+  referenceNode: EsTreeNode,
+  scopes: ScopeAnalysis,
+  isCurrentIterationElement: boolean,
+): boolean => {
+  const expressionRoot = findTransparentExpressionRoot(expression);
+  const parent = expressionRoot.parent;
+  if (
+    parent &&
+    isNodeOfType(parent, "MemberExpression") &&
+    parent.object === expressionRoot &&
+    getStaticPropertyName(parent) === propertyName &&
+    isMutationTarget(parent) &&
+    mutationMayAffectConfigRead(parent, referenceNode, isCurrentIterationElement)
+  ) {
+    return true;
+  }
+  return Boolean(
+    parent &&
+    isNodeOfType(parent, "CallExpression") &&
+    parent.arguments?.[0] === expressionRoot &&
+    globalObjectMutationMayWriteProperty(parent, propertyName, scopes) &&
+    mutationMayAffectConfigRead(parent, referenceNode, isCurrentIterationElement),
+  );
+};
+
+const symbolHasPropertyMutationBefore = (
+  symbol: SymbolDescriptor,
+  propertyName: string,
+  referenceNode: EsTreeNode,
+  scopes: ScopeAnalysis,
+  isCurrentIterationElement: boolean,
+): boolean =>
+  collectConstAliasSymbols(symbol, scopes).some((aliasSymbol) =>
+    aliasSymbol.references.some((reference) =>
+      expressionHasPropertyMutationBefore(
+        reference.identifier,
+        propertyName,
+        referenceNode,
+        scopes,
+        isCurrentIterationElement,
+      ),
+    ),
+  );
+
 const hasNestedIndexedPropertyWriteBefore = (
   arrayIdentifier: EsTreeNodeOfType<"Identifier">,
   propertyName: string,
   referenceNode: EsTreeNode,
 ): boolean => {
-  const arraySymbol = currentScopes?.symbolFor(arrayIdentifier);
-  if (!arraySymbol) return false;
-  return arraySymbol.references.some((reference) => {
-    if (reference.identifier.range[0] >= referenceNode.range[0]) return false;
-    const referenceRoot = findTransparentExpressionRoot(reference.identifier);
-    const indexedMember = referenceRoot.parent;
-    if (
-      !indexedMember ||
-      !isNodeOfType(indexedMember, "MemberExpression") ||
-      indexedMember.object !== referenceRoot ||
-      !indexedMember.computed
-    ) {
-      return false;
+  const scopes = currentScopes;
+  const arraySymbol = scopes?.symbolFor(arrayIdentifier);
+  if (!scopes || !arraySymbol) return false;
+  const elementSymbols = new Map<SymbolDescriptor, boolean>();
+  const arraySymbols = new Set(collectConstAliasSymbols(arraySymbol, scopes));
+
+  for (const aliasSymbol of arraySymbols) {
+    for (const reference of aliasSymbol.references) {
+      const referenceRoot = findTransparentExpressionRoot(reference.identifier);
+      const declarator = referenceRoot.parent;
+      if (
+        declarator &&
+        isNodeOfType(declarator, "VariableDeclarator") &&
+        declarator.init === referenceRoot &&
+        isNodeOfType(declarator.id, "ArrayPattern")
+      ) {
+        for (const element of declarator.id.elements ?? []) {
+          if (!element) continue;
+          if (isNodeOfType(element, "RestElement")) {
+            const restArgument = element.argument as EsTreeNode;
+            if (isNodeOfType(restArgument, "Identifier")) {
+              const restSymbol = scopes.symbolFor(restArgument);
+              if (restSymbol?.kind === "const") {
+                for (const restAliasSymbol of collectConstAliasSymbols(restSymbol, scopes)) {
+                  arraySymbols.add(restAliasSymbol);
+                }
+              }
+            }
+            continue;
+          }
+          const destructuredSymbols = new Set<SymbolDescriptor>();
+          collectPatternSymbols(element as EsTreeNode, scopes, destructuredSymbols);
+          for (const destructuredSymbol of destructuredSymbols) {
+            elementSymbols.set(destructuredSymbol, false);
+          }
+        }
+      }
+      const indexedMember = referenceRoot.parent;
+      if (
+        !indexedMember ||
+        !isNodeOfType(indexedMember, "MemberExpression") ||
+        indexedMember.object !== referenceRoot ||
+        !indexedMember.computed
+      ) {
+        continue;
+      }
+      const indexedRoot = findTransparentExpressionRoot(indexedMember);
+      const isCurrentIterationElement = isCurrentIterationIndex(
+        indexedMember.property as EsTreeNode,
+        referenceNode,
+      );
+      const indexedParent = indexedRoot.parent;
+      if (
+        indexedParent &&
+        isNodeOfType(indexedParent, "VariableDeclarator") &&
+        indexedParent.init === indexedRoot &&
+        isNodeOfType(indexedParent.id, "Identifier")
+      ) {
+        const elementSymbol = scopes.symbolFor(indexedParent.id);
+        if (elementSymbol?.kind === "const") {
+          elementSymbols.set(elementSymbol, isCurrentIterationElement);
+        }
+      }
+      if (
+        isMutationTarget(indexedMember) &&
+        mutationMayAffectConfigRead(indexedMember, referenceNode, isCurrentIterationElement)
+      ) {
+        return true;
+      }
+      if (
+        expressionHasPropertyMutationBefore(
+          indexedMember,
+          propertyName,
+          referenceNode,
+          scopes,
+          isCurrentIterationElement,
+        )
+      ) {
+        return true;
+      }
     }
-    const propertyMember = indexedMember.parent;
-    if (
-      !propertyMember ||
-      !isNodeOfType(propertyMember, "MemberExpression") ||
-      propertyMember.object !== indexedMember ||
-      getStaticPropertyName(propertyMember) !== propertyName
-    ) {
-      return false;
-    }
-    const mutation = findTransparentExpressionRoot(propertyMember).parent;
-    return Boolean(
-      mutation &&
-      ((isNodeOfType(mutation, "AssignmentExpression") && mutation.left === propertyMember) ||
-        (isNodeOfType(mutation, "UpdateExpression") && mutation.argument === propertyMember) ||
-        (isNodeOfType(mutation, "UnaryExpression") &&
-          mutation.operator === "delete" &&
-          mutation.argument === propertyMember)),
-    );
-  });
+  }
+
+  return [...elementSymbols].some(([elementSymbol, isCurrentIterationElement]) =>
+    symbolHasPropertyMutationBefore(
+      elementSymbol,
+      propertyName,
+      referenceNode,
+      scopes,
+      isCurrentIterationElement,
+    ),
+  );
 };
 
 const ARRAY_MUTATING_METHOD_NAMES = new Set([
@@ -417,40 +660,68 @@ const hasArrayMutationBefore = (
   arrayIdentifier: EsTreeNodeOfType<"Identifier">,
   referenceNode: EsTreeNode,
 ): boolean => {
-  const arraySymbol = currentScopes?.symbolFor(arrayIdentifier);
-  if (!arraySymbol) return false;
-  return arraySymbol.references.some((reference) => {
-    if (reference.identifier.range[0] >= referenceNode.range[0]) return false;
-    const referenceRoot = findTransparentExpressionRoot(reference.identifier);
-    const memberExpression = referenceRoot.parent;
-    if (
-      !memberExpression ||
-      !isNodeOfType(memberExpression, "MemberExpression") ||
-      memberExpression.object !== referenceRoot
-    ) {
-      return false;
-    }
-    const memberRoot = findTransparentExpressionRoot(memberExpression);
-    const memberParent = memberRoot.parent;
-    const methodName = getStaticPropertyName(memberExpression);
-    if (
-      methodName &&
-      ARRAY_MUTATING_METHOD_NAMES.has(methodName) &&
-      memberParent &&
-      isNodeOfType(memberParent, "CallExpression") &&
-      memberParent.callee === memberRoot
-    ) {
-      return true;
-    }
-    return Boolean(
-      memberParent &&
-      ((isNodeOfType(memberParent, "AssignmentExpression") && memberParent.left === memberRoot) ||
-        (isNodeOfType(memberParent, "UpdateExpression") && memberParent.argument === memberRoot) ||
-        (isNodeOfType(memberParent, "UnaryExpression") &&
-          memberParent.operator === "delete" &&
-          memberParent.argument === memberRoot)),
-    );
-  });
+  const scopes = currentScopes;
+  const arraySymbol = scopes?.symbolFor(arrayIdentifier);
+  if (!scopes || !arraySymbol) return false;
+  return collectConstAliasSymbols(arraySymbol, scopes).some((aliasSymbol) =>
+    aliasSymbol.references.some((reference) => {
+      const referenceRoot = findTransparentExpressionRoot(reference.identifier);
+      const memberExpression = referenceRoot.parent;
+      if (
+        !memberExpression ||
+        !isNodeOfType(memberExpression, "MemberExpression") ||
+        memberExpression.object !== referenceRoot
+      ) {
+        return false;
+      }
+      const memberRoot = findTransparentExpressionRoot(memberExpression);
+      const memberParent = memberRoot.parent;
+      const isCurrentIterationElement = Boolean(
+        memberExpression.computed &&
+        isCurrentIterationIndex(memberExpression.property as EsTreeNode, referenceNode),
+      );
+      if (
+        !memberParent ||
+        !mutationMayAffectConfigRead(memberParent, referenceNode, isCurrentIterationElement)
+      ) {
+        return false;
+      }
+      const methodName = getStaticPropertyName(memberExpression);
+      if (
+        methodName &&
+        ARRAY_MUTATING_METHOD_NAMES.has(methodName) &&
+        isNodeOfType(memberParent, "CallExpression") &&
+        memberParent.callee === memberRoot
+      ) {
+        return true;
+      }
+      return isMutationTarget(memberExpression);
+    }),
+  );
+};
+
+const hasArrayMethodWriteBefore = (
+  arrayIdentifier: EsTreeNodeOfType<"Identifier">,
+  methodName: string,
+  referenceNode: EsTreeNode,
+): boolean => {
+  const scopes = currentScopes;
+  const arraySymbol = scopes?.symbolFor(arrayIdentifier);
+  if (!scopes || !arraySymbol) return true;
+  return collectConstAliasSymbols(arraySymbol, scopes).some((aliasSymbol) =>
+    aliasSymbol.references.some((reference) => {
+      const referenceRoot = findTransparentExpressionRoot(reference.identifier);
+      const memberExpression = referenceRoot.parent;
+      return Boolean(
+        memberExpression &&
+        isNodeOfType(memberExpression, "MemberExpression") &&
+        memberExpression.object === referenceRoot &&
+        getStaticPropertyName(memberExpression) === methodName &&
+        isMutationTarget(memberExpression) &&
+        mutationMayAffectConfigRead(memberExpression, referenceNode),
+      );
+    }),
+  );
 };
 
 // `EXTERNAL_LINKS.docs` — property read off a same-file const object of
@@ -466,15 +737,43 @@ const isTrustedConstConfigMember = (
   const receiver = stripParenExpression(memberNode.object as EsTreeNode);
   if (!isNodeOfType(receiver, "Identifier")) return false;
   if (!bindingIsUnmodifiedBeforeCurrentOpen(receiver)) return false;
-  if (hasArrayMutationBefore(receiver, memberNode)) return false;
-  if (
-    currentScopes &&
-    hasPossibleStaticPropertyWriteBefore(receiver, propertyName, memberNode, currentScopes)
-  ) {
-    return false;
-  }
 
   const constInitializer = resolveConstInitializer(receiver);
+  const scopes = currentScopes;
+  const elementSymbol = scopes ? resolveConstIdentifierAlias(receiver, scopes) : null;
+  const elementInitializer = elementSymbol?.initializer
+    ? stripParenExpression(elementSymbol.initializer)
+    : null;
+  if (
+    scopes &&
+    elementInitializer &&
+    isNodeOfType(elementInitializer, "MemberExpression") &&
+    elementInitializer.computed &&
+    isNodeOfType(elementInitializer.object, "Identifier") &&
+    isCurrentIterationIndex(elementInitializer.property as EsTreeNode, memberNode)
+  ) {
+    const arraySymbol = resolveConstIdentifierAlias(elementInitializer.object, scopes);
+    const arrayIdentifier = arraySymbol?.bindingIdentifier;
+    const arrayInitializer = arraySymbol?.initializer
+      ? stripParenExpression(arraySymbol.initializer)
+      : null;
+    if (
+      arrayIdentifier &&
+      isNodeOfType(arrayIdentifier, "Identifier") &&
+      arrayInitializer &&
+      isNodeOfType(arrayInitializer, "ArrayExpression") &&
+      bindingIsUnmodifiedBeforeCurrentOpen(arrayIdentifier) &&
+      !hasNestedIndexedPropertyWriteBefore(arrayIdentifier, propertyName, memberNode) &&
+      !hasArrayMutationBefore(arrayIdentifier, memberNode)
+    ) {
+      return everyArrayElementSuppliesTrustedProperty(arrayInitializer, propertyName, depth);
+    }
+  }
+
+  if (hasArrayMutationBefore(receiver, memberNode)) return false;
+  if (scopes && hasPossibleStaticPropertyWriteBefore(receiver, propertyName, memberNode, scopes)) {
+    return false;
+  }
   if (constInitializer && isNodeOfType(constInitializer, "ObjectExpression")) {
     return objectLiteralSuppliesTrustedProperty(constInitializer, propertyName, depth);
   }
@@ -518,31 +817,31 @@ const isTrustedConstConfigMember = (
 const isTrustedDestructuredIterationMember = (
   identifier: EsTreeNodeOfType<"Identifier">,
   depth: number,
-): boolean => {
-  if (!bindingIsUnmodifiedBeforeCurrentOpen(identifier)) return false;
+): boolean | null => {
+  if (!bindingIsUnmodifiedBeforeCurrentOpen(identifier)) return null;
   const binding = findVariableInitializer(identifier, identifier.name);
-  if (!binding) return false;
+  if (!binding) return null;
   let propertyNode = binding.bindingIdentifier.parent;
   if (propertyNode && isNodeOfType(propertyNode, "AssignmentPattern")) {
     propertyNode = propertyNode.parent;
   }
   if (!propertyNode || !isNodeOfType(propertyNode, "Property") || propertyNode.computed) {
-    return false;
+    return null;
   }
-  if (!isNodeOfType(propertyNode.key, "Identifier")) return false;
+  if (!isNodeOfType(propertyNode.key, "Identifier")) return null;
   const propertyName = propertyNode.key.name;
   const objectPattern = propertyNode.parent;
-  if (!objectPattern || !isNodeOfType(objectPattern, "ObjectPattern")) return false;
+  if (!objectPattern || !isNodeOfType(objectPattern, "ObjectPattern")) return null;
   const callbackFunction = objectPattern.parent;
   if (
     !callbackFunction ||
     !isFunctionLike(callbackFunction) ||
     !(callbackFunction.params ?? []).includes(objectPattern as never)
   ) {
-    return false;
+    return null;
   }
   const arrayLiteral = resolveIteratedConstArrayLiteral(callbackFunction);
-  if (!arrayLiteral) return false;
+  if (!arrayLiteral) return null;
   const iterationCall = callbackFunction.parent;
   const iterationCallee =
     iterationCall && isNodeOfType(iterationCall, "CallExpression") ? iterationCall.callee : null;
@@ -553,7 +852,8 @@ const isTrustedDestructuredIterationMember = (
   if (
     iteratedReceiver &&
     isNodeOfType(iteratedReceiver, "Identifier") &&
-    hasArrayMutationBefore(iteratedReceiver, identifier)
+    (hasNestedIndexedPropertyWriteBefore(iteratedReceiver, propertyName, identifier) ||
+      hasArrayMutationBefore(iteratedReceiver, identifier))
   ) {
     return false;
   }
@@ -1761,6 +2061,80 @@ const isGlobalObjectMutationCall = (
   );
 };
 
+const staticMutationPropertyName = (node: EsTreeNode | undefined): string | null => {
+  if (!node) return null;
+  const unwrappedNode = stripParenExpression(node);
+  if (isStringLiteral(unwrappedNode)) return unwrappedNode.value;
+  if (
+    isNodeOfType(unwrappedNode, "TemplateLiteral") &&
+    (unwrappedNode.expressions?.length ?? 0) === 0
+  ) {
+    return unwrappedNode.quasis?.[0]?.value?.cooked ?? null;
+  }
+  return null;
+};
+
+const objectExpressionMayWriteProperty = (
+  node: EsTreeNode | undefined,
+  propertyName: string,
+): boolean => {
+  if (!node) return true;
+  const unwrappedNode = stripParenExpression(node);
+  if (!isNodeOfType(unwrappedNode, "ObjectExpression")) return true;
+  return (unwrappedNode.properties ?? []).some((property) => {
+    if (!isNodeOfType(property, "Property")) return true;
+    const staticPropertyName = getStaticPropertyKeyName(property, {
+      allowComputedString: true,
+    });
+    return staticPropertyName === null || staticPropertyName === propertyName;
+  });
+};
+
+const globalObjectMutationMayWriteProperty = (
+  callExpression: EsTreeNodeOfType<"CallExpression">,
+  propertyName: string,
+  scopes: ScopeAnalysis,
+): boolean => {
+  const resolvesObjectMethod = (methodName: string): boolean =>
+    calleeResolvesToGlobalMutationMethod(
+      callExpression.callee as EsTreeNode,
+      "Object",
+      new Set([methodName]),
+      scopes,
+      0,
+    );
+  const resolvesReflectMethod = (methodName: string): boolean =>
+    calleeResolvesToGlobalMutationMethod(
+      callExpression.callee as EsTreeNode,
+      "Reflect",
+      new Set([methodName]),
+      scopes,
+      0,
+    );
+  if (resolvesObjectMethod("assign")) {
+    return (callExpression.arguments ?? [])
+      .slice(1)
+      .some((argument) => objectExpressionMayWriteProperty(argument as EsTreeNode, propertyName));
+  }
+  if (resolvesObjectMethod("defineProperties")) {
+    return objectExpressionMayWriteProperty(
+      callExpression.arguments?.[1] as EsTreeNode | undefined,
+      propertyName,
+    );
+  }
+  if (
+    resolvesObjectMethod("defineProperty") ||
+    resolvesReflectMethod("defineProperty") ||
+    resolvesReflectMethod("set")
+  ) {
+    const mutationPropertyName = staticMutationPropertyName(
+      callExpression.arguments?.[1] as EsTreeNode | undefined,
+    );
+    return mutationPropertyName === null || mutationPropertyName === propertyName;
+  }
+  return resolvesObjectMethod("setPrototypeOf") || resolvesReflectMethod("setPrototypeOf");
+};
+
 const globalNamespaceBindingIsUnmodifiedBefore = (
   namespaceName: string,
   referenceNode: EsTreeNode,
@@ -2111,8 +2485,12 @@ const isTrustedDestination = (
     if (isLetAssignedOnlyTrustedLiterals(urlArgument, depth + 1)) return true;
     if (isTrustedLocalComponentPropLiteral(urlArgument, depth + 1)) return true;
     if (isTrustedUseStateUrlBinding(urlArgument, depth + 1)) return true;
+    const destructuredIterationVerdict = isTrustedDestructuredIterationMember(
+      urlArgument,
+      depth + 1,
+    );
+    if (destructuredIterationVerdict != null) return destructuredIterationVerdict;
     if (isTrustedLocalWrapperParam(urlArgument, depth + 1)) return true;
-    if (isTrustedDestructuredIterationMember(urlArgument, depth + 1)) return true;
     return isRouterCoNavigatedIdentifier(urlArgument);
   }
   if (isNodeOfType(urlArgument, "ChainExpression")) {
@@ -2313,8 +2691,7 @@ const isProvenBuiltInArrayReceiver = (
   scopes: ScopeAnalysis,
 ): boolean => {
   if (!bindingIsUnmodifiedBefore(receiver, referenceNode)) return false;
-  if (hasPossibleStaticPropertyWriteBefore(receiver, "forEach", referenceNode, scopes))
-    return false;
+  if (hasArrayMethodWriteBefore(receiver, "forEach", referenceNode)) return false;
   const receiverBinding = scopes.symbolFor(receiver)?.bindingIdentifier;
   if (
     receiverBinding &&
@@ -2401,6 +2778,10 @@ const isArrowReturnDiscarded = (arrow: EsTreeNode): boolean => {
   }
   if (isNodeOfType(parent, "ExpressionStatement")) return true;
   if (isNodeOfType(parent, "CallExpression")) {
+    if (parent.callee === arrow) {
+      currentLocalFunctionInvocationReference = parent;
+      return isDiscardedWindowHandle(parent);
+    }
     if (!(parent.arguments?.some((argument) => argument === arrow) ?? false)) return false;
     return callDiscardsCallbackReturn(parent);
   }
@@ -2432,6 +2813,12 @@ const isArrowReturnDiscarded = (arrow: EsTreeNode): boolean => {
       createElementCall.arguments?.[1] === propsObject &&
       isProvenCreateElementCall,
     );
+  }
+  const directCalls = collectDirectLocalFunctionCalls(arrow);
+  if (directCalls?.length === 0) return true;
+  if (directCalls?.every((call) => isDiscardedWindowHandle(call))) {
+    currentLocalFunctionInvocationReference = directCalls.length === 1 ? directCalls[0] : undefined;
+    return true;
   }
   return false;
 };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.ts
@@ -1,4 +1,5 @@
 import * as path from "node:path";
+import { MUTATING_ARRAY_METHODS } from "../../constants/js.js";
 import {
   analyzeScopes,
   type ScopeAnalysis,
@@ -751,18 +752,6 @@ const hasNestedIndexedPropertyWriteBefore = (
   );
 };
 
-const ARRAY_MUTATING_METHOD_NAMES = new Set([
-  "copyWithin",
-  "fill",
-  "pop",
-  "push",
-  "reverse",
-  "shift",
-  "sort",
-  "splice",
-  "unshift",
-]);
-
 const hasArrayMutationBefore = (
   arrayIdentifier: EsTreeNodeOfType<"Identifier">,
   referenceNode: EsTreeNode,
@@ -796,7 +785,7 @@ const hasArrayMutationBefore = (
       const methodName = getStaticPropertyName(memberExpression);
       if (
         methodName &&
-        ARRAY_MUTATING_METHOD_NAMES.has(methodName) &&
+        MUTATING_ARRAY_METHODS.has(methodName) &&
         isNodeOfType(memberParent, "CallExpression") &&
         memberParent.callee === memberRoot
       ) {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.ts
@@ -32,6 +32,8 @@ const NAVIGATING_TARGETS = new Set(["_self", "_top", "_parent"]);
 let currentScopes: ScopeAnalysis | undefined;
 let currentRuleContext: RuleContext | undefined;
 let currentWindowOpenCall: EsTreeNode | undefined;
+let currentDestinationCoercionReference: EsTreeNode | undefined;
+let currentLocalFunctionInvocationReference: EsTreeNode | undefined;
 let trustedTopLevelDestinationMemo = new WeakMap<EsTreeNode, boolean>();
 let symbolHasNonReadReferenceMemo = new WeakMap<SymbolDescriptor, boolean>();
 let localFunctionCallArgumentsMemo = new WeakMap<
@@ -43,6 +45,7 @@ let routerCallsByFunctionMemo = new WeakMap<
   Array<EsTreeNodeOfType<"CallExpression">>
 >();
 let globalNamespaceMutationNodesMemo = new WeakMap<ScopeAnalysis, Map<string, EsTreeNode[]>>();
+let objectMutationCallsBySymbolMemo = new WeakMap<SymbolDescriptor, EsTreeNode[]>();
 
 const writeExecutesBeforeDestinationReference = (
   writeNode: EsTreeNode,
@@ -1612,7 +1615,7 @@ const isTrustedLocalFunctionReturn = (
       }
     }
   }
-  return isTrustedOrNullishDestination(returned, depth + 1);
+  return isTrustedOrNullishDestination(returned, depth);
 };
 
 const isTrustedLocalFunctionCall = (
@@ -1625,13 +1628,106 @@ const isTrustedLocalFunctionCall = (
   const returnedExpressions = localFunction
     ? collectLocalFunctionReturnExpressions(localFunction)
     : null;
-  return Boolean(
-    localFunction &&
-    returnedExpressions &&
-    returnedExpressions.length > 0 &&
-    returnedExpressions.every((returnedExpression) =>
-      isTrustedLocalFunctionReturn(returnedExpression, localFunction, callExpression, depth + 1),
-    ),
+  if (!localFunction || !returnedExpressions || returnedExpressions.length === 0) return false;
+  const previousInvocationReference = currentLocalFunctionInvocationReference;
+  currentLocalFunctionInvocationReference ??= callExpression;
+  try {
+    return returnedExpressions.every((returnedExpression) =>
+      isTrustedLocalFunctionReturn(returnedExpression, localFunction, callExpression, depth),
+    );
+  } finally {
+    currentLocalFunctionInvocationReference = previousInvocationReference;
+  }
+};
+
+const OBJECT_MUTATION_METHOD_NAMES = new Set([
+  "assign",
+  "defineProperties",
+  "defineProperty",
+  "setPrototypeOf",
+]);
+
+const REFLECT_MUTATION_METHOD_NAMES = new Set(["defineProperty", "set", "setPrototypeOf"]);
+
+const destructuredGlobalNamespacePropertyName = (
+  identifier: EsTreeNodeOfType<"Identifier">,
+  namespaceName: string,
+  scopes: ScopeAnalysis,
+): string | null => {
+  const binding = findVariableInitializer(identifier, identifier.name);
+  let propertyNode = binding?.bindingIdentifier.parent;
+  if (propertyNode && isNodeOfType(propertyNode, "AssignmentPattern")) {
+    propertyNode = propertyNode.parent;
+  }
+  if (!propertyNode || !isNodeOfType(propertyNode, "Property")) return null;
+  const objectPattern = propertyNode.parent;
+  if (!objectPattern || !isNodeOfType(objectPattern, "ObjectPattern")) return null;
+  const declarator = objectPattern.parent;
+  if (!declarator || !isNodeOfType(declarator, "VariableDeclarator")) return null;
+  const declaration = declarator.parent;
+  if (
+    !declaration ||
+    !isNodeOfType(declaration, "VariableDeclaration") ||
+    declaration.kind !== "const" ||
+    !declarator.init ||
+    !isProvenGlobalNamespaceReference(declarator.init, namespaceName, scopes)
+  ) {
+    return null;
+  }
+  return getStaticPropertyKeyName(propertyNode, { allowComputedString: true });
+};
+
+const calleeResolvesToGlobalMutationMethod = (
+  calleeNode: EsTreeNode,
+  namespaceName: string,
+  methodNames: Set<string>,
+  scopes: ScopeAnalysis,
+  depth: number,
+): boolean => {
+  if (depth > MAX_BINDING_RESOLUTION_DEPTH) return false;
+  const callee = stripParenExpression(calleeNode);
+  if (isNodeOfType(callee, "MemberExpression")) {
+    const methodName = getStaticPropertyName(callee);
+    return Boolean(
+      methodName &&
+      methodNames.has(methodName) &&
+      isProvenGlobalNamespaceReference(callee.object, namespaceName, scopes),
+    );
+  }
+  if (!isNodeOfType(callee, "Identifier")) return false;
+  const initializer = resolveConstInitializer(callee);
+  if (initializer) {
+    return calleeResolvesToGlobalMutationMethod(
+      initializer,
+      namespaceName,
+      methodNames,
+      scopes,
+      depth + 1,
+    );
+  }
+  const propertyName = destructuredGlobalNamespacePropertyName(callee, namespaceName, scopes);
+  return Boolean(propertyName && methodNames.has(propertyName));
+};
+
+const isGlobalObjectMutationCall = (
+  callExpression: EsTreeNodeOfType<"CallExpression">,
+  scopes: ScopeAnalysis,
+): boolean => {
+  return (
+    calleeResolvesToGlobalMutationMethod(
+      callExpression.callee as EsTreeNode,
+      "Object",
+      OBJECT_MUTATION_METHOD_NAMES,
+      scopes,
+      0,
+    ) ||
+    calleeResolvesToGlobalMutationMethod(
+      callExpression.callee as EsTreeNode,
+      "Reflect",
+      REFLECT_MUTATION_METHOD_NAMES,
+      scopes,
+      0,
+    )
   );
 };
 
@@ -1662,13 +1758,20 @@ const globalNamespaceBindingIsUnmodifiedBefore = (
     return !memoizedMutationNodes.some(mutationExecutesBeforeReference);
   }
   const mutationNodes: EsTreeNode[] = [];
-  const mutationTargetsNamespace = (mutationTarget: EsTreeNode): boolean => {
-    let namespaceCandidate = stripParenExpression(mutationTarget);
+  const mutationTargetsNamespace = (mutationTarget: EsTreeNode, depth = 0): boolean => {
+    if (depth > MAX_BINDING_RESOLUTION_DEPTH) return false;
+    const namespaceCandidate = stripParenExpression(mutationTarget);
     if (isProvenGlobalNamespaceReference(namespaceCandidate, namespaceName, scopes)) return true;
-    while (isNodeOfType(namespaceCandidate, "MemberExpression")) {
-      namespaceCandidate = stripParenExpression(namespaceCandidate.object);
+    if (isNodeOfType(namespaceCandidate, "MemberExpression")) {
+      return mutationTargetsNamespace(namespaceCandidate.object, depth + 1);
     }
-    return isProvenGlobalNamespaceReference(namespaceCandidate, namespaceName, scopes);
+    if (!isNodeOfType(namespaceCandidate, "Identifier")) return false;
+    const initializer = resolveConstInitializer(namespaceCandidate);
+    if (initializer && mutationTargetsNamespace(initializer, depth + 1)) return true;
+    return (
+      destructuredGlobalNamespacePropertyName(namespaceCandidate, namespaceName, scopes) ===
+      "prototype"
+    );
   };
   walkAst(program, (node: EsTreeNode) => {
     let mutationTarget: EsTreeNode | null = null;
@@ -1676,6 +1779,9 @@ const globalNamespaceBindingIsUnmodifiedBefore = (
     if (isNodeOfType(node, "UpdateExpression")) mutationTarget = node.argument;
     if (isNodeOfType(node, "UnaryExpression") && node.operator === "delete") {
       mutationTarget = node.argument;
+    }
+    if (isNodeOfType(node, "CallExpression") && isGlobalObjectMutationCall(node, scopes)) {
+      mutationTarget = (node.arguments?.[0] as EsTreeNode | undefined) ?? null;
     }
     if (mutationTarget && mutationTargetsNamespace(mutationTarget)) {
       mutationNodes.push(node);
@@ -1722,10 +1828,76 @@ const hasUrlOriginMutationBefore = (
 ): boolean => {
   const scopes = currentScopes;
   if (!scopes) return false;
-  return URL_ORIGIN_PROPERTY_NAMES.some((propertyName) =>
+  const hasPropertyMutation = URL_ORIGIN_PROPERTY_NAMES.some((propertyName) =>
     hasPossibleStaticPropertyWriteBefore(identifier, propertyName, referenceNode, scopes),
   );
+  if (hasPropertyMutation) return true;
+  const identifierSymbol = scopes.symbolFor(identifier);
+  if (!identifierSymbol) return false;
+  let mutationCalls = objectMutationCallsBySymbolMemo.get(identifierSymbol);
+  if (!mutationCalls) {
+    mutationCalls = [];
+    const program = findProgramRoot(identifier);
+    const targetResolvesToIdentifier = (targetNode: EsTreeNode, depth: number): boolean => {
+      if (depth > MAX_BINDING_RESOLUTION_DEPTH) return false;
+      const unwrappedTarget = stripParenExpression(targetNode);
+      if (!isNodeOfType(unwrappedTarget, "Identifier")) return false;
+      if (scopes.symbolFor(unwrappedTarget) === identifierSymbol) return true;
+      const initializer = resolveConstInitializer(unwrappedTarget);
+      return Boolean(initializer && targetResolvesToIdentifier(initializer, depth + 1));
+    };
+    if (program) {
+      walkAst(program, (node: EsTreeNode) => {
+        if (!isNodeOfType(node, "CallExpression") || !isGlobalObjectMutationCall(node, scopes)) {
+          return;
+        }
+        const mutationTarget = node.arguments?.[0] as EsTreeNode | undefined;
+        if (mutationTarget && targetResolvesToIdentifier(mutationTarget, 0)) {
+          mutationCalls?.push(node);
+        }
+      });
+    }
+    objectMutationCallsBySymbolMemo.set(identifierSymbol, mutationCalls);
+  }
+  return mutationCalls.some((mutationCall) =>
+    writeExecutesBeforeDestinationReference(mutationCall, referenceNode, scopes),
+  );
 };
+
+const isGlobalUrlConstruction = (node: EsTreeNode): boolean => {
+  const unwrappedNode = stripParenExpression(node);
+  return Boolean(
+    currentScopes &&
+    isNodeOfType(unwrappedNode, "NewExpression") &&
+    isProvenGlobalNamespaceReference(unwrappedNode.callee as EsTreeNode, "URL", currentScopes),
+  );
+};
+
+const isGlobalUrlInstanceExpression = (node: EsTreeNode): boolean => {
+  const unwrappedNode = stripParenExpression(node);
+  if (isGlobalUrlConstruction(unwrappedNode)) return true;
+  if (!isNodeOfType(unwrappedNode, "Identifier")) return false;
+  const initializer = resolveConstInitializer(unwrappedNode);
+  return Boolean(initializer && isGlobalUrlConstruction(initializer));
+};
+
+const withDestinationCoercionReference = <Value>(
+  referenceNode: EsTreeNode,
+  operation: () => Value,
+): Value => {
+  const previousReference = currentDestinationCoercionReference;
+  currentDestinationCoercionReference = referenceNode;
+  try {
+    return operation();
+  } finally {
+    currentDestinationCoercionReference = previousReference;
+  }
+};
+
+const destinationSerializationReference = (boundaryNode: EsTreeNode): EsTreeNode =>
+  currentLocalFunctionInvocationReference ??
+  (isAnalyzingDeferredForeignExport ? currentDestinationCoercionReference : undefined) ??
+  boundaryNode;
 
 const isTrustedUrlInstanceHrefRead = (
   memberNode: EsTreeNodeOfType<"MemberExpression">,
@@ -1738,8 +1910,12 @@ const isTrustedUrlInstanceHrefRead = (
   if (!initializer || !isNodeOfType(stripParenExpression(initializer), "NewExpression")) {
     return false;
   }
-  if (hasUrlOriginMutationBefore(receiver, memberNode)) return false;
-  return isTrustedDestination(initializer, depth + 1);
+  const serializationReference = destinationSerializationReference(memberNode);
+  if (!globalNamespaceBindingIsUnmodifiedBefore("URL", serializationReference)) return false;
+  if (hasUrlOriginMutationBefore(receiver, serializationReference)) return false;
+  return withDestinationCoercionReference(serializationReference, () =>
+    isTrustedDestination(initializer, depth + 1),
+  );
 };
 
 const isSafeInterpolatedDestinationSuffix = (suffixText: string): boolean => {
@@ -1830,13 +2006,29 @@ const isTrustedDestination = (
     (urlArgument.callee.property.name === "toString" ||
       urlArgument.callee.property.name === "toJSON")
   ) {
-    return isTrustedDestination(urlArgument.callee.object as EsTreeNode, depth + 1);
+    const urlReceiver = urlArgument.callee.object as EsTreeNode;
+    const serializationReference = destinationSerializationReference(urlArgument);
+    if (
+      isGlobalUrlInstanceExpression(urlReceiver) &&
+      !globalNamespaceBindingIsUnmodifiedBefore("URL", serializationReference)
+    ) {
+      return false;
+    }
+    return withDestinationCoercionReference(serializationReference, () =>
+      isTrustedDestination(urlReceiver, depth + 1),
+    );
   }
   if (isNodeOfType(urlArgument, "NewExpression")) {
+    const coercionReference = currentDestinationCoercionReference ?? urlArgument;
+    const constructionProgram = findProgramRoot(urlArgument);
+    const coercionProgram = findProgramRoot(coercionReference);
     if (
       !currentScopes ||
+      !constructionProgram ||
+      constructionProgram !== coercionProgram ||
       !isProvenGlobalNamespaceReference(urlArgument.callee as EsTreeNode, "URL", currentScopes) ||
-      !globalNamespaceBindingIsUnmodifiedBefore("URL", urlArgument)
+      !globalNamespaceBindingIsUnmodifiedBefore("URL", urlArgument) ||
+      !globalNamespaceBindingIsUnmodifiedBefore("URL", coercionReference)
     ) {
       return false;
     }
@@ -1869,7 +2061,14 @@ const isTrustedDestination = (
     if (constInitializer != null) {
       if (
         isNodeOfType(stripParenExpression(constInitializer), "NewExpression") &&
-        hasUrlOriginMutationBefore(urlArgument, urlArgument)
+        (hasUrlOriginMutationBefore(
+          urlArgument,
+          currentDestinationCoercionReference ?? urlArgument,
+        ) ||
+          !globalNamespaceBindingIsUnmodifiedBefore(
+            "URL",
+            currentDestinationCoercionReference ?? urlArgument,
+          ))
       ) {
         return false;
       }
@@ -1893,11 +2092,13 @@ const isTrustedDestination = (
     const firstExpression = urlArgument.expressions?.[0];
     if (firstQuasiText.length === 0 && firstExpression) {
       const followingQuasiText = urlArgument.quasis?.[1]?.value?.raw ?? "";
-      return (
-        isSafeInterpolatedDestinationSuffix(followingQuasiText) &&
-        (!followingQuasiText.startsWith("/") ||
-          isProvenNonSlashTerminatedDestination(firstExpression as EsTreeNode, depth + 1)) &&
-        isTrustedDestination(firstExpression as EsTreeNode, depth + 1)
+      return withDestinationCoercionReference(destinationSerializationReference(urlArgument), () =>
+        Boolean(
+          isSafeInterpolatedDestinationSuffix(followingQuasiText) &&
+          (!followingQuasiText.startsWith("/") ||
+            isProvenNonSlashTerminatedDestination(firstExpression as EsTreeNode, depth + 1)) &&
+          isTrustedDestination(firstExpression as EsTreeNode, depth + 1),
+        ),
       );
     }
     return false;
@@ -1934,22 +2135,9 @@ const isTrustedDestination = (
       const crossFileVerdict = crossFileUrlHelperDestinationVerdict(urlArgument.callee);
       if (crossFileVerdict !== null) return crossFileVerdict;
     }
-    // A string method on a trusted same-origin base keeps the leading `/`
-    // (`getLocation().pathname.replace('/iframe/', '/main/')`).
     const callee = urlArgument.callee as EsTreeNode;
     if (isNodeOfType(callee, "MemberExpression")) {
       const methodName = getStaticPropertyName(callee);
-      const replacementArgument = urlArgument.arguments?.[1] as EsTreeNode | undefined;
-      if (
-        methodName === "replace" &&
-        isNodeOfType(callee.object, "MemberExpression") &&
-        getStaticPropertyName(callee.object) === "pathname" &&
-        isLocationShapedReceiver(callee.object.object) &&
-        isStringLiteral(replacementArgument) &&
-        startsSameOriginPath(replacementArgument.value)
-      ) {
-        return true;
-      }
       return (
         methodName !== null &&
         ORIGIN_PRESERVING_STRING_METHOD_NAMES.has(methodName) &&
@@ -1972,7 +2160,9 @@ const isTrustedTopLevelDestination = (urlExpression: EsTreeNode | null | undefin
   const memoKey = strippedExpression;
   const memoizedVerdict = trustedTopLevelDestinationMemo.get(memoKey);
   if (memoizedVerdict !== undefined) return memoizedVerdict;
-  const verdict = isTrustedOrNullishDestination(urlExpression, 0);
+  const verdict = withDestinationCoercionReference(strippedExpression, () =>
+    isTrustedOrNullishDestination(urlExpression, 0),
+  );
   trustedTopLevelDestinationMemo.set(memoKey, verdict);
   return verdict;
 };
@@ -2244,11 +2434,14 @@ export const windowOpenWithoutNoopener = defineRule({
   create: (context) => {
     currentRuleContext = context;
     currentWindowOpenCall = undefined;
+    currentDestinationCoercionReference = undefined;
+    currentLocalFunctionInvocationReference = undefined;
     trustedTopLevelDestinationMemo = new WeakMap();
     symbolHasNonReadReferenceMemo = new WeakMap();
     localFunctionCallArgumentsMemo = new WeakMap();
     routerCallsByFunctionMemo = new WeakMap();
     globalNamespaceMutationNodesMemo = new WeakMap();
+    objectMutationCallsBySymbolMemo = new WeakMap();
     currentLintedFilename =
       typeof context.filename === "string" && path.isAbsolute(context.filename)
         ? context.filename

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.ts
@@ -2423,7 +2423,7 @@ const isTrustedDestination = (
       return false;
     }
     return withDestinationCoercionReference(serializationReference, () =>
-      isTrustedDestination(urlReceiver, depth + 1),
+      isTrustedDestination(stripParenExpression(urlReceiver), depth + 1),
     );
   }
   if (isNodeOfType(urlArgument, "NewExpression")) {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.ts
@@ -1938,8 +1938,7 @@ const isTrustedLocalFunctionReturn = (
           followingQuasiText,
           (returned.expressions?.length ?? 0) > 1,
         ) &&
-        (!followingQuasiText.startsWith("/") ||
-          isProvenNonSlashTerminatedDestination(argument, depth + 1))
+        (!followingQuasiText.startsWith("/") || isProvenSafeSlashJoinedBase(argument, depth + 1))
       ) {
         return isTrustedDestination(argument, depth + 1);
       }
@@ -2333,16 +2332,81 @@ const isSafeInterpolatedDestinationSuffix = (
   return suffixText.startsWith("/") && suffixText[1] !== "/" && suffixText[1] !== "\\";
 };
 
-const isProvenNonSlashTerminatedDestination = (destination: EsTreeNode, depth: number): boolean => {
+const INCOMPLETE_BROWSING_SCHEME_BASE_PATTERN = /^(?:https?|ftp|wss?):\/*$/iu;
+
+const staticPrimitiveTruthiness = (node: EsTreeNode): boolean | null => {
+  const unwrappedNode = stripParenExpression(node);
+  if (isNullishExpression(unwrappedNode)) return false;
+  if (!isNodeOfType(unwrappedNode, "Literal")) return null;
+  if (typeof unwrappedNode.value === "boolean") return unwrappedNode.value;
+  if (typeof unwrappedNode.value === "string") return unwrappedNode.value.length > 0;
+  if (typeof unwrappedNode.value === "number") {
+    return unwrappedNode.value !== 0 && !Number.isNaN(unwrappedNode.value);
+  }
+  if (typeof unwrappedNode.value === "bigint") return unwrappedNode.value !== 0n;
+  return null;
+};
+
+const isProvenSafeSlashJoinedBase = (destination: EsTreeNode, depth: number): boolean => {
   if (depth > MAX_BINDING_RESOLUTION_DEPTH) return false;
   const unwrappedDestination = stripParenExpression(destination);
-  if (isStringLiteral(unwrappedDestination)) {
-    return !unwrappedDestination.value.endsWith("/") && !unwrappedDestination.value.endsWith("\\");
+  if (isNodeOfType(unwrappedDestination, "Literal")) {
+    if (typeof unwrappedDestination.value !== "string") {
+      return staticPrimitiveTruthiness(unwrappedDestination) !== null;
+    }
+    const normalizedValue = unwrappedDestination.value.trim().replaceAll("\\", "/");
+    return (
+      !/^\/+$/u.test(normalizedValue) &&
+      !INCOMPLETE_BROWSING_SCHEME_BASE_PATTERN.test(normalizedValue)
+    );
   }
   if (isSameOriginLocationRead(unwrappedDestination)) return true;
+  if (isNodeOfType(unwrappedDestination, "ConditionalExpression")) {
+    const testTruthiness = staticPrimitiveTruthiness(unwrappedDestination.test);
+    if (testTruthiness !== null) {
+      return isProvenSafeSlashJoinedBase(
+        testTruthiness ? unwrappedDestination.consequent : unwrappedDestination.alternate,
+        depth + 1,
+      );
+    }
+    return (
+      isProvenSafeSlashJoinedBase(unwrappedDestination.consequent, depth + 1) &&
+      isProvenSafeSlashJoinedBase(unwrappedDestination.alternate, depth + 1)
+    );
+  }
+  if (isNodeOfType(unwrappedDestination, "LogicalExpression")) {
+    const leftTruthiness = staticPrimitiveTruthiness(unwrappedDestination.left);
+    if (unwrappedDestination.operator === "&&") {
+      return (
+        leftTruthiness === false ||
+        isProvenSafeSlashJoinedBase(unwrappedDestination.right, depth + 1)
+      );
+    }
+    if (unwrappedDestination.operator === "??") {
+      if (isNullishExpression(unwrappedDestination.left)) {
+        return isProvenSafeSlashJoinedBase(unwrappedDestination.right, depth + 1);
+      }
+      if (leftTruthiness !== null) {
+        return isProvenSafeSlashJoinedBase(unwrappedDestination.left, depth + 1);
+      }
+    }
+    if (unwrappedDestination.operator === "||" && leftTruthiness !== null) {
+      return isProvenSafeSlashJoinedBase(
+        leftTruthiness ? unwrappedDestination.left : unwrappedDestination.right,
+        depth + 1,
+      );
+    }
+    return (
+      isProvenSafeSlashJoinedBase(unwrappedDestination.left, depth + 1) &&
+      isProvenSafeSlashJoinedBase(unwrappedDestination.right, depth + 1)
+    );
+  }
   if (isNodeOfType(unwrappedDestination, "Identifier")) {
-    const initializer = resolveConstInitializer(unwrappedDestination);
-    return Boolean(initializer && isProvenNonSlashTerminatedDestination(initializer, depth + 1));
+    const resolvedSymbol = currentScopes
+      ? resolveConstIdentifierAlias(unwrappedDestination, currentScopes)
+      : null;
+    const initializer = resolvedSymbol?.kind === "const" ? resolvedSymbol.initializer : null;
+    return Boolean(initializer && isProvenSafeSlashJoinedBase(initializer, depth + 1));
   }
   if (
     isNodeOfType(unwrappedDestination, "CallExpression") &&
@@ -2356,11 +2420,59 @@ const isProvenNonSlashTerminatedDestination = (destination: EsTreeNode, depth: n
       returnedExpressions &&
       returnedExpressions.length > 0 &&
       returnedExpressions.every((returnedExpression) =>
-        isProvenNonSlashTerminatedDestination(returnedExpression, depth + 1),
+        isProvenSafeSlashJoinedBase(returnedExpression, depth + 1),
       ),
     );
   }
   return false;
+};
+
+const isTrustedInterpolatedDestinationBase = (destination: EsTreeNode, depth: number): boolean => {
+  const unwrappedDestination = stripParenExpression(destination);
+  if (
+    isNodeOfType(unwrappedDestination, "Literal") &&
+    typeof unwrappedDestination.value !== "string"
+  ) {
+    return staticPrimitiveTruthiness(unwrappedDestination) !== null;
+  }
+  if (isNodeOfType(unwrappedDestination, "ConditionalExpression")) {
+    const testTruthiness = staticPrimitiveTruthiness(unwrappedDestination.test);
+    if (testTruthiness !== null) {
+      return isTrustedInterpolatedDestinationBase(
+        testTruthiness ? unwrappedDestination.consequent : unwrappedDestination.alternate,
+        depth + 1,
+      );
+    }
+    return (
+      isTrustedInterpolatedDestinationBase(unwrappedDestination.consequent, depth + 1) &&
+      isTrustedInterpolatedDestinationBase(unwrappedDestination.alternate, depth + 1)
+    );
+  }
+  if (isNodeOfType(unwrappedDestination, "LogicalExpression")) {
+    const leftTruthiness = staticPrimitiveTruthiness(unwrappedDestination.left);
+    if (unwrappedDestination.operator === "&&") {
+      return (
+        leftTruthiness === false ||
+        isTrustedInterpolatedDestinationBase(unwrappedDestination.right, depth + 1)
+      );
+    }
+    if (unwrappedDestination.operator === "??" && isNullishExpression(unwrappedDestination.left)) {
+      return isTrustedInterpolatedDestinationBase(unwrappedDestination.right, depth + 1);
+    }
+    if (leftTruthiness !== null) {
+      return isTrustedInterpolatedDestinationBase(
+        unwrappedDestination.operator === "||" && !leftTruthiness
+          ? unwrappedDestination.right
+          : unwrappedDestination.left,
+        depth + 1,
+      );
+    }
+    return (
+      isTrustedInterpolatedDestinationBase(unwrappedDestination.left, depth + 1) &&
+      isTrustedInterpolatedDestinationBase(unwrappedDestination.right, depth + 1)
+    );
+  }
+  return isTrustedDestination(unwrappedDestination, depth + 1);
 };
 
 const isTrustedDestination = (
@@ -2503,6 +2615,15 @@ const isTrustedDestination = (
     const firstQuasiText = (urlArgument.quasis?.[0]?.value?.raw ?? "").trimStart();
     const firstExpression = urlArgument.expressions?.[0];
     if (firstQuasiText.length === 0 && firstExpression) {
+      const firstExpressionNode = firstExpression as EsTreeNode;
+      const resolvedFirstExpressionSymbol =
+        currentScopes && isNodeOfType(stripParenExpression(firstExpressionNode), "Identifier")
+          ? resolveConstIdentifierAlias(stripParenExpression(firstExpressionNode), currentScopes)
+          : null;
+      const trustedFirstExpression =
+        resolvedFirstExpressionSymbol?.kind === "const" && resolvedFirstExpressionSymbol.initializer
+          ? resolvedFirstExpressionSymbol.initializer
+          : firstExpressionNode;
       const followingQuasiText = urlArgument.quasis?.[1]?.value?.raw ?? "";
       return withDestinationCoercionReference(destinationSerializationReference(urlArgument), () =>
         Boolean(
@@ -2511,8 +2632,8 @@ const isTrustedDestination = (
             (urlArgument.expressions?.length ?? 0) > 1,
           ) &&
           (!followingQuasiText.startsWith("/") ||
-            isProvenNonSlashTerminatedDestination(firstExpression as EsTreeNode, depth + 1)) &&
-          isTrustedDestination(firstExpression as EsTreeNode, depth + 1),
+            isProvenSafeSlashJoinedBase(trustedFirstExpression, depth + 1)) &&
+          isTrustedInterpolatedDestinationBase(trustedFirstExpression, depth + 1),
         ),
       );
     }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.ts
@@ -9,7 +9,7 @@ import { findTransparentExpressionRoot } from "../../utils/find-transparent-expr
 import { getStaticPropertyKeyName } from "../../utils/get-static-property-key-name.js";
 import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
 import { hasPossibleStaticPropertyWriteBefore } from "../../utils/has-static-property-write-before.js";
-import { hasSymbolWriteBefore } from "../../utils/has-symbol-write-before.js";
+import { isSymbolWriteBefore } from "../../utils/has-symbol-write-before.js";
 import { isProvenGlobalNamespaceReference } from "../../utils/is-proven-global-namespace-reference.js";
 import { isProvenUnmodifiedGlobalNamespaceReference } from "../../utils/is-proven-unmodified-global-namespace-reference.js";
 import { isReactApiCall } from "../../utils/is-react-api-call.js";
@@ -42,7 +42,17 @@ let routerCallsByFunctionMemo = new WeakMap<
   EsTreeNode,
   Array<EsTreeNodeOfType<"CallExpression">>
 >();
-let globalNamespaceMutationOffsetsMemo = new WeakMap<ScopeAnalysis, Map<string, number[]>>();
+let globalNamespaceMutationNodesMemo = new WeakMap<ScopeAnalysis, Map<string, EsTreeNode[]>>();
+
+const writeExecutesBeforeDestinationReference = (
+  writeNode: EsTreeNode,
+  referenceNode: EsTreeNode,
+  scopes: ScopeAnalysis,
+): boolean => {
+  if (isSymbolWriteBefore(writeNode, referenceNode, scopes)) return true;
+  const program = isAnalyzingDeferredForeignExport ? findProgramRoot(referenceNode) : null;
+  return Boolean(program && isSymbolWriteBefore(writeNode, program, scopes));
+};
 
 const bindingIsUnmodifiedBefore = (identifier: EsTreeNode, referenceNode: EsTreeNode): boolean => {
   const scopes = currentScopes;
@@ -56,16 +66,28 @@ const bindingIsUnmodifiedBefore = (identifier: EsTreeNode, referenceNode: EsTree
     scopes &&
     symbol &&
     (!symbolHasNonReadReference ||
-      (!hasSymbolWriteBefore(symbol, referenceNode, scopes) &&
+      (referenceNode.range != null &&
+        !symbol.references.some(
+          (reference) => reference.flag !== "read" && reference.identifier.range == null,
+        ) &&
         !symbol.references.some(
           (reference) =>
-            reference.flag !== "read" && reference.identifier.range[0] < referenceNode.range[0],
+            reference.flag !== "read" &&
+            (writeExecutesBeforeDestinationReference(reference.identifier, referenceNode, scopes) ||
+              (!isAnalyzingForeignExport &&
+                reference.identifier.range[0] < referenceNode.range[0])),
         ))),
   );
 };
 
 const bindingIsUnmodifiedBeforeCurrentOpen = (identifier: EsTreeNode): boolean =>
-  Boolean(currentWindowOpenCall && bindingIsUnmodifiedBefore(identifier, currentWindowOpenCall));
+  Boolean(
+    currentWindowOpenCall &&
+    bindingIsUnmodifiedBefore(
+      identifier,
+      isAnalyzingForeignExport ? identifier : currentWindowOpenCall,
+    ),
+  );
 
 // Matches `window.open` and `globalThis.window.open` — a non-computed
 // `.open` member off the `window` global. Bare `open(...)` (an
@@ -523,8 +545,8 @@ const isTrustedDestructuredIterationMember = (
   return everyArrayElementSuppliesTrustedProperty(arrayLiteral, propertyName, depth);
 };
 
-// A `let url;` whose EVERY assignment in the enclosing scope is a trusted
-// static literal (switch/case link pickers) cannot carry attacker data.
+// A `let url;` whose every assignment that can execute before the read is a
+// trusted static literal (switch/case link pickers) cannot carry attacker data.
 const isLetAssignedOnlyTrustedLiterals = (
   identifier: EsTreeNodeOfType<"Identifier">,
   depth: number,
@@ -536,10 +558,56 @@ const isLetAssignedOnlyTrustedLiterals = (
   if (declarator.init && !isTrustedDestination(declarator.init as EsTreeNode, depth + 1)) {
     return false;
   }
-  const bindingSymbol = currentScopes?.symbolFor(binding.bindingIdentifier);
-  if (!bindingSymbol) return false;
-  let sawAssignment = false;
+  const scopes = currentScopes;
+  const bindingSymbol = scopes?.symbolFor(binding.bindingIdentifier);
+  if (!scopes || !bindingSymbol || identifier.range == null) return false;
+  if (!isAnalyzingForeignExport) {
+    let sawAssignment = false;
+    for (const reference of bindingSymbol.references) {
+      let writeTargetChild = reference.identifier;
+      let writeTargetParent = writeTargetChild.parent;
+      let isNestedWriteTarget = false;
+      while (writeTargetParent) {
+        if (isNodeOfType(writeTargetParent, "AssignmentExpression")) {
+          isNestedWriteTarget =
+            writeTargetParent.left === writeTargetChild &&
+            writeTargetChild !== reference.identifier;
+          break;
+        }
+        if (
+          (isNodeOfType(writeTargetParent, "ForInStatement") ||
+            isNodeOfType(writeTargetParent, "ForOfStatement")) &&
+          writeTargetParent.left === writeTargetChild
+        ) {
+          isNestedWriteTarget = true;
+          break;
+        }
+        if (isFunctionLike(writeTargetParent)) break;
+        writeTargetChild = writeTargetParent;
+        writeTargetParent = writeTargetParent.parent;
+      }
+      if (isNestedWriteTarget) return false;
+      const referenceRoot = findTransparentExpressionRoot(reference.identifier);
+      const referenceParent = referenceRoot.parent;
+      if (
+        referenceParent &&
+        isNodeOfType(referenceParent, "AssignmentExpression") &&
+        referenceParent.operator === "=" &&
+        referenceParent.left === referenceRoot
+      ) {
+        sawAssignment = true;
+        if (!isTrustedDestination(referenceParent.right as EsTreeNode, depth + 1)) {
+          return false;
+        }
+        continue;
+      }
+      if (reference.flag !== "read") return false;
+    }
+    return sawAssignment;
+  }
+  let sawTrustedValue = declarator.init != null;
   for (const reference of bindingSymbol.references) {
+    if (reference.identifier.range == null) return false;
     let writeTargetChild = reference.identifier;
     let writeTargetParent = writeTargetChild.parent;
     let isNestedWriteTarget = false;
@@ -561,7 +629,12 @@ const isLetAssignedOnlyTrustedLiterals = (
       writeTargetChild = writeTargetParent;
       writeTargetParent = writeTargetParent.parent;
     }
-    if (isNestedWriteTarget) return false;
+    if (isNestedWriteTarget) {
+      if (writeExecutesBeforeDestinationReference(reference.identifier, identifier, scopes)) {
+        return false;
+      }
+      continue;
+    }
     const referenceRoot = findTransparentExpressionRoot(reference.identifier);
     const referenceParent = referenceRoot.parent;
     if (
@@ -570,15 +643,23 @@ const isLetAssignedOnlyTrustedLiterals = (
       referenceParent.operator === "=" &&
       referenceParent.left === referenceRoot
     ) {
-      sawAssignment = true;
+      if (!writeExecutesBeforeDestinationReference(reference.identifier, identifier, scopes)) {
+        continue;
+      }
+      sawTrustedValue = true;
       if (!isTrustedDestination(referenceParent.right as EsTreeNode, depth + 1)) {
         return false;
       }
       continue;
     }
-    if (reference.flag !== "read") return false;
+    if (
+      reference.flag !== "read" &&
+      writeExecutesBeforeDestinationReference(reference.identifier, identifier, scopes)
+    ) {
+      return false;
+    }
   }
-  return sawAssignment;
+  return sawTrustedValue;
 };
 
 // `ctaLink` destructured from the props of a module-local, non-exported
@@ -1337,6 +1418,12 @@ const crossFileResolutionMemo = new Map<string, ResolvedCrossFileExport | null>(
 // disabled, so a foreign helper delegating to its OWN imports stays
 // opaque (no transitive resolution chains).
 let isAnalyzingForeignExport = false;
+let isAnalyzingDeferredForeignExport = false;
+
+interface ForeignExportAnalysisOptions {
+  foreignExpression: EsTreeNode;
+  isDeferred: boolean;
+}
 
 interface ImportedExportReference {
   moduleSpecifier: string;
@@ -1393,17 +1480,25 @@ const resolveCrossFileExportWithinBudget = (
 // (the foreign AST carries parent references); literal trust tightens to
 // same-origin (`isTrustedForeignStaticText`) and further cross-file hops
 // are off.
-const isTrustedForeignExportExpression = (foreignExpression: EsTreeNode): boolean => {
+const isTrustedForeignExportExpression = ({
+  foreignExpression,
+  isDeferred,
+}: ForeignExportAnalysisOptions): boolean => {
   const previousScopes = currentScopes;
+  const previousWindowOpenCall = currentWindowOpenCall;
   const foreignProgramRoot = findProgramRoot(foreignExpression);
   currentScopes = foreignProgramRoot ? analyzeScopes(foreignProgramRoot) : undefined;
+  currentWindowOpenCall = foreignExpression;
   isAnalyzingForeignExport = true;
+  isAnalyzingDeferredForeignExport = isDeferred;
   try {
     const strippedExpression = stripParenExpression(foreignExpression);
     return isTrustedDestination(strippedExpression, 0);
   } finally {
     isAnalyzingForeignExport = false;
+    isAnalyzingDeferredForeignExport = false;
     currentScopes = previousScopes;
+    currentWindowOpenCall = previousWindowOpenCall;
   }
 };
 
@@ -1420,7 +1515,10 @@ const crossFileImportedDestinationVerdict = (
   const resolvedExport = resolveCrossFileExportWithinBudget(identifier);
   if (!resolvedExport) return null;
   if (resolvedExport.kind !== "initializer") return null;
-  return isTrustedForeignExportExpression(resolvedExport.node);
+  return isTrustedForeignExportExpression({
+    foreignExpression: resolvedExport.node,
+    isDeferred: false,
+  });
 };
 
 // `get…Url` / `create…Url` / `build…Url` imported helpers: the sync
@@ -1439,7 +1537,7 @@ const crossFileUrlHelperDestinationVerdict = (
   const returnedExpressions = collectLocalFunctionReturnExpressions(resolvedExport.node);
   if (!returnedExpressions || returnedExpressions.length === 0) return false;
   return returnedExpressions.every((returnedExpression) =>
-    isTrustedForeignExportExpression(returnedExpression),
+    isTrustedForeignExportExpression({ foreignExpression: returnedExpression, isDeferred: true }),
   );
 };
 
@@ -1544,17 +1642,26 @@ const globalNamespaceBindingIsUnmodifiedBefore = (
   const scopes = currentScopes;
   const program = findProgramRoot(referenceNode);
   if (!scopes || !program) return false;
-  const referenceStart = referenceNode.range?.[0] ?? Number.POSITIVE_INFINITY;
-  let offsetsByNamespace = globalNamespaceMutationOffsetsMemo.get(scopes);
-  if (!offsetsByNamespace) {
-    offsetsByNamespace = new Map();
-    globalNamespaceMutationOffsetsMemo.set(scopes, offsetsByNamespace);
+  const mutationExecutesBeforeReference = (mutationNode: EsTreeNode): boolean => {
+    if (mutationNode.range == null || referenceNode.range == null) return true;
+    if (!isAnalyzingForeignExport) return mutationNode.range[0] < referenceNode.range[0];
+    return (
+      isSymbolWriteBefore(mutationNode, referenceNode, scopes) ||
+      (isAnalyzingDeferredForeignExport && isSymbolWriteBefore(mutationNode, program, scopes))
+    );
+  };
+  let nodesByNamespace = globalNamespaceMutationNodesMemo.get(scopes);
+  if (!nodesByNamespace) {
+    nodesByNamespace = new Map();
+    globalNamespaceMutationNodesMemo.set(scopes, nodesByNamespace);
   }
-  const memoizedMutationOffsets = offsetsByNamespace.get(namespaceName);
-  if (memoizedMutationOffsets) {
-    return !memoizedMutationOffsets.some((mutationOffset) => mutationOffset < referenceStart);
+  const memoizedMutationNodes = nodesByNamespace.get(namespaceName);
+  if (memoizedMutationNodes) {
+    if (memoizedMutationNodes.length === 0) return true;
+    if (referenceNode.range == null) return false;
+    return !memoizedMutationNodes.some(mutationExecutesBeforeReference);
   }
-  const mutationOffsets: number[] = [];
+  const mutationNodes: EsTreeNode[] = [];
   const mutationTargetsNamespace = (mutationTarget: EsTreeNode): boolean => {
     let namespaceCandidate = stripParenExpression(mutationTarget);
     if (isProvenGlobalNamespaceReference(namespaceCandidate, namespaceName, scopes)) return true;
@@ -1571,11 +1678,13 @@ const globalNamespaceBindingIsUnmodifiedBefore = (
       mutationTarget = node.argument;
     }
     if (mutationTarget && mutationTargetsNamespace(mutationTarget)) {
-      mutationOffsets.push(node.range?.[0] ?? Number.NEGATIVE_INFINITY);
+      mutationNodes.push(node);
     }
   });
-  offsetsByNamespace.set(namespaceName, mutationOffsets);
-  return !mutationOffsets.some((mutationOffset) => mutationOffset < referenceStart);
+  nodesByNamespace.set(namespaceName, mutationNodes);
+  if (mutationNodes.length === 0) return true;
+  if (referenceNode.range == null) return false;
+  return !mutationNodes.some(mutationExecutesBeforeReference);
 };
 
 // `URL.createObjectURL(blob)` — a blob: URL of app-generated content; the
@@ -2139,7 +2248,7 @@ export const windowOpenWithoutNoopener = defineRule({
     symbolHasNonReadReferenceMemo = new WeakMap();
     localFunctionCallArgumentsMemo = new WeakMap();
     routerCallsByFunctionMemo = new WeakMap();
-    globalNamespaceMutationOffsetsMemo = new WeakMap();
+    globalNamespaceMutationNodesMemo = new WeakMap();
     currentLintedFilename =
       typeof context.filename === "string" && path.isAbsolute(context.filename)
         ? context.filename
@@ -2147,6 +2256,7 @@ export const windowOpenWithoutNoopener = defineRule({
     crossFileResolutionsRemaining = CROSS_FILE_RESOLUTION_BUDGET_PER_FILE;
     crossFileResolutionMemo.clear();
     isAnalyzingForeignExport = false;
+    isAnalyzingDeferredForeignExport = false;
     return {
       CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
         currentScopes = context.scopes;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.ts
@@ -8,6 +8,7 @@ import { getAuthoritativeJsxAttribute } from "../../utils/get-authoritative-jsx-
 import { collectConstAliasSymbols } from "../../utils/collect-const-alias-symbols.js";
 import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
 import { findTransparentExpressionRoot } from "../../utils/find-transparent-expression-root.js";
+import { getExecutionReferenceOffset } from "../../utils/get-execution-reference-offset.js";
 import { getStaticPropertyKeyName } from "../../utils/get-static-property-key-name.js";
 import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
 import { hasPossibleStaticPropertyWriteBefore } from "../../utils/has-static-property-write-before.js";
@@ -40,7 +41,12 @@ let currentScopes: ScopeAnalysis | undefined;
 let currentRuleContext: RuleContext | undefined;
 let currentWindowOpenCall: EsTreeNode | undefined;
 let currentDestinationCoercionReference: EsTreeNode | undefined;
+let currentDestinationCoercionBoundaryReference: EsTreeNode | undefined;
 let currentLocalFunctionInvocationReference: EsTreeNode | undefined;
+let currentLocalFunctionSerializationReference: EsTreeNode | undefined;
+let currentAnalyzedLocalFunction: EsTreeNode | undefined;
+let currentOpaqueLocalFunctionSerializationReference: EsTreeNode | undefined;
+let currentDeferredLocalFunctions: EsTreeNode[] = [];
 let trustedTopLevelDestinationMemo = new WeakMap<EsTreeNode, boolean>();
 let symbolHasNonReadReferenceMemo = new WeakMap<SymbolDescriptor, boolean>();
 let localFunctionCallArgumentsMemo = new WeakMap<
@@ -53,6 +59,12 @@ let routerCallsByFunctionMemo = new WeakMap<
 >();
 let globalNamespaceMutationNodesMemo = new WeakMap<ScopeAnalysis, Map<string, EsTreeNode[]>>();
 let objectMutationCallsBySymbolMemo = new WeakMap<SymbolDescriptor, EsTreeNode[]>();
+
+interface LocalFunctionExecutionContext {
+  functions: EsTreeNode[];
+  immediateReferences: Array<EsTreeNodeOfType<"CallExpression">> | null;
+  references: Array<EsTreeNodeOfType<"CallExpression">> | null;
+}
 
 const writeExecutesBeforeDestinationReference = (
   writeNode: EsTreeNode,
@@ -85,7 +97,7 @@ const bindingIsUnmodifiedBefore = (identifier: EsTreeNode, referenceNode: EsTree
             reference.flag !== "read" &&
             (writeExecutesBeforeDestinationReference(reference.identifier, referenceNode, scopes) ||
               (!isAnalyzingForeignExport &&
-                reference.identifier.range[0] < referenceNode.range[0])),
+                reference.identifier.range[0] < getExecutionReferenceOffset(referenceNode))),
         ))),
   );
 };
@@ -408,10 +420,66 @@ const collectDirectLocalFunctionCalls = (
   return calls.length > 0 ? calls : null;
 };
 
+const resolveLocalFunctionExecutionContext = (
+  functionNode: EsTreeNode,
+  depth: number,
+): LocalFunctionExecutionContext => {
+  if (depth > MAX_BINDING_RESOLUTION_DEPTH) {
+    return { functions: [functionNode], immediateReferences: null, references: null };
+  }
+  const functionRoot = findTransparentExpressionRoot(functionNode);
+  const parent = functionRoot.parent;
+  let directCalls: Array<EsTreeNodeOfType<"CallExpression">> | null;
+  const isInlineSynchronousCallback = Boolean(
+    parent &&
+    isNodeOfType(parent, "CallExpression") &&
+    (parent.arguments ?? []).includes(functionRoot as never) &&
+    isRepeatedArrayIterationCallback(functionNode) &&
+    callDiscardsCallbackReturn(parent),
+  );
+  if (
+    parent &&
+    isNodeOfType(parent, "CallExpression") &&
+    (parent.callee === functionRoot || isInlineSynchronousCallback)
+  ) {
+    directCalls = [parent];
+  } else {
+    directCalls = collectDirectLocalFunctionCalls(functionNode);
+  }
+  if (!directCalls || directCalls.length === 0) {
+    return { functions: [functionNode], immediateReferences: null, references: null };
+  }
+  const functions = [functionNode];
+  const references: Array<EsTreeNodeOfType<"CallExpression">> = [];
+  for (const directCall of directCalls) {
+    const enclosingFunction = findEnclosingFunction(directCall);
+    if (!enclosingFunction) {
+      references.push(directCall);
+      continue;
+    }
+    const enclosingContext = resolveLocalFunctionExecutionContext(enclosingFunction, depth + 1);
+    functions.push(...enclosingContext.functions);
+    if (!enclosingContext.references) {
+      return {
+        functions,
+        immediateReferences: isInlineSynchronousCallback ? null : directCalls,
+        references: null,
+      };
+    }
+    references.push(...enclosingContext.references);
+  }
+  return {
+    functions,
+    immediateReferences: isInlineSynchronousCallback ? null : directCalls,
+    references,
+  };
+};
+
 const mutationMayAffectConfigRead = (
   mutationNode: EsTreeNode,
   referenceNode: EsTreeNode,
   isCurrentIterationElement = false,
+  visitedFunctions: ReadonlySet<EsTreeNode> = new Set(),
 ): boolean => {
   const referenceFunction = findEnclosingFunction(referenceNode);
   const mutationFunction = findEnclosingFunction(mutationNode);
@@ -420,18 +488,22 @@ const mutationMayAffectConfigRead = (
     mutationFunction !== referenceFunction &&
     resolveLocalFunctionNameIdentifier(referenceFunction)
   ) {
+    if (visitedFunctions.has(referenceFunction)) return true;
     const invocationReferences = collectDirectLocalFunctionCalls(referenceFunction);
     if (!invocationReferences || invocationReferences.length === 0) return true;
+    const nextVisitedFunctions = new Set(visitedFunctions);
+    nextVisitedFunctions.add(referenceFunction);
     return invocationReferences.some((invocationReference) =>
       mutationMayAffectConfigRead(
         mutationNode,
-        currentLocalFunctionInvocationReference ?? invocationReference,
+        invocationReference,
         isCurrentIterationElement,
+        nextVisitedFunctions,
       ),
     );
   }
   if (mutationNode.range == null || referenceNode.range == null) return true;
-  if (mutationNode.range[0] < referenceNode.range[0]) return true;
+  if (mutationNode.range[0] < getExecutionReferenceOffset(referenceNode)) return true;
   return Boolean(
     !isCurrentIterationElement &&
     referenceFunction &&
@@ -1959,13 +2031,19 @@ const isTrustedLocalFunctionCall = (
     : null;
   if (!localFunction || !returnedExpressions || returnedExpressions.length === 0) return false;
   const previousInvocationReference = currentLocalFunctionInvocationReference;
+  const previousSerializationReference = currentLocalFunctionSerializationReference;
+  const previousAnalyzedLocalFunction = currentAnalyzedLocalFunction;
   currentLocalFunctionInvocationReference ??= callExpression;
+  currentLocalFunctionSerializationReference ??= callExpression;
+  currentAnalyzedLocalFunction = localFunction;
   try {
     return returnedExpressions.every((returnedExpression) =>
       isTrustedLocalFunctionReturn(returnedExpression, localFunction, callExpression, depth),
     );
   } finally {
     currentLocalFunctionInvocationReference = previousInvocationReference;
+    currentLocalFunctionSerializationReference = previousSerializationReference;
+    currentAnalyzedLocalFunction = previousAnalyzedLocalFunction;
   }
 };
 
@@ -2137,13 +2215,21 @@ const globalObjectMutationMayWriteProperty = (
 const globalNamespaceBindingIsUnmodifiedBefore = (
   namespaceName: string,
   referenceNode: EsTreeNode,
+  lexicalBoundaryNode: EsTreeNode = referenceNode,
 ): boolean => {
   const scopes = currentScopes;
   const program = findProgramRoot(referenceNode);
   if (!scopes || !program) return false;
   const mutationExecutesBeforeReference = (mutationNode: EsTreeNode): boolean => {
     if (mutationNode.range == null || referenceNode.range == null) return true;
-    if (!isAnalyzingForeignExport) return mutationNode.range[0] < referenceNode.range[0];
+    if (!isAnalyzingForeignExport) {
+      const lexicalBoundaryFunction = findEnclosingFunction(lexicalBoundaryNode);
+      const comparisonReference =
+        lexicalBoundaryFunction && findEnclosingFunction(mutationNode) === lexicalBoundaryFunction
+          ? lexicalBoundaryNode
+          : referenceNode;
+      return mutationNode.range[0] < getExecutionReferenceOffset(comparisonReference);
+    }
     return (
       isSymbolWriteBefore(mutationNode, referenceNode, scopes) ||
       (isAnalyzingDeferredForeignExport && isSymbolWriteBefore(mutationNode, program, scopes))
@@ -2286,21 +2372,40 @@ const isGlobalUrlInstanceExpression = (node: EsTreeNode): boolean => {
 
 const withDestinationCoercionReference = <Value>(
   referenceNode: EsTreeNode,
+  boundaryNode: EsTreeNode,
   operation: () => Value,
 ): Value => {
   const previousReference = currentDestinationCoercionReference;
+  const previousBoundaryReference = currentDestinationCoercionBoundaryReference;
   currentDestinationCoercionReference = referenceNode;
+  currentDestinationCoercionBoundaryReference = boundaryNode;
   try {
     return operation();
   } finally {
     currentDestinationCoercionReference = previousReference;
+    currentDestinationCoercionBoundaryReference = previousBoundaryReference;
   }
 };
 
-const destinationSerializationReference = (boundaryNode: EsTreeNode): EsTreeNode =>
-  currentLocalFunctionInvocationReference ??
-  (isAnalyzingDeferredForeignExport ? currentDestinationCoercionReference : undefined) ??
-  boundaryNode;
+const destinationSerializationReference = (boundaryNode: EsTreeNode): EsTreeNode => {
+  const boundaryFunction = findEnclosingFunction(boundaryNode);
+  const currentOpenFunction = currentWindowOpenCall
+    ? findEnclosingFunction(currentWindowOpenCall)
+    : null;
+  const localInvocationReference =
+    boundaryFunction &&
+    (boundaryFunction === currentOpenFunction ||
+      boundaryFunction === currentAnalyzedLocalFunction ||
+      currentDeferredLocalFunctions.includes(boundaryFunction))
+      ? (currentLocalFunctionSerializationReference ??
+        currentOpaqueLocalFunctionSerializationReference)
+      : undefined;
+  return (
+    localInvocationReference ??
+    (isAnalyzingDeferredForeignExport ? currentDestinationCoercionReference : undefined) ??
+    boundaryNode
+  );
+};
 
 const isTrustedUrlInstanceHrefRead = (
   memberNode: EsTreeNodeOfType<"MemberExpression">,
@@ -2314,9 +2419,16 @@ const isTrustedUrlInstanceHrefRead = (
     return false;
   }
   const serializationReference = destinationSerializationReference(memberNode);
-  if (!globalNamespaceBindingIsUnmodifiedBefore("URL", serializationReference)) return false;
-  if (hasUrlOriginMutationBefore(receiver, serializationReference)) return false;
-  return withDestinationCoercionReference(serializationReference, () =>
+  if (!globalNamespaceBindingIsUnmodifiedBefore("URL", serializationReference, memberNode)) {
+    return false;
+  }
+  if (
+    hasUrlOriginMutationBefore(receiver, memberNode) &&
+    hasUrlOriginMutationBefore(receiver, serializationReference)
+  ) {
+    return false;
+  }
+  return withDestinationCoercionReference(serializationReference, memberNode, () =>
     isTrustedDestination(initializer, depth + 1),
   );
 };
@@ -2530,11 +2642,11 @@ const isTrustedDestination = (
     const serializationReference = destinationSerializationReference(urlArgument);
     if (
       isGlobalUrlInstanceExpression(urlReceiver) &&
-      !globalNamespaceBindingIsUnmodifiedBefore("URL", serializationReference)
+      !globalNamespaceBindingIsUnmodifiedBefore("URL", serializationReference, urlArgument)
     ) {
       return false;
     }
-    return withDestinationCoercionReference(serializationReference, () =>
+    return withDestinationCoercionReference(serializationReference, urlArgument, () =>
       isTrustedDestination(stripParenExpression(urlReceiver), depth + 1),
     );
   }
@@ -2548,7 +2660,11 @@ const isTrustedDestination = (
       constructionProgram !== coercionProgram ||
       !isProvenGlobalNamespaceReference(urlArgument.callee as EsTreeNode, "URL", currentScopes) ||
       !globalNamespaceBindingIsUnmodifiedBefore("URL", urlArgument) ||
-      !globalNamespaceBindingIsUnmodifiedBefore("URL", coercionReference)
+      !globalNamespaceBindingIsUnmodifiedBefore(
+        "URL",
+        coercionReference,
+        currentDestinationCoercionBoundaryReference ?? urlArgument,
+      )
     ) {
       return false;
     }
@@ -2579,15 +2695,16 @@ const isTrustedDestination = (
     if (crossFileVerdict != null) return crossFileVerdict;
     const constInitializer = resolveConstInitializer(urlArgument);
     if (constInitializer != null) {
+      const coercionBoundaryReference = currentDestinationCoercionBoundaryReference ?? urlArgument;
+      const coercionExecutionReference = currentDestinationCoercionReference ?? urlArgument;
       if (
         isNodeOfType(stripParenExpression(constInitializer), "NewExpression") &&
-        (hasUrlOriginMutationBefore(
-          urlArgument,
-          currentDestinationCoercionReference ?? urlArgument,
-        ) ||
+        ((hasUrlOriginMutationBefore(urlArgument, coercionBoundaryReference) &&
+          hasUrlOriginMutationBefore(urlArgument, coercionExecutionReference)) ||
           !globalNamespaceBindingIsUnmodifiedBefore(
             "URL",
-            currentDestinationCoercionReference ?? urlArgument,
+            coercionExecutionReference,
+            coercionBoundaryReference,
           ))
       ) {
         return false;
@@ -2625,16 +2742,19 @@ const isTrustedDestination = (
           ? resolvedFirstExpressionSymbol.initializer
           : firstExpressionNode;
       const followingQuasiText = urlArgument.quasis?.[1]?.value?.raw ?? "";
-      return withDestinationCoercionReference(destinationSerializationReference(urlArgument), () =>
-        Boolean(
-          isSafeInterpolatedDestinationSuffix(
-            followingQuasiText,
-            (urlArgument.expressions?.length ?? 0) > 1,
-          ) &&
-          (!followingQuasiText.startsWith("/") ||
-            isProvenSafeSlashJoinedBase(trustedFirstExpression, depth + 1)) &&
-          isTrustedInterpolatedDestinationBase(trustedFirstExpression, depth + 1),
-        ),
+      return withDestinationCoercionReference(
+        destinationSerializationReference(urlArgument),
+        urlArgument,
+        () =>
+          Boolean(
+            isSafeInterpolatedDestinationSuffix(
+              followingQuasiText,
+              (urlArgument.expressions?.length ?? 0) > 1,
+            ) &&
+            (!followingQuasiText.startsWith("/") ||
+              isProvenSafeSlashJoinedBase(trustedFirstExpression, depth + 1)) &&
+            isTrustedInterpolatedDestinationBase(trustedFirstExpression, depth + 1),
+          ),
       );
     }
     return false;
@@ -2696,7 +2816,7 @@ const isTrustedTopLevelDestination = (urlExpression: EsTreeNode | null | undefin
   const memoKey = strippedExpression;
   const memoizedVerdict = trustedTopLevelDestinationMemo.get(memoKey);
   if (memoizedVerdict !== undefined) return memoizedVerdict;
-  const verdict = withDestinationCoercionReference(strippedExpression, () =>
+  const verdict = withDestinationCoercionReference(strippedExpression, strippedExpression, () =>
     isTrustedOrNullishDestination(urlExpression, 0),
   );
   trustedTopLevelDestinationMemo.set(memoKey, verdict);
@@ -2998,7 +3118,12 @@ export const windowOpenWithoutNoopener = defineRule({
     currentRuleContext = context;
     currentWindowOpenCall = undefined;
     currentDestinationCoercionReference = undefined;
+    currentDestinationCoercionBoundaryReference = undefined;
     currentLocalFunctionInvocationReference = undefined;
+    currentLocalFunctionSerializationReference = undefined;
+    currentAnalyzedLocalFunction = undefined;
+    currentOpaqueLocalFunctionSerializationReference = undefined;
+    currentDeferredLocalFunctions = [];
     trustedTopLevelDestinationMemo = new WeakMap();
     symbolHasNonReadReferenceMemo = new WeakMap();
     localFunctionCallArgumentsMemo = new WeakMap();
@@ -3017,29 +3142,84 @@ export const windowOpenWithoutNoopener = defineRule({
       CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
         currentScopes = context.scopes;
         if (!isWindowOpenCallee(node.callee, context.scopes)) return;
-        if (!isDiscardedWindowHandle(node)) return;
-        currentWindowOpenCall = node;
+        const previousWindowOpenCall = currentWindowOpenCall;
+        const previousDestinationCoercionReference = currentDestinationCoercionReference;
+        const previousDestinationCoercionBoundaryReference =
+          currentDestinationCoercionBoundaryReference;
+        const previousLocalFunctionInvocationReference = currentLocalFunctionInvocationReference;
+        const previousLocalFunctionSerializationReference =
+          currentLocalFunctionSerializationReference;
+        const previousAnalyzedLocalFunction = currentAnalyzedLocalFunction;
+        const previousOpaqueLocalFunctionSerializationReference =
+          currentOpaqueLocalFunctionSerializationReference;
+        const previousDeferredLocalFunctions = currentDeferredLocalFunctions;
+        currentWindowOpenCall = undefined;
+        currentDestinationCoercionReference = undefined;
+        currentDestinationCoercionBoundaryReference = undefined;
+        currentLocalFunctionInvocationReference = undefined;
+        currentLocalFunctionSerializationReference = undefined;
+        currentAnalyzedLocalFunction = undefined;
+        currentOpaqueLocalFunctionSerializationReference = undefined;
+        currentDeferredLocalFunctions = [];
+        try {
+          if (!isDiscardedWindowHandle(node)) return;
+          const enclosingFunction = findEnclosingFunction(node);
+          const executionContext = enclosingFunction
+            ? resolveLocalFunctionExecutionContext(enclosingFunction, 0)
+            : null;
+          currentDeferredLocalFunctions = executionContext?.functions ?? [];
+          currentLocalFunctionInvocationReference = executionContext?.immediateReferences?.length
+            ? executionContext.immediateReferences.reduce((latestReference, executionReference) =>
+                executionReference.range[0] > latestReference.range[0]
+                  ? executionReference
+                  : latestReference,
+              )
+            : undefined;
+          currentLocalFunctionSerializationReference = executionContext?.references?.length
+            ? executionContext.references.reduce((latestReference, executionReference) =>
+                executionReference.range[0] > latestReference.range[0]
+                  ? executionReference
+                  : latestReference,
+              )
+            : undefined;
+          currentOpaqueLocalFunctionSerializationReference =
+            !currentLocalFunctionSerializationReference && enclosingFunction
+              ? (findProgramRoot(node) ?? undefined)
+              : undefined;
+          currentWindowOpenCall = node;
 
-        const urlArgument = node.arguments?.[0];
-        if (isTrustedTopLevelDestination(urlArgument)) return;
+          const urlArgument = node.arguments?.[0];
+          if (isTrustedTopLevelDestination(urlArgument)) return;
 
-        const targetArgument = node.arguments?.[1];
-        if (isStringLiteral(targetArgument) && NAVIGATING_TARGETS.has(targetArgument.value)) {
-          return;
+          const targetArgument = node.arguments?.[1];
+          if (isStringLiteral(targetArgument) && NAVIGATING_TARGETS.has(targetArgument.value)) {
+            return;
+          }
+
+          const featuresArgument = node.arguments?.[2];
+          if (featuresArgument != null && !isNullishExpression(featuresArgument)) {
+            const featuresText = resolveStaticStringText(featuresArgument, 0);
+            if (featuresText == null) return;
+            if (featuresMayProtectOpener(featuresText)) return;
+          }
+
+          context.report({
+            node,
+            message:
+              "This `window.open` call leaves the opened page able to redirect your tab via `window.opener`, so pass `'noopener'` in the features argument.",
+          });
+        } finally {
+          currentWindowOpenCall = previousWindowOpenCall;
+          currentDestinationCoercionReference = previousDestinationCoercionReference;
+          currentDestinationCoercionBoundaryReference =
+            previousDestinationCoercionBoundaryReference;
+          currentLocalFunctionInvocationReference = previousLocalFunctionInvocationReference;
+          currentLocalFunctionSerializationReference = previousLocalFunctionSerializationReference;
+          currentAnalyzedLocalFunction = previousAnalyzedLocalFunction;
+          currentOpaqueLocalFunctionSerializationReference =
+            previousOpaqueLocalFunctionSerializationReference;
+          currentDeferredLocalFunctions = previousDeferredLocalFunctions;
         }
-
-        const featuresArgument = node.arguments?.[2];
-        if (featuresArgument != null && !isNullishExpression(featuresArgument)) {
-          const featuresText = resolveStaticStringText(featuresArgument, 0);
-          if (featuresText == null) return;
-          if (featuresMayProtectOpener(featuresText)) return;
-        }
-
-        context.report({
-          node,
-          message:
-            "This `window.open` call leaves the opened page able to redirect your tab via `window.opener`, so pass `'noopener'` in the features argument.",
-        });
       },
     };
   },

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.ts
@@ -1407,11 +1407,26 @@ const staticTextPinsConcatDestination = (urlText: string): boolean => {
   return startsUnambiguouslySameOriginTemplatePath(trimmedText);
 };
 
-const isTrustedConcatPrefix = (node: EsTreeNode): boolean => {
-  if (isStringLiteral(node)) return staticTextPinsConcatDestination(node.value);
-  if (!isNodeOfType(node, "TemplateLiteral")) return false;
-  if ((node.expressions?.length ?? 0) > 0) return isTrustedStaticDestination(node);
-  return staticTextPinsConcatDestination(node.quasis?.[0]?.value?.raw ?? "");
+const isTrustedConcatPrefix = (node: EsTreeNode, depth = 0): boolean => {
+  if (depth > MAX_BINDING_RESOLUTION_DEPTH) return false;
+  const unwrappedNode = stripParenExpression(node);
+  if (isStringLiteral(unwrappedNode)) {
+    return staticTextPinsConcatDestination(unwrappedNode.value);
+  }
+  if (isNodeOfType(unwrappedNode, "TemplateLiteral")) {
+    if ((unwrappedNode.expressions?.length ?? 0) > 0) {
+      return isTrustedStaticDestination(unwrappedNode);
+    }
+    return staticTextPinsConcatDestination(unwrappedNode.quasis?.[0]?.value?.raw ?? "");
+  }
+  if (
+    !isNodeOfType(unwrappedNode, "Identifier") ||
+    !bindingIsUnmodifiedBeforeCurrentOpen(unwrappedNode)
+  ) {
+    return false;
+  }
+  const initializer = resolveConstInitializer(unwrappedNode);
+  return Boolean(initializer && isTrustedConcatPrefix(initializer, depth + 1));
 };
 
 // Cross-file resolutions per linted file are capped: oxc-resolver +
@@ -1619,7 +1634,10 @@ const isTrustedLocalFunctionReturn = (
       const followingQuasiText = returned.quasis?.[1]?.value?.raw ?? "";
       if (
         argument &&
-        isSafeInterpolatedDestinationSuffix(followingQuasiText) &&
+        isSafeInterpolatedDestinationSuffix(
+          followingQuasiText,
+          (returned.expressions?.length ?? 0) > 1,
+        ) &&
         (!followingQuasiText.startsWith("/") ||
           isProvenNonSlashTerminatedDestination(argument, depth + 1))
       ) {
@@ -1930,8 +1948,12 @@ const isTrustedUrlInstanceHrefRead = (
   );
 };
 
-const isSafeInterpolatedDestinationSuffix = (suffixText: string): boolean => {
-  if (suffixText.length === 0 || suffixText.startsWith("?") || suffixText.startsWith("#")) {
+const isSafeInterpolatedDestinationSuffix = (
+  suffixText: string,
+  hasFollowingExpression = false,
+): boolean => {
+  if (suffixText.length === 0) return !hasFollowingExpression;
+  if (suffixText.startsWith("?") || suffixText.startsWith("#")) {
     return true;
   }
   return suffixText.startsWith("/") && suffixText[1] !== "/" && suffixText[1] !== "\\";
@@ -2106,7 +2128,10 @@ const isTrustedDestination = (
       const followingQuasiText = urlArgument.quasis?.[1]?.value?.raw ?? "";
       return withDestinationCoercionReference(destinationSerializationReference(urlArgument), () =>
         Boolean(
-          isSafeInterpolatedDestinationSuffix(followingQuasiText) &&
+          isSafeInterpolatedDestinationSuffix(
+            followingQuasiText,
+            (urlArgument.expressions?.length ?? 0) > 1,
+          ) &&
           (!followingQuasiText.startsWith("/") ||
             isProvenNonSlashTerminatedDestination(firstExpression as EsTreeNode, depth + 1)) &&
           isTrustedDestination(firstExpression as EsTreeNode, depth + 1),

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.ts
@@ -123,6 +123,7 @@ const isTrustedDestination = (
         isTrustedOrNullishDestination(urlArgument.right, depth + 1)
       );
     }
+    if (isStaticallyTruthyTrustedDestination(urlArgument.left, depth + 1)) return true;
     return (
       isTrustedOrNullishDestination(urlArgument.left, depth + 1) &&
       isTrustedOrNullishDestination(urlArgument.right, depth + 1)
@@ -140,6 +141,31 @@ const isTrustedOrNullishDestination = (
   urlExpression: EsTreeNode | null | undefined,
   depth: number,
 ): boolean => isNullishExpression(urlExpression) || isTrustedDestination(urlExpression, depth);
+
+// A statically truthy trusted left operand of `||`/`??` short-circuits, so
+// `trustedUrl || dynamicFallback` always opens the trusted destination and
+// the right side never evaluates. Only trusted destinations with nonempty
+// static text qualify — `''` is falsy under `||` and a nullish binding
+// falls through to the right operand under both operators.
+const isStaticallyTruthyTrustedDestination = (
+  urlExpression: EsTreeNode | null | undefined,
+  depth: number,
+): boolean => {
+  if (urlExpression == null || depth > MAX_BINDING_RESOLUTION_DEPTH) return false;
+  if (isStringLiteral(urlExpression)) return urlExpression.value.length > 0;
+  if (isNodeOfType(urlExpression, "TemplateLiteral")) {
+    const hasStaticText =
+      urlExpression.quasis?.some((quasi) => (quasi.value?.raw ?? "").length > 0) ?? false;
+    return hasStaticText && isTrustedStaticDestination(urlExpression);
+  }
+  if (isNodeOfType(urlExpression, "Identifier")) {
+    const constInitializer = resolveConstInitializer(urlExpression);
+    return (
+      constInitializer != null && isStaticallyTruthyTrustedDestination(constInitializer, depth + 1)
+    );
+  }
+  return false;
+};
 
 // Best-effort static text of the features argument: string literals,
 // template literals (interpolations resolved when they are local const
@@ -189,9 +215,12 @@ const isArrowReturnDiscarded = (arrow: EsTreeNode): boolean => {
     return parent.arguments?.some((argument) => argument === arrow) ?? false;
   }
   if (isNodeOfType(parent, "Property") && parent.value === arrow && !parent.computed) {
-    return (
-      isNodeOfType(parent.key, "Identifier") && EVENT_HANDLER_KEY_PATTERN.test(parent.key.name)
-    );
+    const handlerKeyName = isNodeOfType(parent.key, "Identifier")
+      ? parent.key.name
+      : isStringLiteral(parent.key)
+        ? parent.key.value
+        : null;
+    return handlerKeyName != null && EVENT_HANDLER_KEY_PATTERN.test(handlerKeyName);
   }
   return false;
 };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.ts
@@ -1,0 +1,263 @@
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+
+const NAVIGATING_TARGETS = new Set(["_self", "_top", "_parent"]);
+
+// Matches `window.open` and `globalThis.window.open` — a non-computed
+// `.open` member off the `window` global. Bare `open(...)` (an
+// `Identifier` callee) and `foo.postMessage`/`webview.open` are not the
+// window global and never match.
+const isWindowOpenCallee = (callee: EsTreeNode): boolean => {
+  if (!isNodeOfType(callee, "MemberExpression") || callee.computed) return false;
+  if (!isNodeOfType(callee.property, "Identifier") || callee.property.name !== "open") return false;
+  const object = callee.object;
+  if (isNodeOfType(object, "Identifier")) return object.name === "window";
+  if (isNodeOfType(object, "MemberExpression") && !object.computed) {
+    return (
+      isNodeOfType(object.object, "Identifier") &&
+      object.object.name === "globalThis" &&
+      isNodeOfType(object.property, "Identifier") &&
+      object.property.name === "window"
+    );
+  }
+  return false;
+};
+
+const isStringLiteral = (
+  node: EsTreeNode | null | undefined,
+): node is EsTreeNodeOfType<"Literal"> & { value: string } =>
+  node != null && isNodeOfType(node, "Literal") && typeof node.value === "string";
+
+// `mailto:`/`tel:`/`sms:` hand the URL to an OS protocol handler and never
+// open a navigable browsing context, so no `window.opener` is exposed and
+// there is nothing to reverse-tabnab — flagging them is a false positive.
+const NON_BROWSING_URL_SCHEMES = ["mailto:", "tel:", "sms:"];
+
+const getStaticUrlText = (node: EsTreeNode | null | undefined): string | null => {
+  if (isStringLiteral(node)) return node.value;
+  if (node != null && isNodeOfType(node, "TemplateLiteral")) {
+    return node.quasis?.[0]?.value?.raw ?? null;
+  }
+  return null;
+};
+
+const opensProtocolHandlerOnly = (urlArgument: EsTreeNode | null | undefined): boolean => {
+  const urlText = getStaticUrlText(urlArgument)?.trimStart().toLowerCase();
+  if (urlText == null) return false;
+  return NON_BROWSING_URL_SCHEMES.some((scheme) => urlText.startsWith(scheme));
+};
+
+// A fixed `https://host/` prefix pins the origin: the `[/?#]` terminator
+// after the host guarantees any interpolation lands in the path/query,
+// not the host (`` `https://github.com${x}` `` without it could become
+// `https://github.com.evil.com`).
+const COMPLETE_ORIGIN_PATTERN = /^https?:\/\/[^/?#]+[/?#]/i;
+
+const SAME_ORIGIN_URL_PREFIXES = ["./", "../", "?", "#"];
+
+const startsSameOriginPath = (urlText: string): boolean => {
+  if (urlText.startsWith("/")) return !urlText.startsWith("//");
+  return SAME_ORIGIN_URL_PREFIXES.some((prefix) => urlText.startsWith(prefix));
+};
+
+// Reverse tabnabbing needs an attacker-controlled opened page. A
+// developer-hardcoded string literal, a template whose origin is fixed
+// (interpolations confined to the path/query), or a statically
+// same-origin URL is a trusted-by-construction destination — the
+// dominant real-world idiom ("Star on GitHub" buttons, `/preview?…`
+// export routes) and not worth a warning. Dynamic URLs (identifiers,
+// call results, member accesses, templates interpolating the
+// scheme/host) keep firing.
+const isTrustedStaticDestination = (urlArgument: EsTreeNode | null | undefined): boolean => {
+  if (isStringLiteral(urlArgument)) return true;
+  if (urlArgument == null || !isNodeOfType(urlArgument, "TemplateLiteral")) return false;
+  if ((urlArgument.expressions?.length ?? 0) === 0) return true;
+  const firstQuasiText = (urlArgument.quasis?.[0]?.value?.raw ?? "").trimStart();
+  if (firstQuasiText.length === 0) return false;
+  if (COMPLETE_ORIGIN_PATTERN.test(firstQuasiText)) return true;
+  return startsSameOriginPath(firstQuasiText);
+};
+
+const MAX_BINDING_RESOLUTION_DEPTH = 4;
+
+// A nullish branch (`cond ? url : null`) is harmless: `window.open(null)`
+// opens about:blank, which the opener fully controls.
+const isNullishExpression = (node: EsTreeNode | null | undefined): boolean => {
+  if (node == null) return true;
+  if (isNodeOfType(node, "Literal")) return node.value === null;
+  return isNodeOfType(node, "Identifier") && node.name === "undefined";
+};
+
+// Only a direct `const name = <init>` declarator is safe to resolve —
+// `let`/`var` can be reassigned to attacker-controlled input after the
+// trusted initializer, and destructured/parameter bindings carry a
+// default expression here, not the actual runtime value.
+const resolveConstInitializer = (identifier: EsTreeNodeOfType<"Identifier">): EsTreeNode | null => {
+  const binding = findVariableInitializer(identifier, identifier.name);
+  if (binding?.initializer == null) return null;
+  const declarator = binding.bindingIdentifier.parent;
+  if (!declarator || !isNodeOfType(declarator, "VariableDeclarator")) return null;
+  if (declarator.init !== binding.initializer) return null;
+  const declaration = declarator.parent;
+  if (!declaration || !isNodeOfType(declaration, "VariableDeclaration")) return null;
+  if (declaration.kind !== "const") return null;
+  return binding.initializer;
+};
+
+// The trusted-by-construction check, extended one binding hop: a local
+// const holding a ternary over origin-pinned templates
+// (releaseUrl = version ? `https://github.com/…/tag/v${version}` : null)
+// is the same trusted destination as an inline one, just behind a name
+// ("open release page" dialogs). Every non-nullish branch of the
+// initializer must itself be trusted; opaque initializers (call results,
+// awaited API responses, hook-destructured values) resolve to nothing
+// and keep firing.
+const isTrustedDestination = (
+  urlArgument: EsTreeNode | null | undefined,
+  depth: number,
+): boolean => {
+  if (isTrustedStaticDestination(urlArgument)) return true;
+  if (urlArgument == null || depth > MAX_BINDING_RESOLUTION_DEPTH) return false;
+  if (isNodeOfType(urlArgument, "ConditionalExpression")) {
+    return (
+      isTrustedOrNullishBranch(urlArgument.consequent, depth + 1) &&
+      isTrustedOrNullishBranch(urlArgument.alternate, depth + 1)
+    );
+  }
+  if (isNodeOfType(urlArgument, "LogicalExpression")) {
+    if (urlArgument.operator === "&&") {
+      return isTrustedOrNullishBranch(urlArgument.right, depth + 1);
+    }
+    return (
+      isTrustedOrNullishBranch(urlArgument.left, depth + 1) &&
+      isTrustedOrNullishBranch(urlArgument.right, depth + 1)
+    );
+  }
+  if (isNodeOfType(urlArgument, "Identifier")) {
+    const constInitializer = resolveConstInitializer(urlArgument);
+    if (constInitializer == null) return false;
+    return isTrustedDestination(constInitializer, depth + 1);
+  }
+  return false;
+};
+
+const isTrustedOrNullishBranch = (branch: EsTreeNode | null | undefined, depth: number): boolean =>
+  isNullishExpression(branch) || isTrustedDestination(branch, depth);
+
+// Best-effort static text of the features argument: string literals,
+// template literals (interpolations resolved when they are local const
+// strings, empty otherwise so `noopener,width=${w}` still resolves), and
+// identifiers bound to a resolvable initializer in this file. Returns
+// null when the value is opaque (imported constant, call result), in
+// which case the caller must not assume noopener is absent.
+const resolveStaticStringText = (
+  node: EsTreeNode | null | undefined,
+  depth: number,
+): string | null => {
+  if (node == null || depth > MAX_BINDING_RESOLUTION_DEPTH) return null;
+  if (isStringLiteral(node)) return node.value;
+  if (isNodeOfType(node, "TemplateLiteral")) {
+    const quasiTexts = node.quasis?.map((quasi) => quasi.value?.raw ?? "") ?? [];
+    const expressionTexts =
+      node.expressions?.map((expression) => resolveStaticStringText(expression, depth + 1) ?? "") ??
+      [];
+    return quasiTexts
+      .map((quasiText, quasiIndex) => quasiText + (expressionTexts[quasiIndex] ?? ""))
+      .join("");
+  }
+  if (isNodeOfType(node, "Identifier")) {
+    const binding = findVariableInitializer(node, node.name);
+    if (binding?.initializer == null) return null;
+    return resolveStaticStringText(binding.initializer, depth + 1);
+  }
+  return null;
+};
+
+// The opened handle is captured/used when the arrow that returns it is
+// stored or returned (its eventual return value may be consumed via
+// `getPopup().focus()`), so a concise `() => window.open(...)` is only
+// fire-and-forget when the arrow itself is an event handler (JSX prop or
+// an `onX` property in a props object, whose return React/DOM ignores),
+// a callback argument (forEach/map/addEventListener), or a bare
+// statement.
+const EVENT_HANDLER_KEY_PATTERN = /^on[A-Z]/;
+
+const isArrowReturnDiscarded = (arrow: EsTreeNode): boolean => {
+  const parent = arrow.parent;
+  if (!parent) return false;
+  if (isNodeOfType(parent, "JSXExpressionContainer")) return true;
+  if (isNodeOfType(parent, "ExpressionStatement")) return true;
+  if (isNodeOfType(parent, "CallExpression")) {
+    return parent.arguments?.some((argument) => argument === arrow) ?? false;
+  }
+  if (isNodeOfType(parent, "Property") && parent.value === arrow && !parent.computed) {
+    return (
+      isNodeOfType(parent.key, "Identifier") && EVENT_HANDLER_KEY_PATTERN.test(parent.key.name)
+    );
+  }
+  return false;
+};
+
+// The window handle is discarded (so `noopener`'s null return breaks
+// nothing) when the call is a bare statement, the branch of a
+// guard-shaped logical/ternary that is itself discarded, or the concise
+// body of a discarded arrow. Any capturing parent — VariableDeclarator
+// init, AssignmentExpression right, ReturnStatement arg, a member access
+// on the result, or being passed as a call argument — means the caller
+// wants the handle, so we stay quiet.
+const isDiscardedWindowHandle = (callNode: EsTreeNode): boolean => {
+  const parent = callNode.parent;
+  if (!parent) return false;
+  if (isNodeOfType(parent, "ExpressionStatement")) return true;
+  if (isNodeOfType(parent, "LogicalExpression") && parent.right === callNode) {
+    return isDiscardedWindowHandle(parent);
+  }
+  if (
+    isNodeOfType(parent, "ConditionalExpression") &&
+    (parent.consequent === callNode || parent.alternate === callNode)
+  ) {
+    return isDiscardedWindowHandle(parent);
+  }
+  if (isNodeOfType(parent, "ArrowFunctionExpression") && parent.body === callNode) {
+    return isArrowReturnDiscarded(parent);
+  }
+  return false;
+};
+
+export const windowOpenWithoutNoopener = defineRule({
+  id: "window-open-without-noopener",
+  title: "window.open without noopener",
+  severity: "warn",
+  recommendation:
+    "Pass `'noopener'` in the third features argument of `window.open` so the opened page can't control your tab through `window.opener` or leak the referrer.",
+  create: (context) => ({
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+      if (!isWindowOpenCallee(node.callee)) return;
+      if (!isDiscardedWindowHandle(node)) return;
+
+      const urlArgument = node.arguments?.[0];
+      if (isTrustedDestination(urlArgument, 0)) return;
+      if (opensProtocolHandlerOnly(urlArgument)) return;
+
+      const targetArgument = node.arguments?.[1];
+      if (isStringLiteral(targetArgument) && NAVIGATING_TARGETS.has(targetArgument.value)) return;
+
+      const featuresArgument = node.arguments?.[2];
+      if (featuresArgument != null) {
+        const featuresText = resolveStaticStringText(featuresArgument, 0);
+        if (featuresText == null) return;
+        const features = featuresText.toLowerCase();
+        if (features.includes("noopener") || features.includes("noreferrer")) return;
+      }
+
+      context.report({
+        node,
+        message:
+          "This `window.open` call leaves the opened page able to redirect your tab via `window.opener`, so pass `'noopener'` in the features argument.",
+      });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.ts
@@ -208,7 +208,8 @@ const isArrowReturnDiscarded = (arrow: EsTreeNode): boolean => {
 // The window handle is discarded (so `noopener`'s null return breaks
 // nothing) when the call is a bare statement, a `void` operand, the
 // branch of a guard-shaped logical/ternary that is itself discarded, a
-// non-final position in a comma sequence, or the concise
+// non-final position in a comma sequence, an `await` whose own result
+// is discarded, or the concise
 // body of a discarded arrow. Any capturing parent — VariableDeclarator
 // init, AssignmentExpression right, ReturnStatement arg, a member access
 // on the result, or being passed as a call argument — means the caller
@@ -218,6 +219,7 @@ const isDiscardedWindowHandle = (callNode: EsTreeNode): boolean => {
   if (!parent) return false;
   if (isNodeOfType(parent, "ExpressionStatement")) return true;
   if (isNodeOfType(parent, "UnaryExpression") && parent.operator === "void") return true;
+  if (isNodeOfType(parent, "AwaitExpression")) return isDiscardedWindowHandle(parent);
   if (isNodeOfType(parent, "LogicalExpression") && parent.right === callNode) {
     return isDiscardedWindowHandle(parent);
   }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.ts
@@ -48,7 +48,7 @@ let currentAnalyzedLocalFunction: EsTreeNode | undefined;
 let currentOpaqueLocalFunctionSerializationReference: EsTreeNode | undefined;
 let currentDeferredLocalFunctions: EsTreeNode[] = [];
 let trustedTopLevelDestinationMemo = new WeakMap<EsTreeNode, boolean>();
-let symbolHasNonReadReferenceMemo = new WeakMap<SymbolDescriptor, boolean>();
+let symbolHasPossibleWriteReferenceMemo = new WeakMap<SymbolDescriptor, boolean>();
 let localFunctionCallArgumentsMemo = new WeakMap<
   EsTreeNode,
   Map<number, Array<EsTreeNode | null> | null>
@@ -76,25 +76,60 @@ const writeExecutesBeforeDestinationReference = (
   return Boolean(program && isSymbolWriteBefore(writeNode, program, scopes));
 };
 
+const isPatternAssignmentTarget = (identifier: EsTreeNode): boolean => {
+  let targetChild = identifier;
+  let targetParent = targetChild.parent;
+  let isInsidePattern = false;
+  while (targetParent) {
+    if (isNodeOfType(targetParent, "ArrayPattern") || isNodeOfType(targetParent, "ObjectPattern")) {
+      isInsidePattern = true;
+    } else if (isNodeOfType(targetParent, "AssignmentPattern")) {
+      if (targetParent.left !== targetChild) return false;
+    } else if (isNodeOfType(targetParent, "Property")) {
+      if (targetParent.value !== targetChild) return false;
+    } else if (isNodeOfType(targetParent, "RestElement")) {
+      if (targetParent.argument !== targetChild) return false;
+    } else if (isNodeOfType(targetParent, "AssignmentExpression")) {
+      return isInsidePattern && targetParent.left === targetChild;
+    } else if (
+      isNodeOfType(targetParent, "ForInStatement") ||
+      isNodeOfType(targetParent, "ForOfStatement")
+    ) {
+      return isInsidePattern && targetParent.left === targetChild;
+    } else {
+      return false;
+    }
+    targetChild = targetParent;
+    targetParent = targetParent.parent;
+  }
+  return false;
+};
+
 const bindingIsUnmodifiedBefore = (identifier: EsTreeNode, referenceNode: EsTreeNode): boolean => {
   const scopes = currentScopes;
   const symbol = scopes?.symbolFor(identifier);
-  let symbolHasNonReadReference = symbol ? symbolHasNonReadReferenceMemo.get(symbol) : undefined;
-  if (symbol && symbolHasNonReadReference === undefined) {
-    symbolHasNonReadReference = symbol.references.some((reference) => reference.flag !== "read");
-    symbolHasNonReadReferenceMemo.set(symbol, symbolHasNonReadReference);
+  let symbolHasPossibleWriteReference = symbol
+    ? symbolHasPossibleWriteReferenceMemo.get(symbol)
+    : undefined;
+  if (symbol && symbolHasPossibleWriteReference === undefined) {
+    symbolHasPossibleWriteReference = symbol.references.some(
+      (reference) => reference.flag !== "read" || isPatternAssignmentTarget(reference.identifier),
+    );
+    symbolHasPossibleWriteReferenceMemo.set(symbol, symbolHasPossibleWriteReference);
   }
   return Boolean(
     scopes &&
     symbol &&
-    (!symbolHasNonReadReference ||
+    (!symbolHasPossibleWriteReference ||
       (referenceNode.range != null &&
         !symbol.references.some(
-          (reference) => reference.flag !== "read" && reference.identifier.range == null,
+          (reference) =>
+            (reference.flag !== "read" || isPatternAssignmentTarget(reference.identifier)) &&
+            reference.identifier.range == null,
         ) &&
         !symbol.references.some(
           (reference) =>
-            reference.flag !== "read" &&
+            (reference.flag !== "read" || isPatternAssignmentTarget(reference.identifier)) &&
             (writeExecutesBeforeDestinationReference(reference.identifier, referenceNode, scopes) ||
               (!isAnalyzingForeignExport &&
                 reference.identifier.range[0] < getExecutionReferenceOffset(referenceNode))),
@@ -1770,6 +1805,17 @@ const leftmostConcatOperand = (node: EsTreeNode): EsTreeNode => {
   return cursor;
 };
 
+const flattenConcatOperands = (node: EsTreeNode, operands: EsTreeNode[] = []): EsTreeNode[] => {
+  const unwrappedNode = stripParenExpression(node);
+  if (isNodeOfType(unwrappedNode, "BinaryExpression") && unwrappedNode.operator === "+") {
+    flattenConcatOperands(unwrappedNode.left as EsTreeNode, operands);
+    flattenConcatOperands(unwrappedNode.right as EsTreeNode, operands);
+  } else {
+    operands.push(unwrappedNode);
+  }
+  return operands;
+};
+
 const staticTextPinsConcatDestination = (urlText: string): boolean => {
   const trimmedText = urlText.trimStart();
   if (trimmedText.length === 0) return false;
@@ -1990,6 +2036,28 @@ const isTrustedLocalFunctionReturn = (
     const argument = localFunctionParameterArgument(returned, functionNode, callExpression);
     if (argument) return isTrustedOrNullishDestination(argument, depth + 1);
   }
+  if (isNodeOfType(returned, "BinaryExpression") && returned.operator === "+") {
+    const operands = flattenConcatOperands(returned);
+    const firstOperand = operands[0];
+    if (firstOperand && isNodeOfType(firstOperand, "Identifier")) {
+      const argument = localFunctionParameterArgument(firstOperand, functionNode, callExpression);
+      let followingStaticText = "";
+      let operandIndex = 1;
+      while (operandIndex < operands.length) {
+        const operandStaticText = staticStringLiteralText(operands[operandIndex]);
+        if (operandStaticText == null) break;
+        followingStaticText += operandStaticText;
+        operandIndex += 1;
+      }
+      if (
+        argument &&
+        isSafeInterpolatedDestinationSuffix(followingStaticText, operandIndex < operands.length) &&
+        (!followingStaticText.startsWith("/") || isProvenSafeSlashJoinedBase(argument, depth + 1))
+      ) {
+        return isTrustedDestination(argument, depth + 1);
+      }
+    }
+  }
   if (isNodeOfType(returned, "TemplateLiteral")) {
     const firstQuasiText = returned.quasis?.[0]?.value?.raw ?? "";
     const firstExpression = returned.expressions?.[0];
@@ -2138,7 +2206,7 @@ const isGlobalObjectMutationCall = (
   );
 };
 
-const staticMutationPropertyName = (node: EsTreeNode | undefined): string | null => {
+const staticStringLiteralText = (node: EsTreeNode | undefined): string | null => {
   if (!node) return null;
   const unwrappedNode = stripParenExpression(node);
   if (isStringLiteral(unwrappedNode)) return unwrappedNode.value;
@@ -2204,7 +2272,7 @@ const globalObjectMutationMayWriteProperty = (
     resolvesReflectMethod("defineProperty") ||
     resolvesReflectMethod("set")
   ) {
-    const mutationPropertyName = staticMutationPropertyName(
+    const mutationPropertyName = staticStringLiteralText(
       callExpression.arguments?.[1] as EsTreeNode | undefined,
     );
     return mutationPropertyName === null || mutationPropertyName === propertyName;
@@ -2446,6 +2514,18 @@ const isSafeInterpolatedDestinationSuffix = (
 
 const INCOMPLETE_BROWSING_SCHEME_BASE_PATTERN = /^(?:https?|ftp|wss?):\/*$/iu;
 
+const stripUrlLeadingAndTrailingC0ControlOrSpace = (urlText: string): string => {
+  let startIndex = 0;
+  while (startIndex < urlText.length && urlText.charAt(startIndex) <= " ") {
+    startIndex += 1;
+  }
+  let endIndex = urlText.length;
+  while (endIndex > startIndex && urlText.charAt(endIndex - 1) <= " ") {
+    endIndex -= 1;
+  }
+  return urlText.slice(startIndex, endIndex);
+};
+
 const staticPrimitiveTruthiness = (node: EsTreeNode): boolean | null => {
   const unwrappedNode = stripParenExpression(node);
   if (isNullishExpression(unwrappedNode)) return false;
@@ -2466,8 +2546,11 @@ const isProvenSafeSlashJoinedBase = (destination: EsTreeNode, depth: number): bo
     if (typeof unwrappedDestination.value !== "string") {
       return staticPrimitiveTruthiness(unwrappedDestination) !== null;
     }
-    const normalizedValue = unwrappedDestination.value.trim().replaceAll("\\", "/");
+    const normalizedValue = stripUrlLeadingAndTrailingC0ControlOrSpace(
+      unwrappedDestination.value.replaceAll(/[\t\n\r]/gu, ""),
+    ).replaceAll("\\", "/");
     return (
+      normalizedValue.length > 0 &&
       !/^\/+$/u.test(normalizedValue) &&
       !INCOMPLETE_BROWSING_SCHEME_BASE_PATTERN.test(normalizedValue)
     );
@@ -3125,7 +3208,7 @@ export const windowOpenWithoutNoopener = defineRule({
     currentOpaqueLocalFunctionSerializationReference = undefined;
     currentDeferredLocalFunctions = [];
     trustedTopLevelDestinationMemo = new WeakMap();
-    symbolHasNonReadReferenceMemo = new WeakMap();
+    symbolHasPossibleWriteReferenceMemo = new WeakMap();
     localFunctionCallArgumentsMemo = new WeakMap();
     routerCallsByFunctionMemo = new WeakMap();
     globalNamespaceMutationNodesMemo = new WeakMap();

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.ts
@@ -3106,9 +3106,16 @@ const isArrowReturnDiscarded = (arrow: EsTreeNode): boolean => {
       createElementCall && isNodeOfType(createElementCall, "CallExpression")
         ? stripParenExpression(createElementCall.callee as EsTreeNode)
         : null;
-    const isProvenCreateElementCall = Boolean(
+    const elementType =
+      createElementCall && isNodeOfType(createElementCall, "CallExpression")
+        ? createElementCall.arguments?.[0]
+        : null;
+    const isProvenIntrinsicCreateElementCall = Boolean(
       createElementCall &&
       isNodeOfType(createElementCall, "CallExpression") &&
+      elementType &&
+      isNodeOfType(elementType, "Literal") &&
+      typeof elementType.value === "string" &&
       currentScopes &&
       (isReactApiCall(createElementCall, "createElement", currentScopes) ||
         (createElementCallee &&
@@ -3124,7 +3131,7 @@ const isArrowReturnDiscarded = (arrow: EsTreeNode): boolean => {
       createElementCall &&
       isNodeOfType(createElementCall, "CallExpression") &&
       createElementCall.arguments?.[1] === propsObject &&
-      isProvenCreateElementCall,
+      isProvenIntrinsicCreateElementCall,
     );
   }
   const directCalls = collectDirectLocalFunctionCalls(arrow);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.ts
@@ -88,6 +88,7 @@ const MAX_BINDING_RESOLUTION_DEPTH = 4;
 const isNullishExpression = (node: EsTreeNode | null | undefined): boolean => {
   if (node == null) return true;
   if (isNodeOfType(node, "Literal")) return node.value === null;
+  if (isNodeOfType(node, "UnaryExpression")) return node.operator === "void";
   return isNodeOfType(node, "Identifier") && node.name === "undefined";
 };
 
@@ -252,7 +253,7 @@ export const windowOpenWithoutNoopener = defineRule({
       if (isStringLiteral(targetArgument) && NAVIGATING_TARGETS.has(targetArgument.value)) return;
 
       const featuresArgument = node.arguments?.[2];
-      if (featuresArgument != null) {
+      if (featuresArgument != null && !isNullishExpression(featuresArgument)) {
         const featuresText = resolveStaticStringText(featuresArgument, 0);
         if (featuresText == null) return;
         const featureNames = featuresText

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.ts
@@ -45,6 +45,7 @@ let currentDestinationCoercionReference: EsTreeNode | undefined;
 let currentDestinationCoercionBoundaryReference: EsTreeNode | undefined;
 let currentLocalFunctionInvocationReference: EsTreeNode | undefined;
 let currentLocalFunctionSerializationReference: EsTreeNode | undefined;
+let currentImmediateLocalFunctionSerializationReference: EsTreeNode | undefined;
 let currentAnalyzedLocalFunction: EsTreeNode | undefined;
 let currentOpaqueLocalFunctionSerializationReference: EsTreeNode | undefined;
 let currentDeferredLocalFunctions: EsTreeNode[] = [];
@@ -2089,9 +2090,12 @@ const isTrustedLocalFunctionCall = (
   if (!localFunction || !returnedExpressions || returnedExpressions.length === 0) return false;
   const previousInvocationReference = currentLocalFunctionInvocationReference;
   const previousSerializationReference = currentLocalFunctionSerializationReference;
+  const previousImmediateSerializationReference =
+    currentImmediateLocalFunctionSerializationReference;
   const previousAnalyzedLocalFunction = currentAnalyzedLocalFunction;
   currentLocalFunctionInvocationReference ??= callExpression;
   currentLocalFunctionSerializationReference ??= callExpression;
+  currentImmediateLocalFunctionSerializationReference = callExpression;
   currentAnalyzedLocalFunction = localFunction;
   try {
     return returnedExpressions.every((returnedExpression) =>
@@ -2100,6 +2104,7 @@ const isTrustedLocalFunctionCall = (
   } finally {
     currentLocalFunctionInvocationReference = previousInvocationReference;
     currentLocalFunctionSerializationReference = previousSerializationReference;
+    currentImmediateLocalFunctionSerializationReference = previousImmediateSerializationReference;
     currentAnalyzedLocalFunction = previousAnalyzedLocalFunction;
   }
 };
@@ -2480,8 +2485,11 @@ const isTrustedUrlInstanceHrefRead = (
     return false;
   }
   if (
-    hasUrlOriginMutationBefore(receiver, memberNode) &&
-    hasUrlOriginMutationBefore(receiver, serializationReference)
+    hasUrlOriginMutationBefore(receiver, serializationReference) ||
+    Boolean(
+      currentImmediateLocalFunctionSerializationReference &&
+      hasUrlOriginMutationBefore(receiver, currentImmediateLocalFunctionSerializationReference),
+    )
   ) {
     return false;
   }
@@ -2771,8 +2779,14 @@ const isTrustedDestination = (
       const coercionExecutionReference = currentDestinationCoercionReference ?? urlArgument;
       if (
         isNodeOfType(stripParenExpression(constInitializer), "NewExpression") &&
-        ((hasUrlOriginMutationBefore(urlArgument, coercionBoundaryReference) &&
-          hasUrlOriginMutationBefore(urlArgument, coercionExecutionReference)) ||
+        (hasUrlOriginMutationBefore(urlArgument, coercionExecutionReference) ||
+          Boolean(
+            currentImmediateLocalFunctionSerializationReference &&
+            hasUrlOriginMutationBefore(
+              urlArgument,
+              currentImmediateLocalFunctionSerializationReference,
+            ),
+          ) ||
           !globalNamespaceBindingIsUnmodifiedBefore(
             "URL",
             coercionExecutionReference,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.ts
@@ -1,29 +1,89 @@
+import * as path from "node:path";
+import {
+  analyzeScopes,
+  type ScopeAnalysis,
+  type SymbolDescriptor,
+} from "../../semantic/scope-analysis.js";
+import { getAuthoritativeJsxAttribute } from "../../utils/get-authoritative-jsx-attribute.js";
+import { findTransparentExpressionRoot } from "../../utils/find-transparent-expression-root.js";
+import { getStaticPropertyKeyName } from "../../utils/get-static-property-key-name.js";
+import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
+import { hasPossibleStaticPropertyWriteBefore } from "../../utils/has-static-property-write-before.js";
+import { hasSymbolWriteBefore } from "../../utils/has-symbol-write-before.js";
+import { isProvenGlobalNamespaceReference } from "../../utils/is-proven-global-namespace-reference.js";
+import { isProvenUnmodifiedGlobalNamespaceReference } from "../../utils/is-proven-unmodified-global-namespace-reference.js";
+import { isReactApiCall } from "../../utils/is-react-api-call.js";
+import { walkAst } from "../../utils/walk-ast.js";
+import { isFunctionLike } from "../../utils/is-function-like.js";
+import { isNodeReachableWithinFunction } from "../../utils/is-node-reachable-within-function.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
+import { findProgramRoot } from "../../utils/find-program-root.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { resolveImportedExportName } from "../../utils/find-exported-function-body.js";
+import type { ResolvedCrossFileExport } from "../../utils/resolve-cross-file-export.js";
+import { resolveCrossFileExport } from "../../utils/resolve-cross-file-export.js";
+import type { RuleContext } from "../../utils/rule-context.js";
 
 const NAVIGATING_TARGETS = new Set(["_self", "_top", "_parent"]);
+let currentScopes: ScopeAnalysis | undefined;
+let currentRuleContext: RuleContext | undefined;
+let currentWindowOpenCall: EsTreeNode | undefined;
+let trustedTopLevelDestinationMemo = new WeakMap<EsTreeNode, boolean>();
+let symbolHasNonReadReferenceMemo = new WeakMap<SymbolDescriptor, boolean>();
+let localFunctionCallArgumentsMemo = new WeakMap<
+  EsTreeNode,
+  Map<number, Array<EsTreeNode | null> | null>
+>();
+let routerCallsByFunctionMemo = new WeakMap<
+  EsTreeNode,
+  Array<EsTreeNodeOfType<"CallExpression">>
+>();
+let globalNamespaceMutationOffsetsMemo = new WeakMap<ScopeAnalysis, Map<string, number[]>>();
+
+const bindingIsUnmodifiedBefore = (identifier: EsTreeNode, referenceNode: EsTreeNode): boolean => {
+  const scopes = currentScopes;
+  const symbol = scopes?.symbolFor(identifier);
+  let symbolHasNonReadReference = symbol ? symbolHasNonReadReferenceMemo.get(symbol) : undefined;
+  if (symbol && symbolHasNonReadReference === undefined) {
+    symbolHasNonReadReference = symbol.references.some((reference) => reference.flag !== "read");
+    symbolHasNonReadReferenceMemo.set(symbol, symbolHasNonReadReference);
+  }
+  return Boolean(
+    scopes &&
+    symbol &&
+    (!symbolHasNonReadReference ||
+      (!hasSymbolWriteBefore(symbol, referenceNode, scopes) &&
+        !symbol.references.some(
+          (reference) =>
+            reference.flag !== "read" && reference.identifier.range[0] < referenceNode.range[0],
+        ))),
+  );
+};
+
+const bindingIsUnmodifiedBeforeCurrentOpen = (identifier: EsTreeNode): boolean =>
+  Boolean(currentWindowOpenCall && bindingIsUnmodifiedBefore(identifier, currentWindowOpenCall));
 
 // Matches `window.open` and `globalThis.window.open` — a non-computed
 // `.open` member off the `window` global. Bare `open(...)` (an
 // `Identifier` callee) and `foo.postMessage`/`webview.open` are not the
 // window global and never match.
-const isWindowOpenCallee = (callee: EsTreeNode): boolean => {
-  if (!isNodeOfType(callee, "MemberExpression") || callee.computed) return false;
-  if (!isNodeOfType(callee.property, "Identifier") || callee.property.name !== "open") return false;
-  const object = callee.object;
-  if (isNodeOfType(object, "Identifier")) return object.name === "window";
-  if (isNodeOfType(object, "MemberExpression") && !object.computed) {
-    return (
-      isNodeOfType(object.object, "Identifier") &&
-      object.object.name === "globalThis" &&
-      isNodeOfType(object.property, "Identifier") &&
-      object.property.name === "window"
-    );
+const isWindowOpenCallee = (callee: EsTreeNode, scopes: ScopeAnalysis): boolean => {
+  const unwrappedCallee = stripParenExpression(callee);
+  if (
+    isNodeOfType(unwrappedCallee, "Identifier") &&
+    isProvenGlobalNamespaceReference(unwrappedCallee, "open", scopes)
+  ) {
+    return true;
   }
-  return false;
+  return (
+    isNodeOfType(unwrappedCallee, "MemberExpression") &&
+    getStaticPropertyName(unwrappedCallee) === "open" &&
+    isProvenGlobalNamespaceReference(unwrappedCallee.object, "window", scopes)
+  );
 };
 
 const isStringLiteral = (
@@ -33,8 +93,10 @@ const isStringLiteral = (
 
 // `mailto:`/`tel:`/`sms:` hand the URL to an OS protocol handler and never
 // open a navigable browsing context, so no `window.opener` is exposed and
-// there is nothing to reverse-tabnab — flagging them is a false positive.
-const NON_BROWSING_URL_SCHEMES = ["mailto:", "tel:", "sms:"];
+// there is nothing to reverse-tabnab. `file:` is likewise inert: browsers
+// refuse to navigate from a web origin to `file:`, and in desktop shells
+// (Tauri/Electron dev tooling) it opens a local file the app itself wrote.
+const NON_BROWSING_URL_SCHEMES = ["mailto:", "tel:", "sms:", "file:"];
 
 // A fixed `https://host/` prefix pins the origin: the `[/?#]` terminator
 // after the host guarantees any interpolation lands in the path/query,
@@ -44,9 +106,35 @@ const COMPLETE_ORIGIN_PATTERN = /^https?:\/\/[^/?#]+[/?#]/i;
 
 const SAME_ORIGIN_URL_PREFIXES = ["./", "../", "?", "#"];
 
+// A bare relative prefix (`chat/`) pins the URL to the current origin the
+// same way a leading `/` does: a scheme must precede the first `/`, `?`,
+// or `#`, and the colon-free segment before that terminator rules one out
+// no matter what an interpolation appends.
+const BARE_RELATIVE_PATH_PREFIX_PATTERN = /^[\w.~%-]+[/?#]/;
+
 const startsSameOriginPath = (urlText: string): boolean => {
-  if (urlText.startsWith("/")) return !urlText.startsWith("//");
-  return SAME_ORIGIN_URL_PREFIXES.some((prefix) => urlText.startsWith(prefix));
+  if (urlText.startsWith("/")) return urlText[1] !== "/" && urlText[1] !== "\\";
+  if (SAME_ORIGIN_URL_PREFIXES.some((prefix) => urlText.startsWith(prefix))) return true;
+  return BARE_RELATIVE_PATH_PREFIX_PATTERN.test(urlText);
+};
+
+const startsUnambiguouslySameOriginTemplatePath = (urlText: string): boolean =>
+  urlText !== "/" && startsSameOriginPath(urlText);
+
+// While a FOREIGN module's export is under trusted-destination analysis
+// (see `isTrustedForeignExportExpression`), static text is only trusted
+// when it stays same-origin or hands off to an OS protocol handler. The
+// blanket literal exemption below exists for destinations the developer
+// typed at the call site; extending it across files would erase the
+// rule's current true positives on unverified imported constants, and a
+// VERIFIED external origin behind a URL-named import is exactly the
+// recall the name heuristic was giving away.
+const isTrustedForeignStaticText = (urlText: string): boolean => {
+  const trimmedText = urlText.trimStart();
+  if (trimmedText.length === 0) return false;
+  const loweredText = trimmedText.toLowerCase();
+  if (NON_BROWSING_URL_SCHEMES.some((scheme) => loweredText.startsWith(scheme))) return true;
+  return startsSameOriginPath(trimmedText);
 };
 
 // Reverse tabnabbing needs an attacker-controlled opened page. A
@@ -58,18 +146,79 @@ const startsSameOriginPath = (urlText: string): boolean => {
 // call results, member accesses, templates interpolating the
 // scheme/host) keep firing.
 const isTrustedStaticDestination = (urlArgument: EsTreeNode | null | undefined): boolean => {
-  if (isStringLiteral(urlArgument)) return true;
+  if (isStringLiteral(urlArgument)) {
+    return isAnalyzingForeignExport ? isTrustedForeignStaticText(urlArgument.value) : true;
+  }
   if (urlArgument == null || !isNodeOfType(urlArgument, "TemplateLiteral")) return false;
-  if ((urlArgument.expressions?.length ?? 0) === 0) return true;
+  if ((urlArgument.expressions?.length ?? 0) === 0) {
+    return isAnalyzingForeignExport
+      ? isTrustedForeignStaticText(urlArgument.quasis?.[0]?.value?.raw ?? "")
+      : true;
+  }
   const firstQuasiText = (urlArgument.quasis?.[0]?.value?.raw ?? "").trimStart();
   if (firstQuasiText.length === 0) return false;
   const loweredQuasiText = firstQuasiText.toLowerCase();
   if (NON_BROWSING_URL_SCHEMES.some((scheme) => loweredQuasiText.startsWith(scheme))) return true;
-  if (COMPLETE_ORIGIN_PATTERN.test(firstQuasiText)) return true;
-  return startsSameOriginPath(firstQuasiText);
+  if (!isAnalyzingForeignExport && COMPLETE_ORIGIN_PATTERN.test(firstQuasiText)) return true;
+  return startsUnambiguouslySameOriginTemplatePath(firstQuasiText);
 };
 
-const MAX_BINDING_RESOLUTION_DEPTH = 4;
+// Deep enough to resolve state-setter dataflow chains (logical fallback →
+// useState binding → setter argument → const array index → local helper
+// return → const element → path-builder call) while still bounding
+// recursion.
+const MAX_BINDING_RESOLUTION_DEPTH = 8;
+
+// `.pathname` values are path strings, which `window.open` resolves against
+// the current origin. `.origin`/`.href` are only same-origin when read off a
+// location-shaped receiver (`location`, `window.location`, `getLocation()`)
+// — an arbitrary `.origin` (e.g. a postMessage event's) is attacker data.
+const isLocationShapedReceiver = (
+  receiver: EsTreeNode,
+  visitedFunctionNodes = new Set<EsTreeNode>(),
+): boolean => {
+  if (currentScopes && isProvenGlobalNamespaceReference(receiver, "location", currentScopes)) {
+    return true;
+  }
+  if (isNodeOfType(receiver, "CallExpression")) {
+    const callee = receiver.callee as EsTreeNode;
+    if (!isNodeOfType(callee, "Identifier")) return false;
+    const localFunction = resolveLocalFunctionNode(callee);
+    if (!localFunction || visitedFunctionNodes.has(localFunction)) return false;
+    const nextVisitedFunctionNodes = new Set(visitedFunctionNodes);
+    nextVisitedFunctionNodes.add(localFunction);
+    const returnedExpressions = collectLocalFunctionReturnExpressions(localFunction);
+    return Boolean(
+      returnedExpressions &&
+      returnedExpressions.length > 0 &&
+      returnedExpressions.every((returnedExpression) =>
+        isLocationShapedReceiver(
+          stripParenExpression(returnedExpression),
+          nextVisitedFunctionNodes,
+        ),
+      ),
+    );
+  }
+  return false;
+};
+
+// `window.origin` (and `globalThis.window.origin`) is the same value as
+// `window.location.origin` — same-origin by construction.
+const isWindowGlobalReceiver = (receiver: EsTreeNode): boolean => {
+  return Boolean(
+    currentScopes && isProvenGlobalNamespaceReference(receiver, "window", currentScopes),
+  );
+};
+
+const isSameOriginLocationRead = (node: EsTreeNode): boolean => {
+  if (!isNodeOfType(node, "MemberExpression") || node.computed) return false;
+  if (!isNodeOfType(node.property, "Identifier")) return false;
+  if (node.property.name === "origin" && isWindowGlobalReceiver(node.object as EsTreeNode)) {
+    return true;
+  }
+  if (node.property.name !== "origin" && node.property.name !== "href") return false;
+  return isLocationShapedReceiver(node.object as EsTreeNode);
+};
 
 // A nullish URL (`window.open(null)`, `cond ? url : null`) is harmless:
 // it opens about:blank, which the opener fully controls.
@@ -77,7 +226,11 @@ const isNullishExpression = (node: EsTreeNode | null | undefined): boolean => {
   if (node == null) return true;
   if (isNodeOfType(node, "Literal")) return node.value === null;
   if (isNodeOfType(node, "UnaryExpression")) return node.operator === "void";
-  return isNodeOfType(node, "Identifier") && node.name === "undefined";
+  return (
+    isNodeOfType(node, "Identifier") &&
+    node.name === "undefined" &&
+    (!currentScopes || currentScopes.isGlobalReference(node))
+  );
 };
 
 // Only a direct `const name = <init>` declarator is safe to resolve —
@@ -96,6 +249,1040 @@ const resolveConstInitializer = (identifier: EsTreeNodeOfType<"Identifier">): Es
   return binding.initializer;
 };
 
+const objectLiteralSuppliesTrustedProperty = (
+  objectLiteral: EsTreeNode,
+  propertyName: string,
+  depth: number,
+): boolean => {
+  if (!isNodeOfType(objectLiteral, "ObjectExpression")) return false;
+  let propertyTrust: boolean | null | undefined;
+  for (const property of objectLiteral.properties ?? []) {
+    if (isNodeOfType(property, "SpreadElement")) {
+      propertyTrust = null;
+      continue;
+    }
+    if (!isNodeOfType(property, "Property")) {
+      propertyTrust = null;
+      continue;
+    }
+    const staticPropertyName = getStaticPropertyKeyName(property, {
+      allowComputedString: true,
+    });
+    if (staticPropertyName === propertyName) {
+      propertyTrust = isTrustedDestination(property.value as EsTreeNode, depth + 1);
+    } else if (staticPropertyName === null && property.computed) {
+      propertyTrust = null;
+    }
+  }
+  return propertyTrust === true;
+};
+
+const everyArrayElementSuppliesTrustedProperty = (
+  arrayLiteral: EsTreeNodeOfType<"ArrayExpression">,
+  propertyName: string,
+  depth: number,
+): boolean => {
+  const elements = arrayLiteral.elements ?? [];
+  return (
+    elements.length > 0 &&
+    elements.every(
+      (element) =>
+        element != null &&
+        objectLiteralSuppliesTrustedProperty(
+          stripParenExpression(element as EsTreeNode),
+          propertyName,
+          depth,
+        ),
+    )
+  );
+};
+
+// `<CONST_ARRAY>.map((item) => ...)` / `[{...}].map(({ href }) => ...)` —
+// resolves the iterated literal array of a map/forEach callback.
+const resolveIteratedConstArrayLiteral = (
+  callbackFunction: EsTreeNode,
+): EsTreeNodeOfType<"ArrayExpression"> | null => {
+  const iterationCall = callbackFunction.parent;
+  if (
+    !iterationCall ||
+    !isNodeOfType(iterationCall, "CallExpression") ||
+    !isNodeOfType(iterationCall.callee, "MemberExpression") ||
+    iterationCall.arguments?.[0] !== callbackFunction
+  ) {
+    return null;
+  }
+  const iterationMethodName = getStaticPropertyName(iterationCall.callee);
+  if (iterationMethodName !== "map" && iterationMethodName !== "forEach") return null;
+  const iterated = stripParenExpression(iterationCall.callee.object as EsTreeNode);
+  if (isNodeOfType(iterated, "ArrayExpression")) return iterated;
+  if (isNodeOfType(iterated, "Identifier")) {
+    const arrayInitializer = resolveConstInitializer(iterated);
+    if (arrayInitializer && isNodeOfType(arrayInitializer, "ArrayExpression")) {
+      return arrayInitializer;
+    }
+  }
+  return null;
+};
+
+const hasNestedIndexedPropertyWriteBefore = (
+  arrayIdentifier: EsTreeNodeOfType<"Identifier">,
+  propertyName: string,
+  referenceNode: EsTreeNode,
+): boolean => {
+  const arraySymbol = currentScopes?.symbolFor(arrayIdentifier);
+  if (!arraySymbol) return false;
+  return arraySymbol.references.some((reference) => {
+    if (reference.identifier.range[0] >= referenceNode.range[0]) return false;
+    const referenceRoot = findTransparentExpressionRoot(reference.identifier);
+    const indexedMember = referenceRoot.parent;
+    if (
+      !indexedMember ||
+      !isNodeOfType(indexedMember, "MemberExpression") ||
+      indexedMember.object !== referenceRoot ||
+      !indexedMember.computed
+    ) {
+      return false;
+    }
+    const propertyMember = indexedMember.parent;
+    if (
+      !propertyMember ||
+      !isNodeOfType(propertyMember, "MemberExpression") ||
+      propertyMember.object !== indexedMember ||
+      getStaticPropertyName(propertyMember) !== propertyName
+    ) {
+      return false;
+    }
+    const mutation = findTransparentExpressionRoot(propertyMember).parent;
+    return Boolean(
+      mutation &&
+      ((isNodeOfType(mutation, "AssignmentExpression") && mutation.left === propertyMember) ||
+        (isNodeOfType(mutation, "UpdateExpression") && mutation.argument === propertyMember) ||
+        (isNodeOfType(mutation, "UnaryExpression") &&
+          mutation.operator === "delete" &&
+          mutation.argument === propertyMember)),
+    );
+  });
+};
+
+const ARRAY_MUTATING_METHOD_NAMES = new Set([
+  "copyWithin",
+  "fill",
+  "pop",
+  "push",
+  "reverse",
+  "shift",
+  "sort",
+  "splice",
+  "unshift",
+]);
+
+const hasArrayMutationBefore = (
+  arrayIdentifier: EsTreeNodeOfType<"Identifier">,
+  referenceNode: EsTreeNode,
+): boolean => {
+  const arraySymbol = currentScopes?.symbolFor(arrayIdentifier);
+  if (!arraySymbol) return false;
+  return arraySymbol.references.some((reference) => {
+    if (reference.identifier.range[0] >= referenceNode.range[0]) return false;
+    const referenceRoot = findTransparentExpressionRoot(reference.identifier);
+    const memberExpression = referenceRoot.parent;
+    if (
+      !memberExpression ||
+      !isNodeOfType(memberExpression, "MemberExpression") ||
+      memberExpression.object !== referenceRoot
+    ) {
+      return false;
+    }
+    const memberRoot = findTransparentExpressionRoot(memberExpression);
+    const memberParent = memberRoot.parent;
+    const methodName = getStaticPropertyName(memberExpression);
+    if (
+      methodName &&
+      ARRAY_MUTATING_METHOD_NAMES.has(methodName) &&
+      memberParent &&
+      isNodeOfType(memberParent, "CallExpression") &&
+      memberParent.callee === memberRoot
+    ) {
+      return true;
+    }
+    return Boolean(
+      memberParent &&
+      ((isNodeOfType(memberParent, "AssignmentExpression") && memberParent.left === memberRoot) ||
+        (isNodeOfType(memberParent, "UpdateExpression") && memberParent.argument === memberRoot) ||
+        (isNodeOfType(memberParent, "UnaryExpression") &&
+          memberParent.operator === "delete" &&
+          memberParent.argument === memberRoot)),
+    );
+  });
+};
+
+// `EXTERNAL_LINKS.docs` — property read off a same-file const object of
+// trusted literals; `item.href` — property of an element of a const config
+// array iterated by the enclosing map callback. Both are developer-typed
+// destinations behind one level of data structure.
+const isTrustedConstConfigMember = (
+  memberNode: EsTreeNodeOfType<"MemberExpression">,
+  depth: number,
+): boolean => {
+  if (!isNodeOfType(memberNode.property, "Identifier")) return false;
+  const propertyName = memberNode.property.name;
+  const receiver = stripParenExpression(memberNode.object as EsTreeNode);
+  if (!isNodeOfType(receiver, "Identifier")) return false;
+  if (!bindingIsUnmodifiedBeforeCurrentOpen(receiver)) return false;
+  if (hasArrayMutationBefore(receiver, memberNode)) return false;
+  if (
+    currentScopes &&
+    hasPossibleStaticPropertyWriteBefore(receiver, propertyName, memberNode, currentScopes)
+  ) {
+    return false;
+  }
+
+  const constInitializer = resolveConstInitializer(receiver);
+  if (constInitializer && isNodeOfType(constInitializer, "ObjectExpression")) {
+    return objectLiteralSuppliesTrustedProperty(constInitializer, propertyName, depth);
+  }
+
+  // Callback param of `<CONST_ARRAY>.map((item) => ...)`.
+  const binding = findVariableInitializer(receiver, receiver.name);
+  const paramParent = binding?.bindingIdentifier.parent;
+  if (!paramParent) return false;
+  if (
+    !isFunctionLike(paramParent) ||
+    !(paramParent.params ?? []).includes(binding.bindingIdentifier as never)
+  ) {
+    return false;
+  }
+  const arrayLiteral = resolveIteratedConstArrayLiteral(paramParent);
+  if (!arrayLiteral) return false;
+  const iterationCall = paramParent.parent;
+  const iterationCallee =
+    iterationCall && isNodeOfType(iterationCall, "CallExpression") ? iterationCall.callee : null;
+  const iteratedReceiver =
+    iterationCallee && isNodeOfType(iterationCallee, "MemberExpression")
+      ? stripParenExpression(iterationCallee.object)
+      : null;
+  if (
+    iteratedReceiver &&
+    isNodeOfType(iteratedReceiver, "Identifier") &&
+    (hasNestedIndexedPropertyWriteBefore(iteratedReceiver, propertyName, memberNode) ||
+      hasArrayMutationBefore(iteratedReceiver, memberNode))
+  ) {
+    return false;
+  }
+  return everyArrayElementSuppliesTrustedProperty(arrayLiteral, propertyName, depth);
+};
+
+// `[{ href: 'https://…' }, …].map(({ href }) => window.open(href))` — the
+// destructured twin of the const-config member exemption: the identifier is
+// bound by an ObjectPattern in a map-callback param over a literal array
+// whose every element supplies the property as a trusted destination
+// (pwa-kit social-icons idiom). A dynamic iterated value (a prop, server
+// data) resolves to no array literal and stays opaque.
+const isTrustedDestructuredIterationMember = (
+  identifier: EsTreeNodeOfType<"Identifier">,
+  depth: number,
+): boolean => {
+  if (!bindingIsUnmodifiedBeforeCurrentOpen(identifier)) return false;
+  const binding = findVariableInitializer(identifier, identifier.name);
+  if (!binding) return false;
+  let propertyNode = binding.bindingIdentifier.parent;
+  if (propertyNode && isNodeOfType(propertyNode, "AssignmentPattern")) {
+    propertyNode = propertyNode.parent;
+  }
+  if (!propertyNode || !isNodeOfType(propertyNode, "Property") || propertyNode.computed) {
+    return false;
+  }
+  if (!isNodeOfType(propertyNode.key, "Identifier")) return false;
+  const propertyName = propertyNode.key.name;
+  const objectPattern = propertyNode.parent;
+  if (!objectPattern || !isNodeOfType(objectPattern, "ObjectPattern")) return false;
+  const callbackFunction = objectPattern.parent;
+  if (
+    !callbackFunction ||
+    !isFunctionLike(callbackFunction) ||
+    !(callbackFunction.params ?? []).includes(objectPattern as never)
+  ) {
+    return false;
+  }
+  const arrayLiteral = resolveIteratedConstArrayLiteral(callbackFunction);
+  if (!arrayLiteral) return false;
+  const iterationCall = callbackFunction.parent;
+  const iterationCallee =
+    iterationCall && isNodeOfType(iterationCall, "CallExpression") ? iterationCall.callee : null;
+  const iteratedReceiver =
+    iterationCallee && isNodeOfType(iterationCallee, "MemberExpression")
+      ? stripParenExpression(iterationCallee.object)
+      : null;
+  if (
+    iteratedReceiver &&
+    isNodeOfType(iteratedReceiver, "Identifier") &&
+    hasArrayMutationBefore(iteratedReceiver, identifier)
+  ) {
+    return false;
+  }
+  return everyArrayElementSuppliesTrustedProperty(arrayLiteral, propertyName, depth);
+};
+
+// A `let url;` whose EVERY assignment in the enclosing scope is a trusted
+// static literal (switch/case link pickers) cannot carry attacker data.
+const isLetAssignedOnlyTrustedLiterals = (
+  identifier: EsTreeNodeOfType<"Identifier">,
+  depth: number,
+): boolean => {
+  const binding = findVariableInitializer(identifier, identifier.name);
+  if (!binding) return false;
+  const declarator = binding.bindingIdentifier.parent;
+  if (!declarator || !isNodeOfType(declarator, "VariableDeclarator")) return false;
+  if (declarator.init && !isTrustedDestination(declarator.init as EsTreeNode, depth + 1)) {
+    return false;
+  }
+  const bindingSymbol = currentScopes?.symbolFor(binding.bindingIdentifier);
+  if (!bindingSymbol) return false;
+  let sawAssignment = false;
+  for (const reference of bindingSymbol.references) {
+    let writeTargetChild = reference.identifier;
+    let writeTargetParent = writeTargetChild.parent;
+    let isNestedWriteTarget = false;
+    while (writeTargetParent) {
+      if (isNodeOfType(writeTargetParent, "AssignmentExpression")) {
+        isNestedWriteTarget =
+          writeTargetParent.left === writeTargetChild && writeTargetChild !== reference.identifier;
+        break;
+      }
+      if (
+        (isNodeOfType(writeTargetParent, "ForInStatement") ||
+          isNodeOfType(writeTargetParent, "ForOfStatement")) &&
+        writeTargetParent.left === writeTargetChild
+      ) {
+        isNestedWriteTarget = true;
+        break;
+      }
+      if (isFunctionLike(writeTargetParent)) break;
+      writeTargetChild = writeTargetParent;
+      writeTargetParent = writeTargetParent.parent;
+    }
+    if (isNestedWriteTarget) return false;
+    const referenceRoot = findTransparentExpressionRoot(reference.identifier);
+    const referenceParent = referenceRoot.parent;
+    if (
+      referenceParent &&
+      isNodeOfType(referenceParent, "AssignmentExpression") &&
+      referenceParent.operator === "=" &&
+      referenceParent.left === referenceRoot
+    ) {
+      sawAssignment = true;
+      if (!isTrustedDestination(referenceParent.right as EsTreeNode, depth + 1)) {
+        return false;
+      }
+      continue;
+    }
+    if (reference.flag !== "read") return false;
+  }
+  return sawAssignment;
+};
+
+// `ctaLink` destructured from the props of a module-local, non-exported
+// component whose every same-file JSX usage supplies the prop as a
+// trusted literal (`<IntegrationCard ctaLink="/docs/installation" />`)
+// is a developer-typed destination one indirection away. An exported
+// component (unknowable external call sites), a spread-props usage, any
+// non-JSX reference to the component, or a single dynamic prop value
+// keeps the identifier opaque.
+const isTrustedLocalComponentPropLiteral = (
+  identifier: EsTreeNodeOfType<"Identifier">,
+  depth: number,
+): boolean => {
+  if (!bindingIsUnmodifiedBeforeCurrentOpen(identifier)) return false;
+  const binding = findVariableInitializer(identifier, identifier.name);
+  if (!binding) return false;
+  let propertyNode = binding.bindingIdentifier.parent;
+  if (propertyNode && isNodeOfType(propertyNode, "AssignmentPattern")) {
+    propertyNode = propertyNode.parent;
+  }
+  if (!propertyNode || !isNodeOfType(propertyNode, "Property") || propertyNode.computed) {
+    return false;
+  }
+  if (!isNodeOfType(propertyNode.key, "Identifier")) return false;
+  const propName = propertyNode.key.name;
+  const objectPattern = propertyNode.parent;
+  if (!objectPattern || !isNodeOfType(objectPattern, "ObjectPattern")) return false;
+  const componentFunction = objectPattern.parent;
+  if (
+    !componentFunction ||
+    !isFunctionLike(componentFunction) ||
+    !(componentFunction.params ?? []).includes(objectPattern as never)
+  ) {
+    return false;
+  }
+
+  let componentNameNode: EsTreeNodeOfType<"Identifier"> | null = null;
+  let enclosingDeclarationParent: EsTreeNode | null = null;
+  if (isNodeOfType(componentFunction, "FunctionDeclaration") && componentFunction.id) {
+    componentNameNode = componentFunction.id;
+    enclosingDeclarationParent = componentFunction.parent ?? null;
+  } else {
+    const declarator = componentFunction.parent;
+    if (
+      declarator &&
+      isNodeOfType(declarator, "VariableDeclarator") &&
+      isNodeOfType(declarator.id, "Identifier")
+    ) {
+      const declaration = declarator.parent;
+      if (declaration && isNodeOfType(declaration, "VariableDeclaration")) {
+        componentNameNode = declarator.id;
+        enclosingDeclarationParent = declaration.parent ?? null;
+      }
+    }
+  }
+  if (!componentNameNode || !/^[A-Z]/.test(componentNameNode.name)) return false;
+  if (
+    enclosingDeclarationParent != null &&
+    (isNodeOfType(enclosingDeclarationParent, "ExportNamedDeclaration") ||
+      isNodeOfType(enclosingDeclarationParent, "ExportDefaultDeclaration"))
+  ) {
+    return false;
+  }
+
+  const programRoot = findProgramRoot(identifier);
+  if (!programRoot) return false;
+  const componentName = componentNameNode.name;
+  let usageCount = 0;
+  let sawUntrustedUsage = false;
+  let sawNonJsxReference = false;
+  walkAst(programRoot, (node: EsTreeNode) => {
+    if (sawUntrustedUsage || sawNonJsxReference) return false;
+    if (
+      isNodeOfType(node, "Identifier") &&
+      node.name === componentName &&
+      node !== componentNameNode
+    ) {
+      sawNonJsxReference = true;
+      return false;
+    }
+    if (!isNodeOfType(node, "JSXOpeningElement")) return;
+    const elementName = node.name;
+    if (
+      !elementName ||
+      elementName.type !== "JSXIdentifier" ||
+      (elementName as { name?: string }).name !== componentName
+    ) {
+      return;
+    }
+    usageCount += 1;
+    let propValue: EsTreeNode | null = null;
+    let sawPropAttribute = false;
+    for (const attribute of node.attributes ?? []) {
+      if (!isNodeOfType(attribute, "JSXAttribute")) {
+        sawUntrustedUsage = true;
+        return false;
+      }
+      const attributeName = attribute.name;
+      if (
+        attributeName &&
+        attributeName.type === "JSXIdentifier" &&
+        (attributeName as { name?: string }).name === propName
+      ) {
+        sawPropAttribute = true;
+        propValue = (attribute.value as EsTreeNode | null) ?? null;
+      }
+    }
+    // An omitted prop leaves the binding undefined — window.open(undefined)
+    // opens about:blank, which the opener controls.
+    if (!sawPropAttribute) return;
+    if (propValue == null) {
+      sawUntrustedUsage = true;
+      return false;
+    }
+    const suppliedExpression = isNodeOfType(propValue, "JSXExpressionContainer")
+      ? (propValue.expression as EsTreeNode)
+      : propValue;
+    if (!isTrustedOrNullishDestination(suppliedExpression, depth + 1)) {
+      sawUntrustedUsage = true;
+      return false;
+    }
+  });
+  return usageCount > 0 && !sawUntrustedUsage && !sawNonJsxReference;
+};
+
+interface DirectFunctionParamBinding {
+  functionNode: EsTreeNode;
+  parameterIndex: number;
+}
+
+const resolveDirectFunctionParam = (
+  identifier: EsTreeNodeOfType<"Identifier">,
+): DirectFunctionParamBinding | null => {
+  const binding = findVariableInitializer(identifier, identifier.name);
+  if (!binding) return null;
+  const functionNode = binding.bindingIdentifier.parent;
+  if (!functionNode || !isFunctionLike(functionNode)) return null;
+  const parameterIndex = (functionNode.params ?? []).indexOf(binding.bindingIdentifier as never);
+  if (parameterIndex < 0) return null;
+  return { functionNode, parameterIndex };
+};
+
+// The module-visible name a local function is callable under, refusing
+// exported functions (unknowable external call sites). A `useCallback`
+// wrapper is transparent — the declarator name refers to the same function.
+const resolveLocalFunctionNameIdentifier = (
+  functionNode: EsTreeNode,
+): EsTreeNodeOfType<"Identifier"> | null => {
+  if (isNodeOfType(functionNode, "FunctionDeclaration")) {
+    const declarationParent = functionNode.parent;
+    if (
+      declarationParent &&
+      (isNodeOfType(declarationParent, "ExportNamedDeclaration") ||
+        isNodeOfType(declarationParent, "ExportDefaultDeclaration"))
+    ) {
+      return null;
+    }
+    return functionNode.id && isNodeOfType(functionNode.id, "Identifier") ? functionNode.id : null;
+  }
+  let declaratorCandidate: EsTreeNode | null | undefined = functionNode.parent;
+  if (
+    declaratorCandidate &&
+    isNodeOfType(declaratorCandidate, "CallExpression") &&
+    (declaratorCandidate.arguments ?? [])[0] === functionNode &&
+    terminalCalleeName(declaratorCandidate.callee as EsTreeNode) === "useCallback"
+  ) {
+    declaratorCandidate = declaratorCandidate.parent;
+  }
+  if (!declaratorCandidate || !isNodeOfType(declaratorCandidate, "VariableDeclarator")) return null;
+  if (!isNodeOfType(declaratorCandidate.id, "Identifier")) return null;
+  const declaration = declaratorCandidate.parent;
+  if (!declaration || !isNodeOfType(declaration, "VariableDeclaration")) return null;
+  if (declaration.kind !== "const") return null;
+  const declarationParent = declaration.parent;
+  if (
+    declarationParent &&
+    (isNodeOfType(declarationParent, "ExportNamedDeclaration") ||
+      isNodeOfType(declarationParent, "ExportDefaultDeclaration"))
+  ) {
+    return null;
+  }
+  return declaratorCandidate.id;
+};
+
+// The argument supplied at `parameterIndex` by every same-file call of a
+// local function. Returns null when the function is exported, anonymous, or
+// escapes by reference (any non-call use of its name keeps it opaque), or
+// when it is never called.
+const collectLocalFunctionCallArguments = (
+  functionNode: EsTreeNode,
+  parameterIndex: number,
+): Array<EsTreeNode | null> | null => {
+  let argumentsByParameter = localFunctionCallArgumentsMemo.get(functionNode);
+  if (!argumentsByParameter) {
+    argumentsByParameter = new Map();
+    localFunctionCallArgumentsMemo.set(functionNode, argumentsByParameter);
+  }
+  if (argumentsByParameter.has(parameterIndex)) {
+    return argumentsByParameter.get(parameterIndex) ?? null;
+  }
+  const nameIdentifier = resolveLocalFunctionNameIdentifier(functionNode);
+  if (!nameIdentifier) {
+    argumentsByParameter.set(parameterIndex, null);
+    return null;
+  }
+  const programRoot = findProgramRoot(functionNode);
+  if (!programRoot) {
+    argumentsByParameter.set(parameterIndex, null);
+    return null;
+  }
+  const callArguments: Array<EsTreeNode | null> = [];
+  let sawNonCallReference = false;
+  walkAst(programRoot, (node: EsTreeNode) => {
+    if (sawNonCallReference) return false;
+    if (
+      !isNodeOfType(node, "Identifier") ||
+      node.name !== nameIdentifier.name ||
+      node === nameIdentifier ||
+      findVariableInitializer(node, node.name)?.bindingIdentifier !== nameIdentifier
+    ) {
+      return;
+    }
+    const referenceParent = node.parent;
+    if (
+      referenceParent &&
+      isNodeOfType(referenceParent, "CallExpression") &&
+      referenceParent.callee === node
+    ) {
+      callArguments.push(
+        ((referenceParent.arguments ?? [])[parameterIndex] as EsTreeNode | undefined) ?? null,
+      );
+      return;
+    }
+    sawNonCallReference = true;
+    return false;
+  });
+  if (sawNonCallReference || callArguments.length === 0) {
+    argumentsByParameter.set(parameterIndex, null);
+    return null;
+  }
+  argumentsByParameter.set(parameterIndex, callArguments);
+  return callArguments;
+};
+
+// `openLink('https://discord.gg/…')` — a URL that is a parameter of a local
+// wrapper is trusted when every same-file call of the wrapper passes a
+// trusted destination (rad-ui "Star on GitHub" idiom, one indirection away).
+const isTrustedLocalWrapperParam = (
+  identifier: EsTreeNodeOfType<"Identifier">,
+  depth: number,
+): boolean => {
+  if (!bindingIsUnmodifiedBeforeCurrentOpen(identifier)) return false;
+  const paramBinding = resolveDirectFunctionParam(identifier);
+  if (!paramBinding) return false;
+  const callArguments = collectLocalFunctionCallArguments(
+    paramBinding.functionNode,
+    paramBinding.parameterIndex,
+  );
+  if (!callArguments) return false;
+  return callArguments.every((argument) => isTrustedOrNullishDestination(argument, depth + 1));
+};
+
+const JSX_EVENT_HANDLER_ATTRIBUTE_PATTERN = /^on[A-Z]/;
+
+const jsxAttributeName = (attribute: EsTreeNodeOfType<"JSXAttribute">): string | null => {
+  const nameNode = attribute.name;
+  return nameNode && nameNode.type === "JSXIdentifier"
+    ? ((nameNode as { name?: string }).name ?? null)
+    : null;
+};
+
+const resolveHandlerAttributeElement = (
+  expressionContainer: EsTreeNode,
+): EsTreeNodeOfType<"JSXOpeningElement"> | null => {
+  const attribute = expressionContainer.parent;
+  if (!attribute || !isNodeOfType(attribute, "JSXAttribute")) return null;
+  const attributeName = jsxAttributeName(attribute);
+  if (!attributeName || !JSX_EVENT_HANDLER_ATTRIBUTE_PATTERN.test(attributeName)) return null;
+  const openingElement = attribute.parent;
+  return openingElement && isNodeOfType(openingElement, "JSXOpeningElement")
+    ? openingElement
+    : null;
+};
+
+const elementSuppliesTrustedHref = (
+  openingElement: EsTreeNodeOfType<"JSXOpeningElement">,
+  depth: number,
+): boolean => {
+  const elementName = openingElement.name;
+  if (!elementName || elementName.type !== "JSXIdentifier" || elementName.name !== "a") {
+    return false;
+  }
+  const hrefAttribute = getAuthoritativeJsxAttribute(openingElement.attributes ?? [], "href");
+  if (!hrefAttribute) return false;
+  const attributeValue = hrefAttribute.value as EsTreeNode | null;
+  if (attributeValue == null) return false;
+  if (isNodeOfType(attributeValue, "JSXExpressionContainer")) {
+    return isTrustedDestination(attributeValue.expression as EsTreeNode, depth + 1);
+  }
+  return isTrustedStaticDestination(attributeValue);
+};
+
+// The handler function receiving the event is wired — inline or by name —
+// exclusively to JSX event-handler attributes of elements whose `href` is a
+// trusted destination.
+const handlerFunctionOnlyServesTrustedHrefElements = (
+  handlerFunction: EsTreeNode,
+  depth: number,
+): boolean => {
+  const handlerParent = handlerFunction.parent;
+  if (handlerParent && isNodeOfType(handlerParent, "JSXExpressionContainer")) {
+    const openingElement = resolveHandlerAttributeElement(handlerParent);
+    return openingElement != null && elementSuppliesTrustedHref(openingElement, depth);
+  }
+  const nameIdentifier = resolveLocalFunctionNameIdentifier(handlerFunction);
+  if (!nameIdentifier) return false;
+  const programRoot = findProgramRoot(handlerFunction);
+  if (!programRoot) return false;
+  let handlerUsageCount = 0;
+  let sawUntrustedHandlerUsage = false;
+  walkAst(programRoot, (node: EsTreeNode) => {
+    if (sawUntrustedHandlerUsage) return false;
+    if (
+      !isNodeOfType(node, "Identifier") ||
+      node.name !== nameIdentifier.name ||
+      node === nameIdentifier ||
+      findVariableInitializer(node, node.name)?.bindingIdentifier !== nameIdentifier
+    ) {
+      return;
+    }
+    const referenceParent = node.parent;
+    const openingElement =
+      referenceParent && isNodeOfType(referenceParent, "JSXExpressionContainer")
+        ? resolveHandlerAttributeElement(referenceParent)
+        : null;
+    if (!openingElement || !elementSuppliesTrustedHref(openingElement, depth)) {
+      sawUntrustedHandlerUsage = true;
+      return false;
+    }
+    handlerUsageCount += 1;
+  });
+  return handlerUsageCount > 0 && !sawUntrustedHandlerUsage;
+};
+
+// `window.open(anchorEl.href)` inside a local helper whose every call site
+// passes `event.currentTarget` from a click handler wired to a JSX element
+// whose `href` attribute is itself trusted — the DOM merely round-trips an
+// already-trusted destination (react-cosmos cmd+click-fixture idiom).
+const isTrustedAnchorParamHrefRead = (
+  memberNode: EsTreeNodeOfType<"MemberExpression">,
+  depth: number,
+): boolean => {
+  if (!isNodeOfType(memberNode.property, "Identifier") || memberNode.property.name !== "href") {
+    return false;
+  }
+  const receiver = stripParenExpression(memberNode.object as EsTreeNode);
+  if (!isNodeOfType(receiver, "Identifier")) return false;
+  if (!bindingIsUnmodifiedBeforeCurrentOpen(receiver)) return false;
+  if (
+    currentScopes &&
+    hasPossibleStaticPropertyWriteBefore(receiver, "href", memberNode, currentScopes)
+  ) {
+    return false;
+  }
+  const paramBinding = resolveDirectFunctionParam(receiver);
+  if (!paramBinding) return false;
+  const callArguments = collectLocalFunctionCallArguments(
+    paramBinding.functionNode,
+    paramBinding.parameterIndex,
+  );
+  if (!callArguments) return false;
+  return callArguments.every((argument) => {
+    if (argument == null) return false;
+    const anchorSource = stripParenExpression(argument);
+    if (!isNodeOfType(anchorSource, "MemberExpression") || anchorSource.computed) return false;
+    if (
+      !isNodeOfType(anchorSource.property, "Identifier") ||
+      anchorSource.property.name !== "currentTarget"
+    ) {
+      return false;
+    }
+    const eventReceiver = stripParenExpression(anchorSource.object as EsTreeNode);
+    if (!isNodeOfType(eventReceiver, "Identifier")) return false;
+    const eventParamBinding = resolveDirectFunctionParam(eventReceiver);
+    if (!eventParamBinding) return false;
+    return handlerFunctionOnlyServesTrustedHrefElements(eventParamBinding.functionNode, depth);
+  });
+};
+
+// `const [imageUrl, setImageUrl] = useState()` where the initializer and
+// every same-scope setter call carry a trusted destination — the state can
+// only ever hold trusted URLs (dtale MissingNoCharts idiom). A setter that
+// escapes by reference or receives an updater function keeps the binding
+// opaque.
+const isTrustedUseStateUrlBinding = (
+  identifier: EsTreeNodeOfType<"Identifier">,
+  depth: number,
+): boolean => {
+  const binding = findVariableInitializer(identifier, identifier.name);
+  if (!binding) return false;
+  const arrayPattern = binding.bindingIdentifier.parent;
+  if (!arrayPattern || !isNodeOfType(arrayPattern, "ArrayPattern")) return false;
+  const patternElements = arrayPattern.elements ?? [];
+  if (patternElements[0] !== binding.bindingIdentifier) return false;
+  const setterIdentifier = patternElements[1] as EsTreeNode | null | undefined;
+  if (!setterIdentifier || !isNodeOfType(setterIdentifier, "Identifier")) return false;
+  const declarator = arrayPattern.parent;
+  if (!declarator || !isNodeOfType(declarator, "VariableDeclarator")) return false;
+  if (declarator.id !== arrayPattern) return false;
+  const declaration = declarator.parent;
+  if (!declaration || !isNodeOfType(declaration, "VariableDeclaration")) return false;
+  if (declaration.kind !== "const") return false;
+  const useStateCall = declarator.init as EsTreeNode | null;
+  if (!useStateCall || !isNodeOfType(useStateCall, "CallExpression")) return false;
+  if (terminalCalleeName(useStateCall.callee as EsTreeNode) !== "useState") return false;
+  if (
+    !isTrustedOrNullishDestination(
+      ((useStateCall.arguments ?? [])[0] as EsTreeNode | undefined) ?? null,
+      depth + 1,
+    )
+  ) {
+    return false;
+  }
+  let sawUntrustedSetterUse = false;
+  const setterSymbol = currentScopes?.symbolFor(setterIdentifier);
+  walkAst(binding.scopeOwner, (node: EsTreeNode) => {
+    if (sawUntrustedSetterUse) return false;
+    if (
+      !isNodeOfType(node, "Identifier") ||
+      node.name !== setterIdentifier.name ||
+      node === setterIdentifier ||
+      (setterSymbol && currentScopes?.symbolFor(node) !== setterSymbol)
+    ) {
+      return;
+    }
+    const referenceParent = node.parent;
+    if (
+      referenceParent &&
+      isNodeOfType(referenceParent, "CallExpression") &&
+      referenceParent.callee === node
+    ) {
+      const setterArgument =
+        ((referenceParent.arguments ?? [])[0] as EsTreeNode | undefined) ?? null;
+      if (setterArgument != null && isFunctionLike(setterArgument)) {
+        sawUntrustedSetterUse = true;
+        return false;
+      }
+      if (!isTrustedOrNullishDestination(setterArgument, depth + 1)) {
+        sawUntrustedSetterUse = true;
+        return false;
+      }
+      return;
+    }
+    sawUntrustedSetterUse = true;
+    return false;
+  });
+  return !sawUntrustedSetterUse;
+};
+
+// All expressions a local function can return; null when any return is bare
+// (the resulting undefined makes an index read meaningless) or the body is
+// missing.
+const collectLocalFunctionReturnExpressions = (functionNode: EsTreeNode): EsTreeNode[] | null => {
+  if (!isFunctionLike(functionNode)) return null;
+  const body = functionNode.body as EsTreeNode | null | undefined;
+  if (!body) return null;
+  if (!isNodeOfType(body, "BlockStatement")) return [body];
+  const returnedExpressions: EsTreeNode[] = [];
+  let sawBareReturn = false;
+  walkAst(body, (node: EsTreeNode) => {
+    if (node !== body && isFunctionLike(node)) return false;
+    if (isNodeOfType(node, "ReturnStatement")) {
+      if (node.argument == null) sawBareReturn = true;
+      else returnedExpressions.push(node.argument as EsTreeNode);
+    }
+  });
+  if (sawBareReturn) return null;
+  return returnedExpressions;
+};
+
+const resolveLocalFunctionNode = (
+  calleeIdentifier: EsTreeNodeOfType<"Identifier">,
+): EsTreeNode | null => {
+  if (!bindingIsUnmodifiedBeforeCurrentOpen(calleeIdentifier)) return null;
+  const binding = findVariableInitializer(calleeIdentifier, calleeIdentifier.name);
+  if (!binding?.initializer || !isFunctionLike(binding.initializer)) return null;
+  if (isNodeOfType(binding.initializer, "FunctionDeclaration")) return binding.initializer;
+  const declarator = binding.bindingIdentifier.parent;
+  if (!declarator || !isNodeOfType(declarator, "VariableDeclarator")) return null;
+  if (declarator.init !== binding.initializer) return null;
+  const declaration = declarator.parent;
+  if (!declaration || !isNodeOfType(declaration, "VariableDeclaration")) return null;
+  if (declaration.kind !== "const") return null;
+  return binding.initializer;
+};
+
+// `urls[0]` — an index read off a const binding holding either a literal
+// array of trusted destinations or the result of a same-file helper whose
+// every return is such an array (dtale buildUrls idiom).
+const isTrustedConstArrayIndexRead = (
+  memberNode: EsTreeNodeOfType<"MemberExpression">,
+  depth: number,
+): boolean => {
+  const indexNode = memberNode.property as EsTreeNode;
+  if (!isNodeOfType(indexNode, "Literal") || typeof indexNode.value !== "number") return false;
+  const elementIndex = indexNode.value;
+  const receiver = stripParenExpression(memberNode.object as EsTreeNode);
+  if (!isNodeOfType(receiver, "Identifier")) return false;
+  if (!bindingIsUnmodifiedBeforeCurrentOpen(receiver)) return false;
+  if (hasArrayMutationBefore(receiver, memberNode)) return false;
+  const constInitializer = resolveConstInitializer(receiver);
+  if (constInitializer == null) return false;
+
+  const arrayElementIsTrusted = (arrayCandidate: EsTreeNode): boolean => {
+    if (!isNodeOfType(arrayCandidate, "ArrayExpression")) return false;
+    const element = (arrayCandidate.elements ?? [])[elementIndex] as EsTreeNode | null | undefined;
+    return element != null && isTrustedDestination(stripParenExpression(element), depth + 1);
+  };
+
+  if (isNodeOfType(constInitializer, "ArrayExpression")) {
+    return arrayElementIsTrusted(constInitializer);
+  }
+  if (
+    isNodeOfType(constInitializer, "CallExpression") &&
+    isNodeOfType(constInitializer.callee, "Identifier")
+  ) {
+    const helperFunction = resolveLocalFunctionNode(constInitializer.callee);
+    if (!helperFunction) return false;
+    const returnedExpressions = collectLocalFunctionReturnExpressions(helperFunction);
+    if (!returnedExpressions || returnedExpressions.length === 0) return false;
+    return returnedExpressions.every((returned) =>
+      arrayElementIsTrusted(stripParenExpression(returned)),
+    );
+  }
+  return false;
+};
+
+const NEXT_ROUTER_MODULES = new Set(["next/router", "next/navigation"]);
+
+const isProvenRouterReceiver = (receiver: EsTreeNodeOfType<"Identifier">): boolean => {
+  const directImport = resolveImportedExportReference(receiver);
+  if (directImport?.moduleSpecifier === "next/router" && directImport.exportedName === "default") {
+    return true;
+  }
+  const initializer = resolveConstInitializer(receiver);
+  if (!initializer || !isNodeOfType(initializer, "CallExpression")) return false;
+  const initializerCallee = stripParenExpression(initializer.callee as EsTreeNode);
+  if (!isNodeOfType(initializerCallee, "Identifier")) return false;
+  const hookImport = resolveImportedExportReference(initializerCallee);
+  return Boolean(
+    hookImport &&
+    hookImport.exportedName === "useRouter" &&
+    NEXT_ROUTER_MODULES.has(hookImport.moduleSpecifier),
+  );
+};
+
+const conditionalBranchContaining = (
+  node: EsTreeNode,
+  conditional: EsTreeNode,
+): "alternate" | "consequent" | null => {
+  if (
+    !isNodeOfType(conditional, "IfStatement") &&
+    !isNodeOfType(conditional, "ConditionalExpression")
+  ) {
+    return null;
+  }
+  let cursor: EsTreeNode | null | undefined = node;
+  while (cursor?.parent && cursor.parent !== conditional) cursor = cursor.parent;
+  if (!cursor || cursor.parent !== conditional) return null;
+  if (conditional.consequent === cursor) return "consequent";
+  if (conditional.alternate === cursor) return "alternate";
+  return null;
+};
+
+const callsExecuteInOppositeConditionalBranches = (
+  windowOpenCall: EsTreeNode,
+  routerCall: EsTreeNode,
+): boolean => {
+  let conditional: EsTreeNode | null | undefined = windowOpenCall.parent;
+  while (conditional) {
+    if (
+      isNodeOfType(conditional, "IfStatement") ||
+      isNodeOfType(conditional, "ConditionalExpression")
+    ) {
+      const windowOpenBranch = conditionalBranchContaining(windowOpenCall, conditional);
+      const routerBranch = conditionalBranchContaining(routerCall, conditional);
+      if (windowOpenBranch && routerBranch && windowOpenBranch !== routerBranch) return true;
+    }
+    if (isFunctionLike(conditional)) return false;
+    conditional = conditional.parent ?? null;
+  }
+  return false;
+};
+
+const containingJsxOpeningElement = (
+  node: EsTreeNode,
+): EsTreeNodeOfType<"JSXOpeningElement"> | null => {
+  let cursor: EsTreeNode | null | undefined = node.parent;
+  while (cursor) {
+    if (isNodeOfType(cursor, "JSXOpeningElement")) return cursor;
+    cursor = cursor.parent ?? null;
+  }
+  return null;
+};
+
+const elementHasBranchLocalRouterContract = (
+  identifier: EsTreeNodeOfType<"Identifier">,
+): boolean => {
+  const scopes = currentScopes;
+  const ruleContext = currentRuleContext;
+  if (!currentWindowOpenCall || !scopes || !ruleContext) return false;
+  const openingElement = containingJsxOpeningElement(currentWindowOpenCall);
+  const identifierSymbol = scopes.symbolFor(identifier);
+  if (!openingElement || !identifierSymbol) return false;
+  const routerCalls: EsTreeNodeOfType<"CallExpression">[] = [];
+  const matchingWindowOpenCalls: EsTreeNodeOfType<"CallExpression">[] = [];
+  walkAst(openingElement, (node: EsTreeNode) => {
+    if (!isNodeOfType(node, "CallExpression")) return;
+    const firstArgument = node.arguments?.[0] as EsTreeNode | undefined;
+    const destination = firstArgument ? stripParenExpression(firstArgument) : null;
+    if (
+      !destination ||
+      !isNodeOfType(destination, "Identifier") ||
+      scopes.symbolFor(destination) !== identifierSymbol
+    ) {
+      return;
+    }
+    if (isWindowOpenCallee(node.callee, scopes)) {
+      matchingWindowOpenCalls.push(node);
+      return;
+    }
+    const callee = stripParenExpression(node.callee as EsTreeNode);
+    if (!isNodeOfType(callee, "MemberExpression")) return;
+    const methodName = getStaticPropertyName(callee);
+    const receiver = stripParenExpression(callee.object);
+    if (
+      (methodName === "push" || methodName === "replace") &&
+      isNodeOfType(receiver, "Identifier") &&
+      isProvenRouterReceiver(receiver) &&
+      isNodeReachableWithinFunction(node, ruleContext)
+    ) {
+      routerCalls.push(node);
+    }
+  });
+  return matchingWindowOpenCalls.some((windowOpenCall) =>
+    routerCalls.some((routerCall) =>
+      callsExecuteInOppositeConditionalBranches(windowOpenCall, routerCall),
+    ),
+  );
+};
+
+// `e.metaKey ? window.open(href) : Router.push(href)` — feeding the same
+// binding to a client-side router push/replace declares it an app-internal
+// SPA route, which resolves same-origin (hyperdx cmd+click-row idiom). Bare
+// `navigate(href)` does NOT qualify: any local helper can be named navigate
+// and such wrappers commonly forward external URLs.
+const isRouterCoNavigatedIdentifier = (identifier: EsTreeNodeOfType<"Identifier">): boolean => {
+  if (!currentWindowOpenCall) return false;
+  if (!bindingIsUnmodifiedBeforeCurrentOpen(identifier)) return false;
+  const windowOpenCall = currentWindowOpenCall;
+  let scopeCursor: EsTreeNode | null | undefined = identifier.parent;
+  while (scopeCursor && !isFunctionLike(scopeCursor)) scopeCursor = scopeCursor.parent ?? null;
+  if (!scopeCursor) return false;
+  const enclosingFunction = scopeCursor;
+  const identifierSymbol = currentScopes?.symbolFor(identifier);
+  let routerCalls = routerCallsByFunctionMemo.get(enclosingFunction);
+  if (!routerCalls) {
+    routerCalls = [];
+    walkAst(enclosingFunction, (node: EsTreeNode) => {
+      if (node !== enclosingFunction && isFunctionLike(node)) return false;
+      if (!isNodeOfType(node, "CallExpression")) return;
+      if (!currentRuleContext || !isNodeReachableWithinFunction(node, currentRuleContext)) return;
+      const callee = node.callee;
+      if (!isNodeOfType(callee, "MemberExpression") || callee.computed) return;
+      if (
+        !isNodeOfType(callee.property, "Identifier") ||
+        (callee.property.name !== "push" && callee.property.name !== "replace")
+      ) {
+        return;
+      }
+      const routerReceiver = stripParenExpression(callee.object as EsTreeNode);
+      if (!isNodeOfType(routerReceiver, "Identifier") || !isProvenRouterReceiver(routerReceiver)) {
+        return;
+      }
+      routerCalls?.push(node);
+    });
+    routerCallsByFunctionMemo.set(enclosingFunction, routerCalls);
+  }
+  const sawRouterCoNavigation = routerCalls.some((node) => {
+    if (!callsExecuteInOppositeConditionalBranches(windowOpenCall, node)) return false;
+    const callee = node.callee;
+    if (!isNodeOfType(callee, "MemberExpression")) return false;
+    const routeArgument = (node.arguments ?? [])[0] as EsTreeNode | undefined;
+    const routeIdentifier = routeArgument ? stripParenExpression(routeArgument) : null;
+    return Boolean(
+      routeIdentifier &&
+      isNodeOfType(routeIdentifier, "Identifier") &&
+      routeIdentifier.name === identifier.name &&
+      (!identifierSymbol || currentScopes?.symbolFor(routeIdentifier) === identifierSymbol),
+    );
+  });
+  return sawRouterCoNavigation || elementHasBranchLocalRouterContract(identifier);
+};
+
 // The trusted-by-construction check, extended one binding hop: a local
 // const holding a ternary over origin-pinned templates
 // (releaseUrl = version ? `https://github.com/…/tag/v${version}` : null)
@@ -104,6 +1291,354 @@ const resolveConstInitializer = (identifier: EsTreeNodeOfType<"Identifier">): Es
 // initializer must itself be trusted; opaque initializers (call results,
 // awaited API responses, hook-destructured values) resolve to nothing
 // and keep firing.
+// `'https://github.com/' + owner + '/' + repo` — concatenation whose
+// LEFTMOST operand pins the origin (or a same-origin path) is the semantic
+// twin of the exempt template.
+const leftmostConcatOperand = (node: EsTreeNode): EsTreeNode => {
+  let cursor = node;
+  while (isNodeOfType(cursor, "BinaryExpression") && cursor.operator === "+") {
+    cursor = stripParenExpression(cursor.left as EsTreeNode);
+  }
+  return cursor;
+};
+
+// Cross-file resolutions per linted file are capped: oxc-resolver +
+// re-parsing foreign modules is filesystem work, and a file rarely opens
+// more than a couple of imported destinations.
+const CROSS_FILE_RESOLUTION_BUDGET_PER_FILE = 3;
+
+// Per-file cross-file analysis state, reset in `create` before each lint.
+// The absolute filename anchors import resolution (an undefined / relative
+// filename makes every cross-file lookup a no-op, so hosts without
+// filenames keep the pure name-heuristic behavior); the memo keeps
+// repeated reads of the same import from re-consuming the budget.
+let currentLintedFilename: string | undefined;
+let crossFileResolutionsRemaining = 0;
+const crossFileResolutionMemo = new Map<string, ResolvedCrossFileExport | null>();
+
+// Foreign exports must be self-contained proofs: while a foreign
+// initializer / return is being analyzed, further cross-file hops are
+// disabled, so a foreign helper delegating to its OWN imports stays
+// opaque (no transitive resolution chains).
+let isAnalyzingForeignExport = false;
+
+interface ImportedExportReference {
+  moduleSpecifier: string;
+  exportedName: string;
+}
+
+// The import declaration a destination identifier is bound to, resolved
+// scope-aware (a local shadowing the import wins), with the SOURCE-side
+// export name so renamed imports resolve to the right foreign binding.
+const resolveImportedExportReference = (
+  identifier: EsTreeNodeOfType<"Identifier">,
+): ImportedExportReference | null => {
+  const binding = findVariableInitializer(identifier, identifier.name);
+  const importSpecifier = binding?.bindingIdentifier.parent;
+  if (
+    !importSpecifier ||
+    (!isNodeOfType(importSpecifier, "ImportSpecifier") &&
+      !isNodeOfType(importSpecifier, "ImportDefaultSpecifier"))
+  ) {
+    return null;
+  }
+  const exportedName = resolveImportedExportName(importSpecifier);
+  if (!exportedName) return null;
+  const importDeclaration = importSpecifier.parent;
+  if (!importDeclaration || !isNodeOfType(importDeclaration, "ImportDeclaration")) return null;
+  const sourceNode = importDeclaration.source;
+  if (!sourceNode || !isNodeOfType(sourceNode, "Literal")) return null;
+  if (typeof sourceNode.value !== "string") return null;
+  return { moduleSpecifier: sourceNode.value, exportedName };
+};
+
+const resolveCrossFileExportWithinBudget = (
+  identifier: EsTreeNodeOfType<"Identifier">,
+): ResolvedCrossFileExport | null => {
+  if (isAnalyzingForeignExport || currentLintedFilename == null) return null;
+  const importReference = resolveImportedExportReference(identifier);
+  if (!importReference) return null;
+  const memoKey = `${importReference.moduleSpecifier}\u0000${importReference.exportedName}`;
+  const memoized = crossFileResolutionMemo.get(memoKey);
+  if (memoized !== undefined) return memoized;
+  if (crossFileResolutionsRemaining <= 0) return null;
+  crossFileResolutionsRemaining -= 1;
+  const resolved = resolveCrossFileExport(
+    currentLintedFilename,
+    importReference.moduleSpecifier,
+    importReference.exportedName,
+  );
+  crossFileResolutionMemo.set(memoKey, resolved);
+  return resolved;
+};
+
+// Runs the trusted-destination machinery against an expression that lives
+// in a FOREIGN module. Bindings inside the foreign file resolve within it
+// (the foreign AST carries parent references); literal trust tightens to
+// same-origin (`isTrustedForeignStaticText`) and further cross-file hops
+// are off.
+const isTrustedForeignExportExpression = (foreignExpression: EsTreeNode): boolean => {
+  const previousScopes = currentScopes;
+  const foreignProgramRoot = findProgramRoot(foreignExpression);
+  currentScopes = foreignProgramRoot ? analyzeScopes(foreignProgramRoot) : undefined;
+  isAnalyzingForeignExport = true;
+  try {
+    const strippedExpression = stripParenExpression(foreignExpression);
+    return isTrustedDestination(strippedExpression, 0);
+  } finally {
+    isAnalyzingForeignExport = false;
+    currentScopes = previousScopes;
+  }
+};
+
+// Content-verified verdict for an imported destination identifier: when
+// the foreign export RESOLVES, the initializer's own analysis decides —
+// in both directions, overriding the name heuristic (a URL-named import
+// verified to hold an external origin flags; an unnamed-pattern import
+// verified same-origin goes quiet). `null` (node_modules, missing file,
+// no filename, budget spent, or a function-kind export) leaves the
+// decision to the existing heuristics.
+const crossFileImportedDestinationVerdict = (
+  identifier: EsTreeNodeOfType<"Identifier">,
+): boolean | null => {
+  const resolvedExport = resolveCrossFileExportWithinBudget(identifier);
+  if (!resolvedExport) return null;
+  if (resolvedExport.kind !== "initializer") return null;
+  return isTrustedForeignExportExpression(resolvedExport.node);
+};
+
+// `get…Url` / `create…Url` / `build…Url` imported helpers: the sync
+// URL-builder naming family worth a cross-file look. `build…` helpers are
+// otherwise opaque (they can compose arbitrary origins from arguments),
+// so verifying that EVERY return is a same-origin-built URL is what turns
+// the dtale `buildCorrelationsUrl` idiom quiet.
+const CROSS_FILE_URL_HELPER_CALLEE_NAME_PATTERN = /^(?:get|create|build)[A-Za-z0-9]*(?:Url|URL)$/;
+
+const crossFileUrlHelperDestinationVerdict = (
+  calleeIdentifier: EsTreeNodeOfType<"Identifier">,
+): boolean | null => {
+  if (!CROSS_FILE_URL_HELPER_CALLEE_NAME_PATTERN.test(calleeIdentifier.name)) return null;
+  const resolvedExport = resolveCrossFileExportWithinBudget(calleeIdentifier);
+  if (!resolvedExport || resolvedExport.kind !== "function") return null;
+  const returnedExpressions = collectLocalFunctionReturnExpressions(resolvedExport.node);
+  if (!returnedExpressions || returnedExpressions.length === 0) return false;
+  return returnedExpressions.every((returnedExpression) =>
+    isTrustedForeignExportExpression(returnedExpression),
+  );
+};
+
+// `getViewUrl`, `getSearchUrl`, `createRelativePlaygroundUrl` — sync
+// getter/factory helpers building the app's own route URLs. `build…`
+// helpers stay opaque: `buildUrl(externalHost, path)` composes arbitrary
+// origins from its arguments.
+const URL_GETTER_CALLEE_NAME_PATTERN = /^(?:get|create)[A-Za-z0-9]*(?:Url|URL)$/;
+const ORIGIN_PRESERVING_STRING_METHOD_NAMES = new Set(["toString", "trim", "trimEnd", "trimStart"]);
+
+const terminalCalleeName = (callee: EsTreeNode): string | null => {
+  if (isNodeOfType(callee, "Identifier")) return callee.name;
+  if (
+    isNodeOfType(callee, "MemberExpression") &&
+    !callee.computed &&
+    isNodeOfType(callee.property, "Identifier")
+  ) {
+    return callee.property.name;
+  }
+  return null;
+};
+
+const localFunctionParameterArgument = (
+  identifier: EsTreeNodeOfType<"Identifier">,
+  functionNode: EsTreeNode,
+  callExpression: EsTreeNodeOfType<"CallExpression">,
+): EsTreeNode | null => {
+  if (!isFunctionLike(functionNode)) return null;
+  if (!bindingIsUnmodifiedBeforeCurrentOpen(identifier)) return null;
+  const symbol = currentScopes?.symbolFor(identifier);
+  const parameterIndex = (functionNode.params ?? []).findIndex(
+    (parameter) =>
+      isNodeOfType(parameter, "Identifier") && currentScopes?.symbolFor(parameter) === symbol,
+  );
+  return parameterIndex >= 0
+    ? ((callExpression.arguments?.[parameterIndex] as EsTreeNode | undefined) ?? null)
+    : null;
+};
+
+const isTrustedLocalFunctionReturn = (
+  returnedExpression: EsTreeNode,
+  functionNode: EsTreeNode,
+  callExpression: EsTreeNodeOfType<"CallExpression">,
+  depth: number,
+): boolean => {
+  const returned = stripParenExpression(returnedExpression);
+  if (isNodeOfType(returned, "Identifier")) {
+    const argument = localFunctionParameterArgument(returned, functionNode, callExpression);
+    if (argument) return isTrustedOrNullishDestination(argument, depth + 1);
+  }
+  if (isNodeOfType(returned, "TemplateLiteral")) {
+    const firstQuasiText = returned.quasis?.[0]?.value?.raw ?? "";
+    const firstExpression = returned.expressions?.[0];
+    if (
+      firstQuasiText.length === 0 &&
+      firstExpression &&
+      isNodeOfType(firstExpression, "Identifier")
+    ) {
+      const argument = localFunctionParameterArgument(
+        firstExpression,
+        functionNode,
+        callExpression,
+      );
+      const followingQuasiText = returned.quasis?.[1]?.value?.raw ?? "";
+      if (
+        argument &&
+        isSafeInterpolatedDestinationSuffix(followingQuasiText) &&
+        (!followingQuasiText.startsWith("/") ||
+          isProvenNonSlashTerminatedDestination(argument, depth + 1))
+      ) {
+        return isTrustedDestination(argument, depth + 1);
+      }
+    }
+  }
+  return isTrustedOrNullishDestination(returned, depth + 1);
+};
+
+const isTrustedLocalFunctionCall = (
+  callExpression: EsTreeNodeOfType<"CallExpression">,
+  depth: number,
+): boolean => {
+  const callee = stripParenExpression(callExpression.callee as EsTreeNode);
+  if (!isNodeOfType(callee, "Identifier")) return false;
+  const localFunction = resolveLocalFunctionNode(callee);
+  const returnedExpressions = localFunction
+    ? collectLocalFunctionReturnExpressions(localFunction)
+    : null;
+  return Boolean(
+    localFunction &&
+    returnedExpressions &&
+    returnedExpressions.length > 0 &&
+    returnedExpressions.every((returnedExpression) =>
+      isTrustedLocalFunctionReturn(returnedExpression, localFunction, callExpression, depth + 1),
+    ),
+  );
+};
+
+const globalNamespaceBindingIsUnmodifiedBefore = (
+  namespaceName: string,
+  referenceNode: EsTreeNode,
+): boolean => {
+  const scopes = currentScopes;
+  const program = findProgramRoot(referenceNode);
+  if (!scopes || !program) return false;
+  const referenceStart = referenceNode.range?.[0] ?? Number.POSITIVE_INFINITY;
+  let offsetsByNamespace = globalNamespaceMutationOffsetsMemo.get(scopes);
+  if (!offsetsByNamespace) {
+    offsetsByNamespace = new Map();
+    globalNamespaceMutationOffsetsMemo.set(scopes, offsetsByNamespace);
+  }
+  const memoizedMutationOffsets = offsetsByNamespace.get(namespaceName);
+  if (memoizedMutationOffsets) {
+    return !memoizedMutationOffsets.some((mutationOffset) => mutationOffset < referenceStart);
+  }
+  const mutationOffsets: number[] = [];
+  const mutationTargetsNamespace = (mutationTarget: EsTreeNode): boolean => {
+    let namespaceCandidate = stripParenExpression(mutationTarget);
+    if (isProvenGlobalNamespaceReference(namespaceCandidate, namespaceName, scopes)) return true;
+    while (isNodeOfType(namespaceCandidate, "MemberExpression")) {
+      namespaceCandidate = stripParenExpression(namespaceCandidate.object);
+    }
+    return isProvenGlobalNamespaceReference(namespaceCandidate, namespaceName, scopes);
+  };
+  walkAst(program, (node: EsTreeNode) => {
+    let mutationTarget: EsTreeNode | null = null;
+    if (isNodeOfType(node, "AssignmentExpression")) mutationTarget = node.left;
+    if (isNodeOfType(node, "UpdateExpression")) mutationTarget = node.argument;
+    if (isNodeOfType(node, "UnaryExpression") && node.operator === "delete") {
+      mutationTarget = node.argument;
+    }
+    if (mutationTarget && mutationTargetsNamespace(mutationTarget)) {
+      mutationOffsets.push(node.range?.[0] ?? Number.NEGATIVE_INFINITY);
+    }
+  });
+  offsetsByNamespace.set(namespaceName, mutationOffsets);
+  return !mutationOffsets.some((mutationOffset) => mutationOffset < referenceStart);
+};
+
+// `URL.createObjectURL(blob)` — a blob: URL of app-generated content; the
+// opened document is same-process content, no opener hazard.
+const isCreateObjectUrlCall = (node: EsTreeNode): boolean =>
+  isNodeOfType(node, "CallExpression") &&
+  isNodeOfType(node.callee, "MemberExpression") &&
+  getStaticPropertyName(node.callee) === "createObjectURL" &&
+  Boolean(
+    currentScopes &&
+    globalNamespaceBindingIsUnmodifiedBefore("URL", node) &&
+    isProvenUnmodifiedGlobalNamespaceReference(
+      node.callee.object,
+      "URL",
+      currentScopes,
+      "createObjectURL",
+    ),
+  );
+
+const URL_ORIGIN_PROPERTY_NAMES = [
+  "href",
+  "host",
+  "hostname",
+  "password",
+  "port",
+  "protocol",
+  "toJSON",
+  "toString",
+  "username",
+];
+
+const hasUrlOriginMutationBefore = (
+  identifier: EsTreeNodeOfType<"Identifier">,
+  referenceNode: EsTreeNode,
+): boolean => {
+  const scopes = currentScopes;
+  if (!scopes) return false;
+  return URL_ORIGIN_PROPERTY_NAMES.some((propertyName) =>
+    hasPossibleStaticPropertyWriteBefore(identifier, propertyName, referenceNode, scopes),
+  );
+};
+
+const isSafeInterpolatedDestinationSuffix = (suffixText: string): boolean => {
+  if (suffixText.length === 0 || suffixText.startsWith("?") || suffixText.startsWith("#")) {
+    return true;
+  }
+  return suffixText.startsWith("/") && suffixText[1] !== "/" && suffixText[1] !== "\\";
+};
+
+const isProvenNonSlashTerminatedDestination = (destination: EsTreeNode, depth: number): boolean => {
+  if (depth > MAX_BINDING_RESOLUTION_DEPTH) return false;
+  const unwrappedDestination = stripParenExpression(destination);
+  if (isStringLiteral(unwrappedDestination)) {
+    return !unwrappedDestination.value.endsWith("/") && !unwrappedDestination.value.endsWith("\\");
+  }
+  if (isSameOriginLocationRead(unwrappedDestination)) return true;
+  if (isNodeOfType(unwrappedDestination, "Identifier")) {
+    const initializer = resolveConstInitializer(unwrappedDestination);
+    return Boolean(initializer && isProvenNonSlashTerminatedDestination(initializer, depth + 1));
+  }
+  if (
+    isNodeOfType(unwrappedDestination, "CallExpression") &&
+    isNodeOfType(unwrappedDestination.callee, "Identifier")
+  ) {
+    const localFunction = resolveLocalFunctionNode(unwrappedDestination.callee);
+    const returnedExpressions = localFunction
+      ? collectLocalFunctionReturnExpressions(localFunction)
+      : null;
+    return Boolean(
+      returnedExpressions &&
+      returnedExpressions.length > 0 &&
+      returnedExpressions.every((returnedExpression) =>
+        isProvenNonSlashTerminatedDestination(returnedExpression, depth + 1),
+      ),
+    );
+  }
+  return false;
+};
+
 const isTrustedDestination = (
   urlArgument: EsTreeNode | null | undefined,
   depth: number,
@@ -129,10 +1664,158 @@ const isTrustedDestination = (
       isTrustedOrNullishDestination(urlArgument.right, depth + 1)
     );
   }
+  // TS assertions (`'https://…' as const`) are transparent.
+  if (
+    urlArgument.type === "TSAsExpression" ||
+    urlArgument.type === "TSSatisfiesExpression" ||
+    urlArgument.type === "TSNonNullExpression"
+  ) {
+    return isTrustedDestination(
+      (urlArgument as { expression?: EsTreeNode }).expression ?? null,
+      depth + 1,
+    );
+  }
+  if (isNodeOfType(urlArgument, "BinaryExpression") && urlArgument.operator === "+") {
+    return isTrustedStaticDestination(leftmostConcatOperand(urlArgument));
+  }
+  if (isCreateObjectUrlCall(urlArgument)) return true;
+  // `shareUrl.toString()` / `shareUrl.href` where shareUrl is a const
+  // `new URL('<trusted>')` builder — searchParams mutation cannot change
+  // the origin.
+  if (
+    isNodeOfType(urlArgument, "CallExpression") &&
+    isNodeOfType(urlArgument.callee, "MemberExpression") &&
+    !urlArgument.callee.computed &&
+    isNodeOfType(urlArgument.callee.property, "Identifier") &&
+    (urlArgument.callee.property.name === "toString" ||
+      urlArgument.callee.property.name === "toJSON")
+  ) {
+    return isTrustedDestination(urlArgument.callee.object as EsTreeNode, depth + 1);
+  }
+  if (isNodeOfType(urlArgument, "NewExpression")) {
+    if (
+      !currentScopes ||
+      !isProvenGlobalNamespaceReference(urlArgument.callee as EsTreeNode, "URL", currentScopes) ||
+      !globalNamespaceBindingIsUnmodifiedBefore("URL", urlArgument)
+    ) {
+      return false;
+    }
+    if (!isTrustedDestination((urlArgument.arguments?.[0] as EsTreeNode) ?? null, depth + 1)) {
+      return false;
+    }
+    // WHATWG URL resolves a relative first argument against the BASE, so
+    // `new URL('/store', externalBase)` navigates to the base's origin —
+    // the base must be as trusted as the path.
+    const baseArgument = urlArgument.arguments?.[1];
+    return baseArgument === undefined
+      ? true
+      : isTrustedDestination(baseArgument as EsTreeNode, depth + 1);
+  }
+  // `EXTERNAL_LINKS.docs` / `item.href` — a member read off a const
+  // object/array config whose relevant values are all trusted literals;
+  // `anchorEl.href` — a DOM round-trip of a trusted JSX href; `urls[0]` —
+  // an index read off a const array of trusted destinations.
+  // Non-terminal: location-shaped member reads are handled below.
+  if (isNodeOfType(urlArgument, "MemberExpression")) {
+    if (!urlArgument.computed && isTrustedConstConfigMember(urlArgument, depth + 1)) return true;
+    if (!urlArgument.computed && isTrustedAnchorParamHrefRead(urlArgument, depth + 1)) return true;
+    if (urlArgument.computed && isTrustedConstArrayIndexRead(urlArgument, depth + 1)) return true;
+  }
   if (isNodeOfType(urlArgument, "Identifier")) {
+    const crossFileVerdict = crossFileImportedDestinationVerdict(urlArgument);
+    if (crossFileVerdict != null) return crossFileVerdict;
     const constInitializer = resolveConstInitializer(urlArgument);
-    if (constInitializer == null) return false;
-    return isTrustedOrNullishDestination(constInitializer, depth + 1);
+    if (constInitializer != null) {
+      if (
+        isNodeOfType(stripParenExpression(constInitializer), "NewExpression") &&
+        hasUrlOriginMutationBefore(urlArgument, urlArgument)
+      ) {
+        return false;
+      }
+      return isTrustedOrNullishDestination(constInitializer, depth + 1);
+    }
+    if (isLetAssignedOnlyTrustedLiterals(urlArgument, depth + 1)) return true;
+    if (isTrustedLocalComponentPropLiteral(urlArgument, depth + 1)) return true;
+    if (isTrustedUseStateUrlBinding(urlArgument, depth + 1)) return true;
+    if (isTrustedLocalWrapperParam(urlArgument, depth + 1)) return true;
+    if (isTrustedDestructuredIterationMember(urlArgument, depth + 1)) return true;
+    return isRouterCoNavigatedIdentifier(urlArgument);
+  }
+  if (isNodeOfType(urlArgument, "ChainExpression")) {
+    return isTrustedDestination(urlArgument.expression as EsTreeNode, depth + 1);
+  }
+  // A template that LEADS with an interpolation is trusted when that
+  // interpolation itself is (`` `${fullPath('/export', id)}?type=csv` `` —
+  // the rest of the template lands in the path/query of the same URL).
+  if (isNodeOfType(urlArgument, "TemplateLiteral")) {
+    const firstQuasiText = (urlArgument.quasis?.[0]?.value?.raw ?? "").trimStart();
+    const firstExpression = urlArgument.expressions?.[0];
+    if (firstQuasiText.length === 0 && firstExpression) {
+      const followingQuasiText = urlArgument.quasis?.[1]?.value?.raw ?? "";
+      return (
+        isSafeInterpolatedDestinationSuffix(followingQuasiText) &&
+        (!followingQuasiText.startsWith("/") ||
+          isProvenNonSlashTerminatedDestination(firstExpression as EsTreeNode, depth + 1)) &&
+        isTrustedDestination(firstExpression as EsTreeNode, depth + 1)
+      );
+    }
+    return false;
+  }
+  // `location.pathname` / `location.origin` / `getLocation().href` reads
+  // are same-origin values by construction (the dtale "open in new tab"
+  // idiom re-opens the current page under a different route).
+  if (isSameOriginLocationRead(urlArgument)) return true;
+  if (isNodeOfType(urlArgument, "CallExpression")) {
+    if (isTrustedLocalFunctionCall(urlArgument, depth + 1)) return true;
+    // A helper NAMED as a path builder (`fullPath(path, dataId)`,
+    // `menuFuncs.fullPath(...)`) returns a same-origin path by its own
+    // contract — a "path" has no origin. A synchronous `get…Url` /
+    // `create…Url` getter called with local data (`getViewUrl(view, id)`,
+    // `getSearchUrl({ service })`) is the app's own route builder;
+    // server-fetched external URLs arrive through `await`ed calls, which
+    // stay opaque (the AwaitExpression is never trusted).
+    const calleeName = terminalCalleeName(urlArgument.callee as EsTreeNode);
+    if (calleeName != null) {
+      if (
+        isNodeOfType(urlArgument.callee, "Identifier") &&
+        URL_GETTER_CALLEE_NAME_PATTERN.test(calleeName)
+      ) {
+        const crossFileVerdict = crossFileUrlHelperDestinationVerdict(urlArgument.callee);
+        if (crossFileVerdict !== null) return crossFileVerdict;
+        return false;
+      }
+    }
+    // `buildCorrelationsUrl(dataId, …)` — an imported URL-builder helper
+    // is opaque by name, but when its module resolves, the call is
+    // trusted if EVERY return the foreign function can produce is a
+    // same-origin-built URL (dtale CorrelationsGrid idiom).
+    if (isNodeOfType(urlArgument.callee, "Identifier")) {
+      const crossFileVerdict = crossFileUrlHelperDestinationVerdict(urlArgument.callee);
+      if (crossFileVerdict !== null) return crossFileVerdict;
+    }
+    // A string method on a trusted same-origin base keeps the leading `/`
+    // (`getLocation().pathname.replace('/iframe/', '/main/')`).
+    const callee = urlArgument.callee as EsTreeNode;
+    if (isNodeOfType(callee, "MemberExpression")) {
+      const methodName = getStaticPropertyName(callee);
+      const replacementArgument = urlArgument.arguments?.[1] as EsTreeNode | undefined;
+      if (
+        methodName === "replace" &&
+        isNodeOfType(callee.object, "MemberExpression") &&
+        getStaticPropertyName(callee.object) === "pathname" &&
+        isLocationShapedReceiver(callee.object.object) &&
+        isStringLiteral(replacementArgument) &&
+        startsSameOriginPath(replacementArgument.value)
+      ) {
+        return true;
+      }
+      return (
+        methodName !== null &&
+        ORIGIN_PRESERVING_STRING_METHOD_NAMES.has(methodName) &&
+        isTrustedDestination(callee.object, depth + 1)
+      );
+    }
+    return false;
   }
   return false;
 };
@@ -141,6 +1824,17 @@ const isTrustedOrNullishDestination = (
   urlExpression: EsTreeNode | null | undefined,
   depth: number,
 ): boolean => isNullishExpression(urlExpression) || isTrustedDestination(urlExpression, depth);
+
+const isTrustedTopLevelDestination = (urlExpression: EsTreeNode | null | undefined): boolean => {
+  if (urlExpression == null) return true;
+  const strippedExpression = stripParenExpression(urlExpression);
+  const memoKey = strippedExpression;
+  const memoizedVerdict = trustedTopLevelDestinationMemo.get(memoKey);
+  if (memoizedVerdict !== undefined) return memoizedVerdict;
+  const verdict = isTrustedOrNullishDestination(urlExpression, 0);
+  trustedTopLevelDestinationMemo.set(memoKey, verdict);
+  return verdict;
+};
 
 // A statically truthy trusted left operand of `||`/`??` short-circuits, so
 // `trustedUrl || dynamicFallback` always opens the trusted destination and
@@ -152,7 +1846,9 @@ const isStaticallyTruthyTrustedDestination = (
   depth: number,
 ): boolean => {
   if (urlExpression == null || depth > MAX_BINDING_RESOLUTION_DEPTH) return false;
-  if (isStringLiteral(urlExpression)) return urlExpression.value.length > 0;
+  if (isStringLiteral(urlExpression)) {
+    return urlExpression.value.length > 0 && isTrustedStaticDestination(urlExpression);
+  }
   if (isNodeOfType(urlExpression, "TemplateLiteral")) {
     const hasStaticText =
       urlExpression.quasis?.some((quasi) => (quasi.value?.raw ?? "").length > 0) ?? false;
@@ -183,8 +1879,9 @@ const resolveStaticStringText = (
   if (isNodeOfType(node, "TemplateLiteral")) {
     const quasiTexts = node.quasis?.map((quasi) => quasi.value?.raw ?? "") ?? [];
     const expressionTexts =
-      node.expressions?.map((expression) => resolveStaticStringText(expression, depth + 1) ?? "") ??
-      [];
+      node.expressions?.map(
+        (expression) => resolveStaticStringText(expression, depth + 1) ?? "\u0000",
+      ) ?? [];
     return quasiTexts
       .map((quasiText, quasiIndex) => quasiText + (expressionTexts[quasiIndex] ?? ""))
       .join("");
@@ -205,24 +1902,158 @@ const resolveStaticStringText = (
 // a callback argument (forEach/map/addEventListener), or a bare
 // statement.
 const EVENT_HANDLER_KEY_PATTERN = /^on[A-Z]/;
+const RETURN_DISCARDING_GLOBAL_CALLBACK_NAMES = new Set([
+  "queueMicrotask",
+  "requestAnimationFrame",
+  "setInterval",
+  "setTimeout",
+]);
+
+const hasBuiltInArrayTypeAnnotation = (identifier: EsTreeNodeOfType<"Identifier">): boolean => {
+  const annotation = identifier.typeAnnotation;
+  if (!annotation || !isNodeOfType(annotation, "TSTypeAnnotation")) return false;
+  const typeNode = annotation.typeAnnotation;
+  if (isNodeOfType(typeNode, "TSArrayType") || isNodeOfType(typeNode, "TSTupleType")) return true;
+  return Boolean(
+    isNodeOfType(typeNode, "TSTypeReference") &&
+    isNodeOfType(typeNode.typeName, "Identifier") &&
+    (typeNode.typeName.name === "Array" || typeNode.typeName.name === "ReadonlyArray"),
+  );
+};
+
+const isProvenBuiltInArrayReceiver = (
+  receiver: EsTreeNodeOfType<"Identifier">,
+  referenceNode: EsTreeNode,
+  scopes: ScopeAnalysis,
+): boolean => {
+  if (!bindingIsUnmodifiedBefore(receiver, referenceNode)) return false;
+  if (hasPossibleStaticPropertyWriteBefore(receiver, "forEach", referenceNode, scopes))
+    return false;
+  const receiverBinding = scopes.symbolFor(receiver)?.bindingIdentifier;
+  if (
+    receiverBinding &&
+    isNodeOfType(receiverBinding, "Identifier") &&
+    hasBuiltInArrayTypeAnnotation(receiverBinding)
+  ) {
+    return true;
+  }
+  const initializer = resolveConstInitializer(receiver);
+  if (!initializer) return false;
+  const unwrappedInitializer = stripParenExpression(initializer);
+  if (isNodeOfType(unwrappedInitializer, "ArrayExpression")) return true;
+  if (
+    isNodeOfType(unwrappedInitializer, "NewExpression") &&
+    isProvenGlobalNamespaceReference(unwrappedInitializer.callee, "Array", scopes) &&
+    globalNamespaceBindingIsUnmodifiedBefore("Array", referenceNode)
+  ) {
+    return true;
+  }
+  if (
+    isNodeOfType(unwrappedInitializer, "CallExpression") &&
+    isNodeOfType(unwrappedInitializer.callee, "MemberExpression") &&
+    (getStaticPropertyName(unwrappedInitializer.callee) === "from" ||
+      getStaticPropertyName(unwrappedInitializer.callee) === "of") &&
+    isProvenUnmodifiedGlobalNamespaceReference(
+      unwrappedInitializer.callee.object,
+      "Array",
+      scopes,
+      getStaticPropertyName(unwrappedInitializer.callee) ?? "",
+    ) &&
+    globalNamespaceBindingIsUnmodifiedBefore("Array", referenceNode)
+  ) {
+    return true;
+  }
+  return false;
+};
+
+const callDiscardsCallbackReturn = (
+  callExpression: EsTreeNodeOfType<"CallExpression">,
+): boolean => {
+  const scopes = currentScopes;
+  if (!scopes) return false;
+  const callee = stripParenExpression(callExpression.callee as EsTreeNode);
+  if (isNodeOfType(callee, "Identifier")) {
+    return (
+      (RETURN_DISCARDING_GLOBAL_CALLBACK_NAMES.has(callee.name) ||
+        callee.name === "addEventListener") &&
+      isProvenGlobalNamespaceReference(callee, callee.name, scopes)
+    );
+  }
+  if (!isNodeOfType(callee, "MemberExpression")) return false;
+  const methodName = getStaticPropertyName(callee);
+  if (
+    methodName === "addEventListener" &&
+    isProvenGlobalNamespaceReference(callee.object, "window", scopes)
+  ) {
+    return true;
+  }
+  if (methodName !== "forEach") return false;
+  const receiver = stripParenExpression(callee.object);
+  if (isNodeOfType(receiver, "ArrayExpression")) return true;
+  if (!isNodeOfType(receiver, "Identifier")) return false;
+  return isProvenBuiltInArrayReceiver(receiver, callExpression, scopes);
+};
 
 const isArrowReturnDiscarded = (arrow: EsTreeNode): boolean => {
   const parent = arrow.parent;
   if (!parent) return false;
-  if (isNodeOfType(parent, "JSXExpressionContainer")) return true;
+  if (isNodeOfType(parent, "JSXExpressionContainer")) {
+    const attribute = parent.parent;
+    const openingElement = attribute?.parent;
+    const elementName =
+      openingElement && isNodeOfType(openingElement, "JSXOpeningElement")
+        ? openingElement.name
+        : null;
+    return Boolean(
+      attribute &&
+      isNodeOfType(attribute, "JSXAttribute") &&
+      EVENT_HANDLER_KEY_PATTERN.test(jsxAttributeName(attribute) ?? "") &&
+      elementName &&
+      elementName.type === "JSXIdentifier" &&
+      /^[a-z]/.test(elementName.name),
+    );
+  }
   if (isNodeOfType(parent, "ExpressionStatement")) return true;
   if (isNodeOfType(parent, "CallExpression")) {
-    return parent.arguments?.some((argument) => argument === arrow) ?? false;
+    if (!(parent.arguments?.some((argument) => argument === arrow) ?? false)) return false;
+    return callDiscardsCallbackReturn(parent);
   }
   if (isNodeOfType(parent, "Property") && parent.value === arrow && !parent.computed) {
-    const handlerKeyName = isNodeOfType(parent.key, "Identifier")
-      ? parent.key.name
-      : isStringLiteral(parent.key)
-        ? parent.key.value
+    const handlerKeyName = getStaticPropertyKeyName(parent);
+    const propsObject = parent.parent;
+    const createElementCall = propsObject?.parent;
+    const createElementCallee =
+      createElementCall && isNodeOfType(createElementCall, "CallExpression")
+        ? stripParenExpression(createElementCall.callee as EsTreeNode)
         : null;
-    return handlerKeyName != null && EVENT_HANDLER_KEY_PATTERN.test(handlerKeyName);
+    const isProvenCreateElementCall = Boolean(
+      createElementCall &&
+      isNodeOfType(createElementCall, "CallExpression") &&
+      currentScopes &&
+      (isReactApiCall(createElementCall, "createElement", currentScopes) ||
+        (createElementCallee &&
+          isNodeOfType(createElementCallee, "MemberExpression") &&
+          getStaticPropertyName(createElementCallee) === "createElement" &&
+          isProvenGlobalNamespaceReference(createElementCallee.object, "React", currentScopes))),
+    );
+    return Boolean(
+      handlerKeyName &&
+      EVENT_HANDLER_KEY_PATTERN.test(handlerKeyName) &&
+      propsObject &&
+      isNodeOfType(propsObject, "ObjectExpression") &&
+      createElementCall &&
+      isNodeOfType(createElementCall, "CallExpression") &&
+      createElementCall.arguments?.[1] === propsObject &&
+      isProvenCreateElementCall,
+    );
   }
   return false;
+};
+
+const isReturnedHandleDiscarded = (returnStatement: EsTreeNode): boolean => {
+  let functionNode = returnStatement.parent ?? null;
+  while (functionNode && !isFunctionLike(functionNode)) functionNode = functionNode.parent ?? null;
+  return functionNode !== null && isArrowReturnDiscarded(functionNode);
 };
 
 // The window handle is discarded (so `noopener`'s null return breaks
@@ -235,25 +2066,29 @@ const isArrowReturnDiscarded = (arrow: EsTreeNode): boolean => {
 // on the result, or being passed as a call argument — means the caller
 // wants the handle, so we stay quiet.
 const isDiscardedWindowHandle = (callNode: EsTreeNode): boolean => {
-  const parent = callNode.parent;
+  const expressionRoot = findTransparentExpressionRoot(callNode);
+  const parent = expressionRoot.parent;
   if (!parent) return false;
   if (isNodeOfType(parent, "ExpressionStatement")) return true;
   if (isNodeOfType(parent, "UnaryExpression") && parent.operator === "void") return true;
   if (isNodeOfType(parent, "AwaitExpression")) return isDiscardedWindowHandle(parent);
-  if (isNodeOfType(parent, "LogicalExpression") && parent.right === callNode) {
+  if (isNodeOfType(parent, "ReturnStatement") && parent.argument === expressionRoot) {
+    return isReturnedHandleDiscarded(parent);
+  }
+  if (isNodeOfType(parent, "LogicalExpression") && parent.right === expressionRoot) {
     return isDiscardedWindowHandle(parent);
   }
   if (
     isNodeOfType(parent, "ConditionalExpression") &&
-    (parent.consequent === callNode || parent.alternate === callNode)
+    (parent.consequent === expressionRoot || parent.alternate === expressionRoot)
   ) {
     return isDiscardedWindowHandle(parent);
   }
   if (isNodeOfType(parent, "SequenceExpression")) {
     const finalExpression = parent.expressions?.[parent.expressions.length - 1];
-    return finalExpression !== callNode || isDiscardedWindowHandle(parent);
+    return finalExpression !== expressionRoot || isDiscardedWindowHandle(parent);
   }
-  if (isNodeOfType(parent, "ArrowFunctionExpression") && parent.body === callNode) {
+  if (isNodeOfType(parent, "ArrowFunctionExpression") && parent.body === expressionRoot) {
     return isArrowReturnDiscarded(parent);
   }
   return false;
@@ -265,33 +2100,67 @@ export const windowOpenWithoutNoopener = defineRule({
   severity: "warn",
   recommendation:
     "Pass `'noopener'` in the third features argument of `window.open` so the opened page can't control your tab through `window.opener` or leak the referrer.",
-  create: (context) => ({
-    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
-      if (!isWindowOpenCallee(node.callee)) return;
-      if (!isDiscardedWindowHandle(node)) return;
+  create: (context) => {
+    currentRuleContext = context;
+    currentWindowOpenCall = undefined;
+    trustedTopLevelDestinationMemo = new WeakMap();
+    symbolHasNonReadReferenceMemo = new WeakMap();
+    localFunctionCallArgumentsMemo = new WeakMap();
+    routerCallsByFunctionMemo = new WeakMap();
+    globalNamespaceMutationOffsetsMemo = new WeakMap();
+    currentLintedFilename =
+      typeof context.filename === "string" && path.isAbsolute(context.filename)
+        ? context.filename
+        : undefined;
+    crossFileResolutionsRemaining = CROSS_FILE_RESOLUTION_BUDGET_PER_FILE;
+    crossFileResolutionMemo.clear();
+    isAnalyzingForeignExport = false;
+    return {
+      CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+        currentScopes = context.scopes;
+        if (!isWindowOpenCallee(node.callee, context.scopes)) return;
+        if (!isDiscardedWindowHandle(node)) return;
+        currentWindowOpenCall = node;
 
-      const urlArgument = node.arguments?.[0];
-      if (isTrustedOrNullishDestination(urlArgument, 0)) return;
+        const urlArgument = node.arguments?.[0];
+        if (isTrustedTopLevelDestination(urlArgument)) return;
 
-      const targetArgument = node.arguments?.[1];
-      if (isStringLiteral(targetArgument) && NAVIGATING_TARGETS.has(targetArgument.value)) return;
+        const targetArgument = node.arguments?.[1];
+        if (isStringLiteral(targetArgument) && NAVIGATING_TARGETS.has(targetArgument.value)) {
+          return;
+        }
 
-      const featuresArgument = node.arguments?.[2];
-      if (featuresArgument != null && !isNullishExpression(featuresArgument)) {
-        const featuresText = resolveStaticStringText(featuresArgument, 0);
-        if (featuresText == null) return;
-        const featureNames = featuresText
-          .toLowerCase()
-          .split(/[\s,]+/)
-          .map((featureEntry) => featureEntry.split("=")[0]);
-        if (featureNames.some((name) => name === "noopener" || name === "noreferrer")) return;
-      }
+        const featuresArgument = node.arguments?.[2];
+        if (featuresArgument != null && !isNullishExpression(featuresArgument)) {
+          const featuresText = resolveStaticStringText(featuresArgument, 0);
+          if (featuresText == null) return;
+          const enabledFeatureNames = featuresText
+            .toLowerCase()
+            .split(/[\s,]+/)
+            .map((featureEntry) => featureEntry.split("="))
+            .filter(
+              ([, featureValue]) =>
+                featureValue === undefined ||
+                featureValue === "yes" ||
+                featureValue === "1" ||
+                featureValue === "true",
+            )
+            .map(([featureName]) => featureName);
+          if (
+            enabledFeatureNames.some(
+              (featureName) => featureName === "noopener" || featureName === "noreferrer",
+            )
+          ) {
+            return;
+          }
+        }
 
-      context.report({
-        node,
-        message:
-          "This `window.open` call leaves the opened page able to redirect your tab via `window.opener`, so pass `'noopener'` in the features argument.",
-      });
-    },
-  }),
+        context.report({
+          node,
+          message:
+            "This `window.open` call leaves the opened page able to redirect your tab via `window.opener`, so pass `'noopener'` in the features argument.",
+        });
+      },
+    };
+  },
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.ts
@@ -83,8 +83,8 @@ const isTrustedStaticDestination = (urlArgument: EsTreeNode | null | undefined):
 
 const MAX_BINDING_RESOLUTION_DEPTH = 4;
 
-// A nullish branch (`cond ? url : null`) is harmless: `window.open(null)`
-// opens about:blank, which the opener fully controls.
+// A nullish URL (`window.open(null)`, `cond ? url : null`) is harmless:
+// it opens about:blank, which the opener fully controls.
 const isNullishExpression = (node: EsTreeNode | null | undefined): boolean => {
   if (node == null) return true;
   if (isNodeOfType(node, "Literal")) return node.value === null;
@@ -124,29 +124,31 @@ const isTrustedDestination = (
   if (urlArgument == null || depth > MAX_BINDING_RESOLUTION_DEPTH) return false;
   if (isNodeOfType(urlArgument, "ConditionalExpression")) {
     return (
-      isTrustedOrNullishBranch(urlArgument.consequent, depth + 1) &&
-      isTrustedOrNullishBranch(urlArgument.alternate, depth + 1)
+      isTrustedOrNullishDestination(urlArgument.consequent, depth + 1) &&
+      isTrustedOrNullishDestination(urlArgument.alternate, depth + 1)
     );
   }
   if (isNodeOfType(urlArgument, "LogicalExpression")) {
     if (urlArgument.operator === "&&") {
-      return isTrustedOrNullishBranch(urlArgument.right, depth + 1);
+      return isTrustedOrNullishDestination(urlArgument.right, depth + 1);
     }
     return (
-      isTrustedOrNullishBranch(urlArgument.left, depth + 1) &&
-      isTrustedOrNullishBranch(urlArgument.right, depth + 1)
+      isTrustedOrNullishDestination(urlArgument.left, depth + 1) &&
+      isTrustedOrNullishDestination(urlArgument.right, depth + 1)
     );
   }
   if (isNodeOfType(urlArgument, "Identifier")) {
     const constInitializer = resolveConstInitializer(urlArgument);
     if (constInitializer == null) return false;
-    return isTrustedDestination(constInitializer, depth + 1);
+    return isTrustedOrNullishDestination(constInitializer, depth + 1);
   }
   return false;
 };
 
-const isTrustedOrNullishBranch = (branch: EsTreeNode | null | undefined, depth: number): boolean =>
-  isNullishExpression(branch) || isTrustedDestination(branch, depth);
+const isTrustedOrNullishDestination = (
+  urlExpression: EsTreeNode | null | undefined,
+  depth: number,
+): boolean => isNullishExpression(urlExpression) || isTrustedDestination(urlExpression, depth);
 
 // Best-effort static text of the features argument: string literals,
 // template literals (interpolations resolved when they are local const
@@ -204,9 +206,9 @@ const isArrowReturnDiscarded = (arrow: EsTreeNode): boolean => {
 };
 
 // The window handle is discarded (so `noopener`'s null return breaks
-// nothing) when the call is a bare statement, the branch of a
-// guard-shaped logical/ternary that is itself discarded, a non-final
-// position in a comma sequence, or the concise
+// nothing) when the call is a bare statement, a `void` operand, the
+// branch of a guard-shaped logical/ternary that is itself discarded, a
+// non-final position in a comma sequence, or the concise
 // body of a discarded arrow. Any capturing parent — VariableDeclarator
 // init, AssignmentExpression right, ReturnStatement arg, a member access
 // on the result, or being passed as a call argument — means the caller
@@ -215,6 +217,7 @@ const isDiscardedWindowHandle = (callNode: EsTreeNode): boolean => {
   const parent = callNode.parent;
   if (!parent) return false;
   if (isNodeOfType(parent, "ExpressionStatement")) return true;
+  if (isNodeOfType(parent, "UnaryExpression") && parent.operator === "void") return true;
   if (isNodeOfType(parent, "LogicalExpression") && parent.right === callNode) {
     return isDiscardedWindowHandle(parent);
   }
@@ -246,7 +249,7 @@ export const windowOpenWithoutNoopener = defineRule({
       if (!isDiscardedWindowHandle(node)) return;
 
       const urlArgument = node.arguments?.[0];
-      if (isTrustedDestination(urlArgument, 0)) return;
+      if (isTrustedOrNullishDestination(urlArgument, 0)) return;
       if (opensProtocolHandlerOnly(urlArgument)) return;
 
       const targetArgument = node.arguments?.[1];

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.ts
@@ -36,20 +36,6 @@ const isStringLiteral = (
 // there is nothing to reverse-tabnab — flagging them is a false positive.
 const NON_BROWSING_URL_SCHEMES = ["mailto:", "tel:", "sms:"];
 
-const getStaticUrlText = (node: EsTreeNode | null | undefined): string | null => {
-  if (isStringLiteral(node)) return node.value;
-  if (node != null && isNodeOfType(node, "TemplateLiteral")) {
-    return node.quasis?.[0]?.value?.raw ?? null;
-  }
-  return null;
-};
-
-const opensProtocolHandlerOnly = (urlArgument: EsTreeNode | null | undefined): boolean => {
-  const urlText = getStaticUrlText(urlArgument)?.trimStart().toLowerCase();
-  if (urlText == null) return false;
-  return NON_BROWSING_URL_SCHEMES.some((scheme) => urlText.startsWith(scheme));
-};
-
 // A fixed `https://host/` prefix pins the origin: the `[/?#]` terminator
 // after the host guarantees any interpolation lands in the path/query,
 // not the host (`` `https://github.com${x}` `` without it could become
@@ -77,6 +63,8 @@ const isTrustedStaticDestination = (urlArgument: EsTreeNode | null | undefined):
   if ((urlArgument.expressions?.length ?? 0) === 0) return true;
   const firstQuasiText = (urlArgument.quasis?.[0]?.value?.raw ?? "").trimStart();
   if (firstQuasiText.length === 0) return false;
+  const loweredQuasiText = firstQuasiText.toLowerCase();
+  if (NON_BROWSING_URL_SCHEMES.some((scheme) => loweredQuasiText.startsWith(scheme))) return true;
   if (COMPLETE_ORIGIN_PATTERN.test(firstQuasiText)) return true;
   return startsSameOriginPath(firstQuasiText);
 };
@@ -130,7 +118,10 @@ const isTrustedDestination = (
   }
   if (isNodeOfType(urlArgument, "LogicalExpression")) {
     if (urlArgument.operator === "&&") {
-      return isTrustedOrNullishDestination(urlArgument.right, depth + 1);
+      return (
+        isNullishExpression(urlArgument.left) ||
+        isTrustedOrNullishDestination(urlArgument.right, depth + 1)
+      );
     }
     return (
       isTrustedOrNullishDestination(urlArgument.left, depth + 1) &&
@@ -252,7 +243,6 @@ export const windowOpenWithoutNoopener = defineRule({
 
       const urlArgument = node.arguments?.[0];
       if (isTrustedOrNullishDestination(urlArgument, 0)) return;
-      if (opensProtocolHandlerOnly(urlArgument)) return;
 
       const targetArgument = node.arguments?.[1];
       if (isStringLiteral(targetArgument) && NAVIGATING_TARGETS.has(targetArgument.value)) return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.ts
@@ -29,6 +29,10 @@ import { resolveCrossFileExport } from "../../utils/resolve-cross-file-export.js
 import type { RuleContext } from "../../utils/rule-context.js";
 
 const NAVIGATING_TARGETS = new Set(["_self", "_top", "_parent"]);
+const GLOBAL_OPEN_RECEIVER_NAMES = ["frames", "globalThis", "parent", "self", "top", "window"];
+const OPAQUE_FEATURE_TEXT = "\u0000";
+const OPENER_PROTECTION_FEATURE_NAMES = new Set(["noopener", "noreferrer"]);
+const ENABLED_FEATURE_VALUES = new Set(["1", "true", "yes"]);
 let currentScopes: ScopeAnalysis | undefined;
 let currentRuleContext: RuleContext | undefined;
 let currentWindowOpenCall: EsTreeNode | undefined;
@@ -92,23 +96,31 @@ const bindingIsUnmodifiedBeforeCurrentOpen = (identifier: EsTreeNode): boolean =
     ),
   );
 
-// Matches `window.open` and `globalThis.window.open` — a non-computed
-// `.open` member off the `window` global. Bare `open(...)` (an
-// `Identifier` callee) and `foo.postMessage`/`webview.open` are not the
-// window global and never match.
+// Matches the browser-global open method through bare/global references
+// and the top, parent, and frames WindowProxy namespaces.
 const isWindowOpenCallee = (callee: EsTreeNode, scopes: ScopeAnalysis): boolean => {
-  const unwrappedCallee = stripParenExpression(callee);
-  if (
-    isNodeOfType(unwrappedCallee, "Identifier") &&
-    isProvenGlobalNamespaceReference(unwrappedCallee, "open", scopes)
-  ) {
-    return true;
-  }
-  return (
-    isNodeOfType(unwrappedCallee, "MemberExpression") &&
-    getStaticPropertyName(unwrappedCallee) === "open" &&
-    isProvenGlobalNamespaceReference(unwrappedCallee.object, "window", scopes)
-  );
+  const isGlobalOpenReference = (candidate: EsTreeNode, depth: number): boolean => {
+    if (depth > MAX_BINDING_RESOLUTION_DEPTH) return false;
+    const unwrappedCandidate = stripParenExpression(candidate);
+    if (isNodeOfType(unwrappedCandidate, "Identifier")) {
+      if (isProvenGlobalNamespaceReference(unwrappedCandidate, "open", scopes)) return true;
+      const initializer = resolveConstInitializer(unwrappedCandidate);
+      if (initializer && isGlobalOpenReference(initializer, depth + 1)) return true;
+      return GLOBAL_OPEN_RECEIVER_NAMES.some(
+        (receiverName) =>
+          destructuredGlobalNamespacePropertyName(unwrappedCandidate, receiverName, scopes) ===
+          "open",
+      );
+    }
+    return (
+      isNodeOfType(unwrappedCandidate, "MemberExpression") &&
+      getStaticPropertyName(unwrappedCandidate) === "open" &&
+      GLOBAL_OPEN_RECEIVER_NAMES.some((receiverName) =>
+        isProvenGlobalNamespaceReference(unwrappedCandidate.object, receiverName, scopes),
+      )
+    );
+  };
+  return isGlobalOpenReference(callee, 0);
 };
 
 const isStringLiteral = (
@@ -2196,7 +2208,7 @@ const isStaticallyTruthyTrustedDestination = (
 
 // Best-effort static text of the features argument: string literals,
 // template literals (interpolations resolved when they are local const
-// strings, empty otherwise so `noopener,width=${w}` still resolves), and
+// strings, marked opaque otherwise so entry boundaries stay visible), and
 // identifiers bound to a local const initializer (`let`/`var` can be
 // reassigned after the initializer, so they stay opaque). Returns
 // null when the value is opaque (imported constant, call result), in
@@ -2211,7 +2223,7 @@ const resolveStaticStringText = (
     const quasiTexts = node.quasis?.map((quasi) => quasi.value?.raw ?? "") ?? [];
     const expressionTexts =
       node.expressions?.map(
-        (expression) => resolveStaticStringText(expression, depth + 1) ?? "\u0000",
+        (expression) => resolveStaticStringText(expression, depth + 1) ?? OPAQUE_FEATURE_TEXT,
       ) ?? [];
     return quasiTexts
       .map((quasiText, quasiIndex) => quasiText + (expressionTexts[quasiIndex] ?? ""))
@@ -2224,6 +2236,24 @@ const resolveStaticStringText = (
   }
   return null;
 };
+
+const isEntirelyOpaqueFeatureText = (featureText: string | undefined): boolean =>
+  featureText != null &&
+  featureText.length > 0 &&
+  [...featureText].every((featureCharacter) => featureCharacter === OPAQUE_FEATURE_TEXT);
+
+const featureEntryMayProtectOpener = (featureEntry: string): boolean => {
+  const [featureName, featureValue] = featureEntry.toLowerCase().split("=");
+  const valueMayEnableFeature =
+    featureValue === undefined ||
+    ENABLED_FEATURE_VALUES.has(featureValue) ||
+    isEntirelyOpaqueFeatureText(featureValue);
+  if (OPENER_PROTECTION_FEATURE_NAMES.has(featureName)) return valueMayEnableFeature;
+  return isEntirelyOpaqueFeatureText(featureName) && valueMayEnableFeature;
+};
+
+const featuresMayProtectOpener = (featuresText: string): boolean =>
+  featuresText.split(/[\s,]+/).some(featureEntryMayProtectOpener);
 
 // The opened handle is captured/used when the arrow that returns it is
 // stored or returned (its eventual return value may be consumed via
@@ -2469,25 +2499,7 @@ export const windowOpenWithoutNoopener = defineRule({
         if (featuresArgument != null && !isNullishExpression(featuresArgument)) {
           const featuresText = resolveStaticStringText(featuresArgument, 0);
           if (featuresText == null) return;
-          const enabledFeatureNames = featuresText
-            .toLowerCase()
-            .split(/[\s,]+/)
-            .map((featureEntry) => featureEntry.split("="))
-            .filter(
-              ([, featureValue]) =>
-                featureValue === undefined ||
-                featureValue === "yes" ||
-                featureValue === "1" ||
-                featureValue === "true",
-            )
-            .map(([featureName]) => featureName);
-          if (
-            enabledFeatureNames.some(
-              (featureName) => featureName === "noopener" || featureName === "noreferrer",
-            )
-          ) {
-            return;
-          }
+          if (featuresMayProtectOpener(featuresText)) return;
         }
 
         context.report({

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.ts
@@ -150,7 +150,8 @@ const isTrustedOrNullishBranch = (branch: EsTreeNode | null | undefined, depth: 
 // Best-effort static text of the features argument: string literals,
 // template literals (interpolations resolved when they are local const
 // strings, empty otherwise so `noopener,width=${w}` still resolves), and
-// identifiers bound to a resolvable initializer in this file. Returns
+// identifiers bound to a local const initializer (`let`/`var` can be
+// reassigned after the initializer, so they stay opaque). Returns
 // null when the value is opaque (imported constant, call result), in
 // which case the caller must not assume noopener is absent.
 const resolveStaticStringText = (
@@ -169,9 +170,9 @@ const resolveStaticStringText = (
       .join("");
   }
   if (isNodeOfType(node, "Identifier")) {
-    const binding = findVariableInitializer(node, node.name);
-    if (binding?.initializer == null) return null;
-    return resolveStaticStringText(binding.initializer, depth + 1);
+    const constInitializer = resolveConstInitializer(node);
+    if (constInitializer == null) return null;
+    return resolveStaticStringText(constInitializer, depth + 1);
   }
   return null;
 };
@@ -203,7 +204,8 @@ const isArrowReturnDiscarded = (arrow: EsTreeNode): boolean => {
 
 // The window handle is discarded (so `noopener`'s null return breaks
 // nothing) when the call is a bare statement, the branch of a
-// guard-shaped logical/ternary that is itself discarded, or the concise
+// guard-shaped logical/ternary that is itself discarded, a non-final
+// position in a comma sequence, or the concise
 // body of a discarded arrow. Any capturing parent — VariableDeclarator
 // init, AssignmentExpression right, ReturnStatement arg, a member access
 // on the result, or being passed as a call argument — means the caller
@@ -220,6 +222,10 @@ const isDiscardedWindowHandle = (callNode: EsTreeNode): boolean => {
     (parent.consequent === callNode || parent.alternate === callNode)
   ) {
     return isDiscardedWindowHandle(parent);
+  }
+  if (isNodeOfType(parent, "SequenceExpression")) {
+    const finalExpression = parent.expressions?.[parent.expressions.length - 1];
+    return finalExpression !== callNode || isDiscardedWindowHandle(parent);
   }
   if (isNodeOfType(parent, "ArrowFunctionExpression") && parent.body === callNode) {
     return isArrowReturnDiscarded(parent);
@@ -249,8 +255,11 @@ export const windowOpenWithoutNoopener = defineRule({
       if (featuresArgument != null) {
         const featuresText = resolveStaticStringText(featuresArgument, 0);
         if (featuresText == null) return;
-        const features = featuresText.toLowerCase();
-        if (features.includes("noopener") || features.includes("noreferrer")) return;
+        const featureNames = featuresText
+          .toLowerCase()
+          .split(/[\s,]+/)
+          .map((featureEntry) => featureEntry.split("=")[0]);
+        if (featureNames.some((name) => name === "noopener" || name === "noreferrer")) return;
       }
 
       context.report({

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/window-open-without-noopener.ts
@@ -169,10 +169,10 @@ const isTrustedStaticDestination = (urlArgument: EsTreeNode | null | undefined):
 // recursion.
 const MAX_BINDING_RESOLUTION_DEPTH = 8;
 
-// `.pathname` values are path strings, which `window.open` resolves against
-// the current origin. `.origin`/`.href` are only same-origin when read off a
-// location-shaped receiver (`location`, `window.location`, `getLocation()`)
-// — an arbitrary `.origin` (e.g. a postMessage event's) is attacker data.
+// `.origin`/`.href` are only same-origin when read off a location-shaped
+// receiver (`location`, `window.location`, `getLocation()`). Bare `.pathname`
+// stays opaque because a value beginning with `//` becomes protocol-relative
+// when passed back to `window.open`.
 const isLocationShapedReceiver = (
   receiver: EsTreeNode,
   visitedFunctionNodes = new Set<EsTreeNode>(),
@@ -1302,6 +1302,22 @@ const leftmostConcatOperand = (node: EsTreeNode): EsTreeNode => {
   return cursor;
 };
 
+const staticTextPinsConcatDestination = (urlText: string): boolean => {
+  const trimmedText = urlText.trimStart();
+  if (trimmedText.length === 0) return false;
+  const loweredText = trimmedText.toLowerCase();
+  if (NON_BROWSING_URL_SCHEMES.some((scheme) => loweredText.startsWith(scheme))) return true;
+  if (!isAnalyzingForeignExport && COMPLETE_ORIGIN_PATTERN.test(trimmedText)) return true;
+  return startsUnambiguouslySameOriginTemplatePath(trimmedText);
+};
+
+const isTrustedConcatPrefix = (node: EsTreeNode): boolean => {
+  if (isStringLiteral(node)) return staticTextPinsConcatDestination(node.value);
+  if (!isNodeOfType(node, "TemplateLiteral")) return false;
+  if ((node.expressions?.length ?? 0) > 0) return isTrustedStaticDestination(node);
+  return staticTextPinsConcatDestination(node.quasis?.[0]?.value?.raw ?? "");
+};
+
 // Cross-file resolutions per linted file are capped: oxc-resolver +
 // re-parsing foreign modules is filesystem work, and a file rarely opens
 // more than a couple of imported destinations.
@@ -1602,6 +1618,21 @@ const hasUrlOriginMutationBefore = (
   );
 };
 
+const isTrustedUrlInstanceHrefRead = (
+  memberNode: EsTreeNodeOfType<"MemberExpression">,
+  depth: number,
+): boolean => {
+  if (memberNode.computed || getStaticPropertyName(memberNode) !== "href") return false;
+  const receiver = stripParenExpression(memberNode.object);
+  if (!isNodeOfType(receiver, "Identifier")) return false;
+  const initializer = resolveConstInitializer(receiver);
+  if (!initializer || !isNodeOfType(stripParenExpression(initializer), "NewExpression")) {
+    return false;
+  }
+  if (hasUrlOriginMutationBefore(receiver, memberNode)) return false;
+  return isTrustedDestination(initializer, depth + 1);
+};
+
 const isSafeInterpolatedDestinationSuffix = (suffixText: string): boolean => {
   if (suffixText.length === 0 || suffixText.startsWith("?") || suffixText.startsWith("#")) {
     return true;
@@ -1676,7 +1707,7 @@ const isTrustedDestination = (
     );
   }
   if (isNodeOfType(urlArgument, "BinaryExpression") && urlArgument.operator === "+") {
-    return isTrustedStaticDestination(leftmostConcatOperand(urlArgument));
+    return isTrustedConcatPrefix(leftmostConcatOperand(urlArgument));
   }
   if (isCreateObjectUrlCall(urlArgument)) return true;
   // `shareUrl.toString()` / `shareUrl.href` where shareUrl is a const
@@ -1717,6 +1748,7 @@ const isTrustedDestination = (
   // an index read off a const array of trusted destinations.
   // Non-terminal: location-shaped member reads are handled below.
   if (isNodeOfType(urlArgument, "MemberExpression")) {
+    if (!urlArgument.computed && isTrustedUrlInstanceHrefRead(urlArgument, depth + 1)) return true;
     if (!urlArgument.computed && isTrustedConstConfigMember(urlArgument, depth + 1)) return true;
     if (!urlArgument.computed && isTrustedAnchorParamHrefRead(urlArgument, depth + 1)) return true;
     if (urlArgument.computed && isTrustedConstArrayIndexRead(urlArgument, depth + 1)) return true;
@@ -1761,9 +1793,9 @@ const isTrustedDestination = (
     }
     return false;
   }
-  // `location.pathname` / `location.origin` / `getLocation().href` reads
-  // are same-origin values by construction (the dtale "open in new tab"
-  // idiom re-opens the current page under a different route).
+  // `location.origin` / `getLocation().href` reads are same-origin values by
+  // construction. Bare pathname reads stay opaque because `//host` is a valid
+  // pathname shape and becomes a protocol-relative destination when reopened.
   if (isSameOriginLocationRead(urlArgument)) return true;
   if (isNodeOfType(urlArgument, "CallExpression")) {
     if (isTrustedLocalFunctionCall(urlArgument, depth + 1)) return true;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-fetch-in-effect.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-fetch-in-effect.ts
@@ -8,6 +8,7 @@ import { getEffectCallback } from "../../utils/get-effect-callback.js";
 import { getRangeStart } from "../../utils/get-range-start.js";
 import { getStaticPropertyKeyName } from "../../utils/get-static-property-key-name.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
+import { isAstDescendant } from "../../utils/is-ast-descendant.js";
 import { isReactApiCall } from "../../utils/is-react-api-call.js";
 import { isSetterCall } from "../../utils/is-setter-call.js";
 import { resolveExpressionKey } from "../../utils/resolve-expression-key.js";
@@ -406,15 +407,6 @@ const isCompletionSinkGuardedByCancellationFlag = (
   isCompletionSinkInsideCancellationGuard(completionSink, cancellationFlagKey, context) ||
   isCompletionSinkAfterCancellationEarlyExit(completionSink, cancellationFlagKey, context);
 
-const isDescendantOf = (node: EsTreeNode, ancestor: EsTreeNode): boolean => {
-  let currentNode: EsTreeNode | null | undefined = node;
-  while (currentNode) {
-    if (currentNode === ancestor) return true;
-    currentNode = currentNode.parent ?? null;
-  }
-  return false;
-};
-
 const isPromiseContinuationForRequest = (
   functionNode: EsTreeNode,
   request: EsTreeNode,
@@ -430,7 +422,7 @@ const isPromiseContinuationForRequest = (
   ) {
     return false;
   }
-  return isDescendantOf(request, callNode.callee.object);
+  return isAstDescendant(request, callNode.callee.object);
 };
 
 const isAwaitedInFunction = (request: EsTreeNode, functionNode: EsTreeNode): boolean => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/semantic/control-flow-graph.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/semantic/control-flow-graph.test.ts
@@ -102,6 +102,48 @@ describe("control-flow-graph", () => {
       ).toBe(true);
     });
 
+    it.each([
+      "while (true)",
+      "while (1)",
+      'while ("run")',
+      "while (1n)",
+      "while (!false)",
+      "for (;;)",
+    ])("%s enters its body before a reachable break", (loopHeader) => {
+      const analysis = analyze(`
+          function fn() {
+            ${loopHeader} {
+              beforeBreak();
+              break;
+            }
+            afterLoop();
+          }
+        `);
+      expect(
+        analysis.isUnconditionalFromEntry(findCalleeNode(analysis.program, "beforeBreak")!),
+      ).toBe(true);
+      expect(
+        analysis.isUnconditionalFromEntry(findCalleeNode(analysis.program, "afterLoop")!),
+      ).toBe(true);
+    });
+
+    it.each(["while (false)", "while (0)", 'while ("")'])("%s can skip its body", (loopHeader) => {
+      const analysis = analyze(`
+          function fn() {
+            ${loopHeader} {
+              inLoop();
+            }
+            afterLoop();
+          }
+        `);
+      expect(analysis.isUnconditionalFromEntry(findCalleeNode(analysis.program, "inLoop")!)).toBe(
+        false,
+      );
+      expect(
+        analysis.isUnconditionalFromEntry(findCalleeNode(analysis.program, "afterLoop")!),
+      ).toBe(true);
+    });
+
     it("for loop body is conditional", () => {
       const analysis = analyze(`
         function fn() {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/semantic/control-flow-graph.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/semantic/control-flow-graph.ts
@@ -135,6 +135,18 @@ const hasInternalControlFlow = (node: EsTreeNode): boolean => {
   }
 };
 
+const getStaticBooleanValue = (expression: EsTreeNode): boolean | null => {
+  if (isNodeOfType(expression, "Literal")) return Boolean(expression.value);
+  if (isNodeOfType(expression, "UnaryExpression") && expression.operator === "!") {
+    const argumentValue = getStaticBooleanValue(expression.argument);
+    return argumentValue === null ? null : !argumentValue;
+  }
+  return null;
+};
+
+const isStaticallyTrueLoopTest = (test: EsTreeNode | null): boolean =>
+  test === null || getStaticBooleanValue(test) === true;
+
 const findLabel = (
   builder: CfgBuilder,
   name: string | null,
@@ -280,6 +292,7 @@ const buildStatement = (
 
   if (isNodeOfType(statement, "WhileStatement") || isNodeOfType(statement, "DoWhileStatement")) {
     const isDoWhile = isNodeOfType(statement, "DoWhileStatement");
+    const hasStaticallyTrueTest = isStaticallyTrueLoopTest(statement.test);
     mapDescendantsToBlock(builder, statement.test as EsTreeNode, current);
     const header = createBlock(builder);
     const body = createBlock(builder);
@@ -289,8 +302,8 @@ const buildStatement = (
       addEdge(current, body, "uncond");
     } else {
       addEdge(current, header, "uncond");
-      addEdge(header, body, "cond");
-      addEdge(header, merge, "cond");
+      addEdge(header, body, hasStaticallyTrueTest ? "uncond" : "cond");
+      if (!hasStaticallyTrueTest) addEdge(header, merge, "cond");
     }
     builder.loopStack.push({ header, merge, label: null });
     const bodyEnd = buildStatement(builder, statement.body as EsTreeNode, body);
@@ -298,8 +311,8 @@ const buildStatement = (
     if (isDoWhile) {
       // After body, test is evaluated → loop back or merge.
       addEdge(bodyEnd, header, "uncond");
-      addEdge(header, body, "cond");
-      addEdge(header, merge, "cond");
+      addEdge(header, body, hasStaticallyTrueTest ? "uncond" : "cond");
+      if (!hasStaticallyTrueTest) addEdge(header, merge, "cond");
     } else {
       addEdge(bodyEnd, header, "uncond");
     }
@@ -312,9 +325,10 @@ const buildStatement = (
     const header = createBlock(builder);
     const body = createBlock(builder);
     const merge = createBlock(builder);
+    const hasStaticallyTrueTest = isStaticallyTrueLoopTest(statement.test ?? null);
     addEdge(current, header, "uncond");
-    addEdge(header, body, "cond");
-    addEdge(header, merge, "cond");
+    addEdge(header, body, hasStaticallyTrueTest ? "uncond" : "cond");
+    if (!hasStaticallyTrueTest) addEdge(header, merge, "cond");
     builder.loopStack.push({ header, merge, label: null });
     const bodyEnd = buildStatement(builder, statement.body as EsTreeNode, body);
     builder.loopStack.pop();

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/attach-parent-references.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/attach-parent-references.ts
@@ -1,6 +1,13 @@
 import type { EsTreeNode } from "./es-tree-node.js";
 import { isAstNode } from "./is-ast-node.js";
 
+interface WritableAstNode {
+  parent?: EsTreeNode | null;
+  range?: [number, number];
+  start?: number;
+  end?: number;
+}
+
 // Walks the AST setting each child's `.parent` to its owning parent
 // node. oxlint already attaches parents before invoking JS plugins
 // for the file being linted, but cross-file parsing (used by rules
@@ -8,12 +15,20 @@ import { isAstNode } from "./is-ast-node.js";
 // `oxc-parser` directly, which emits an unparented AST. Our rules
 // rely on `node.parent` for ancestor-walking, so we re-attach here.
 //
-// Also used by the test harness for the same reason — fixture
-// parsing bypasses oxlint.
+// The direct parser exposes `start` / `end` instead of the ESTree `range`
+// consumed by semantic utilities, so normalize that shape while walking.
+// Also used by the test harness because fixture parsing bypasses oxlint.
 export const attachParentReferences = (root: EsTreeNode): void => {
   const visit = (node: EsTreeNode, parent: EsTreeNode | null): void => {
-    const writableNode = node as unknown as { parent?: EsTreeNode | null };
+    const writableNode = node as unknown as WritableAstNode;
     writableNode.parent = parent;
+    if (
+      writableNode.range == null &&
+      typeof writableNode.start === "number" &&
+      typeof writableNode.end === "number"
+    ) {
+      writableNode.range = [writableNode.start, writableNode.end];
+    }
     const nodeRecord = node as unknown as Record<string, unknown>;
     for (const key of Object.keys(nodeRecord)) {
       if (key === "parent") continue;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/capability.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/capability.ts
@@ -36,6 +36,7 @@ export type Capability =
   | "client-only"
   | "nextjs:static-export"
   | "nextjs:15"
+  | "nextjs:16"
   | "tailwind"
   | "tailwind:3.4"
   | "zod"

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/executes-during-render.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/executes-during-render.ts
@@ -1,10 +1,12 @@
 import type { ScopeAnalysis } from "../semantic/scope-analysis.js";
 import { findDeclaratorForBinding } from "./find-declarator-for-binding.js";
 import { findVariableInitializer } from "./find-variable-initializer.js";
+import { hasStaticPropertyWriteBefore } from "./has-static-property-write-before.js";
 import type { EsTreeNode } from "./es-tree-node.js";
 import { isHookCall } from "./is-hook-call.js";
 import { isNodeOfType } from "./is-node-of-type.js";
 import { isReactApiCall } from "./is-react-api-call.js";
+import { resolveConstIdentifierAlias } from "./resolve-const-identifier-alias.js";
 import { stripParenExpression } from "./strip-paren-expression.js";
 
 // Array iteration methods that invoke their callback synchronously — the
@@ -28,6 +30,10 @@ const SYNCHRONOUS_ITERATION_METHOD_NAMES = new Set([
 ]);
 
 const REACT_RENDER_PHASE_HOOK_NAMES = new Set(["useMemo", "useState"]);
+
+export interface ExecutesDuringRenderOptions {
+  requireProvenSynchronousCallbackReceiver?: boolean;
+}
 
 const isGlobalArrayFromMember = (node: EsTreeNode, scopes: ScopeAnalysis): boolean => {
   const unwrappedNode = stripParenExpression(node);
@@ -61,13 +67,68 @@ const isConstAliasOfGlobalArrayFrom = (node: EsTreeNode, scopes: ScopeAnalysis):
   );
 };
 
+const isGlobalArrayConstructor = (
+  node: EsTreeNode,
+  scopes: ScopeAnalysis,
+  visitedSymbolIds: Set<number> = new Set(),
+): boolean => {
+  const unwrappedNode = stripParenExpression(node);
+  if (!isNodeOfType(unwrappedNode, "Identifier")) return false;
+  if (unwrappedNode.name === "Array" && scopes.isGlobalReference(unwrappedNode)) return true;
+  const symbol = scopes.symbolFor(unwrappedNode);
+  if (symbol?.kind !== "const" || !symbol.initializer || visitedSymbolIds.has(symbol.id)) {
+    return false;
+  }
+  visitedSymbolIds.add(symbol.id);
+  return isGlobalArrayConstructor(symbol.initializer, scopes, visitedSymbolIds);
+};
+
+const isProvenArrayReceiver = (
+  node: EsTreeNode,
+  scopes: ScopeAnalysis,
+  referenceNode: EsTreeNode,
+  methodName: string,
+): boolean => {
+  const receiver = stripParenExpression(node);
+  if (isNodeOfType(receiver, "ArrayExpression")) return true;
+  if (isNodeOfType(receiver, "Identifier")) {
+    const symbol = resolveConstIdentifierAlias(receiver, scopes);
+    return Boolean(
+      symbol?.kind === "const" &&
+      symbol.initializer &&
+      !hasStaticPropertyWriteBefore(receiver, methodName, referenceNode, scopes) &&
+      isProvenArrayReceiver(symbol.initializer, scopes, referenceNode, methodName),
+    );
+  }
+  if (isNodeOfType(receiver, "NewExpression")) {
+    return isGlobalArrayConstructor(receiver.callee, scopes);
+  }
+  if (!isNodeOfType(receiver, "CallExpression")) return false;
+  const callee = stripParenExpression(receiver.callee);
+  if (isGlobalArrayConstructor(callee, scopes)) return true;
+  if (!isNodeOfType(callee, "MemberExpression")) return false;
+  const arrayIdentifier = stripParenExpression(callee.object);
+  return Boolean(
+    isNodeOfType(arrayIdentifier, "Identifier") &&
+    arrayIdentifier.name === "Array" &&
+    scopes.isGlobalReference(arrayIdentifier) &&
+    !callee.computed &&
+    isNodeOfType(callee.property, "Identifier") &&
+    (callee.property.name === "from" || callee.property.name === "of"),
+  );
+};
+
 // A nested function usually runs on a user event, not during the render
 // pass — but four shapes DO execute while rendering: an immediately
 // invoked function (`{(() => new Date().toLocaleString())()}`), a
 // useMemo factory (`{useMemo(() => Date.now(), [])}`), and a synchronous
 // iteration callback (`{rows.map((row) => …)}`), or a global Promise
 // constructor executor (`new Promise((resolve) => resolve())`).
-export const executesDuringRender = (functionNode: EsTreeNode, scopes?: ScopeAnalysis): boolean => {
+export const executesDuringRender = (
+  functionNode: EsTreeNode,
+  scopes?: ScopeAnalysis,
+  options: ExecutesDuringRenderOptions = {},
+): boolean => {
   const parent = functionNode.parent;
   if (isNodeOfType(parent, "NewExpression")) {
     const callee = stripParenExpression(parent.callee);
@@ -100,6 +161,11 @@ export const executesDuringRender = (functionNode: EsTreeNode, scopes?: ScopeAna
     !parent.callee.computed &&
     isNodeOfType(parent.callee.property, "Identifier") &&
     SYNCHRONOUS_ITERATION_METHOD_NAMES.has(parent.callee.property.name) &&
-    parent.arguments?.[0] === functionNode
+    parent.arguments?.[0] === functionNode &&
+    (!options.requireProvenSynchronousCallbackReceiver ||
+      Boolean(
+        scopes &&
+        isProvenArrayReceiver(parent.callee.object, scopes, parent, parent.callee.property.name),
+      ))
   );
 };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/find-visible-symbol.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/find-visible-symbol.ts
@@ -1,0 +1,19 @@
+import type { ScopeAnalysis, SymbolDescriptor } from "../semantic/scope-analysis.js";
+import type { EsTreeNode } from "./es-tree-node.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+
+export const findVisibleSymbol = (
+  identifier: EsTreeNode,
+  scopes: ScopeAnalysis,
+): SymbolDescriptor | null => {
+  const referenceSymbol = scopes.symbolFor(identifier);
+  if (referenceSymbol) return referenceSymbol;
+  if (!isNodeOfType(identifier, "Identifier")) return null;
+  let scope = scopes.scopeFor(identifier);
+  while (true) {
+    const symbol = scope.symbolsByName.get(identifier.name);
+    if (symbol) return symbol;
+    if (!scope.parent) return null;
+    scope = scope.parent;
+  }
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-execution-reference-offset.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-execution-reference-offset.test.ts
@@ -1,0 +1,26 @@
+import { expect, it } from "vite-plus/test";
+import type { EsTreeNode } from "./es-tree-node.js";
+import { getExecutionReferenceOffset } from "./get-execution-reference-offset.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+import { parseSourceText } from "./parse-source-file.js";
+import { walkAst } from "./walk-ast.js";
+
+it("uses normalized starts for nodes and the normalized end for a Program", () => {
+  const sourceText = "const destination = source;";
+  const program = parseSourceText({ filename: "/tmp/reference.ts", sourceText });
+  expect(program).not.toBeNull();
+  if (!program) return;
+
+  let sourceIdentifier: EsTreeNode | null = null;
+  walkAst(program, (node) => {
+    if (isNodeOfType(node, "Identifier") && node.name === "source") {
+      sourceIdentifier = node;
+    }
+  });
+
+  expect(program.range).toEqual([0, sourceText.length]);
+  expect(sourceIdentifier).not.toBeNull();
+  if (!sourceIdentifier) return;
+  expect(getExecutionReferenceOffset(sourceIdentifier)).toBe(sourceText.indexOf("source"));
+  expect(getExecutionReferenceOffset(program)).toBe(sourceText.length);
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-execution-reference-offset.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-execution-reference-offset.ts
@@ -1,0 +1,5 @@
+import type { EsTreeNode } from "./es-tree-node.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+
+export const getExecutionReferenceOffset = (referenceNode: EsTreeNode): number =>
+  isNodeOfType(referenceNode, "Program") ? referenceNode.range[1] : referenceNode.range[0];

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/has-static-property-write-before.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/has-static-property-write-before.ts
@@ -1,6 +1,7 @@
 import type { ScopeAnalysis, SymbolDescriptor } from "../semantic/scope-analysis.js";
 import type { EsTreeNode } from "./es-tree-node.js";
 import { findEnclosingFunction } from "./find-enclosing-function.js";
+import { getExecutionReferenceOffset } from "./get-execution-reference-offset.js";
 import { findProgramRoot } from "./find-program-root.js";
 import { findTransparentExpressionRoot } from "./find-transparent-expression-root.js";
 import { getStaticPropertyName } from "./get-static-property-name.js";
@@ -290,7 +291,7 @@ export const getFunctionSynchronousInvocationPathsBefore = (
       return [];
     }
     if (callBoundary === referenceBoundary) {
-      return call.range[0] < referenceNode.range[0] ? [[call.range[0]]] : [];
+      return call.range[0] < getExecutionReferenceOffset(referenceNode) ? [[call.range[0]]] : [];
     }
     if (!isFunctionLike(callBoundary)) return [];
     return getFunctionSynchronousInvocationPathsBefore(
@@ -377,7 +378,7 @@ const symbolHasStaticPropertyWriteBefore = (
       return false;
     }
     if (writeBoundary === referenceBoundary) {
-      return writeTarget.range[0] < referenceNode.range[0];
+      return writeTarget.range[0] < getExecutionReferenceOffset(referenceNode);
     }
     return (
       isFunctionLike(writeBoundary) &&
@@ -421,7 +422,7 @@ const canExecuteBefore = (
   const referenceBoundary = findExecutionBoundary(referenceNode);
   if (!candidateBoundary || !referenceBoundary) return true;
   if (candidateBoundary === referenceBoundary) {
-    return candidateNode.range[0] < referenceNode.range[0];
+    return candidateNode.range[0] < getExecutionReferenceOffset(referenceNode);
   }
   if (!isFunctionLike(candidateBoundary)) return true;
   return isFunctionSynchronouslyInvokedBefore(candidateBoundary, referenceNode, scopes);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/has-symbol-write-before.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/has-symbol-write-before.ts
@@ -1,6 +1,7 @@
 import type { ScopeAnalysis, SymbolDescriptor } from "../semantic/scope-analysis.js";
 import type { EsTreeNode } from "./es-tree-node.js";
 import { findEnclosingFunction } from "./find-enclosing-function.js";
+import { getExecutionReferenceOffset } from "./get-execution-reference-offset.js";
 import {
   getFunctionSynchronousInvocationPathsBefore,
   isNodeOnUnconditionalPath,
@@ -21,7 +22,7 @@ export const getSymbolWriteExecutionPathsBefore = (
   const referenceFunction = findEnclosingFunction(referenceNode);
   if (writeFunction === referenceFunction) {
     if (
-      writeIdentifier.range[0] >= referenceNode.range[0] ||
+      writeIdentifier.range[0] >= getExecutionReferenceOffset(referenceNode) ||
       (options.requireSynchronousWrite &&
         (!writeFunction ||
           !isNodeOnUnconditionalPath(writeIdentifier, writeFunction) ||

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/symbol-has-react-component-type-annotation.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/symbol-has-react-component-type-annotation.ts
@@ -1,5 +1,6 @@
 import type { ScopeAnalysis, SymbolDescriptor } from "../semantic/scope-analysis.js";
 import type { EsTreeNode } from "./es-tree-node.js";
+import { findVisibleSymbol } from "./find-visible-symbol.js";
 import { getImportedName } from "./get-imported-name.js";
 import { isImportedFromReact } from "./is-react-api-call.js";
 import { isNodeOfType } from "./is-node-of-type.js";
@@ -10,20 +11,6 @@ const REACT_COMPONENT_TYPE_NAMES: ReadonlySet<string> = new Set([
   "FC",
   "FunctionComponent",
 ]);
-
-const findVisibleSymbol = (
-  identifier: EsTreeNode,
-  scopes: ScopeAnalysis,
-): SymbolDescriptor | null => {
-  if (!isNodeOfType(identifier, "Identifier")) return null;
-  let scope = scopes.scopeFor(identifier);
-  while (true) {
-    const symbol = scope.symbolsByName.get(identifier.name);
-    if (symbol) return symbol;
-    if (!scope.parent) return null;
-    scope = scope.parent;
-  }
-};
 
 const isReactNamespaceType = (identifier: EsTreeNode, scopes: ScopeAnalysis): boolean => {
   const symbol = findVisibleSymbol(identifier, scopes);


### PR DESCRIPTION
## Why

Catches popup navigations that can expose the originating tab through `window.opener`.

Opening an untrusted destination in a new browsing context without `noopener` lets the destination navigate or inspect the opener. The rule follows local URL provenance while staying quiet when the destination or callback contract is proven safe.

Before:

```tsx
window.open(destination, "_blank");
```

After:

```tsx
window.open(destination, "_blank", "noopener");
```

## What changed

- Added `window-open-without-noopener` to the security rule set and cross-file dependency registry.
- Detects discarded global `open`/`window.open` handles without an enabled `noopener` feature.
- Proves trusted literals, same-origin URL construction, blob URLs, authoritative anchor/config values, local wrappers, and exact Next.js router co-navigation.
- Rejects mutable, shadowed, unresolved, transitive, unreachable, or ambiguous safety proofs.
- Adds adversarial unit, performance, liveness, cross-file, and fuzz regression coverage.

## Eval results

| Check                 | Result                                                                                                                       |
| --------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
| Repos scanned         | `12` distinct repositories                                                                                                   |
| RootDir scans         | `99` completed entries; the known `excalidraw/packages/excalidraw` whole-registry outlier was bounded and terminated         |
| Target rule           | `window-open-without-noopener`                                                                                               |
| Diagnostics           | `0`                                                                                                                          |
| False positives found | `0`                                                                                                                          |
| Output artifact       | `react-doctor-evals/.evals/-var-folders-…-tmp-eRJCz8noeU-react-doctor.jsonl`; target digest reported 0 diagnostics / 0 repos |

## Test plan

- `pnpm exec vp test run src/plugin/rules/security/window-open-without-noopener.test.ts src/plugin/rules/security/window-open-without-noopener.performance.test.ts` — 177 passed
- `FUZZ_RULE=window-open-without-noopener FUZZ_ITERATIONS=1000 FUZZ_INVARIANTS=1 pnpm --filter @react-doctor/fuzz fuzz` — passed
- `pnpm --filter oxlint-plugin-react-doctor test` — 640 files passed, 18,196 passed / 188 skipped
- `pnpm --filter @react-doctor/fuzz test` — 91 passed / 458 skipped
- `pnpm typecheck` — 15/15 tasks passed
- `pnpm lint` and `pnpm format:check` — passed (existing corpus warnings only)
- `pnpm build` and `pnpm smoke:json-report` — passed

Changeset: `.changeset/rd-new-rules-security.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New cross-file security and large control-flow Next.js rules can affect scan performance and diagnostic noise; behavior is heavily tested but edge-case FPs/FNs remain possible on real codebases.
> 
> **Overview**
> Adds two lint rules and wires them through capabilities, the rule registry, cross-file cache classification, fuzz corpora, and changesets.
> 
> **`nextjs-async-dynamic-api-not-awaited`** (gated on `nextjs:15`) flags synchronous use of async `next/headers` APIs and official route `params` / `searchParams` (plus Next.js 16 metadata `id` when `nextjs:16` is present). It tracks promise provenance through aliases, control flow, and callbacks while honoring official `UnsafeUnwrapped*` casts on 15 and treating `await`, `use()`, and promise settlement as safe unwrapping.
> 
> **`window-open-without-noopener`** warns when `window.open` (including global aliases) opens a destination without an enabled `noopener`/`noreferrer` feature, using URL provenance and cross-file resolution; it is registered as an **unbounded** cross-file rule so the lint cache always re-runs it.
> 
> Project capabilities now emit **`nextjs:16`** for Next.js 16+. Small shared refactors add `PROMISE_SETTLE_METHODS` and replace local `isDescendantOf` helpers with **`isAstDescendant`** in a couple of correctness rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63ba70eec8f79fb7a6c27f9e33e905a0668a4886. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->