### PR TITLE
docs: add inline suppression documentation

### DIFF
--- a/.changeset/doc-inline-suppressions.md
+++ b/.changeset/doc-inline-suppressions.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Add inline suppression documentation to README. Clarifies how to use `// react-doctor-disable-next-line` and related comment syntaxes to suppress individual diagnostics. Includes regression test confirming the feature works correctly.

--- a/packages/react-doctor/README.md
+++ b/packages/react-doctor/README.md
@@ -62,25 +62,25 @@ You can suppress individual diagnostics using inline comments:
 ```tsx
 // Suppress one rule on the next line
 // react-doctor-disable-next-line react-doctor/no-ref-current-in-render
-valueRef.current = value
+valueRef.current = value;
 
 // Suppress one rule on the same line
-valueRef.current = value // react-doctor-disable-line react-doctor/no-ref-current-in-render
+valueRef.current = value; // react-doctor-disable-line react-doctor/no-ref-current-in-render
 
 // Suppress multiple rules
 // react-doctor-disable-next-line react-doctor/no-ref-current-in-render, react-doctor/no-derived-state-effect
-valueRef.current = value
+valueRef.current = value;
 
 // Suppress all rules on the next line
 // react-doctor-disable-next-line
-valueRef.current = value
+valueRef.current = value;
 ```
 
 Block comments (`/* */`) and JSX comment syntax (`{/* */}`) also work. You can add an explanation after `--`:
 
 ```tsx
 // react-doctor-disable-next-line react-doctor/no-ref-current-in-render -- intentional for performance
-valueRef.current = value
+valueRef.current = value;
 ```
 
 `eslint-disable` and `oxlint-disable` comments are also respected.

--- a/packages/react-doctor/README.md
+++ b/packages/react-doctor/README.md
@@ -55,7 +55,39 @@ You can configure which rules to run and how to run them in `doctor.config.ts`.
 
 [Learn more →](https://react.doctor/docs/configuration/config-files)
 
-### 5. Consume JSON
+### 5. Suppress specific diagnostics
+
+You can suppress individual diagnostics using inline comments:
+
+```tsx
+// Suppress one rule on the next line
+// react-doctor-disable-next-line react-doctor/no-ref-current-in-render
+valueRef.current = value
+
+// Suppress one rule on the same line
+valueRef.current = value // react-doctor-disable-line react-doctor/no-ref-current-in-render
+
+// Suppress multiple rules
+// react-doctor-disable-next-line react-doctor/no-ref-current-in-render, react-doctor/no-derived-state-effect
+valueRef.current = value
+
+// Suppress all rules on the next line
+// react-doctor-disable-next-line
+valueRef.current = value
+```
+
+Block comments (`/* */`) and JSX comment syntax (`{/* */}`) also work. You can add an explanation after `--`:
+
+```tsx
+// react-doctor-disable-next-line react-doctor/no-ref-current-in-render -- intentional for performance
+valueRef.current = value
+```
+
+`eslint-disable` and `oxlint-disable` comments are also respected.
+
+To disable inline suppressions (audit mode), use `--no-respect-inline-disables` or set `"respectInlineDisables": false` in your config.
+
+### 6. Consume JSON
 
 Use `--json` for stdout or `--json-out <path>` for a file. The default
 `schemaVersion: 3` report includes deterministic diagnostic IDs and exact

--- a/packages/react-doctor/tests/regressions/issue-1406-disable-next-line.test.ts
+++ b/packages/react-doctor/tests/regressions/issue-1406-disable-next-line.test.ts
@@ -100,8 +100,6 @@ describe("issue #1406: disable-next-line suppresses no-ref-current-in-render", (
       ],
     );
     expect(filtered).toHaveLength(1);
-    expect(filtered[0].suppressionHint).toContain(
-      "1 line of code separate it from the diagnostic",
-    );
+    expect(filtered[0].suppressionHint).toContain("1 line of code separate it from the diagnostic");
   });
 });

--- a/packages/react-doctor/tests/regressions/issue-1406-disable-next-line.test.ts
+++ b/packages/react-doctor/tests/regressions/issue-1406-disable-next-line.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Regression test for GitHub issue #1406:
+ * Verifies that `// react-doctor-disable-next-line` correctly suppresses
+ * the `no-ref-current-in-render` diagnostic.
+ */
+
+import * as fs from "node:fs";
+import os from "node:os";
+import * as path from "node:path";
+import { afterAll, describe, expect, it } from "vite-plus/test";
+
+import type { Diagnostic } from "@react-doctor/core";
+import { createNodeReadFileLinesSync, mergeAndFilterDiagnostics } from "@react-doctor/core";
+import { buildDiagnostic, writeFile } from "./_helpers.js";
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "rd-issue-1406-"));
+
+afterAll(() => {
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+});
+
+const runFilter = (
+  caseId: string,
+  fileContents: string,
+  diagnostics: Diagnostic[],
+): Diagnostic[] => {
+  const projectDir = path.join(tempRoot, caseId);
+  writeFile(path.join(projectDir, "src", "repro.tsx"), fileContents);
+  return mergeAndFilterDiagnostics(
+    diagnostics,
+    projectDir,
+    null,
+    createNodeReadFileLinesSync(projectDir),
+    { warnings: true },
+  );
+};
+
+describe("issue #1406: disable-next-line suppresses no-ref-current-in-render", () => {
+  it("suppresses no-ref-current-in-render with react-doctor-disable-next-line", () => {
+    const filtered = runFilter(
+      "suppress-ref-mutation",
+      `import { useRef } from "react"\n\n` +
+        `export function Repro({ value }: { value: string }) {\n` +
+        `  const valueRef = useRef(value)\n\n` +
+        `  // react-doctor-disable-next-line react-doctor/no-ref-current-in-render -- minimal reproduction\n` +
+        `  valueRef.current = value\n\n` +
+        `  return <div>{value}</div>\n` +
+        `}\n`,
+      [
+        buildDiagnostic({
+          plugin: "react-doctor",
+          rule: "no-ref-current-in-render",
+          line: 7,
+          filePath: "src/repro.tsx",
+        }),
+      ],
+    );
+    expect(filtered).toHaveLength(0);
+  });
+
+  it("fires no-ref-current-in-render without suppression comment", () => {
+    const filtered = runFilter(
+      "no-suppress-ref-mutation",
+      `import { useRef } from "react"\n\n` +
+        `export function Repro({ value }: { value: string }) {\n` +
+        `  const valueRef = useRef(value)\n\n` +
+        `  valueRef.current = value\n\n` +
+        `  return <div>{value}</div>\n` +
+        `}\n`,
+      [
+        buildDiagnostic({
+          plugin: "react-doctor",
+          rule: "no-ref-current-in-render",
+          line: 6,
+          filePath: "src/repro.tsx",
+        }),
+      ],
+    );
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].rule).toBe("no-ref-current-in-render");
+  });
+
+  it("shows near-miss hint when suppression is one line away", () => {
+    const filtered = runFilter(
+      "gap-hint-ref-mutation",
+      `import { useRef } from "react"\n\n` +
+        `export function Repro({ value }: { value: string }) {\n` +
+        `  const valueRef = useRef(value)\n` +
+        `  // react-doctor-disable-next-line react-doctor/no-ref-current-in-render\n\n` +
+        `  valueRef.current = value\n\n` +
+        `  return <div>{value}</div>\n` +
+        `}\n`,
+      [
+        buildDiagnostic({
+          plugin: "react-doctor",
+          rule: "no-ref-current-in-render",
+          line: 7,
+          filePath: "src/repro.tsx",
+        }),
+      ],
+    );
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].suppressionHint).toContain(
+      "1 line of code separate it from the diagnostic",
+    );
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds comprehensive documentation for inline suppression comments to the CLI README and includes regression tests.

## Root Cause Analysis

Issue #1406 reported that `// react-doctor-disable-next-line` wasn't working. After extensive testing, I **cannot reproduce the issue** - the suppression mechanism works correctly in v0.8.1.

Testing confirmed:
- ✅ `// react-doctor-disable-next-line` works correctly
- ✅ Block comments (`/* */`) work correctly
- ✅ JSX comments (`{/* */}`) work correctly
- ✅ Multiple rule lists work correctly
- ✅ Rationale text after `--` works correctly
- ✅ Near-miss hints work correctly (when comment is slightly misplaced)
- ✅ `eslint-disable` and `oxlint-disable` are also respected

The only scenario where suppressions don't work is when using `--no-respect-inline-disables` (audit mode), which is intentional.

## Changes

### Documentation
- Added new "Suppress specific diagnostics" section to README with examples
- Documents all supported comment syntaxes
- Explains audit mode and how to disable inline suppressions
- Notes compatibility with `eslint-disable` and `oxlint-disable` comments

### Tests
- Added comprehensive regression test (`issue-1406-disable-next-line.test.ts`)
- Tests the exact scenario reported in the issue
- Tests near-miss hint when comment is misplaced
- Confirms diagnostic fires without suppression

## Scope Decision

This is a **documentation-only fix** because:
1. The feature works correctly (cannot reproduce reported bug)
2. The CLI README had zero documentation about inline suppressions
3. Users may be confused about how to use this feature
4. The reporter may have had a local configuration issue (`respectInlineDisables: false`) they didn't mention

## Testing

✅ All checks passing:
```bash
pnpm test issue-1406          # New regression tests (3 tests)
pnpm test inline-suppressions  # Existing suppression tests (30 tests)
pnpm lint                      # Linting passed
pnpm typecheck                 # Type checking passed
pnpm format                    # Formatting applied
```

Also manually tested with the exact reproduction case from the issue using both:
- Built from source
- Published npm version 0.8.1
- LF and CRLF line endings

Suppression works correctly in all scenarios.

## Potential User Issues

If users are experiencing suppression failures, likely causes:
1. **Config file with `"respectInlineDisables": false`** - check `doctor.config.ts`
2. **Audit mode flag** - check if `--no-respect-inline-disables` is being passed
3. **Typo in comment** - ensure comment format is exactly `// react-doctor-disable-next-line`
4. **Wrong rule name** - verify the rule name matches the diagnostic (e.g. `react-doctor/no-ref-current-in-render`)
5. **Comment not adjacent** - ensure no blank lines between comment and code

Closes #1406
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aff9a66f-1301-476f-bebc-524f89ef11ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aff9a66f-1301-476f-bebc-524f89ef11ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

