### PR TITLE
fix: no-all-caps-body-text false positive on CJK text

### DIFF
--- a/.changeset/fix-cjk-false-positive.md
+++ b/.changeset/fix-cjk-false-positive.md
@@ -1,0 +1,9 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Fix `no-all-caps-body-text` false positive on CJK text (caseless scripts)
+
+The rule was incorrectly flagging Japanese, Chinese, Korean, and Arabic text as "all caps" because it treated any text without lowercase letters as uppercase. Caseless scripts have no letter case, so they were always flagged.
+
+Now the rule only flags text that actually contains uppercase letters AND lacks lowercase letters. Caseless scripts are skipped entirely.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-all-caps-body-text.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-all-caps-body-text.test.ts
@@ -50,4 +50,52 @@ describe("no-all-caps-body-text", () => {
     );
     expect(result.diagnostics).toHaveLength(0);
   });
+
+  it("does not flag long Japanese text (caseless script)", () => {
+    const result = runRule(
+      noAllCapsBodyText,
+      `const Example = () => <p className="text-sm">一部のフォルダにアクセスできないため、移動対象を検出できていない可能性があります。フォルダのアクセス権を確認してから更新してください。</p>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag long Chinese text (caseless script)", () => {
+    const result = runRule(
+      noAllCapsBodyText,
+      `const Example = () => <p>由于无法访问某些文件夹，可能无法检测到移动目标。请检查文件夹的访问权限，然后更新。</p>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag long Korean text (caseless script)", () => {
+    const result = runRule(
+      noAllCapsBodyText,
+      `const Example = () => <p>일부 폴더에 액세스할 수 없으므로 이동 대상을 감지할 수 없습니다. 폴더 액세스 권한을 확인한 후 업데이트하십시오.</p>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag long Arabic text (caseless script)", () => {
+    const result = runRule(
+      noAllCapsBodyText,
+      `const Example = () => <p>لا يمكن الوصول إلى بعض المجلدات، لذا قد لا يتم اكتشاف أهداف النقل. يرجى التحقق من أذونات الوصول إلى المجلد، ثم التحديث.</p>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag mixed script text (English + Japanese) without uppercase", () => {
+    const result = runRule(
+      noAllCapsBodyText,
+      `const Example = () => <p>Please check フォルダのアクセス権を確認してから更新してください your folder permissions before continuing.</p>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags mixed script text when English portion is all caps", () => {
+    const result = runRule(
+      noAllCapsBodyText,
+      `const Example = () => <p>PLEASE CHECK フォルダのアクセス権を確認してから更新してください YOUR FOLDER PERMISSIONS.</p>;`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-all-caps-body-text.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-all-caps-body-text.ts
@@ -12,6 +12,7 @@ import { getStylePropertyStringValue } from "./utils/get-style-property-string-v
 
 const BODY_TEXT_ELEMENT_NAMES = new Set(["blockquote", "dd", "figcaption", "li", "p", "td"]);
 const LETTER_PATTERN = /\p{L}/u;
+const UPPERCASE_LETTER_PATTERN = /\p{Lu}/u;
 const LOWERCASE_LETTER_PATTERN = /\p{Ll}/u;
 
 const hasUppercaseStyle = (node: EsTreeNodeOfType<"JSXOpeningElement">): boolean => {
@@ -47,7 +48,9 @@ export const noAllCapsBodyText = defineRule({
       if (staticText.length < LONG_BODY_TEXT_MIN_CHARACTERS || !LETTER_PATTERN.test(staticText)) {
         return;
       }
-      const isLiteralUppercase = !LOWERCASE_LETTER_PATTERN.test(staticText);
+      const hasUppercase = UPPERCASE_LETTER_PATTERN.test(staticText);
+      const hasLowercase = LOWERCASE_LETTER_PATTERN.test(staticText);
+      const isLiteralUppercase = hasUppercase && !hasLowercase;
       if (!isLiteralUppercase && !hasUppercaseStyle(openingElement)) return;
       context.report({
         node: openingElement,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes `no-all-caps-body-text` false positive on Japanese, Chinese, Korean, and Arabic text (caseless scripts).

Closes #1429

## Root Cause

The rule's detection logic treated **any text without lowercase letters** as "all caps":

```typescript
const isLiteralUppercase = !LOWERCASE_LETTER_PATTERN.test(staticText);
```

For CJK scripts (Japanese, Chinese, Korean) and Arabic, which have no letter case, this condition is always true. Every long paragraph in these languages was incorrectly flagged as all-caps body copy, with no actionable fix (there is no "sentence case" for caseless scripts).

## The Fix

Changed the logic to **require actual uppercase letters** before considering text "all caps":

```typescript
const hasUppercase = UPPERCASE_LETTER_PATTERN.test(staticText);
const hasLowercase = LOWERCASE_LETTER_PATTERN.test(staticText);
const isLiteralUppercase = hasUppercase && !hasLowercase;
```

Now:
- **Caseless scripts** (CJK, Arabic, etc.) are skipped entirely
- **Latin text in all caps** is still caught correctly
- **Mixed-script text** is only flagged if the cased portion is all uppercase

## Scope

This fix is deliberately narrow and conservative:
- Only changes the "literal uppercase" detection logic
- Does not touch the `hasUppercaseStyle()` check (CSS `text-transform: uppercase` detection)
- Makes the rule MORE conservative (fewer false positives, no new false negatives)

## Testing

Added comprehensive unit tests covering:
- Japanese (Hiragana/Katakana/Kanji)
- Chinese (Simplified characters)
- Korean (Hangul)
- Arabic
- Mixed-script text (English + Japanese)
- Edge case: mixed script where only the English portion is all-caps (correctly flagged)

All existing tests pass.

## Parity

Could not run `rde parity` due to schema version mismatch in the eval environment (expecting v1, current is v3). However:
- The fix is highly targeted (one detection condition)
- Makes the rule more conservative (reduces findings, doesn't add new ones)
- No possibility of introducing false positives elsewhere
- Comprehensive unit tests cover the edge cases

## Changeset

Added patch-level changeset for `oxlint-plugin-react-doctor`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf666ee4-a3e7-4e67-a5f4-54bf514af487"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf666ee4-a3e7-4e67-a5f4-54bf514af487"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

