### PR TITLE
fix: detect React Compiler from compatibility runtime

### DIFF
--- a/.changeset/fix-react-compiler-detection-1436.md
+++ b/.changeset/fix-react-compiler-detection-1436.md
@@ -1,0 +1,12 @@
+---
+"@react-doctor/core": patch
+"react-doctor": patch
+---
+
+fix: detect React Compiler when babel-plugin-react-compiler is installed
+
+Fixes false positive in `context-provider-value-from-unmemoized-local-literal` and other React Compiler-gated rules when the compiler is installed as a package dependency without explicit configuration in config files.
+
+The detector now checks for `babel-plugin-react-compiler` and `react-compiler-runtime` in package dependencies, not just in babel/vite/next config files.
+
+Closes #1436

--- a/.changeset/fix-react-compiler-detection-1436.md
+++ b/.changeset/fix-react-compiler-detection-1436.md
@@ -3,10 +3,4 @@
 "react-doctor": patch
 ---
 
-fix: detect React Compiler when babel-plugin-react-compiler is installed
-
-Fixes false positive in `context-provider-value-from-unmemoized-local-literal` and other React Compiler-gated rules when the compiler is installed as a package dependency without explicit configuration in config files.
-
-The detector now checks for `babel-plugin-react-compiler` and `react-compiler-runtime` in package dependencies, not just in babel/vite/next config files.
-
-Closes #1436
+Detect React Compiler from its compatibility runtime so compiler-gated diagnostics stay disabled when configuration lives outside the scanned package.

--- a/packages/core/src/project-info/detectors.ts
+++ b/packages/core/src/project-info/detectors.ts
@@ -278,6 +278,10 @@ export const frameworkMergeRank = (framework: Framework): number => {
 };
 
 const REACT_COMPILER_LINT_PACKAGES = new Set(["eslint-plugin-react-compiler"]);
+const REACT_COMPILER_PACKAGES = new Set([
+  "babel-plugin-react-compiler",
+  "react-compiler-runtime",
+]);
 
 const NEXT_CONFIG_FILENAMES = [
   "next.config.js",
@@ -2045,6 +2049,8 @@ const hasCompilerConfigurationInAncestors = (directory: string): boolean => {
 };
 
 export const detectReactCompiler = (directory: string, packageJson: PackageJson): boolean =>
+  hasCompilerPackage(packageJson, REACT_COMPILER_PACKAGES) ||
+  hasCompilerPackageInAncestors(directory, REACT_COMPILER_PACKAGES) ||
   hasCompilerConfiguration(directory, packageJson) ||
   hasCompilerConfigurationInAncestors(directory);
 

--- a/packages/core/src/project-info/detectors.ts
+++ b/packages/core/src/project-info/detectors.ts
@@ -278,10 +278,7 @@ export const frameworkMergeRank = (framework: Framework): number => {
 };
 
 const REACT_COMPILER_LINT_PACKAGES = new Set(["eslint-plugin-react-compiler"]);
-const REACT_COMPILER_PACKAGES = new Set([
-  "babel-plugin-react-compiler",
-  "react-compiler-runtime",
-]);
+const REACT_COMPILER_RUNTIME_PACKAGES = new Set(["react-compiler-runtime"]);
 
 const NEXT_CONFIG_FILENAMES = [
   "next.config.js",
@@ -2049,8 +2046,8 @@ const hasCompilerConfigurationInAncestors = (directory: string): boolean => {
 };
 
 export const detectReactCompiler = (directory: string, packageJson: PackageJson): boolean =>
-  hasCompilerPackage(packageJson, REACT_COMPILER_PACKAGES) ||
-  hasCompilerPackageInAncestors(directory, REACT_COMPILER_PACKAGES) ||
+  hasCompilerPackage(packageJson, REACT_COMPILER_RUNTIME_PACKAGES) ||
+  hasCompilerPackageInAncestors(directory, REACT_COMPILER_RUNTIME_PACKAGES) ||
   hasCompilerConfiguration(directory, packageJson) ||
   hasCompilerConfigurationInAncestors(directory);
 

--- a/packages/core/tests/discover-project.test.ts
+++ b/packages/core/tests/discover-project.test.ts
@@ -1238,6 +1238,35 @@ describe("discoverProject", () => {
     expect(discoverProject(projectDirectory).hasReactCompiler).toBe(true);
   });
 
+  it("detects React Compiler when babel-plugin-react-compiler is installed without explicit config", () => {
+    const projectDirectory = path.join(tempDirectory, "installed-react-compiler");
+    fs.mkdirSync(projectDirectory, { recursive: true });
+    fs.writeFileSync(
+      path.join(projectDirectory, "package.json"),
+      JSON.stringify({
+        name: "installed-react-compiler",
+        dependencies: { react: "^19.0.0" },
+        devDependencies: { "babel-plugin-react-compiler": "^0.0.0" },
+      }),
+    );
+
+    expect(discoverProject(projectDirectory).hasReactCompiler).toBe(true);
+  });
+
+  it("detects React Compiler when react-compiler-runtime is installed", () => {
+    const projectDirectory = path.join(tempDirectory, "runtime-react-compiler");
+    fs.mkdirSync(projectDirectory, { recursive: true });
+    fs.writeFileSync(
+      path.join(projectDirectory, "package.json"),
+      JSON.stringify({
+        name: "runtime-react-compiler",
+        dependencies: { react: "^19.0.0", "react-compiler-runtime": "^19.0.0" },
+      }),
+    );
+
+    expect(discoverProject(projectDirectory).hasReactCompiler).toBe(true);
+  });
+
   it("detects React Compiler configured through a required CommonJS helper", () => {
     const projectDirectory = path.join(tempDirectory, "required-react-compiler-config");
     fs.mkdirSync(path.join(projectDirectory, "build"), { recursive: true });

--- a/packages/core/tests/discover-project.test.ts
+++ b/packages/core/tests/discover-project.test.ts
@@ -1238,29 +1238,38 @@ describe("discoverProject", () => {
     expect(discoverProject(projectDirectory).hasReactCompiler).toBe(true);
   });
 
-  it("detects React Compiler when babel-plugin-react-compiler is installed without explicit config", () => {
-    const projectDirectory = path.join(tempDirectory, "installed-react-compiler");
-    fs.mkdirSync(projectDirectory, { recursive: true });
-    fs.writeFileSync(
-      path.join(projectDirectory, "package.json"),
-      JSON.stringify({
-        name: "installed-react-compiler",
-        dependencies: { react: "^19.0.0" },
-        devDependencies: { "babel-plugin-react-compiler": "^0.0.0" },
-      }),
-    );
-
-    expect(discoverProject(projectDirectory).hasReactCompiler).toBe(true);
-  });
-
-  it("detects React Compiler when react-compiler-runtime is installed", () => {
+  it("detects React Compiler from its compatibility runtime", () => {
     const projectDirectory = path.join(tempDirectory, "runtime-react-compiler");
     fs.mkdirSync(projectDirectory, { recursive: true });
     fs.writeFileSync(
       path.join(projectDirectory, "package.json"),
       JSON.stringify({
         name: "runtime-react-compiler",
-        dependencies: { react: "^19.0.0", "react-compiler-runtime": "^19.0.0" },
+        dependencies: { react: "^18.0.0", "react-compiler-runtime": "^1.0.0" },
+      }),
+    );
+
+    expect(discoverProject(projectDirectory).hasReactCompiler).toBe(true);
+  });
+
+  it("detects React Compiler from an ancestor compatibility runtime", () => {
+    const monorepoDirectory = path.join(tempDirectory, "runtime-react-compiler-monorepo");
+    const projectDirectory = path.join(monorepoDirectory, "packages", "app");
+    fs.mkdirSync(projectDirectory, { recursive: true });
+    fs.writeFileSync(
+      path.join(monorepoDirectory, "package.json"),
+      JSON.stringify({
+        name: "runtime-react-compiler-monorepo",
+        private: true,
+        dependencies: { "react-compiler-runtime": "^1.0.0" },
+        workspaces: ["packages/*"],
+      }),
+    );
+    fs.writeFileSync(
+      path.join(projectDirectory, "package.json"),
+      JSON.stringify({
+        name: "runtime-react-compiler-app",
+        dependencies: { react: "^18.0.0" },
       }),
     );
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/context-provider-value-from-unmemoized-local-literal.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/context-provider-value-from-unmemoized-local-literal.test.ts
@@ -1245,24 +1245,4 @@ describe("context-provider-value-from-unmemoized-local-literal", () => {
   it("is disabled on React Compiler projects", () => {
     expect(contextProviderValueFromUnmemoizedLocalLiteral.disabledWhen).toContain("react-compiler");
   });
-
-  it("does not flag when babel-plugin-react-compiler is installed", () => {
-    const result = runRule(
-      contextProviderValueFromUnmemoizedLocalLiteral,
-      `
-      import { createContext, useState } from "react";
-      const ThemeContext = createContext(null);
-      function App({ theme }) {
-        const value = { theme };
-        return <ThemeContext.Provider value={value}><Child /></ThemeContext.Provider>;
-      }
-    `,
-      {
-        projectInfo: {
-          hasReactCompiler: true,
-        } as any,
-      },
-    );
-    expect(result.diagnostics).toHaveLength(0);
-  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/context-provider-value-from-unmemoized-local-literal.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/context-provider-value-from-unmemoized-local-literal.test.ts
@@ -1245,4 +1245,24 @@ describe("context-provider-value-from-unmemoized-local-literal", () => {
   it("is disabled on React Compiler projects", () => {
     expect(contextProviderValueFromUnmemoizedLocalLiteral.disabledWhen).toContain("react-compiler");
   });
+
+  it("does not flag when babel-plugin-react-compiler is installed", () => {
+    const result = runRule(
+      contextProviderValueFromUnmemoizedLocalLiteral,
+      `
+      import { createContext, useState } from "react";
+      const ThemeContext = createContext(null);
+      function App({ theme }) {
+        const value = { theme };
+        return <ThemeContext.Provider value={value}><Child /></ThemeContext.Provider>;
+      }
+    `,
+      {
+        projectInfo: {
+          hasReactCompiler: true,
+        } as any,
+      },
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
## Why

React Compiler-gated diagnostics should stay disabled when a scanned package contains code compiled for React 17 or 18, even if the compiler configuration lives elsewhere in the workspace.

Before, project discovery recognized active build-tool configuration but not the `react-compiler-runtime` dependency required by compiled React 17/18 output. Treating `babel-plugin-react-compiler` installation alone as activation would suppress valid diagnostics in projects that installed but never enabled the transform, so this keeps configuration detection strict and uses the compatibility runtime as the additional evidence.

## What changed

- detect `react-compiler-runtime` in the scanned package or an ancestor package
- preserve the existing rule capability gate and package-only transform false-positive guard
- cover direct-package and monorepo-ancestor runtime detection
- add a patch changeset for `@react-doctor/core` and `react-doctor`

## Eval results

Daytona parity could not run because `DAYTONA_API_KEY` is unavailable in the ship environment. The parity comparator and input validator passed all 31 tests. The bounded local RDE fallback was also blocked because its checkout requires an unavailable `AXIOM_DATASET` setting.

## Test plan

- `nr build`
- `nr -C packages/core test tests/discover-project.test.ts` — 276 passed
- `nr test` — 15 workspace tasks passed
- `nr lint` — passed (existing fuzz-fixture warnings only)
- `nr typecheck` — 16 workspace tasks passed
- `nr format:check` — 5,614 files checked
- `nr smoke:json-report` — schema v3 smoke passed
- `node --test .agents/skills/run-parity/scripts/compare-parity.test.mjs` — 16 passed
- `node --test .agents/skills/run-parity/scripts/validate-parity-input.test.mjs` — 15 passed

Refs #1436