### PR TITLE
fix(action): upgrade actions/cache to v6.1.0 for Node.js 24 support

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -80,7 +80,7 @@ runs:
     # ABI. On a hit, the ~15s install collapses to a ~1-2s restore.
     - id: toolchain-cache
       if: ${{ steps.resolve-version.outputs.cacheable == 'true' }}
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ${{ runner.temp }}/react-doctor-toolchain
         key: react-doctor-toolchain-${{ steps.resolve-version.outputs.resolved }}-node${{ inputs.node-version }}-${{ runner.os }}-${{ runner.arch }}
@@ -111,7 +111,7 @@ runs:
     # missing every run.
     - id: scan-cache
       if: ${{ steps.resolve-version.outputs.cacheable == 'true' }}
-      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ${{ runner.temp }}/react-doctor-cache
         key: react-doctor-scan-cache-${{ runner.os }}-${{ runner.arch }}-${{ steps.resolve-version.outputs.resolved }}-${{ github.run_id }}-${{ github.run_attempt }}
@@ -351,7 +351,7 @@ runs:
     # crash) rather than the job's.
     - name: Save scan cache
       if: ${{ always() && steps.scan.outcome == 'success' && steps.resolve-version.outputs.cacheable == 'true' }}
-      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ${{ runner.temp }}/react-doctor-cache
         key: react-doctor-scan-cache-${{ runner.os }}-${{ runner.arch }}-${{ steps.resolve-version.outputs.resolved }}-${{ github.run_id }}-${{ github.run_attempt }}

--- a/packages/react-doctor/tests/github-action.test.ts
+++ b/packages/react-doctor/tests/github-action.test.ts
@@ -347,7 +347,7 @@ describe("GitHub Action contract", () => {
     // prefix on a published version and runs the local binary, falling back to
     // npx for a local-path spec.
     expect(resolveStep).toContain("scripts/resolve-package-spec.mjs");
-    expect(actionYaml).toMatch(/actions\/cache@(?:v4\b|[0-9a-f]{40} # v4\b)/);
+    expect(actionYaml).toMatch(/actions\/cache@(?:v6\.1\.0\b|[0-9a-f]{40} # v6\.1\.0\b)/);
     expect(actionYaml).toContain("react-doctor-toolchain");
     expect(actionYaml).toContain("react-doctor-scan-cache-");
     expect(scanStep).toContain('npm install --prefix "$TOOLCHAIN_DIR"');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Root Cause

The action uses `actions/cache@v4` which runs on Node.js 20. GitHub Actions has deprecated Node.js 20 and is forcing actions to run on Node.js 24, causing deprecation warnings in CI runs.

## Fix

Upgraded all three uses of `actions/cache` from v4 (commit `0057852b...`) to v6.1.0 (commit `55cc8345...`):

- **toolchain-cache** (line 83): full cache operation
- **scan-cache** (line 114): restore-only operation with prefix fallbacks  
- **Save scan cache** (line 354): explicit save operation

## Compatibility

v6.1.0 is backward compatible with v4:
- Same inputs/outputs API
- Runs on Node.js 24 (required for GitHub Actions)
- Cache keys unchanged — existing caches continue to work
- ESM migration is internal only

## Testing

This change only affects the action's runtime environment and caching mechanism. It does not modify react-doctor's diagnostic behavior, so `rde parity` testing is not applicable.

The action will be tested through CI on this PR itself. The cache operations should work identically to v4 but without the Node.js 20 deprecation warning.

## Post-Merge

Per AGENTS.md GitHub Action versioning rules, this fix requires a patch version bump (e.g., v2.2.4 → v2.2.5) since it's a `fix` to action.yml. After merge:

1. Tag the commit: `git tag -a v2.2.X <commit> -m "react-doctor action v2.2.X"`
2. Move the floating major: `git tag -fa v2 <commit> -m "react-doctor action v2 (floating major -> v2.2.X)"`  
3. Push tags: `git push origin v2.2.X && git push --force origin v2`

Closes #1416
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ce550ff9-9c05-42bf-88fa-b1af2533698b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ce550ff9-9c05-42bf-88fa-b1af2533698b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

