### PR TITLE
Add Cursor plugin manifest

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "react-doctor",
+  "displayName": "React Doctor",
+  "version": "1.0.0",
+  "description": "Scan, understand, and fix React codebase diagnostics with React Doctor.",
+  "author": {
+    "name": "Million Software, Inc.",
+    "email": "founders@million.dev"
+  },
+  "homepage": "https://react.doctor",
+  "repository": "https://github.com/millionco/react-doctor",
+  "logo": "packages/website/public/react-doctor-icon.svg",
+  "keywords": [
+    "react",
+    "react-native",
+    "static-analysis",
+    "code-quality",
+    "accessibility",
+    "performance"
+  ],
+  "category": "developer-tools",
+  "tags": ["react", "linting", "code-review"],
+  "skills": "./skills/react-doctor/"
+}

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -20,5 +20,5 @@
   ],
   "category": "developer-tools",
   "tags": ["react", "linting", "code-review"],
-  "skills": "./skills/react-doctor/"
+  "skills": "./skills/react-doctor/SKILL.md"
 }

--- a/packages/react-doctor/README.md
+++ b/packages/react-doctor/README.md
@@ -47,6 +47,12 @@ npx react-doctor@latest install
 
 Works with Claude Code, Cursor, Codex, OpenCode, and many more.
 
+#### Cursor plugin
+
+In Cursor, install React Doctor from Customize or run `/add-plugin react-doctor`. The plugin
+bundles the same `react-doctor` skill as the CLI installer; scans still run through the local
+React Doctor CLI.
+
 ### 4. Run in CI
 
 React Doctor reviews every pull request and reports only the issues your change introduced, not your existing backlog. Set it up with one command:

--- a/packages/react-doctor/README.md
+++ b/packages/react-doctor/README.md
@@ -47,12 +47,6 @@ npx react-doctor@latest install
 
 Works with Claude Code, Cursor, Codex, OpenCode, and many more.
 
-#### Cursor plugin
-
-In Cursor, install React Doctor from Customize or run `/add-plugin react-doctor`. The plugin
-bundles the same `react-doctor` skill as the CLI installer; scans still run through the local
-React Doctor CLI.
-
 ### 4. Run in CI
 
 React Doctor reviews every pull request and reports only the issues your change introduced, not your existing backlog. Set it up with one command:


### PR DESCRIPTION
## Summary

- add a Cursor plugin manifest for React Doctor
- expose only the canonical `skills/react-doctor/SKILL.md`
- package no hooks, MCP servers, agents, commands, or additional skills

## Product brief

**Job:** Cursor users want one-step discovery and installation of React Doctor's canonical agent workflow.

**Change:** Package only the existing `react-doctor` skill as a Cursor plugin.

**Reuse:** The manifest points directly to `skills/react-doctor/SKILL.md`, keeping one source of truth and excluding the separate `improve-react` skill.

**Metric:** Cursor Marketplace weekly usage. Success is 100 weekly uses by the second plugin release.

**Compatibility:** Installation is opt-in. This does not change the CLI, package APIs, JSON schema, score, or GitHub Action, so no changeset or Action tag is required.

**Kill metric:** Remove the marketplace wrapper if usage remains below 20 weekly uses after two releases.

## Checks

- Cursor manifest schema and exact skill-path validation
- `nr format:check -- .cursor-plugin/plugin.json`
- `nr typecheck`
- `nr lint`
- `nr test` attempted; existing CLI integration tests fail because they try to spawn the missing `/opt/homebrew/Cellar/node/25.8.2/bin/node` executable