### PR TITLE
feat: add deterministic design diagnostics

### DIFF
--- a/.changeset/brave-design-rules.md
+++ b/.changeset/brave-design-rules.md
@@ -1,0 +1,6 @@
+---
+"oxlint-plugin-react-doctor": patch
+"react-doctor": patch
+---
+
+Add seven conservative diagnostics for responsive accessible names, reduced-motion content, animation ownership and focus timing, loading-control identity, request error states, and composite-widget feedback. Keep project-wide reduced-motion policy on the existing `require-reduced-motion` diagnostic instead of introducing a duplicate rule.

--- a/packages/fuzz/corpus/regressions/loading-action-preserves-trigger--intentional-transition.tsx
+++ b/packages/fuzz/corpus/regressions/loading-action-preserves-trigger--intentional-transition.tsx
@@ -1,0 +1,23 @@
+// rule: loading-action-preserves-trigger
+// weakness: control-flow
+// source: adversarial audit of deterministic design rules
+// verdict: pass
+
+import { useState } from "react";
+
+export const Save = () => {
+  const [pending, setPending] = useState(false);
+  const save = async () => {
+    setPending(true);
+    setPending(false);
+    await fetch("/api/save");
+    router.navigate("/done");
+  };
+  return pending ? (
+    <retry-button />
+  ) : (
+    <button type="submit" form="target" onClick={save}>
+      Save
+    </button>
+  );
+};

--- a/packages/fuzz/corpus/regressions/no-collapse-request-error-to-empty-state--visible-error-route.tsx
+++ b/packages/fuzz/corpus/regressions/no-collapse-request-error-to-empty-state--visible-error-route.tsx
@@ -1,0 +1,20 @@
+// rule: no-collapse-request-error-to-empty-state
+// weakness: control-flow
+// source: adversarial audit of deterministic design rules
+// verdict: pass
+
+import { useState } from "react";
+
+export const Search = ({ raw }) => {
+  const [items, setItems] = useState([]);
+  const load = async () => {
+    try {
+      await fetch("/ping").catch(() => null);
+      setItems(JSON.parse(raw));
+    } catch {
+      setItems([]);
+    }
+  };
+  if (!items.length) return <p>No items — error loading results</p>;
+  return <ResultList items={items} />;
+};

--- a/packages/fuzz/corpus/regressions/no-focus-in-animation-completion-handler--ref-provenance.tsx
+++ b/packages/fuzz/corpus/regressions/no-focus-in-animation-completion-handler--ref-provenance.tsx
@@ -1,0 +1,24 @@
+// rule: no-focus-in-animation-completion-handler
+// weakness: stale-binding-provenance
+// source: adversarial audit of deterministic design rules
+// verdict: pass
+
+import { useRef } from "react";
+
+export const CompletionFocus = () => {
+  let reassignedRef = useRef(null);
+  const plainRef = useRef(null);
+  reassignedRef = { current: editor };
+  return (
+    <>
+      <div ref={plainRef} />
+      <div onAnimationEnd={() => searchIndex.focus()} />
+      <div
+        onTransitionEnd={() => {
+          if (false) plainRef.current.focus();
+        }}
+      />
+      <div onAnimationEnd={() => reassignedRef.current.focus()} />
+    </>
+  );
+};

--- a/packages/fuzz/corpus/regressions/no-mixed-animation-owners--unreachable-variants.tsx
+++ b/packages/fuzz/corpus/regressions/no-mixed-animation-owners--unreachable-variants.tsx
@@ -1,0 +1,17 @@
+// rule: no-mixed-animation-owners
+// weakness: control-flow
+// source: adversarial audit of deterministic design rules
+// verdict: pass
+
+import { motion } from "motion/react";
+
+export const MotionOwnership = () => (
+  <>
+    <motion.div animate={{ opacity: 1 }} className={false ? "transition-opacity" : ""} />
+    <motion.div animate={{ opacity: 1 }} className="motion-safe:motion-reduce:transition-opacity" />
+    <motion.div
+      animate={{ opacity: 1 }}
+      className="transition-opacity motion-safe:transition-none motion-reduce:transition-none"
+    />
+  </>
+);

--- a/packages/fuzz/corpus/regressions/no-reduced-motion-content-removal--uncertain-fallbacks.tsx
+++ b/packages/fuzz/corpus/regressions/no-reduced-motion-content-removal--uncertain-fallbacks.tsx
@@ -1,0 +1,19 @@
+// rule: no-reduced-motion-content-removal
+// weakness: cross-file
+// source: adversarial audit of deterministic design rules
+// verdict: pass
+
+import { useReducedMotion } from "motion/react";
+
+export const ReducedContent = ({ fallback }) => {
+  const reduced = useReducedMotion();
+  const unused = reduced ? null : <p>Unused</p>;
+  return (
+    <div>
+      <p className="hidden motion-reduce:hidden">Already hidden</p>
+      <p className="motion-reduce:hidden">Saved</p>
+      <ReducedMotionFallback />
+      {fallback}
+    </div>
+  );
+};

--- a/packages/fuzz/corpus/regressions/no-responsive-hidden-accessible-name--uncertain-boundaries.tsx
+++ b/packages/fuzz/corpus/regressions/no-responsive-hidden-accessible-name--uncertain-boundaries.tsx
@@ -1,0 +1,30 @@
+// rule: no-responsive-hidden-accessible-name
+// weakness: dynamic-computed
+// source: adversarial audit of deterministic design rules
+// verdict: pass
+
+const Button = condition ? "div" : "span";
+
+export const ResponsiveNames = () => (
+  <Composer
+    action={
+      condition ? (
+        <button>
+          <span className="md:hidden">Save</span>
+        </button>
+      ) : null
+    }
+  >
+    <Button>
+      <span className="md:hidden">Not a control</span>
+    </Button>
+    <button inert>
+      <span className="md:hidden">Inactive</span>
+    </button>
+    <button>
+      <span data-state="open" className="md:hidden data-[state=open]:block">
+        Still named
+      </span>
+    </button>
+  </Composer>
+);

--- a/packages/fuzz/corpus/regressions/no-transitioned-composite-widget-state--theme-and-state-uncertainty.tsx
+++ b/packages/fuzz/corpus/regressions/no-transitioned-composite-widget-state--theme-and-state-uncertainty.tsx
@@ -3,6 +3,9 @@
 // source: adversarial audit of deterministic design rules
 // verdict: pass
 
+const ALWAYS_SELECTED = true;
+const NEVER_SELECTED = false;
+
 export const Option = ({ selected, loading }) => (
   <>
     <div
@@ -27,5 +30,35 @@ export const Option = ({ selected, loading }) => (
     >
       Invalid variant
     </div>
+    <div
+      role="option"
+      aria-selected={selected ? "true" : "false"}
+      className="forced-colors:bg-[#fff] forced-colors:transition-colors forced-colors:aria-selected:bg-[#000]"
+    >
+      Forced colors
+    </div>
+    <div
+      role="option"
+      aria-selected={ALWAYS_SELECTED ? "true" : "false"}
+      className="bg-[#fff] transition-colors aria-selected:bg-[#000]"
+    >
+      Constant true
+    </div>
+    <div
+      role="option"
+      aria-selected={NEVER_SELECTED ? "true" : "false"}
+      className="bg-[#fff] transition-colors aria-selected:bg-[#000]"
+    >
+      Constant false
+    </div>
+    {NEVER_SELECTED ? (
+      <div
+        role="option"
+        aria-selected={selected ? "true" : "false"}
+        className="bg-[#fff] transition-colors aria-selected:bg-[#000]"
+      >
+        Unreachable
+      </div>
+    ) : null}
   </>
 );

--- a/packages/fuzz/corpus/regressions/no-transitioned-composite-widget-state--theme-and-state-uncertainty.tsx
+++ b/packages/fuzz/corpus/regressions/no-transitioned-composite-widget-state--theme-and-state-uncertainty.tsx
@@ -1,0 +1,31 @@
+// rule: no-transitioned-composite-widget-state
+// weakness: dynamic-computed
+// source: adversarial audit of deterministic design rules
+// verdict: pass
+
+export const Option = ({ selected, loading }) => (
+  <>
+    <div
+      role="option"
+      aria-selected={selected ? "true" : "false"}
+      className="bg-white transition-colors aria-selected:bg-black"
+    >
+      Theme colors
+    </div>
+    <div
+      role="option"
+      aria-selected={selected ? "true" : "false"}
+      data-state={loading ? "selected" : "idle"}
+      className="bg-[#fff] transition-colors data-[state=selected]:bg-[#000]"
+    >
+      Loading state
+    </div>
+    <div
+      role="option"
+      aria-selected={selected ? "true" : "false"}
+      className="bg-[#fff] transition-colors ARIA-selected:bg-[#000]"
+    >
+      Invalid variant
+    </div>
+  </>
+);

--- a/packages/fuzz/corpus/targets/no-transitioned-composite-widget-state--selected-option.tsx
+++ b/packages/fuzz/corpus/targets/no-transitioned-composite-widget-state--selected-option.tsx
@@ -1,0 +1,11 @@
+// rule: no-transitioned-composite-widget-state
+
+export const Option = ({ selected }) => (
+  <div
+    role="option"
+    aria-selected={selected ? "true" : "false"}
+    className="bg-[#fff] transition-colors aria-selected:bg-[#000]"
+  >
+    Value
+  </div>
+);

--- a/packages/oxlint-plugin-react-doctor/scripts/generate-rule-registry.mjs
+++ b/packages/oxlint-plugin-react-doctor/scripts/generate-rule-registry.mjs
@@ -144,6 +144,8 @@ const RULES_NOT_PORTED_FROM_EXTERNAL = new Set([
   "no-multiple-main-landmarks",
   "no-nonresizable-textarea",
   "no-placeholder-only-field",
+  "no-reduced-motion-content-removal",
+  "no-responsive-hidden-accessible-name",
   "no-skipped-heading-level",
   "no-static-motion-config-never",
   "no-ungated-tailwind-animation",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/tailwind.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/tailwind.ts
@@ -1,0 +1,8 @@
+export const TAILWIND_NAMED_BREAKPOINTS: ReadonlyArray<string> = ["sm", "md", "lg", "xl", "2xl"];
+export const TAILWIND_BREAKPOINT_NAMES: ReadonlyArray<string> = ["", ...TAILWIND_NAMED_BREAKPOINTS];
+export const TAILWIND_BREAKPOINT_RANKS: ReadonlyMap<string, number> = new Map(
+  TAILWIND_NAMED_BREAKPOINTS.map((breakpointName, breakpointIndex) => [
+    breakpointName,
+    breakpointIndex,
+  ]),
+);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness-fixtures.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness-fixtures.ts
@@ -2429,4 +2429,26 @@ export const livenessFixtures: Readonly<Record<string, LivenessFixture>> = {
   "zustand-no-whole-store-destructure": {
     code: '\n      import { create } from "zustand";\n      const useBearStore = create(() => ({ bears: 0 }));\n      export const BearCounter = () => {\n        const { bears } = useBearStore();\n        return <span>{bears}</span>;\n      };\n    ',
   },
+  "loading-action-preserves-trigger": {
+    code: 'import { useState } from "react";\nexport const Save = () => { const [pending, setPending] = useState(false); const save = async () => { setPending(true); await fetch("/api/save"); setPending(false); }; return pending ? <span role="status">Saving</span> : <button type="button" onClick={save}>Save</button>; };',
+  },
+  "no-collapse-request-error-to-empty-state": {
+    code: 'import { useState } from "react";\nexport const Search = () => { const [items, setItems] = useState([]); const load = async () => { try { setItems(await (await fetch("/api/items")).json()); } catch { setItems([]); } }; if (!items.length) return <p>No results found</p>; return <ResultList items={items} />; };',
+  },
+  "no-focus-in-animation-completion-handler": {
+    code: 'import { useRef } from "react";\nexport const Dialog = () => { const inputRef = useRef(null); return <><input ref={inputRef} /><div onAnimationEnd={() => inputRef.current.focus()} /></>; };',
+  },
+  "no-mixed-animation-owners": {
+    code: 'import { motion } from "motion/react";\nexport const Demo = () => <motion.div animate={{ opacity: 1 }} className="transition-opacity duration-200" />;',
+  },
+  "no-reduced-motion-content-removal": {
+    code: 'export const Status = () => <p className="motion-reduce:hidden">Payment failed</p>;',
+  },
+  "no-responsive-hidden-accessible-name": {
+    code: 'export const Menu = () => <button><span className="md:hidden">Menu</span></button>;',
+  },
+  "no-transitioned-composite-widget-state": {
+    code: 'export const Option = ({ selected }) => <div role="option" aria-selected={selected ? "true" : "false"} className="bg-[#fff] transition-colors aria-selected:bg-[#000]">Value</div>;',
+    settings: { "react-doctor": { capabilities: ["tailwind"] } },
+  },
 };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
@@ -158,6 +158,7 @@ import { jwtInsecureVerification } from "./rules/security-scan/jwt-insecure-veri
 import { keyLifecycleRisk } from "./rules/security-scan/key-lifecycle-risk.js";
 import { labelHasAssociatedControl } from "./rules/a11y/label-has-associated-control.js";
 import { lang } from "./rules/a11y/lang.js";
+import { loadingActionPreservesTrigger } from "./rules/state-and-effects/loading-action-preserves-trigger.js";
 import { localRpcNativeBridgeRisk } from "./rules/security-scan/local-rpc-native-bridge-risk.js";
 import { mcpToolCapabilityRisk } from "./rules/security-scan/mcp-tool-capability-risk.js";
 import { mdxSsrExecutionRisk } from "./rules/security-scan/mdx-ssr-execution-risk.js";
@@ -230,6 +231,7 @@ import { noChainStateUpdates } from "./rules/state-and-effects/no-chain-state-up
 import { noChildrenProp } from "./rules/react-builtins/no-children-prop.js";
 import { noClippedOverlay } from "./rules/design/no-clipped-overlay.js";
 import { noCloneElement } from "./rules/react-builtins/no-clone-element.js";
+import { noCollapseRequestErrorToEmptyState } from "./rules/state-and-effects/no-collapse-request-error-to-empty-state.js";
 import { noCollapsedLiteralOrChainAsValue } from "./rules/correctness/no-collapsed-literal-or-chain-as-value.js";
 import { noCommonRootFont } from "./rules/design/no-common-root-font.js";
 import { noConflictingSpringOptions } from "./rules/performance/no-conflicting-spring-options.js";
@@ -293,6 +295,7 @@ import { noFixedInsideTransformedAncestor } from "./rules/design/no-fixed-inside
 import { noFlatPageTypeScale } from "./rules/design/no-flat-page-type-scale.js";
 import { noFloatingThenInJsxHandler } from "./rules/correctness/no-floating-then-in-jsx-handler.js";
 import { noFlushSync } from "./rules/view-transitions/no-flush-sync.js";
+import { noFocusInAnimationCompletionHandler } from "./rules/design/no-focus-in-animation-completion-handler.js";
 import { noFocusableContentInAriaHidden } from "./rules/a11y/no-focusable-content-in-aria-hidden.js";
 import { noFocusableContentInRoleText } from "./rules/a11y/no-focusable-content-in-role-text.js";
 import { noFullLodashImport } from "./rules/bundle-size/no-full-lodash-import.js";
@@ -345,6 +348,7 @@ import { noManufacturedContrastCopy } from "./rules/design/no-manufactured-contr
 import { noManyBooleanProps } from "./rules/architecture/no-many-boolean-props.js";
 import { noMatchMediaInStateInitializer } from "./rules/performance/no-match-media-in-state-initializer.js";
 import { noMirrorPropEffect } from "./rules/state-and-effects/no-mirror-prop-effect.js";
+import { noMixedAnimationOwners } from "./rules/design/no-mixed-animation-owners.js";
 import { noMixedIconLibraries } from "./rules/design/no-mixed-icon-libraries.js";
 import { noMixedSrcsetDescriptors } from "./rules/correctness/no-mixed-srcset-descriptors.js";
 import { noMoment } from "./rules/bundle-size/no-moment.js";
@@ -396,6 +400,7 @@ import { noRandomKey } from "./rules/correctness/no-random-key.js";
 import { noReactChildren } from "./rules/react-builtins/no-react-children.js";
 import { noReactDomDeprecatedApis } from "./rules/architecture/no-react-dom-deprecated-apis.js";
 import { noReact19DeprecatedApis } from "./rules/architecture/no-react19-deprecated-apis.js";
+import { noReducedMotionContentRemoval } from "./rules/a11y/no-reduced-motion-content-removal.js";
 import { noRedundantDisplayClass } from "./rules/design/no-redundant-display-class.js";
 import { noRedundantRoles } from "./rules/a11y/no-redundant-roles.js";
 import { noRedundantShouldComponentUpdate } from "./rules/react-builtins/no-redundant-should-component-update.js";
@@ -413,6 +418,7 @@ import { noRepeatedPlaceholderNavigation } from "./rules/design/no-repeated-plac
 import { noRepeatedSectionShells } from "./rules/design/no-repeated-section-shells.js";
 import { noRepeatingGradientDecoration } from "./rules/design/no-repeating-gradient-decoration.js";
 import { noResetAllStateOnPropChange } from "./rules/state-and-effects/no-reset-all-state-on-prop-change.js";
+import { noResponsiveHiddenAccessibleName } from "./rules/a11y/no-responsive-hidden-accessible-name.js";
 import { noScaleFromZero } from "./rules/performance/no-scale-from-zero.js";
 import { noSecretsInClientCode } from "./rules/security/no-secrets-in-client-code.js";
 import { noSelfUpdatingEffect } from "./rules/state-and-effects/no-self-updating-effect.js";
@@ -444,6 +450,7 @@ import { noTightDisplayTracking } from "./rules/design/no-tight-display-tracking
 import { noTinyText } from "./rules/design/no-tiny-text.js";
 import { noTinyUppercaseTrackedLabel } from "./rules/design/no-tiny-uppercase-tracked-label.js";
 import { noTransitionAll } from "./rules/performance/no-transition-all.js";
+import { noTransitionedCompositeWidgetState } from "./rules/design/no-transitioned-composite-widget-state.js";
 import { noTransitionedFocusRing } from "./rules/design/no-transitioned-focus-ring.js";
 import { noUnboundedAnimationFrameLoop } from "./rules/performance/no-unbounded-animation-frame-loop.js";
 import { noUncontrolledInput } from "./rules/correctness/no-uncontrolled-input.js";
@@ -2556,6 +2563,20 @@ export const reactDoctorRules = [
     },
   },
   {
+    key: "react-doctor/loading-action-preserves-trigger",
+    id: "loading-action-preserves-trigger",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...loadingActionPreservesTrigger,
+      framework: "global",
+      category: "Accessibility",
+      requires: [
+        ...new Set<Capability>(["react", ...(loadingActionPreservesTrigger.requires ?? [])]),
+      ],
+    },
+  },
+  {
     key: "react-doctor/local-rpc-native-bridge-risk",
     id: "local-rpc-native-bridge-risk",
     source: "react-doctor",
@@ -3390,6 +3411,20 @@ export const reactDoctorRules = [
     },
   },
   {
+    key: "react-doctor/no-collapse-request-error-to-empty-state",
+    id: "no-collapse-request-error-to-empty-state",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noCollapseRequestErrorToEmptyState,
+      framework: "global",
+      category: "Bugs",
+      requires: [
+        ...new Set<Capability>(["react", ...(noCollapseRequestErrorToEmptyState.requires ?? [])]),
+      ],
+    },
+  },
+  {
     key: "react-doctor/no-collapsed-literal-or-chain-as-value",
     id: "no-collapsed-literal-or-chain-as-value",
     source: "react-doctor",
@@ -4147,6 +4182,18 @@ export const reactDoctorRules = [
     },
   },
   {
+    key: "react-doctor/no-focus-in-animation-completion-handler",
+    id: "no-focus-in-animation-completion-handler",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noFocusInAnimationCompletionHandler,
+      framework: "global",
+      category: "Accessibility",
+      tags: [...new Set(["design", ...(noFocusInAnimationCompletionHandler.tags ?? [])])],
+    },
+  },
+  {
     key: "react-doctor/no-focusable-content-in-aria-hidden",
     id: "no-focusable-content-in-aria-hidden",
     source: "react-doctor",
@@ -4781,6 +4828,18 @@ export const reactDoctorRules = [
     },
   },
   {
+    key: "react-doctor/no-mixed-animation-owners",
+    id: "no-mixed-animation-owners",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noMixedAnimationOwners,
+      framework: "global",
+      category: "Maintainability",
+      tags: [...new Set(["design", ...(noMixedAnimationOwners.tags ?? [])])],
+    },
+  },
+  {
     key: "react-doctor/no-mixed-icon-libraries",
     id: "no-mixed-icon-libraries",
     source: "react-doctor",
@@ -5394,6 +5453,20 @@ export const reactDoctorRules = [
     },
   },
   {
+    key: "react-doctor/no-reduced-motion-content-removal",
+    id: "no-reduced-motion-content-removal",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noReducedMotionContentRemoval,
+      framework: "global",
+      category: "Accessibility",
+      requires: [
+        ...new Set<Capability>(["react", ...(noReducedMotionContentRemoval.requires ?? [])]),
+      ],
+    },
+  },
+  {
     key: "react-doctor/no-redundant-display-class",
     id: "no-redundant-display-class",
     source: "react-doctor",
@@ -5595,6 +5668,20 @@ export const reactDoctorRules = [
       category: "Bugs",
       requires: [
         ...new Set<Capability>(["react", ...(noResetAllStateOnPropChange.requires ?? [])]),
+      ],
+    },
+  },
+  {
+    key: "react-doctor/no-responsive-hidden-accessible-name",
+    id: "no-responsive-hidden-accessible-name",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noResponsiveHiddenAccessibleName,
+      framework: "global",
+      category: "Accessibility",
+      requires: [
+        ...new Set<Capability>(["react", ...(noResponsiveHiddenAccessibleName.requires ?? [])]),
       ],
     },
   },
@@ -5978,6 +6065,18 @@ export const reactDoctorRules = [
       framework: "global",
       category: "Performance",
       requires: [...new Set<Capability>(["react", ...(noTransitionAll.requires ?? [])])],
+    },
+  },
+  {
+    key: "react-doctor/no-transitioned-composite-widget-state",
+    id: "no-transitioned-composite-widget-state",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noTransitionedCompositeWidgetState,
+      framework: "global",
+      category: "Accessibility",
+      tags: [...new Set(["design", ...(noTransitionedCompositeWidgetState.tags ?? [])])],
     },
   },
   {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/no-reduced-motion-content-removal.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/no-reduced-motion-content-removal.test.ts
@@ -188,6 +188,20 @@ describe("no-reduced-motion-content-removal", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("skips unsupported Tailwind variant scopes", () => {
+    const result = runRule(
+      noReducedMotionContentRemoval,
+      `const Example = () => <>
+        <p className="motion-reduce:hover:hidden">Interaction state</p>
+        <p className="motion-reduce:data-[state=open]:hidden">Data state</p>
+        <p className="motion-reduce:group-hover:hidden">Group state</p>
+        <p className="motion-reduce:max-[700px]:hidden">Arbitrary breakpoint</p>
+        <p className="motion-reduce:tablet:hidden">Custom breakpoint</p>
+      </>;`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("allows equivalent persistent text and actions", () => {
     const result = runRule(
       noReducedMotionContentRemoval,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/no-reduced-motion-content-removal.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/no-reduced-motion-content-removal.test.ts
@@ -1,0 +1,384 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noReducedMotionContentRemoval } from "./no-reduced-motion-content-removal.js";
+
+describe("no-reduced-motion-content-removal", () => {
+  it("does not interpret Tailwind syntax when the capability is unavailable", () => {
+    const result = runRule(
+      noReducedMotionContentRemoval,
+      `const Status = () => <p className="motion-reduce:hidden">Payment failed</p>;`,
+      { settings: { "react-doctor": { capabilities: [] } } },
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("reports static text, interactive controls, and live regions hidden under reduced motion", () => {
+    const result = runRule(
+      noReducedMotionContentRemoval,
+      `const Example = ({ error }) => <>
+        <p className="motion-reduce:hidden">Payment failed</p>
+        <section className="motion-reduce:invisible"><button type="button">Retry</button></section>
+        <div className="motion-reduce:hidden" role="status">Saving</div>
+        <div className="motion-reduce:hidden" aria-live="assertive">{error}</div>
+        <output className="motion-reduce:hidden">{error}</output>
+        <p className="motion-reduce:hidden" style={{ color: "red", display: "block" }}>Session expired</p>
+      </>;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(6);
+  });
+
+  it("reports effective responsive and important reduced-motion removals", () => {
+    const result = runRule(
+      noReducedMotionContentRemoval,
+      `const Example = () => <>
+        <p className="md:motion-reduce:hidden">Compact details</p>
+        <p className="block motion-reduce:hidden">Account status</p>
+        <p className="motion-reduce:!invisible visible">Connection lost</p>
+        <p className="motion-reduce:!hidden motion-reduce:block">Upload failed</p>
+      </>;`,
+    );
+    expect(result.diagnostics).toHaveLength(4);
+  });
+
+  it("requires the removed subtree and its ancestors to be visible before reduced motion", () => {
+    const result = runRule(
+      noReducedMotionContentRemoval,
+      `const Example = ({ className }) => <>
+        <section><p className="hidden motion-reduce:hidden">Already hidden</p></section>
+        <section><p className="motion-safe:hidden motion-reduce:hidden">Hidden in both modes</p></section>
+        <section hidden><p className="motion-reduce:hidden">Hidden ancestor</p></section>
+        <section className={className}><p className="motion-reduce:hidden">Unknown ancestor</p></section>
+        <Wrapper><p className="motion-reduce:hidden">Opaque ancestor</p></Wrapper>
+        <section><div className="motion-reduce:hidden"><p className="motion-reduce:hidden">One removal</p></div></section>
+      </>;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("requires Tailwind removals to directly reach a component render", () => {
+    const result = runRule(
+      noReducedMotionContentRemoval,
+      `const Example = () => {
+        const unused = <p className="motion-reduce:hidden">Detached</p>;
+        const callback = () => <p className="motion-reduce:hidden">Callback</p>;
+        [1].map(() => <p className="motion-reduce:hidden">Detached map result</p>);
+        return <p className="motion-reduce:hidden">Rendered</p>;
+      };
+      const UnreachableLogical = () => <>{false && <p className="motion-reduce:hidden">Unreachable logical branch</p>}</>;
+      const UnreachableConditional = () => <>{true ? <p>Reachable branch</p> : <p className="motion-reduce:hidden">Unreachable conditional branch</p>}</>;
+      const lowercaseHelper = () => <p className="motion-reduce:hidden">Helper</p>;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports exact null branches from imported useReducedMotion hooks", () => {
+    const result = runRule(
+      noReducedMotionContentRemoval,
+      `import { useReducedMotion, useReducedMotion as useMotionPreference } from "motion/react";
+       import * as Motion from "framer-motion";
+       const A = () => useReducedMotion() ? null : <p>Upload complete</p>;
+       const B = () => { const shouldReduceMotion = useMotionPreference(); return shouldReduceMotion ? null : <button type="button">Retry</button>; };
+       const C = () => { const shouldReduceMotion = Motion.useReducedMotion(); return !shouldReduceMotion ? <div role="status">Saved</div> : null; };`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(3);
+  });
+
+  it("requires a useReducedMotion conditional to directly reach rendered output", () => {
+    const result = runRule(
+      noReducedMotionContentRemoval,
+      `import { useReducedMotion } from "motion/react";
+       const Example = () => {
+         const reduced = useReducedMotion();
+         const unused = reduced ? null : <p>Unused</p>;
+         const metadata = { view: reduced ? null : <p>Metadata</p> };
+         const callback = () => reduced ? null : <p>Callback result</p>;
+         [1].map(() => reduced ? null : <p>Detached map result</p>);
+         return <main>{reduced ? null : <p>Rendered</p>}</main>;
+       };
+       const Unreachable = () => { const reduced = useReducedMotion(); return <>{false && (reduced ? null : <p>Unreachable</p>)}</>; };
+       const lowercaseHelper = () => useReducedMotion() ? null : <p>Helper result</p>;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("requires visible hook-branch ancestors and no possible persistent fallback", () => {
+    const result = runRule(
+      noReducedMotionContentRemoval,
+      `import { useReducedMotion } from "motion/react";
+       const Example = ({ fallback }) => {
+         const reduced = useReducedMotion();
+         return <>
+           <section hidden>{reduced ? null : <p>Hidden ancestor</p>}</section>
+           <div><p>Saved</p>{reduced ? null : <p>Saved</p>}</div>
+           <div>{fallback}{reduced ? null : <p>Unknown fallback</p>}</div>
+         </>;
+       };`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("evaluates hook sibling fallbacks in the reduced-motion state", () => {
+    const result = runRule(
+      noReducedMotionContentRemoval,
+      `import { useReducedMotion } from "motion/react";
+       const HasFallback = () => {
+         const reduced = useReducedMotion();
+         return <div><p className="motion-safe:hidden motion-reduce:block">Saved</p>{reduced ? null : <p>Saved</p>}</div>;
+       };
+       const NoFallback = () => {
+         const reduced = useReducedMotion();
+         return <div><p className="motion-reduce:hidden">Deleted in reduced motion</p>{reduced ? null : <p>Saved</p>}</div>;
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("allows effective visibility overrides and ambiguous Tailwind precedence", () => {
+    const result = runRule(
+      noReducedMotionContentRemoval,
+      `const Example = () => <>
+        <p className="motion-reduce:hidden motion-reduce:block">Saved</p>
+        <p className="motion-reduce:invisible motion-reduce:visible">Saved</p>
+        <p className="motion-reduce:hidden motion-reduce:!block">Saved</p>
+        <p className="motion-reduce:invisible motion-reduce:!visible">Saved</p>
+        <p className="!block motion-reduce:hidden">Saved</p>
+        <p className="!visible motion-reduce:invisible">Saved</p>
+      </>;`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("resolves arbitrary Tailwind display and visibility utilities conservatively", () => {
+    const result = runRule(
+      noReducedMotionContentRemoval,
+      `const Example = () => <>
+        <div><p className="motion-reduce:hidden motion-reduce:[display:block]">Ambiguous display</p></div>
+        <div><p className="motion-reduce:hidden motion-reduce:![display:block]">Visible display</p></div>
+        <div><p className="motion-reduce:!hidden motion-reduce:[display:block]">Hidden display</p></div>
+        <div><p className="motion-reduce:invisible motion-reduce:[visibility:visible]">Ambiguous visibility</p></div>
+        <div><p className="motion-reduce:hidden motion-reduce:[display:var(--display)]">Unknown display</p></div>
+      </>;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("allows descendants to override an inherited invisible state", () => {
+    const result = runRule(
+      noReducedMotionContentRemoval,
+      `const Example = () => <>
+        <div className="motion-reduce:invisible"><span className="motion-reduce:visible">Saved</span></div>
+        <div className="motion-reduce:invisible"><span style={{ visibility: "visible" }}>Saved</span></div>
+      </>;`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("rejects contradictory motion variants and empty responsive intervals", () => {
+    const result = runRule(
+      noReducedMotionContentRemoval,
+      `const Example = () => <>
+        <p className="motion-safe:motion-reduce:hidden">Impossible preference</p>
+        <p className="hover:not-hover:motion-reduce:hidden">Impossible interaction</p>
+        <p className="md:max-sm:motion-reduce:hidden">Impossible breakpoint</p>
+        <p className="max-md:lg:motion-reduce:hidden">Another impossible breakpoint</p>
+      </>;`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("allows equivalent persistent text and actions", () => {
+    const result = runRule(
+      noReducedMotionContentRemoval,
+      `const Example = ({ save }) => <>
+        <div><span className="motion-reduce:hidden">Loading account</span><span>Loading account</span></div>
+        <div><button className="motion-reduce:hidden" type="submit">Save</button><button className="hidden motion-reduce:block" type="submit">Save</button></div>
+        <div><button className="motion-reduce:hidden" type="button" onClick={save}>Save</button><button type="button" onClick={save}>Save</button></div>
+        <div><a className="motion-reduce:invisible" href="/settings">Settings</a><a href="/settings">Settings</a></div>
+      </>;`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("finds equivalent reduced-motion fallbacks in neighboring neutral wrappers", () => {
+    const result = runRule(
+      noReducedMotionContentRemoval,
+      `const Example = () => <section>
+        <div><p className="motion-reduce:hidden">Saved</p></div>
+        <div className="hidden motion-reduce:block"><p>Saved</p></div>
+      </section>;`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("finds descendant-switched fallbacks in neighboring section wrappers", () => {
+    const result = runRule(
+      noReducedMotionContentRemoval,
+      `const Example = () => <>
+        <section><p className="motion-reduce:hidden">Saved</p></section>
+        <section><p className="hidden motion-reduce:block">Saved</p></section>
+      </>;`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not cross interactive, live-region, or named-region wrapper boundaries", () => {
+    const result = runRule(
+      noReducedMotionContentRemoval,
+      `const Example = () => <>
+        <button><span className="motion-reduce:hidden">Save</span></button>
+        <button><span className="hidden motion-reduce:block">Save</span></button>
+        <section role="status"><p className="motion-reduce:hidden">Saved</p></section>
+        <section role="status"><p className="hidden motion-reduce:block">Saved</p></section>
+        <section aria-label="Primary status"><p className="motion-reduce:hidden">Ready</p></section>
+        <section aria-label="Reduced status"><p className="hidden motion-reduce:block">Ready</p></section>
+      </>;`,
+    );
+    expect(result.diagnostics).toHaveLength(3);
+  });
+
+  it("abstains when an opaque or dynamic sibling could be an equivalent fallback", () => {
+    const result = runRule(
+      noReducedMotionContentRemoval,
+      `const Example = ({ fallback, className }) => <>
+        <div><p className="motion-reduce:hidden">Saved</p><Fallback /></div>
+        <div><p className="motion-reduce:hidden">Saved</p>{fallback}</div>
+        <div><p className="motion-reduce:hidden">Saved</p><span className={className}>Saved</span></div>
+      </>;`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not mistake same-looking but non-equivalent content for a fallback", () => {
+    const result = runRule(
+      noReducedMotionContentRemoval,
+      `const Example = ({ retry, cancel }) => <>
+        <div><button className="motion-reduce:hidden" type="button">Retry</button><span>Retry</span></div>
+        <div><a className="motion-reduce:hidden" href="/billing">Settings</a><a href="/profile">Settings</a></div>
+        <div><p className="motion-reduce:hidden">Saving</p><p>Saved</p></div>
+        <div><button className="motion-reduce:hidden" type="button" onClick={retry}>Retry</button><button type="button" onClick={cancel}>Retry</button></div>
+        <div><button className="motion-reduce:hidden" type="submit">Save</button><button type="submit" disabled>Save</button></div>
+      </>;`,
+    );
+    expect(result.diagnostics).toHaveLength(5);
+  });
+
+  it("includes form submission behavior when comparing buttons with click handlers", () => {
+    const result = runRule(
+      noReducedMotionContentRemoval,
+      `const Example = ({ save }) => <>
+        <div><button className="motion-reduce:hidden" type="submit" formAction="/save" onClick={save}>Save</button><button type="submit" formAction="/draft" onClick={save}>Save</button></div>
+        <div><button className="motion-reduce:hidden" type="reset" formAction="/save" onClick={save}>Reset</button><button type="reset" formAction="/save" onClick={save}>Reset</button></div>
+      </>;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("skips decorative, already hidden, empty, spinner-only, and opaque subtrees", () => {
+    const result = runRule(
+      noReducedMotionContentRemoval,
+      `const Example = () => <>
+        <span className="animate-spin motion-reduce:hidden" aria-hidden="true">Loading</span>
+        <span className="motion-reduce:hidden"><svg><title>Spinner</title></svg></span>
+        <span className="motion-reduce:hidden"><Spinner /></span>
+        <template className="motion-reduce:hidden"><p>Deferred content</p></template>
+        <span className="motion-reduce:hidden" />
+        <Status className="motion-reduce:hidden">Saved</Status>
+        <span className="motion-reduce:hidden" hidden>Saved</span>
+      </>;`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not treat inert template contents as a visible fallback", () => {
+    const result = runRule(
+      noReducedMotionContentRemoval,
+      `const Example = () => <div>
+        <p className="motion-reduce:hidden">Saved</p>
+        <template><p>Saved</p></template>
+      </div>;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("keeps traversing meaningful descendants of presentational wrappers", () => {
+    const result = runRule(
+      noReducedMotionContentRemoval,
+      `const Example = ({ retry }) => <>
+        <div className="motion-reduce:hidden" role="presentation">System offline</div>
+        <div className="motion-reduce:hidden" role="none"><button type="button" onClick={retry}>Retry</button></div>
+      </>;`,
+    );
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
+  it("skips dynamic classes, spreads, hidden semantics, and custom opaque content", () => {
+    const result = runRule(
+      noReducedMotionContentRemoval,
+      `const Example = ({ className, props, hidden }) => <>
+        <p className={className}>Saved</p>
+        <p className="motion-reduce:hidden" {...props}>Saved</p>
+        <p className="motion-reduce:hidden" aria-hidden={hidden}>Saved</p>
+        <div className="motion-reduce:hidden"><Panel /></div>
+        <div className="motion-reduce:hidden"><span className={className}>Saved</span></div>
+        <p className="motion-reduce:hidden" style={{ display: "none" }}>Saved</p>
+        <p className="motion-reduce:hidden" style={{ visibility: "hidden" }}>Saved</p>
+        <p className="motion-reduce:hidden" style={{ display: "var(--display)" }}>Saved</p>
+        <p className="motion-reduce:hidden" style={{ visibility: "var(--visibility)" }}>Saved</p>
+        <p className="motion-reduce:hidden" style={props}>Saved</p>
+      </>;`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("preserves unknown attribute states and ignores unsupported unnamed controls", () => {
+    const result = runRule(
+      noReducedMotionContentRemoval,
+      `const Example = ({ role, live, label, href, action }) => <>
+        <div className="motion-reduce:hidden" role={role}>{action}</div>
+        <div className="motion-reduce:hidden" aria-live={live}>{action}</div>
+        <button className="motion-reduce:hidden" type="button" aria-label={label} />
+        <a className="motion-reduce:hidden" href={href} aria-label="Account" />
+        <button className="motion-reduce:hidden" formAction={action} aria-label="Save" />
+        <button className="motion-reduce:hidden" aria-labelledby="external-label" />
+        <input className="motion-reduce:hidden" aria-label="Email" />
+        <video className="motion-reduce:hidden" />
+      </>;`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("recognizes numeric and static-template text and HTML boolean disabled presence", () => {
+    const result = runRule(
+      noReducedMotionContentRemoval,
+      'const Example = ({ save }) => <><p className="motion-reduce:hidden">{42}</p><p className="motion-reduce:hidden">{`Saved`}</p><button className="motion-reduce:hidden" disabled="false" onClick={save} aria-label="Save" /></>;',
+    );
+    expect(result.diagnostics).toHaveLength(3);
+  });
+
+  it("skips shadowed and unrelated useReducedMotion functions", () => {
+    const result = runRule(
+      noReducedMotionContentRemoval,
+      `import { useReducedMotion as importedPreference } from "motion/react";
+       import { useReducedMotion as useOtherPreference } from "other-motion";
+       const A = () => { const useReducedMotion = () => true; return useReducedMotion() ? null : <p>Saved</p>; };
+       const B = () => useOtherPreference() ? null : <p>Saved</p>;
+       const C = () => { const importedPreference = () => true; return importedPreference() ? null : <p>Saved</p>; };`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("skips hook branches that preserve content or cannot prove removal", () => {
+    const result = runRule(
+      noReducedMotionContentRemoval,
+      `import { useReducedMotion } from "motion/react";
+       const A = () => { const reduced = useReducedMotion(); return reduced ? <p>Static summary</p> : null; };
+       const B = () => { const reduced = useReducedMotion(); return reduced ? <p>Static summary</p> : <p>Animated summary</p>; };
+       const C = () => { let reduced = useReducedMotion(); return reduced ? null : <p>Saved</p>; };
+       const D = ({ reduced }) => reduced ? null : <p>Saved</p>;
+       const E = () => useReducedMotion() ? null : <Spinner />;`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/no-reduced-motion-content-removal.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/no-reduced-motion-content-removal.test.ts
@@ -150,6 +150,21 @@ describe("no-reduced-motion-content-removal", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("preserves ambiguous Tailwind visibility on ancestors", () => {
+    const result = runRule(
+      noReducedMotionContentRemoval,
+      `const Example = () => <>
+        <div className="motion-reduce:block motion-reduce:hidden">
+          <p className="motion-reduce:hidden">Ambiguous display ancestor</p>
+        </div>
+        <div className="motion-reduce:visible motion-reduce:invisible">
+          <p className="motion-reduce:hidden">Ambiguous visibility ancestor</p>
+        </div>
+      </>;`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("resolves arbitrary Tailwind display and visibility utilities conservatively", () => {
     const result = runRule(
       noReducedMotionContentRemoval,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/no-reduced-motion-content-removal.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/no-reduced-motion-content-removal.test.ts
@@ -210,6 +210,7 @@ describe("no-reduced-motion-content-removal", () => {
         <p className="motion-reduce:hover:hidden">Interaction state</p>
         <p className="motion-reduce:data-[state=open]:hidden">Data state</p>
         <p className="motion-reduce:group-hover:hidden">Group state</p>
+        <p className="motion-reduce/compact:hidden">Modified preference variant</p>
         <p className="motion-reduce:max-[700px]:hidden">Arbitrary breakpoint</p>
         <p className="motion-reduce:tablet:hidden">Custom breakpoint</p>
       </>;`,
@@ -274,6 +275,7 @@ describe("no-reduced-motion-content-removal", () => {
         <div><p className="motion-reduce:hidden">Saved</p><Fallback /></div>
         <div><p className="motion-reduce:hidden">Saved</p>{fallback}</div>
         <div><p className="motion-reduce:hidden">Saved</p><span className={className}>Saved</span></div>
+        <div><p className="motion-reduce:hidden">Saved</p><span><i className={className}>Saved</i></span></div>
       </>;`,
     );
     expect(result.diagnostics).toEqual([]);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/no-reduced-motion-content-removal.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/no-reduced-motion-content-removal.ts
@@ -1,0 +1,1132 @@
+import { TAILWIND_BREAKPOINT_NAMES } from "../../constants/tailwind.js";
+import { defineRule } from "../../utils/define-rule.js";
+import { doesTailwindVariantScopeCover } from "../../utils/does-tailwind-variant-scope-cover.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
+import { findTransparentExpressionRoot } from "../../utils/find-transparent-expression-root.js";
+import { getAuthoritativeJsxAttribute } from "../../utils/get-authoritative-jsx-attribute.js";
+import { getHighestPriorityTailwindClassNameTokens } from "../../utils/get-highest-priority-tailwind-class-name-tokens.js";
+import { getMotionReactApiPath } from "../../utils/get-motion-react-api-path.js";
+import { getStaticTemplateLiteralValue } from "../../utils/get-static-template-literal-value.js";
+import { getTailwindVisibilityEffect } from "../../utils/get-tailwind-visibility-effect.js";
+import type { TailwindVisibilityEffect } from "../../utils/get-tailwind-visibility-effect.js";
+import { hasCapabilityOrUnspecified } from "../../utils/get-react-doctor-setting.js";
+import { hasJsxSpreadAttribute } from "../../utils/has-jsx-spread-attribute.js";
+import { isComponentFunction } from "../../utils/is-component-function.js";
+import { isInteractiveElement } from "../../utils/is-interactive-element.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { isTailwindMotionSafeVariant } from "../../utils/is-tailwind-motion-safe-variant.js";
+import { isTailwindReducedMotionVariant } from "../../utils/is-tailwind-reduced-motion-variant.js";
+import { parseTailwindClassNameToken } from "../../utils/parse-tailwind-class-name-token.js";
+import type { TailwindClassNameToken } from "../../utils/parse-tailwind-class-name-token.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+import { splitTailwindClassName } from "../../utils/split-tailwind-class-name.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import { getEffectiveStyleProperty } from "../design/utils/get-effective-style-property.js";
+import { getInlineStyleExpression } from "../design/utils/get-inline-style-expression.js";
+import { getStringFromClassNameAttr } from "../design/utils/get-string-from-class-name-attr.js";
+import { getStylePropertyKey } from "../design/utils/get-style-property-key.js";
+import { getStylePropertyStringValue } from "../design/utils/get-style-property-string-value.js";
+
+const LIVE_REGION_ROLES: ReadonlySet<string> = new Set(["alert", "log", "status"]);
+const NEUTRAL_FALLBACK_WRAPPER_TAGS: ReadonlySet<string> = new Set(["div", "section", "span"]);
+const PRESENTATIONAL_ROLES: ReadonlySet<string> = new Set(["none", "presentation"]);
+const STATIC_TEXT_PATTERN = /[\p{L}\p{N}]/u;
+const VISIBLE_DISPLAY_VALUES: ReadonlySet<string> = new Set([
+  "block",
+  "contents",
+  "flex",
+  "flow-root",
+  "grid",
+  "inline",
+  "inline-block",
+  "inline-flex",
+  "inline-grid",
+  "inline-table",
+  "list-item",
+  "table",
+  "table-caption",
+  "table-cell",
+  "table-column",
+  "table-column-group",
+  "table-footer-group",
+  "table-header-group",
+  "table-row",
+  "table-row-group",
+]);
+
+interface StaticAttributeResolution {
+  status: "absent" | "known" | "unknown";
+  value: string;
+}
+
+interface StaticBooleanAttributeResolution {
+  status: "absent" | "known" | "unknown";
+  value: boolean;
+}
+
+interface SemanticIdentityResolution {
+  status: "absent" | "known" | "unknown";
+  value: string;
+}
+
+interface SemanticSummary {
+  actionIdentities: string[];
+  hasUnknownSemantics: boolean;
+  liveRegionIdentities: string[];
+  staticTextParts: string[];
+}
+
+const createSemanticSummary = (): SemanticSummary => ({
+  actionIdentities: [],
+  hasUnknownSemantics: false,
+  liveRegionIdentities: [],
+  staticTextParts: [],
+});
+
+const mergeSemanticSummary = (target: SemanticSummary, source: SemanticSummary): void => {
+  target.actionIdentities.push(...source.actionIdentities);
+  target.liveRegionIdentities.push(...source.liveRegionIdentities);
+  target.staticTextParts.push(...source.staticTextParts);
+  target.hasUnknownSemantics ||= source.hasUnknownSemantics;
+};
+
+const normalizeStaticText = (textParts: ReadonlyArray<string>): string =>
+  textParts.join(" ").replace(/\s+/g, " ").trim();
+
+const getStaticTextFromJsxChild = (child: EsTreeNode): StaticAttributeResolution => {
+  if (isNodeOfType(child, "JSXText")) {
+    return { status: "known", value: child.value };
+  }
+  if (!isNodeOfType(child, "JSXExpressionContainer")) {
+    return { status: "absent", value: "" };
+  }
+  const expression = stripParenExpression(child.expression);
+  if (isNodeOfType(expression, "JSXEmptyExpression")) {
+    return { status: "known", value: "" };
+  }
+  if (isNodeOfType(expression, "Literal")) {
+    if (typeof expression.value === "string" || typeof expression.value === "number") {
+      return { status: "known", value: String(expression.value) };
+    }
+    if (typeof expression.value === "bigint") {
+      return { status: "known", value: expression.value.toString() };
+    }
+    if (
+      expression.value === null ||
+      typeof expression.value === "boolean" ||
+      expression.value === undefined
+    ) {
+      return { status: "known", value: "" };
+    }
+  }
+  if (isNodeOfType(expression, "TemplateLiteral")) {
+    const value = getStaticTemplateLiteralValue(expression);
+    return value === null ? { status: "unknown", value: "" } : { status: "known", value };
+  }
+  return { status: "unknown", value: "" };
+};
+
+const getStaticAttributeResolution = (
+  openingElement: EsTreeNodeOfType<"JSXOpeningElement">,
+  attributeName: string,
+): StaticAttributeResolution => {
+  const attribute = getAuthoritativeJsxAttribute(openingElement.attributes, attributeName, false);
+  if (!attribute) return { status: "absent", value: "" };
+  if (!attribute.value) return { status: "unknown", value: "" };
+  if (isNodeOfType(attribute.value, "Literal") && typeof attribute.value.value === "string") {
+    return { status: "known", value: attribute.value.value };
+  }
+  if (!isNodeOfType(attribute.value, "JSXExpressionContainer")) {
+    return { status: "unknown", value: "" };
+  }
+  const expression = stripParenExpression(attribute.value.expression);
+  if (isNodeOfType(expression, "Literal") && typeof expression.value === "string") {
+    return { status: "known", value: expression.value };
+  }
+  if (isNodeOfType(expression, "TemplateLiteral")) {
+    const value = getStaticTemplateLiteralValue(expression);
+    return value === null ? { status: "unknown", value: "" } : { status: "known", value };
+  }
+  return { status: "unknown", value: "" };
+};
+
+const getStaticBooleanAttributeResolution = (
+  openingElement: EsTreeNodeOfType<"JSXOpeningElement">,
+  attributeName: string,
+): StaticBooleanAttributeResolution => {
+  const attribute = getAuthoritativeJsxAttribute(openingElement.attributes, attributeName, false);
+  if (!attribute) return { status: "absent", value: false };
+  if (!attribute.value) return { status: "known", value: true };
+  if (isNodeOfType(attribute.value, "Literal")) {
+    return { status: "known", value: Boolean(attribute.value.value) };
+  }
+  if (!isNodeOfType(attribute.value, "JSXExpressionContainer")) {
+    return { status: "unknown", value: false };
+  }
+  const expression = stripParenExpression(attribute.value.expression);
+  if (isNodeOfType(expression, "Literal")) {
+    return { status: "known", value: Boolean(expression.value) };
+  }
+  if (isNodeOfType(expression, "TemplateLiteral")) {
+    const value = getStaticTemplateLiteralValue(expression);
+    return value === null
+      ? { status: "unknown", value: false }
+      : { status: "known", value: Boolean(value) };
+  }
+  return { status: "unknown", value: false };
+};
+
+const getAriaHiddenResolution = (
+  openingElement: EsTreeNodeOfType<"JSXOpeningElement">,
+): StaticBooleanAttributeResolution => {
+  const attribute = getAuthoritativeJsxAttribute(openingElement.attributes, "aria-hidden", false);
+  if (!attribute) return { status: "absent", value: false };
+  if (!attribute.value) return { status: "known", value: true };
+  if (isNodeOfType(attribute.value, "Literal")) {
+    if (typeof attribute.value.value === "boolean") {
+      return { status: "known", value: attribute.value.value };
+    }
+    if (typeof attribute.value.value === "string") {
+      return { status: "known", value: attribute.value.value.toLowerCase() === "true" };
+    }
+    return { status: "unknown", value: false };
+  }
+  if (!isNodeOfType(attribute.value, "JSXExpressionContainer")) {
+    return { status: "unknown", value: false };
+  }
+  const expression = stripParenExpression(attribute.value.expression);
+  if (isNodeOfType(expression, "Literal")) {
+    if (typeof expression.value === "boolean") {
+      return { status: "known", value: expression.value };
+    }
+    if (typeof expression.value === "string") {
+      return { status: "known", value: expression.value.toLowerCase() === "true" };
+    }
+  }
+  return { status: "unknown", value: false };
+};
+
+const getInlineStylePropertyVisibility = (
+  openingElement: EsTreeNodeOfType<"JSXOpeningElement">,
+  propertyName: TailwindVisibilityEffect["propertyName"],
+  context: RuleContext,
+): "hidden" | "unknown" | "unset" | "visible" => {
+  const styleAttribute = getAuthoritativeJsxAttribute(openingElement.attributes, "style", false);
+  if (!styleAttribute) return "unset";
+  const styleExpression = getInlineStyleExpression(styleAttribute, context.scopes);
+  if (
+    !styleExpression ||
+    styleExpression.properties.some((property) => getStylePropertyKey(property) === null)
+  ) {
+    return "unknown";
+  }
+  const property = getEffectiveStyleProperty(styleExpression.properties, propertyName);
+  if (!property) return "unset";
+  const value = getStylePropertyStringValue(property)?.trim().toLowerCase();
+  if (!value) return "unknown";
+  if (propertyName === "display") {
+    if (value === "none") return "hidden";
+    return VISIBLE_DISPLAY_VALUES.has(value) ? "visible" : "unknown";
+  }
+  if (value === "hidden" || value === "collapse") return "hidden";
+  return value === "visible" ? "visible" : "unknown";
+};
+
+const getEffectiveTailwindVisibilityOverride = (
+  parsedTokens: ReadonlyArray<TailwindClassNameToken>,
+  targetVariantScope: ReadonlyArray<string>,
+  propertyName: TailwindVisibilityEffect["propertyName"],
+): boolean | null | undefined => {
+  const effectiveTokens = getHighestPriorityTailwindClassNameTokens(parsedTokens, (parsedToken) => {
+    const resolution = getTailwindVisibilityEffect(parsedToken.utility);
+    return (
+      resolution.propertyName === propertyName &&
+      doesTailwindVariantScopeCover(parsedToken.variants, targetVariantScope)
+    );
+  });
+  if (effectiveTokens.length === 0) return undefined;
+  const effectiveStates = new Set<boolean>();
+  for (const token of effectiveTokens) {
+    const resolution = getTailwindVisibilityEffect(token.utility);
+    if (resolution.status !== "known" || resolution.isVisible === null) return null;
+    effectiveStates.add(resolution.isVisible);
+  }
+  return effectiveStates.size === 1 ? (effectiveStates.values().next().value ?? null) : null;
+};
+
+const getEffectiveTailwindVisibility = (
+  parsedTokens: ReadonlyArray<TailwindClassNameToken>,
+  targetVariantScope: ReadonlyArray<string>,
+  propertyName: TailwindVisibilityEffect["propertyName"],
+): boolean | null =>
+  getEffectiveTailwindVisibilityOverride(parsedTokens, targetVariantScope, propertyName) ?? true;
+
+const hasSatisfiableReducedMotionScope = (variants: ReadonlyArray<string>): boolean => {
+  if (variants.some(isTailwindReducedMotionVariant) && variants.some(isTailwindMotionSafeVariant)) {
+    return false;
+  }
+  const normalizedVariants = new Set(variants.map((variant) => variant.split("/")[0]));
+  if (
+    [...normalizedVariants].some(
+      (variant) =>
+        variant.startsWith("not-") && normalizedVariants.has(variant.slice("not-".length)),
+    )
+  ) {
+    return false;
+  }
+  let minimumBreakpointIndex = 0;
+  let maximumBreakpointIndex = TAILWIND_BREAKPOINT_NAMES.length;
+  for (const variant of variants) {
+    const minimumVariantIndex = TAILWIND_BREAKPOINT_NAMES.indexOf(variant);
+    if (minimumVariantIndex > 0) {
+      minimumBreakpointIndex = Math.max(minimumBreakpointIndex, minimumVariantIndex);
+      continue;
+    }
+    if (!variant.startsWith("max-")) continue;
+    const maximumVariantIndex = TAILWIND_BREAKPOINT_NAMES.indexOf(variant.slice("max-".length));
+    if (maximumVariantIndex > 0) {
+      maximumBreakpointIndex = Math.min(maximumBreakpointIndex, maximumVariantIndex);
+    }
+  }
+  return minimumBreakpointIndex < maximumBreakpointIndex;
+};
+
+const getEffectiveReducedMotionScopes = (className: string): string[][] => {
+  const parsedTokens = splitTailwindClassName(className).map(parseTailwindClassNameToken);
+  const reducedMotionScopes: string[][] = [];
+  const seenVariantScopes = new Set<string>();
+  for (const token of parsedTokens) {
+    if (
+      (token.utility !== "hidden" && token.utility !== "invisible") ||
+      !token.variants.some(isTailwindReducedMotionVariant) ||
+      !hasSatisfiableReducedMotionScope(token.variants)
+    ) {
+      continue;
+    }
+    const propertyName = token.utility === "hidden" ? "display" : "visibility";
+    if (getEffectiveTailwindVisibility(parsedTokens, token.variants, propertyName) !== false) {
+      continue;
+    }
+    const variantScopeKey = token.variants.join(":");
+    if (seenVariantScopes.has(variantScopeKey)) continue;
+    seenVariantScopes.add(variantScopeKey);
+    reducedMotionScopes.push([...token.variants]);
+  }
+  return reducedMotionScopes;
+};
+
+const getProvenIntrinsicTagName = (
+  openingElement: EsTreeNodeOfType<"JSXOpeningElement">,
+): string | null => {
+  if (!isNodeOfType(openingElement.name, "JSXIdentifier")) return null;
+  return openingElement.name.name === openingElement.name.name.toLowerCase()
+    ? openingElement.name.name
+    : null;
+};
+
+const getElementNonTailwindVisibility = (
+  openingElement: EsTreeNodeOfType<"JSXOpeningElement">,
+  context: RuleContext,
+): "hidden" | "unknown" | "visible" => {
+  const tagName = getProvenIntrinsicTagName(openingElement);
+  if (!tagName) return "unknown";
+  if (hasJsxSpreadAttribute(openingElement.attributes)) return "unknown";
+  const hiddenResolution = getStaticBooleanAttributeResolution(openingElement, "hidden");
+  if (hiddenResolution.status === "unknown") return "unknown";
+  if (hiddenResolution.status === "known" && hiddenResolution.value) return "hidden";
+  const ariaHiddenResolution = getAriaHiddenResolution(openingElement);
+  if (ariaHiddenResolution.status === "unknown") return "unknown";
+  if (ariaHiddenResolution.status === "known" && ariaHiddenResolution.value) return "hidden";
+  if (tagName === "input") {
+    const typeResolution = getStaticAttributeResolution(openingElement, "type");
+    if (typeResolution.status === "unknown") return "unknown";
+    if (typeResolution.status === "known" && typeResolution.value.toLowerCase() === "hidden") {
+      return "hidden";
+    }
+  }
+  const displayVisibility = getInlineStylePropertyVisibility(openingElement, "display", context);
+  const visibilityVisibility = getInlineStylePropertyVisibility(
+    openingElement,
+    "visibility",
+    context,
+  );
+  if (displayVisibility === "unknown" || visibilityVisibility === "unknown") return "unknown";
+  if (displayVisibility === "hidden" || visibilityVisibility === "hidden") return "hidden";
+  return "visible";
+};
+
+const getElementVisibilityInScope = (
+  openingElement: EsTreeNodeOfType<"JSXOpeningElement">,
+  targetVariantScope: ReadonlyArray<string>,
+  context: RuleContext,
+): "hidden" | "unknown" | "visible" => {
+  const nonTailwindVisibility = getElementNonTailwindVisibility(openingElement, context);
+  if (nonTailwindVisibility !== "visible") return nonTailwindVisibility;
+  const classNameAttribute = getAuthoritativeJsxAttribute(openingElement.attributes, "className");
+  if (!classNameAttribute) return "visible";
+  const className = getStringFromClassNameAttr(openingElement);
+  if (className === null) return "unknown";
+  const parsedTokens = splitTailwindClassName(className).map(parseTailwindClassNameToken);
+  const displayVisibility = getEffectiveTailwindVisibility(
+    parsedTokens,
+    targetVariantScope,
+    "display",
+  );
+  const visibilityVisibility = getEffectiveTailwindVisibility(
+    parsedTokens,
+    targetVariantScope,
+    "visibility",
+  );
+  if (displayVisibility === null || visibilityVisibility === null) return "unknown";
+  return displayVisibility && visibilityVisibility ? "visible" : "hidden";
+};
+
+const getExplicitElementVisibilityOverride = (
+  openingElement: EsTreeNodeOfType<"JSXOpeningElement">,
+  targetVariantScope: ReadonlyArray<string>,
+  context: RuleContext,
+): "hidden" | "unknown" | "unset" | "visible" => {
+  if (!getProvenIntrinsicTagName(openingElement)) return "unknown";
+  if (hasJsxSpreadAttribute(openingElement.attributes)) return "unknown";
+  const inlineVisibility = getInlineStylePropertyVisibility(openingElement, "visibility", context);
+  const classNameAttribute = getAuthoritativeJsxAttribute(openingElement.attributes, "className");
+  if (!classNameAttribute) return inlineVisibility;
+  const className = getStringFromClassNameAttr(openingElement);
+  if (className === null) return "unknown";
+  const parsedTokens = splitTailwindClassName(className).map(parseTailwindClassNameToken);
+  const tailwindVisibility = getEffectiveTailwindVisibilityOverride(
+    parsedTokens,
+    targetVariantScope,
+    "visibility",
+  );
+  if (tailwindVisibility === null || inlineVisibility === "unknown") return "unknown";
+  if (tailwindVisibility === undefined) return inlineVisibility;
+  const tailwindState = tailwindVisibility ? "visible" : "hidden";
+  if (inlineVisibility === "unset" || inlineVisibility === tailwindState) return tailwindState;
+  return "unknown";
+};
+
+const getDescendantVisibilityEscape = (
+  children: ReadonlyArray<EsTreeNode>,
+  targetVariantScope: ReadonlyArray<string>,
+  context: RuleContext,
+): "absent" | "present" | "unknown" => {
+  let hasUnknownEscape = false;
+  for (const child of children) {
+    if (isNodeOfType(child, "JSXElement")) {
+      const tagName = getProvenIntrinsicTagName(child.openingElement);
+      if (!tagName) {
+        hasUnknownEscape = true;
+        continue;
+      }
+      if (tagName === "template") continue;
+      const visibilityOverride = getExplicitElementVisibilityOverride(
+        child.openingElement,
+        targetVariantScope,
+        context,
+      );
+      if (visibilityOverride === "visible") return "present";
+      if (visibilityOverride === "unknown") hasUnknownEscape = true;
+      const descendantEscape = getDescendantVisibilityEscape(
+        child.children,
+        targetVariantScope,
+        context,
+      );
+      if (descendantEscape === "present") return "present";
+      if (descendantEscape === "unknown") hasUnknownEscape = true;
+      continue;
+    }
+    if (isNodeOfType(child, "JSXFragment")) {
+      const descendantEscape = getDescendantVisibilityEscape(
+        child.children,
+        targetVariantScope,
+        context,
+      );
+      if (descendantEscape === "present") return "present";
+      if (descendantEscape === "unknown") hasUnknownEscape = true;
+      continue;
+    }
+    const textResolution = getStaticTextFromJsxChild(child);
+    if (textResolution.status === "unknown") hasUnknownEscape = true;
+  }
+  return hasUnknownEscape ? "unknown" : "absent";
+};
+
+const getNormalMotionScope = (reducedMotionScope: ReadonlyArray<string>): string[] =>
+  reducedMotionScope.map((variant) =>
+    isTailwindReducedMotionVariant(variant) ? "motion-safe" : variant,
+  );
+
+const isRootAndAncestorsVisibleBeforeRemoval = (
+  element: EsTreeNodeOfType<"JSXElement">,
+  reducedMotionScope: ReadonlyArray<string>,
+  context: RuleContext,
+): boolean => {
+  const normalMotionScope = getNormalMotionScope(reducedMotionScope);
+  if (
+    getElementVisibilityInScope(element.openingElement, normalMotionScope, context) !== "visible"
+  ) {
+    return false;
+  }
+  let ancestor: EsTreeNode | null | undefined = element.parent;
+  while (ancestor) {
+    if (isNodeOfType(ancestor, "JSXElement")) {
+      if (
+        getElementVisibilityInScope(ancestor.openingElement, normalMotionScope, context) !==
+          "visible" ||
+        getElementVisibilityInScope(ancestor.openingElement, reducedMotionScope, context) !==
+          "visible"
+      ) {
+        return false;
+      }
+    }
+    ancestor = ancestor.parent;
+    if (
+      ancestor &&
+      (isNodeOfType(ancestor, "ReturnStatement") ||
+        isNodeOfType(ancestor, "ArrowFunctionExpression"))
+    ) {
+      break;
+    }
+  }
+  return true;
+};
+
+const getInteractiveName = (
+  element: EsTreeNodeOfType<"JSXElement">,
+  childSummary: SemanticSummary,
+): SemanticIdentityResolution => {
+  if (getAuthoritativeJsxAttribute(element.openingElement.attributes, "aria-labelledby", false)) {
+    return { status: "unknown", value: "" };
+  }
+  const ariaLabelResolution = getStaticAttributeResolution(element.openingElement, "aria-label");
+  if (ariaLabelResolution.status === "unknown") return { status: "unknown", value: "" };
+  if (ariaLabelResolution.status === "known") {
+    const label = ariaLabelResolution.value.trim();
+    return label ? { status: "known", value: label } : { status: "unknown", value: "" };
+  }
+  if (childSummary.hasUnknownSemantics) return { status: "unknown", value: "" };
+  const text = normalizeStaticText(childSummary.staticTextParts);
+  return STATIC_TEXT_PATTERN.test(text)
+    ? { status: "known", value: text }
+    : { status: "unknown", value: "" };
+};
+
+const getButtonActionIdentity = (
+  element: EsTreeNodeOfType<"JSXElement">,
+  name: string,
+  context: RuleContext,
+): SemanticIdentityResolution => {
+  const openingElement = element.openingElement;
+  const disabledResolution = getStaticBooleanAttributeResolution(openingElement, "disabled");
+  if (disabledResolution.status === "unknown") return { status: "unknown", value: "" };
+  if (disabledResolution.status === "known" && disabledResolution.value) {
+    return { status: "known", value: `button|disabled|${name}` };
+  }
+  const typeResolution = getStaticAttributeResolution(openingElement, "type");
+  if (typeResolution.status === "unknown") return { status: "unknown", value: "" };
+  const buttonType =
+    typeResolution.status === "known" ? typeResolution.value.toLowerCase() : "submit";
+  const formResolution = getStaticAttributeResolution(openingElement, "form");
+  const formActionResolution = getStaticAttributeResolution(openingElement, "formAction");
+  if (
+    (buttonType === "submit" || buttonType === "reset") &&
+    (formResolution.status === "unknown" || formActionResolution.status === "unknown")
+  ) {
+    return { status: "unknown", value: "" };
+  }
+  const formBehavior =
+    buttonType === "submit" || buttonType === "reset"
+      ? `form:${formResolution.value}:${formActionResolution.value}`
+      : "no-form-action";
+  const onClickAttribute = getAuthoritativeJsxAttribute(
+    openingElement.attributes,
+    "onClick",
+    false,
+  );
+  if (onClickAttribute) {
+    if (
+      !onClickAttribute.value ||
+      !isNodeOfType(onClickAttribute.value, "JSXExpressionContainer")
+    ) {
+      return { status: "unknown", value: "" };
+    }
+    const onClickExpression = stripParenExpression(onClickAttribute.value.expression);
+    if (!isNodeOfType(onClickExpression, "Identifier")) {
+      return { status: "unknown", value: "" };
+    }
+    const onClickSymbol = context.scopes.symbolFor(onClickExpression);
+    return onClickSymbol
+      ? {
+          status: "known",
+          value: `button|${buttonType}|${formBehavior}|click:${onClickSymbol.id}|${name}`,
+        }
+      : { status: "unknown", value: "" };
+  }
+  if (buttonType !== "submit" && buttonType !== "reset") {
+    return { status: "known", value: `button|${buttonType}|no-action|${name}` };
+  }
+  return {
+    status: "known",
+    value: `button|${buttonType}|${formBehavior}|${name}`,
+  };
+};
+
+const getInteractiveIdentity = (
+  element: EsTreeNodeOfType<"JSXElement">,
+  tagName: string,
+  childSummary: SemanticSummary,
+  context: RuleContext,
+): SemanticIdentityResolution => {
+  if (!isInteractiveElement(tagName, element.openingElement)) {
+    return { status: "absent", value: "" };
+  }
+  const nameResolution = getInteractiveName(element, childSummary);
+  if (nameResolution.status !== "known") return nameResolution;
+  if (tagName === "a" || tagName === "area") {
+    const hrefResolution = getStaticAttributeResolution(element.openingElement, "href");
+    if (hrefResolution.status === "unknown") return { status: "unknown", value: "" };
+    return hrefResolution.status === "known" && hrefResolution.value
+      ? { status: "known", value: `${tagName}|${hrefResolution.value}|${nameResolution.value}` }
+      : { status: "absent", value: "" };
+  }
+  if (tagName === "button") {
+    return getButtonActionIdentity(element, nameResolution.value, context);
+  }
+  return { status: "unknown", value: "" };
+};
+
+const summarizeSemanticChildren = (
+  children: ReadonlyArray<EsTreeNode>,
+  targetVariantScope: ReadonlyArray<string>,
+  context: RuleContext,
+): SemanticSummary => {
+  const summary = createSemanticSummary();
+  for (const child of children) {
+    const staticTextResolution = getStaticTextFromJsxChild(child);
+    if (staticTextResolution.status === "known") {
+      if (staticTextResolution.value) summary.staticTextParts.push(staticTextResolution.value);
+      continue;
+    }
+    if (staticTextResolution.status === "unknown") {
+      summary.hasUnknownSemantics = true;
+      continue;
+    }
+    if (isNodeOfType(child, "JSXElement")) {
+      mergeSemanticSummary(
+        summary,
+        summarizeSemanticElement(child, targetVariantScope, context, false),
+      );
+      continue;
+    }
+    if (isNodeOfType(child, "JSXFragment")) {
+      mergeSemanticSummary(
+        summary,
+        summarizeSemanticChildren(child.children, targetVariantScope, context),
+      );
+      continue;
+    }
+    summary.hasUnknownSemantics = true;
+  }
+  return summary;
+};
+
+const summarizeSemanticElement = (
+  element: EsTreeNodeOfType<"JSXElement">,
+  targetVariantScope: ReadonlyArray<string>,
+  context: RuleContext,
+  skipRootTailwindVisibility: boolean,
+): SemanticSummary => {
+  const summary = createSemanticSummary();
+  const openingElement = element.openingElement;
+  const tagName = getProvenIntrinsicTagName(openingElement);
+  if (!tagName) {
+    summary.hasUnknownSemantics = true;
+    return summary;
+  }
+  if (hasJsxSpreadAttribute(openingElement.attributes)) {
+    summary.hasUnknownSemantics = true;
+    return summary;
+  }
+  const rootVisibility = skipRootTailwindVisibility
+    ? getElementNonTailwindVisibility(openingElement, context)
+    : getElementVisibilityInScope(openingElement, targetVariantScope, context);
+  if (rootVisibility !== "visible") {
+    return summary;
+  }
+  if (tagName === "svg" || tagName === "canvas" || tagName === "template") return summary;
+  const childSummary = summarizeSemanticChildren(element.children, targetVariantScope, context);
+  mergeSemanticSummary(summary, childSummary);
+
+  const roleResolution = getStaticAttributeResolution(openingElement, "role");
+  if (roleResolution.status === "unknown") summary.hasUnknownSemantics = true;
+  const role = roleResolution.status === "known" ? roleResolution.value.toLowerCase() : "";
+  const isPresentational = PRESENTATIONAL_ROLES.has(role);
+  if (!isPresentational) {
+    if (tagName === "output" || LIVE_REGION_ROLES.has(role)) {
+      summary.liveRegionIdentities.push(tagName === "output" ? "output" : `role:${role}`);
+    }
+    const ariaLiveResolution = getStaticAttributeResolution(openingElement, "aria-live");
+    if (ariaLiveResolution.status === "unknown") summary.hasUnknownSemantics = true;
+    if (
+      ariaLiveResolution.status === "known" &&
+      (ariaLiveResolution.value.toLowerCase() === "assertive" ||
+        ariaLiveResolution.value.toLowerCase() === "polite")
+    ) {
+      summary.liveRegionIdentities.push(`aria-live:${ariaLiveResolution.value.toLowerCase()}`);
+    }
+    const interactiveIdentity = getInteractiveIdentity(element, tagName, childSummary, context);
+    if (interactiveIdentity.status === "known") {
+      summary.actionIdentities.push(interactiveIdentity.value);
+    } else if (interactiveIdentity.status === "unknown") {
+      summary.hasUnknownSemantics = true;
+    }
+  }
+  return summary;
+};
+
+const summarizeSemanticExpression = (
+  expression: EsTreeNode,
+  targetVariantScope: ReadonlyArray<string>,
+  context: RuleContext,
+): SemanticSummary => {
+  const unwrappedExpression = stripParenExpression(expression);
+  if (isNodeOfType(unwrappedExpression, "JSXElement")) {
+    return summarizeSemanticElement(unwrappedExpression, targetVariantScope, context, false);
+  }
+  if (isNodeOfType(unwrappedExpression, "JSXFragment")) {
+    return summarizeSemanticChildren(unwrappedExpression.children, targetVariantScope, context);
+  }
+  const summary = createSemanticSummary();
+  summary.hasUnknownSemantics = true;
+  return summary;
+};
+
+const hasMeaningfulSemantics = (summary: SemanticSummary): boolean =>
+  summary.actionIdentities.length > 0 ||
+  summary.liveRegionIdentities.length > 0 ||
+  STATIC_TEXT_PATTERN.test(normalizeStaticText(summary.staticTextParts));
+
+const compareSemanticSummaries = (
+  leftSummary: SemanticSummary,
+  rightSummary: SemanticSummary,
+): boolean | null => {
+  if (leftSummary.hasUnknownSemantics || rightSummary.hasUnknownSemantics) return null;
+  const leftActions = leftSummary.actionIdentities.toSorted();
+  const rightActions = rightSummary.actionIdentities.toSorted();
+  const leftLiveRegions = leftSummary.liveRegionIdentities.toSorted();
+  const rightLiveRegions = rightSummary.liveRegionIdentities.toSorted();
+  if (leftActions.some((identity, index) => identity !== rightActions[index])) return false;
+  if (rightActions.length !== leftActions.length) return false;
+  if (leftLiveRegions.some((identity, index) => identity !== rightLiveRegions[index])) return false;
+  if (rightLiveRegions.length !== leftLiveRegions.length) return false;
+  return (
+    normalizeStaticText(leftSummary.staticTextParts) ===
+    normalizeStaticText(rightSummary.staticTextParts)
+  );
+};
+
+const getDirectSiblingFallbackStatus = (
+  renderedChild: EsTreeNode,
+  hiddenSummary: SemanticSummary,
+  targetVariantScope: ReadonlyArray<string>,
+  context: RuleContext,
+): "absent" | "equivalent" | "unknown" => {
+  const parent = renderedChild.parent;
+  if (!parent || (!isNodeOfType(parent, "JSXElement") && !isNodeOfType(parent, "JSXFragment"))) {
+    return "absent";
+  }
+  let hasUnknownSibling = false;
+  for (const sibling of parent.children) {
+    if (sibling === renderedChild) continue;
+    if (isNodeOfType(sibling, "JSXText")) {
+      if (!STATIC_TEXT_PATTERN.test(sibling.value)) continue;
+      const siblingSummary = createSemanticSummary();
+      siblingSummary.staticTextParts.push(sibling.value);
+      const comparison = compareSemanticSummaries(hiddenSummary, siblingSummary);
+      if (comparison === true) return "equivalent";
+      if (comparison === null) hasUnknownSibling = true;
+      continue;
+    }
+    if (isNodeOfType(sibling, "JSXExpressionContainer")) {
+      const textResolution = getStaticTextFromJsxChild(sibling);
+      if (textResolution.status === "unknown") {
+        hasUnknownSibling = true;
+        continue;
+      }
+      if (textResolution.status === "known" && STATIC_TEXT_PATTERN.test(textResolution.value)) {
+        const siblingSummary = createSemanticSummary();
+        siblingSummary.staticTextParts.push(textResolution.value);
+        const comparison = compareSemanticSummaries(hiddenSummary, siblingSummary);
+        if (comparison === true) return "equivalent";
+        if (comparison === null) hasUnknownSibling = true;
+      }
+      continue;
+    }
+    if (isNodeOfType(sibling, "JSXElement")) {
+      const visibility = getElementVisibilityInScope(
+        sibling.openingElement,
+        targetVariantScope,
+        context,
+      );
+      if (visibility === "hidden") continue;
+      if (visibility === "unknown") {
+        hasUnknownSibling = true;
+        continue;
+      }
+      const siblingSummary = summarizeSemanticElement(sibling, targetVariantScope, context, true);
+      const comparison = compareSemanticSummaries(hiddenSummary, siblingSummary);
+      if (comparison === true) return "equivalent";
+      if (comparison === null) hasUnknownSibling = true;
+      continue;
+    }
+    if (isNodeOfType(sibling, "JSXFragment")) {
+      const siblingSummary = summarizeSemanticChildren(
+        sibling.children,
+        targetVariantScope,
+        context,
+      );
+      const comparison = compareSemanticSummaries(hiddenSummary, siblingSummary);
+      if (comparison === true) return "equivalent";
+      if (comparison === null) hasUnknownSibling = true;
+      continue;
+    }
+    if (!isNodeOfType(sibling, "JSXClosingElement")) hasUnknownSibling = true;
+  }
+  return hasUnknownSibling ? "unknown" : "absent";
+};
+
+const isTransparentFallbackWrapper = (
+  element: EsTreeNodeOfType<"JSXElement">,
+  targetVariantScope: ReadonlyArray<string>,
+  context: RuleContext,
+): boolean => {
+  const tagName = getProvenIntrinsicTagName(element.openingElement);
+  if (!tagName || !NEUTRAL_FALLBACK_WRAPPER_TAGS.has(tagName)) return false;
+  if (hasJsxSpreadAttribute(element.openingElement.attributes)) return false;
+  if (
+    getStaticAttributeResolution(element.openingElement, "role").status !== "absent" ||
+    getStaticAttributeResolution(element.openingElement, "aria-live").status !== "absent" ||
+    getStaticAttributeResolution(element.openingElement, "aria-label").status !== "absent" ||
+    getStaticAttributeResolution(element.openingElement, "aria-labelledby").status !== "absent"
+  ) {
+    return false;
+  }
+  return (
+    getElementVisibilityInScope(element.openingElement, targetVariantScope, context) === "visible"
+  );
+};
+
+const getSiblingFallbackStatus = (
+  renderedChild: EsTreeNode,
+  hiddenSummary: SemanticSummary,
+  targetVariantScope: ReadonlyArray<string>,
+  context: RuleContext,
+): "absent" | "equivalent" | "unknown" => {
+  const directStatus = getDirectSiblingFallbackStatus(
+    renderedChild,
+    hiddenSummary,
+    targetVariantScope,
+    context,
+  );
+  if (directStatus !== "absent") return directStatus;
+  const wrapper = renderedChild.parent;
+  if (
+    !wrapper ||
+    !isNodeOfType(wrapper, "JSXElement") ||
+    !isTransparentFallbackWrapper(wrapper, targetVariantScope, context)
+  ) {
+    return "absent";
+  }
+  const wrapperParent = wrapper.parent;
+  if (
+    !wrapperParent ||
+    (!isNodeOfType(wrapperParent, "JSXElement") && !isNodeOfType(wrapperParent, "JSXFragment"))
+  ) {
+    return "absent";
+  }
+  const wrapperPair = wrapperParent.children.filter((child) => isNodeOfType(child, "JSXElement"));
+  if (wrapperPair.length !== 2) return "absent";
+  let hasUnknownSibling = false;
+  const normalVariantScope = getNormalMotionScope(targetVariantScope);
+  for (const sibling of wrapperPair) {
+    if (sibling === wrapper) continue;
+    const reducedVisibility = getElementVisibilityInScope(
+      sibling.openingElement,
+      targetVariantScope,
+      context,
+    );
+    const normalVisibility = getElementVisibilityInScope(
+      sibling.openingElement,
+      normalVariantScope,
+      context,
+    );
+    if (reducedVisibility === "unknown" || normalVisibility === "unknown") {
+      hasUnknownSibling = true;
+      continue;
+    }
+    if (reducedVisibility !== "visible") continue;
+    const normalSummary =
+      normalVisibility === "hidden"
+        ? createSemanticSummary()
+        : summarizeSemanticElement(sibling, normalVariantScope, context, true);
+    if (normalSummary.hasUnknownSemantics) {
+      hasUnknownSibling = true;
+      continue;
+    }
+    if (hasMeaningfulSemantics(normalSummary)) continue;
+    const siblingSummary = summarizeSemanticElement(sibling, targetVariantScope, context, true);
+    const comparison = compareSemanticSummaries(hiddenSummary, siblingSummary);
+    if (comparison === true) return "equivalent";
+    if (comparison === null) hasUnknownSibling = true;
+  }
+  return hasUnknownSibling ? "unknown" : "absent";
+};
+
+const getReducedMotionCondition = (
+  rawExpression: EsTreeNode,
+  context: RuleContext,
+): boolean | null => {
+  const expression = stripParenExpression(rawExpression);
+  if (isNodeOfType(expression, "UnaryExpression") && expression.operator === "!") {
+    const condition = getReducedMotionCondition(expression.argument, context);
+    return condition === null ? null : !condition;
+  }
+  if (isNodeOfType(expression, "CallExpression")) {
+    return getMotionReactApiPath(expression.callee, context.scopes) === "useReducedMotion"
+      ? true
+      : null;
+  }
+  if (!isNodeOfType(expression, "Identifier")) return null;
+  const symbol = context.scopes.symbolFor(expression);
+  if (!symbol || symbol.kind !== "const" || !symbol.initializer) return null;
+  const initializer = stripParenExpression(symbol.initializer);
+  if (
+    !isNodeOfType(initializer, "CallExpression") ||
+    getMotionReactApiPath(initializer.callee, context.scopes) !== "useReducedMotion"
+  ) {
+    return null;
+  }
+  return true;
+};
+
+const isNullExpression = (expression: EsTreeNode): boolean => {
+  const unwrappedExpression = stripParenExpression(expression);
+  return isNodeOfType(unwrappedExpression, "Literal") && unwrappedExpression.value === null;
+};
+
+const getStaticExpressionTruthiness = (expression: EsTreeNode): boolean | null => {
+  const unwrappedExpression = stripParenExpression(expression);
+  if (isNodeOfType(unwrappedExpression, "Literal")) {
+    if (
+      unwrappedExpression.value === null ||
+      typeof unwrappedExpression.value === "boolean" ||
+      typeof unwrappedExpression.value === "number" ||
+      typeof unwrappedExpression.value === "string" ||
+      typeof unwrappedExpression.value === "bigint"
+    ) {
+      return Boolean(unwrappedExpression.value);
+    }
+    return null;
+  }
+  if (isNodeOfType(unwrappedExpression, "TemplateLiteral")) {
+    const value = getStaticTemplateLiteralValue(unwrappedExpression);
+    return value === null ? null : Boolean(value);
+  }
+  if (
+    isNodeOfType(unwrappedExpression, "UnaryExpression") &&
+    unwrappedExpression.operator === "!"
+  ) {
+    const truthiness = getStaticExpressionTruthiness(unwrappedExpression.argument);
+    return truthiness === null ? null : !truthiness;
+  }
+  return null;
+};
+
+const canLogicalRightExpressionRun = (
+  expression: EsTreeNodeOfType<"LogicalExpression">,
+): boolean => {
+  const leftTruthiness = getStaticExpressionTruthiness(expression.left);
+  if (expression.operator === "&&") return leftTruthiness !== false;
+  if (expression.operator === "||") return leftTruthiness !== true;
+  const left = stripParenExpression(expression.left);
+  return !isNodeOfType(left, "Literal") || left.value === null || left.value === undefined;
+};
+
+const directlyReachesRenderedOutput = (node: EsTreeNode): boolean => {
+  let current = findTransparentExpressionRoot(node);
+  while (current.parent) {
+    const parent = current.parent;
+    if (isNodeOfType(parent, "ReturnStatement") && parent.argument === current) {
+      const enclosingFunction = findEnclosingFunction(parent);
+      return Boolean(enclosingFunction && isComponentFunction(enclosingFunction));
+    }
+    if (isNodeOfType(parent, "ArrowFunctionExpression") && parent.body === current) {
+      return isComponentFunction(parent);
+    }
+    if (isNodeOfType(parent, "ConditionalExpression")) {
+      if (parent.consequent !== current && parent.alternate !== current) return false;
+      const testTruthiness = getStaticExpressionTruthiness(parent.test);
+      if (
+        testTruthiness !== null &&
+        current !== (testTruthiness ? parent.consequent : parent.alternate)
+      ) {
+        return false;
+      }
+      current = findTransparentExpressionRoot(parent);
+      continue;
+    }
+    if (isNodeOfType(parent, "LogicalExpression") && parent.right === current) {
+      if (!canLogicalRightExpressionRun(parent)) return false;
+      current = findTransparentExpressionRoot(parent);
+      continue;
+    }
+    if (
+      (isNodeOfType(parent, "JSXExpressionContainer") && parent.expression === current) ||
+      ((isNodeOfType(parent, "JSXElement") || isNodeOfType(parent, "JSXFragment")) &&
+        (isNodeOfType(current, "JSXElement") ||
+          isNodeOfType(current, "JSXFragment") ||
+          isNodeOfType(current, "JSXExpressionContainer")))
+    ) {
+      current = findTransparentExpressionRoot(parent);
+      continue;
+    }
+    return false;
+  }
+  return false;
+};
+
+const getRenderedSiblingAnchor = (node: EsTreeNode): EsTreeNode | null => {
+  let current = findTransparentExpressionRoot(node);
+  while (current.parent) {
+    const parent = current.parent;
+    if (isNodeOfType(parent, "JSXExpressionContainer") && parent.expression === current) {
+      return parent;
+    }
+    if (
+      (isNodeOfType(parent, "ConditionalExpression") &&
+        (parent.consequent === current || parent.alternate === current)) ||
+      (isNodeOfType(parent, "LogicalExpression") && parent.right === current)
+    ) {
+      current = findTransparentExpressionRoot(parent);
+      continue;
+    }
+    return null;
+  }
+  return null;
+};
+
+const areRenderedJsxAncestorsVisible = (
+  node: EsTreeNode,
+  targetVariantScope: ReadonlyArray<string>,
+  context: RuleContext,
+): boolean => {
+  let ancestor: EsTreeNode | null | undefined = node.parent;
+  while (ancestor) {
+    if (
+      isNodeOfType(ancestor, "ReturnStatement") ||
+      isNodeOfType(ancestor, "ArrowFunctionExpression")
+    ) {
+      return true;
+    }
+    if (
+      isNodeOfType(ancestor, "JSXElement") &&
+      getElementVisibilityInScope(ancestor.openingElement, targetVariantScope, context) !==
+        "visible"
+    ) {
+      return false;
+    }
+    ancestor = ancestor.parent;
+  }
+  return true;
+};
+
+export const noReducedMotionContentRemoval = defineRule({
+  id: "no-reduced-motion-content-removal",
+  title: "Reduced motion removes meaningful content",
+  severity: "warn",
+  category: "Accessibility",
+  defaultEnabled: false,
+  tags: ["react-jsx-only"],
+  recommendation:
+    "Keep the same content and actions available under reduced motion, replacing spatial movement with a static or non-spatial presentation.",
+  create: (context: RuleContext) => ({
+    JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
+      if (!hasCapabilityOrUnspecified(context.settings, "tailwind")) return;
+      if (!getProvenIntrinsicTagName(node)) return;
+      if (hasJsxSpreadAttribute(node.attributes)) return;
+      const className = getStringFromClassNameAttr(node);
+      if (className === null) return;
+      const element = node.parent;
+      if (!element || !isNodeOfType(element, "JSXElement")) return;
+      if (!directlyReachesRenderedOutput(element)) return;
+      const parsedTokens = splitTailwindClassName(className).map(parseTailwindClassNameToken);
+      for (const reducedMotionScope of getEffectiveReducedMotionScopes(className)) {
+        if (!isRootAndAncestorsVisibleBeforeRemoval(element, reducedMotionScope, context)) continue;
+        const displayVisibility = getEffectiveTailwindVisibility(
+          parsedTokens,
+          reducedMotionScope,
+          "display",
+        );
+        const visibilityVisibility = getEffectiveTailwindVisibility(
+          parsedTokens,
+          reducedMotionScope,
+          "visibility",
+        );
+        if (
+          displayVisibility !== false &&
+          visibilityVisibility === false &&
+          getDescendantVisibilityEscape(element.children, reducedMotionScope, context) !== "absent"
+        ) {
+          continue;
+        }
+        const summary = summarizeSemanticElement(
+          element,
+          getNormalMotionScope(reducedMotionScope),
+          context,
+          true,
+        );
+        if (!hasMeaningfulSemantics(summary)) continue;
+        if (getSiblingFallbackStatus(element, summary, reducedMotionScope, context) !== "absent") {
+          continue;
+        }
+        context.report({
+          node,
+          message:
+            "This reduced-motion utility hides meaningful content or an action. Keep equivalent content available and remove only the spatial motion.",
+        });
+        return;
+      }
+    },
+    ConditionalExpression(node: EsTreeNodeOfType<"ConditionalExpression">) {
+      if (!directlyReachesRenderedOutput(node)) return;
+      if (
+        !areRenderedJsxAncestorsVisible(node, ["motion-safe"], context) ||
+        !areRenderedJsxAncestorsVisible(node, ["motion-reduce"], context)
+      ) {
+        return;
+      }
+      const condition = getReducedMotionCondition(node.test, context);
+      if (condition === null) return;
+      const reducedBranch = condition ? node.consequent : node.alternate;
+      const motionBranch = condition ? node.alternate : node.consequent;
+      if (!isNullExpression(reducedBranch)) return;
+      const summary = summarizeSemanticExpression(motionBranch, ["motion-safe"], context);
+      if (!hasMeaningfulSemantics(summary)) return;
+      const siblingAnchor = getRenderedSiblingAnchor(node);
+      if (
+        siblingAnchor &&
+        getSiblingFallbackStatus(siblingAnchor, summary, ["motion-reduce"], context) !== "absent"
+      ) {
+        return;
+      }
+      context.report({
+        node,
+        message:
+          "This useReducedMotion branch removes meaningful content or an action. Render an equivalent static presentation instead of null.",
+      });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/no-reduced-motion-content-removal.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/no-reduced-motion-content-removal.ts
@@ -263,7 +263,21 @@ const getEffectiveTailwindVisibility = (
 ): boolean | null =>
   getEffectiveTailwindVisibilityOverride(parsedTokens, targetVariantScope, propertyName) ?? true;
 
-const hasSatisfiableReducedMotionScope = (variants: ReadonlyArray<string>): boolean => {
+const isSupportedSatisfiableReducedMotionScope = (variants: ReadonlyArray<string>): boolean => {
+  if (
+    variants.some((variant) => {
+      if (isTailwindReducedMotionVariant(variant) || isTailwindMotionSafeVariant(variant)) {
+        return false;
+      }
+      if (TAILWIND_BREAKPOINT_NAMES.indexOf(variant) > 0) return false;
+      return (
+        !variant.startsWith("max-") ||
+        TAILWIND_BREAKPOINT_NAMES.indexOf(variant.slice("max-".length)) <= 0
+      );
+    })
+  ) {
+    return false;
+  }
   if (variants.some(isTailwindReducedMotionVariant) && variants.some(isTailwindMotionSafeVariant)) {
     return false;
   }
@@ -301,7 +315,7 @@ const getEffectiveReducedMotionScopes = (className: string): string[][] => {
     if (
       (token.utility !== "hidden" && token.utility !== "invisible") ||
       !token.variants.some(isTailwindReducedMotionVariant) ||
-      !hasSatisfiableReducedMotionScope(token.variants)
+      !isSupportedSatisfiableReducedMotionScope(token.variants)
     ) {
       continue;
     }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/no-reduced-motion-content-removal.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/no-reduced-motion-content-removal.ts
@@ -260,8 +260,14 @@ const getEffectiveTailwindVisibility = (
   parsedTokens: ReadonlyArray<TailwindClassNameToken>,
   targetVariantScope: ReadonlyArray<string>,
   propertyName: TailwindVisibilityEffect["propertyName"],
-): boolean | null =>
-  getEffectiveTailwindVisibilityOverride(parsedTokens, targetVariantScope, propertyName) ?? true;
+): boolean | null => {
+  const visibility = getEffectiveTailwindVisibilityOverride(
+    parsedTokens,
+    targetVariantScope,
+    propertyName,
+  );
+  return visibility === undefined ? true : visibility;
+};
 
 const isSupportedSatisfiableReducedMotionScope = (variants: ReadonlyArray<string>): boolean => {
   if (

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/no-reduced-motion-content-removal.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/no-reduced-motion-content-removal.ts
@@ -273,7 +273,7 @@ const isSupportedSatisfiableReducedMotionScope = (variants: ReadonlyArray<string
   if (
     variants.some((variant) => {
       if (isTailwindReducedMotionVariant(variant) || isTailwindMotionSafeVariant(variant)) {
-        return false;
+        return variant !== "motion-reduce" && variant !== "motion-safe";
       }
       if (TAILWIND_BREAKPOINT_NAMES.indexOf(variant) > 0) return false;
       return (
@@ -673,9 +673,8 @@ const summarizeSemanticElement = (
   const rootVisibility = skipRootTailwindVisibility
     ? getElementNonTailwindVisibility(openingElement, context)
     : getElementVisibilityInScope(openingElement, targetVariantScope, context);
-  if (rootVisibility !== "visible") {
-    return summary;
-  }
+  if (rootVisibility === "unknown") summary.hasUnknownSemantics = true;
+  if (rootVisibility !== "visible") return summary;
   if (tagName === "svg" || tagName === "canvas" || tagName === "template") return summary;
   const childSummary = summarizeSemanticChildren(element.children, targetVariantScope, context);
   mergeSemanticSummary(summary, childSummary);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/no-responsive-hidden-accessible-name.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/no-responsive-hidden-accessible-name.test.ts
@@ -59,6 +59,22 @@ describe("no-responsive-hidden-accessible-name", () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("preserves intrinsic ancestor visibility through rendered arrays", () => {
+    const result = runRule(
+      noResponsiveHiddenAccessibleName,
+      `const Action = () => <section className="md:hidden">{[<button key="save"><span className="md:hidden">Save</span></button>]}</section>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("abstains when a callback boundary prevents proving rendered ancestry", () => {
+    const result = runRule(
+      noResponsiveHiddenAccessibleName,
+      `const Actions = ({ items }) => <section className="md:hidden">{items.map(() => <button><span className="md:hidden">Save</span></button>)}</section>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("reports static expression and numeric text contributors", () => {
     const result = runRule(
       noResponsiveHiddenAccessibleName,
@@ -150,7 +166,7 @@ describe("no-responsive-hidden-accessible-name", () => {
   it("skips unsupported Tailwind visibility variant scopes", () => {
     const result = runRule(
       noResponsiveHiddenAccessibleName,
-      `const Actions = () => <><button><span className="md:hidden data-[state=open]:block">Data</span></button><button><span className="md:hidden aria-[expanded=true]:inline">ARIA</span></button><button><span className="md:hidden group-hover:flex">Group</span></button><button><span className="md:invisible tablet:visible">Custom breakpoint</span></button></>;`,
+      `const Actions = () => <><button><span className="md:hidden data-[state=open]:block">Data</span></button><button><span aria-expanded="true" className="md:hidden aria-expanded:block">ARIA</span></button><button><span className="md:hidden group-hover:flex">Group</span></button><button><span className="md:invisible tablet:visible">Custom breakpoint</span></button></>;`,
     );
     expect(result.diagnostics).toHaveLength(0);
   });
@@ -230,7 +246,15 @@ describe("no-responsive-hidden-accessible-name", () => {
   it("skips wrapped controls across custom prop, render, and child boundaries", () => {
     const result = runRule(
       noResponsiveHiddenAccessibleName,
-      `const Actions = () => <><Composer action={(<button><span className="md:hidden">Prop</span></button>)} /><Composer render={() => (<button><span className="md:hidden">Render</span></button>)} /><Wrapper>{(<button><span className="md:hidden">Child</span></button>)}</Wrapper></>;`,
+      `const Actions = ({ condition }) => <><Composer actions={[<button><span className="md:hidden">Array prop</span></button>]} /><Composer action={condition ? <button><span className="md:hidden">Conditional prop</span></button> : null} /><Composer render={() => <button><span className="md:hidden">Render</span></button>} /><Wrapper>{condition && <button><span className="md:hidden">Logical child</span></button>}</Wrapper></>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("skips non-JSX component props and expressions that do not prove rendering", () => {
+    const result = runRule(
+      noResponsiveHiddenAccessibleName,
+      `const unused = <button><span className="md:hidden">Unused</span></button>; const Actions = () => <><div>{() => <button><span className="md:hidden">Function child</span></button>}</div>{(<button><span className="md:hidden">Discarded</span></button>, null)}</>; const Created = () => createElement(Composer, { action: <button><span className="md:hidden">Prop</span></button> });`,
     );
     expect(result.diagnostics).toHaveLength(0);
   });
@@ -255,6 +279,14 @@ describe("no-responsive-hidden-accessible-name", () => {
     const result = runRule(
       noResponsiveHiddenAccessibleName,
       `const Actions = () => <><button className="before:content-['Save']"><span className="md:hidden">Save</span></button><button><span className="after:content-['menu'] md:hidden">Open</span></button></>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("skips mixed-case arbitrary generated-content alternatives", () => {
+    const result = runRule(
+      noResponsiveHiddenAccessibleName,
+      `const Action = () => <button className="before:[CoNtEnT:'Save']"><span className="md:hidden">Save</span></button>;`,
     );
     expect(result.diagnostics).toHaveLength(0);
   });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/no-responsive-hidden-accessible-name.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/no-responsive-hidden-accessible-name.test.ts
@@ -1,0 +1,270 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noResponsiveHiddenAccessibleName } from "./no-responsive-hidden-accessible-name.js";
+
+describe("no-responsive-hidden-accessible-name", () => {
+  it("reports buttons whose only text is hidden at a standard breakpoint", () => {
+    const result = runRule(
+      noResponsiveHiddenAccessibleName,
+      `const Actions = () => <><button><span className="hidden md:inline">Settings</span></button><button><span className="md:hidden">Menu</span></button><button><span className="max-md:hidden">Account</span></button></>;`,
+    );
+    expect(result.diagnostics).toHaveLength(3);
+  });
+
+  it("reports nested and multiple contributors only when they all disappear together", () => {
+    const result = runRule(
+      noResponsiveHiddenAccessibleName,
+      `const Actions = () => <><button><span className="md:hidden"><strong>Save</strong></span><span className="md:hidden">changes</span></button><button><span className="md:hidden">Open</span><span>menu</span></button></>;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports statically named anchors and constant intrinsic aliases", () => {
+    const result = runRule(
+      noResponsiveHiddenAccessibleName,
+      `const Button = "button"; const href = "/settings"; const labelClass = "hidden md:inline"; const Actions = () => <><a href={href}><span className={labelClass}>Settings</span></a><Button><span className="lg:hidden">Close</span></Button></>;`,
+    );
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
+  it("does not infer an intrinsic tag from an unresolved alias name", () => {
+    const result = runRule(
+      noResponsiveHiddenAccessibleName,
+      `const Button = compact ? "button" : "div"; const Action = () => <Button><span className="md:hidden">Settings</span></Button>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("lets a descendant visibility utility override inherited invisibility", () => {
+    const result = runRule(
+      noResponsiveHiddenAccessibleName,
+      `const Action = () => <button><span className="md:invisible"><strong className="md:visible">Settings</strong></span></button>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("recognizes controls that override an invisible ancestor", () => {
+    const result = runRule(
+      noResponsiveHiddenAccessibleName,
+      `const Action = () => <section className="md:invisible"><button className="md:visible"><span className="md:hidden">Settings</span></button></section>;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("preserves intrinsic ancestor visibility through logical and conditional wrappers", () => {
+    const result = runRule(
+      noResponsiveHiddenAccessibleName,
+      `const Actions = ({ show, compact }) => <><section className="md:hidden">{show && <button><span className="md:hidden">Logical</span></button>}</section><section className="md:hidden">{compact ? <button><span className="md:hidden">Conditional</span></button> : null}</section></>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("reports static expression and numeric text contributors", () => {
+    const result = runRule(
+      noResponsiveHiddenAccessibleName,
+      `const Actions = () => <><button><span className="md:hidden">{"Save"}</span></button><button><span className="md:hidden">{42}</span></button></>;`,
+    );
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
+  it("reports immutable static strings and transparent JSX expressions", () => {
+    const result = runRule(
+      noResponsiveHiddenAccessibleName,
+      `const label = "Save"; const alias = label; const Actions = () => <><button><span className="md:hidden">{alias}</span></button><button>{(<span className="md:hidden">Open</span>)}</button><button>{(<><span className="md:hidden">Close</span></>)}</button></>;`,
+    );
+    expect(result.diagnostics).toHaveLength(3);
+  });
+
+  it("accepts persistent visible and sr-only name content", () => {
+    const result = runRule(
+      noResponsiveHiddenAccessibleName,
+      `const Actions = () => <><button><span className="md:hidden">Open</span><span className="sr-only">menu</span></button><button><span className="hidden md:inline">Settings</span><span>account</span></button><a href="#profile"><span className="sr-only md:not-sr-only">Profile</span></a></>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("accepts authoritative ARIA and native naming sources", () => {
+    const result = runRule(
+      noResponsiveHiddenAccessibleName,
+      `const Actions = () => <><button aria-label="Settings"><span className="md:hidden">Settings</span></button><button aria-labelledby="save-label"><span className="md:hidden">Save</span></button><button title="Open menu"><span className="md:hidden">Open</span></button><button id="delete-action"><span className="md:hidden">Delete</span></button></>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("skips dynamic or ambiguous control naming evidence", () => {
+    const result = runRule(
+      noResponsiveHiddenAccessibleName,
+      `const Actions = ({ ariaLabel, labelledBy, title, id }) => <><button aria-label={ariaLabel}><span className="md:hidden">A</span></button><button aria-labelledby={labelledBy}><span className="md:hidden">B</span></button><button title={title}><span className="md:hidden">C</span></button><button id={id}><span className="md:hidden">D</span></button></>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("skips native, custom, interactive, and opaque descendants", () => {
+    const result = runRule(
+      noResponsiveHiddenAccessibleName,
+      `const Actions = () => <><button><img alt="Settings" /><span className="md:hidden">Settings</span></button><button><Icon /><span className="md:hidden">Save</span></button><button><svg><title>Close</title></svg><span className="md:hidden">Close</span></button><button><a href="/help">Help</a><span className="md:hidden">Menu</span></button><button><span aria-label="Account" /><span className="md:hidden">Account</span></button></>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not treat template contents as rendered name contributors", () => {
+    const result = runRule(
+      noResponsiveHiddenAccessibleName,
+      `const Action = () => <button><template><span>Persistent template text</span></template><span className="md:hidden">Save</span></button>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("ignores statically excluded opaque subtrees before evaluating their contents", () => {
+    const result = runRule(
+      noResponsiveHiddenAccessibleName,
+      `const Actions = ({ dynamicClass }) => <><button><svg aria-hidden="true" className={dynamicClass}><title>Decoration</title></svg><span className="md:hidden">Save</span></button><button><img hidden alt="Decoration" className="[display:block]" /><span className="md:hidden">Open</span></button></>;`,
+    );
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
+  it("skips dynamic child expressions and child prop composition", () => {
+    const result = runRule(
+      noResponsiveHiddenAccessibleName,
+      `const Actions = ({ label, children, markup }) => <><button><span className="md:hidden">{label}</span></button><button children={children}><span className="md:hidden">Save</span></button><button dangerouslySetInnerHTML={markup}><span className="md:hidden">Open</span></button></>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("skips spreads at every relevant evidence boundary", () => {
+    const result = runRule(
+      noResponsiveHiddenAccessibleName,
+      `const Actions = ({ controlProps, labelProps, wrapperProps }) => <><button {...controlProps}><span className="md:hidden">Save</span></button><button><span {...labelProps} className="md:hidden">Open</span></button><section {...wrapperProps}><button><span className="md:hidden">Close</span></button></section></>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("skips dynamic classes, conflicting utilities, and inline styles", () => {
+    const result = runRule(
+      noResponsiveHiddenAccessibleName,
+      `const Actions = ({ className, wrapperClassName }) => <><button><span className={className}>Save</span></button><button><span className="hidden block md:hidden">Open</span></button><button><span className="md:hidden" style={{ display: "inline" }}>Close</span></button><section className={wrapperClassName}><button><span className="md:hidden">Delete</span></button></section></>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("skips unsupported Tailwind visibility variant scopes", () => {
+    const result = runRule(
+      noResponsiveHiddenAccessibleName,
+      `const Actions = () => <><button><span className="md:hidden data-[state=open]:block">Data</span></button><button><span className="md:hidden aria-[expanded=true]:inline">ARIA</span></button><button><span className="md:hidden group-hover:flex">Group</span></button><button><span className="md:invisible tablet:visible">Custom breakpoint</span></button></>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("skips unsupported Tailwind visibility scopes on controls and ancestors", () => {
+    const result = runRule(
+      noResponsiveHiddenAccessibleName,
+      `const Actions = () => <><button className="data-[ready=true]:hidden"><span className="md:hidden">Control</span></button><section className="group-hover:hidden"><button><span className="md:hidden">Ancestor</span></button></section></>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("treats arbitrary display and visibility declarations as unknown", () => {
+    const result = runRule(
+      noResponsiveHiddenAccessibleName,
+      `const Actions = () => <><button><span className="md:hidden [display:block]">Save</span></button><button><span className="md:invisible [visibility:visible]">Open</span></button><button><span className="md:hidden [dIsPlAy:block]">Close</span></button></>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("skips controls hidden with their names or by an ancestor", () => {
+    const result = runRule(
+      noResponsiveHiddenAccessibleName,
+      `const Actions = () => <><button className="md:hidden"><span className="md:hidden">Menu</span></button><section className="md:hidden"><button><span className="md:hidden">Save</span></button></section><button hidden><span className="md:hidden">Close</span></button><button aria-hidden="true"><span className="md:hidden">Delete</span></button></>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("skips controls without proven interactive semantics", () => {
+    const result = runRule(
+      noResponsiveHiddenAccessibleName,
+      `const Actions = ({ href, disabled }) => <><a href={href}><span className="md:hidden">Dynamic</span></a><a href=""><span className="md:hidden">Empty</span></a><button disabled><span className="md:hidden">Disabled</span></button><button disabled={disabled}><span className="md:hidden">Maybe</span></button><button role="presentation"><span className="md:hidden">Role</span></button><div role="button"><span className="md:hidden">Custom</span></div></>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("uses presence semantics for HTML boolean attribute strings", () => {
+    const result = runRule(
+      noResponsiveHiddenAccessibleName,
+      `const Actions = () => <><button disabled={"false"}><span className="md:hidden">Disabled</span></button><button hidden={"false"}><span className="md:hidden">Hidden</span></button><button inert={"false"}><span className="md:hidden">Inert</span></button><section hidden={"false"}><button><span className="md:hidden">Hidden ancestor</span></button></section><a href="/settings" disabled={"false"}><span className="md:hidden">Anchor</span></a></>;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("inherits disabled state from fieldset ancestors for buttons", () => {
+    const result = runRule(
+      noResponsiveHiddenAccessibleName,
+      `const Actions = ({ isDisabled }) => <><fieldset disabled><button><span className="md:hidden">Static</span></button></fieldset><fieldset disabled={"false"}><button><span className="md:hidden">String</span></button></fieldset><fieldset disabled={isDisabled}><button><span className="md:hidden">Dynamic</span></button></fieldset><fieldset disabled={false}><button><span className="md:hidden">Enabled</span></button></fieldset><fieldset disabled><a href="/settings"><span className="md:hidden">Anchor</span></a></fieldset></>;`,
+    );
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
+  it("suppresses statically inert and dynamically inert controls", () => {
+    const result = runRule(
+      noResponsiveHiddenAccessibleName,
+      `const Actions = ({ isInert }) => <><button inert><span className="md:hidden">Save</span></button><section inert><button><span className="md:hidden">Open</span></button></section><button inert={isInert}><span className="md:hidden">Close</span></button><section inert={isInert}><button><span className="md:hidden">Delete</span></button></section></>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not treat disabled as an anchor state", () => {
+    const result = runRule(
+      noResponsiveHiddenAccessibleName,
+      `const Action = () => <a href="/settings" disabled><span className="md:hidden">Settings</span></a>;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("skips controls inside labels, custom component boundaries, and JSX prop values", () => {
+    const result = runRule(
+      noResponsiveHiddenAccessibleName,
+      `const Actions = () => <><label>External name<button><span className="md:hidden">Save</span></button></label><Wrapper><button><span className="md:hidden">Open</span></button></Wrapper><Composer action={<button><span className="md:hidden">Close</span></button>} /></>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("skips wrapped controls across custom prop, render, and child boundaries", () => {
+    const result = runRule(
+      noResponsiveHiddenAccessibleName,
+      `const Actions = () => <><Composer action={(<button><span className="md:hidden">Prop</span></button>)} /><Composer render={() => (<button><span className="md:hidden">Render</span></button>)} /><Wrapper>{(<button><span className="md:hidden">Child</span></button>)}</Wrapper></>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("keeps wrapped controls under proven intrinsic JSX ancestors", () => {
+    const result = runRule(
+      noResponsiveHiddenAccessibleName,
+      `const Action = () => <section>{(<button><span className="md:hidden">Save</span></button>)}</section>;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("skips controls that never have an accessible-name contributor", () => {
+    const result = runRule(
+      noResponsiveHiddenAccessibleName,
+      `const Actions = () => <><button /><button><span className="hidden">Always hidden</span></button><button><span aria-hidden="true">Always hidden</span></button></>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("skips Tailwind generated-content alternatives", () => {
+    const result = runRule(
+      noResponsiveHiddenAccessibleName,
+      `const Actions = () => <><button className="before:content-['Save']"><span className="md:hidden">Save</span></button><button><span className="after:content-['menu'] md:hidden">Open</span></button></>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not run when Tailwind is explicitly unavailable", () => {
+    const result = runRule(
+      noResponsiveHiddenAccessibleName,
+      `const Action = () => <button><span className="md:hidden">Save</span></button>;`,
+      { settings: { "react-doctor": { capabilities: [] } } },
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/no-responsive-hidden-accessible-name.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/no-responsive-hidden-accessible-name.ts
@@ -1,0 +1,617 @@
+import { TAILWIND_BREAKPOINT_NAMES } from "../../constants/tailwind.js";
+import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { getAuthoritativeJsxAttribute } from "../../utils/get-authoritative-jsx-attribute.js";
+import { getJsxPropExhaustiveStaticStringValues } from "../../utils/get-jsx-prop-static-string-values.js";
+import { getTailwindVisibilityAtBreakpoints } from "../../utils/get-tailwind-visibility-at-breakpoints.js";
+import { hasJsxSpreadAttribute } from "../../utils/has-jsx-spread-attribute.js";
+import { hasCapabilityOrUnspecified } from "../../utils/get-react-doctor-setting.js";
+import { isInteractiveElement } from "../../utils/is-interactive-element.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { isNullishExpression } from "../../utils/is-nullish-expression.js";
+import { isProvenIntrinsicJsxElement } from "../../utils/is-proven-intrinsic-jsx-element.js";
+import { parseTailwindClassNameToken } from "../../utils/parse-tailwind-class-name-token.js";
+import { resolveJsxElementType } from "../../utils/resolve-jsx-element-type.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+import { splitTailwindClassName } from "../../utils/split-tailwind-class-name.js";
+import {
+  stripParenExpression,
+  TRANSPARENT_EXPRESSION_WRAPPER_TYPES,
+} from "../../utils/strip-paren-expression.js";
+
+interface ElementVisibilityEvidence {
+  displayAtBreakpoints: ReadonlyArray<boolean>;
+  hasGeneratedContent: boolean;
+  isInert: boolean;
+  visibilityOverridesAtBreakpoints: ReadonlyArray<boolean | null>;
+}
+
+interface ResponsiveVisibilityState {
+  displayAtBreakpoints: ReadonlyArray<boolean>;
+  visibilityAtBreakpoints: ReadonlyArray<boolean>;
+}
+
+interface ControlVisibilityEvidence extends ResponsiveVisibilityState {
+  hasGeneratedContent: boolean;
+}
+
+interface TailwindClassVisibilityEvidence {
+  displayAtBreakpoints: ReadonlyArray<boolean>;
+  hasGeneratedContent: boolean;
+  visibilityOverridesAtBreakpoints: ReadonlyArray<boolean | null>;
+}
+
+interface AccessibleNameEvidence {
+  availabilityAtBreakpoints: boolean[];
+  didFindContributor: boolean;
+  isUnknown: boolean;
+}
+
+const CONTENT_NAMED_INTERACTIVE_TAGS = new Set(["a", "button"]);
+const TAILWIND_DISPLAY_UTILITIES = new Set([
+  "block",
+  "contents",
+  "flex",
+  "flow-root",
+  "grid",
+  "hidden",
+  "inline",
+  "inline-block",
+  "inline-flex",
+  "inline-grid",
+  "inline-table",
+  "list-item",
+  "table",
+  "table-caption",
+  "table-cell",
+  "table-column",
+  "table-column-group",
+  "table-footer-group",
+  "table-header-group",
+  "table-row",
+  "table-row-group",
+]);
+const TAILWIND_VISIBILITY_UTILITIES = new Set(["collapse", "invisible", "visible"]);
+const NON_CONTENT_NAME_ATTRIBUTES = ["aria-label", "aria-labelledby", "title"];
+const DESCENDANT_NATIVE_NAME_ATTRIBUTES = [
+  ...NON_CONTENT_NAME_ATTRIBUTES,
+  "alt",
+  "placeholder",
+  "value",
+];
+const OPAQUE_ACCESSIBLE_NAME_TAGS = new Set([
+  "area",
+  "audio",
+  "canvas",
+  "embed",
+  "iframe",
+  "img",
+  "input",
+  "math",
+  "object",
+  "script",
+  "select",
+  "slot",
+  "style",
+  "svg",
+  "template",
+  "textarea",
+  "video",
+]);
+
+const resolveNonEmptyTextAttribute = (
+  openingElement: EsTreeNodeOfType<"JSXOpeningElement">,
+  attributeName: string,
+  scopes: ScopeAnalysis,
+): boolean | null => {
+  const attribute = getAuthoritativeJsxAttribute(openingElement.attributes, attributeName, false);
+  if (!attribute) return false;
+  const values = getJsxPropExhaustiveStaticStringValues(attribute, scopes);
+  if (!values) return null;
+  return values.some((value) => value.trim().length > 0);
+};
+
+const resolveBooleanAttribute = (
+  openingElement: EsTreeNodeOfType<"JSXOpeningElement">,
+  attributeName: string,
+  isHtmlBooleanAttribute: boolean,
+): boolean | null => {
+  const attribute = getAuthoritativeJsxAttribute(openingElement.attributes, attributeName, false);
+  if (!attribute) return false;
+  if (!attribute.value) return true;
+  if (isNodeOfType(attribute.value, "Literal")) {
+    if (isHtmlBooleanAttribute && typeof attribute.value.value === "string") return true;
+    if (attribute.value.value === true || attribute.value.value === "true") return true;
+    if (attribute.value.value === false || attribute.value.value === "false") return false;
+    if (attribute.value.value === null) return false;
+    return null;
+  }
+  if (!isNodeOfType(attribute.value, "JSXExpressionContainer")) return null;
+  const expression = attribute.value.expression;
+  if (isNullishExpression(expression)) return false;
+  if (!isNodeOfType(expression, "Literal")) return null;
+  if (isHtmlBooleanAttribute && typeof expression.value === "string") return true;
+  if (expression.value === true || expression.value === "true") return true;
+  if (expression.value === false || expression.value === "false") return false;
+  return null;
+};
+
+const areVisibilityStatesEqual = (
+  firstState: ReadonlyArray<boolean>,
+  secondState: ReadonlyArray<boolean>,
+): boolean =>
+  firstState.length === secondState.length &&
+  firstState.every((isVisible, breakpointIndex) => isVisible === secondState[breakpointIndex]);
+
+const hasTailwindGeneratedContent = (className: string): boolean =>
+  splitTailwindClassName(className)
+    .map(parseTailwindClassNameToken)
+    .some(({ utility }) => utility.startsWith("content-") || utility.startsWith("[content:"));
+
+const getResponsiveVariantApplicability = (
+  variants: ReadonlyArray<string>,
+): ReadonlyArray<boolean> | null => {
+  let minimumBreakpointIndex = 0;
+  let maximumBreakpointIndex = TAILWIND_BREAKPOINT_NAMES.length;
+  for (const variant of variants) {
+    const minimumVariantIndex = TAILWIND_BREAKPOINT_NAMES.indexOf(variant);
+    if (minimumVariantIndex > 0) {
+      minimumBreakpointIndex = Math.max(minimumBreakpointIndex, minimumVariantIndex);
+      continue;
+    }
+    if (variant.startsWith("max-")) {
+      const maximumVariantIndex = TAILWIND_BREAKPOINT_NAMES.indexOf(variant.slice("max-".length));
+      if (maximumVariantIndex > 0) {
+        maximumBreakpointIndex = Math.min(maximumBreakpointIndex, maximumVariantIndex);
+        continue;
+      }
+    }
+    return null;
+  }
+  return TAILWIND_BREAKPOINT_NAMES.map(
+    (_, breakpointIndex) =>
+      breakpointIndex >= minimumBreakpointIndex && breakpointIndex < maximumBreakpointIndex,
+  );
+};
+
+const resolveTailwindClassVisibility = (
+  className: string,
+): TailwindClassVisibilityEvidence | null => {
+  const rawTokens = splitTailwindClassName(className);
+  const parsedTokens = rawTokens.map((rawToken) => ({
+    parsedToken: parseTailwindClassNameToken(rawToken),
+    rawToken,
+  }));
+  if (
+    parsedTokens.some(({ parsedToken }) => {
+      const normalizedUtility = parsedToken.utility.toLowerCase();
+      return (
+        normalizedUtility.startsWith("[display:") || normalizedUtility.startsWith("[visibility:")
+      );
+    })
+  ) {
+    return null;
+  }
+  for (const { parsedToken } of parsedTokens) {
+    if (
+      !TAILWIND_DISPLAY_UTILITIES.has(parsedToken.utility) &&
+      !TAILWIND_VISIBILITY_UTILITIES.has(parsedToken.utility)
+    ) {
+      continue;
+    }
+    if (!getResponsiveVariantApplicability(parsedToken.variants)) return null;
+  }
+  if (!getTailwindVisibilityAtBreakpoints(className)) return null;
+  const displayRawTokens: string[] = [];
+  const visibilityTokens: typeof parsedTokens = [];
+  for (const parsedToken of parsedTokens) {
+    if (TAILWIND_VISIBILITY_UTILITIES.has(parsedToken.parsedToken.utility)) {
+      visibilityTokens.push(parsedToken);
+    } else {
+      displayRawTokens.push(parsedToken.rawToken);
+    }
+  }
+  const displayClassName = displayRawTokens.join(" ");
+  const visibilityClassName = visibilityTokens.map(({ rawToken }) => rawToken).join(" ");
+  const displayAtBreakpoints = getTailwindVisibilityAtBreakpoints(displayClassName);
+  const visibilityAtBreakpoints = getTailwindVisibilityAtBreakpoints(visibilityClassName);
+  if (!displayAtBreakpoints || !visibilityAtBreakpoints) return null;
+  const hasVisibilityOverrideAtBreakpoints = TAILWIND_BREAKPOINT_NAMES.map(() => false);
+  for (const { parsedToken } of visibilityTokens) {
+    const applicability = getResponsiveVariantApplicability(parsedToken.variants);
+    if (!applicability) return null;
+    for (
+      let breakpointIndex = 0;
+      breakpointIndex < hasVisibilityOverrideAtBreakpoints.length;
+      breakpointIndex += 1
+    ) {
+      hasVisibilityOverrideAtBreakpoints[breakpointIndex] =
+        hasVisibilityOverrideAtBreakpoints[breakpointIndex] ||
+        Boolean(applicability[breakpointIndex]);
+    }
+  }
+  return {
+    displayAtBreakpoints,
+    hasGeneratedContent: hasTailwindGeneratedContent(className),
+    visibilityOverridesAtBreakpoints: visibilityAtBreakpoints.map((isVisible, breakpointIndex) =>
+      hasVisibilityOverrideAtBreakpoints[breakpointIndex] ? isVisible : null,
+    ),
+  };
+};
+
+const resolveSubtreeExclusion = (
+  openingElement: EsTreeNodeOfType<"JSXOpeningElement">,
+): boolean | null => {
+  if (hasJsxSpreadAttribute(openingElement.attributes)) return null;
+  const hiddenState = resolveBooleanAttribute(openingElement, "hidden", true);
+  const ariaHiddenState = resolveBooleanAttribute(openingElement, "aria-hidden", false);
+  const inertState = resolveBooleanAttribute(openingElement, "inert", true);
+  if (hiddenState === null || ariaHiddenState === null || inertState === null) return null;
+  return hiddenState || ariaHiddenState || inertState;
+};
+
+const resolveElementVisibility = (
+  openingElement: EsTreeNodeOfType<"JSXOpeningElement">,
+  scopes: ScopeAnalysis,
+): ElementVisibilityEvidence | null => {
+  if (hasJsxSpreadAttribute(openingElement.attributes)) return null;
+  if (getAuthoritativeJsxAttribute(openingElement.attributes, "class", false)) return null;
+  if (getAuthoritativeJsxAttribute(openingElement.attributes, "style", false)) return null;
+  const hiddenState = resolveBooleanAttribute(openingElement, "hidden", true);
+  const ariaHiddenState = resolveBooleanAttribute(openingElement, "aria-hidden", false);
+  const inertState = resolveBooleanAttribute(openingElement, "inert", true);
+  if (hiddenState === null || ariaHiddenState === null || inertState === null) return null;
+
+  const classNameAttribute = getAuthoritativeJsxAttribute(
+    openingElement.attributes,
+    "className",
+    false,
+  );
+  const classNames = classNameAttribute
+    ? getJsxPropExhaustiveStaticStringValues(classNameAttribute, scopes)
+    : [""];
+  if (!classNames || classNames.length === 0) return null;
+  const candidateVisibilityStates = classNames.map(resolveTailwindClassVisibility);
+  const firstVisibilityState = candidateVisibilityStates[0];
+  if (
+    !firstVisibilityState ||
+    candidateVisibilityStates.some(
+      (candidate) =>
+        !candidate ||
+        candidate.hasGeneratedContent !== firstVisibilityState.hasGeneratedContent ||
+        !areVisibilityStatesEqual(
+          firstVisibilityState.displayAtBreakpoints,
+          candidate.displayAtBreakpoints,
+        ) ||
+        candidate.visibilityOverridesAtBreakpoints.some(
+          (visibilityOverride, breakpointIndex) =>
+            visibilityOverride !==
+            firstVisibilityState.visibilityOverridesAtBreakpoints[breakpointIndex],
+        ),
+    )
+  ) {
+    return null;
+  }
+  const isStaticallyHidden = hiddenState || ariaHiddenState;
+  return {
+    displayAtBreakpoints: isStaticallyHidden
+      ? firstVisibilityState.displayAtBreakpoints.map(() => false)
+      : firstVisibilityState.displayAtBreakpoints,
+    hasGeneratedContent: firstVisibilityState.hasGeneratedContent,
+    isInert: inertState,
+    visibilityOverridesAtBreakpoints: firstVisibilityState.visibilityOverridesAtBreakpoints,
+  };
+};
+
+const combineVisibility = (
+  inheritedVisibility: ResponsiveVisibilityState,
+  ownVisibility: ElementVisibilityEvidence,
+): ResponsiveVisibilityState => ({
+  displayAtBreakpoints: inheritedVisibility.displayAtBreakpoints.map(
+    (isAncestorDisplayed, breakpointIndex) =>
+      isAncestorDisplayed && Boolean(ownVisibility.displayAtBreakpoints[breakpointIndex]),
+  ),
+  visibilityAtBreakpoints: inheritedVisibility.visibilityAtBreakpoints.map(
+    (inheritedVisibilityState, breakpointIndex) =>
+      ownVisibility.visibilityOverridesAtBreakpoints[breakpointIndex] ?? inheritedVisibilityState,
+  ),
+});
+
+const getEffectiveVisibility = (visibility: ResponsiveVisibilityState): ReadonlyArray<boolean> =>
+  visibility.displayAtBreakpoints.map(
+    (isDisplayed, breakpointIndex) =>
+      isDisplayed && Boolean(visibility.visibilityAtBreakpoints[breakpointIndex]),
+  );
+
+const hasPotentialNonContentName = (
+  openingElement: EsTreeNodeOfType<"JSXOpeningElement">,
+  attributeNames: ReadonlyArray<string>,
+  scopes: ScopeAnalysis,
+): boolean =>
+  attributeNames.some(
+    (attributeName) =>
+      resolveNonEmptyTextAttribute(openingElement, attributeName, scopes) !== false,
+  );
+
+const resolveExactIntrinsicTagName = (
+  openingElement: EsTreeNodeOfType<"JSXOpeningElement">,
+  scopes: ScopeAnalysis,
+): string | null => {
+  if (!isProvenIntrinsicJsxElement(openingElement, scopes)) return null;
+  const resolvedTagName = resolveJsxElementType(openingElement);
+  return resolvedTagName === resolvedTagName.toLowerCase() ? resolvedTagName : null;
+};
+
+const isInsideOpaqueJsxCompositionBoundary = (
+  element: EsTreeNodeOfType<"JSXElement">,
+  scopes: ScopeAnalysis,
+): boolean => {
+  let ancestor = element.parent;
+  while (ancestor) {
+    if (isNodeOfType(ancestor, "JSXAttribute")) return true;
+    if (
+      isNodeOfType(ancestor, "JSXElement") &&
+      !resolveExactIntrinsicTagName(ancestor.openingElement, scopes)
+    ) {
+      return true;
+    }
+    ancestor = ancestor.parent;
+  }
+  return false;
+};
+
+const resolveImmutableStaticString = (
+  rawExpression: EsTreeNode,
+  scopes: ScopeAnalysis,
+  visitedSymbolIds = new Set<number>(),
+): string | null => {
+  const expression = stripParenExpression(rawExpression);
+  if (isNodeOfType(expression, "Literal") && typeof expression.value === "string") {
+    return expression.value;
+  }
+  if (isNodeOfType(expression, "TemplateLiteral") && expression.expressions.length === 0) {
+    return expression.quasis[0]?.value.cooked ?? expression.quasis[0]?.value.raw ?? null;
+  }
+  if (!isNodeOfType(expression, "Identifier")) return null;
+  const symbol = scopes.symbolFor(expression);
+  if (
+    symbol?.kind !== "const" ||
+    !symbol.initializer ||
+    visitedSymbolIds.has(symbol.id) ||
+    !isNodeOfType(symbol.declarationNode, "VariableDeclarator") ||
+    symbol.declarationNode.id !== symbol.bindingIdentifier
+  ) {
+    return null;
+  }
+  const nextVisitedSymbolIds = new Set(visitedSymbolIds);
+  nextVisitedSymbolIds.add(symbol.id);
+  return resolveImmutableStaticString(symbol.initializer, scopes, nextVisitedSymbolIds);
+};
+
+const recordTextContributor = (
+  visibilityAtBreakpoints: ReadonlyArray<boolean>,
+  evidence: AccessibleNameEvidence,
+): void => {
+  evidence.didFindContributor = true;
+  for (
+    let breakpointIndex = 0;
+    breakpointIndex < evidence.availabilityAtBreakpoints.length;
+    breakpointIndex += 1
+  ) {
+    evidence.availabilityAtBreakpoints[breakpointIndex] =
+      evidence.availabilityAtBreakpoints[breakpointIndex] ||
+      Boolean(visibilityAtBreakpoints[breakpointIndex]);
+  }
+};
+
+const collectAccessibleNameEvidence = (
+  children: ReadonlyArray<EsTreeNode>,
+  inheritedVisibility: ResponsiveVisibilityState,
+  evidence: AccessibleNameEvidence,
+  context: RuleContext,
+): void => {
+  for (const child of children) {
+    if (evidence.isUnknown) return;
+    if (isNodeOfType(child, "JSXText")) {
+      if (child.value.trim().length > 0) {
+        recordTextContributor(getEffectiveVisibility(inheritedVisibility), evidence);
+      }
+      continue;
+    }
+    if (isNodeOfType(child, "JSXExpressionContainer")) {
+      const expression = stripParenExpression(child.expression);
+      if (isNodeOfType(expression, "JSXEmptyExpression")) continue;
+      if (isNullishExpression(expression)) continue;
+      if (isNodeOfType(expression, "JSXElement") || isNodeOfType(expression, "JSXFragment")) {
+        collectAccessibleNameEvidence([expression], inheritedVisibility, evidence, context);
+        continue;
+      }
+      if (isNodeOfType(expression, "Literal")) {
+        if (typeof expression.value === "boolean") continue;
+        if (
+          (typeof expression.value === "string" && expression.value.trim().length > 0) ||
+          typeof expression.value === "number"
+        ) {
+          recordTextContributor(getEffectiveVisibility(inheritedVisibility), evidence);
+          continue;
+        }
+      }
+      const staticString = resolveImmutableStaticString(expression, context.scopes);
+      if (staticString !== null) {
+        if (staticString.trim().length > 0) {
+          recordTextContributor(getEffectiveVisibility(inheritedVisibility), evidence);
+        }
+        continue;
+      }
+      evidence.isUnknown = true;
+      return;
+    }
+    if (isNodeOfType(child, "JSXFragment")) {
+      collectAccessibleNameEvidence(child.children, inheritedVisibility, evidence, context);
+      continue;
+    }
+    if (!isNodeOfType(child, "JSXElement")) {
+      evidence.isUnknown = true;
+      return;
+    }
+
+    const openingElement = child.openingElement;
+    const tagName = resolveExactIntrinsicTagName(openingElement, context.scopes);
+    if (!tagName) {
+      evidence.isUnknown = true;
+      return;
+    }
+    const subtreeExclusion = resolveSubtreeExclusion(openingElement);
+    if (subtreeExclusion === null) {
+      evidence.isUnknown = true;
+      return;
+    }
+    if (subtreeExclusion) continue;
+    if (
+      OPAQUE_ACCESSIBLE_NAME_TAGS.has(tagName) ||
+      isInteractiveElement(tagName, openingElement) ||
+      hasPotentialNonContentName(
+        openingElement,
+        DESCENDANT_NATIVE_NAME_ATTRIBUTES,
+        context.scopes,
+      ) ||
+      getAuthoritativeJsxAttribute(openingElement.attributes, "role", false)
+    ) {
+      evidence.isUnknown = true;
+      return;
+    }
+    const visibilityEvidence = resolveElementVisibility(openingElement, context.scopes);
+    if (
+      !visibilityEvidence ||
+      visibilityEvidence.isInert ||
+      visibilityEvidence.hasGeneratedContent
+    ) {
+      evidence.isUnknown = true;
+      return;
+    }
+    collectAccessibleNameEvidence(
+      child.children,
+      combineVisibility(inheritedVisibility, visibilityEvidence),
+      evidence,
+      context,
+    );
+  }
+};
+
+const resolveControlVisibility = (
+  controlElement: EsTreeNodeOfType<"JSXElement">,
+  controlTagName: string,
+  context: RuleContext,
+): ControlVisibilityEvidence | null => {
+  const elementChain: Array<EsTreeNodeOfType<"JSXElement">> = [];
+  let current: EsTreeNode | null | undefined = controlElement;
+  while (current) {
+    if (isNodeOfType(current, "JSXElement")) {
+      elementChain.push(current);
+    } else if (
+      isNodeOfType(current, "JSXExpressionContainer") ||
+      isNodeOfType(current, "LogicalExpression") ||
+      isNodeOfType(current, "ConditionalExpression") ||
+      TRANSPARENT_EXPRESSION_WRAPPER_TYPES.has(current.type)
+    ) {
+      current = current.parent;
+      continue;
+    } else if (!isNodeOfType(current, "JSXFragment")) {
+      break;
+    }
+    current = current.parent;
+  }
+  let combinedVisibility: ResponsiveVisibilityState = {
+    displayAtBreakpoints: TAILWIND_BREAKPOINT_NAMES.map(() => true),
+    visibilityAtBreakpoints: TAILWIND_BREAKPOINT_NAMES.map(() => true),
+  };
+  let hasGeneratedContent = false;
+  for (const element of elementChain.reverse()) {
+    const openingElement = element.openingElement;
+    const tagName = resolveExactIntrinsicTagName(openingElement, context.scopes);
+    if (!tagName || (element !== controlElement && tagName === "label")) return null;
+    if (controlTagName === "button" && element !== controlElement && tagName === "fieldset") {
+      const fieldsetDisabledState = resolveBooleanAttribute(openingElement, "disabled", true);
+      if (fieldsetDisabledState !== false) return null;
+    }
+    const visibilityEvidence = resolveElementVisibility(openingElement, context.scopes);
+    if (!visibilityEvidence || visibilityEvidence.isInert) return null;
+    combinedVisibility = combineVisibility(combinedVisibility, visibilityEvidence);
+    if (element === controlElement) {
+      hasGeneratedContent = visibilityEvidence.hasGeneratedContent;
+    }
+  }
+  return {
+    ...combinedVisibility,
+    hasGeneratedContent,
+  };
+};
+
+const hasProvenInteractiveSemantics = (
+  openingElement: EsTreeNodeOfType<"JSXOpeningElement">,
+  tagName: string,
+  context: RuleContext,
+): boolean => {
+  if (!CONTENT_NAMED_INTERACTIVE_TAGS.has(tagName)) return false;
+  if (!isInteractiveElement(tagName, openingElement)) return false;
+  if (getAuthoritativeJsxAttribute(openingElement.attributes, "role", false)) return false;
+  if (tagName === "button") {
+    const disabledState = resolveBooleanAttribute(openingElement, "disabled", true);
+    if (disabledState !== false) return false;
+  }
+  if (tagName !== "a") return true;
+  const hrefState = resolveNonEmptyTextAttribute(openingElement, "href", context.scopes);
+  return hrefState === true;
+};
+
+export const noResponsiveHiddenAccessibleName = defineRule({
+  id: "no-responsive-hidden-accessible-name",
+  title: "Responsive styles hide a control's accessible name",
+  severity: "warn",
+  category: "Accessibility",
+  tags: ["react-jsx-only"],
+  recommendation:
+    "Keep an accessible name available at every breakpoint, such as persistent sr-only text or an aria-label on the control.",
+  create: (context: RuleContext) => ({
+    JSXElement(node: EsTreeNodeOfType<"JSXElement">) {
+      if (!hasCapabilityOrUnspecified(context.settings, "tailwind")) return;
+      const openingElement = node.openingElement;
+      if (hasJsxSpreadAttribute(openingElement.attributes)) return;
+      if (isInsideOpaqueJsxCompositionBoundary(node, context.scopes)) return;
+      const tagName = resolveExactIntrinsicTagName(openingElement, context.scopes);
+      if (!tagName) return;
+      if (!hasProvenInteractiveSemantics(openingElement, tagName, context)) return;
+      if (
+        hasPotentialNonContentName(openingElement, NON_CONTENT_NAME_ATTRIBUTES, context.scopes) ||
+        hasPotentialNonContentName(openingElement, ["id"], context.scopes) ||
+        getAuthoritativeJsxAttribute(openingElement.attributes, "children", false) ||
+        getAuthoritativeJsxAttribute(openingElement.attributes, "dangerouslySetInnerHTML", false)
+      ) {
+        return;
+      }
+      const controlVisibility = resolveControlVisibility(node, tagName, context);
+      if (!controlVisibility || controlVisibility.hasGeneratedContent) return;
+      const effectiveControlVisibility = getEffectiveVisibility(controlVisibility);
+      const evidence: AccessibleNameEvidence = {
+        availabilityAtBreakpoints: effectiveControlVisibility.map(() => false),
+        didFindContributor: false,
+        isUnknown: false,
+      };
+      collectAccessibleNameEvidence(node.children, controlVisibility, evidence, context);
+      if (evidence.isUnknown || !evidence.didFindContributor) return;
+      const hasNamedVisibleBreakpoint = evidence.availabilityAtBreakpoints.some(Boolean);
+      const hasVisibleUnnamedBreakpoint = effectiveControlVisibility.some(
+        (isControlVisible, breakpointIndex) =>
+          isControlVisible && !evidence.availabilityAtBreakpoints[breakpointIndex],
+      );
+      if (!hasNamedVisibleBreakpoint || !hasVisibleUnnamedBreakpoint) return;
+      context.report({
+        node: openingElement,
+        message:
+          "This control stays visible at a responsive breakpoint after all of its accessible-name content is hidden. Keep a screen-reader-readable name available at every breakpoint.",
+      });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/no-responsive-hidden-accessible-name.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/no-responsive-hidden-accessible-name.ts
@@ -148,7 +148,10 @@ const areVisibilityStatesEqual = (
 const hasTailwindGeneratedContent = (className: string): boolean =>
   splitTailwindClassName(className)
     .map(parseTailwindClassNameToken)
-    .some(({ utility }) => utility.startsWith("content-") || utility.startsWith("[content:"));
+    .some(({ utility }) => {
+      const normalizedUtility = utility.toLowerCase();
+      return normalizedUtility.startsWith("content-") || normalizedUtility.startsWith("[content:");
+    });
 
 const getResponsiveVariantApplicability = (
   variants: ReadonlyArray<string>,
@@ -506,6 +509,7 @@ const resolveControlVisibility = (
   context: RuleContext,
 ): ControlVisibilityEvidence | null => {
   const elementChain: Array<EsTreeNodeOfType<"JSXElement">> = [];
+  const enclosingFunction = context.cfg.enclosingFunction(controlElement);
   let current: EsTreeNode | null | undefined = controlElement;
   while (current) {
     if (isNodeOfType(current, "JSXElement")) {
@@ -514,12 +518,23 @@ const resolveControlVisibility = (
       isNodeOfType(current, "JSXExpressionContainer") ||
       isNodeOfType(current, "LogicalExpression") ||
       isNodeOfType(current, "ConditionalExpression") ||
+      isNodeOfType(current, "ArrayExpression") ||
       TRANSPARENT_EXPRESSION_WRAPPER_TYPES.has(current.type)
     ) {
       current = current.parent;
       continue;
-    } else if (!isNodeOfType(current, "JSXFragment")) {
+    } else if (isNodeOfType(current, "ReturnStatement")) {
       break;
+    } else if (current === enclosingFunction && isNodeOfType(current, "ArrowFunctionExpression")) {
+      if (
+        !isNodeOfType(current.parent, "VariableDeclarator") &&
+        !isNodeOfType(current.parent, "ExportDefaultDeclaration")
+      ) {
+        return null;
+      }
+      break;
+    } else if (!isNodeOfType(current, "JSXFragment")) {
+      return null;
     }
     current = current.parent;
   }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-focus-in-animation-completion-handler.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-focus-in-animation-completion-handler.test.ts
@@ -149,6 +149,34 @@ describe("no-focus-in-animation-completion-handler", () => {
     expect(result.diagnostics).toHaveLength(2);
   });
 
+  it("allows an attached ref identity in an exact React useCallback dependency list", () => {
+    const result = runRule(
+      noFocusInAnimationCompletionHandler,
+      `import { useCallback, useRef } from "react";
+       const Panel = () => {
+         const inputRef = useRef(null);
+         const finish = useCallback(() => inputRef.current.focus(), [inputRef]);
+         return <><input ref={inputRef} /><div onAnimationEnd={finish} /></>;
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags focus on an intrinsic completion event currentTarget", () => {
+    const result = runRule(
+      noFocusInAnimationCompletionHandler,
+      `const Panel = () => {
+         const finish = (event) => event.currentTarget.focus();
+         return <>
+           <button onAnimationEnd={(event) => event.currentTarget.focus()} />
+           <div tabIndex={-1} onTransitionEnd={finish} />
+           <div onAnimationEnd={(event) => other.currentTarget.focus()} />
+         </>;
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
   it("follows synchronous IIFEs but prunes forEach and promise callbacks", () => {
     const result = runRule(
       noFocusInAnimationCompletionHandler,
@@ -351,6 +379,171 @@ describe("no-focus-in-animation-completion-handler", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("requires the ref attachment and handler to belong to the same returned JSX tree", () => {
+    const result = runRule(
+      noFocusInAnimationCompletionHandler,
+      `import { useRef } from "react";
+       const Panel = ({ mode, show }) => {
+         const unusedTargetRef = useRef(null);
+         const unusedHandlerRef = useRef(null);
+         const crossComponentRef = useRef(null);
+         const branchRef = useRef(null);
+         const unusedTarget = <input ref={unusedTargetRef} />;
+         const unusedHandler = <div onAnimationEnd={() => unusedHandlerRef.current.focus()} />;
+         const Nested = () => <div onAnimationEnd={() => crossComponentRef.current.focus()} />;
+         if (mode === "target") return <input ref={branchRef} />;
+         if (mode === "handler") {
+           return <div onAnimationEnd={() => branchRef.current.focus()} />;
+         }
+         return show
+           ? <><input ref={unusedHandlerRef} /><input ref={crossComponentRef} /></>
+           : <><Nested /><div onAnimationEnd={() => unusedTargetRef.current.focus()} /></>;
+       };`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not infer mounting through unresolved local JSX values or opaque composition", () => {
+    const result = runRule(
+      noFocusInAnimationCompletionHandler,
+      `import { useRef } from "react";
+       const Panel = ({ show }) => {
+         const localValueRef = useRef(null);
+         const wrappedRef = useRef(null);
+         const localInput = <input ref={localValueRef} />;
+         return <>
+           {show ? localInput : <div onAnimationEnd={() => localValueRef.current.focus()} />}
+           <Wrapper><input ref={wrappedRef} /></Wrapper>
+           <div onTransitionEnd={() => wrappedRef.current.focus()} />
+         </>;
+       };`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not treat a discarded logical-and left operand as rendered JSX", () => {
+    const result = runRule(
+      noFocusInAnimationCompletionHandler,
+      `import { useRef } from "react";
+       const Panel = () => {
+         const discardedTargetRef = useRef(null);
+         const discardedHandlerRef = useRef(null);
+         return <>
+           {(<input ref={discardedTargetRef} /> && false)}
+           <div onAnimationEnd={() => discardedTargetRef.current.focus()} />
+           <input ref={discardedHandlerRef} />
+           {(<div onTransitionEnd={() => discardedHandlerRef.current.focus()} /> && false)}
+         </>;
+       };`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("correlates the focus-call path with the rendered ref attachment", () => {
+    const result = runRule(
+      noFocusInAnimationCompletionHandler,
+      `import { useRef } from "react";
+       const Panel = ({ open }) => {
+         const inputRef = useRef(null);
+         return <>
+           {open && <input ref={inputRef} />}
+           <div onAnimationEnd={() => {
+             if (!open) inputRef.current.focus();
+           }} />
+         </>;
+       };`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("ignores statically impossible completion-handler paths", () => {
+    const result = runRule(
+      noFocusInAnimationCompletionHandler,
+      `import { useRef } from "react";
+       const Panel = ({ open }) => {
+         const inputRef = useRef(null);
+         return <>
+           <input ref={inputRef} />
+           <div onAnimationEnd={() => {
+             if (0) inputRef.current.focus();
+             if (open && !open) inputRef.current.focus();
+             if (true) return;
+             inputRef.current.focus();
+           }} />
+           <div onTransitionEnd={() => {
+             switch ("first") {
+               case "second": inputRef.current.focus();
+             }
+           }} />
+         </>;
+       };`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("ignores generator handlers and generator IIFEs", () => {
+    const result = runRule(
+      noFocusInAnimationCompletionHandler,
+      `import { useRef } from "react";
+       const Panel = () => {
+         const inputRef = useRef(null);
+         function* finish() { inputRef.current.focus(); }
+         return <>
+           <input ref={inputRef} />
+           <div onAnimationEnd={finish} />
+           <div onTransitionEnd={() => {
+             (function* () { inputRef.current.focus(); })();
+           }} />
+         </>;
+       };`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("ignores targets excluded by inert, hidden, disabled, or visibility ancestry", () => {
+    const result = runRule(
+      noFocusInAnimationCompletionHandler,
+      `import { useRef } from "react";
+       const Panel = () => {
+         const inertRef = useRef(null);
+         const hiddenRef = useRef(null);
+         const fieldsetRef = useRef(null);
+         const invisibleRef = useRef(null);
+         const collapsedRef = useRef(null);
+         return <>
+           <button inert ref={inertRef} />
+           <div hidden><button ref={hiddenRef} /></div>
+           <fieldset disabled><button ref={fieldsetRef} /></fieldset>
+           <button className="invisible" ref={invisibleRef} />
+           <div style={{ visibility: "collapse" }}><button ref={collapsedRef} /></div>
+           <div onAnimationEnd={() => inertRef.current.focus()} />
+           <div onAnimationEnd={() => hiddenRef.current.focus()} />
+           <div onAnimationEnd={() => fieldsetRef.current.focus()} />
+           <div onAnimationEnd={() => invisibleRef.current.focus()} />
+           <div onAnimationEnd={() => collapsedRef.current.focus()} />
+         </>;
+       };`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("ignores dynamically typed inputs that may be hidden", () => {
+    const result = runRule(
+      noFocusInAnimationCompletionHandler,
+      `import { useRef } from "react";
+       const Panel = ({ hidden }) => {
+         const inputRef = useRef(null);
+         return <>
+           <input type={hidden ? "hidden" : "text"} ref={inputRef} />
+           {hidden && <div onAnimationEnd={() => inputRef.current.focus()} />}
+         </>;
+       };`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("treats refs passed to calls or custom-component non-ref props as escaped", () => {
     const result = runRule(
       noFocusInAnimationCompletionHandler,
@@ -376,7 +569,7 @@ describe("no-focus-in-animation-completion-handler", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
-  it("resolves an unreassigned alias of attached ref.current", () => {
+  it("requires direct ref.current focus without an escaping node alias", () => {
     const result = runRule(
       noFocusInAnimationCompletionHandler,
       `import { useRef } from "react";
@@ -389,7 +582,27 @@ describe("no-focus-in-animation-completion-handler", () => {
          </>;
        };`,
     );
-    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("treats ref.current and focus-method mutations as uncertain", () => {
+    const result = runRule(
+      noFocusInAnimationCompletionHandler,
+      `import { useRef } from "react";
+       const Panel = () => {
+         const assignedRef = useRef(null);
+         const escapedRef = useRef(null);
+         assignedRef.current.focus = cleanup;
+         mutate(escapedRef.current);
+         return <>
+           <input ref={assignedRef} />
+           <input ref={escapedRef} />
+           <div onAnimationEnd={() => assignedRef.current.focus()} />
+           <div onAnimationEnd={() => escapedRef.current.focus()} />
+         </>;
+       };`,
+    );
+    expect(result.diagnostics).toEqual([]);
   });
 
   it("deduplicates a shared focus call wired through multiple handler attributes", () => {
@@ -447,6 +660,39 @@ describe("no-focus-in-animation-completion-handler", () => {
            <div onTransitionEnd={() => hiddenAgainRef.current.focus()} {...{ onTransitionEnd: cleanup }} />
          </>;
        };`,
+    );
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
+  it("resolves exact completion handlers from static inline spreads", () => {
+    const result = runRule(
+      noFocusInAnimationCompletionHandler,
+      `import { useRef } from "react";
+       const Panel = () => {
+         const inputRef = useRef(null);
+         return <>
+           <input ref={inputRef} />
+           <div {...{ onAnimationEnd: () => inputRef.current.focus() }} />
+           <div {...{ onTransitionEnd: () => cleanup() }} />
+         </>;
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("supports exact attached React createRef receivers", () => {
+    const result = runRule(
+      noFocusInAnimationCompletionHandler,
+      `import React, { createRef } from "react";
+       const firstRef = createRef();
+       const secondRef = React.createRef();
+       const finish = () => firstRef.current.focus();
+       const Panel = () => <>
+         <input ref={firstRef} />
+         <button ref={secondRef} />
+         <div onAnimationEnd={finish} />
+         <div onTransitionEnd={() => secondRef.current.focus()} />
+       </>;`,
     );
     expect(result.diagnostics).toHaveLength(2);
   });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-focus-in-animation-completion-handler.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-focus-in-animation-completion-handler.test.ts
@@ -1,0 +1,569 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noFocusInAnimationCompletionHandler } from "./no-focus-in-animation-completion-handler.js";
+
+describe("no-focus-in-animation-completion-handler", () => {
+  it("flags DOM ref focus in animation and transition completion handlers", () => {
+    const result = runRule(
+      noFocusInAnimationCompletionHandler,
+      `import { useRef } from "react";
+       const Dialog = () => {
+         const inputRef = useRef(null);
+         const searchRef = useRef(null);
+         return <>
+           <input ref={inputRef} />
+           <input ref={searchRef} />
+           <div onAnimationEnd={() => inputRef.current.focus()} />
+           <div onTransitionEnd={function () { searchRef.current.focus(); }} />
+         </>;
+       };`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(2);
+    expect(result.diagnostics[0]?.message).toContain("onAnimationEnd");
+    expect(result.diagnostics[1]?.message).toContain("onTransitionEnd");
+  });
+
+  it("flags capture-phase animation and transition completion handlers", () => {
+    const result = runRule(
+      noFocusInAnimationCompletionHandler,
+      `import { useRef } from "react";
+       const Dialog = () => {
+         const inputRef = useRef(null);
+         return <>
+           <input ref={inputRef} />
+           <div onAnimationEndCapture={() => inputRef.current.focus()} />
+           <div onTransitionEndCapture={() => inputRef.current.focus()} />
+         </>;
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(2);
+    expect(result.diagnostics[0]?.message).toContain("onAnimationEndCapture");
+    expect(result.diagnostics[1]?.message).toContain("onTransitionEndCapture");
+  });
+
+  it("flags static computed focus calls through transparent TypeScript wrappers", () => {
+    const result = runRule(
+      noFocusInAnimationCompletionHandler,
+      `import { useRef } from "react";
+       const Dialog = () => {
+         const inputRef = useRef<HTMLInputElement | null>(null);
+         return <>
+           <input ref={inputRef} />
+           <div onTransitionEnd={() => {
+             (inputRef.current as HTMLInputElement)["focus"]();
+             (inputRef.current!)[\`focus\`]();
+             (inputRef.current!.focus as () => void)();
+           }} />
+         </>;
+       };`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(3);
+  });
+
+  it("resolves exact local function handlers and const aliases", () => {
+    const result = runRule(
+      noFocusInAnimationCompletionHandler,
+      `import { useRef } from "react";
+       const Panel = () => {
+         const firstRef = useRef(null);
+         const secondRef = useRef(null);
+         function finishTransition() { firstRef.current.focus(); }
+         const aliased = finishTransition;
+         const finishAnimation = () => secondRef.current.focus();
+         return <>
+           <input ref={firstRef} />
+           <input ref={secondRef} />
+           <section onTransitionEnd={aliased} />
+           <section onAnimationEnd={finishAnimation} />
+         </>;
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
+  it("resolves a hoisted function-declaration handler textually after return", () => {
+    const result = runRule(
+      noFocusInAnimationCompletionHandler,
+      `import { useRef } from "react";
+       const Panel = () => {
+         const inputRef = useRef(null);
+         return <>
+           <input ref={inputRef} />
+           <section onAnimationEnd={finishAnimation} />
+         </>;
+         function finishAnimation() { inputRef.current.focus(); }
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("resolves named, renamed, default, and namespace React useCallback handlers", () => {
+    const result = runRule(
+      noFocusInAnimationCompletionHandler,
+      `import React, { useCallback, useCallback as useStableCallback, useRef } from "react";
+       import * as ReactRuntime from "react";
+       const Panel = () => {
+         const firstRef = useRef(null);
+         const secondRef = useRef(null);
+         const thirdRef = useRef(null);
+         const fourthRef = useRef(null);
+         const first = useCallback(() => firstRef.current.focus(), []);
+         const second = useStableCallback(() => secondRef.current.focus(), []);
+         const third = React.useCallback(() => thirdRef.current.focus(), []);
+         const fourth = ReactRuntime["useCallback"](() => fourthRef.current.focus(), []);
+         return <>
+           <input ref={firstRef} />
+           <input ref={secondRef} />
+           <input ref={thirdRef} />
+           <input ref={fourthRef} />
+           <div onAnimationEnd={first} />
+           <div onAnimationEnd={second} />
+           <div onTransitionEnd={third} />
+           <div onTransitionEnd={fourth} />
+         </>;
+       };`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(4);
+  });
+
+  it("resolves a local function supplied to React useCallback and a direct wrapper", () => {
+    const result = runRule(
+      noFocusInAnimationCompletionHandler,
+      `import { useCallback, useRef } from "react";
+       const Panel = () => {
+         const inputRef = useRef(null);
+         const searchRef = useRef(null);
+         const moveFocus = () => inputRef.current.focus();
+         const stableHandler = useCallback(moveFocus, []);
+         return <>
+           <input ref={inputRef} />
+           <input ref={searchRef} />
+           <div onAnimationEnd={stableHandler} />
+           <div onTransitionEnd={useCallback(() => searchRef.current.focus(), [])} />
+         </>;
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
+  it("follows synchronous IIFEs but prunes forEach and promise callbacks", () => {
+    const result = runRule(
+      noFocusInAnimationCompletionHandler,
+      `import { useRef } from "react";
+       const Panel = () => {
+         const immediateRef = useRef(null);
+         const deferredRef = useRef(null);
+         const promiseRef = useRef(null);
+         const nestedRef = useRef(null);
+         return <>
+           <input ref={immediateRef} />
+           <input ref={deferredRef} />
+           <input ref={promiseRef} />
+           <input ref={nestedRef} />
+           <div onAnimationEnd={() => {
+             (() => immediateRef.current.focus())();
+             items.forEach(() => deferredRef.current.focus());
+             Promise.resolve().then(() => promiseRef.current.focus());
+             const later = () => nestedRef.current.focus();
+           }} />
+         </>;
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports each reachable focus call on conditional paths", () => {
+    const result = runRule(
+      noFocusInAnimationCompletionHandler,
+      `import { useRef } from "react";
+       const Panel = () => {
+         const firstRef = useRef(null);
+         const secondRef = useRef(null);
+         return <>
+           <input ref={firstRef} />
+           <input ref={secondRef} />
+           <div onAnimationEnd={() => {
+             if (shouldFocusFirst) firstRef.current.focus();
+             else secondRef.current.focus();
+           }} />
+         </>;
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
+  it("ignores focus calls after return and inside statically false branches", () => {
+    const result = runRule(
+      noFocusInAnimationCompletionHandler,
+      `import { useRef } from "react";
+       const Panel = () => {
+         const inputRef = useRef(null);
+         const afterReturn = () => { return; inputRef.current.focus(); };
+         const falseBranch = () => { if (false) inputRef.current.focus(); };
+         return <>
+           <input ref={inputRef} />
+           <div onAnimationEnd={afterReturn} />
+           <div onTransitionEnd={falseBranch} />
+         </>;
+       };`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("prunes class field initializers that do not execute when the handler runs", () => {
+    const result = runRule(
+      noFocusInAnimationCompletionHandler,
+      `import { useRef } from "react";
+       const Panel = () => {
+         const inputRef = useRef(null);
+         return <>
+           <input ref={inputRef} />
+           <div onAnimationEnd={() => {
+             class DeferredFocus { field = inputRef.current.focus(); }
+             const DeferredExpression = class { field = inputRef.current.focus(); };
+           }} />
+         </>;
+       };`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("requires the focus receiver to originate from an intrinsic React ref", () => {
+    const result = runRule(
+      noFocusInAnimationCompletionHandler,
+      `import { useRef } from "react";
+       const Panel = ({ editor }) => {
+         const unattachedRef = useRef(null);
+         const customRef = useRef(null);
+         const mixedRef = useRef(null);
+         const overwrittenRef = useRef(null);
+         const unreachableRef = useRef(null);
+         const fakeRef = { current: editor };
+         if (false) return <input ref={unreachableRef} />;
+         return <>
+           <CustomInput ref={customRef} />
+           <input ref={mixedRef} />
+           <CustomInput ref={mixedRef} />
+           <input ref={overwrittenRef} />
+           <div onAnimationEnd={() => editor.focus()} />
+           <div onAnimationEnd={() => fakeRef.current.focus()} />
+           <div onTransitionEnd={() => unattachedRef.current.focus()} />
+           <div onTransitionEnd={() => customRef.current.focus()} />
+           <div onAnimationEnd={() => mixedRef.current.focus()} />
+           <div onAnimationEnd={() => unreachableRef.current.focus()} />
+           <div onTransitionEnd={() => {
+             overwrittenRef.current = editor;
+             overwrittenRef.current.focus();
+           }} />
+         </>;
+       };`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("requires an unreassigned direct const useRef binding", () => {
+    const result = runRule(
+      noFocusInAnimationCompletionHandler,
+      `import { useRef } from "react";
+       const Panel = () => {
+         let reassignedRef = useRef(null);
+         let updatedRef = useRef(null);
+         const directRef = useRef(null);
+         const aliasedRef = directRef;
+         reassignedRef = replacementRef;
+         updatedRef++;
+         return <>
+           <input ref={reassignedRef} />
+           <input ref={updatedRef} />
+           <input ref={aliasedRef} />
+           <div onAnimationEnd={() => reassignedRef.current.focus()} />
+           <div onTransitionEnd={() => updatedRef.current.focus()} />
+           <div onAnimationEndCapture={() => directRef.current.focus()} />
+         </>;
+       };`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("requires the attached intrinsic to be programmatically focusable", () => {
+    const result = runRule(
+      noFocusInAnimationCompletionHandler,
+      `import { useRef } from "react";
+       const Panel = () => {
+         const plainDivRef = useRef(null);
+         const negativeTabRef = useRef(null);
+         const disabledRef = useRef(null);
+         const hiddenInputRef = useRef(null);
+         const hiddenAttributeRef = useRef(null);
+         const hiddenClassRef = useRef(null);
+         const hiddenStyleRef = useRef(null);
+         return <>
+           <div ref={plainDivRef} />
+           <div ref={negativeTabRef} tabIndex={-1} />
+           <button ref={disabledRef} disabled />
+           <input ref={hiddenInputRef} type="hidden" />
+           <input ref={hiddenAttributeRef} hidden />
+           <input ref={hiddenClassRef} className="hidden" />
+           <input ref={hiddenStyleRef} style={{ display: "none" }} />
+           <section onAnimationEnd={() => plainDivRef.current.focus()} />
+           <section onAnimationEnd={() => negativeTabRef.current.focus()} />
+           <section onAnimationEnd={() => disabledRef.current.focus()} />
+           <section onAnimationEnd={() => hiddenInputRef.current.focus()} />
+           <section onAnimationEnd={() => hiddenAttributeRef.current.focus()} />
+           <section onAnimationEnd={() => hiddenClassRef.current.focus()} />
+           <section onAnimationEnd={() => hiddenStyleRef.current.focus()} />
+         </>;
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("requires the ref attachment and completion handler to be able to co-execute", () => {
+    const result = runRule(
+      noFocusInAnimationCompletionHandler,
+      `import { useRef } from "react";
+       const Panel = ({ showTarget }) => {
+         const inputRef = useRef(null);
+         const finish = () => inputRef.current.focus();
+         return showTarget
+           ? <input ref={inputRef} />
+           : <div onAnimationEnd={finish} />;
+       };`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("ignores completion handlers defined on unreachable render paths", () => {
+    const result = runRule(
+      noFocusInAnimationCompletionHandler,
+      `import { useRef } from "react";
+       const Panel = () => {
+         const inputRef = useRef(null);
+         if (false) return <div onAnimationEnd={() => inputRef.current.focus()} />;
+         return <input ref={inputRef} />;
+       };`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("treats refs passed to calls or custom-component non-ref props as escaped", () => {
+    const result = runRule(
+      noFocusInAnimationCompletionHandler,
+      `import { useRef } from "react";
+       const Panel = () => {
+         const unresolvedRef = useRef(null);
+         const localRef = useRef(null);
+         const propRef = useRef(null);
+         const inspect = (value) => value;
+         observe(unresolvedRef);
+         inspect(localRef);
+         return <>
+           <input ref={unresolvedRef} />
+           <input ref={localRef} />
+           <input ref={propRef} />
+           <CustomInput inputRef={propRef} />
+           <div onAnimationEnd={() => unresolvedRef.current.focus()} />
+           <div onAnimationEnd={() => localRef.current.focus()} />
+           <div onAnimationEnd={() => propRef.current.focus()} />
+         </>;
+       };`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("resolves an unreassigned alias of attached ref.current", () => {
+    const result = runRule(
+      noFocusInAnimationCompletionHandler,
+      `import { useRef } from "react";
+       const Panel = () => {
+         const inputRef = useRef(null);
+         const input = inputRef.current;
+         return <>
+           <input ref={inputRef} />
+           <div onTransitionEnd={() => input.focus()} />
+         </>;
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("deduplicates a shared focus call wired through multiple handler attributes", () => {
+    const result = runRule(
+      noFocusInAnimationCompletionHandler,
+      `import { useRef } from "react";
+       const Panel = () => {
+         const inputRef = useRef(null);
+         const finish = () => inputRef.current.focus();
+         return <>
+           <input ref={inputRef} />
+           <div onAnimationEnd={finish} onTransitionEnd={finish} />
+           <section onAnimationEndCapture={finish} />
+         </>;
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("uses only the authoritative duplicate completion handler", () => {
+    const result = runRule(
+      noFocusInAnimationCompletionHandler,
+      `import { useRef } from "react";
+       const Panel = () => {
+         const staleRef = useRef(null);
+         const activeRef = useRef(null);
+         return <>
+           <input ref={staleRef} />
+           <input ref={activeRef} />
+           <div onAnimationEnd={() => staleRef.current.focus()} onAnimationEnd={() => cleanup()} />
+           <div onTransitionEnd={() => cleanup()} onTransitionEnd={() => activeRef.current.focus()} />
+         </>;
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("respects spread precedence around completion handlers", () => {
+    const result = runRule(
+      noFocusInAnimationCompletionHandler,
+      `import { useRef } from "react";
+       const Panel = () => {
+         const firstRef = useRef(null);
+         const hiddenRef = useRef(null);
+         const secondRef = useRef(null);
+         const hiddenAgainRef = useRef(null);
+         return <>
+           <input ref={firstRef} />
+           <input ref={hiddenRef} />
+           <input ref={secondRef} />
+           <input ref={hiddenAgainRef} />
+           <div {...props} onAnimationEnd={() => firstRef.current.focus()} />
+           <div onAnimationEnd={() => hiddenRef.current.focus()} {...props} />
+           <div onTransitionEnd={() => secondRef.current.focus()} {...{ className: "panel" }} />
+           <div onTransitionEnd={() => hiddenAgainRef.current.focus()} {...{ onTransitionEnd: cleanup }} />
+         </>;
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
+  it("stays quiet for custom components and member-expression components", () => {
+    const result = runRule(
+      noFocusInAnimationCompletionHandler,
+      `import { useRef } from "react";
+       const Panel = () => {
+         const inputRef = useRef(null);
+         return <>
+           <input ref={inputRef} />
+           <AnimatedPanel onAnimationEnd={() => inputRef.current.focus()} />
+           <motion.div onTransitionEnd={() => inputRef.current.focus()} />
+         </>;
+       };`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays quiet for imported, opaque, shadowed, and unrelated handlers", () => {
+    const result = runRule(
+      noFocusInAnimationCompletionHandler,
+      `import { useCallback as customUseCallback } from "@custom/hooks";
+       import { finishAnimation } from "./animation";
+       const useCallback = (callback) => callback;
+       const handlers = { finish: () => editor.focus() };
+       const first = useCallback(() => editor.focus(), []);
+       const second = customUseCallback(() => editor.focus(), []);
+       const React = { useCallback };
+       const third = React.useCallback(() => editor.focus(), []);
+       const Panel = ({ onDone }) => <>
+         <div onAnimationEnd={finishAnimation} />
+         <div onTransitionEnd={handlers.finish} />
+         <div onAnimationEnd={onDone} />
+         <div onAnimationEnd={first} />
+         <div onAnimationEnd={second} />
+         <div onTransitionEnd={third} />
+       </>;`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays quiet for reassigned local handlers", () => {
+    const result = runRule(
+      noFocusInAnimationCompletionHandler,
+      `import { useRef } from "react";
+       const Panel = () => {
+         const inputRef = useRef(null);
+         function finish() { inputRef.current.focus(); }
+         finish = cleanup;
+         return <><input ref={inputRef} /><div onAnimationEnd={finish} /></>;
+       };`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays quiet for dynamic event props, dynamic focus members, and visual cleanup", () => {
+    const result = runRule(
+      noFocusInAnimationCompletionHandler,
+      `import { useRef } from "react";
+       const eventProps = { onAnimationEnd: () => editor.focus() };
+       const method = "focus";
+       const Panel = () => {
+         const inputRef = useRef(null);
+         return <>
+           <input ref={inputRef} />
+           <div {...eventProps} />
+           <div onAnimationEnd={() => inputRef.current[method]()} />
+           <div onTransitionEnd={() => inputRef.current.classList.remove("animating")} />
+           <div onTransitionEnd={() => inputRef.current.blur()} />
+         </>;
+       };`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays quiet when focus is moved outside the completion handler", () => {
+    const result = runRule(
+      noFocusInAnimationCompletionHandler,
+      `import { useRef } from "react";
+       const Panel = () => {
+         const inputRef = useRef(null);
+         const openPanel = () => { setOpen(true); inputRef.current.focus(); };
+         return <><input ref={inputRef} /><div onAnimationEnd={() => setAnimating(false)} /></>;
+       };`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not follow local or imported helper calls from the completion handler", () => {
+    const result = runRule(
+      noFocusInAnimationCompletionHandler,
+      `import { useRef } from "react";
+       import { focusSearch } from "./focus";
+       const Panel = () => {
+         const inputRef = useRef(null);
+         const focusInput = () => inputRef.current.focus();
+         return <>
+           <input ref={inputRef} />
+           <div onAnimationEnd={() => focusInput()} />
+           <div onTransitionEnd={() => focusSearch()} />
+         </>;
+       };`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not treat a concise handler returning a function as immediate execution", () => {
+    const result = runRule(
+      noFocusInAnimationCompletionHandler,
+      `import { useRef } from "react";
+       const Panel = () => {
+         const inputRef = useRef(null);
+         return <><input ref={inputRef} /><div onAnimationEnd={() => () => inputRef.current.focus()} /></>;
+       };`,
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-focus-in-animation-completion-handler.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-focus-in-animation-completion-handler.ts
@@ -1,0 +1,302 @@
+import { defineRule } from "../../utils/define-rule.js";
+import type { SymbolDescriptor } from "../../semantic/scope-analysis.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
+import { findProgramRoot } from "../../utils/find-program-root.js";
+import { findTransparentExpressionRoot } from "../../utils/find-transparent-expression-root.js";
+import { getAuthoritativeJsxAttribute } from "../../utils/get-authoritative-jsx-attribute.js";
+import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
+import { hasJsxSpreadAttribute } from "../../utils/has-jsx-spread-attribute.js";
+import { isFocusableJsxOpeningElement } from "../../utils/is-focusable-jsx-opening-element.js";
+import { isFunctionLike } from "../../utils/is-function-like.js";
+import { isImmediatelyInvokedFunction } from "../../utils/is-immediately-invoked-function.js";
+import { isNodeReachableWithinFunction } from "../../utils/is-node-reachable-within-function.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { isReactApiCall } from "../../utils/is-react-api-call.js";
+import { nodesCanCoExecute } from "../../utils/nodes-can-co-execute.js";
+import {
+  resolveReactRefCurrentOriginSymbol,
+  resolveReactRefSymbol,
+} from "../../utils/react-ref-origin.js";
+import { resolveConstIdentifierAlias } from "../../utils/resolve-const-identifier-alias.js";
+import { resolveExactLocalFunction } from "../../utils/resolve-exact-local-function.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import { walkAst } from "../../utils/walk-ast.js";
+
+const ANIMATION_COMPLETION_HANDLER_NAMES = [
+  "onAnimationEnd",
+  "onAnimationEndCapture",
+  "onTransitionEnd",
+  "onTransitionEndCapture",
+];
+
+interface IntrinsicReactRefIndex {
+  attachmentNodesBySymbolId: ReadonlyMap<
+    number,
+    ReadonlyArray<EsTreeNodeOfType<"JSXOpeningElement">>
+  >;
+}
+
+const getHandlerExpression = (attribute: EsTreeNode): EsTreeNode | null => {
+  if (
+    !isNodeOfType(attribute, "JSXAttribute") ||
+    !attribute.value ||
+    !isNodeOfType(attribute.value, "JSXExpressionContainer") ||
+    isNodeOfType(attribute.value.expression, "JSXEmptyExpression")
+  ) {
+    return null;
+  }
+  return attribute.value.expression;
+};
+
+const resolveReactCompletionHandler = (
+  expression: EsTreeNode,
+  context: RuleContext,
+): EsTreeNode | null => {
+  const directFunction = resolveExactLocalFunction(expression, context.scopes);
+  if (directFunction) return directFunction;
+  const unwrappedExpression = stripParenExpression(expression);
+  const callbackSymbol = isNodeOfType(unwrappedExpression, "Identifier")
+    ? resolveConstIdentifierAlias(unwrappedExpression, context.scopes)
+    : null;
+  const callbackInitializer = callbackSymbol?.kind === "const" ? callbackSymbol.initializer : null;
+  const useCallbackCall = stripParenExpression(callbackInitializer ?? unwrappedExpression);
+  if (
+    !isNodeOfType(useCallbackCall, "CallExpression") ||
+    !isReactApiCall(useCallbackCall, "useCallback", context.scopes, {
+      resolveNamedAliases: true,
+    })
+  ) {
+    return null;
+  }
+  const wrappedCallback = useCallbackCall.arguments[0];
+  if (!wrappedCallback || isNodeOfType(wrappedCallback, "SpreadElement")) return null;
+  return resolveExactLocalFunction(wrappedCallback, context.scopes);
+};
+
+const isSafeDirectReactRefReference = (identifier: EsTreeNode): boolean => {
+  const expressionRoot = findTransparentExpressionRoot(identifier);
+  const parent = expressionRoot.parent;
+  if (
+    parent &&
+    isNodeOfType(parent, "MemberExpression") &&
+    parent.object === expressionRoot &&
+    getStaticPropertyName(parent) === "current"
+  ) {
+    return true;
+  }
+  if (!parent || !isNodeOfType(parent, "JSXExpressionContainer")) return false;
+  const attribute = parent.parent;
+  return Boolean(
+    attribute &&
+    isNodeOfType(attribute, "JSXAttribute") &&
+    isNodeOfType(attribute.name, "JSXIdentifier") &&
+    attribute.name.name === "ref" &&
+    attribute.value === parent,
+  );
+};
+
+const collectIntrinsicReactRefIndex = (
+  program: EsTreeNodeOfType<"Program">,
+  context: RuleContext,
+): IntrinsicReactRefIndex => {
+  const attachmentNodesBySymbolId = new Map<number, EsTreeNodeOfType<"JSXOpeningElement">[]>();
+  const refSymbolsById = new Map<number, SymbolDescriptor>();
+  const uncertainRefSymbolIds = new Set<number>();
+  walkAst(program, (candidate) => {
+    if (!isNodeOfType(candidate, "JSXOpeningElement")) return;
+    if (!isNodeReachableWithinFunction(candidate, context)) return false;
+    if (hasJsxSpreadAttribute(candidate.attributes)) return false;
+    const refAttribute = getAuthoritativeJsxAttribute(candidate.attributes, "ref");
+    if (
+      !refAttribute?.value ||
+      !isNodeOfType(refAttribute.value, "JSXExpressionContainer") ||
+      !isNodeOfType(refAttribute.value.expression, "Identifier")
+    ) {
+      return;
+    }
+    const refSymbol = context.scopes.symbolFor(refAttribute.value.expression);
+    if (
+      !refSymbol?.initializer ||
+      refSymbol.kind !== "const" ||
+      !isNodeOfType(refSymbol.declarationNode, "VariableDeclarator") ||
+      refSymbol.declarationNode.id !== refSymbol.bindingIdentifier ||
+      refSymbol.references.some((reference) => reference.flag !== "read")
+    ) {
+      return;
+    }
+    const initializer = stripParenExpression(refSymbol.initializer);
+    if (
+      isNodeOfType(initializer, "CallExpression") &&
+      isReactApiCall(initializer, "useRef", context.scopes, { resolveNamedAliases: true })
+    ) {
+      refSymbolsById.set(refSymbol.id, refSymbol);
+      if (
+        isNodeOfType(candidate.name, "JSXIdentifier") &&
+        /^[a-z]/.test(candidate.name.name) &&
+        isFocusableJsxOpeningElement(candidate, candidate.name.name, true)
+      ) {
+        const attachmentNodes = attachmentNodesBySymbolId.get(refSymbol.id) ?? [];
+        attachmentNodes.push(candidate);
+        attachmentNodesBySymbolId.set(refSymbol.id, attachmentNodes);
+      } else {
+        uncertainRefSymbolIds.add(refSymbol.id);
+      }
+    }
+  });
+  walkAst(program, (candidate) => {
+    let assignmentTarget: EsTreeNode | null = null;
+    if (isNodeOfType(candidate, "AssignmentExpression")) {
+      assignmentTarget = candidate.left;
+    } else if (
+      isNodeOfType(candidate, "UpdateExpression") ||
+      (isNodeOfType(candidate, "UnaryExpression") && candidate.operator === "delete")
+    ) {
+      assignmentTarget = candidate.argument;
+    }
+    if (!assignmentTarget) return;
+    const refSymbol = resolveReactRefSymbol(
+      stripParenExpression(assignmentTarget),
+      context.scopes,
+      {
+        resolveNamedAliases: true,
+      },
+    );
+    if (refSymbol) uncertainRefSymbolIds.add(refSymbol.id);
+  });
+  for (const [refSymbolId, refSymbol] of refSymbolsById) {
+    if (
+      refSymbol?.references.some(
+        (reference) => !isSafeDirectReactRefReference(reference.identifier),
+      )
+    ) {
+      uncertainRefSymbolIds.add(refSymbolId);
+    }
+  }
+  for (const uncertainRefSymbolId of uncertainRefSymbolIds) {
+    attachmentNodesBySymbolId.delete(uncertainRefSymbolId);
+  }
+  return { attachmentNodesBySymbolId };
+};
+
+const isHandlerDefinitionReachable = (handler: EsTreeNode, context: RuleContext): boolean => {
+  if (!isNodeReachableWithinFunction(handler.parent ?? handler, context)) return false;
+  const outerFunction = findEnclosingFunction(handler);
+  if (!outerFunction) return true;
+  if (
+    isNodeOfType(handler, "FunctionDeclaration") &&
+    isFunctionLike(outerFunction) &&
+    isNodeOfType(outerFunction.body, "BlockStatement") &&
+    handler.parent === outerFunction.body
+  ) {
+    return true;
+  }
+  const outerCfg = context.cfg.cfgFor(outerFunction);
+  const targetBlock = outerCfg?.blockOf(handler);
+  if (!outerCfg || !targetBlock) return true;
+  const reachableBlocks = new Set([outerCfg.entry]);
+  const pendingBlocks = [outerCfg.entry];
+  while (pendingBlocks.length > 0) {
+    const currentBlock = pendingBlocks.pop();
+    if (!currentBlock) break;
+    if (currentBlock === targetBlock) return true;
+    for (const edge of currentBlock.successors) {
+      if (reachableBlocks.has(edge.to)) continue;
+      reachableBlocks.add(edge.to);
+      pendingBlocks.push(edge.to);
+    }
+  }
+  return false;
+};
+
+const collectDirectFocusCalls = (
+  handler: EsTreeNode,
+  handlerSite: EsTreeNode,
+  intrinsicRefIndex: IntrinsicReactRefIndex,
+  context: RuleContext,
+): EsTreeNodeOfType<"CallExpression">[] => {
+  if (!isFunctionLike(handler)) return [];
+  const focusCalls: EsTreeNodeOfType<"CallExpression">[] = [];
+  walkAst(handler.body, (child) => {
+    if (isFunctionLike(child) && !isImmediatelyInvokedFunction(child)) return false;
+    if (isNodeOfType(child, "PropertyDefinition") || isNodeOfType(child, "AccessorProperty")) {
+      return false;
+    }
+    if (!isNodeOfType(child, "CallExpression")) return;
+    if (!isNodeReachableWithinFunction(child, context)) return false;
+    const callee = stripParenExpression(child.callee);
+    if (!isNodeOfType(callee, "MemberExpression")) return;
+    if (getStaticPropertyName(callee) !== "focus") return;
+    const refSymbol = resolveReactRefCurrentOriginSymbol(callee.object, context.scopes);
+    const attachmentNodes = refSymbol
+      ? intrinsicRefIndex.attachmentNodesBySymbolId.get(refSymbol.id)
+      : null;
+    if (
+      attachmentNodes?.some(
+        (attachmentNode) =>
+          nodesCanCoExecute(attachmentNode, handler, context) &&
+          nodesCanCoExecute(attachmentNode, handlerSite, context),
+      )
+    ) {
+      focusCalls.push(child);
+    }
+  });
+  return focusCalls;
+};
+
+export const noFocusInAnimationCompletionHandler = defineRule({
+  id: "no-focus-in-animation-completion-handler",
+  title: "Focus waits for animation completion",
+  severity: "warn",
+  category: "Accessibility",
+  tags: ["react-jsx-only"],
+  recommendation:
+    "Move focus when the interaction state changes, independently of visual animation completion, so canceled or reduced animations cannot delay or suppress keyboard focus.",
+  create: (context: RuleContext) => {
+    const intrinsicRefIndexesByProgram = new WeakMap<EsTreeNode, IntrinsicReactRefIndex>();
+    const reportedFocusCalls = new WeakSet<EsTreeNode>();
+    return {
+      JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
+        if (!isNodeOfType(node.name, "JSXIdentifier") || !/^[a-z]/.test(node.name.name)) {
+          return;
+        }
+        for (const handlerName of ANIMATION_COMPLETION_HANDLER_NAMES) {
+          const attribute = getAuthoritativeJsxAttribute(node.attributes, handlerName);
+          if (!attribute) continue;
+          const handlerExpression = getHandlerExpression(attribute);
+          if (!handlerExpression) continue;
+          const handler = resolveReactCompletionHandler(handlerExpression, context);
+          if (
+            !handler ||
+            !isNodeReachableWithinFunction(attribute, context) ||
+            !isHandlerDefinitionReachable(handler, context)
+          ) {
+            continue;
+          }
+          const program = findProgramRoot(node);
+          if (!program) continue;
+          let intrinsicRefIndex = intrinsicRefIndexesByProgram.get(program);
+          if (!intrinsicRefIndex) {
+            intrinsicRefIndex = collectIntrinsicReactRefIndex(program, context);
+            intrinsicRefIndexesByProgram.set(program, intrinsicRefIndex);
+          }
+          for (const focusCall of collectDirectFocusCalls(
+            handler,
+            attribute,
+            intrinsicRefIndex,
+            context,
+          )) {
+            if (reportedFocusCalls.has(focusCall)) continue;
+            reportedFocusCalls.add(focusCall);
+            context.report({
+              node: focusCall,
+              message: `This ${handlerName} handler moves focus after visual completion. Completion events can be skipped when animation is canceled, reduced, or removed; move focus when the interaction state changes instead.`,
+            });
+          }
+        }
+      },
+    };
+  },
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-focus-in-animation-completion-handler.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-focus-in-animation-completion-handler.ts
@@ -6,7 +6,9 @@ import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
 import { findProgramRoot } from "../../utils/find-program-root.js";
 import { findTransparentExpressionRoot } from "../../utils/find-transparent-expression-root.js";
 import { getAuthoritativeJsxAttribute } from "../../utils/get-authoritative-jsx-attribute.js";
+import { getJsxPropStringValue } from "../../utils/get-jsx-prop-string-value.js";
 import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
+import { hasJsxPropIgnoreCase } from "../../utils/has-jsx-prop-ignore-case.js";
 import { hasJsxSpreadAttribute } from "../../utils/has-jsx-spread-attribute.js";
 import { isFocusableJsxOpeningElement } from "../../utils/is-focusable-jsx-opening-element.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
@@ -15,13 +17,13 @@ import { isNodeReachableWithinFunction } from "../../utils/is-node-reachable-wit
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isReactApiCall } from "../../utils/is-react-api-call.js";
 import { nodesCanCoExecute } from "../../utils/nodes-can-co-execute.js";
-import {
-  resolveReactRefCurrentOriginSymbol,
-  resolveReactRefSymbol,
-} from "../../utils/react-ref-origin.js";
+import { resolveReactRefSymbol } from "../../utils/react-ref-origin.js";
 import { resolveConstIdentifierAlias } from "../../utils/resolve-const-identifier-alias.js";
 import { resolveExactLocalFunction } from "../../utils/resolve-exact-local-function.js";
+import { resolveStaticJsxAttribute } from "../../utils/resolve-static-jsx-attribute.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { splitTailwindClassName } from "../../utils/split-tailwind-class-name.js";
+import { statementAlwaysExits } from "../../utils/statement-always-exits.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import { walkAst } from "../../utils/walk-ast.js";
 
@@ -31,13 +33,337 @@ const ANIMATION_COMPLETION_HANDLER_NAMES = [
   "onTransitionEnd",
   "onTransitionEndCapture",
 ];
+const REACT_REF_CREATION_API_NAMES = new Set(["createRef", "useRef"]);
+
+interface ProvenRenderLocation {
+  owner: EsTreeNode;
+  root: EsTreeNode;
+}
+
+interface IntrinsicReactRefAttachment {
+  location: ProvenRenderLocation;
+  node: EsTreeNodeOfType<"JSXOpeningElement">;
+}
 
 interface IntrinsicReactRefIndex {
-  attachmentNodesBySymbolId: ReadonlyMap<
-    number,
-    ReadonlyArray<EsTreeNodeOfType<"JSXOpeningElement">>
-  >;
+  attachmentsBySymbolId: ReadonlyMap<number, ReadonlyArray<IntrinsicReactRefAttachment>>;
 }
+
+const isGeneratorFunction = (node: EsTreeNode): boolean =>
+  (isNodeOfType(node, "FunctionDeclaration") ||
+    isNodeOfType(node, "FunctionExpression") ||
+    isNodeOfType(node, "ArrowFunctionExpression")) &&
+  node.generator;
+
+const isIntrinsicOpeningElement = (node: EsTreeNodeOfType<"JSXOpeningElement">): boolean =>
+  isNodeOfType(node.name, "JSXIdentifier") && /^[a-z]/.test(node.name.name);
+
+const getProvenRenderLocation = (
+  openingElement: EsTreeNodeOfType<"JSXOpeningElement">,
+): ProvenRenderLocation | null => {
+  let current: EsTreeNode = openingElement;
+  let didLeaveOwnElement = false;
+  while (current.parent) {
+    const transparentRoot = findTransparentExpressionRoot(current);
+    if (transparentRoot !== current) {
+      current = transparentRoot;
+      continue;
+    }
+    const parent = current.parent;
+    if (isNodeOfType(parent, "JSXElement")) {
+      if (parent.openingElement === current) {
+        didLeaveOwnElement = true;
+      } else if (didLeaveOwnElement && !isIntrinsicOpeningElement(parent.openingElement)) {
+        return null;
+      }
+      current = parent;
+      continue;
+    }
+    if (isNodeOfType(parent, "JSXFragment")) {
+      current = parent;
+      continue;
+    }
+    if (
+      isNodeOfType(parent, "JSXExpressionContainer") &&
+      parent.expression === current &&
+      parent.parent &&
+      !isNodeOfType(parent.parent, "JSXAttribute")
+    ) {
+      current = parent;
+      continue;
+    }
+    if (
+      (isNodeOfType(parent, "ConditionalExpression") &&
+        (parent.consequent === current || parent.alternate === current)) ||
+      (isNodeOfType(parent, "LogicalExpression") &&
+        (parent.right === current || (parent.left === current && parent.operator !== "&&"))) ||
+      (isNodeOfType(parent, "ArrayExpression") &&
+        parent.elements.some((element) => element === current))
+    ) {
+      current = parent;
+      continue;
+    }
+    if (isNodeOfType(parent, "SequenceExpression")) {
+      if (parent.expressions.at(-1) !== current) return null;
+      current = parent;
+      continue;
+    }
+    if (isNodeOfType(parent, "ReturnStatement") && parent.argument === current) {
+      const owner = findEnclosingFunction(parent);
+      return owner && !isGeneratorFunction(owner) ? { owner, root: parent } : null;
+    }
+    if (
+      isNodeOfType(parent, "ArrowFunctionExpression") &&
+      parent.body === current &&
+      !parent.generator
+    ) {
+      return { owner: parent, root: parent };
+    }
+    return null;
+  }
+  return null;
+};
+
+const getStaticBooleanAttributeState = (
+  openingElement: EsTreeNodeOfType<"JSXOpeningElement">,
+  attributeName: string,
+): boolean | null => {
+  const attribute = hasJsxPropIgnoreCase(openingElement.attributes, attributeName);
+  if (!attribute) return false;
+  if (!attribute.value) return true;
+  if (!isNodeOfType(attribute.value, "JSXExpressionContainer")) return true;
+  const expression = stripParenExpression(attribute.value.expression);
+  return isNodeOfType(expression, "Literal") && typeof expression.value === "boolean"
+    ? expression.value
+    : null;
+};
+
+const hasStaticallyHidingClassName = (
+  openingElement: EsTreeNodeOfType<"JSXOpeningElement">,
+): boolean => {
+  const classNameAttribute = hasJsxPropIgnoreCase(openingElement.attributes, "className");
+  if (!classNameAttribute?.value) return false;
+  const className = getJsxPropStringValue(classNameAttribute);
+  return Boolean(
+    className &&
+    splitTailwindClassName(className).some((token) => {
+      const utility = token.split(":").at(-1)?.replace(/^!/, "").replace(/!$/, "");
+      return utility === "hidden" || utility === "invisible" || utility === "collapse";
+    }),
+  );
+};
+
+const hasStaticallyHidingStyle = (
+  openingElement: EsTreeNodeOfType<"JSXOpeningElement">,
+): boolean => {
+  const styleAttribute = hasJsxPropIgnoreCase(openingElement.attributes, "style");
+  if (
+    !styleAttribute?.value ||
+    !isNodeOfType(styleAttribute.value, "JSXExpressionContainer") ||
+    !isNodeOfType(styleAttribute.value.expression, "ObjectExpression")
+  ) {
+    return false;
+  }
+  for (const property of styleAttribute.value.expression.properties) {
+    if (!isNodeOfType(property, "Property")) continue;
+    let propertyName: string | null = null;
+    if (isNodeOfType(property.key, "Identifier")) {
+      propertyName = property.key.name;
+    } else if (isNodeOfType(property.key, "Literal") && typeof property.key.value === "string") {
+      propertyName = property.key.value;
+    }
+    const propertyValue =
+      isNodeOfType(property.value, "Literal") && typeof property.value.value === "string"
+        ? property.value.value
+        : null;
+    if (
+      (propertyName === "display" && propertyValue === "none") ||
+      (propertyName === "visibility" &&
+        (propertyValue === "hidden" || propertyValue === "collapse")) ||
+      (propertyName === "contentVisibility" && propertyValue === "hidden")
+    ) {
+      return true;
+    }
+  }
+  return false;
+};
+
+const isStaticallyExcludedOpeningElement = (
+  openingElement: EsTreeNodeOfType<"JSXOpeningElement">,
+  isTarget: boolean,
+): boolean => {
+  const tagName = isNodeOfType(openingElement.name, "JSXIdentifier")
+    ? openingElement.name.name
+    : null;
+  if (!tagName || !/^[a-z]/.test(tagName)) return true;
+  const hiddenState = getStaticBooleanAttributeState(openingElement, "hidden");
+  const inertState = getStaticBooleanAttributeState(openingElement, "inert");
+  if (
+    hiddenState !== false ||
+    inertState !== false ||
+    hasStaticallyHidingClassName(openingElement) ||
+    hasStaticallyHidingStyle(openingElement) ||
+    tagName === "template"
+  ) {
+    return true;
+  }
+  if (
+    tagName === "fieldset" &&
+    getStaticBooleanAttributeState(openingElement, "disabled") !== false
+  ) {
+    return true;
+  }
+  if (
+    (tagName === "dialog" || tagName === "details") &&
+    getStaticBooleanAttributeState(openingElement, "open") !== true
+  ) {
+    return true;
+  }
+  if (isTarget && tagName === "input") {
+    const typeAttribute = hasJsxPropIgnoreCase(openingElement.attributes, "type");
+    if (typeAttribute && (!typeAttribute.value || getJsxPropStringValue(typeAttribute) === null)) {
+      return true;
+    }
+  }
+  return false;
+};
+
+const hasStaticallyExcludedAncestry = (
+  openingElement: EsTreeNodeOfType<"JSXOpeningElement">,
+  renderRoot: EsTreeNode,
+): boolean => {
+  if (isStaticallyExcludedOpeningElement(openingElement, true)) return true;
+  let current: EsTreeNode = openingElement.parent ?? openingElement;
+  while (current !== renderRoot && current.parent) {
+    const parent = current.parent;
+    if (
+      isNodeOfType(parent, "JSXElement") &&
+      parent.openingElement !== openingElement &&
+      isStaticallyExcludedOpeningElement(parent.openingElement, false)
+    ) {
+      return true;
+    }
+    current = parent;
+  }
+  return false;
+};
+
+const getStaticTruthiness = (expression: EsTreeNode): boolean | null => {
+  const unwrappedExpression = stripParenExpression(expression);
+  if (isNodeOfType(unwrappedExpression, "Literal")) {
+    return Boolean(unwrappedExpression.value);
+  }
+  if (
+    isNodeOfType(unwrappedExpression, "TemplateLiteral") &&
+    unwrappedExpression.expressions.length === 0
+  ) {
+    return Boolean(unwrappedExpression.quasis[0]?.value.cooked);
+  }
+  if (
+    isNodeOfType(unwrappedExpression, "UnaryExpression") &&
+    unwrappedExpression.operator === "!"
+  ) {
+    const argumentTruthiness = getStaticTruthiness(unwrappedExpression.argument);
+    return argumentTruthiness === null ? null : !argumentTruthiness;
+  }
+  return null;
+};
+
+const hasContradictoryBooleanRequirements = (
+  expression: EsTreeNode,
+  expectedTruthiness: boolean,
+  context: RuleContext,
+): boolean => {
+  const requirements = new Map<number, boolean>();
+  const collectRequirements = (candidate: EsTreeNode, requiredTruthiness: boolean): boolean => {
+    const unwrappedCandidate = stripParenExpression(candidate);
+    const staticTruthiness = getStaticTruthiness(unwrappedCandidate);
+    if (staticTruthiness !== null) return staticTruthiness !== requiredTruthiness;
+    if (
+      isNodeOfType(unwrappedCandidate, "UnaryExpression") &&
+      unwrappedCandidate.operator === "!"
+    ) {
+      return collectRequirements(unwrappedCandidate.argument, !requiredTruthiness);
+    }
+    if (
+      isNodeOfType(unwrappedCandidate, "LogicalExpression") &&
+      ((unwrappedCandidate.operator === "&&" && requiredTruthiness) ||
+        (unwrappedCandidate.operator === "||" && !requiredTruthiness))
+    ) {
+      return (
+        collectRequirements(unwrappedCandidate.left, requiredTruthiness) ||
+        collectRequirements(unwrappedCandidate.right, requiredTruthiness)
+      );
+    }
+    if (!isNodeOfType(unwrappedCandidate, "Identifier")) return false;
+    const symbol = context.scopes.symbolFor(unwrappedCandidate);
+    if (!symbol) return false;
+    const previousRequirement = requirements.get(symbol.id);
+    if (previousRequirement !== undefined && previousRequirement !== requiredTruthiness) {
+      return true;
+    }
+    requirements.set(symbol.id, requiredTruthiness);
+    return false;
+  };
+  return collectRequirements(expression, expectedTruthiness);
+};
+
+const isInStaticallyImpossiblePath = (
+  node: EsTreeNode,
+  boundary: EsTreeNode,
+  context: RuleContext,
+): boolean => {
+  let child = node;
+  let parent = node.parent;
+  while (parent && parent !== boundary) {
+    if (isNodeOfType(parent, "SwitchCase")) return true;
+    if (isNodeOfType(parent, "IfStatement")) {
+      const expectedTruthiness = parent.consequent === child;
+      if (
+        (parent.consequent === child || parent.alternate === child) &&
+        (getStaticTruthiness(parent.test) === !expectedTruthiness ||
+          hasContradictoryBooleanRequirements(parent.test, expectedTruthiness, context))
+      ) {
+        return true;
+      }
+    } else if (isNodeOfType(parent, "ConditionalExpression")) {
+      const expectedTruthiness = parent.consequent === child;
+      if (
+        (parent.consequent === child || parent.alternate === child) &&
+        (getStaticTruthiness(parent.test) === !expectedTruthiness ||
+          hasContradictoryBooleanRequirements(parent.test, expectedTruthiness, context))
+      ) {
+        return true;
+      }
+    } else if (isNodeOfType(parent, "LogicalExpression") && parent.right === child) {
+      const requiredTruthiness = parent.operator === "&&";
+      if (
+        parent.operator !== "??" &&
+        (getStaticTruthiness(parent.left) === !requiredTruthiness ||
+          hasContradictoryBooleanRequirements(parent.left, requiredTruthiness, context))
+      ) {
+        return true;
+      }
+    } else if (isNodeOfType(parent, "BlockStatement")) {
+      let containingStatement = child;
+      while (containingStatement.parent && containingStatement.parent !== parent) {
+        containingStatement = containingStatement.parent;
+      }
+      const statementIndex = parent.body.findIndex(
+        (statement) => statement === containingStatement,
+      );
+      if (
+        statementIndex > 0 &&
+        parent.body.slice(0, statementIndex).some((statement) => statementAlwaysExits(statement))
+      ) {
+        return true;
+      }
+    }
+    child = parent;
+    parent = parent.parent;
+  }
+  return false;
+};
 
 const getHandlerExpression = (attribute: EsTreeNode): EsTreeNode | null => {
   if (
@@ -49,6 +375,15 @@ const getHandlerExpression = (attribute: EsTreeNode): EsTreeNode | null => {
     return null;
   }
   return attribute.value.expression;
+};
+
+const resolveHandlerExpression = (
+  openingElement: EsTreeNodeOfType<"JSXOpeningElement">,
+  handlerName: string,
+): EsTreeNode | null => {
+  const resolution = resolveStaticJsxAttribute(openingElement.attributes, handlerName);
+  if (!resolution.isPresent || resolution.isUnknown) return null;
+  return resolution.expression ?? getHandlerExpression(resolution.attribute ?? openingElement);
 };
 
 const resolveReactCompletionHandler = (
@@ -76,7 +411,7 @@ const resolveReactCompletionHandler = (
   return resolveExactLocalFunction(wrappedCallback, context.scopes);
 };
 
-const isSafeDirectReactRefReference = (identifier: EsTreeNode): boolean => {
+const isSafeDirectReactRefReference = (identifier: EsTreeNode, context: RuleContext): boolean => {
   const expressionRoot = findTransparentExpressionRoot(identifier);
   const parent = expressionRoot.parent;
   if (
@@ -84,6 +419,33 @@ const isSafeDirectReactRefReference = (identifier: EsTreeNode): boolean => {
     isNodeOfType(parent, "MemberExpression") &&
     parent.object === expressionRoot &&
     getStaticPropertyName(parent) === "current"
+  ) {
+    const currentRoot = findTransparentExpressionRoot(parent);
+    const focusMember = currentRoot.parent;
+    if (
+      focusMember &&
+      isNodeOfType(focusMember, "MemberExpression") &&
+      focusMember.object === currentRoot &&
+      getStaticPropertyName(focusMember) === "focus"
+    ) {
+      const focusRoot = findTransparentExpressionRoot(focusMember);
+      return Boolean(
+        focusRoot.parent &&
+        isNodeOfType(focusRoot.parent, "CallExpression") &&
+        focusRoot.parent.callee === focusRoot,
+      );
+    }
+    return false;
+  }
+  if (
+    parent &&
+    isNodeOfType(parent, "ArrayExpression") &&
+    parent.parent &&
+    isNodeOfType(parent.parent, "CallExpression") &&
+    parent.parent.arguments[1] === parent &&
+    isReactApiCall(parent.parent, "useCallback", context.scopes, {
+      resolveNamedAliases: true,
+    })
   ) {
     return true;
   }
@@ -102,12 +464,16 @@ const collectIntrinsicReactRefIndex = (
   program: EsTreeNodeOfType<"Program">,
   context: RuleContext,
 ): IntrinsicReactRefIndex => {
-  const attachmentNodesBySymbolId = new Map<number, EsTreeNodeOfType<"JSXOpeningElement">[]>();
+  const attachmentsBySymbolId = new Map<number, IntrinsicReactRefAttachment[]>();
   const refSymbolsById = new Map<number, SymbolDescriptor>();
   const uncertainRefSymbolIds = new Set<number>();
   walkAst(program, (candidate) => {
     if (!isNodeOfType(candidate, "JSXOpeningElement")) return;
     if (!isNodeReachableWithinFunction(candidate, context)) return false;
+    const renderLocation = getProvenRenderLocation(candidate);
+    if (!renderLocation || isInStaticallyImpossiblePath(candidate, renderLocation.owner, context)) {
+      return false;
+    }
     if (hasJsxSpreadAttribute(candidate.attributes)) return false;
     const refAttribute = getAuthoritativeJsxAttribute(candidate.attributes, "ref");
     if (
@@ -130,17 +496,21 @@ const collectIntrinsicReactRefIndex = (
     const initializer = stripParenExpression(refSymbol.initializer);
     if (
       isNodeOfType(initializer, "CallExpression") &&
-      isReactApiCall(initializer, "useRef", context.scopes, { resolveNamedAliases: true })
+      isReactApiCall(initializer, REACT_REF_CREATION_API_NAMES, context.scopes, {
+        resolveNamedAliases: true,
+      })
     ) {
       refSymbolsById.set(refSymbol.id, refSymbol);
+      const tagName = isNodeOfType(candidate.name, "JSXIdentifier") ? candidate.name.name : null;
       if (
-        isNodeOfType(candidate.name, "JSXIdentifier") &&
-        /^[a-z]/.test(candidate.name.name) &&
-        isFocusableJsxOpeningElement(candidate, candidate.name.name, true)
+        tagName &&
+        /^[a-z]/.test(tagName) &&
+        isFocusableJsxOpeningElement(candidate, tagName, true) &&
+        !hasStaticallyExcludedAncestry(candidate, renderLocation.root)
       ) {
-        const attachmentNodes = attachmentNodesBySymbolId.get(refSymbol.id) ?? [];
-        attachmentNodes.push(candidate);
-        attachmentNodesBySymbolId.set(refSymbol.id, attachmentNodes);
+        const attachments = attachmentsBySymbolId.get(refSymbol.id) ?? [];
+        attachments.push({ location: renderLocation, node: candidate });
+        attachmentsBySymbolId.set(refSymbol.id, attachments);
       } else {
         uncertainRefSymbolIds.add(refSymbol.id);
       }
@@ -161,6 +531,7 @@ const collectIntrinsicReactRefIndex = (
       stripParenExpression(assignmentTarget),
       context.scopes,
       {
+        includeCreateRef: true,
         resolveNamedAliases: true,
       },
     );
@@ -168,17 +539,17 @@ const collectIntrinsicReactRefIndex = (
   });
   for (const [refSymbolId, refSymbol] of refSymbolsById) {
     if (
-      refSymbol?.references.some(
-        (reference) => !isSafeDirectReactRefReference(reference.identifier),
+      refSymbol.references.some(
+        (reference) => !isSafeDirectReactRefReference(reference.identifier, context),
       )
     ) {
       uncertainRefSymbolIds.add(refSymbolId);
     }
   }
   for (const uncertainRefSymbolId of uncertainRefSymbolIds) {
-    attachmentNodesBySymbolId.delete(uncertainRefSymbolId);
+    attachmentsBySymbolId.delete(uncertainRefSymbolId);
   }
-  return { attachmentNodesBySymbolId };
+  return { attachmentsBySymbolId };
 };
 
 const isHandlerDefinitionReachable = (handler: EsTreeNode, context: RuleContext): boolean => {
@@ -211,33 +582,82 @@ const isHandlerDefinitionReachable = (handler: EsTreeNode, context: RuleContext)
   return false;
 };
 
+const isHandlerCurrentTarget = (
+  expression: EsTreeNode,
+  handler: EsTreeNode,
+  context: RuleContext,
+): boolean => {
+  const currentTargetMember = stripParenExpression(expression);
+  if (
+    !isFunctionLike(handler) ||
+    !isNodeOfType(currentTargetMember, "MemberExpression") ||
+    getStaticPropertyName(currentTargetMember) !== "currentTarget"
+  ) {
+    return false;
+  }
+  const eventExpression = stripParenExpression(currentTargetMember.object);
+  const eventParameter = handler.params[0];
+  return Boolean(
+    eventParameter &&
+    isNodeOfType(eventParameter, "Identifier") &&
+    isNodeOfType(eventExpression, "Identifier") &&
+    context.scopes.symbolFor(eventParameter)?.id === context.scopes.symbolFor(eventExpression)?.id,
+  );
+};
+
 const collectDirectFocusCalls = (
   handler: EsTreeNode,
-  handlerSite: EsTreeNode,
+  handlerSite: EsTreeNodeOfType<"JSXOpeningElement">,
+  handlerRenderLocation: ProvenRenderLocation,
   intrinsicRefIndex: IntrinsicReactRefIndex,
   context: RuleContext,
 ): EsTreeNodeOfType<"CallExpression">[] => {
-  if (!isFunctionLike(handler)) return [];
+  if (!isFunctionLike(handler) || isGeneratorFunction(handler)) return [];
   const focusCalls: EsTreeNodeOfType<"CallExpression">[] = [];
   walkAst(handler.body, (child) => {
-    if (isFunctionLike(child) && !isImmediatelyInvokedFunction(child)) return false;
+    if (
+      isFunctionLike(child) &&
+      (isGeneratorFunction(child) || !isImmediatelyInvokedFunction(child))
+    ) {
+      return false;
+    }
     if (isNodeOfType(child, "PropertyDefinition") || isNodeOfType(child, "AccessorProperty")) {
       return false;
     }
     if (!isNodeOfType(child, "CallExpression")) return;
-    if (!isNodeReachableWithinFunction(child, context)) return false;
+    if (
+      !isNodeReachableWithinFunction(child, context) ||
+      isInStaticallyImpossiblePath(child, handler, context)
+    ) {
+      return false;
+    }
     const callee = stripParenExpression(child.callee);
     if (!isNodeOfType(callee, "MemberExpression")) return;
     if (getStaticPropertyName(callee) !== "focus") return;
-    const refSymbol = resolveReactRefCurrentOriginSymbol(callee.object, context.scopes);
-    const attachmentNodes = refSymbol
-      ? intrinsicRefIndex.attachmentNodesBySymbolId.get(refSymbol.id)
+    if (
+      isHandlerCurrentTarget(callee.object, handler, context) &&
+      isNodeOfType(handlerSite.name, "JSXIdentifier") &&
+      isFocusableJsxOpeningElement(handlerSite, handlerSite.name.name, true) &&
+      !hasStaticallyExcludedAncestry(handlerSite, handlerRenderLocation.root)
+    ) {
+      focusCalls.push(child);
+      return;
+    }
+    const refSymbol = resolveReactRefSymbol(stripParenExpression(callee.object), context.scopes, {
+      includeCreateRef: true,
+      resolveNamedAliases: true,
+    });
+    const attachments = refSymbol
+      ? intrinsicRefIndex.attachmentsBySymbolId.get(refSymbol.id)
       : null;
     if (
-      attachmentNodes?.some(
-        (attachmentNode) =>
-          nodesCanCoExecute(attachmentNode, handler, context) &&
-          nodesCanCoExecute(attachmentNode, handlerSite, context),
+      attachments?.some(
+        (attachment) =>
+          attachment.location.owner === handlerRenderLocation.owner &&
+          attachment.location.root === handlerRenderLocation.root &&
+          nodesCanCoExecute(attachment.node, handler, context) &&
+          nodesCanCoExecute(attachment.node, handlerSite, context) &&
+          nodesCanCoExecute(attachment.node, child, context),
       )
     ) {
       focusCalls.push(child);
@@ -259,18 +679,21 @@ export const noFocusInAnimationCompletionHandler = defineRule({
     const reportedFocusCalls = new WeakSet<EsTreeNode>();
     return {
       JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
-        if (!isNodeOfType(node.name, "JSXIdentifier") || !/^[a-z]/.test(node.name.name)) {
+        if (!isIntrinsicOpeningElement(node)) return;
+        const handlerRenderLocation = getProvenRenderLocation(node);
+        if (
+          !handlerRenderLocation ||
+          isInStaticallyImpossiblePath(node, handlerRenderLocation.owner, context)
+        ) {
           return;
         }
         for (const handlerName of ANIMATION_COMPLETION_HANDLER_NAMES) {
-          const attribute = getAuthoritativeJsxAttribute(node.attributes, handlerName);
-          if (!attribute) continue;
-          const handlerExpression = getHandlerExpression(attribute);
+          const handlerExpression = resolveHandlerExpression(node, handlerName);
           if (!handlerExpression) continue;
           const handler = resolveReactCompletionHandler(handlerExpression, context);
           if (
             !handler ||
-            !isNodeReachableWithinFunction(attribute, context) ||
+            !isNodeReachableWithinFunction(handlerExpression, context) ||
             !isHandlerDefinitionReachable(handler, context)
           ) {
             continue;
@@ -284,7 +707,8 @@ export const noFocusInAnimationCompletionHandler = defineRule({
           }
           for (const focusCall of collectDirectFocusCalls(
             handler,
-            attribute,
+            node,
+            handlerRenderLocation,
             intrinsicRefIndex,
             context,
           )) {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-mixed-animation-owners.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-mixed-animation-owners.test.ts
@@ -1,0 +1,503 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noMixedAnimationOwners } from "./no-mixed-animation-owners.js";
+
+describe("no-mixed-animation-owners", () => {
+  it("reports Motion and Tailwind transitions that own the same property", () => {
+    const result = runRule(
+      noMixedAnimationOwners,
+      `import { motion } from "motion/react";
+       const Demo = () => <>
+         <motion.div animate={{ x: 100 }} className="transition-transform" />
+         <motion.div animate={{ opacity: 1 }} className="transition-opacity duration-200" />
+         <motion.div animate={{ backgroundColor: "red" }} className="transition-colors" />
+         <motion.div animate={{ boxShadow: "0 0 10px red" }} className="transition-shadow" />
+       </>;`,
+    );
+    expect(result.diagnostics).toHaveLength(4);
+  });
+
+  it("normalizes Motion transform aliases and camel-cased CSS keys", () => {
+    const result = runRule(
+      noMixedAnimationOwners,
+      `import { m } from "framer-motion";
+       const Demo = () => <>
+         <m.div animate={{ y: 20, rotateZ: 10, transformPerspective: 800 }} className="transition-transform" />
+         <m.div animate={{ borderTopColor: "red" }} className="transition-[border-top-color]" />
+         <m.div exit={{ transformOrigin: "center" }} className="transition-[transform-origin]" />
+         <m.div animate={{ WebkitFilter: "blur(0)" }} className="transition-[-webkit-filter]" />
+       </>;`,
+    );
+    expect(result.diagnostics).toHaveLength(4);
+  });
+
+  it("reports authoritative static target objects through supported Motion imports", () => {
+    const result = runRule(
+      noMixedAnimationOwners,
+      `import { motion as animated } from "framer-motion";
+       import * as Motion from "motion/react";
+       import { div as MotionDiv } from "motion/react-m";
+       const Factory = animated;
+       const Created = animated.create("div");
+       const Demo = () => <>
+         <animated.div animate={{ opacity: 1 }} className="transition-opacity" />
+         <Motion.motion.div animate={{ x: 1 }} className="transition-transform" />
+         <MotionDiv animate={{ color: "red" }} className="transition-colors" />
+         <Factory.div animate={{ scale: 1 }} className="transition-transform" />
+         <Created animate={{ filter: "blur(0)" }} className="transition-[filter] duration-200" />
+       </>;`,
+    );
+    expect(result.diagnostics).toHaveLength(5);
+  });
+
+  it("reports positive inline transitions and property-duration lists", () => {
+    const result = runRule(
+      noMixedAnimationOwners,
+      `import { motion } from "motion/react";
+       const opacityTransition = { transitionProperty: "opacity", transitionDuration: "200ms" };
+       const Demo = () => <>
+         <motion.div animate={{ x: 10 }} style={{ transition: "transform 150ms ease" }} />
+         <motion.div animate={{ opacity: 1 }} style={opacityTransition} />
+         <motion.div animate={{ color: "red" }} style={{ transitionProperty: "opacity, color", transitionDuration: "0ms, 120ms" }} />
+       </>;`,
+    );
+    expect(result.diagnostics).toHaveLength(3);
+  });
+
+  it("merges statically effective Tailwind and inline transition declarations", () => {
+    const result = runRule(
+      noMixedAnimationOwners,
+      `import { motion } from "motion/react";
+       const Demo = () => <>
+         <motion.div animate={{ x: 10 }} className="duration-200" style={{ transitionProperty: "transform" }} />
+         <motion.div animate={{ opacity: 1 }} className="transition-opacity" style={{ transitionDuration: "250ms" }} />
+         <motion.div animate={{ color: "red" }} className="!transition-colors" style={{ transitionProperty: "opacity" }} />
+         <motion.div animate={{ x: 10 }} className="!duration-200" style={{ transition: "transform 0ms" }} />
+       </>;`,
+    );
+    expect(result.diagnostics).toHaveLength(4);
+  });
+
+  it("supports exact arbitrary Tailwind transition declarations", () => {
+    const result = runRule(
+      noMixedAnimationOwners,
+      `import { motion } from "motion/react";
+       const Demo = () => <>
+         <motion.div animate={{ opacity: 1 }} className="transition-[opacity] duration-[175ms]" />
+         <motion.div animate={{ x: 10 }} className="[transition-property:transform] [transition-duration:0.2s]" />
+         <motion.div animate={{ color: "red" }} className="[transition:color_120ms_ease-out]" />
+       </>;`,
+    );
+    expect(result.diagnostics).toHaveLength(3);
+  });
+
+  it("uses Tailwind v4 individual transform and outline transition properties", () => {
+    const result = runRule(
+      noMixedAnimationOwners,
+      `import { motion } from "motion/react";
+       const Demo = () => <>
+         <motion.div animate={{ translate: "10px" }} className="transition-transform" />
+         <motion.div animate={{ outlineColor: "red" }} className="transition-colors" />
+       </>;`,
+      { settings: { "react-doctor": { capabilities: ["tailwind", "tailwind:4"] } } },
+    );
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
+  it("does not assume Tailwind v4-only transition properties in older projects", () => {
+    const result = runRule(
+      noMixedAnimationOwners,
+      `import { motion } from "motion/react";
+       const Demo = () => <>
+         <motion.div animate={{ translate: "10px" }} className="transition-transform" />
+         <motion.div animate={{ outlineColor: "red" }} className="transition-colors" />
+       </>;`,
+      { settings: { "react-doctor": { capabilities: ["tailwind"] } } },
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("allows different Motion and CSS transition properties", () => {
+    const result = runRule(
+      noMixedAnimationOwners,
+      `import { motion } from "motion/react";
+       const Demo = () => <>
+         <motion.div animate={{ x: 10 }} className="transition-opacity" />
+         <motion.div animate={{ opacity: 1 }} className="transition-transform" />
+         <motion.div animate={{ color: "red" }} style={{ transition: "background-color 200ms" }} />
+         <motion.div animate={{ boxShadow: "none" }} className="transition-colors" />
+       </>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("keeps parent and child animation ownership separate", () => {
+    const result = runRule(
+      noMixedAnimationOwners,
+      `import { motion } from "motion/react";
+       const Demo = () => <>
+         <motion.div animate={{ x: 10 }}><span className="transition-transform" /></motion.div>
+         <motion.div className="transition-transform"><motion.span animate={{ x: 10 }} /></motion.div>
+       </>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("ignores Tailwind transitions that target descendants or pseudo-elements", () => {
+    const result = runRule(
+      noMixedAnimationOwners,
+      `import { motion } from "motion/react";
+       const Demo = () => <>
+         <motion.div animate={{ opacity: 1 }} className="[&>span]:transition-opacity" />
+         <motion.div animate={{ opacity: 1 }} className="[&_span]:transition-opacity" />
+         <motion.div animate={{ opacity: 1 }} className="before:transition-opacity" />
+         <motion.div animate={{ opacity: 1 }} className="after:transition-opacity" />
+         <motion.div animate={{ opacity: 1 }} className="*:transition-opacity" />
+         <motion.div animate={{ opacity: 1 }} className="group-hover:transition-opacity" />
+         <motion.div animate={{ opacity: 1 }} className="peer-focus:transition-opacity" />
+         <motion.div animate={{ opacity: 1 }} className="has-[span]:transition-opacity" />
+       </>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("allows an exact arbitrary self selector", () => {
+    const result = runRule(
+      noMixedAnimationOwners,
+      `import { motion } from "motion/react";
+       const Demo = () => <motion.div animate={{ opacity: 1 }} className="[&]:transition-opacity" />;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("requires local data variants to match static attributes", () => {
+    const result = runRule(
+      noMixedAnimationOwners,
+      `import { motion } from "motion/react";
+       const Demo = ({ state }) => <>
+         <motion.div data-state="open" animate={{ opacity: 1 }} className="data-[state=open]:transition-opacity" />
+         <motion.div data-state="closed" animate={{ opacity: 1 }} className="data-[state=open]:transition-opacity" />
+         <motion.div animate={{ opacity: 1 }} className="data-[state=open]:transition-opacity" />
+         <motion.div data-state={state} animate={{ opacity: 1 }} className="data-[state=open]:transition-opacity" />
+         <motion.div data-active="" animate={{ opacity: 1 }} className="data-active:transition-opacity" />
+       </>;`,
+    );
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
+  it("requires local ARIA variants to match static attributes", () => {
+    const result = runRule(
+      noMixedAnimationOwners,
+      `import { motion } from "motion/react";
+       const Demo = ({ expanded }) => <>
+         <motion.button aria-expanded="true" animate={{ opacity: 1 }} className="aria-[expanded=true]:transition-opacity" />
+         <motion.button aria-expanded="false" animate={{ opacity: 1 }} className="aria-[expanded=true]:transition-opacity" />
+         <motion.button animate={{ opacity: 1 }} className="aria-[expanded=true]:transition-opacity" />
+         <motion.button aria-expanded={expanded} animate={{ opacity: 1 }} className="aria-[expanded=true]:transition-opacity" />
+         <motion.button aria-pressed={true} animate={{ opacity: 1 }} className="aria-pressed:transition-opacity" />
+       </>;`,
+    );
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
+  it("suppresses transition-all ownership handled by no-transition-all", () => {
+    const result = runRule(
+      noMixedAnimationOwners,
+      `import { motion } from "motion/react";
+       const Demo = () => <>
+         <motion.div animate={{ x: 10 }} className="transition-all" />
+         <motion.div animate={{ opacity: 1 }} style={{ transition: "all 200ms" }} />
+         <motion.div animate={{ color: "red" }} className="[transition-property:all] duration-200" />
+       </>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for CSS custom and non-interpolable transition properties", () => {
+    const result = runRule(
+      noMixedAnimationOwners,
+      `import { motion } from "motion/react";
+       const Demo = () => <>
+         <motion.div animate={{ "--progress": 1 }} style={{ transition: "--progress 200ms" }} />
+         <motion.div animate={{ display: "none" }} style={{ transition: "display 200ms" }} />
+         <motion.div animate={{ pointerEvents: "none" }} className="transition-[pointer-events]" />
+       </>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("allows zero-duration and disabled transitions", () => {
+    const result = runRule(
+      noMixedAnimationOwners,
+      `import { motion } from "motion/react";
+       const Demo = () => <>
+         <motion.div animate={{ x: 10 }} className="transition-transform duration-0" />
+         <motion.div animate={{ opacity: 1 }} className="transition-none duration-200" />
+         <motion.div animate={{ color: "red" }} style={{ transition: "color 0ms" }} />
+         <motion.div animate={{ filter: "none" }} style={{ transitionProperty: "filter", transitionDuration: "0s" }} />
+         <motion.div initial={{ opacity: 0 }} className="transition-opacity" />
+       </>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for conflicting Tailwind properties and durations", () => {
+    const result = runRule(
+      noMixedAnimationOwners,
+      `import { motion } from "motion/react";
+       const Demo = () => <>
+         <motion.div animate={{ x: 10 }} className="transition-transform transition-opacity" />
+         <motion.div animate={{ x: 10 }} className="transition-transform duration-0 duration-200" />
+         <motion.div animate={{ opacity: 1 }} className="!transition-opacity !transition-transform" />
+         <motion.div animate={{ opacity: 1 }} className="transition-opacity !duration-0 !duration-200" />
+       </>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("respects important precedence when Tailwind and inline styles conflict", () => {
+    const result = runRule(
+      noMixedAnimationOwners,
+      `import { motion } from "motion/react";
+       const Demo = () => <>
+         <motion.div animate={{ x: 10 }} className="!transition-none" style={{ transition: "transform 200ms" }} />
+         <motion.div animate={{ opacity: 1 }} className="!duration-0 transition-opacity" style={{ transitionDuration: "200ms" }} />
+         <motion.div animate={{ x: 10 }} className="transition-transform" style={{ transitionProperty: "opacity" }} />
+         <motion.div animate={{ opacity: 1 }} className="transition-opacity duration-0" style={{ transitionDuration: "200ms" }} />
+       </>;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("recognizes co-executing interaction states and explicit exclusions", () => {
+    const result = runRule(
+      noMixedAnimationOwners,
+      `import { motion } from "motion/react";
+       const Demo = () => <>
+         <motion.div whileHover={{ x: 10 }} className="hover:transition-transform" />
+         <motion.div whileFocus={{ opacity: 1 }} className="focus-visible:transition-opacity" />
+         <motion.div whileTap={{ scale: 0.9 }} className="active:transition-transform" />
+         <motion.div whileHover={{ x: 10 }} className="focus:transition-transform" />
+         <motion.div whileFocus={{ opacity: 1 }} className="hover:transition-opacity" />
+         <motion.div whileTap={{ scale: 0.9 }} className="focus:transition-transform" />
+         <motion.div whileHover={{ x: 10 }} className="not-hover:transition-transform" />
+         <motion.div whileFocus={{ opacity: 1 }} className="not-focus:transition-opacity" />
+         <motion.div whileTap={{ scale: 0.9 }} className="not-active:transition-transform" />
+       </>;`,
+    );
+    expect(result.diagnostics).toHaveLength(6);
+  });
+
+  it("reports base transitions that overlap gesture-owned properties", () => {
+    const result = runRule(
+      noMixedAnimationOwners,
+      `import { motion } from "motion/react";
+       const Demo = () => <>
+         <motion.div whileHover={{ x: 10 }} className="transition-transform" />
+         <motion.div whileFocus={{ opacity: 1 }} style={{ transition: "opacity 200ms" }} />
+       </>;`,
+    );
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
+  it("supports drag and in-view ownership across base and responsive scopes", () => {
+    const result = runRule(
+      noMixedAnimationOwners,
+      `import { motion } from "motion/react";
+       const Demo = () => <>
+         <motion.div whileDrag={{ x: 10 }} className="transition-transform" />
+         <motion.div whileInView={{ opacity: 1 }} className="md:transition-opacity" />
+         <motion.div whileDrag={{ color: "red" }} className="focus:transition-colors" />
+       </>;`,
+    );
+    expect(result.diagnostics).toHaveLength(3);
+  });
+
+  it("uses matching state overrides before considering a base inline transition", () => {
+    const result = runRule(
+      noMixedAnimationOwners,
+      `import { motion } from "motion/react";
+       const Demo = () => <>
+         <motion.div whileHover={{ x: 10 }} className="hover:!transition-none" style={{ transition: "transform 200ms" }} />
+         <motion.div whileFocus={{ opacity: 1 }} className="focus:!duration-0" style={{ transition: "opacity 200ms" }} />
+       </>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("uses effective nested Tailwind scopes for property and duration", () => {
+    const result = runRule(
+      noMixedAnimationOwners,
+      `import { motion } from "motion/react";
+       const Demo = () => <>
+         <motion.div whileHover={{ x: 10 }} className="md:hover:transition-transform md:hover:duration-200" />
+         <motion.div whileHover={{ x: 10 }} className="hover:[transition-property:transform] focus:duration-200" />
+         <motion.div whileHover={{ x: 10 }} className="hover:[transition-property:transform] hover:duration-0 focus:duration-200" />
+       </>;`,
+    );
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
+  it("combines proven co-executing property and duration scopes", () => {
+    const result = runRule(
+      noMixedAnimationOwners,
+      `import { motion } from "motion/react";
+       const Demo = () => <>
+         <motion.div animate={{ x: 10 }} className="md:[transition-property:transform] hover:duration-200" />
+         <motion.div animate={{ opacity: 1 }} className="motion-safe:[transition-property:opacity] dark:duration-200" />
+         <motion.div animate={{ color: "red" }} className="focus:[transition-property:color] hover:duration-200" />
+       </>;`,
+    );
+    expect(result.diagnostics).toHaveLength(3);
+  });
+
+  it("does not combine mutually exclusive Tailwind scopes", () => {
+    const result = runRule(
+      noMixedAnimationOwners,
+      `import { motion } from "motion/react";
+       const Demo = () => <>
+         <motion.div animate={{ opacity: 1 }} className="motion-safe:[transition-property:opacity] motion-reduce:duration-200" />
+         <motion.div animate={{ opacity: 1 }} className="portrait:[transition-property:opacity] landscape:duration-200" />
+         <motion.div animate={{ opacity: 1 }} className="lg:[transition-property:opacity] max-md:duration-200" />
+         <motion.div animate={{ opacity: 1 }} className="data-[state=open]:[transition-property:opacity] data-[state=closed]:duration-200" />
+       </>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("rejects internally contradictory transition scopes", () => {
+    const result = runRule(
+      noMixedAnimationOwners,
+      `import { motion } from "motion/react";
+       const Demo = () => <>
+         <motion.div animate={{ opacity: 1 }} className="motion-safe:motion-reduce:transition-opacity" />
+         <motion.div animate={{ opacity: 1 }} className="portrait:landscape:transition-opacity" />
+         <motion.div animate={{ opacity: 1 }} className="md:max-md:transition-opacity" />
+         <motion.div animate={{ opacity: 1 }} className="data-[state=open]:data-[state=closed]:transition-opacity" />
+       </>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not combine additional mutually exclusive state families", () => {
+    const result = runRule(
+      noMixedAnimationOwners,
+      `import { motion } from "motion/react";
+       const Demo = () => <>
+         <motion.div animate={{ opacity: 1 }} className="in-range:[transition-property:opacity] out-of-range:duration-200" />
+         <motion.div animate={{ opacity: 1 }} className="read-only:[transition-property:opacity] read-write:duration-200" />
+         <motion.div animate={{ opacity: 1 }} className="pointer-coarse:[transition-property:opacity] pointer-fine:duration-200" />
+         <motion.a animate={{ opacity: 1 }} className="link:[transition-property:opacity] visited:duration-200" />
+         <motion.div animate={{ opacity: 1 }} className="odd:[transition-property:opacity] even:duration-200" />
+       </>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not report phantom base states covered by exhaustive transition overrides", () => {
+    const result = runRule(
+      noMixedAnimationOwners,
+      `import { motion } from "motion/react";
+       const Demo = () => <>
+         <motion.div animate={{ opacity: 1 }} className="transition-opacity motion-safe:transition-none motion-reduce:transition-none" />
+         <motion.div animate={{ opacity: 1 }} className="transition-opacity max-md:transition-none md:transition-none" />
+         <motion.div animate={{ opacity: 1 }} className="motion-safe:!transition-none motion-reduce:!transition-none" style={{ transition: "opacity 200ms" }} />
+       </>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("retains reachable base states outside incomplete or qualified partitions", () => {
+    const result = runRule(
+      noMixedAnimationOwners,
+      `import { motion } from "motion/react";
+       const Demo = () => <>
+         <motion.div animate={{ opacity: 1 }} className="transition-opacity motion-safe:transition-none" />
+         <motion.div animate={{ opacity: 1 }} className="transition-opacity max-md:transition-none" />
+         <motion.div animate={{ opacity: 1 }} className="transition-opacity dark:motion-safe:transition-none dark:motion-reduce:transition-none" />
+       </>;`,
+    );
+    expect(result.diagnostics).toHaveLength(3);
+  });
+
+  it("stays quiet for dynamic Motion targets and target spreads", () => {
+    const result = runRule(
+      noMixedAnimationOwners,
+      `import { motion } from "motion/react";
+       const target = { opacity: 1 };
+       const Demo = ({ animate, keyName, props }) => <>
+         <motion.div animate={animate} className="transition-opacity" />
+         <motion.div animate={target} className="transition-opacity" />
+         <motion.div animate={{ [keyName]: 1 }} className="transition-opacity" />
+         <motion.div animate={{ ...props, opacity: 1 }} className="transition-opacity" />
+         <motion.div animate={{ opacity: 1 }} {...props} className="transition-opacity" />
+       </>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("accepts fully static inline target spreads", () => {
+    const result = runRule(
+      noMixedAnimationOwners,
+      `import { motion } from "motion/react";
+       const Demo = () => <motion.div animate={{ ...{ opacity: 1 } }} className="transition-opacity" />;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays quiet for dynamic classes and styles", () => {
+    const result = runRule(
+      noMixedAnimationOwners,
+      `import { motion } from "motion/react";
+       const Demo = ({ className, style, enabled }) => <>
+         <motion.div animate={{ opacity: 1 }} className={className} />
+         <motion.div animate={{ opacity: 1 }} style={style} />
+         <motion.div animate={{ opacity: 1 }} className={\`transition-opacity \${className}\`} />
+         <motion.div animate={{ opacity: 1 }} className={enabled ? "transition-opacity" : className} />
+         <motion.div animate={{ opacity: 1 }} style={{ ...style, transition: "opacity 200ms" }} />
+       </>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("folds unreachable literal className branches", () => {
+    const result = runRule(
+      noMixedAnimationOwners,
+      `import { motion } from "motion/react";
+       const Demo = () => <>
+         <motion.div animate={{ x: 10 }} className={false ? "transition-transform" : "transition-opacity"} />
+         <motion.div animate={{ x: 10 }} className={true ? "transition-transform" : "transition-opacity"} />
+       </>;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays quiet for custom Motion lookalikes, type imports, and shadowed bindings", () => {
+    const result = runRule(
+      noMixedAnimationOwners,
+      `import type { motion as MotionType } from "motion/react";
+       import { motion as importedMotion } from "motion/react";
+       const motion = { div: "div" };
+       const Custom = ({ animate, className }) => <div />;
+       const Demo = () => <>
+         <motion.div animate={{ opacity: 1 }} className="transition-opacity" />
+         <Custom animate={{ opacity: 1 }} className="transition-opacity" />
+         <MotionType.div animate={{ opacity: 1 }} className="transition-opacity" />
+       </>;
+       const Shadowed = () => { const importedMotion = { div: "div" }; return <importedMotion.div animate={{ opacity: 1 }} className="transition-opacity" />; };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("ignores Motion metadata and SVG attribute-only target keys", () => {
+    const result = runRule(
+      noMixedAnimationOwners,
+      `import { motion } from "motion/react";
+       const Demo = () => <>
+         <motion.path animate={{ transition: { duration: 1 }, transitionEnd: { opacity: 0 } }} className="transition-opacity" />
+         <motion.path animate={{ pathLength: 1, attrX: 10 }} className="transition-[path-length] duration-200" />
+       </>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-mixed-animation-owners.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-mixed-animation-owners.ts
@@ -1,0 +1,851 @@
+import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
+import { TAILWIND_BREAKPOINT_RANKS } from "../../constants/tailwind.js";
+import { defineRule } from "../../utils/define-rule.js";
+import { doesTailwindVariantScopeCover } from "../../utils/does-tailwind-variant-scope-cover.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { getAuthoritativeJsxAttribute } from "../../utils/get-authoritative-jsx-attribute.js";
+import { getEffectiveObjectPropertiesInInsertionOrder } from "../../utils/get-effective-object-properties-in-insertion-order.js";
+import { getHighestPriorityTailwindClassNameTokens } from "../../utils/get-highest-priority-tailwind-class-name-tokens.js";
+import { getJsxPropExhaustiveStaticStringValues } from "../../utils/get-jsx-prop-static-string-values.js";
+import { getStaticMotionPropObject } from "../../utils/get-static-motion-prop-object.js";
+import { getStaticPropertyKeyName } from "../../utils/get-static-property-key-name.js";
+import { getTailwindTransitionPropertyEffect } from "../../utils/get-tailwind-transition-property-effect.js";
+import { hasCapability, hasCapabilityOrUnspecified } from "../../utils/get-react-doctor-setting.js";
+import { hasJsxSpreadAttribute } from "../../utils/has-jsx-spread-attribute.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { normalizeTailwindArbitraryUtilityValue } from "../../utils/normalize-tailwind-arbitrary-utility-value.js";
+import { parseTailwindClassNameToken } from "../../utils/parse-tailwind-class-name-token.js";
+import type { TailwindClassNameToken } from "../../utils/parse-tailwind-class-name-token.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+import { splitTailwindClassName } from "../../utils/split-tailwind-class-name.js";
+import { getCssTransitionShorthandEvidence } from "./utils/get-css-transition-shorthand-evidence.js";
+import { getEffectiveCssTransitionEvidence } from "./utils/get-effective-css-transition-evidence.js";
+import type { CssTransitionDefaultEvidence } from "./utils/get-effective-css-transition-evidence.js";
+import { getInlineStyleExpression } from "./utils/get-inline-style-expression.js";
+
+interface MotionOwnedPropertyEvidence {
+  activationTailwindVariant: string | null;
+  excludedTailwindVariants: ReadonlySet<string>;
+  propertyName: string;
+}
+
+interface MotionTargetTailwindConstraints {
+  activationVariant: string | null;
+  excludedVariants: ReadonlySet<string>;
+}
+
+interface TailwindLocalAttributeConstraint {
+  attributeName: string;
+  expectedValue: string | null;
+}
+
+interface TailwindTransitionDeclaration {
+  durationStates: ReadonlyArray<boolean> | null;
+  propertyNames: ReadonlyArray<string> | null;
+}
+
+interface TailwindTransitionState {
+  defaultEvidence: CssTransitionDefaultEvidence[];
+  isDurationImportant: boolean;
+  isPropertyImportant: boolean;
+}
+
+interface TailwindExhaustiveTransitionPartition {
+  commonScope: ReadonlyArray<string>;
+  leftVariant: string;
+  rightVariant: string;
+}
+
+const MOTION_TARGET_PROPERTIES: ReadonlyArray<string> = [
+  "animate",
+  "exit",
+  "whileDrag",
+  "whileFocus",
+  "whileHover",
+  "whileInView",
+  "whileTap",
+];
+const MOTION_TARGET_TAILWIND_CONSTRAINTS = new Map<string, MotionTargetTailwindConstraints>([
+  ["animate", { activationVariant: null, excludedVariants: new Set() }],
+  ["exit", { activationVariant: null, excludedVariants: new Set() }],
+  ["whileDrag", { activationVariant: null, excludedVariants: new Set() }],
+  [
+    "whileFocus",
+    { activationVariant: "focus", excludedVariants: new Set(["disabled", "not-focus"]) },
+  ],
+  ["whileHover", { activationVariant: "hover", excludedVariants: new Set(["not-hover"]) }],
+  ["whileInView", { activationVariant: null, excludedVariants: new Set() }],
+  [
+    "whileTap",
+    { activationVariant: "active", excludedVariants: new Set(["disabled", "not-active"]) },
+  ],
+]);
+const MOTION_TRANSFORM_PROPERTIES = new Set([
+  "originX",
+  "originY",
+  "originZ",
+  "rotate",
+  "rotateX",
+  "rotateY",
+  "rotateZ",
+  "scale",
+  "scaleX",
+  "scaleY",
+  "scaleZ",
+  "skew",
+  "skewX",
+  "skewY",
+  "transform",
+  "transformPerspective",
+  "translateX",
+  "translateY",
+  "translateZ",
+  "x",
+  "y",
+  "z",
+]);
+const MOTION_TARGET_METADATA_PROPERTIES = new Set(["transition", "transitionEnd"]);
+const MOTION_SVG_ATTRIBUTE_PROPERTIES = new Set([
+  "attrScale",
+  "attrX",
+  "attrY",
+  "d",
+  "pathLength",
+  "pathOffset",
+  "pathSpacing",
+  "points",
+  "viewBox",
+]);
+const TAILWIND_DEFAULT_TRANSITION_PROPERTIES = [
+  "backdrop-filter",
+  "background-color",
+  "border-color",
+  "box-shadow",
+  "color",
+  "fill",
+  "filter",
+  "opacity",
+  "rotate",
+  "scale",
+  "stroke",
+  "text-decoration-color",
+  "transform",
+  "translate",
+];
+const TAILWIND_COLOR_TRANSITION_PROPERTIES = [
+  "background-color",
+  "border-color",
+  "color",
+  "fill",
+  "stroke",
+  "text-decoration-color",
+];
+const CSS_TIME_PATTERN = /^([+-]?\d*\.?\d+)(ms|s)$/i;
+const TAILWIND_TRANSITION_DURATION_PREFIX = "[transition-duration:";
+const NON_INTERPOLABLE_CSS_TRANSITION_PROPERTIES = new Set([
+  "content-visibility",
+  "display",
+  "overlay",
+  "pointer-events",
+]);
+const TAILWIND_EXCLUSIVE_VARIANT_FAMILIES = new Map([
+  ["contrast-less", "contrast"],
+  ["contrast-more", "contrast"],
+  ["disabled", "availability"],
+  ["enabled", "availability"],
+  ["even", "sibling-position"],
+  ["in-range", "range-validity"],
+  ["invalid", "validity"],
+  ["landscape", "orientation"],
+  ["link", "link-history"],
+  ["ltr", "direction"],
+  ["motion-reduce", "reduced-motion"],
+  ["motion-safe", "reduced-motion"],
+  ["optional", "requirement"],
+  ["odd", "sibling-position"],
+  ["out-of-range", "range-validity"],
+  ["pointer-coarse", "primary-pointer"],
+  ["pointer-fine", "primary-pointer"],
+  ["portrait", "orientation"],
+  ["read-only", "editability"],
+  ["read-write", "editability"],
+  ["required", "requirement"],
+  ["rtl", "direction"],
+  ["valid", "validity"],
+  ["visited", "link-history"],
+]);
+const TAILWIND_COEXECUTING_VARIANTS = new Set([
+  "active",
+  "any-pointer-coarse",
+  "any-pointer-fine",
+  "checked",
+  "dark",
+  "disabled",
+  "empty",
+  "enabled",
+  "first",
+  "first-of-type",
+  "focus",
+  "focus-visible",
+  "focus-within",
+  "forced-colors",
+  "hover",
+  "in-range",
+  "indeterminate",
+  "invalid",
+  "last",
+  "last-of-type",
+  "link",
+  "motion-reduce",
+  "motion-safe",
+  "odd",
+  "only",
+  "only-of-type",
+  "open",
+  "optional",
+  "out-of-range",
+  "placeholder-shown",
+  "pointer-coarse",
+  "pointer-fine",
+  "read-only",
+  "read-write",
+  "required",
+  "target",
+  "valid",
+  "visited",
+]);
+const TAILWIND_PSEUDO_ELEMENT_VARIANTS = new Set([
+  "after",
+  "backdrop",
+  "before",
+  "details-content",
+  "file",
+  "first-letter",
+  "first-line",
+  "marker",
+  "placeholder",
+  "selection",
+]);
+
+const normalizeMotionTargetPropertyName = (propertyName: string): string | null => {
+  if (
+    MOTION_TARGET_METADATA_PROPERTIES.has(propertyName) ||
+    MOTION_SVG_ATTRIBUTE_PROPERTIES.has(propertyName)
+  ) {
+    return null;
+  }
+  if (MOTION_TRANSFORM_PROPERTIES.has(propertyName)) {
+    return propertyName.startsWith("origin") ? "transform-origin" : "transform";
+  }
+  if (propertyName.startsWith("--")) return propertyName;
+  const kebabCasePropertyName = propertyName
+    .replace(/^Webkit(?=[A-Z])/, "-webkit")
+    .replace(/^Moz(?=[A-Z])/, "-moz")
+    .replace(/^ms(?=[A-Z])/, "-ms")
+    .replace(/[A-Z]/g, (character) => `-${character.toLowerCase()}`)
+    .toLowerCase();
+  return /^--[a-z0-9_-]+$|^-?[a-z][a-z0-9-]*$/.test(kebabCasePropertyName)
+    ? kebabCasePropertyName
+    : null;
+};
+
+const getMotionOwnedPropertyEvidence = (
+  node: EsTreeNodeOfType<"JSXOpeningElement">,
+  scopes: ScopeAnalysis,
+): MotionOwnedPropertyEvidence[] | null => {
+  const evidenceByKey = new Map<string, MotionOwnedPropertyEvidence>();
+  for (const targetPropertyName of MOTION_TARGET_PROPERTIES) {
+    const attribute = getAuthoritativeJsxAttribute(node.attributes, targetPropertyName);
+    if (!attribute) {
+      const hasOverriddenTargetAttribute = node.attributes.some(
+        (candidate) =>
+          isNodeOfType(candidate, "JSXAttribute") &&
+          isNodeOfType(candidate.name, "JSXIdentifier") &&
+          candidate.name.name === targetPropertyName,
+      );
+      if (hasOverriddenTargetAttribute) return null;
+      continue;
+    }
+    const objectExpression = getStaticMotionPropObject(node, targetPropertyName, scopes);
+    if (!objectExpression) return null;
+    const properties = getEffectiveObjectPropertiesInInsertionOrder(objectExpression.properties);
+    if (!properties) return null;
+    const tailwindConstraints = MOTION_TARGET_TAILWIND_CONSTRAINTS.get(targetPropertyName);
+    if (!tailwindConstraints) return null;
+    for (const property of properties) {
+      const propertyName = getStaticPropertyKeyName(property, { allowComputedString: true });
+      if (!propertyName) return null;
+      const normalizedPropertyName = normalizeMotionTargetPropertyName(propertyName);
+      if (!normalizedPropertyName) continue;
+      const evidenceKey = `${normalizedPropertyName}:${targetPropertyName}`;
+      evidenceByKey.set(evidenceKey, {
+        activationTailwindVariant: tailwindConstraints.activationVariant,
+        excludedTailwindVariants: tailwindConstraints.excludedVariants,
+        propertyName: normalizedPropertyName,
+      });
+    }
+  }
+  return [...evidenceByKey.values()];
+};
+
+const parseTransitionDurationStates = (value: string): boolean[] | null => {
+  const states: boolean[] = [];
+  for (const rawDuration of value.split(",")) {
+    const durationMatch = CSS_TIME_PATTERN.exec(rawDuration.trim());
+    if (!durationMatch) return null;
+    const duration = Number(durationMatch[1]);
+    if (duration < 0) return null;
+    states.push(duration > 0);
+  }
+  return states.length > 0 ? states : null;
+};
+
+const getTailwindDurationDeclaration = (utility: string): TailwindTransitionDeclaration | null => {
+  if (utility.startsWith("duration-")) {
+    const durationValue = utility.slice("duration-".length);
+    const normalizedDurationValue =
+      durationValue.startsWith("[") && durationValue.endsWith("]")
+        ? normalizeTailwindArbitraryUtilityValue(durationValue.slice(1, -1))
+        : `${durationValue}ms`;
+    return {
+      durationStates: parseTransitionDurationStates(normalizedDurationValue),
+      propertyNames: null,
+    };
+  }
+  if (utility.startsWith(TAILWIND_TRANSITION_DURATION_PREFIX) && utility.endsWith("]")) {
+    return {
+      durationStates: parseTransitionDurationStates(
+        normalizeTailwindArbitraryUtilityValue(
+          utility.slice(TAILWIND_TRANSITION_DURATION_PREFIX.length, -1),
+        ),
+      ),
+      propertyNames: null,
+    };
+  }
+  return null;
+};
+
+const getTailwindTransitionDeclaration = (
+  utility: string,
+  hasTailwindIndividualTransformProperties: boolean,
+): TailwindTransitionDeclaration | null => {
+  const effect = getTailwindTransitionPropertyEffect(utility);
+  if (!effect) return null;
+  if (utility === "transition") {
+    return {
+      durationStates: [true],
+      propertyNames: hasTailwindIndividualTransformProperties
+        ? [...TAILWIND_DEFAULT_TRANSITION_PROPERTIES, "outline-color"]
+        : TAILWIND_DEFAULT_TRANSITION_PROPERTIES,
+    };
+  }
+  if (utility === "transition-colors") {
+    return {
+      durationStates: [true],
+      propertyNames: hasTailwindIndividualTransformProperties
+        ? [...TAILWIND_COLOR_TRANSITION_PROPERTIES, "outline-color"]
+        : TAILWIND_COLOR_TRANSITION_PROPERTIES,
+    };
+  }
+  if (utility === "transition-opacity") {
+    return { durationStates: [true], propertyNames: ["opacity"] };
+  }
+  if (utility === "transition-shadow") {
+    return { durationStates: [true], propertyNames: ["box-shadow"] };
+  }
+  if (utility === "transition-transform") {
+    return {
+      durationStates: [true],
+      propertyNames: hasTailwindIndividualTransformProperties
+        ? ["rotate", "scale", "transform", "translate"]
+        : ["transform"],
+    };
+  }
+  if (utility === "transition-none") {
+    return { durationStates: [false], propertyNames: ["none"] };
+  }
+  if (utility === "transition-all") {
+    return { durationStates: [true], propertyNames: ["all"] };
+  }
+  if (utility.startsWith("[transition-property:")) {
+    return { durationStates: null, propertyNames: effect.propertyNames };
+  }
+  if (utility.startsWith("transition-[")) {
+    return { durationStates: [true], propertyNames: effect.propertyNames };
+  }
+  if (utility.startsWith("[transition:")) {
+    const shorthandValue = utility.slice("[transition:".length, -1);
+    const transitions = shorthandValue
+      ? getCssTransitionShorthandEvidence(normalizeTailwindArbitraryUtilityValue(shorthandValue))
+      : [];
+    if (transitions.length === 0) return null;
+    return {
+      durationStates: transitions.map((transition) => transition.hasPositiveDuration),
+      propertyNames: transitions.map((transition) => transition.propertyName),
+    };
+  }
+  return effect.propertyNames
+    ? { durationStates: [true], propertyNames: effect.propertyNames }
+    : null;
+};
+
+const serializeTailwindTransitionDeclaration = (
+  declaration: TailwindTransitionDeclaration,
+): string => JSON.stringify(declaration);
+
+const resolveTailwindTransitionDeclaration = (
+  parsedTokens: ReadonlyArray<TailwindClassNameToken>,
+  variantScope: ReadonlyArray<string>,
+  getDeclaration: (utility: string) => TailwindTransitionDeclaration | null,
+): { declaration: TailwindTransitionDeclaration | null; isImportant: boolean } | null => {
+  const effectiveTokens = getHighestPriorityTailwindClassNameTokens(
+    parsedTokens,
+    (parsedToken) =>
+      doesTailwindVariantScopeCover(parsedToken.variants, variantScope) &&
+      getDeclaration(parsedToken.utility) !== null,
+  );
+  if (effectiveTokens.length === 0) return { declaration: null, isImportant: false };
+  const declarations = effectiveTokens.flatMap((parsedToken) => {
+    const declaration = getDeclaration(parsedToken.utility);
+    return declaration ? [declaration] : [];
+  });
+  const serializedDeclarations = new Set(declarations.map(serializeTailwindTransitionDeclaration));
+  if (serializedDeclarations.size !== 1) return null;
+  return {
+    declaration: declarations[0] ?? null,
+    isImportant: effectiveTokens[0]?.isImportant ?? false,
+  };
+};
+
+const getTailwindTransitionState = (
+  className: string,
+  variantScope: ReadonlyArray<string>,
+  reportNode: EsTreeNode,
+  hasTailwindIndividualTransformProperties: boolean,
+): TailwindTransitionState | null => {
+  const parsedTokens = splitTailwindClassName(className).map(parseTailwindClassNameToken);
+  const propertyResolution = resolveTailwindTransitionDeclaration(
+    parsedTokens,
+    variantScope,
+    (utility) =>
+      getTailwindTransitionDeclaration(utility, hasTailwindIndividualTransformProperties),
+  );
+  const durationResolution = resolveTailwindTransitionDeclaration(
+    parsedTokens,
+    variantScope,
+    getTailwindDurationDeclaration,
+  );
+  if (!propertyResolution || !durationResolution) return null;
+  const propertyDeclaration = propertyResolution.declaration;
+  const explicitDurationDeclaration = durationResolution.declaration;
+  const propertyNames = propertyDeclaration?.propertyNames ?? ["all"];
+  const durationStates = explicitDurationDeclaration?.durationStates ??
+    propertyDeclaration?.durationStates ?? [false];
+  if (!propertyNames || !durationStates) return null;
+  return {
+    defaultEvidence: propertyNames.map((propertyName, propertyIndex) => ({
+      hasPositiveDuration: durationStates[propertyIndex % durationStates.length] ?? false,
+      propertyName,
+      sourceNode: reportNode,
+    })),
+    isDurationImportant: explicitDurationDeclaration
+      ? durationResolution.isImportant
+      : propertyResolution.isImportant,
+    isPropertyImportant: propertyResolution.isImportant,
+  };
+};
+
+const getTailwindBreakpointConstraint = (
+  variant: string,
+): { isMaximum: boolean; rank: number } | null => {
+  const isMaximum = variant.startsWith("max-");
+  const breakpointName = isMaximum ? variant.slice("max-".length) : variant;
+  const rank = TAILWIND_BREAKPOINT_RANKS.get(breakpointName);
+  return rank === undefined ? null : { isMaximum, rank };
+};
+
+const getTailwindKeyedState = (
+  variant: string,
+): { family: string; key: string; value: string } | null => {
+  const match = /^(aria|data)-\[([^=\]]+)=([^\]]+)\]$/.exec(variant);
+  return match?.[1] && match[2] && match[3]
+    ? { family: match[1], key: match[2], value: match[3] }
+    : null;
+};
+
+const isRecognizedCoexecutingTailwindVariant = (variant: string): boolean =>
+  TAILWIND_COEXECUTING_VARIANTS.has(variant) ||
+  TAILWIND_BREAKPOINT_RANKS.has(variant) ||
+  (variant.startsWith("max-") && TAILWIND_BREAKPOINT_RANKS.has(variant.slice("max-".length))) ||
+  TAILWIND_EXCLUSIVE_VARIANT_FAMILIES.has(variant) ||
+  getTailwindKeyedState(variant) !== null;
+
+const areTailwindVariantsMutuallyExclusive = (
+  leftVariant: string,
+  rightVariant: string,
+): boolean => {
+  if (leftVariant === rightVariant) return false;
+  if (leftVariant === `not-${rightVariant}` || rightVariant === `not-${leftVariant}`) return true;
+  const leftBreakpoint = getTailwindBreakpointConstraint(leftVariant);
+  const rightBreakpoint = getTailwindBreakpointConstraint(rightVariant);
+  if (leftBreakpoint && rightBreakpoint) {
+    if (leftBreakpoint.isMaximum === rightBreakpoint.isMaximum) return false;
+    const minimum = leftBreakpoint.isMaximum ? rightBreakpoint : leftBreakpoint;
+    const maximum = leftBreakpoint.isMaximum ? leftBreakpoint : rightBreakpoint;
+    return minimum.rank >= maximum.rank;
+  }
+  const leftFamily = TAILWIND_EXCLUSIVE_VARIANT_FAMILIES.get(leftVariant);
+  const rightFamily = TAILWIND_EXCLUSIVE_VARIANT_FAMILIES.get(rightVariant);
+  if (leftFamily && leftFamily === rightFamily) return true;
+  const leftKeyedState = getTailwindKeyedState(leftVariant);
+  const rightKeyedState = getTailwindKeyedState(rightVariant);
+  if (
+    leftKeyedState &&
+    rightKeyedState &&
+    leftKeyedState.family === rightKeyedState.family &&
+    leftKeyedState.key === rightKeyedState.key
+  ) {
+    return leftKeyedState.value !== rightKeyedState.value;
+  }
+  return false;
+};
+
+const areTailwindVariantsProvenCompatible = (
+  leftVariant: string,
+  rightVariant: string,
+): boolean => {
+  if (areTailwindVariantsMutuallyExclusive(leftVariant, rightVariant)) return false;
+  return (
+    isRecognizedCoexecutingTailwindVariant(leftVariant) &&
+    isRecognizedCoexecutingTailwindVariant(rightVariant)
+  );
+};
+
+const isTailwindVariantScopeInternallyContradictory = (
+  variantScope: ReadonlyArray<string>,
+): boolean =>
+  variantScope.some((leftVariant, leftIndex) =>
+    variantScope
+      .slice(leftIndex + 1)
+      .some((rightVariant) => areTailwindVariantsMutuallyExclusive(leftVariant, rightVariant)),
+  );
+
+const areTailwindVariantScopesProvenCompatible = (
+  leftScope: ReadonlyArray<string>,
+  rightScope: ReadonlyArray<string>,
+): boolean =>
+  leftScope.every((leftVariant) =>
+    rightScope.every((rightVariant) =>
+      areTailwindVariantsProvenCompatible(leftVariant, rightVariant),
+    ),
+  );
+
+const getTailwindVariantScopes = (
+  parsedTokens: ReadonlyArray<TailwindClassNameToken>,
+): string[][] => {
+  const serializedScopes = new Set(["[]"]);
+  const variantScopes: string[][] = [[]];
+  for (const parsedToken of parsedTokens) {
+    if (isTailwindVariantScopeInternallyContradictory(parsedToken.variants)) continue;
+    const serializedScope = JSON.stringify(parsedToken.variants);
+    if (serializedScopes.has(serializedScope)) continue;
+    serializedScopes.add(serializedScope);
+    variantScopes.push(parsedToken.variants);
+  }
+  const sourceScopes = [...variantScopes];
+  for (const [leftIndex, leftScope] of sourceScopes.entries()) {
+    for (const rightScope of sourceScopes.slice(leftIndex + 1)) {
+      if (!areTailwindVariantScopesProvenCompatible(leftScope, rightScope)) continue;
+      const combinedScope = [...leftScope, ...rightScope];
+      const serializedScope = JSON.stringify(combinedScope);
+      if (serializedScopes.has(serializedScope)) continue;
+      serializedScopes.add(serializedScope);
+      variantScopes.push(combinedScope);
+    }
+  }
+  return variantScopes;
+};
+
+const getTailwindComplementaryVariant = (variant: string): string | null => {
+  if (variant === "motion-safe") return "motion-reduce";
+  if (variant === "motion-reduce") return "motion-safe";
+  if (variant === "portrait") return "landscape";
+  if (variant === "landscape") return "portrait";
+  if (variant === "odd") return "even";
+  if (variant === "even") return "odd";
+  if (TAILWIND_BREAKPOINT_RANKS.has(variant)) return `max-${variant}`;
+  if (variant.startsWith("max-") && TAILWIND_BREAKPOINT_RANKS.has(variant.slice("max-".length))) {
+    return variant.slice("max-".length);
+  }
+  return null;
+};
+
+const isTailwindTransitionSetter = (
+  utility: string,
+  hasTailwindIndividualTransformProperties: boolean,
+): boolean =>
+  getTailwindDurationDeclaration(utility) !== null ||
+  getTailwindTransitionDeclaration(utility, hasTailwindIndividualTransformProperties) !== null;
+
+const getTailwindExhaustiveTransitionPartitions = (
+  parsedTokens: ReadonlyArray<TailwindClassNameToken>,
+  hasTailwindIndividualTransformProperties: boolean,
+): TailwindExhaustiveTransitionPartition[] => {
+  const transitionScopes: Array<ReadonlyArray<string>> = [];
+  for (const parsedToken of parsedTokens) {
+    if (
+      !isTailwindVariantScopeInternallyContradictory(parsedToken.variants) &&
+      isTailwindTransitionSetter(parsedToken.utility, hasTailwindIndividualTransformProperties)
+    ) {
+      transitionScopes.push(parsedToken.variants);
+    }
+  }
+  const partitions: TailwindExhaustiveTransitionPartition[] = [];
+  const partitionKeys = new Set<string>();
+  for (const leftScope of transitionScopes) {
+    for (const [leftVariantIndex, leftVariant] of leftScope.entries()) {
+      const rightVariant = getTailwindComplementaryVariant(leftVariant);
+      if (!rightVariant) continue;
+      const commonScope = leftScope.filter((_, variantIndex) => variantIndex !== leftVariantIndex);
+      const hasRightBranch = transitionScopes.some((rightScope) => {
+        const rightVariantIndex = rightScope.indexOf(rightVariant);
+        if (rightVariantIndex < 0) return false;
+        const rightCommonScope = rightScope.filter(
+          (_, variantIndex) => variantIndex !== rightVariantIndex,
+        );
+        return JSON.stringify(rightCommonScope) === JSON.stringify(commonScope);
+      });
+      if (!hasRightBranch) continue;
+      const orderedVariants = [leftVariant, rightVariant].sort();
+      const partitionKey = JSON.stringify([commonScope, ...orderedVariants]);
+      if (partitionKeys.has(partitionKey)) continue;
+      partitionKeys.add(partitionKey);
+      partitions.push({ commonScope, leftVariant, rightVariant });
+    }
+  }
+  return partitions;
+};
+
+const doesTailwindScopeSelectExhaustiveTransitionBranches = (
+  variantScope: ReadonlyArray<string>,
+  partitions: ReadonlyArray<TailwindExhaustiveTransitionPartition>,
+): boolean => {
+  const variantScopeSet = new Set(variantScope);
+  return partitions.every(
+    (partition) =>
+      !doesTailwindVariantScopeCover(partition.commonScope, variantScope) ||
+      variantScopeSet.has(partition.leftVariant) ||
+      variantScopeSet.has(partition.rightVariant),
+  );
+};
+
+const parseTailwindLocalAttributeConstraint = (
+  variant: string,
+): TailwindLocalAttributeConstraint | null => {
+  const arbitraryMatch = /^(aria|data)-\[([^=\]]+)(?:=([^\]]+))?\]$/.exec(variant);
+  if (arbitraryMatch?.[1] && arbitraryMatch[2]) {
+    const rawExpectedValue = arbitraryMatch[3];
+    const expectedValue = rawExpectedValue?.replace(/^(['"])(.*)\1$/, "$2") ?? null;
+    return {
+      attributeName: `${arbitraryMatch[1]}-${arbitraryMatch[2]}`,
+      expectedValue,
+    };
+  }
+  const dataPresenceMatch = /^data-([a-z0-9_-]+)$/.exec(variant);
+  if (dataPresenceMatch?.[1]) {
+    return { attributeName: `data-${dataPresenceMatch[1]}`, expectedValue: null };
+  }
+  const ariaBooleanMatch = /^aria-([a-z0-9_-]+)$/.exec(variant);
+  if (!ariaBooleanMatch?.[1]) return null;
+  return { attributeName: `aria-${ariaBooleanMatch[1]}`, expectedValue: "true" };
+};
+
+const getStaticAttributePrimitiveValues = (
+  attribute: EsTreeNodeOfType<"JSXAttribute">,
+  scopes: ScopeAnalysis,
+): ReadonlyArray<string> | null => {
+  const stringValues = getJsxPropExhaustiveStaticStringValues(attribute, scopes);
+  if (stringValues) return stringValues;
+  if (
+    attribute.value &&
+    isNodeOfType(attribute.value, "JSXExpressionContainer") &&
+    isNodeOfType(attribute.value.expression, "Literal") &&
+    (typeof attribute.value.expression.value === "boolean" ||
+      typeof attribute.value.expression.value === "number")
+  ) {
+    return [String(attribute.value.expression.value)];
+  }
+  return null;
+};
+
+const doesElementSatisfyTailwindLocalAttributeConstraint = (
+  node: EsTreeNodeOfType<"JSXOpeningElement">,
+  constraint: TailwindLocalAttributeConstraint,
+  scopes: ScopeAnalysis,
+): boolean => {
+  const attribute = getAuthoritativeJsxAttribute(node.attributes, constraint.attributeName, false);
+  if (!attribute) return false;
+  if (!attribute.value) return constraint.expectedValue === null;
+  const values = getStaticAttributePrimitiveValues(attribute, scopes);
+  if (!values) return false;
+  if (constraint.expectedValue === null) {
+    return values.some((value) => value !== "false");
+  }
+  return values.includes(constraint.expectedValue);
+};
+
+const isTailwindVariantSameElementAndSatisfiable = (
+  variant: string,
+  node: EsTreeNodeOfType<"JSXOpeningElement">,
+  scopes: ScopeAnalysis,
+): boolean => {
+  if (TAILWIND_PSEUDO_ELEMENT_VARIANTS.has(variant) || variant === "*" || variant === "**") {
+    return false;
+  }
+  if (variant.startsWith("[")) return variant === "[&]";
+  if (
+    variant.startsWith("group-") ||
+    variant.startsWith("peer-") ||
+    variant.startsWith("has-") ||
+    variant.startsWith("in-[")
+  ) {
+    return false;
+  }
+  const localAttributeConstraint = parseTailwindLocalAttributeConstraint(variant);
+  if (!localAttributeConstraint) return true;
+  return doesElementSatisfyTailwindLocalAttributeConstraint(node, localAttributeConstraint, scopes);
+};
+
+const isTailwindVariantScopeSameElementAndSatisfiable = (
+  variantScope: ReadonlyArray<string>,
+  node: EsTreeNodeOfType<"JSXOpeningElement">,
+  scopes: ScopeAnalysis,
+): boolean =>
+  variantScope.every((variant) =>
+    isTailwindVariantSameElementAndSatisfiable(variant, node, scopes),
+  );
+
+const isMotionOwnershipCompatibleWithTailwindScope = (
+  ownership: MotionOwnedPropertyEvidence,
+  variantScope: ReadonlyArray<string>,
+  availableVariantScopes: ReadonlyArray<ReadonlyArray<string>>,
+): boolean => {
+  if (variantScope.some((variant) => ownership.excludedTailwindVariants.has(variant))) {
+    return false;
+  }
+  if (variantScope.length === 0 && ownership.activationTailwindVariant) {
+    return !availableVariantScopes.some((availableVariantScope) =>
+      availableVariantScope.includes(ownership.activationTailwindVariant ?? ""),
+    );
+  }
+  return true;
+};
+
+const getMixedAnimationOwnerPropertyName = (
+  className: string,
+  styleExpression: EsTreeNodeOfType<"ObjectExpression"> | null,
+  ownershipEvidence: ReadonlyArray<MotionOwnedPropertyEvidence>,
+  reportNode: EsTreeNodeOfType<"JSXOpeningElement">,
+  hasTailwindIndividualTransformProperties: boolean,
+  scopes: ScopeAnalysis,
+): string | null => {
+  const parsedTokens = splitTailwindClassName(className).map(parseTailwindClassNameToken);
+  const variantScopes = getTailwindVariantScopes(parsedTokens);
+  const exhaustiveTransitionPartitions = getTailwindExhaustiveTransitionPartitions(
+    parsedTokens,
+    hasTailwindIndividualTransformProperties,
+  );
+  for (const variantScope of variantScopes) {
+    if (!isTailwindVariantScopeSameElementAndSatisfiable(variantScope, reportNode, scopes)) {
+      continue;
+    }
+    if (
+      !doesTailwindScopeSelectExhaustiveTransitionBranches(
+        variantScope,
+        exhaustiveTransitionPartitions,
+      )
+    ) {
+      continue;
+    }
+    const tailwindState = getTailwindTransitionState(
+      className,
+      variantScope,
+      reportNode,
+      hasTailwindIndividualTransformProperties,
+    );
+    if (!tailwindState) continue;
+    const transitionEvidence = getEffectiveCssTransitionEvidence(
+      styleExpression?.properties,
+      tailwindState.defaultEvidence,
+      {
+        duration: tailwindState.isDurationImportant,
+        property: tailwindState.isPropertyImportant,
+      },
+    );
+    if (!transitionEvidence) continue;
+    const conflictingOwnership = ownershipEvidence.find(
+      (ownership) =>
+        isMotionOwnershipCompatibleWithTailwindScope(ownership, variantScope, variantScopes) &&
+        transitionEvidence.some(
+          (transition) =>
+            transition.propertyName !== "all" &&
+            !transition.propertyName.startsWith("--") &&
+            !NON_INTERPOLABLE_CSS_TRANSITION_PROPERTIES.has(transition.propertyName) &&
+            transition.propertyName === ownership.propertyName &&
+            transition.durationMilliseconds > 0,
+        ),
+    );
+    if (conflictingOwnership) return conflictingOwnership.propertyName;
+  }
+  return null;
+};
+
+export const noMixedAnimationOwners = defineRule({
+  id: "no-mixed-animation-owners",
+  title: "CSS and Motion animate the same property",
+  severity: "warn",
+  category: "Design",
+  defaultEnabled: false,
+  tags: ["react-jsx-only"],
+  recommendation:
+    "Give each property one animation owner. Remove its CSS transition when Motion controls it, or move the CSS transition to a different element or property.",
+  create: (context: RuleContext) => ({
+    JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
+      if (hasJsxSpreadAttribute(node.attributes)) return;
+      const ownershipEvidence = getMotionOwnedPropertyEvidence(node, context.scopes);
+      if (!ownershipEvidence || ownershipEvidence.length === 0) return;
+      const classNameAttribute = getAuthoritativeJsxAttribute(node.attributes, "className");
+      let classNameValues: ReadonlyArray<string> | null = [""];
+      if (classNameAttribute && hasCapabilityOrUnspecified(context.settings, "tailwind")) {
+        classNameValues = getJsxPropExhaustiveStaticStringValues(
+          classNameAttribute,
+          context.scopes,
+        );
+      }
+      if (!classNameValues) return;
+      const styleAttribute = getAuthoritativeJsxAttribute(node.attributes, "style");
+      const styleExpression = styleAttribute
+        ? getInlineStyleExpression(styleAttribute, context.scopes)
+        : null;
+      if (styleAttribute && !styleExpression) return;
+      const conflictingPropertyName = classNameValues
+        .map((className) =>
+          getMixedAnimationOwnerPropertyName(
+            className,
+            styleExpression,
+            ownershipEvidence,
+            node,
+            hasCapability(context.settings, "tailwind:4"),
+            context.scopes,
+          ),
+        )
+        .find((propertyName): propertyName is string => propertyName !== null);
+      if (!conflictingPropertyName) return;
+      context.report({
+        node,
+        message: `Motion and CSS can both animate \`${conflictingPropertyName}\` on this element. Keep one animation owner per property to avoid retargeting and lag.`,
+      });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-transitioned-composite-widget-state.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-transitioned-composite-widget-state.test.ts
@@ -1,0 +1,326 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noTransitionedCompositeWidgetState } from "./no-transitioned-composite-widget-state.js";
+
+const run = (code: string) => runRule(noTransitionedCompositeWidgetState, code);
+
+describe("no-transitioned-composite-widget-state", () => {
+  it("runs only when Tailwind is detected", () => {
+    expect(noTransitionedCompositeWidgetState.requires).toEqual(["tailwind"]);
+  });
+
+  it("flags a selected option whose background transition uses Tailwind defaults", () => {
+    const result = run(
+      `const Option = ({ selected }) => <div role="option" aria-selected={selected ? "true" : "false"} className="bg-[#fff] transition-colors aria-selected:bg-[#000]">Value</div>;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags checked menu items using arbitrary border transitions", () => {
+    const result = run(
+      `const Item = ({ checked }) => <div role="menuitemcheckbox" aria-checked={checked ? "true" : "false"} className="border-[#fff] transition-[border-color] duration-100 aria-checked:border-[#000]">Value</div>;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags current menu items using an inline color transition", () => {
+    const result = run(
+      `const Item = ({ current }) => <a role="menuitem" aria-current={current ? "page" : "false"} className="text-[#fff] aria-[current=page]:text-[#000]" style={{ transition: "color 120ms ease-out" }}>Value</a>;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("leaves data-state styling out of v1", () => {
+    const result = run(
+      `const Item = ({ checked }) => <div role="treeitem" aria-checked={checked ? "true" : "false"} data-state={checked ? "checked" : "unchecked"} className="bg-[#fff] transition-colors data-[state=checked]:bg-[#000]">Value</div>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags an ARIA-selected tree item with literal paint evidence", () => {
+    const result = run(
+      `const Item = ({ selected }) => <div role="treeitem" aria-selected={selected ? "true" : "false"} className="bg-[#fff] transition-colors aria-selected:bg-[#000]">Value</div>;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("leaves data current styling out of v1", () => {
+    const result = run(
+      `const Item = ({ current }) => <a role="menuitem" aria-current={current ? "page" : "false"} data-state={current ? "current" : "inactive"} className="text-[#fff] transition-colors data-[state=current]:text-[#000]">Value</a>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags a single const-bound target role", () => {
+    const result = run(
+      `const ROLE = "option"; const Option = ({ selected }) => <div role={ROLE} aria-selected={selected ? "true" : "false"} className="text-[#fff] transition-colors aria-selected:text-[#000]">Value</div>;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags state transitions inside a stable responsive and dark scope", () => {
+    const result = run(
+      `const Option = ({ selected }) => <div role="option" aria-selected={selected ? "true" : "false"} className="dark:md:bg-[#fff] dark:md:transition-colors dark:md:aria-selected:bg-[#000]">Value</div>;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags radio menu items and explicit arbitrary color declarations", () => {
+    const result = run(
+      `const Item = ({ checked }) => <div role="menuitemradio" aria-checked={checked ? "true" : "false"} className="[background-color:#fff] transition-[background-color] aria-checked:[background-color:#2563eb]">Value</div>;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("requires a provably distinct resting paint value", () => {
+    const result = run(
+      `const Option = ({ selected }) => <div role="option" aria-selected={selected ? "true" : "false"} className="transition-colors aria-selected:bg-blue-600">Value</div>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags an inline longhand transition assembled with a Tailwind duration", () => {
+    const result = run(
+      `const Option = ({ selected }) => <div role="option" aria-selected={selected ? "true" : "false"} className="bg-[#fff] duration-100 aria-selected:bg-[#000]" style={{ transitionProperty: "background-color" }}>Value</div>;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("allows tabs and other roles outside the v1 contract", () => {
+    const result = run(
+      `const Tabs = ({ selected }) => <><div role="tab" aria-selected={selected} className="bg-white transition-colors aria-selected:bg-blue-600" /><div role="radio" aria-checked={selected} className="bg-white transition-colors aria-checked:bg-blue-600" /></>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("allows mixed and fallback role candidates", () => {
+    const result = run(
+      `const Items = ({ tree, selected }) => <><div role={tree ? "treeitem" : "option"} aria-selected={selected} className="bg-white transition-colors aria-selected:bg-blue-600" /><div role="option button" aria-selected={selected} className="bg-white transition-colors aria-selected:bg-blue-600" /></>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("allows opaque dynamic roles", () => {
+    const result = run(
+      `const Option = ({ role, selected }) => <div role={role} aria-selected={selected} className="bg-white transition-colors aria-selected:bg-blue-600" />;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("allows custom components even when they receive a target role", () => {
+    const result = run(
+      `const Option = ({ selected }) => <OptionPrimitive role="option" aria-selected={selected} className="bg-white transition-colors aria-selected:bg-blue-600" />;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("allows elements with spreads because ownership is not authoritative", () => {
+    const result = run(
+      `const Option = ({ props, selected }) => <div role="option" aria-selected={selected} className="bg-white transition-colors aria-selected:bg-blue-600" {...props} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("requires a dynamic matching ARIA state attribute", () => {
+    const result = run(
+      `const Options = () => <><div role="option" className="bg-white transition-colors aria-selected:bg-blue-600" /><div role="option" aria-selected="true" className="bg-white transition-colors aria-selected:bg-blue-600" /></>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("requires a matching data attribute for data-state variants", () => {
+    const result = run(
+      `const Option = ({ selected }) => <div role="option" aria-selected={selected} className="bg-white transition-colors data-[state=selected]:bg-blue-600" />;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("allows dynamic class and style expressions", () => {
+    const result = run(
+      `const Options = ({ className, selected, style }) => <><div role="option" aria-selected={selected} className={className} /><div role="option" aria-selected={selected} className="bg-white transition-colors aria-selected:bg-blue-600" style={style} /></>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("allows non-paint state feedback and transformed descendants", () => {
+    const result = run(
+      `const Option = ({ selected }) => <div role="option" aria-selected={selected} className="transition-transform aria-selected:scale-95"><span className="transition-transform aria-selected:scale-95" /></div>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("leaves focus-ring transitions to the existing focus rule", () => {
+    const result = run(
+      `const Option = ({ selected }) => <div role="option" aria-selected={selected} className="ring-0 transition-shadow aria-selected:ring-2" />;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("requires a positive transition on the changed property", () => {
+    const result = run(
+      `const Options = ({ selected }) => <><div role="option" aria-selected={selected} className="bg-white aria-selected:bg-blue-600" /><div role="option" aria-selected={selected} className="bg-white transition-colors duration-0 aria-selected:bg-blue-600" /><div role="option" aria-selected={selected} className="bg-white transition-none duration-200 aria-selected:bg-blue-600" /><div role="option" aria-selected={selected} className="bg-white transition-opacity duration-200 aria-selected:bg-blue-600" /></>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("leaves transition-all to the existing rule", () => {
+    const result = run(
+      `const Option = ({ selected }) => <div role="option" aria-selected={selected} className="bg-white transition-all duration-200 aria-selected:bg-blue-600" />;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("allows an unchanged effective state color", () => {
+    const result = run(
+      `const Options = ({ selected }) => <><div role="option" aria-selected={selected} className="bg-blue-600 transition-colors aria-selected:bg-blue-600" /><div role="option" aria-selected={selected} className="bg-blue-600 transition-colors aria-selected:bg-blue-600/100" /></>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("allows ambiguous state and transition conflicts", () => {
+    const result = run(
+      `const Options = ({ selected }) => <><div role="option" aria-selected={selected} className="bg-white transition-colors aria-selected:bg-blue-600 aria-selected:bg-red-600" /><div role="option" aria-selected={selected} className="bg-white transition-colors transition-none aria-selected:bg-blue-600" /><div role="option" aria-selected={selected} className="bg-white transition-colors duration-100 duration-0 aria-selected:bg-blue-600" /></>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("allows important state and transition declarations", () => {
+    const result = run(
+      `const Options = ({ selected }) => <><div role="option" aria-selected={selected} className="bg-white transition-colors !aria-selected:bg-blue-600" /><div role="option" aria-selected={selected} className="bg-white !transition-colors aria-selected:bg-blue-600" /><div role="option" aria-selected={selected} className="bg-white transition-colors !duration-100 aria-selected:bg-blue-600" /></>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("allows inline paint declarations that override the state utility", () => {
+    const result = run(
+      `const Option = ({ selected }) => <div role="option" aria-selected={selected} className="bg-white transition-colors aria-selected:bg-blue-600" style={{ backgroundColor: "white" }} />;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("honors inline transition overrides", () => {
+    const result = run(
+      `const Options = ({ selected }) => <><div role="option" aria-selected={selected} className="bg-white transition-colors aria-selected:bg-blue-600" style={{ transitionDuration: "0ms" }} /><div role="option" aria-selected={selected} className="bg-white transition-colors aria-selected:bg-blue-600" style={{ transitionProperty: "opacity" }} /></>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("requires a state supported by the resolved role", () => {
+    const result = run(
+      `const Item = ({ selected }) => <div role="menuitem" aria-selected={selected} className="bg-white transition-colors aria-selected:bg-blue-600" />;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("allows state styling gated by hover or focus interaction", () => {
+    const result = run(
+      `const Option = ({ selected }) => <div role="option" aria-selected={selected} className="bg-white transition-colors hover:aria-selected:bg-blue-600 focus:aria-selected:bg-red-600" />;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("allows unproven state variant contexts", () => {
+    const result = run(
+      `const Options = ({ selected }) => <><div role="option" aria-selected={selected ? "true" : "false"} className="print:bg-gray-50 print:transition-colors print:aria-selected:bg-blue-600" /><div role="option" aria-selected={selected ? "true" : "false"} className="disabled:bg-gray-50 disabled:transition-colors disabled:aria-selected:bg-blue-600" /><div role="option" aria-selected={selected ? "true" : "false"} className="[&>span]:bg-gray-50 [&>span]:transition-colors [&>span]:aria-selected:bg-blue-600" /></>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("allows forced-colors because its paint substitutions are not proven", () => {
+    const result = run(
+      `const Option = ({ selected }) => <div role="option" aria-selected={selected ? "true" : "false"} className="forced-colors:bg-[#fff] forced-colors:transition-colors forced-colors:aria-selected:bg-[#000]" />;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("preserves exact variant and selector-value casing", () => {
+    const result = run(
+      `const Options = ({ selected, current }) => <><div role="option" aria-selected={selected ? "true" : "false"} className="bg-[#fff] transition-colors ARIA-selected:bg-[#000]" /><a role="menuitem" aria-current={current ? "PAGE" : "false"} className="text-[#fff] transition-colors aria-[current=PAGE]:text-[#000]" /><div role="option" aria-selected={selected ? "TRUE" : "false"} className="bg-[#fff] transition-colors aria-selected:bg-[#000]" /><div role="option" aria-selected={selected ? "true" : "false"} data-state={selected ? "SELECTED" : "idle"} className="bg-[#fff] transition-colors data-[state=SELECTED]:bg-[#000]" /></>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("requires exhaustive values that can enter and leave the selector", () => {
+    const result = run(
+      `const Options = ({ selected }) => <><div role="option" aria-selected={selected} className="bg-gray-50 transition-colors aria-selected:bg-blue-600" /><div role="option" aria-selected={selected ? "mixed" : "false"} className="bg-gray-50 transition-colors aria-selected:bg-blue-600" /><div role="option" aria-selected={selected ? "true" : "true"} className="bg-gray-50 transition-colors aria-selected:bg-blue-600" /></>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("follows a simple const alias back to a component parameter", () => {
+    const result = run(
+      `const Option = ({ selected }) => { const isSelected = selected; return <div role="option" aria-selected={isSelected ? "true" : "false"} className="bg-[#fff] transition-colors aria-selected:bg-[#000]" />; };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("allows a selector parameter assigned before the element", () => {
+    const result = run(
+      `const Option = ({ selected }) => { selected = true; return <div role="option" aria-selected={selected ? "true" : "false"} className="bg-[#fff] transition-colors aria-selected:bg-[#000]" />; };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("allows an element reached after one selector state returns early", () => {
+    const result = run(
+      `const Option = ({ selected }) => { if (!selected) return null; return <div role="option" aria-selected={selected ? "true" : "false"} className="bg-[#fff] transition-colors aria-selected:bg-[#000]" />; };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("allows an element mounted in only one selector branch", () => {
+    const result = run(
+      `const Option = ({ selected }) => selected ? <div role="option" aria-selected={selected ? "true" : "false"} className="bg-[#fff] transition-colors aria-selected:bg-[#000]" /> : null;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("requires the composite element key to remain stable between selector states", () => {
+    const result = run(
+      `const Options = ({ selected }) => <><div key={selected} role="option" aria-selected={selected ? "true" : "false"} className="bg-[#fff] transition-colors aria-selected:bg-[#000]" /><div key={selected ? "selected" : "rest"} role="option" aria-selected={selected ? "true" : "false"} className="bg-[#fff] transition-colors aria-selected:bg-[#000]" /><div key="stable" role="option" aria-selected={selected ? "true" : "false"} className="bg-[#fff] transition-colors aria-selected:bg-[#000]" /></>;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("allows locally constant and unresolved selector conditions", () => {
+    const result = run(
+      `const LOCAL_SELECTED = true; const Options = () => <><div role="option" aria-selected={LOCAL_SELECTED ? "true" : "false"} className="bg-[#fff] transition-colors aria-selected:bg-[#000]" /><div role="option" aria-selected={externalSelected ? "true" : "false"} className="bg-[#fff] transition-colors aria-selected:bg-[#000]" /></>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("allows presence selectors on attributes that never disappear", () => {
+    const result = run(
+      `const Options = ({ selected }) => <><div role="option" aria-selected={selected ? "true" : "false"} data-selected={selected ? "true" : "false"} className="bg-gray-50 transition-colors data-selected:bg-blue-600" /><div role="option" aria-selected={selected ? "true" : "false"} data-selected={selected ? "true" : "false"} className="bg-gray-50 transition-colors data-[selected]:bg-blue-600" /></>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("allows canonically equivalent white, black, rgb, and alpha colors", () => {
+    const result = run(
+      `const Options = ({ selected }) => <><div role="option" aria-selected={selected ? "true" : "false"} className="bg-[white] transition-colors aria-selected:bg-[#fff]" /><div role="option" aria-selected={selected ? "true" : "false"} className="bg-[black] transition-colors aria-selected:bg-[rgb(0_0_0)]" /><div role="option" aria-selected={selected ? "true" : "false"} className="bg-[black]/50 transition-colors aria-selected:bg-[rgb(0_0_0/0.5)]" /></>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("allows theme palette comparisons and palette-to-arbitrary comparisons", () => {
+    const result = run(
+      `const Options = ({ selected }) => <><div role="option" aria-selected={selected ? "true" : "false"} className="bg-gray-50 transition-colors aria-selected:bg-blue-600" /><div role="option" aria-selected={selected ? "true" : "false"} className="bg-blue-600 transition-colors aria-selected:bg-[#2563eb]" /></>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("treats bare white and black utilities as theme-dependent", () => {
+    const result = run(
+      `const Option = ({ selected }) => <div role="option" aria-selected={selected ? "true" : "false"} className="bg-white transition-colors aria-selected:bg-black" />;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("keeps theme-dependent and non-color utilities out of scope", () => {
+    const result = run(
+      `const Options = ({ selected }) => <><div role="option" aria-selected={selected} className="bg-surface transition-colors aria-selected:bg-primary" /><div role="option" aria-selected={selected} className="bg-cover transition-colors aria-selected:bg-[url('/selected.svg')]" /><div role="option" aria-selected={selected} className="text-sm transition-colors aria-selected:text-lg" /><div role="option" aria-selected={selected} className="border-2 transition-colors aria-selected:border-4" /></>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-transitioned-composite-widget-state.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-transitioned-composite-widget-state.test.ts
@@ -32,7 +32,7 @@ describe("no-transitioned-composite-widget-state", () => {
 
   it("leaves data-state styling out of v1", () => {
     const result = run(
-      `const Item = ({ checked }) => <div role="treeitem" aria-checked={checked ? "true" : "false"} data-state={checked ? "checked" : "unchecked"} className="bg-[#fff] transition-colors data-[state=checked]:bg-[#000]">Value</div>;`,
+      `const Items = ({ checked, loading }) => <><div role="treeitem" aria-checked={checked ? "true" : "false"} data-state={checked ? "checked" : "unchecked"} className="bg-[#fff] transition-colors data-[state=checked]:bg-[#000]">Value</div><div role="treeitem" aria-checked={checked ? "true" : "false"} data-state={loading ? "checked" : "unchecked"} className="bg-[#fff] transition-colors data-[state=checked]:bg-[#000]">Loading</div></>;`,
     );
     expect(result.diagnostics).toHaveLength(0);
   });
@@ -284,7 +284,14 @@ describe("no-transitioned-composite-widget-state", () => {
 
   it("allows locally constant and unresolved selector conditions", () => {
     const result = run(
-      `const LOCAL_SELECTED = true; const Options = () => <><div role="option" aria-selected={LOCAL_SELECTED ? "true" : "false"} className="bg-[#fff] transition-colors aria-selected:bg-[#000]" /><div role="option" aria-selected={externalSelected ? "true" : "false"} className="bg-[#fff] transition-colors aria-selected:bg-[#000]" /></>;`,
+      `const ALWAYS_SELECTED = true; const NEVER_SELECTED = false; const Options = () => <><div role="option" aria-selected={ALWAYS_SELECTED ? "true" : "false"} className="bg-[#fff] transition-colors aria-selected:bg-[#000]" /><div role="option" aria-selected={NEVER_SELECTED ? "true" : "false"} className="bg-[#fff] transition-colors aria-selected:bg-[#000]" /><div role="option" aria-selected={externalSelected ? "true" : "false"} className="bg-[#fff] transition-colors aria-selected:bg-[#000]" /></>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("allows elements in const-resolved unreachable render branches", () => {
+    const result = run(
+      `const SHOW_FIRST = false; const HIDE_SECOND = true; const Options = ({ selected }) => <>{SHOW_FIRST ? <div role="option" aria-selected={selected ? "true" : "false"} className="bg-[#fff] transition-colors aria-selected:bg-[#000]" /> : null}{HIDE_SECOND ? null : <div role="option" aria-selected={selected ? "true" : "false"} className="bg-[#fff] transition-colors aria-selected:bg-[#000]" />}{SHOW_FIRST && <div role="option" aria-selected={selected ? "true" : "false"} className="bg-[#fff] transition-colors aria-selected:bg-[#000]" />}</>;`,
     );
     expect(result.diagnostics).toHaveLength(0);
   });
@@ -312,7 +319,7 @@ describe("no-transitioned-composite-widget-state", () => {
 
   it("treats bare white and black utilities as theme-dependent", () => {
     const result = run(
-      `const Option = ({ selected }) => <div role="option" aria-selected={selected ? "true" : "false"} className="bg-white transition-colors aria-selected:bg-black" />;`,
+      `const Options = ({ selected }) => <><div role="option" aria-selected={selected ? "true" : "false"} className="bg-white transition-colors aria-selected:bg-black" /><div role="option" aria-selected={selected ? "true" : "false"} className="bg-white transition-colors aria-selected:bg-[#000]" /><div role="option" aria-selected={selected ? "true" : "false"} className="bg-[#fff] transition-colors aria-selected:bg-black" /></>;`,
     );
     expect(result.diagnostics).toHaveLength(0);
   });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-transitioned-composite-widget-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-transitioned-composite-widget-state.ts
@@ -13,6 +13,7 @@ import { getTailwindTopLevelCharacterIndices } from "../../utils/get-tailwind-to
 import { getTailwindTransitionPropertyEffect } from "../../utils/get-tailwind-transition-property-effect.js";
 import { hasJsxSpreadAttribute } from "../../utils/has-jsx-spread-attribute.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
+import { isGatedByFalsyInitialState } from "../../utils/is-gated-by-falsy-initial-state.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isProvenIntrinsicJsxElement } from "../../utils/is-proven-intrinsic-jsx-element.js";
 import { normalizeTailwindArbitraryUtilityValue } from "../../utils/normalize-tailwind-arbitrary-utility-value.js";
@@ -259,7 +260,8 @@ const canBothConditionOutcomesReachElement = (
     parameterSymbol.references.some((reference) => reference.flag !== "read") ||
     !hasStableElementKey(node, parameterSymbol, context) ||
     !context.cfg.isUnconditionalFromEntry(node) ||
-    isMountedWithinSelectorBranch(node, parameterSymbol, context)
+    isMountedWithinSelectorBranch(node, parameterSymbol, context) ||
+    isGatedByFalsyInitialState(node, context.scopes)
   ) {
     return false;
   }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-transitioned-composite-widget-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-transitioned-composite-widget-state.ts
@@ -1,0 +1,762 @@
+import { HTML_TAGS } from "../../constants/html-tags.js";
+import type { SymbolDescriptor } from "../../semantic/scope-analysis.js";
+import { defineRule } from "../../utils/define-rule.js";
+import { doesTailwindVariantScopeCover } from "../../utils/does-tailwind-variant-scope-cover.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { getAuthoritativeJsxAttribute } from "../../utils/get-authoritative-jsx-attribute.js";
+import { getElementType } from "../../utils/get-element-type.js";
+import { getHighestPriorityTailwindClassNameTokens } from "../../utils/get-highest-priority-tailwind-class-name-tokens.js";
+import { getJsxPropExhaustiveStaticStringValues } from "../../utils/get-jsx-prop-static-string-values.js";
+import { getJsxPropStaticStringValues } from "../../utils/get-jsx-prop-static-string-values.js";
+import { getTailwindTopLevelCharacterIndices } from "../../utils/get-tailwind-top-level-character-indices.js";
+import { getTailwindTransitionPropertyEffect } from "../../utils/get-tailwind-transition-property-effect.js";
+import { hasJsxSpreadAttribute } from "../../utils/has-jsx-spread-attribute.js";
+import { isFunctionLike } from "../../utils/is-function-like.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { isProvenIntrinsicJsxElement } from "../../utils/is-proven-intrinsic-jsx-element.js";
+import { normalizeTailwindArbitraryUtilityValue } from "../../utils/normalize-tailwind-arbitrary-utility-value.js";
+import { parseTailwindClassNameToken } from "../../utils/parse-tailwind-class-name-token.js";
+import type { TailwindClassNameToken } from "../../utils/parse-tailwind-class-name-token.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+import { resolveTailwindTransitionDurationState } from "../../utils/resolve-tailwind-transition-duration-state.js";
+import { splitTailwindClassName } from "../../utils/split-tailwind-class-name.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import { walkAst } from "../../utils/walk-ast.js";
+import { getEffectiveCssTransitionEvidence } from "./utils/get-effective-css-transition-evidence.js";
+import { getEffectiveStylePropertyAmong } from "./utils/get-effective-style-property-among.js";
+import { getInlineStyleExpression } from "./utils/get-inline-style-expression.js";
+import { getStringFromClassNameAttr } from "./utils/get-string-from-class-name-attr.js";
+import { parseColorToRgb } from "./utils/parse-color-to-rgb.js";
+import { resolveEffectiveTailwindClassNameToken } from "./utils/resolve-effective-tailwind-class-name-token.js";
+
+interface CompositeWidgetRoleContract {
+  stateNames: ReadonlySet<string>;
+}
+
+interface CompositeWidgetStateVariant {
+  selectorValue: string;
+  stateAttributeName: string;
+  stateName: string;
+}
+
+interface TailwindPaintDeclaration {
+  color: CanonicalPaintColor;
+  propertyName: string;
+}
+
+interface CanonicalPaintColor {
+  alpha: number;
+  blue: number | null;
+  green: number | null;
+  red: number | null;
+}
+
+interface TailwindTransitionDefaults {
+  hasPositiveDuration: boolean;
+  propertyNames: ReadonlyArray<string>;
+}
+
+const COMPOSITE_WIDGET_ROLE_CONTRACTS: ReadonlyMap<string, CompositeWidgetRoleContract> = new Map([
+  ["option", { stateNames: new Set(["current", "selected"]) }],
+  ["menuitem", { stateNames: new Set(["current"]) }],
+  ["menuitemcheckbox", { stateNames: new Set(["checked", "current"]) }],
+  ["menuitemradio", { stateNames: new Set(["checked", "current"]) }],
+  ["treeitem", { stateNames: new Set(["checked", "current", "selected"]) }],
+]);
+const STATE_ATTRIBUTE_NAMES: ReadonlyMap<string, string> = new Map([
+  ["checked", "aria-checked"],
+  ["current", "aria-current"],
+  ["selected", "aria-selected"],
+]);
+const PAINT_PROPERTY_NAMES: ReadonlySet<string> = new Set([
+  "background-color",
+  "border-color",
+  "color",
+]);
+const TRANSITION_COLORS_PROPERTY_NAMES = [
+  "color",
+  "background-color",
+  "border-color",
+  "text-decoration-color",
+  "fill",
+  "stroke",
+];
+const TRANSITION_DEFAULT_PROPERTY_NAMES = [
+  ...TRANSITION_COLORS_PROPERTY_NAMES,
+  "opacity",
+  "box-shadow",
+  "transform",
+  "translate",
+  "scale",
+  "rotate",
+  "filter",
+  "backdrop-filter",
+  "display",
+  "content-visibility",
+  "overlay",
+  "pointer-events",
+];
+const NON_COLOR_BACKGROUND_PATTERN =
+  /^bg-(?:auto|bottom|center|contain|cover|fixed|left(?:-bottom|-top)?|local|none|origin-|repeat|right(?:-bottom|-top)?|scroll|top|clip-|gradient-|linear-|radial|conic|blend-)/;
+const NON_COLOR_TEXT_PATTERN =
+  /^text-(?:left|right|center|justify|start|end|wrap|nowrap|balance|pretty|ellipsis|clip|xs|sm|base|lg|xl|[2-9]xl|opacity-|shadow|shadow-|box|box-)/;
+const NON_COLOR_BORDER_PATTERN =
+  /^border-(?:0|2|4|8|x|y|t|r|b|l|s|e|solid|dashed|dotted|double|hidden|none|collapse|separate|spacing|opacity)(?:-|$)/;
+const ARBITRARY_LENGTH_PATTERN =
+  /^\[(?:(?:length|percentage|absolute-size|relative-size):|(?:calc|min|max|clamp)\(|-?(?:\d*\.)?\d+(?:%|[a-z]+)\])/i;
+const ARBITRARY_NON_COLOR_PATTERN =
+  /^\[(?:image|url|position|length|size|angle|percentage|number|integer):/i;
+const STATIC_COLOR_PATTERN =
+  /^\[(?:color:)?(?:transparent|black|white|#[\da-f]{3,4}|#[\da-f]{6}|#[\da-f]{8}|(?:rgb|hsl|hwb|lab|lch|oklab|oklch|color)\([^\]]+\))\]$/i;
+const STATIC_ARBITRARY_COLOR_VALUE_PATTERN =
+  /^(?:transparent|black|white|#[\da-f]{3,4}|#[\da-f]{6}|#[\da-f]{8}|(?:rgb|hsl|hwb|lab|lch|oklab|oklch|color)\(.+\))$/i;
+const STATIC_RGB_COLOR_PATTERN =
+  /^rgba?\(\s*\d+(?:\s*,\s*\d+\s*,\s*\d+(?:\s*,\s*[\d.]+%?)?|\s+\d+\s+\d+(?:\s*\/\s*[\d.]+%?)?)\s*\)$/i;
+const HEX_RADIX = 16;
+const MAX_ALPHA_BYTE = 255;
+const MAX_ALPHA_NIBBLE = 15;
+const PERCENT_SCALE = 100;
+const STABLE_STATE_CONTEXT_VARIANTS = new Set([
+  "2xl",
+  "contrast-less",
+  "contrast-more",
+  "dark",
+  "landscape",
+  "lg",
+  "ltr",
+  "md",
+  "motion-reduce",
+  "motion-safe",
+  "portrait",
+  "rtl",
+  "sm",
+  "xl",
+]);
+const ARIA_CURRENT_ACTIVE_VALUES = new Set(["date", "location", "page", "step", "time", "true"]);
+const ARIA_BOOLEAN_ACTIVE_VALUES = new Set(["true"]);
+
+const getRuntimeConditionParameter = (
+  expression: EsTreeNode,
+  context: RuleContext,
+  visitedSymbolIds: ReadonlySet<number> = new Set(),
+): SymbolDescriptor | null => {
+  const candidate = stripParenExpression(expression);
+  if (isNodeOfType(candidate, "UnaryExpression") && candidate.operator === "!") {
+    return getRuntimeConditionParameter(candidate.argument, context, visitedSymbolIds);
+  }
+  if (!isNodeOfType(candidate, "Identifier")) return null;
+  const symbol = context.scopes.referenceFor(candidate)?.resolvedSymbol;
+  if (!symbol) return null;
+  if (symbol.kind === "parameter") return symbol;
+  if (symbol.kind !== "const" || !symbol.initializer || visitedSymbolIds.has(symbol.id)) {
+    return null;
+  }
+  const nextVisitedSymbolIds = new Set(visitedSymbolIds);
+  nextVisitedSymbolIds.add(symbol.id);
+  return getRuntimeConditionParameter(symbol.initializer, context, nextVisitedSymbolIds);
+};
+
+const getSelectorConditionParameter = (
+  expression: EsTreeNode,
+  context: RuleContext,
+  visitedSymbolIds: ReadonlySet<number> = new Set(),
+): SymbolDescriptor | null => {
+  const candidate = stripParenExpression(expression);
+  if (isNodeOfType(candidate, "ConditionalExpression")) {
+    return getRuntimeConditionParameter(candidate.test, context);
+  }
+  if (!isNodeOfType(candidate, "Identifier")) return null;
+  const symbol = context.scopes.referenceFor(candidate)?.resolvedSymbol;
+  if (
+    !symbol ||
+    symbol.kind !== "const" ||
+    !symbol.initializer ||
+    visitedSymbolIds.has(symbol.id)
+  ) {
+    return null;
+  }
+  const nextVisitedSymbolIds = new Set(visitedSymbolIds);
+  nextVisitedSymbolIds.add(symbol.id);
+  return getSelectorConditionParameter(symbol.initializer, context, nextVisitedSymbolIds);
+};
+
+const expressionReferencesParameter = (
+  expression: EsTreeNode,
+  parameterSymbol: SymbolDescriptor,
+  context: RuleContext,
+  visitedSymbolIds: ReadonlySet<number> = new Set(),
+): boolean => {
+  let doesReferenceParameter = false;
+  walkAst(expression, (candidate) => {
+    if (doesReferenceParameter) return false;
+    if (candidate !== expression && isFunctionLike(candidate)) return false;
+    if (!isNodeOfType(candidate, "Identifier")) return;
+    const symbol = context.scopes.referenceFor(candidate)?.resolvedSymbol;
+    if (!symbol) return;
+    if (symbol === parameterSymbol) {
+      doesReferenceParameter = true;
+      return false;
+    }
+    if (symbol.kind !== "const" || !symbol.initializer || visitedSymbolIds.has(symbol.id)) {
+      return;
+    }
+    const nextVisitedSymbolIds = new Set(visitedSymbolIds);
+    nextVisitedSymbolIds.add(symbol.id);
+    if (
+      expressionReferencesParameter(
+        symbol.initializer,
+        parameterSymbol,
+        context,
+        nextVisitedSymbolIds,
+      )
+    ) {
+      doesReferenceParameter = true;
+      return false;
+    }
+  });
+  return doesReferenceParameter;
+};
+
+const hasStableElementKey = (
+  node: EsTreeNodeOfType<"JSXOpeningElement">,
+  parameterSymbol: SymbolDescriptor,
+  context: RuleContext,
+): boolean => {
+  const keyAttribute = getAuthoritativeJsxAttribute(node.attributes, "key", false);
+  if (!keyAttribute?.value || !isNodeOfType(keyAttribute.value, "JSXExpressionContainer")) {
+    return true;
+  }
+  return !expressionReferencesParameter(keyAttribute.value.expression, parameterSymbol, context);
+};
+
+const isMountedWithinSelectorBranch = (
+  node: EsTreeNodeOfType<"JSXOpeningElement">,
+  parameterSymbol: SymbolDescriptor,
+  context: RuleContext,
+): boolean => {
+  let ancestor = node.parent;
+  while (ancestor && !isFunctionLike(ancestor)) {
+    if (
+      ((isNodeOfType(ancestor, "IfStatement") || isNodeOfType(ancestor, "ConditionalExpression")) &&
+        expressionReferencesParameter(ancestor.test, parameterSymbol, context)) ||
+      (isNodeOfType(ancestor, "LogicalExpression") &&
+        expressionReferencesParameter(ancestor.left, parameterSymbol, context))
+    ) {
+      return true;
+    }
+    ancestor = ancestor.parent;
+  }
+  return false;
+};
+
+const canBothConditionOutcomesReachElement = (
+  node: EsTreeNodeOfType<"JSXOpeningElement">,
+  parameterSymbol: SymbolDescriptor,
+  context: RuleContext,
+): boolean => {
+  if (
+    parameterSymbol.references.some((reference) => reference.flag !== "read") ||
+    !hasStableElementKey(node, parameterSymbol, context) ||
+    !context.cfg.isUnconditionalFromEntry(node) ||
+    isMountedWithinSelectorBranch(node, parameterSymbol, context)
+  ) {
+    return false;
+  }
+  return true;
+};
+
+const getExhaustiveAttributeValues = (
+  node: EsTreeNodeOfType<"JSXOpeningElement">,
+  attributeName: string,
+  context: RuleContext,
+): ReadonlySet<string> | null => {
+  const attribute = getAuthoritativeJsxAttribute(node.attributes, attributeName, false);
+  if (!attribute) return null;
+  if (!attribute.value || !isNodeOfType(attribute.value, "JSXExpressionContainer")) {
+    return null;
+  }
+  const parameterSymbol = getSelectorConditionParameter(attribute.value.expression, context);
+  if (!parameterSymbol || !canBothConditionOutcomesReachElement(node, parameterSymbol, context)) {
+    return null;
+  }
+  const values = getJsxPropExhaustiveStaticStringValues(attribute, context.scopes);
+  return values ? new Set(values.map((value) => value.trim())) : null;
+};
+
+const canAttributeSelectorActivationVary = (
+  node: EsTreeNodeOfType<"JSXOpeningElement">,
+  attributeName: string,
+  selectorValue: string,
+  context: RuleContext,
+): boolean => {
+  const values = getExhaustiveAttributeValues(node, attributeName, context);
+  return Boolean(
+    values?.has(selectorValue) && [...values].some((value) => value !== selectorValue),
+  );
+};
+
+const canAriaStateVary = (
+  node: EsTreeNodeOfType<"JSXOpeningElement">,
+  stateVariant: CompositeWidgetStateVariant,
+  context: RuleContext,
+): boolean => {
+  const values = getExhaustiveAttributeValues(node, stateVariant.stateAttributeName, context);
+  if (!values) return false;
+  const activeValues =
+    stateVariant.stateName === "current" ? ARIA_CURRENT_ACTIVE_VALUES : ARIA_BOOLEAN_ACTIVE_VALUES;
+  return (
+    [...values].some((value) => activeValues.has(value)) &&
+    [...values].some((value) => !activeValues.has(value))
+  );
+};
+
+const getCompositeWidgetRole = (
+  node: EsTreeNodeOfType<"JSXOpeningElement">,
+  context: RuleContext,
+): string | null => {
+  const roleAttribute = getAuthoritativeJsxAttribute(node.attributes, "role", false);
+  if (!roleAttribute) return null;
+  const roleCandidates = getJsxPropStaticStringValues(roleAttribute, context.scopes);
+  if (!roleCandidates) return null;
+  const normalizedRoles = new Set(
+    roleCandidates.map((candidate) => candidate.trim().toLowerCase()),
+  );
+  if (normalizedRoles.size !== 1) return null;
+  const role = normalizedRoles.values().next().value;
+  if (!role || role.split(/\s+/).length !== 1 || !COMPOSITE_WIDGET_ROLE_CONTRACTS.has(role)) {
+    return null;
+  }
+  return role;
+};
+
+const parseCompositeWidgetStateVariant = (variant: string): CompositeWidgetStateVariant | null => {
+  for (const [stateName, stateAttributeName] of STATE_ATTRIBUTE_NAMES) {
+    if (
+      variant === `aria-${stateName}` ||
+      variant === `aria-[${stateName}=true]` ||
+      (stateName === "current" &&
+        /^aria-\[current=(?:page|step|location|date|time)\]$/.test(variant))
+    ) {
+      const selectorValue = /^aria-\[[^=]+=([^\]]+)\]$/.exec(variant)?.[1] ?? "true";
+      return { selectorValue, stateAttributeName, stateName };
+    }
+  }
+  return null;
+};
+
+const getStateVariant = (
+  node: EsTreeNodeOfType<"JSXOpeningElement">,
+  role: string,
+  variants: ReadonlyArray<string>,
+  context: RuleContext,
+): CompositeWidgetStateVariant | null => {
+  const stateVariants = variants.flatMap((variant) => {
+    const stateVariant = parseCompositeWidgetStateVariant(variant);
+    return stateVariant ? [stateVariant] : [];
+  });
+  if (stateVariants.length !== 1) return null;
+  if (
+    variants.some(
+      (variant) =>
+        parseCompositeWidgetStateVariant(variant) === null &&
+        !STABLE_STATE_CONTEXT_VARIANTS.has(variant),
+    )
+  ) {
+    return null;
+  }
+  const stateVariant = stateVariants[0];
+  const roleContract = COMPOSITE_WIDGET_ROLE_CONTRACTS.get(role);
+  if (!stateVariant || !roleContract?.stateNames.has(stateVariant.stateName)) return null;
+  if (!canAriaStateVary(node, stateVariant, context)) return null;
+  if (
+    !canAttributeSelectorActivationVary(
+      node,
+      stateVariant.stateAttributeName,
+      stateVariant.selectorValue,
+      context,
+    )
+  ) {
+    return null;
+  }
+  return stateVariant;
+};
+
+const splitUtilityOpacityModifier = (utility: string): [string, string | null] => {
+  const modifierIndex = getTailwindTopLevelCharacterIndices(
+    utility,
+    (character) => character === "/",
+  )[0];
+  return modifierIndex === undefined
+    ? [utility, null]
+    : [utility.slice(0, modifierIndex), utility.slice(modifierIndex + 1)];
+};
+
+const parseAlpha = (rawAlpha: string): number | null => {
+  if (!/^\d*\.?\d+%?$/.test(rawAlpha)) return null;
+  const alpha = Number.parseFloat(rawAlpha);
+  if (!Number.isFinite(alpha)) return null;
+  const normalizedAlpha = rawAlpha.endsWith("%") ? alpha / PERCENT_SCALE : alpha;
+  return normalizedAlpha >= 0 && normalizedAlpha <= 1 ? normalizedAlpha : null;
+};
+
+const getColorFunctionAlpha = (value: string): number | null => {
+  const functionBody = /^rgba?\((.*)\)$/i.exec(value)?.[1];
+  if (!functionBody) return null;
+  const slashAlpha = /\/\s*([\d.]+%?)\s*$/.exec(functionBody)?.[1];
+  if (slashAlpha) return parseAlpha(slashAlpha);
+  const commaParts = functionBody.split(",").map((part) => part.trim());
+  if (commaParts.length === 4 && commaParts[3]) return parseAlpha(commaParts[3]);
+  return 1;
+};
+
+const getHexAlpha = (value: string): number | null => {
+  const hex = value.slice(1);
+  if (hex.length === 3 || hex.length === 6) return 1;
+  if (hex.length === 4) return Number.parseInt(hex[3] ?? "", HEX_RADIX) / MAX_ALPHA_NIBBLE;
+  if (hex.length === 8) {
+    return Number.parseInt(hex.slice(6), HEX_RADIX) / MAX_ALPHA_BYTE;
+  }
+  return null;
+};
+
+const getOpacityModifier = (rawModifier: string | null): number | null => {
+  if (rawModifier === null) return 1;
+  const arbitraryModifier = /^\[([\d.]+%?)\]$/.exec(rawModifier)?.[1];
+  if (arbitraryModifier) return parseAlpha(arbitraryModifier);
+  if (!/^\d*\.?\d+$/.test(rawModifier)) return null;
+  return parseAlpha(`${rawModifier}%`);
+};
+
+const getCanonicalPaintColor = (
+  rawValue: string,
+  rawOpacityModifier: string | null,
+): CanonicalPaintColor | null => {
+  const opacityModifier = getOpacityModifier(rawOpacityModifier);
+  if (opacityModifier === null) return null;
+  const normalizedValue = normalizeTailwindArbitraryUtilityValue(rawValue).toLowerCase();
+  if (normalizedValue === "transparent") {
+    return { alpha: 0, blue: 0, green: 0, red: 0 };
+  }
+  if (normalizedValue === "white") {
+    return {
+      alpha: opacityModifier,
+      blue: MAX_ALPHA_BYTE,
+      green: MAX_ALPHA_BYTE,
+      red: MAX_ALPHA_BYTE,
+    };
+  }
+  if (normalizedValue === "black") {
+    return { alpha: opacityModifier, blue: 0, green: 0, red: 0 };
+  }
+  const unwrappedArbitraryValue = /^\[(?:color:)?(.+)\]$/.exec(normalizedValue)?.[1];
+  const cssColor = unwrappedArbitraryValue ?? normalizedValue;
+  if (cssColor.startsWith("#") || STATIC_RGB_COLOR_PATTERN.test(cssColor)) {
+    const rgb = parseColorToRgb(cssColor);
+    const colorAlpha = cssColor.startsWith("#")
+      ? getHexAlpha(cssColor)
+      : getColorFunctionAlpha(cssColor);
+    if (
+      !rgb ||
+      colorAlpha === null ||
+      rgb.red > MAX_ALPHA_BYTE ||
+      rgb.green > MAX_ALPHA_BYTE ||
+      rgb.blue > MAX_ALPHA_BYTE
+    ) {
+      return null;
+    }
+    return {
+      alpha: colorAlpha * opacityModifier,
+      blue: rgb.blue,
+      green: rgb.green,
+      red: rgb.red,
+    };
+  }
+  return null;
+};
+
+const getArbitraryPropertyDeclaration = (utility: string): TailwindPaintDeclaration | null => {
+  const match = /^\[(background-color|border-color|color):(.+)\]$/i.exec(utility);
+  if (!match?.[1] || !match[2]) return null;
+  const value = normalizeTailwindArbitraryUtilityValue(match[2]).toLowerCase();
+  if (!STATIC_ARBITRARY_COLOR_VALUE_PATTERN.test(value)) return null;
+  const color = getCanonicalPaintColor(value, null);
+  if (!color) return null;
+  return {
+    color,
+    propertyName: match[1].toLowerCase(),
+  };
+};
+
+const getTailwindPaintDeclaration = (utility: string): TailwindPaintDeclaration | null => {
+  const arbitraryProperty = getArbitraryPropertyDeclaration(utility);
+  if (arbitraryProperty) return arbitraryProperty;
+  const [utilityWithoutModifier, opacityModifier] = splitUtilityOpacityModifier(utility);
+  const utilityParts = utilityWithoutModifier.split("-");
+  const prefix = utilityParts[0];
+  const rawValue = utilityWithoutModifier.slice((prefix?.length ?? 0) + 1);
+  if (!prefix || !rawValue) return null;
+  const color = getCanonicalPaintColor(rawValue, opacityModifier);
+  if (!color) return null;
+  if (prefix === "bg") {
+    if (
+      NON_COLOR_BACKGROUND_PATTERN.test(utilityWithoutModifier) ||
+      ARBITRARY_NON_COLOR_PATTERN.test(rawValue)
+    ) {
+      return null;
+    }
+    if (!STATIC_COLOR_PATTERN.test(rawValue)) return null;
+    return { color, propertyName: "background-color" };
+  }
+  if (prefix === "text") {
+    if (
+      NON_COLOR_TEXT_PATTERN.test(utilityWithoutModifier) ||
+      ARBITRARY_LENGTH_PATTERN.test(rawValue)
+    ) {
+      return null;
+    }
+    if (!STATIC_COLOR_PATTERN.test(rawValue)) return null;
+    return { color, propertyName: "color" };
+  }
+  if (prefix === "border") {
+    if (NON_COLOR_BORDER_PATTERN.test(utilityWithoutModifier)) return null;
+    if (!STATIC_COLOR_PATTERN.test(rawValue)) return null;
+    return { color, propertyName: "border-color" };
+  }
+  return null;
+};
+
+const areCanonicalColorsEquivalent = (
+  leftColor: CanonicalPaintColor,
+  rightColor: CanonicalPaintColor,
+): boolean => {
+  if (leftColor.alpha === 0 && rightColor.alpha === 0) return true;
+  return (
+    leftColor.red === rightColor.red &&
+    leftColor.green === rightColor.green &&
+    leftColor.blue === rightColor.blue &&
+    leftColor.alpha === rightColor.alpha
+  );
+};
+
+const areCanonicalColorsProvablyDistinct = (
+  leftColor: CanonicalPaintColor,
+  rightColor: CanonicalPaintColor,
+): boolean => {
+  if (areCanonicalColorsEquivalent(leftColor, rightColor)) return false;
+  return true;
+};
+
+const getEffectiveStatePaintProperty = (
+  node: EsTreeNodeOfType<"JSXOpeningElement">,
+  role: string,
+  rawTokens: ReadonlyArray<string>,
+  parsedTokens: ReadonlyArray<TailwindClassNameToken>,
+  context: RuleContext,
+): TailwindPaintDeclaration | null => {
+  for (const parsedToken of parsedTokens) {
+    const stateVariant = getStateVariant(node, role, parsedToken.variants, context);
+    const stateDeclaration = getTailwindPaintDeclaration(parsedToken.utility);
+    if (!stateVariant || !stateDeclaration || parsedToken.isImportant) continue;
+    const propertyPredicate = (utility: string): boolean =>
+      getTailwindPaintDeclaration(utility)?.propertyName === stateDeclaration.propertyName;
+    const effectiveState = resolveEffectiveTailwindClassNameToken(
+      [...rawTokens],
+      propertyPredicate,
+      parsedToken.variants,
+    );
+    if (
+      effectiveState.isAmbiguous ||
+      effectiveState.isImportant ||
+      effectiveState.utility !== parsedToken.utility
+    ) {
+      continue;
+    }
+    const restingTokens: string[] = [];
+    for (const candidate of parsedTokens) {
+      if (candidate.variants.some((variant) => parseCompositeWidgetStateVariant(variant))) {
+        continue;
+      }
+      restingTokens.push(
+        `${candidate.variants.map((variant) => `${variant}:`).join("")}${
+          candidate.isImportant ? "!" : ""
+        }${candidate.utility}`,
+      );
+    }
+    const restingState = resolveEffectiveTailwindClassNameToken(
+      restingTokens,
+      propertyPredicate,
+      parsedToken.variants,
+    );
+    if (restingState.isAmbiguous || restingState.isImportant) continue;
+    const restingDeclaration = restingState.utility
+      ? getTailwindPaintDeclaration(restingState.utility)
+      : null;
+    if (
+      !restingDeclaration ||
+      !areCanonicalColorsProvablyDistinct(restingDeclaration.color, stateDeclaration.color)
+    ) {
+      continue;
+    }
+    return stateDeclaration;
+  }
+  return null;
+};
+
+const getTransitionPropertyNames = (utility: string): ReadonlyArray<string> | null => {
+  if (utility === "transition-colors") return TRANSITION_COLORS_PROPERTY_NAMES;
+  if (utility === "transition") return TRANSITION_DEFAULT_PROPERTY_NAMES;
+  return getTailwindTransitionPropertyEffect(utility)?.propertyNames ?? null;
+};
+
+const isTransitionDurationSetter = (utility: string): boolean =>
+  utility.startsWith("duration-") ||
+  utility.startsWith("[transition-duration:") ||
+  utility.startsWith("[transition:");
+
+const transitionUtilityHasDefaultDuration = (utility: string): boolean =>
+  utility === "transition" ||
+  utility === "transition-colors" ||
+  (utility.startsWith("transition-[") && utility.endsWith("]"));
+
+const getTailwindTransitionDefaults = (
+  parsedTokens: ReadonlyArray<TailwindClassNameToken>,
+  targetVariantScope: ReadonlyArray<string>,
+): TailwindTransitionDefaults | null => {
+  const propertyTokens = getHighestPriorityTailwindClassNameTokens(
+    parsedTokens,
+    (parsedToken) =>
+      doesTailwindVariantScopeCover(parsedToken.variants, targetVariantScope) &&
+      getTailwindTransitionPropertyEffect(parsedToken.utility) !== null,
+  );
+  if (propertyTokens.some((parsedToken) => parsedToken.isImportant)) return null;
+  const propertyNameLists = propertyTokens.map((parsedToken) =>
+    getTransitionPropertyNames(parsedToken.utility),
+  );
+  if (propertyNameLists.some((propertyNames) => propertyNames === null)) return null;
+  const serializedPropertyNameLists = new Set(
+    propertyNameLists.map((propertyNames) => JSON.stringify(propertyNames)),
+  );
+  if (serializedPropertyNameLists.size > 1) return null;
+  const propertyNames = propertyNameLists[0] ?? ["all"];
+  const relevantDurationTokens = parsedTokens.filter(
+    (parsedToken) =>
+      doesTailwindVariantScopeCover(parsedToken.variants, targetVariantScope) &&
+      isTransitionDurationSetter(parsedToken.utility),
+  );
+  if (relevantDurationTokens.some((parsedToken) => parsedToken.isImportant)) return null;
+  const targetPropertyNames = new Set(
+    propertyNames.filter((propertyName) => PAINT_PROPERTY_NAMES.has(propertyName)),
+  );
+  if (targetPropertyNames.size === 0) targetPropertyNames.add("all");
+  const durationState = resolveTailwindTransitionDurationState(
+    parsedTokens,
+    targetVariantScope,
+    targetPropertyNames,
+  );
+  if (durationState !== null) return { hasPositiveDuration: durationState, propertyNames };
+  if (relevantDurationTokens.length > 0) return null;
+  const hasDefaultDuration = propertyTokens.some((parsedToken) =>
+    transitionUtilityHasDefaultDuration(parsedToken.utility),
+  );
+  return { hasPositiveDuration: hasDefaultDuration, propertyNames };
+};
+
+const hasTransitionedPaintProperty = (
+  node: EsTreeNodeOfType<"JSXOpeningElement">,
+  parsedTokens: ReadonlyArray<TailwindClassNameToken>,
+  targetVariantScope: ReadonlyArray<string>,
+  targetPropertyName: string,
+  context: RuleContext,
+): boolean => {
+  const styleAttribute = getAuthoritativeJsxAttribute(node.attributes, "style");
+  const styleExpression = styleAttribute
+    ? getInlineStyleExpression(styleAttribute, context.scopes)
+    : null;
+  if (styleAttribute && !styleExpression) return false;
+  let paintStylePropertyNames = new Set(["color"]);
+  if (targetPropertyName === "background-color") {
+    paintStylePropertyNames = new Set(["background", "backgroundColor"]);
+  } else if (targetPropertyName === "border-color") {
+    paintStylePropertyNames = new Set(["border", "borderColor"]);
+  }
+  if (getEffectiveStylePropertyAmong(styleExpression?.properties, paintStylePropertyNames)) {
+    return false;
+  }
+  const transitionDefaults = getTailwindTransitionDefaults(parsedTokens, targetVariantScope);
+  if (!transitionDefaults) return false;
+  const transitionEvidence = getEffectiveCssTransitionEvidence(
+    styleExpression?.properties,
+    transitionDefaults.propertyNames.map((propertyName) => ({
+      hasPositiveDuration: transitionDefaults.hasPositiveDuration,
+      propertyName,
+      sourceNode: node,
+    })),
+  );
+  return Boolean(
+    transitionEvidence?.some(
+      (transition) =>
+        transition.propertyName === targetPropertyName && transition.durationMilliseconds > 0,
+    ),
+  );
+};
+
+export const noTransitionedCompositeWidgetState = defineRule({
+  id: "no-transitioned-composite-widget-state",
+  title: "Composite widget state feedback is delayed",
+  severity: "warn",
+  category: "Accessibility",
+  defaultEnabled: false,
+  tags: ["react-jsx-only", "test-noise"],
+  requires: ["tailwind"],
+  recommendation:
+    "Keep selected, checked, and current-item color feedback instant in options, menus, and trees. Reserve transitions for the widget container opening or closing.",
+  create: (context: RuleContext) => ({
+    JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
+      if (
+        hasJsxSpreadAttribute(node.attributes) ||
+        !isProvenIntrinsicJsxElement(node, context.scopes) ||
+        !HTML_TAGS.has(getElementType(node, context.settings))
+      ) {
+        return;
+      }
+      const role = getCompositeWidgetRole(node, context);
+      const className = getStringFromClassNameAttr(node);
+      if (!role || !className) return;
+      const rawTokens = splitTailwindClassName(className);
+      const parsedTokens = rawTokens.map(parseTailwindClassNameToken);
+      const statePaintDeclaration = getEffectiveStatePaintProperty(
+        node,
+        role,
+        rawTokens,
+        parsedTokens,
+        context,
+      );
+      if (!statePaintDeclaration) return;
+      const stateToken = parsedTokens.find((parsedToken) => {
+        const declaration = getTailwindPaintDeclaration(parsedToken.utility);
+        return (
+          declaration?.propertyName === statePaintDeclaration.propertyName &&
+          areCanonicalColorsEquivalent(declaration.color, statePaintDeclaration.color) &&
+          getStateVariant(node, role, parsedToken.variants, context) !== null
+        );
+      });
+      if (
+        !stateToken ||
+        !hasTransitionedPaintProperty(
+          node,
+          parsedTokens,
+          stateToken.variants,
+          statePaintDeclaration.propertyName,
+          context,
+        )
+      ) {
+        return;
+      }
+      context.report({
+        node,
+        message: `The ${role} transitions its ${statePaintDeclaration.propertyName} when its state changes. Keep high-frequency composite-widget feedback instant.`,
+      });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/loading-action-preserves-trigger.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/loading-action-preserves-trigger.test.ts
@@ -126,6 +126,7 @@ describe("loading-action-preserves-trigger", () => {
     ["an as expression", `true as boolean`],
     ["a satisfies expression", `true satisfies boolean`],
     ["a non-null expression", `true!`],
+    ["nested transparent wrappers", `((true as const) satisfies boolean)!`],
   ])("flags when the pending setter receives %s", (_description, setterValue) => {
     const result = run(`
       import { useState } from "react";
@@ -363,6 +364,10 @@ describe("loading-action-preserves-trigger", () => {
       "resets pending before the suspension",
       `setPending(true); setPending(false); await fetch("/api/save");`,
     ],
+    [
+      "resets pending through transparent wrappers before the suspension",
+      `setPending(true as boolean); setPending(false satisfies boolean); await fetch("/api/save");`,
+    ],
   ])("stays quiet when the handler %s", (_description, body) => {
     const result = run(`
       import { useState } from "react";
@@ -381,6 +386,7 @@ describe("loading-action-preserves-trigger", () => {
     ["uses a router", `router.push("/done")`],
     ["uses a receiver navigation method", `router.navigate("/done")`],
     ["assigns a location href", `window.location.href = "/done"`],
+    ["assigns window.location", `window.location = "/done"`],
     ["requests a form submission", `formRef.current.requestSubmit()`],
     ["submits a form", `formRef.current.submit()`],
   ])("stays quiet when the handler intentionally %s", (_description, transfer) => {
@@ -401,23 +407,31 @@ describe("loading-action-preserves-trigger", () => {
   });
 
   it.each([
-    ["a custom action", `<Button onClick={save}>Save</Button>`],
-    ["an action spread", `<button {...buttonProps} onClick={save}>Save</button>`],
-    ["an imported handler", `<button onClick={save}>Save</button>`],
-    ["a useCallback handler", `<button onClick={save}>Save</button>`],
-  ])("stays quiet for %s", (description, action) => {
-    const handler =
-      description === "an imported handler"
-        ? ""
-        : description === "a useCallback handler"
-          ? `const save = useCallback(async () => { setPending(true); await fetch("/api/save"); }, []);`
-          : `async function save() { setPending(true); await fetch("/api/save"); }`;
-    const imports =
-      description === "an imported handler"
-        ? `import { save } from "./actions";`
-        : description === "a useCallback handler"
-          ? `import { useCallback, useState } from "react";`
-          : `import { useState } from "react";`;
+    [
+      "a custom action",
+      `<Button onClick={save}>Save</Button>`,
+      `import { useState } from "react";`,
+      `async function save() { setPending(true); await fetch("/api/save"); }`,
+    ],
+    [
+      "an action spread",
+      `<button {...buttonProps} onClick={save}>Save</button>`,
+      `import { useState } from "react";`,
+      `async function save() { setPending(true); await fetch("/api/save"); }`,
+    ],
+    [
+      "an imported handler",
+      `<button onClick={save}>Save</button>`,
+      `import { save } from "./actions";`,
+      "",
+    ],
+    [
+      "a useCallback handler",
+      `<button onClick={save}>Save</button>`,
+      `import { useCallback, useState } from "react";`,
+      `const save = useCallback(async () => { setPending(true); await fetch("/api/save"); }, []);`,
+    ],
+  ])("stays quiet for %s", (_description, action, imports, handler) => {
     const result = run(`
       ${imports}
       const Save = () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/loading-action-preserves-trigger.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/loading-action-preserves-trigger.test.ts
@@ -1,0 +1,671 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { loadingActionPreservesTrigger } from "./loading-action-preserves-trigger.js";
+
+const run = (source: string) => runRule(loadingActionPreservesTrigger, source);
+
+describe("loading-action-preserves-trigger", () => {
+  it("flags a button replaced by passive status text during its fetch", () => {
+    const result = run(`
+      import { useState } from "react";
+      const Save = () => {
+        const [isSaving, setIsSaving] = useState(false);
+        const save = async () => {
+          setIsSaving(true);
+          await fetch("/api/save", { method: "POST" });
+          setIsSaving(false);
+        };
+        return isSaving ? <span role="status">Saving</span> : <button onClick={save}>Save</button>;
+      };
+    `);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a negated state test and an inline handler", () => {
+    const result = run(`
+      import * as React from "react";
+      function Upload() {
+        const [pending, setPending] = React.useState(false);
+        return <section>{!pending ? (
+          <button onClick={async () => {
+            setPending(true);
+            await fetch("/api/upload", { method: "POST" });
+            setPending(false);
+          }}>Upload</button>
+        ) : <p aria-live="polite">Uploading</p>}</section>;
+      }
+    `);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a button replaced by null", () => {
+    const result = run(`
+      import { useState } from "react";
+      function DeleteButton() {
+        const [pending, setPending] = useState(false);
+        async function remove() {
+          setPending(true);
+          await fetch("/api/item", { method: "DELETE" });
+          setPending(false);
+        }
+        return <div>{pending ? null : <button onClick={remove}>Delete</button>}</div>;
+      }
+    `);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a submit input with a direct click handler", () => {
+    const result = run(`
+      import { useState } from "react";
+      function Submit() {
+        const [pending, setPending] = useState(false);
+        async function submit() {
+          setPending(true);
+          await fetch("/api/submit", { method: "POST" });
+          setPending(false);
+        }
+        return pending ? <span>Submitting</span> : <input type="submit" onClick={submit} />;
+      }
+    `);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it.each([
+    ["disabled", "disabled={false}"],
+    ["aria-disabled", 'aria-disabled="false"'],
+  ])("flags an action whose static %s value proves it is enabled", (_description, attribute) => {
+    const result = run(`
+      import { useState } from "react";
+      function Save() {
+        const [pending, setPending] = useState(false);
+        async function save() {
+          setPending(true);
+          await fetch("/api/save");
+          setPending(false);
+        }
+        return pending ? <span>Saving</span> : <button ${attribute} onClick={save}>Save</button>;
+      }
+    `);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags an explicit type=button action inside a form", () => {
+    const result = run(`
+      import { useState } from "react";
+      function Save() {
+        const [pending, setPending] = useState(false);
+        async function save() {
+          setPending(true);
+          await fetch("/api/save");
+          setPending(false);
+        }
+        return <form>{pending ? <span>Saving</span> : <button type="button" onClick={save}>Save</button>}</form>;
+      }
+    `);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("uses the first valid fallback role when proving passive status content", () => {
+    const result = run(`
+      import { useState } from "react";
+      function Save() {
+        const [pending, setPending] = useState(false);
+        async function save() {
+          setPending(true);
+          await fetch("/api/save");
+          setPending(false);
+        }
+        return pending ? <span role="unsupported status">Saving</span> : <button onClick={save}>Save</button>;
+      }
+    `);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it.each([
+    ["an as expression", `true as boolean`],
+    ["a satisfies expression", `true satisfies boolean`],
+    ["a non-null expression", `true!`],
+  ])("flags when the pending setter receives %s", (_description, setterValue) => {
+    const result = run(`
+      import { useState } from "react";
+      function Save() {
+        const [pending, setPending] = useState(false);
+        async function save() {
+          setPending(${setterValue});
+          await fetch("/api/save");
+          setPending(false);
+        }
+        return pending ? <span>Saving</span> : <button onClick={save}>Save</button>;
+      }
+    `);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays quiet when the same button root is preserved", () => {
+    const result = run(`
+      import { useState } from "react";
+      const Save = () => {
+        const [pending, setPending] = useState(false);
+        const save = async () => {
+          setPending(true);
+          await fetch("/api/save");
+          setPending(false);
+        };
+        return pending
+          ? <button disabled>Saving</button>
+          : <button onClick={save}>Save</button>;
+      };
+    `);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when the action remains mounted and changes its contents", () => {
+    const result = run(`
+      import { useState } from "react";
+      const Save = () => {
+        const [pending, setPending] = useState(false);
+        const save = async () => {
+          setPending(true);
+          await fetch("/api/save");
+          setPending(false);
+        };
+        return <button onClick={save} disabled={pending}>{pending ? "Saving" : "Save"}</button>;
+      };
+    `);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for an opaque pending component", () => {
+    const result = run(`
+      import { useState } from "react";
+      const Save = () => {
+        const [pending, setPending] = useState(false);
+        async function save() {
+          setPending(true);
+          await fetch("/api/save");
+          setPending(false);
+        }
+        return pending ? <Spinner /> : <button onClick={save}>Save</button>;
+      };
+    `);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when passive-looking content contains an opaque child", () => {
+    const result = run(`
+      import { useState } from "react";
+      const Save = () => {
+        const [pending, setPending] = useState(false);
+        async function save() {
+          setPending(true);
+          await fetch("/api/save");
+          setPending(false);
+        }
+        return pending ? <span><Status /></span> : <button onClick={save}>Save</button>;
+      };
+    `);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it.each([
+    ["an interactive descendant", `<span><a href="/help">Help</a></span>`],
+    ["an event handler", `<span onClick={() => retry()}>Retrying</span>`],
+    ["an interactive role", `<span role="button">Retrying</span>`],
+    ["a focus target", `<span tabIndex={-1}>Saving</span>`],
+    ["a spread", `<span {...statusProps}>Saving</span>`],
+    ["dynamic children", `<span>{pendingContent}</span>`],
+    ["an iframe", `<iframe title="Saving" />`],
+    ["a label", `<label htmlFor="save">Saving</label>`],
+    ["an htmlFor relationship", `<div htmlFor="save">Saving</div>`],
+    ["inline HTML", `<div dangerouslySetInnerHTML={{ __html: statusHtml }} />`],
+    ["a ref", `<div ref={statusRef}>Saving</div>`],
+    ["an invalid role fallback", `<span role="unsupported">Saving</span>`],
+    ["an interactive fallback role", `<span role="unsupported button">Saving</span>`],
+  ])("stays quiet when the pending branch has %s", (_description, pendingBranch) => {
+    const result = run(`
+      import { useState } from "react";
+      const Save = () => {
+        const [pending, setPending] = useState(false);
+        async function save() {
+          setPending(true);
+          await fetch("/api/save");
+          setPending(false);
+        }
+        return pending ? ${pendingBranch} : <button onClick={save}>Save</button>;
+      };
+    `);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it.each([
+    ["a prop", `const Save = ({ pending }) => { const setPending = () => {};`],
+    ["a custom hook", `const Save = () => { const [pending, setPending] = usePending();`],
+    [
+      "useReducer",
+      `const Save = () => { const [pending, setPending] = useReducer(reducer, false);`,
+    ],
+    [
+      "a query result",
+      `const Save = () => { const { isPending: pending, mutateAsync: setPending } = useMutation();`,
+    ],
+  ])("stays quiet when pending comes from %s", (_description, componentStart) => {
+    const result = run(`
+      import { useState } from "react";
+      ${componentStart}
+        async function save() {
+          setPending(true);
+          await fetch("/api/save");
+        }
+        return pending ? <span>Saving</span> : <button onClick={save}>Save</button>;
+      };
+    `);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for an unproven global useState", () => {
+    const result = run(`
+      const Save = () => {
+        const [pending, setPending] = useState(false);
+        async function save() {
+          setPending(true);
+          await fetch("/api/save");
+        }
+        return pending ? <span>Saving</span> : <button onClick={save}>Save</button>;
+      };
+    `);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for a locally shadowed useState", () => {
+    const result = run(`
+      const useState = (value) => [value, () => {}];
+      const Save = () => {
+        const [pending, setPending] = useState(false);
+        async function save() {
+          setPending(true);
+          await fetch("/api/save");
+        }
+        return pending ? <span>Saving</span> : <button onClick={save}>Save</button>;
+      };
+    `);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it.each([
+    ["true initial state", `useState(true)`],
+    ["lazy initial state", `useState(() => false)`],
+    ["an extra tuple element", `useState(false)`],
+  ])("stays quiet for %s", (description, initializer) => {
+    const tuple =
+      description === "an extra tuple element"
+        ? `[pending, setPending, metadata]`
+        : `[pending, setPending]`;
+    const result = run(`
+      import { useState } from "react";
+      const Save = () => {
+        const ${tuple} = ${initializer};
+        async function save() {
+          setPending(true);
+          await fetch("/api/save");
+        }
+        return pending ? <span>Saving</span> : <button onClick={save}>Save</button>;
+      };
+    `);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it.each([
+    ["a compound guard", `pending && enabled`],
+    ["an aliased guard", `isBusy`],
+  ])("stays quiet for %s", (_description, test) => {
+    const result = run(`
+      import { useState } from "react";
+      const Save = () => {
+        const [pending, setPending] = useState(false);
+        const isBusy = pending;
+        async function save() {
+          setPending(true);
+          await fetch("/api/save");
+        }
+        return ${test} ? <span>Saving</span> : <button onClick={save}>Save</button>;
+      };
+    `);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when multiple rendered actions consume the same state", () => {
+    const result = run(`
+      import { useState } from "react";
+      const Save = () => {
+        const [pending, setPending] = useState(false);
+        async function save() {
+          setPending(true);
+          await fetch("/api/save");
+        }
+        return <>
+          {pending ? <span>Saving</span> : <button onClick={save}>Save</button>}
+          {pending ? <span>Saving copy</span> : <button onClick={save}>Save copy</button>}
+        </>;
+      };
+    `);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it.each([
+    ["sets pending after the suspension", `await fetch("/api/save"); setPending(true);`],
+    ["does not await", `setPending(true); return fetch("/api/save");`],
+    ["uses promise then", `setPending(true); fetch("/api/save").then(done);`],
+    ["awaits opaque work", `setPending(true); await saveRequest();`],
+    ["has an unreachable fetch suspension", `setPending(true); return; await fetch("/api/save");`],
+    ["sets pending conditionally", `if (enabled) setPending(true); await fetch("/api/save");`],
+    [
+      "resets pending before the suspension",
+      `setPending(true); setPending(false); await fetch("/api/save");`,
+    ],
+  ])("stays quiet when the handler %s", (_description, body) => {
+    const result = run(`
+      import { useState } from "react";
+      const Save = () => {
+        const [pending, setPending] = useState(false);
+        async function save() { ${body} }
+        return pending ? <span>Saving</span> : <button onClick={save}>Save</button>;
+      };
+    `);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it.each([
+    ["moves focus", `inputRef.current.focus()`],
+    ["navigates", `navigate("/done")`],
+    ["uses a router", `router.push("/done")`],
+    ["uses a receiver navigation method", `router.navigate("/done")`],
+    ["assigns a location href", `window.location.href = "/done"`],
+    ["requests a form submission", `formRef.current.requestSubmit()`],
+    ["submits a form", `formRef.current.submit()`],
+  ])("stays quiet when the handler intentionally %s", (_description, transfer) => {
+    const result = run(`
+      import { useState } from "react";
+      const Save = () => {
+        const [pending, setPending] = useState(false);
+        async function save() {
+          setPending(true);
+          await fetch("/api/save");
+          ${transfer};
+          setPending(false);
+        }
+        return pending ? <span>Saving</span> : <button onClick={save}>Save</button>;
+      };
+    `);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it.each([
+    ["a custom action", `<Button onClick={save}>Save</Button>`],
+    ["an action spread", `<button {...buttonProps} onClick={save}>Save</button>`],
+    ["an imported handler", `<button onClick={save}>Save</button>`],
+    ["a useCallback handler", `<button onClick={save}>Save</button>`],
+  ])("stays quiet for %s", (description, action) => {
+    const handler =
+      description === "an imported handler"
+        ? ""
+        : description === "a useCallback handler"
+          ? `const save = useCallback(async () => { setPending(true); await fetch("/api/save"); }, []);`
+          : `async function save() { setPending(true); await fetch("/api/save"); }`;
+    const imports =
+      description === "an imported handler"
+        ? `import { save } from "./actions";`
+        : description === "a useCallback handler"
+          ? `import { useCallback, useState } from "react";`
+          : `import { useState } from "react";`;
+    const result = run(`
+      ${imports}
+      const Save = () => {
+        const [pending, setPending] = useState(false);
+        ${handler}
+        return pending ? <span>Saving</span> : ${action};
+      };
+    `);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it.each([
+    [
+      "an implicit button with a literal owner",
+      `<button form="save-form" onClick={save}>Save</button>`,
+    ],
+    [
+      "a submit button with a dynamic owner",
+      `<button type="submit" form={formId} onClick={save}>Save</button>`,
+    ],
+    [
+      "a submit input with a literal owner",
+      `<input type="submit" form="save-form" onClick={save} />`,
+    ],
+    ["an image input with a dynamic owner", `<input type="image" form={formId} onClick={save} />`],
+  ])("stays quiet for %s outside form ancestry", (_description, action) => {
+    const result = run(`
+      import { useState } from "react";
+      function Save() {
+        const [pending, setPending] = useState(false);
+        async function save() {
+          setPending(true);
+          await fetch("/api/save", { method: "POST" });
+          setPending(false);
+        }
+        return pending ? <span>Saving</span> : ${action};
+      }
+    `);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still flags a type=button with a form owner attribute", () => {
+    const result = run(`
+      import { useState } from "react";
+      function Save() {
+        const [pending, setPending] = useState(false);
+        async function save() {
+          setPending(true);
+          await fetch("/api/save");
+          setPending(false);
+        }
+        return pending ? <span>Saving</span> : <button type="button" form="save-form" onClick={save}>Save</button>;
+      }
+    `);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays quiet when the handler escapes", () => {
+    const result = run(`
+      import { useState } from "react";
+      const Save = () => {
+        const [pending, setPending] = useState(false);
+        async function save() {
+          setPending(true);
+          await fetch("/api/save");
+        }
+        registerSave(save);
+        return pending ? <span>Saving</span> : <button onClick={save}>Save</button>;
+      };
+    `);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when the setter escapes", () => {
+    const result = run(`
+      import { useState } from "react";
+      const Save = () => {
+        const [pending, setPending] = useState(false);
+        async function save() {
+          setPending(true);
+          await fetch("/api/save");
+        }
+        registerSetter(setPending);
+        return pending ? <span>Saving</span> : <button onClick={save}>Save</button>;
+      };
+    `);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for a shadowed fetch implementation", () => {
+    const result = run(`
+      import { useState } from "react";
+      const fetch = async () => navigate("/next");
+      const Save = () => {
+        const [pending, setPending] = useState(false);
+        async function save() {
+          setPending(true);
+          await fetch();
+        }
+        return pending ? <span>Saving</span> : <button onClick={save}>Save</button>;
+      };
+    `);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when the action relies on an ancestor form submit", () => {
+    const result = run(`
+      import { useState } from "react";
+      const Save = () => {
+        const [pending, setPending] = useState(false);
+        async function save(event) {
+          event.preventDefault();
+          setPending(true);
+          await fetch("/api/save", { method: "POST" });
+        }
+        return <form onSubmit={save}>{pending ? <span>Saving</span> : <button type="submit">Save</button>}</form>;
+      };
+    `);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it.each([
+    ["an implicit submit button", `<button onClick={save}>Save</button>`],
+    ["an explicit submit button", `<button type="submit" onClick={save}>Save</button>`],
+    ["a dynamic button type", `<button type={buttonType} onClick={save}>Save</button>`],
+    ["an empty button type", `<button type="" onClick={save}>Save</button>`],
+    ["an invalid button type", `<button type="wat" onClick={save}>Save</button>`],
+    ["a submit input", `<input type="submit" onClick={save} />`],
+  ])("stays quiet for %s inside a form", (_description, action) => {
+    const result = run(`
+      import { useState } from "react";
+      function Save() {
+        const [pending, setPending] = useState(false);
+        async function save() {
+          setPending(true);
+          await fetch("/api/save", { method: "POST" });
+          setPending(false);
+        }
+        return <form>{pending ? <span>Saving</span> : ${action}}</form>;
+      }
+    `);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it.each([
+    ["an implicit button", `<button onClick={save}>Save</button>`],
+    ["an explicit submit button", `<button type="submit" onClick={save}>Save</button>`],
+    ["an empty button type", `<button type="" onClick={save}>Save</button>`],
+    ["an invalid button type", `<button type="wat" onClick={save}>Save</button>`],
+    ["a submit input", `<input type="submit" onClick={save} />`],
+  ])("stays quiet for %s under an opaque custom ancestor", (_description, action) => {
+    const result = run(`
+      import { useState } from "react";
+      function Save() {
+        const [pending, setPending] = useState(false);
+        async function save() {
+          setPending(true);
+          await fetch("/api/save", { method: "POST" });
+          setPending(false);
+        }
+        return <Form>{pending ? <span>Saving</span> : ${action}}</Form>;
+      }
+    `);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still flags a type=button action under an opaque custom ancestor", () => {
+    const result = run(`
+      import { useState } from "react";
+      function Save() {
+        const [pending, setPending] = useState(false);
+        async function save() {
+          setPending(true);
+          await fetch("/api/save");
+          setPending(false);
+        }
+        return <Form>{pending ? <span>Saving</span> : <button type="button" onClick={save}>Save</button>}</Form>;
+      }
+    `);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it.each([
+    ["a dynamic disabled value", `disabled={isDisabled}`],
+    ["a dynamic aria-disabled value", `aria-disabled={isDisabled}`],
+    ["a statically disabled action", `disabled`],
+    ["a statically aria-disabled action", `aria-disabled="true"`],
+  ])("stays quiet for %s", (_description, attribute) => {
+    const result = run(`
+      import { useState } from "react";
+      function Save() {
+        const [pending, setPending] = useState(false);
+        async function save() {
+          setPending(true);
+          await fetch("/api/save");
+          setPending(false);
+        }
+        return pending ? <span>Saving</span> : <button ${attribute} onClick={save}>Save</button>;
+      }
+    `);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for route and Suspense loading states", () => {
+    const result = run(`
+      import { Suspense, useState } from "react";
+      const Route = () => {
+        const [pending, setPending] = useState(false);
+        async function load() {
+          setPending(true);
+          await fetch("/api/route");
+        }
+        return <Suspense fallback={<Spinner />}>
+          {pending ? <RoutePending /> : <button onClick={load}>Open</button>}
+        </Suspense>;
+      };
+    `);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when the ternary is stored instead of directly rendered", () => {
+    const result = run(`
+      import { useState } from "react";
+      const Save = () => {
+        const [pending, setPending] = useState(false);
+        async function save() {
+          setPending(true);
+          await fetch("/api/save");
+        }
+        const content = pending ? <span>Saving</span> : <button onClick={save}>Save</button>;
+        return content;
+      };
+    `);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when the ternary runs inside a repeated render callback", () => {
+    const result = run(`
+      import { useState } from "react";
+      const List = ({ items }) => {
+        const [pending, setPending] = useState(false);
+        async function save() {
+          setPending(true);
+          await fetch("/api/save");
+        }
+        return <div>{items.map(() => pending ? <span>Saving</span> : <button onClick={save}>Save</button>)}</div>;
+      };
+    `);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/loading-action-preserves-trigger.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/loading-action-preserves-trigger.ts
@@ -1,0 +1,538 @@
+import { PRESENTATION_ROLES, VALID_ARIA_ROLES } from "../../constants/aria-roles.js";
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
+import { findTransparentExpressionRoot } from "../../utils/find-transparent-expression-root.js";
+import { getAuthoritativeJsxAttribute } from "../../utils/get-authoritative-jsx-attribute.js";
+import { getJsxAttributeName } from "../../utils/get-jsx-attribute-name.js";
+import { getRangeStart } from "../../utils/get-range-start.js";
+import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
+import { hasJsxSpreadAttribute } from "../../utils/has-jsx-spread-attribute.js";
+import { isFunctionLike } from "../../utils/is-function-like.js";
+import { isInteractiveElement } from "../../utils/is-interactive-element.js";
+import { isInteractiveRole } from "../../utils/is-interactive-role.js";
+import { isNonInteractiveRole } from "../../utils/is-non-interactive-role.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { isNodeReachableWithinFunction } from "../../utils/is-node-reachable-within-function.js";
+import { isProvenIntrinsicJsxElement } from "../../utils/is-proven-intrinsic-jsx-element.js";
+import { isReactApiCall } from "../../utils/is-react-api-call.js";
+import { nodesCanCoExecute } from "../../utils/nodes-can-co-execute.js";
+import { resolveExactLocalFunction } from "../../utils/resolve-exact-local-function.js";
+import { resolveJsxElementType } from "../../utils/resolve-jsx-element-type.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+import type { RuleVisitors } from "../../utils/rule-visitors.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import { walkAst } from "../../utils/walk-ast.js";
+
+const ACTION_INPUT_TYPES = new Set(["button", "image", "submit"]);
+const FOCUS_TRANSFER_METHOD_NAMES = new Set(["blur", "focus"]);
+const NON_SUBMITTING_BUTTON_TYPES = new Set(["button", "reset"]);
+const NAVIGATION_FUNCTION_NAMES = new Set(["navigate", "redirect"]);
+const NAVIGATION_METHOD_NAMES = new Set([
+  "assign",
+  "back",
+  "forward",
+  "go",
+  "open",
+  "push",
+  "reload",
+  "replace",
+  "requestSubmit",
+  "submit",
+  "navigate",
+]);
+const PASSIVE_INTRINSIC_TAG_NAMES = new Set([
+  "article",
+  "aside",
+  "b",
+  "blockquote",
+  "code",
+  "dd",
+  "div",
+  "dl",
+  "dt",
+  "em",
+  "figcaption",
+  "figure",
+  "footer",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "header",
+  "i",
+  "li",
+  "main",
+  "mark",
+  "ol",
+  "output",
+  "p",
+  "pre",
+  "progress",
+  "s",
+  "section",
+  "small",
+  "span",
+  "strong",
+  "time",
+  "u",
+  "ul",
+]);
+const PASSIVITY_UNKNOWN_ATTRIBUTE_NAMES = new Set([
+  "accesskey",
+  "children",
+  "dangerouslysetinnerhtml",
+  "draggable",
+  "htmlfor",
+  "ref",
+]);
+
+interface PendingStateProof {
+  idleBranch: EsTreeNode;
+  pendingBranch: EsTreeNode;
+  setterBinding: EsTreeNode;
+}
+
+const getStaticJsxAttributeString = (
+  openingElement: EsTreeNodeOfType<"JSXOpeningElement">,
+  attributeName: string,
+): string | null => {
+  const attribute = getAuthoritativeJsxAttribute(openingElement.attributes, attributeName, false);
+  if (!attribute?.value) return null;
+  if (isNodeOfType(attribute.value, "Literal") && typeof attribute.value.value === "string") {
+    return attribute.value.value;
+  }
+  if (!isNodeOfType(attribute.value, "JSXExpressionContainer")) return null;
+  const expression = stripParenExpression(attribute.value.expression);
+  return isNodeOfType(expression, "Literal") && typeof expression.value === "string"
+    ? expression.value
+    : null;
+};
+
+const isDirectlyRenderedConditional = (conditional: EsTreeNode): boolean => {
+  const expressionRoot = findTransparentExpressionRoot(conditional);
+  const parent = expressionRoot.parent;
+  if (!parent) return false;
+  if (isNodeOfType(parent, "ReturnStatement") && parent.argument === expressionRoot) return true;
+  if (isNodeOfType(parent, "ArrowFunctionExpression") && parent.body === expressionRoot)
+    return true;
+  return (
+    isNodeOfType(parent, "JSXExpressionContainer") &&
+    parent.expression === expressionRoot &&
+    Boolean(
+      parent.parent &&
+      (isNodeOfType(parent.parent, "JSXElement") || isNodeOfType(parent.parent, "JSXFragment")),
+    )
+  );
+};
+
+const resolvePendingStateProof = (
+  conditional: EsTreeNodeOfType<"ConditionalExpression">,
+  context: RuleContext,
+): PendingStateProof | null => {
+  const test = stripParenExpression(conditional.test);
+  const isNegated = isNodeOfType(test, "UnaryExpression") && test.operator === "!";
+  const stateReference = isNegated ? stripParenExpression(test.argument) : test;
+  if (!isNodeOfType(stateReference, "Identifier")) return null;
+  const stateSymbol = context.scopes.symbolFor(stateReference);
+  if (
+    !stateSymbol ||
+    stateSymbol.kind !== "const" ||
+    stateSymbol.references.length !== 1 ||
+    stateSymbol.references[0]?.identifier !== stateReference ||
+    !isNodeOfType(stateSymbol.declarationNode, "VariableDeclarator")
+  ) {
+    return null;
+  }
+  const declarator = stateSymbol.declarationNode;
+  if (!isNodeOfType(declarator.id, "ArrayPattern")) return null;
+  const stateBinding = declarator.id.elements[0];
+  const setterBinding = declarator.id.elements[1];
+  if (
+    stateBinding !== stateSymbol.bindingIdentifier ||
+    !isNodeOfType(stateBinding, "Identifier") ||
+    !isNodeOfType(setterBinding, "Identifier") ||
+    declarator.id.elements.length !== 2 ||
+    !declarator.init
+  ) {
+    return null;
+  }
+  const initializer = stripParenExpression(declarator.init);
+  if (
+    !isNodeOfType(initializer, "CallExpression") ||
+    !isReactApiCall(initializer, "useState", context.scopes, { resolveNamedAliases: true }) ||
+    initializer.arguments.length !== 1
+  ) {
+    return null;
+  }
+  const initialState = stripParenExpression(initializer.arguments[0]);
+  if (!isNodeOfType(initialState, "Literal") || initialState.value !== false) return null;
+  if (findEnclosingFunction(stateBinding) !== findEnclosingFunction(conditional)) return null;
+  return {
+    idleBranch: isNegated ? conditional.consequent : conditional.alternate,
+    pendingBranch: isNegated ? conditional.alternate : conditional.consequent,
+    setterBinding,
+  };
+};
+
+const getActionOpeningElement = (
+  branch: EsTreeNode,
+  context: RuleContext,
+): EsTreeNodeOfType<"JSXOpeningElement"> | null => {
+  const branchExpression = stripParenExpression(branch);
+  if (!isNodeOfType(branchExpression, "JSXElement")) return null;
+  const openingElement = branchExpression.openingElement;
+  if (
+    !isProvenIntrinsicJsxElement(openingElement, context.scopes) ||
+    hasJsxSpreadAttribute(openingElement.attributes)
+  ) {
+    return null;
+  }
+  const tagName = resolveJsxElementType(openingElement).toLowerCase();
+  if (tagName === "button") return openingElement;
+  if (tagName !== "input") return null;
+  const inputType = getStaticJsxAttributeString(openingElement, "type")?.toLowerCase();
+  return inputType && ACTION_INPUT_TYPES.has(inputType) ? openingElement : null;
+};
+
+const jsxAttributeHasStaticNullValue = (attribute: EsTreeNode): boolean => {
+  if (!isNodeOfType(attribute, "JSXAttribute") || !attribute.value) return false;
+  if (!isNodeOfType(attribute.value, "JSXExpressionContainer")) return false;
+  const expression = stripParenExpression(attribute.value.expression);
+  return isNodeOfType(expression, "Literal") && expression.value === null;
+};
+
+const resolveStaticRole = (
+  openingElement: EsTreeNodeOfType<"JSXOpeningElement">,
+): string | null | undefined => {
+  const roleAttribute = getAuthoritativeJsxAttribute(openingElement.attributes, "role", false);
+  if (!roleAttribute) return null;
+  const role = getStaticJsxAttributeString(openingElement, "role");
+  if (role === null) return undefined;
+  const firstValidRole = role
+    .trim()
+    .toLowerCase()
+    .split(/\s+/)
+    .find((roleToken) => VALID_ARIA_ROLES.has(roleToken));
+  return firstValidRole ?? undefined;
+};
+
+const proveBranchIsPassive = (branch: EsTreeNode, context: RuleContext): boolean | null => {
+  const expression = stripParenExpression(branch);
+  if (isNodeOfType(expression, "Literal")) {
+    return expression.value === null ||
+      expression.value === false ||
+      expression.value === true ||
+      typeof expression.value === "string" ||
+      typeof expression.value === "number"
+      ? true
+      : null;
+  }
+  if (isNodeOfType(expression, "JSXText") || isNodeOfType(expression, "JSXEmptyExpression")) {
+    return true;
+  }
+  if (isNodeOfType(expression, "JSXExpressionContainer")) {
+    return proveBranchIsPassive(expression.expression, context);
+  }
+  if (isNodeOfType(expression, "JSXFragment")) {
+    for (const child of expression.children) {
+      const childProof = proveBranchIsPassive(child, context);
+      if (childProof !== true) return childProof;
+    }
+    return true;
+  }
+  if (!isNodeOfType(expression, "JSXElement")) return null;
+  const openingElement = expression.openingElement;
+  if (
+    !isProvenIntrinsicJsxElement(openingElement, context.scopes) ||
+    hasJsxSpreadAttribute(openingElement.attributes)
+  ) {
+    return null;
+  }
+  const tagName = resolveJsxElementType(openingElement).toLowerCase();
+  if (isInteractiveElement(tagName, openingElement)) return false;
+  if (!PASSIVE_INTRINSIC_TAG_NAMES.has(tagName)) return null;
+  const staticRole = resolveStaticRole(openingElement);
+  if (staticRole === undefined) return null;
+  if (staticRole && isInteractiveRole(staticRole)) return false;
+  if (staticRole && !isNonInteractiveRole(staticRole) && !PRESENTATION_ROLES.has(staticRole)) {
+    return null;
+  }
+  for (const attribute of openingElement.attributes) {
+    if (!isNodeOfType(attribute, "JSXAttribute")) continue;
+    const attributeName = getJsxAttributeName(attribute.name);
+    if (!attributeName) return null;
+    const normalizedAttributeName = attributeName.toLowerCase();
+    if (PASSIVITY_UNKNOWN_ATTRIBUTE_NAMES.has(normalizedAttributeName)) return null;
+    if (/^on[A-Z]/.test(attributeName) && !jsxAttributeHasStaticNullValue(attribute)) return false;
+    if (
+      normalizedAttributeName === "tabindex" ||
+      normalizedAttributeName === "contenteditable" ||
+      normalizedAttributeName === "autofocus"
+    ) {
+      return false;
+    }
+  }
+  for (const child of expression.children) {
+    const childProof = proveBranchIsPassive(child, context);
+    if (childProof !== true) return childProof;
+  }
+  return true;
+};
+
+const getBranchRootIdentity = (branch: EsTreeNode, context: RuleContext): string | null => {
+  const expression = stripParenExpression(branch);
+  if (
+    isNodeOfType(expression, "Literal") &&
+    (expression.value === null || expression.value === false)
+  ) {
+    return null;
+  }
+  if (isNodeOfType(expression, "JSXFragment")) return "#fragment";
+  if (!isNodeOfType(expression, "JSXElement")) return null;
+  const openingElement = expression.openingElement;
+  return isProvenIntrinsicJsxElement(openingElement, context.scopes)
+    ? resolveJsxElementType(openingElement).toLowerCase()
+    : null;
+};
+
+const getJsxAttributeExpression = (attribute: EsTreeNode): EsTreeNode | null => {
+  if (
+    !isNodeOfType(attribute, "JSXAttribute") ||
+    !attribute.value ||
+    !isNodeOfType(attribute.value, "JSXExpressionContainer")
+  ) {
+    return null;
+  }
+  return stripParenExpression(attribute.value.expression);
+};
+
+const readStaticDisabledState = (
+  openingElement: EsTreeNodeOfType<"JSXOpeningElement">,
+  attributeName: "aria-disabled" | "disabled",
+): boolean | null => {
+  const attribute = getAuthoritativeJsxAttribute(openingElement.attributes, attributeName, false);
+  if (!attribute) return false;
+  if (!attribute.value) return true;
+  const value = isNodeOfType(attribute.value, "JSXExpressionContainer")
+    ? stripParenExpression(attribute.value.expression)
+    : attribute.value;
+  if (!isNodeOfType(value, "Literal")) return null;
+  if (value.value === null || value.value === false) return false;
+  if (value.value === true) return true;
+  if (attributeName === "disabled")
+    return typeof value.value === "string" ? true : Boolean(value.value);
+  if (typeof value.value !== "string") return null;
+  const normalizedValue = value.value.toLowerCase();
+  if (normalizedValue === "false") return false;
+  if (normalizedValue === "true") return true;
+  return null;
+};
+
+const hasPossibleAncestorFormOwner = (
+  openingElement: EsTreeNodeOfType<"JSXOpeningElement">,
+  context: RuleContext,
+): boolean => {
+  let ancestor = openingElement.parent?.parent;
+  while (ancestor) {
+    if (isNodeOfType(ancestor, "JSXElement")) {
+      const ancestorOpeningElement = ancestor.openingElement;
+      if (!isProvenIntrinsicJsxElement(ancestorOpeningElement, context.scopes)) return true;
+      if (resolveJsxElementType(ancestorOpeningElement).toLowerCase() === "form") return true;
+    }
+    ancestor = ancestor.parent;
+  }
+  return false;
+};
+
+const actionMaySubmitEnclosingForm = (
+  openingElement: EsTreeNodeOfType<"JSXOpeningElement">,
+  context: RuleContext,
+): boolean => {
+  const tagName = resolveJsxElementType(openingElement).toLowerCase();
+  const actionType = getStaticJsxAttributeString(openingElement, "type")?.toLowerCase();
+  const hasFormOwnerAttribute = Boolean(
+    getAuthoritativeJsxAttribute(openingElement.attributes, "form", false),
+  );
+  const isSubmitCapable =
+    tagName === "button"
+      ? !NON_SUBMITTING_BUTTON_TYPES.has(actionType ?? "")
+      : tagName === "input" && (actionType === "image" || actionType === "submit");
+  if (!isSubmitCapable) return false;
+  return hasFormOwnerAttribute || hasPossibleAncestorFormOwner(openingElement, context);
+};
+
+const resolveActionHandler = (
+  openingElement: EsTreeNodeOfType<"JSXOpeningElement">,
+  context: RuleContext,
+): EsTreeNode | null => {
+  if (readStaticDisabledState(openingElement, "disabled") !== false) return null;
+  if (readStaticDisabledState(openingElement, "aria-disabled") !== false) return null;
+  if (actionMaySubmitEnclosingForm(openingElement, context)) return null;
+  const handlerAttribute = getAuthoritativeJsxAttribute(openingElement.attributes, "onClick");
+  if (!handlerAttribute) return null;
+  const handlerExpression = getJsxAttributeExpression(handlerAttribute);
+  if (!handlerExpression) return null;
+  if (isFunctionLike(handlerExpression)) return handlerExpression;
+  if (!isNodeOfType(handlerExpression, "Identifier")) return null;
+  const handlerSymbol = context.scopes.symbolFor(handlerExpression);
+  if (
+    !handlerSymbol ||
+    handlerSymbol.references.length !== 1 ||
+    handlerSymbol.references[0]?.identifier !== handlerExpression
+  ) {
+    return null;
+  }
+  return resolveExactLocalFunction(handlerExpression, context.scopes);
+};
+
+const callTransfersFocusOrNavigates = (
+  callExpression: EsTreeNodeOfType<"CallExpression">,
+): boolean => {
+  const callee = stripParenExpression(callExpression.callee);
+  if (isNodeOfType(callee, "Identifier")) {
+    return NAVIGATION_FUNCTION_NAMES.has(callee.name) || /^setFocus$/i.test(callee.name);
+  }
+  if (!isNodeOfType(callee, "MemberExpression")) return false;
+  const methodName = getStaticPropertyName(callee);
+  return Boolean(
+    methodName &&
+    (FOCUS_TRANSFER_METHOD_NAMES.has(methodName) || NAVIGATION_METHOD_NAMES.has(methodName)),
+  );
+};
+
+const handlerTransfersFocusOrNavigates = (handler: EsTreeNode): boolean => {
+  let transfers = false;
+  walkAst(handler, (node: EsTreeNode) => {
+    if (node !== handler && isFunctionLike(node)) return false;
+    if (isNodeOfType(node, "CallExpression") && callTransfersFocusOrNavigates(node)) {
+      transfers = true;
+      return false;
+    }
+    if (isNodeOfType(node, "AssignmentExpression")) {
+      const assignmentTarget = stripParenExpression(node.left);
+      if (isNodeOfType(assignmentTarget, "MemberExpression")) {
+        const propertyName = getStaticPropertyName(assignmentTarget);
+        if (propertyName === "href" || propertyName === "location") {
+          transfers = true;
+          return false;
+        }
+      }
+    }
+  });
+  return transfers;
+};
+
+const isProvenFetchSuspension = (node: EsTreeNode, context: RuleContext): boolean => {
+  if (!isNodeOfType(node, "AwaitExpression")) return false;
+  const argument = stripParenExpression(node.argument);
+  return (
+    isNodeOfType(argument, "CallExpression") &&
+    isNodeOfType(argument.callee, "Identifier") &&
+    argument.callee.name === "fetch" &&
+    context.scopes.isGlobalReference(argument.callee)
+  );
+};
+
+const handlerStartsPendingBeforeFetch = (
+  handler: EsTreeNode,
+  setterBinding: EsTreeNode,
+  context: RuleContext,
+): boolean => {
+  if (!isFunctionLike(handler) || !handler.async) return false;
+  const setterSymbol = context.scopes.symbolFor(setterBinding);
+  if (!setterSymbol || setterSymbol.references.length === 0) return false;
+  const setterCalls: EsTreeNodeOfType<"CallExpression">[] = [];
+  for (const reference of setterSymbol.references) {
+    const referenceRoot = findTransparentExpressionRoot(reference.identifier);
+    const callExpression = referenceRoot.parent;
+    if (
+      reference.flag !== "read" ||
+      !callExpression ||
+      !isNodeOfType(callExpression, "CallExpression") ||
+      callExpression.callee !== referenceRoot ||
+      findEnclosingFunction(callExpression) !== handler ||
+      callExpression.arguments.length !== 1
+    ) {
+      return false;
+    }
+    const setterValue = stripParenExpression(callExpression.arguments[0]);
+    if (!isNodeOfType(setterValue, "Literal") || typeof setterValue.value !== "boolean") {
+      return false;
+    }
+    setterCalls.push(callExpression);
+  }
+  const truthyCalls = setterCalls.filter((callExpression) => {
+    const argument = stripParenExpression(callExpression.arguments[0]);
+    return isNodeOfType(argument, "Literal") && argument.value === true;
+  });
+  if (truthyCalls.length !== 1) return false;
+  const truthyCall = truthyCalls[0];
+  if (!truthyCall || !isNodeOfType(truthyCall.parent, "ExpressionStatement")) return false;
+  const fetchSuspensions: EsTreeNode[] = [];
+  walkAst(handler, (node: EsTreeNode) => {
+    if (node !== handler && isFunctionLike(node)) return false;
+    if (isProvenFetchSuspension(node, context) && isNodeReachableWithinFunction(node, context)) {
+      fetchSuspensions.push(node);
+    }
+  });
+  const functionCfg = context.cfg.cfgFor(handler);
+  const truthyBlock = functionCfg?.blockOf(truthyCall);
+  const truthyStart = getRangeStart(truthyCall);
+  if (!functionCfg || !truthyBlock || truthyStart === null) return false;
+  return fetchSuspensions.some((suspension) => {
+    const suspensionStart = getRangeStart(suspension);
+    if (
+      suspensionStart === null ||
+      truthyStart >= suspensionStart ||
+      functionCfg.blockOf(suspension) !== truthyBlock
+    ) {
+      return false;
+    }
+    const precedingSetterCalls = setterCalls
+      .filter((setterCall) => {
+        const setterStart = getRangeStart(setterCall);
+        return (
+          setterStart !== null &&
+          setterStart < suspensionStart &&
+          nodesCanCoExecute(setterCall, suspension, context)
+        );
+      })
+      .sort((left, right) => (getRangeStart(left) ?? 0) - (getRangeStart(right) ?? 0));
+    return precedingSetterCalls.at(-1) === truthyCall;
+  });
+};
+
+export const loadingActionPreservesTrigger = defineRule({
+  id: "loading-action-preserves-trigger",
+  title: "Loading state removes its initiating action",
+  tags: ["react-jsx-only"],
+  severity: "warn",
+  category: "Accessibility",
+  defaultEnabled: false,
+  recommendation:
+    "Keep the initiating control mounted while work is pending. Disable it or mark it busy, and put the spinner or status inside the same control so focus and action identity remain stable.",
+  create: (context: RuleContext): RuleVisitors => ({
+    ConditionalExpression(conditional: EsTreeNodeOfType<"ConditionalExpression">) {
+      if (!isDirectlyRenderedConditional(conditional)) return;
+      const stateProof = resolvePendingStateProof(conditional, context);
+      if (!stateProof) return;
+      const actionOpeningElement = getActionOpeningElement(stateProof.idleBranch, context);
+      if (!actionOpeningElement) return;
+      if (proveBranchIsPassive(stateProof.pendingBranch, context) !== true) return;
+      const actionRootIdentity = resolveJsxElementType(actionOpeningElement).toLowerCase();
+      if (getBranchRootIdentity(stateProof.pendingBranch, context) === actionRootIdentity) return;
+      const handler = resolveActionHandler(actionOpeningElement, context);
+      if (!handler || handlerTransfersFocusOrNavigates(handler)) return;
+      if (!handlerStartsPendingBeforeFetch(handler, stateProof.setterBinding, context)) return;
+      context.report({
+        node: conditional,
+        message:
+          "This pending branch replaces the control that started the request with passive content, so the control and its focus disappear while the request is in flight. Keep the control mounted and render its busy state inside it.",
+      });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-collapse-request-error-to-empty-state.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-collapse-request-error-to-empty-state.test.ts
@@ -1,0 +1,1047 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noCollapseRequestErrorToEmptyState } from "./no-collapse-request-error-to-empty-state.js";
+
+const run = (code: string) => runRule(noCollapseRequestErrorToEmptyState, code);
+
+describe("no-collapse-request-error-to-empty-state", () => {
+  it.each([
+    [
+      "a direct empty-array write correlated with an early empty-result return",
+      `import { useState } from "react";
+       const Search = () => {
+         const [items, setItems] = useState([]);
+         const load = async () => {
+           try { setItems(await (await fetch("/api/items")).json()); }
+           catch { setItems([]); }
+         };
+         if (!items.length) return <p className="text-sm">No results found</p>;
+         return <ResultList items={items} />;
+       };`,
+    ],
+    [
+      "a strict zero-length guard",
+      `import { useState } from "react";
+       const Inbox = () => {
+         const [messages, setMessages] = useState([]);
+         const load = async () => {
+           try { setMessages(await (await fetch("/api/messages")).json()); }
+           catch (error) { setMessages([]); }
+         };
+         if (messages.length === 0) {
+           return <section class="py-4">Nothing here</section>;
+         }
+         return <MessageList messages={messages} />;
+       };`,
+    ],
+    [
+      "a reversed strict zero-length guard",
+      `import { useState } from "react";
+       const Files = () => {
+         const [files, setFiles] = useState([]);
+         const load = async () => {
+           try { setFiles(await (await globalThis.fetch("/api/files")).json()); }
+           catch { setFiles([]); }
+         };
+         if (0 === files.length) return <div>No files</div>;
+         return <FileList files={files} />;
+       };`,
+    ],
+    [
+      "a functional empty-array write",
+      `import { useState } from "react";
+       const Orders = () => {
+         const [orders, setOrders] = useState([]);
+         const load = async () => {
+           try { setOrders(await (await window.fetch("/api/orders")).json()); }
+           catch { setOrders((previousOrders) => []); }
+         };
+         return !orders.length ? <p>No orders</p> : <OrderList orders={orders} />;
+       };`,
+    ],
+    [
+      "block-bodied empty-array updater and lazy initializer",
+      `import React from "react";
+       const Events = () => {
+         const [events, setEvents] = React.useState(() => { return []; });
+         const load = async () => {
+           try { setEvents(await (await fetch("/api/events")).json()); }
+           catch { setEvents(() => { return []; }); }
+         };
+         return events.length === 0 ? <aside>No events</aside> : <EventList events={events} />;
+       };`,
+    ],
+    [
+      "an inverse length ternary",
+      `import * as React from "react";
+       const Tasks = () => {
+         const [tasks, setTasks] = React.useState([]);
+         const load = async () => {
+           try { setTasks(await (await fetch("/api/tasks")).json()); }
+           catch { setTasks([]); }
+         };
+         return tasks.length ? <TaskList tasks={tasks} /> : <div>Nothing to show</div>;
+       };`,
+    ],
+    [
+      "a returned JSX tree containing the ternary",
+      `import { useState } from "react";
+       const Products = () => {
+         const [products, setProducts] = useState([]);
+         const load = async () => {
+           try { setProducts(await (await fetch("/api/products")).json()); }
+           catch { setProducts([]); }
+         };
+         return <main>{products.length ? <ProductGrid products={products} /> : <p>No products</p>}</main>;
+       };`,
+    ],
+    [
+      "nested static intrinsic empty-result copy",
+      `import { useState } from "react";
+       const Records = () => {
+         const [records, setRecords] = useState([]);
+         const load = async () => {
+           try { setRecords(await (await fetch("/api/records")).json()); }
+           catch { setRecords([]); }
+         };
+         if (!records.length) return <section><p>No <span>records</span> found</p></section>;
+         return <RecordTable records={records} />;
+       };`,
+    ],
+    [
+      "an aliased React useState import with transparent TypeScript wrappers",
+      `import { useState as useCollectionState } from "react";
+       interface Item { id: string }
+       const Items = () => {
+         const [items, setItems] = useCollectionState<Item[]>([] as Item[]);
+         const load = async () => {
+           try { setItems(await (await fetch("/api/items")).json()); }
+           catch { setItems(([] as Item[])); }
+         };
+         return items.length ? <ItemList items={items} /> : <div>No items</div>;
+       };`,
+    ],
+    [
+      "an awaited exact local request helper",
+      `import { useState } from "react";
+       const requestItems = async () => {
+         const response = await fetch("/api/items");
+         return response.json();
+       };
+       const Items = () => {
+         const [items, setItems] = useState([]);
+         const load = async () => {
+           try { setItems(await requestItems()); }
+           catch { setItems([]); }
+         };
+         if (!items.length) return <p>No items</p>;
+         return <ItemList items={items} />;
+       };`,
+    ],
+    [
+      "an exact expression-bodied fetch helper",
+      `import { useState } from "react";
+       const requestItems = () => fetch("/api/items").then((response) => response.json());
+       const Items = () => {
+         const [items, setItems] = useState([]);
+         const load = async () => {
+           try { setItems(await requestItems()); }
+           catch { setItems([]); }
+         };
+         if (!items.length) return <p>No items</p>;
+         return <ItemList items={items} />;
+       };`,
+    ],
+    [
+      "a fetch rejection handler that rethrows",
+      `import { useState } from "react";
+       const Items = () => {
+         const [items, setItems] = useState([]);
+         const load = async () => {
+           try { setItems(await fetch("/api/items").catch((error) => { throw error; })); }
+           catch { setItems([]); }
+         };
+         if (!items.length) return <p>No items</p>;
+         return <ItemList items={items} />;
+       };`,
+    ],
+    [
+      "an inner catch that unconditionally rethrows",
+      `import { useState } from "react";
+       const Items = () => {
+         const [items, setItems] = useState([]);
+         const load = async () => {
+           try {
+             try { setItems(await (await fetch("/api/items")).json()); }
+             catch (error) { throw error; }
+           } catch { setItems([]); }
+         };
+         if (!items.length) return <p>No items</p>;
+         return <ItemList items={items} />;
+       };`,
+    ],
+  ])("reports %s", (_name, code) => {
+    const result = run(code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it.each([
+    [
+      "a catch that records the error",
+      `import { useState } from "react";
+       const Search = () => {
+         const [items, setItems] = useState([]);
+         const [, setError] = useState(null);
+         try { setItems(readItems()); }
+         catch (error) { setError(error); setItems([]); }
+         if (!items.length) return <p>No items</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "a catch that delegates to a toast",
+      `import { useState } from "react";
+       const Search = () => {
+         const [items, setItems] = useState([]);
+         try { setItems(readItems()); }
+         catch (error) { toast.error(error); setItems([]); }
+         if (!items.length) return <p>No items</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "a catch that rethrows",
+      `import { useState } from "react";
+       const Search = () => {
+         const [items, setItems] = useState([]);
+         try { setItems(readItems()); }
+         catch (error) { setItems([]); throw error; }
+         if (!items.length) return <p>No items</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "a conditional abort branch",
+      `import { useState } from "react";
+       const Search = () => {
+         const [items, setItems] = useState([]);
+         try { setItems(readItems()); }
+         catch (error) { if (error.name === "AbortError") setItems([]); }
+         if (!items.length) return <p>No items</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "a conditional 404 fallback",
+      `import { useState } from "react";
+       const Search = () => {
+         const [items, setItems] = useState([]);
+         try { setItems(readItems()); }
+         catch (error) { if (error.status === 404) setItems([]); else throw error; }
+         if (!items.length) return <p>No items</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "an object sentinel",
+      `import { useState } from "react";
+       const Search = () => {
+         const [items, setItems] = useState([]);
+         try { setItems(readItems()); }
+         catch { setItems({}); }
+         if (!items.length) return <p>No items</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "a null sentinel",
+      `import { useState } from "react";
+       const Search = () => {
+         const [items, setItems] = useState([]);
+         try { setItems(readItems()); }
+         catch { setItems(null); }
+         if (!items.length) return <p>No items</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "a non-empty initial collection",
+      `import { useState } from "react";
+       const Search = () => {
+         const [items, setItems] = useState(initialItems);
+         try { setItems(readItems()); }
+         catch { setItems([]); }
+         if (!items.length) return <p>No items</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "an unsafe lazy initializer with another statement",
+      `import { useState } from "react";
+       const Search = () => {
+         const [items, setItems] = useState(() => { track(); return []; });
+         try { setItems(readItems()); }
+         catch { setItems([]); }
+         if (!items.length) return <p>No items</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "a custom hook setter",
+      `const Search = () => {
+         const [items, setItems] = useItems();
+         try { setItems(readItems()); }
+         catch { setItems([]); }
+         if (!items.length) return <p>No items</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "a reducer dispatcher",
+      `import { useReducer } from "react";
+       const Search = () => {
+         const [items, setItems] = useReducer(reducer, []);
+         try { setItems({ type: "replace", items: readItems() }); }
+         catch { setItems([]); }
+         if (!items.length) return <p>No items</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "an imported setter",
+      `import { items, setItems } from "./store";
+       const Search = () => {
+         try { setItems(readItems()); }
+         catch { setItems([]); }
+         if (!items.length) return <p>No items</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "a local setter alias",
+      `import { useState } from "react";
+       const Search = () => {
+         const [items, setItems] = useState([]);
+         const clearItems = setItems;
+         try { setItems(readItems()); }
+         catch { clearItems([]); }
+         if (!items.length) return <p>No items</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "a shadowed setter inside the catch",
+      `import { useState } from "react";
+       const Search = () => {
+         const [items, setItems] = useState([]);
+         try { setItems(readItems()); }
+         catch { const setItems = clearCache; setItems([]); }
+         if (!items.length) return <p>No items</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "a functional write with an unknown side effect",
+      `import { useState } from "react";
+       const Search = () => {
+         const [items, setItems] = useState([]);
+         try { setItems(readItems()); }
+         catch { setItems(() => { auditFallback(); return []; }); }
+         if (!items.length) return <p>No items</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "a shadowed useState function",
+      `const useState = (value) => [value, () => {}];
+       const Search = () => {
+         const [items, setItems] = useState([]);
+         try { setItems(readItems()); }
+         catch { setItems([]); }
+         if (!items.length) return <p>No items</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "a Promise catch callback",
+      `import { useState } from "react";
+       const Search = () => {
+         const [items, setItems] = useState([]);
+         readItems().then(setItems).catch(() => setItems([]));
+         if (!items.length) return <p>No items</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "no correlated empty render",
+      `import { useState } from "react";
+       const Search = () => {
+         const [items, setItems] = useState([]);
+         try { setItems(readItems()); }
+         catch { setItems([]); }
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "a different collection drives the empty render",
+      `import { useState } from "react";
+       const Search = () => {
+         const [items, setItems] = useState([]);
+         const [filteredItems] = useState([]);
+         try { setItems(readItems()); }
+         catch { setItems([]); }
+         if (!filteredItems.length) return <p>No items</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "a compound empty guard",
+      `import { useState } from "react";
+       const Search = () => {
+         const [items, setItems] = useState([]);
+         try { setItems(readItems()); }
+         catch { setItems([]); }
+         if (!items.length && hasLoaded) return <p>No items</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "a derived empty guard",
+      `import { useState } from "react";
+       const Search = () => {
+         const [items, setItems] = useState([]);
+         const hasNoItems = !items.length;
+         try { setItems(readItems()); }
+         catch { setItems([]); }
+         if (hasNoItems) return <p>No items</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "an opaque EmptyState component",
+      `import { useState } from "react";
+       const Search = () => {
+         const [items, setItems] = useState([]);
+         try { setItems(readItems()); }
+         catch { setItems([]); }
+         if (!items.length) return <EmptyState>No items</EmptyState>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "dynamic empty-result copy",
+      `import { useState } from "react";
+       const Search = () => {
+         const [items, setItems] = useState([]);
+         try { setItems(readItems()); }
+         catch { setItems([]); }
+         if (!items.length) return <p>{emptyMessage}</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "unrecognized static fallback copy",
+      `import { useState } from "react";
+       const Search = () => {
+         const [items, setItems] = useState([]);
+         try { setItems(readItems()); }
+         catch { setItems([]); }
+         if (!items.length) return <p>Please change your filters</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "a conditional used outside rendered output",
+      `import { useState } from "react";
+       const Search = () => {
+         const [items, setItems] = useState([]);
+         try { setItems(readItems()); }
+         catch { setItems([]); }
+         const label = items.length ? <span>Available</span> : <span>No items</span>;
+         return <List items={items} label={label} />;
+       };`,
+    ],
+    [
+      "a conditional used only as an attribute",
+      `import { useState } from "react";
+       const Search = () => {
+         const [items, setItems] = useState([]);
+         try { setItems(readItems()); }
+         catch { setItems([]); }
+         return <List title={items.length ? <span>Available</span> : <span>No items</span>} items={items} />;
+       };`,
+    ],
+    [
+      "an empty render inside a nested callback",
+      `import { useState } from "react";
+       const Search = () => {
+         const [items, setItems] = useState([]);
+         try { setItems(readItems()); }
+         catch { setItems([]); }
+         const renderEmpty = () => !items.length ? <p>No items</p> : null;
+         return <List items={items} empty={renderEmpty} />;
+       };`,
+    ],
+    [
+      "a synchronous JSON parse failure with no request evidence",
+      `import { useState } from "react";
+       const Search = ({ rawItems }) => {
+         const [items, setItems] = useState([]);
+         try { setItems(JSON.parse(rawItems)); }
+         catch { setItems([]); }
+         if (!items.length) return <p>No items</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "a localStorage failure with no request evidence",
+      `import { useState } from "react";
+       const Search = () => {
+         const [items, setItems] = useState([]);
+         try { setItems(JSON.parse(localStorage.getItem("items"))); }
+         catch { setItems([]); }
+         if (!items.length) return <p>No items</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "a shadowed fetch function",
+      `import { useState } from "react";
+       const Search = () => {
+         const [items, setItems] = useState([]);
+         const fetch = async () => readFixture();
+         const load = async () => {
+           try { setItems(await fetch()); }
+           catch { setItems([]); }
+         };
+         if (!items.length) return <p>No items</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "an unreachable catch",
+      `import { useState } from "react";
+       const Search = () => {
+         const [items, setItems] = useState([]);
+         const load = async () => {
+           return;
+           try { setItems(await (await fetch("/api/items")).json()); }
+           catch { setItems([]); }
+         };
+         if (!items.length) return <p>No items</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "an unreachable request await",
+      `import { useState } from "react";
+       const Search = () => {
+         const [items, setItems] = useState([]);
+         const load = async () => {
+           try { if (false) await fetch("/api/items"); setItems(JSON.parse(raw)); }
+           catch { setItems([]); }
+         };
+         if (!items.length) return <p>No items</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "a fetch inside an uncalled nested callback",
+      `import { useState } from "react";
+       const Search = () => {
+         const [items, setItems] = useState([]);
+         const load = async () => {
+           try { const later = async () => fetch("/api/items"); setItems(JSON.parse(raw)); }
+           catch { setItems([]); }
+         };
+         if (!items.length) return <p>No items</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "an unreachable empty-result return",
+      `import { useState } from "react";
+       const Search = () => {
+         const [items, setItems] = useState([]);
+         const load = async () => {
+           try { setItems(await (await fetch("/api/items")).json()); }
+           catch { setItems([]); }
+         };
+         return <List items={items} />;
+         if (!items.length) return <p>No items</p>;
+       };`,
+    ],
+    [
+      "a try statement with a finalizer",
+      `import { useState } from "react";
+       const Search = () => {
+         const [items, setItems] = useState([]);
+         const load = async () => {
+           try { setItems(await (await fetch("/api/items")).json()); }
+           catch { setItems([]); }
+           finally { stopLoading(); }
+         };
+         if (!items.length) return <p>No items</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "an async empty-array updater",
+      `import { useState } from "react";
+       const Search = () => {
+         const [items, setItems] = useState([]);
+         const load = async () => {
+           try { setItems(await (await fetch("/api/items")).json()); }
+           catch { setItems(async () => []); }
+         };
+         if (!items.length) return <p>No items</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "a generator empty-array updater",
+      `import { useState } from "react";
+       const Search = () => {
+         const [items, setItems] = useState([]);
+         const load = async () => {
+           try { setItems(await (await fetch("/api/items")).json()); }
+           catch { setItems(function* () { return []; }); }
+         };
+         if (!items.length) return <p>No items</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "a hidden empty-result branch",
+      `import { useState } from "react";
+       const Search = () => {
+         const [items, setItems] = useState([]);
+         const load = async () => {
+           try { setItems(await (await fetch("/api/items")).json()); }
+           catch { setItems([]); }
+         };
+         if (!items.length) return <p hidden>No items</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "an aria-hidden empty-result branch",
+      `import { useState } from "react";
+       const Search = () => {
+         const [items, setItems] = useState([]);
+         const load = async () => {
+           try { setItems(await (await fetch("/api/items")).json()); }
+           catch { setItems([]); }
+         };
+         if (!items.length) return <p aria-hidden="true">No items</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "a Tailwind-hidden empty-result branch",
+      `import { useState } from "react";
+       const Search = () => {
+         const [items, setItems] = useState([]);
+         const load = async () => {
+           try { setItems(await (await fetch("/api/items")).json()); }
+           catch { setItems([]); }
+         };
+         if (!items.length) return <p className="md:hidden">No items</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "an empty-result branch with unknown classes",
+      `import { useState } from "react";
+       const Search = ({ emptyClassName }) => {
+         const [items, setItems] = useState([]);
+         const load = async () => {
+           try { setItems(await (await fetch("/api/items")).json()); }
+           catch { setItems([]); }
+         };
+         if (!items.length) return <p className={emptyClassName}>No items</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "an empty-result branch with unknown aria-hidden state",
+      `import { useState } from "react";
+       const Search = ({ isEmptyHidden }) => {
+         const [items, setItems] = useState([]);
+         const load = async () => {
+           try { setItems(await (await fetch("/api/items")).json()); }
+           catch { setItems([]); }
+         };
+         if (!items.length) return <p aria-hidden={isEmptyHidden}>No items</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "an empty-result branch with unknown spread visibility",
+      `import { useState } from "react";
+       const Search = ({ emptyProps }) => {
+         const [items, setItems] = useState([]);
+         const load = async () => {
+           try { setItems(await (await fetch("/api/items")).json()); }
+           catch { setItems([]); }
+         };
+         if (!items.length) return <p {...emptyProps}>No items</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "an empty-result branch inside a hidden ancestor",
+      `import { useState } from "react";
+       const Search = () => {
+         const [items, setItems] = useState([]);
+         const load = async () => {
+           try { setItems(await (await fetch("/api/items")).json()); }
+           catch { setItems([]); }
+         };
+         return <main hidden>{items.length ? <List items={items} /> : <p>No items</p>}</main>;
+       };`,
+    ],
+    [
+      "imperative copy containing bare Empty",
+      `import { useState } from "react";
+       const Search = () => {
+         const [items, setItems] = useState([]);
+         const load = async () => {
+           try { setItems(await (await fetch("/api/items")).json()); }
+           catch { setItems([]); }
+         };
+         if (!items.length) return <p>Empty the local cache</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "an explicit prior error return",
+      `import { useState } from "react";
+       const Search = ({ requestError }) => {
+         const [items, setItems] = useState([]);
+         const load = async () => {
+           try { setItems(await (await fetch("/api/items")).json()); }
+           catch { setItems([]); }
+         };
+         if (requestError) return <p>Request failed</p>;
+         if (!items.length) return <p>No items</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "mutually exclusive if and else routes",
+      `import { useState } from "react";
+       const Search = async ({ remoteMode }) => {
+         const [items, setItems] = useState([]);
+         if (remoteMode) {
+           try { setItems(await (await fetch("/api/items")).json()); }
+           catch { setItems([]); }
+         } else {
+           if (!items.length) return <p>No items</p>;
+         }
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "contradictory guarded routes",
+      `import { useState } from "react";
+       const Search = async ({ remoteMode }) => {
+         const [items, setItems] = useState([]);
+         if (remoteMode) {
+           try { setItems(await (await fetch("/api/items")).json()); }
+           catch { setItems([]); }
+         }
+         if (!remoteMode) {
+           if (!items.length) return <p>No items</p>;
+         }
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "a local request helper that swallows its own fetch rejection",
+      `import { useState } from "react";
+       const requestItems = async () => {
+         try { return await (await fetch("/api/items")).json(); }
+         catch { return []; }
+       };
+       const Search = () => {
+         const [items, setItems] = useState([]);
+         const load = async () => {
+           try { setItems(await requestItems()); }
+           catch { setItems([]); }
+         };
+         if (!items.length) return <p>No items</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "a local request helper whose finalizer overrides rejection",
+      `import { useState } from "react";
+       const requestItems = async () => {
+         try { return await (await fetch("/api/items")).json(); }
+         finally { return []; }
+       };
+       const Search = () => {
+         const [items, setItems] = useState([]);
+         const load = async () => {
+           try { setItems(await requestItems()); }
+           catch { setItems([]); }
+         };
+         if (!items.length) return <p>No items</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "a responsive arbitrary Tailwind display-none branch",
+      `import { useState } from "react";
+       const Search = () => {
+         const [items, setItems] = useState([]);
+         const load = async () => {
+           try { setItems(await (await fetch("/api/items")).json()); }
+           catch { setItems([]); }
+         };
+         if (!items.length) return <p className="md:[display:none]">No items</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "empty-result copy that also describes a request failure",
+      `import { useState } from "react";
+       const Search = () => {
+         const [items, setItems] = useState([]);
+         const load = async () => {
+           try { setItems(await (await fetch("/api/items")).json()); }
+           catch { setItems([]); }
+         };
+         if (!items.length) return <p>No items because the request failed</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "a directly absorbed fetch rejection",
+      `import { useState } from "react";
+       const Search = () => {
+         const [items, setItems] = useState([]);
+         const load = async () => {
+           try { setItems(await fetch("/api/items").catch(() => [])); }
+           catch { setItems([]); }
+         };
+         if (!items.length) return <p>No items</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "a fetch rejection absorbed by the second then callback",
+      `import { useState } from "react";
+       const Search = () => {
+         const [items, setItems] = useState([]);
+         const load = async () => {
+           try { setItems(await fetch("/api/items").then((response) => response.json(), () => [])); }
+           catch { setItems([]); }
+         };
+         if (!items.length) return <p>No items</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "a local request helper that absorbs a fetch rejection",
+      `import { useState } from "react";
+       const requestItems = () => fetch("/api/items").catch(() => []);
+       const Search = () => {
+         const [items, setItems] = useState([]);
+         const load = async () => {
+           try { setItems(await requestItems()); }
+           catch { setItems([]); }
+         };
+         if (!items.length) return <p>No items</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "a generator request helper",
+      `import { useState } from "react";
+       function* requestItems() { return fetch("/api/items"); }
+       const Search = () => {
+         const [items, setItems] = useState([]);
+         const load = async () => {
+           try { setItems(await requestItems()); }
+           catch { setItems([]); }
+         };
+         if (!items.length) return <p>No items</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "a prior rejected-status return",
+      `import { useState } from "react";
+       const Search = ({ status }) => {
+         const [items, setItems] = useState([]);
+         const load = async () => {
+           try { setItems(await (await fetch("/api/items")).json()); }
+           catch { setItems([]); }
+         };
+         if (status === "rejected") return <p>Try again</p>;
+         if (!items.length) return <p>No items</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "a prior response-status return",
+      `import { useState } from "react";
+       const Search = ({ response }) => {
+         const [items, setItems] = useState([]);
+         const load = async () => {
+           try { setItems(await (await fetch("/api/items")).json()); }
+           catch { setItems([]); }
+         };
+         if (!response.ok) return <p>Try again</p>;
+         if (!items.length) return <p>No items</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "a prior switch route with an early return",
+      `import { useState } from "react";
+       const Search = ({ status }) => {
+         const [items, setItems] = useState([]);
+         const load = async () => {
+           try { setItems(await (await fetch("/api/items")).json()); }
+           catch { setItems([]); }
+         };
+         switch (status) {
+           case "rejected": return <p>Try again</p>;
+           case "pending": return <p>Loading</p>;
+         }
+         if (!items.length) return <p>No items</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "an alternate early return beside the empty-result route",
+      `import { useState } from "react";
+       const Search = ({ mayShowResults }) => {
+         const [items, setItems] = useState([]);
+         const load = async () => {
+           try { setItems(await (await fetch("/api/items")).json()); }
+           catch { setItems([]); }
+         };
+         if (mayShowResults) {
+           if (!items.length) return <p>No items</p>;
+         } else {
+           return <p>Request unavailable</p>;
+         }
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "equality-based modes around a nested request handler",
+      `import { useState } from "react";
+       const Search = ({ mode }) => {
+         const [items, setItems] = useState([]);
+         if (mode === "remote") {
+           const load = async () => {
+             try { setItems(await (await fetch("/api/items")).json()); }
+             catch { setItems([]); }
+           };
+         }
+         if (mode !== "remote") {
+           if (!items.length) return <p>No items</p>;
+         }
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "a trailing-important className visibility utility",
+      `import { useState } from "react";
+       const Search = () => {
+         const [items, setItems] = useState([]);
+         const load = async () => {
+           try { setItems(await (await fetch("/api/items")).json()); }
+           catch { setItems([]); }
+         };
+         if (!items.length) return <p className="md:hidden!">No items</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "a trailing-important class visibility utility",
+      `import { useState } from "react";
+       const Search = () => {
+         const [items, setItems] = useState([]);
+         const load = async () => {
+           try { setItems(await (await fetch("/api/items")).json()); }
+           catch { setItems([]); }
+         };
+         if (!items.length) return <p class="hidden!">No items</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "a fetch in an unreachable conditional branch",
+      `import { useState } from "react";
+       const Search = () => {
+         const [items, setItems] = useState([]);
+         const load = async () => {
+           try {
+             const result = await (false ? fetch("/api/items") : Promise.resolve([]));
+             setItems(result);
+           } catch { setItems([]); }
+         };
+         if (!items.length) return <p>No items</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "a fetch behind an unreachable logical right side",
+      `import { useState } from "react";
+       const Search = () => {
+         const [items, setItems] = useState([]);
+         const load = async () => {
+           try {
+             await (false && fetch("/api/items"));
+             setItems(JSON.parse(rawItems));
+           } catch { setItems([]); }
+         };
+         if (!items.length) return <p>No items</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "a fetch rejection absorbed by an inner try catch",
+      `import { useState } from "react";
+       const Search = () => {
+         const [items, setItems] = useState([]);
+         const load = async () => {
+           try {
+             try { await fetch("/api/items"); }
+             catch { recoverFromRequestFailure(); }
+             setItems(JSON.parse(rawItems));
+           } catch { setItems([]); }
+         };
+         if (!items.length) return <p>No items</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "an inner catch that only conditionally rethrows",
+      `import { useState } from "react";
+       const Search = ({ shouldRethrow }) => {
+         const [items, setItems] = useState([]);
+         const load = async () => {
+           try {
+             try { await fetch("/api/items"); }
+             catch (error) { if (shouldRethrow) throw error; recoverFromRequestFailure(); }
+             setItems(JSON.parse(rawItems));
+           } catch { setItems([]); }
+         };
+         if (!items.length) return <p>No items</p>;
+         return <List items={items} />;
+       };`,
+    ],
+  ])("stays quiet for %s", (_name, code) => {
+    const result = run(code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-collapse-request-error-to-empty-state.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-collapse-request-error-to-empty-state.test.ts
@@ -819,6 +819,45 @@ describe("no-collapse-request-error-to-empty-state", () => {
        };`,
     ],
     [
+      "empty-result copy that says files could not be loaded",
+      `import { useState } from "react";
+       const Search = () => {
+         const [items, setItems] = useState([]);
+         const load = async () => {
+           try { setItems(await (await fetch("/api/items")).json()); }
+           catch { setItems([]); }
+         };
+         if (!items.length) return <p>No files could be loaded because the request failed</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "empty-result copy that names a loading error",
+      `import { useState } from "react";
+       const Search = () => {
+         const [items, setItems] = useState([]);
+         const load = async () => {
+           try { setItems(await (await fetch("/api/items")).json()); }
+           catch { setItems([]); }
+         };
+         if (!items.length) return <p>No items — error loading results</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "empty-result copy that names a network failure",
+      `import { useState } from "react";
+       const Search = () => {
+         const [items, setItems] = useState([]);
+         const load = async () => {
+           try { setItems(await (await fetch("/api/items")).json()); }
+           catch { setItems([]); }
+         };
+         if (!items.length) return <p>No results due to a network failure</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
       "a directly absorbed fetch rejection",
       `import { useState } from "react";
        const Search = () => {
@@ -974,6 +1013,19 @@ describe("no-collapse-request-error-to-empty-state", () => {
            catch { setItems([]); }
          };
          if (!items.length) return <p class="hidden!">No items</p>;
+         return <List items={items} />;
+       };`,
+    ],
+    [
+      "a trailing-important arbitrary visibility utility",
+      `import { useState } from "react";
+       const Search = () => {
+         const [items, setItems] = useState([]);
+         const load = async () => {
+           try { setItems(await (await fetch("/api/items")).json()); }
+           catch { setItems([]); }
+         };
+         if (!items.length) return <p className="md:[display:none]!">No items</p>;
          return <List items={items} />;
        };`,
     ],

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-collapse-request-error-to-empty-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-collapse-request-error-to-empty-state.ts
@@ -1,0 +1,566 @@
+import type { SymbolDescriptor } from "../../semantic/scope-analysis.js";
+import { areNodesOnContradictoryGuardBranches } from "../../utils/are-nodes-on-contradictory-guard-branches.js";
+import { areNodesOnExclusiveConditionalBranches } from "../../utils/are-nodes-on-exclusive-conditional-branches.js";
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
+import { findTransparentExpressionRoot } from "../../utils/find-transparent-expression-root.js";
+import { getStaticJsxText } from "../../utils/get-static-jsx-text.js";
+import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
+import { getStaticStringExpression } from "../../utils/get-static-string-expression.js";
+import { getStringLiteralAttributeValue } from "../../utils/get-string-literal-attribute-value.js";
+import { isAstDescendant } from "../../utils/is-ast-descendant.js";
+import { isFunctionLike } from "../../utils/is-function-like.js";
+import { isHiddenFromScreenReader } from "../../utils/is-hidden-from-screen-reader.js";
+import {
+  chainCarriesRejectionHandler,
+  isInsideNonRethrowingTry,
+} from "../../utils/is-never-rejecting-expression.js";
+import { isNodeReachableWithinFunction } from "../../utils/is-node-reachable-within-function.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { nodesCanCoExecute } from "../../utils/nodes-can-co-execute.js";
+import { parseTailwindClassNameToken } from "../../utils/parse-tailwind-class-name-token.js";
+import { isReactApiCall } from "../../utils/is-react-api-call.js";
+import { resolveExactLocalFunction } from "../../utils/resolve-exact-local-function.js";
+import { resolveReactUseStatePair } from "../../utils/resolve-react-use-state-pair.js";
+import { resolveStaticJsxAttribute } from "../../utils/resolve-static-jsx-attribute.js";
+import type { StaticJsxAttributeResolution } from "../../utils/resolve-static-jsx-attribute.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import { walkAst } from "../../utils/walk-ast.js";
+import { walkOwnFunctionScope } from "../../utils/walk-own-function-scope.js";
+
+const MESSAGE =
+  "This catch replaces a failure with an empty collection, and that same state renders a no-results message, so users see an empty result instead of an error. Preserve an error and retry path instead of writing `[]`.";
+
+const EMPTY_RESULT_CONTAINER_NAMES = new Set([
+  "article",
+  "aside",
+  "div",
+  "li",
+  "main",
+  "p",
+  "section",
+  "span",
+  "td",
+]);
+
+const EMPTY_RESULT_TEXT_PATTERN =
+  /\b(?:no\s+(?:data|entries|events|files|items?|matches?|messages?|notifications?|orders?|posts?|products?|records?|results?|tasks?|users?)|nothing\s+(?:found|here|to\s+(?:display|show))|(?:collection|inbox|list|results?)\s+is\s+empty)\b/i;
+
+const ERROR_RESULT_TEXT_PATTERN = /\b(?:error(?:ed|s)?|fail(?:ed|ure)?|unable)\b/i;
+const HIDDEN_CLASS_NAMES = new Set(["collapse", "hidden", "invisible"]);
+const HIDDEN_ARBITRARY_CLASS_TOKEN_PATTERN =
+  /^\[(?:display\s*:\s*none|visibility\s*:\s*hidden)\]$/i;
+
+interface EmptyCatchUseStatePair {
+  componentFunction: EsTreeNode;
+  stateSymbol: SymbolDescriptor;
+}
+
+const isEmptyArrayExpression = (node: EsTreeNode): boolean => {
+  const expression = stripParenExpression(node);
+  return isNodeOfType(expression, "ArrayExpression") && expression.elements.length === 0;
+};
+
+const getSingleReturnedExpression = (functionNode: EsTreeNode): EsTreeNode | null => {
+  if (!isFunctionLike(functionNode)) return null;
+  const body = functionNode.body;
+  if (!isNodeOfType(body, "BlockStatement")) return body;
+  if (body.body.length !== 1 || !isNodeOfType(body.body[0], "ReturnStatement")) return null;
+  return body.body[0].argument ?? null;
+};
+
+const isProvenEmptyArrayValue = (node: EsTreeNode, allowUpdater: boolean): boolean => {
+  const expression = stripParenExpression(node);
+  if (isEmptyArrayExpression(expression)) return true;
+  if (!allowUpdater || !isFunctionLike(expression) || expression.async || expression.generator) {
+    return false;
+  }
+  const returnedExpression = getSingleReturnedExpression(expression);
+  return Boolean(returnedExpression && isEmptyArrayExpression(returnedExpression));
+};
+
+const isGlobalFetchCall = (
+  node: EsTreeNodeOfType<"CallExpression">,
+  context: RuleContext,
+): boolean => {
+  const callee = stripParenExpression(node.callee);
+  if (isNodeOfType(callee, "Identifier")) {
+    return callee.name === "fetch" && context.scopes.isGlobalReference(callee);
+  }
+  if (!isNodeOfType(callee, "MemberExpression") || getStaticPropertyName(callee) !== "fetch") {
+    return false;
+  }
+  const receiver = stripParenExpression(callee.object);
+  return (
+    isNodeOfType(receiver, "Identifier") &&
+    (receiver.name === "globalThis" || receiver.name === "window") &&
+    context.scopes.isGlobalReference(receiver)
+  );
+};
+
+const getPromiseChainRoot = (node: EsTreeNode, boundary: EsTreeNode): EsTreeNode => {
+  let chainRoot = findTransparentExpressionRoot(node);
+  while (chainRoot !== boundary && chainRoot.parent) {
+    const parent = chainRoot.parent;
+    if (isNodeOfType(parent, "MemberExpression") && parent.object === chainRoot) {
+      chainRoot = parent;
+      continue;
+    }
+    if (isNodeOfType(parent, "CallExpression") && parent.callee === chainRoot) {
+      chainRoot = parent;
+      continue;
+    }
+    if (isNodeOfType(parent, "ChainExpression") && parent.expression === chainRoot) {
+      chainRoot = parent;
+      continue;
+    }
+    break;
+  }
+  return chainRoot;
+};
+
+const expressionHasEscapingGlobalFetch = (node: EsTreeNode, context: RuleContext): boolean => {
+  let didFindEscapingFetch = false;
+  walkAst(node, (child) => {
+    if (didFindEscapingFetch) return false;
+    if (child !== node && isFunctionLike(child)) return false;
+    if (
+      isNodeOfType(child, "CallExpression") &&
+      isGlobalFetchCall(child, context) &&
+      isNodeReachableWithinFunction(child, context)
+    ) {
+      const promiseChainRoot = getPromiseChainRoot(child, node);
+      if (!chainCarriesRejectionHandler(promiseChainRoot, context.scopes)) {
+        didFindEscapingFetch = true;
+      }
+      return false;
+    }
+  });
+  return didFindEscapingFetch;
+};
+
+const localFunctionProducesRequest = (functionNode: EsTreeNode, context: RuleContext): boolean => {
+  if (!isFunctionLike(functionNode) || functionNode.generator) return false;
+  if (
+    isNodeOfType(functionNode, "ArrowFunctionExpression") &&
+    !isNodeOfType(functionNode.body, "BlockStatement")
+  ) {
+    return expressionHasEscapingGlobalFetch(functionNode.body, context);
+  }
+  let hasTryStatement = false;
+  let hasRequestEvidence = false;
+  walkOwnFunctionScope(functionNode, (child) => {
+    if (isNodeOfType(child, "TryStatement")) {
+      hasTryStatement = true;
+      return false;
+    }
+    if (!isNodeReachableWithinFunction(child, context)) return false;
+    if (
+      isNodeOfType(child, "AwaitExpression") &&
+      expressionHasEscapingGlobalFetch(child.argument, context)
+    ) {
+      hasRequestEvidence = true;
+      return false;
+    }
+    if (
+      isNodeOfType(child, "ReturnStatement") &&
+      child.argument &&
+      expressionHasEscapingGlobalFetch(child.argument, context)
+    ) {
+      hasRequestEvidence = true;
+      return false;
+    }
+  });
+  return !hasTryStatement && hasRequestEvidence;
+};
+
+const isAwaitCaughtBeforeBoundary = (
+  awaitExpression: EsTreeNode,
+  boundary: EsTreeNode,
+): boolean => {
+  if (isInsideNonRethrowingTry(awaitExpression, boundary)) return true;
+  let child = awaitExpression;
+  let ancestor = awaitExpression.parent;
+  while (ancestor && ancestor !== boundary) {
+    if (isNodeOfType(ancestor, "TryStatement") && ancestor.block === child) {
+      if (ancestor.finalizer) return true;
+      if (ancestor.handler) {
+        const handlerStatements = ancestor.handler.body.body;
+        if (
+          handlerStatements.length !== 1 ||
+          !isNodeOfType(handlerStatements[0], "ThrowStatement")
+        ) {
+          return true;
+        }
+      }
+    }
+    child = ancestor;
+    ancestor = ancestor.parent;
+  }
+  return false;
+};
+
+const hasProvenRequestAwait = (tryBlock: EsTreeNode, context: RuleContext): boolean => {
+  let didFindRequestAwait = false;
+  walkAst(tryBlock, (child) => {
+    if (didFindRequestAwait) return false;
+    if (child !== tryBlock && isFunctionLike(child)) return false;
+    if (!isNodeOfType(child, "AwaitExpression")) return;
+    if (!isNodeReachableWithinFunction(child, context)) return false;
+    if (isAwaitCaughtBeforeBoundary(child, tryBlock)) return false;
+    if (expressionHasEscapingGlobalFetch(child.argument, context)) {
+      didFindRequestAwait = true;
+      return false;
+    }
+    const awaitedExpression = stripParenExpression(child.argument);
+    if (!isNodeOfType(awaitedExpression, "CallExpression")) return;
+    const localFunction = resolveExactLocalFunction(awaitedExpression.callee, context.scopes);
+    if (localFunction && localFunctionProducesRequest(localFunction, context)) {
+      didFindRequestAwait = true;
+      return false;
+    }
+  });
+  return didFindRequestAwait;
+};
+
+const getUseStatePairForEmptyCatch = (
+  catchClause: EsTreeNodeOfType<"CatchClause">,
+  context: RuleContext,
+): EmptyCatchUseStatePair | null => {
+  const tryStatement = catchClause.parent;
+  if (
+    !isNodeOfType(tryStatement, "TryStatement") ||
+    tryStatement.handler !== catchClause ||
+    tryStatement.finalizer ||
+    !isNodeReachableWithinFunction(catchClause, context) ||
+    !hasProvenRequestAwait(tryStatement.block, context)
+  ) {
+    return null;
+  }
+  if (catchClause.body.body.length !== 1) return null;
+  const onlyStatement = catchClause.body.body[0];
+  if (!isNodeOfType(onlyStatement, "ExpressionStatement")) return null;
+  const expression = stripParenExpression(onlyStatement.expression);
+  if (
+    !isNodeOfType(expression, "CallExpression") ||
+    !isNodeOfType(stripParenExpression(expression.callee), "Identifier") ||
+    expression.arguments.length !== 1
+  ) {
+    return null;
+  }
+  const setterIdentifier = stripParenExpression(expression.callee);
+  const nextStateArgument = expression.arguments[0];
+  if (
+    !isNodeOfType(setterIdentifier, "Identifier") ||
+    !nextStateArgument ||
+    !isProvenEmptyArrayValue(nextStateArgument, true)
+  ) {
+    return null;
+  }
+  const directSetterSymbol = context.scopes.symbolFor(setterIdentifier);
+  const statePair = resolveReactUseStatePair(setterIdentifier, context.scopes);
+  if (
+    !directSetterSymbol ||
+    !statePair ||
+    directSetterSymbol.id !== statePair.setterSymbol.id ||
+    !statePair.stateSymbol
+  ) {
+    return null;
+  }
+  const initializer = statePair.declarator.init
+    ? stripParenExpression(statePair.declarator.init)
+    : null;
+  if (
+    !initializer ||
+    !isNodeOfType(initializer, "CallExpression") ||
+    !isReactApiCall(initializer, "useState", context.scopes, {
+      allowGlobalReactNamespace: true,
+      resolveNamedAliases: true,
+    }) ||
+    initializer.arguments.length !== 1 ||
+    !isProvenEmptyArrayValue(initializer.arguments[0], true)
+  ) {
+    return null;
+  }
+  const componentFunction = findEnclosingFunction(statePair.declarator);
+  if (!componentFunction) return null;
+  return { componentFunction, stateSymbol: statePair.stateSymbol };
+};
+
+const isExactStateLengthRead = (
+  node: EsTreeNode,
+  stateSymbol: SymbolDescriptor,
+  context: RuleContext,
+): boolean => {
+  const expression = stripParenExpression(node);
+  if (
+    !isNodeOfType(expression, "MemberExpression") ||
+    getStaticPropertyName(expression) !== "length"
+  ) {
+    return false;
+  }
+  const receiver = stripParenExpression(expression.object);
+  return (
+    isNodeOfType(receiver, "Identifier") &&
+    context.scopes.symbolFor(receiver)?.id === stateSymbol.id
+  );
+};
+
+const classifyEmptyResultCondition = (
+  node: EsTreeNode,
+  stateSymbol: SymbolDescriptor,
+  context: RuleContext,
+): "empty" | "nonempty" | null => {
+  const expression = stripParenExpression(node);
+  if (isExactStateLengthRead(expression, stateSymbol, context)) return "nonempty";
+  if (
+    isNodeOfType(expression, "UnaryExpression") &&
+    expression.operator === "!" &&
+    isExactStateLengthRead(expression.argument, stateSymbol, context)
+  ) {
+    return "empty";
+  }
+  if (!isNodeOfType(expression, "BinaryExpression") || expression.operator !== "===") {
+    return null;
+  }
+  const leftIsZero = isNodeOfType(expression.left, "Literal") && expression.left.value === 0;
+  const rightIsZero = isNodeOfType(expression.right, "Literal") && expression.right.value === 0;
+  if (leftIsZero && isExactStateLengthRead(expression.right, stateSymbol, context)) return "empty";
+  if (rightIsZero && isExactStateLengthRead(expression.left, stateSymbol, context)) return "empty";
+  return null;
+};
+
+const getStaticClassAttributeValue = (resolution: StaticJsxAttributeResolution): string | null => {
+  if (resolution.attribute) return getStringLiteralAttributeValue(resolution.attribute);
+  return getStaticStringExpression(resolution.expression);
+};
+
+const isOpeningElementProvenVisible = (
+  openingElement: EsTreeNodeOfType<"JSXOpeningElement">,
+  context: RuleContext,
+): boolean => {
+  if (isHiddenFromScreenReader(openingElement, context.settings)) return false;
+  for (const attributeName of ["aria-hidden", "hidden", "style"]) {
+    const resolution = resolveStaticJsxAttribute(openingElement.attributes, attributeName, false);
+    if (resolution.isPresent || resolution.isUnknown) return false;
+  }
+  for (const classAttributeName of ["class", "className"]) {
+    const classResolution = resolveStaticJsxAttribute(
+      openingElement.attributes,
+      classAttributeName,
+      false,
+    );
+    if (classResolution.isUnknown) return false;
+    if (!classResolution.isPresent) continue;
+    const className = getStaticClassAttributeValue(classResolution);
+    if (className === null) return false;
+    const hasHiddenClass = className.split(/\s+/).some((classToken) => {
+      const utility = parseTailwindClassNameToken(classToken).utility;
+      return HIDDEN_CLASS_NAMES.has(utility) || HIDDEN_ARBITRARY_CLASS_TOKEN_PATTERN.test(utility);
+    });
+    if (hasHiddenClass) return false;
+  }
+  return true;
+};
+
+const isStaticIntrinsicJsx = (node: EsTreeNode, context: RuleContext): boolean => {
+  if (!isNodeOfType(node, "JSXElement")) return false;
+  if (
+    !isNodeOfType(node.openingElement.name, "JSXIdentifier") ||
+    !EMPTY_RESULT_CONTAINER_NAMES.has(node.openingElement.name.name) ||
+    !isOpeningElementProvenVisible(node.openingElement, context)
+  ) {
+    return false;
+  }
+  return node.children.every((child) => {
+    if (isNodeOfType(child, "JSXText")) return true;
+    if (isNodeOfType(child, "JSXElement")) return isStaticIntrinsicJsx(child, context);
+    if (!isNodeOfType(child, "JSXExpressionContainer")) return false;
+    const childExpression = stripParenExpression(child.expression);
+    if (isNodeOfType(childExpression, "JSXEmptyExpression")) return true;
+    if (isNodeOfType(childExpression, "Literal")) {
+      return typeof childExpression.value === "string";
+    }
+    return (
+      isNodeOfType(childExpression, "TemplateLiteral") && childExpression.expressions.length === 0
+    );
+  });
+};
+
+const isExplicitEmptyResult = (
+  node: EsTreeNode | null | undefined,
+  context: RuleContext,
+): boolean => {
+  if (!node) return false;
+  const expression = stripParenExpression(node);
+  const emptyResultText = getStaticJsxText(expression).replace(/\s+/g, " ").trim();
+  return (
+    isStaticIntrinsicJsx(expression, context) &&
+    EMPTY_RESULT_TEXT_PATTERN.test(emptyResultText) &&
+    !ERROR_RESULT_TEXT_PATTERN.test(emptyResultText)
+  );
+};
+
+const getDirectReturnExpression = (node: EsTreeNode): EsTreeNode | null => {
+  if (isNodeOfType(node, "ReturnStatement")) return node.argument ?? null;
+  if (
+    isNodeOfType(node, "BlockStatement") &&
+    node.body.length === 1 &&
+    isNodeOfType(node.body[0], "ReturnStatement")
+  ) {
+    return node.body[0].argument ?? null;
+  }
+  return null;
+};
+
+const isDirectlyRenderedExpression = (
+  node: EsTreeNode,
+  componentFunction: EsTreeNode,
+  context: RuleContext,
+): boolean => {
+  let expressionRoot = findTransparentExpressionRoot(node);
+  while (expressionRoot.parent) {
+    const parent = expressionRoot.parent;
+    if (
+      isNodeOfType(parent, "JSXExpressionContainer") &&
+      parent.expression === expressionRoot &&
+      !isNodeOfType(parent.parent, "JSXAttribute")
+    ) {
+      expressionRoot = parent;
+      continue;
+    }
+    if (isNodeOfType(parent, "JSXElement")) {
+      if (!isOpeningElementProvenVisible(parent.openingElement, context)) return false;
+      expressionRoot = parent;
+      continue;
+    }
+    if (isNodeOfType(parent, "JSXFragment")) {
+      expressionRoot = parent;
+      continue;
+    }
+    break;
+  }
+  if (isFunctionLike(componentFunction) && componentFunction.body === expressionRoot) return true;
+  return Boolean(
+    isNodeOfType(expressionRoot.parent, "ReturnStatement") &&
+    findEnclosingFunction(expressionRoot.parent) === componentFunction,
+  );
+};
+
+const routeContainsReachableReturn = (route: EsTreeNode, context: RuleContext): boolean => {
+  let didFindReturn = false;
+  walkAst(route, (child) => {
+    if (didFindReturn) return false;
+    if (child !== route && isFunctionLike(child)) return false;
+    if (isNodeOfType(child, "ReturnStatement") && isNodeReachableWithinFunction(child, context)) {
+      didFindReturn = true;
+      return false;
+    }
+  });
+  return didFindReturn;
+};
+
+const routeCanPreemptEmptyResult = (
+  route: EsTreeNodeOfType<"IfStatement"> | EsTreeNodeOfType<"SwitchStatement">,
+  emptyResultNode: EsTreeNode,
+  context: RuleContext,
+): boolean => {
+  if (!isAstDescendant(emptyResultNode, route)) {
+    return routeContainsReachableReturn(route, context);
+  }
+  if (isNodeOfType(route, "IfStatement")) {
+    if (isAstDescendant(emptyResultNode, route.consequent)) {
+      return Boolean(route.alternate && routeContainsReachableReturn(route.alternate, context));
+    }
+    return routeContainsReachableReturn(route.consequent, context);
+  }
+  return route.cases.some(
+    (switchCase) =>
+      !isAstDescendant(emptyResultNode, switchCase) &&
+      routeContainsReachableReturn(switchCase, context),
+  );
+};
+
+const hasPriorPreemptingRoute = (
+  componentFunction: EsTreeNode,
+  emptyResultNode: EsTreeNode,
+  context: RuleContext,
+): boolean => {
+  let didFindPreemptingRoute = false;
+  const emptyResultStart = emptyResultNode.range[0];
+  walkOwnFunctionScope(componentFunction, (node) => {
+    if (didFindPreemptingRoute) return false;
+    if (
+      (!isNodeOfType(node, "IfStatement") && !isNodeOfType(node, "SwitchStatement")) ||
+      node.range[0] >= emptyResultStart ||
+      !isNodeReachableWithinFunction(node, context) ||
+      !routeCanPreemptEmptyResult(node, emptyResultNode, context)
+    ) {
+      return;
+    }
+    didFindPreemptingRoute = true;
+  });
+  return didFindPreemptingRoute;
+};
+
+const hasDirectEmptyResultRender = (
+  componentFunction: EsTreeNode,
+  stateSymbol: SymbolDescriptor,
+  context: RuleContext,
+): EsTreeNode | null => {
+  let emptyResultNode: EsTreeNode | null = null;
+  walkOwnFunctionScope(componentFunction, (node) => {
+    if (emptyResultNode) return false;
+    if (!isNodeReachableWithinFunction(node, context)) return false;
+    if (isNodeOfType(node, "IfStatement")) {
+      if (classifyEmptyResultCondition(node.test, stateSymbol, context) !== "empty") return;
+      const returnedExpression = getDirectReturnExpression(node.consequent);
+      if (isExplicitEmptyResult(returnedExpression, context)) emptyResultNode = node;
+      return;
+    }
+    if (!isNodeOfType(node, "ConditionalExpression")) return;
+    const conditionKind = classifyEmptyResultCondition(node.test, stateSymbol, context);
+    if (!conditionKind || !isDirectlyRenderedExpression(node, componentFunction, context)) return;
+    const emptyBranch = conditionKind === "empty" ? node.consequent : node.alternate;
+    if (isExplicitEmptyResult(emptyBranch, context)) emptyResultNode = node;
+  });
+  return emptyResultNode;
+};
+
+export const noCollapseRequestErrorToEmptyState = defineRule({
+  id: "no-collapse-request-error-to-empty-state",
+  title: "Request failure rendered as an empty result",
+  severity: "warn",
+  tags: ["react-jsx-only"],
+  defaultEnabled: false,
+  recommendation:
+    "Keep request failure separate from an empty successful response, render an error with a retry action, and leave the previous result visible when appropriate.",
+  create: (context: RuleContext) => ({
+    CatchClause(node: EsTreeNodeOfType<"CatchClause">) {
+      const statePair = getUseStatePairForEmptyCatch(node, context);
+      if (!statePair) return;
+      const emptyResultNode = hasDirectEmptyResultRender(
+        statePair.componentFunction,
+        statePair.stateSymbol,
+        context,
+      );
+      if (!emptyResultNode) return;
+      if (
+        hasPriorPreemptingRoute(statePair.componentFunction, emptyResultNode, context) ||
+        !nodesCanCoExecute(node, emptyResultNode, context) ||
+        areNodesOnExclusiveConditionalBranches(
+          node,
+          emptyResultNode,
+          statePair.componentFunction,
+        ) ||
+        areNodesOnContradictoryGuardBranches(node, emptyResultNode, context.scopes)
+      ) {
+        return;
+      }
+      context.report({ node: node.body.body[0], message: MESSAGE });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-tailwind-visibility-at-breakpoints.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-tailwind-visibility-at-breakpoints.test.ts
@@ -43,10 +43,13 @@ describe("getTailwindVisibilityAtBreakpoints", () => {
   it("returns unknown for arbitrary breakpoint visibility", () => {
     expect(getTailwindVisibilityAtBreakpoints("block max-[700px]:hidden")).toBeNull();
     expect(getTailwindVisibilityAtBreakpoints("hidden min-[700px]:block")).toBeNull();
+    expect(getTailwindVisibilityAtBreakpoints("[display:var(--layout)]")).toBeNull();
+    expect(getTailwindVisibilityAtBreakpoints("md:[visibility:var(--visibility)]")).toBeNull();
+    expect(getTailwindVisibilityAtBreakpoints("md:[dIsPlAy:var(--layout)]")).toBeNull();
   });
 
-  it("ignores non-responsive variants", () => {
-    expect(getTailwindVisibilityAtBreakpoints("block hover:hidden")).toEqual([
+  it("ignores visibility effects in empty responsive intervals", () => {
+    expect(getTailwindVisibilityAtBreakpoints("md:max-sm:hidden")).toEqual([
       true,
       true,
       true,
@@ -54,6 +57,20 @@ describe("getTailwindVisibilityAtBreakpoints", () => {
       true,
       true,
     ]);
+    expect(getTailwindVisibilityAtBreakpoints("max-md:lg:[display:var(--layout)]")).toEqual([
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+    ]);
+  });
+
+  it("returns unknown for unsupported variant scopes", () => {
+    expect(getTailwindVisibilityAtBreakpoints("block hover:hidden")).toBeNull();
+    expect(getTailwindVisibilityAtBreakpoints("block tablet:hidden")).toBeNull();
+    expect(getTailwindVisibilityAtBreakpoints("block data-[state=open]:hidden")).toBeNull();
   });
 
   it("returns null for conflicting visibility utilities", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-tailwind-visibility-at-breakpoints.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-tailwind-visibility-at-breakpoints.ts
@@ -1,13 +1,9 @@
-import { getTailwindArbitraryUtilityValue } from "./get-tailwind-arbitrary-utility-value.js";
-import { normalizeTailwindArbitraryUtilityValue } from "./normalize-tailwind-arbitrary-utility-value.js";
+import { TAILWIND_BREAKPOINT_NAMES } from "../constants/tailwind.js";
+import { getTailwindVisibilityEffect } from "./get-tailwind-visibility-effect.js";
+import type { TailwindVisibilityEffect } from "./get-tailwind-visibility-effect.js";
 import { parseTailwindClassNameToken } from "./parse-tailwind-class-name-token.js";
 import type { TailwindClassNameToken } from "./parse-tailwind-class-name-token.js";
 import { splitTailwindClassName } from "./split-tailwind-class-name.js";
-
-interface TailwindVisibilityEffect {
-  isVisible: boolean;
-  propertyName: "display" | "visibility";
-}
 
 interface TailwindResponsiveVariantScope {
   maximumBreakpointIndex: number;
@@ -20,86 +16,6 @@ interface TailwindScopedVisibilityEffect {
   scope: TailwindResponsiveVariantScope;
   token: TailwindClassNameToken;
 }
-
-const TAILWIND_BREAKPOINT_NAMES = ["", "sm", "md", "lg", "xl", "2xl"];
-const DISPLAY_VISIBILITY_EFFECTS = new Map<string, TailwindVisibilityEffect>([
-  ["hidden", { isVisible: false, propertyName: "display" }],
-  ["block", { isVisible: true, propertyName: "display" }],
-  ["contents", { isVisible: true, propertyName: "display" }],
-  ["flex", { isVisible: true, propertyName: "display" }],
-  ["flow-root", { isVisible: true, propertyName: "display" }],
-  ["grid", { isVisible: true, propertyName: "display" }],
-  ["inline", { isVisible: true, propertyName: "display" }],
-  ["inline-block", { isVisible: true, propertyName: "display" }],
-  ["inline-flex", { isVisible: true, propertyName: "display" }],
-  ["inline-grid", { isVisible: true, propertyName: "display" }],
-  ["inline-table", { isVisible: true, propertyName: "display" }],
-  ["list-item", { isVisible: true, propertyName: "display" }],
-  ["table", { isVisible: true, propertyName: "display" }],
-  ["table-caption", { isVisible: true, propertyName: "display" }],
-  ["table-cell", { isVisible: true, propertyName: "display" }],
-  ["table-column", { isVisible: true, propertyName: "display" }],
-  ["table-column-group", { isVisible: true, propertyName: "display" }],
-  ["table-footer-group", { isVisible: true, propertyName: "display" }],
-  ["table-header-group", { isVisible: true, propertyName: "display" }],
-  ["table-row", { isVisible: true, propertyName: "display" }],
-  ["table-row-group", { isVisible: true, propertyName: "display" }],
-]);
-const VISIBILITY_VISIBILITY_EFFECTS = new Map<string, TailwindVisibilityEffect>([
-  ["collapse", { isVisible: false, propertyName: "visibility" }],
-  ["invisible", { isVisible: false, propertyName: "visibility" }],
-  ["visible", { isVisible: true, propertyName: "visibility" }],
-]);
-const VISIBLE_ARBITRARY_DISPLAY_VALUES = new Set([
-  "block",
-  "contents",
-  "flex",
-  "flow-root",
-  "grid",
-  "inline",
-  "inline block",
-  "inline flex",
-  "inline flow-root",
-  "inline grid",
-  "inline table",
-  "list-item",
-  "table",
-  "table-caption",
-  "table-cell",
-  "table-column",
-  "table-column-group",
-  "table-footer-group",
-  "table-header-group",
-  "table-row",
-  "table-row-group",
-]);
-
-const getVisibilityEffect = (utility: string): TailwindVisibilityEffect | null => {
-  const knownEffect =
-    DISPLAY_VISIBILITY_EFFECTS.get(utility) ?? VISIBILITY_VISIBILITY_EFFECTS.get(utility);
-  if (knownEffect) return knownEffect;
-
-  const arbitraryDisplayValue = getTailwindArbitraryUtilityValue(utility, "[display:");
-  if (arbitraryDisplayValue !== null) {
-    const displayValue = normalizeTailwindArbitraryUtilityValue(arbitraryDisplayValue)
-      .trim()
-      .toLowerCase();
-    if (displayValue === "none") return { isVisible: false, propertyName: "display" };
-    return VISIBLE_ARBITRARY_DISPLAY_VALUES.has(displayValue)
-      ? { isVisible: true, propertyName: "display" }
-      : null;
-  }
-
-  const arbitraryVisibilityValue = getTailwindArbitraryUtilityValue(utility, "[visibility:");
-  if (arbitraryVisibilityValue === null) return null;
-  const visibilityValue = normalizeTailwindArbitraryUtilityValue(arbitraryVisibilityValue)
-    .trim()
-    .toLowerCase();
-  if (visibilityValue === "visible") return { isVisible: true, propertyName: "visibility" };
-  return visibilityValue === "hidden" || visibilityValue === "collapse"
-    ? { isVisible: false, propertyName: "visibility" }
-    : null;
-};
 
 const getResponsiveVariantScope = (
   variants: ReadonlyArray<string>,
@@ -119,8 +35,7 @@ const getResponsiveVariantScope = (
         continue;
       }
     }
-    if (variant.startsWith("min-[") || variant.startsWith("max-[")) return null;
-    return undefined;
+    return null;
   }
   return {
     maximumBreakpointIndex,
@@ -175,11 +90,23 @@ export const getTailwindVisibilityAtBreakpoints = (
 ): ReadonlyArray<boolean> | null => {
   const scopedEffects: TailwindScopedVisibilityEffect[] = [];
   for (const token of splitTailwindClassName(className).map(parseTailwindClassNameToken)) {
-    const effect = getVisibilityEffect(token.utility);
-    if (!effect) continue;
+    const resolution = getTailwindVisibilityEffect(token.utility);
+    if (resolution.status === "not-relevant") continue;
     const scope = getResponsiveVariantScope(token.variants);
     if (scope === null) return null;
-    if (scope) scopedEffects.push({ effect, scope, token });
+    if (!scope || scope.minimumBreakpointIndex >= scope.maximumBreakpointIndex) continue;
+    if (
+      resolution.status === "unknown" ||
+      resolution.propertyName === null ||
+      resolution.isVisible === null
+    ) {
+      return null;
+    }
+    const effect: TailwindVisibilityEffect = {
+      isVisible: resolution.isVisible,
+      propertyName: resolution.propertyName,
+    };
+    scopedEffects.push({ effect, scope, token });
   }
 
   const visibilityAtBreakpoints: boolean[] = [];

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-tailwind-visibility-effect.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-tailwind-visibility-effect.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vite-plus/test";
+import { getTailwindVisibilityEffect } from "./get-tailwind-visibility-effect.js";
+
+describe("getTailwindVisibilityEffect", () => {
+  it("distinguishes known, unknown, and unrelated utilities", () => {
+    expect(getTailwindVisibilityEffect("hidden")).toEqual({
+      isVisible: false,
+      propertyName: "display",
+      status: "known",
+    });
+    expect(getTailwindVisibilityEffect("[display:var(--layout)]")).toEqual({
+      isVisible: null,
+      propertyName: "display",
+      status: "unknown",
+    });
+    expect(getTailwindVisibilityEffect("[visibility:var(--visibility)]")).toEqual({
+      isVisible: null,
+      propertyName: "visibility",
+      status: "unknown",
+    });
+    expect(getTailwindVisibilityEffect("text-red-500")).toEqual({
+      isVisible: null,
+      propertyName: null,
+      status: "not-relevant",
+    });
+  });
+
+  it("matches arbitrary CSS property names case-insensitively", () => {
+    expect(getTailwindVisibilityEffect("[dIsPlAy:none]")).toEqual({
+      isVisible: false,
+      propertyName: "display",
+      status: "known",
+    });
+    expect(getTailwindVisibilityEffect("[VISIBILITY:VISIBLE]")).toEqual({
+      isVisible: true,
+      propertyName: "visibility",
+      status: "known",
+    });
+    expect(getTailwindVisibilityEffect("[DiSpLaY:var(--layout)]")).toEqual({
+      isVisible: null,
+      propertyName: "display",
+      status: "unknown",
+    });
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-tailwind-visibility-effect.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-tailwind-visibility-effect.ts
@@ -1,0 +1,106 @@
+import { normalizeTailwindArbitraryUtilityValue } from "./normalize-tailwind-arbitrary-utility-value.js";
+
+export interface TailwindVisibilityEffect {
+  isVisible: boolean;
+  propertyName: "display" | "visibility";
+}
+
+export interface TailwindVisibilityEffectResolution {
+  isVisible: boolean | null;
+  propertyName: TailwindVisibilityEffect["propertyName"] | null;
+  status: "known" | "not-relevant" | "unknown";
+}
+
+const DISPLAY_VISIBILITY_EFFECTS = new Map<string, TailwindVisibilityEffect>([
+  ["hidden", { isVisible: false, propertyName: "display" }],
+  ["block", { isVisible: true, propertyName: "display" }],
+  ["contents", { isVisible: true, propertyName: "display" }],
+  ["flex", { isVisible: true, propertyName: "display" }],
+  ["flow-root", { isVisible: true, propertyName: "display" }],
+  ["grid", { isVisible: true, propertyName: "display" }],
+  ["inline", { isVisible: true, propertyName: "display" }],
+  ["inline-block", { isVisible: true, propertyName: "display" }],
+  ["inline-flex", { isVisible: true, propertyName: "display" }],
+  ["inline-grid", { isVisible: true, propertyName: "display" }],
+  ["inline-table", { isVisible: true, propertyName: "display" }],
+  ["list-item", { isVisible: true, propertyName: "display" }],
+  ["table", { isVisible: true, propertyName: "display" }],
+  ["table-caption", { isVisible: true, propertyName: "display" }],
+  ["table-cell", { isVisible: true, propertyName: "display" }],
+  ["table-column", { isVisible: true, propertyName: "display" }],
+  ["table-column-group", { isVisible: true, propertyName: "display" }],
+  ["table-footer-group", { isVisible: true, propertyName: "display" }],
+  ["table-header-group", { isVisible: true, propertyName: "display" }],
+  ["table-row", { isVisible: true, propertyName: "display" }],
+  ["table-row-group", { isVisible: true, propertyName: "display" }],
+]);
+const VISIBILITY_VISIBILITY_EFFECTS = new Map<string, TailwindVisibilityEffect>([
+  ["collapse", { isVisible: false, propertyName: "visibility" }],
+  ["invisible", { isVisible: false, propertyName: "visibility" }],
+  ["visible", { isVisible: true, propertyName: "visibility" }],
+]);
+const VISIBLE_ARBITRARY_DISPLAY_VALUES = new Set([
+  "block",
+  "contents",
+  "flex",
+  "flow-root",
+  "grid",
+  "inline",
+  "inline block",
+  "inline flex",
+  "inline flow-root",
+  "inline grid",
+  "inline table",
+  "list-item",
+  "table",
+  "table-caption",
+  "table-cell",
+  "table-column",
+  "table-column-group",
+  "table-footer-group",
+  "table-header-group",
+  "table-row",
+  "table-row-group",
+]);
+
+const getArbitraryCssPropertyValue = (utility: string, propertyName: string): string | null => {
+  const propertyPrefix = `[${propertyName}:`;
+  return utility.toLowerCase().startsWith(propertyPrefix) && utility.endsWith("]")
+    ? utility.slice(propertyPrefix.length, -1)
+    : null;
+};
+
+export const getTailwindVisibilityEffect = (
+  utility: string,
+): TailwindVisibilityEffectResolution => {
+  const knownEffect =
+    DISPLAY_VISIBILITY_EFFECTS.get(utility) ?? VISIBILITY_VISIBILITY_EFFECTS.get(utility);
+  if (knownEffect) return { ...knownEffect, status: "known" };
+
+  const arbitraryDisplayValue = getArbitraryCssPropertyValue(utility, "display");
+  if (arbitraryDisplayValue !== null) {
+    const displayValue = normalizeTailwindArbitraryUtilityValue(arbitraryDisplayValue)
+      .trim()
+      .toLowerCase();
+    if (displayValue === "none") {
+      return { isVisible: false, propertyName: "display", status: "known" };
+    }
+    return VISIBLE_ARBITRARY_DISPLAY_VALUES.has(displayValue)
+      ? { isVisible: true, propertyName: "display", status: "known" }
+      : { isVisible: null, propertyName: "display", status: "unknown" };
+  }
+
+  const arbitraryVisibilityValue = getArbitraryCssPropertyValue(utility, "visibility");
+  if (arbitraryVisibilityValue === null) {
+    return { isVisible: null, propertyName: null, status: "not-relevant" };
+  }
+  const visibilityValue = normalizeTailwindArbitraryUtilityValue(arbitraryVisibilityValue)
+    .trim()
+    .toLowerCase();
+  if (visibilityValue === "visible") {
+    return { isVisible: true, propertyName: "visibility", status: "known" };
+  }
+  return visibilityValue === "hidden" || visibilityValue === "collapse"
+    ? { isVisible: false, propertyName: "visibility", status: "known" }
+    : { isVisible: null, propertyName: "visibility", status: "unknown" };
+};


### PR DESCRIPTION
## Why

React applications can preserve syntactic accessibility while still losing names, content, focus continuity, action identity, error semantics, or animation ownership across responsive and asynchronous UI states. These failures were not covered by React Doctor's existing rules.

Before, these patterns passed silently. After, React Doctor reports only when static provenance, visibility, control-flow, and semantic-equivalence evidence make the diagnosis deterministic; ambiguous cases abstain.

## What changed

- Add seven diagnostics for responsive accessible names, reduced-motion content removal, animation-completion focus, mixed animation ownership, loading-trigger replacement, collapsed request errors, and transitioned composite-widget state.
- Keep project-wide reduced-motion policy on the existing `require-reduced-motion` diagnostic rather than adding a duplicate per-file rule.
- Add conservative Tailwind visibility and breakpoint analysis, including unknown-state handling for arbitrary properties and unsupported variants.
- Register all rules, add liveness fixtures, regression fuzz seeds, and a patch changeset.
- Add adversarial tests for control-flow reachability, import/ref provenance, form ownership, variant satisfiability, React key continuity, semantic fallbacks, and opaque boundaries.

Parity is currently blocked because `DAYTONA_API_KEY` is unavailable in the execution environment. Local RDE was attempted separately, but that checkout expects report `schemaVersion: 1` while React Doctor emits `schemaVersion: 3`.

## Test plan

- `nr test` — 15 tasks passed; React Doctor suite: 2,329 tests passed.
- `nr -C packages/oxlint-plugin-react-doctor test` — 910 files and 23,694 tests passed.
- `nr lint`
- `nr typecheck` — 16 tasks passed.
- `nr format:check`
- `nr build` — 9 tasks passed.
- `nr smoke:json-report` — schema version 3 smoke passed.
- Strict fuzz: 500 iterations for each of the seven new rules.
- Changed-scope React Doctor scan: no issues found.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new static-analysis surface in accessibility-critical paths; rules are designed to abstain when uncertain, but false positives/negatives on Tailwind and control-flow edge cases are possible until broadly exercised.
> 
> **Overview**
> Adds **seven new React Doctor oxlint rules** that flag responsive/a11y and async UI patterns only when static analysis can prove the issue; ambiguous cases abstain.
> 
> **Accessibility & design:** `no-responsive-hidden-accessible-name` (visible controls lose all name text at a breakpoint), `no-reduced-motion-content-removal` (Tailwind `motion-reduce:*` or `useReducedMotion` null branches drop meaningful content without an equivalent fallback), `no-focus-in-animation-completion-handler` (focus tied to `onAnimationEnd` / `onTransitionEnd`), `no-mixed-animation-owners`, `no-transitioned-composite-widget-state` (animated `aria-selected` / option styling).
> 
> **State & effects:** `loading-action-preserves-trigger`, `no-collapse-request-error-to-empty-state`.
> 
> Shared **Tailwind breakpoint constants** and deeper visibility/breakpoint utilities power the responsive rules. Rules are wired through **rule registry**, **generate-rule-registry**, **liveness fixtures**, a **patch changeset**, and **fuzz regression/target corpora** with adversarial pass cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49a68213ed036c2b95d6fe8f5dc3ae1541ff1df7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->