### PR TITLE
test: cover ref mutation inline suppression

### DIFF
--- a/packages/react-doctor/tests/regressions/inline-suppressions.test.ts
+++ b/packages/react-doctor/tests/regressions/inline-suppressions.test.ts
@@ -18,7 +18,8 @@ import { afterAll, describe, expect, it } from "vite-plus/test";
 
 import type { Diagnostic } from "@react-doctor/core";
 import { createNodeReadFileLinesSync, mergeAndFilterDiagnostics } from "@react-doctor/core";
-import { buildDiagnostic, writeFile } from "./_helpers.js";
+import { inspect } from "../../src/inspect.js";
+import { buildDiagnostic, setupReactProject, writeFile } from "./_helpers.js";
 
 const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "rd-inline-suppression-"));
 
@@ -49,6 +50,19 @@ const runFilter = (
 
 const baseDiagnostic = (overrides: Partial<Diagnostic> = {}): Diagnostic =>
   buildDiagnostic({ rule: "no-derived-state-effect", ...overrides });
+
+const buildRefMutationSource = (
+  suppressionDirective = "",
+): string => `import { useRef } from "react";
+
+export function Repro({ value }: { value: string }) {
+  const valueRef = useRef(value);
+
+${suppressionDirective}  valueRef.current = value;
+
+  return <div>{value}</div>;
+}
+`;
 
 describe("issue #72: inline suppressions — variants", () => {
   it("disable-line suppresses a diagnostic on the SAME line", () => {
@@ -126,6 +140,53 @@ describe("issue #72: inline suppressions — variants", () => {
       baseDiagnostic({ rule: "no-fetch-in-effect", line: 1 }),
     ]);
     expect(filtered).toHaveLength(0);
+  });
+});
+
+describe("issue #1406: inline suppressions — end-to-end rule diagnostics", () => {
+  it("suppresses no-ref-current-in-render on the next line", async () => {
+    const unsuppressedProjectDirectory = setupReactProject(
+      tempRoot,
+      "no-ref-current-in-render-control",
+      {
+        files: {
+          "src/repro.tsx": buildRefMutationSource(),
+        },
+      },
+    );
+    const suppressedProjectDirectory = setupReactProject(tempRoot, "no-ref-current-in-render", {
+      files: {
+        "src/repro.tsx": buildRefMutationSource(
+          "  // react-doctor-disable-next-line react-doctor/no-ref-current-in-render -- minimal reproduction\n",
+        ),
+      },
+    });
+
+    const unsuppressedResult = await inspect(unsuppressedProjectDirectory, {
+      deadCode: false,
+      isCi: true,
+      noScore: true,
+      silent: true,
+      warnings: false,
+    });
+    const suppressedResult = await inspect(suppressedProjectDirectory, {
+      deadCode: false,
+      isCi: true,
+      noScore: true,
+      silent: true,
+      warnings: false,
+    });
+
+    expect(
+      unsuppressedResult.diagnostics.filter(
+        (diagnostic) => diagnostic.rule === "no-ref-current-in-render",
+      ),
+    ).toHaveLength(1);
+    expect(
+      suppressedResult.diagnostics.filter(
+        (diagnostic) => diagnostic.rule === "no-ref-current-in-render",
+      ),
+    ).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Why

Issue #1406 reports that `react-doctor-disable-next-line` does not suppress `react-doctor/no-ref-current-in-render` when React Doctor runs in CI mode.

The exact reproduction suppresses correctly in clean installs of published `react-doctor@0.8.1` and against current source, so this PR captures the reported case end to end to prevent a regression and to make the expected behavior explicit.

Refs #1406.

## What changed

- add an unsuppressed control proving `no-ref-current-in-render` fires
- add the exact reported next-line directive, including its description
- exercise both fixtures through `inspect()` with `isCi: true`
- assert the directive removes only the expected diagnostic

This is test-only, so no changeset is required. Rule parity and RDE were skipped because detector behavior did not change.

## Test plan

- `nr test tests/regressions/inline-suppressions.test.ts` (from `packages/react-doctor`)
- `nr test`
- `nr lint`
- `nr typecheck`
- `nr format:check`
- `nr smoke:json-report`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change in `inline-suppressions.test.ts`; no runtime or rule behavior changes.
> 
> **Overview**
> Adds **regression coverage for issue #1406** so `react-doctor-disable-next-line` is verified against a real `no-ref-current-in-render` diagnostic, not only `mergeAndFilterDiagnostics` fixtures.
> 
> A shared `buildRefMutationSource` helper builds a minimal `useRef` + `valueRef.current = value` repro. The new test spins up two temp projects (unsuppressed control vs. the reported next-line directive with a `--` description), runs **`inspect()` with `isCi: true`**, and asserts the rule fires once without the comment and is absent when suppressed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fb1c7da9c4acb447c415a1b03478f3861eefc56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->