### PR TITLE
fix: detect React Compiler in babel config files and package.json babel field

### DIFF
--- a/.changeset/fix-babel-compiler-detection-1448.md
+++ b/.changeset/fix-babel-compiler-detection-1448.md
@@ -1,0 +1,6 @@
+---
+"@react-doctor/core": patch
+"react-doctor": patch
+---
+
+Detect React Compiler in babel config files and package.json babel field. Previously, projects using babel-plugin-react-compiler in package.json babel config or babel config files would fail detection, causing React Compiler-gated rules like context-provider-value-from-unmemoized-local-literal to incorrectly fire. Fixes #1448.

--- a/packages/core/src/project-info/detectors.ts
+++ b/packages/core/src/project-info/detectors.ts
@@ -2003,7 +2003,7 @@ const analyzeConfigNode = (
 };
 
 const hasCompilerInConfigFile = (filePath: string): boolean =>
-  analyzeConfigModuleExport(filePath, "default", false, 0, new Set<string>());
+  analyzeConfigModuleExport(filePath, "default", true, 0, new Set<string>());
 
 const hasCompilerInConfigFiles = (directory: string, filenames: string[]): boolean =>
   filenames.some((filename) => hasCompilerInConfigFile(path.join(directory, filename)));
@@ -2014,7 +2014,7 @@ const hasCompilerInPackageJsonConfig = (packageJson: PackageJson): boolean =>
     ts.parseJsonText("package.json", JSON.stringify(packageJson.babel)),
     "package.json#babel",
     "default",
-    false,
+    true,
     0,
     new Set<string>(),
   );

--- a/packages/core/tests/discover-project.test.ts
+++ b/packages/core/tests/discover-project.test.ts
@@ -1238,6 +1238,23 @@ describe("discoverProject", () => {
     expect(discoverProject(projectDirectory).hasReactCompiler).toBe(true);
   });
 
+  it("detects React Compiler from package.json babel config", () => {
+    const projectDirectory = path.join(tempDirectory, "package-json-babel-react-compiler");
+    fs.mkdirSync(projectDirectory, { recursive: true });
+    fs.writeFileSync(
+      path.join(projectDirectory, "package.json"),
+      JSON.stringify({
+        name: "package-json-babel-react-compiler",
+        dependencies: { react: "^18.0.0" },
+        babel: {
+          plugins: ["babel-plugin-react-compiler"],
+        },
+      }),
+    );
+
+    expect(discoverProject(projectDirectory).hasReactCompiler).toBe(true);
+  });
+
   it("detects React Compiler from its compatibility runtime", () => {
     const projectDirectory = path.join(tempDirectory, "runtime-react-compiler");
     fs.mkdirSync(projectDirectory, { recursive: true });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Root Cause

The React Compiler detection was failing for projects using `babel-plugin-react-compiler` in:
- package.json `babel` field
- babel config files (.babelrc, babel.config.js, etc.)

This caused React Compiler-gated rules like `context-provider-value-from-unmemoized-local-literal` to incorrectly fire even when React Compiler was enabled.

The bug was in `packages/core/src/project-info/detectors.ts`:
- `hasCompilerInConfigFile` used `allowCompilerTransform: false` 
- `hasCompilerInPackageJsonConfig` used `allowCompilerTransform: false`

When `allowCompilerTransform: false`, the code at line 1512 won't detect the string literals `"babel-plugin-react-compiler"` or `"react-compiler"`.

## Fix

Changed both functions to use `allowCompilerTransform: true`, enabling proper detection of the babel plugin in configuration files.

## Testing

- Added unit test for package.json babel config detection
- Verified fix works with manual testing
- All existing tests pass

## Note

Full `rde parity` run recommended before merge to validate no cross-repo regressions, though the fix is very targeted and low-risk.

Closes #1448
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-38ca5954-e85b-4446-8faf-78512b5dfa84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-38ca5954-e85b-4446-8faf-78512b5dfa84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

