### PR TITLE
feat(plugin): detect Zustand state mutation

### DIFF
--- a/.changeset/soft-stores-smile.md
+++ b/.changeset/soft-stores-smile.md
@@ -1,0 +1,6 @@
+---
+"oxlint-plugin-react-doctor": patch
+"eslint-plugin-react-doctor": patch
+---
+
+Detect in-place mutation of proven Zustand state snapshots that can prevent subscriber updates.

--- a/docs/zustand-rule-research.md
+++ b/docs/zustand-rule-research.md
@@ -161,7 +161,10 @@ Detector contract:
 - Treat a surrounding `set` updater's returned value as the notifier for `get()` snapshots read
   inside that updater, and abstain whenever replacement freshness cannot be proven.
 - Match notifiers to the exact creator or bound store, including same-branch ordering for simple
-  `if` statements. Another store or mutually exclusive branch cannot publish the mutation.
+  `if` statements and aliases introduced inside a branch. Another store or mutually exclusive
+  branch cannot publish the mutation.
+- Compare nested replacement paths from the snapshot root so a direct `get()` or `getState()`
+  chain cannot hide reuse inside a nested object update.
 - Treat clone-before-mutate as valid when the clone is statically proven fresh.
 - Treat mutation inside a creator wrapped by the official `immer` middleware as valid.
 - Follow mutations through simple `if`/`else` branches when every branch rejoins before the

--- a/docs/zustand-rule-research.md
+++ b/docs/zustand-rule-research.md
@@ -158,6 +158,8 @@ Detector contract:
 - Require the paired `set` parameter to be used before treating `get()` mutations without a
   notifier as reactive-state bugs. A creator with an unused `set` parameter can deliberately use
   Zustand as an imperative cache with no subscribers.
+- Treat a surrounding `set` updater's returned value as the notifier for `get()` snapshots read
+  inside that updater, and abstain whenever replacement freshness cannot be proven.
 - Treat clone-before-mutate as valid when the clone is statically proven fresh.
 - Treat mutation inside a creator wrapped by the official `immer` middleware as valid.
 - Follow mutations through simple `if`/`else` branches when every branch rejoins before the

--- a/docs/zustand-rule-research.md
+++ b/docs/zustand-rule-research.md
@@ -160,6 +160,8 @@ Detector contract:
   Zustand as an imperative cache with no subscribers.
 - Treat a surrounding `set` updater's returned value as the notifier for `get()` snapshots read
   inside that updater, and abstain whenever replacement freshness cannot be proven.
+- Match notifiers to the exact creator or bound store, including same-branch ordering for simple
+  `if` statements. Another store or mutually exclusive branch cannot publish the mutation.
 - Treat clone-before-mutate as valid when the clone is statically proven fresh.
 - Treat mutation inside a creator wrapped by the official `immer` middleware as valid.
 - Follow mutations through simple `if`/`else` branches when every branch rejoins before the

--- a/docs/zustand-rule-research.md
+++ b/docs/zustand-rule-research.md
@@ -157,6 +157,8 @@ Detector contract:
   back to `setState`, or mutated without a notifying update.
 - Treat clone-before-mutate as valid when the clone is statically proven fresh.
 - Treat mutation inside a creator wrapped by the official `immer` middleware as valid.
+- Follow mutations through simple `if`/`else` branches when every branch rejoins before the
+  notifying update; fail closed when a branch returns or throws.
 - Skip unknown custom middleware, unresolved helper calls, and cross-file stores unless ownership
   and freshness can be proven.
 - Reuse existing mutation and fresh-reference analysis. Do not add a second general-purpose walker.

--- a/docs/zustand-rule-research.md
+++ b/docs/zustand-rule-research.md
@@ -155,6 +155,9 @@ Detector contract:
 - Track direct assignment, update expressions, mutating array methods, and `Map` or `Set` mutators.
 - Report when the mutated snapshot or a mutated child reference is returned through `set`, passed
   back to `setState`, or mutated without a notifying update.
+- Require the paired `set` parameter to be used before treating `get()` mutations without a
+  notifier as reactive-state bugs. A creator with an unused `set` parameter can deliberately use
+  Zustand as an imperative cache with no subscribers.
 - Treat clone-before-mutate as valid when the clone is statically proven fresh.
 - Treat mutation inside a creator wrapped by the official `immer` middleware as valid.
 - Follow mutations through simple `if`/`else` branches when every branch rejoins before the

--- a/docs/zustand-rule-research.md
+++ b/docs/zustand-rule-research.md
@@ -152,6 +152,8 @@ Detector contract:
 
 - Resolve `set` callback parameters, `get()` snapshots, and `store.getState()` snapshots only from
   proven same-file Zustand stores.
+- Analyze updater state parameters passed to both creator `set(...)` and bound or vanilla
+  `store.setState(...)` calls.
 - Track direct assignment, update expressions, mutating array methods, and `Map` or `Set` mutators.
 - Report when the mutated snapshot or a mutated child reference is returned through `set`, passed
   back to `setState`, or mutated without a notifying update.

--- a/docs/zustand-rule-research.md
+++ b/docs/zustand-rule-research.md
@@ -157,14 +157,17 @@ Detector contract:
 - Track direct assignment, update expressions, mutating array methods, and `Map` or `Set` mutators.
 - Report when the mutated snapshot or a mutated child reference is returned through `set`, passed
   back to `setState`, or mutated without a notifying update.
-- Require the paired `set` parameter to be used before treating `get()` mutations without a
-  notifier as reactive-state bugs. A creator with an unused `set` parameter can deliberately use
-  Zustand as an imperative cache with no subscribers.
+- Require the paired `set` parameter or resulting bound store's `setState` to be used before
+  treating `get()` mutations without a notifier as reactive-state bugs. A creator with neither
+  can deliberately use Zustand as an imperative cache with no subscribers.
 - Treat a surrounding `set` updater's returned value as the notifier for `get()` snapshots read
   inside that updater, and abstain whenever replacement freshness cannot be proven.
 - Match notifiers to the exact creator or bound store, including same-branch ordering for simple
   `if` statements and aliases introduced inside a branch. Another store or mutually exclusive
   branch cannot publish the mutation.
+- Pair creator `get()` snapshots with either its `set` parameter or the resulting bound store's
+  `setState`, while keeping `getState` snapshot provenance exact to one store.
+- Follow ordered mutable-alias rebindings and accept a clone published at the original state path.
 - Compare nested replacement paths from the snapshot root so a direct `get()` or `getState()`
   chain cannot hide reuse inside a nested object update.
 - Treat clone-before-mutate as valid when the clone is statically proven fresh.

--- a/docs/zustand-rule-research.md
+++ b/docs/zustand-rule-research.md
@@ -167,7 +167,9 @@ Detector contract:
   branch cannot publish the mutation.
 - Pair creator `get()` snapshots with either its `set` parameter or the resulting bound store's
   `setState`, while keeping `getState` snapshot provenance exact to one store.
-- Follow ordered mutable-alias rebindings and accept a clone published at the original state path.
+- Follow ordered mutable-alias rebindings on the mutation's execution path and accept a clone
+  published at the original state path. Ignore mutually exclusive branch rebindings and abstain
+  when a conditional rebind cannot be proven to run.
 - Compare nested replacement paths from the snapshot root so a direct `get()` or `getState()`
   chain cannot hide reuse inside a nested object update.
 - Treat clone-before-mutate as valid when the clone is statically proven fresh.

--- a/packages/core/tests/oxlint-config-settings.test.ts
+++ b/packages/core/tests/oxlint-config-settings.test.ts
@@ -291,7 +291,7 @@ describe("createOxlintConfig settings", () => {
     }
   });
 
-  it("gates Zustand initialization diagnostics to supported major versions", () => {
+  it("gates Zustand initialization and mutation diagnostics to supported major versions", () => {
     for (const zustandMajorVersion of [1, 2, 3, 4, 5]) {
       const config = createOxlintConfig({
         pluginPath: "/tmp/plugin.js",
@@ -303,6 +303,7 @@ describe("createOxlintConfig settings", () => {
         }),
       });
       expect(config.rules["react-doctor/zustand-no-get-during-initialization"]).toBe("error");
+      expect(config.rules["react-doctor/zustand-no-mutating-state"]).toBe("error");
     }
 
     for (const project of [
@@ -322,6 +323,7 @@ describe("createOxlintConfig settings", () => {
     ]) {
       const config = createOxlintConfig({ pluginPath: "/tmp/plugin.js", project });
       expect(config.rules).not.toHaveProperty("react-doctor/zustand-no-get-during-initialization");
+      expect(config.rules).not.toHaveProperty("react-doctor/zustand-no-mutating-state");
     }
   });
 

--- a/packages/fuzz/corpus/regressions/zustand-no-mutating-state--conditional-notifier.tsx
+++ b/packages/fuzz/corpus/regressions/zustand-no-mutating-state--conditional-notifier.tsx
@@ -1,0 +1,14 @@
+// rule: zustand-no-mutating-state
+// weakness: control-flow
+// source: Cursor Bugbot review on millionco/react-doctor#1410
+
+import { create } from "zustand";
+
+export const useFuzzStore = create((set, get) => ({
+  items: [] as string[],
+  update: (shouldNotify: boolean) => {
+    const items = get().items;
+    items.push("next");
+    shouldNotify && set({ items: [...items] });
+  },
+}));

--- a/packages/fuzz/corpus/regressions/zustand-no-mutating-state--custom-mutator-name.tsx
+++ b/packages/fuzz/corpus/regressions/zustand-no-mutating-state--custom-mutator-name.tsx
@@ -1,0 +1,16 @@
+// rule: zustand-no-mutating-state
+// weakness: name-heuristic
+// source: PR #1410 deep rule audit
+
+import { create } from "zustand";
+
+const stableQueue = {};
+
+export const useStore = create((set) => ({
+  queue: { push: (_value: string) => stableQueue },
+  update: () =>
+    set((state) => {
+      state.queue.push("value");
+      return { queue: state.queue };
+    }),
+}));

--- a/packages/fuzz/corpus/regressions/zustand-no-mutating-state--enclosing-notifier.tsx
+++ b/packages/fuzz/corpus/regressions/zustand-no-mutating-state--enclosing-notifier.tsx
@@ -1,0 +1,13 @@
+// rule: zustand-no-mutating-state
+// weakness: library-idiom
+// source: Cursor Bugbot review on millionco/react-doctor#1410
+
+import { create } from "zustand";
+
+export const useFuzzStore = create((set, get) => ({
+  items: [] as string[],
+  update: () => {
+    const items = get().items;
+    set({ items: (items.push("next"), [...items]) });
+  },
+}));

--- a/packages/fuzz/corpus/regressions/zustand-no-mutating-state--imperative-cache.tsx
+++ b/packages/fuzz/corpus/regressions/zustand-no-mutating-state--imperative-cache.tsx
@@ -1,0 +1,15 @@
+// rule: zustand-no-mutating-state
+// weakness: library-idiom
+// source: tiajinsha/JKVideo@3592d036b1930af19d78e4a08bf3e60399c54467
+
+import { create } from "zustand";
+
+export const useFuzzStore = create((_set, get) => ({
+  cache: new Map<string, string>(),
+  read: (key: string) => get().cache.get(key),
+  write: (key: string, value: string) => {
+    const cache = get().cache;
+    cache.set(key, value);
+    if (cache.size > 30) cache.delete(cache.keys().next().value);
+  },
+}));

--- a/packages/fuzz/corpus/regressions/zustand-no-mutating-state--nested-notifier-branches.tsx
+++ b/packages/fuzz/corpus/regressions/zustand-no-mutating-state--nested-notifier-branches.tsx
@@ -1,0 +1,20 @@
+// rule: zustand-no-mutating-state
+// weakness: control-flow
+// source: Cursor Bugbot review on millionco/react-doctor#1410
+
+import { create } from "zustand";
+
+export const useStore = create((set, get) => ({
+  items: [] as string[],
+  update: (isOuterEnabled: boolean, isInnerEnabled: boolean) => {
+    if (isOuterEnabled) {
+      const items = get().items;
+      items.push("next");
+      if (isInnerEnabled) {
+        set({ items: [...items] });
+      } else {
+        set({ items: items.slice() });
+      }
+    }
+  },
+}));

--- a/packages/fuzz/corpus/regressions/zustand-no-mutating-state--official-immer-set-state.tsx
+++ b/packages/fuzz/corpus/regressions/zustand-no-mutating-state--official-immer-set-state.tsx
@@ -1,0 +1,10 @@
+// rule: zustand-no-mutating-state
+// weakness: library-idiom
+// source: Cursor Bugbot review on millionco/react-doctor#1410
+
+import { create } from "zustand";
+import { immer } from "zustand/middleware/immer";
+
+export const useStore = create(immer(() => ({ count: 0 })));
+
+useStore.setState((state) => void state.count++);

--- a/packages/fuzz/corpus/regressions/zustand-no-mutating-state--official-immer.tsx
+++ b/packages/fuzz/corpus/regressions/zustand-no-mutating-state--official-immer.tsx
@@ -1,0 +1,13 @@
+// rule: zustand-no-mutating-state
+// weakness: library-idiom
+// source: Zustand Immer middleware documentation
+
+import { create } from "zustand";
+import { immer } from "zustand/middleware/immer";
+
+export const useFuzzStore = create(
+  immer((set) => ({
+    count: 0,
+    increment: () => set((state) => void state.count++),
+  })),
+);

--- a/packages/fuzz/corpus/regressions/zustand-no-mutating-state--unproven-and-updater-replacements.tsx
+++ b/packages/fuzz/corpus/regressions/zustand-no-mutating-state--unproven-and-updater-replacements.tsx
@@ -34,4 +34,15 @@ export const useFuzzStore = create((set, get) => ({
       set({ items: items.slice() });
     }
   },
+  updateWithRebind: () => {
+    let items = get().items;
+    items.push("next");
+    items = [...items];
+    set({ items });
+  },
+  updateWithBoundSetState: () => {
+    const items = get().items;
+    items.push("next");
+    useFuzzStore.setState({ items: items.slice() });
+  },
 }));

--- a/packages/fuzz/corpus/regressions/zustand-no-mutating-state--unproven-and-updater-replacements.tsx
+++ b/packages/fuzz/corpus/regressions/zustand-no-mutating-state--unproven-and-updater-replacements.tsx
@@ -25,4 +25,13 @@ export const useFuzzStore = create((set, get) => ({
       set({ items: [...items] });
     }
   },
+  updateBeforeBranch: (enabled: boolean) => {
+    const items = get().items;
+    items.push("next");
+    if (enabled) {
+      set({ items: [...items] });
+    } else {
+      set({ items: items.slice() });
+    }
+  },
 }));

--- a/packages/fuzz/corpus/regressions/zustand-no-mutating-state--unproven-and-updater-replacements.tsx
+++ b/packages/fuzz/corpus/regressions/zustand-no-mutating-state--unproven-and-updater-replacements.tsx
@@ -1,0 +1,21 @@
+// rule: zustand-no-mutating-state
+// weakness: copy-tracking
+// source: Cursor Bugbot review on millionco/react-doctor#1410
+
+import { create } from "zustand";
+
+export const useFuzzStore = create((set, get) => ({
+  items: [] as string[],
+  updateWithBinding: () => {
+    const items = get().items;
+    items.push("next");
+    const nextItems = [...items];
+    set({ items: nextItems });
+  },
+  updateInsideUpdater: () =>
+    set(() => {
+      const items = get().items;
+      items.push("next");
+      return { items: [...items] };
+    }),
+}));

--- a/packages/fuzz/corpus/regressions/zustand-no-mutating-state--unproven-and-updater-replacements.tsx
+++ b/packages/fuzz/corpus/regressions/zustand-no-mutating-state--unproven-and-updater-replacements.tsx
@@ -18,4 +18,11 @@ export const useFuzzStore = create((set, get) => ({
       items.push("next");
       return { items: [...items] };
     }),
+  updateInBranch: (enabled: boolean) => {
+    const items = get().items;
+    if (enabled) {
+      items.push("next");
+      set({ items: [...items] });
+    }
+  },
 }));

--- a/packages/fuzz/corpus/true-positives/zustand-no-mutating-state--branch-alias.tsx
+++ b/packages/fuzz/corpus/true-positives/zustand-no-mutating-state--branch-alias.tsx
@@ -1,0 +1,16 @@
+// rule: zustand-no-mutating-state
+// weakness: control-flow
+// source: Cursor Bugbot review on millionco/react-doctor#1410
+
+import { create } from "zustand";
+
+export const useFuzzStore = create((set, get) => ({
+  items: [] as string[],
+  update: (enabled: boolean) => {
+    if (enabled) {
+      const items = get().items;
+      items.push("next");
+      set({ items });
+    }
+  },
+}));

--- a/packages/fuzz/corpus/true-positives/zustand-no-mutating-state--branch-reused-snapshot.tsx
+++ b/packages/fuzz/corpus/true-positives/zustand-no-mutating-state--branch-reused-snapshot.tsx
@@ -1,0 +1,18 @@
+// rule: zustand-no-mutating-state
+// weakness: control-flow
+// source: Laudiolin
+
+import { create } from "zustand";
+
+export const useFuzzStore = create((set, get) => ({
+  items: [] as string[],
+  add: (item: string, prepend: boolean) => {
+    const { items } = get();
+    if (prepend) {
+      items.unshift(item);
+    } else {
+      items.push(item);
+    }
+    set({ items });
+  },
+}));

--- a/packages/fuzz/corpus/true-positives/zustand-no-mutating-state--creator-get-state-updater.tsx
+++ b/packages/fuzz/corpus/true-positives/zustand-no-mutating-state--creator-get-state-updater.tsx
@@ -1,0 +1,14 @@
+// rule: zustand-no-mutating-state
+// weakness: snapshot-provenance
+// source: Cursor Bugbot review on millionco/react-doctor#1410
+
+import { create } from "zustand";
+
+export const useFuzzStore = create((set) => ({
+  items: [] as string[],
+  update: () =>
+    set((state) => {
+      state.items.push("next");
+      return useFuzzStore.getState();
+    }),
+}));

--- a/packages/fuzz/corpus/true-positives/zustand-no-mutating-state--cross-branch-rebind.tsx
+++ b/packages/fuzz/corpus/true-positives/zustand-no-mutating-state--cross-branch-rebind.tsx
@@ -1,0 +1,18 @@
+// rule: zustand-no-mutating-state
+// weakness: control-flow
+// source: Cursor Bugbot review on millionco/react-doctor#1410
+
+import { create } from "zustand";
+
+export const useFuzzStore = create((set, get) => ({
+  items: [] as string[],
+  update: (shouldMutate: boolean) => {
+    let items = get().items;
+    if (shouldMutate) {
+      items.push("next");
+    } else {
+      items = [...items];
+    }
+    set({ items });
+  },
+}));

--- a/packages/fuzz/corpus/true-positives/zustand-no-mutating-state--cross-store-notifier.tsx
+++ b/packages/fuzz/corpus/true-positives/zustand-no-mutating-state--cross-store-notifier.tsx
@@ -1,0 +1,12 @@
+// rule: zustand-no-mutating-state
+// weakness: provenance
+// source: Cursor Bugbot review on millionco/react-doctor#1410
+
+import { create } from "zustand";
+
+export const useFuzzStore = create(() => ({ items: [] as string[] }));
+export const useOtherFuzzStore = create(() => ({ items: [] as string[] }));
+
+const items = useFuzzStore.getState().items;
+items.push("next");
+useOtherFuzzStore.setState({ items: [] });

--- a/packages/fuzz/corpus/true-positives/zustand-no-mutating-state--get-updater-reuse.tsx
+++ b/packages/fuzz/corpus/true-positives/zustand-no-mutating-state--get-updater-reuse.tsx
@@ -1,0 +1,14 @@
+// rule: zustand-no-mutating-state
+// weakness: snapshot-provenance
+// source: Cursor Bugbot review on millionco/react-doctor#1410
+
+import { create } from "zustand";
+
+export const useFuzzStore = create((set, get) => ({
+  items: [] as string[],
+  update: () =>
+    set((state) => {
+      state.items.push("next");
+      return get();
+    }),
+}));

--- a/packages/fuzz/corpus/true-positives/zustand-no-mutating-state--inline-map-set.tsx
+++ b/packages/fuzz/corpus/true-positives/zustand-no-mutating-state--inline-map-set.tsx
@@ -1,0 +1,13 @@
+// rule: zustand-no-mutating-state
+// weakness: library-idiom
+// source: PR #1410 deep rule audit
+
+import { create } from "zustand";
+
+export const useStore = create((set) => ({
+  values: new Map<string, number>(),
+  update: () =>
+    set((state) => ({
+      values: state.values.set("key", 1),
+    })),
+}));

--- a/packages/fuzz/corpus/true-positives/zustand-no-mutating-state--nested-alias-spread.tsx
+++ b/packages/fuzz/corpus/true-positives/zustand-no-mutating-state--nested-alias-spread.tsx
@@ -1,0 +1,14 @@
+// rule: zustand-no-mutating-state
+// weakness: path-tracking
+// source: Cursor Bugbot review on millionco/react-doctor#1410
+
+import { create } from "zustand";
+
+export const useFuzzStore = create((set, get) => ({
+  nested: { items: [] as string[] },
+  update: () => {
+    const nested = get().nested;
+    nested.items.push("next");
+    set({ nested: { ...nested } });
+  },
+}));

--- a/packages/fuzz/corpus/true-positives/zustand-no-mutating-state--nested-branch-notifier.tsx
+++ b/packages/fuzz/corpus/true-positives/zustand-no-mutating-state--nested-branch-notifier.tsx
@@ -1,0 +1,19 @@
+// rule: zustand-no-mutating-state
+// weakness: control-flow
+// source: Cursor Bugbot review on millionco/react-doctor#1410
+
+import { create } from "zustand";
+
+export const useFuzzStore = create((set, get) => ({
+  items: [] as string[],
+  update: (isEnabled: boolean, shouldMutate: boolean) => {
+    if (isEnabled) {
+      const items = get().items;
+      if (shouldMutate) {
+        items.push("next");
+      } else {
+        set({ items: [...items] });
+      }
+    }
+  },
+}));

--- a/packages/fuzz/corpus/true-positives/zustand-no-mutating-state--nested-snapshot.tsx
+++ b/packages/fuzz/corpus/true-positives/zustand-no-mutating-state--nested-snapshot.tsx
@@ -1,0 +1,13 @@
+// rule: zustand-no-mutating-state
+// weakness: path-tracking
+// source: Cursor Bugbot review on millionco/react-doctor#1410
+
+import { create } from "zustand";
+
+export const useFuzzStore = create((set, get) => ({
+  nested: { items: [] as string[] },
+  update: () => {
+    get().nested.items.push("next");
+    set({ nested: { items: get().nested.items } });
+  },
+}));

--- a/packages/fuzz/corpus/true-positives/zustand-no-mutating-state--notifier-before-mutation.tsx
+++ b/packages/fuzz/corpus/true-positives/zustand-no-mutating-state--notifier-before-mutation.tsx
@@ -1,0 +1,13 @@
+// rule: zustand-no-mutating-state
+// weakness: ordering
+// source: Cursor Bugbot review on millionco/react-doctor#1410
+
+import { create } from "zustand";
+
+export const useFuzzStore = create((set, get) => ({
+  items: [] as string[],
+  update: () => {
+    const items = get().items;
+    (set({ items: [...items] }), items.push("next"));
+  },
+}));

--- a/packages/fuzz/corpus/true-positives/zustand-no-mutating-state--partial-nested-notifier.tsx
+++ b/packages/fuzz/corpus/true-positives/zustand-no-mutating-state--partial-nested-notifier.tsx
@@ -1,0 +1,14 @@
+import { create } from "zustand";
+
+export const useStore = create((set, get) => ({
+  items: [] as string[],
+  update: (isOuterEnabled: boolean, isInnerEnabled: boolean) => {
+    const items = get().items;
+    items.push("next");
+    if (isOuterEnabled) {
+      if (isInnerEnabled) set({ items: [...items] });
+    } else {
+      set({ items: items.slice() });
+    }
+  },
+}));

--- a/packages/fuzz/corpus/true-positives/zustand-no-mutating-state--reused-snapshot.tsx
+++ b/packages/fuzz/corpus/true-positives/zustand-no-mutating-state--reused-snapshot.tsx
@@ -1,0 +1,14 @@
+// rule: zustand-no-mutating-state
+// weakness: copy-tracking
+// source: Zustand issue #244
+
+import { create } from "zustand";
+
+export const useFuzzStore = create((set) => ({
+  items: [] as string[],
+  add: (item: string) =>
+    set((state) => {
+      state.items.push(item);
+      return { items: state.items };
+    }),
+}));

--- a/packages/fuzz/corpus/true-positives/zustand-no-mutating-state--set-state-updater.tsx
+++ b/packages/fuzz/corpus/true-positives/zustand-no-mutating-state--set-state-updater.tsx
@@ -1,0 +1,12 @@
+// rule: zustand-no-mutating-state
+// weakness: library-idiom
+// source: Cursor Bugbot review on millionco/react-doctor#1410
+
+import { createStore } from "zustand/vanilla";
+
+export const fuzzStore = createStore(() => ({ items: [] as string[] }));
+
+fuzzStore.setState((state) => {
+  state.items.push("next");
+  return { items: state.items };
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness-fixtures.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness-fixtures.ts
@@ -1425,7 +1425,7 @@ export const livenessFixtures: Readonly<Record<string, LivenessFixture>> = {
     code: 'import { create } from "zustand";\nconst useStore = create((_set, get) => ({ count: get().count }));',
   },
   "zustand-no-mutating-state": {
-    code: '\n      import { create } from "zustand";\n      create((set) => ({ update: () => set((state) => { state.items.push("next"); return { items: state.items }; }) }));\n    ',
+    code: '\n      import { create } from "zustand";\n      create((set) => ({ items: [], update: () => set((state) => { state.items.push("next"); return { items: state.items }; }) }));\n    ',
   },
   "zod-v4-no-deprecated-error-apis": {
     code: '\n      import { z } from "zod";\n      const error = z.ZodError.create([]);\n    ',

--- a/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness-fixtures.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness-fixtures.ts
@@ -1424,6 +1424,9 @@ export const livenessFixtures: Readonly<Record<string, LivenessFixture>> = {
   "zustand-no-get-during-initialization": {
     code: 'import { create } from "zustand";\nconst useStore = create((_set, get) => ({ count: get().count }));',
   },
+  "zustand-no-mutating-state": {
+    code: '\n      import { create } from "zustand";\n      create((set) => ({ update: () => set((state) => { state.items.push("next"); return { items: state.items }; }) }));\n    ',
+  },
   "zod-v4-no-deprecated-error-apis": {
     code: '\n      import { z } from "zod";\n      const error = z.ZodError.create([]);\n    ',
   },

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
@@ -426,6 +426,7 @@ import { zodV4NoDeprecatedSchemaApis } from "./rules/zod/zod-v4-no-deprecated-sc
 import { zodV4PreferTopLevelStringFormats } from "./rules/zod/zod-v4-prefer-top-level-string-formats.js";
 import { zustandNoFreshSelectorResult } from "./rules/state-and-effects/zustand-no-fresh-selector-result.js";
 import { zustandNoGetDuringInitialization } from "./rules/state-and-effects/zustand-no-get-during-initialization.js";
+import { zustandNoMutatingState } from "./rules/state-and-effects/zustand-no-mutating-state.js";
 import { zustandNoWholeStoreDestructure } from "./rules/state-and-effects/zustand-no-whole-store-destructure.js";
 
 export const reactDoctorRules = [
@@ -5371,6 +5372,18 @@ export const reactDoctorRules = [
       requires: [
         ...new Set<Capability>(["react", ...(zustandNoGetDuringInitialization.requires ?? [])]),
       ],
+    },
+  },
+  {
+    key: "react-doctor/zustand-no-mutating-state",
+    id: "zustand-no-mutating-state",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...zustandNoMutatingState,
+      framework: "global",
+      category: "Bugs",
+      requires: [...new Set<Capability>(["react", ...(zustandNoMutatingState.requires ?? [])])],
     },
   },
   {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-mutating-reducer-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-mutating-reducer-state.ts
@@ -1,5 +1,3 @@
-import { MUTATING_ARRAY_METHODS, MUTATING_COLLECTION_METHODS } from "../../constants/js.js";
-import { OBJECT_PROPERTY_MUTATION_METHOD_NAMES } from "../../constants/mutation-methods.js";
 import { REDUCER_PATH_STATE_LIMIT } from "../../constants/thresholds.js";
 import { collectPatternNames } from "../../utils/collect-pattern-names.js";
 import { defineRule } from "../../utils/define-rule.js";
@@ -8,10 +6,14 @@ import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
-import { isResultDiscardedCall } from "../../utils/is-result-discarded-call.js";
+import {
+  collectMutableStateReferenceMutations,
+  updateMutableStateReferencesForIdentifierAssignment,
+  updateMutableStateReferencesForVariableDeclaration,
+  type MutableStateReferenceMutation,
+} from "../../utils/mutable-state-reference-analysis.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
-import { walkAst } from "../../utils/walk-ast.js";
 import { isLodashMutatorCall } from "./utils/lodash-mutator-call.js";
 import { resolveReducerFunction } from "./utils/resolve-reducer-function.js";
 import { getStaticMemberPropertyName } from "./utils/static-member-property-name.js";
@@ -19,8 +21,6 @@ import { getStaticMemberPropertyName } from "./utils/static-member-property-name
 const MESSAGE = "This reducer changes state in place, so your update is silently skipped.";
 
 const SAME_REFERENCE_ARRAY_RETURN_METHODS = new Set(["copyWithin", "fill", "reverse", "sort"]);
-
-const REFLECT_MUTATION_METHODS = new Set(["deleteProperty", "set"]);
 
 // React reducer state is compared by identity (`Object.is`). A reducer may
 // legitimately return the previous state object for no-op actions, and it may
@@ -94,10 +94,6 @@ const REFLECT_MUTATION_METHODS = new Set(["deleteProperty", "set"]);
 // reachability are approximated because mutation collection walks their AST
 // without modeling every execution path. Add CFG-backed path analysis before
 // treating those cases as precise.
-interface ReducerStateMutation {
-  node: EsTreeNode;
-}
-
 interface ReducerPathState {
   // Names that refer to the original reducer state object, so returning one
   // of them returns the same top-level reference React compares with Object.is.
@@ -105,7 +101,7 @@ interface ReducerPathState {
   // Names that refer to either the original state object or data reachable
   // from it. Mutating any of these mutates the previous reducer state.
   mutableStateSourceNames: Set<string>;
-  mutations: ReducerStateMutation[];
+  mutations: MutableStateReferenceMutation[];
 }
 
 const cloneReducerPathState = (state: ReducerPathState): ReducerPathState => ({
@@ -179,37 +175,6 @@ const isCallToImportedReactUseReducer = (node: EsTreeNodeOfType<"CallExpression"
 // We resolve the identifier through `findVariableInitializer`: if it
 // has a same-file binding the static call is treated as opaque and
 // skipped. Only an unresolved (i.e. global) name passes through.
-const isStaticMethodCallOnNamedObject = (
-  node: EsTreeNode,
-  objectName: string,
-  methodNames: ReadonlySet<string>,
-): boolean => {
-  const unwrappedNode = stripParenExpression(node);
-  if (!isNodeOfType(unwrappedNode, "CallExpression")) return false;
-  if (!isNodeOfType(unwrappedNode.callee, "MemberExpression")) return false;
-  const calleeObject = unwrappedNode.callee.object;
-  if (!isNodeOfType(calleeObject, "Identifier")) return false;
-  if (calleeObject.name !== objectName) return false;
-  if (!methodNames.has(getStaticMemberPropertyName(unwrappedNode.callee) ?? "")) return false;
-  // If the global name is shadowed by an in-scope binding, abstain.
-  const shadow = findVariableInitializer(calleeObject, calleeObject.name);
-  if (shadow) return false;
-  return true;
-};
-
-// Determines whether an expression's root identifier is known to be the
-// original reducer state, an alias to it, or a value reachable from it.
-const isExpressionRootedInMutableReducerStateSource = (
-  node: EsTreeNode,
-  state: ReducerPathState,
-): boolean => {
-  let current: EsTreeNode | null | undefined = stripParenExpression(node);
-  while (current && isNodeOfType(current, "MemberExpression")) {
-    current = stripParenExpression(current.object);
-  }
-  return isNodeOfType(current, "Identifier") && state.mutableStateSourceNames.has(current.name);
-};
-
 const isExpressionOriginalReducerStateReference = (
   node: EsTreeNode | null | undefined,
   state: ReducerPathState,
@@ -224,19 +189,6 @@ const isExpressionOriginalReducerStateReference = (
 
 // Captures assignments like `const items = state.items`, where mutating `items`
 // still mutates data reachable from the original reducer state.
-const isExpressionReachableFromOriginalReducerState = (
-  node: EsTreeNode | null | undefined,
-  state: ReducerPathState,
-): boolean => {
-  if (!node) return false;
-  if (isExpressionOriginalReducerStateReference(node, state)) return true;
-  const unwrappedNode = stripParenExpression(node);
-  return (
-    isNodeOfType(unwrappedNode, "MemberExpression") &&
-    isExpressionRootedInMutableReducerStateSource(unwrappedNode, state)
-  );
-};
-
 // Detects whether a return expression can hand React the original state object
 // back, including conditional/logical expressions and APIs that return their
 // receiver or first argument.
@@ -324,139 +276,13 @@ const canExpressionReturnOriginalReducerStateReference = (
   return false;
 };
 
-// Walks one statement/expression and records direct mutations of the original
-// reducer state, aliases to it, or values reachable from it.
 const collectReducerStateMutationsInExpressionOrStatement = (
   node: EsTreeNode,
   state: ReducerPathState,
-): ReducerStateMutation[] => {
-  // Nested reducer-local helpers are declarations, not code that runs on this
-  // path. Their bodies may mutate a parameter named `state`, but that is a
-  // different binding and should not be attributed to the outer reducer path.
-  if (isFunctionLike(node)) return [];
-  const mutations: ReducerStateMutation[] = [];
-  walkAst(node, (child: EsTreeNode) => {
-    const unwrappedChild = stripParenExpression(child);
-    // Prune nested function bodies for the same reason: only collect mutations
-    // that execute in the currently analyzed reducer path.
-    if (child !== node && isFunctionLike(unwrappedChild)) return false;
-
-    if (isNodeOfType(unwrappedChild, "AssignmentExpression")) {
-      // Direct property writes mutate the previous state when their left-hand
-      // side is rooted in the original state or a state-derived alias:
-      //
-      //   state.count = 1;
-      //   alias.items[index] = item;
-      if (
-        isNodeOfType(stripParenExpression(unwrappedChild.left), "MemberExpression") &&
-        isExpressionRootedInMutableReducerStateSource(unwrappedChild.left, state)
-      ) {
-        mutations.push({ node: unwrappedChild });
-      }
-      return;
-    }
-
-    if (isNodeOfType(unwrappedChild, "UpdateExpression")) {
-      // Updates are writes too:
-      //
-      //   state.count++;
-      //   --alias.count;
-      if (
-        isNodeOfType(stripParenExpression(unwrappedChild.argument), "MemberExpression") &&
-        isExpressionRootedInMutableReducerStateSource(unwrappedChild.argument, state)
-      ) {
-        mutations.push({ node: unwrappedChild });
-      }
-      return;
-    }
-
-    if (isNodeOfType(unwrappedChild, "UnaryExpression") && unwrappedChild.operator === "delete") {
-      // Deleting a property mutates the containing object:
-      //
-      //   delete state.items[id];
-      if (
-        isNodeOfType(stripParenExpression(unwrappedChild.argument), "MemberExpression") &&
-        isExpressionRootedInMutableReducerStateSource(unwrappedChild.argument, state)
-      ) {
-        mutations.push({ node: unwrappedChild });
-      }
-      return;
-    }
-
-    if (!isNodeOfType(unwrappedChild, "CallExpression")) return;
-    const firstArgument = unwrappedChild.arguments?.[0];
-    // Built-in object APIs mutate their first argument:
-    //
-    //   Object.assign(state, patch);
-    //   Reflect.set(state, key, value);
-    //
-    // Only count them when that first argument is rooted in reducer state.
-    if (
-      firstArgument &&
-      isExpressionRootedInMutableReducerStateSource(firstArgument, state) &&
-      (isStaticMethodCallOnNamedObject(
-        unwrappedChild,
-        "Object",
-        OBJECT_PROPERTY_MUTATION_METHOD_NAMES,
-      ) ||
-        isStaticMethodCallOnNamedObject(unwrappedChild, "Reflect", REFLECT_MUTATION_METHODS))
-    ) {
-      mutations.push({ node: unwrappedChild });
-      return;
-    }
-    // Lodash mutators take the target object as their first argument:
-    //
-    //   _.set(state, "user.name", "Ada");
-    //   set(state, "user.name", "Ada");
-    //
-    // Resolved via `findVariableInitializer` so we only fire when the
-    // callee resolves back to an import from the mutating lodash
-    // package (NOT lodash/fp, which is non-mutating).
-    if (
-      firstArgument &&
-      isExpressionRootedInMutableReducerStateSource(firstArgument, state) &&
-      isLodashMutatorCall(unwrappedChild)
-    ) {
-      mutations.push({ node: unwrappedChild });
-      return;
-    }
-    if (!isNodeOfType(unwrappedChild.callee, "MemberExpression")) return;
-    const methodName = getStaticMemberPropertyName(unwrappedChild.callee);
-    // Receiver-mutating methods mutate the object/array/collection they are
-    // called on. We only record them when the receiver is state-derived:
-    //
-    //   state.items.push(item);
-    //   items.splice(index, 1);
-    //   stateMap.set(key, value);
-    if (
-      !methodName ||
-      (!MUTATING_ARRAY_METHODS.has(methodName) && !MUTATING_COLLECTION_METHODS.has(methodName))
-    )
-      return;
-    // Collection method names like `set` / `add` / `delete` are shared with
-    // immutable-API containers (Immutable.js Map, Mori) whose calls return a
-    // NEW collection instead of mutating the receiver. Distinguishing them
-    // from native Map/Set needs type info the lint pipeline doesn't have, so
-    // the escape is result-shaped: a call whose result is CONSUMED
-    // (`return state.set(k, v)`, `const next = state.set(k, v)`) matches the
-    // immutable idiom and is skipped; a discarded-result call
-    // (`state.set(k, v);`) is either a native mutation or a no-op immutable
-    // call — both worth reporting. Array mutators stay unconditional:
-    // consuming a native `.splice()` / `.push()` result is idiomatic
-    // (`const removed = items.splice(i, 1)`) and still mutates.
-    if (
-      MUTATING_COLLECTION_METHODS.has(methodName) &&
-      !MUTATING_ARRAY_METHODS.has(methodName) &&
-      !isResultDiscardedCall(unwrappedChild)
-    ) {
-      return;
-    }
-    if (isExpressionRootedInMutableReducerStateSource(unwrappedChild.callee.object, state)) {
-      mutations.push({ node: unwrappedChild });
-    }
+): MutableStateReferenceMutation[] =>
+  collectMutableStateReferenceMutations(node, state, {
+    isAdditionalMutatingCall: isLodashMutatorCall,
   });
-  return mutations;
-};
 
 const collectBlockScopedBindingNames = (
   blockStatement: EsTreeNodeOfType<"BlockStatement">,
@@ -493,93 +319,19 @@ const restoreOuterIdentityForBlockScopedNames = (
   return nextState;
 };
 
-// Walks a destructure pattern, marking each binding as reachable
-// from the reducer state when the surrounding initializer is itself
-// reachable. The names added to `mutableStateSourceNames` lose their
-// original-identity status: `const { items } = state` means
-// `items === state.items`, which is reachable but NOT the same
-// top-level reference React compares — only mutations through it
-// matter.
-//
-// Conservative scope: only ObjectPattern + ArrayPattern with
-// Identifier / AssignmentPattern leaves. Nested patterns (e.g.
-// `const { a: { b } } = state`) are NOT modelled — those rebind
-// `b` to `state.a.b`, also reachable, but the second-level recursion
-// adds noise without a clear win. The single-level case is the
-// canonical Redux reducer pattern.
-const recordDestructuredAliasNames = (pattern: EsTreeNode, state: ReducerPathState): void => {
-  if (isNodeOfType(pattern, "ObjectPattern")) {
-    for (const property of pattern.properties ?? []) {
-      if (!isNodeOfType(property, "Property")) continue;
-      const valueNode = property.value;
-      // `const { items } = state`         (shorthand)        → Identifier
-      // `const { items: localItems } = state`               → Identifier
-      // `const { items = [] } = state`                     → AssignmentPattern wrapping Identifier
-      // `const { items: localItems = [] } = state`         → AssignmentPattern wrapping Identifier
-      let leafIdentifier: EsTreeNodeOfType<"Identifier"> | null = null;
-      if (isNodeOfType(valueNode, "Identifier")) {
-        leafIdentifier = valueNode;
-      } else if (
-        isNodeOfType(valueNode, "AssignmentPattern") &&
-        isNodeOfType(valueNode.left, "Identifier")
-      ) {
-        leafIdentifier = valueNode.left;
-      }
-      if (!leafIdentifier) continue;
-      state.mutableStateSourceNames.add(leafIdentifier.name);
-    }
-    return;
-  }
-  if (isNodeOfType(pattern, "ArrayPattern")) {
-    for (const element of pattern.elements ?? []) {
-      if (!element) continue;
-      if (isNodeOfType(element, "Identifier")) {
-        state.mutableStateSourceNames.add(element.name);
-        continue;
-      }
-      if (isNodeOfType(element, "AssignmentPattern") && isNodeOfType(element.left, "Identifier")) {
-        state.mutableStateSourceNames.add(element.left.name);
-        continue;
-      }
-      if (isNodeOfType(element, "RestElement") && isNodeOfType(element.argument, "Identifier")) {
-        // `const [first, ...rest] = state.items` — `rest` is a fresh
-        // array (slice copy at runtime), not reachable from state.
-        // Intentionally NOT added.
-      }
-    }
-  }
-};
-
 const updateReducerStateIdentityForVariableDeclaration = (
   declaration: EsTreeNodeOfType<"VariableDeclaration">,
   state: ReducerPathState,
 ): void => {
+  updateMutableStateReferencesForVariableDeclaration(declaration, state);
   for (const declarator of declaration.declarations ?? []) {
     if (isNodeOfType(declarator.id, "Identifier")) {
       const name = declarator.id.name;
       state.originalStateReferenceNames.delete(name);
-      state.mutableStateSourceNames.delete(name);
 
       if (isExpressionOriginalReducerStateReference(declarator.init, state)) {
         state.originalStateReferenceNames.add(name);
-        state.mutableStateSourceNames.add(name);
-        continue;
       }
-
-      if (isExpressionReachableFromOriginalReducerState(declarator.init, state)) {
-        state.mutableStateSourceNames.add(name);
-      }
-      continue;
-    }
-
-    // Destructure off the original state object (or anything reachable from
-    // it). Each top-level binding becomes a new alias reachable from state.
-    if (
-      (isNodeOfType(declarator.id, "ObjectPattern") ||
-        isNodeOfType(declarator.id, "ArrayPattern")) &&
-      isExpressionReachableFromOriginalReducerState(declarator.init, state)
-    ) {
-      recordDestructuredAliasNames(declarator.id, state);
     }
   }
 };
@@ -591,18 +343,12 @@ const updateReducerStateIdentityForIdentifierAssignment = (
   state: ReducerPathState,
 ): void => {
   if (!isNodeOfType(assignment.left, "Identifier")) return;
+  updateMutableStateReferencesForIdentifierAssignment(assignment, state);
   const name = assignment.left.name;
   state.originalStateReferenceNames.delete(name);
-  state.mutableStateSourceNames.delete(name);
 
   if (isExpressionOriginalReducerStateReference(assignment.right, state)) {
     state.originalStateReferenceNames.add(name);
-    state.mutableStateSourceNames.add(name);
-    return;
-  }
-
-  if (isExpressionReachableFromOriginalReducerState(assignment.right, state)) {
-    state.mutableStateSourceNames.add(name);
   }
 };
 
@@ -638,7 +384,7 @@ const analyzeReactUseReducerFunctionForStateMutation = (
       : null;
   if (!stateName) return;
 
-  const reportReducerStateMutations = (mutations: ReducerStateMutation[]): void => {
+  const reportReducerStateMutations = (mutations: MutableStateReferenceMutation[]): void => {
     if (mutations.length === 0) return;
 
     if (options.crossFileConsumerCallSite && options.crossFileSourceDisplay) {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.test.ts
@@ -400,6 +400,25 @@ describe("zustand-no-mutating-state", () => {
     );
   });
 
+  it("fails closed when unsupported control flow is nested in a branch", () => {
+    expectDiagnosticCount(
+      `
+        import { create } from "zustand";
+        create((set, get) => ({
+          update: (isEnabled, values) => {
+            const items = get().items;
+            items.push("next");
+            set({ items });
+            if (isEnabled) {
+              for (const value of values) set({ value });
+            }
+          },
+        }));
+      `,
+      0,
+    );
+  });
+
   it("abstains from unproven snapshot replacements", () => {
     expectDiagnosticCount(
       `
@@ -440,6 +459,26 @@ describe("zustand-no-mutating-state", () => {
         }));
       `,
       1,
+    );
+  });
+
+  it("recognizes updater returns that reuse get snapshots", () => {
+    expectDiagnosticCount(
+      `
+        import { create } from "zustand";
+        const useStore = create((set, get) => ({
+          items: [],
+          update: () => set((state) => {
+            state.items.push("next");
+            return get();
+          }),
+        }));
+        useStore.setState((state) => {
+          state.items.push("next");
+          return useStore.getState();
+        });
+      `,
+      2,
     );
   });
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.test.ts
@@ -282,6 +282,62 @@ describe("zustand-no-mutating-state", () => {
     );
   });
 
+  it("uses the bound store setState as a get snapshot notifier", () => {
+    expectDiagnosticCount(
+      `
+        import { create } from "zustand";
+        const useStore = create((set, get) => ({
+          safe: () => {
+            const items = get().items;
+            items.push("next");
+            useStore.setState({ items: [...items] });
+          },
+          unsafe: () => {
+            const items = get().items;
+            items.push("next");
+            useStore.setState({ items });
+          },
+        }));
+      `,
+      1,
+    );
+  });
+
+  it("tracks fresh and reused mutable snapshot rebindings", () => {
+    expectDiagnosticCount(
+      `
+        import { create } from "zustand";
+        create((set, get) => ({
+          safe: () => {
+            let selected = get().items;
+            selected.push("next");
+            selected = [...selected];
+            set({ items: selected });
+          },
+          unknown: () => {
+            let items = get().items;
+            items.push("next");
+            items = cloneItems(items);
+            set({ items });
+          },
+          unsafe: () => {
+            let items = get().items;
+            items.push("next");
+            items = items;
+            set({ items });
+          },
+          wrongProperty: () => {
+            let items = get().items;
+            items.push("next");
+            items = items.slice();
+            set({ archivedItems: items });
+          },
+        }));
+      `,
+      2,
+    );
+  });
+
   it("abstains from unproven snapshot replacements", () => {
     expectDiagnosticCount(
       `

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.test.ts
@@ -513,6 +513,22 @@ describe("zustand-no-mutating-state", () => {
     );
   });
 
+  it("recognizes creator updater returns that reuse bound getState snapshots", () => {
+    expectDiagnosticCount(
+      `
+        import { create } from "zustand";
+        const useStore = create((set) => ({
+          items: [],
+          update: () => set((state) => {
+            state.items.push("next");
+            return useStore.getState();
+          }),
+        }));
+      `,
+      1,
+    );
+  });
+
   it("analyzes setState updater snapshots and returned notifications", () => {
     expectDiagnosticCount(
       `

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.test.ts
@@ -377,7 +377,7 @@ describe("zustand-no-mutating-state", () => {
     );
   });
 
-  it("fails closed for branch-dependent mutation and notification paths", () => {
+  it("supports non-exiting snapshot branches and fails closed for updater branches", () => {
     expectDiagnosticCount(
       `
         import { create } from "zustand";
@@ -391,9 +391,42 @@ describe("zustand-no-mutating-state", () => {
             if (enabled) items.push("next");
             set({ items });
           },
+          safeExternal: (enabled) => {
+            const items = get().items;
+            if (enabled) items.push("next");
+            set({ items: [...items] });
+          },
+          earlyExit: (enabled) => {
+            const items = get().items;
+            if (enabled) {
+              items.push("next");
+              return;
+            }
+            set({ items });
+          },
         }));
       `,
-      0,
+      1,
+    );
+  });
+
+  it("reports mutations in both branches before a reused snapshot notification", () => {
+    expectDiagnosticCount(
+      `
+        import { create } from "zustand";
+        create((set, get) => ({
+          add: (item, prepend) => {
+            const { items } = get();
+            if (prepend) {
+              items.unshift(item);
+            } else {
+              items.push(item);
+            }
+            set({ items });
+          },
+        }));
+      `,
+      2,
     );
   });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.test.ts
@@ -662,6 +662,27 @@ describe("zustand-no-mutating-state", () => {
     );
   });
 
+  it("reports nested child reuse through an intermediate snapshot alias", () => {
+    expectDiagnosticCount(
+      `
+        import { create } from "zustand";
+        create((set, get) => ({
+          unsafe: () => {
+            const nested = get().nested;
+            nested.items.push("next");
+            set({ nested: { ...nested } });
+          },
+          safe: () => {
+            const nested = get().nested;
+            nested.items.push("next");
+            set({ nested: { ...nested, items: [...nested.items] } });
+          },
+        }));
+      `,
+      1,
+    );
+  });
+
   it("matches the replacement property to the mutated snapshot path", () => {
     expectDiagnosticCount(
       `

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.test.ts
@@ -630,6 +630,37 @@ describe("zustand-no-mutating-state", () => {
     );
   });
 
+  it("models nested notifier branches without flattening their paths", () => {
+    expectDiagnosticCount(
+      `
+        import { create } from "zustand";
+        create((set, get) => ({
+          unsafe: (isOuterEnabled, isInnerEnabled) => {
+            const items = get().items;
+            items.push("next");
+            if (isOuterEnabled) {
+              if (isInnerEnabled) set({ items: [...items] });
+            } else {
+              set({ items: items.slice() });
+            }
+          },
+          safe: (isOuterEnabled, isInnerEnabled) => {
+            if (isOuterEnabled) {
+              const items = get().items;
+              items.push("next");
+              if (isInnerEnabled) {
+                set({ items: [...items] });
+              } else {
+                set({ items: items.slice() });
+              }
+            }
+          },
+        }));
+      `,
+      1,
+    );
+  });
+
   it("tracks snapshot aliases introduced inside branches", () => {
     expectDiagnosticCount(
       `

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.test.ts
@@ -212,6 +212,24 @@ describe("zustand-no-mutating-state", () => {
     );
   });
 
+  it("allows intentionally non-reactive stores with an unused set parameter", () => {
+    expectDiagnosticCount(
+      `
+        import { create } from "zustand";
+        create((_set, get) => ({
+          cache: new Map(),
+          read: (key) => get().cache.get(key),
+          write: (key, value) => {
+            const cache = get().cache;
+            cache.set(key, value);
+            if (cache.size > 30) cache.delete(cache.keys().next().value);
+          },
+        }));
+      `,
+      0,
+    );
+  });
+
   it("reports immutable aliases of get and set", () => {
     expectDiagnosticCount(
       `

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.test.ts
@@ -34,6 +34,11 @@ describe("zustand-no-mutating-state", () => {
       `
         import { create } from "zustand";
         create((set) => ({
+          rows: [],
+          count: 0,
+          cache: { stale: true },
+          user: { active: false },
+          map: new Map(),
           update: () => set((state) => {
             const rows = state.rows;
             rows.push({ id: 1 });
@@ -49,11 +54,51 @@ describe("zustand-no-mutating-state", () => {
     );
   });
 
+  it("reports inline Map and Set mutations that reuse the returned collection", () => {
+    expectDiagnosticCount(
+      `
+        import { create } from "zustand";
+        create((set) => ({
+          values: new Map(),
+          selected: new Set(),
+          update: () => set((state) => ({
+            values: state.values.set("key", 1),
+            selected: state.selected.add("key"),
+          })),
+        }));
+      `,
+      2,
+    );
+  });
+
+  it("does not infer built-in mutation from user-defined method names", () => {
+    expectDiagnosticCount(
+      `
+        import { create } from "zustand";
+        const stableQueue = {};
+        create((set) => ({
+          queue: {
+            push: (_value) => stableQueue,
+            set: (_key, _value) => stableQueue,
+          },
+          update: () => set((state) => {
+            state.queue.push("value");
+            state.queue.set("key", "value");
+            return { queue: state.queue };
+          }),
+        }));
+      `,
+      0,
+    );
+  });
+
   it("reports concise updater mutations and callbacks without a returned update", () => {
     expectDiagnosticCount(
       `
         import { create } from "zustand";
         create((set) => ({
+          items: [],
+          count: 0,
           sort: () => set((state) => ({ items: state.items.sort() })),
           increment: () => set((state) => { state.count += 1; }),
           decrement: () => set((state) => void state.count--),
@@ -271,6 +316,7 @@ describe("zustand-no-mutating-state", () => {
         import { create } from "zustand";
         import { createStore } from "zustand/vanilla";
         const useStore = create((set, get) => ({
+          items: [],
           update: () => {
             get().items.push("next");
             set({ items: get().items });
@@ -288,6 +334,7 @@ describe("zustand-no-mutating-state", () => {
       `
         import { create } from "zustand";
         create((set, get) => ({
+          items: [],
           update: () => {
             const items = get().items;
             items.push("next");
@@ -304,6 +351,7 @@ describe("zustand-no-mutating-state", () => {
       `
         import { create } from "zustand";
         const useStore = create((set, get) => ({
+          items: [],
           safe: () => {
             const items = get().items;
             items.push("next");
@@ -325,6 +373,7 @@ describe("zustand-no-mutating-state", () => {
       `
         import { create } from "zustand";
         create((set, get) => ({
+          items: [],
           safe: () => {
             let selected = get().items;
             selected.push("next");
@@ -360,6 +409,7 @@ describe("zustand-no-mutating-state", () => {
       `
         import { create } from "zustand";
         create((set, get) => ({
+          items: [],
           unsafe: (shouldMutate) => {
             let items = get().items;
             if (shouldMutate) {
@@ -394,6 +444,7 @@ describe("zustand-no-mutating-state", () => {
       `
         import { create } from "zustand";
         create((set, get) => ({
+          items: [],
           unsafe: (isOuterEnabled, shouldMutate) => {
             if (isOuterEnabled) {
               const items = get().items;
@@ -422,6 +473,7 @@ describe("zustand-no-mutating-state", () => {
       `
         import { create } from "zustand";
         create((set, get) => ({
+          items: [],
           update: () => {
             const items = get().items;
             set({ items: [...items] }), items.push("next");
@@ -437,6 +489,7 @@ describe("zustand-no-mutating-state", () => {
       `
         import { create } from "zustand";
         create((set, get) => ({
+          items: [],
           update: (isEnabled, values) => {
             const items = get().items;
             items.push("next");
@@ -456,6 +509,7 @@ describe("zustand-no-mutating-state", () => {
       `
         import { create } from "zustand";
         create((set, get) => ({
+          items: [],
           update: (shouldNotify) => {
             const items = get().items;
             items.push("next");
@@ -472,6 +526,7 @@ describe("zustand-no-mutating-state", () => {
       `
         import { create } from "zustand";
         create((set, get) => ({
+          items: [],
           updateWithBinding: () => {
             const items = get().items;
             items.push("next");
@@ -494,6 +549,7 @@ describe("zustand-no-mutating-state", () => {
       `
         import { create } from "zustand";
         create((set, get) => ({
+          items: [],
           safe: () => set(() => {
             const items = get().items;
             items.push("next");
@@ -601,6 +657,7 @@ describe("zustand-no-mutating-state", () => {
       `
         import { create } from "zustand";
         create((set, get) => ({
+          items: [],
           safe: (enabled) => {
             const items = get().items;
             if (enabled) {
@@ -652,6 +709,7 @@ describe("zustand-no-mutating-state", () => {
       `
         import { create } from "zustand";
         create((set, get) => ({
+          items: [],
           unsafe: (isOuterEnabled, isInnerEnabled) => {
             const items = get().items;
             items.push("next");
@@ -683,6 +741,7 @@ describe("zustand-no-mutating-state", () => {
       `
         import { create } from "zustand";
         create((set, get) => ({
+          items: [],
           update: (enabled) => {
             if (enabled) {
               const items = get().items;
@@ -712,6 +771,8 @@ describe("zustand-no-mutating-state", () => {
       `
         import { create } from "zustand";
         create((set, get) => ({
+          items: [],
+          nested: { items: [] },
           unsafe: () => {
             get().nested.items.push("next");
             set({ nested: { items: get().nested.items } });
@@ -731,6 +792,8 @@ describe("zustand-no-mutating-state", () => {
       `
         import { create } from "zustand";
         create((set, get) => ({
+          items: [],
+          nested: { items: [] },
           unsafe: () => {
             const nested = get().nested;
             nested.items.push("next");
@@ -752,6 +815,7 @@ describe("zustand-no-mutating-state", () => {
       `
         import { create } from "zustand";
         create((set, get) => ({
+          items: [],
           unsafe: () => {
             const items = get().items;
             items.push("next");
@@ -849,6 +913,7 @@ describe("zustand-no-mutating-state", () => {
       `
         import { create } from "zustand";
         create((set, get) => ({
+          items: [],
           update: (set, get) => {
             const items = get().items;
             items.push("next");
@@ -865,6 +930,7 @@ describe("zustand-no-mutating-state", () => {
       `
         import { create } from "zustand";
         create((set, get) => ({
+          items: [],
           update: (enabled) => set((state) => {
             if (enabled) state.items.push("next");
             return { items: state.items };
@@ -898,6 +964,7 @@ describe("zustand-no-mutating-state", () => {
       `
         import { create } from "zustand";
         create((set, get) => ({
+          items: [],
           add: (item, prepend) => {
             const { items } = get();
             if (prepend) {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.test.ts
@@ -366,9 +366,27 @@ describe("zustand-no-mutating-state", () => {
               set({ items: [...items] });
             }
           },
+          safeBeforeBranch: (enabled) => {
+            const items = get().items;
+            items.push("next");
+            if (enabled) {
+              set({ items: [...items] });
+            } else {
+              set({ items: items.slice() });
+            }
+          },
+          missingBeforeBranchNotifier: (enabled) => {
+            const items = get().items;
+            items.push("next");
+            if (enabled) {
+              set({ items: [...items] });
+            } else {
+              console.log(items.length);
+            }
+          },
         }));
       `,
-      2,
+      3,
     );
   });
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.test.ts
@@ -372,6 +372,34 @@ describe("zustand-no-mutating-state", () => {
     );
   });
 
+  it("does not match notifiers from mutually exclusive nested branches", () => {
+    expectDiagnosticCount(
+      `
+        import { create } from "zustand";
+        create((set, get) => ({
+          unsafe: (isOuterEnabled, shouldMutate) => {
+            if (isOuterEnabled) {
+              const items = get().items;
+              if (shouldMutate) {
+                items.push("next");
+              } else {
+                set({ items: [...items] });
+              }
+            }
+          },
+          safe: (isOuterEnabled, shouldMutate) => {
+            if (isOuterEnabled && shouldMutate) {
+              const items = get().items;
+              items.push("next");
+              set({ items: [...items] });
+            }
+          },
+        }));
+      `,
+      1,
+    );
+  });
+
   it("abstains from unproven snapshot replacements", () => {
     expectDiagnosticCount(
       `

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.test.ts
@@ -282,6 +282,49 @@ describe("zustand-no-mutating-state", () => {
     );
   });
 
+  it("abstains from unproven snapshot replacements", () => {
+    expectDiagnosticCount(
+      `
+        import { create } from "zustand";
+        create((set, get) => ({
+          updateWithBinding: () => {
+            const items = get().items;
+            items.push("next");
+            const nextItems = [...items];
+            set({ items: nextItems });
+          },
+          updateWithHelper: () => {
+            const items = get().items;
+            items.push("next");
+            set({ items: Array.from(items) });
+          },
+        }));
+      `,
+      0,
+    );
+  });
+
+  it("uses set updater returns as snapshot notifications", () => {
+    expectDiagnosticCount(
+      `
+        import { create } from "zustand";
+        create((set, get) => ({
+          safe: () => set(() => {
+            const items = get().items;
+            items.push("next");
+            return { items: [...items] };
+          }),
+          unsafe: () => set(() => {
+            const items = get().items;
+            items.push("next");
+            return { items };
+          }),
+        }));
+      `,
+      1,
+    );
+  });
+
   it("matches the replacement property to the mutated snapshot path", () => {
     expectDiagnosticCount(
       `

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.test.ts
@@ -325,6 +325,53 @@ describe("zustand-no-mutating-state", () => {
     );
   });
 
+  it("does not use another store as the snapshot notifier", () => {
+    expectDiagnosticCount(
+      `
+        import { create } from "zustand";
+        const storeA = create(() => ({ items: [] }));
+        const storeB = create(() => ({ items: [] }));
+        const items = storeA.getState().items;
+        items.push("next");
+        storeB.setState({ items: [] });
+      `,
+      1,
+    );
+  });
+
+  it("matches branch-local notifiers to the mutation branch", () => {
+    expectDiagnosticCount(
+      `
+        import { create } from "zustand";
+        create((set, get) => ({
+          safe: (enabled) => {
+            const items = get().items;
+            if (enabled) {
+              items.push("next");
+              set({ items: [...items] });
+            }
+          },
+          unsafe: (enabled) => {
+            const items = get().items;
+            if (enabled) {
+              items.push("next");
+              set({ items });
+            }
+          },
+          crossBranch: (enabled) => {
+            const items = get().items;
+            if (enabled) {
+              items.push("next");
+            } else {
+              set({ items: [...items] });
+            }
+          },
+        }));
+      `,
+      2,
+    );
+  });
+
   it("matches the replacement property to the mutated snapshot path", () => {
     expectDiagnosticCount(
       `

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.test.ts
@@ -166,8 +166,25 @@ describe("zustand-no-mutating-state", () => {
           count: 0,
           increment: () => set((state) => void state.count++),
         })));
+        const useStore = create(withDrafts(() => ({ count: 0 })));
+        useStore.setState((state) => void state.count++);
       `,
       0,
+    );
+  });
+
+  it("gates bound updater semantics for each store using a shared creator", () => {
+    expectDiagnosticCount(
+      `
+        import { create } from "zustand";
+        import { immer } from "zustand/middleware/immer";
+        const creator = () => ({ count: 0 });
+        const immerStore = create(immer(creator));
+        const plainStore = create(creator);
+        immerStore.setState((state) => void state.count++);
+        plainStore.setState((state) => void state.count++);
+      `,
+      1,
     );
   });
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.test.ts
@@ -338,6 +338,40 @@ describe("zustand-no-mutating-state", () => {
     );
   });
 
+  it("does not apply rebindings from mutually exclusive branches", () => {
+    expectDiagnosticCount(
+      `
+        import { create } from "zustand";
+        create((set, get) => ({
+          unsafe: (shouldMutate) => {
+            let items = get().items;
+            if (shouldMutate) {
+              items.push("next");
+            } else {
+              items = [...items];
+            }
+            set({ items });
+          },
+          safeInBranch: (shouldMutate) => {
+            let items = get().items;
+            if (shouldMutate) {
+              items.push("next");
+              items = [...items];
+              set({ items });
+            }
+          },
+          safeAfterBranch: (shouldMutate) => {
+            let items = get().items;
+            if (shouldMutate) items.push("next");
+            items = [...items];
+            set({ items });
+          },
+        }));
+      `,
+      1,
+    );
+  });
+
   it("abstains from unproven snapshot replacements", () => {
     expectDiagnosticCount(
       `

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.test.ts
@@ -390,6 +390,54 @@ describe("zustand-no-mutating-state", () => {
     );
   });
 
+  it("tracks snapshot aliases introduced inside branches", () => {
+    expectDiagnosticCount(
+      `
+        import { create } from "zustand";
+        create((set, get) => ({
+          update: (enabled) => {
+            if (enabled) {
+              const items = get().items;
+              items.push("next");
+              set({ items });
+            } else {
+              const { items } = get();
+              items.push("fallback");
+              set({ items });
+            }
+          },
+          safe: (enabled) => {
+            if (enabled) {
+              const items = get().items;
+              items.push("next");
+              set({ items: [...items] });
+            }
+          },
+        }));
+      `,
+      2,
+    );
+  });
+
+  it("matches nested direct snapshot paths against nested updates", () => {
+    expectDiagnosticCount(
+      `
+        import { create } from "zustand";
+        create((set, get) => ({
+          unsafe: () => {
+            get().nested.items.push("next");
+            set({ nested: { items: get().nested.items } });
+          },
+          safe: () => {
+            get().nested.items.push("next");
+            set({ nested: { items: [...get().nested.items] } });
+          },
+        }));
+      `,
+      1,
+    );
+  });
+
   it("matches the replacement property to the mutated snapshot path", () => {
     expectDiagnosticCount(
       `

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.test.ts
@@ -1,0 +1,399 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { zustandNoMutatingState } from "./zustand-no-mutating-state.js";
+
+const expectDiagnosticCount = (code: string, count: number): void => {
+  const result = runRule(zustandNoMutatingState, code);
+  expect(result.parseErrors).toEqual([]);
+  expect(result.diagnostics).toHaveLength(count);
+};
+
+describe("zustand-no-mutating-state", () => {
+  it("requires a supported Zustand dependency", () => {
+    expect(zustandNoMutatingState.requires).toEqual(["zustand", "zustand:1"]);
+  });
+
+  it("reports a mutated nested object returned through set", () => {
+    expectDiagnosticCount(
+      `
+        import { create } from "zustand";
+        const useStore = create((set) => ({
+          user: { name: "Ada" },
+          rename: (name) => set((state) => {
+            state.user.name = name;
+            return { user: state.user };
+          }),
+        }));
+      `,
+      1,
+    );
+  });
+
+  it("reports aliases, updates, deletes, and built-in mutators", () => {
+    expectDiagnosticCount(
+      `
+        import { create } from "zustand";
+        create((set) => ({
+          update: () => set((state) => {
+            const rows = state.rows;
+            rows.push({ id: 1 });
+            state.count++;
+            delete state.cache.stale;
+            Object.assign(state.user, { active: true });
+            state.map.set("ready", true);
+            return state;
+          }),
+        }));
+      `,
+      5,
+    );
+  });
+
+  it("reports concise updater mutations and callbacks without a returned update", () => {
+    expectDiagnosticCount(
+      `
+        import { create } from "zustand";
+        create((set) => ({
+          sort: () => set((state) => ({ items: state.items.sort() })),
+          increment: () => set((state) => { state.count += 1; }),
+          decrement: () => set((state) => void state.count--),
+        }));
+      `,
+      3,
+    );
+  });
+
+  it("reports shallow cloning an ancestor that preserves the mutated child", () => {
+    expectDiagnosticCount(
+      `
+        import { create } from "zustand";
+        create((set) => ({
+          rename: () => set((state) => {
+            state.user.name = "Grace";
+            return { ...state };
+          }),
+          touchProfile: () => set((state) => {
+            state.user.profile.label = "new";
+            return { ...state, user: { ...state.user } };
+          }),
+          updateOther: () => set((state) => {
+            state.user.name = "Lin";
+            return { other: true };
+          }),
+        }));
+      `,
+      3,
+    );
+  });
+
+  it("allows clone-before-mutate and clone-after-mutate replacements", () => {
+    expectDiagnosticCount(
+      `
+        import { create } from "zustand";
+        create((set) => ({
+          append: (item) => set((state) => {
+            const items = [...state.items];
+            items.push(item);
+            return { items };
+          }),
+          rename: () => set((state) => {
+            state.user.name = "Grace";
+            return { user: { ...state.user } };
+          }),
+          renameWithRootClone: () => set((state) => {
+            state.user.name = "Lin";
+            return { ...state, user: { ...state.user } };
+          }),
+          touchProfile: () => set((state) => {
+            state.user.profile.label = "new";
+            return {
+              ...state,
+              user: {
+                ...state.user,
+                profile: { ...state.user.profile },
+              },
+            };
+          }),
+        }));
+      `,
+      0,
+    );
+  });
+
+  it("fails closed when a replacement identity cannot be proven", () => {
+    expectDiagnosticCount(
+      `
+        import { create } from "zustand";
+        create((set) => ({
+          replace: () => set((state) => {
+            state.user.name = "Grace";
+            return { user: buildUser(state.user) };
+          }),
+          shadowed: () => set((state) => {
+            const undefined = { count: state.count };
+            state.count++;
+            return undefined;
+          }),
+        }));
+      `,
+      0,
+    );
+  });
+
+  it("allows immutable object, array, Map, and Set updates", () => {
+    expectDiagnosticCount(
+      `
+        import { create } from "zustand";
+        create((set) => ({
+          update: () => set((state) => ({
+            user: { ...state.user, active: true },
+            items: [...state.items, "next"],
+            map: new Map(state.map).set("ready", true),
+            selected: new Set(state.selected).add("next"),
+          })),
+        }));
+      `,
+      0,
+    );
+  });
+
+  it("allows the official Immer middleware updater semantics", () => {
+    expectDiagnosticCount(
+      `
+        import { create } from "zustand";
+        import { immer as withDrafts } from "zustand/middleware/immer";
+        create(withDrafts((set) => ({
+          count: 0,
+          increment: () => set((state) => void state.count++),
+        })));
+      `,
+      0,
+    );
+  });
+
+  it("reports a creator reused by a non-Immer store regardless of declaration order", () => {
+    expectDiagnosticCount(
+      `
+        import { create } from "zustand";
+        import { immer } from "zustand/middleware/immer";
+        const creator = (set) => ({
+          increment: () => set((state) => void state.count++),
+        });
+        create(creator);
+        create(immer(creator));
+        const reverseCreator = (set) => ({
+          increment: () => set((state) => void state.count++),
+        });
+        create(immer(reverseCreator));
+        create(reverseCreator);
+      `,
+      2,
+    );
+  });
+
+  it("reports mutations of snapshots read with get", () => {
+    expectDiagnosticCount(
+      `
+        import { create } from "zustand";
+        create((set, get) => ({
+          items: [],
+          add: (item) => {
+            const items = get().items;
+            items.push(item);
+            set({ items });
+          },
+          clear: () => {
+            const state = get();
+            state.items.length = 0;
+          },
+        }));
+      `,
+      2,
+    );
+  });
+
+  it("reports immutable aliases of get and set", () => {
+    expectDiagnosticCount(
+      `
+        import { create } from "zustand";
+        create((set, get) => ({
+          update: () => {
+            const read = get;
+            const write = set;
+            const state = read();
+            state.user.active = true;
+            write({ user: state.user });
+          },
+        }));
+      `,
+      1,
+    );
+  });
+
+  it("reports direct mutations on get and getState snapshots", () => {
+    expectDiagnosticCount(
+      `
+        import { create } from "zustand";
+        import { createStore } from "zustand/vanilla";
+        const useStore = create((set, get) => ({
+          update: () => {
+            get().items.push("next");
+            set({ items: get().items });
+          },
+        }));
+        const store = createStore(() => ({ count: 0 }));
+        store.getState().count++;
+      `,
+      2,
+    );
+  });
+
+  it("allows replacing a mutated get snapshot child with a proven clone", () => {
+    expectDiagnosticCount(
+      `
+        import { create } from "zustand";
+        create((set, get) => ({
+          update: () => {
+            const items = get().items;
+            items.push("next");
+            set({ items: [...items] });
+          },
+        }));
+      `,
+      0,
+    );
+  });
+
+  it("matches the replacement property to the mutated snapshot path", () => {
+    expectDiagnosticCount(
+      `
+        import { create } from "zustand";
+        create((set, get) => ({
+          unsafe: () => {
+            const items = get().items;
+            items.push("next");
+            set({ archivedItems: [...items] });
+          },
+          safe: () => {
+            const items = get().items;
+            items.push("next");
+            set({ items: [] });
+          },
+          topLevel: () => {
+            const state = get();
+            state.count++;
+            set({ count: state.count });
+          },
+        }));
+      `,
+      1,
+    );
+  });
+
+  it("reports snapshots read from same-file bound and vanilla stores", () => {
+    expectDiagnosticCount(
+      `
+        import { create } from "zustand";
+        import { createStore } from "zustand/vanilla";
+        const useStore = create(() => ({ items: [] }));
+        const vanillaStore = createStore(() => ({ selected: new Set() }));
+        const items = useStore.getState().items;
+        items.push("next");
+        useStore.setState({ items });
+        const selected = vanillaStore.getState().selected;
+        selected.add("next");
+      `,
+      2,
+    );
+  });
+
+  it("allows immutable updates to same-file store snapshots", () => {
+    expectDiagnosticCount(
+      `
+        import { createStore } from "zustand/vanilla";
+        const store = createStore(() => ({ items: [], selected: new Set() }));
+        const nextItems = [...store.getState().items, "next"];
+        const nextSelected = new Set(store.getState().selected).add("next");
+        store.setState({ items: nextItems, selected: nextSelected });
+      `,
+      0,
+    );
+  });
+
+  it("supports curried, namespace, aliased, traditional, and middleware creators", () => {
+    expectDiagnosticCount(
+      `
+        import * as Zustand from "zustand";
+        import { createWithEqualityFn } from "zustand/traditional";
+        import { devtools } from "zustand/middleware";
+        const makeStore = Zustand.create;
+        makeStore()(devtools((set) => ({
+          update: () => set((state) => { state.count++; return state; }),
+        })));
+        createWithEqualityFn()((set) => ({
+          update: () => set((state) => { state.count++; return state; }),
+        }));
+      `,
+      2,
+    );
+  });
+
+  it("rejects userland factories, imported stores, unknown middleware, and mutable aliases", () => {
+    expectDiagnosticCount(
+      `
+        import { create } from "zustand";
+        import { useImportedStore } from "./store";
+        let makeStore = create;
+        makeStore = customCreate;
+        customCreate((set) => ({
+          update: () => set((state) => { state.count++; return state; }),
+        }));
+        makeStore((set) => ({
+          update: () => set((state) => { state.count++; return state; }),
+        }));
+        create(customMiddleware((set) => ({
+          update: () => set((state) => { state.count++; return state; }),
+        })));
+        const items = useImportedStore.getState().items;
+        items.push("next");
+      `,
+      0,
+    );
+  });
+
+  it("rejects shadowed set and get bindings", () => {
+    expectDiagnosticCount(
+      `
+        import { create } from "zustand";
+        create((set, get) => ({
+          update: (set, get) => {
+            const items = get().items;
+            items.push("next");
+            set({ items });
+          },
+        }));
+      `,
+      0,
+    );
+  });
+
+  it("fails closed for branch-dependent mutation and notification paths", () => {
+    expectDiagnosticCount(
+      `
+        import { create } from "zustand";
+        create((set, get) => ({
+          update: (enabled) => set((state) => {
+            if (enabled) state.items.push("next");
+            return { items: state.items };
+          }),
+          external: (enabled) => {
+            const items = get().items;
+            if (enabled) items.push("next");
+            set({ items });
+          },
+        }));
+      `,
+      0,
+    );
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.test.ts
@@ -325,6 +325,42 @@ describe("zustand-no-mutating-state", () => {
     );
   });
 
+  it("analyzes setState updater snapshots and returned notifications", () => {
+    expectDiagnosticCount(
+      `
+        import { create } from "zustand";
+        import { createStore } from "zustand/vanilla";
+        const useStore = create(() => ({ items: [] }));
+        const vanillaStore = createStore(() => ({ items: [] }));
+        useStore.setState((state) => {
+          state.items.push("next");
+          return { items: state.items };
+        });
+        vanillaStore.setState((state) => {
+          state.items.push("next");
+          return { items: state.items };
+        });
+        useStore.setState((state) => {
+          state.items.push("safe");
+          return { items: [...state.items] };
+        });
+        useStore.setState(() => {
+          const items = useStore.getState().items;
+          items.push("safe");
+          return { items: [...items] };
+        });
+        const sharedUpdater = () => {
+          const items = useStore.getState().items;
+          items.push("safe");
+          return { items: items.slice() };
+        };
+        useStore.setState(sharedUpdater);
+        vanillaStore.setState(sharedUpdater);
+      `,
+      2,
+    );
+  });
+
   it("does not use another store as the snapshot notifier", () => {
     expectDiagnosticCount(
       `

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.test.ts
@@ -434,6 +434,22 @@ describe("zustand-no-mutating-state", () => {
     );
   });
 
+  it("fails closed for expression-level conditional notifiers", () => {
+    expectDiagnosticCount(
+      `
+        import { create } from "zustand";
+        create((set, get) => ({
+          update: (shouldNotify) => {
+            const items = get().items;
+            items.push("next");
+            shouldNotify && set({ items: [...items] });
+          },
+        }));
+      `,
+      0,
+    );
+  });
+
   it("abstains from unproven snapshot replacements", () => {
     expectDiagnosticCount(
       `

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.test.ts
@@ -400,6 +400,21 @@ describe("zustand-no-mutating-state", () => {
     );
   });
 
+  it("does not match an earlier notifier in the mutation statement", () => {
+    expectDiagnosticCount(
+      `
+        import { create } from "zustand";
+        create((set, get) => ({
+          update: () => {
+            const items = get().items;
+            set({ items: [...items] }), items.push("next");
+          },
+        }));
+      `,
+      1,
+    );
+  });
+
   it("fails closed when unsupported control flow is nested in a branch", () => {
     expectDiagnosticCount(
       `

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.test.ts
@@ -566,6 +566,26 @@ describe("zustand-no-mutating-state", () => {
     );
   });
 
+  it("treats enclosing notifier calls as following nested argument mutations", () => {
+    expectDiagnosticCount(
+      `
+        import { create } from "zustand";
+        create((set, get) => ({
+          items: [],
+          safe: () => {
+            const items = get().items;
+            set({ items: (items.push("next"), [...items]) });
+          },
+          unsafe: () => {
+            const items = get().items;
+            set({ items: (items.push("next"), items) });
+          },
+        }));
+      `,
+      1,
+    );
+  });
+
   it("recognizes updater returns that reuse get snapshots", () => {
     expectDiagnosticCount(
       `

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.ts
@@ -1,0 +1,659 @@
+import type { SymbolDescriptor } from "../../semantic/scope-analysis.js";
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { getStaticPropertyKeyName } from "../../utils/get-static-property-key-name.js";
+import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
+import { isFunctionLike } from "../../utils/is-function-like.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import {
+  addMutableStateReferenceBindings,
+  collectMutableStateReferenceMutations,
+  updateMutableStateReferencesForIdentifierAssignment,
+  updateMutableStateReferencesForVariableDeclaration,
+  type MutableStateReferenceMutation,
+  type MutableStateReferenceState,
+} from "../../utils/mutable-state-reference-analysis.js";
+import { resolveConstIdentifierAlias } from "../../utils/resolve-const-identifier-alias.js";
+import { resolveExactLocalFunction } from "../../utils/resolve-exact-local-function.js";
+import { resolveExpressionKey } from "../../utils/resolve-expression-key.js";
+import {
+  resolveZustandStoreCreator,
+  type ZustandStoreCreator,
+} from "../../utils/resolve-zustand-api.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import { walkAst } from "../../utils/walk-ast.js";
+
+const MESSAGE =
+  "This Zustand state reference is mutated and reused, so subscribers can miss the update.";
+
+const FRESH_ARRAY_METHOD_NAMES = new Set([
+  "concat",
+  "filter",
+  "flat",
+  "flatMap",
+  "map",
+  "slice",
+  "toReversed",
+  "toSorted",
+  "toSpliced",
+  "with",
+]);
+
+const UNSUPPORTED_CONTROL_FLOW_TYPES = new Set([
+  "DoWhileStatement",
+  "ForInStatement",
+  "ForOfStatement",
+  "ForStatement",
+  "IfStatement",
+  "LabeledStatement",
+  "BlockStatement",
+  "SwitchStatement",
+  "TryStatement",
+  "WhileStatement",
+  "WithStatement",
+]);
+
+interface ZustandCreatorBinding {
+  creatorFunction: ZustandStoreCreator["creatorFunction"];
+  getSymbol: SymbolDescriptor | null;
+  hasNonImmerUsage: boolean;
+  setSymbol: SymbolDescriptor | null;
+}
+
+interface MutationWithStatementIndex {
+  mutation: MutableStateReferenceMutation;
+  statementIndex: number;
+}
+
+interface NotifierCallWithStatementIndex {
+  callExpression: EsTreeNodeOfType<"CallExpression">;
+  statementIndex: number;
+}
+
+const findIdentifierParameter = (
+  parameter: EsTreeNode | undefined,
+): EsTreeNodeOfType<"Identifier"> | null => {
+  if (!parameter) return null;
+  if (isNodeOfType(parameter, "Identifier")) return parameter;
+  if (isNodeOfType(parameter, "AssignmentPattern") && isNodeOfType(parameter.left, "Identifier")) {
+    return parameter.left;
+  }
+  return null;
+};
+
+const symbolForParameter = (
+  creatorFunction: ZustandStoreCreator["creatorFunction"],
+  parameterIndex: number,
+  context: RuleContext,
+): SymbolDescriptor | null => {
+  const parameter = findIdentifierParameter(creatorFunction.params[parameterIndex]);
+  return parameter ? (context.scopes.symbolFor(parameter) ?? null) : null;
+};
+
+const isCallToSymbol = (
+  callExpression: EsTreeNodeOfType<"CallExpression">,
+  symbolIds: ReadonlySet<number>,
+  context: RuleContext,
+): boolean => {
+  const callee = stripParenExpression(callExpression.callee);
+  if (!isNodeOfType(callee, "Identifier")) return false;
+  const symbol = resolveConstIdentifierAlias(callee, context.scopes);
+  return Boolean(symbol && symbolIds.has(symbol.id));
+};
+
+const rootCallForExpression = (
+  expression: EsTreeNode,
+): EsTreeNodeOfType<"CallExpression"> | null => {
+  let current = stripParenExpression(expression);
+  while (isNodeOfType(current, "MemberExpression")) {
+    current = stripParenExpression(current.object);
+  }
+  return isNodeOfType(current, "CallExpression") ? current : null;
+};
+
+const isStoreMethodCall = (
+  callExpression: EsTreeNodeOfType<"CallExpression">,
+  methodName: "getState" | "setState",
+  storeSymbolIds: ReadonlySet<number>,
+  context: RuleContext,
+): boolean => {
+  const callee = stripParenExpression(callExpression.callee);
+  if (!isNodeOfType(callee, "MemberExpression")) return false;
+  if (getStaticPropertyName(callee) !== methodName) return false;
+  const receiver = stripParenExpression(callee.object);
+  if (!isNodeOfType(receiver, "Identifier")) return false;
+  const symbol = resolveConstIdentifierAlias(receiver, context.scopes);
+  return Boolean(symbol && storeSymbolIds.has(symbol.id));
+};
+
+const isSnapshotExpression = (
+  expression: EsTreeNode | null | undefined,
+  getSymbolIds: ReadonlySet<number>,
+  storeSymbolIds: ReadonlySet<number>,
+  context: RuleContext,
+): boolean => {
+  if (!expression) return false;
+  const rootCall = rootCallForExpression(expression);
+  return Boolean(
+    rootCall &&
+    (isCallToSymbol(rootCall, getSymbolIds, context) ||
+      isStoreMethodCall(rootCall, "getState", storeSymbolIds, context)),
+  );
+};
+
+const expressionKeyPreservesTarget = (
+  expression: EsTreeNode,
+  targetKey: string,
+  context: RuleContext,
+): boolean => {
+  const expressionKey = resolveExpressionKey(expression, context);
+  return Boolean(
+    expressionKey && (expressionKey === targetKey || targetKey.startsWith(`${expressionKey}.`)),
+  );
+};
+
+const expressionPreservesTarget = (
+  expression: EsTreeNode | null | undefined,
+  targetKey: string,
+  mutationNode: EsTreeNode,
+  context: RuleContext,
+): boolean => {
+  if (!expression) return false;
+  const candidate = stripParenExpression(expression);
+  if (candidate === mutationNode) return true;
+  if (isNodeOfType(candidate, "Identifier") || isNodeOfType(candidate, "MemberExpression")) {
+    return expressionKeyPreservesTarget(candidate, targetKey, context);
+  }
+  if (isNodeOfType(candidate, "ObjectExpression")) {
+    return candidate.properties.some((property) => {
+      if (isNodeOfType(property, "SpreadElement")) {
+        const spreadKey = resolveExpressionKey(property.argument, context);
+        return Boolean(
+          spreadKey && spreadKey !== targetKey && targetKey.startsWith(`${spreadKey}.`),
+        );
+      }
+      return (
+        isNodeOfType(property, "Property") &&
+        expressionPreservesTarget(property.value, targetKey, mutationNode, context)
+      );
+    });
+  }
+  if (isNodeOfType(candidate, "ArrayExpression")) {
+    return candidate.elements.some(
+      (element) =>
+        Boolean(element) &&
+        !isNodeOfType(element, "SpreadElement") &&
+        expressionPreservesTarget(element, targetKey, mutationNode, context),
+    );
+  }
+  if (isNodeOfType(candidate, "ConditionalExpression")) {
+    return (
+      expressionPreservesTarget(candidate.consequent, targetKey, mutationNode, context) ||
+      expressionPreservesTarget(candidate.alternate, targetKey, mutationNode, context)
+    );
+  }
+  if (isNodeOfType(candidate, "LogicalExpression")) {
+    return (
+      expressionPreservesTarget(candidate.left, targetKey, mutationNode, context) ||
+      expressionPreservesTarget(candidate.right, targetKey, mutationNode, context)
+    );
+  }
+  if (isNodeOfType(candidate, "SequenceExpression")) {
+    return expressionPreservesTarget(
+      candidate.expressions[candidate.expressions.length - 1],
+      targetKey,
+      mutationNode,
+      context,
+    );
+  }
+  return false;
+};
+
+const expressionContainsFreshCloneOfTarget = (
+  expression: EsTreeNode | null | undefined,
+  targetKey: string,
+  context: RuleContext,
+): boolean => {
+  if (!expression) return false;
+  let didFindFreshClone = false;
+  walkAst(expression, (node: EsTreeNode) => {
+    const candidate = stripParenExpression(node);
+    if (isFunctionLike(candidate)) return false;
+    if (isNodeOfType(candidate, "SpreadElement")) {
+      if (resolveExpressionKey(candidate.argument, context) === targetKey) {
+        didFindFreshClone = true;
+      }
+      return false;
+    }
+    if (isNodeOfType(candidate, "NewExpression")) {
+      const callee = stripParenExpression(candidate.callee);
+      const firstArgument = candidate.arguments[0];
+      if (
+        isNodeOfType(callee, "Identifier") &&
+        (callee.name === "Map" || callee.name === "Set") &&
+        firstArgument &&
+        !isNodeOfType(firstArgument, "SpreadElement") &&
+        resolveExpressionKey(firstArgument, context) === targetKey
+      ) {
+        didFindFreshClone = true;
+      }
+      return;
+    }
+    if (!isNodeOfType(candidate, "CallExpression")) return;
+    const callee = stripParenExpression(candidate.callee);
+    if (!isNodeOfType(callee, "MemberExpression")) return;
+    const methodName = getStaticPropertyName(callee);
+    if (
+      methodName &&
+      FRESH_ARRAY_METHOD_NAMES.has(methodName) &&
+      resolveExpressionKey(callee.object, context) === targetKey
+    ) {
+      didFindFreshClone = true;
+    }
+  });
+  return didFindFreshClone;
+};
+
+const isDefinitelyNoUpdateExpression = (expression: EsTreeNode, context: RuleContext): boolean => {
+  const candidate = stripParenExpression(expression);
+  return (
+    (isNodeOfType(candidate, "UnaryExpression") && candidate.operator === "void") ||
+    (isNodeOfType(candidate, "Identifier") &&
+      candidate.name === "undefined" &&
+      context.scopes.isGlobalReference(candidate))
+  );
+};
+
+const returnedExpressionsForFunction = (functionNode: EsTreeNode): EsTreeNode[] => {
+  if (!isFunctionLike(functionNode)) return [];
+  if (!isNodeOfType(functionNode.body, "BlockStatement")) return [functionNode.body];
+  const returnedExpressions: EsTreeNode[] = [];
+  for (const statement of functionNode.body.body) {
+    if (isNodeOfType(statement, "ReturnStatement") && statement.argument) {
+      returnedExpressions.push(statement.argument);
+    }
+  }
+  return returnedExpressions;
+};
+
+const hasUnsupportedControlFlow = (statements: readonly EsTreeNode[]): boolean =>
+  statements.some((statement) => UNSUPPORTED_CONTROL_FLOW_TYPES.has(statement.type));
+
+const analyzeSetUpdater = (
+  updaterFunction: EsTreeNode,
+  context: RuleContext,
+  reportedNodes: WeakSet<EsTreeNode>,
+): void => {
+  if (!isFunctionLike(updaterFunction) || updaterFunction.async || updaterFunction.generator)
+    return;
+  const stateParameter = findIdentifierParameter(updaterFunction.params[0]);
+  if (!stateParameter) return;
+  const state: MutableStateReferenceState = {
+    mutableStateSourceNames: new Set([stateParameter.name]),
+  };
+  const returnedExpressions = returnedExpressionsForFunction(updaterFunction);
+  const mutations: MutableStateReferenceMutation[] = [];
+  if (isNodeOfType(updaterFunction.body, "BlockStatement")) {
+    if (hasUnsupportedControlFlow(updaterFunction.body.body)) return;
+    for (const statement of updaterFunction.body.body) {
+      mutations.push(...collectMutableStateReferenceMutations(statement, state));
+      if (isNodeOfType(statement, "VariableDeclaration")) {
+        updateMutableStateReferencesForVariableDeclaration(statement, state);
+      } else if (isNodeOfType(statement, "ExpressionStatement")) {
+        const assignment = stripParenExpression(statement.expression);
+        if (isNodeOfType(assignment, "AssignmentExpression")) {
+          updateMutableStateReferencesForIdentifierAssignment(assignment, state);
+        }
+      }
+      if (isNodeOfType(statement, "ReturnStatement")) break;
+    }
+  } else {
+    mutations.push(...collectMutableStateReferenceMutations(updaterFunction.body, state));
+  }
+  for (const mutation of mutations) {
+    const hasNoUpdateReturn = returnedExpressions.some((expression) =>
+      isDefinitelyNoUpdateExpression(expression, context),
+    );
+    const doesPreserveTarget = returnedExpressions.some(
+      (expression) => updateTargetReplacementDisposition(expression, mutation, context) === false,
+    );
+    if (returnedExpressions.length > 0 && !doesPreserveTarget && !hasNoUpdateReturn) continue;
+    if (reportedNodes.has(mutation.node)) continue;
+    reportedNodes.add(mutation.node);
+    context.report({ node: mutation.node, message: MESSAGE });
+  }
+};
+
+const collectNotifierCalls = (
+  statement: EsTreeNode,
+  setSymbolIds: ReadonlySet<number>,
+  storeSymbolIds: ReadonlySet<number>,
+  context: RuleContext,
+): EsTreeNodeOfType<"CallExpression">[] => {
+  const notifierCalls: EsTreeNodeOfType<"CallExpression">[] = [];
+  walkAst(statement, (node: EsTreeNode) => {
+    if (isFunctionLike(node)) return false;
+    if (!isNodeOfType(node, "CallExpression")) return;
+    if (
+      isCallToSymbol(node, setSymbolIds, context) ||
+      isStoreMethodCall(node, "setState", storeSymbolIds, context)
+    ) {
+      notifierCalls.push(node);
+    }
+  });
+  return notifierCalls;
+};
+
+const staticPropertyPathForExpression = (
+  expression: EsTreeNode,
+  context: RuleContext,
+  visitedSymbolIds: Set<number> = new Set(),
+): string[] | null => {
+  const candidate = stripParenExpression(expression);
+  if (isNodeOfType(candidate, "Identifier")) {
+    const symbol = context.scopes.symbolFor(candidate);
+    if (!symbol || visitedSymbolIds.has(symbol.id)) return [];
+    visitedSymbolIds.add(symbol.id);
+    const bindingProperty = symbol.bindingIdentifier.parent;
+    const bindingPattern = bindingProperty?.parent;
+    const variableDeclarator = bindingPattern?.parent;
+    if (
+      isNodeOfType(bindingProperty, "Property") &&
+      isNodeOfType(bindingPattern, "ObjectPattern") &&
+      isNodeOfType(variableDeclarator, "VariableDeclarator")
+    ) {
+      const propertyName = getStaticPropertyKeyName(bindingProperty);
+      const objectPath = variableDeclarator.init
+        ? staticPropertyPathForExpression(variableDeclarator.init, context, visitedSymbolIds)
+        : null;
+      return propertyName && objectPath ? [...objectPath, propertyName] : null;
+    }
+    if (symbol.kind !== "const" || !symbol.initializer) return [];
+    return staticPropertyPathForExpression(symbol.initializer, context, visitedSymbolIds);
+  }
+  if (isNodeOfType(candidate, "MemberExpression")) {
+    const propertyName = getStaticPropertyName(candidate);
+    const objectPath = staticPropertyPathForExpression(candidate.object, context, visitedSymbolIds);
+    return propertyName && objectPath ? [...objectPath, propertyName] : null;
+  }
+  if (isNodeOfType(candidate, "CallExpression")) return [];
+  return null;
+};
+
+const isProvenFreshReplacementExpression = (
+  expression: EsTreeNode,
+  targetKey: string,
+  context: RuleContext,
+): boolean => {
+  const candidate = stripParenExpression(expression);
+  return (
+    isNodeOfType(candidate, "ObjectExpression") ||
+    isNodeOfType(candidate, "ArrayExpression") ||
+    isNodeOfType(candidate, "NewExpression") ||
+    isNodeOfType(candidate, "Literal") ||
+    isNodeOfType(candidate, "TemplateLiteral") ||
+    expressionContainsFreshCloneOfTarget(candidate, targetKey, context)
+  );
+};
+
+const objectTargetReplacementDisposition = (
+  objectExpression: EsTreeNodeOfType<"ObjectExpression">,
+  targetPath: readonly string[],
+  targetKey: string,
+  ancestorKey: string,
+  mutationNode: EsTreeNode,
+  isPartialUpdateRoot: boolean,
+  context: RuleContext,
+): boolean | null => {
+  const propertyName = targetPath[0];
+  if (!propertyName) return true;
+  let disposition: boolean | null = isPartialUpdateRoot ? false : true;
+  for (const property of objectExpression.properties) {
+    if (isNodeOfType(property, "SpreadElement")) {
+      const spreadKey = resolveExpressionKey(property.argument, context);
+      disposition = spreadKey === ancestorKey ? false : null;
+      continue;
+    }
+    if (!isNodeOfType(property, "Property")) continue;
+    if (getStaticPropertyKeyName(property) !== propertyName) continue;
+    if (targetPath.length === 1) {
+      if (expressionPreservesTarget(property.value, targetKey, mutationNode, context)) {
+        disposition = false;
+      } else {
+        disposition = isProvenFreshReplacementExpression(property.value, targetKey, context)
+          ? true
+          : null;
+      }
+      continue;
+    }
+    const propertyValue = stripParenExpression(property.value);
+    if (isNodeOfType(propertyValue, "ObjectExpression")) {
+      disposition = objectTargetReplacementDisposition(
+        propertyValue,
+        targetPath.slice(1),
+        targetKey,
+        `${ancestorKey}.${propertyName}`,
+        mutationNode,
+        false,
+        context,
+      );
+    } else if (expressionKeyPreservesTarget(propertyValue, targetKey, context)) {
+      disposition = false;
+    } else {
+      disposition = isProvenFreshReplacementExpression(propertyValue, targetKey, context)
+        ? true
+        : null;
+    }
+  }
+  return disposition;
+};
+
+const updateTargetReplacementDisposition = (
+  updateExpression: EsTreeNode,
+  mutation: MutableStateReferenceMutation,
+  context: RuleContext,
+): boolean | null => {
+  const targetKey = resolveExpressionKey(mutation.receiver, context);
+  const targetPath = staticPropertyPathForExpression(mutation.receiver, context);
+  if (!targetKey || !targetPath) return null;
+  const candidate = stripParenExpression(updateExpression);
+  if (targetPath.length === 0) {
+    if (expressionPreservesTarget(candidate, targetKey, mutation.node, context)) return false;
+    return isProvenFreshReplacementExpression(candidate, targetKey, context) ? true : null;
+  }
+  if (!isNodeOfType(candidate, "ObjectExpression")) {
+    return expressionPreservesTarget(candidate, targetKey, mutation.node, context) ? false : null;
+  }
+  const ancestorKeySuffix = `.${targetPath.join(".")}`;
+  const ancestorKey = targetKey.endsWith(ancestorKeySuffix)
+    ? targetKey.slice(0, -ancestorKeySuffix.length)
+    : targetKey;
+  return objectTargetReplacementDisposition(
+    candidate,
+    targetPath,
+    targetKey,
+    ancestorKey,
+    mutation.node,
+    true,
+    context,
+  );
+};
+
+const notifierReplacesTarget = (
+  notifierCall: EsTreeNodeOfType<"CallExpression">,
+  mutation: MutableStateReferenceMutation,
+  context: RuleContext,
+): boolean => {
+  const targetKey = resolveExpressionKey(mutation.receiver, context);
+  const updateArgument = notifierCall.arguments[0];
+  if (!targetKey || !updateArgument || isNodeOfType(updateArgument, "SpreadElement")) return false;
+  const updateFunction = resolveExactLocalFunction(updateArgument, context.scopes);
+  const updateExpressions = updateFunction
+    ? returnedExpressionsForFunction(updateFunction)
+    : [updateArgument];
+  return updateExpressions.some(
+    (expression) => updateTargetReplacementDisposition(expression, mutation, context) === true,
+  );
+};
+
+const analyzeSnapshotContainer = (
+  statements: readonly EsTreeNode[],
+  getSymbolIds: ReadonlySet<number>,
+  setSymbolIds: ReadonlySet<number>,
+  storeSymbolIds: ReadonlySet<number>,
+  context: RuleContext,
+  reportedNodes: WeakSet<EsTreeNode>,
+): void => {
+  if (hasUnsupportedControlFlow(statements)) return;
+  const state: MutableStateReferenceState = {
+    isAdditionalMutableStateSource: (expression) =>
+      isSnapshotExpression(expression, getSymbolIds, storeSymbolIds, context),
+    mutableStateSourceNames: new Set(),
+  };
+  const mutations: MutationWithStatementIndex[] = [];
+  const notifierCalls: NotifierCallWithStatementIndex[] = [];
+  for (let statementIndex = 0; statementIndex < statements.length; statementIndex += 1) {
+    const statement = statements[statementIndex];
+    for (const mutation of collectMutableStateReferenceMutations(statement, state)) {
+      mutations.push({ mutation, statementIndex });
+    }
+    for (const callExpression of collectNotifierCalls(
+      statement,
+      setSymbolIds,
+      storeSymbolIds,
+      context,
+    )) {
+      notifierCalls.push({ callExpression, statementIndex });
+    }
+    if (isNodeOfType(statement, "VariableDeclaration")) {
+      updateMutableStateReferencesForVariableDeclaration(statement, state);
+      for (const declarator of statement.declarations) {
+        if (isSnapshotExpression(declarator.init, getSymbolIds, storeSymbolIds, context)) {
+          addMutableStateReferenceBindings(declarator.id, state);
+        }
+      }
+    } else if (isNodeOfType(statement, "ExpressionStatement")) {
+      const assignment = stripParenExpression(statement.expression);
+      if (!isNodeOfType(assignment, "AssignmentExpression")) continue;
+      updateMutableStateReferencesForIdentifierAssignment(assignment, state);
+      if (
+        isNodeOfType(assignment.left, "Identifier") &&
+        isSnapshotExpression(assignment.right, getSymbolIds, storeSymbolIds, context)
+      ) {
+        state.mutableStateSourceNames.add(assignment.left.name);
+      }
+    }
+    if (isNodeOfType(statement, "ReturnStatement")) break;
+  }
+  for (const { mutation, statementIndex } of mutations) {
+    const followingNotifiers = notifierCalls.filter(
+      (notifier) => notifier.statementIndex >= statementIndex,
+    );
+    if (
+      followingNotifiers.some((notifier) =>
+        notifierReplacesTarget(notifier.callExpression, mutation, context),
+      )
+    ) {
+      continue;
+    }
+    if (reportedNodes.has(mutation.node)) continue;
+    reportedNodes.add(mutation.node);
+    context.report({ node: mutation.node, message: MESSAGE });
+  }
+};
+
+export const zustandNoMutatingState = defineRule({
+  id: "zustand-no-mutating-state",
+  title: "Zustand state mutated in place",
+  severity: "error",
+  category: "Correctness",
+  recommendation:
+    "Create a new object, array, Map, or Set before passing the updated value to Zustand.",
+  requires: ["zustand", "zustand:1"],
+  create: (context: RuleContext) => {
+    const creatorBindings = new Map<
+      ZustandStoreCreator["creatorFunction"],
+      ZustandCreatorBinding
+    >();
+    const functionContainers = new Set<EsTreeNode>();
+    const storeSymbolIds = new Set<number>();
+    const reportedNodes = new WeakSet<EsTreeNode>();
+    let programNode: EsTreeNodeOfType<"Program"> | null = null;
+    return {
+      Program(node: EsTreeNodeOfType<"Program">) {
+        programNode = node;
+      },
+      CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+        const creator = resolveZustandStoreCreator(node, context.scopes);
+        if (!creator) return;
+        const existingBinding = creatorBindings.get(creator.creatorFunction);
+        if (existingBinding) {
+          if (!creator.middlewareNames.has("immer")) existingBinding.hasNonImmerUsage = true;
+        } else {
+          creatorBindings.set(creator.creatorFunction, {
+            creatorFunction: creator.creatorFunction,
+            getSymbol: symbolForParameter(creator.creatorFunction, 1, context),
+            hasNonImmerUsage: !creator.middlewareNames.has("immer"),
+            setSymbol: symbolForParameter(creator.creatorFunction, 0, context),
+          });
+        }
+        const parent = node.parent;
+        if (isNodeOfType(parent, "VariableDeclarator") && isNodeOfType(parent.id, "Identifier")) {
+          const storeSymbol = context.scopes.symbolFor(parent.id);
+          if (storeSymbol) storeSymbolIds.add(storeSymbol.id);
+        }
+      },
+      ArrowFunctionExpression(node: EsTreeNodeOfType<"ArrowFunctionExpression">) {
+        functionContainers.add(node);
+      },
+      FunctionDeclaration(node: EsTreeNodeOfType<"FunctionDeclaration">) {
+        functionContainers.add(node);
+      },
+      FunctionExpression(node: EsTreeNodeOfType<"FunctionExpression">) {
+        functionContainers.add(node);
+      },
+      "Program:exit"() {
+        const getSymbolIds = new Set<number>();
+        const setSymbolIds = new Set<number>();
+        for (const binding of creatorBindings.values()) {
+          if (binding.getSymbol) getSymbolIds.add(binding.getSymbol.id);
+          if (binding.setSymbol) setSymbolIds.add(binding.setSymbol.id);
+          if (!binding.hasNonImmerUsage || !binding.setSymbol) continue;
+          const creatorSetSymbolIds = new Set([binding.setSymbol.id]);
+          walkAst(binding.creatorFunction.body, (node: EsTreeNode) => {
+            if (!isNodeOfType(node, "CallExpression")) return;
+            if (!isCallToSymbol(node, creatorSetSymbolIds, context)) return;
+            const updaterArgument = node.arguments[0];
+            if (!updaterArgument || isNodeOfType(updaterArgument, "SpreadElement")) return;
+            const updaterFunction = resolveExactLocalFunction(updaterArgument, context.scopes);
+            if (updaterFunction) analyzeSetUpdater(updaterFunction, context, reportedNodes);
+          });
+        }
+        if (programNode) {
+          analyzeSnapshotContainer(
+            programNode.body,
+            getSymbolIds,
+            setSymbolIds,
+            storeSymbolIds,
+            context,
+            reportedNodes,
+          );
+        }
+        for (const functionContainer of functionContainers) {
+          if (!isFunctionLike(functionContainer)) continue;
+          if (!isNodeOfType(functionContainer.body, "BlockStatement")) continue;
+          analyzeSnapshotContainer(
+            functionContainer.body.body,
+            getSymbolIds,
+            setSymbolIds,
+            storeSymbolIds,
+            context,
+            reportedNodes,
+          );
+        }
+      },
+    };
+  },
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.ts
@@ -2,6 +2,7 @@ import type { SymbolDescriptor } from "../../semantic/scope-analysis.js";
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
 import { getRangeStart } from "../../utils/get-range-start.js";
 import { getStaticPropertyKeyName } from "../../utils/get-static-property-key-name.js";
 import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
@@ -386,6 +387,7 @@ const staticPropertyPathForExpression = (
   expression: EsTreeNode,
   context: RuleContext,
   visitedSymbolIds: Set<number> = new Set(),
+  followMutableInitializer = false,
 ): string[] | null => {
   const candidate = stripParenExpression(expression);
   if (isNodeOfType(candidate, "Identifier")) {
@@ -402,16 +404,31 @@ const staticPropertyPathForExpression = (
     ) {
       const propertyName = getStaticPropertyKeyName(bindingProperty);
       const objectPath = variableDeclarator.init
-        ? staticPropertyPathForExpression(variableDeclarator.init, context, visitedSymbolIds)
+        ? staticPropertyPathForExpression(
+            variableDeclarator.init,
+            context,
+            visitedSymbolIds,
+            followMutableInitializer,
+          )
         : null;
       return propertyName && objectPath ? [...objectPath, propertyName] : null;
     }
-    if (symbol.kind !== "const" || !symbol.initializer) return [];
-    return staticPropertyPathForExpression(symbol.initializer, context, visitedSymbolIds);
+    if ((!followMutableInitializer && symbol.kind !== "const") || !symbol.initializer) return [];
+    return staticPropertyPathForExpression(
+      symbol.initializer,
+      context,
+      visitedSymbolIds,
+      followMutableInitializer,
+    );
   }
   if (isNodeOfType(candidate, "MemberExpression")) {
     const propertyName = getStaticPropertyName(candidate);
-    const objectPath = staticPropertyPathForExpression(candidate.object, context, visitedSymbolIds);
+    const objectPath = staticPropertyPathForExpression(
+      candidate.object,
+      context,
+      visitedSymbolIds,
+      followMutableInitializer,
+    );
     return propertyName && objectPath ? [...objectPath, propertyName] : null;
   }
   if (isNodeOfType(candidate, "CallExpression")) return [];
@@ -538,13 +555,109 @@ const objectTargetPathReplacementDisposition = (
   return disposition;
 };
 
+const rootIdentifierForExpression = (
+  expression: EsTreeNode,
+): EsTreeNodeOfType<"Identifier"> | null => {
+  let current = stripParenExpression(expression);
+  while (isNodeOfType(current, "MemberExpression")) {
+    current = stripParenExpression(current.object);
+  }
+  return isNodeOfType(current, "Identifier") ? current : null;
+};
+
+const objectExpressionPublishesSymbolAtPath = (
+  objectExpression: EsTreeNodeOfType<"ObjectExpression">,
+  targetPath: readonly string[],
+  symbolId: number,
+  context: RuleContext,
+): boolean => {
+  const propertyName = targetPath[0];
+  if (!propertyName) return false;
+  for (const property of objectExpression.properties) {
+    if (!isNodeOfType(property, "Property")) continue;
+    if (getStaticPropertyKeyName(property) !== propertyName) continue;
+    const propertyValue = stripParenExpression(property.value);
+    if (targetPath.length > 1) {
+      return (
+        isNodeOfType(propertyValue, "ObjectExpression") &&
+        objectExpressionPublishesSymbolAtPath(propertyValue, targetPath.slice(1), symbolId, context)
+      );
+    }
+    return (
+      isNodeOfType(propertyValue, "Identifier") &&
+      context.scopes.symbolFor(propertyValue)?.id === symbolId
+    );
+  }
+  return false;
+};
+
+const targetRebindReplacementDisposition = (
+  updateExpression: EsTreeNode,
+  mutation: MutableStateReferenceMutation,
+  targetPath: readonly string[],
+  targetKey: string,
+  context: RuleContext,
+): boolean | null | undefined => {
+  const targetIdentifier = rootIdentifierForExpression(mutation.receiver);
+  if (!targetIdentifier) return undefined;
+  const targetSymbol = context.scopes.symbolFor(targetIdentifier);
+  if (!targetSymbol || targetSymbol.kind === "const") return undefined;
+  const candidate = stripParenExpression(updateExpression);
+  const doesPublishTarget =
+    targetPath.length === 0
+      ? isNodeOfType(candidate, "Identifier") &&
+        context.scopes.symbolFor(candidate)?.id === targetSymbol.id
+      : isNodeOfType(candidate, "ObjectExpression") &&
+        objectExpressionPublishesSymbolAtPath(candidate, targetPath, targetSymbol.id, context);
+  if (!doesPublishTarget) return undefined;
+  const mutationStart = getRangeStart(mutation.node);
+  const updateStart = getRangeStart(updateExpression);
+  const mutationFunction = findEnclosingFunction(mutation.node);
+  if (mutationStart === null || updateStart === null) return undefined;
+  let latestAssignment: EsTreeNodeOfType<"AssignmentExpression"> | null = null;
+  let latestAssignmentStart: number | null = null;
+  for (const reference of targetSymbol.references) {
+    if (reference.flag === "read") continue;
+    const assignment = reference.identifier.parent;
+    if (
+      !isNodeOfType(assignment, "AssignmentExpression") ||
+      assignment.operator !== "=" ||
+      assignment.left !== reference.identifier ||
+      findEnclosingFunction(assignment) !== mutationFunction
+    ) {
+      continue;
+    }
+    const assignmentStart = getRangeStart(assignment);
+    if (
+      assignmentStart === null ||
+      assignmentStart <= mutationStart ||
+      assignmentStart >= updateStart ||
+      (latestAssignmentStart !== null && assignmentStart <= latestAssignmentStart)
+    ) {
+      continue;
+    }
+    latestAssignment = assignment;
+    latestAssignmentStart = assignmentStart;
+  }
+  if (!latestAssignment) return undefined;
+  if (expressionKeyPreservesTarget(latestAssignment.right, targetKey, context)) return false;
+  return isProvenFreshReplacementExpression(latestAssignment.right, targetKey, context)
+    ? true
+    : null;
+};
+
 const updateTargetReplacementDisposition = (
   updateExpression: EsTreeNode,
   mutation: MutableStateReferenceMutation,
   context: RuleContext,
 ): boolean | null => {
   const targetKey = resolveExpressionKey(mutation.receiver, context);
-  const targetPath = staticPropertyPathForExpression(mutation.receiver, context);
+  const targetPath = staticPropertyPathForExpression(
+    mutation.receiver,
+    context,
+    new Set<number>(),
+    true,
+  );
   if (!targetPath) return null;
   const candidate = stripParenExpression(updateExpression);
   if (!targetKey) {
@@ -560,7 +673,16 @@ const updateTargetReplacementDisposition = (
     return objectTargetPathReplacementDisposition(candidate, targetPath, true, context);
   }
   if (targetPath.length === 0) {
-    if (expressionPreservesTarget(candidate, targetKey, mutation.node, context)) return false;
+    if (expressionPreservesTarget(candidate, targetKey, mutation.node, context)) {
+      const rebindDisposition = targetRebindReplacementDisposition(
+        candidate,
+        mutation,
+        targetPath,
+        targetKey,
+        context,
+      );
+      return rebindDisposition === undefined ? false : rebindDisposition;
+    }
     return isProvenFreshReplacementExpression(candidate, targetKey, context) ? true : null;
   }
   if (!isNodeOfType(candidate, "ObjectExpression")) {
@@ -570,7 +692,7 @@ const updateTargetReplacementDisposition = (
   const ancestorKey = targetKey.endsWith(ancestorKeySuffix)
     ? targetKey.slice(0, -ancestorKeySuffix.length)
     : targetKey;
-  return objectTargetReplacementDisposition(
+  const disposition = objectTargetReplacementDisposition(
     candidate,
     targetPath,
     targetKey,
@@ -579,6 +701,15 @@ const updateTargetReplacementDisposition = (
     true,
     context,
   );
+  if (disposition !== false) return disposition;
+  const rebindDisposition = targetRebindReplacementDisposition(
+    candidate,
+    mutation,
+    targetPath,
+    targetKey,
+    context,
+  );
+  return rebindDisposition === undefined ? false : rebindDisposition;
 };
 
 const notifierTargetReplacementDisposition = (
@@ -662,7 +793,8 @@ const analyzeSnapshotContainer = (
   statements: readonly EsTreeNode[],
   getSymbolIds: ReadonlySet<number>,
   setSymbolIds: ReadonlySet<number>,
-  storeSymbolIds: ReadonlySet<number>,
+  snapshotStoreSymbolIds: ReadonlySet<number>,
+  notifierStoreSymbolIds: ReadonlySet<number>,
   context: RuleContext,
   reportedNodes: WeakSet<EsTreeNode>,
   returnedUpdateExpressions: readonly EsTreeNode[] = [],
@@ -670,7 +802,7 @@ const analyzeSnapshotContainer = (
   if (hasUnsupportedSnapshotControlFlow(statements)) return;
   const state: MutableStateReferenceState = {
     isAdditionalMutableStateSource: (expression) =>
-      isSnapshotExpression(expression, getSymbolIds, storeSymbolIds, context),
+      isSnapshotExpression(expression, getSymbolIds, snapshotStoreSymbolIds, context),
     mutableStateSourceNames: new Set(),
   };
   const mutations: MutationWithStatementIndex[] = [];
@@ -685,7 +817,12 @@ const analyzeSnapshotContainer = (
         for (const mutation of collectSequentialSnapshotMutations(branchRoot, state)) {
           mutations.push({ branchRoot, mutation, statementIndex });
         }
-        const calls = collectNotifierCalls(branchRoot, setSymbolIds, storeSymbolIds, context);
+        const calls = collectNotifierCalls(
+          branchRoot,
+          setSymbolIds,
+          notifierStoreSymbolIds,
+          context,
+        );
         branchCalls.push(calls);
         for (const callExpression of calls) {
           notifierCalls.push({ branchRoot, callExpression, statementIndex });
@@ -699,7 +836,7 @@ const analyzeSnapshotContainer = (
       for (const callExpression of collectNotifierCalls(
         statement,
         setSymbolIds,
-        storeSymbolIds,
+        notifierStoreSymbolIds,
         context,
       )) {
         notifierCalls.push({ branchRoot: null, callExpression, statementIndex });
@@ -753,6 +890,7 @@ export const zustandNoMutatingState = defineRule({
       ZustandStoreCreator["creatorFunction"],
       ZustandCreatorBinding
     >();
+    const bindingsWithBoundStoreNotifier = new Set<ZustandCreatorBinding>();
     const functionContainers = new Set<EsTreeNode>();
     const updaterFunctionNotifierSymbolIds = new Map<EsTreeNode, Set<number>>();
     const recordUpdaterFunctionNotifier = (
@@ -824,6 +962,7 @@ export const zustandNoMutatingState = defineRule({
             if (!isNodeOfType(node, "CallExpression")) return;
             const storeSymbolId = storeSymbolIdForMethodCall(node, "setState", context);
             if (storeSymbolId === null || !binding.storeSymbolIds.has(storeSymbolId)) return;
+            bindingsWithBoundStoreNotifier.add(binding);
             const updaterArgument = node.arguments[0];
             if (!updaterArgument || isNodeOfType(updaterArgument, "SpreadElement")) return;
             const updaterFunction = resolveExactLocalFunction(updaterArgument, context.scopes);
@@ -835,14 +974,16 @@ export const zustandNoMutatingState = defineRule({
         const analyzeProvenance = (
           getSymbolIds: ReadonlySet<number>,
           setSymbolIds: ReadonlySet<number>,
-          storeSymbolIds: ReadonlySet<number>,
+          snapshotStoreSymbolIds: ReadonlySet<number>,
+          notifierStoreSymbolIds: ReadonlySet<number>,
         ): void => {
           if (programNode) {
             analyzeSnapshotContainer(
               programNode.body,
               getSymbolIds,
               setSymbolIds,
-              storeSymbolIds,
+              snapshotStoreSymbolIds,
+              notifierStoreSymbolIds,
               context,
               reportedNodes,
             );
@@ -856,14 +997,16 @@ export const zustandNoMutatingState = defineRule({
               updaterNotifierSymbolIds &&
               Array.from(updaterNotifierSymbolIds).some(
                 (notifierSymbolId) =>
-                  setSymbolIds.has(notifierSymbolId) || storeSymbolIds.has(notifierSymbolId),
+                  setSymbolIds.has(notifierSymbolId) ||
+                  notifierStoreSymbolIds.has(notifierSymbolId),
               ),
             );
             analyzeSnapshotContainer(
               functionContainer.body.body,
               getSymbolIds,
               setSymbolIds,
-              storeSymbolIds,
+              snapshotStoreSymbolIds,
+              notifierStoreSymbolIds,
               context,
               reportedNodes,
               isUpdaterNotifierForProvenance
@@ -875,13 +1018,18 @@ export const zustandNoMutatingState = defineRule({
         for (const binding of creatorBindings.values()) {
           const getSymbolIds = new Set<number>();
           const setSymbolIds = new Set<number>();
-          if (binding.getSymbol && binding.setSymbol && binding.setSymbol.references.length > 0) {
+          if (
+            binding.getSymbol &&
+            binding.setSymbol &&
+            (binding.setSymbol.references.length > 0 || bindingsWithBoundStoreNotifier.has(binding))
+          ) {
             getSymbolIds.add(binding.getSymbol.id);
           }
           if (binding.setSymbol) setSymbolIds.add(binding.setSymbol.id);
-          analyzeProvenance(getSymbolIds, setSymbolIds, new Set<number>());
+          analyzeProvenance(getSymbolIds, setSymbolIds, new Set<number>(), binding.storeSymbolIds);
           for (const storeSymbolId of binding.storeSymbolIds) {
-            analyzeProvenance(new Set<number>(), new Set<number>(), new Set([storeSymbolId]));
+            const storeSymbolIds = new Set([storeSymbolId]);
+            analyzeProvenance(new Set<number>(), new Set<number>(), storeSymbolIds, storeSymbolIds);
           }
         }
       },

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.ts
@@ -76,6 +76,11 @@ interface NotifierCallWithStatementIndex {
   statementIndex: number;
 }
 
+interface ConditionalNotifierGroupWithStatementIndex {
+  branchCalls: EsTreeNodeOfType<"CallExpression">[][];
+  statementIndex: number;
+}
+
 const findIdentifierParameter = (
   parameter: EsTreeNode | undefined,
 ): EsTreeNodeOfType<"Identifier"> | null => {
@@ -583,6 +588,23 @@ const notifierTargetReplacementDisposition = (
   return false;
 };
 
+const conditionalNotifierTargetReplacementDisposition = (
+  branchCalls: readonly (readonly EsTreeNodeOfType<"CallExpression">[])[],
+  mutation: MutableStateReferenceMutation,
+  context: RuleContext,
+): boolean | null => {
+  const branchDispositions = branchCalls.map((calls) => {
+    const dispositions = calls.map((callExpression) =>
+      notifierTargetReplacementDisposition(callExpression, mutation, context),
+    );
+    if (dispositions.some((disposition) => disposition === true)) return true;
+    if (dispositions.some((disposition) => disposition === null)) return null;
+    return false;
+  });
+  if (branchDispositions.some((disposition) => disposition === false)) return false;
+  return branchDispositions.every((disposition) => disposition === true) ? true : null;
+};
+
 const analyzeSnapshotContainer = (
   statements: readonly EsTreeNode[],
   getSymbolIds: ReadonlySet<number>,
@@ -600,23 +622,23 @@ const analyzeSnapshotContainer = (
   };
   const mutations: MutationWithStatementIndex[] = [];
   const notifierCalls: NotifierCallWithStatementIndex[] = [];
+  const conditionalNotifierGroups: ConditionalNotifierGroupWithStatementIndex[] = [];
   for (let statementIndex = 0; statementIndex < statements.length; statementIndex += 1) {
     const statement = statements[statementIndex];
     if (isNodeOfType(statement, "IfStatement")) {
+      const branchCalls: EsTreeNodeOfType<"CallExpression">[][] = [];
       for (const branchRoot of [statement.consequent, statement.alternate]) {
         if (!branchRoot) continue;
         for (const mutation of collectMutableStateReferenceMutations(branchRoot, state)) {
           mutations.push({ branchRoot, mutation, statementIndex });
         }
-        for (const callExpression of collectNotifierCalls(
-          branchRoot,
-          setSymbolIds,
-          storeSymbolIds,
-          context,
-        )) {
+        const calls = collectNotifierCalls(branchRoot, setSymbolIds, storeSymbolIds, context);
+        branchCalls.push(calls);
+        for (const callExpression of calls) {
           notifierCalls.push({ branchRoot, callExpression, statementIndex });
         }
       }
+      if (statement.alternate) conditionalNotifierGroups.push({ branchCalls, statementIndex });
     } else {
       for (const mutation of collectMutableStateReferenceMutations(statement, state)) {
         mutations.push({ branchRoot: null, mutation, statementIndex });
@@ -667,6 +689,11 @@ const analyzeSnapshotContainer = (
       ...returnedUpdateExpressions.map((expression) =>
         updateTargetReplacementDisposition(expression, mutation, context),
       ),
+      ...conditionalNotifierGroups
+        .filter((group) => group.statementIndex > statementIndex)
+        .map((group) =>
+          conditionalNotifierTargetReplacementDisposition(group.branchCalls, mutation, context),
+        ),
     ];
     if (replacementDispositions.some((disposition) => disposition !== false)) {
       continue;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.ts
@@ -56,6 +56,11 @@ const UNSUPPORTED_CONTROL_FLOW_TYPES = new Set([
   "WithStatement",
 ]);
 
+const UNSUPPORTED_SNAPSHOT_EXPRESSION_CONTROL_FLOW_TYPES = new Set([
+  "ConditionalExpression",
+  "LogicalExpression",
+]);
+
 interface ZustandCreatorBinding {
   creatorFunction: ZustandStoreCreator["creatorFunction"];
   getSymbol: SymbolDescriptor | null;
@@ -324,8 +329,20 @@ const hasUnsupportedSnapshotStatement = (statement: EsTreeNode): boolean => {
   return branchStatements.some(hasUnsupportedSnapshotStatement);
 };
 
-const hasUnsupportedSnapshotControlFlow = (statements: readonly EsTreeNode[]): boolean =>
-  statements.some(hasUnsupportedSnapshotStatement);
+const hasUnsupportedSnapshotControlFlow = (statements: readonly EsTreeNode[]): boolean => {
+  if (statements.some(hasUnsupportedSnapshotStatement)) return true;
+  let didFindUnsupportedExpressionControlFlow = false;
+  for (const statement of statements) {
+    walkAst(statement, (node: EsTreeNode) => {
+      if (node !== statement && isFunctionLike(node)) return false;
+      if (UNSUPPORTED_SNAPSHOT_EXPRESSION_CONTROL_FLOW_TYPES.has(node.type)) {
+        didFindUnsupportedExpressionControlFlow = true;
+        return false;
+      }
+    });
+  }
+  return didFindUnsupportedExpressionControlFlow;
+};
 
 const analyzeSetUpdater = (
   updaterFunction: EsTreeNode,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.ts
@@ -311,15 +311,26 @@ const hasAbruptCompletion = (node: EsTreeNode): boolean => {
   return didFindAbruptCompletion;
 };
 
+const hasUnsupportedSnapshotStatement = (statement: EsTreeNode): boolean => {
+  if (!isNodeOfType(statement, "IfStatement")) {
+    return UNSUPPORTED_CONTROL_FLOW_TYPES.has(statement.type);
+  }
+  if (hasAbruptCompletion(statement)) return true;
+  const branchStatements: EsTreeNode[] = [];
+  for (const branch of [statement.consequent, statement.alternate]) {
+    if (!branch) continue;
+    branchStatements.push(...(isNodeOfType(branch, "BlockStatement") ? branch.body : [branch]));
+  }
+  return branchStatements.some(hasUnsupportedSnapshotStatement);
+};
+
 const hasUnsupportedSnapshotControlFlow = (statements: readonly EsTreeNode[]): boolean =>
-  statements.some(
-    (statement) =>
-      UNSUPPORTED_CONTROL_FLOW_TYPES.has(statement.type) &&
-      (!isNodeOfType(statement, "IfStatement") || hasAbruptCompletion(statement)),
-  );
+  statements.some(hasUnsupportedSnapshotStatement);
 
 const analyzeSetUpdater = (
   updaterFunction: EsTreeNode,
+  getSymbolIds: ReadonlySet<number>,
+  storeSymbolIds: ReadonlySet<number>,
   context: RuleContext,
   reportedNodes: WeakSet<EsTreeNode>,
 ): void => {
@@ -350,11 +361,19 @@ const analyzeSetUpdater = (
     mutations.push(...collectMutableStateReferenceMutations(updaterFunction.body, state));
   }
   for (const mutation of mutations) {
+    const mutationPath = staticPropertyPathForExpression(mutation.receiver, context);
     const hasNoUpdateReturn = returnedExpressions.some((expression) =>
       isDefinitelyNoUpdateExpression(expression, context),
     );
     const doesPreserveTarget = returnedExpressions.some(
-      (expression) => updateTargetReplacementDisposition(expression, mutation, context) === false,
+      (expression) =>
+        updateTargetReplacementDisposition(expression, mutation, context) === false ||
+        (isSnapshotExpression(expression, getSymbolIds, storeSymbolIds, context) &&
+          mutationPath !== null &&
+          staticPathPreservesTarget(
+            staticPropertyPathForExpression(expression, context),
+            mutationPath,
+          )),
     );
     if (returnedExpressions.length > 0 && !doesPreserveTarget && !hasNoUpdateReturn) continue;
     if (reportedNodes.has(mutation.node)) continue;
@@ -1014,7 +1033,13 @@ export const zustandNoMutatingState = defineRule({
               const updaterFunction = resolveExactLocalFunction(updaterArgument, context.scopes);
               if (!updaterFunction) return;
               recordUpdaterFunctionNotifier(updaterFunction, setSymbolId);
-              analyzeSetUpdater(updaterFunction, context, reportedNodes);
+              analyzeSetUpdater(
+                updaterFunction,
+                binding.getSymbol ? new Set([binding.getSymbol.id]) : new Set(),
+                new Set(),
+                context,
+                reportedNodes,
+              );
             });
           }
           if (!programNode || binding.storeSymbolIds.size === 0) continue;
@@ -1028,7 +1053,13 @@ export const zustandNoMutatingState = defineRule({
             const updaterFunction = resolveExactLocalFunction(updaterArgument, context.scopes);
             if (!updaterFunction) return;
             recordUpdaterFunctionNotifier(updaterFunction, storeSymbolId);
-            analyzeSetUpdater(updaterFunction, context, reportedNodes);
+            analyzeSetUpdater(
+              updaterFunction,
+              new Set(),
+              new Set([storeSymbolId]),
+              context,
+              reportedNodes,
+            );
           });
         }
         const analyzeProvenance = (

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.ts
@@ -469,6 +469,53 @@ const objectTargetReplacementDisposition = (
   return disposition;
 };
 
+const staticPathPreservesTarget = (
+  candidatePath: readonly string[] | null,
+  targetPath: readonly string[],
+): boolean =>
+  Boolean(
+    candidatePath &&
+    candidatePath.length <= targetPath.length &&
+    candidatePath.every((propertyName, index) => propertyName === targetPath[index]),
+  );
+
+const objectTargetPathReplacementDisposition = (
+  objectExpression: EsTreeNodeOfType<"ObjectExpression">,
+  targetPath: readonly string[],
+  isPartialUpdateRoot: boolean,
+  context: RuleContext,
+): boolean | null => {
+  const propertyName = targetPath[0];
+  if (!propertyName) return true;
+  let disposition: boolean | null = isPartialUpdateRoot ? false : true;
+  for (const property of objectExpression.properties) {
+    if (isNodeOfType(property, "SpreadElement")) {
+      disposition = null;
+      continue;
+    }
+    if (!isNodeOfType(property, "Property")) continue;
+    if (getStaticPropertyKeyName(property) !== propertyName) continue;
+    const propertyValue = stripParenExpression(property.value);
+    if (targetPath.length > 1 && isNodeOfType(propertyValue, "ObjectExpression")) {
+      disposition = objectTargetPathReplacementDisposition(
+        propertyValue,
+        targetPath.slice(1),
+        false,
+        context,
+      );
+      continue;
+    }
+    if (
+      staticPathPreservesTarget(staticPropertyPathForExpression(propertyValue, context), targetPath)
+    ) {
+      disposition = false;
+      continue;
+    }
+    disposition = isProvenFreshReplacementExpression(propertyValue, "", context) ? true : null;
+  }
+  return disposition;
+};
+
 const updateTargetReplacementDisposition = (
   updateExpression: EsTreeNode,
   mutation: MutableStateReferenceMutation,
@@ -476,8 +523,20 @@ const updateTargetReplacementDisposition = (
 ): boolean | null => {
   const targetKey = resolveExpressionKey(mutation.receiver, context);
   const targetPath = staticPropertyPathForExpression(mutation.receiver, context);
-  if (!targetKey || !targetPath) return null;
+  if (!targetPath) return null;
   const candidate = stripParenExpression(updateExpression);
+  if (!targetKey) {
+    if (targetPath.length === 0) return null;
+    if (!isNodeOfType(candidate, "ObjectExpression")) {
+      return staticPathPreservesTarget(
+        staticPropertyPathForExpression(candidate, context),
+        targetPath,
+      )
+        ? false
+        : null;
+    }
+    return objectTargetPathReplacementDisposition(candidate, targetPath, true, context);
+  }
   if (targetPath.length === 0) {
     if (expressionPreservesTarget(candidate, targetKey, mutation.node, context)) return false;
     return isProvenFreshReplacementExpression(candidate, targetKey, context) ? true : null;
@@ -500,21 +559,24 @@ const updateTargetReplacementDisposition = (
   );
 };
 
-const notifierReplacesTarget = (
+const notifierTargetReplacementDisposition = (
   notifierCall: EsTreeNodeOfType<"CallExpression">,
   mutation: MutableStateReferenceMutation,
   context: RuleContext,
-): boolean => {
-  const targetKey = resolveExpressionKey(mutation.receiver, context);
+): boolean | null => {
   const updateArgument = notifierCall.arguments[0];
-  if (!targetKey || !updateArgument || isNodeOfType(updateArgument, "SpreadElement")) return false;
+  if (!updateArgument) return false;
+  if (isNodeOfType(updateArgument, "SpreadElement")) return null;
   const updateFunction = resolveExactLocalFunction(updateArgument, context.scopes);
   const updateExpressions = updateFunction
     ? returnedExpressionsForFunction(updateFunction)
     : [updateArgument];
-  return updateExpressions.some(
-    (expression) => updateTargetReplacementDisposition(expression, mutation, context) === true,
+  const dispositions = updateExpressions.map((expression) =>
+    updateTargetReplacementDisposition(expression, mutation, context),
   );
+  if (dispositions.some((disposition) => disposition === true)) return true;
+  if (dispositions.some((disposition) => disposition === null)) return null;
+  return false;
 };
 
 const analyzeSnapshotContainer = (
@@ -524,6 +586,7 @@ const analyzeSnapshotContainer = (
   storeSymbolIds: ReadonlySet<number>,
   context: RuleContext,
   reportedNodes: WeakSet<EsTreeNode>,
+  returnedUpdateExpressions: readonly EsTreeNode[] = [],
 ): void => {
   if (hasUnsupportedSnapshotControlFlow(statements)) return;
   const state: MutableStateReferenceState = {
@@ -572,11 +635,15 @@ const analyzeSnapshotContainer = (
     const followingNotifiers = notifierCalls.filter(
       (notifier) => notifier.statementIndex >= statementIndex,
     );
-    if (
-      followingNotifiers.some((notifier) =>
-        notifierReplacesTarget(notifier.callExpression, mutation, context),
-      )
-    ) {
+    const replacementDispositions = [
+      ...followingNotifiers.map((notifier) =>
+        notifierTargetReplacementDisposition(notifier.callExpression, mutation, context),
+      ),
+      ...returnedUpdateExpressions.map((expression) =>
+        updateTargetReplacementDisposition(expression, mutation, context),
+      ),
+    ];
+    if (replacementDispositions.some((disposition) => disposition !== false)) {
       continue;
     }
     if (reportedNodes.has(mutation.node)) continue;
@@ -599,6 +666,7 @@ export const zustandNoMutatingState = defineRule({
       ZustandCreatorBinding
     >();
     const functionContainers = new Set<EsTreeNode>();
+    const setUpdaterFunctions = new Set<EsTreeNode>();
     const storeSymbolIds = new Set<number>();
     const reportedNodes = new WeakSet<EsTreeNode>();
     let programNode: EsTreeNodeOfType<"Program"> | null = null;
@@ -651,7 +719,9 @@ export const zustandNoMutatingState = defineRule({
             const updaterArgument = node.arguments[0];
             if (!updaterArgument || isNodeOfType(updaterArgument, "SpreadElement")) return;
             const updaterFunction = resolveExactLocalFunction(updaterArgument, context.scopes);
-            if (updaterFunction) analyzeSetUpdater(updaterFunction, context, reportedNodes);
+            if (!updaterFunction) return;
+            setUpdaterFunctions.add(updaterFunction);
+            analyzeSetUpdater(updaterFunction, context, reportedNodes);
           });
         }
         if (programNode) {
@@ -674,6 +744,9 @@ export const zustandNoMutatingState = defineRule({
             storeSymbolIds,
             context,
             reportedNodes,
+            setUpdaterFunctions.has(functionContainer)
+              ? returnedExpressionsForFunction(functionContainer)
+              : [],
           );
         }
       },

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.ts
@@ -2,6 +2,7 @@ import type { SymbolDescriptor } from "../../semantic/scope-analysis.js";
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { getRangeStart } from "../../utils/get-range-start.js";
 import { getStaticPropertyKeyName } from "../../utils/get-static-property-key-name.js";
 import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
@@ -60,14 +61,17 @@ interface ZustandCreatorBinding {
   getSymbol: SymbolDescriptor | null;
   hasNonImmerUsage: boolean;
   setSymbol: SymbolDescriptor | null;
+  storeSymbolIds: Set<number>;
 }
 
 interface MutationWithStatementIndex {
+  branchRoot: EsTreeNode | null;
   mutation: MutableStateReferenceMutation;
   statementIndex: number;
 }
 
 interface NotifierCallWithStatementIndex {
+  branchRoot: EsTreeNode | null;
   callExpression: EsTreeNodeOfType<"CallExpression">;
   statementIndex: number;
 }
@@ -598,17 +602,32 @@ const analyzeSnapshotContainer = (
   const notifierCalls: NotifierCallWithStatementIndex[] = [];
   for (let statementIndex = 0; statementIndex < statements.length; statementIndex += 1) {
     const statement = statements[statementIndex];
-    for (const mutation of collectMutableStateReferenceMutations(statement, state)) {
-      mutations.push({ mutation, statementIndex });
-    }
-    if (!isNodeOfType(statement, "IfStatement")) {
+    if (isNodeOfType(statement, "IfStatement")) {
+      for (const branchRoot of [statement.consequent, statement.alternate]) {
+        if (!branchRoot) continue;
+        for (const mutation of collectMutableStateReferenceMutations(branchRoot, state)) {
+          mutations.push({ branchRoot, mutation, statementIndex });
+        }
+        for (const callExpression of collectNotifierCalls(
+          branchRoot,
+          setSymbolIds,
+          storeSymbolIds,
+          context,
+        )) {
+          notifierCalls.push({ branchRoot, callExpression, statementIndex });
+        }
+      }
+    } else {
+      for (const mutation of collectMutableStateReferenceMutations(statement, state)) {
+        mutations.push({ branchRoot: null, mutation, statementIndex });
+      }
       for (const callExpression of collectNotifierCalls(
         statement,
         setSymbolIds,
         storeSymbolIds,
         context,
       )) {
-        notifierCalls.push({ callExpression, statementIndex });
+        notifierCalls.push({ branchRoot: null, callExpression, statementIndex });
       }
     }
     if (isNodeOfType(statement, "VariableDeclaration")) {
@@ -631,10 +650,16 @@ const analyzeSnapshotContainer = (
     }
     if (isNodeOfType(statement, "ReturnStatement")) break;
   }
-  for (const { mutation, statementIndex } of mutations) {
-    const followingNotifiers = notifierCalls.filter(
-      (notifier) => notifier.statementIndex >= statementIndex,
-    );
+  for (const { branchRoot, mutation, statementIndex } of mutations) {
+    const followingNotifiers = notifierCalls.filter((notifier) => {
+      if (!notifier.branchRoot) return notifier.statementIndex >= statementIndex;
+      if (notifier.statementIndex !== statementIndex || notifier.branchRoot !== branchRoot) {
+        return false;
+      }
+      const mutationStart = getRangeStart(mutation.node);
+      const notifierStart = getRangeStart(notifier.callExpression);
+      return mutationStart !== null && notifierStart !== null && notifierStart >= mutationStart;
+    });
     const replacementDispositions = [
       ...followingNotifiers.map((notifier) =>
         notifierTargetReplacementDisposition(notifier.callExpression, mutation, context),
@@ -666,8 +691,7 @@ export const zustandNoMutatingState = defineRule({
       ZustandCreatorBinding
     >();
     const functionContainers = new Set<EsTreeNode>();
-    const setUpdaterFunctions = new Set<EsTreeNode>();
-    const storeSymbolIds = new Set<number>();
+    const setUpdaterFunctionSymbolIds = new Map<EsTreeNode, number>();
     const reportedNodes = new WeakSet<EsTreeNode>();
     let programNode: EsTreeNodeOfType<"Program"> | null = null;
     return {
@@ -677,21 +701,23 @@ export const zustandNoMutatingState = defineRule({
       CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
         const creator = resolveZustandStoreCreator(node, context.scopes);
         if (!creator) return;
-        const existingBinding = creatorBindings.get(creator.creatorFunction);
-        if (existingBinding) {
-          if (!creator.middlewareNames.has("immer")) existingBinding.hasNonImmerUsage = true;
+        let binding = creatorBindings.get(creator.creatorFunction);
+        if (binding) {
+          if (!creator.middlewareNames.has("immer")) binding.hasNonImmerUsage = true;
         } else {
-          creatorBindings.set(creator.creatorFunction, {
+          binding = {
             creatorFunction: creator.creatorFunction,
             getSymbol: symbolForParameter(creator.creatorFunction, 1, context),
             hasNonImmerUsage: !creator.middlewareNames.has("immer"),
             setSymbol: symbolForParameter(creator.creatorFunction, 0, context),
-          });
+            storeSymbolIds: new Set(),
+          };
+          creatorBindings.set(creator.creatorFunction, binding);
         }
         const parent = node.parent;
         if (isNodeOfType(parent, "VariableDeclarator") && isNodeOfType(parent.id, "Identifier")) {
           const storeSymbol = context.scopes.symbolFor(parent.id);
-          if (storeSymbol) storeSymbolIds.add(storeSymbol.id);
+          if (storeSymbol) binding.storeSymbolIds.add(storeSymbol.id);
         }
       },
       ArrowFunctionExpression(node: EsTreeNodeOfType<"ArrowFunctionExpression">) {
@@ -704,15 +730,10 @@ export const zustandNoMutatingState = defineRule({
         functionContainers.add(node);
       },
       "Program:exit"() {
-        const getSymbolIds = new Set<number>();
-        const setSymbolIds = new Set<number>();
         for (const binding of creatorBindings.values()) {
-          if (binding.getSymbol && binding.setSymbol && binding.setSymbol.references.length > 0) {
-            getSymbolIds.add(binding.getSymbol.id);
-          }
-          if (binding.setSymbol) setSymbolIds.add(binding.setSymbol.id);
           if (!binding.hasNonImmerUsage || !binding.setSymbol) continue;
-          const creatorSetSymbolIds = new Set([binding.setSymbol.id]);
+          const setSymbolId = binding.setSymbol.id;
+          const creatorSetSymbolIds = new Set([setSymbolId]);
           walkAst(binding.creatorFunction.body, (node: EsTreeNode) => {
             if (!isNodeOfType(node, "CallExpression")) return;
             if (!isCallToSymbol(node, creatorSetSymbolIds, context)) return;
@@ -720,34 +741,53 @@ export const zustandNoMutatingState = defineRule({
             if (!updaterArgument || isNodeOfType(updaterArgument, "SpreadElement")) return;
             const updaterFunction = resolveExactLocalFunction(updaterArgument, context.scopes);
             if (!updaterFunction) return;
-            setUpdaterFunctions.add(updaterFunction);
+            setUpdaterFunctionSymbolIds.set(updaterFunction, setSymbolId);
             analyzeSetUpdater(updaterFunction, context, reportedNodes);
           });
         }
-        if (programNode) {
-          analyzeSnapshotContainer(
-            programNode.body,
-            getSymbolIds,
-            setSymbolIds,
-            storeSymbolIds,
-            context,
-            reportedNodes,
-          );
-        }
-        for (const functionContainer of functionContainers) {
-          if (!isFunctionLike(functionContainer)) continue;
-          if (!isNodeOfType(functionContainer.body, "BlockStatement")) continue;
-          analyzeSnapshotContainer(
-            functionContainer.body.body,
-            getSymbolIds,
-            setSymbolIds,
-            storeSymbolIds,
-            context,
-            reportedNodes,
-            setUpdaterFunctions.has(functionContainer)
-              ? returnedExpressionsForFunction(functionContainer)
-              : [],
-          );
+        const analyzeProvenance = (
+          getSymbolIds: ReadonlySet<number>,
+          setSymbolIds: ReadonlySet<number>,
+          storeSymbolIds: ReadonlySet<number>,
+        ): void => {
+          if (programNode) {
+            analyzeSnapshotContainer(
+              programNode.body,
+              getSymbolIds,
+              setSymbolIds,
+              storeSymbolIds,
+              context,
+              reportedNodes,
+            );
+          }
+          for (const functionContainer of functionContainers) {
+            if (!isFunctionLike(functionContainer)) continue;
+            if (!isNodeOfType(functionContainer.body, "BlockStatement")) continue;
+            const updaterSetSymbolId = setUpdaterFunctionSymbolIds.get(functionContainer);
+            analyzeSnapshotContainer(
+              functionContainer.body.body,
+              getSymbolIds,
+              setSymbolIds,
+              storeSymbolIds,
+              context,
+              reportedNodes,
+              updaterSetSymbolId !== undefined && setSymbolIds.has(updaterSetSymbolId)
+                ? returnedExpressionsForFunction(functionContainer)
+                : [],
+            );
+          }
+        };
+        for (const binding of creatorBindings.values()) {
+          const getSymbolIds = new Set<number>();
+          const setSymbolIds = new Set<number>();
+          if (binding.getSymbol && binding.setSymbol && binding.setSymbol.references.length > 0) {
+            getSymbolIds.add(binding.getSymbol.id);
+          }
+          if (binding.setSymbol) setSymbolIds.add(binding.setSymbol.id);
+          analyzeProvenance(getSymbolIds, setSymbolIds, new Set<number>());
+          for (const storeSymbolId of binding.storeSymbolIds) {
+            analyzeProvenance(new Set<number>(), new Set<number>(), new Set([storeSymbolId]));
+          }
         }
       },
     };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.ts
@@ -925,7 +925,14 @@ const analyzeSnapshotContainer = (
   }
   for (const { branchRoot, mutation, statementIndex } of mutations) {
     const followingNotifiers = notifierCalls.filter((notifier) => {
-      if (!notifier.branchRoot) return notifier.statementIndex >= statementIndex;
+      if (!notifier.branchRoot) {
+        if (notifier.statementIndex !== statementIndex) {
+          return notifier.statementIndex > statementIndex;
+        }
+        const mutationStart = getRangeStart(mutation.node);
+        const notifierStart = getRangeStart(notifier.callExpression);
+        return mutationStart !== null && notifierStart !== null && notifierStart >= mutationStart;
+      }
       if (notifier.statementIndex !== statementIndex || notifier.branchRoot !== branchRoot) {
         return false;
       }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.ts
@@ -121,19 +121,28 @@ const rootCallForExpression = (
   return isNodeOfType(current, "CallExpression") ? current : null;
 };
 
+const storeSymbolIdForMethodCall = (
+  callExpression: EsTreeNodeOfType<"CallExpression">,
+  methodName: "getState" | "setState",
+  context: RuleContext,
+): number | null => {
+  const callee = stripParenExpression(callExpression.callee);
+  if (!isNodeOfType(callee, "MemberExpression")) return null;
+  if (getStaticPropertyName(callee) !== methodName) return null;
+  const receiver = stripParenExpression(callee.object);
+  if (!isNodeOfType(receiver, "Identifier")) return null;
+  const symbol = resolveConstIdentifierAlias(receiver, context.scopes);
+  return symbol?.id ?? null;
+};
+
 const isStoreMethodCall = (
   callExpression: EsTreeNodeOfType<"CallExpression">,
   methodName: "getState" | "setState",
   storeSymbolIds: ReadonlySet<number>,
   context: RuleContext,
 ): boolean => {
-  const callee = stripParenExpression(callExpression.callee);
-  if (!isNodeOfType(callee, "MemberExpression")) return false;
-  if (getStaticPropertyName(callee) !== methodName) return false;
-  const receiver = stripParenExpression(callee.object);
-  if (!isNodeOfType(receiver, "Identifier")) return false;
-  const symbol = resolveConstIdentifierAlias(receiver, context.scopes);
-  return Boolean(symbol && storeSymbolIds.has(symbol.id));
+  const storeSymbolId = storeSymbolIdForMethodCall(callExpression, methodName, context);
+  return storeSymbolId !== null && storeSymbolIds.has(storeSymbolId);
 };
 
 const isSnapshotExpression = (
@@ -745,7 +754,18 @@ export const zustandNoMutatingState = defineRule({
       ZustandCreatorBinding
     >();
     const functionContainers = new Set<EsTreeNode>();
-    const setUpdaterFunctionSymbolIds = new Map<EsTreeNode, number>();
+    const updaterFunctionNotifierSymbolIds = new Map<EsTreeNode, Set<number>>();
+    const recordUpdaterFunctionNotifier = (
+      updaterFunction: EsTreeNode,
+      notifierSymbolId: number,
+    ): void => {
+      const notifierSymbolIds = updaterFunctionNotifierSymbolIds.get(updaterFunction);
+      if (notifierSymbolIds) {
+        notifierSymbolIds.add(notifierSymbolId);
+      } else {
+        updaterFunctionNotifierSymbolIds.set(updaterFunction, new Set([notifierSymbolId]));
+      }
+    };
     const reportedNodes = new WeakSet<EsTreeNode>();
     let programNode: EsTreeNodeOfType<"Program"> | null = null;
     return {
@@ -785,17 +805,30 @@ export const zustandNoMutatingState = defineRule({
       },
       "Program:exit"() {
         for (const binding of creatorBindings.values()) {
-          if (!binding.hasNonImmerUsage || !binding.setSymbol) continue;
-          const setSymbolId = binding.setSymbol.id;
-          const creatorSetSymbolIds = new Set([setSymbolId]);
-          walkAst(binding.creatorFunction.body, (node: EsTreeNode) => {
+          if (binding.hasNonImmerUsage && binding.setSymbol) {
+            const setSymbolId = binding.setSymbol.id;
+            const creatorSetSymbolIds = new Set([setSymbolId]);
+            walkAst(binding.creatorFunction.body, (node: EsTreeNode) => {
+              if (!isNodeOfType(node, "CallExpression")) return;
+              if (!isCallToSymbol(node, creatorSetSymbolIds, context)) return;
+              const updaterArgument = node.arguments[0];
+              if (!updaterArgument || isNodeOfType(updaterArgument, "SpreadElement")) return;
+              const updaterFunction = resolveExactLocalFunction(updaterArgument, context.scopes);
+              if (!updaterFunction) return;
+              recordUpdaterFunctionNotifier(updaterFunction, setSymbolId);
+              analyzeSetUpdater(updaterFunction, context, reportedNodes);
+            });
+          }
+          if (!programNode || binding.storeSymbolIds.size === 0) continue;
+          walkAst(programNode, (node: EsTreeNode) => {
             if (!isNodeOfType(node, "CallExpression")) return;
-            if (!isCallToSymbol(node, creatorSetSymbolIds, context)) return;
+            const storeSymbolId = storeSymbolIdForMethodCall(node, "setState", context);
+            if (storeSymbolId === null || !binding.storeSymbolIds.has(storeSymbolId)) return;
             const updaterArgument = node.arguments[0];
             if (!updaterArgument || isNodeOfType(updaterArgument, "SpreadElement")) return;
             const updaterFunction = resolveExactLocalFunction(updaterArgument, context.scopes);
             if (!updaterFunction) return;
-            setUpdaterFunctionSymbolIds.set(updaterFunction, setSymbolId);
+            recordUpdaterFunctionNotifier(updaterFunction, storeSymbolId);
             analyzeSetUpdater(updaterFunction, context, reportedNodes);
           });
         }
@@ -817,7 +850,15 @@ export const zustandNoMutatingState = defineRule({
           for (const functionContainer of functionContainers) {
             if (!isFunctionLike(functionContainer)) continue;
             if (!isNodeOfType(functionContainer.body, "BlockStatement")) continue;
-            const updaterSetSymbolId = setUpdaterFunctionSymbolIds.get(functionContainer);
+            const updaterNotifierSymbolIds =
+              updaterFunctionNotifierSymbolIds.get(functionContainer);
+            const isUpdaterNotifierForProvenance = Boolean(
+              updaterNotifierSymbolIds &&
+              Array.from(updaterNotifierSymbolIds).some(
+                (notifierSymbolId) =>
+                  setSymbolIds.has(notifierSymbolId) || storeSymbolIds.has(notifierSymbolId),
+              ),
+            );
             analyzeSnapshotContainer(
               functionContainer.body.body,
               getSymbolIds,
@@ -825,7 +866,7 @@ export const zustandNoMutatingState = defineRule({
               storeSymbolIds,
               context,
               reportedNodes,
-              updaterSetSymbolId !== undefined && setSymbolIds.has(updaterSetSymbolId)
+              isUpdaterNotifierForProvenance
                 ? returnedExpressionsForFunction(functionContainer)
                 : [],
             );

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.ts
@@ -1066,7 +1066,7 @@ export const zustandNoMutatingState = defineRule({
               analyzeSetUpdater(
                 updaterFunction,
                 binding.getSymbol ? new Set([binding.getSymbol.id]) : new Set(),
-                new Set(),
+                binding.storeSymbolIds,
                 context,
                 reportedNodes,
               );

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.ts
@@ -639,7 +639,9 @@ export const zustandNoMutatingState = defineRule({
         const getSymbolIds = new Set<number>();
         const setSymbolIds = new Set<number>();
         for (const binding of creatorBindings.values()) {
-          if (binding.getSymbol) getSymbolIds.add(binding.getSymbol.id);
+          if (binding.getSymbol && binding.setSymbol && binding.setSymbol.references.length > 0) {
+            getSymbolIds.add(binding.getSymbol.id);
+          }
           if (binding.setSymbol) setSymbolIds.add(binding.setSymbol.id);
           if (!binding.hasNonImmerUsage || !binding.setSymbol) continue;
           const creatorSetSymbolIds = new Set([binding.setSymbol.id]);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.ts
@@ -495,6 +495,7 @@ const objectTargetReplacementDisposition = (
   mutationNode: EsTreeNode,
   isPartialUpdateRoot: boolean,
   context: RuleContext,
+  ancestorPath: readonly string[] = [],
 ): boolean | null => {
   const propertyName = targetPath[0];
   if (!propertyName) return true;
@@ -502,7 +503,11 @@ const objectTargetReplacementDisposition = (
   for (const property of objectExpression.properties) {
     if (isNodeOfType(property, "SpreadElement")) {
       const spreadKey = resolveExpressionKey(property.argument, context);
-      disposition = spreadKey === ancestorKey ? false : null;
+      const spreadPath = staticPropertyPathForExpression(property.argument, context);
+      disposition =
+        spreadKey === ancestorKey || staticPathPreservesTarget(spreadPath, ancestorPath)
+          ? false
+          : null;
       continue;
     }
     if (!isNodeOfType(property, "Property")) continue;
@@ -527,6 +532,7 @@ const objectTargetReplacementDisposition = (
         mutationNode,
         false,
         context,
+        [...ancestorPath, propertyName],
       );
     } else if (expressionKeyPreservesTarget(propertyValue, targetKey, context)) {
       disposition = false;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.ts
@@ -1,8 +1,10 @@
 import type { SymbolDescriptor } from "../../semantic/scope-analysis.js";
+import { MUTATING_ARRAY_METHODS, MUTATING_COLLECTION_METHODS } from "../../constants/js.js";
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
+import { functionReturnsCollectionAtPath } from "../../utils/function-returns-collection-at-path.js";
 import { getRangeStart } from "../../utils/get-range-start.js";
 import { getStaticPropertyKeyName } from "../../utils/get-static-property-key-name.js";
 import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
@@ -349,6 +351,7 @@ const analyzeSetUpdater = (
   updaterFunction: EsTreeNode,
   getSymbolIds: ReadonlySet<number>,
   storeSymbolIds: ReadonlySet<number>,
+  creatorFunction: ZustandStoreCreator["creatorFunction"],
   context: RuleContext,
   reportedNodes: WeakSet<EsTreeNode>,
 ): void => {
@@ -361,10 +364,14 @@ const analyzeSetUpdater = (
   };
   const returnedExpressions = returnedExpressionsForFunction(updaterFunction);
   const mutations: MutableStateReferenceMutation[] = [];
+  const mutationOptions = {
+    isProvenMutatingMethodCall: (callExpression: EsTreeNodeOfType<"CallExpression">) =>
+      isProvenZustandMutatingMethodCall(callExpression, creatorFunction, context),
+  };
   if (isNodeOfType(updaterFunction.body, "BlockStatement")) {
     if (hasUnsupportedControlFlow(updaterFunction.body.body)) return;
     for (const statement of updaterFunction.body.body) {
-      mutations.push(...collectMutableStateReferenceMutations(statement, state));
+      mutations.push(...collectMutableStateReferenceMutations(statement, state, mutationOptions));
       if (isNodeOfType(statement, "VariableDeclaration")) {
         updateMutableStateReferencesForVariableDeclaration(statement, state);
       } else if (isNodeOfType(statement, "ExpressionStatement")) {
@@ -376,7 +383,9 @@ const analyzeSetUpdater = (
       if (isNodeOfType(statement, "ReturnStatement")) break;
     }
   } else {
-    mutations.push(...collectMutableStateReferenceMutations(updaterFunction.body, state));
+    mutations.push(
+      ...collectMutableStateReferenceMutations(updaterFunction.body, state, mutationOptions),
+    );
   }
   for (const mutation of mutations) {
     const mutationPath = staticPropertyPathForExpression(mutation.receiver, context);
@@ -470,6 +479,43 @@ const staticPropertyPathForExpression = (
   }
   if (isNodeOfType(candidate, "CallExpression")) return [];
   return null;
+};
+
+const isProvenZustandMutatingMethodCall = (
+  callExpression: EsTreeNodeOfType<"CallExpression">,
+  creatorFunction: ZustandStoreCreator["creatorFunction"],
+  context: RuleContext,
+): boolean => {
+  const callee = stripParenExpression(callExpression.callee);
+  if (!isNodeOfType(callee, "MemberExpression")) return false;
+  const methodName = getStaticPropertyName(callee);
+  const receiverPath = staticPropertyPathForExpression(
+    callee.object,
+    context,
+    new Set<number>(),
+    true,
+  );
+  if (!methodName || !receiverPath) return false;
+  if (
+    MUTATING_ARRAY_METHODS.has(methodName) &&
+    functionReturnsCollectionAtPath({
+      collectionKind: "array",
+      functionNode: creatorFunction,
+      propertyPath: receiverPath,
+      scopes: context.scopes,
+    })
+  ) {
+    return true;
+  }
+  return (
+    MUTATING_COLLECTION_METHODS.has(methodName) &&
+    functionReturnsCollectionAtPath({
+      collectionKind: "map-or-set",
+      functionNode: creatorFunction,
+      propertyPath: receiverPath,
+      scopes: context.scopes,
+    })
+  );
 };
 
 const isProvenFreshReplacementExpression = (
@@ -927,6 +973,8 @@ const updateSnapshotStateForStatement = (
 const collectSequentialSnapshotMutations = (
   branchRoot: EsTreeNode,
   state: MutableStateReferenceState,
+  creatorFunction: ZustandStoreCreator["creatorFunction"],
+  context: RuleContext,
 ): MutableStateReferenceMutation[] => {
   const branchState: MutableStateReferenceState = {
     mutableStateSourceNames: new Set(state.mutableStateSourceNames),
@@ -936,15 +984,35 @@ const collectSequentialSnapshotMutations = (
   }
   const statements = isNodeOfType(branchRoot, "BlockStatement") ? branchRoot.body : [branchRoot];
   const mutations: MutableStateReferenceMutation[] = [];
+  const mutationOptions = {
+    isProvenMutatingMethodCall: (callExpression: EsTreeNodeOfType<"CallExpression">) =>
+      isProvenZustandMutatingMethodCall(callExpression, creatorFunction, context),
+  };
   for (const statement of statements) {
     if (isNodeOfType(statement, "IfStatement")) {
-      mutations.push(...collectSequentialSnapshotMutations(statement.consequent, branchState));
+      mutations.push(
+        ...collectSequentialSnapshotMutations(
+          statement.consequent,
+          branchState,
+          creatorFunction,
+          context,
+        ),
+      );
       if (statement.alternate) {
-        mutations.push(...collectSequentialSnapshotMutations(statement.alternate, branchState));
+        mutations.push(
+          ...collectSequentialSnapshotMutations(
+            statement.alternate,
+            branchState,
+            creatorFunction,
+            context,
+          ),
+        );
       }
       continue;
     }
-    mutations.push(...collectMutableStateReferenceMutations(statement, branchState));
+    mutations.push(
+      ...collectMutableStateReferenceMutations(statement, branchState, mutationOptions),
+    );
     updateSnapshotStateForStatement(statement, branchState);
   }
   return mutations;
@@ -956,6 +1024,7 @@ const analyzeSnapshotContainer = (
   setSymbolIds: ReadonlySet<number>,
   snapshotStoreSymbolIds: ReadonlySet<number>,
   notifierStoreSymbolIds: ReadonlySet<number>,
+  creatorFunction: ZustandStoreCreator["creatorFunction"],
   context: RuleContext,
   reportedNodes: WeakSet<EsTreeNode>,
   returnedUpdateExpressions: readonly EsTreeNode[] = [],
@@ -969,12 +1038,21 @@ const analyzeSnapshotContainer = (
   const mutations: MutationWithStatementIndex[] = [];
   const notifierCalls: NotifierCallWithStatementIndex[] = [];
   const conditionalNotifierGroups: ConditionalNotifierGroupWithStatementIndex[] = [];
+  const mutationOptions = {
+    isProvenMutatingMethodCall: (callExpression: EsTreeNodeOfType<"CallExpression">) =>
+      isProvenZustandMutatingMethodCall(callExpression, creatorFunction, context),
+  };
   for (let statementIndex = 0; statementIndex < statements.length; statementIndex += 1) {
     const statement = statements[statementIndex];
     if (isNodeOfType(statement, "IfStatement")) {
       for (const branchRoot of [statement.consequent, statement.alternate]) {
         if (!branchRoot) continue;
-        for (const mutation of collectSequentialSnapshotMutations(branchRoot, state)) {
+        for (const mutation of collectSequentialSnapshotMutations(
+          branchRoot,
+          state,
+          creatorFunction,
+          context,
+        )) {
           mutations.push({ branchRoot, mutation, statementIndex });
         }
         const calls = collectNotifierCalls(
@@ -988,7 +1066,11 @@ const analyzeSnapshotContainer = (
         }
       }
     } else {
-      for (const mutation of collectMutableStateReferenceMutations(statement, state)) {
+      for (const mutation of collectMutableStateReferenceMutations(
+        statement,
+        state,
+        mutationOptions,
+      )) {
         mutations.push({ branchRoot: null, mutation, statementIndex });
       }
       for (const callExpression of collectNotifierCalls(
@@ -1029,28 +1111,29 @@ const analyzeSnapshotContainer = (
       ...returnedUpdateExpressions.map((expression) =>
         updateTargetReplacementDisposition(expression, mutation, context),
       ),
-      ...conditionalNotifierGroups
-        .filter((group) => {
-          if (group.statementIndex < statementIndex) return false;
-          const mutationStart = getRangeStart(mutation.node);
-          const groupStart = getRangeStart(group.statement);
-          return (
-            mutationStart !== null &&
-            groupStart !== null &&
-            groupStart > mutationStart &&
-            branchPathCompatibility(group.statement, mutation) === true
-          );
-        })
-        .map((group) =>
-          notifierFlowTargetReplacementDisposition(
-            group.statement,
-            mutation,
-            setSymbolIds,
-            notifierStoreSymbolIds,
-            context,
-          ),
-        ),
     ];
+    for (const group of conditionalNotifierGroups) {
+      if (group.statementIndex < statementIndex) continue;
+      const mutationStart = getRangeStart(mutation.node);
+      const groupStart = getRangeStart(group.statement);
+      if (
+        mutationStart === null ||
+        groupStart === null ||
+        groupStart <= mutationStart ||
+        branchPathCompatibility(group.statement, mutation) !== true
+      ) {
+        continue;
+      }
+      replacementDispositions.push(
+        notifierFlowTargetReplacementDisposition(
+          group.statement,
+          mutation,
+          setSymbolIds,
+          notifierStoreSymbolIds,
+          context,
+        ),
+      );
+    }
     if (replacementDispositions.some((disposition) => disposition !== false)) {
       continue;
     }
@@ -1146,6 +1229,7 @@ export const zustandNoMutatingState = defineRule({
                 updaterFunction,
                 binding.getSymbol ? new Set([binding.getSymbol.id]) : new Set(),
                 binding.storeSymbolIds,
+                binding.creatorFunction,
                 context,
                 reportedNodes,
               );
@@ -1167,6 +1251,7 @@ export const zustandNoMutatingState = defineRule({
               updaterFunction,
               new Set(),
               new Set([storeSymbolId]),
+              binding.creatorFunction,
               context,
               reportedNodes,
             );
@@ -1177,6 +1262,7 @@ export const zustandNoMutatingState = defineRule({
           setSymbolIds: ReadonlySet<number>,
           snapshotStoreSymbolIds: ReadonlySet<number>,
           notifierStoreSymbolIds: ReadonlySet<number>,
+          creatorFunction: ZustandStoreCreator["creatorFunction"],
         ): void => {
           if (programNode) {
             analyzeSnapshotContainer(
@@ -1185,6 +1271,7 @@ export const zustandNoMutatingState = defineRule({
               setSymbolIds,
               snapshotStoreSymbolIds,
               notifierStoreSymbolIds,
+              creatorFunction,
               context,
               reportedNodes,
             );
@@ -1208,6 +1295,7 @@ export const zustandNoMutatingState = defineRule({
               setSymbolIds,
               snapshotStoreSymbolIds,
               notifierStoreSymbolIds,
+              creatorFunction,
               context,
               reportedNodes,
               isUpdaterNotifierForProvenance
@@ -1227,10 +1315,22 @@ export const zustandNoMutatingState = defineRule({
             getSymbolIds.add(binding.getSymbol.id);
           }
           if (binding.setSymbol) setSymbolIds.add(binding.setSymbol.id);
-          analyzeProvenance(getSymbolIds, setSymbolIds, new Set<number>(), binding.storeSymbolIds);
+          analyzeProvenance(
+            getSymbolIds,
+            setSymbolIds,
+            new Set<number>(),
+            binding.storeSymbolIds,
+            binding.creatorFunction,
+          );
           for (const storeSymbolId of binding.storeSymbolIds) {
             const storeSymbolIds = new Set([storeSymbolId]);
-            analyzeProvenance(new Set<number>(), new Set<number>(), storeSymbolIds, storeSymbolIds);
+            analyzeProvenance(
+              new Set<number>(),
+              new Set<number>(),
+              storeSymbolIds,
+              storeSymbolIds,
+              binding.creatorFunction,
+            );
           }
         }
       },

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.ts
@@ -5,9 +5,11 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
 import { functionReturnsCollectionAtPath } from "../../utils/function-returns-collection-at-path.js";
+import { getRootIdentifier } from "../../utils/get-root-identifier.js";
 import { getRangeStart } from "../../utils/get-range-start.js";
 import { getStaticPropertyKeyName } from "../../utils/get-static-property-key-name.js";
 import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
+import { isAstDescendant } from "../../utils/is-ast-descendant.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import {
@@ -644,16 +646,6 @@ const objectTargetPathReplacementDisposition = (
   return disposition;
 };
 
-const rootIdentifierForExpression = (
-  expression: EsTreeNode,
-): EsTreeNodeOfType<"Identifier"> | null => {
-  let current = stripParenExpression(expression);
-  while (isNodeOfType(current, "MemberExpression")) {
-    current = stripParenExpression(current.object);
-  }
-  return isNodeOfType(current, "Identifier") ? current : null;
-};
-
 const objectExpressionPublishesSymbolAtPath = (
   objectExpression: EsTreeNodeOfType<"ObjectExpression">,
   targetPath: readonly string[],
@@ -680,15 +672,6 @@ const objectExpressionPublishesSymbolAtPath = (
   return false;
 };
 
-const isNodeWithin = (node: EsTreeNode, ancestor: EsTreeNode): boolean => {
-  let current: EsTreeNode | null | undefined = node;
-  while (current) {
-    if (current === ancestor) return true;
-    current = current.parent;
-  }
-  return false;
-};
-
 const branchPathCompatibility = (
   candidate: EsTreeNode,
   mutation: MutableStateReferenceMutation,
@@ -701,12 +684,12 @@ const branchPathCompatibility = (
       isNodeOfType(parent, "IfStatement") &&
       (parent.consequent === current || parent.alternate === current)
     ) {
-      if (isNodeWithin(mutation.node, current)) {
+      if (isAstDescendant(mutation.node, current)) {
         current = parent;
         continue;
       }
       const otherBranch = parent.consequent === current ? parent.alternate : parent.consequent;
-      return otherBranch && isNodeWithin(mutation.node, otherBranch) ? false : null;
+      return otherBranch && isAstDescendant(mutation.node, otherBranch) ? false : null;
     }
     current = parent;
   }
@@ -728,7 +711,7 @@ const targetRebindReplacementDisposition = (
   targetKey: string,
   context: RuleContext,
 ): boolean | null | undefined => {
-  const targetIdentifier = rootIdentifierForExpression(mutation.receiver);
+  const targetIdentifier = getRootIdentifier(mutation.receiver);
   if (!targetIdentifier) return undefined;
   const targetSymbol = context.scopes.symbolFor(targetIdentifier);
   if (!targetSymbol || targetSymbol.kind === "const") return undefined;
@@ -1094,7 +1077,10 @@ const analyzeSnapshotContainer = (
         }
         const mutationStart = getRangeStart(mutation.node);
         const notifierStart = getRangeStart(notifier.callExpression);
-        return mutationStart !== null && notifierStart !== null && notifierStart >= mutationStart;
+        return (
+          isAstDescendant(mutation.node, notifier.callExpression) ||
+          (mutationStart !== null && notifierStart !== null && notifierStart >= mutationStart)
+        );
       }
       if (notifier.statementIndex !== statementIndex || notifier.branchRoot !== branchRoot) {
         return false;
@@ -1102,7 +1088,10 @@ const analyzeSnapshotContainer = (
       if (branchPathCompatibility(notifier.callExpression, mutation) !== true) return false;
       const mutationStart = getRangeStart(mutation.node);
       const notifierStart = getRangeStart(notifier.callExpression);
-      return mutationStart !== null && notifierStart !== null && notifierStart >= mutationStart;
+      return (
+        isAstDescendant(mutation.node, notifier.callExpression) ||
+        (mutationStart !== null && notifierStart !== null && notifierStart >= mutationStart)
+      );
     });
     const replacementDispositions = [
       ...followingNotifiers.map((notifier) =>

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.ts
@@ -8,7 +8,6 @@ import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import {
-  addMutableStateReferenceBindings,
   collectMutableStateReferenceMutations,
   updateMutableStateReferencesForIdentifierAssignment,
   updateMutableStateReferencesForVariableDeclaration,
@@ -493,6 +492,7 @@ const objectTargetPathReplacementDisposition = (
   targetPath: readonly string[],
   isPartialUpdateRoot: boolean,
   context: RuleContext,
+  ancestorPath: readonly string[] = [],
 ): boolean | null => {
   const propertyName = targetPath[0];
   if (!propertyName) return true;
@@ -511,11 +511,15 @@ const objectTargetPathReplacementDisposition = (
         targetPath.slice(1),
         false,
         context,
+        [...ancestorPath, propertyName],
       );
       continue;
     }
     if (
-      staticPathPreservesTarget(staticPropertyPathForExpression(propertyValue, context), targetPath)
+      staticPathPreservesTarget(staticPropertyPathForExpression(propertyValue, context), [
+        ...ancestorPath,
+        ...targetPath,
+      ])
     ) {
       disposition = false;
       continue;
@@ -605,6 +609,46 @@ const conditionalNotifierTargetReplacementDisposition = (
   return branchDispositions.every((disposition) => disposition === true) ? true : null;
 };
 
+const updateSnapshotStateForStatement = (
+  statement: EsTreeNode,
+  state: MutableStateReferenceState,
+): void => {
+  if (isNodeOfType(statement, "VariableDeclaration")) {
+    updateMutableStateReferencesForVariableDeclaration(statement, state);
+    return;
+  }
+  if (!isNodeOfType(statement, "ExpressionStatement")) return;
+  const assignment = stripParenExpression(statement.expression);
+  if (!isNodeOfType(assignment, "AssignmentExpression")) return;
+  updateMutableStateReferencesForIdentifierAssignment(assignment, state);
+};
+
+const collectSequentialSnapshotMutations = (
+  branchRoot: EsTreeNode,
+  state: MutableStateReferenceState,
+): MutableStateReferenceMutation[] => {
+  const branchState: MutableStateReferenceState = {
+    mutableStateSourceNames: new Set(state.mutableStateSourceNames),
+  };
+  if (state.isAdditionalMutableStateSource) {
+    branchState.isAdditionalMutableStateSource = state.isAdditionalMutableStateSource;
+  }
+  const statements = isNodeOfType(branchRoot, "BlockStatement") ? branchRoot.body : [branchRoot];
+  const mutations: MutableStateReferenceMutation[] = [];
+  for (const statement of statements) {
+    if (isNodeOfType(statement, "IfStatement")) {
+      mutations.push(...collectSequentialSnapshotMutations(statement.consequent, branchState));
+      if (statement.alternate) {
+        mutations.push(...collectSequentialSnapshotMutations(statement.alternate, branchState));
+      }
+      continue;
+    }
+    mutations.push(...collectMutableStateReferenceMutations(statement, branchState));
+    updateSnapshotStateForStatement(statement, branchState);
+  }
+  return mutations;
+};
+
 const analyzeSnapshotContainer = (
   statements: readonly EsTreeNode[],
   getSymbolIds: ReadonlySet<number>,
@@ -629,7 +673,7 @@ const analyzeSnapshotContainer = (
       const branchCalls: EsTreeNodeOfType<"CallExpression">[][] = [];
       for (const branchRoot of [statement.consequent, statement.alternate]) {
         if (!branchRoot) continue;
-        for (const mutation of collectMutableStateReferenceMutations(branchRoot, state)) {
+        for (const mutation of collectSequentialSnapshotMutations(branchRoot, state)) {
           mutations.push({ branchRoot, mutation, statementIndex });
         }
         const calls = collectNotifierCalls(branchRoot, setSymbolIds, storeSymbolIds, context);
@@ -652,24 +696,7 @@ const analyzeSnapshotContainer = (
         notifierCalls.push({ branchRoot: null, callExpression, statementIndex });
       }
     }
-    if (isNodeOfType(statement, "VariableDeclaration")) {
-      updateMutableStateReferencesForVariableDeclaration(statement, state);
-      for (const declarator of statement.declarations) {
-        if (isSnapshotExpression(declarator.init, getSymbolIds, storeSymbolIds, context)) {
-          addMutableStateReferenceBindings(declarator.id, state);
-        }
-      }
-    } else if (isNodeOfType(statement, "ExpressionStatement")) {
-      const assignment = stripParenExpression(statement.expression);
-      if (!isNodeOfType(assignment, "AssignmentExpression")) continue;
-      updateMutableStateReferencesForIdentifierAssignment(assignment, state);
-      if (
-        isNodeOfType(assignment.left, "Identifier") &&
-        isSnapshotExpression(assignment.right, getSymbolIds, storeSymbolIds, context)
-      ) {
-        state.mutableStateSourceNames.add(assignment.left.name);
-      }
-    }
+    updateSnapshotStateForStatement(statement, state);
     if (isNodeOfType(statement, "ReturnStatement")) break;
   }
   for (const { branchRoot, mutation, statementIndex } of mutations) {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.ts
@@ -600,12 +600,11 @@ const isNodeWithin = (node: EsTreeNode, ancestor: EsTreeNode): boolean => {
   return false;
 };
 
-const rebindPathCompatibility = (
-  assignment: EsTreeNodeOfType<"AssignmentExpression">,
+const branchPathCompatibility = (
+  candidate: EsTreeNode,
   mutation: MutableStateReferenceMutation,
 ): boolean | null => {
-  if (!isNodeOfType(assignment.parent, "ExpressionStatement")) return null;
-  let current: EsTreeNode = assignment.parent;
+  let current: EsTreeNode = candidate;
   const mutationFunction = findEnclosingFunction(mutation.node);
   while (current.parent && current.parent !== mutationFunction) {
     const parent: EsTreeNode = current.parent;
@@ -623,6 +622,14 @@ const rebindPathCompatibility = (
     current = parent;
   }
   return true;
+};
+
+const rebindPathCompatibility = (
+  assignment: EsTreeNodeOfType<"AssignmentExpression">,
+  mutation: MutableStateReferenceMutation,
+): boolean | null => {
+  if (!isNodeOfType(assignment.parent, "ExpressionStatement")) return null;
+  return branchPathCompatibility(assignment.parent, mutation);
 };
 
 const targetRebindReplacementDisposition = (
@@ -903,6 +910,7 @@ const analyzeSnapshotContainer = (
       if (notifier.statementIndex !== statementIndex || notifier.branchRoot !== branchRoot) {
         return false;
       }
+      if (branchPathCompatibility(notifier.callExpression, mutation) !== true) return false;
       const mutationStart = getRangeStart(mutation.node);
       const notifierStart = getRangeStart(notifier.callExpression);
       return mutationStart !== null && notifierStart !== null && notifierStart >= mutationStart;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.ts
@@ -591,6 +591,40 @@ const objectExpressionPublishesSymbolAtPath = (
   return false;
 };
 
+const isNodeWithin = (node: EsTreeNode, ancestor: EsTreeNode): boolean => {
+  let current: EsTreeNode | null | undefined = node;
+  while (current) {
+    if (current === ancestor) return true;
+    current = current.parent;
+  }
+  return false;
+};
+
+const rebindPathCompatibility = (
+  assignment: EsTreeNodeOfType<"AssignmentExpression">,
+  mutation: MutableStateReferenceMutation,
+): boolean | null => {
+  if (!isNodeOfType(assignment.parent, "ExpressionStatement")) return null;
+  let current: EsTreeNode = assignment.parent;
+  const mutationFunction = findEnclosingFunction(mutation.node);
+  while (current.parent && current.parent !== mutationFunction) {
+    const parent: EsTreeNode = current.parent;
+    if (
+      isNodeOfType(parent, "IfStatement") &&
+      (parent.consequent === current || parent.alternate === current)
+    ) {
+      if (isNodeWithin(mutation.node, current)) {
+        current = parent;
+        continue;
+      }
+      const otherBranch = parent.consequent === current ? parent.alternate : parent.consequent;
+      return otherBranch && isNodeWithin(mutation.node, otherBranch) ? false : null;
+    }
+    current = parent;
+  }
+  return true;
+};
+
 const targetRebindReplacementDisposition = (
   updateExpression: EsTreeNode,
   mutation: MutableStateReferenceMutation,
@@ -616,6 +650,7 @@ const targetRebindReplacementDisposition = (
   if (mutationStart === null || updateStart === null) return undefined;
   let latestAssignment: EsTreeNodeOfType<"AssignmentExpression"> | null = null;
   let latestAssignmentStart: number | null = null;
+  let latestConditionalAssignmentStart: number | null = null;
   for (const reference of targetSymbol.references) {
     if (reference.flag === "read") continue;
     const assignment = reference.identifier.parent;
@@ -631,13 +666,30 @@ const targetRebindReplacementDisposition = (
     if (
       assignmentStart === null ||
       assignmentStart <= mutationStart ||
-      assignmentStart >= updateStart ||
-      (latestAssignmentStart !== null && assignmentStart <= latestAssignmentStart)
+      assignmentStart >= updateStart
     ) {
       continue;
     }
+    const pathCompatibility = rebindPathCompatibility(assignment, mutation);
+    if (pathCompatibility === false) continue;
+    if (pathCompatibility === null) {
+      if (
+        latestConditionalAssignmentStart === null ||
+        assignmentStart > latestConditionalAssignmentStart
+      ) {
+        latestConditionalAssignmentStart = assignmentStart;
+      }
+      continue;
+    }
+    if (latestAssignmentStart !== null && assignmentStart <= latestAssignmentStart) continue;
     latestAssignment = assignment;
     latestAssignmentStart = assignmentStart;
+  }
+  if (
+    latestConditionalAssignmentStart !== null &&
+    (latestAssignmentStart === null || latestConditionalAssignmentStart > latestAssignmentStart)
+  ) {
+    return null;
   }
   if (!latestAssignment) return undefined;
   if (expressionKeyPreservesTarget(latestAssignment.right, targetKey, context)) return false;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.ts
@@ -65,6 +65,7 @@ interface ZustandCreatorBinding {
   creatorFunction: ZustandStoreCreator["creatorFunction"];
   getSymbol: SymbolDescriptor | null;
   hasNonImmerUsage: boolean;
+  nonImmerStoreSymbolIds: Set<number>;
   setSymbol: SymbolDescriptor | null;
   storeSymbolIds: Set<number>;
 }
@@ -1095,14 +1096,16 @@ export const zustandNoMutatingState = defineRule({
       CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
         const creator = resolveZustandStoreCreator(node, context.scopes);
         if (!creator) return;
+        const hasNonImmerUsage = !creator.middlewareNames.has("immer");
         let binding = creatorBindings.get(creator.creatorFunction);
         if (binding) {
-          if (!creator.middlewareNames.has("immer")) binding.hasNonImmerUsage = true;
+          if (hasNonImmerUsage) binding.hasNonImmerUsage = true;
         } else {
           binding = {
             creatorFunction: creator.creatorFunction,
             getSymbol: symbolForParameter(creator.creatorFunction, 1, context),
-            hasNonImmerUsage: !creator.middlewareNames.has("immer"),
+            hasNonImmerUsage,
+            nonImmerStoreSymbolIds: new Set(),
             setSymbol: symbolForParameter(creator.creatorFunction, 0, context),
             storeSymbolIds: new Set(),
           };
@@ -1111,7 +1114,10 @@ export const zustandNoMutatingState = defineRule({
         const parent = node.parent;
         if (isNodeOfType(parent, "VariableDeclarator") && isNodeOfType(parent.id, "Identifier")) {
           const storeSymbol = context.scopes.symbolFor(parent.id);
-          if (storeSymbol) binding.storeSymbolIds.add(storeSymbol.id);
+          if (storeSymbol) {
+            binding.storeSymbolIds.add(storeSymbol.id);
+            if (hasNonImmerUsage) binding.nonImmerStoreSymbolIds.add(storeSymbol.id);
+          }
         }
       },
       ArrowFunctionExpression(node: EsTreeNodeOfType<"ArrowFunctionExpression">) {
@@ -1156,6 +1162,7 @@ export const zustandNoMutatingState = defineRule({
             const updaterFunction = resolveExactLocalFunction(updaterArgument, context.scopes);
             if (!updaterFunction) return;
             recordUpdaterFunctionNotifier(updaterFunction, storeSymbolId);
+            if (!binding.nonImmerStoreSymbolIds.has(storeSymbolId)) return;
             analyzeSetUpdater(
               updaterFunction,
               new Set(),

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.ts
@@ -281,6 +281,25 @@ const returnedExpressionsForFunction = (functionNode: EsTreeNode): EsTreeNode[] 
 const hasUnsupportedControlFlow = (statements: readonly EsTreeNode[]): boolean =>
   statements.some((statement) => UNSUPPORTED_CONTROL_FLOW_TYPES.has(statement.type));
 
+const hasAbruptCompletion = (node: EsTreeNode): boolean => {
+  let didFindAbruptCompletion = false;
+  walkAst(node, (child: EsTreeNode) => {
+    if (child !== node && isFunctionLike(child)) return false;
+    if (isNodeOfType(child, "ReturnStatement") || isNodeOfType(child, "ThrowStatement")) {
+      didFindAbruptCompletion = true;
+      return false;
+    }
+  });
+  return didFindAbruptCompletion;
+};
+
+const hasUnsupportedSnapshotControlFlow = (statements: readonly EsTreeNode[]): boolean =>
+  statements.some(
+    (statement) =>
+      UNSUPPORTED_CONTROL_FLOW_TYPES.has(statement.type) &&
+      (!isNodeOfType(statement, "IfStatement") || hasAbruptCompletion(statement)),
+  );
+
 const analyzeSetUpdater = (
   updaterFunction: EsTreeNode,
   context: RuleContext,
@@ -506,7 +525,7 @@ const analyzeSnapshotContainer = (
   context: RuleContext,
   reportedNodes: WeakSet<EsTreeNode>,
 ): void => {
-  if (hasUnsupportedControlFlow(statements)) return;
+  if (hasUnsupportedSnapshotControlFlow(statements)) return;
   const state: MutableStateReferenceState = {
     isAdditionalMutableStateSource: (expression) =>
       isSnapshotExpression(expression, getSymbolIds, storeSymbolIds, context),
@@ -519,13 +538,15 @@ const analyzeSnapshotContainer = (
     for (const mutation of collectMutableStateReferenceMutations(statement, state)) {
       mutations.push({ mutation, statementIndex });
     }
-    for (const callExpression of collectNotifierCalls(
-      statement,
-      setSymbolIds,
-      storeSymbolIds,
-      context,
-    )) {
-      notifierCalls.push({ callExpression, statementIndex });
+    if (!isNodeOfType(statement, "IfStatement")) {
+      for (const callExpression of collectNotifierCalls(
+        statement,
+        setSymbolIds,
+        storeSymbolIds,
+        context,
+      )) {
+        notifierCalls.push({ callExpression, statementIndex });
+      }
     }
     if (isNodeOfType(statement, "VariableDeclaration")) {
       updateMutableStateReferencesForVariableDeclaration(statement, state);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-mutating-state.ts
@@ -82,7 +82,7 @@ interface NotifierCallWithStatementIndex {
 }
 
 interface ConditionalNotifierGroupWithStatementIndex {
-  branchCalls: EsTreeNodeOfType<"CallExpression">[][];
+  statement: EsTreeNodeOfType<"IfStatement">;
   statementIndex: number;
 }
 
@@ -833,21 +833,80 @@ const notifierTargetReplacementDisposition = (
   return false;
 };
 
-const conditionalNotifierTargetReplacementDisposition = (
-  branchCalls: readonly (readonly EsTreeNodeOfType<"CallExpression">[])[],
+const sequentialNotifierTargetReplacementDisposition = (
+  previousDisposition: boolean | null,
+  nextDisposition: boolean | null,
+): boolean | null => {
+  if (previousDisposition === true || nextDisposition === true) return true;
+  if (previousDisposition === null || nextDisposition === null) return null;
+  return false;
+};
+
+const notifierFlowTargetReplacementDisposition = (
+  statement: EsTreeNode,
   mutation: MutableStateReferenceMutation,
+  setSymbolIds: ReadonlySet<number>,
+  storeSymbolIds: ReadonlySet<number>,
   context: RuleContext,
 ): boolean | null => {
-  const branchDispositions = branchCalls.map((calls) => {
-    const dispositions = calls.map((callExpression) =>
-      notifierTargetReplacementDisposition(callExpression, mutation, context),
+  if (isNodeOfType(statement, "BlockStatement")) {
+    return statement.body.reduce<boolean | null>(
+      (disposition, childStatement) =>
+        sequentialNotifierTargetReplacementDisposition(
+          disposition,
+          notifierFlowTargetReplacementDisposition(
+            childStatement,
+            mutation,
+            setSymbolIds,
+            storeSymbolIds,
+            context,
+          ),
+        ),
+      false,
     );
-    if (dispositions.some((disposition) => disposition === true)) return true;
-    if (dispositions.some((disposition) => disposition === null)) return null;
-    return false;
+  }
+  if (isNodeOfType(statement, "IfStatement")) {
+    const consequentDisposition = notifierFlowTargetReplacementDisposition(
+      statement.consequent,
+      mutation,
+      setSymbolIds,
+      storeSymbolIds,
+      context,
+    );
+    const alternateDisposition = statement.alternate
+      ? notifierFlowTargetReplacementDisposition(
+          statement.alternate,
+          mutation,
+          setSymbolIds,
+          storeSymbolIds,
+          context,
+        )
+      : false;
+    if (consequentDisposition === false || alternateDisposition === false) return false;
+    return consequentDisposition === true && alternateDisposition === true ? true : null;
+  }
+  return collectNotifierCalls(statement, setSymbolIds, storeSymbolIds, context).reduce<
+    boolean | null
+  >(
+    (disposition, callExpression) =>
+      sequentialNotifierTargetReplacementDisposition(
+        disposition,
+        notifierTargetReplacementDisposition(callExpression, mutation, context),
+      ),
+    false,
+  );
+};
+
+const collectConditionalNotifierGroups = (
+  statement: EsTreeNode,
+  statementIndex: number,
+): ConditionalNotifierGroupWithStatementIndex[] => {
+  const groups: ConditionalNotifierGroupWithStatementIndex[] = [];
+  walkAst(statement, (node: EsTreeNode) => {
+    if (isFunctionLike(node)) return false;
+    if (isNodeOfType(node, "IfStatement")) groups.push({ statement: node, statementIndex });
   });
-  if (branchDispositions.some((disposition) => disposition === false)) return false;
-  return branchDispositions.every((disposition) => disposition === true) ? true : null;
+  return groups;
 };
 
 const updateSnapshotStateForStatement = (
@@ -912,7 +971,6 @@ const analyzeSnapshotContainer = (
   for (let statementIndex = 0; statementIndex < statements.length; statementIndex += 1) {
     const statement = statements[statementIndex];
     if (isNodeOfType(statement, "IfStatement")) {
-      const branchCalls: EsTreeNodeOfType<"CallExpression">[][] = [];
       for (const branchRoot of [statement.consequent, statement.alternate]) {
         if (!branchRoot) continue;
         for (const mutation of collectSequentialSnapshotMutations(branchRoot, state)) {
@@ -924,12 +982,10 @@ const analyzeSnapshotContainer = (
           notifierStoreSymbolIds,
           context,
         );
-        branchCalls.push(calls);
         for (const callExpression of calls) {
           notifierCalls.push({ branchRoot, callExpression, statementIndex });
         }
       }
-      if (statement.alternate) conditionalNotifierGroups.push({ branchCalls, statementIndex });
     } else {
       for (const mutation of collectMutableStateReferenceMutations(statement, state)) {
         mutations.push({ branchRoot: null, mutation, statementIndex });
@@ -943,6 +999,7 @@ const analyzeSnapshotContainer = (
         notifierCalls.push({ branchRoot: null, callExpression, statementIndex });
       }
     }
+    conditionalNotifierGroups.push(...collectConditionalNotifierGroups(statement, statementIndex));
     updateSnapshotStateForStatement(statement, state);
     if (isNodeOfType(statement, "ReturnStatement")) break;
   }
@@ -972,9 +1029,25 @@ const analyzeSnapshotContainer = (
         updateTargetReplacementDisposition(expression, mutation, context),
       ),
       ...conditionalNotifierGroups
-        .filter((group) => group.statementIndex > statementIndex)
+        .filter((group) => {
+          if (group.statementIndex < statementIndex) return false;
+          const mutationStart = getRangeStart(mutation.node);
+          const groupStart = getRangeStart(group.statement);
+          return (
+            mutationStart !== null &&
+            groupStart !== null &&
+            groupStart > mutationStart &&
+            branchPathCompatibility(group.statement, mutation) === true
+          );
+        })
         .map((group) =>
-          conditionalNotifierTargetReplacementDisposition(group.branchCalls, mutation, context),
+          notifierFlowTargetReplacementDisposition(
+            group.statement,
+            mutation,
+            setSymbolIds,
+            notifierStoreSymbolIds,
+            context,
+          ),
         ),
     ];
     if (replacementDispositions.some((disposition) => disposition !== false)) {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/mutable-state-reference-analysis.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/mutable-state-reference-analysis.ts
@@ -1,0 +1,215 @@
+import { MUTATING_ARRAY_METHODS, MUTATING_COLLECTION_METHODS } from "../constants/js.js";
+import { OBJECT_PROPERTY_MUTATION_METHOD_NAMES } from "../constants/mutation-methods.js";
+import { collectPatternNames } from "./collect-pattern-names.js";
+import type { EsTreeNode } from "./es-tree-node.js";
+import type { EsTreeNodeOfType } from "./es-tree-node-of-type.js";
+import { findVariableInitializer } from "./find-variable-initializer.js";
+import { getStaticPropertyName } from "./get-static-property-name.js";
+import { isFunctionLike } from "./is-function-like.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+import { isResultDiscardedCall } from "./is-result-discarded-call.js";
+import { stripParenExpression } from "./strip-paren-expression.js";
+import { walkAst } from "./walk-ast.js";
+
+const REFLECT_MUTATION_METHODS = new Set(["deleteProperty", "set"]);
+
+export interface MutableStateReferenceState {
+  isAdditionalMutableStateSource?: (expression: EsTreeNode) => boolean;
+  mutableStateSourceNames: Set<string>;
+}
+
+export interface MutableStateReferenceMutation {
+  node: EsTreeNode;
+  receiver: EsTreeNode;
+}
+
+export interface CollectMutableStateReferenceMutationsOptions {
+  isAdditionalMutatingCall?: (callExpression: EsTreeNodeOfType<"CallExpression">) => boolean;
+}
+
+const isStaticMethodCallOnNamedObject = (
+  node: EsTreeNodeOfType<"CallExpression">,
+  objectName: string,
+  methodNames: ReadonlySet<string>,
+): boolean => {
+  const callee = stripParenExpression(node.callee);
+  if (!isNodeOfType(callee, "MemberExpression")) return false;
+  const calleeObject = stripParenExpression(callee.object);
+  if (!isNodeOfType(calleeObject, "Identifier") || calleeObject.name !== objectName) return false;
+  const methodName = getStaticPropertyName(callee);
+  if (!methodName || !methodNames.has(methodName)) return false;
+  return !findVariableInitializer(calleeObject, calleeObject.name);
+};
+
+export const isExpressionRootedInMutableStateSource = (
+  node: EsTreeNode,
+  state: MutableStateReferenceState,
+): boolean => {
+  let current: EsTreeNode | null | undefined = stripParenExpression(node);
+  while (current && isNodeOfType(current, "MemberExpression")) {
+    current = stripParenExpression(current.object);
+  }
+  return (
+    (isNodeOfType(current, "Identifier") && state.mutableStateSourceNames.has(current.name)) ||
+    Boolean(current && state.isAdditionalMutableStateSource?.(current))
+  );
+};
+
+export const isExpressionReachableFromMutableState = (
+  node: EsTreeNode | null | undefined,
+  state: MutableStateReferenceState,
+): boolean => {
+  if (!node) return false;
+  const expression = stripParenExpression(node);
+  return (
+    (isNodeOfType(expression, "Identifier") &&
+      state.mutableStateSourceNames.has(expression.name)) ||
+    (isNodeOfType(expression, "MemberExpression") &&
+      isExpressionRootedInMutableStateSource(expression, state)) ||
+    Boolean(state.isAdditionalMutableStateSource?.(expression))
+  );
+};
+
+export const addMutableStateReferenceBindings = (
+  pattern: EsTreeNode,
+  state: MutableStateReferenceState,
+): void => {
+  if (isNodeOfType(pattern, "Identifier")) {
+    state.mutableStateSourceNames.add(pattern.name);
+    return;
+  }
+  if (isNodeOfType(pattern, "ObjectPattern")) {
+    for (const property of pattern.properties) {
+      if (!isNodeOfType(property, "Property")) continue;
+      const value = property.value;
+      if (isNodeOfType(value, "Identifier")) {
+        state.mutableStateSourceNames.add(value.name);
+      } else if (
+        isNodeOfType(value, "AssignmentPattern") &&
+        isNodeOfType(value.left, "Identifier")
+      ) {
+        state.mutableStateSourceNames.add(value.left.name);
+      }
+    }
+    return;
+  }
+  if (!isNodeOfType(pattern, "ArrayPattern")) return;
+  for (const element of pattern.elements) {
+    if (isNodeOfType(element, "Identifier")) {
+      state.mutableStateSourceNames.add(element.name);
+    } else if (
+      isNodeOfType(element, "AssignmentPattern") &&
+      isNodeOfType(element.left, "Identifier")
+    ) {
+      state.mutableStateSourceNames.add(element.left.name);
+    }
+  }
+};
+
+export const updateMutableStateReferencesForVariableDeclaration = (
+  declaration: EsTreeNodeOfType<"VariableDeclaration">,
+  state: MutableStateReferenceState,
+): void => {
+  for (const declarator of declaration.declarations) {
+    const bindingNames = new Set<string>();
+    collectPatternNames(declarator.id, bindingNames);
+    for (const bindingName of bindingNames) state.mutableStateSourceNames.delete(bindingName);
+    if (!isExpressionReachableFromMutableState(declarator.init, state)) continue;
+    if (isNodeOfType(declarator.id, "Identifier")) {
+      state.mutableStateSourceNames.add(declarator.id.name);
+    } else {
+      addMutableStateReferenceBindings(declarator.id, state);
+    }
+  }
+};
+
+export const updateMutableStateReferencesForIdentifierAssignment = (
+  assignment: EsTreeNodeOfType<"AssignmentExpression">,
+  state: MutableStateReferenceState,
+): void => {
+  if (!isNodeOfType(assignment.left, "Identifier")) return;
+  state.mutableStateSourceNames.delete(assignment.left.name);
+  if (isExpressionReachableFromMutableState(assignment.right, state)) {
+    state.mutableStateSourceNames.add(assignment.left.name);
+  }
+};
+
+export const collectMutableStateReferenceMutations = (
+  node: EsTreeNode,
+  state: MutableStateReferenceState,
+  options: CollectMutableStateReferenceMutationsOptions = {},
+): MutableStateReferenceMutation[] => {
+  if (isFunctionLike(node)) return [];
+  const mutations: MutableStateReferenceMutation[] = [];
+  walkAst(node, (child: EsTreeNode) => {
+    const candidate = stripParenExpression(child);
+    if (child !== node && isFunctionLike(candidate)) return false;
+    if (isNodeOfType(candidate, "AssignmentExpression")) {
+      const assignmentTarget = stripParenExpression(candidate.left);
+      if (
+        isNodeOfType(assignmentTarget, "MemberExpression") &&
+        isExpressionRootedInMutableStateSource(candidate.left, state)
+      ) {
+        mutations.push({ node: candidate, receiver: assignmentTarget.object });
+      }
+      return;
+    }
+    if (isNodeOfType(candidate, "UpdateExpression")) {
+      const updateTarget = stripParenExpression(candidate.argument);
+      if (
+        isNodeOfType(updateTarget, "MemberExpression") &&
+        isExpressionRootedInMutableStateSource(candidate.argument, state)
+      ) {
+        mutations.push({ node: candidate, receiver: updateTarget.object });
+      }
+      return;
+    }
+    if (isNodeOfType(candidate, "UnaryExpression") && candidate.operator === "delete") {
+      const deleteTarget = stripParenExpression(candidate.argument);
+      if (
+        isNodeOfType(deleteTarget, "MemberExpression") &&
+        isExpressionRootedInMutableStateSource(candidate.argument, state)
+      ) {
+        mutations.push({ node: candidate, receiver: deleteTarget.object });
+      }
+      return;
+    }
+    if (!isNodeOfType(candidate, "CallExpression")) return;
+    const firstArgument = candidate.arguments[0];
+    if (
+      firstArgument &&
+      !isNodeOfType(firstArgument, "SpreadElement") &&
+      isExpressionRootedInMutableStateSource(firstArgument, state) &&
+      (isStaticMethodCallOnNamedObject(
+        candidate,
+        "Object",
+        OBJECT_PROPERTY_MUTATION_METHOD_NAMES,
+      ) ||
+        isStaticMethodCallOnNamedObject(candidate, "Reflect", REFLECT_MUTATION_METHODS) ||
+        options.isAdditionalMutatingCall?.(candidate))
+    ) {
+      mutations.push({ node: candidate, receiver: firstArgument });
+      return;
+    }
+    const callee = stripParenExpression(candidate.callee);
+    if (!isNodeOfType(callee, "MemberExpression")) return;
+    const methodName = getStaticPropertyName(callee);
+    if (
+      !methodName ||
+      (!MUTATING_ARRAY_METHODS.has(methodName) && !MUTATING_COLLECTION_METHODS.has(methodName))
+    ) {
+      return;
+    }
+    if (
+      MUTATING_COLLECTION_METHODS.has(methodName) &&
+      !MUTATING_ARRAY_METHODS.has(methodName) &&
+      !isResultDiscardedCall(candidate)
+    ) {
+      return;
+    }
+    if (isExpressionRootedInMutableStateSource(callee.object, state)) {
+      mutations.push({ node: candidate, receiver: callee.object });
+    }
+  });
+  return mutations;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/mutable-state-reference-analysis.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/mutable-state-reference-analysis.ts
@@ -25,6 +25,7 @@ export interface MutableStateReferenceMutation {
 
 export interface CollectMutableStateReferenceMutationsOptions {
   isAdditionalMutatingCall?: (callExpression: EsTreeNodeOfType<"CallExpression">) => boolean;
+  isProvenMutatingMethodCall?: (callExpression: EsTreeNodeOfType<"CallExpression">) => boolean;
 }
 
 const isStaticMethodCallOnNamedObject = (
@@ -194,22 +195,22 @@ export const collectMutableStateReferenceMutations = (
     const callee = stripParenExpression(candidate.callee);
     if (!isNodeOfType(callee, "MemberExpression")) return;
     const methodName = getStaticPropertyName(callee);
-    if (
-      !methodName ||
-      (!MUTATING_ARRAY_METHODS.has(methodName) && !MUTATING_COLLECTION_METHODS.has(methodName))
-    ) {
-      return;
+    if (!methodName || !isExpressionRootedInMutableStateSource(callee.object, state)) return;
+    if (options.isProvenMutatingMethodCall) {
+      if (!options.isProvenMutatingMethodCall(candidate)) return;
+    } else {
+      if (!MUTATING_ARRAY_METHODS.has(methodName) && !MUTATING_COLLECTION_METHODS.has(methodName)) {
+        return;
+      }
+      if (
+        MUTATING_COLLECTION_METHODS.has(methodName) &&
+        !MUTATING_ARRAY_METHODS.has(methodName) &&
+        !isResultDiscardedCall(candidate)
+      ) {
+        return;
+      }
     }
-    if (
-      MUTATING_COLLECTION_METHODS.has(methodName) &&
-      !MUTATING_ARRAY_METHODS.has(methodName) &&
-      !isResultDiscardedCall(candidate)
-    ) {
-      return;
-    }
-    if (isExpressionRootedInMutableStateSource(callee.object, state)) {
-      mutations.push({ node: candidate, receiver: callee.object });
-    }
+    mutations.push({ node: candidate, receiver: callee.object });
   });
   return mutations;
 };


### PR DESCRIPTION
## Why

Zustand relies on new references to notify selectors reliably. Mutating a proven store snapshot and publishing the same object, array, `Map`, or `Set` reference can leave subscribers observing unchanged identity.

Bad — mutate and reuse an array:

```ts
const useTodoStore = create((set) => ({
  todos: [] as string[],
  add: (todo: string) =>
    set((state) => {
      state.todos.push(todo);
      return { todos: state.todos };
    }),
}));
```

Bad — `Map.set` returns the same mutated map:

```ts
const useCacheStore = create((set) => ({
  cache: new Map<string, number>(),
  put: (key: string, value: number) =>
    set((state) => ({ cache: state.cache.set(key, value) })),
}));
```

Good — publish a fresh reference:

```ts
const useTodoStore = create((set) => ({
  todos: [] as string[],
  add: (todo: string) =>
    set((state) => ({ todos: [...state.todos, todo] })),
}));
```

## What the rule reports

`zustand-no-mutating-state` follows proven Zustand state references through:

- creator `set((state) => ...)` updaters
- bound and vanilla `store.setState((state) => ...)`
- snapshots returned by the creator's `get()`
- same-file bound/vanilla `store.getState()`
- immutable aliases and destructuring
- direct assignment, compound assignment, updates, and `delete`
- `Object` / `Reflect` mutation APIs
- proven Array, Map, and Set mutators
- branch-local notifiers and nested snapshot paths

A diagnostic is emitted only when the mutated path is reused, omitted from a notifier, or cannot be proven freshly replaced.

## Precision boundaries

- Array/Map/Set method names are not enough. The same-file creator must prove the receiver path is initialized as the matching built-in collection.
- Custom APIs with methods named `.push()`, `.set()`, `.add()`, or `.delete()` stay quiet.
- Used-result `Map.set` and `Set.add` calls report because those APIs mutate and return the same collection.
- Proven spreads, slices, constructors, and other fresh replacements stay quiet.
- A notifier call that encloses the mutation in its argument is ordered after that mutation, matching JavaScript argument evaluation and preventing false positives when it publishes a fresh replacement.
- Official Zustand Immer middleware is excluded.
- Stores whose `set` parameter is unused as a notifier, shadowed APIs, imported/unproven stores, unsupported control flow, and ambiguous replacements fail closed.
- Assignment/update/delete mutations do not depend on collection-shape inference.

## Version gate

The rule requires `zustand:1`, enabling declared majors 1–5. Missing Zustand, unresolved declarations, and future v6 projects remain disabled until revalidated.

## Validation

Current head: `2664542bb`.

- Focused rule tests: 45/45.
- Version-applicability suite: 16/16.
- Full plugin suite at the current head: 591 files, 16,284 passed / 200 skipped.
- Package typecheck passed after replaying onto current main/foundation.
- Strict targeted fuzz: 500 iterations, no crashes or invariant findings.
- Fuzz package: 48 passed; targeted true-positive and false-positive corpora added, including an enclosing-notifier regression.
- Staged React Doctor regression scan: clean after replacing an existing chained-iteration warning in the touched analyzer.
- Root foundation gates: 15/15 test tasks, 16/16 typecheck tasks, lint, format check, and JSON smoke.

Historical 163-project parity added eight diagnostics and removed none. All eight were manually confirmed true positives: two in `Levix0501/notra` and six in `seiKiMo-Inc/Laudiolin`. The collection-shape precision and inline Map/Set coverage fixes postdate that run, so it is retained as historical evidence.

## React Bench drift audit

All four Zustand rules were explicitly enabled while reconstructing completed `react-bench-internal` job diffs, source files, scan roots, and verifier outputs.

- 20,125 completed trials inspected
- 49 source-relevant trials and 12 unique Zustand-changing diffs
- 168 deleted files plus five modified before/after pairs reconstructed
- zero in-scope added diagnostics
- zero removed diagnostics
- zero stored-verdict changes
- zero false positives

One raw whole-store true positive appeared in a deleted package outside that verifier's configured scan root. Two early-return mutation candidates remain outside this rule's documented v1 control-flow boundary.

## Exact combined parity

The final five-PR stack was assembled at integration ref `fb20a2ea9b0f1b8722f73197dc7165936d26c6c3` and compared in Daytona with foundation ref `b3e34f271f1e1259b6e2acb006e5b5e5a0a190ae` on the exact same pinned corpus.

- 255 projects from 100 repositories completed on both sides
- zero evaluation failures and zero skipped parity projects
- 27,045 diagnostics unchanged
- zero diagnostics added
- zero diagnostics removed
- parity comparator regression test passed

This exact run includes all four rules enabled together and postdates the final Bugbot fixes for split curried factories, `Object.entries(...).map(...)`, collection-shape proof, and nested notifier ordering.

## Stack

Depends on #1399 for version capabilities, exact Zustand provenance, and conservative collection-shape analysis.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new static-analysis rule (~1.3k LOC) on hot store-update paths; precision relies on provenance and control-flow heuristics, though extensive tests and fail-closed behavior limit false positives.
> 
> **Overview**
> Adds **`zustand-no-mutating-state`**, a Zustand v1–5 lint that flags in-place mutation of proven store snapshots when subscribers may not see updates because the same object/array/`Map`/`Set` reference is reused or never paired with a fresh notifier.
> 
> Coverage spans creator **`set`** updaters, bound/vanilla **`setState`**, **`get()`** / **`getState()`** snapshots, nested paths, branch-local notifier ordering, Immer middleware exemptions, and imperative caches with unused **`set`**. Ambiguous control flow and unproven replacements **fail closed**.
> 
> **Refactor:** mutation tracking moves into shared **`mutable-state-reference-analysis`**, which **`no-mutating-reducer-state`** now uses instead of inline walkers.
> 
> Also updates the Zustand research doc, oxlint version-gating tests, fuzz true-positive/regression corpora, and a patch changeset for both oxlint and eslint plugin packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f6621bf093684ae764d7d3a77dff1f68ae0e61f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->