### PR TITLE
perf(fuzz): reuse parsed rule fixtures

### DIFF
--- a/packages/fuzz/src/fuzz-rule.ts
+++ b/packages/fuzz/src/fuzz-rule.ts
@@ -1,6 +1,7 @@
 import type { Rule } from "../../oxlint-plugin-react-doctor/src/plugin/utils/rule.js";
 import { parseFixture } from "../../oxlint-plugin-react-doctor/src/test-utils/parse-fixture.js";
-import { runRule } from "../../oxlint-plugin-react-doctor/src/test-utils/run-rule.js";
+import type { ParseFixtureResult } from "../../oxlint-plugin-react-doctor/src/test-utils/parse-fixture.js";
+import { runRuleOnParsedFixture } from "../../oxlint-plugin-react-doctor/src/test-utils/run-rule.js";
 import { runScanRule } from "../../oxlint-plugin-react-doctor/src/test-utils/run-scan-rule.js";
 import {
   CORPUS_PROGRAM_PROBABILITY,
@@ -65,31 +66,37 @@ interface RunOutcome {
   diagnosticSignature?: string[];
   crashDetail?: string;
   elapsedMs: number;
+  hasParseErrors?: boolean;
 }
 
-// Parseability is checked BEFORE the crash oracle runs — oxlint never runs
-// rules on unparseable files, so a rule throw on one is not a real crash.
-// `forceJsx` mirrors the run below: the rotated filename's extension is for
-// path gating, not lang selection.
-const hasParseErrors = (code: string, filename: string): boolean => {
-  try {
-    return parseFixture(code, { filename, forceJsx: true }).errors.length > 0;
-  } catch {
-    return true;
-  }
-};
-
 const runRuleOnCode = (rule: Rule, code: string, filename: string): RunOutcome => {
-  const startedAt = performance.now();
-  try {
-    if (typeof rule.scan === "function") {
+  if (typeof rule.scan === "function") {
+    const startedAt = performance.now();
+    try {
       const findings = runScanRule(rule, { relativePath: filename, content: code });
       return {
         diagnosticSignature: findings.map((finding) => finding.message).sort(),
         elapsedMs: performance.now() - startedAt,
       };
+    } catch (thrown) {
+      const detail = thrown instanceof Error ? (thrown.stack ?? thrown.message) : String(thrown);
+      return { crashDetail: detail, elapsedMs: performance.now() - startedAt };
     }
-    const result = runRule(rule, code, { filename, forceJsx: true });
+  }
+
+  let parsed: ParseFixtureResult;
+  try {
+    parsed = parseFixture(code, { filename, forceJsx: true });
+  } catch {
+    return { elapsedMs: 0, hasParseErrors: true };
+  }
+  if (parsed.errors.length > 0) {
+    return { elapsedMs: 0, hasParseErrors: true };
+  }
+
+  const startedAt = performance.now();
+  try {
+    const result = runRuleOnParsedFixture(rule, code, parsed, { filename, forceJsx: true });
     return {
       diagnosticSignature: result.diagnostics
         .map((diagnostic) => `${diagnostic.nodeType}: ${diagnostic.message}`)
@@ -143,11 +150,11 @@ export const fuzzRuleWithStats = (
     iteration: number,
     variantLabel?: string,
   ): RunOutcome | null => {
-    if (!isScanRule && hasParseErrors(code, filename)) {
+    const outcome = runRuleOnCode(rule, code, filename);
+    if (!isScanRule && outcome.hasParseErrors === true) {
       stats.skippedParseErrorCount += 1;
       return null;
     }
-    const outcome = runRuleOnCode(rule, code, filename);
     stats.executedProgramCount += 1;
     if (outcome.crashDetail !== undefined) {
       findings.push({
@@ -278,6 +285,7 @@ export const fuzzRuleWithStats = (
       for (const variant of buildVerdictPreservingVariants(code, filename)) {
         if (!variant.mustPreserveVerdict) continue;
         const variantOutcome = runRuleOnCode(rule, variant.code, filename);
+        if (variantOutcome.hasParseErrors === true) continue;
         if (variantOutcome.crashDetail !== undefined) {
           findings.push({
             ruleId,
@@ -308,8 +316,8 @@ export const fuzzRuleWithStats = (
       ...buildEquivalentFuzzVariants(code, sections),
       ...buildAstEquivalentFuzzVariants(code, filename, EFFECT_CALLBACK_ALIAS_RULE_IDS.has(ruleId)),
     ]) {
-      if (hasParseErrors(variant.code, filename)) continue;
       const variantOutcome = runRuleOnCode(rule, variant.code, filename);
+      if (variantOutcome.hasParseErrors === true) continue;
       if (variantOutcome.crashDetail !== undefined) {
         findings.push({
           ruleId,

--- a/packages/oxlint-plugin-react-doctor/src/test-utils/parse-fixture.ts
+++ b/packages/oxlint-plugin-react-doctor/src/test-utils/parse-fixture.ts
@@ -11,7 +11,7 @@ interface ParseFixtureOptions {
   forceJsx?: boolean;
 }
 
-interface ParseFixtureResult {
+export interface ParseFixtureResult {
   program: EsTreeNode;
   errors: ReadonlyArray<{ message: string }>;
 }

--- a/packages/oxlint-plugin-react-doctor/src/test-utils/run-rule.ts
+++ b/packages/oxlint-plugin-react-doctor/src/test-utils/run-rule.ts
@@ -1,6 +1,7 @@
 import { attachParentReferences } from "./attach-parent-references.js";
 import { attachSourceLocations } from "./attach-source-locations.js";
 import { parseFixture } from "./parse-fixture.js";
+import type { ParseFixtureResult } from "./parse-fixture.js";
 import { isAstNode } from "../plugin/utils/is-ast-node.js";
 import type { EsTreeNode } from "../plugin/utils/es-tree-node.js";
 import type { ReportDescriptor } from "../plugin/utils/report-descriptor.js";
@@ -8,7 +9,9 @@ import type { Rule } from "../plugin/utils/rule.js";
 import type { RuleContext } from "../plugin/utils/rule-context.js";
 import type { RuleVisitors } from "../plugin/utils/rule-visitors.js";
 import { analyzeScopes } from "../plugin/semantic/scope-analysis.js";
+import type { ScopeAnalysis } from "../plugin/semantic/scope-analysis.js";
 import { analyzeControlFlow } from "../plugin/semantic/control-flow-graph.js";
+import type { ControlFlowAnalysis } from "../plugin/semantic/control-flow-graph.js";
 
 export interface RunRuleOptions {
   filename?: string;
@@ -58,17 +61,18 @@ const dispatchTreeWalk = (root: EsTreeNode, visitors: RuleVisitors): void => {
 // every `report({...})` call as a `RuleDiagnostic`. Used by every
 // `<rule>.test.ts` to assert pass/fail semantics ported from OXC's
 // `Tester::new(...).pass / .fail`.
-export const runRule = (rule: Rule, code: string, options: RunRuleOptions = {}): RunRuleResult => {
-  const parsed = parseFixture(code, {
-    filename: options.filename,
-    forceJsx: options.forceJsx,
-  });
+export const runRuleOnParsedFixture = (
+  rule: Rule,
+  code: string,
+  parsed: ParseFixtureResult,
+  options: RunRuleOptions = {},
+): RunRuleResult => {
   attachParentReferences(parsed.program);
   attachSourceLocations(parsed.program, code);
 
   const diagnostics: RuleDiagnostic[] = [];
-  const scopes = analyzeScopes(parsed.program);
-  const cfg = analyzeControlFlow(parsed.program);
+  let scopes: ScopeAnalysis | undefined;
+  let controlFlow: ControlFlowAnalysis | undefined;
   const context: RuleContext = {
     report: (descriptor: ReportDescriptor) => {
       diagnostics.push({
@@ -80,12 +84,26 @@ export const runRule = (rule: Rule, code: string, options: RunRuleOptions = {}):
     // to exercise a host with no filename.
     filename: "filename" in options ? options.filename : "fixture.tsx",
     settings: options.settings,
-    scopes,
-    cfg,
+    get scopes() {
+      scopes ??= analyzeScopes(parsed.program);
+      return scopes;
+    },
+    get cfg() {
+      controlFlow ??= analyzeControlFlow(parsed.program);
+      return controlFlow;
+    },
   };
 
   const visitors = rule.create(context);
   dispatchTreeWalk(parsed.program, visitors);
 
   return { diagnostics, parseErrors: parsed.errors };
+};
+
+export const runRule = (rule: Rule, code: string, options: RunRuleOptions = {}): RunRuleResult => {
+  const parsed = parseFixture(code, {
+    filename: options.filename,
+    forceJsx: options.forceJsx,
+  });
+  return runRuleOnParsedFixture(rule, code, parsed, options);
 };


### PR DESCRIPTION
## Why

The rule fuzzer parsed every valid AST twice: once to reject malformed programs, then again to execute the rule. It also eagerly built scope and control-flow analyses for every parsed fixture, even when a rule never accessed them.

On a 1,000-iteration strict corpus benchmark, fuzz execution took 8.08 seconds and the process tree peaked at 2.91 GB RSS. Reusing parsed fixtures and lazily computing semantic analyses reduced execution to 4.46 seconds (about 45% faster) and peak RSS to 2.67 GB.

## What changed

- expose the internal parsed-fixture result and add a test-runner entry point that accepts it
- parse fuzz programs once while preserving malformed-input skips and the rule-only slow timer
- compute scope and control-flow analysis only when the tested rule accesses it
- preserve the existing `runRule` API for all rule tests

## Eval results

RDE/parity was not run because this changes only the private fuzz harness and internal test utilities; it does not change detector behavior or published runtime code.

## Test plan

- `FUZZ_ITERATIONS=1 nr fuzz` — 746 tests passed
- `nr test` — 15/15 workspace tasks passed
- `nr lint` — passed with existing corpus warnings
- `nr typecheck` — 16/16 workspace tasks passed
- `nr format:check` — passed
- `nr smoke:json-report` — passed (`schemaVersion=3`, 0 diagnostics)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the fuzz package and internal test utilities; detector and runtime plugin code are untouched.
> 
> **Overview**
> **Speeds up the rule fuzz harness** by parsing each valid program once and feeding that AST into rule execution, instead of parsing again inside the test runner.
> 
> The fuzz path now exports **`ParseFixtureResult`** and **`runRuleOnParsedFixture`**, with **`runRule`** unchanged for existing rule tests. **`runRuleOnParsedFixture`** defers **scope** and **control-flow** analysis until a rule actually reads **`context.scopes`** or **`context.cfg`**.
> 
> **`fuzz-rule.ts`** folds parse-error detection into **`runRuleOnCode`** via a **`hasParseErrors`** flag on **`RunOutcome`**, so malformed inputs are still skipped before crash/slow/invariant oracles while timing covers rule work only (not duplicate parses).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80ea0d33cf89ee9d3db282c5dd915cce79c874ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->