### PR TITLE
fix(rule): preserve effect cleanup ownership

### DIFF
--- a/.changeset/hip-knives-knock.md
+++ b/.changeset/hip-knives-knock.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Fix effect-needs-cleanup cleanup ownership for matched listener capture projections, one-shot timers with stable unmount ownership, and separately guarded timer releases.

--- a/packages/fuzz/corpus/regressions/effect-needs-cleanup--computed-listener-capture.tsx
+++ b/packages/fuzz/corpus/regressions/effect-needs-cleanup--computed-listener-capture.tsx
@@ -1,0 +1,28 @@
+// rule: effect-needs-cleanup
+// weakness: control-flow
+// source: ASAP_FIX ReactTooltip fix-react-reacttooltip-react-too__PdQZ9Sz
+
+import { useEffect } from "react";
+
+export const ComputedCaptureListeners = () => {
+  useEffect(() => {
+    const element = document.body;
+    const listener = () => {};
+    const enabledEvents = [
+      { event: "focus", listener },
+      { event: "blur", listener },
+    ];
+
+    enabledEvents.forEach(({ event, listener: eventListener }) => {
+      element.addEventListener(event, eventListener, event === "focus" || event === "blur");
+    });
+
+    return () => {
+      enabledEvents.forEach(({ event, listener: eventListener }) => {
+        element.removeEventListener(event, eventListener, event === "focus" || event === "blur");
+      });
+    };
+  }, []);
+
+  return null;
+};

--- a/packages/fuzz/corpus/regressions/effect-needs-cleanup--defaulted-listener-capture.tsx
+++ b/packages/fuzz/corpus/regressions/effect-needs-cleanup--defaulted-listener-capture.tsx
@@ -1,0 +1,31 @@
+// rule: effect-needs-cleanup
+// weakness: wrapper-transparency
+// source: ASAP_FIX ReactTooltip fix-react-reacttooltip-react-too__iXxrTMb
+
+import { useEffect } from "react";
+
+interface DefaultedCaptureListener {
+  event: string;
+  listener: EventListener;
+  capture?: boolean;
+}
+
+export const DefaultedCaptureListeners = () => {
+  useEffect(() => {
+    const element = document.body;
+    const listener = () => {};
+    const enabledEvents: DefaultedCaptureListener[] = [{ event: "focus", listener, capture: true }];
+
+    enabledEvents.forEach(({ event, listener: eventListener, capture = false }) => {
+      element.addEventListener(event, eventListener, capture);
+    });
+
+    return () => {
+      enabledEvents.forEach(({ event, listener: eventListener, capture = false }) => {
+        element.removeEventListener(event, eventListener, capture);
+      });
+    };
+  }, []);
+
+  return null;
+};

--- a/packages/fuzz/corpus/regressions/effect-needs-cleanup--one-shot-timer-unmount-owner.tsx
+++ b/packages/fuzz/corpus/regressions/effect-needs-cleanup--one-shot-timer-unmount-owner.tsx
@@ -1,0 +1,40 @@
+// rule: effect-needs-cleanup
+// weakness: control-flow
+// source: ASAP_FIX ReactTooltip fix-react-reacttooltip-react-too__mMYsnZp
+
+import { useEffect, useRef } from "react";
+
+interface PendingOpen {
+  delay: number;
+}
+
+interface PendingOpenTimerProps {
+  delay: number;
+}
+
+export const PendingOpenTimer = ({ delay }: PendingOpenTimerProps) => {
+  const pendingOpenRef = useRef<PendingOpen | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    const pendingOpen = pendingOpenRef.current;
+    if (!pendingOpen) return;
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(
+      () => {
+        timerRef.current = null;
+        pendingOpenRef.current = null;
+      },
+      Math.max(delay, pendingOpen.delay),
+    );
+  }, [delay]);
+
+  useEffect(
+    () => () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    },
+    [],
+  );
+
+  return null;
+};

--- a/packages/fuzz/corpus/true-positives/effect-needs-cleanup--separately-guarded-timeout-release.tsx
+++ b/packages/fuzz/corpus/true-positives/effect-needs-cleanup--separately-guarded-timeout-release.tsx
@@ -1,0 +1,23 @@
+// rule: effect-needs-cleanup
+// weakness: control-flow
+// source: PR #1394 Bugbot review — same-block CFG identity hid a separately guarded release
+
+import { useEffect, useRef } from "react";
+
+interface DeferredCommitProps {
+  shouldRelease: boolean;
+  value: string;
+}
+
+export const DeferredCommit = ({ shouldRelease, value }: DeferredCommitProps) => {
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (shouldRelease) clearTimeout(timeoutRef.current ?? undefined);
+    timeoutRef.current = setTimeout(() => commit(value), 300);
+  }, [shouldRelease, value]);
+
+  useEffect(() => () => clearTimeout(timeoutRef.current ?? undefined), []);
+
+  return null;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
@@ -3208,7 +3208,7 @@ export const Debounced = ({ value }) => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
-  it("rejects split cleanup when an early return skips the rerun release", () => {
+  it("accepts one-shot timer cleanup owned by a stable unmount effect after an early return", () => {
     const result = runRule(
       effectNeedsCleanup,
       `import { useEffect, useRef } from "react";
@@ -3224,10 +3224,10 @@ export const Debounced = ({ enabled, value }) => {
 };`,
     );
     expect(result.parseErrors).toEqual([]);
-    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics).toHaveLength(0);
   });
 
-  it("rejects split cleanup when an outer condition skips the rerun release", () => {
+  it("accepts one-shot timer cleanup owned by a stable unmount effect inside a condition", () => {
     const result = runRule(
       effectNeedsCleanup,
       `import { useEffect, useRef } from "react";
@@ -3239,6 +3239,60 @@ export const Debounced = ({ enabled, value }) => {
       timeoutRef.current = setTimeout(() => commit(value), 300);
     }
   }, [enabled, value]);
+  useEffect(() => () => clearTimeout(timeoutRef.current), []);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("rejects repeating timer cleanup when an early return skips the rerun release", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect, useRef } from "react";
+export const Poller = ({ enabled, value }) => {
+  const intervalRef = useRef(null);
+  useEffect(() => {
+    if (!enabled) return;
+    if (intervalRef.current) clearInterval(intervalRef.current);
+    intervalRef.current = setInterval(() => poll(value), 300);
+  }, [enabled, value]);
+  useEffect(() => () => clearInterval(intervalRef.current), []);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("rejects one-shot timer cleanup when rerenders can overwrite a live handle", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect, useRef } from "react";
+export const DeferredCommit = ({ value }) => {
+  const timeoutRef = useRef(null);
+  useEffect(() => {
+    timeoutRef.current = setTimeout(() => commit(value), 300);
+  }, [value]);
+  useEffect(() => () => clearTimeout(timeoutRef.current), []);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("rejects one-shot timer cleanup when a separate guard can skip the rerun release", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect, useRef } from "react";
+export const DeferredCommit = ({ shouldRelease, value }) => {
+  const timeoutRef = useRef(null);
+  useEffect(() => {
+    if (shouldRelease) clearTimeout(timeoutRef.current);
+    timeoutRef.current = setTimeout(() => commit(value), 300);
+  }, [shouldRelease, value]);
   useEffect(() => () => clearTimeout(timeoutRef.current), []);
   return null;
 };`,
@@ -5152,15 +5206,6 @@ export const MediaQuery = ({ breakpoint }) => {
       cleanupEvent: "event",
       cleanupListener: "listener",
     },
-    {
-      name: "defaulted object properties",
-      setupParameters: '{ event = "focus", listener = handleFocus }',
-      setupEvent: "event",
-      setupListener: "listener",
-      cleanupParameters: '{ event = "focus", listener = handleFocus }',
-      cleanupEvent: "event",
-      cleanupListener: "listener",
-    },
   ])("does not infer cleanup identity through $name", (fixture) => {
     const result = runRule(
       effectNeedsCleanup,
@@ -5182,6 +5227,162 @@ export const MediaQuery = ({ breakpoint }) => {
             enabledEvents.forEach((${fixture.cleanupParameters}) => {
               elementRefs.forEach((elementRef) => {
                 elementRef.current?.removeEventListener(${fixture.cleanupEvent}, ${fixture.cleanupListener});
+              });
+            });
+          };
+        }, [anchorRefs]);
+
+        return null;
+      }
+    `,
+      { filename: "Tooltip.tsx" },
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("accepts replay cleanup through matching defaulted object properties", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `
+      function Tooltip({ anchorRefs }) {
+        const handleFocus = () => {};
+
+        useEffect(() => {
+          const elementRefs = new Set(anchorRefs);
+          const enabledEvents = [{ event: "focus", listener: handleFocus }];
+
+          enabledEvents.forEach(({ event = "focus", listener = handleFocus, capture = false }) => {
+            elementRefs.forEach((elementRef) => {
+              elementRef.current?.addEventListener(event, listener, capture);
+            });
+          });
+
+          return () => {
+            enabledEvents.forEach(({ event = "focus", listener = handleFocus, capture = false }) => {
+              elementRefs.forEach((elementRef) => {
+                elementRef.current?.removeEventListener(event, listener, capture);
+              });
+            });
+          };
+        }, [anchorRefs]);
+
+        return null;
+      }
+    `,
+      { filename: "Tooltip.tsx" },
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("rejects replay cleanup through different defaulted object properties", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `
+      function Tooltip({ anchorRefs }) {
+        const handleFocus = () => {};
+
+        useEffect(() => {
+          const elementRefs = new Set(anchorRefs);
+          const enabledEvents = [{ event: "focus", listener: handleFocus }];
+
+          enabledEvents.forEach(({ event, listener, capture = false }) => {
+            elementRefs.forEach((elementRef) => {
+              elementRef.current?.addEventListener(event, listener, capture);
+            });
+          });
+
+          return () => {
+            enabledEvents.forEach(({ event, listener, capture = true }) => {
+              elementRefs.forEach((elementRef) => {
+                elementRef.current?.removeEventListener(event, listener, capture);
+              });
+            });
+          };
+        }, [anchorRefs]);
+
+        return null;
+      }
+    `,
+      { filename: "Tooltip.tsx" },
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("accepts replay cleanup through matching computed capture expressions", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `
+      function Tooltip({ anchorRefs }) {
+        const handleFocus = () => {};
+
+        useEffect(() => {
+          const elementRefs = new Set(anchorRefs);
+          const enabledEvents = [{ event: "focus", listener: handleFocus }];
+
+          enabledEvents.forEach(({ event, listener }) => {
+            elementRefs.forEach((elementRef) => {
+              elementRef.current?.addEventListener(
+                event,
+                listener,
+                event === "focus" || event === "blur",
+              );
+            });
+          });
+
+          return () => {
+            enabledEvents.forEach(({ event, listener }) => {
+              elementRefs.forEach((elementRef) => {
+                elementRef.current?.removeEventListener(
+                  event,
+                  listener,
+                  event === "focus" || event === "blur",
+                );
+              });
+            });
+          };
+        }, [anchorRefs]);
+
+        return null;
+      }
+    `,
+      { filename: "Tooltip.tsx" },
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("rejects replay cleanup through different computed capture expressions", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `
+      function Tooltip({ anchorRefs }) {
+        const handleFocus = () => {};
+
+        useEffect(() => {
+          const elementRefs = new Set(anchorRefs);
+          const enabledEvents = [{ event: "focus", listener: handleFocus }];
+
+          enabledEvents.forEach(({ event, listener }) => {
+            elementRefs.forEach((elementRef) => {
+              elementRef.current?.addEventListener(
+                event,
+                listener,
+                event === "focus" || event === "blur",
+              );
+            });
+          });
+
+          return () => {
+            enabledEvents.forEach(({ event, listener }) => {
+              elementRefs.forEach((elementRef) => {
+                elementRef.current?.removeEventListener(event, listener, event === "focus");
               });
             });
           };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -24,6 +24,7 @@ import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
 import { findTransparentExpressionRoot } from "../../utils/find-transparent-expression-root.js";
 import { getCalleeName } from "../../utils/get-callee-name.js";
 import { getDirectUnreassignedInitializer } from "../../utils/get-direct-unreassigned-initializer.js";
+import { getDestructuredBindingPropertyName } from "../../utils/get-destructured-binding-property-name.js";
 import { getEffectCallback } from "../../utils/get-effect-callback.js";
 import { getFinalSequenceExpressionValue } from "../../utils/get-final-sequence-expression-value.js";
 import { doNodesCoverEveryPathFromFunctionEntry } from "../../utils/do-nodes-cover-every-path-from-function-entry.js";
@@ -214,7 +215,9 @@ const resolveExpressionKey = (
   if (isNodeOfType(unwrappedExpression, "ThisExpression")) return "this";
   if (
     isNodeOfType(unwrappedExpression, "Literal") &&
-    (typeof unwrappedExpression.value === "string" || typeof unwrappedExpression.value === "number")
+    (typeof unwrappedExpression.value === "string" ||
+      typeof unwrappedExpression.value === "number" ||
+      typeof unwrappedExpression.value === "boolean")
   ) {
     return `literal:${String(unwrappedExpression.value)}`;
   }
@@ -250,15 +253,24 @@ const resolveForEachProjection = (
   const collectionKey = resolveExpressionKey(forEachCallee.object, context);
   if (!collectionKey) return null;
   const firstParameter = callbackNode.params[0];
-  const bindingProperty = symbol.bindingIdentifier.parent;
-  const propertyName =
-    isNodeOfType(firstParameter, "ObjectPattern") &&
-    isNodeOfType(bindingProperty, "Property") &&
-    bindingProperty.parent === firstParameter &&
-    bindingProperty.value === symbol.bindingIdentifier
-      ? getStaticPropertyKeyName(bindingProperty)
+  const assignmentPattern =
+    isNodeOfType(symbol.bindingIdentifier.parent, "AssignmentPattern") &&
+    symbol.bindingIdentifier.parent.left === symbol.bindingIdentifier
+      ? symbol.bindingIdentifier.parent
       : null;
-  const parameterProjection = firstParameter === symbol.bindingIdentifier ? "value" : propertyName;
+  const propertyName = isNodeOfType(firstParameter, "ObjectPattern")
+    ? getDestructuredBindingPropertyName(symbol.bindingIdentifier)
+    : null;
+  const defaultValueKey = assignmentPattern
+    ? resolveExpressionKey(assignmentPattern.right, context)
+    : null;
+  if (assignmentPattern && !defaultValueKey) return null;
+  const parameterProjection =
+    firstParameter === symbol.bindingIdentifier
+      ? "value"
+      : propertyName && defaultValueKey
+        ? `${propertyName}=default:${defaultValueKey}`
+        : propertyName;
   if (!parameterProjection) return null;
   return {
     collectionKey,
@@ -280,6 +292,33 @@ const resolveResourceIdentityKey = (
 ): string | null =>
   resolveForEachProjectionKey(expression, context) ?? resolveExpressionKey(expression, context);
 
+const resolveEventListenerCaptureValueIdentityKey = (
+  expression: EsTreeNode | null | undefined,
+  context: RuleContext,
+): string | null => {
+  if (!expression) return null;
+  const directIdentityKey = resolveResourceIdentityKey(expression, context);
+  if (directIdentityKey) return directIdentityKey;
+  const unwrappedExpression = stripParenExpression(expression);
+  if (
+    !isNodeOfType(unwrappedExpression, "BinaryExpression") &&
+    !isNodeOfType(unwrappedExpression, "LogicalExpression")
+  ) {
+    return null;
+  }
+  const leftIdentityKey = resolveEventListenerCaptureValueIdentityKey(
+    unwrappedExpression.left,
+    context,
+  );
+  const rightIdentityKey = resolveEventListenerCaptureValueIdentityKey(
+    unwrappedExpression.right,
+    context,
+  );
+  return leftIdentityKey && rightIdentityKey
+    ? `${unwrappedExpression.type}:${unwrappedExpression.operator}:${leftIdentityKey}:${rightIdentityKey}`
+    : null;
+};
+
 const resolveEventListenerCaptureIdentityKey = (
   optionsNode: EsTreeNode | null | undefined,
   context: RuleContext,
@@ -293,7 +332,7 @@ const resolveEventListenerCaptureIdentityKey = (
   const unwrappedOptions = stripParenExpression(optionsNode);
   if (!isNodeOfType(unwrappedOptions, "ObjectExpression")) {
     const optionsKey = allowOpaqueOptionsIdentity
-      ? resolveResourceIdentityKey(unwrappedOptions, context)
+      ? resolveEventListenerCaptureValueIdentityKey(unwrappedOptions, context)
       : null;
     return optionsKey ? `options:${optionsKey}` : null;
   }
@@ -309,7 +348,7 @@ const resolveEventListenerCaptureIdentityKey = (
       continue;
     }
     if (propertyName === "capture") {
-      const propertyValueKey = resolveResourceIdentityKey(property.value, context);
+      const propertyValueKey = resolveEventListenerCaptureValueIdentityKey(property.value, context);
       captureKey = propertyValueKey ? `capture-value:${propertyValueKey}` : null;
     }
   }
@@ -1586,10 +1625,49 @@ const findDirectHandleGuardForRelease = (
     ? null
     : findLiveExpressionGuardForRelease(releaseCall, owner, usage.handleKey, context);
 
+const hasExecutionBoundaryNotSharedWithUsage = (
+  node: EsTreeNode,
+  usageNode: EsTreeNode,
+  owner: EsTreeNode,
+): boolean => {
+  const usageAncestors = new Set<EsTreeNode>();
+  let usageAncestor: EsTreeNode | null = usageNode;
+  while (usageAncestor && usageAncestor !== owner) {
+    usageAncestors.add(usageAncestor);
+    usageAncestor = usageAncestor.parent ?? null;
+  }
+  let descendant = node;
+  let ancestor = descendant.parent ?? null;
+  while (ancestor && ancestor !== owner) {
+    const guardedSubtree =
+      (isNodeOfType(ancestor, "IfStatement") &&
+        (ancestor.consequent === descendant || ancestor.alternate === descendant)) ||
+      (isNodeOfType(ancestor, "ConditionalExpression") &&
+        (ancestor.consequent === descendant || ancestor.alternate === descendant)) ||
+      (isNodeOfType(ancestor, "LogicalExpression") && ancestor.right === descendant) ||
+      (isNodeOfType(ancestor, "AssignmentPattern") && ancestor.right === descendant) ||
+      ((isNodeOfType(ancestor, "ForStatement") ||
+        isNodeOfType(ancestor, "ForInStatement") ||
+        isNodeOfType(ancestor, "ForOfStatement") ||
+        isNodeOfType(ancestor, "WhileStatement") ||
+        isNodeOfType(ancestor, "DoWhileStatement")) &&
+        ancestor.body === descendant)
+        ? descendant
+        : isNodeOfType(ancestor, "SwitchCase")
+          ? ancestor
+          : null;
+    if (guardedSubtree && !usageAncestors.has(guardedSubtree)) return true;
+    descendant = ancestor;
+    ancestor = descendant.parent ?? null;
+  }
+  return false;
+};
+
 const hasRerunReleaseBeforeUsage = (
   callback: EsTreeNode,
   usage: SubscribeLikeUsage,
   context: RuleContext,
+  allowUnreleasedPathsWithoutUsage = false,
 ): boolean => {
   if (
     (!isNodeOfType(callback, "ArrowFunctionExpression") &&
@@ -1607,10 +1685,12 @@ const hasRerunReleaseBeforeUsage = (
     if (!isNodeOfType(child, "CallExpression")) return;
     const releaseStart = getRangeStart(child);
     const handleGuard = findDirectHandleGuardForRelease(child, callback, usage, context);
+    const releaseBlock = functionCfg.blockOf(child);
     if (
       releaseStart === null ||
       releaseStart >= usageStart ||
-      (functionCfg.blockOf(child) !== usageBlock && !handleGuard)
+      (releaseBlock !== usageBlock && !handleGuard) ||
+      (!handleGuard && hasExecutionBoundaryNotSharedWithUsage(child, usage.node, callback))
     ) {
       return;
     }
@@ -1627,7 +1707,14 @@ const hasRerunReleaseBeforeUsage = (
       matchingReleaseAnchors.push(handleGuard ?? child);
     }
   });
-  return doNodesCoverEveryPathFromFunctionEntry(callback, matchingReleaseAnchors, context);
+  return allowUnreleasedPathsWithoutUsage
+    ? doMatchingNodesCoverEveryPathBeforeUsage(
+        usage.node,
+        matchingReleaseAnchors,
+        callback,
+        context,
+      )
+    : doNodesCoverEveryPathFromFunctionEntry(callback, matchingReleaseAnchors, context);
 };
 
 const hasStableUnmountCleanupForUsage = (
@@ -1677,8 +1764,8 @@ const hasSplitLifecycleCleanup = (
   context: RuleContext,
 ): boolean =>
   usage.handleKey !== null &&
-  hasRerunReleaseBeforeUsage(callback, usage, context) &&
-  hasStableUnmountCleanupForUsage(callback, usage, context);
+  hasStableUnmountCleanupForUsage(callback, usage, context) &&
+  hasRerunReleaseBeforeUsage(callback, usage, context, usage.registrationVerbName === "setTimeout");
 
 const collectBlockingBooleanStates = (
   expression: EsTreeNode,


### PR DESCRIPTION
## Why

`effect-needs-cleanup` still reported valid ReactTooltip cleanup in three related shapes from the latest ASAP audit:

- listener capture values projected through matching defaulted destructuring
- matching computed capture expressions such as `event === "focus" || event === "blur"`
- one-shot timers whose rerun effect clears every path that reaches allocation while a stable unmount effect owns final cleanup

The timer relaxation remains limited to `setTimeout`: repeating timers, separately guarded releases, and rerenders that can overwrite a live handle are still reported.

## What changed

- preserve default-value identity in `forEach` projections
- compare binary/logical listener capture expressions structurally with scope-aware resource identity
- prove rerun cleanup on every path that reaches one-shot timer allocation
- reject release guards that do not also enclose the corresponding allocation
- add adversarial regression tests and permanent fuzz corpus seeds
- add a patch changeset for `oxlint-plugin-react-doctor`

## Validation

- full plugin suite: 16,047 passed, 200 skipped
- plugin typecheck, root lint, format check, and full build passed
- strict fuzz: 1,000 iterations against the react-bench-internal-derived corpus, rerun after review fixes
- ReactTooltip replay: five corrected trials clean; three unrelated real timer leaks remain reported
- RDE comparison: 99 roots, 38 `effect-needs-cleanup` diagnostics before and after, with no new target diagnostics attributable to this change

No release workflow or action release files are changed.