### PR TITLE
feat(rules): add version-gated Ink diagnostics

### DIFF
--- a/.changeset/inky-terminals-render.md
+++ b/.changeset/inky-terminals-render.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Add 22 version-gated Ink rules for terminal layout, input, lifecycle, accessibility, rendering, and modern Ink APIs.

--- a/.changeset/inky-terminals-render.md
+++ b/.changeset/inky-terminals-render.md
@@ -2,4 +2,4 @@
 "oxlint-plugin-react-doctor": patch
 ---
 
-Add 22 version-gated Ink rules for terminal layout, input, lifecycle, accessibility, rendering, and modern Ink APIs.
+Add a version-gated Ink ruleset with 19 default checks and an opt-in `usePaste` migration. Preserve the two disproven Newline and Suspense rule IDs as retired configuration aliases.

--- a/packages/core/tests/cross-file-rule-ids.test.ts
+++ b/packages/core/tests/cross-file-rule-ids.test.ts
@@ -124,7 +124,10 @@ const detectCrossFileRuleIds = (): Set<string> => {
     // Scan rules run via core's check-security-scan, never the oxlint config,
     // so they're irrelevant to the lint cache even if they read other files.
     if (/\bscan:\s*(?:\(|async)/.test(stripCommentsAndStrings(source))) continue;
-    if (reachesCrossFilePrimitive(path.resolve(ruleFile))) detected.add(ruleId);
+    const usesInkVersionGate = /\bminimumInkVersion\s*:/.test(stripCommentsAndStrings(source));
+    if (usesInkVersionGate || reachesCrossFilePrimitive(path.resolve(ruleFile))) {
+      detected.add(ruleId);
+    }
   }
   return detected;
 };
@@ -140,6 +143,28 @@ describe("CROSS_FILE_RULE_IDS", () => {
     expect([...CROSS_FILE_RULE_IDS].sort()).toEqual([
       "client-passive-event-listeners",
       "exhaustive-deps",
+      "ink-ctrl-c-handler-requires-exit-option",
+      "ink-newline-inside-text",
+      "ink-no-bare-process-exit",
+      "ink-no-direct-raw-mode",
+      "ink-no-dom-host-elements",
+      "ink-no-dom-router",
+      "ink-no-focus-in-render",
+      "ink-no-layout-inside-text",
+      "ink-no-live-hooks-in-render-to-string",
+      "ink-no-measure-element-in-render",
+      "ink-no-multiple-static",
+      "ink-no-raw-text",
+      "ink-no-repeated-render",
+      "ink-prefer-use-animation",
+      "ink-prefer-use-paste",
+      "ink-static-is-append-only",
+      "ink-static-requires-key",
+      "ink-suspense-requires-concurrent",
+      "ink-use-reactive-window-size",
+      "ink-use-string-width-for-cursor",
+      "ink-use-suspend-terminal",
+      "ink-valid-aria-semantics",
       "nextjs-async-dynamic-api-not-awaited",
       "nextjs-missing-metadata",
       "nextjs-no-img-element",

--- a/packages/fuzz/corpus/liveness/ink-rules.tsx
+++ b/packages/fuzz/corpus/liveness/ink-rules.tsx
@@ -1,0 +1,59 @@
+import { Suspense, useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { spawn } from "node:child_process";
+import {
+  Box,
+  Newline,
+  Static,
+  Text,
+  measureElement,
+  render,
+  renderToString,
+  useCursor,
+  useFocusManager,
+  useInput,
+  useStdin,
+} from "ink";
+
+export const InkFuzzTarget = ({ items, label, node }) => {
+  const focusManager = useFocusManager();
+  const cursor = useCursor();
+  const { setRawMode } = useStdin();
+  const [frame, setFrame] = useState(0);
+  measureElement(node);
+  focusManager.focus("target");
+  setRawMode(true);
+  cursor.setCursorPosition(label.length, 0);
+  useInput((input, key) => {
+    if (key.ctrl && input === "c") process.exit(0);
+    if (input.includes("\n")) paste(input);
+    spawn("vim", [], { stdio: "inherit" });
+  });
+  useEffect(() => {
+    const timer = setInterval(() => setFrame((value) => value + 1), 80);
+    return () => clearInterval(timer);
+  }, []);
+  return (
+    <Box>
+      raw
+      <div />
+      <Link to="/" />
+      <Newline />
+      <Text aria-role="dialog">
+        <Box />
+      </Text>
+      <Static items={items.filter(Boolean)}>{(item) => <Text>{item}</Text>}</Static>
+      <Static items={items} />
+      <Text>{process.stdout.columns + frame}</Text>
+    </Box>
+  );
+};
+
+render(
+  <Suspense fallback={null}>
+    <Text />
+    <InkFuzzTarget items={[]} label="界" node={null} />
+  </Suspense>,
+);
+render(<Text />);
+renderToString(<InkFuzzTarget items={[]} label="界" node={null} />);

--- a/packages/fuzz/corpus/liveness/ink-rules.tsx
+++ b/packages/fuzz/corpus/liveness/ink-rules.tsx
@@ -23,7 +23,7 @@ export const InkFuzzTarget = ({ items, label, node }) => {
   measureElement(node);
   focusManager.focus("target");
   setRawMode(true);
-  cursor.setCursorPosition(label.length, 0);
+  cursor.setCursorPosition({ x: label.length, y: 0 });
   useInput((input, key) => {
     if (key.ctrl && input === "c") process.exit(0);
     if (input.includes("\n")) paste(input);
@@ -42,7 +42,7 @@ export const InkFuzzTarget = ({ items, label, node }) => {
       <Text aria-role="dialog">
         <Box />
       </Text>
-      <Static items={items.filter(Boolean)}>{(item) => <Text>{item}</Text>}</Static>
+      <Static items={items.toReversed()}>{(item) => <Text>{item}</Text>}</Static>
       <Static items={items} />
       <Text>{process.stdout.columns + frame}</Text>
     </Box>

--- a/packages/fuzz/corpus/regressions/ink-ctrl-c-handler-requires-exit-option--control-flow.tsx
+++ b/packages/fuzz/corpus/regressions/ink-ctrl-c-handler-requires-exit-option--control-flow.tsx
@@ -1,0 +1,14 @@
+// rule: ink-ctrl-c-handler-requires-exit-option
+// weakness: control-flow
+// source: Cursor Bugbot review on PR 1404
+import { render, useInput } from "ink";
+
+const App = () => {
+  useInput((input, key) => {
+    if (key.ctrl) toggleMode();
+    if (input === "c") copySelection();
+  });
+  return null;
+};
+
+render(<App />);

--- a/packages/fuzz/corpus/regressions/ink-ctrl-c-handler-requires-exit-option--dynamic-options.tsx
+++ b/packages/fuzz/corpus/regressions/ink-ctrl-c-handler-requires-exit-option--dynamic-options.tsx
@@ -1,0 +1,14 @@
+// rule: ink-ctrl-c-handler-requires-exit-option
+// weakness: dynamic-computed
+// source: adversarial audit of PR 1404 renderer option resolution
+import { render, useInput } from "ink";
+
+const App = () => {
+  useInput((input, key) => {
+    if (key.ctrl && input === "c") save();
+  });
+  return null;
+};
+
+const options = { exitOnCtrlC: false };
+render(<App />, { ...options });

--- a/packages/fuzz/corpus/regressions/ink-ctrl-c-handler-requires-exit-option--unmounted-component.tsx
+++ b/packages/fuzz/corpus/regressions/ink-ctrl-c-handler-requires-exit-option--unmounted-component.tsx
@@ -1,0 +1,15 @@
+// rule: ink-ctrl-c-handler-requires-exit-option
+// weakness: component-ownership
+// source: Cursor Bugbot review on PR 1404
+import { render, useInput } from "ink";
+
+const Root = () => null;
+
+export const Unmounted = () => {
+  useInput((input, key) => {
+    if (key.ctrl && input === "c") copySelection();
+  });
+  return null;
+};
+
+render(<Root />);

--- a/packages/fuzz/corpus/regressions/ink-no-bare-process-exit--explicit-restore.tsx
+++ b/packages/fuzz/corpus/regressions/ink-no-bare-process-exit--explicit-restore.tsx
@@ -1,0 +1,16 @@
+// rule: ink-no-bare-process-exit
+// weakness: explicit-cleanup
+// source: explicit terminal restoration permits a deliberate process exit
+import { useInput } from "ink";
+
+interface AppProperties {
+  restore: () => void;
+}
+
+export const App = ({ restore }: AppProperties) => {
+  useInput(() => {
+    restore();
+    process.exit(0);
+  });
+  return null;
+};

--- a/packages/fuzz/corpus/regressions/ink-no-live-hooks-in-render-to-string--shared-live-component.tsx
+++ b/packages/fuzz/corpus/regressions/ink-no-live-hooks-in-render-to-string--shared-live-component.tsx
@@ -1,0 +1,20 @@
+// rule: ink-no-live-hooks-in-render-to-string
+// weakness: component-ownership
+// source: Ink renderToString docs support no-op terminal hooks and shared components
+import { render, renderToString, useInput, useStdout } from "ink";
+
+const App = () => {
+  useInput(() => {});
+  return null;
+};
+
+render(<App />);
+renderToString(<App />);
+
+export const SharedApp = () => {
+  useInput(() => {});
+  useStdout();
+  return null;
+};
+
+renderToString(<SharedApp />);

--- a/packages/fuzz/corpus/regressions/ink-no-multiple-static--exclusive-branches.tsx
+++ b/packages/fuzz/corpus/regressions/ink-no-multiple-static--exclusive-branches.tsx
@@ -1,0 +1,11 @@
+// rule: ink-no-multiple-static
+// weakness: control-flow
+// source: adversarial audit of PR 1404 against Ink Static ownership
+import { Static } from "ink";
+
+export const App = ({ compact }: { compact: boolean }) => (
+  <>
+    {compact && <Static items={[]} />}
+    {!compact && <Static items={[]} />}
+  </>
+);

--- a/packages/fuzz/corpus/regressions/ink-no-raw-text--jsx-attribute-values.tsx
+++ b/packages/fuzz/corpus/regressions/ink-no-raw-text--jsx-attribute-values.tsx
@@ -1,0 +1,10 @@
+// rule: ink-no-raw-text
+// weakness: jsx-position
+// source: RDE hyperdxio/hyperdx Ink CLI sample
+import { Box, Text } from "ink";
+
+export const PaddedBox = () => (
+  <Box paddingX={1} paddingY={0}>
+    <Text>Ready</Text>
+  </Box>
+);

--- a/packages/fuzz/corpus/regressions/ink-no-repeated-render--destructured-unmount.tsx
+++ b/packages/fuzz/corpus/regressions/ink-no-repeated-render--destructured-unmount.tsx
@@ -1,0 +1,10 @@
+// rule: ink-no-repeated-render
+// weakness: library-idiom
+// source: Ink render returns a destructurable unmount method
+import { render } from "ink";
+
+export const remount = () => {
+  const { unmount } = render(null);
+  unmount();
+  render(null);
+};

--- a/packages/fuzz/corpus/regressions/ink-no-repeated-render--different-stdout.tsx
+++ b/packages/fuzz/corpus/regressions/ink-no-repeated-render--different-stdout.tsx
@@ -1,0 +1,23 @@
+// rule: ink-no-repeated-render
+// weakness: library-idiom
+// source: Ink render docs permit separate instances on different stdout streams
+import { render } from "ink";
+
+export const mountBoth = (firstOutput: NodeJS.WriteStream, secondOutput: NodeJS.WriteStream) => {
+  render(null, { stdout: firstOutput });
+  render(null, { stdout: secondOutput });
+};
+
+export const mountShadowed = (
+  firstOutput: NodeJS.WriteStream,
+  secondOutput: NodeJS.WriteStream,
+) => {
+  {
+    const output = firstOutput;
+    render(null, { stdout: output });
+  }
+  {
+    const output = secondOutput;
+    render(null, { stdout: output });
+  }
+};

--- a/packages/fuzz/corpus/regressions/ink-no-repeated-render--exclusive-handlers.tsx
+++ b/packages/fuzz/corpus/regressions/ink-no-repeated-render--exclusive-handlers.tsx
@@ -1,0 +1,12 @@
+// rule: ink-no-repeated-render
+// weakness: control-flow-path
+// source: RDE hyperdxio/hyperdx Ink CLI sample
+import { render } from "ink";
+
+export const selectServer = (hasServer: boolean) => {
+  if (hasServer) render(null);
+  else render(null);
+};
+
+export const login = () => render(null);
+export const logout = () => render(null);

--- a/packages/fuzz/corpus/regressions/ink-prefer-use-animation--non-ink-component.tsx
+++ b/packages/fuzz/corpus/regressions/ink-prefer-use-animation--non-ink-component.tsx
@@ -1,0 +1,13 @@
+// rule: ink-prefer-use-animation
+// weakness: framework-gating
+// source: adversarial audit of PR 1404 Ink component ownership
+import { useEffect, useState } from "react";
+
+export const Dashboard = () => {
+  const [frame, setFrame] = useState(0);
+  useEffect(() => {
+    const timer = setInterval(() => setFrame((value) => value + 1), 80);
+    return () => clearInterval(timer);
+  }, []);
+  return <div>{frame}</div>;
+};

--- a/packages/fuzz/corpus/regressions/ink-prefer-use-paste--shadowed-input.tsx
+++ b/packages/fuzz/corpus/regressions/ink-prefer-use-paste--shadowed-input.tsx
@@ -1,0 +1,12 @@
+// rule: ink-prefer-use-paste
+// weakness: alias-guard
+// source: adversarial audit of PR 1404 nested callback scope
+import { useInput } from "ink";
+
+export const App = () => {
+  useInput((input) => {
+    ["a"].some((input) => input.includes("\n"));
+    if (input.length >= 1) consume(input);
+  });
+  return null;
+};

--- a/packages/fuzz/corpus/regressions/ink-static-is-append-only--stable-filter.tsx
+++ b/packages/fuzz/corpus/regressions/ink-static-is-append-only--stable-filter.tsx
@@ -1,0 +1,8 @@
+// rule: ink-static-is-append-only
+// weakness: library-idiom
+// source: adversarial audit of PR 1404 against Ink Static semantics
+import { Static } from "ink";
+
+export const App = () => <Static items={[1, 2, 3].filter(Boolean)}>{() => null}</Static>;
+
+export const SortedApp = () => <Static items={[3, 1, 2].toSorted()}>{() => null}</Static>;

--- a/packages/fuzz/corpus/regressions/ink-suspense-requires-concurrent--unmounted-component.tsx
+++ b/packages/fuzz/corpus/regressions/ink-suspense-requires-concurrent--unmounted-component.tsx
@@ -1,0 +1,15 @@
+// rule: ink-suspense-requires-concurrent
+// weakness: component-ownership
+// source: Cursor Bugbot review on PR 1404
+import { Suspense } from "react";
+import { render, Text } from "ink";
+
+const Root = () => <Text>root</Text>;
+
+export const Unmounted = () => (
+  <Suspense fallback={null}>
+    <Text>unused</Text>
+  </Suspense>
+);
+
+render(<Root />);

--- a/packages/fuzz/corpus/regressions/ink-suspense-requires-concurrent--unreachable-branch.tsx
+++ b/packages/fuzz/corpus/regressions/ink-suspense-requires-concurrent--unreachable-branch.tsx
@@ -1,0 +1,17 @@
+// rule: ink-suspense-requires-concurrent
+// weakness: control-flow
+// source: adversarial audit of PR 1404 renderer graph reachability
+import { Suspense } from "react";
+import { render, Text } from "ink";
+
+const App = () => (
+  <>
+    {false && (
+      <Suspense fallback={null}>
+        <Text>unused</Text>
+      </Suspense>
+    )}
+  </>
+);
+
+render(<App />);

--- a/packages/fuzz/corpus/regressions/ink-suspense-requires-concurrent--unused-nested-component.tsx
+++ b/packages/fuzz/corpus/regressions/ink-suspense-requires-concurrent--unused-nested-component.tsx
@@ -1,0 +1,16 @@
+// rule: ink-suspense-requires-concurrent
+// weakness: component-ownership
+// source: adversarial audit of PR 1404 same-file renderer graph
+import { Suspense } from "react";
+import { render, Text } from "ink";
+
+const Root = () => {
+  const _Unused = () => (
+    <Suspense fallback={null}>
+      <Text>unused</Text>
+    </Suspense>
+  );
+  return <Text>root</Text>;
+};
+
+render(<Root />);

--- a/packages/fuzz/corpus/regressions/ink-use-reactive-window-size--manual-resize-listener.tsx
+++ b/packages/fuzz/corpus/regressions/ink-use-reactive-window-size--manual-resize-listener.tsx
@@ -1,0 +1,15 @@
+// rule: ink-use-reactive-window-size
+// weakness: library-idiom
+// source: aflekkas/rawdog manual SIGWINCH-compatible resize handling
+import { Text } from "ink";
+import { useEffect, useState } from "react";
+
+export const App = () => {
+  const [columns, setColumns] = useState(process.stdout.columns);
+  useEffect(() => {
+    const update = () => setColumns(process.stdout.columns);
+    process.stdout.on("resize", update);
+    return () => process.stdout.off("resize", update);
+  }, []);
+  return <Text>{columns}</Text>;
+};

--- a/packages/fuzz/corpus/regressions/ink-use-string-width-for-cursor--ascii-constant.tsx
+++ b/packages/fuzz/corpus/regressions/ink-use-string-width-for-cursor--ascii-constant.tsx
@@ -1,0 +1,11 @@
+// rule: ink-use-string-width-for-cursor
+// weakness: copy-tracking
+// source: adversarial audit of PR 1404 ASCII-only cursor labels
+import { useCursor } from "ink";
+
+export const App = () => {
+  const label = "Ready";
+  const cursor = useCursor();
+  cursor.setCursorPosition({ x: label.length, y: 0 });
+  return null;
+};

--- a/packages/fuzz/corpus/regressions/ink-use-suspend-terminal--inactive-ink-module.tsx
+++ b/packages/fuzz/corpus/regressions/ink-use-suspend-terminal--inactive-ink-module.tsx
@@ -1,0 +1,8 @@
+// rule: ink-use-suspend-terminal
+// weakness: component-ownership
+// source: adversarial audit of PR 1404 terminal lifecycle ownership
+import { spawn } from "node:child_process";
+import { Text } from "ink";
+
+export const launchEditor = () => spawn("vim", [], { stdio: "inherit" });
+export const App = () => <Text>Ready</Text>;

--- a/packages/fuzz/corpus/true-positives/ink-no-bare-process-exit--after-ink-exit.tsx
+++ b/packages/fuzz/corpus/true-positives/ink-no-bare-process-exit--after-ink-exit.tsx
@@ -1,0 +1,13 @@
+// rule: ink-no-bare-process-exit
+// weakness: cleanup-provenance
+// source: Ink exit does not make a later process.exit safe
+import { useApp, useInput } from "ink";
+
+export const App = () => {
+  const { exit } = useApp();
+  useInput(() => {
+    exit();
+    process.exit(0);
+  });
+  return null;
+};

--- a/packages/fuzz/corpus/true-positives/ink-no-bare-process-exit--arbitrary-restore.tsx
+++ b/packages/fuzz/corpus/true-positives/ink-no-bare-process-exit--arbitrary-restore.tsx
@@ -1,6 +1,5 @@
 // rule: ink-no-bare-process-exit
-// weakness: explicit-cleanup
-// source: explicit terminal restoration permits a deliberate process exit
+// source: an arbitrary restore helper does not prove complete Ink terminal cleanup
 import { useInput } from "ink";
 
 interface AppProperties {

--- a/packages/fuzz/corpus/true-positives/ink-no-live-hooks-in-render-to-string--nested-export.tsx
+++ b/packages/fuzz/corpus/true-positives/ink-no-live-hooks-in-render-to-string--nested-export.tsx
@@ -1,0 +1,13 @@
+// rule: ink-no-live-hooks-in-render-to-string
+// weakness: component-ownership
+// source: Cursor Bugbot review on PR 1404
+import { renderToString, useInput } from "ink";
+
+export const makeSnapshot = () => {
+  const SnapshotInput = () => {
+    useInput(() => {});
+    return null;
+  };
+
+  return renderToString(<SnapshotInput />);
+};

--- a/packages/fuzz/corpus/true-positives/ink-no-repeated-render--unrelated-unmount.tsx
+++ b/packages/fuzz/corpus/true-positives/ink-no-repeated-render--unrelated-unmount.tsx
@@ -1,0 +1,14 @@
+// rule: ink-no-repeated-render
+// weakness: binding-identity
+// source: unrelated cleanup does not release Ink's renderer
+import { render } from "ink";
+
+interface OtherRenderer {
+  unmount: () => void;
+}
+
+export const mountTwice = (otherRenderer: OtherRenderer) => {
+  render(null);
+  otherRenderer.unmount();
+  render(null);
+};

--- a/packages/fuzz/corpus/true-positives/ink-suspense-requires-concurrent--ink-ancestor.tsx
+++ b/packages/fuzz/corpus/true-positives/ink-suspense-requires-concurrent--ink-ancestor.tsx
@@ -1,0 +1,15 @@
+// rule: ink-suspense-requires-concurrent
+// weakness: component-ownership
+// source: Cursor Bugbot review on PR 1404
+import { Suspense } from "react";
+import { Box, render } from "ink";
+
+const LazyScreen = () => null;
+
+render(
+  <Box>
+    <Suspense fallback={null}>
+      <LazyScreen />
+    </Suspense>
+  </Box>,
+);

--- a/packages/oxlint-plugin-react-doctor/scripts/generate-rule-registry.mjs
+++ b/packages/oxlint-plugin-react-doctor/scripts/generate-rule-registry.mjs
@@ -62,6 +62,7 @@ const BUCKETS_REQUIRING_REACT = new Set([
 // inherit a bucket tag and carry its own.
 const BUCKET_TO_AUTO_TAGS = {
   design: ["design"],
+  ink: ["ink"],
   "react-native": ["react-native"],
   "security-scan": ["security-scan"],
   server: ["server-action"],
@@ -175,6 +176,7 @@ const BUCKET_TO_DEFAULT_CATEGORY = {
   client: "Performance",
   correctness: "Correctness",
   design: "Architecture",
+  ink: "Correctness",
   "js-performance": "Performance",
   jotai: "State & Effects",
   mobx: "State & Effects",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/cross-file-rule-ids.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/cross-file-rule-ids.ts
@@ -1,3 +1,5 @@
+import { INK_RULE_IDS } from "./ink.js";
+
 // Rules whose verdict for a file can depend on the content of OTHER files at
 // lint time. The per-file lint cache (`@react-doctor/core`'s `file-lint-cache`)
 // keys cached diagnostics on a single file's own content, so it would serve
@@ -34,6 +36,7 @@
 // also forces every rule here into the bounded/unbounded classification in
 // `cross-file-dependencies.ts`.
 export const CROSS_FILE_RULE_IDS: ReadonlySet<string> = new Set([
+  ...INK_RULE_IDS,
   "client-passive-event-listeners",
   "exhaustive-deps",
   "no-barrel-import",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/ink.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/ink.ts
@@ -1,0 +1,37 @@
+export const INK_MODULE = "ink";
+
+export const MINIMUM_INK_VERSIONS = {
+  base: "3.0.0",
+  textLayoutGuard: "3.0.1",
+  aria: "6.2.0",
+  cursor: "6.7.0",
+  concurrent: "6.7.0",
+  renderToString: "6.8.0",
+  modernHooks: "7.0.0",
+  suspendTerminal: "7.1.0",
+};
+
+export const INK_RULE_IDS: ReadonlyArray<string> = [
+  "ink-ctrl-c-handler-requires-exit-option",
+  "ink-newline-inside-text",
+  "ink-no-bare-process-exit",
+  "ink-no-direct-raw-mode",
+  "ink-no-dom-host-elements",
+  "ink-no-dom-router",
+  "ink-no-focus-in-render",
+  "ink-no-layout-inside-text",
+  "ink-no-live-hooks-in-render-to-string",
+  "ink-no-measure-element-in-render",
+  "ink-no-multiple-static",
+  "ink-no-raw-text",
+  "ink-no-repeated-render",
+  "ink-prefer-use-animation",
+  "ink-prefer-use-paste",
+  "ink-static-is-append-only",
+  "ink-static-requires-key",
+  "ink-suspense-requires-concurrent",
+  "ink-use-reactive-window-size",
+  "ink-use-string-width-for-cursor",
+  "ink-use-suspend-terminal",
+  "ink-valid-aria-semantics",
+];

--- a/packages/oxlint-plugin-react-doctor/src/plugin/cross-file-dependencies.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/cross-file-dependencies.test.ts
@@ -389,6 +389,25 @@ describe("react-native collectors", () => {
   });
 });
 
+describe("Ink collectors", () => {
+  it("records the owning manifest when no installed Ink package is available", () => {
+    writeFixtureFile("package.json", `{ "dependencies": { "ink": "^7.1.0" } }\n`);
+    const appPath = writeFixtureFile("src/App.tsx", "export const App = () => null;\n");
+    const trace = collectFor(appPath, ["ink-no-raw-text"]);
+    expect(trace?.contentPaths.has(fixturePath("package.json"))).toBe(true);
+    expect(trace?.existencePaths.has(fixturePath("src/package.json"))).toBe(true);
+  });
+
+  it("records the installed Ink manifest instead of the declared range", () => {
+    writeFixtureFile("package.json", `{ "dependencies": { "ink": "^3.0.0" } }\n`);
+    writeFixtureFile("node_modules/ink/package.json", `{ "name": "ink", "version": "7.1.1" }\n`);
+    const appPath = writeFixtureFile("src/App.tsx", "export const App = () => null;\n");
+    const trace = collectFor(appPath, ["ink-use-suspend-terminal"]);
+    expect(trace?.contentPaths.has(fixturePath("node_modules/ink/package.json"))).toBe(true);
+    expect(trace?.contentPaths.has(fixturePath("package.json"))).toBe(false);
+  });
+});
+
 describe("no-create-ref-in-function-component collector", () => {
   it("records the modules in the createRef consumer chain on warm and cold collection", () => {
     writeFixtureFile(

--- a/packages/oxlint-plugin-react-doctor/src/plugin/cross-file-dependencies.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/cross-file-dependencies.test.ts
@@ -398,6 +398,22 @@ describe("Ink collectors", () => {
     expect(trace?.existencePaths.has(fixturePath("src/package.json"))).toBe(true);
   });
 
+  it("records imported JSX wrappers for ink-no-raw-text", () => {
+    writeFixtureFile("package.json", `{ "dependencies": { "ink": "^7.1.0" } }\n`);
+    writeFixtureFile(
+      "src/Panel.tsx",
+      `import { Box } from "ink";\nexport const Panel = ({ children }) => <Box>{children}</Box>;\n`,
+    );
+    writeFixtureFile("src/helper.ts", "export const helper = () => 1;\n");
+    const appPath = writeFixtureFile(
+      "src/App.tsx",
+      `import { Panel } from "./Panel";\nimport { helper } from "./helper";\nexport const App = () => <Panel>hi {helper()}</Panel>;\n`,
+    );
+    const trace = collectFor(appPath, ["ink-no-raw-text"]);
+    expect(trace?.contentPaths.has(fixturePath("src/Panel.tsx"))).toBe(true);
+    expect(trace?.contentPaths.has(fixturePath("src/helper.ts"))).toBe(false);
+  });
+
   it("records the installed Ink manifest instead of the declared range", () => {
     writeFixtureFile("package.json", `{ "dependencies": { "ink": "^3.0.0" } }\n`);
     writeFixtureFile("node_modules/ink/package.json", `{ "name": "ink", "version": "7.1.1" }\n`);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/cross-file-dependencies.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/cross-file-dependencies.ts
@@ -9,6 +9,7 @@ import {
 import { CUSTOM_HOOK_DEPENDENCY_FORWARD_DEPTH } from "./constants/thresholds.js";
 import { INK_RULE_IDS } from "./constants/ink.js";
 import { classifyPackagePlatform } from "./utils/classify-package-platform.js";
+import { collectImportedJsxComponentDependencies } from "./utils/collect-imported-jsx-component-dependencies.js";
 import { collectCrossFileProbes } from "./utils/cross-file-probe-recorder.js";
 import type { CrossFileProbeTrace } from "./utils/cross-file-probe-recorder.js";
 import type { EsTreeNode } from "./utils/es-tree-node.js";
@@ -301,12 +302,10 @@ const collectMutatingReducerDependencies: CrossFileDependencyCollector = ({
   for (const staticImport of staticImports) {
     if (staticImport.moduleRequest.value !== "react") continue;
     for (const entry of staticImport.entries) {
-      if (entry.importName.kind === "Name" && entry.importName.name === "useReducer") {
+      const { importName } = entry;
+      if (importName.kind === "Name" && importName.name === "useReducer") {
         namedUseReducerLocals.add(entry.localName.value);
-      } else if (
-        entry.importName.kind === "Default" ||
-        entry.importName.kind === "NamespaceObject"
-      ) {
+      } else if (importName.kind === "Default" || importName.kind === "NamespaceObject") {
         reactObjectLocals.add(entry.localName.value);
       }
     }
@@ -366,31 +365,6 @@ const collectMutatingReducerDependencies: CrossFileDependencyCollector = ({
   }
 };
 
-// The JSX names rn-no-raw-text's boundary checks consult
-// (`resolveTextBoundaryName`): plain identifiers, the property of a member
-// tag, and the namespace of a namespaced tag.
-const collectJsxBoundaryNames = (program: EsTreeNode): Set<string> => {
-  const jsxNames = new Set<string>();
-  walkAst(program, (node) => {
-    if (node.type !== "JSXOpeningElement") return;
-    const nameNode = (node as { name?: EsTreeNode }).name;
-    if (!nameNode) return;
-    if (nameNode.type === "JSXIdentifier") {
-      const name = (nameNode as { name?: unknown }).name;
-      if (typeof name === "string") jsxNames.add(name);
-    } else if (nameNode.type === "JSXMemberExpression") {
-      const property = (nameNode as { property?: { type?: string; name?: unknown } }).property;
-      if (property?.type === "JSXIdentifier" && typeof property.name === "string") {
-        jsxNames.add(property.name);
-      }
-    } else if (nameNode.type === "JSXNamespacedName") {
-      const namespace = (nameNode as { namespace?: { name?: unknown } }).namespace;
-      if (typeof namespace?.name === "string") jsxNames.add(namespace.name);
-    }
-  });
-  return jsxNames;
-};
-
 // rn-no-raw-text reads other files two ways: the package-platform gate
 // (`wrapReactNativeRule` + the rule's own RN checks — probed on EVERY file
 // the rule is enabled for) and `resolveImportedComponentForwarding` for JSX
@@ -404,22 +378,7 @@ const collectRnNoRawTextDependencies: CrossFileDependencyCollector = ({
   program,
 }) => {
   classifyPackagePlatform(absoluteFilePath);
-  const jsxNames = collectJsxBoundaryNames(program);
-  if (jsxNames.size === 0) return;
-  for (const staticImport of staticImports) {
-    for (const entry of staticImport.entries) {
-      if (entry.importName.kind === "NamespaceObject") continue;
-      if (!jsxNames.has(entry.localName.value)) continue;
-      const exportedName = entry.importName.kind === "Default" ? "default" : entry.importName.name;
-      if (exportedName) {
-        resolveCrossFileFunctionExport(
-          absoluteFilePath,
-          staticImport.moduleRequest.value,
-          exportedName,
-        );
-      }
-    }
-  }
+  collectImportedJsxComponentDependencies({ absoluteFilePath, staticImports, program });
 };
 
 // no-dynamic-import-path / no-full-lodash-import (`is-inside-node-cli-package`),
@@ -449,12 +408,20 @@ const collectInkVersionDependencies: CrossFileDependencyCollector = ({ absoluteF
   resolveInkVersion(absoluteFilePath);
 };
 
+// ink-no-raw-text also reads imported JSX wrapper implementations. Resolving
+// every imported JSX name is a safe superset of the wrappers the rule follows.
+const collectInkNoRawTextDependencies: CrossFileDependencyCollector = (input) => {
+  collectInkVersionDependencies(input);
+  collectImportedJsxComponentDependencies(input);
+};
+
 export const CROSS_FILE_DEPENDENCY_COLLECTORS: ReadonlyMap<string, CrossFileDependencyCollector> =
   new Map([
     ...INK_RULE_IDS.map((ruleId): [string, CrossFileDependencyCollector] => [
       ruleId,
       collectInkVersionDependencies,
     ]),
+    ["ink-no-raw-text", collectInkNoRawTextDependencies],
     ["client-passive-event-listeners", collectEffectValueHelperDependencies],
     ["exhaustive-deps", collectForwardedHookDependencies],
     ["no-barrel-import", collectNoBarrelImportDependencies],

--- a/packages/oxlint-plugin-react-doctor/src/plugin/cross-file-dependencies.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/cross-file-dependencies.ts
@@ -7,6 +7,7 @@ import {
   PAGE_OR_LAYOUT_FILE_PATTERN,
 } from "./constants/nextjs.js";
 import { CUSTOM_HOOK_DEPENDENCY_FORWARD_DEPTH } from "./constants/thresholds.js";
+import { INK_RULE_IDS } from "./constants/ink.js";
 import { classifyPackagePlatform } from "./utils/classify-package-platform.js";
 import { collectCrossFileProbes } from "./utils/cross-file-probe-recorder.js";
 import type { CrossFileProbeTrace } from "./utils/cross-file-probe-recorder.js";
@@ -16,6 +17,7 @@ import { hasAncestorMetadataLayout } from "./utils/find-ancestor-metadata-layout
 import { hasAncestorSuspenseLayout } from "./utils/find-ancestor-suspense-layout.js";
 import { isBarrelIndexModule } from "./utils/is-barrel-index-module.js";
 import { isLegacyArchReactNativeFile } from "./utils/is-legacy-arch-react-native-file.js";
+import { resolveInkVersion } from "./utils/resolve-ink-version.js";
 import { isNodeOfType } from "./utils/is-node-of-type.js";
 import { isReactApiCall } from "./utils/is-react-api-call.js";
 import { normalizeFilename } from "./utils/normalize-filename.js";
@@ -443,8 +445,16 @@ const collectLegacyArchDependencies: CrossFileDependencyCollector = ({ absoluteF
   isLegacyArchReactNativeFile(absoluteFilePath);
 };
 
+const collectInkVersionDependencies: CrossFileDependencyCollector = ({ absoluteFilePath }) => {
+  resolveInkVersion(absoluteFilePath);
+};
+
 export const CROSS_FILE_DEPENDENCY_COLLECTORS: ReadonlyMap<string, CrossFileDependencyCollector> =
   new Map([
+    ...INK_RULE_IDS.map((ruleId): [string, CrossFileDependencyCollector] => [
+      ruleId,
+      collectInkVersionDependencies,
+    ]),
     ["client-passive-event-listeners", collectEffectValueHelperDependencies],
     ["exhaustive-deps", collectForwardedHookDependencies],
     ["no-barrel-import", collectNoBarrelImportDependencies],

--- a/packages/oxlint-plugin-react-doctor/src/plugin/liveness/known-uncovered.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/liveness/known-uncovered.ts
@@ -11,4 +11,7 @@ export const KNOWN_UNCOVERED: Readonly<Record<string, string>> = {
     "resolves the imported barrel module on the real filesystem to count its re-exports, which the in-memory liveness harness cannot fake",
   "rn-animate-layout-property": "retired rule: create() intentionally never reports",
   "rn-prefer-content-inset-adjustment": "retired rule: create() intentionally never reports",
+  "ink-newline-inside-text": "retired rule: Ink supports Newline as a standalone text node",
+  "ink-suspense-requires-concurrent":
+    "retired rule: Ink supports Suspense fallback rendering without concurrent mode",
 };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness-fixtures.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness-fixtures.ts
@@ -331,7 +331,7 @@ export const livenessFixtures: Readonly<Record<string, LivenessFixture>> = {
     code: 'import {useInput} from "ink";const App=()=>{useInput(input=>{if(input.includes("\\n"))paste(input)});return null};',
   },
   "ink-static-is-append-only": {
-    code: 'import {Static} from "ink";const App=({items})=> <Static items={items.filter(Boolean)}/>;',
+    code: 'import {Static} from "ink";const App=({items})=> <Static items={items.toReversed()}/>;',
   },
   "ink-static-requires-key": {
     code: 'import {Static,Text} from "ink";const App=({items})=> <Static items={items}>{item=><Text>{item}</Text>}</Static>;',
@@ -343,7 +343,7 @@ export const livenessFixtures: Readonly<Record<string, LivenessFixture>> = {
     code: 'import {Text} from "ink";const App=()=> <Text>{process.stdout.columns}</Text>;',
   },
   "ink-use-string-width-for-cursor": {
-    code: 'import {useCursor} from "ink";const App=({label})=>{const cursor=useCursor();cursor.setCursorPosition(label.length,0);return null};',
+    code: 'import {useCursor} from "ink";const App=({label})=>{const cursor=useCursor();cursor.setCursorPosition({x:label.length,y:0});return null};',
   },
   "ink-use-suspend-terminal": {
     code: 'import {useInput} from "ink";import {spawn} from "node:child_process";const App=()=>{useInput(()=>spawn("vim",[],{stdio:"inherit"}));return null};',

--- a/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness-fixtures.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness-fixtures.ts
@@ -285,6 +285,72 @@ export const livenessFixtures: Readonly<Record<string, LivenessFixture>> = {
     code: 'import { createHash } from "node:crypto";\n\nexport const hashPassword = (password: string) =>\n  createHash("md5").update(password).digest("hex");\n',
     filePath: "src/server/auth.ts",
   },
+  "ink-ctrl-c-handler-requires-exit-option": {
+    code: 'import {render,useInput} from "ink";const App=()=>{useInput((input,key)=>{if(key.ctrl&&input==="c")work()});return null};render(<App/>);',
+  },
+  "ink-newline-inside-text": {
+    code: 'import {Box,Newline} from "ink";const App=()=> <Box><Newline/></Box>;',
+  },
+  "ink-no-bare-process-exit": {
+    code: 'import {useInput} from "ink";const App=()=>{useInput(()=>process.exit(0));return null};',
+  },
+  "ink-no-direct-raw-mode": {
+    code: 'import {useStdin} from "ink";const App=()=>{const {setRawMode}=useStdin();setRawMode(true);return null};',
+  },
+  "ink-no-dom-host-elements": {
+    code: 'import {Box} from "ink";const App=()=> <Box><div/></Box>;',
+  },
+  "ink-no-dom-router": {
+    code: 'import {Box} from "ink";import {Link} from "react-router-dom";const App=()=> <Box><Link to="/"/></Box>;',
+  },
+  "ink-no-focus-in-render": {
+    code: 'import {useFocusManager} from "ink";const App=()=>{const manager=useFocusManager();manager.focus("name");return null};',
+  },
+  "ink-no-layout-inside-text": {
+    code: 'import {Box,Text} from "ink";const App=()=> <Text><Box/></Text>;',
+  },
+  "ink-no-live-hooks-in-render-to-string": {
+    code: 'import {renderToString,useInput} from "ink";const App=()=>{useInput(()=>{});return null};renderToString(<App/>);',
+  },
+  "ink-no-measure-element-in-render": {
+    code: 'import {measureElement} from "ink";const App=({node})=>{measureElement(node);return null};',
+  },
+  "ink-no-multiple-static": {
+    code: 'import {Static} from "ink";const App=()=> <><Static items={[]}/><Static items={[]}/></>;',
+  },
+  "ink-no-raw-text": {
+    code: 'import {Box} from "ink";const App=()=> <Box>hello</Box>;',
+  },
+  "ink-no-repeated-render": {
+    code: 'import {render} from "ink";render(null);render(null);',
+  },
+  "ink-prefer-use-animation": {
+    code: 'import {useEffect,useState} from "react";import {Text} from "ink";const App=()=>{const [frame,setFrame]=useState(0);useEffect(()=>{const timer=setInterval(()=>setFrame(value=>value+1),80);return()=>clearInterval(timer)},[]);return <Text>{frame}</Text>};',
+  },
+  "ink-prefer-use-paste": {
+    code: 'import {useInput} from "ink";const App=()=>{useInput(input=>{if(input.includes("\\n"))paste(input)});return null};',
+  },
+  "ink-static-is-append-only": {
+    code: 'import {Static} from "ink";const App=({items})=> <Static items={items.filter(Boolean)}/>;',
+  },
+  "ink-static-requires-key": {
+    code: 'import {Static,Text} from "ink";const App=({items})=> <Static items={items}>{item=><Text>{item}</Text>}</Static>;',
+  },
+  "ink-suspense-requires-concurrent": {
+    code: 'import {render,Text} from "ink";import {Suspense} from "react";render(<Suspense fallback={null}><Text/></Suspense>);',
+  },
+  "ink-use-reactive-window-size": {
+    code: 'import {Text} from "ink";const App=()=> <Text>{process.stdout.columns}</Text>;',
+  },
+  "ink-use-string-width-for-cursor": {
+    code: 'import {useCursor} from "ink";const App=({label})=>{const cursor=useCursor();cursor.setCursorPosition(label.length,0);return null};',
+  },
+  "ink-use-suspend-terminal": {
+    code: 'import {useInput} from "ink";import {spawn} from "node:child_process";const App=()=>{useInput(()=>spawn("vim",[],{stdio:"inherit"}));return null};',
+  },
+  "ink-valid-aria-semantics": {
+    code: 'import {Text} from "ink";const App=()=> <Text aria-role="dialog">open</Text>;',
+  },
   "insecure-session-cookie": {
     code: 'res.cookie("session_token", token, { httpOnly: false, secure: false });\n',
     filePath: "src/server/session.ts",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness-fixtures.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness-fixtures.ts
@@ -288,9 +288,6 @@ export const livenessFixtures: Readonly<Record<string, LivenessFixture>> = {
   "ink-ctrl-c-handler-requires-exit-option": {
     code: 'import {render,useInput} from "ink";const App=()=>{useInput((input,key)=>{if(key.ctrl&&input==="c")work()});return null};render(<App/>);',
   },
-  "ink-newline-inside-text": {
-    code: 'import {Box,Newline} from "ink";const App=()=> <Box><Newline/></Box>;',
-  },
   "ink-no-bare-process-exit": {
     code: 'import {useInput} from "ink";const App=()=>{useInput(()=>process.exit(0));return null};',
   },
@@ -335,9 +332,6 @@ export const livenessFixtures: Readonly<Record<string, LivenessFixture>> = {
   },
   "ink-static-requires-key": {
     code: 'import {Static,Text} from "ink";const App=({items})=> <Static items={items}>{item=><Text>{item}</Text>}</Static>;',
-  },
-  "ink-suspense-requires-concurrent": {
-    code: 'import {render,Text} from "ink";import {Suspense} from "react";render(<Suspense fallback={null}><Text/></Suspense>);',
   },
   "ink-use-reactive-window-size": {
     code: 'import {Text} from "ink";const App=()=> <Text>{process.stdout.columns}</Text>;',

--- a/packages/oxlint-plugin-react-doctor/src/plugin/react-doctor-plugin.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/react-doctor-plugin.ts
@@ -2,6 +2,7 @@ import { ruleRegistry } from "./rule-registry.js";
 import type { Rule } from "./utils/rule.js";
 import type { HostRule } from "./utils/rule-plugin.js";
 import type { RulePlugin } from "./utils/rule-plugin.js";
+import { wrapInkRule } from "./utils/wrap-ink-rule.js";
 import { wrapNextjsRule } from "./utils/wrap-nextjs-rule.js";
 import { wrapReactNativeRule } from "./utils/wrap-react-native-rule.js";
 import { wrapWithSemanticContext } from "./utils/wrap-with-semantic-context.js";
@@ -19,6 +20,7 @@ import { wrapWithSemanticContext } from "./utils/wrap-with-semantic-context.js";
 // build on first `context.scopes` / `context.cfg` access and are memoized
 // per Program, so rules that never read them pay only the root capture.
 const applyFrameworkGate = (rule: Rule): Rule => {
+  if (rule.minimumInkVersion) return wrapInkRule(rule);
   if (rule.framework === "react-native") return wrapReactNativeRule(rule);
   if (rule.framework === "nextjs") return wrapNextjsRule(rule);
   return rule;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
@@ -90,6 +90,28 @@ import { iframeMissingSandbox } from "./rules/react-builtins/iframe-missing-sand
 import { iframeTitleUnique } from "./rules/a11y/iframe-title-unique.js";
 import { imgRedundantAlt } from "./rules/a11y/img-redundant-alt.js";
 import { importMetadataExecutionRisk } from "./rules/security-scan/import-metadata-execution-risk.js";
+import { inkCtrlCHandlerRequiresExitOption } from "./rules/ink/ink-ctrl-c-handler-requires-exit-option.js";
+import { inkNewlineInsideText } from "./rules/ink/ink-newline-inside-text.js";
+import { inkNoBareProcessExit } from "./rules/ink/ink-no-bare-process-exit.js";
+import { inkNoDirectRawMode } from "./rules/ink/ink-no-direct-raw-mode.js";
+import { inkNoDomHostElements } from "./rules/ink/ink-no-dom-host-elements.js";
+import { inkNoDomRouter } from "./rules/ink/ink-no-dom-router.js";
+import { inkNoFocusInRender } from "./rules/ink/ink-no-focus-in-render.js";
+import { inkNoLayoutInsideText } from "./rules/ink/ink-no-layout-inside-text.js";
+import { inkNoLiveHooksInRenderToString } from "./rules/ink/ink-no-live-hooks-in-render-to-string.js";
+import { inkNoMeasureElementInRender } from "./rules/ink/ink-no-measure-element-in-render.js";
+import { inkNoMultipleStatic } from "./rules/ink/ink-no-multiple-static.js";
+import { inkNoRawText } from "./rules/ink/ink-no-raw-text.js";
+import { inkNoRepeatedRender } from "./rules/ink/ink-no-repeated-render.js";
+import { inkPreferUseAnimation } from "./rules/ink/ink-prefer-use-animation.js";
+import { inkPreferUsePaste } from "./rules/ink/ink-prefer-use-paste.js";
+import { inkStaticIsAppendOnly } from "./rules/ink/ink-static-is-append-only.js";
+import { inkStaticRequiresKey } from "./rules/ink/ink-static-requires-key.js";
+import { inkSuspenseRequiresConcurrent } from "./rules/ink/ink-suspense-requires-concurrent.js";
+import { inkUseReactiveWindowSize } from "./rules/ink/ink-use-reactive-window-size.js";
+import { inkUseStringWidthForCursor } from "./rules/ink/ink-use-string-width-for-cursor.js";
+import { inkUseSuspendTerminal } from "./rules/ink/ink-use-suspend-terminal.js";
+import { inkValidAriaSemantics } from "./rules/ink/ink-valid-aria-semantics.js";
 import { insecureCryptoRisk } from "./rules/security-scan/insecure-crypto-risk.js";
 import { insecureSessionCookie } from "./rules/security-scan/insecure-session-cookie.js";
 import { interactiveSupportsFocus } from "./rules/a11y/interactive-supports-focus.js";
@@ -1619,6 +1641,270 @@ export const reactDoctorRules = [
       framework: "global",
       category: "Security",
       tags: [...new Set(["security-scan", ...(importMetadataExecutionRisk.tags ?? [])])],
+    },
+  },
+  {
+    key: "react-doctor/ink-ctrl-c-handler-requires-exit-option",
+    id: "ink-ctrl-c-handler-requires-exit-option",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...inkCtrlCHandlerRequiresExitOption,
+      framework: "global",
+      category: "Bugs",
+      tags: [...new Set(["ink", ...(inkCtrlCHandlerRequiresExitOption.tags ?? [])])],
+    },
+  },
+  {
+    key: "react-doctor/ink-newline-inside-text",
+    id: "ink-newline-inside-text",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...inkNewlineInsideText,
+      framework: "global",
+      category: "Bugs",
+      tags: [...new Set(["ink", ...(inkNewlineInsideText.tags ?? [])])],
+    },
+  },
+  {
+    key: "react-doctor/ink-no-bare-process-exit",
+    id: "ink-no-bare-process-exit",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...inkNoBareProcessExit,
+      framework: "global",
+      category: "Bugs",
+      tags: [...new Set(["ink", ...(inkNoBareProcessExit.tags ?? [])])],
+    },
+  },
+  {
+    key: "react-doctor/ink-no-direct-raw-mode",
+    id: "ink-no-direct-raw-mode",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...inkNoDirectRawMode,
+      framework: "global",
+      category: "Bugs",
+      tags: [...new Set(["ink", ...(inkNoDirectRawMode.tags ?? [])])],
+    },
+  },
+  {
+    key: "react-doctor/ink-no-dom-host-elements",
+    id: "ink-no-dom-host-elements",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...inkNoDomHostElements,
+      framework: "global",
+      category: "Bugs",
+      tags: [...new Set(["ink", ...(inkNoDomHostElements.tags ?? [])])],
+    },
+  },
+  {
+    key: "react-doctor/ink-no-dom-router",
+    id: "ink-no-dom-router",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...inkNoDomRouter,
+      framework: "global",
+      category: "Bugs",
+      tags: [...new Set(["ink", ...(inkNoDomRouter.tags ?? [])])],
+    },
+  },
+  {
+    key: "react-doctor/ink-no-focus-in-render",
+    id: "ink-no-focus-in-render",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...inkNoFocusInRender,
+      framework: "global",
+      category: "Bugs",
+      tags: [...new Set(["ink", ...(inkNoFocusInRender.tags ?? [])])],
+    },
+  },
+  {
+    key: "react-doctor/ink-no-layout-inside-text",
+    id: "ink-no-layout-inside-text",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...inkNoLayoutInsideText,
+      framework: "global",
+      category: "Bugs",
+      tags: [...new Set(["ink", ...(inkNoLayoutInsideText.tags ?? [])])],
+    },
+  },
+  {
+    key: "react-doctor/ink-no-live-hooks-in-render-to-string",
+    id: "ink-no-live-hooks-in-render-to-string",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...inkNoLiveHooksInRenderToString,
+      framework: "global",
+      category: "Bugs",
+      tags: [...new Set(["ink", ...(inkNoLiveHooksInRenderToString.tags ?? [])])],
+    },
+  },
+  {
+    key: "react-doctor/ink-no-measure-element-in-render",
+    id: "ink-no-measure-element-in-render",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...inkNoMeasureElementInRender,
+      framework: "global",
+      category: "Bugs",
+      tags: [...new Set(["ink", ...(inkNoMeasureElementInRender.tags ?? [])])],
+    },
+  },
+  {
+    key: "react-doctor/ink-no-multiple-static",
+    id: "ink-no-multiple-static",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...inkNoMultipleStatic,
+      framework: "global",
+      category: "Bugs",
+      tags: [...new Set(["ink", ...(inkNoMultipleStatic.tags ?? [])])],
+    },
+  },
+  {
+    key: "react-doctor/ink-no-raw-text",
+    id: "ink-no-raw-text",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...inkNoRawText,
+      framework: "global",
+      category: "Bugs",
+      tags: [...new Set(["ink", ...(inkNoRawText.tags ?? [])])],
+    },
+  },
+  {
+    key: "react-doctor/ink-no-repeated-render",
+    id: "ink-no-repeated-render",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...inkNoRepeatedRender,
+      framework: "global",
+      category: "Bugs",
+      tags: [...new Set(["ink", ...(inkNoRepeatedRender.tags ?? [])])],
+    },
+  },
+  {
+    key: "react-doctor/ink-prefer-use-animation",
+    id: "ink-prefer-use-animation",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...inkPreferUseAnimation,
+      framework: "global",
+      category: "Performance",
+      tags: [...new Set(["ink", ...(inkPreferUseAnimation.tags ?? [])])],
+    },
+  },
+  {
+    key: "react-doctor/ink-prefer-use-paste",
+    id: "ink-prefer-use-paste",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...inkPreferUsePaste,
+      framework: "global",
+      category: "Bugs",
+      tags: [...new Set(["ink", ...(inkPreferUsePaste.tags ?? [])])],
+    },
+  },
+  {
+    key: "react-doctor/ink-static-is-append-only",
+    id: "ink-static-is-append-only",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...inkStaticIsAppendOnly,
+      framework: "global",
+      category: "Bugs",
+      tags: [...new Set(["ink", ...(inkStaticIsAppendOnly.tags ?? [])])],
+    },
+  },
+  {
+    key: "react-doctor/ink-static-requires-key",
+    id: "ink-static-requires-key",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...inkStaticRequiresKey,
+      framework: "global",
+      category: "Bugs",
+      tags: [...new Set(["ink", ...(inkStaticRequiresKey.tags ?? [])])],
+    },
+  },
+  {
+    key: "react-doctor/ink-suspense-requires-concurrent",
+    id: "ink-suspense-requires-concurrent",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...inkSuspenseRequiresConcurrent,
+      framework: "global",
+      category: "Bugs",
+      tags: [...new Set(["ink", ...(inkSuspenseRequiresConcurrent.tags ?? [])])],
+    },
+  },
+  {
+    key: "react-doctor/ink-use-reactive-window-size",
+    id: "ink-use-reactive-window-size",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...inkUseReactiveWindowSize,
+      framework: "global",
+      category: "Bugs",
+      tags: [...new Set(["ink", ...(inkUseReactiveWindowSize.tags ?? [])])],
+    },
+  },
+  {
+    key: "react-doctor/ink-use-string-width-for-cursor",
+    id: "ink-use-string-width-for-cursor",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...inkUseStringWidthForCursor,
+      framework: "global",
+      category: "Bugs",
+      tags: [...new Set(["ink", ...(inkUseStringWidthForCursor.tags ?? [])])],
+    },
+  },
+  {
+    key: "react-doctor/ink-use-suspend-terminal",
+    id: "ink-use-suspend-terminal",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...inkUseSuspendTerminal,
+      framework: "global",
+      category: "Bugs",
+      tags: [...new Set(["ink", ...(inkUseSuspendTerminal.tags ?? [])])],
+    },
+  },
+  {
+    key: "react-doctor/ink-valid-aria-semantics",
+    id: "ink-valid-aria-semantics",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...inkValidAriaSemantics,
+      framework: "global",
+      category: "Accessibility",
+      tags: [...new Set(["ink", ...(inkValidAriaSemantics.tags ?? [])])],
     },
   },
   {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-ctrl-c-handler-requires-exit-option.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-ctrl-c-handler-requires-exit-option.ts
@@ -2,38 +2,16 @@ import { MINIMUM_INK_VERSIONS } from "../../constants/ink.js";
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
-import { getStaticPropertyKeyName } from "../../utils/get-static-property-key-name.js";
 import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { resolveInkApiName } from "../../utils/resolve-ink-api-name.js";
+import {
+  collectInkRenderCalls,
+  hasInkRenderBooleanOption,
+  resolveInkRenderCallsForNode,
+} from "../../utils/resolve-ink-render-calls.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { walkAst } from "../../utils/walk-ast.js";
-
-const hasExitOnCtrlCDisabled = (program: EsTreeNode, context: RuleContext): boolean => {
-  let isDisabled = false;
-  walkAst(program, (descendantNode) => {
-    if (
-      !isNodeOfType(descendantNode, "CallExpression") ||
-      resolveInkApiName(descendantNode.callee, context.scopes) !== "render"
-    ) {
-      return;
-    }
-    for (const argumentNode of descendantNode.arguments) {
-      if (!isNodeOfType(argumentNode, "ObjectExpression")) continue;
-      for (const propertyNode of argumentNode.properties) {
-        if (
-          isNodeOfType(propertyNode, "Property") &&
-          getStaticPropertyKeyName(propertyNode, { allowComputedString: true }) === "exitOnCtrlC" &&
-          isNodeOfType(propertyNode.value, "Literal") &&
-          propertyNode.value.value === false
-        ) {
-          isDisabled = true;
-        }
-      }
-    }
-  });
-  return isDisabled;
-};
 
 const handlesCtrlC = (handler: EsTreeNode): boolean => {
   let hasCtrlRead = false;
@@ -59,7 +37,7 @@ export const inkCtrlCHandlerRequiresExitOption = defineRule({
     "Pass `{exitOnCtrlC: false}` to `render()` before handling Ctrl-C with `useInput`.",
   create: (context) => ({
     Program(node: EsTreeNodeOfType<"Program">) {
-      if (hasExitOnCtrlCDisabled(node, context)) return;
+      const renderCalls = collectInkRenderCalls(node, context);
       walkAst(node, (descendantNode) => {
         if (
           !isNodeOfType(descendantNode, "CallExpression") ||
@@ -69,6 +47,15 @@ export const inkCtrlCHandlerRequiresExitOption = defineRule({
         }
         const handler = descendantNode.arguments[0];
         if (!handler || !handlesCtrlC(handler)) return;
+        const relatedRenderCalls = resolveInkRenderCallsForNode(descendantNode, renderCalls);
+        if (
+          relatedRenderCalls.length === 0 ||
+          relatedRenderCalls.every((renderCall) =>
+            hasInkRenderBooleanOption(renderCall.node, "exitOnCtrlC", false),
+          )
+        ) {
+          return;
+        }
         context.report({
           node: descendantNode,
           message:

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-ctrl-c-handler-requires-exit-option.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-ctrl-c-handler-requires-exit-option.ts
@@ -47,7 +47,11 @@ export const inkCtrlCHandlerRequiresExitOption = defineRule({
         }
         const handler = descendantNode.arguments[0];
         if (!handler || !handlesCtrlC(handler)) return;
-        const relatedRenderCalls = resolveInkRenderCallsForNode(descendantNode, renderCalls);
+        const relatedRenderCalls = resolveInkRenderCallsForNode(
+          descendantNode,
+          renderCalls,
+          context,
+        );
         if (
           relatedRenderCalls.length === 0 ||
           relatedRenderCalls.every((renderCall) =>

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-ctrl-c-handler-requires-exit-option.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-ctrl-c-handler-requires-exit-option.ts
@@ -2,6 +2,7 @@ import { MINIMUM_INK_VERSIONS } from "../../constants/ink.js";
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { flattenLogicalAndChain } from "../../utils/flatten-logical-and-chain.js";
 import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { resolveInkApiName } from "../../utils/resolve-ink-api-name.js";
@@ -11,21 +12,69 @@ import {
   resolveInkRenderCallsForNode,
 } from "../../utils/resolve-ink-render-calls.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import { walkAst } from "../../utils/walk-ast.js";
 
-const handlesCtrlC = (handler: EsTreeNode): boolean => {
-  let hasCtrlRead = false;
-  let hasCValue = false;
-  walkAst(handler, (descendantNode) => {
-    if (
-      isNodeOfType(descendantNode, "MemberExpression") &&
-      getStaticPropertyName(descendantNode) === "ctrl"
-    ) {
-      hasCtrlRead = true;
+const handlesCtrlC = (handler: EsTreeNode, context: RuleContext): boolean => {
+  if (
+    (!isNodeOfType(handler, "ArrowFunctionExpression") &&
+      !isNodeOfType(handler, "FunctionExpression")) ||
+    !isNodeOfType(handler.params[0], "Identifier") ||
+    !isNodeOfType(handler.params[1], "Identifier")
+  ) {
+    return false;
+  }
+  const inputSymbolId = context.scopes.symbolFor(handler.params[0])?.id;
+  const keySymbolId = context.scopes.symbolFor(handler.params[1])?.id;
+  if (inputSymbolId === undefined || keySymbolId === undefined) return false;
+
+  let hasCtrlCCondition = false;
+  walkAst(handler.body, (descendantNode) => {
+    if (!isNodeOfType(descendantNode, "LogicalExpression") || descendantNode.operator !== "&&") {
+      return;
     }
-    if (isNodeOfType(descendantNode, "Literal") && descendantNode.value === "c") hasCValue = true;
+    const operands = flattenLogicalAndChain(descendantNode);
+    const hasCtrlOperand = operands.some((operand) => {
+      const candidate = stripParenExpression(operand);
+      if (
+        !isNodeOfType(candidate, "MemberExpression") ||
+        getStaticPropertyName(candidate) !== "ctrl"
+      ) {
+        return false;
+      }
+      const receiver = stripParenExpression(candidate.object);
+      return (
+        isNodeOfType(receiver, "Identifier") &&
+        context.scopes.symbolFor(receiver)?.id === keySymbolId
+      );
+    });
+    const hasCOperand = operands.some((operand) => {
+      const candidate = stripParenExpression(operand);
+      if (
+        !isNodeOfType(candidate, "BinaryExpression") ||
+        (candidate.operator !== "===" && candidate.operator !== "==")
+      ) {
+        return false;
+      }
+      const left = stripParenExpression(candidate.left);
+      const right = stripParenExpression(candidate.right);
+      return (
+        (isNodeOfType(left, "Identifier") &&
+          context.scopes.symbolFor(left)?.id === inputSymbolId &&
+          isNodeOfType(right, "Literal") &&
+          right.value === "c") ||
+        (isNodeOfType(right, "Identifier") &&
+          context.scopes.symbolFor(right)?.id === inputSymbolId &&
+          isNodeOfType(left, "Literal") &&
+          left.value === "c")
+      );
+    });
+    if (hasCtrlOperand && hasCOperand) {
+      hasCtrlCCondition = true;
+      return false;
+    }
   });
-  return hasCtrlRead && hasCValue;
+  return hasCtrlCCondition;
 };
 
 export const inkCtrlCHandlerRequiresExitOption = defineRule({
@@ -46,7 +95,7 @@ export const inkCtrlCHandlerRequiresExitOption = defineRule({
           return;
         }
         const handler = descendantNode.arguments[0];
-        if (!handler || !handlesCtrlC(handler)) return;
+        if (!handler || !handlesCtrlC(handler, context)) return;
         const relatedRenderCalls = resolveInkRenderCallsForNode(
           descendantNode,
           renderCalls,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-ctrl-c-handler-requires-exit-option.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-ctrl-c-handler-requires-exit-option.ts
@@ -54,7 +54,7 @@ export const inkCtrlCHandlerRequiresExitOption = defineRule({
   id: "ink-ctrl-c-handler-requires-exit-option",
   title: "Ctrl-C handler is unreachable",
   severity: "error",
-  minimumInkVersion: MINIMUM_INK_VERSIONS.modernHooks,
+  minimumInkVersion: MINIMUM_INK_VERSIONS.base,
   recommendation:
     "Pass `{exitOnCtrlC: false}` to `render()` before handling Ctrl-C with `useInput`.",
   create: (context) => ({

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-ctrl-c-handler-requires-exit-option.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-ctrl-c-handler-requires-exit-option.ts
@@ -8,7 +8,7 @@ import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { resolveInkApiName } from "../../utils/resolve-ink-api-name.js";
 import {
   collectInkRenderCalls,
-  hasInkRenderBooleanOption,
+  getInkRenderBooleanOption,
   resolveInkRenderCallsForNode,
 } from "../../utils/resolve-ink-render-calls.js";
 import type { RuleContext } from "../../utils/rule-context.js";
@@ -103,8 +103,9 @@ export const inkCtrlCHandlerRequiresExitOption = defineRule({
         );
         if (
           relatedRenderCalls.length === 0 ||
-          relatedRenderCalls.every((renderCall) =>
-            hasInkRenderBooleanOption(renderCall.node, "exitOnCtrlC", false),
+          !relatedRenderCalls.some(
+            (renderCall) =>
+              getInkRenderBooleanOption(renderCall.node, "exitOnCtrlC", true) === true,
           )
         ) {
           return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-ctrl-c-handler-requires-exit-option.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-ctrl-c-handler-requires-exit-option.ts
@@ -1,0 +1,80 @@
+import { MINIMUM_INK_VERSIONS } from "../../constants/ink.js";
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { getStaticPropertyKeyName } from "../../utils/get-static-property-key-name.js";
+import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { resolveInkApiName } from "../../utils/resolve-ink-api-name.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+import { walkAst } from "../../utils/walk-ast.js";
+
+const hasExitOnCtrlCDisabled = (program: EsTreeNode, context: RuleContext): boolean => {
+  let isDisabled = false;
+  walkAst(program, (descendantNode) => {
+    if (
+      !isNodeOfType(descendantNode, "CallExpression") ||
+      resolveInkApiName(descendantNode.callee, context.scopes) !== "render"
+    ) {
+      return;
+    }
+    for (const argumentNode of descendantNode.arguments) {
+      if (!isNodeOfType(argumentNode, "ObjectExpression")) continue;
+      for (const propertyNode of argumentNode.properties) {
+        if (
+          isNodeOfType(propertyNode, "Property") &&
+          getStaticPropertyKeyName(propertyNode, { allowComputedString: true }) === "exitOnCtrlC" &&
+          isNodeOfType(propertyNode.value, "Literal") &&
+          propertyNode.value.value === false
+        ) {
+          isDisabled = true;
+        }
+      }
+    }
+  });
+  return isDisabled;
+};
+
+const handlesCtrlC = (handler: EsTreeNode): boolean => {
+  let hasCtrlRead = false;
+  let hasCValue = false;
+  walkAst(handler, (descendantNode) => {
+    if (
+      isNodeOfType(descendantNode, "MemberExpression") &&
+      getStaticPropertyName(descendantNode) === "ctrl"
+    ) {
+      hasCtrlRead = true;
+    }
+    if (isNodeOfType(descendantNode, "Literal") && descendantNode.value === "c") hasCValue = true;
+  });
+  return hasCtrlRead && hasCValue;
+};
+
+export const inkCtrlCHandlerRequiresExitOption = defineRule({
+  id: "ink-ctrl-c-handler-requires-exit-option",
+  title: "Ctrl-C handler is unreachable",
+  severity: "error",
+  minimumInkVersion: MINIMUM_INK_VERSIONS.modernHooks,
+  recommendation:
+    "Pass `{exitOnCtrlC: false}` to `render()` before handling Ctrl-C with `useInput`.",
+  create: (context) => ({
+    Program(node: EsTreeNodeOfType<"Program">) {
+      if (hasExitOnCtrlCDisabled(node, context)) return;
+      walkAst(node, (descendantNode) => {
+        if (
+          !isNodeOfType(descendantNode, "CallExpression") ||
+          resolveInkApiName(descendantNode.callee, context.scopes) !== "useInput"
+        ) {
+          return;
+        }
+        const handler = descendantNode.arguments[0];
+        if (!handler || !handlesCtrlC(handler)) return;
+        context.report({
+          node: descendantNode,
+          message:
+            "Ink consumes Ctrl-C before `useInput` unless `render()` disables `exitOnCtrlC`.",
+        });
+      });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-newline-inside-text.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-newline-inside-text.ts
@@ -1,0 +1,26 @@
+import { MINIMUM_INK_VERSIONS } from "../../constants/ink.js";
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findNearestInkJsxElement } from "../../utils/find-nearest-ink-jsx-element.js";
+import { resolveInkJsxElementName } from "../../utils/resolve-ink-api-name.js";
+
+const TEXT_COMPONENT_NAMES = new Set(["Text", "Transform"]);
+
+export const inkNewlineInsideText = defineRule({
+  id: "ink-newline-inside-text",
+  title: "Ink Newline outside text",
+  severity: "error",
+  minimumInkVersion: MINIMUM_INK_VERSIONS.base,
+  recommendation: "Render `<Newline>` inside Ink's `<Text>` or `<Transform>` component.",
+  create: (context) => ({
+    JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
+      if (resolveInkJsxElementName(node, context.scopes) !== "Newline" || !node.parent) return;
+      const parentInkElementName = findNearestInkJsxElement(node.parent, context.scopes);
+      if (!parentInkElementName || TEXT_COMPONENT_NAMES.has(parentInkElementName)) return;
+      context.report({
+        node,
+        message: "Ink `<Newline>` only has text semantics inside `<Text>` or `<Transform>`.",
+      });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-newline-inside-text.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-newline-inside-text.ts
@@ -1,26 +1,10 @@
 import { MINIMUM_INK_VERSIONS } from "../../constants/ink.js";
-import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
-import { findNearestInkJsxElement } from "../../utils/find-nearest-ink-jsx-element.js";
-import { resolveInkJsxElementName } from "../../utils/resolve-ink-api-name.js";
+import { defineRetiredRule } from "../../utils/define-retired-rule.js";
 
-const TEXT_COMPONENT_NAMES = new Set(["Text", "Transform"]);
-
-export const inkNewlineInsideText = defineRule({
+export const inkNewlineInsideText = defineRetiredRule({
   id: "ink-newline-inside-text",
-  title: "Ink Newline outside text",
+  title: "Retired: Ink Newline placement",
   severity: "error",
   minimumInkVersion: MINIMUM_INK_VERSIONS.base,
-  recommendation: "Render `<Newline>` inside Ink's `<Text>` or `<Transform>` component.",
-  create: (context) => ({
-    JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
-      if (resolveInkJsxElementName(node, context.scopes) !== "Newline" || !node.parent) return;
-      const parentInkElementName = findNearestInkJsxElement(node.parent, context.scopes);
-      if (!parentInkElementName || TEXT_COMPONENT_NAMES.has(parentInkElementName)) return;
-      context.report({
-        node,
-        message: "Ink `<Newline>` only has text semantics inside `<Text>` or `<Transform>`.",
-      });
-    },
-  }),
+  recommendation: "No change is required; Ink supports standalone `<Newline>` elements.",
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-no-bare-process-exit.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-no-bare-process-exit.ts
@@ -1,0 +1,72 @@
+import { MINIMUM_INK_VERSIONS } from "../../constants/ink.js";
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
+import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { isProvenGlobalNamespaceReference } from "../../utils/is-proven-global-namespace-reference.js";
+import { resolveInkApiName } from "../../utils/resolve-ink-api-name.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+import { walkAst } from "../../utils/walk-ast.js";
+
+const CLEANUP_METHOD_PATTERN =
+  /^(?:abort|cleanup|close|destroy|disconnect|dispose|exit|restore|unmount)$/i;
+
+const findUseInputHandler = (node: EsTreeNode, context: RuleContext): EsTreeNode | null => {
+  const enclosingFunction = findEnclosingFunction(node);
+  if (!enclosingFunction) return null;
+  const parentNode = enclosingFunction.parent;
+  return parentNode &&
+    isNodeOfType(parentNode, "CallExpression") &&
+    parentNode.arguments[0] === enclosingFunction &&
+    resolveInkApiName(parentNode.callee, context.scopes) === "useInput"
+    ? enclosingFunction
+    : null;
+};
+
+const hasCleanupBeforeExit = (handler: EsTreeNode, exitCall: EsTreeNode): boolean => {
+  let hasCleanup = false;
+  walkAst(handler, (descendantNode) => {
+    if (descendantNode === exitCall) return false;
+    if (
+      isNodeOfType(descendantNode, "CallExpression") &&
+      descendantNode.range[1] <= exitCall.range[0]
+    ) {
+      const callee = descendantNode.callee;
+      const methodName = isNodeOfType(callee, "Identifier")
+        ? callee.name
+        : isNodeOfType(callee, "MemberExpression")
+          ? getStaticPropertyName(callee)
+          : null;
+      if (methodName && CLEANUP_METHOD_PATTERN.test(methodName)) hasCleanup = true;
+    }
+  });
+  return hasCleanup;
+};
+
+export const inkNoBareProcessExit = defineRule({
+  id: "ink-no-bare-process-exit",
+  title: "Process exits before Ink cleanup",
+  severity: "error",
+  minimumInkVersion: MINIMUM_INK_VERSIONS.base,
+  recommendation:
+    "Use Ink's `useApp().exit()` or perform explicit cleanup before `process.exit()`.",
+  create: (context) => ({
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+      if (
+        !isNodeOfType(node.callee, "MemberExpression") ||
+        getStaticPropertyName(node.callee) !== "exit" ||
+        !isProvenGlobalNamespaceReference(node.callee.object, "process", context.scopes)
+      ) {
+        return;
+      }
+      const handler = findUseInputHandler(node, context);
+      if (!handler || hasCleanupBeforeExit(handler, node)) return;
+      context.report({
+        node,
+        message: "`process.exit()` in an Ink input handler bypasses Ink's terminal cleanup.",
+      });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-no-bare-process-exit.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-no-bare-process-exit.ts
@@ -8,10 +8,6 @@ import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isProvenGlobalNamespaceReference } from "../../utils/is-proven-global-namespace-reference.js";
 import { resolveInkApiName } from "../../utils/resolve-ink-api-name.js";
 import type { RuleContext } from "../../utils/rule-context.js";
-import { walkAst } from "../../utils/walk-ast.js";
-
-const CLEANUP_METHOD_PATTERN =
-  /^(?:abort|cleanup|close|destroy|disconnect|dispose|restore|unmount)$/i;
 
 const findUseInputHandler = (node: EsTreeNode, context: RuleContext): EsTreeNode | null => {
   const enclosingFunction = findEnclosingFunction(node);
@@ -25,33 +21,12 @@ const findUseInputHandler = (node: EsTreeNode, context: RuleContext): EsTreeNode
     : null;
 };
 
-const hasCleanupBeforeExit = (handler: EsTreeNode, exitCall: EsTreeNode): boolean => {
-  let hasCleanup = false;
-  walkAst(handler, (descendantNode) => {
-    if (descendantNode === exitCall) return false;
-    if (
-      isNodeOfType(descendantNode, "CallExpression") &&
-      descendantNode.range[1] <= exitCall.range[0]
-    ) {
-      const callee = descendantNode.callee;
-      const methodName = isNodeOfType(callee, "Identifier")
-        ? callee.name
-        : isNodeOfType(callee, "MemberExpression")
-          ? getStaticPropertyName(callee)
-          : null;
-      if (methodName && CLEANUP_METHOD_PATTERN.test(methodName)) hasCleanup = true;
-    }
-  });
-  return hasCleanup;
-};
-
 export const inkNoBareProcessExit = defineRule({
   id: "ink-no-bare-process-exit",
   title: "Process exits before Ink cleanup",
   severity: "error",
   minimumInkVersion: MINIMUM_INK_VERSIONS.base,
-  recommendation:
-    "Use Ink's `useApp().exit()` or perform explicit cleanup before `process.exit()`.",
+  recommendation: "Use Ink's `useApp().exit()` so Ink restores terminal state.",
   create: (context) => ({
     CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
       if (
@@ -61,8 +36,7 @@ export const inkNoBareProcessExit = defineRule({
       ) {
         return;
       }
-      const handler = findUseInputHandler(node, context);
-      if (!handler || hasCleanupBeforeExit(handler, node)) return;
+      if (!findUseInputHandler(node, context)) return;
       context.report({
         node,
         message: "`process.exit()` in an Ink input handler bypasses Ink's terminal cleanup.",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-no-bare-process-exit.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-no-bare-process-exit.ts
@@ -11,7 +11,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { walkAst } from "../../utils/walk-ast.js";
 
 const CLEANUP_METHOD_PATTERN =
-  /^(?:abort|cleanup|close|destroy|disconnect|dispose|exit|restore|unmount)$/i;
+  /^(?:abort|cleanup|close|destroy|disconnect|dispose|restore|unmount)$/i;
 
 const findUseInputHandler = (node: EsTreeNode, context: RuleContext): EsTreeNode | null => {
   const enclosingFunction = findEnclosingFunction(node);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-no-direct-raw-mode.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-no-direct-raw-mode.ts
@@ -7,13 +7,16 @@ import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { resolveInkApiName } from "../../utils/resolve-ink-api-name.js";
 import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 
-const isUseStdinCall = (node: EsTreeNode | null | undefined, scopes: ScopeAnalysis): boolean =>
-  Boolean(
-    node &&
-    isNodeOfType(node, "CallExpression") &&
-    resolveInkApiName(node.callee, scopes) === "useStdin",
+const isUseStdinCall = (node: EsTreeNode | null | undefined, scopes: ScopeAnalysis): boolean => {
+  if (!node) return false;
+  const unwrappedNode = stripParenExpression(node);
+  return (
+    isNodeOfType(unwrappedNode, "CallExpression") &&
+    resolveInkApiName(unwrappedNode.callee, scopes) === "useStdin"
   );
+};
 
 const isInkSetRawModeCall = (
   callExpression: EsTreeNodeOfType<"CallExpression">,
@@ -22,10 +25,11 @@ const isInkSetRawModeCall = (
   const callee = callExpression.callee;
   if (isNodeOfType(callee, "MemberExpression")) {
     if (getStaticPropertyName(callee) !== "setRawMode") return false;
-    if (isUseStdinCall(callee.object, context)) return true;
+    const stdinObject = stripParenExpression(callee.object);
+    if (isUseStdinCall(stdinObject, context)) return true;
     return (
-      isNodeOfType(callee.object, "Identifier") &&
-      isUseStdinCall(context.symbolFor(callee.object)?.initializer, context)
+      isNodeOfType(stdinObject, "Identifier") &&
+      isUseStdinCall(context.symbolFor(stdinObject)?.initializer, context)
     );
   }
   if (!isNodeOfType(callee, "Identifier") || callee.name !== "setRawMode") return false;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-no-direct-raw-mode.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-no-direct-raw-mode.ts
@@ -39,17 +39,17 @@ const isInkSetRawModeCall = (
 
 export const inkNoDirectRawMode = defineRule({
   id: "ink-no-direct-raw-mode",
-  title: "Raw mode managed outside Ink",
+  title: "Raw mode changed during render",
   severity: "error",
   minimumInkVersion: MINIMUM_INK_VERSIONS.base,
-  recommendation: "Let Ink's input hooks manage terminal raw mode and cleanup.",
+  recommendation: "Move `useStdin().setRawMode()` to an effect and restore it in cleanup.",
   create: (context) => ({
     CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
       if (!isInkSetRawModeCall(node, context.scopes)) return;
       if (!findRenderPhaseComponentOrHook(node, context.scopes)) return;
       context.report({
         node,
-        message: "Direct `setRawMode` calls can leave the terminal corrupted after exit.",
+        message: "Changing terminal raw mode during render is an untracked side effect.",
       });
     },
   }),

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-no-direct-raw-mode.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-no-direct-raw-mode.ts
@@ -1,0 +1,56 @@
+import { MINIMUM_INK_VERSIONS } from "../../constants/ink.js";
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findRenderPhaseComponentOrHook } from "../../utils/find-render-phase-component-or-hook.js";
+import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { resolveInkApiName } from "../../utils/resolve-ink-api-name.js";
+import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
+
+const isUseStdinCall = (node: EsTreeNode | null | undefined, scopes: ScopeAnalysis): boolean =>
+  Boolean(
+    node &&
+    isNodeOfType(node, "CallExpression") &&
+    resolveInkApiName(node.callee, scopes) === "useStdin",
+  );
+
+const isInkSetRawModeCall = (
+  callExpression: EsTreeNodeOfType<"CallExpression">,
+  context: Parameters<typeof findRenderPhaseComponentOrHook>[1],
+): boolean => {
+  const callee = callExpression.callee;
+  if (isNodeOfType(callee, "MemberExpression")) {
+    if (getStaticPropertyName(callee) !== "setRawMode") return false;
+    if (isUseStdinCall(callee.object, context)) return true;
+    return (
+      isNodeOfType(callee.object, "Identifier") &&
+      isUseStdinCall(context.symbolFor(callee.object)?.initializer, context)
+    );
+  }
+  if (!isNodeOfType(callee, "Identifier") || callee.name !== "setRawMode") return false;
+  const symbol = context.symbolFor(callee);
+  return Boolean(
+    symbol &&
+    isNodeOfType(symbol.declarationNode, "VariableDeclarator") &&
+    isUseStdinCall(symbol.declarationNode.init, context),
+  );
+};
+
+export const inkNoDirectRawMode = defineRule({
+  id: "ink-no-direct-raw-mode",
+  title: "Raw mode managed outside Ink",
+  severity: "error",
+  minimumInkVersion: MINIMUM_INK_VERSIONS.base,
+  recommendation: "Let Ink's input hooks manage terminal raw mode and cleanup.",
+  create: (context) => ({
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+      if (!isInkSetRawModeCall(node, context.scopes)) return;
+      if (!findRenderPhaseComponentOrHook(node, context.scopes)) return;
+      context.report({
+        node,
+        message: "Direct `setRawMode` calls can leave the terminal corrupted after exit.",
+      });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-no-dom-host-elements.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-no-dom-host-elements.ts
@@ -1,0 +1,28 @@
+import { MINIMUM_INK_VERSIONS } from "../../constants/ink.js";
+import { HTML_TAGS } from "../../constants/html-tags.js";
+import { containsInkJsxElement } from "../../utils/contains-ink-jsx-element.js";
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findNearestInkJsxElement } from "../../utils/find-nearest-ink-jsx-element.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+
+export const inkNoDomHostElements = defineRule({
+  id: "ink-no-dom-host-elements",
+  title: "DOM element used in an Ink tree",
+  severity: "error",
+  minimumInkVersion: MINIMUM_INK_VERSIONS.base,
+  recommendation: "Use Ink primitives such as `<Box>` and `<Text>` instead of DOM host elements.",
+  create: (context) => ({
+    JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
+      if (!isNodeOfType(node.name, "JSXIdentifier") || !HTML_TAGS.has(node.name.name)) return;
+      const isInkTree =
+        (node.parent ? findNearestInkJsxElement(node.parent, context.scopes) !== null : false) ||
+        (node.parent ? containsInkJsxElement(node.parent, context.scopes) : false);
+      if (!isInkTree) return;
+      context.report({
+        node,
+        message: `DOM host \`<${node.name.name}>\` cannot be rendered by Ink.`,
+      });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-no-dom-router.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-no-dom-router.ts
@@ -1,0 +1,61 @@
+import { MINIMUM_INK_VERSIONS } from "../../constants/ink.js";
+import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
+import { containsInkJsxElement } from "../../utils/contains-ink-jsx-element.js";
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findNearestInkJsxElement } from "../../utils/find-nearest-ink-jsx-element.js";
+import { getImportedNameFromModule } from "../../utils/find-import-source-for-name.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+
+const DOM_ROUTER_COMPONENT_NAMES = new Set(["BrowserRouter", "HashRouter", "Link", "NavLink"]);
+const DOM_ROUTER_FACTORY_NAMES = new Set(["createBrowserRouter", "createHashRouter"]);
+const ROUTER_MODULE_NAMES = ["react-router", "react-router-dom"];
+
+const resolveRouterImportName = (
+  node: EsTreeNodeOfType<"JSXOpeningElement">,
+  scopes: ScopeAnalysis,
+): string | null => {
+  if (!isNodeOfType(node.name, "JSXIdentifier")) return null;
+  if (scopes.symbolFor(node.name)?.kind !== "import") return null;
+  for (const moduleName of ROUTER_MODULE_NAMES) {
+    const importedName = getImportedNameFromModule(node, node.name.name, moduleName);
+    if (importedName) return importedName;
+  }
+  return null;
+};
+
+export const inkNoDomRouter = defineRule({
+  id: "ink-no-dom-router",
+  title: "DOM router used in an Ink tree",
+  severity: "error",
+  minimumInkVersion: MINIMUM_INK_VERSIONS.base,
+  recommendation: "Use React Router's memory router APIs in Ink applications.",
+  create: (context) => ({
+    JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
+      const importedName = resolveRouterImportName(node, context.scopes);
+      if (!importedName || !DOM_ROUTER_COMPONENT_NAMES.has(importedName)) return;
+      const isInkTree =
+        (node.parent ? findNearestInkJsxElement(node.parent, context.scopes) !== null : false) ||
+        (node.parent ? containsInkJsxElement(node.parent, context.scopes) : false);
+      if (!isInkTree) return;
+      context.report({
+        node,
+        message: `\`${importedName}\` depends on DOM history; use a memory router with Ink.`,
+      });
+    },
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+      if (!isNodeOfType(node.callee, "Identifier")) return;
+      if (context.scopes.symbolFor(node.callee)?.kind !== "import") return;
+      const localName = node.callee.name;
+      const importedName = ROUTER_MODULE_NAMES.map((moduleName) =>
+        getImportedNameFromModule(node, localName, moduleName),
+      ).find(Boolean);
+      if (!importedName || !DOM_ROUTER_FACTORY_NAMES.has(importedName)) return;
+      if (!containsInkJsxElement(node.parent ?? node, context.scopes)) return;
+      context.report({
+        node,
+        message: `\`${importedName}\` requires a DOM; use \`createMemoryRouter\` with Ink.`,
+      });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-no-focus-in-render.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-no-focus-in-render.ts
@@ -1,0 +1,63 @@
+import { MINIMUM_INK_VERSIONS } from "../../constants/ink.js";
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findRenderPhaseComponentOrHook } from "../../utils/find-render-phase-component-or-hook.js";
+import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { resolveInkApiName } from "../../utils/resolve-ink-api-name.js";
+import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+
+const FOCUS_METHOD_NAMES = new Set(["focus", "focusNext", "focusPrevious"]);
+
+const isUseFocusManagerCall = (
+  node: EsTreeNode | null | undefined,
+  scopes: ScopeAnalysis,
+): boolean =>
+  Boolean(
+    node &&
+    isNodeOfType(node, "CallExpression") &&
+    resolveInkApiName(node.callee, scopes) === "useFocusManager",
+  );
+
+const isFocusManagerMethodCall = (
+  callExpression: EsTreeNodeOfType<"CallExpression">,
+  context: Parameters<typeof findRenderPhaseComponentOrHook>[1],
+): boolean => {
+  const callee = callExpression.callee;
+  if (isNodeOfType(callee, "MemberExpression")) {
+    const methodName = getStaticPropertyName(callee);
+    if (!methodName || !FOCUS_METHOD_NAMES.has(methodName)) return false;
+    const focusManagerObject = stripParenExpression(callee.object);
+    if (isUseFocusManagerCall(focusManagerObject, context)) return true;
+    if (!isNodeOfType(focusManagerObject, "Identifier")) return false;
+    return isUseFocusManagerCall(context.symbolFor(focusManagerObject)?.initializer, context);
+  }
+  if (!isNodeOfType(callee, "Identifier") || !FOCUS_METHOD_NAMES.has(callee.name)) return false;
+  const symbol = context.symbolFor(callee);
+  if (!symbol || !isNodeOfType(symbol.declarationNode, "VariableDeclarator")) return false;
+  return isUseFocusManagerCall(symbol.declarationNode.init, context);
+};
+
+export const inkNoFocusInRender = defineRule({
+  id: "ink-no-focus-in-render",
+  title: "Ink focus changed during render",
+  severity: "error",
+  minimumInkVersion: MINIMUM_INK_VERSIONS.base,
+  recommendation: "Move focus-manager calls to an effect or input handler.",
+  create: (context) => ({
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+      if (
+        !isFocusManagerMethodCall(node, context.scopes) ||
+        !findRenderPhaseComponentOrHook(node, context.scopes)
+      ) {
+        return;
+      }
+      context.report({
+        node,
+        message: "Changing Ink focus during render can trigger render loops.",
+      });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-no-layout-inside-text.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-no-layout-inside-text.ts
@@ -1,0 +1,28 @@
+import { MINIMUM_INK_VERSIONS } from "../../constants/ink.js";
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findNearestInkJsxElement } from "../../utils/find-nearest-ink-jsx-element.js";
+import { resolveInkJsxElementName } from "../../utils/resolve-ink-api-name.js";
+
+const LAYOUT_COMPONENT_NAMES = new Set(["Box", "Spacer", "Static"]);
+const TEXT_COMPONENT_NAMES = new Set(["Text", "Transform"]);
+
+export const inkNoLayoutInsideText = defineRule({
+  id: "ink-no-layout-inside-text",
+  title: "Layout component nested in Ink Text",
+  severity: "error",
+  minimumInkVersion: MINIMUM_INK_VERSIONS.textLayoutGuard,
+  recommendation: "Move Ink layout components outside `<Text>` and `<Transform>` boundaries.",
+  create: (context) => ({
+    JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
+      const elementName = resolveInkJsxElementName(node, context.scopes);
+      if (!elementName || !LAYOUT_COMPONENT_NAMES.has(elementName) || !node.parent) return;
+      const parentInkElementName = findNearestInkJsxElement(node.parent, context.scopes);
+      if (!parentInkElementName || !TEXT_COMPONENT_NAMES.has(parentInkElementName)) return;
+      context.report({
+        node,
+        message: `Ink \`<${elementName}>\` cannot render inside \`<${parentInkElementName}>\`.`,
+      });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-no-live-hooks-in-render-to-string.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-no-live-hooks-in-render-to-string.ts
@@ -15,17 +15,6 @@ import { walkAst } from "../../utils/walk-ast.js";
 const INERT_INPUT_HOOK_NAMES = new Set(["useInput", "usePaste"]);
 
 const isExportedComponent = (componentNode: EsTreeNode, scopes: ScopeAnalysis): boolean => {
-  let ancestorNode: EsTreeNode | null | undefined = componentNode;
-  while (ancestorNode && !isNodeOfType(ancestorNode, "Program")) {
-    if (
-      isNodeOfType(ancestorNode, "ExportDefaultDeclaration") ||
-      isNodeOfType(ancestorNode, "ExportNamedDeclaration")
-    ) {
-      return true;
-    }
-    ancestorNode = ancestorNode.parent;
-  }
-
   let bindingIdentifier: EsTreeNode | null = null;
   if (isNodeOfType(componentNode, "FunctionDeclaration") && componentNode.id) {
     bindingIdentifier = componentNode.id;
@@ -37,6 +26,13 @@ const isExportedComponent = (componentNode: EsTreeNode, scopes: ScopeAnalysis): 
     bindingIdentifier = componentNode.parent.id;
   }
   const symbol = bindingIdentifier ? scopes.symbolFor(bindingIdentifier) : null;
+  const declarationParent = symbol?.declarationNode.parent;
+  const isDirectExport =
+    isNodeOfType(declarationParent, "ExportDefaultDeclaration") ||
+    isNodeOfType(declarationParent, "ExportNamedDeclaration") ||
+    (isNodeOfType(declarationParent, "VariableDeclaration") &&
+      isNodeOfType(declarationParent.parent, "ExportNamedDeclaration"));
+  if (isDirectExport) return true;
   return Boolean(
     symbol?.references.some((reference) => {
       const parentNode = reference.identifier.parent;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-no-live-hooks-in-render-to-string.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-no-live-hooks-in-render-to-string.ts
@@ -40,7 +40,6 @@ export const inkNoLiveHooksInRenderToString = defineRule({
           descendantNode,
           renderCalls,
           context,
-          { allowSingleRenderFallback: false },
         );
         if (relatedRenderCalls.length === 0) return;
         context.report({

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-no-live-hooks-in-render-to-string.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-no-live-hooks-in-render-to-string.ts
@@ -1,0 +1,74 @@
+import { MINIMUM_INK_VERSIONS } from "../../constants/ink.js";
+import { componentOrHookDisplayNameForFunction } from "../../utils/component-or-hook-display-name.js";
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { resolveInkApiName } from "../../utils/resolve-ink-api-name.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+import { walkAst } from "../../utils/walk-ast.js";
+
+const LIVE_HOOK_NAMES = new Set([
+  "useApp",
+  "useCursor",
+  "useFocus",
+  "useFocusManager",
+  "useInput",
+  "usePaste",
+  "useStderr",
+  "useStdin",
+  "useStdout",
+  "useWindowSize",
+]);
+
+const collectRenderedComponentNames = (
+  program: EsTreeNode,
+  context: RuleContext,
+): ReadonlySet<string> => {
+  const componentNames = new Set<string>();
+  walkAst(program, (descendantNode) => {
+    if (
+      !isNodeOfType(descendantNode, "CallExpression") ||
+      resolveInkApiName(descendantNode.callee, context.scopes) !== "renderToString"
+    ) {
+      return;
+    }
+    const renderedNode = descendantNode.arguments[0];
+    if (
+      isNodeOfType(renderedNode, "JSXElement") &&
+      isNodeOfType(renderedNode.openingElement.name, "JSXIdentifier")
+    ) {
+      componentNames.add(renderedNode.openingElement.name.name);
+    }
+  });
+  return componentNames;
+};
+
+export const inkNoLiveHooksInRenderToString = defineRule({
+  id: "ink-no-live-hooks-in-render-to-string",
+  title: "Live terminal hook used during string rendering",
+  severity: "error",
+  minimumInkVersion: MINIMUM_INK_VERSIONS.renderToString,
+  recommendation: "Keep `renderToString()` components independent of live terminal hooks.",
+  create: (context) => ({
+    Program(node: EsTreeNodeOfType<"Program">) {
+      const renderedComponentNames = collectRenderedComponentNames(node, context);
+      if (renderedComponentNames.size === 0) return;
+      walkAst(node, (descendantNode) => {
+        if (!isNodeOfType(descendantNode, "CallExpression")) return;
+        const hookName = resolveInkApiName(descendantNode.callee, context.scopes);
+        if (!hookName || !LIVE_HOOK_NAMES.has(hookName)) return;
+        const componentFunction = findEnclosingFunction(descendantNode);
+        const componentName = componentFunction
+          ? componentOrHookDisplayNameForFunction(componentFunction)
+          : null;
+        if (!componentName || !renderedComponentNames.has(componentName)) return;
+        context.report({
+          node: descendantNode,
+          message: `Ink \`${hookName}\` has no live terminal lifecycle under \`renderToString()\`.`,
+        });
+      });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-no-live-hooks-in-render-to-string.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-no-live-hooks-in-render-to-string.ts
@@ -1,12 +1,12 @@
 import { MINIMUM_INK_VERSIONS } from "../../constants/ink.js";
-import { componentOrHookDisplayNameForFunction } from "../../utils/component-or-hook-display-name.js";
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
-import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { resolveInkApiName } from "../../utils/resolve-ink-api-name.js";
-import type { RuleContext } from "../../utils/rule-context.js";
+import {
+  collectInkRenderCalls,
+  resolveInkRenderCallsForNode,
+} from "../../utils/resolve-ink-render-calls.js";
 import { walkAst } from "../../utils/walk-ast.js";
 
 const LIVE_HOOK_NAMES = new Set([
@@ -22,29 +22,6 @@ const LIVE_HOOK_NAMES = new Set([
   "useWindowSize",
 ]);
 
-const collectRenderedComponentNames = (
-  program: EsTreeNode,
-  context: RuleContext,
-): ReadonlySet<string> => {
-  const componentNames = new Set<string>();
-  walkAst(program, (descendantNode) => {
-    if (
-      !isNodeOfType(descendantNode, "CallExpression") ||
-      resolveInkApiName(descendantNode.callee, context.scopes) !== "renderToString"
-    ) {
-      return;
-    }
-    const renderedNode = descendantNode.arguments[0];
-    if (
-      isNodeOfType(renderedNode, "JSXElement") &&
-      isNodeOfType(renderedNode.openingElement.name, "JSXIdentifier")
-    ) {
-      componentNames.add(renderedNode.openingElement.name.name);
-    }
-  });
-  return componentNames;
-};
-
 export const inkNoLiveHooksInRenderToString = defineRule({
   id: "ink-no-live-hooks-in-render-to-string",
   title: "Live terminal hook used during string rendering",
@@ -53,17 +30,19 @@ export const inkNoLiveHooksInRenderToString = defineRule({
   recommendation: "Keep `renderToString()` components independent of live terminal hooks.",
   create: (context) => ({
     Program(node: EsTreeNodeOfType<"Program">) {
-      const renderedComponentNames = collectRenderedComponentNames(node, context);
-      if (renderedComponentNames.size === 0) return;
+      const renderCalls = collectInkRenderCalls(node, context, "renderToString");
+      if (renderCalls.length === 0) return;
       walkAst(node, (descendantNode) => {
         if (!isNodeOfType(descendantNode, "CallExpression")) return;
         const hookName = resolveInkApiName(descendantNode.callee, context.scopes);
         if (!hookName || !LIVE_HOOK_NAMES.has(hookName)) return;
-        const componentFunction = findEnclosingFunction(descendantNode);
-        const componentName = componentFunction
-          ? componentOrHookDisplayNameForFunction(componentFunction)
-          : null;
-        if (!componentName || !renderedComponentNames.has(componentName)) return;
+        const relatedRenderCalls = resolveInkRenderCallsForNode(
+          descendantNode,
+          renderCalls,
+          context,
+          { allowSingleRenderFallback: false },
+        );
+        if (relatedRenderCalls.length === 0) return;
         context.report({
           node: descendantNode,
           message: `Ink \`${hookName}\` has no live terminal lifecycle under \`renderToString()\`.`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-no-live-hooks-in-render-to-string.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-no-live-hooks-in-render-to-string.ts
@@ -1,6 +1,9 @@
 import { MINIMUM_INK_VERSIONS } from "../../constants/ink.js";
+import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
 import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findRenderPhaseComponentOrHook } from "../../utils/find-render-phase-component-or-hook.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { resolveInkApiName } from "../../utils/resolve-ink-api-name.js";
 import {
@@ -9,42 +12,71 @@ import {
 } from "../../utils/resolve-ink-render-calls.js";
 import { walkAst } from "../../utils/walk-ast.js";
 
-const LIVE_HOOK_NAMES = new Set([
-  "useApp",
-  "useCursor",
-  "useFocus",
-  "useFocusManager",
-  "useInput",
-  "usePaste",
-  "useStderr",
-  "useStdin",
-  "useStdout",
-  "useWindowSize",
-]);
+const INERT_INPUT_HOOK_NAMES = new Set(["useInput", "usePaste"]);
+
+const isExportedComponent = (componentNode: EsTreeNode, scopes: ScopeAnalysis): boolean => {
+  let ancestorNode: EsTreeNode | null | undefined = componentNode;
+  while (ancestorNode && !isNodeOfType(ancestorNode, "Program")) {
+    if (
+      isNodeOfType(ancestorNode, "ExportDefaultDeclaration") ||
+      isNodeOfType(ancestorNode, "ExportNamedDeclaration")
+    ) {
+      return true;
+    }
+    ancestorNode = ancestorNode.parent;
+  }
+
+  let bindingIdentifier: EsTreeNode | null = null;
+  if (isNodeOfType(componentNode, "FunctionDeclaration") && componentNode.id) {
+    bindingIdentifier = componentNode.id;
+  } else if (
+    isNodeOfType(componentNode.parent, "VariableDeclarator") &&
+    componentNode.parent.init === componentNode &&
+    isNodeOfType(componentNode.parent.id, "Identifier")
+  ) {
+    bindingIdentifier = componentNode.parent.id;
+  }
+  const symbol = bindingIdentifier ? scopes.symbolFor(bindingIdentifier) : null;
+  return Boolean(
+    symbol?.references.some((reference) => {
+      const parentNode = reference.identifier.parent;
+      return (
+        isNodeOfType(parentNode, "ExportDefaultDeclaration") ||
+        (isNodeOfType(parentNode, "ExportSpecifier") && parentNode.local === reference.identifier)
+      );
+    }),
+  );
+};
 
 export const inkNoLiveHooksInRenderToString = defineRule({
   id: "ink-no-live-hooks-in-render-to-string",
-  title: "Live terminal hook used during string rendering",
+  title: "Inert input hook used during string rendering",
   severity: "error",
   minimumInkVersion: MINIMUM_INK_VERSIONS.renderToString,
-  recommendation: "Keep `renderToString()` components independent of live terminal hooks.",
+  recommendation: "Keep input subscriptions out of components used only by `renderToString()`.",
   create: (context) => ({
     Program(node: EsTreeNodeOfType<"Program">) {
       const renderCalls = collectInkRenderCalls(node, context, "renderToString");
       if (renderCalls.length === 0) return;
+      const liveRenderCalls = collectInkRenderCalls(node, context);
       walkAst(node, (descendantNode) => {
         if (!isNodeOfType(descendantNode, "CallExpression")) return;
         const hookName = resolveInkApiName(descendantNode.callee, context.scopes);
-        if (!hookName || !LIVE_HOOK_NAMES.has(hookName)) return;
+        if (!hookName || !INERT_INPUT_HOOK_NAMES.has(hookName)) return;
+        const componentNode = findRenderPhaseComponentOrHook(descendantNode, context.scopes);
+        if (!componentNode || isExportedComponent(componentNode, context.scopes)) return;
         const relatedRenderCalls = resolveInkRenderCallsForNode(
           descendantNode,
           renderCalls,
           context,
         );
         if (relatedRenderCalls.length === 0) return;
+        if (resolveInkRenderCallsForNode(descendantNode, liveRenderCalls, context).length > 0) {
+          return;
+        }
         context.report({
           node: descendantNode,
-          message: `Ink \`${hookName}\` has no live terminal lifecycle under \`renderToString()\`.`,
+          message: `Ink \`${hookName}\` never receives input under \`renderToString()\`.`,
         });
       });
     },

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-no-measure-element-in-render.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-no-measure-element-in-render.ts
@@ -1,0 +1,28 @@
+import { MINIMUM_INK_VERSIONS } from "../../constants/ink.js";
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findRenderPhaseComponentOrHook } from "../../utils/find-render-phase-component-or-hook.js";
+import { resolveInkApiName } from "../../utils/resolve-ink-api-name.js";
+
+export const inkNoMeasureElementInRender = defineRule({
+  id: "ink-no-measure-element-in-render",
+  title: "Ink element measured during render",
+  severity: "error",
+  minimumInkVersion: MINIMUM_INK_VERSIONS.base,
+  recommendation:
+    "Measure Ink elements in a layout effect, effect, callback ref, or event handler.",
+  create: (context) => ({
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+      if (
+        resolveInkApiName(node.callee, context.scopes) !== "measureElement" ||
+        !findRenderPhaseComponentOrHook(node, context.scopes)
+      ) {
+        return;
+      }
+      context.report({
+        node,
+        message: "Calling `measureElement` during render reads layout before Ink commits it.",
+      });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-no-multiple-static.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-no-multiple-static.ts
@@ -2,6 +2,7 @@ import { MINIMUM_INK_VERSIONS } from "../../constants/ink.js";
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { isNodeConditionallyExecuted } from "../../utils/is-node-conditionally-executed.js";
 import { resolveInkJsxElementName } from "../../utils/resolve-ink-api-name.js";
 
 export const inkNoMultipleStatic = defineRule({
@@ -11,15 +12,32 @@ export const inkNoMultipleStatic = defineRule({
   minimumInkVersion: MINIMUM_INK_VERSIONS.base,
   recommendation: "Consolidate permanent output into one `<Static>` region when possible.",
   create: (context) => {
-    const staticCountByOwner = new Map<EsTreeNode, number>();
+    const staticNodesByRenderRoot = new Map<EsTreeNode, EsTreeNodeOfType<"JSXOpeningElement">[]>();
     return {
       JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
         if (resolveInkJsxElementName(node, context.scopes) !== "Static") return;
         const owner = context.cfg.enclosingFunction(node);
         if (!owner) return;
-        const staticCount = (staticCountByOwner.get(owner) ?? 0) + 1;
-        staticCountByOwner.set(owner, staticCount);
-        if (staticCount < 2) return;
+        let renderRoot = node.parent;
+        let ancestorNode = renderRoot?.parent;
+        while (ancestorNode && ancestorNode !== owner) {
+          if (ancestorNode.type === "JSXAttribute" || /Function/.test(ancestorNode.type)) return;
+          if (ancestorNode.type === "JSXElement" || ancestorNode.type === "JSXFragment") {
+            renderRoot = ancestorNode;
+          }
+          ancestorNode = ancestorNode.parent;
+        }
+        if (!renderRoot) return;
+        const previousStaticNodes = staticNodesByRenderRoot.get(renderRoot) ?? [];
+        staticNodesByRenderRoot.set(renderRoot, [...previousStaticNodes, node]);
+        if (isNodeConditionallyExecuted(node, renderRoot)) return;
+        if (
+          !previousStaticNodes.some(
+            (previousStaticNode) => !isNodeConditionallyExecuted(previousStaticNode, renderRoot),
+          )
+        ) {
+          return;
+        }
         context.report({
           node,
           message:

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-no-multiple-static.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-no-multiple-static.ts
@@ -1,0 +1,31 @@
+import { MINIMUM_INK_VERSIONS } from "../../constants/ink.js";
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { resolveInkJsxElementName } from "../../utils/resolve-ink-api-name.js";
+
+export const inkNoMultipleStatic = defineRule({
+  id: "ink-no-multiple-static",
+  title: "Multiple Static regions in one Ink tree",
+  severity: "warn",
+  minimumInkVersion: MINIMUM_INK_VERSIONS.base,
+  recommendation: "Consolidate permanent output into one `<Static>` region when possible.",
+  create: (context) => {
+    const staticCountByOwner = new Map<EsTreeNode, number>();
+    return {
+      JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
+        if (resolveInkJsxElementName(node, context.scopes) !== "Static") return;
+        const owner = context.cfg.enclosingFunction(node);
+        if (!owner) return;
+        const staticCount = (staticCountByOwner.get(owner) ?? 0) + 1;
+        staticCountByOwner.set(owner, staticCount);
+        if (staticCount < 2) return;
+        context.report({
+          node,
+          message:
+            "Multiple `<Static>` regions make permanent output ordering difficult to reason about.",
+        });
+      },
+    };
+  },
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-no-multiple-static.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-no-multiple-static.ts
@@ -7,10 +7,10 @@ import { resolveInkJsxElementName } from "../../utils/resolve-ink-api-name.js";
 
 export const inkNoMultipleStatic = defineRule({
   id: "ink-no-multiple-static",
-  title: "Multiple Static regions in one Ink tree",
+  title: "Multiple unconditional Static regions in one render root",
   severity: "warn",
   minimumInkVersion: MINIMUM_INK_VERSIONS.base,
-  recommendation: "Consolidate permanent output into one `<Static>` region when possible.",
+  recommendation: "Combine unconditional output in one render root into a single `<Static>`.",
   create: (context) => {
     const staticNodesByRenderRoot = new Map<EsTreeNode, EsTreeNodeOfType<"JSXOpeningElement">[]>();
     return {
@@ -40,8 +40,7 @@ export const inkNoMultipleStatic = defineRule({
         }
         context.report({
           node,
-          message:
-            "Multiple `<Static>` regions make permanent output ordering difficult to reason about.",
+          message: "Ink tracks one `<Static>` node per root; combine these unconditional regions.",
         });
       },
     };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-no-raw-text.cross-file.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-no-raw-text.cross-file.test.ts
@@ -1,0 +1,67 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { inkNoRawText } from "./ink-no-raw-text.js";
+
+let temporaryDirectory = "";
+let entryFilename = "";
+
+const writeSource = (relativePath: string, source: string): void => {
+  const absolutePath = path.join(temporaryDirectory, relativePath);
+  fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+  fs.writeFileSync(absolutePath, source);
+};
+
+beforeAll(() => {
+  temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-ink-raw-text-"));
+  entryFilename = path.join(temporaryDirectory, "app.tsx");
+});
+
+afterAll(() => {
+  fs.rmSync(temporaryDirectory, { force: true, recursive: true });
+});
+
+describe("ink-no-raw-text cross-file wrappers", () => {
+  it("reports raw text forwarded into an imported Ink Box", () => {
+    writeSource(
+      "panel.tsx",
+      `import {Box} from "ink"; export const Panel=({children}) => <Box>{children}</Box>;`,
+    );
+    const code = `import {Panel} from "./panel"; const App=()=> <Panel>bad</Panel>;`;
+    expect(runRule(inkNoRawText, code, { filename: entryFilename }).diagnostics).toHaveLength(1);
+  });
+
+  it("accepts raw text forwarded into an imported Ink Text", () => {
+    writeSource(
+      "label.tsx",
+      `import {Text} from "ink"; export const Label=({children}) => <Text>{children}</Text>;`,
+    );
+    const code = `import {Label} from "./label"; const App=()=> <Label>good</Label>;`;
+    expect(runRule(inkNoRawText, code, { filename: entryFilename }).diagnostics).toHaveLength(0);
+  });
+
+  it("resolves a first-party wrapper chain within the imported module", () => {
+    writeSource(
+      "layout.tsx",
+      `import {Box} from "ink"; const Inner=({children}) => <Box>{children}</Box>; export const Layout=({children}) => <Inner>{children}</Inner>;`,
+    );
+    const code = `import {Layout} from "./layout"; const App=()=> <Layout>bad</Layout>;`;
+    expect(runRule(inkNoRawText, code, { filename: entryFilename }).diagnostics).toHaveLength(1);
+  });
+
+  it("does not reuse an imported wrapper result for a shadowed component", () => {
+    writeSource(
+      "panel.tsx",
+      `import {Box} from "ink"; export const Panel=({children}) => <Box>{children}</Box>;`,
+    );
+    const code = `
+      import {Panel} from "./panel";
+      import {Text} from "ink";
+      const Unsafe=()=> <Panel>bad</Panel>;
+      const Safe=(Panel)=> <Panel>good</Panel>;
+    `;
+    expect(runRule(inkNoRawText, code, { filename: entryFilename }).diagnostics).toHaveLength(1);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-no-raw-text.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-no-raw-text.ts
@@ -1,0 +1,63 @@
+import { MINIMUM_INK_VERSIONS } from "../../constants/ink.js";
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findNearestInkJsxElement } from "../../utils/find-nearest-ink-jsx-element.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+
+const TEXT_COMPONENT_NAMES = new Set(["Text", "Transform"]);
+
+const isStaticRawText = (node: EsTreeNode): boolean => {
+  if (isNodeOfType(node, "JSXText")) return Boolean(node.value.trim());
+  if (!isNodeOfType(node, "JSXExpressionContainer")) return false;
+  const parent = node.parent;
+  if (!isNodeOfType(parent, "JSXElement") && !isNodeOfType(parent, "JSXFragment")) {
+    return false;
+  }
+  if (!parent.children.some((child) => child === node)) return false;
+  if (isNodeOfType(parent, "JSXElement") && node.range[0] < parent.openingElement.range[1]) {
+    return false;
+  }
+  const expression = node.expression;
+  return (
+    (isNodeOfType(expression, "Literal") &&
+      (typeof expression.value === "string" || typeof expression.value === "number")) ||
+    (isNodeOfType(expression, "TemplateLiteral") && expression.expressions.length === 0)
+  );
+};
+
+export const inkNoRawText = defineRule({
+  id: "ink-no-raw-text",
+  title: "Raw text outside Ink Text",
+  severity: "error",
+  minimumInkVersion: MINIMUM_INK_VERSIONS.base,
+  recommendation: "Wrap terminal text in Ink's `<Text>` component.",
+  create: (context) => ({
+    JSXText(node: EsTreeNodeOfType<"JSXText">) {
+      const parentInkElementName = findNearestInkJsxElement(node, context.scopes);
+      if (
+        isStaticRawText(node) &&
+        parentInkElementName &&
+        !TEXT_COMPONENT_NAMES.has(parentInkElementName)
+      ) {
+        context.report({
+          node,
+          message: "Raw text outside `<Text>` crashes Ink; wrap it in `<Text>`.",
+        });
+      }
+    },
+    JSXExpressionContainer(node: EsTreeNodeOfType<"JSXExpressionContainer">) {
+      const parentInkElementName = findNearestInkJsxElement(node, context.scopes);
+      if (
+        isStaticRawText(node) &&
+        parentInkElementName &&
+        !TEXT_COMPONENT_NAMES.has(parentInkElementName)
+      ) {
+        context.report({
+          node,
+          message: "Raw text outside `<Text>` crashes Ink; wrap it in `<Text>`.",
+        });
+      }
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-no-raw-text.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-no-raw-text.ts
@@ -1,11 +1,49 @@
 import { MINIMUM_INK_VERSIONS } from "../../constants/ink.js";
+import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
+import { collectTextWrapperComponents } from "../../utils/collect-text-wrapper-components.js";
+import { containsJsxElement } from "../../utils/contains-jsx-element.js";
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
-import { findNearestInkJsxElement } from "../../utils/find-nearest-ink-jsx-element.js";
+import {
+  getImportedNameFromModule,
+  isNamespaceImportFromModule,
+} from "../../utils/find-import-source-for-name.js";
+import { isJsxFragmentElement } from "../../utils/is-jsx-fragment-element.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { isReactComponentName } from "../../utils/is-react-component-name.js";
+import { resolveImportedComponentForwarding } from "../../utils/resolve-imported-component-forwarding.js";
+import { resolveInkJsxElementName } from "../../utils/resolve-ink-api-name.js";
+import { resolveJsxElementName } from "../../utils/resolve-jsx-element-name.js";
 
 const TEXT_COMPONENT_NAMES = new Set(["Text", "Transform"]);
+
+const resolveImportedInkElementName = (
+  elementName: string,
+  contextNode: EsTreeNode,
+  scopes: ScopeAnalysis,
+): string | null => {
+  if (isNodeOfType(contextNode, "JSXElement")) {
+    const directInkElementName = resolveInkJsxElementName(contextNode.openingElement, scopes);
+    if (directInkElementName) return directInkElementName;
+    const jsxName = contextNode.openingElement.name;
+    const bindingIdentifier = isNodeOfType(jsxName, "JSXIdentifier")
+      ? jsxName
+      : isNodeOfType(jsxName, "JSXMemberExpression") &&
+          isNodeOfType(jsxName.object, "JSXIdentifier")
+        ? jsxName.object
+        : null;
+    if (bindingIdentifier && scopes.symbolFor(bindingIdentifier)) return null;
+    if (
+      isNodeOfType(jsxName, "JSXMemberExpression") &&
+      isNodeOfType(jsxName.object, "JSXIdentifier") &&
+      isNamespaceImportFromModule(contextNode, jsxName.object.name, "ink")
+    ) {
+      return jsxName.property.name;
+    }
+  }
+  return getImportedNameFromModule(contextNode, elementName, "ink");
+};
 
 const isStaticRawText = (node: EsTreeNode): boolean => {
   if (isNodeOfType(node, "JSXText")) return Boolean(node.value.trim());
@@ -26,38 +64,109 @@ const isStaticRawText = (node: EsTreeNode): boolean => {
   );
 };
 
+const findRawTextReceiver = (
+  node: EsTreeNode,
+  context: Parameters<typeof isJsxFragmentElement>[1],
+): EsTreeNodeOfType<"JSXElement"> | null => {
+  let parentNode = node.parent;
+  while (parentNode) {
+    if (isNodeOfType(parentNode, "JSXFragment")) {
+      parentNode = parentNode.parent;
+      continue;
+    }
+    if (!isNodeOfType(parentNode, "JSXElement")) return null;
+    if (isJsxFragmentElement(parentNode.openingElement, context)) {
+      parentNode = parentNode.parent;
+      continue;
+    }
+    return parentNode;
+  }
+  return null;
+};
+
 export const inkNoRawText = defineRule({
   id: "ink-no-raw-text",
   title: "Raw text outside Ink Text",
   severity: "error",
   minimumInkVersion: MINIMUM_INK_VERSIONS.base,
   recommendation: "Wrap terminal text in Ink's `<Text>` component.",
-  create: (context) => ({
-    JSXText(node: EsTreeNodeOfType<"JSXText">) {
-      const parentInkElementName = findNearestInkJsxElement(node, context.scopes);
-      if (
-        isStaticRawText(node) &&
-        parentInkElementName &&
-        !TEXT_COMPONENT_NAMES.has(parentInkElementName)
-      ) {
-        context.report({
+  create: (context) => {
+    let textWrappers: ReadonlySet<string> = new Set();
+    let nonTextWrappers: ReadonlySet<string> = new Set();
+
+    const isTextHandlingRoot = (elementName: string, contextNode: EsTreeNode): boolean => {
+      const inkElementName = resolveImportedInkElementName(
+        elementName,
+        contextNode,
+        context.scopes,
+      );
+      return inkElementName !== null && TEXT_COMPONENT_NAMES.has(inkElementName);
+    };
+    const isNonTextRoot = (elementName: string, contextNode: EsTreeNode): boolean => {
+      const inkElementName = resolveImportedInkElementName(
+        elementName,
+        contextNode,
+        context.scopes,
+      );
+      return inkElementName !== null && !TEXT_COMPONENT_NAMES.has(inkElementName);
+    };
+    const resolveImportedForwarding = (
+      elementName: string,
+      contextNode: EsTreeNode,
+    ): "text" | "nonText" | "unknown" => {
+      return context.filename
+        ? (resolveImportedComponentForwarding(
+            contextNode,
+            context.scopes,
+            context.filename,
+            elementName,
+            isTextHandlingRoot,
+            isNonTextRoot,
+          ) ?? "unknown")
+        : "unknown";
+    };
+    const reportRawText = (node: EsTreeNode): void => {
+      if (!isStaticRawText(node)) return;
+      const receiver = findRawTextReceiver(node, context.scopes);
+      if (!receiver) return;
+      const directInkElementName = resolveInkJsxElementName(
+        receiver.openingElement,
+        context.scopes,
+      );
+      if (directInkElementName && TEXT_COMPONENT_NAMES.has(directInkElementName)) return;
+      const elementName = resolveJsxElementName(receiver.openingElement);
+      const isProvenNonTextReceiver = Boolean(
+        directInkElementName ||
+        (elementName &&
+          !textWrappers.has(elementName) &&
+          (nonTextWrappers.has(elementName) ||
+            (isReactComponentName(elementName) &&
+              resolveImportedForwarding(elementName, receiver) === "nonText"))),
+      );
+      if (!isProvenNonTextReceiver) return;
+      context.report({
+        node,
+        message: "Raw text reaches Ink without a `<Text>` boundary.",
+      });
+    };
+
+    return {
+      Program(node: EsTreeNodeOfType<"Program">) {
+        if (!containsJsxElement(node)) return;
+        const childrenForwarding = collectTextWrapperComponents(
           node,
-          message: "Raw text outside `<Text>` crashes Ink; wrap it in `<Text>`.",
-        });
-      }
-    },
-    JSXExpressionContainer(node: EsTreeNodeOfType<"JSXExpressionContainer">) {
-      const parentInkElementName = findNearestInkJsxElement(node, context.scopes);
-      if (
-        isStaticRawText(node) &&
-        parentInkElementName &&
-        !TEXT_COMPONENT_NAMES.has(parentInkElementName)
-      ) {
-        context.report({
-          node,
-          message: "Raw text outside `<Text>` crashes Ink; wrap it in `<Text>`.",
-        });
-      }
-    },
-  }),
+          isTextHandlingRoot,
+          isNonTextRoot,
+        );
+        textWrappers = childrenForwarding.textWrappers;
+        nonTextWrappers = childrenForwarding.nonTextWrappers;
+      },
+      JSXText(node: EsTreeNodeOfType<"JSXText">) {
+        reportRawText(node);
+      },
+      JSXExpressionContainer(node: EsTreeNodeOfType<"JSXExpressionContainer">) {
+        reportRawText(node);
+      },
+    };
+  },
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-no-repeated-render.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-no-repeated-render.ts
@@ -1,0 +1,96 @@
+import { MINIMUM_INK_VERSIONS } from "../../constants/ink.js";
+import type { BasicBlock } from "../../semantic/control-flow-graph.js";
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { resolveInkApiName } from "../../utils/resolve-ink-api-name.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+import { walkAst } from "../../utils/walk-ast.js";
+
+const canReachBlock = (sourceBlock: BasicBlock, targetBlock: BasicBlock): boolean => {
+  if (sourceBlock === targetBlock) return true;
+  const visitedBlocks = new Set([sourceBlock]);
+  const pendingBlocks = [sourceBlock];
+  while (pendingBlocks.length > 0) {
+    const currentBlock = pendingBlocks.pop();
+    if (!currentBlock) break;
+    for (const edge of currentBlock.successors) {
+      if (edge.to === targetBlock) return true;
+      if (visitedBlocks.has(edge.to)) continue;
+      visitedBlocks.add(edge.to);
+      pendingBlocks.push(edge.to);
+    }
+  }
+  return false;
+};
+
+const canExecuteAfter = (
+  earlierCall: EsTreeNode,
+  laterCall: EsTreeNode,
+  owner: EsTreeNode,
+  context: RuleContext,
+): boolean => {
+  const ownerControlFlow = context.cfg.cfgFor(owner);
+  const earlierBlock = ownerControlFlow?.blockOf(earlierCall);
+  const laterBlock = ownerControlFlow?.blockOf(laterCall);
+  if (!earlierBlock || !laterBlock) return false;
+  return canReachBlock(earlierBlock, laterBlock);
+};
+
+const hasUnmountBetween = (
+  owner: EsTreeNode,
+  earlierCall: EsTreeNode,
+  laterCall: EsTreeNode,
+  context: RuleContext,
+): boolean => {
+  let hasUnmount = false;
+  walkAst(owner, (descendantNode) => {
+    if (
+      isNodeOfType(descendantNode, "CallExpression") &&
+      descendantNode.range[0] > earlierCall.range[1] &&
+      descendantNode.range[1] < laterCall.range[0] &&
+      context.cfg.enclosingFunction(descendantNode) === owner &&
+      isNodeOfType(descendantNode.callee, "MemberExpression") &&
+      getStaticPropertyName(descendantNode.callee) === "unmount"
+    ) {
+      hasUnmount = true;
+    }
+  });
+  return hasUnmount;
+};
+
+export const inkNoRepeatedRender = defineRule({
+  id: "ink-no-repeated-render",
+  title: "Ink rendered repeatedly to one process",
+  severity: "error",
+  minimumInkVersion: MINIMUM_INK_VERSIONS.base,
+  recommendation: "Call Ink `render()` once and update or rerender the returned instance.",
+  create: (context) => {
+    const renderCallsByOwner = new Map<EsTreeNode, EsTreeNodeOfType<"CallExpression">[]>();
+    return {
+      CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+        if (resolveInkApiName(node.callee, context.scopes) !== "render") return;
+        const owner = context.cfg.enclosingFunction(node);
+        if (!owner) return;
+        const previousRenderCalls = renderCallsByOwner.get(owner) ?? [];
+        renderCallsByOwner.set(owner, [...previousRenderCalls, node]);
+        if (
+          !previousRenderCalls.some(
+            (call) =>
+              canExecuteAfter(call, node, owner, context) &&
+              !hasUnmountBetween(owner, call, node, context),
+          )
+        ) {
+          return;
+        }
+        context.report({
+          node,
+          message:
+            "A second Ink `render()` call can create competing renderers for the same output.",
+        });
+      },
+    };
+  },
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-no-repeated-render.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-no-repeated-render.ts
@@ -16,6 +16,11 @@ interface InkRenderOutput {
   isDefault: boolean;
 }
 
+interface InkRenderCleanupBindings {
+  instanceSymbolIds: Set<number>;
+  unmountSymbolIds: Set<number>;
+}
+
 const resolveInkRenderOutput = (
   renderCall: EsTreeNodeOfType<"CallExpression">,
 ): InkRenderOutput | null => {
@@ -86,7 +91,11 @@ const doInkRenderCallsShareOutput = (
   return areSameStableOutputBindings(leftOutput.expression, rightOutput.expression, context);
 };
 
-const canReachBlock = (sourceBlock: BasicBlock, targetBlock: BasicBlock): boolean => {
+const canReachBlock = (
+  sourceBlock: BasicBlock,
+  targetBlock: BasicBlock,
+  excludedBlocks: ReadonlySet<BasicBlock> = new Set(),
+): boolean => {
   if (sourceBlock === targetBlock) return true;
   const visitedBlocks = new Set([sourceBlock]);
   const pendingBlocks = [sourceBlock];
@@ -94,6 +103,7 @@ const canReachBlock = (sourceBlock: BasicBlock, targetBlock: BasicBlock): boolea
     const currentBlock = pendingBlocks.pop();
     if (!currentBlock) break;
     for (const edge of currentBlock.successors) {
+      if (excludedBlocks.has(edge.to)) continue;
       if (edge.to === targetBlock) return true;
       if (visitedBlocks.has(edge.to)) continue;
       visitedBlocks.add(edge.to);
@@ -116,26 +126,107 @@ const canExecuteAfter = (
   return canReachBlock(earlierBlock, laterBlock);
 };
 
-const hasUnmountBetween = (
+const addBindingSymbolId = (
+  bindingNode: EsTreeNode | null | undefined,
+  symbolIds: Set<number>,
+  context: RuleContext,
+): void => {
+  const identifier = isNodeOfType(bindingNode, "Identifier")
+    ? bindingNode
+    : isNodeOfType(bindingNode, "AssignmentPattern") && isNodeOfType(bindingNode.left, "Identifier")
+      ? bindingNode.left
+      : null;
+  const symbol = identifier ? context.scopes.symbolFor(identifier) : null;
+  if (symbol) symbolIds.add(symbol.id);
+};
+
+const collectRenderCleanupBindings = (
+  renderCall: EsTreeNodeOfType<"CallExpression">,
+  context: RuleContext,
+): InkRenderCleanupBindings => {
+  const bindings: InkRenderCleanupBindings = {
+    instanceSymbolIds: new Set(),
+    unmountSymbolIds: new Set(),
+  };
+  const parentNode = renderCall.parent;
+  const bindingPattern =
+    isNodeOfType(parentNode, "VariableDeclarator") && parentNode.init === renderCall
+      ? parentNode.id
+      : isNodeOfType(parentNode, "AssignmentExpression") && parentNode.right === renderCall
+        ? parentNode.left
+        : null;
+  if (isNodeOfType(bindingPattern, "Identifier")) {
+    addBindingSymbolId(bindingPattern, bindings.instanceSymbolIds, context);
+    return bindings;
+  }
+  if (!isNodeOfType(bindingPattern, "ObjectPattern")) return bindings;
+  for (const propertyNode of bindingPattern.properties) {
+    if (
+      isNodeOfType(propertyNode, "Property") &&
+      getStaticPropertyKeyName(propertyNode, { allowComputedString: true }) === "unmount"
+    ) {
+      addBindingSymbolId(propertyNode.value, bindings.unmountSymbolIds, context);
+    }
+  }
+  return bindings;
+};
+
+const isRenderUnmountCall = (
+  callNode: EsTreeNodeOfType<"CallExpression">,
+  renderCall: EsTreeNodeOfType<"CallExpression">,
+  bindings: InkRenderCleanupBindings,
+  context: RuleContext,
+): boolean => {
+  const calleeNode = callNode.callee;
+  if (isNodeOfType(calleeNode, "Identifier")) {
+    const symbol = context.scopes.symbolFor(calleeNode);
+    return Boolean(symbol && bindings.unmountSymbolIds.has(symbol.id));
+  }
+  if (
+    !isNodeOfType(calleeNode, "MemberExpression") ||
+    getStaticPropertyName(calleeNode) !== "unmount"
+  ) {
+    return false;
+  }
+  if (calleeNode.object === renderCall) return true;
+  if (!isNodeOfType(calleeNode.object, "Identifier")) return false;
+  const symbol = context.scopes.symbolFor(calleeNode.object);
+  return Boolean(symbol && bindings.instanceSymbolIds.has(symbol.id));
+};
+
+const isRenderUnmountedBefore = (
   owner: EsTreeNode,
-  earlierCall: EsTreeNode,
+  earlierCall: EsTreeNodeOfType<"CallExpression">,
   laterCall: EsTreeNode,
   context: RuleContext,
 ): boolean => {
-  let hasUnmount = false;
+  const bindings = collectRenderCleanupBindings(earlierCall, context);
+  const cleanupCalls: EsTreeNodeOfType<"CallExpression">[] = [];
   walkAst(owner, (descendantNode) => {
     if (
       isNodeOfType(descendantNode, "CallExpression") &&
-      descendantNode.range[0] > earlierCall.range[1] &&
+      descendantNode.range[1] > earlierCall.range[1] &&
       descendantNode.range[1] < laterCall.range[0] &&
       context.cfg.enclosingFunction(descendantNode) === owner &&
-      isNodeOfType(descendantNode.callee, "MemberExpression") &&
-      getStaticPropertyName(descendantNode.callee) === "unmount"
+      isRenderUnmountCall(descendantNode, earlierCall, bindings, context)
     ) {
-      hasUnmount = true;
+      cleanupCalls.push(descendantNode);
     }
   });
-  return hasUnmount;
+  if (cleanupCalls.length === 0) return false;
+  const ownerControlFlow = context.cfg.cfgFor(owner);
+  if (!ownerControlFlow) return false;
+  const earlierBlock = ownerControlFlow.blockOf(earlierCall);
+  const laterBlock = ownerControlFlow.blockOf(laterCall);
+  if (!earlierBlock || !laterBlock) return false;
+  const cleanupBlocks = new Set<BasicBlock>();
+  for (const cleanupCall of cleanupCalls) {
+    const cleanupBlock = ownerControlFlow.blockOf(cleanupCall);
+    if (!cleanupBlock) continue;
+    if (cleanupBlock === earlierBlock || cleanupBlock === laterBlock) return true;
+    cleanupBlocks.add(cleanupBlock);
+  }
+  return !canReachBlock(earlierBlock, laterBlock, cleanupBlocks);
 };
 
 export const inkNoRepeatedRender = defineRule({
@@ -158,7 +249,7 @@ export const inkNoRepeatedRender = defineRule({
             (call) =>
               doInkRenderCallsShareOutput(call, node, context) &&
               canExecuteAfter(call, node, owner, context) &&
-              !hasUnmountBetween(owner, call, node, context),
+              !isRenderUnmountedBefore(owner, call, node, context),
           )
         ) {
           return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-no-repeated-render.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-no-repeated-render.ts
@@ -231,7 +231,7 @@ const isRenderUnmountedBefore = (
 
 export const inkNoRepeatedRender = defineRule({
   id: "ink-no-repeated-render",
-  title: "Ink rendered repeatedly to one process",
+  title: "Ink render reused before unmount",
   severity: "error",
   minimumInkVersion: MINIMUM_INK_VERSIONS.base,
   recommendation: "Call Ink `render()` once and update or rerender the returned instance.",
@@ -257,7 +257,7 @@ export const inkNoRepeatedRender = defineRule({
         context.report({
           node,
           message:
-            "A second Ink `render()` call can create competing renderers for the same output.",
+            "Ink reuses the existing output instance and ignores fresh renderer options; use its `rerender()` method or unmount it first.",
         });
       },
     };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-no-repeated-render.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-no-repeated-render.ts
@@ -3,11 +3,88 @@ import type { BasicBlock } from "../../semantic/control-flow-graph.js";
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { getStaticPropertyKeyName } from "../../utils/get-static-property-key-name.js";
 import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { isProvenGlobalNamespaceReference } from "../../utils/is-proven-global-namespace-reference.js";
 import { resolveInkApiName } from "../../utils/resolve-ink-api-name.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { walkAst } from "../../utils/walk-ast.js";
+
+interface InkRenderOutput {
+  expression: EsTreeNode | null;
+  isDefault: boolean;
+}
+
+const resolveInkRenderOutput = (
+  renderCall: EsTreeNodeOfType<"CallExpression">,
+): InkRenderOutput | null => {
+  const optionsNode = renderCall.arguments[1];
+  if (!optionsNode) return { expression: null, isDefault: true };
+  if (!isNodeOfType(optionsNode, "ObjectExpression")) return null;
+
+  let output: InkRenderOutput | null = { expression: null, isDefault: true };
+  for (const propertyNode of optionsNode.properties) {
+    if (isNodeOfType(propertyNode, "SpreadElement")) {
+      output = null;
+      continue;
+    }
+    if (!isNodeOfType(propertyNode, "Property")) continue;
+    const propertyName = getStaticPropertyKeyName(propertyNode, {
+      allowComputedString: true,
+    });
+    if (propertyName === null) {
+      if (propertyNode.computed) output = null;
+      continue;
+    }
+    if (propertyName !== "stdout") continue;
+    output = { expression: propertyNode.value, isDefault: false };
+  }
+  return output;
+};
+
+const isProcessStdoutExpression = (node: EsTreeNode | null, context: RuleContext): boolean =>
+  Boolean(
+    node &&
+    isNodeOfType(node, "MemberExpression") &&
+    getStaticPropertyName(node) === "stdout" &&
+    isProvenGlobalNamespaceReference(node.object, "process", context.scopes),
+  );
+
+const areSameStableOutputBindings = (
+  leftNode: EsTreeNode | null,
+  rightNode: EsTreeNode | null,
+  context: RuleContext,
+): boolean => {
+  if (!isNodeOfType(leftNode, "Identifier") || !isNodeOfType(rightNode, "Identifier")) {
+    return false;
+  }
+  const leftSymbol = context.scopes.symbolFor(leftNode);
+  const rightSymbol = context.scopes.symbolFor(rightNode);
+  return Boolean(
+    leftSymbol &&
+    leftSymbol.id === rightSymbol?.id &&
+    leftSymbol.references.every((reference) => reference.flag === "read"),
+  );
+};
+
+const doInkRenderCallsShareOutput = (
+  leftCall: EsTreeNodeOfType<"CallExpression">,
+  rightCall: EsTreeNodeOfType<"CallExpression">,
+  context: RuleContext,
+): boolean => {
+  const leftOutput = resolveInkRenderOutput(leftCall);
+  const rightOutput = resolveInkRenderOutput(rightCall);
+  if (!leftOutput || !rightOutput) return false;
+  const leftUsesProcessStdout =
+    leftOutput.isDefault || isProcessStdoutExpression(leftOutput.expression, context);
+  const rightUsesProcessStdout =
+    rightOutput.isDefault || isProcessStdoutExpression(rightOutput.expression, context);
+  if (leftUsesProcessStdout || rightUsesProcessStdout) {
+    return leftUsesProcessStdout && rightUsesProcessStdout;
+  }
+  return areSameStableOutputBindings(leftOutput.expression, rightOutput.expression, context);
+};
 
 const canReachBlock = (sourceBlock: BasicBlock, targetBlock: BasicBlock): boolean => {
   if (sourceBlock === targetBlock) return true;
@@ -79,6 +156,7 @@ export const inkNoRepeatedRender = defineRule({
         if (
           !previousRenderCalls.some(
             (call) =>
+              doInkRenderCallsShareOutput(call, node, context) &&
               canExecuteAfter(call, node, owner, context) &&
               !hasUnmountBetween(owner, call, node, context),
           )

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-prefer-use-animation.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-prefer-use-animation.ts
@@ -1,0 +1,85 @@
+import { MINIMUM_INK_VERSIONS } from "../../constants/ink.js";
+import { defineRule } from "../../utils/define-rule.js";
+import { collectFunctionReturnStatements } from "../../utils/collect-function-return-statements.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { getImportedNameFromModule } from "../../utils/find-import-source-for-name.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { walkAst } from "../../utils/walk-ast.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+
+const hasIncrementExpression = (updaterNode: EsTreeNode): boolean => {
+  if (
+    !isNodeOfType(updaterNode, "ArrowFunctionExpression") &&
+    !isNodeOfType(updaterNode, "FunctionExpression")
+  ) {
+    return false;
+  }
+  const returnedExpressions = isNodeOfType(updaterNode.body, "BlockStatement")
+    ? collectFunctionReturnStatements(updaterNode).flatMap((returnStatement) =>
+        returnStatement.argument ? [returnStatement.argument] : [],
+      )
+    : [updaterNode.body];
+  return returnedExpressions.some((returnedExpression) => {
+    const unwrappedExpression = stripParenExpression(returnedExpression);
+    return (
+      isNodeOfType(unwrappedExpression, "BinaryExpression") &&
+      ["+", "-", "%"].includes(unwrappedExpression.operator)
+    );
+  });
+};
+
+const isFrameIncrement = (callbackNode: EsTreeNode): boolean => {
+  let hasFrameIncrement = false;
+  walkAst(callbackNode, (descendantNode) => {
+    if (
+      !isNodeOfType(descendantNode, "CallExpression") ||
+      !isNodeOfType(descendantNode.callee, "Identifier") ||
+      !/^set(?:Frame|Index|Step|Tick)/.test(descendantNode.callee.name)
+    ) {
+      return;
+    }
+    const updaterNode = descendantNode.arguments[0];
+    if (updaterNode && hasIncrementExpression(updaterNode)) {
+      hasFrameIncrement = true;
+    }
+  });
+  return hasFrameIncrement;
+};
+
+export const inkPreferUseAnimation = defineRule({
+  id: "ink-prefer-use-animation",
+  title: "Animation loop implemented with setInterval",
+  category: "Performance",
+  severity: "warn",
+  minimumInkVersion: MINIMUM_INK_VERSIONS.modernHooks,
+  recommendation: "Use Ink's shared `useAnimation()` scheduler and automatic unmount cleanup.",
+  create: (context) => ({
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+      if (!isNodeOfType(node.callee, "Identifier") || node.callee.name !== "setInterval") return;
+      const effectFunction = node.parent;
+      let ancestorNode: EsTreeNode | null | undefined = effectFunction;
+      let isInsideReactEffect = false;
+      while (ancestorNode) {
+        if (
+          isNodeOfType(ancestorNode, "CallExpression") &&
+          isNodeOfType(ancestorNode.callee, "Identifier") &&
+          context.scopes.symbolFor(ancestorNode.callee)?.kind === "import" &&
+          ["useEffect", "useLayoutEffect"].includes(
+            getImportedNameFromModule(ancestorNode, ancestorNode.callee.name, "react") ?? "",
+          )
+        ) {
+          isInsideReactEffect = true;
+          break;
+        }
+        ancestorNode = ancestorNode.parent;
+      }
+      const intervalCallback = node.arguments[0];
+      if (!isInsideReactEffect || !intervalCallback || !isFrameIncrement(intervalCallback)) return;
+      context.report({
+        node,
+        message: "This frame-counter interval is an Ink animation; prefer `useAnimation()`.",
+      });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-prefer-use-animation.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-prefer-use-animation.ts
@@ -4,7 +4,10 @@ import { collectFunctionReturnStatements } from "../../utils/collect-function-re
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { getImportedNameFromModule } from "../../utils/find-import-source-for-name.js";
+import { findRenderPhaseComponentOrHook } from "../../utils/find-render-phase-component-or-hook.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { resolveInkJsxElementName } from "../../utils/resolve-ink-api-name.js";
+import type { RuleContext } from "../../utils/rule-context.js";
 import { walkAst } from "../../utils/walk-ast.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 
@@ -32,10 +35,11 @@ const hasIncrementExpression = (updaterNode: EsTreeNode): boolean => {
 const isFrameIncrement = (callbackNode: EsTreeNode): boolean => {
   let hasFrameIncrement = false;
   walkAst(callbackNode, (descendantNode) => {
+    if (descendantNode !== callbackNode && /Function/.test(descendantNode.type)) return false;
     if (
       !isNodeOfType(descendantNode, "CallExpression") ||
       !isNodeOfType(descendantNode.callee, "Identifier") ||
-      !/^set(?:Frame|Index|Step|Tick)/.test(descendantNode.callee.name)
+      descendantNode.callee.name !== "setFrame"
     ) {
       return;
     }
@@ -45,6 +49,26 @@ const isFrameIncrement = (callbackNode: EsTreeNode): boolean => {
     }
   });
   return hasFrameIncrement;
+};
+
+const componentRendersInk = (componentNode: EsTreeNode, context: RuleContext): boolean => {
+  let doesRenderInk = false;
+  walkAst(componentNode, (descendantNode) => {
+    if (
+      descendantNode !== componentNode &&
+      (/Function/.test(descendantNode.type) || isNodeOfType(descendantNode, "JSXAttribute"))
+    ) {
+      return false;
+    }
+    if (
+      isNodeOfType(descendantNode, "JSXOpeningElement") &&
+      resolveInkJsxElementName(descendantNode, context.scopes)
+    ) {
+      doesRenderInk = true;
+      return false;
+    }
+  });
+  return doesRenderInk;
 };
 
 export const inkPreferUseAnimation = defineRule({
@@ -57,9 +81,9 @@ export const inkPreferUseAnimation = defineRule({
   create: (context) => ({
     CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
       if (!isNodeOfType(node.callee, "Identifier") || node.callee.name !== "setInterval") return;
-      const effectFunction = node.parent;
-      let ancestorNode: EsTreeNode | null | undefined = effectFunction;
-      let isInsideReactEffect = false;
+      if (!context.scopes.isGlobalReference(node.callee)) return;
+      let ancestorNode: EsTreeNode | null | undefined = node.parent;
+      let effectCall: EsTreeNodeOfType<"CallExpression"> | null = null;
       while (ancestorNode) {
         if (
           isNodeOfType(ancestorNode, "CallExpression") &&
@@ -69,13 +93,15 @@ export const inkPreferUseAnimation = defineRule({
             getImportedNameFromModule(ancestorNode, ancestorNode.callee.name, "react") ?? "",
           )
         ) {
-          isInsideReactEffect = true;
+          effectCall = ancestorNode;
           break;
         }
         ancestorNode = ancestorNode.parent;
       }
       const intervalCallback = node.arguments[0];
-      if (!isInsideReactEffect || !intervalCallback || !isFrameIncrement(intervalCallback)) return;
+      if (!effectCall || !intervalCallback || !isFrameIncrement(intervalCallback)) return;
+      const componentNode = findRenderPhaseComponentOrHook(effectCall, context.scopes);
+      if (!componentNode || !componentRendersInk(componentNode, context)) return;
       context.report({
         node,
         message: "This frame-counter interval is an Ink animation; prefer `useAnimation()`.",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-prefer-use-animation.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-prefer-use-animation.ts
@@ -1,13 +1,12 @@
 import { MINIMUM_INK_VERSIONS } from "../../constants/ink.js";
 import { defineRule } from "../../utils/define-rule.js";
 import { collectFunctionReturnStatements } from "../../utils/collect-function-return-statements.js";
+import { componentRendersInk } from "../../utils/component-renders-ink.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { getImportedNameFromModule } from "../../utils/find-import-source-for-name.js";
 import { findRenderPhaseComponentOrHook } from "../../utils/find-render-phase-component-or-hook.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
-import { resolveInkJsxElementName } from "../../utils/resolve-ink-api-name.js";
-import type { RuleContext } from "../../utils/rule-context.js";
 import { walkAst } from "../../utils/walk-ast.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 
@@ -51,26 +50,6 @@ const isFrameIncrement = (callbackNode: EsTreeNode): boolean => {
   return hasFrameIncrement;
 };
 
-const componentRendersInk = (componentNode: EsTreeNode, context: RuleContext): boolean => {
-  let doesRenderInk = false;
-  walkAst(componentNode, (descendantNode) => {
-    if (
-      descendantNode !== componentNode &&
-      (/Function/.test(descendantNode.type) || isNodeOfType(descendantNode, "JSXAttribute"))
-    ) {
-      return false;
-    }
-    if (
-      isNodeOfType(descendantNode, "JSXOpeningElement") &&
-      resolveInkJsxElementName(descendantNode, context.scopes)
-    ) {
-      doesRenderInk = true;
-      return false;
-    }
-  });
-  return doesRenderInk;
-};
-
 export const inkPreferUseAnimation = defineRule({
   id: "ink-prefer-use-animation",
   title: "Animation loop implemented with setInterval",
@@ -101,7 +80,7 @@ export const inkPreferUseAnimation = defineRule({
       const intervalCallback = node.arguments[0];
       if (!effectCall || !intervalCallback || !isFrameIncrement(intervalCallback)) return;
       const componentNode = findRenderPhaseComponentOrHook(effectCall, context.scopes);
-      if (!componentNode || !componentRendersInk(componentNode, context)) return;
+      if (!componentNode || !componentRendersInk(componentNode, context.scopes)) return;
       context.report({
         node,
         message: "This frame-counter interval is an Ink animation; prefer `useAnimation()`.",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-prefer-use-paste.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-prefer-use-paste.ts
@@ -63,6 +63,7 @@ export const inkPreferUsePaste = defineRule({
   id: "ink-prefer-use-paste",
   title: "Paste interpreted through useInput",
   severity: "warn",
+  defaultEnabled: false,
   minimumInkVersion: MINIMUM_INK_VERSIONS.modernHooks,
   recommendation: "Use Ink's `usePaste()` for bracketed multi-character paste input.",
   create: (context) => ({

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-prefer-use-paste.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-prefer-use-paste.ts
@@ -1,0 +1,75 @@
+import { MINIMUM_INK_VERSIONS } from "../../constants/ink.js";
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { resolveInkApiName } from "../../utils/resolve-ink-api-name.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import { walkAst } from "../../utils/walk-ast.js";
+
+const interpretsPastedInput = (handler: EsTreeNode): boolean => {
+  if (
+    (!isNodeOfType(handler, "ArrowFunctionExpression") &&
+      !isNodeOfType(handler, "FunctionExpression")) ||
+    !isNodeOfType(handler.params[0], "Identifier")
+  ) {
+    return false;
+  }
+  const inputName = handler.params[0].name;
+  let isPasteLogic = false;
+  walkAst(handler.body, (descendantNode) => {
+    if (isNodeOfType(descendantNode, "CallExpression")) {
+      const callee = descendantNode.callee;
+      const inputReceiver = isNodeOfType(callee, "MemberExpression")
+        ? stripParenExpression(callee.object)
+        : null;
+      if (
+        isNodeOfType(callee, "MemberExpression") &&
+        inputReceiver &&
+        isNodeOfType(inputReceiver, "Identifier") &&
+        inputReceiver.name === inputName &&
+        (getStaticPropertyName(callee) === "includes" ||
+          getStaticPropertyName(callee) === "split") &&
+        descendantNode.arguments.some(
+          (argumentNode) => isNodeOfType(argumentNode, "Literal") && argumentNode.value === "\n",
+        )
+      ) {
+        isPasteLogic = true;
+      }
+    }
+    if (
+      isNodeOfType(descendantNode, "BinaryExpression") &&
+      [">", ">="].includes(descendantNode.operator) &&
+      isNodeOfType(descendantNode.left, "MemberExpression") &&
+      isNodeOfType(descendantNode.left.object, "Identifier") &&
+      descendantNode.left.object.name === inputName &&
+      getStaticPropertyName(descendantNode.left) === "length" &&
+      isNodeOfType(descendantNode.right, "Literal") &&
+      typeof descendantNode.right.value === "number" &&
+      descendantNode.right.value >= 1
+    ) {
+      isPasteLogic = true;
+    }
+  });
+  return isPasteLogic;
+};
+
+export const inkPreferUsePaste = defineRule({
+  id: "ink-prefer-use-paste",
+  title: "Paste interpreted through useInput",
+  severity: "warn",
+  minimumInkVersion: MINIMUM_INK_VERSIONS.modernHooks,
+  recommendation: "Use Ink's `usePaste()` for bracketed multi-character paste input.",
+  create: (context) => ({
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+      if (resolveInkApiName(node.callee, context.scopes) !== "useInput") return;
+      const handler = node.arguments[0];
+      if (!handler || !interpretsPastedInput(handler)) return;
+      context.report({
+        node,
+        message: "Use `usePaste()` instead of inferring paste events from `useInput()` chunks.",
+      });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-prefer-use-paste.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-prefer-use-paste.ts
@@ -5,10 +5,11 @@ import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { resolveInkApiName } from "../../utils/resolve-ink-api-name.js";
+import type { RuleContext } from "../../utils/rule-context.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import { walkAst } from "../../utils/walk-ast.js";
 
-const interpretsPastedInput = (handler: EsTreeNode): boolean => {
+const interpretsPastedInput = (handler: EsTreeNode, context: RuleContext): boolean => {
   if (
     (!isNodeOfType(handler, "ArrowFunctionExpression") &&
       !isNodeOfType(handler, "FunctionExpression")) ||
@@ -16,9 +17,11 @@ const interpretsPastedInput = (handler: EsTreeNode): boolean => {
   ) {
     return false;
   }
-  const inputName = handler.params[0].name;
+  const inputSymbolId = context.scopes.symbolFor(handler.params[0])?.id;
+  if (inputSymbolId === undefined) return false;
   let isPasteLogic = false;
   walkAst(handler.body, (descendantNode) => {
+    if (descendantNode !== handler.body && /Function/.test(descendantNode.type)) return false;
     if (isNodeOfType(descendantNode, "CallExpression")) {
       const callee = descendantNode.callee;
       const inputReceiver = isNodeOfType(callee, "MemberExpression")
@@ -28,7 +31,7 @@ const interpretsPastedInput = (handler: EsTreeNode): boolean => {
         isNodeOfType(callee, "MemberExpression") &&
         inputReceiver &&
         isNodeOfType(inputReceiver, "Identifier") &&
-        inputReceiver.name === inputName &&
+        context.scopes.symbolFor(inputReceiver)?.id === inputSymbolId &&
         (getStaticPropertyName(callee) === "includes" ||
           getStaticPropertyName(callee) === "split") &&
         descendantNode.arguments.some(
@@ -43,11 +46,12 @@ const interpretsPastedInput = (handler: EsTreeNode): boolean => {
       [">", ">="].includes(descendantNode.operator) &&
       isNodeOfType(descendantNode.left, "MemberExpression") &&
       isNodeOfType(descendantNode.left.object, "Identifier") &&
-      descendantNode.left.object.name === inputName &&
+      context.scopes.symbolFor(descendantNode.left.object)?.id === inputSymbolId &&
       getStaticPropertyName(descendantNode.left) === "length" &&
       isNodeOfType(descendantNode.right, "Literal") &&
       typeof descendantNode.right.value === "number" &&
-      descendantNode.right.value >= 1
+      ((descendantNode.operator === ">" && descendantNode.right.value >= 1) ||
+        (descendantNode.operator === ">=" && descendantNode.right.value >= 2))
     ) {
       isPasteLogic = true;
     }
@@ -65,7 +69,7 @@ export const inkPreferUsePaste = defineRule({
     CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
       if (resolveInkApiName(node.callee, context.scopes) !== "useInput") return;
       const handler = node.arguments[0];
-      if (!handler || !interpretsPastedInput(handler)) return;
+      if (!handler || !interpretsPastedInput(handler, context)) return;
       context.report({
         node,
         message: "Use `usePaste()` instead of inferring paste events from `useInput()` chunks.",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-rules.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-rules.test.ts
@@ -284,4 +284,28 @@ describe("Ink rules", () => {
     expect(runRule(inkSuspenseRequiresConcurrent, suspenseCode).diagnostics).toHaveLength(1);
     expect(runRule(inkCtrlCHandlerRequiresExitOption, ctrlCCode).diagnostics).toHaveLength(1);
   });
+
+  it("associates renderer options through same-file component wrappers", () => {
+    const suspenseCode = `
+      import {render,Text} from "ink";
+      import {Suspense} from "react";
+      const SafeBoundary=()=> <Suspense fallback={null}><Text>safe</Text></Suspense>;
+      const UnsafeBoundary=()=> <Suspense fallback={null}><Text>unsafe</Text></Suspense>;
+      const SafeRoot=()=> <SafeBoundary/>;
+      const UnsafeRoot=()=> <UnsafeBoundary/>;
+      render(<SafeRoot/>,{concurrent:true});
+      render(<UnsafeRoot/>);
+    `;
+    const ctrlCCode = `
+      import {render,useInput} from "ink";
+      const SafeInput=()=> { useInput((input,key)=>{if(key.ctrl&&input==="c") work()}); return null; };
+      const UnsafeInput=()=> { useInput((input,key)=>{if(key.ctrl&&input==="c") work()}); return null; };
+      const SafeRoot=()=> <SafeInput/>;
+      const UnsafeRoot=()=> <UnsafeInput/>;
+      render(<SafeRoot/>,{exitOnCtrlC:false});
+      render(<UnsafeRoot/>);
+    `;
+    expect(runRule(inkSuspenseRequiresConcurrent, suspenseCode).diagnostics).toHaveLength(1);
+    expect(runRule(inkCtrlCHandlerRequiresExitOption, ctrlCCode).diagnostics).toHaveLength(1);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-rules.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-rules.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, it } from "vite-plus/test";
+import type { Rule } from "../../utils/rule.js";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { inkCtrlCHandlerRequiresExitOption } from "./ink-ctrl-c-handler-requires-exit-option.js";
+import { inkNewlineInsideText } from "./ink-newline-inside-text.js";
+import { inkNoBareProcessExit } from "./ink-no-bare-process-exit.js";
+import { inkNoDirectRawMode } from "./ink-no-direct-raw-mode.js";
+import { inkNoDomHostElements } from "./ink-no-dom-host-elements.js";
+import { inkNoDomRouter } from "./ink-no-dom-router.js";
+import { inkNoFocusInRender } from "./ink-no-focus-in-render.js";
+import { inkNoLayoutInsideText } from "./ink-no-layout-inside-text.js";
+import { inkNoLiveHooksInRenderToString } from "./ink-no-live-hooks-in-render-to-string.js";
+import { inkNoMeasureElementInRender } from "./ink-no-measure-element-in-render.js";
+import { inkNoMultipleStatic } from "./ink-no-multiple-static.js";
+import { inkNoRawText } from "./ink-no-raw-text.js";
+import { inkNoRepeatedRender } from "./ink-no-repeated-render.js";
+import { inkPreferUseAnimation } from "./ink-prefer-use-animation.js";
+import { inkPreferUsePaste } from "./ink-prefer-use-paste.js";
+import { inkStaticIsAppendOnly } from "./ink-static-is-append-only.js";
+import { inkStaticRequiresKey } from "./ink-static-requires-key.js";
+import { inkSuspenseRequiresConcurrent } from "./ink-suspense-requires-concurrent.js";
+import { inkUseReactiveWindowSize } from "./ink-use-reactive-window-size.js";
+import { inkUseStringWidthForCursor } from "./ink-use-string-width-for-cursor.js";
+import { inkUseSuspendTerminal } from "./ink-use-suspend-terminal.js";
+import { inkValidAriaSemantics } from "./ink-valid-aria-semantics.js";
+
+interface InkRuleCase {
+  name: string;
+  rule: Rule;
+  invalid: string;
+  valid: string;
+}
+
+const RULE_CASES: ReadonlyArray<InkRuleCase> = [
+  {
+    name: "raw text",
+    rule: inkNoRawText,
+    invalid: `import {Box as Layout} from "ink"; const App=()=> <Layout>hello</Layout>;`,
+    valid: `import {Box, Text} from "ink"; const App=()=> <Box><Text>hello</Text>{children}</Box>;`,
+  },
+  {
+    name: "layout inside text",
+    rule: inkNoLayoutInsideText,
+    invalid: `import {Text, Box} from "ink"; const App=()=> <Text><><Box /></></Text>;`,
+    valid: `import {Text, Box} from "ink"; const App=()=> <Box><Text>ok</Text></Box>;`,
+  },
+  {
+    name: "newline placement",
+    rule: inkNewlineInsideText,
+    invalid: `import {Box, Newline} from "ink"; const App=()=> <Box><Newline /></Box>;`,
+    valid: `import {Text, Newline} from "ink"; const App=()=> <Text><Newline /></Text>;`,
+  },
+  {
+    name: "Static key",
+    rule: inkStaticRequiresKey,
+    invalid: `import {Static, Text} from "ink"; const App=({items})=> <Static items={items}>{item => <Text>{item}</Text>}</Static>;`,
+    valid: `import {Static, Text} from "ink"; const App=({items})=> <Static items={items}>{(item,index) => <Text key={index}>{item}</Text>}</Static>;`,
+  },
+  {
+    name: "measureElement render phase",
+    rule: inkNoMeasureElementInRender,
+    invalid: `import {measureElement as measure, Text} from "ink"; const App=({node})=> { measure(node); return <Text />; };`,
+    valid: `import {measureElement, Text} from "ink"; import {useLayoutEffect} from "react"; const App=({node})=> { useLayoutEffect(()=>measureElement(node), [node]); return <Text />; };`,
+  },
+  {
+    name: "focus render phase",
+    rule: inkNoFocusInRender,
+    invalid: `import {useFocusManager, Text} from "ink"; const App=()=> { const manager=useFocusManager(); manager.focus("name"); return <Text />; };`,
+    valid: `import {useFocusManager, useInput, Text} from "ink"; const App=()=> { const manager=useFocusManager(); useInput(()=>manager.focus("name")); return <Text />; };`,
+  },
+  {
+    name: "DOM router",
+    rule: inkNoDomRouter,
+    invalid: `import {Box} from "ink"; import {Link} from "react-router-dom"; const App=()=> <Box><Link to="/" /></Box>;`,
+    valid: `import {Box} from "ink"; import {MemoryRouter, Route, Routes} from "react-router"; const App=()=> <MemoryRouter><Box><Routes><Route path="/" element={null} /></Routes></Box></MemoryRouter>;`,
+  },
+  {
+    name: "raw mode",
+    rule: inkNoDirectRawMode,
+    invalid: `import {useStdin, Text} from "ink"; const App=()=> { const {setRawMode}=useStdin(); setRawMode(true); return <Text />; };`,
+    valid: `import {useInput, Text} from "ink"; const App=()=> { useInput(()=>{}); return <Text />; };`,
+  },
+  {
+    name: "terminal suspension",
+    rule: inkUseSuspendTerminal,
+    invalid: `import {useInput} from "ink"; import {spawn} from "node:child_process"; const App=()=> { useInput(()=>spawn("vim", [], {stdio:"inherit"})); return null; };`,
+    valid: `import {useApp, useInput} from "ink"; import {spawn} from "node:child_process"; const App=()=> { const {suspendTerminal}=useApp(); useInput(()=>suspendTerminal(()=>spawn("vim", [], {stdio:"inherit"}))); return null; };`,
+  },
+  {
+    name: "append-only Static",
+    rule: inkStaticIsAppendOnly,
+    invalid: `import {Static} from "ink"; const App=({items})=> <Static items={items.filter(Boolean)}>{item => null}</Static>;`,
+    valid: `import {Static} from "ink"; const App=({items})=> <Static items={items}>{item => null}</Static>;`,
+  },
+  {
+    name: "multiple Static regions",
+    rule: inkNoMultipleStatic,
+    invalid: `import {Static} from "ink"; const App=()=> <><Static items={[]} /> <Static items={[]} /></>;`,
+    valid: `import {Static} from "ink"; const App=()=> <Static items={[]} />;`,
+  },
+  {
+    name: "repeated render",
+    rule: inkNoRepeatedRender,
+    invalid: `import {render as mount} from "ink"; mount(null); mount(null);`,
+    valid: `import {render} from "ink"; const instance=render(null); instance.rerender(null);`,
+  },
+  {
+    name: "bare process exit",
+    rule: inkNoBareProcessExit,
+    invalid: `import {useInput} from "ink"; const App=()=> { useInput(()=>process.exit(0)); return null; };`,
+    valid: `import {useApp, useInput} from "ink"; const App=()=> { const {exit}=useApp(); useInput(()=>exit()); return null; };`,
+  },
+  {
+    name: "Ctrl-C option",
+    rule: inkCtrlCHandlerRequiresExitOption,
+    invalid: `import {render, useInput} from "ink"; const App=()=> { useInput((input,key)=> { if (key.ctrl && input === "c") work(); }); return null; }; render(<App />);`,
+    valid: `import {render, useInput} from "ink"; const App=()=> { useInput((input,key)=> { if (key.ctrl && input === "c") work(); }); return null; }; render(<App />, {exitOnCtrlC:false});`,
+  },
+  {
+    name: "Suspense concurrent mode",
+    rule: inkSuspenseRequiresConcurrent,
+    invalid: `import {render, Text} from "ink"; import {Suspense} from "react"; render(<Suspense fallback={null}><Text /></Suspense>);`,
+    valid: `import {render, Text} from "ink"; import {Suspense} from "react"; render(<Suspense fallback={null}><Text /></Suspense>, {concurrent:true});`,
+  },
+  {
+    name: "renderToString live hooks",
+    rule: inkNoLiveHooksInRenderToString,
+    invalid: `import {renderToString, useInput, Text} from "ink"; const App=()=> { useInput(()=>{}); return <Text />; }; renderToString(<App />);`,
+    valid: `import {renderToString, Text} from "ink"; const App=()=> <Text>snapshot</Text>; renderToString(<App />);`,
+  },
+  {
+    name: "cursor width",
+    rule: inkUseStringWidthForCursor,
+    invalid: `import {useCursor} from "ink"; const App=({label})=> { const cursor=useCursor(); cursor.setCursorPosition(label.length, 0); return null; };`,
+    valid: `import {useCursor} from "ink"; import stringWidth from "string-width"; const App=({label})=> { const cursor=useCursor(); cursor.setCursorPosition(stringWidth(label), 0); return null; };`,
+  },
+  {
+    name: "reactive window size",
+    rule: inkUseReactiveWindowSize,
+    invalid: `import {Text} from "ink"; const App=()=> <Text>{process.stdout.columns}</Text>;`,
+    valid: `import {useWindowSize, Text} from "ink"; const App=()=> { const {columns}=useWindowSize(); return <Text>{columns}</Text>; };`,
+  },
+  {
+    name: "paste hook",
+    rule: inkPreferUsePaste,
+    invalid: `import {useInput} from "ink"; const App=()=> { useInput(input=> { if (input.includes("\\n")) paste(input); }); return null; };`,
+    valid: `import {usePaste} from "ink"; const App=()=> { usePaste(input=>paste(input)); return null; };`,
+  },
+  {
+    name: "DOM host elements",
+    rule: inkNoDomHostElements,
+    invalid: `import {Box} from "ink"; const App=()=> <Box><div /></Box>;`,
+    valid: `import {Box, Text} from "ink"; const App=()=> <Box><Text>ok</Text></Box>;`,
+  },
+  {
+    name: "ARIA semantics",
+    rule: inkValidAriaSemantics,
+    invalid: `import {Text} from "ink"; const App=()=> <Text aria-role="dialog">open</Text>;`,
+    valid: `import {Box,Text} from "ink"; const App=()=> <Box aria-role="button" aria-label="Open"><Text>open</Text></Box>;`,
+  },
+  {
+    name: "animation hook",
+    rule: inkPreferUseAnimation,
+    invalid: `import {useEffect, useState} from "react"; import {Text} from "ink"; const App=()=> { const [frame,setFrame]=useState(0); useEffect(()=> { const timer=setInterval(()=>setFrame(value=>value+1), 80); return ()=>clearInterval(timer); }, []); return <Text>{frame}</Text>; };`,
+    valid: `import {useAnimation, Text} from "ink"; const App=()=> { const {frame}=useAnimation({interval:80}); return <Text>{frame}</Text>; };`,
+  },
+];
+
+describe("Ink rules", () => {
+  for (const ruleCase of RULE_CASES) {
+    it(`reports ${ruleCase.name}`, () => {
+      expect(runRule(ruleCase.rule, ruleCase.invalid).diagnostics).toHaveLength(1);
+    });
+
+    it(`accepts valid ${ruleCase.name}`, () => {
+      expect(runRule(ruleCase.rule, ruleCase.valid).diagnostics).toHaveLength(0);
+    });
+  }
+
+  it("ignores same-named local APIs", () => {
+    const code = `const Text=({children}) => <span>{children}</span>; const measureElement=()=>{}; const App=()=> { measureElement(); return <Text>hello</Text>; };`;
+    expect(runRule(inkNoRawText, code).diagnostics).toHaveLength(0);
+    expect(runRule(inkNoMeasureElementInRender, code).diagnostics).toHaveLength(0);
+  });
+
+  it("ignores imported names shadowed by local bindings", () => {
+    const renderCode = `import {render} from "ink"; const run=(render)=>{render(null);render(null)};`;
+    const jsxCode = `import {Box} from "ink"; const App=(Box)=> <Box>hello</Box>;`;
+    const routerCode = `import {Box} from "ink"; import {Link} from "react-router-dom"; const App=(Link)=> <Box><Link /></Box>;`;
+    expect(runRule(inkNoRepeatedRender, renderCode).diagnostics).toHaveLength(0);
+    expect(runRule(inkNoRawText, jsxCode).diagnostics).toHaveLength(0);
+    expect(runRule(inkNoDomRouter, routerCode).diagnostics).toHaveLength(0);
+  });
+
+  it("recognizes Ink namespace imports", () => {
+    const renderCode = `import * as Ink from "ink"; Ink.render(null); Ink.render(null);`;
+    const jsxCode = `import * as Ink from "ink"; const App=()=> <Ink.Box>hello</Ink.Box>;`;
+    expect(runRule(inkNoRepeatedRender, renderCode).diagnostics).toHaveLength(1);
+    expect(runRule(inkNoRawText, jsxCode).diagnostics).toHaveLength(1);
+  });
+
+  it("preserves receiver diagnostics through transparent TypeScript wrappers", () => {
+    const code = `
+      import {useCursor,useFocusManager,useInput} from "ink";
+      const App=({label})=> {
+        const cursor=useCursor();
+        const manager=useFocusManager();
+        (manager as any).focus("name");
+        (cursor!).setCursorPosition(label.length,0);
+        useInput(input=>{if((input as any).includes("\\n")) paste(input)});
+        return null;
+      };
+    `;
+    expect(runRule(inkNoFocusInRender, code).diagnostics).toHaveLength(1);
+    expect(runRule(inkUseStringWidthForCursor, code).diagnostics).toHaveLength(1);
+    expect(runRule(inkPreferUsePaste, code).diagnostics).toHaveLength(1);
+  });
+
+  it("recognizes block-bodied frame updater arrows", () => {
+    const code = `
+      import {useEffect,useState} from "react";
+      const App=()=> {
+        const [frame,setFrame]=useState(0);
+        useEffect(()=>{setInterval(()=>setFrame(value=>{return value+1}),80)},[]);
+        return frame;
+      };
+    `;
+    expect(runRule(inkPreferUseAnimation, code).diagnostics).toHaveLength(1);
+  });
+
+  it("ignores JSX attribute values when checking Box text children", () => {
+    const code = `import {Box,Text} from "ink"; const App=()=> <Box paddingX={1}><Text>ok</Text></Box>;`;
+    expect(runRule(inkNoRawText, code).diagnostics).toHaveLength(0);
+  });
+
+  it("ignores mutually exclusive and separately owned render calls", () => {
+    const code = `
+      import {render} from "ink";
+      const choose=(server)=> { if (!server) render(null); else render(null); };
+      const first=()=>render(null);
+      const second=()=>render(null);
+    `;
+    expect(runRule(inkNoRepeatedRender, code).diagnostics).toHaveLength(0);
+  });
+
+  it("allows a fresh renderer after unmount", () => {
+    const code = `import {render} from "ink"; const first=render(null); first.unmount(); render(null);`;
+    expect(runRule(inkNoRepeatedRender, code).diagnostics).toHaveLength(0);
+  });
+
+  it("counts Static regions per component", () => {
+    const code = `import {Static} from "ink"; const First=()=> <Static items={[]} />; const Second=()=> <Static items={[]} />;`;
+    expect(runRule(inkNoMultipleStatic, code).diagnostics).toHaveLength(0);
+  });
+
+  it("accepts Ink's complete ARIA role set and rejects unsupported states", () => {
+    const validCode = `import {Box} from "ink"; const App=()=> <><Box aria-role="listbox" /><Box aria-role="table" /></>;`;
+    const invalidCode = `import {Box} from "ink"; const App=()=> <Box aria-state={{pressed:true}} />;`;
+    expect(runRule(inkValidAriaSemantics, validCode).diagnostics).toHaveLength(0);
+    expect(runRule(inkValidAriaSemantics, invalidCode).diagnostics).toHaveLength(1);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-rules.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-rules.test.ts
@@ -45,12 +45,6 @@ const RULE_CASES: ReadonlyArray<InkRuleCase> = [
     valid: `import {Text, Box} from "ink"; const App=()=> <Box><Text>ok</Text></Box>;`,
   },
   {
-    name: "newline placement",
-    rule: inkNewlineInsideText,
-    invalid: `import {Box, Newline} from "ink"; const App=()=> <Box><Newline /></Box>;`,
-    valid: `import {Text, Newline} from "ink"; const App=()=> <Text><Newline /></Text>;`,
-  },
-  {
     name: "Static key",
     rule: inkStaticRequiresKey,
     invalid: `import {Static, Text} from "ink"; const App=({items})=> <Static items={items}>{item => <Text>{item}</Text>}</Static>;`,
@@ -117,12 +111,6 @@ const RULE_CASES: ReadonlyArray<InkRuleCase> = [
     valid: `import {render, useInput} from "ink"; const App=()=> { useInput((input,key)=> { if (key.ctrl && input === "c") work(); }); return null; }; render(<App />, {exitOnCtrlC:false});`,
   },
   {
-    name: "Suspense concurrent mode",
-    rule: inkSuspenseRequiresConcurrent,
-    invalid: `import {render, Text} from "ink"; import {Suspense} from "react"; render(<Suspense fallback={null}><Text /></Suspense>);`,
-    valid: `import {render, Text} from "ink"; import {Suspense} from "react"; render(<Suspense fallback={null}><Text /></Suspense>, {concurrent:true});`,
-  },
-  {
     name: "renderToString live hooks",
     rule: inkNoLiveHooksInRenderToString,
     invalid: `import {renderToString, useInput, Text} from "ink"; const App=()=> { useInput(()=>{}); return <Text />; }; renderToString(<App />);`,
@@ -177,6 +165,21 @@ describe("Ink rules", () => {
     });
   }
 
+  it("keeps disproven rule IDs retired for config compatibility", () => {
+    const newlineCode = `import {Box,Newline} from "ink"; const App=()=> <Box><Newline /></Box>;`;
+    const suspenseCode = `import {render,Text} from "ink"; import {Suspense} from "react"; render(<Suspense fallback={null}><Text /></Suspense>);`;
+    expect(inkNewlineInsideText.lifecycle).toBe("retired");
+    expect(inkNewlineInsideText.defaultEnabled).toBe(false);
+    expect(runRule(inkNewlineInsideText, newlineCode).diagnostics).toHaveLength(0);
+    expect(inkSuspenseRequiresConcurrent.lifecycle).toBe("retired");
+    expect(inkSuspenseRequiresConcurrent.defaultEnabled).toBe(false);
+    expect(runRule(inkSuspenseRequiresConcurrent, suspenseCode).diagnostics).toHaveLength(0);
+  });
+
+  it("keeps paste migration opt-in", () => {
+    expect(inkPreferUsePaste.defaultEnabled).toBe(false);
+  });
+
   it("ignores same-named local APIs", () => {
     const code = `const Text=({children}) => <span>{children}</span>; const measureElement=()=>{}; const App=()=> { measureElement(); return <Text>hello</Text>; };`;
     expect(runRule(inkNoRawText, code).diagnostics).toHaveLength(0);
@@ -185,6 +188,49 @@ describe("Ink rules", () => {
 
   it("stops at local JSX wrappers whose rendered host is unknown", () => {
     const code = `import {Box,Text} from "ink"; const Wrapper=({children}) => <Text>{children}</Text>; const App=()=> <Box><Wrapper>hello</Wrapper></Box>;`;
+    expect(runRule(inkNoRawText, code).diagnostics).toHaveLength(0);
+  });
+
+  it("classifies same-file Ink children forwarders", () => {
+    const code = `
+      import {Box as InkBox,Text as InkText} from "ink";
+      const Unsafe=({children}) => <InkBox>{children}</InkBox>;
+      const Safe=({children}) => <InkText>{children}</InkText>;
+      const App=()=> <InkBox><Unsafe>bad</Unsafe><Safe>good</Safe></InkBox>;
+    `;
+    expect(runRule(inkNoRawText, code).diagnostics).toHaveLength(1);
+  });
+
+  it("classifies Ink wrapper chains regardless of declaration order", () => {
+    const code = `
+      import {Box} from "ink";
+      const Outer=({children}) => <Inner>{children}</Inner>;
+      const Inner=({children}) => <Box>{children}</Box>;
+      const App=()=> <Outer>bad</Outer>;
+    `;
+    expect(runRule(inkNoRawText, code).diagnostics).toHaveLength(1);
+  });
+
+  it("follows shorthand and named fragments to an Ink receiver", () => {
+    const code = `
+      import React,{Fragment as Group} from "react";
+      import {Box} from "ink";
+      const App=()=> <Box><>one</><Group>two</Group><React.Fragment>three</React.Fragment></Box>;
+    `;
+    expect(runRule(inkNoRawText, code).diagnostics).toHaveLength(3);
+  });
+
+  it("stays quiet for custom receivers with unknown forwarding", () => {
+    const code = `import {Box} from "ink"; import {Panel} from "third-party-ui"; const App=()=> <Box><Panel>unknown</Panel></Box>;`;
+    expect(runRule(inkNoRawText, code).diagnostics).toHaveLength(0);
+  });
+
+  it("does not mistake a local Fragment component for React.Fragment", () => {
+    const code = `
+      import {Box,Text} from "ink";
+      const Fragment=({children}) => <Text>{children}</Text>;
+      const App=()=> <Box><Fragment>safe</Fragment></Box>;
+    `;
     expect(runRule(inkNoRawText, code).diagnostics).toHaveLength(0);
   });
 
@@ -280,9 +326,9 @@ describe("Ink rules", () => {
     expect(runRule(inkNoBareProcessExit, code).diagnostics).toHaveLength(1);
   });
 
-  it("allows process exit after explicit terminal cleanup", () => {
+  it("does not accept an arbitrary restore helper as complete Ink cleanup", () => {
     const code = `import {useInput} from "ink"; const App=()=> {useInput(()=>{restore(); process.exit(0);}); return null;};`;
-    expect(runRule(inkNoBareProcessExit, code).diagnostics).toHaveLength(0);
+    expect(runRule(inkNoBareProcessExit, code).diagnostics).toHaveLength(1);
   });
 
   it("allows separate renderers on different output streams", () => {
@@ -325,14 +371,6 @@ describe("Ink rules", () => {
   });
 
   it("associates renderer options with the component each call mounts", () => {
-    const suspenseCode = `
-      import {render,Text} from "ink";
-      import {Suspense} from "react";
-      const Safe=()=> <Suspense fallback={null}><Text>safe</Text></Suspense>;
-      const Unsafe=()=> <Suspense fallback={null}><Text>unsafe</Text></Suspense>;
-      render(<Safe/>,{concurrent:true});
-      render(<Unsafe/>);
-    `;
     const ctrlCCode = `
       import {render,useInput} from "ink";
       const Safe=()=> { useInput((input,key)=>{if(key.ctrl&&input==="c") work()}); return null; };
@@ -340,21 +378,10 @@ describe("Ink rules", () => {
       render(<Safe/>,{exitOnCtrlC:false});
       render(<Unsafe/>);
     `;
-    expect(runRule(inkSuspenseRequiresConcurrent, suspenseCode).diagnostics).toHaveLength(1);
     expect(runRule(inkCtrlCHandlerRequiresExitOption, ctrlCCode).diagnostics).toHaveLength(1);
   });
 
   it("associates renderer options through same-file component wrappers", () => {
-    const suspenseCode = `
-      import {render,Text} from "ink";
-      import {Suspense} from "react";
-      const SafeBoundary=()=> <Suspense fallback={null}><Text>safe</Text></Suspense>;
-      const UnsafeBoundary=()=> <Suspense fallback={null}><Text>unsafe</Text></Suspense>;
-      const SafeRoot=()=> <SafeBoundary/>;
-      const UnsafeRoot=()=> <UnsafeBoundary/>;
-      render(<SafeRoot/>,{concurrent:true});
-      render(<UnsafeRoot/>);
-    `;
     const ctrlCCode = `
       import {render,useInput} from "ink";
       const SafeInput=()=> { useInput((input,key)=>{if(key.ctrl&&input==="c") work()}); return null; };
@@ -364,42 +391,26 @@ describe("Ink rules", () => {
       render(<SafeRoot/>,{exitOnCtrlC:false});
       render(<UnsafeRoot/>);
     `;
-    expect(runRule(inkSuspenseRequiresConcurrent, suspenseCode).diagnostics).toHaveLength(1);
     expect(runRule(inkCtrlCHandlerRequiresExitOption, ctrlCCode).diagnostics).toHaveLength(1);
   });
 
   it("does not associate renderer options through unused nested components or JSX props", () => {
-    const suspenseCode = `
-      import {render,Text} from "ink";
-      import {Suspense} from "react";
-      const Root=()=> { const Unused=()=> <Suspense fallback={null}><Text /></Suspense>; return <Text />; };
-      render(<Root/>);
-    `;
     const ctrlCCode = `
       import {render,useInput} from "ink";
       const Unused=()=> { useInput((input,key)=>{if(key.ctrl&&input==="c") work()}); return null; };
       const Root=()=> null;
       render(<Root unused={<Unused/>}/>);
     `;
-    expect(runRule(inkSuspenseRequiresConcurrent, suspenseCode).diagnostics).toHaveLength(0);
     expect(runRule(inkCtrlCHandlerRequiresExitOption, ctrlCCode).diagnostics).toHaveLength(0);
   });
 
   it("fails closed for unresolved renderer options", () => {
-    const suspenseCode = `
-      import {render,Text} from "ink";
-      import {Suspense} from "react";
-      const App=()=> <Suspense fallback={null}><Text /></Suspense>;
-      const options={concurrent:true};
-      render(<App/>,options);
-    `;
     const ctrlCCode = `
       import {render,useInput} from "ink";
       const App=()=> { useInput((input,key)=>{if(key.ctrl&&input==="c") work()}); return null; };
       const options={exitOnCtrlC:false};
       render(<App/>,{...options});
     `;
-    expect(runRule(inkSuspenseRequiresConcurrent, suspenseCode).diagnostics).toHaveLength(0);
     expect(runRule(inkCtrlCHandlerRequiresExitOption, ctrlCCode).diagnostics).toHaveLength(0);
   });
 
@@ -487,6 +498,99 @@ describe("Ink rules", () => {
     expect(runRule(inkUseReactiveWindowSize, code).diagnostics).toHaveLength(0);
   });
 
+  it("does not let an unrelated resize listener hide a non-reactive dimension", () => {
+    const code = `
+      import {Text} from "ink";
+      import {useEffect} from "react";
+      const App=()=> {
+        useEffect(()=> {
+          const update=()=>console.info("resized");
+          process.stdout.on("resize",update);
+          return()=>process.stdout.off("resize",update);
+        },[]);
+        return <Text>{process.stdout.columns}</Text>;
+      };
+    `;
+    expect(runRule(inkUseReactiveWindowSize, code).diagnostics).toHaveLength(1);
+  });
+
+  it("does not use a resize listener from an unmounted nested component", () => {
+    const code = `
+      import {Text} from "ink";
+      import {useEffect,useState} from "react";
+      const App=()=> {
+        const [,refresh]=useState(0);
+        const Unmounted=()=> {
+          useEffect(()=>process.stdout.on("resize",()=>refresh(value=>value+1)),[]);
+          return <Text>unused</Text>;
+        };
+        return <Text>{process.stdout.columns}</Text>;
+      };
+    `;
+    expect(runRule(inkUseReactiveWindowSize, code).diagnostics).toHaveLength(1);
+  });
+
+  it("does not confuse shadowed Ink hosts with imported bindings", () => {
+    const code = `
+      import {Box,Text} from "ink";
+      const Wrapper=({children})=> {
+        const Box=({children})=><Text>{children}</Text>;
+        return <Box>{children}</Box>;
+      };
+      const App=()=> <Wrapper>safe</Wrapper>;
+    `;
+    expect(runRule(inkNoRawText, code).diagnostics).toHaveLength(0);
+  });
+
+  it("accepts a proven resize-triggered render for every dimension", () => {
+    const code = `
+      import {Text} from "ink";
+      import {useEffect,useState} from "react";
+      const App=()=> {
+        const [columns,setColumns]=useState(process.stdout.columns);
+        useEffect(()=> {
+          process.stdout.on("resize",()=>setColumns(process.stdout.columns));
+        },[]);
+        return <Text>{columns+process.stdout.rows}</Text>;
+      };
+    `;
+    expect(runRule(inkUseReactiveWindowSize, code).diagnostics).toHaveLength(0);
+  });
+
+  it("accepts a resize-triggered reducer dispatch", () => {
+    const code = `
+      import {Text} from "ink";
+      import {useEffect,useReducer} from "react";
+      const App=()=> {
+        const [,refresh]=useReducer(value=>value+1,0);
+        useEffect(()=> {
+          process.stdout.on("resize",refresh);
+          return()=>process.stdout.off("resize",refresh);
+        },[refresh]);
+        return <Text>{process.stdout.columns}</Text>;
+      };
+    `;
+    expect(runRule(inkUseReactiveWindowSize, code).diagnostics).toHaveLength(0);
+  });
+
+  it("ignores terminal dimensions in components that do not render Ink", () => {
+    const code = `import {Text} from "ink"; const Dashboard=()=> <div>{process.stdout.columns}</div>;`;
+    expect(runRule(inkUseReactiveWindowSize, code).diagnostics).toHaveLength(0);
+  });
+
+  it("allows raw mode changes in an effect with cleanup", () => {
+    const code = `
+      import {useStdin,Text} from "ink";
+      import {useEffect} from "react";
+      const App=()=> {
+        const {setRawMode}=useStdin();
+        useEffect(()=>{setRawMode(true);return()=>setRawMode(false)},[setRawMode]);
+        return <Text>ready</Text>;
+      };
+    `;
+    expect(runRule(inkNoDirectRawMode, code).diagnostics).toHaveLength(0);
+  });
+
   it("allows cursor lengths for provably ASCII-only strings", () => {
     const code = `import {useCursor} from "ink"; const App=()=> { const label="Ready"; const cursor=useCursor(); cursor.setCursorPosition({x:label.length,y:0}); return null; };`;
     expect(runRule(inkUseStringWidthForCursor, code).diagnostics).toHaveLength(0);
@@ -537,40 +641,6 @@ describe("Ink rules", () => {
       const Unmounted=()=> {useInput((input,key)=>{if(key.ctrl&&input==="c") work()}); return null};
       render(<Root/>);
     `;
-    const suspenseCode = `
-      import {render,Text} from "ink";
-      import {Suspense} from "react";
-      const Root=()=> <Text>root</Text>;
-      const Unmounted=()=> <Suspense fallback={null}><Text>unused</Text></Suspense>;
-      render(<Root/>);
-    `;
     expect(runRule(inkCtrlCHandlerRequiresExitOption, ctrlCCode).diagnostics).toHaveLength(0);
-    expect(runRule(inkSuspenseRequiresConcurrent, suspenseCode).diagnostics).toHaveLength(0);
-  });
-
-  it("does not associate renderer options through statically unreachable branches", () => {
-    const componentBranchCode = `
-      import {render,Text} from "ink";
-      import {Suspense} from "react";
-      const Root=()=> <>{false && <Suspense fallback={null}><Text /></Suspense>}</>;
-      render(<Root/>);
-    `;
-    const renderBranchCode = `
-      import {render,Text} from "ink";
-      import {Suspense} from "react";
-      false && render(<Suspense fallback={null}><Text /></Suspense>);
-    `;
-    expect(runRule(inkSuspenseRequiresConcurrent, componentBranchCode).diagnostics).toHaveLength(0);
-    expect(runRule(inkSuspenseRequiresConcurrent, renderBranchCode).diagnostics).toHaveLength(0);
-  });
-
-  it("recognizes Suspense boundaries owned by an Ink ancestor", () => {
-    const code = `
-      import {render,Box} from "ink";
-      import {Suspense,lazy} from "react";
-      const Lazy=lazy(()=>import("./screen"));
-      render(<Box><Suspense fallback={null}><Lazy/></Suspense></Box>);
-    `;
-    expect(runRule(inkSuspenseRequiresConcurrent, code).diagnostics).toHaveLength(1);
   });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-rules.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-rules.test.ts
@@ -505,4 +505,20 @@ describe("Ink rules", () => {
     expect(runRule(inkCtrlCHandlerRequiresExitOption, ctrlCCode).diagnostics).toHaveLength(0);
     expect(runRule(inkSuspenseRequiresConcurrent, suspenseCode).diagnostics).toHaveLength(0);
   });
+
+  it("does not associate renderer options through statically unreachable branches", () => {
+    const componentBranchCode = `
+      import {render,Text} from "ink";
+      import {Suspense} from "react";
+      const Root=()=> <>{false && <Suspense fallback={null}><Text /></Suspense>}</>;
+      render(<Root/>);
+    `;
+    const renderBranchCode = `
+      import {render,Text} from "ink";
+      import {Suspense} from "react";
+      false && render(<Suspense fallback={null}><Text /></Suspense>);
+    `;
+    expect(runRule(inkSuspenseRequiresConcurrent, componentBranchCode).diagnostics).toHaveLength(0);
+    expect(runRule(inkSuspenseRequiresConcurrent, renderBranchCode).diagnostics).toHaveLength(0);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-rules.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-rules.test.ts
@@ -402,6 +402,17 @@ describe("Ink rules", () => {
     );
   });
 
+  it("does not treat nested snapshot-only components as exported", () => {
+    const code = `
+      import {renderToString,useInput} from "ink";
+      export const makeSnapshot=()=> {
+        const Inner=()=> { useInput(()=>{}); return null; };
+        return renderToString(<Inner/>);
+      };
+    `;
+    expect(runRule(inkNoLiveHooksInRenderToString, code).diagnostics).toHaveLength(1);
+  });
+
   it("requires active Ink input ownership before suggesting terminal suspension", () => {
     const code = `
       import {Text} from "ink";
@@ -520,5 +531,15 @@ describe("Ink rules", () => {
     `;
     expect(runRule(inkSuspenseRequiresConcurrent, componentBranchCode).diagnostics).toHaveLength(0);
     expect(runRule(inkSuspenseRequiresConcurrent, renderBranchCode).diagnostics).toHaveLength(0);
+  });
+
+  it("recognizes Suspense boundaries owned by an Ink ancestor", () => {
+    const code = `
+      import {render,Box} from "ink";
+      import {Suspense,lazy} from "react";
+      const Lazy=lazy(()=>import("./screen"));
+      render(<Box><Suspense fallback={null}><Lazy/></Suspense></Box>);
+    `;
+    expect(runRule(inkSuspenseRequiresConcurrent, code).diagnostics).toHaveLength(1);
   });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-rules.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-rules.test.ts
@@ -308,4 +308,42 @@ describe("Ink rules", () => {
     expect(runRule(inkSuspenseRequiresConcurrent, suspenseCode).diagnostics).toHaveLength(1);
     expect(runRule(inkCtrlCHandlerRequiresExitOption, ctrlCCode).diagnostics).toHaveLength(1);
   });
+
+  it("requires Ctrl-C operands to share a condition", () => {
+    const code = `
+      import {render,useInput} from "ink";
+      const App=()=> {
+        useInput((input,key)=>{if(key.ctrl) toggle(); if(input==="c") work()});
+        return null;
+      };
+      render(<App/>);
+    `;
+    expect(runRule(inkCtrlCHandlerRequiresExitOption, code).diagnostics).toHaveLength(0);
+  });
+
+  it("follows renderToString through same-file component wrappers", () => {
+    const invalidCode = `
+      import {renderToString,useInput} from "ink";
+      const Live=()=> {useInput(()=>{}); return null};
+      const Root=()=> <Live/>;
+      renderToString(<Root/>);
+    `;
+    const validCode = `
+      import {renderToString,useInput} from "ink";
+      const Unmounted=()=> {useInput(()=>{}); return null};
+      const Root=()=> null;
+      renderToString(<Root/>);
+    `;
+    expect(runRule(inkNoLiveHooksInRenderToString, invalidCode).diagnostics).toHaveLength(1);
+    expect(runRule(inkNoLiveHooksInRenderToString, validCode).diagnostics).toHaveLength(0);
+  });
+
+  it("follows renderToString through direct fragment children", () => {
+    const code = `
+      import {renderToString,useInput,Box} from "ink";
+      const Live=()=> {useInput(()=>{}); return null};
+      renderToString(<><Box><Live/></Box></>);
+    `;
+    expect(runRule(inkNoLiveHooksInRenderToString, code).diagnostics).toHaveLength(1);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-rules.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-rules.test.ts
@@ -264,4 +264,24 @@ describe("Ink rules", () => {
     expect(runRule(inkValidAriaSemantics, validCode).diagnostics).toHaveLength(0);
     expect(runRule(inkValidAriaSemantics, invalidCode).diagnostics).toHaveLength(1);
   });
+
+  it("associates renderer options with the component each call mounts", () => {
+    const suspenseCode = `
+      import {render,Text} from "ink";
+      import {Suspense} from "react";
+      const Safe=()=> <Suspense fallback={null}><Text>safe</Text></Suspense>;
+      const Unsafe=()=> <Suspense fallback={null}><Text>unsafe</Text></Suspense>;
+      render(<Safe/>,{concurrent:true});
+      render(<Unsafe/>);
+    `;
+    const ctrlCCode = `
+      import {render,useInput} from "ink";
+      const Safe=()=> { useInput((input,key)=>{if(key.ctrl&&input==="c") work()}); return null; };
+      const Unsafe=()=> { useInput((input,key)=>{if(key.ctrl&&input==="c") work()}); return null; };
+      render(<Safe/>,{exitOnCtrlC:false});
+      render(<Unsafe/>);
+    `;
+    expect(runRule(inkSuspenseRequiresConcurrent, suspenseCode).diagnostics).toHaveLength(1);
+    expect(runRule(inkCtrlCHandlerRequiresExitOption, ctrlCCode).diagnostics).toHaveLength(1);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-rules.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-rules.test.ts
@@ -275,6 +275,16 @@ describe("Ink rules", () => {
     expect(runRule(inkNoRepeatedRender, code).diagnostics).toHaveLength(0);
   });
 
+  it("still reports process exit after Ink exit", () => {
+    const code = `import {useApp,useInput} from "ink"; const App=()=> {const {exit}=useApp(); useInput(()=>{exit(); process.exit(0);}); return null;};`;
+    expect(runRule(inkNoBareProcessExit, code).diagnostics).toHaveLength(1);
+  });
+
+  it("allows process exit after explicit terminal cleanup", () => {
+    const code = `import {useInput} from "ink"; const App=()=> {useInput(()=>{restore(); process.exit(0);}); return null;};`;
+    expect(runRule(inkNoBareProcessExit, code).diagnostics).toHaveLength(0);
+  });
+
   it("allows separate renderers on different output streams", () => {
     const validCode = `import {render} from "ink"; const run=(firstOutput,secondOutput)=> { render(null,{stdout:firstOutput}); render(null,{stdout:secondOutput}); };`;
     const invalidCode = `import {render} from "ink"; const run=(output)=> { render(null,{stdout:output}); render(null,{stdout:output}); };`;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-rules.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-rules.test.ts
@@ -346,4 +346,22 @@ describe("Ink rules", () => {
     `;
     expect(runRule(inkNoLiveHooksInRenderToString, code).diagnostics).toHaveLength(1);
   });
+
+  it("does not associate a lone render call with unmounted components", () => {
+    const ctrlCCode = `
+      import {render,useInput} from "ink";
+      const Root=()=> null;
+      const Unmounted=()=> {useInput((input,key)=>{if(key.ctrl&&input==="c") work()}); return null};
+      render(<Root/>);
+    `;
+    const suspenseCode = `
+      import {render,Text} from "ink";
+      import {Suspense} from "react";
+      const Root=()=> <Text>root</Text>;
+      const Unmounted=()=> <Suspense fallback={null}><Text>unused</Text></Suspense>;
+      render(<Root/>);
+    `;
+    expect(runRule(inkCtrlCHandlerRequiresExitOption, ctrlCCode).diagnostics).toHaveLength(0);
+    expect(runRule(inkSuspenseRequiresConcurrent, suspenseCode).diagnostics).toHaveLength(0);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-rules.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-rules.test.ts
@@ -591,6 +591,19 @@ describe("Ink rules", () => {
     expect(runRule(inkNoDirectRawMode, code).diagnostics).toHaveLength(0);
   });
 
+  it("recognizes parenthesized raw-mode receivers", () => {
+    const code = `
+      import {useStdin,Text} from "ink";
+      const App=()=> {
+        (useStdin()).setRawMode(true);
+        const stdin=(useStdin());
+        (stdin).setRawMode(true);
+        return <Text>ready</Text>;
+      };
+    `;
+    expect(runRule(inkNoDirectRawMode, code).diagnostics).toHaveLength(2);
+  });
+
   it("allows cursor lengths for provably ASCII-only strings", () => {
     const code = `import {useCursor} from "ink"; const App=()=> { const label="Ready"; const cursor=useCursor(); cursor.setCursorPosition({x:label.length,y:0}); return null; };`;
     expect(runRule(inkUseStringWidthForCursor, code).diagnostics).toHaveLength(0);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-rules.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-rules.test.ts
@@ -89,7 +89,7 @@ const RULE_CASES: ReadonlyArray<InkRuleCase> = [
   {
     name: "append-only Static",
     rule: inkStaticIsAppendOnly,
-    invalid: `import {Static} from "ink"; const App=({items})=> <Static items={items.filter(Boolean)}>{item => null}</Static>;`,
+    invalid: `import {Static} from "ink"; const App=({items})=> <Static items={items.toReversed()}>{item => null}</Static>;`,
     valid: `import {Static} from "ink"; const App=({items})=> <Static items={items}>{item => null}</Static>;`,
   },
   {
@@ -131,8 +131,8 @@ const RULE_CASES: ReadonlyArray<InkRuleCase> = [
   {
     name: "cursor width",
     rule: inkUseStringWidthForCursor,
-    invalid: `import {useCursor} from "ink"; const App=({label})=> { const cursor=useCursor(); cursor.setCursorPosition(label.length, 0); return null; };`,
-    valid: `import {useCursor} from "ink"; import stringWidth from "string-width"; const App=({label})=> { const cursor=useCursor(); cursor.setCursorPosition(stringWidth(label), 0); return null; };`,
+    invalid: `import {useCursor} from "ink"; const App=({label})=> { const cursor=useCursor(); cursor.setCursorPosition({x:label.length,y:0}); return null; };`,
+    valid: `import {useCursor} from "ink"; import stringWidth from "string-width"; const App=({label})=> { const cursor=useCursor(); cursor.setCursorPosition({x:stringWidth(label),y:0}); return null; };`,
   },
   {
     name: "reactive window size",
@@ -211,7 +211,7 @@ describe("Ink rules", () => {
         const cursor=useCursor();
         const manager=useFocusManager();
         (manager as any).focus("name");
-        (cursor!).setCursorPosition(label.length,0);
+        (cursor!).setCursorPosition({x:label.length,y:0});
         useInput(input=>{if((input as any).includes("\\n")) paste(input)});
         return null;
       };
@@ -224,10 +224,11 @@ describe("Ink rules", () => {
   it("recognizes block-bodied frame updater arrows", () => {
     const code = `
       import {useEffect,useState} from "react";
+      import {Text} from "ink";
       const App=()=> {
         const [frame,setFrame]=useState(0);
         useEffect(()=>{setInterval(()=>setFrame(value=>{return value+1}),80)},[]);
-        return frame;
+        return <Text>{frame}</Text>;
       };
     `;
     expect(runRule(inkPreferUseAnimation, code).diagnostics).toHaveLength(1);
@@ -253,9 +254,36 @@ describe("Ink rules", () => {
     expect(runRule(inkNoRepeatedRender, code).diagnostics).toHaveLength(0);
   });
 
+  it("allows separate renderers on different output streams", () => {
+    const validCode = `import {render} from "ink"; const run=(firstOutput,secondOutput)=> { render(null,{stdout:firstOutput}); render(null,{stdout:secondOutput}); };`;
+    const invalidCode = `import {render} from "ink"; const run=(output)=> { render(null,{stdout:output}); render(null,{stdout:output}); };`;
+    const shadowedCode = `import {render} from "ink"; const run=(firstOutput,secondOutput)=> { {const output=firstOutput; render(null,{stdout:output})} {const output=secondOutput; render(null,{stdout:output})} };`;
+    const explicitDefaultCode = `import {render} from "ink"; render(null); render(null,{stdout:process.stdout});`;
+    expect(runRule(inkNoRepeatedRender, validCode).diagnostics).toHaveLength(0);
+    expect(runRule(inkNoRepeatedRender, invalidCode).diagnostics).toHaveLength(1);
+    expect(runRule(inkNoRepeatedRender, shadowedCode).diagnostics).toHaveLength(0);
+    expect(runRule(inkNoRepeatedRender, explicitDefaultCode).diagnostics).toHaveLength(1);
+  });
+
   it("counts Static regions per component", () => {
     const code = `import {Static} from "ink"; const First=()=> <Static items={[]} />; const Second=()=> <Static items={[]} />;`;
     expect(runRule(inkNoMultipleStatic, code).diagnostics).toHaveLength(0);
+  });
+
+  it("allows mutually exclusive Static regions", () => {
+    const separateReturns = `import {Static} from "ink"; const App=({compact})=> compact ? <Static items={[]} /> : <Static items={[]} />;`;
+    const sharedRoot = `import {Static} from "ink"; const App=({compact})=> <>{compact ? <Static items={[]} /> : <Static items={[]} />}</>;`;
+    const logicalBranches = `import {Static} from "ink"; const App=({compact})=> <>{compact && <Static items={[]} />}{!compact && <Static items={[]} />}</>;`;
+    expect(runRule(inkNoMultipleStatic, separateReturns).diagnostics).toHaveLength(0);
+    expect(runRule(inkNoMultipleStatic, sharedRoot).diagnostics).toHaveLength(0);
+    expect(runRule(inkNoMultipleStatic, logicalBranches).diagnostics).toHaveLength(0);
+  });
+
+  it("allows stable derived collections in Static", () => {
+    const filteredCode = `import {Static} from "ink"; const App=()=> <Static items={[1,2,3].filter(Boolean)}>{item=>null}</Static>;`;
+    const sortedCode = `import {Static} from "ink"; const App=()=> <Static items={[3,1,2].toSorted()}>{item=>null}</Static>;`;
+    expect(runRule(inkStaticIsAppendOnly, filteredCode).diagnostics).toHaveLength(0);
+    expect(runRule(inkStaticIsAppendOnly, sortedCode).diagnostics).toHaveLength(0);
   });
 
   it("accepts Ink's complete ARIA role set and rejects unsupported states", () => {
@@ -307,6 +335,119 @@ describe("Ink rules", () => {
     `;
     expect(runRule(inkSuspenseRequiresConcurrent, suspenseCode).diagnostics).toHaveLength(1);
     expect(runRule(inkCtrlCHandlerRequiresExitOption, ctrlCCode).diagnostics).toHaveLength(1);
+  });
+
+  it("does not associate renderer options through unused nested components or JSX props", () => {
+    const suspenseCode = `
+      import {render,Text} from "ink";
+      import {Suspense} from "react";
+      const Root=()=> { const Unused=()=> <Suspense fallback={null}><Text /></Suspense>; return <Text />; };
+      render(<Root/>);
+    `;
+    const ctrlCCode = `
+      import {render,useInput} from "ink";
+      const Unused=()=> { useInput((input,key)=>{if(key.ctrl&&input==="c") work()}); return null; };
+      const Root=()=> null;
+      render(<Root unused={<Unused/>}/>);
+    `;
+    expect(runRule(inkSuspenseRequiresConcurrent, suspenseCode).diagnostics).toHaveLength(0);
+    expect(runRule(inkCtrlCHandlerRequiresExitOption, ctrlCCode).diagnostics).toHaveLength(0);
+  });
+
+  it("fails closed for unresolved renderer options", () => {
+    const suspenseCode = `
+      import {render,Text} from "ink";
+      import {Suspense} from "react";
+      const App=()=> <Suspense fallback={null}><Text /></Suspense>;
+      const options={concurrent:true};
+      render(<App/>,options);
+    `;
+    const ctrlCCode = `
+      import {render,useInput} from "ink";
+      const App=()=> { useInput((input,key)=>{if(key.ctrl&&input==="c") work()}); return null; };
+      const options={exitOnCtrlC:false};
+      render(<App/>,{...options});
+    `;
+    expect(runRule(inkSuspenseRequiresConcurrent, suspenseCode).diagnostics).toHaveLength(0);
+    expect(runRule(inkCtrlCHandlerRequiresExitOption, ctrlCCode).diagnostics).toHaveLength(0);
+  });
+
+  it("allows live hooks in components that also have a live renderer", () => {
+    const code = `
+      import {render,renderToString,useInput} from "ink";
+      const App=()=> { useInput(()=>{}); return null; };
+      render(<App/>);
+      renderToString(<App/>);
+    `;
+    expect(runRule(inkNoLiveHooksInRenderToString, code).diagnostics).toHaveLength(0);
+  });
+
+  it("allows supported renderToString hook defaults and externally reusable components", () => {
+    const supportedDefaultsCode = `
+      import {renderToString,useApp,useStdout,useWindowSize} from "ink";
+      const App=()=> { const {stdout}=useStdout(); const {columns}=useWindowSize(); const {exit}=useApp(); return null; };
+      renderToString(<App/>);
+    `;
+    const exportedComponentCode = `
+      import {renderToString,useInput} from "ink";
+      const App=()=> { useInput(()=>{}); return null; };
+      export {App};
+      renderToString(<App/>);
+    `;
+    expect(runRule(inkNoLiveHooksInRenderToString, supportedDefaultsCode).diagnostics).toHaveLength(
+      0,
+    );
+    expect(runRule(inkNoLiveHooksInRenderToString, exportedComponentCode).diagnostics).toHaveLength(
+      0,
+    );
+  });
+
+  it("requires active Ink input ownership before suggesting terminal suspension", () => {
+    const code = `
+      import {Text} from "ink";
+      import {spawn} from "node:child_process";
+      export const launchEditor=()=>spawn("vim",[],{stdio:"inherit"});
+      export const App=()=> <Text>Ready</Text>;
+    `;
+    expect(runRule(inkUseSuspendTerminal, code).diagnostics).toHaveLength(0);
+  });
+
+  it("ignores ordinary input length checks and shadowed nested input", () => {
+    const ordinaryLengthCode = `import {useInput} from "ink"; const App=()=> { useInput(input=>{if(input.length>=1) accept(input)}); return null; };`;
+    const shadowedInputCode = `import {useInput} from "ink"; const App=()=> { useInput(input=>{["a"].some(input=>input.includes("\\n")); consume(input)}); return null; };`;
+    expect(runRule(inkPreferUsePaste, ordinaryLengthCode).diagnostics).toHaveLength(0);
+    expect(runRule(inkPreferUsePaste, shadowedInputCode).diagnostics).toHaveLength(0);
+  });
+
+  it("requires an Ink frame animation before suggesting useAnimation", () => {
+    const domCode = `import {useEffect,useState} from "react"; const Dashboard=()=> { const [frame,setFrame]=useState(0); useEffect(()=>{const timer=setInterval(()=>setFrame(value=>value+1),80); return()=>clearInterval(timer)},[]); return <div>{frame}</div>; };`;
+    const indexCode = `import {Text} from "ink"; import {useEffect,useState} from "react"; const App=()=> { const [index,setIndex]=useState(0); useEffect(()=>{const timer=setInterval(()=>setIndex(value=>value+1),80); return()=>clearInterval(timer)},[]); return <Text>{index}</Text>; };`;
+    const localTimerCode = `import {Text} from "ink"; import {useEffect,useState} from "react"; const App=()=> { const [frame,setFrame]=useState(0); const setInterval=(callback)=>callback(); useEffect(()=>{setInterval(()=>setFrame(value=>value+1))},[]); return <Text>{frame}</Text>; };`;
+    expect(runRule(inkPreferUseAnimation, domCode).diagnostics).toHaveLength(0);
+    expect(runRule(inkPreferUseAnimation, indexCode).diagnostics).toHaveLength(0);
+    expect(runRule(inkPreferUseAnimation, localTimerCode).diagnostics).toHaveLength(0);
+  });
+
+  it("allows process stdout dimensions with an explicit resize subscription", () => {
+    const code = `
+      import {Text} from "ink";
+      import {useEffect,useState} from "react";
+      const App=()=> {
+        const [columns,setColumns]=useState(process.stdout.columns);
+        useEffect(()=> {
+          const update=()=>setColumns(process.stdout.columns);
+          process.stdout.on("resize",update);
+          return()=>process.stdout.off("resize",update);
+        },[]);
+        return <Text>{columns}</Text>;
+      };
+    `;
+    expect(runRule(inkUseReactiveWindowSize, code).diagnostics).toHaveLength(0);
+  });
+
+  it("allows cursor lengths for provably ASCII-only strings", () => {
+    const code = `import {useCursor} from "ink"; const App=()=> { const label="Ready"; const cursor=useCursor(); cursor.setCursorPosition({x:label.length,y:0}); return null; };`;
+    expect(runRule(inkUseStringWidthForCursor, code).diagnostics).toHaveLength(0);
   });
 
   it("requires Ctrl-C operands to share a condition", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-rules.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-rules.test.ts
@@ -254,6 +254,27 @@ describe("Ink rules", () => {
     expect(runRule(inkNoRepeatedRender, code).diagnostics).toHaveLength(0);
   });
 
+  it("allows destructured and immediate renderer cleanup", () => {
+    const destructuredCode = `import {render} from "ink"; const {unmount: stop}=render(null); stop(); render(null);`;
+    const immediateCode = `import {render} from "ink"; render(null).unmount(); render(null);`;
+    expect(runRule(inkNoRepeatedRender, destructuredCode).diagnostics).toHaveLength(0);
+    expect(runRule(inkNoRepeatedRender, immediateCode).diagnostics).toHaveLength(0);
+  });
+
+  it("does not mistake unrelated or conditional unmount calls for renderer cleanup", () => {
+    const unrelatedCode = `import {render} from "ink"; const first=render(null); other.unmount(); render(null);`;
+    const conditionalCode = `import {render} from "ink"; const first=render(null); if (shouldStop) first.unmount(); render(null);`;
+    const shadowedCode = `import {render} from "ink"; const {unmount}=render(null); {const unmount=()=>{}; unmount();} render(null);`;
+    expect(runRule(inkNoRepeatedRender, unrelatedCode).diagnostics).toHaveLength(1);
+    expect(runRule(inkNoRepeatedRender, conditionalCode).diagnostics).toHaveLength(1);
+    expect(runRule(inkNoRepeatedRender, shadowedCode).diagnostics).toHaveLength(1);
+  });
+
+  it("allows renderer cleanup on every branch", () => {
+    const code = `import {render} from "ink"; const first=render(null); if (shouldStop) first.unmount(); else first.unmount(); render(null);`;
+    expect(runRule(inkNoRepeatedRender, code).diagnostics).toHaveLength(0);
+  });
+
   it("allows separate renderers on different output streams", () => {
     const validCode = `import {render} from "ink"; const run=(firstOutput,secondOutput)=> { render(null,{stdout:firstOutput}); render(null,{stdout:secondOutput}); };`;
     const invalidCode = `import {render} from "ink"; const run=(output)=> { render(null,{stdout:output}); render(null,{stdout:output}); };`;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-rules.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-rules.test.ts
@@ -183,6 +183,11 @@ describe("Ink rules", () => {
     expect(runRule(inkNoMeasureElementInRender, code).diagnostics).toHaveLength(0);
   });
 
+  it("stops at local JSX wrappers whose rendered host is unknown", () => {
+    const code = `import {Box,Text} from "ink"; const Wrapper=({children}) => <Text>{children}</Text>; const App=()=> <Box><Wrapper>hello</Wrapper></Box>;`;
+    expect(runRule(inkNoRawText, code).diagnostics).toHaveLength(0);
+  });
+
   it("ignores imported names shadowed by local bindings", () => {
     const renderCode = `import {render} from "ink"; const run=(render)=>{render(null);render(null)};`;
     const jsxCode = `import {Box} from "ink"; const App=(Box)=> <Box>hello</Box>;`;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-static-is-append-only.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-static-is-append-only.ts
@@ -1,0 +1,43 @@
+import { MINIMUM_INK_VERSIONS } from "../../constants/ink.js";
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findJsxAttribute } from "../../utils/find-jsx-attribute.js";
+import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { resolveInkJsxElementName } from "../../utils/resolve-ink-api-name.js";
+
+const NON_APPEND_COLLECTION_METHODS = new Set([
+  "filter",
+  "reverse",
+  "sort",
+  "toReversed",
+  "toSorted",
+]);
+
+export const inkStaticIsAppendOnly = defineRule({
+  id: "ink-static-is-append-only",
+  title: "Static receives a non-append-only collection",
+  severity: "warn",
+  minimumInkVersion: MINIMUM_INK_VERSIONS.base,
+  recommendation: "Pass `<Static>` a collection whose existing entries never reorder or disappear.",
+  create: (context) => ({
+    JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
+      if (resolveInkJsxElementName(node, context.scopes) !== "Static") return;
+      const itemsAttribute = findJsxAttribute(node.attributes, "items");
+      if (!itemsAttribute || !isNodeOfType(itemsAttribute.value, "JSXExpressionContainer")) return;
+      const expression = itemsAttribute.value.expression;
+      if (
+        !isNodeOfType(expression, "CallExpression") ||
+        !isNodeOfType(expression.callee, "MemberExpression")
+      ) {
+        return;
+      }
+      const methodName = getStaticPropertyName(expression.callee);
+      if (!methodName || !NON_APPEND_COLLECTION_METHODS.has(methodName)) return;
+      context.report({
+        node: itemsAttribute,
+        message: `\`<Static>\` never revises prior output, but \`.${methodName}()\` can reorder or remove it.`,
+      });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-static-is-append-only.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-static-is-append-only.ts
@@ -6,13 +6,7 @@ import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { resolveInkJsxElementName } from "../../utils/resolve-ink-api-name.js";
 
-const NON_APPEND_COLLECTION_METHODS = new Set([
-  "filter",
-  "reverse",
-  "sort",
-  "toReversed",
-  "toSorted",
-]);
+const NON_APPEND_COLLECTION_METHODS = new Set(["reverse", "sort", "toReversed", "toSorted"]);
 
 export const inkStaticIsAppendOnly = defineRule({
   id: "ink-static-is-append-only",
@@ -34,6 +28,17 @@ export const inkStaticIsAppendOnly = defineRule({
       }
       const methodName = getStaticPropertyName(expression.callee);
       if (!methodName || !NON_APPEND_COLLECTION_METHODS.has(methodName)) return;
+      if (
+        isNodeOfType(expression.callee.object, "ArrayExpression") &&
+        expression.callee.object.elements.every(
+          (elementNode) =>
+            elementNode === null ||
+            isNodeOfType(elementNode, "Literal") ||
+            (isNodeOfType(elementNode, "TemplateLiteral") && elementNode.expressions.length === 0),
+        )
+      ) {
+        return;
+      }
       context.report({
         node: itemsAttribute,
         message: `\`<Static>\` never revises prior output, but \`.${methodName}()\` can reorder or remove it.`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-static-is-append-only.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-static-is-append-only.ts
@@ -41,7 +41,7 @@ export const inkStaticIsAppendOnly = defineRule({
       }
       context.report({
         node: itemsAttribute,
-        message: `\`<Static>\` never revises prior output, but \`.${methodName}()\` can reorder or remove it.`,
+        message: `\`<Static>\` never revises prior output, but \`.${methodName}()\` can change existing item order.`,
       });
     },
   }),

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-static-requires-key.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-static-requires-key.ts
@@ -1,0 +1,61 @@
+import { MINIMUM_INK_VERSIONS } from "../../constants/ink.js";
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { hasJsxKeyAttribute } from "../../utils/has-jsx-key-attribute.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { resolveInkJsxElementName } from "../../utils/resolve-ink-api-name.js";
+import { walkAst } from "../../utils/walk-ast.js";
+
+const collectReturnedElements = (renderFunction: EsTreeNode): EsTreeNodeOfType<"JSXElement">[] => {
+  if (
+    (isNodeOfType(renderFunction, "ArrowFunctionExpression") ||
+      isNodeOfType(renderFunction, "FunctionExpression")) &&
+    isNodeOfType(renderFunction.body, "JSXElement")
+  ) {
+    return [renderFunction.body];
+  }
+  if (
+    (!isNodeOfType(renderFunction, "ArrowFunctionExpression") &&
+      !isNodeOfType(renderFunction, "FunctionExpression")) ||
+    !isNodeOfType(renderFunction.body, "BlockStatement")
+  ) {
+    return [];
+  }
+  const returnedElements: EsTreeNodeOfType<"JSXElement">[] = [];
+  walkAst(renderFunction.body, (descendantNode) => {
+    if (descendantNode !== renderFunction.body && /Function/.test(descendantNode.type))
+      return false;
+    if (
+      isNodeOfType(descendantNode, "ReturnStatement") &&
+      isNodeOfType(descendantNode.argument, "JSXElement")
+    ) {
+      returnedElements.push(descendantNode.argument);
+    }
+  });
+  return returnedElements;
+};
+
+export const inkStaticRequiresKey = defineRule({
+  id: "ink-static-requires-key",
+  title: "Static item root missing a key",
+  severity: "error",
+  minimumInkVersion: MINIMUM_INK_VERSIONS.base,
+  recommendation: "Put a stable `key` on the root element returned by `<Static>`.",
+  create: (context) => ({
+    JSXElement(node: EsTreeNodeOfType<"JSXElement">) {
+      if (resolveInkJsxElementName(node.openingElement, context.scopes) !== "Static") return;
+      for (const childNode of node.children) {
+        if (!isNodeOfType(childNode, "JSXExpressionContainer")) continue;
+        const renderFunction = childNode.expression;
+        for (const returnedElement of collectReturnedElements(renderFunction)) {
+          if (hasJsxKeyAttribute(returnedElement.openingElement)) continue;
+          context.report({
+            node: returnedElement.openingElement,
+            message: "The root element returned by `<Static>` needs a `key`.",
+          });
+        }
+      }
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-suspense-requires-concurrent.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-suspense-requires-concurrent.ts
@@ -6,7 +6,7 @@ import { getImportedNameFromModule } from "../../utils/find-import-source-for-na
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import {
   collectInkRenderCalls,
-  hasInkRenderBooleanOption,
+  getInkRenderBooleanOption,
   resolveInkRenderCallsForNode,
 } from "../../utils/resolve-ink-render-calls.js";
 import { walkAst } from "../../utils/walk-ast.js";
@@ -39,8 +39,9 @@ export const inkSuspenseRequiresConcurrent = defineRule({
         );
         if (
           relatedRenderCalls.length === 0 ||
-          relatedRenderCalls.every((renderCall) =>
-            hasInkRenderBooleanOption(renderCall.node, "concurrent", true),
+          !relatedRenderCalls.some(
+            (renderCall) =>
+              getInkRenderBooleanOption(renderCall.node, "concurrent", false) === false,
           )
         ) {
           return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-suspense-requires-concurrent.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-suspense-requires-concurrent.ts
@@ -1,0 +1,64 @@
+import { MINIMUM_INK_VERSIONS } from "../../constants/ink.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+import { containsInkJsxElement } from "../../utils/contains-ink-jsx-element.js";
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { getImportedNameFromModule } from "../../utils/find-import-source-for-name.js";
+import { getStaticPropertyKeyName } from "../../utils/get-static-property-key-name.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { resolveInkApiName } from "../../utils/resolve-ink-api-name.js";
+import { walkAst } from "../../utils/walk-ast.js";
+
+const hasConcurrentRender = (program: EsTreeNode, context: RuleContext): boolean => {
+  let hasConcurrent = false;
+  walkAst(program, (descendantNode) => {
+    if (
+      !isNodeOfType(descendantNode, "CallExpression") ||
+      resolveInkApiName(descendantNode.callee, context.scopes) !== "render"
+    ) {
+      return;
+    }
+    for (const argumentNode of descendantNode.arguments) {
+      if (!isNodeOfType(argumentNode, "ObjectExpression")) continue;
+      hasConcurrent ||= argumentNode.properties.some(
+        (propertyNode) =>
+          isNodeOfType(propertyNode, "Property") &&
+          getStaticPropertyKeyName(propertyNode, { allowComputedString: true }) === "concurrent" &&
+          isNodeOfType(propertyNode.value, "Literal") &&
+          propertyNode.value.value === true,
+      );
+    }
+  });
+  return hasConcurrent;
+};
+
+export const inkSuspenseRequiresConcurrent = defineRule({
+  id: "ink-suspense-requires-concurrent",
+  title: "Ink Suspense without concurrent rendering",
+  severity: "error",
+  minimumInkVersion: MINIMUM_INK_VERSIONS.concurrent,
+  recommendation: "Enable `{concurrent: true}` on Ink `render()` when the tree uses Suspense.",
+  create: (context) => ({
+    Program(node: EsTreeNodeOfType<"Program">) {
+      if (hasConcurrentRender(node, context)) return;
+      walkAst(node, (descendantNode) => {
+        if (
+          !isNodeOfType(descendantNode, "JSXOpeningElement") ||
+          !isNodeOfType(descendantNode.name, "JSXIdentifier") ||
+          context.scopes.symbolFor(descendantNode.name)?.kind !== "import" ||
+          getImportedNameFromModule(descendantNode, descendantNode.name.name, "react") !==
+            "Suspense" ||
+          !descendantNode.parent ||
+          !containsInkJsxElement(descendantNode.parent, context.scopes)
+        ) {
+          return;
+        }
+        context.report({
+          node: descendantNode,
+          message: "Ink Suspense boundaries require the renderer's `concurrent` option.",
+        });
+      });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-suspense-requires-concurrent.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-suspense-requires-concurrent.ts
@@ -1,58 +1,10 @@
 import { MINIMUM_INK_VERSIONS } from "../../constants/ink.js";
-import { containsInkJsxElement } from "../../utils/contains-ink-jsx-element.js";
-import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
-import { findNearestInkJsxElement } from "../../utils/find-nearest-ink-jsx-element.js";
-import { getImportedNameFromModule } from "../../utils/find-import-source-for-name.js";
-import { isNodeOfType } from "../../utils/is-node-of-type.js";
-import {
-  collectInkRenderCalls,
-  getInkRenderBooleanOption,
-  resolveInkRenderCallsForNode,
-} from "../../utils/resolve-ink-render-calls.js";
-import { walkAst } from "../../utils/walk-ast.js";
+import { defineRetiredRule } from "../../utils/define-retired-rule.js";
 
-export const inkSuspenseRequiresConcurrent = defineRule({
+export const inkSuspenseRequiresConcurrent = defineRetiredRule({
   id: "ink-suspense-requires-concurrent",
-  title: "Ink Suspense without concurrent rendering",
+  title: "Retired: Ink Suspense rendering mode",
   severity: "error",
   minimumInkVersion: MINIMUM_INK_VERSIONS.concurrent,
-  recommendation: "Enable `{concurrent: true}` on Ink `render()` when the tree uses Suspense.",
-  create: (context) => ({
-    Program(node: EsTreeNodeOfType<"Program">) {
-      const renderCalls = collectInkRenderCalls(node, context);
-      walkAst(node, (descendantNode) => {
-        if (
-          !isNodeOfType(descendantNode, "JSXOpeningElement") ||
-          !isNodeOfType(descendantNode.name, "JSXIdentifier") ||
-          context.scopes.symbolFor(descendantNode.name)?.kind !== "import" ||
-          getImportedNameFromModule(descendantNode, descendantNode.name.name, "react") !==
-            "Suspense" ||
-          !descendantNode.parent ||
-          (!containsInkJsxElement(descendantNode.parent, context.scopes) &&
-            findNearestInkJsxElement(descendantNode.parent, context.scopes) === null)
-        ) {
-          return;
-        }
-        const relatedRenderCalls = resolveInkRenderCallsForNode(
-          descendantNode,
-          renderCalls,
-          context,
-        );
-        if (
-          relatedRenderCalls.length === 0 ||
-          !relatedRenderCalls.some(
-            (renderCall) =>
-              getInkRenderBooleanOption(renderCall.node, "concurrent", false) === false,
-          )
-        ) {
-          return;
-        }
-        context.report({
-          node: descendantNode,
-          message: "Ink Suspense boundaries require the renderer's `concurrent` option.",
-        });
-      });
-    },
-  }),
+  recommendation: "No change is required; Ink can render Suspense fallbacks without concurrency.",
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-suspense-requires-concurrent.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-suspense-requires-concurrent.ts
@@ -2,6 +2,7 @@ import { MINIMUM_INK_VERSIONS } from "../../constants/ink.js";
 import { containsInkJsxElement } from "../../utils/contains-ink-jsx-element.js";
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findNearestInkJsxElement } from "../../utils/find-nearest-ink-jsx-element.js";
 import { getImportedNameFromModule } from "../../utils/find-import-source-for-name.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import {
@@ -28,7 +29,8 @@ export const inkSuspenseRequiresConcurrent = defineRule({
           getImportedNameFromModule(descendantNode, descendantNode.name.name, "react") !==
             "Suspense" ||
           !descendantNode.parent ||
-          !containsInkJsxElement(descendantNode.parent, context.scopes)
+          (!containsInkJsxElement(descendantNode.parent, context.scopes) &&
+            findNearestInkJsxElement(descendantNode.parent, context.scopes) === null)
         ) {
           return;
         }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-suspense-requires-concurrent.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-suspense-requires-concurrent.ts
@@ -1,37 +1,15 @@
 import { MINIMUM_INK_VERSIONS } from "../../constants/ink.js";
-import type { RuleContext } from "../../utils/rule-context.js";
 import { containsInkJsxElement } from "../../utils/contains-ink-jsx-element.js";
 import { defineRule } from "../../utils/define-rule.js";
-import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { getImportedNameFromModule } from "../../utils/find-import-source-for-name.js";
-import { getStaticPropertyKeyName } from "../../utils/get-static-property-key-name.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
-import { resolveInkApiName } from "../../utils/resolve-ink-api-name.js";
+import {
+  collectInkRenderCalls,
+  hasInkRenderBooleanOption,
+  resolveInkRenderCallsForNode,
+} from "../../utils/resolve-ink-render-calls.js";
 import { walkAst } from "../../utils/walk-ast.js";
-
-const hasConcurrentRender = (program: EsTreeNode, context: RuleContext): boolean => {
-  let hasConcurrent = false;
-  walkAst(program, (descendantNode) => {
-    if (
-      !isNodeOfType(descendantNode, "CallExpression") ||
-      resolveInkApiName(descendantNode.callee, context.scopes) !== "render"
-    ) {
-      return;
-    }
-    for (const argumentNode of descendantNode.arguments) {
-      if (!isNodeOfType(argumentNode, "ObjectExpression")) continue;
-      hasConcurrent ||= argumentNode.properties.some(
-        (propertyNode) =>
-          isNodeOfType(propertyNode, "Property") &&
-          getStaticPropertyKeyName(propertyNode, { allowComputedString: true }) === "concurrent" &&
-          isNodeOfType(propertyNode.value, "Literal") &&
-          propertyNode.value.value === true,
-      );
-    }
-  });
-  return hasConcurrent;
-};
 
 export const inkSuspenseRequiresConcurrent = defineRule({
   id: "ink-suspense-requires-concurrent",
@@ -41,7 +19,7 @@ export const inkSuspenseRequiresConcurrent = defineRule({
   recommendation: "Enable `{concurrent: true}` on Ink `render()` when the tree uses Suspense.",
   create: (context) => ({
     Program(node: EsTreeNodeOfType<"Program">) {
-      if (hasConcurrentRender(node, context)) return;
+      const renderCalls = collectInkRenderCalls(node, context);
       walkAst(node, (descendantNode) => {
         if (
           !isNodeOfType(descendantNode, "JSXOpeningElement") ||
@@ -51,6 +29,15 @@ export const inkSuspenseRequiresConcurrent = defineRule({
             "Suspense" ||
           !descendantNode.parent ||
           !containsInkJsxElement(descendantNode.parent, context.scopes)
+        ) {
+          return;
+        }
+        const relatedRenderCalls = resolveInkRenderCallsForNode(descendantNode, renderCalls);
+        if (
+          relatedRenderCalls.length === 0 ||
+          relatedRenderCalls.every((renderCall) =>
+            hasInkRenderBooleanOption(renderCall.node, "concurrent", true),
+          )
         ) {
           return;
         }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-suspense-requires-concurrent.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-suspense-requires-concurrent.ts
@@ -32,7 +32,11 @@ export const inkSuspenseRequiresConcurrent = defineRule({
         ) {
           return;
         }
-        const relatedRenderCalls = resolveInkRenderCallsForNode(descendantNode, renderCalls);
+        const relatedRenderCalls = resolveInkRenderCallsForNode(
+          descendantNode,
+          renderCalls,
+          context,
+        );
         if (
           relatedRenderCalls.length === 0 ||
           relatedRenderCalls.every((renderCall) =>

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-use-reactive-window-size.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-use-reactive-window-size.ts
@@ -1,21 +1,97 @@
 import { MINIMUM_INK_VERSIONS } from "../../constants/ink.js";
+import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
+import { componentOrHookDisplayNameForFunction } from "../../utils/component-or-hook-display-name.js";
+import { componentRendersInk } from "../../utils/component-renders-ink.js";
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
 import { findRenderPhaseComponentOrHook } from "../../utils/find-render-phase-component-or-hook.js";
 import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isProvenGlobalNamespaceReference } from "../../utils/is-proven-global-namespace-reference.js";
-import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
+import { isReactApiCall } from "../../utils/is-react-api-call.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import { walkAst } from "../../utils/walk-ast.js";
 
 const WINDOW_DIMENSION_NAMES = new Set(["columns", "rows"]);
 const RESIZE_LISTENER_METHOD_NAMES = new Set(["addListener", "on", "once"]);
+const REACTIVE_HOOK_NAMES = new Set(["useReducer", "useState"]);
 
 const isProcessStdout = (node: EsTreeNode, scopes: ScopeAnalysis): boolean =>
   isNodeOfType(node, "MemberExpression") &&
   getStaticPropertyName(node) === "stdout" &&
   isProvenGlobalNamespaceReference(node.object, "process", scopes);
+
+const resolveListenerFunction = (
+  node: EsTreeNode | null | undefined,
+  scopes: ScopeAnalysis,
+  visitedSymbolIds: ReadonlySet<number> = new Set(),
+): EsTreeNode | null => {
+  if (!node) return null;
+  const unwrappedNode = stripParenExpression(node);
+  if (
+    isNodeOfType(unwrappedNode, "ArrowFunctionExpression") ||
+    isNodeOfType(unwrappedNode, "FunctionExpression")
+  ) {
+    return unwrappedNode;
+  }
+  if (!isNodeOfType(unwrappedNode, "Identifier")) return null;
+  const symbol = scopes.symbolFor(unwrappedNode);
+  if (!symbol || visitedSymbolIds.has(symbol.id) || !symbol.initializer) return null;
+  return resolveListenerFunction(
+    symbol.initializer,
+    scopes,
+    new Set([...visitedSymbolIds, symbol.id]),
+  );
+};
+
+const isReactStateUpdater = (node: EsTreeNode, scopes: ScopeAnalysis): boolean => {
+  if (!isNodeOfType(node, "Identifier")) return false;
+  const symbol = scopes.symbolFor(node);
+  if (!symbol || !isNodeOfType(symbol.declarationNode, "VariableDeclarator")) return false;
+  const declarator = symbol.declarationNode;
+  if (!isNodeOfType(declarator.id, "ArrayPattern")) return false;
+  const setterElement = declarator.id.elements[1];
+  const setterIdentifier = isNodeOfType(setterElement, "AssignmentPattern")
+    ? setterElement.left
+    : setterElement;
+  if (setterIdentifier !== symbol.bindingIdentifier) return false;
+  return Boolean(
+    isNodeOfType(declarator.init, "CallExpression") &&
+    isReactApiCall(declarator.init, REACTIVE_HOOK_NAMES, scopes, {
+      allowGlobalReactNamespace: true,
+      resolveNamedAliases: true,
+    }),
+  );
+};
+
+const listenerTriggersRender = (listenerNode: EsTreeNode, scopes: ScopeAnalysis): boolean => {
+  let doesTriggerRender = false;
+  walkAst(listenerNode, (descendantNode) => {
+    if (descendantNode !== listenerNode && /Function/.test(descendantNode.type)) return false;
+    if (
+      isNodeOfType(descendantNode, "CallExpression") &&
+      isReactStateUpdater(descendantNode.callee, scopes)
+    ) {
+      doesTriggerRender = true;
+      return false;
+    }
+  });
+  return doesTriggerRender;
+};
+
+const listenerBelongsToComponent = (
+  listenerRegistration: EsTreeNode,
+  componentNode: EsTreeNode,
+): boolean => {
+  let enclosingFunction = findEnclosingFunction(listenerRegistration);
+  while (enclosingFunction && enclosingFunction !== componentNode) {
+    if (componentOrHookDisplayNameForFunction(enclosingFunction)) return false;
+    enclosingFunction = findEnclosingFunction(enclosingFunction);
+  }
+  return enclosingFunction === componentNode;
+};
 
 const hasStdoutResizeListener = (componentNode: EsTreeNode, scopes: ScopeAnalysis): boolean => {
   let hasListener = false;
@@ -26,7 +102,16 @@ const hasStdoutResizeListener = (componentNode: EsTreeNode, scopes: ScopeAnalysi
       !RESIZE_LISTENER_METHOD_NAMES.has(getStaticPropertyName(descendantNode.callee) ?? "") ||
       !isProcessStdout(descendantNode.callee.object, scopes) ||
       !isNodeOfType(descendantNode.arguments[0], "Literal") ||
-      descendantNode.arguments[0].value !== "resize"
+      descendantNode.arguments[0].value !== "resize" ||
+      !listenerBelongsToComponent(descendantNode, componentNode)
+    ) {
+      return;
+    }
+    const listenerArgument = descendantNode.arguments[1];
+    const listenerNode = resolveListenerFunction(listenerArgument, scopes);
+    if (
+      (!listenerArgument || !isReactStateUpdater(listenerArgument, scopes)) &&
+      (!listenerNode || !listenerTriggersRender(listenerNode, scopes))
     ) {
       return;
     }
@@ -49,9 +134,9 @@ export const inkUseReactiveWindowSize = defineRule({
       const componentNode = findRenderPhaseComponentOrHook(node, context.scopes);
       if (
         !isNodeOfType(node.object, "MemberExpression") ||
-        getStaticPropertyName(node.object) !== "stdout" ||
-        !isProvenGlobalNamespaceReference(node.object.object, "process", context.scopes) ||
+        !isProcessStdout(node.object, context.scopes) ||
         !componentNode ||
+        !componentRendersInk(componentNode, context.scopes) ||
         hasStdoutResizeListener(componentNode, context.scopes)
       ) {
         return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-use-reactive-window-size.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-use-reactive-window-size.ts
@@ -1,28 +1,58 @@
 import { MINIMUM_INK_VERSIONS } from "../../constants/ink.js";
 import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { findRenderPhaseComponentOrHook } from "../../utils/find-render-phase-component-or-hook.js";
 import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isProvenGlobalNamespaceReference } from "../../utils/is-proven-global-namespace-reference.js";
+import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
+import { walkAst } from "../../utils/walk-ast.js";
 
 const WINDOW_DIMENSION_NAMES = new Set(["columns", "rows"]);
+const RESIZE_LISTENER_METHOD_NAMES = new Set(["addListener", "on", "once"]);
+
+const isProcessStdout = (node: EsTreeNode, scopes: ScopeAnalysis): boolean =>
+  isNodeOfType(node, "MemberExpression") &&
+  getStaticPropertyName(node) === "stdout" &&
+  isProvenGlobalNamespaceReference(node.object, "process", scopes);
+
+const hasStdoutResizeListener = (componentNode: EsTreeNode, scopes: ScopeAnalysis): boolean => {
+  let hasListener = false;
+  walkAst(componentNode, (descendantNode) => {
+    if (
+      !isNodeOfType(descendantNode, "CallExpression") ||
+      !isNodeOfType(descendantNode.callee, "MemberExpression") ||
+      !RESIZE_LISTENER_METHOD_NAMES.has(getStaticPropertyName(descendantNode.callee) ?? "") ||
+      !isProcessStdout(descendantNode.callee.object, scopes) ||
+      !isNodeOfType(descendantNode.arguments[0], "Literal") ||
+      descendantNode.arguments[0].value !== "resize"
+    ) {
+      return;
+    }
+    hasListener = true;
+    return false;
+  });
+  return hasListener;
+};
 
 export const inkUseReactiveWindowSize = defineRule({
   id: "ink-use-reactive-window-size",
   title: "Terminal dimensions read non-reactively",
-  severity: "error",
+  severity: "warn",
   minimumInkVersion: MINIMUM_INK_VERSIONS.modernHooks,
   recommendation: "Use Ink's `useWindowSize()` so resize events trigger a render.",
   create: (context) => ({
     MemberExpression(node: EsTreeNodeOfType<"MemberExpression">) {
       const dimensionName = getStaticPropertyName(node);
       if (!dimensionName || !WINDOW_DIMENSION_NAMES.has(dimensionName)) return;
+      const componentNode = findRenderPhaseComponentOrHook(node, context.scopes);
       if (
         !isNodeOfType(node.object, "MemberExpression") ||
         getStaticPropertyName(node.object) !== "stdout" ||
         !isProvenGlobalNamespaceReference(node.object.object, "process", context.scopes) ||
-        !findRenderPhaseComponentOrHook(node, context.scopes)
+        !componentNode ||
+        hasStdoutResizeListener(componentNode, context.scopes)
       ) {
         return;
       }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-use-reactive-window-size.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-use-reactive-window-size.ts
@@ -1,0 +1,35 @@
+import { MINIMUM_INK_VERSIONS } from "../../constants/ink.js";
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findRenderPhaseComponentOrHook } from "../../utils/find-render-phase-component-or-hook.js";
+import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { isProvenGlobalNamespaceReference } from "../../utils/is-proven-global-namespace-reference.js";
+
+const WINDOW_DIMENSION_NAMES = new Set(["columns", "rows"]);
+
+export const inkUseReactiveWindowSize = defineRule({
+  id: "ink-use-reactive-window-size",
+  title: "Terminal dimensions read non-reactively",
+  severity: "error",
+  minimumInkVersion: MINIMUM_INK_VERSIONS.modernHooks,
+  recommendation: "Use Ink's `useWindowSize()` so resize events trigger a render.",
+  create: (context) => ({
+    MemberExpression(node: EsTreeNodeOfType<"MemberExpression">) {
+      const dimensionName = getStaticPropertyName(node);
+      if (!dimensionName || !WINDOW_DIMENSION_NAMES.has(dimensionName)) return;
+      if (
+        !isNodeOfType(node.object, "MemberExpression") ||
+        getStaticPropertyName(node.object) !== "stdout" ||
+        !isProvenGlobalNamespaceReference(node.object.object, "process", context.scopes) ||
+        !findRenderPhaseComponentOrHook(node, context.scopes)
+      ) {
+        return;
+      }
+      context.report({
+        node,
+        message: `\`process.stdout.${dimensionName}\` does not make an Ink component react to resize.`,
+      });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-use-string-width-for-cursor.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-use-string-width-for-cursor.ts
@@ -1,0 +1,55 @@
+import { MINIMUM_INK_VERSIONS } from "../../constants/ink.js";
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { resolveInkApiName } from "../../utils/resolve-ink-api-name.js";
+import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+
+const isUseCursorCall = (node: EsTreeNode | null | undefined, scopes: ScopeAnalysis): boolean =>
+  Boolean(
+    node &&
+    isNodeOfType(node, "CallExpression") &&
+    resolveInkApiName(node.callee, scopes) === "useCursor",
+  );
+
+export const inkUseStringWidthForCursor = defineRule({
+  id: "ink-use-string-width-for-cursor",
+  title: "String length used as terminal column width",
+  severity: "error",
+  minimumInkVersion: MINIMUM_INK_VERSIONS.cursor,
+  recommendation:
+    "Measure terminal columns with `string-width` before calling `setCursorPosition`.",
+  create: (context) => ({
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+      if (!isNodeOfType(node.callee, "MemberExpression")) return;
+      if (getStaticPropertyName(node.callee) !== "setCursorPosition") return;
+      const cursorObject = stripParenExpression(node.callee.object);
+      const isCursor =
+        isUseCursorCall(cursorObject, context.scopes) ||
+        (isNodeOfType(cursorObject, "Identifier") &&
+          isUseCursorCall(context.scopes.symbolFor(cursorObject)?.initializer, context.scopes));
+      if (!isCursor) return;
+      const horizontalPosition = node.arguments[0];
+      if (
+        !isNodeOfType(horizontalPosition, "MemberExpression") ||
+        getStaticPropertyName(horizontalPosition) !== "length"
+      ) {
+        return;
+      }
+      if (
+        isNodeOfType(horizontalPosition.object, "Literal") &&
+        typeof horizontalPosition.object.value === "string" &&
+        /^[\x20-\x7e]*$/.test(horizontalPosition.object.value)
+      ) {
+        return;
+      }
+      context.report({
+        node: horizontalPosition,
+        message: "JavaScript string length is not a terminal column width for Unicode text.",
+      });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-use-string-width-for-cursor.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-use-string-width-for-cursor.ts
@@ -2,6 +2,8 @@ import { MINIMUM_INK_VERSIONS } from "../../constants/ink.js";
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { getDirectUnreassignedInitializer } from "../../utils/get-direct-unreassigned-initializer.js";
+import { getStaticPropertyKeyName } from "../../utils/get-static-property-key-name.js";
 import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { resolveInkApiName } from "../../utils/resolve-ink-api-name.js";
@@ -15,10 +17,56 @@ const isUseCursorCall = (node: EsTreeNode | null | undefined, scopes: ScopeAnaly
     resolveInkApiName(node.callee, scopes) === "useCursor",
   );
 
+const getHorizontalPosition = (
+  callExpression: EsTreeNodeOfType<"CallExpression">,
+): EsTreeNode | null => {
+  const positionNode = callExpression.arguments[0];
+  if (!positionNode) return null;
+  if (!isNodeOfType(positionNode, "ObjectExpression")) return positionNode;
+  const horizontalProperty = positionNode.properties.find(
+    (propertyNode) =>
+      isNodeOfType(propertyNode, "Property") &&
+      getStaticPropertyKeyName(propertyNode, { allowComputedString: true }) === "x",
+  );
+  return horizontalProperty && isNodeOfType(horizontalProperty, "Property")
+    ? horizontalProperty.value
+    : null;
+};
+
+const isProvablyAsciiString = (
+  node: EsTreeNode,
+  scopes: ScopeAnalysis,
+  visitedSymbolIds = new Set<number>(),
+): boolean => {
+  const expression = stripParenExpression(node);
+  if (isNodeOfType(expression, "Literal")) {
+    return typeof expression.value === "string" && /^[\x20-\x7e]*$/.test(expression.value);
+  }
+  if (isNodeOfType(expression, "TemplateLiteral") && expression.expressions.length === 0) {
+    const value = expression.quasis[0]?.value.cooked ?? expression.quasis[0]?.value.raw ?? "";
+    return /^[\x20-\x7e]*$/.test(value);
+  }
+  if (
+    isNodeOfType(expression, "BinaryExpression") &&
+    expression.operator === "+" &&
+    isProvablyAsciiString(expression.left, scopes, visitedSymbolIds) &&
+    isProvablyAsciiString(expression.right, scopes, visitedSymbolIds)
+  ) {
+    return true;
+  }
+  if (!isNodeOfType(expression, "Identifier")) return false;
+  const symbol = scopes.symbolFor(expression);
+  if (!symbol || visitedSymbolIds.has(symbol.id)) return false;
+  const initializer = getDirectUnreassignedInitializer(symbol);
+  if (!initializer) return false;
+  visitedSymbolIds.add(symbol.id);
+  return isProvablyAsciiString(initializer, scopes, visitedSymbolIds);
+};
+
 export const inkUseStringWidthForCursor = defineRule({
   id: "ink-use-string-width-for-cursor",
   title: "String length used as terminal column width",
-  severity: "error",
+  severity: "warn",
   minimumInkVersion: MINIMUM_INK_VERSIONS.cursor,
   recommendation:
     "Measure terminal columns with `string-width` before calling `setCursorPosition`.",
@@ -32,20 +80,14 @@ export const inkUseStringWidthForCursor = defineRule({
         (isNodeOfType(cursorObject, "Identifier") &&
           isUseCursorCall(context.scopes.symbolFor(cursorObject)?.initializer, context.scopes));
       if (!isCursor) return;
-      const horizontalPosition = node.arguments[0];
+      const horizontalPosition = getHorizontalPosition(node);
       if (
         !isNodeOfType(horizontalPosition, "MemberExpression") ||
         getStaticPropertyName(horizontalPosition) !== "length"
       ) {
         return;
       }
-      if (
-        isNodeOfType(horizontalPosition.object, "Literal") &&
-        typeof horizontalPosition.object.value === "string" &&
-        /^[\x20-\x7e]*$/.test(horizontalPosition.object.value)
-      ) {
-        return;
-      }
+      if (isProvablyAsciiString(horizontalPosition.object, context.scopes)) return;
       context.report({
         node: horizontalPosition,
         message: "JavaScript string length is not a terminal column width for Unicode text.",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-use-suspend-terminal.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-use-suspend-terminal.ts
@@ -2,8 +2,8 @@ import { MINIMUM_INK_VERSIONS } from "../../constants/ink.js";
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
 import { getImportedNameFromModule } from "../../utils/find-import-source-for-name.js";
-import { hasImportFromModules } from "../../utils/find-import-source-for-name.js";
 import { getStaticPropertyKeyName } from "../../utils/get-static-property-key-name.js";
 import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
@@ -73,6 +73,17 @@ const isInsideSuspendTerminal = (node: EsTreeNode, context: RuleContext): boolea
   return false;
 };
 
+const isInsideUseInputHandler = (node: EsTreeNode, context: RuleContext): boolean => {
+  const enclosingFunction = findEnclosingFunction(node);
+  const hookCall = enclosingFunction?.parent;
+  return Boolean(
+    hookCall &&
+    isNodeOfType(hookCall, "CallExpression") &&
+    hookCall.arguments[0] === enclosingFunction &&
+    resolveInkApiName(hookCall.callee, context.scopes) === "useInput",
+  );
+};
+
 export const inkUseSuspendTerminal = defineRule({
   id: "ink-use-suspend-terminal",
   title: "Interactive child process bypasses Ink suspension",
@@ -89,7 +100,7 @@ export const inkUseSuspendTerminal = defineRule({
       ).find(Boolean);
       if (!importedName || !CHILD_PROCESS_METHOD_NAMES.has(importedName)) return;
       if (!node.arguments.some(isInheritedStdio) || isInsideSuspendTerminal(node, context)) return;
-      if (!hasImportFromModules(node, ["ink"])) return;
+      if (!isInsideUseInputHandler(node, context)) return;
       context.report({
         node,
         message: "Suspend Ink before giving an interactive child process control of the terminal.",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-use-suspend-terminal.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-use-suspend-terminal.ts
@@ -1,0 +1,99 @@
+import { MINIMUM_INK_VERSIONS } from "../../constants/ink.js";
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { getImportedNameFromModule } from "../../utils/find-import-source-for-name.js";
+import { hasImportFromModules } from "../../utils/find-import-source-for-name.js";
+import { getStaticPropertyKeyName } from "../../utils/get-static-property-key-name.js";
+import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { resolveInkApiName } from "../../utils/resolve-ink-api-name.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+
+const CHILD_PROCESS_MODULE_NAMES = ["child_process", "node:child_process"];
+const CHILD_PROCESS_METHOD_NAMES = new Set(["exec", "execFile", "spawn", "spawnSync"]);
+
+const isUseAppCall = (node: EsTreeNode | null | undefined, context: RuleContext): boolean =>
+  Boolean(
+    node &&
+    isNodeOfType(node, "CallExpression") &&
+    resolveInkApiName(node.callee, context.scopes) === "useApp",
+  );
+
+const isInheritedStdio = (node: EsTreeNode): boolean => {
+  if (!isNodeOfType(node, "ObjectExpression")) return false;
+  return node.properties.some(
+    (property) =>
+      isNodeOfType(property, "Property") &&
+      getStaticPropertyKeyName(property, { allowComputedString: true }) === "stdio" &&
+      isNodeOfType(property.value, "Literal") &&
+      property.value.value === "inherit",
+  );
+};
+
+const isSuspendTerminalCall = (
+  callExpression: EsTreeNodeOfType<"CallExpression">,
+  context: RuleContext,
+): boolean => {
+  const callee = callExpression.callee;
+  if (isNodeOfType(callee, "MemberExpression")) {
+    return (
+      getStaticPropertyName(callee) === "suspendTerminal" && isUseAppCall(callee.object, context)
+    );
+  }
+  if (!isNodeOfType(callee, "Identifier")) return false;
+  const symbol = context.scopes.symbolFor(callee);
+  if (
+    !symbol ||
+    !isNodeOfType(symbol.declarationNode, "VariableDeclarator") ||
+    !isNodeOfType(symbol.declarationNode.id, "ObjectPattern") ||
+    !isUseAppCall(symbol.initializer, context)
+  ) {
+    return false;
+  }
+  const property = symbol.bindingIdentifier.parent;
+  return Boolean(
+    property &&
+    isNodeOfType(property, "Property") &&
+    getStaticPropertyKeyName(property, { allowComputedString: true }) === "suspendTerminal",
+  );
+};
+
+const isInsideSuspendTerminal = (node: EsTreeNode, context: RuleContext): boolean => {
+  let ancestorNode = node.parent;
+  while (ancestorNode) {
+    if (
+      isNodeOfType(ancestorNode, "CallExpression") &&
+      isSuspendTerminalCall(ancestorNode, context)
+    ) {
+      return true;
+    }
+    ancestorNode = ancestorNode.parent;
+  }
+  return false;
+};
+
+export const inkUseSuspendTerminal = defineRule({
+  id: "ink-use-suspend-terminal",
+  title: "Interactive child process bypasses Ink suspension",
+  severity: "error",
+  minimumInkVersion: MINIMUM_INK_VERSIONS.suspendTerminal,
+  recommendation: "Run inherited-TTY child processes inside `useApp().suspendTerminal()`.",
+  create: (context) => ({
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+      if (!isNodeOfType(node.callee, "Identifier")) return;
+      if (context.scopes.symbolFor(node.callee)?.kind !== "import") return;
+      const localName = node.callee.name;
+      const importedName = CHILD_PROCESS_MODULE_NAMES.map((moduleName) =>
+        getImportedNameFromModule(node, localName, moduleName),
+      ).find(Boolean);
+      if (!importedName || !CHILD_PROCESS_METHOD_NAMES.has(importedName)) return;
+      if (!node.arguments.some(isInheritedStdio) || isInsideSuspendTerminal(node, context)) return;
+      if (!hasImportFromModules(node, ["ink"])) return;
+      context.report({
+        node,
+        message: "Suspend Ink before giving an interactive child process control of the terminal.",
+      });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-valid-aria-semantics.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/ink/ink-valid-aria-semantics.ts
@@ -1,0 +1,109 @@
+import { MINIMUM_INK_VERSIONS } from "../../constants/ink.js";
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findJsxAttribute } from "../../utils/find-jsx-attribute.js";
+import { getStaticPropertyKeyName } from "../../utils/get-static-property-key-name.js";
+import { getJsxPropStringValue } from "../../utils/get-jsx-prop-string-value.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { resolveInkJsxElementName } from "../../utils/resolve-ink-api-name.js";
+
+const INK_ARIA_ROLES = new Set([
+  "button",
+  "checkbox",
+  "combobox",
+  "list",
+  "listbox",
+  "listitem",
+  "menu",
+  "menuitem",
+  "option",
+  "progressbar",
+  "radio",
+  "radiogroup",
+  "tab",
+  "tablist",
+  "table",
+  "textbox",
+  "timer",
+  "toolbar",
+]);
+
+const INK_ARIA_STATE_NAMES = new Set([
+  "busy",
+  "checked",
+  "disabled",
+  "expanded",
+  "multiline",
+  "multiselectable",
+  "readonly",
+  "required",
+  "selected",
+]);
+
+export const inkValidAriaSemantics = defineRule({
+  id: "ink-valid-aria-semantics",
+  title: "Invalid Ink accessibility semantics",
+  category: "Accessibility",
+  severity: "error",
+  minimumInkVersion: MINIMUM_INK_VERSIONS.aria,
+  recommendation:
+    "Use a role supported by Ink and do not label elements hidden from screen readers.",
+  create: (context) => ({
+    JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
+      const elementName = resolveInkJsxElementName(node, context.scopes);
+      if (!elementName) return;
+      const roleAttribute = findJsxAttribute(node.attributes, "aria-role");
+      const role = roleAttribute ? getJsxPropStringValue(roleAttribute) : null;
+      if (roleAttribute && elementName !== "Box") {
+        context.report({
+          node: roleAttribute,
+          message: `Ink \`<${elementName}>\` does not support \`aria-role\`; put semantics on a \`<Box>\`.`,
+        });
+      } else if (roleAttribute && role && !INK_ARIA_ROLES.has(role)) {
+        context.report({
+          node: roleAttribute,
+          message: `Ink does not expose the ARIA role \`${role}\` to screen readers.`,
+        });
+      }
+      const stateAttribute = findJsxAttribute(node.attributes, "aria-state");
+      if (stateAttribute && elementName !== "Box") {
+        context.report({
+          node: stateAttribute,
+          message: `Ink \`<${elementName}>\` does not support \`aria-state\`; put semantics on a \`<Box>\`.`,
+        });
+      } else if (
+        stateAttribute &&
+        isNodeOfType(stateAttribute.value, "JSXExpressionContainer") &&
+        isNodeOfType(stateAttribute.value.expression, "ObjectExpression")
+      ) {
+        const invalidStateProperty = stateAttribute.value.expression.properties.find((property) => {
+          if (!isNodeOfType(property, "Property")) return false;
+          const stateName = getStaticPropertyKeyName(property, { allowComputedString: true });
+          return stateName !== null && !INK_ARIA_STATE_NAMES.has(stateName);
+        });
+        if (invalidStateProperty && isNodeOfType(invalidStateProperty, "Property")) {
+          const stateName = getStaticPropertyKeyName(invalidStateProperty, {
+            allowComputedString: true,
+          });
+          context.report({
+            node: invalidStateProperty,
+            message: `Ink does not expose the ARIA state \`${stateName}\` to screen readers.`,
+          });
+        }
+      }
+      const labelAttribute = findJsxAttribute(node.attributes, "aria-label");
+      const hiddenAttribute = findJsxAttribute(node.attributes, "aria-hidden");
+      const isHidden =
+        hiddenAttribute &&
+        (hiddenAttribute.value === null ||
+          (isNodeOfType(hiddenAttribute.value, "JSXExpressionContainer") &&
+            isNodeOfType(hiddenAttribute.value.expression, "Literal") &&
+            hiddenAttribute.value.expression.value === true));
+      if (!labelAttribute || !isHidden) return;
+      context.report({
+        node: labelAttribute,
+        message: "`aria-label` has no effect when the Ink element is `aria-hidden`.",
+      });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-list-data-mapped.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-list-data-mapped.ts
@@ -9,7 +9,7 @@ import { findVariableInitializer } from "../../utils/find-variable-initializer.j
 import { getInitializerModuleSource } from "../../utils/get-initializer-module-source.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { RuleContext } from "../../utils/rule-context.js";
-import { resolveJsxElementName } from "./utils/resolve-jsx-element-name.js";
+import { resolveJsxElementName } from "../../utils/resolve-jsx-element-name.js";
 import { resolveImportedRecyclerName } from "./utils/resolve-imported-recycler-name.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-list-missing-estimated-item-size.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-list-missing-estimated-item-size.ts
@@ -6,7 +6,7 @@ import {
 } from "../../constants/react-native.js";
 import { hasImportFromModules } from "../../utils/find-import-source-for-name.js";
 import type { RuleContext } from "../../utils/rule-context.js";
-import { resolveJsxElementName } from "./utils/resolve-jsx-element-name.js";
+import { resolveJsxElementName } from "../../utils/resolve-jsx-element-name.js";
 import { resolveImportedRecyclerName } from "./utils/resolve-imported-recycler-name.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-list-recyclable-without-types.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-list-recyclable-without-types.ts
@@ -2,7 +2,7 @@ import { RECYCLABLE_LIST_PACKAGE_SOURCES } from "../../constants/react-native.js
 import { defineRule } from "../../utils/define-rule.js";
 import { hasImportFromModules } from "../../utils/find-import-source-for-name.js";
 import type { RuleContext } from "../../utils/rule-context.js";
-import { resolveJsxElementName } from "./utils/resolve-jsx-element-name.js";
+import { resolveJsxElementName } from "../../utils/resolve-jsx-element-name.js";
 import { resolveImportedRecyclerName } from "./utils/resolve-imported-recycler-name.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-image-children.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-image-children.ts
@@ -1,7 +1,7 @@
 import { defineRule } from "../../utils/define-rule.js";
 import { getImportedNameFromModule } from "../../utils/find-import-source-for-name.js";
 import type { RuleContext } from "../../utils/rule-context.js";
-import { resolveJsxElementName } from "./utils/resolve-jsx-element-name.js";
+import { resolveJsxElementName } from "../../utils/resolve-jsx-element-name.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-inline-flatlist-renderitem.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-inline-flatlist-renderitem.ts
@@ -1,7 +1,7 @@
 import { REACT_NATIVE_LIST_COMPONENTS } from "../../constants/react-native.js";
 import { defineRule } from "../../utils/define-rule.js";
 import type { RuleContext } from "../../utils/rule-context.js";
-import { resolveJsxElementName } from "./utils/resolve-jsx-element-name.js";
+import { resolveJsxElementName } from "../../utils/resolve-jsx-element-name.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-raw-text.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-raw-text.ts
@@ -14,9 +14,9 @@ import { isInsidePlatformOsWebBranch } from "../../utils/is-inside-platform-os-w
 import { isReactComponentName } from "../../utils/is-react-component-name.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { RuleContext } from "../../utils/rule-context.js";
-import { resolveJsxElementName } from "./utils/resolve-jsx-element-name.js";
-import { collectTextWrapperComponents } from "./utils/collect-text-wrapper-components.js";
-import { resolveImportedComponentForwarding } from "./utils/resolve-imported-component-forwarding.js";
+import { resolveJsxElementName } from "../../utils/resolve-jsx-element-name.js";
+import { collectTextWrapperComponents } from "../../utils/collect-text-wrapper-components.js";
+import { resolveImportedComponentForwarding } from "../../utils/resolve-imported-component-forwarding.js";
 import { isExpoUiComponentElement } from "./utils/is-expo-ui-component-element.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
@@ -151,10 +151,7 @@ export const rnNoRawText = defineRule({
 
     // Resolve an imported component cross-file: "nonText" (renders children into
     // a host) → reported; "text" or unresolvable (`node_modules`, namespace
-    // imports, unanalyzable exports) → left alone. Cached per name and gated on
-    // `context.filename` (which drives path resolution), so `runRule` tests with
-    // no filename keep single-file behavior.
-    const importedNonTextWrapperCache = new Map<string, boolean>();
+    // imports, shadowed bindings, unanalyzable exports) → left alone.
     const isImportedNonTextWrapper = (
       elementName: string | null,
       contextNode: EsTreeNode,
@@ -162,18 +159,15 @@ export const rnNoRawText = defineRule({
       if (elementName === null || !isReactComponentName(elementName)) return false;
       const { filename } = context;
       if (filename === undefined) return false;
-      const cached = importedNonTextWrapperCache.get(elementName);
-      if (cached !== undefined) return cached;
       const forwardingKind = resolveImportedComponentForwarding(
         contextNode,
+        context.scopes,
         filename,
         elementName,
         isTextHandlingComponent,
         isNonTextHostName,
       );
-      const isNonTextWrapper = forwardingKind === "nonText";
-      importedNonTextWrapperCache.set(elementName, isNonTextWrapper);
-      return isNonTextWrapper;
+      return forwardingKind === "nonText";
     };
 
     return {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-renderitem-key.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-renderitem-key.ts
@@ -11,7 +11,7 @@ import { isAstNode } from "../../utils/is-ast-node.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
-import { resolveJsxElementName } from "./utils/resolve-jsx-element-name.js";
+import { resolveJsxElementName } from "../../utils/resolve-jsx-element-name.js";
 
 const collectTopLevelReturnExpressions = (
   functionNode:

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-scrollview-mapped-list.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-scrollview-mapped-list.ts
@@ -5,7 +5,7 @@ import { isFunctionLike } from "../../utils/is-function-like.js";
 import { walkAst } from "../../utils/walk-ast.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { RuleContext } from "../../utils/rule-context.js";
-import { resolveJsxElementName } from "./utils/resolve-jsx-element-name.js";
+import { resolveJsxElementName } from "../../utils/resolve-jsx-element-name.js";
 import { isExpoUiComponentElement } from "./utils/is-expo-ui-component-element.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-prefer-pressable-over-gesture-detector.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-prefer-pressable-over-gesture-detector.ts
@@ -2,7 +2,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import type { RuleContext } from "../../utils/rule-context.js";
-import { resolveJsxElementName } from "./utils/resolve-jsx-element-name.js";
+import { resolveJsxElementName } from "../../utils/resolve-jsx-element-name.js";
 import { isImportedFromModule } from "../../utils/find-import-source-for-name.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-pressable-shared-value-mutation.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-pressable-shared-value-mutation.ts
@@ -2,7 +2,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import { walkAst } from "../../utils/walk-ast.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { RuleContext } from "../../utils/rule-context.js";
-import { resolveJsxElementName } from "./utils/resolve-jsx-element-name.js";
+import { resolveJsxElementName } from "../../utils/resolve-jsx-element-name.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-scrollview-dynamic-padding.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-scrollview-dynamic-padding.ts
@@ -4,7 +4,7 @@ import { getStaticTemplateLiteralValue } from "../../utils/get-static-template-l
 import { isConstDeclaredBinding } from "../../utils/is-const-declared-binding.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { RuleContext } from "../../utils/rule-context.js";
-import { resolveJsxElementName } from "./utils/resolve-jsx-element-name.js";
+import { resolveJsxElementName } from "../../utils/resolve-jsx-element-name.js";
 import { SCROLLVIEW_NAMES } from "./utils/scrollview_names.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-scrollview-flex-in-content-container.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-scrollview-flex-in-content-container.ts
@@ -3,7 +3,7 @@ import { findVariableInitializer } from "../../utils/find-variable-initializer.j
 import { getRootIdentifierName } from "../../utils/get-root-identifier-name.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import type { RuleContext } from "../../utils/rule-context.js";
-import { resolveJsxElementName } from "./utils/resolve-jsx-element-name.js";
+import { resolveJsxElementName } from "../../utils/resolve-jsx-element-name.js";
 import { SCROLLVIEW_NAMES } from "./utils/scrollview_names.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/collect-imported-jsx-component-dependencies.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/collect-imported-jsx-component-dependencies.ts
@@ -1,0 +1,52 @@
+import type { StaticImport } from "oxc-parser";
+import { resolveCrossFileFunctionExport } from "./resolve-cross-file-function-export.js";
+import type { EsTreeNode } from "./es-tree-node.js";
+import { walkAst } from "./walk-ast.js";
+
+export interface CollectImportedJsxComponentDependenciesInput {
+  readonly absoluteFilePath: string;
+  readonly staticImports: ReadonlyArray<StaticImport>;
+  readonly program: EsTreeNode;
+}
+
+export const collectImportedJsxComponentDependencies = ({
+  absoluteFilePath,
+  staticImports,
+  program,
+}: CollectImportedJsxComponentDependenciesInput): void => {
+  const jsxNames = new Set<string>();
+  walkAst(program, (node) => {
+    if (node.type !== "JSXOpeningElement") return;
+    const nameNode = (node as { name?: EsTreeNode }).name;
+    if (!nameNode) return;
+    if (nameNode.type === "JSXIdentifier") {
+      const name = (nameNode as { name?: unknown }).name;
+      if (typeof name === "string") jsxNames.add(name);
+    } else if (nameNode.type === "JSXMemberExpression") {
+      const property = (nameNode as { property?: { type?: string; name?: unknown } }).property;
+      if (property?.type === "JSXIdentifier" && typeof property.name === "string") {
+        jsxNames.add(property.name);
+      }
+    } else if (nameNode.type === "JSXNamespacedName") {
+      const namespace = (nameNode as { namespace?: { name?: unknown } }).namespace;
+      if (typeof namespace?.name === "string") jsxNames.add(namespace.name);
+    }
+  });
+  if (jsxNames.size === 0) return;
+
+  for (const staticImport of staticImports) {
+    for (const entry of staticImport.entries) {
+      const { importName } = entry;
+      if (importName.kind === "NamespaceObject") continue;
+      if (!jsxNames.has(entry.localName.value)) continue;
+      const exportedName = importName.kind === "Default" ? "default" : importName.name;
+      if (exportedName) {
+        resolveCrossFileFunctionExport(
+          absoluteFilePath,
+          staticImport.moduleRequest.value,
+          exportedName,
+        );
+      }
+    }
+  }
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/collect-text-wrapper-components.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/collect-text-wrapper-components.ts
@@ -1,10 +1,10 @@
-import type { EsTreeNode } from "../../../utils/es-tree-node.js";
-import type { EsTreeNodeOfType } from "../../../utils/es-tree-node-of-type.js";
-import { isJsxFragmentElement } from "../../../utils/is-jsx-fragment-element.js";
-import { isNodeOfType } from "../../../utils/is-node-of-type.js";
-import { isReactComponentName } from "../../../utils/is-react-component-name.js";
-import { stripParenExpression } from "../../../utils/strip-paren-expression.js";
-import { walkAst } from "../../../utils/walk-ast.js";
+import type { EsTreeNode } from "./es-tree-node.js";
+import type { EsTreeNodeOfType } from "./es-tree-node-of-type.js";
+import { isJsxFragmentElement } from "./is-jsx-fragment-element.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+import { isReactComponentName } from "./is-react-component-name.js";
+import { stripParenExpression } from "./strip-paren-expression.js";
+import { walkAst } from "./walk-ast.js";
 import { resolveJsxElementName } from "./resolve-jsx-element-name.js";
 
 type FunctionNode =
@@ -258,14 +258,14 @@ const isChildrenForwardingAttribute = (
 const jsxRootForwardsChildrenIntoText = (
   jsxRoot: EsTreeNode,
   bindings: ChildrenBindings,
-  isTextHandlingElement: (elementName: string) => boolean,
+  isTextHandlingElement: (elementName: string, contextNode: EsTreeNode) => boolean,
 ): boolean => {
   let didForwardIntoText = false;
   walkAst(jsxRoot, (node) => {
     if (didForwardIntoText || isFunctionNode(node)) return false;
     if (!isNodeOfType(node, "JSXElement")) return undefined;
     const elementName = resolveJsxElementName(node.openingElement);
-    if (!elementName || !isTextHandlingElement(elementName)) return;
+    if (!elementName || !isTextHandlingElement(elementName, node)) return;
     didForwardIntoText =
       (node.children ?? []).some((child) =>
         isChildrenForwardingJsxChildThroughFragments(child, bindings),
@@ -292,7 +292,7 @@ const isNonWhitespaceJsxChild = (child: EsTreeNode): boolean =>
 const jsxRootForwardsChildren = (
   jsxRoot: EsTreeNode,
   bindings: ChildrenBindings,
-  isTextHandlingElement: (elementName: string) => boolean,
+  isTextHandlingElement: (elementName: string, contextNode: EsTreeNode) => boolean,
   countsAsForwardTarget: (node: EsTreeNode) => boolean,
 ): boolean => {
   let didForward = false;
@@ -303,7 +303,7 @@ const jsxRootForwardsChildren = (
     }
     if (isNodeOfType(node, "JSXElement")) {
       const elementName = resolveJsxElementName(node.openingElement);
-      if (elementName && isTextHandlingElement(elementName)) return false;
+      if (elementName && isTextHandlingElement(elementName, node)) return false;
       const hasJsxChildren = (node.children ?? []).some(isNonWhitespaceJsxChild);
       if (
         !hasJsxChildren &&
@@ -335,7 +335,7 @@ const jsxRootForwardsChildren = (
 const jsxRootRendersChildrenOutsideText = (
   jsxRoot: EsTreeNode,
   bindings: ChildrenBindings,
-  isTextHandlingElement: (elementName: string) => boolean,
+  isTextHandlingElement: (elementName: string, contextNode: EsTreeNode) => boolean,
 ): boolean => jsxRootForwardsChildren(jsxRoot, bindings, isTextHandlingElement, () => true);
 
 // True when a return path forwards the component's children into a *known*
@@ -347,13 +347,13 @@ const jsxRootRendersChildrenOutsideText = (
 const jsxRootRendersChildrenIntoNonTextHost = (
   jsxRoot: EsTreeNode,
   bindings: ChildrenBindings,
-  isTextHandlingElement: (elementName: string) => boolean,
-  isNonTextHostElement: (elementName: string) => boolean,
+  isTextHandlingElement: (elementName: string, contextNode: EsTreeNode) => boolean,
+  isNonTextHostElement: (elementName: string, contextNode: EsTreeNode) => boolean,
 ): boolean =>
   jsxRootForwardsChildren(jsxRoot, bindings, isTextHandlingElement, (node) => {
     if (!isNodeOfType(node, "JSXElement")) return false;
     const elementName = resolveJsxElementName(node.openingElement);
-    return elementName !== null && isNonTextHostElement(elementName);
+    return elementName !== null && isNonTextHostElement(elementName, node);
   });
 
 // Resolves a styled-component factory back to its base element name —
@@ -410,8 +410,7 @@ const resolveClassRenderFunction = (classNode: EsTreeNode): FunctionNode | null 
 export interface ChildrenForwardingComponents {
   // Forward their children into a `<Text>` — raw text inside them is safe.
   textWrappers: ReadonlySet<string>;
-  // Proven to render their children into a non-text host — raw text inside them
-  // is a certain crash, so `rn-no-raw-text` reports it.
+  // Proven to render their children into a non-text host.
   nonTextWrappers: ReadonlySet<string>;
 }
 
@@ -419,7 +418,7 @@ export type ChildrenForwardingKind = "text" | "nonText" | "unknown";
 
 // Classifies a component definition by where it forwards its `children`:
 // "text" — into a `<Text>` (raw text inside it is safe); "nonText" — into a
-// known non-text host (a certain crash); "unknown" — into an unanalyzed import
+// known non-text host; "unknown" — into an unanalyzed import
 // that may itself wrap them in `<Text>`, or not forwarded at all (so raw text
 // renders nothing). `isTextHandlingElement` / `isNonTextHostElement` decide
 // which receiving elements count as text vs. host — pass the in-file-aware
@@ -427,14 +426,14 @@ export type ChildrenForwardingKind = "text" | "nonText" | "unknown";
 // component resolved from another file.
 export const classifyChildrenForwarding = (
   definitionNode: EsTreeNode,
-  isTextHandlingElement: (elementName: string) => boolean,
-  isNonTextHostElement: (elementName: string) => boolean,
+  isTextHandlingElement: (elementName: string, contextNode: EsTreeNode) => boolean,
+  isNonTextHostElement: (elementName: string, contextNode: EsTreeNode) => boolean,
 ): ChildrenForwardingKind => {
   const unwrapped = unwrapComponentDefinition(definitionNode);
   const styledBaseName = resolveStyledFactoryBaseName(unwrapped);
   if (styledBaseName) {
-    if (isTextHandlingElement(styledBaseName)) return "text";
-    if (isNonTextHostElement(styledBaseName)) return "nonText";
+    if (isTextHandlingElement(styledBaseName, definitionNode)) return "text";
+    if (isNonTextHostElement(styledBaseName, definitionNode)) return "nonText";
     return "unknown";
   }
   const functionNode =
@@ -456,7 +455,7 @@ export const classifyChildrenForwarding = (
     return "nonText";
   }
   // Forwarded somewhere non-text but not into a known host — an unanalyzed
-  // import that may itself wrap them in `<Text>`. Not safe, not a proven crash.
+  // import that may itself wrap them in `<Text>`. Not safe, but not proven non-text.
   if (
     jsxRoots.some((jsxRoot) =>
       jsxRootRendersChildrenOutsideText(jsxRoot, bindings, isTextHandlingElement),
@@ -467,7 +466,7 @@ export const classifyChildrenForwarding = (
   for (const jsxRoot of jsxRoots) {
     if (isNodeOfType(jsxRoot, "JSXElement")) {
       const rootName = resolveJsxElementName(jsxRoot.openingElement);
-      if (rootName && isTextHandlingElement(rootName)) return "text";
+      if (rootName && isTextHandlingElement(rootName, jsxRoot)) return "text";
     }
     if (jsxRootForwardsChildrenIntoText(jsxRoot, bindings, isTextHandlingElement)) return "text";
   }
@@ -479,8 +478,8 @@ export const classifyChildrenForwarding = (
 const recordWrapperFromDeclaration = (
   componentName: string | null,
   definitionNode: EsTreeNode | null | undefined,
-  isTextHandlingElement: (elementName: string) => boolean,
-  isNonTextHostElement: (elementName: string) => boolean,
+  isTextHandlingElement: (elementName: string, contextNode: EsTreeNode) => boolean,
+  isNonTextHostElement: (elementName: string, contextNode: EsTreeNode) => boolean,
   wrappers: Set<string>,
   nonTextWrappers: Set<string>,
 ): void => {
@@ -498,7 +497,7 @@ const recordWrapperFromDeclaration = (
 
 // Walks a program and classifies its in-file PascalCase components into
 // `textWrappers` / `nonTextWrappers` (see `ChildrenForwardingComponents`).
-// `isNonTextHostRoot` seeds the built-in crash hosts; the walk extends it
+// `isNonTextHostRoot` seeds the built-in non-text hosts; the walk extends it
 // transitively (a component forwarding into a proven non-text wrapper is itself
 // non-text), repeating to a fixpoint so wrappers-of-wrappers
 // (`const Badge = ({ children }) => <Chip>{children}</Chip>`) resolve regardless
@@ -510,17 +509,39 @@ const recordWrapperFromDeclaration = (
 // forwards into is known.
 export const collectTextWrapperComponents = (
   programNode: EsTreeNode,
-  isTextHandlingRoot: (elementName: string) => boolean,
-  isNonTextHostRoot: (elementName: string) => boolean,
+  isTextHandlingRoot: (elementName: string, contextNode: EsTreeNode) => boolean,
+  isNonTextHostRoot: (elementName: string, contextNode: EsTreeNode) => boolean,
 ): ChildrenForwardingComponents => {
   const wrappers = new Set<string>();
   const nonTextWrappers = new Set<string>();
-  const isTextHandlingElement = (elementName: string): boolean =>
-    isTextHandlingRoot(elementName) || wrappers.has(elementName);
-  const isNonTextHostElement = (elementName: string): boolean =>
-    isNonTextHostRoot(elementName) || nonTextWrappers.has(elementName);
+  const componentBindingCounts = new Map<string, number>();
+  walkAst(programNode, (node) => {
+    let componentName: string | null = null;
+    if (
+      (isNodeOfType(node, "ImportSpecifier") ||
+        isNodeOfType(node, "ImportDefaultSpecifier") ||
+        isNodeOfType(node, "ImportNamespaceSpecifier")) &&
+      isNodeOfType(node.local, "Identifier")
+    ) {
+      componentName = node.local.name;
+    } else if (isNodeOfType(node, "VariableDeclarator") && isNodeOfType(node.id, "Identifier")) {
+      componentName = node.id.name;
+    } else if (
+      (isNodeOfType(node, "FunctionDeclaration") || isNodeOfType(node, "ClassDeclaration")) &&
+      isNodeOfType(node.id, "Identifier")
+    ) {
+      componentName = node.id.name;
+    }
+    if (!componentName || !isReactComponentName(componentName)) return;
+    componentBindingCounts.set(componentName, (componentBindingCounts.get(componentName) ?? 0) + 1);
+  });
+  const isTextHandlingElement = (elementName: string, contextNode: EsTreeNode): boolean =>
+    isTextHandlingRoot(elementName, contextNode) || wrappers.has(elementName);
+  const isNonTextHostElement = (elementName: string, contextNode: EsTreeNode): boolean =>
+    isNonTextHostRoot(elementName, contextNode) || nonTextWrappers.has(elementName);
 
-  const recordDeclaration = (componentName: string | null, definitionNode: EsTreeNode | null) =>
+  const recordDeclaration = (componentName: string | null, definitionNode: EsTreeNode | null) => {
+    if (componentName && componentBindingCounts.get(componentName) !== 1) return;
     recordWrapperFromDeclaration(
       componentName,
       definitionNode,
@@ -529,6 +550,7 @@ export const collectTextWrapperComponents = (
       wrappers,
       nonTextWrappers,
     );
+  };
 
   while (true) {
     const wrappersSizeBeforePass = wrappers.size;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/component-renders-ink.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/component-renders-ink.ts
@@ -1,0 +1,25 @@
+import type { ScopeAnalysis } from "../semantic/scope-analysis.js";
+import type { EsTreeNode } from "./es-tree-node.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+import { resolveInkJsxElementName } from "./resolve-ink-api-name.js";
+import { walkAst } from "./walk-ast.js";
+
+export const componentRendersInk = (componentNode: EsTreeNode, scopes: ScopeAnalysis): boolean => {
+  let doesRenderInk = false;
+  walkAst(componentNode, (descendantNode) => {
+    if (
+      descendantNode !== componentNode &&
+      (/Function/.test(descendantNode.type) || isNodeOfType(descendantNode, "JSXAttribute"))
+    ) {
+      return false;
+    }
+    if (
+      isNodeOfType(descendantNode, "JSXOpeningElement") &&
+      resolveInkJsxElementName(descendantNode, scopes)
+    ) {
+      doesRenderInk = true;
+      return false;
+    }
+  });
+  return doesRenderInk;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/contains-ink-jsx-element.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/contains-ink-jsx-element.ts
@@ -1,0 +1,19 @@
+import type { EsTreeNode } from "./es-tree-node.js";
+import type { ScopeAnalysis } from "../semantic/scope-analysis.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+import { resolveInkJsxElementName } from "./resolve-ink-api-name.js";
+import { walkAst } from "./walk-ast.js";
+
+export const containsInkJsxElement = (node: EsTreeNode, scopes: ScopeAnalysis): boolean => {
+  let didFindInkElement = false;
+  walkAst(node, (descendantNode) => {
+    if (
+      isNodeOfType(descendantNode, "JSXOpeningElement") &&
+      resolveInkJsxElementName(descendantNode, scopes)
+    ) {
+      didFindInkElement = true;
+      return false;
+    }
+  });
+  return didFindInkElement;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/find-nearest-ink-jsx-element.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/find-nearest-ink-jsx-element.ts
@@ -1,0 +1,20 @@
+import type { EsTreeNode } from "./es-tree-node.js";
+import type { ScopeAnalysis } from "../semantic/scope-analysis.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+import { resolveInkJsxElementName } from "./resolve-ink-api-name.js";
+
+export const findNearestInkJsxElement = (
+  node: EsTreeNode,
+  scopes: ScopeAnalysis,
+): string | null => {
+  let ancestorNode = node.parent;
+  while (ancestorNode) {
+    if (isNodeOfType(ancestorNode, "JSXElement")) {
+      const inkElementName = resolveInkJsxElementName(ancestorNode.openingElement, scopes);
+      if (inkElementName) return inkElementName;
+      return null;
+    }
+    ancestorNode = ancestorNode.parent;
+  }
+  return null;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/read-nearest-package-manifest.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/read-nearest-package-manifest.ts
@@ -28,6 +28,7 @@ export interface PackageManifest {
   optionalDependencies?: Record<string, unknown>;
   scripts?: Record<string, unknown>;
   source?: unknown;
+  version?: unknown;
   // Metro's resolution key — libraries that ship an RN-only entry
   // point declare this field at the manifest root (string path) so
   // Metro picks it over `main` / `module`. Treated as a strong

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-imported-component-forwarding.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-imported-component-forwarding.ts
@@ -1,7 +1,9 @@
-import { findProgramRoot } from "../../../utils/find-program-root.js";
-import { getImportBindingForName } from "../../../utils/find-import-source-for-name.js";
-import { resolveCrossFileFunctionExport } from "../../../utils/resolve-cross-file-function-export.js";
-import type { EsTreeNode } from "../../../utils/es-tree-node.js";
+import { findProgramRoot } from "./find-program-root.js";
+import { getImportBindingForName } from "./find-import-source-for-name.js";
+import { resolveCrossFileFunctionExport } from "./resolve-cross-file-function-export.js";
+import type { ScopeAnalysis } from "../semantic/scope-analysis.js";
+import type { EsTreeNode } from "./es-tree-node.js";
+import { isNodeOfType } from "./is-node-of-type.js";
 import {
   classifyChildrenForwarding,
   collectTextWrapperComponents,
@@ -16,11 +18,23 @@ import {
 // that doesn't bind to an analyzable function — so the caller stays conservative.
 export const resolveImportedComponentForwarding = (
   contextNode: EsTreeNode,
+  scopes: ScopeAnalysis,
   fromFilename: string,
   localName: string,
-  isTextHandlingRoot: (elementName: string) => boolean,
-  isNonTextHostRoot: (elementName: string) => boolean,
+  isTextHandlingRoot: (elementName: string, contextNode: EsTreeNode) => boolean,
+  isNonTextHostRoot: (elementName: string, contextNode: EsTreeNode) => boolean,
 ): ChildrenForwardingKind | null => {
+  if (!isNodeOfType(contextNode, "JSXElement")) return null;
+  const jsxName = contextNode.openingElement.name;
+  if (!isNodeOfType(jsxName, "JSXIdentifier") || jsxName.name !== localName) return null;
+  const symbol = scopes.symbolFor(jsxName);
+  if (
+    !symbol ||
+    (!isNodeOfType(symbol.declarationNode, "ImportSpecifier") &&
+      !isNodeOfType(symbol.declarationNode, "ImportDefaultSpecifier"))
+  ) {
+    return null;
+  }
   const binding = getImportBindingForName(contextNode, localName);
   if (!binding || binding.isNamespace || binding.exportedName === null) return null;
   const resolvedNode = resolveCrossFileFunctionExport(
@@ -32,7 +46,7 @@ export const resolveImportedComponentForwarding = (
 
   // Classify against the resolved component's OWN module so a wrapper that
   // forwards its children through another component declared there (`Card` →
-  // `Inner` → `<View>`) resolves instead of bailing to "unknown".
+  // `Inner` → a host element) resolves instead of bailing to "unknown".
   // `collectTextWrapperComponents` does no further file I/O, so this stays
   // bounded to that module (a chain hopping into yet another file is left
   // unresolved). `parseSourceFile` attaches parents, so there's always a root.
@@ -47,7 +61,7 @@ export const resolveImportedComponentForwarding = (
   );
   return classifyChildrenForwarding(
     resolvedNode,
-    (elementName) => isTextHandlingRoot(elementName) || textWrappers.has(elementName),
-    (elementName) => isNonTextHostRoot(elementName) || nonTextWrappers.has(elementName),
+    (elementName, node) => isTextHandlingRoot(elementName, node) || textWrappers.has(elementName),
+    (elementName, node) => isNonTextHostRoot(elementName, node) || nonTextWrappers.has(elementName),
   );
 };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-ink-api-name.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-ink-api-name.ts
@@ -1,0 +1,46 @@
+import { INK_MODULE } from "../constants/ink.js";
+import type { ScopeAnalysis } from "../semantic/scope-analysis.js";
+import type { EsTreeNode } from "./es-tree-node.js";
+import type { EsTreeNodeOfType } from "./es-tree-node-of-type.js";
+import {
+  getImportedNameFromModule,
+  isNamespaceImportFromModule,
+} from "./find-import-source-for-name.js";
+import { getStaticPropertyName } from "./get-static-property-name.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+
+export const resolveInkApiName = (node: EsTreeNode, scopes: ScopeAnalysis): string | null => {
+  if (isNodeOfType(node, "Identifier")) {
+    if (scopes.symbolFor(node)?.kind !== "import") return null;
+    return getImportedNameFromModule(node, node.name, INK_MODULE);
+  }
+  if (
+    isNodeOfType(node, "MemberExpression") &&
+    isNodeOfType(node.object, "Identifier") &&
+    scopes.symbolFor(node.object)?.kind === "import" &&
+    isNamespaceImportFromModule(node, node.object.name, INK_MODULE)
+  ) {
+    return getStaticPropertyName(node);
+  }
+  return null;
+};
+
+export const resolveInkJsxElementName = (
+  openingElement: EsTreeNodeOfType<"JSXOpeningElement">,
+  scopes: ScopeAnalysis,
+): string | null => {
+  const elementName = openingElement.name;
+  if (isNodeOfType(elementName, "JSXIdentifier")) {
+    if (scopes.symbolFor(elementName)?.kind !== "import") return null;
+    return getImportedNameFromModule(openingElement, elementName.name, INK_MODULE);
+  }
+  if (
+    isNodeOfType(elementName, "JSXMemberExpression") &&
+    isNodeOfType(elementName.object, "JSXIdentifier") &&
+    scopes.symbolFor(elementName.object)?.kind === "import" &&
+    isNamespaceImportFromModule(openingElement, elementName.object.name, INK_MODULE)
+  ) {
+    return elementName.property.name;
+  }
+  return null;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-ink-render-calls.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-ink-render-calls.ts
@@ -39,6 +39,12 @@ const canRenderComponent = (
   let canReachTarget = false;
   walkAst(componentDefinition, (descendantNode) => {
     if (
+      descendantNode !== componentDefinition &&
+      (/Function/.test(descendantNode.type) || isNodeOfType(descendantNode, "JSXAttribute"))
+    ) {
+      return false;
+    }
+    if (
       !isNodeOfType(descendantNode, "JSXOpeningElement") ||
       !isNodeOfType(descendantNode.name, "JSXIdentifier")
     ) {
@@ -61,6 +67,12 @@ const renderCallCanMountComponent = (
   if (!renderedNode) return false;
   let canMountTarget = false;
   walkAst(renderedNode, (descendantNode) => {
+    if (
+      descendantNode !== renderedNode &&
+      (/Function/.test(descendantNode.type) || isNodeOfType(descendantNode, "JSXAttribute"))
+    ) {
+      return false;
+    }
     if (
       !isNodeOfType(descendantNode, "JSXOpeningElement") ||
       !isNodeOfType(descendantNode.name, "JSXIdentifier")
@@ -96,22 +108,36 @@ export const collectInkRenderCalls = (
   return renderCalls;
 };
 
-export const hasInkRenderBooleanOption = (
+export const getInkRenderBooleanOption = (
   renderCall: EsTreeNodeOfType<"CallExpression">,
   optionName: string,
-  expectedValue: boolean,
-): boolean => {
+  defaultValue: boolean,
+): boolean | null => {
   const optionsNode = renderCall.arguments[1];
-  return Boolean(
-    isNodeOfType(optionsNode, "ObjectExpression") &&
-    optionsNode.properties.some(
-      (propertyNode) =>
-        isNodeOfType(propertyNode, "Property") &&
-        getStaticPropertyKeyName(propertyNode, { allowComputedString: true }) === optionName &&
-        isNodeOfType(propertyNode.value, "Literal") &&
-        propertyNode.value.value === expectedValue,
-    ),
-  );
+  if (!optionsNode) return defaultValue;
+  if (!isNodeOfType(optionsNode, "ObjectExpression")) return null;
+
+  let resolvedValue: boolean | null = defaultValue;
+  for (const propertyNode of optionsNode.properties) {
+    if (isNodeOfType(propertyNode, "SpreadElement")) {
+      resolvedValue = null;
+      continue;
+    }
+    if (!isNodeOfType(propertyNode, "Property")) continue;
+    const propertyName = getStaticPropertyKeyName(propertyNode, {
+      allowComputedString: true,
+    });
+    if (propertyName === null) {
+      if (propertyNode.computed) resolvedValue = null;
+      continue;
+    }
+    if (propertyName !== optionName) continue;
+    resolvedValue =
+      isNodeOfType(propertyNode.value, "Literal") && typeof propertyNode.value.value === "boolean"
+        ? propertyNode.value.value
+        : null;
+  }
+  return resolvedValue;
 };
 
 export const resolveInkRenderCallsForNode = (

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-ink-render-calls.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-ink-render-calls.ts
@@ -3,6 +3,7 @@ import type { EsTreeNode } from "./es-tree-node.js";
 import type { EsTreeNodeOfType } from "./es-tree-node-of-type.js";
 import { findEnclosingFunction } from "./find-enclosing-function.js";
 import { getStaticPropertyKeyName } from "./get-static-property-key-name.js";
+import { isNodeReachableWithinFunction } from "./is-node-reachable-within-function.js";
 import { isNodeOfType } from "./is-node-of-type.js";
 import { resolveInkApiName } from "./resolve-ink-api-name.js";
 import type { RuleContext } from "./rule-context.js";
@@ -46,7 +47,8 @@ const canRenderComponent = (
     }
     if (
       !isNodeOfType(descendantNode, "JSXOpeningElement") ||
-      !isNodeOfType(descendantNode.name, "JSXIdentifier")
+      !isNodeOfType(descendantNode.name, "JSXIdentifier") ||
+      !isNodeReachableWithinFunction(descendantNode, context)
     ) {
       return;
     }
@@ -75,7 +77,8 @@ const renderCallCanMountComponent = (
     }
     if (
       !isNodeOfType(descendantNode, "JSXOpeningElement") ||
-      !isNodeOfType(descendantNode.name, "JSXIdentifier")
+      !isNodeOfType(descendantNode.name, "JSXIdentifier") ||
+      !isNodeReachableWithinFunction(descendantNode, context)
     ) {
       return;
     }
@@ -96,7 +99,8 @@ export const collectInkRenderCalls = (
   walkAst(program, (descendantNode) => {
     if (
       !isNodeOfType(descendantNode, "CallExpression") ||
-      resolveInkApiName(descendantNode.callee, context.scopes) !== apiName
+      resolveInkApiName(descendantNode.callee, context.scopes) !== apiName ||
+      !isNodeReachableWithinFunction(descendantNode, context)
     ) {
       return;
     }
@@ -145,6 +149,7 @@ export const resolveInkRenderCallsForNode = (
   renderCalls: ReadonlyArray<InkRenderCall>,
   context: RuleContext,
 ): ReadonlyArray<InkRenderCall> => {
+  if (!isNodeReachableWithinFunction(node, context)) return [];
   const directRenderCalls = renderCalls.filter((renderCall) => {
     const renderedNode = renderCall.node.arguments[0];
     return (

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-ink-render-calls.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-ink-render-calls.ts
@@ -13,6 +13,10 @@ interface InkRenderCall {
   renderedComponentName: string | null;
 }
 
+interface ResolveInkRenderCallsOptions {
+  allowSingleRenderFallback?: boolean;
+}
+
 const getRenderedComponentName = (
   renderCall: EsTreeNodeOfType<"CallExpression">,
 ): string | null => {
@@ -58,22 +62,33 @@ const renderCallCanMountComponent = (
   context: RuleContext,
 ): boolean => {
   const renderedNode = renderCall.node.arguments[0];
-  return Boolean(
-    isNodeOfType(renderedNode, "JSXElement") &&
-    isNodeOfType(renderedNode.openingElement.name, "JSXIdentifier") &&
-    canRenderComponent(renderedNode.openingElement.name, targetComponentName, context, new Set()),
-  );
+  if (!renderedNode) return false;
+  let canMountTarget = false;
+  walkAst(renderedNode, (descendantNode) => {
+    if (
+      !isNodeOfType(descendantNode, "JSXOpeningElement") ||
+      !isNodeOfType(descendantNode.name, "JSXIdentifier")
+    ) {
+      return;
+    }
+    if (canRenderComponent(descendantNode.name, targetComponentName, context, new Set())) {
+      canMountTarget = true;
+      return false;
+    }
+  });
+  return canMountTarget;
 };
 
 export const collectInkRenderCalls = (
   program: EsTreeNode,
   context: RuleContext,
+  apiName: "render" | "renderToString" = "render",
 ): ReadonlyArray<InkRenderCall> => {
   const renderCalls: InkRenderCall[] = [];
   walkAst(program, (descendantNode) => {
     if (
       !isNodeOfType(descendantNode, "CallExpression") ||
-      resolveInkApiName(descendantNode.callee, context.scopes) !== "render"
+      resolveInkApiName(descendantNode.callee, context.scopes) !== apiName
     ) {
       return;
     }
@@ -107,6 +122,7 @@ export const resolveInkRenderCallsForNode = (
   node: EsTreeNode,
   renderCalls: ReadonlyArray<InkRenderCall>,
   context: RuleContext,
+  options: ResolveInkRenderCallsOptions = {},
 ): ReadonlyArray<InkRenderCall> => {
   const directRenderCalls = renderCalls.filter((renderCall) => {
     const renderedNode = renderCall.node.arguments[0];
@@ -131,5 +147,5 @@ export const resolveInkRenderCallsForNode = (
     if (componentRenderCalls.length > 0) return componentRenderCalls;
   }
 
-  return renderCalls.length === 1 ? renderCalls : [];
+  return options.allowSingleRenderFallback !== false && renderCalls.length === 1 ? renderCalls : [];
 };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-ink-render-calls.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-ink-render-calls.ts
@@ -1,0 +1,90 @@
+import { componentOrHookDisplayNameForFunction } from "./component-or-hook-display-name.js";
+import type { EsTreeNode } from "./es-tree-node.js";
+import type { EsTreeNodeOfType } from "./es-tree-node-of-type.js";
+import { findEnclosingFunction } from "./find-enclosing-function.js";
+import { getStaticPropertyKeyName } from "./get-static-property-key-name.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+import { resolveInkApiName } from "./resolve-ink-api-name.js";
+import type { RuleContext } from "./rule-context.js";
+import { walkAst } from "./walk-ast.js";
+
+interface InkRenderCall {
+  node: EsTreeNodeOfType<"CallExpression">;
+  renderedComponentName: string | null;
+}
+
+const getRenderedComponentName = (
+  renderCall: EsTreeNodeOfType<"CallExpression">,
+): string | null => {
+  const renderedNode = renderCall.arguments[0];
+  return isNodeOfType(renderedNode, "JSXElement") &&
+    isNodeOfType(renderedNode.openingElement.name, "JSXIdentifier")
+    ? renderedNode.openingElement.name.name
+    : null;
+};
+
+export const collectInkRenderCalls = (
+  program: EsTreeNode,
+  context: RuleContext,
+): ReadonlyArray<InkRenderCall> => {
+  const renderCalls: InkRenderCall[] = [];
+  walkAst(program, (descendantNode) => {
+    if (
+      !isNodeOfType(descendantNode, "CallExpression") ||
+      resolveInkApiName(descendantNode.callee, context.scopes) !== "render"
+    ) {
+      return;
+    }
+    renderCalls.push({
+      node: descendantNode,
+      renderedComponentName: getRenderedComponentName(descendantNode),
+    });
+  });
+  return renderCalls;
+};
+
+export const hasInkRenderBooleanOption = (
+  renderCall: EsTreeNodeOfType<"CallExpression">,
+  optionName: string,
+  expectedValue: boolean,
+): boolean => {
+  const optionsNode = renderCall.arguments[1];
+  return Boolean(
+    isNodeOfType(optionsNode, "ObjectExpression") &&
+    optionsNode.properties.some(
+      (propertyNode) =>
+        isNodeOfType(propertyNode, "Property") &&
+        getStaticPropertyKeyName(propertyNode, { allowComputedString: true }) === optionName &&
+        isNodeOfType(propertyNode.value, "Literal") &&
+        propertyNode.value.value === expectedValue,
+    ),
+  );
+};
+
+export const resolveInkRenderCallsForNode = (
+  node: EsTreeNode,
+  renderCalls: ReadonlyArray<InkRenderCall>,
+): ReadonlyArray<InkRenderCall> => {
+  const directRenderCalls = renderCalls.filter((renderCall) => {
+    const renderedNode = renderCall.node.arguments[0];
+    return (
+      renderedNode !== undefined &&
+      renderedNode.range[0] <= node.range[0] &&
+      renderedNode.range[1] >= node.range[1]
+    );
+  });
+  if (directRenderCalls.length > 0) return directRenderCalls;
+
+  const enclosingFunction = findEnclosingFunction(node);
+  const componentName = enclosingFunction
+    ? componentOrHookDisplayNameForFunction(enclosingFunction)
+    : null;
+  if (componentName) {
+    const componentRenderCalls = renderCalls.filter(
+      (renderCall) => renderCall.renderedComponentName === componentName,
+    );
+    if (componentRenderCalls.length > 0) return componentRenderCalls;
+  }
+
+  return renderCalls.length === 1 ? renderCalls : [];
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-ink-render-calls.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-ink-render-calls.ts
@@ -23,6 +23,48 @@ const getRenderedComponentName = (
     : null;
 };
 
+const canRenderComponent = (
+  componentNameNode: EsTreeNodeOfType<"JSXIdentifier">,
+  targetComponentName: string,
+  context: RuleContext,
+  visitedSymbolIds: Set<number>,
+): boolean => {
+  if (componentNameNode.name === targetComponentName) return true;
+  const symbol = context.scopes.symbolFor(componentNameNode);
+  if (!symbol || symbol.kind === "import" || visitedSymbolIds.has(symbol.id)) return false;
+  visitedSymbolIds.add(symbol.id);
+  const componentDefinition = symbol.initializer;
+  if (!componentDefinition) return false;
+
+  let canReachTarget = false;
+  walkAst(componentDefinition, (descendantNode) => {
+    if (
+      !isNodeOfType(descendantNode, "JSXOpeningElement") ||
+      !isNodeOfType(descendantNode.name, "JSXIdentifier")
+    ) {
+      return;
+    }
+    if (canRenderComponent(descendantNode.name, targetComponentName, context, visitedSymbolIds)) {
+      canReachTarget = true;
+      return false;
+    }
+  });
+  return canReachTarget;
+};
+
+const renderCallCanMountComponent = (
+  renderCall: InkRenderCall,
+  targetComponentName: string,
+  context: RuleContext,
+): boolean => {
+  const renderedNode = renderCall.node.arguments[0];
+  return Boolean(
+    isNodeOfType(renderedNode, "JSXElement") &&
+    isNodeOfType(renderedNode.openingElement.name, "JSXIdentifier") &&
+    canRenderComponent(renderedNode.openingElement.name, targetComponentName, context, new Set()),
+  );
+};
+
 export const collectInkRenderCalls = (
   program: EsTreeNode,
   context: RuleContext,
@@ -64,6 +106,7 @@ export const hasInkRenderBooleanOption = (
 export const resolveInkRenderCallsForNode = (
   node: EsTreeNode,
   renderCalls: ReadonlyArray<InkRenderCall>,
+  context: RuleContext,
 ): ReadonlyArray<InkRenderCall> => {
   const directRenderCalls = renderCalls.filter((renderCall) => {
     const renderedNode = renderCall.node.arguments[0];
@@ -81,7 +124,9 @@ export const resolveInkRenderCallsForNode = (
     : null;
   if (componentName) {
     const componentRenderCalls = renderCalls.filter(
-      (renderCall) => renderCall.renderedComponentName === componentName,
+      (renderCall) =>
+        renderCall.renderedComponentName === componentName ||
+        renderCallCanMountComponent(renderCall, componentName, context),
     );
     if (componentRenderCalls.length > 0) return componentRenderCalls;
   }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-ink-render-calls.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-ink-render-calls.ts
@@ -13,10 +13,6 @@ interface InkRenderCall {
   renderedComponentName: string | null;
 }
 
-interface ResolveInkRenderCallsOptions {
-  allowSingleRenderFallback?: boolean;
-}
-
 const getRenderedComponentName = (
   renderCall: EsTreeNodeOfType<"CallExpression">,
 ): string | null => {
@@ -122,7 +118,6 @@ export const resolveInkRenderCallsForNode = (
   node: EsTreeNode,
   renderCalls: ReadonlyArray<InkRenderCall>,
   context: RuleContext,
-  options: ResolveInkRenderCallsOptions = {},
 ): ReadonlyArray<InkRenderCall> => {
   const directRenderCalls = renderCalls.filter((renderCall) => {
     const renderedNode = renderCall.node.arguments[0];
@@ -147,5 +142,5 @@ export const resolveInkRenderCallsForNode = (
     if (componentRenderCalls.length > 0) return componentRenderCalls;
   }
 
-  return options.allowSingleRenderFallback !== false && renderCalls.length === 1 ? renderCalls : [];
+  return [];
 };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-ink-version.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-ink-version.test.ts
@@ -3,6 +3,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { afterAll, beforeEach, describe, expect, it } from "vite-plus/test";
 import { inkNoRawText } from "../rules/ink/ink-no-raw-text.js";
+import { inkCtrlCHandlerRequiresExitOption } from "../rules/ink/ink-ctrl-c-handler-requires-exit-option.js";
 import { runRule } from "../../test-utils/run-rule.js";
 import { resetManifestCaches } from "./read-nearest-package-manifest.js";
 import { isInkVersionAtLeast } from "./resolve-ink-version.js";
@@ -87,5 +88,12 @@ describe("Ink version resolution", () => {
     const code = `import {Box} from "ink"; const App=()=> <Box>hello</Box>;`;
     expect(runRule(wrappedRule, code, { filename: modernFile }).diagnostics).toHaveLength(1);
     expect(runRule(wrappedRule, code, { filename: legacyFile }).diagnostics).toHaveLength(0);
+  });
+
+  it("enables the Ctrl-C rule for Ink 3", () => {
+    const sourceFile = createPackageFile("ctrl-c-ink-3", "3.0.0");
+    const wrappedRule = wrapInkRule(inkCtrlCHandlerRequiresExitOption);
+    const code = `import {render,useInput} from "ink"; const App=()=>{useInput((input,key)=>{if(key.ctrl&&input==="c") work()});return null};render(<App/>);`;
+    expect(runRule(wrappedRule, code, { filename: sourceFile }).diagnostics).toHaveLength(1);
   });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-ink-version.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-ink-version.test.ts
@@ -68,6 +68,20 @@ describe("Ink version resolution", () => {
       JSON.stringify({ name: "ink", version: "unknown" }),
     );
     expect(isInkVersionAtLeast(sourceFile, "3.0.0")).toBe(false);
+
+    const trailingGarbageFile = createPackageFile("invalid-installed-suffix", "^7.1.0");
+    const trailingGarbagePackageDirectory = path.join(
+      temporaryDirectory,
+      "invalid-installed-suffix",
+      "node_modules",
+      "ink",
+    );
+    fs.mkdirSync(trailingGarbagePackageDirectory, { recursive: true });
+    fs.writeFileSync(
+      path.join(trailingGarbagePackageDirectory, "package.json"),
+      JSON.stringify({ name: "ink", version: "7.1.0garbage" }),
+    );
+    expect(isInkVersionAtLeast(trailingGarbageFile, "3.0.0")).toBe(false);
   });
 
   it("uses the lowest supported branch of a declared range", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-ink-version.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-ink-version.test.ts
@@ -1,0 +1,91 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterAll, beforeEach, describe, expect, it } from "vite-plus/test";
+import { inkNoRawText } from "../rules/ink/ink-no-raw-text.js";
+import { runRule } from "../../test-utils/run-rule.js";
+import { resetManifestCaches } from "./read-nearest-package-manifest.js";
+import { isInkVersionAtLeast } from "./resolve-ink-version.js";
+import { wrapInkRule } from "./wrap-ink-rule.js";
+
+const temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-ink-version-"));
+
+const createPackageFile = (packageName: string, inkVersion: string): string => {
+  const packageDirectory = path.join(temporaryDirectory, packageName);
+  const sourceDirectory = path.join(packageDirectory, "src");
+  fs.mkdirSync(sourceDirectory, { recursive: true });
+  fs.writeFileSync(
+    path.join(packageDirectory, "package.json"),
+    JSON.stringify({ dependencies: { ink: inkVersion } }),
+  );
+  return path.join(sourceDirectory, "app.tsx");
+};
+
+describe("Ink version resolution", () => {
+  beforeEach(() => resetManifestCaches());
+  afterAll(() => fs.rmSync(temporaryDirectory, { force: true, recursive: true }));
+
+  it("uses the nearest owning package in mixed monorepos", () => {
+    const modernFile = createPackageFile("modern", "^7.1.0");
+    const legacyFile = createPackageFile("legacy", "^2.0.0");
+    expect(isInkVersionAtLeast(modernFile, "7.1.0")).toBe(true);
+    expect(isInkVersionAtLeast(legacyFile, "3.0.0")).toBe(false);
+  });
+
+  it("fails closed for unresolved workspace and dist-tag specs", () => {
+    expect(isInkVersionAtLeast(createPackageFile("workspace", "workspace:*"), "3.0.0")).toBe(false);
+    expect(isInkVersionAtLeast(createPackageFile("tag", "latest"), "3.0.0")).toBe(false);
+  });
+
+  it("prefers an installed package version over the declared range", () => {
+    const sourceFile = createPackageFile("installed", "^3.0.0");
+    const installedPackageDirectory = path.join(
+      temporaryDirectory,
+      "installed",
+      "node_modules",
+      "ink",
+    );
+    fs.mkdirSync(installedPackageDirectory, { recursive: true });
+    fs.writeFileSync(
+      path.join(installedPackageDirectory, "package.json"),
+      JSON.stringify({ name: "ink", version: "7.1.1" }),
+    );
+    expect(isInkVersionAtLeast(sourceFile, "7.1.0")).toBe(true);
+  });
+
+  it("fails closed when the installed package version is invalid", () => {
+    const sourceFile = createPackageFile("invalid-installed", "^7.1.0");
+    const installedPackageDirectory = path.join(
+      temporaryDirectory,
+      "invalid-installed",
+      "node_modules",
+      "ink",
+    );
+    fs.mkdirSync(installedPackageDirectory, { recursive: true });
+    fs.writeFileSync(
+      path.join(installedPackageDirectory, "package.json"),
+      JSON.stringify({ name: "ink", version: "unknown" }),
+    );
+    expect(isInkVersionAtLeast(sourceFile, "3.0.0")).toBe(false);
+  });
+
+  it("uses the lowest supported branch of a declared range", () => {
+    const sourceFile = createPackageFile("range", "^6.8.0 || ^7.1.0");
+    expect(isInkVersionAtLeast(sourceFile, "6.8.0")).toBe(true);
+    expect(isInkVersionAtLeast(sourceFile, "7.0.0")).toBe(false);
+  });
+
+  it("orders prereleases below their matching stable version", () => {
+    const sourceFile = createPackageFile("prerelease", "7.1.0-beta.1");
+    expect(isInkVersionAtLeast(sourceFile, "7.1.0")).toBe(false);
+  });
+
+  it("suppresses a wrapped rule below its Ink introduction version", () => {
+    const modernFile = createPackageFile("rule-modern", "7.1.1");
+    const legacyFile = createPackageFile("rule-legacy", "2.9.0");
+    const wrappedRule = wrapInkRule(inkNoRawText);
+    const code = `import {Box} from "ink"; const App=()=> <Box>hello</Box>;`;
+    expect(runRule(wrappedRule, code, { filename: modernFile }).diagnostics).toHaveLength(1);
+    expect(runRule(wrappedRule, code, { filename: legacyFile }).diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-ink-version.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-ink-version.ts
@@ -1,0 +1,119 @@
+import * as path from "node:path";
+import { INK_MODULE } from "../constants/ink.js";
+import {
+  findNearestPackageDirectory,
+  readPackageManifest,
+} from "./read-nearest-package-manifest.js";
+import type { PackageManifest } from "./read-nearest-package-manifest.js";
+
+interface ParsedPackageVersion {
+  major: number;
+  minor: number;
+  patch: number;
+  isPrerelease: boolean;
+}
+
+interface InstalledInkVersionResolution {
+  didFindPackage: boolean;
+  version: ParsedPackageVersion | null;
+}
+
+const parseVersionToken = (version: string): ParsedPackageVersion | null => {
+  const match = version.match(/^(\d+)(?:\.(\d+))?(?:\.(\d+))?(-[0-9A-Za-z.-]+)?/);
+  if (!match) return null;
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2] ?? 0),
+    patch: Number(match[3] ?? 0),
+    isPrerelease: Boolean(match[4]),
+  };
+};
+
+const compareVersions = (
+  leftVersion: ParsedPackageVersion,
+  rightVersion: ParsedPackageVersion,
+): number =>
+  leftVersion.major - rightVersion.major ||
+  leftVersion.minor - rightVersion.minor ||
+  leftVersion.patch - rightVersion.patch ||
+  Number(rightVersion.isPrerelease) - Number(leftVersion.isPrerelease);
+
+const parseDeclaredLowerBound = (versionRange: unknown): ParsedPackageVersion | null => {
+  if (typeof versionRange !== "string") return null;
+  const trimmedRange = versionRange.trim();
+  if (
+    !trimmedRange ||
+    /^(?:catalog|file|git|https?|link|npm|workspace):/.test(trimmedRange) ||
+    /^(?:latest|next|\*)$/.test(trimmedRange)
+  ) {
+    return null;
+  }
+
+  const branchLowerBounds: ParsedPackageVersion[] = [];
+  for (const rangeBranch of trimmedRange.split("||")) {
+    const trimmedBranch = rangeBranch.trim();
+    if (/^<(?!=)/.test(trimmedBranch) || /^<=/.test(trimmedBranch)) return null;
+    const versionToken = trimmedBranch.match(/\d+(?:\.\d+)?(?:\.\d+)?(?:-[0-9A-Za-z.-]+)?/)?.[0];
+    if (!versionToken) return null;
+    const parsedVersion = parseVersionToken(versionToken);
+    if (!parsedVersion) return null;
+    branchLowerBounds.push(parsedVersion);
+  }
+  return branchLowerBounds.reduce((lowestVersion, candidateVersion) =>
+    compareVersions(candidateVersion, lowestVersion) < 0 ? candidateVersion : lowestVersion,
+  );
+};
+
+const getDeclaredInkVersion = (manifest: PackageManifest): ParsedPackageVersion | null =>
+  parseDeclaredLowerBound(
+    manifest.dependencies?.[INK_MODULE] ??
+      manifest.devDependencies?.[INK_MODULE] ??
+      manifest.peerDependencies?.[INK_MODULE] ??
+      manifest.optionalDependencies?.[INK_MODULE],
+  );
+
+const findInstalledInkVersion = (packageDirectory: string): InstalledInkVersionResolution => {
+  let currentDirectory = packageDirectory;
+  while (true) {
+    const installedManifest = readPackageManifest(
+      path.join(currentDirectory, "node_modules", INK_MODULE),
+    );
+    if (installedManifest) {
+      return {
+        didFindPackage: true,
+        version:
+          typeof installedManifest.version === "string"
+            ? parseVersionToken(installedManifest.version)
+            : null,
+      };
+    }
+    const parentDirectory = path.dirname(currentDirectory);
+    if (parentDirectory === currentDirectory) {
+      return { didFindPackage: false, version: null };
+    }
+    currentDirectory = parentDirectory;
+  }
+};
+
+export const resolveInkVersion = (filename: string | undefined): ParsedPackageVersion | null => {
+  if (!filename) return null;
+  const packageDirectory = findNearestPackageDirectory(path.resolve(filename));
+  if (!packageDirectory) return null;
+  const installedVersionResolution = findInstalledInkVersion(packageDirectory);
+  if (installedVersionResolution.didFindPackage) return installedVersionResolution.version;
+  const owningManifest = readPackageManifest(packageDirectory);
+  return owningManifest ? getDeclaredInkVersion(owningManifest) : null;
+};
+
+export const isInkVersionAtLeast = (
+  filename: string | undefined,
+  minimumVersion: string,
+): boolean => {
+  const resolvedVersion = resolveInkVersion(filename);
+  const parsedMinimumVersion = parseVersionToken(minimumVersion);
+  return Boolean(
+    resolvedVersion &&
+    parsedMinimumVersion &&
+    compareVersions(resolvedVersion, parsedMinimumVersion) >= 0,
+  );
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-ink-version.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-ink-version.ts
@@ -19,7 +19,9 @@ interface InstalledInkVersionResolution {
 }
 
 const parseVersionToken = (version: string): ParsedPackageVersion | null => {
-  const match = version.match(/^(\d+)(?:\.(\d+))?(?:\.(\d+))?(-[0-9A-Za-z.-]+)?/);
+  const match = version.match(
+    /^(\d+)(?:\.(\d+))?(?:\.(\d+))?(-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/,
+  );
   if (!match) return null;
   return {
     major: Number(match[1]),

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-jsx-element-name.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-jsx-element-name.ts
@@ -1,5 +1,5 @@
-import type { EsTreeNode } from "../../../utils/es-tree-node.js";
-import { isNodeOfType } from "../../../utils/is-node-of-type.js";
+import type { EsTreeNode } from "./es-tree-node.js";
+import { isNodeOfType } from "./is-node-of-type.js";
 
 export const resolveJsxElementName = (openingElement: EsTreeNode): string | null => {
   if (!isNodeOfType(openingElement, "JSXOpeningElement")) return null;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/rule.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/rule.ts
@@ -50,6 +50,7 @@ export interface Rule {
   // for the rule to be enabled. Omit for rules that always apply once
   // their framework gate is met.
   requires?: ReadonlyArray<Capability>;
+  minimumInkVersion?: string;
   // Inverse of `requires`: list of capability tokens whose presence
   // DISABLES the rule. Used for rules that become irrelevant when a
   // project ships with React Compiler (auto-memoization makes the four

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/wrap-ink-rule.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/wrap-ink-rule.ts
@@ -1,0 +1,21 @@
+import { isInkVersionAtLeast } from "./resolve-ink-version.js";
+import type { Rule } from "./rule.js";
+import type { RuleVisitors } from "./rule-visitors.js";
+
+const EMPTY_VISITORS: RuleVisitors = {};
+
+export const wrapInkRule = (rule: Rule): Rule => {
+  const innerCreate = rule.create.bind(rule);
+  return {
+    ...rule,
+    create: (context) => {
+      if (
+        !rule.minimumInkVersion ||
+        !isInkVersionAtLeast(context.filename, rule.minimumInkVersion)
+      ) {
+        return EMPTY_VISITORS;
+      }
+      return innerCreate(context);
+    },
+  };
+};

--- a/packages/react-doctor/tests/run-oxlint/sidecar-lint-cache.test.ts
+++ b/packages/react-doctor/tests/run-oxlint/sidecar-lint-cache.test.ts
@@ -24,6 +24,12 @@ const USER_CONFIG = {
   },
 } as const;
 
+const INK_USER_CONFIG = {
+  rules: {
+    "react-doctor/ink-no-raw-text": "error",
+  },
+} as const;
+
 const APP_SOURCE = `import { Button } from "./components";
 export const App = () => <div><Button /></div>;
 `;
@@ -78,6 +84,33 @@ const scan = (projectDir: string, options: ScanOptions = {}): Promise<Diagnostic
 
 const scanFull = (projectDir: string): Promise<Diagnostic[]> =>
   scan(projectDir, { perFileLintCacheEnabled: false, sidecarLintCacheEnabled: false });
+
+const setupInkFixture = (caseId: string): string => {
+  const projectDir = setupReactProject(tempRoot, caseId, {
+    files: {
+      "src/App.tsx": `import { Panel } from "./Panel";
+export const App = () => <Panel>raw text</Panel>;
+`,
+      "src/Panel.tsx": `import { Box } from "ink";
+export const Panel = ({ children }) => <Box>{children}</Box>;
+`,
+    },
+  });
+  writeFile(
+    path.join(projectDir, "node_modules/ink/package.json"),
+    `{ "name": "ink", "version": "7.1.1" }\n`,
+  );
+  return projectDir;
+};
+
+const scanInk = (projectDir: string, sidecarLintCacheEnabled: boolean): Promise<Diagnostic[]> =>
+  runOxlint({
+    rootDirectory: projectDir,
+    project: buildTestProject({ rootDirectory: projectDir, framework: "vite" }),
+    userConfig: INK_USER_CONFIG,
+    perFileLintCacheEnabled: false,
+    sidecarLintCacheEnabled,
+  });
 
 const serialize = (diagnostics: ReadonlyArray<Diagnostic>): string =>
   JSON.stringify(
@@ -153,6 +186,25 @@ describe("sidecar lint cache", () => {
 
     expect(serialize(incremental)).toBe(serialize(full));
     expect(ruleHitsOn(incremental, "no-barrel-import", "src/App.tsx")).toHaveLength(0);
+  });
+
+  it("flips an unchanged Ink importer's verdict when its wrapper changes", async () => {
+    const projectDir = setupInkFixture("ink-wrapper-flip");
+    const before = await scanInk(projectDir, true);
+    await scanInk(projectDir, true);
+    expect(ruleHitsOn(before, "ink-no-raw-text", "src/App.tsx")).toHaveLength(1);
+
+    writeFile(
+      path.join(projectDir, "src/Panel.tsx"),
+      `import { Text } from "ink";
+export const Panel = ({ children }) => <Text>{children}</Text>;
+`,
+    );
+    const incremental = await scanInk(projectDir, true);
+    const full = await scanInk(projectDir, false);
+
+    expect(serialize(incremental)).toBe(serialize(full));
+    expect(ruleHitsOn(incremental, "ink-no-raw-text", "src/App.tsx")).toHaveLength(0);
   });
 
   it("re-points the suggestion when the barrel's re-export target moves", async () => {


### PR DESCRIPTION
## Why

Ink has renderer and terminal-lifecycle contracts that ordinary React rules do not model. Violations can bypass terminal cleanup, compete for a renderer, read layout before commit, lose resize reactivity, or emit markup Ink cannot render.

This PR adds a deliberately conservative Ink suite:

- **19 checks enabled by default**
- **1 opt-in migration check** (`ink-prefer-use-paste`)
- **2 retired, no-op aliases** kept so existing configuration does not break
- **A minimum Ink version on every rule**, evaluated from the consuming package

The implementation resolves actual imports from `ink`, local aliases, namespace imports, shadowing, JSX ownership, same-file component reachability, renderer ownership, and manifest changes before reporting. When dependency provenance, stream identity, wrapper ownership, or a version cannot be proved, it does not guess.

## Version gating

The installed `node_modules/ink/package.json` version wins over the declared range. Otherwise, exact and semver declarations are resolved conservatively. Unknown, malformed, workspace, Git, file, URL, and dist-tag declarations fail closed with no diagnostic. Manifest fingerprints invalidate the cross-file cache when dependency metadata changes. Imported JSX wrapper implementations are also content dependencies for `ink-no-raw-text`, so changing a wrapper while leaving its importer untouched cannot reuse a stale verdict.

| Minimum Ink | Active rules |
| --- | --- |
| `3.0.0` | `ink-ctrl-c-handler-requires-exit-option`, `ink-no-bare-process-exit`, `ink-no-direct-raw-mode`, `ink-no-dom-host-elements`, `ink-no-dom-router`, `ink-no-focus-in-render`, `ink-no-measure-element-in-render`, `ink-no-multiple-static`, `ink-no-raw-text`, `ink-no-repeated-render`, `ink-static-is-append-only`, `ink-static-requires-key` |
| `3.0.1` | `ink-no-layout-inside-text` |
| `6.2.0` | `ink-valid-aria-semantics` |
| `6.7.0` | `ink-use-string-width-for-cursor` |
| `6.8.0` | `ink-no-live-hooks-in-render-to-string` |
| `7.0.0` | `ink-prefer-use-animation`, `ink-prefer-use-paste` (opt-in), `ink-use-reactive-window-size` |
| `7.1.0` | `ink-use-suspend-terminal` |

The retired aliases retain their historical gates (`3.0.0` and `6.7.0`) but their visitors are empty and they never report.

## Rule contracts and examples

### 1. `ink-ctrl-c-handler-requires-exit-option`: default, error, Ink >= 3.0.0

A custom Ctrl-C input handler conflicts with Ink's built-in Ctrl-C exit unless the render that reaches that component proves `exitOnCtrlC: false`.

```tsx
// Reports
render(<AppWithCustomCtrlC />);

// Valid
render(<AppWithCustomCtrlC />, { exitOnCtrlC: false });
```

### 2. `ink-no-bare-process-exit`: default, error, Ink >= 3.0.0

`process.exit()` in an Ink input handler bypasses Ink's terminal cleanup. Unrelated application cleanup does not restore Ink's renderer state.

```tsx
// Reports
useInput(input => input === "q" && process.exit(0));

// Valid
const { exit } = useApp();
useInput(input => input === "q" && exit());
```

### 3. `ink-no-direct-raw-mode`: default, error, Ink >= 3.0.0

Calling Ink's `setRawMode()` while rendering is an untracked terminal side effect. Input should flow through Ink hooks.

```tsx
// Reports
const { setRawMode } = useStdin();
setRawMode(true);

// Valid
useInput((input, key) => handleInput(input, key));
```

### 4. `ink-no-dom-host-elements`: default, error, Ink >= 3.0.0

DOM host elements cannot be rendered by Ink. Same-named custom components are ignored.

```tsx
// Reports
const App = () => <Box><div>Ready</div></Box>;

// Valid
const App = () => <Box><Text>Ready</Text></Box>;
```

### 5. `ink-no-dom-router`: default, error, Ink >= 3.0.0

DOM-history routers and components do not belong in an Ink tree. Platform-neutral memory routing is supported.

```tsx
// Reports
const App = () => <Box><BrowserRouter /></Box>;

// Valid
const App = () => <Box><MemoryRouter /></Box>;
```

### 6. `ink-no-focus-in-render`: default, error, Ink >= 3.0.0

Imperatively changing Ink focus during render can cause render loops. Event callbacks are valid.

```tsx
// Reports
const { focus } = useFocusManager();
focus("search");

// Valid
const { focus } = useFocusManager();
useInput(() => focus("search"));
```

### 7. `ink-no-layout-inside-text`: default, error, Ink >= 3.0.1

Ink layout primitives cannot be descendants of `<Text>`, including through fragments.

```tsx
// Reports
const App = () => <Text><Box /></Text>;

// Valid
const App = () => <Box><Text>Ready</Text></Box>;
```

### 8. `ink-no-live-hooks-in-render-to-string`: default, error, Ink >= 6.8.0

Local component graphs passed only to `renderToString()` cannot receive live input. Shared/exported components and supported snapshot-safe hooks are ignored because their live ownership is unknown or valid.

```tsx
// Reports
const Snapshot = () => { useInput(() => {}); return <Text />; };
renderToString(<Snapshot />);

// Valid
const Snapshot = () => <Text>Snapshot</Text>;
renderToString(<Snapshot />);
```

### 9. `ink-no-measure-element-in-render`: default, error, Ink >= 3.0.0

`measureElement()` reads layout before Ink commits it. Measurements belong in an effect or event callback.

```tsx
// Reports
const size = measureElement(ref.current);

// Valid
useLayoutEffect(() => setSize(measureElement(ref.current)), []);
```

### 10. `ink-no-multiple-static`: default, warning, Ink >= 3.0.0

One rendered root should not contain multiple unconditional `<Static>` regions. Separate roots and mutually exclusive branches are ignored.

```tsx
// Reports
const App = () => <><Static items={logs}>{renderLog}</Static><Static items={jobs}>{renderJob}</Static></>;

// Valid
const App = () => <Static items={entries}>{renderEntry}</Static>;
```

### 11. `ink-no-raw-text`: default, error, Ink >= 3.0.0

Printable children reaching an Ink layout primitive must be wrapped in `<Text>`. The detector follows local and imported wrappers only when their import/export and children-forwarding provenance is proven; shadowed or ambiguous wrappers fail closed. Its forwarding logic is shared with `rn-no-raw-text` instead of duplicating a name-based approximation.

```tsx
// Reports
const App = () => <Box>Hello {name}</Box>;

// Valid
const App = () => <Box><Text>Hello {name}</Text></Box>;
```

### 12. `ink-no-repeated-render`: default, error, Ink >= 3.0.0

Two live `render()` calls proven to target the same stdout compete for one renderer. Different streams, unresolved streams, `rerender()`, and a later render after path-complete `unmount()` are valid.

```tsx
// Reports
render(<First />);
render(<Second />);

// Valid
const instance = render(<First />);
instance.rerender(<Second />);
```

### 13. `ink-prefer-use-animation`: default, warning, Ink >= 7.0.0

A React effect whose interval only advances a frame counter duplicates Ink's animation lifecycle. Ordinary timers are ignored.

```tsx
// Reports
useEffect(() => { const id = setInterval(() => setFrame(value => value + 1), 80); return () => clearInterval(id); }, []);

// Valid
const { frame } = useAnimation({ interval: 80 });
```

### 14. `ink-prefer-use-paste`: opt-in, warning, Ink >= 7.0.0

Multi-character or newline heuristics inside `useInput()` can misclassify ordinary input. Ink 7 provides a dedicated paste hook. This remains opt-in because some applications intentionally consume raw input chunks.

```tsx
// Reports only when enabled
useInput(input => { if (input.includes("\n")) handlePaste(input); });

// Preferred
usePaste(input => handlePaste(input));
```

### 15. `ink-static-is-append-only`: default, warning, Ink >= 3.0.0

`<Static>` permanently writes new items, so reordering an evolving collection can rewrite its logical history. Fixed literal arrays and filtering alone are ignored.

```tsx
// Reports
<Static items={items.toReversed()}>{renderItem}</Static>

// Valid
<Static items={emittedItems}>{renderItem}</Static>
```

### 16. `ink-static-requires-key`: default, error, Ink >= 3.0.0

The root element returned for each `<Static>` item needs a stable key.

```tsx
// Reports
<Static items={items}>{item => <Text>{item.label}</Text>}</Static>

// Valid
<Static items={items}>{item => <Text key={item.id}>{item.label}</Text>}</Static>
```

### 17. `ink-use-reactive-window-size`: default, warning, Ink >= 7.0.0

Reading `process.stdout.columns` or `.rows` does not rerender after resize. Components with their own same-component stdout resize subscription are exempt; subscriptions in nested or unrelated components do not suppress the finding.

```tsx
// Reports
const App = () => <Text>{process.stdout.columns}</Text>;

// Valid
const App = () => { const { columns } = useWindowSize(); return <Text>{columns}</Text>; };
```

### 18. `ink-use-string-width-for-cursor`: default, warning, Ink >= 6.7.0

JavaScript string length is not terminal column width for Unicode or wide glyphs.

```tsx
// Reports
cursor.setCursorPosition({ x: label.length, y: 0 });

// Valid
cursor.setCursorPosition({ x: stringWidth(label), y: 0 });
```

### 19. `ink-use-suspend-terminal`: default, error, Ink >= 7.1.0

An interactive child process inheriting stdio must run through `suspendTerminal()` so Ink releases and restores terminal control. Non-interactive child processes are ignored.

```tsx
// Reports
useInput(() => spawn("vim", [], { stdio: "inherit" }));

// Valid
const { suspendTerminal } = useApp();
useInput(() => suspendTerminal(() => spawn("vim", [], { stdio: "inherit" })));
```

### 20. `ink-valid-aria-semantics`: default, error, Ink >= 6.2.0

Validates Ink's supported role/state set, element-role compatibility, and contradictory hidden/label combinations.

```tsx
// Reports: Text does not own Ink roles, and dialog is unsupported
const App = () => <Text aria-role="dialog">Open</Text>;

// Valid
const App = () => <Box aria-role="button" aria-label="Open"><Text>Open</Text></Box>;
```

### 21. `ink-newline-inside-text`: retired alias, no diagnostics

Research disproved the proposed contract: Ink supports standalone `<Newline>` elements. The ID remains registered only for configuration compatibility.

```tsx
// Allowed; this retired rule never reports
const App = () => <Box><Newline /></Box>;
```

### 22. `ink-suspense-requires-concurrent`: retired alias, no diagnostics

Research disproved the proposed contract: Ink can render Suspense fallbacks without `{ concurrent: true }`. The ID remains registered only for configuration compatibility.

```tsx
// Allowed; this retired rule never reports
render(<Suspense fallback={<Text>Loading</Text>}><LazyView /></Suspense>);
```

## Precision boundaries

- Every API and JSX name must resolve semantically to `ink`; same-named locals, parameters, and shadowed bindings are ignored.
- Renderer options are associated only through direct containment or reachable same-file component graphs, with cycle guards.
- Imported wrapper traversal requires a real import binding and an unambiguous exported component that forwards children to an Ink host.
- Stream comparisons require default stdout, `process.stdout`, or an immutable semantic alias.
- Cleanup must belong to the earlier renderer and cover every path to a later render.
- Unsupported or unresolved Ink versions produce no finding.

## Research and validation

- Contracts were checked against Ink's [renderer options](https://github.com/vadimdemedes/ink/blob/70af033dbd2b126a16f144164685612b2c1fd554/readme.md#renderoptions), [Static behavior](https://github.com/vadimdemedes/ink/blob/70af033dbd2b126a16f144164685612b2c1fd554/readme.md#static), [input hooks](https://github.com/vadimdemedes/ink/blob/70af033dbd2b126a16f144164685612b2c1fd554/readme.md#useinputinputhandler-options), [screen-reader support](https://github.com/vadimdemedes/ink/blob/70af033dbd2b126a16f144164685612b2c1fd554/readme.md#screen-reader-support), and [renderToString](https://github.com/vadimdemedes/ink/blob/70af033dbd2b126a16f144164685612b2c1fd554/readme.md#rendertostringtree-options), plus upstream issues and PRs.
- Targeted open-source evaluation completed on real Ink projects. HyperDX produced one confirmed `ink-no-bare-process-exit` true positive; no other Ink diagnostics drifted.
- Final Daytona parity used all 22 registered IDs enabled in the candidate harness, including the opt-in rule and both retired aliases. Across **1,985 comparable pinned projects**, diagnostics were **129,577 unchanged, 1 added, 0 removed**.
- The sole addition was a confirmed `ink-no-bare-process-exit` true positive in `bamlab/flashlight` (`packages/commands/measure/src/server/ServerApp.tsx`): its `q`/`c` input path calls application profiler cleanup and then `process.exit()`, but never asks Ink to clean up its renderer/terminal.
- Parity excluded 11 baseline scans that hit the per-project evaluation ceiling and 4 candidate tail jobs that exhausted the global run budget. They are infrastructure exclusions, not compared outcomes; the comparator correctly returned a skipped-project status rather than hiding them.
- The local `react-bench-internal` reconstruction covered **20,380** complete `model.patch` + `rd-before.json` + `rd-after.json` verifier bundles and found **zero Ink rule IDs**. Its only real Ink source occurrence was an untouched mock prompt visible in two agent trajectories; both submitted diffs changed unrelated interaction-card files and failed the same unrelated TypeScript contract test. The benchmark therefore has no Ink comparison surface and is not claimed as Ink validation.

## Test plan

- `nr test`: 15/15 tasks passed after the final rebase
- `nr lint`: passed with only existing warnings
- `nr typecheck`: 16/16 tasks passed
- `nr format:check`: passed
- `nr smoke:json-report`: schema v3 smoke test passed
- Focused rule, cross-file provenance, version-gate, manifest-cache, liveness, and adversarial regression tests passed
- Strict fuzzing passed at 500 mutations for the most provenance-sensitive rules after the final hardening pass
- Final head: `ecf5801f99f9b9ba48be2a0a679eab45871a6adc`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new rule surface and cross-file caching paths can affect scan correctness and performance on Ink projects; version gating fails closed, limiting false positives but requiring accurate dependency resolution.
> 
> **Overview**
> Adds a **version-gated Ink ruleset** to `oxlint-plugin-react-doctor`: **19 default checks**, **opt-in** `ink-prefer-use-paste`, and **two retired no-op aliases** (`ink-newline-inside-text`, `ink-suspense-requires-concurrent`) so old config IDs still resolve.
> 
> Rules with `minimumInkVersion` run through **`wrapInkRule`**, which skips visitors when the installed or declared Ink version cannot be proved high enough. All Ink rule IDs join **`CROSS_FILE_RULE_IDS`** with collectors for **`resolveInkVersion`** (and imported JSX wrappers for **`ink-no-raw-text`**) so lint cache stays correct when manifests or wrapper modules change.
> 
> New shared utilities cover Ink API/JSX resolution, render-call ownership, cross-file children forwarding (also refactored for **`rn-no-raw-text`** via **`collect-imported-jsx-component-dependencies`**). The **`ink`** bucket is wired into registry generation (tag/category) and the plugin load path.
> 
> Coverage includes unit tests, cross-file tests, liveness fixtures, fuzz corpus regressions, and a changeset patch for the plugin package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecf5801f99f9b9ba48be2a0a679eab45871a6adc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->