### PR TITLE
fix: ignore caseless body text in all-caps rule

### DIFF
--- a/.changeset/new-garlics-fold.md
+++ b/.changeset/new-garlics-fold.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Skip caseless scripts in no-all-caps-body-text so CJK body copy is not mistaken for uppercase.

--- a/packages/fuzz/corpus/regressions/no-all-caps-body-text--caseless-script.tsx
+++ b/packages/fuzz/corpus/regressions/no-all-caps-body-text--caseless-script.tsx
@@ -1,0 +1,10 @@
+// rule: no-all-caps-body-text
+// verdict: pass
+// weakness: copy-tracking
+// source: GitHub issue #1429
+
+export const JapaneseParagraph = () => (
+  <p>
+    一部のフォルダにアクセスできないため、移動対象を検出できていない可能性があります。フォルダのアクセス権を確認してから更新してください。
+  </p>
+);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-all-caps-body-text.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-all-caps-body-text.test.ts
@@ -35,6 +35,14 @@ describe("no-all-caps-body-text", () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("does not flag long body copy in caseless scripts", () => {
+    const result = runRule(
+      noAllCapsBodyText,
+      `const Example = () => <><p>一部のフォルダにアクセスできないため、移動対象を検出できていない可能性があります。フォルダのアクセス権を確認してから更新してください。</p><p className="uppercase">일부 폴더에 접근할 수 없어서 이동할 항목을 찾지 못했을 수 있습니다. 폴더 접근 권한을 확인한 다음 다시 시도해 주세요.</p></>;`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("uses the last duplicate inline text transform", () => {
     const result = runRule(
       noAllCapsBodyText,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-all-caps-body-text.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-all-caps-body-text.ts
@@ -11,8 +11,8 @@ import { getStringFromClassNameAttr } from "./utils/get-string-from-class-name-a
 import { getStylePropertyStringValue } from "./utils/get-style-property-string-value.js";
 
 const BODY_TEXT_ELEMENT_NAMES = new Set(["blockquote", "dd", "figcaption", "li", "p", "td"]);
-const LETTER_PATTERN = /\p{L}/u;
-const LOWERCASE_LETTER_PATTERN = /\p{Ll}/u;
+const CASED_LETTER_PATTERN = /[\p{Lu}\p{Ll}\p{Lt}]/u;
+const UPPERCASE_LETTER_PATTERN = /\p{Lu}/u;
 
 const hasUppercaseStyle = (node: EsTreeNodeOfType<"JSXOpeningElement">): boolean => {
   const classNameValue = getStringFromClassNameAttr(node);
@@ -44,10 +44,14 @@ export const noAllCapsBodyText = defineRule({
       if (!isNodeOfType(openingElement.name, "JSXIdentifier")) return;
       if (!BODY_TEXT_ELEMENT_NAMES.has(openingElement.name.name)) return;
       const staticText = getStaticJsxText(node).replace(/\s+/g, " ").trim();
-      if (staticText.length < LONG_BODY_TEXT_MIN_CHARACTERS || !LETTER_PATTERN.test(staticText)) {
+      if (
+        staticText.length < LONG_BODY_TEXT_MIN_CHARACTERS ||
+        !CASED_LETTER_PATTERN.test(staticText)
+      ) {
         return;
       }
-      const isLiteralUppercase = !LOWERCASE_LETTER_PATTERN.test(staticText);
+      const isLiteralUppercase =
+        UPPERCASE_LETTER_PATTERN.test(staticText) && staticText === staticText.toUpperCase();
       if (!isLiteralUppercase && !hasUppercaseStyle(openingElement)) return;
       context.report({
         node: openingElement,


### PR DESCRIPTION
## Why

Closes #1429.

`no-all-caps-body-text` treated any long passage without lowercase letters as literal uppercase. Caseless scripts such as Japanese and Korean therefore produced a warning even though sentence case is not applicable.

## What changed

- require body copy to contain a Unicode cased letter before checking literal or styled uppercase treatment
- require literal all-caps copy to contain an uppercase letter and equal its uppercase mapping
- add Japanese and Korean regression coverage, including the CSS `uppercase` path
- preserve the false-positive case in the fuzz corpus and add a patch changeset

## Eval results

Local RDE evaluation could not complete because the current harness expects JSON schema version `1`, while React Doctor now emits schema version `3`. No project result was classified as clean.

PR parity was not run because `DAYTONA_API_KEY` is not configured in this environment.

## Test plan

- `nr test`
- `nr typecheck`
- `nr lint`
- `nr format:check`
- `nr build`
- `nr smoke:json-report`
- `nr -C packages/oxlint-plugin-react-doctor test src/plugin/rules/design/no-all-caps-body-text.test.ts`
- `nr -C packages/fuzz test`
- `FUZZ_RULE=no-all-caps-body-text FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to one accessibility lint rule’s text heuristics; no runtime, auth, or data paths affected.
> 
> **Overview**
> Fixes false positives where long **Japanese, Korean, and other caseless** body copy was treated as “all caps” because the rule inferred uppercase from the absence of lowercase Latin letters.
> 
> The **`no-all-caps-body-text`** rule now **bails out** when static text has no Unicode **cased** letters (`Lu` / `Ll` / `Lt`), and treats **literal** all-caps only when the string contains an uppercase letter **and** equals `toUpperCase()`. Styled uppercase (`uppercase` class / `textTransform`) still applies for Latin text as before.
> 
> Adds **unit** coverage for long JP/KO paragraphs (including a styled-uppercase Korean case) and a **fuzz regression** for the GitHub #1429 Japanese example, plus a patch **changeset** for `oxlint-plugin-react-doctor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4f1a7b8ad352d3b230bc09728bd4767005282d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->