### PR TITLE
feat(rules): detect Valtio snapshot reads in callbacks

### DIFF
--- a/.changeset/warm-snapshots-listen.md
+++ b/.changeset/warm-snapshots-listen.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Add `valtio-no-snapshot-in-callback` to warn when deferred callbacks read Valtio snapshots and accidentally track callback-only fields as render dependencies.

--- a/packages/fuzz/corpus/true-positives/valtio-no-snapshot-in-callback--const-handler-alias.tsx
+++ b/packages/fuzz/corpus/true-positives/valtio-no-snapshot-in-callback--const-handler-alias.tsx
@@ -1,0 +1,14 @@
+// rule: valtio-no-snapshot-in-callback
+// weakness: library-idiom
+// source: adversarial-review
+
+import { proxy, useSnapshot } from "valtio";
+
+const state = proxy({ count: 0 });
+
+export const Counter = () => {
+  const snapshot = useSnapshot(state);
+  const handleClick = () => console.log(snapshot.count);
+  const aliasedHandler = handleClick;
+  return <button onClick={aliasedHandler}>Read</button>;
+};

--- a/packages/fuzz/corpus/true-positives/valtio-no-snapshot-in-callback--effect-cleanup.tsx
+++ b/packages/fuzz/corpus/true-positives/valtio-no-snapshot-in-callback--effect-cleanup.tsx
@@ -1,0 +1,14 @@
+// rule: valtio-no-snapshot-in-callback
+// weakness: library-idiom
+// source: adversarial-review
+
+import { useEffect } from "react";
+import { proxy, useSnapshot } from "valtio";
+
+const state = proxy({ count: 0 });
+
+export const Counter = () => {
+  const snapshot = useSnapshot(state);
+  useEffect(() => () => console.log(snapshot.count), []);
+  return null;
+};

--- a/packages/fuzz/corpus/true-positives/valtio-no-snapshot-in-callback--jsx-handler.tsx
+++ b/packages/fuzz/corpus/true-positives/valtio-no-snapshot-in-callback--jsx-handler.tsx
@@ -1,0 +1,12 @@
+// rule: valtio-no-snapshot-in-callback
+// weakness: library-idiom
+// source: pmndrs/valtio discussion #290
+
+import { proxy, useSnapshot } from "valtio";
+
+const state = proxy({ count: 0 });
+
+export const Counter = () => {
+  const snapshot = useSnapshot(state);
+  return <button onClick={() => console.log(snapshot.count)}>Read</button>;
+};

--- a/packages/fuzz/src/snippet-pools.ts
+++ b/packages/fuzz/src/snippet-pools.ts
@@ -140,6 +140,7 @@ export const EFFECT_SNIPPET_POOL = [
 // State — lazy initializers (incl. SSR-hazardous localStorage/matchMedia),
 // toggles, loading triples, prop mirrors, reducers, ref-sync.
 export const STATE_SNIPPET_POOL = [
+  `const fuzzValtioState = fuzzValtioProxy({ count: 0 }); const fuzzValtioSnapshot = useFuzzValtioSnapshot(fuzzValtioState); const handleFuzzValtioRead = () => console.log(fuzzValtioSnapshot.count); const fuzzValtioButton = <button onClick={handleFuzzValtioRead}>Read</button>;`,
   `const FuzzArrayConsumer = memo(() => null); const FuzzArrayHost = () => <FuzzArrayConsumer payload={[value]} />;`,
   `const FuzzEffectEventHost = ({ delay, onSearch }) => { useEffect(() => { const timeoutId = setTimeout(() => onSearch("done"), delay); return () => clearTimeout(timeoutId); }, [delay, onSearch]); return null; }; function FuzzTransitionHost() { const [isLoading, setIsLoading] = useState(false); const toggleLoading = () => setIsLoading(true); return <button onClick={toggleLoading}>{isLoading ? "Loading" : "Go"}</button>; } function FuzzMemoEarlyReturnHost({ loading }) { const content = useMemo(() => <Heavy />, []); if (loading) return null; return <div>{content}</div>; }`,
   `const shallowEqual = (previousProps, nextProps) => previousProps.id === nextProps.id; const FuzzCustomComparedItem = React.memo(({ foo }) => <div>{foo.label}</div>, shallowEqual); const fuzzCustomComparedItemNode = <FuzzCustomComparedItem id="item" foo={{ label: String(value) }} />;`,
@@ -682,6 +683,8 @@ export const IMPORT_LINE_POOL = [
   `import { reaction, autorun } from "mobx";`,
   `import styled from "styled-components";`,
   `import { atom, useAtom } from "jotai";`,
+  `import { proxy as fuzzValtioProxy, useSnapshot as useFuzzValtioSnapshot } from "valtio";`,
+  `import { proxy as fuzzValtioScenarioProxy, useSnapshot as useFuzzValtioScenarioSnapshot } from "valtio"; const FuzzValtioCallbackScenario = () => { const fuzzValtioScenarioState = fuzzValtioScenarioProxy({ count: 0 }); const fuzzValtioScenarioSnapshot = useFuzzValtioScenarioSnapshot(fuzzValtioScenarioState); return <button onClick={() => console.log(fuzzValtioScenarioSnapshot.count)}>Read</button>; };`,
   `import { useDispatch, useSelector } from "react-redux";`,
   `import { useNavigate, useSearchParams, useParams } from "react-router-dom";`,
   `import { useForm } from "react-hook-form";`,

--- a/packages/fuzz/tests/verdict-robustness.test.ts
+++ b/packages/fuzz/tests/verdict-robustness.test.ts
@@ -55,6 +55,7 @@ const AUDITED_RULE_IDS = [
   "role-supports-aria-props",
   "rules-of-hooks",
   "valtio-no-proxy-read-in-render",
+  "valtio-no-snapshot-in-callback",
 ] as const;
 
 // Rule × variant pairs where losing the diagnostic is the rule's DOCUMENTED

--- a/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness-fixtures.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness-fixtures.ts
@@ -1372,6 +1372,9 @@ export const livenessFixtures: Readonly<Record<string, LivenessFixture>> = {
   "valtio-no-proxy-read-in-render": {
     code: 'import { useSnapshot } from "valtio";\nexport const Count = ({ state }) => { const snapshot = useSnapshot(state); return <span>{state.count}</span>; };',
   },
+  "valtio-no-snapshot-in-callback": {
+    code: 'import { useSnapshot } from "valtio"; function Counter() { const snap = useSnapshot(state); return <button onClick={() => console.log(snap.count)}>read</button>; }',
+  },
   "void-dom-elements-no-children": {
     code: "const a = <img>hi</img>;",
   },

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
@@ -405,6 +405,7 @@ import { untrustedRedirectFollowing } from "./rules/security-scan/untrusted-redi
 import { urlPrefilledPrivilegedAction } from "./rules/security-scan/url-prefilled-privileged-action.js";
 import { useLazyMotion } from "./rules/bundle-size/use-lazy-motion.js";
 import { valtioNoProxyReadInRender } from "./rules/valtio/valtio-no-proxy-read-in-render.js";
+import { valtioNoSnapshotInCallback } from "./rules/valtio/valtio-no-snapshot-in-callback.js";
 import { voidDomElementsNoChildren } from "./rules/react-builtins/void-dom-elements-no-children.js";
 import { webhookSignatureRisk } from "./rules/security-scan/webhook-signature-risk.js";
 import { zodV4NoDeprecatedErrorApis } from "./rules/zod/zod-v4-no-deprecated-error-apis.js";
@@ -5115,6 +5116,18 @@ export const reactDoctorRules = [
       framework: "global",
       category: "Bugs",
       requires: [...new Set<Capability>(["react", ...(valtioNoProxyReadInRender.requires ?? [])])],
+    },
+  },
+  {
+    key: "react-doctor/valtio-no-snapshot-in-callback",
+    id: "valtio-no-snapshot-in-callback",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...valtioNoSnapshotInCallback,
+      framework: "global",
+      category: "Bugs",
+      requires: [...new Set<Capability>(["react", ...(valtioNoSnapshotInCallback.requires ?? [])])],
     },
   },
   {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/valtio/valtio-no-snapshot-in-callback.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/valtio/valtio-no-snapshot-in-callback.test.ts
@@ -1,0 +1,294 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { valtioNoSnapshotInCallback } from "./valtio-no-snapshot-in-callback.js";
+
+const getDiagnosticCount = (code: string): number =>
+  runRule(valtioNoSnapshotInCallback, code).diagnostics.length;
+
+describe("valtio-no-snapshot-in-callback", () => {
+  it("reports a snapshot member read in an inline JSX event handler", () => {
+    expect(
+      getDiagnosticCount(`
+        import { useSnapshot } from "valtio";
+        const Counter = () => {
+          const snap = useSnapshot(state);
+          return <button onClick={() => console.log(snap.count)}>{snap.count}</button>;
+        };
+      `),
+    ).toBe(1);
+  });
+
+  it("reports named and aliased snapshot bindings wired to JSX handlers", () => {
+    expect(
+      getDiagnosticCount(`
+        import { useSnapshot as readSnapshot } from "valtio/react";
+        function Counter() {
+          const snap = readSnapshot(state);
+          const current = snap;
+          const handleClick = () => console.log(current.count);
+          return <button onClick={handleClick}>read</button>;
+        }
+      `),
+    ).toBe(1);
+  });
+
+  it("reports namespace imports and transparent TypeScript wrappers", () => {
+    expect(
+      getDiagnosticCount(`
+        import * as Valtio from "valtio";
+        interface Handler { (): void }
+        function Counter() {
+          const snap = (Valtio.useSnapshot(state) as State)!;
+          const handleClick = (() => console.log((snap as State)!.count)) satisfies Handler;
+          return <button onClick={handleClick}>read</button>;
+        }
+      `),
+    ).toBe(1);
+  });
+
+  it("reports TypeScript-wrapped handlers assigned to existing bindings", () => {
+    expect(
+      getDiagnosticCount(`
+        import { useSnapshot } from "valtio";
+        interface Handler { (): void }
+        let handleClick: Handler;
+        function Counter() {
+          const snap = useSnapshot(state);
+          handleClick = (() => console.log(snap.count)) satisfies Handler;
+          return <button onClick={handleClick}>read</button>;
+        }
+      `),
+    ).toBe(1);
+  });
+
+  it("reports const aliases of named hooks and namespace imports", () => {
+    expect(
+      getDiagnosticCount(`
+        import { useSnapshot } from "valtio";
+        import * as Valtio from "valtio/react";
+        const readSnapshot = useSnapshot;
+        const ValtioReact = Valtio;
+        function Counter() {
+          const first = readSnapshot(state);
+          const second = ValtioReact.useSnapshot(otherState);
+          return <button onClick={() => console.log(first.count, second.count)}>read</button>;
+        }
+      `),
+    ).toBe(2);
+  });
+
+  it("reports React effect callbacks through aliases and namespace calls", () => {
+    expect(
+      getDiagnosticCount(`
+        import React from "react";
+        import { useEffect as afterCommit } from "react";
+        import { useSnapshot } from "valtio";
+        function Counter() {
+          const snap = useSnapshot(state);
+          afterCommit(() => console.log(snap.count), []);
+          React.useLayoutEffect(() => console.log(snap.label), []);
+          return null;
+        }
+      `),
+    ).toBe(2);
+  });
+
+  it("reports effect reads when the snapshot also feeds stable callbacks", () => {
+    expect(
+      getDiagnosticCount(`
+        import { useCallback, useEffect } from "react";
+        import { useSnapshot } from "valtio";
+        const useConsentToast = () => {
+          const snap = useSnapshot(consentState);
+          const acceptAll = useCallback(() => snap.acceptAll(), [snap.acceptAll]);
+          useEffect(() => {
+            if (snap.showConsentToast) toast(acceptAll);
+          }, [snap.showConsentToast]);
+          return snap.hasConsented;
+        };
+      `),
+    ).toBe(1);
+  });
+
+  it("reports global timers, schedulers, observers, and promise continuations", () => {
+    expect(
+      getDiagnosticCount(`
+        import { useSnapshot } from "valtio";
+        function Counter() {
+          const snap = useSnapshot(state);
+          setTimeout(() => console.log(snap.a), 0);
+          window.requestAnimationFrame(() => console.log(snap.b));
+          queueMicrotask(() => console.log(snap.c));
+          new ResizeObserver(() => console.log(snap.d));
+          Promise.resolve().then(() => console.log(snap.e));
+          return null;
+        }
+      `),
+    ).toBe(5);
+  });
+
+  it("reports listener and subscription callbacks passed inline or by reference", () => {
+    expect(
+      getDiagnosticCount(`
+        import { useSnapshot } from "valtio";
+        function Counter() {
+          const snap = useSnapshot(state);
+          const onResize = () => console.log(snap.width);
+          window.addEventListener("resize", onResize);
+          store.subscribe(() => console.log(snap.count));
+          emitter.on("change", () => console.log(snap.label));
+          return null;
+        }
+      `),
+    ).toBe(3);
+  });
+
+  it("reports synchronous nested callbacks when their enclosing callback is deferred", () => {
+    expect(
+      getDiagnosticCount(`
+        import { useSnapshot } from "valtio";
+        function Counter() {
+          const snap = useSnapshot(state);
+          return <button onClick={() => snap.items.map((item) => item + snap.offset)}>read</button>;
+        }
+      `),
+    ).toBe(2);
+  });
+
+  it("reports local helpers invoked from a deferred callback", () => {
+    expect(
+      getDiagnosticCount(`
+        import { useSnapshot } from "valtio";
+        function Counter() {
+          const snap = useSnapshot(state);
+          const readCount = () => snap.count;
+          return <button onClick={() => readCount()}>read</button>;
+        }
+      `),
+    ).toBe(1);
+  });
+
+  it("reports destructuring performed inside a deferred callback", () => {
+    expect(
+      getDiagnosticCount(`
+        import { useSnapshot } from "valtio";
+        function Counter() {
+          const snap = useSnapshot(state);
+          return <button onClick={() => { const { count } = snap; console.log(count); }}>read</button>;
+        }
+      `),
+    ).toBe(1);
+  });
+
+  it("allows direct proxy reads in callbacks", () => {
+    expect(
+      getDiagnosticCount(`
+        import { useSnapshot } from "valtio";
+        function Counter() {
+          const snap = useSnapshot(state);
+          return <button onClick={() => console.log(state.count)}>{snap.count}</button>;
+        }
+      `),
+    ).toBe(0);
+  });
+
+  it("allows snapshot reads in render and synchronous iteration callbacks", () => {
+    expect(
+      getDiagnosticCount(`
+        import { useSnapshot } from "valtio";
+        function List() {
+          const snap = useSnapshot(state);
+          const labels = snap.items.map((item) => item.label + snap.suffix);
+          const visible = snap.items.filter(function filterItem(item) { return item.visible && snap.enabled; });
+          return <>{labels.join(",")}{visible.length}</>;
+        }
+      `),
+    ).toBe(0);
+  });
+
+  it("allows synchronous helpers invoked during render", () => {
+    expect(
+      getDiagnosticCount(`
+        import { useSnapshot } from "valtio";
+        function Counter() {
+          const snap = useSnapshot(state);
+          const readCount = () => snap.count;
+          return <span>{readCount()}</span>;
+        }
+      `),
+    ).toBe(0);
+  });
+
+  it("allows a render-time destructure captured by a handler", () => {
+    expect(
+      getDiagnosticCount(`
+        import { useSnapshot } from "valtio";
+        function Counter() {
+          const { count } = useSnapshot(state);
+          return <button onClick={() => console.log(count)}>read</button>;
+        }
+      `),
+    ).toBe(0);
+  });
+
+  it("allows unknown callback arguments without proof that they are deferred", () => {
+    expect(
+      getDiagnosticCount(`
+        import { useSnapshot } from "valtio";
+        function Counter() {
+          const snap = useSnapshot(state);
+          runWithValue(() => console.log(snap.count));
+          return null;
+        }
+      `),
+    ).toBe(0);
+  });
+
+  it("allows same-named imports from other modules and local shadowing", () => {
+    expect(
+      getDiagnosticCount(`
+        import { useSnapshot } from "other-store";
+        import * as Valtio from "valtio";
+        function First() {
+          const snap = useSnapshot(state);
+          return <button onClick={() => console.log(snap.count)}>read</button>;
+        }
+        function Second() {
+          const Valtio = { useSnapshot: (value) => value };
+          const snap = Valtio.useSnapshot(state);
+          return <button onClick={() => console.log(snap.count)}>read</button>;
+        }
+      `),
+    ).toBe(0);
+  });
+
+  it("allows shadowed timers and React effect names", () => {
+    expect(
+      getDiagnosticCount(`
+        import { useEffect } from "other-hooks";
+        import { useSnapshot } from "valtio";
+        function Counter() {
+          const setTimeout = (callback) => callback();
+          const snap = useSnapshot(state);
+          setTimeout(() => console.log(snap.count), 0);
+          useEffect(() => console.log(snap.label));
+          return null;
+        }
+      `),
+    ).toBe(0);
+  });
+
+  it("allows unused nested helpers and snapshot aliases", () => {
+    expect(
+      getDiagnosticCount(`
+        import { useSnapshot } from "valtio";
+        function Counter() {
+          const snap = useSnapshot(state);
+          const current = snap;
+          const unused = () => current.count;
+          return <span>{snap.count}</span>;
+        }
+      `),
+    ).toBe(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/valtio/valtio-no-snapshot-in-callback.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/valtio/valtio-no-snapshot-in-callback.test.ts
@@ -6,6 +6,10 @@ const getDiagnosticCount = (code: string): number =>
   runRule(valtioNoSnapshotInCallback, code).diagnostics.length;
 
 describe("valtio-no-snapshot-in-callback", () => {
+  it("uses the unversioned Valtio capability because useSnapshot callback semantics span majors", () => {
+    expect(valtioNoSnapshotInCallback.requires).toEqual(["valtio"]);
+  });
+
   it("reports a snapshot member read in an inline JSX event handler", () => {
     expect(
       getDiagnosticCount(`

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/valtio/valtio-no-snapshot-in-callback.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/valtio/valtio-no-snapshot-in-callback.test.ts
@@ -6,8 +6,8 @@ const getDiagnosticCount = (code: string): number =>
   runRule(valtioNoSnapshotInCallback, code).diagnostics.length;
 
 describe("valtio-no-snapshot-in-callback", () => {
-  it("uses the unversioned Valtio capability because useSnapshot callback semantics span majors", () => {
-    expect(valtioNoSnapshotInCallback.requires).toEqual(["valtio"]);
+  it("requires Valtio 1+, where useSnapshot is a stable public API", () => {
+    expect(valtioNoSnapshotInCallback.requires).toEqual(["valtio", "valtio:1"]);
   });
 
   it("reports a snapshot member read in an inline JSX event handler", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/valtio/valtio-no-snapshot-in-callback.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/valtio/valtio-no-snapshot-in-callback.test.ts
@@ -36,6 +36,21 @@ describe("valtio-no-snapshot-in-callback", () => {
     ).toBe(1);
   });
 
+  it("reports handlers wired through const alias chains", () => {
+    expect(
+      getDiagnosticCount(`
+        import { useSnapshot } from "valtio";
+        function Counter() {
+          const snap = useSnapshot(state);
+          const handleClick = () => console.log(snap.count);
+          const firstAlias = handleClick;
+          const secondAlias = firstAlias;
+          return <button onClick={secondAlias}>read</button>;
+        }
+      `),
+    ).toBe(1);
+  });
+
   it("reports namespace imports and transparent TypeScript wrappers", () => {
     expect(
       getDiagnosticCount(`
@@ -112,6 +127,27 @@ describe("valtio-no-snapshot-in-callback", () => {
         };
       `),
     ).toBe(1);
+  });
+
+  it("reports direct and aliased React effect cleanup callbacks", () => {
+    expect(
+      getDiagnosticCount(`
+        import { useEffect, useLayoutEffect } from "react";
+        import { useSnapshot } from "valtio";
+        function Counter() {
+          const snap = useSnapshot(state);
+          useEffect(() => () => console.log(snap.count), []);
+          useLayoutEffect(() => {
+            const cleanup = () => console.log(snap.label);
+            return cleanup;
+          }, []);
+          const effectBody = () => () => console.log(snap.enabled);
+          const aliasedEffectBody = effectBody;
+          useEffect(aliasedEffectBody, []);
+          return null;
+        }
+      `),
+    ).toBe(3);
   });
 
   it("reports global timers, schedulers, observers, and promise continuations", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/valtio/valtio-no-snapshot-in-callback.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/valtio/valtio-no-snapshot-in-callback.ts
@@ -266,6 +266,7 @@ export const valtioNoSnapshotInCallback = defineRule({
   id: "valtio-no-snapshot-in-callback",
   title: "Valtio snapshot read in a callback",
   severity: "warn",
+  requires: ["valtio"],
   recommendation:
     "Read from the original Valtio proxy inside callbacks. `useSnapshot()` results are for render reads; callback reads can become tracked render dependencies and cause extra re-renders.",
   create: (context: RuleContext) => ({

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/valtio/valtio-no-snapshot-in-callback.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/valtio/valtio-no-snapshot-in-callback.ts
@@ -368,7 +368,7 @@ export const valtioNoSnapshotInCallback = defineRule({
   id: "valtio-no-snapshot-in-callback",
   title: "Valtio snapshot read in a callback",
   severity: "warn",
-  requires: ["valtio"],
+  requires: ["valtio", "valtio:1"],
   recommendation:
     "Read from the original Valtio proxy inside callbacks. `useSnapshot()` results are for render reads; callback reads can become tracked render dependencies and cause extra re-renders.",
   create: (context: RuleContext) => ({

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/valtio/valtio-no-snapshot-in-callback.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/valtio/valtio-no-snapshot-in-callback.ts
@@ -170,8 +170,86 @@ const isDeferredCallbackArgument = (expression: EsTreeNode, context: RuleContext
   );
 };
 
+const isReactEffectCallbackValue = (expression: EsTreeNode, context: RuleContext): boolean => {
+  const expressionRoot = findTransparentExpressionRoot(expression);
+  const parent = expressionRoot.parent;
+  return Boolean(
+    isNodeOfType(parent, "CallExpression") &&
+    parent.arguments?.[0] === expressionRoot &&
+    isReactApiCall(parent, DEFERRED_REACT_HOOK_NAMES, context.scopes, {
+      allowGlobalReactNamespace: true,
+      resolveNamedAliases: true,
+    }),
+  );
+};
+
+const isSymbolUsedAsReactEffectCallback = (
+  symbol: SymbolDescriptor,
+  context: RuleContext,
+  visitedSymbolIds: Set<number>,
+): boolean => {
+  if (visitedSymbolIds.has(symbol.id)) return false;
+  visitedSymbolIds.add(symbol.id);
+  return symbol.references.some((reference) => {
+    const referenceRoot = findTransparentExpressionRoot(reference.identifier);
+    if (isReactEffectCallbackValue(referenceRoot, context)) return true;
+    const aliasSymbol = getConstAliasSymbol(referenceRoot, context);
+    return Boolean(
+      aliasSymbol && isSymbolUsedAsReactEffectCallback(aliasSymbol, context, visitedSymbolIds),
+    );
+  });
+};
+
+const isFunctionUsedAsReactEffectCallback = (
+  functionNode: EsTreeNode,
+  context: RuleContext,
+): boolean => {
+  if (isReactEffectCallbackValue(functionNode, context)) return true;
+  const bindingIdentifier = getFunctionBindingIdentifier(functionNode);
+  const symbol = bindingIdentifier ? context.scopes.symbolFor(bindingIdentifier) : null;
+  return Boolean(symbol && isSymbolUsedAsReactEffectCallback(symbol, context, new Set()));
+};
+
+const isReactEffectCleanupValue = (expression: EsTreeNode, context: RuleContext): boolean => {
+  const expressionRoot = findTransparentExpressionRoot(expression);
+  const returnStatement = expressionRoot.parent;
+  if (
+    isNodeOfType(returnStatement, "ArrowFunctionExpression") &&
+    returnStatement.body === expressionRoot
+  ) {
+    return isFunctionUsedAsReactEffectCallback(returnStatement, context);
+  }
+  if (
+    !isNodeOfType(returnStatement, "ReturnStatement") ||
+    returnStatement.argument !== expressionRoot
+  ) {
+    return false;
+  }
+  const effectCallback = findEnclosingFunction(returnStatement);
+  return Boolean(effectCallback && isFunctionUsedAsReactEffectCallback(effectCallback, context));
+};
+
 const isDeferredCallbackValue = (expression: EsTreeNode, context: RuleContext): boolean =>
-  isJsxEventHandlerValue(expression) || isDeferredCallbackArgument(expression, context);
+  isJsxEventHandlerValue(expression) ||
+  isDeferredCallbackArgument(expression, context) ||
+  isReactEffectCleanupValue(expression, context);
+
+const getConstAliasSymbol = (
+  expression: EsTreeNode,
+  context: RuleContext,
+): SymbolDescriptor | null => {
+  const expressionRoot = findTransparentExpressionRoot(expression);
+  const declarator = expressionRoot.parent;
+  if (
+    !isNodeOfType(declarator, "VariableDeclarator") ||
+    declarator.init !== expressionRoot ||
+    !isNodeOfType(declarator.id, "Identifier")
+  ) {
+    return null;
+  }
+  const aliasSymbol = context.scopes.symbolFor(declarator.id);
+  return aliasSymbol?.kind === "const" ? aliasSymbol : null;
+};
 
 const isCallTarget = (expression: EsTreeNode): EsTreeNodeOfType<"CallExpression"> | null => {
   const parent = expression.parent;
@@ -205,31 +283,29 @@ const isNodeExecutedFromDeferredCallback = (
   );
 };
 
-const isFunctionExecutedAsDeferredCallback = (
-  functionNode: EsTreeNode,
+const isSymbolExecutedAsDeferredCallback = (
+  symbol: SymbolDescriptor,
   snapshotOwner: EsTreeNode,
   context: RuleContext,
   visitedFunctionSymbolIds: Set<number>,
 ): boolean => {
-  const functionRoot = findTransparentExpressionRoot(functionNode);
-  if (isDeferredCallbackValue(functionRoot, context)) return true;
-  const synchronousInvocation = getSynchronousCallbackInvocation(functionRoot, context);
-  if (synchronousInvocation) {
-    return isNodeExecutedFromDeferredCallback(
-      synchronousInvocation,
-      snapshotOwner,
-      context,
-      visitedFunctionSymbolIds,
-    );
-  }
-  const bindingIdentifier = getFunctionBindingIdentifier(functionNode);
-  if (!bindingIdentifier) return false;
-  const symbol = context.scopes.symbolFor(bindingIdentifier);
-  if (!symbol || visitedFunctionSymbolIds.has(symbol.id)) return false;
+  if (visitedFunctionSymbolIds.has(symbol.id)) return false;
   visitedFunctionSymbolIds.add(symbol.id);
   return symbol.references.some((reference) => {
     const referenceRoot = findTransparentExpressionRoot(reference.identifier);
     if (isDeferredCallbackValue(referenceRoot, context)) return true;
+    const aliasSymbol = getConstAliasSymbol(referenceRoot, context);
+    if (
+      aliasSymbol &&
+      isSymbolExecutedAsDeferredCallback(
+        aliasSymbol,
+        snapshotOwner,
+        context,
+        visitedFunctionSymbolIds,
+      )
+    ) {
+      return true;
+    }
     const callTarget = isCallTarget(referenceRoot);
     if (callTarget) {
       return isNodeExecutedFromDeferredCallback(
@@ -250,6 +326,32 @@ const isFunctionExecutedAsDeferredCallback = (
       ),
     );
   });
+};
+
+const isFunctionExecutedAsDeferredCallback = (
+  functionNode: EsTreeNode,
+  snapshotOwner: EsTreeNode,
+  context: RuleContext,
+  visitedFunctionSymbolIds: Set<number>,
+): boolean => {
+  const functionRoot = findTransparentExpressionRoot(functionNode);
+  if (isDeferredCallbackValue(functionRoot, context)) return true;
+  const synchronousInvocation = getSynchronousCallbackInvocation(functionRoot, context);
+  if (synchronousInvocation) {
+    return isNodeExecutedFromDeferredCallback(
+      synchronousInvocation,
+      snapshotOwner,
+      context,
+      visitedFunctionSymbolIds,
+    );
+  }
+  const bindingIdentifier = getFunctionBindingIdentifier(functionNode);
+  if (!bindingIdentifier) return false;
+  const symbol = context.scopes.symbolFor(bindingIdentifier);
+  return Boolean(
+    symbol &&
+    isSymbolExecutedAsDeferredCallback(symbol, snapshotOwner, context, visitedFunctionSymbolIds),
+  );
 };
 
 const isDirectSnapshotAliasInitializer = (identifier: EsTreeNode): boolean => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/valtio/valtio-no-snapshot-in-callback.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/valtio/valtio-no-snapshot-in-callback.ts
@@ -1,0 +1,293 @@
+import { TIMER_AND_SCHEDULER_DIRECT_CALLEE_NAMES } from "../../constants/dom.js";
+import { REACT_HANDLER_PROP_PATTERN, SUBSCRIPTION_METHOD_NAMES } from "../../constants/react.js";
+import type { ScopeAnalysis, SymbolDescriptor } from "../../semantic/scope-analysis.js";
+import { defineRule } from "../../utils/define-rule.js";
+import { executesDuringRender } from "../../utils/executes-during-render.js";
+import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
+import { findTransparentExpressionRoot } from "../../utils/find-transparent-expression-root.js";
+import { getDirectUnreassignedInitializer } from "../../utils/get-direct-unreassigned-initializer.js";
+import { getFunctionBindingIdentifier } from "../../utils/get-function-binding-name.js";
+import { getImportDeclarationForSymbol } from "../../utils/get-import-declaration-for-symbol.js";
+import { getImportedName } from "../../utils/get-imported-name.js";
+import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { isReactApiCall } from "../../utils/is-react-api-call.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+
+const VALTIO_REACT_MODULE_SOURCES = new Set(["valtio", "valtio/react"]);
+const DEFERRED_REACT_HOOK_NAMES = new Set(["useEffect", "useInsertionEffect", "useLayoutEffect"]);
+const PROMISE_CONTINUATION_METHOD_NAMES = new Set(["catch", "finally", "then"]);
+const DEFERRED_CONSTRUCTOR_NAMES = new Set([
+  "IntersectionObserver",
+  "MutationObserver",
+  "PerformanceObserver",
+  "ResizeObserver",
+]);
+
+const isValtioImport = (symbol: SymbolDescriptor): boolean => {
+  const source = getImportDeclarationForSymbol(symbol)?.source.value;
+  return typeof source === "string" && VALTIO_REACT_MODULE_SOURCES.has(source);
+};
+
+const resolvesToValtioNamespace = (
+  expression: EsTreeNode,
+  scopes: ScopeAnalysis,
+  visitedSymbolIds: Set<number>,
+): boolean => {
+  const candidate = stripParenExpression(expression);
+  if (!isNodeOfType(candidate, "Identifier")) return false;
+  const symbol = scopes.symbolFor(candidate);
+  if (!symbol || visitedSymbolIds.has(symbol.id)) return false;
+  if (
+    symbol.kind === "import" &&
+    isNodeOfType(symbol.declarationNode, "ImportNamespaceSpecifier") &&
+    isValtioImport(symbol)
+  ) {
+    return true;
+  }
+  const initializer = getDirectUnreassignedInitializer(symbol);
+  if (!initializer) return false;
+  visitedSymbolIds.add(symbol.id);
+  return resolvesToValtioNamespace(initializer, scopes, visitedSymbolIds);
+};
+
+const isValtioUseSnapshotCallee = (
+  expression: EsTreeNode,
+  scopes: ScopeAnalysis,
+  visitedSymbolIds = new Set<number>(),
+): boolean => {
+  const candidate = stripParenExpression(expression);
+  if (isNodeOfType(candidate, "Identifier")) {
+    const symbol = scopes.symbolFor(candidate);
+    if (!symbol || visitedSymbolIds.has(symbol.id)) return false;
+    if (
+      symbol.kind === "import" &&
+      isValtioImport(symbol) &&
+      getImportedName(symbol.declarationNode) === "useSnapshot"
+    ) {
+      return true;
+    }
+    const initializer = getDirectUnreassignedInitializer(symbol);
+    if (!initializer) return false;
+    visitedSymbolIds.add(symbol.id);
+    return isValtioUseSnapshotCallee(initializer, scopes, visitedSymbolIds);
+  }
+  if (
+    !isNodeOfType(candidate, "MemberExpression") ||
+    getStaticPropertyName(candidate) !== "useSnapshot"
+  ) {
+    return false;
+  }
+  return resolvesToValtioNamespace(candidate.object, scopes, visitedSymbolIds);
+};
+
+const getSnapshotOriginCall = (
+  expression: EsTreeNode,
+  context: RuleContext,
+  visitedSymbolIds = new Set<number>(),
+): EsTreeNodeOfType<"CallExpression"> | null => {
+  const candidate = stripParenExpression(expression);
+  if (isNodeOfType(candidate, "CallExpression")) {
+    return isValtioUseSnapshotCallee(candidate.callee, context.scopes) ? candidate : null;
+  }
+  if (!isNodeOfType(candidate, "Identifier")) return null;
+  const symbol = context.scopes.symbolFor(candidate);
+  if (!symbol || visitedSymbolIds.has(symbol.id)) return null;
+  const initializer = getDirectUnreassignedInitializer(symbol);
+  if (!initializer) return null;
+  visitedSymbolIds.add(symbol.id);
+  return getSnapshotOriginCall(initializer, context, visitedSymbolIds);
+};
+
+const isJsxEventHandlerValue = (expression: EsTreeNode): boolean => {
+  const expressionContainer = expression.parent;
+  if (!isNodeOfType(expressionContainer, "JSXExpressionContainer")) return false;
+  const attribute = expressionContainer.parent;
+  return Boolean(
+    isNodeOfType(attribute, "JSXAttribute") &&
+    isNodeOfType(attribute.name, "JSXIdentifier") &&
+    REACT_HANDLER_PROP_PATTERN.test(attribute.name.name),
+  );
+};
+
+const isGlobalDeferredFunctionCall = (
+  callExpression: EsTreeNodeOfType<"CallExpression">,
+  context: RuleContext,
+): boolean => {
+  const callee = stripParenExpression(callExpression.callee);
+  if (
+    isNodeOfType(callee, "Identifier") &&
+    TIMER_AND_SCHEDULER_DIRECT_CALLEE_NAMES.has(callee.name)
+  ) {
+    return context.scopes.isGlobalReference(callee);
+  }
+  if (!isNodeOfType(callee, "MemberExpression")) return false;
+  const methodName = getStaticPropertyName(callee);
+  if (!methodName || !TIMER_AND_SCHEDULER_DIRECT_CALLEE_NAMES.has(methodName)) return false;
+  const receiver = stripParenExpression(callee.object);
+  return Boolean(
+    isNodeOfType(receiver, "Identifier") &&
+    (receiver.name === "globalThis" || receiver.name === "window") &&
+    context.scopes.isGlobalReference(receiver),
+  );
+};
+
+const isDeferredCallbackArgument = (expression: EsTreeNode, context: RuleContext): boolean => {
+  const parent = expression.parent;
+  if (isNodeOfType(parent, "NewExpression")) {
+    const callee = stripParenExpression(parent.callee);
+    return Boolean(
+      parent.arguments?.[0] === expression &&
+      isNodeOfType(callee, "Identifier") &&
+      DEFERRED_CONSTRUCTOR_NAMES.has(callee.name) &&
+      context.scopes.isGlobalReference(callee),
+    );
+  }
+  if (!isNodeOfType(parent, "CallExpression")) return false;
+  if (!(parent.arguments ?? []).some((argument) => argument === expression)) return false;
+  if (
+    parent.arguments?.[0] === expression &&
+    isReactApiCall(parent, DEFERRED_REACT_HOOK_NAMES, context.scopes, {
+      allowGlobalReactNamespace: true,
+      resolveNamedAliases: true,
+    })
+  ) {
+    return true;
+  }
+  if (parent.arguments?.[0] === expression && isGlobalDeferredFunctionCall(parent, context)) {
+    return true;
+  }
+  const callee = stripParenExpression(parent.callee);
+  if (!isNodeOfType(callee, "MemberExpression")) return false;
+  const methodName = getStaticPropertyName(callee);
+  return Boolean(
+    methodName &&
+    (SUBSCRIPTION_METHOD_NAMES.has(methodName) ||
+      PROMISE_CONTINUATION_METHOD_NAMES.has(methodName)),
+  );
+};
+
+const isDeferredCallbackValue = (expression: EsTreeNode, context: RuleContext): boolean =>
+  isJsxEventHandlerValue(expression) || isDeferredCallbackArgument(expression, context);
+
+const isCallTarget = (expression: EsTreeNode): EsTreeNodeOfType<"CallExpression"> | null => {
+  const parent = expression.parent;
+  return isNodeOfType(parent, "CallExpression") && parent.callee === expression ? parent : null;
+};
+
+const getSynchronousCallbackInvocation = (
+  expression: EsTreeNode,
+  context: RuleContext,
+): EsTreeNode | null => {
+  if (!executesDuringRender(expression, context.scopes)) return null;
+  const parent = expression.parent;
+  return isNodeOfType(parent, "CallExpression") || isNodeOfType(parent, "NewExpression")
+    ? parent
+    : null;
+};
+
+const isNodeExecutedFromDeferredCallback = (
+  node: EsTreeNode,
+  snapshotOwner: EsTreeNode,
+  context: RuleContext,
+  visitedFunctionSymbolIds: Set<number>,
+): boolean => {
+  const enclosingFunction = findEnclosingFunction(node);
+  if (!enclosingFunction || enclosingFunction === snapshotOwner) return false;
+  return isFunctionExecutedAsDeferredCallback(
+    enclosingFunction,
+    snapshotOwner,
+    context,
+    visitedFunctionSymbolIds,
+  );
+};
+
+const isFunctionExecutedAsDeferredCallback = (
+  functionNode: EsTreeNode,
+  snapshotOwner: EsTreeNode,
+  context: RuleContext,
+  visitedFunctionSymbolIds: Set<number>,
+): boolean => {
+  const functionRoot = findTransparentExpressionRoot(functionNode);
+  if (isDeferredCallbackValue(functionRoot, context)) return true;
+  const synchronousInvocation = getSynchronousCallbackInvocation(functionRoot, context);
+  if (synchronousInvocation) {
+    return isNodeExecutedFromDeferredCallback(
+      synchronousInvocation,
+      snapshotOwner,
+      context,
+      visitedFunctionSymbolIds,
+    );
+  }
+  const bindingIdentifier = getFunctionBindingIdentifier(functionNode);
+  if (!bindingIdentifier) return false;
+  const symbol = context.scopes.symbolFor(bindingIdentifier);
+  if (!symbol || visitedFunctionSymbolIds.has(symbol.id)) return false;
+  visitedFunctionSymbolIds.add(symbol.id);
+  return symbol.references.some((reference) => {
+    const referenceRoot = findTransparentExpressionRoot(reference.identifier);
+    if (isDeferredCallbackValue(referenceRoot, context)) return true;
+    const callTarget = isCallTarget(referenceRoot);
+    if (callTarget) {
+      return isNodeExecutedFromDeferredCallback(
+        callTarget,
+        snapshotOwner,
+        context,
+        visitedFunctionSymbolIds,
+      );
+    }
+    const callbackInvocation = getSynchronousCallbackInvocation(referenceRoot, context);
+    return Boolean(
+      callbackInvocation &&
+      isNodeExecutedFromDeferredCallback(
+        callbackInvocation,
+        snapshotOwner,
+        context,
+        visitedFunctionSymbolIds,
+      ),
+    );
+  });
+};
+
+const isDirectSnapshotAliasInitializer = (identifier: EsTreeNode): boolean => {
+  const expressionRoot = findTransparentExpressionRoot(identifier);
+  const parent = expressionRoot.parent;
+  return Boolean(
+    isNodeOfType(parent, "VariableDeclarator") &&
+    parent.init === expressionRoot &&
+    isNodeOfType(parent.id, "Identifier"),
+  );
+};
+
+export const valtioNoSnapshotInCallback = defineRule({
+  id: "valtio-no-snapshot-in-callback",
+  title: "Valtio snapshot read in a callback",
+  severity: "warn",
+  recommendation:
+    "Read from the original Valtio proxy inside callbacks. `useSnapshot()` results are for render reads; callback reads can become tracked render dependencies and cause extra re-renders.",
+  create: (context: RuleContext) => ({
+    Identifier(node: EsTreeNodeOfType<"Identifier">) {
+      const reference = context.scopes.referenceFor(node);
+      if (!reference || reference.flag === "write") return;
+      const snapshotOriginCall = getSnapshotOriginCall(node, context);
+      if (!snapshotOriginCall || isDirectSnapshotAliasInitializer(node)) return;
+      const snapshotOwner = findEnclosingFunction(snapshotOriginCall);
+      if (!snapshotOwner) return;
+      const referenceOwner = findEnclosingFunction(node);
+      if (!referenceOwner || referenceOwner === snapshotOwner) return;
+      if (
+        !isFunctionExecutedAsDeferredCallback(referenceOwner, snapshotOwner, context, new Set())
+      ) {
+        return;
+      }
+      context.report({
+        node,
+        message:
+          "This callback reads a Valtio snapshot. Read the original proxy instead so callback-only fields do not become tracked render dependencies.",
+      });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/executes-during-render.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/executes-during-render.ts
@@ -1,5 +1,6 @@
 import type { ScopeAnalysis } from "../semantic/scope-analysis.js";
 import { findDeclaratorForBinding } from "./find-declarator-for-binding.js";
+import { findTransparentExpressionRoot } from "./find-transparent-expression-root.js";
 import { findVariableInitializer } from "./find-variable-initializer.js";
 import type { EsTreeNode } from "./es-tree-node.js";
 import { isHookCall } from "./is-hook-call.js";
@@ -67,29 +68,33 @@ const isConstAliasOfGlobalArrayFrom = (node: EsTreeNode, scopes: ScopeAnalysis):
 // useMemo factory (`{useMemo(() => Date.now(), [])}`), and a synchronous
 // iteration callback (`{rows.map((row) => …)}`), or a global Promise
 // constructor executor (`new Promise((resolve) => resolve())`).
-export const executesDuringRender = (functionNode: EsTreeNode, scopes?: ScopeAnalysis): boolean => {
-  const parent = functionNode.parent;
+export const executesDuringRender = (
+  callbackExpression: EsTreeNode,
+  scopes?: ScopeAnalysis,
+): boolean => {
+  const callbackRoot = findTransparentExpressionRoot(callbackExpression);
+  const parent = callbackRoot.parent;
   if (isNodeOfType(parent, "NewExpression")) {
     const callee = stripParenExpression(parent.callee);
     return Boolean(
       scopes &&
-      parent.arguments?.[0] === functionNode &&
+      parent.arguments?.[0] === callbackRoot &&
       isNodeOfType(callee, "Identifier") &&
       callee.name === "Promise" &&
       scopes.isGlobalReference(callee),
     );
   }
   if (!isNodeOfType(parent, "CallExpression")) return false;
-  if (parent.callee === functionNode) return true;
+  if (parent.callee === callbackRoot) return true;
   const isRenderPhaseHook = scopes
     ? isReactApiCall(parent, REACT_RENDER_PHASE_HOOK_NAMES, scopes, {
         allowGlobalReactNamespace: true,
       })
     : isHookCall(parent, REACT_RENDER_PHASE_HOOK_NAMES);
-  if (isRenderPhaseHook && parent.arguments?.[0] === functionNode) return true;
+  if (isRenderPhaseHook && parent.arguments?.[0] === callbackRoot) return true;
   if (
     scopes &&
-    parent.arguments?.[1] === functionNode &&
+    parent.arguments?.[1] === callbackRoot &&
     (isGlobalArrayFromMember(parent.callee, scopes) ||
       isConstAliasOfGlobalArrayFrom(parent.callee, scopes))
   ) {
@@ -100,6 +105,6 @@ export const executesDuringRender = (functionNode: EsTreeNode, scopes?: ScopeAna
     !parent.callee.computed &&
     isNodeOfType(parent.callee.property, "Identifier") &&
     SYNCHRONOUS_ITERATION_METHOD_NAMES.has(parent.callee.property.name) &&
-    parent.arguments?.[0] === functionNode
+    parent.arguments?.[0] === callbackRoot
   );
 };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-function-binding-name.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-function-binding-name.ts
@@ -1,5 +1,6 @@
 import type { EsTreeNode } from "./es-tree-node.js";
 import type { EsTreeNodeOfType } from "./es-tree-node-of-type.js";
+import { findTransparentExpressionRoot } from "./find-transparent-expression-root.js";
 import { isNodeOfType } from "./is-node-of-type.js";
 
 // The Identifier a function is bound to: its own id (`function foo() {}`),
@@ -15,13 +16,14 @@ export const getFunctionBindingIdentifier = (
   ) {
     return functionNode.id;
   }
-  const parent = functionNode.parent;
+  const functionRoot = findTransparentExpressionRoot(functionNode);
+  const parent = functionRoot.parent;
   if (isNodeOfType(parent, "VariableDeclarator") && isNodeOfType(parent.id, "Identifier")) {
     return parent.id;
   }
   if (
     isNodeOfType(parent, "AssignmentExpression") &&
-    parent.right === functionNode &&
+    parent.right === functionRoot &&
     isNodeOfType(parent.left, "Identifier")
   ) {
     return parent.left;


### PR DESCRIPTION
## Why

Valtio snapshots track the properties React reads during render. Reading a snapshot later inside a callback can add callback-only fields to that render dependency set. Valtio’s [useSnapshot guidance](https://valtio.dev/docs/api/basic/useSnapshot) recommends reading the original proxy inside callbacks.

This change adds one warning-level rule for that boundary.

## Rule: `valtio-no-snapshot-in-callback`

| Property | Value |
| --- | --- |
| Severity | Warning |
| Enabled for | Projects with `valtio` and `valtio:1` capabilities |
| Reports | Snapshot reads inside callbacks proven to run after render |
| Recommends | Read the same value from the original proxy |

The rule reports `snapshot.count` inside `onClick`. It allows the snapshot read in the button label because that read happens during render.

```tsx
import { useSnapshot } from "valtio";

interface CounterProps {
  readonly state: { count: number };
}

const Counter = ({ state }: CounterProps) => {
  const snapshot = useSnapshot(state);

  return (
    <button onClick={() => console.log(snapshot.count)}>
      {snapshot.count}
    </button>
  );
};
```

Read from `state` inside the callback to satisfy the rule. Continue reading from `snapshot` during render.

```tsx
import { useSnapshot } from "valtio";

interface CounterProps {
  readonly state: { count: number };
}

const Counter = ({ state }: CounterProps) => {
  const snapshot = useSnapshot(state);

  return (
    <button onClick={() => console.log(state.count)}>
      {snapshot.count}
    </button>
  );
};
```

### Callbacks the rule recognizes

The detector reports snapshot reads in these proven deferred paths:

- React event-handler props such as `onClick`, including named handlers and const alias chains
- `useEffect`, `useInsertionEffect`, and `useLayoutEffect` bodies
- Direct, named, and aliased React effect cleanup functions
- Global timers, animation schedulers, and microtask schedulers
- Intersection, mutation, performance, and resize observers
- Promise `then`, `catch`, and `finally` continuations
- Listener and subscription methods such as `addEventListener`, `subscribe`, and `on`
- Local helpers and synchronous nested callbacks reached from a deferred callback

The detector follows direct snapshot aliases, hook aliases, namespace aliases, and transparent TypeScript wrappers.

### Cases the rule preserves

The detector stays quiet for these cases:

- Snapshot reads during render
- Synchronous render callbacks such as `map` and `filter`
- Helpers invoked synchronously during render
- Values destructured from the snapshot during render and captured later
- Direct proxy reads inside callbacks
- Unknown callback consumers without proof that they defer execution
- Unused nested helpers and snapshot aliases
- Shadowed globals, shadowed React hooks, and non-Valtio `useSnapshot` imports

The related [`valtio-no-proxy-read-in-render` rule](https://github.com/millionco/react-doctor/pull/1396) checks the opposite boundary: proxy reads during render.

## Version boundary

The rule requires Valtio 1 or newer. The capability system gates dependencies by major version, and Valtio 1 is the first precise supported boundary. `useSnapshot` exists in the [Valtio 1 source](https://github.com/pmndrs/valtio/blob/v1.0.0/src/react.ts) and remains in the [Valtio 2 source](https://github.com/pmndrs/valtio/blob/v2.0.0/src/react.ts).

## What changed

- Added `valtio-no-snapshot-in-callback` to the State & Effects category
- Added Valtio dependency discovery and `valtio:<major>` capability gating
- Added deferred callback, cleanup, helper-call, and alias tracking
- Extended shared render-execution helpers for transparent TypeScript wrappers
- Added liveness, strict fuzz, verdict robustness, and registry coverage
- Added a patch changeset for `oxlint-plugin-react-doctor`

## Eval results

| Check | Result |
| --- | --- |
| Authoritative React Doctor Evals (RDE) | 489 roots, 482 reports, 3 findings in 1 repository |
| Default Daytona parity | 255 of 255 projects, 0 skipped |
| Default diagnostic delta | 0 added, 0 removed |
| Focused Valtio parity | 2 of 2 projects, 0 skipped |
| Target-rule delta | 3 added, 0 removed |
| False positives | 0 confirmed |
| React Bench reconstruction | 20,125 complete artifact sets across 46 repositories |
| Jumper Exchange parity | 970 diagnostics unchanged, 0 skipped |

All three focused additions are true positives in `supabase/supabase` at `packages/ui-patterns/src/consent.tsx`. Manual review found no in-scope false positive or false negative. The React Bench corpus contained no Valtio source usage, so it serves as negative activation evidence.

## Test plan

- Focused rule suite: 23 of 23 adversarial tests passed
- Strict targeted fuzz: 500 requested seeds with zero findings
- Capability, discovery, characterization, and liveness checks passed
- `nr test`
- `nr lint`
- `nr typecheck`
- `nr format:check`
- `nr smoke:json-report`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds opt-in static analysis only (warn severity, `valtio:1` gated); no runtime or security path changes, though Valtio apps may see new diagnostics.
> 
> **Overview**
> Adds a **warning-level** oxlint rule **`valtio-no-snapshot-in-callback`** for Valtio 1+ projects: it flags reads of `useSnapshot()` results inside callbacks that are treated as running **after** render (event handlers, effect bodies/cleanups, timers, observers, promise continuations, subscriptions, and helpers reached through those paths). Render-time snapshot use and **proxy** reads in callbacks stay allowed—the inverse of **`valtio-no-proxy-read-in-render`**.
> 
> The rule is registered under Bugs, wired with a liveness fixture, fuzz true-positive corpus entries, snippet-pool coverage, and verdict-robustness auditing. Shared helpers **`executesDuringRender`** and **`getFunctionBindingIdentifier`** now normalize through transparent TypeScript wrappers so deferred-vs-render detection stays accurate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86ca6d364b43323af4438d9b989c07f0af4b113a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


