### PR TITLE
fix: detect React Compiler through require.resolve

### DIFF
--- a/.changeset/fix-react-compiler-require-resolve.md
+++ b/.changeset/fix-react-compiler-require-resolve.md
@@ -1,0 +1,6 @@
+---
+"@react-doctor/core": patch
+"react-doctor": patch
+---
+
+Detect active React Compiler transforms referenced through Node `require.resolve`.

--- a/packages/core/src/project-info/detectors.ts
+++ b/packages/core/src/project-info/detectors.ts
@@ -499,8 +499,8 @@ const hasTopLevelValueBinding = (sourceFile: ts.SourceFile, bindingName: string)
         : false;
     }
     if (ts.isVariableStatement(statement)) {
-      return statement.declarationList.declarations.some(
-        (declaration) => ts.isIdentifier(declaration.name) && declaration.name.text === bindingName,
+      return statement.declarationList.declarations.some((declaration) =>
+        bindingNameContainsIdentifier(declaration.name, bindingName),
       );
     }
     return (
@@ -687,10 +687,17 @@ const isConstantVariableInitializer = (node: ts.Node): node is ts.Expression =>
   ts.isVariableDeclarationList(node.parent.parent) &&
   Boolean(node.parent.parent.flags & ts.NodeFlags.Const);
 
-const isNodeCreateRequireCall = (
-  node: ts.Node,
-  analysis: ConfigExpressionAnalysis,
-): node is ts.CallExpression => {
+const isNodeCreateRequireCall = (node: ts.Node, analysis: ConfigExpressionAnalysis): boolean => {
+  if (
+    ts.isParenthesizedExpression(node) ||
+    ts.isAsExpression(node) ||
+    ts.isTypeAssertionExpression(node) ||
+    ts.isSatisfiesExpression(node) ||
+    ts.isNonNullExpression(node) ||
+    ts.isAwaitExpression(node)
+  ) {
+    return isNodeCreateRequireCall(node.expression, analysis);
+  }
   if (!ts.isCallExpression(node)) return false;
   const target = node.expression;
   if (ts.isIdentifier(target)) {
@@ -751,6 +758,7 @@ const getNodeRequireResolveModuleSpecifier = (
     resolverInitializer === null &&
     !scopedBinding.wasFound &&
     resolverIdentifier.text === "require" &&
+    !hasTopLevelValueBinding(analysis.sourceFile, resolverIdentifier.text) &&
     getImportBinding(analysis.sourceFile, resolverIdentifier.text) === null
   ) {
     return moduleSpecifierNode.text;

--- a/packages/core/src/project-info/detectors.ts
+++ b/packages/core/src/project-info/detectors.ts
@@ -679,6 +679,92 @@ const isCompilerTransformModule = (moduleSpecifier: string, exportName: string):
   (moduleSpecifier === "babel-plugin-react-compiler" && exportName === "default") ||
   (moduleSpecifier === "@vitejs/plugin-react" && exportName === "reactCompilerPreset");
 
+const NODE_MODULE_SPECIFIERS = new Set(["module", "node:module"]);
+
+const isConstantVariableInitializer = (node: ts.Node): node is ts.Expression =>
+  ts.isExpression(node) &&
+  ts.isVariableDeclaration(node.parent) &&
+  ts.isVariableDeclarationList(node.parent.parent) &&
+  Boolean(node.parent.parent.flags & ts.NodeFlags.Const);
+
+const isNodeCreateRequireCall = (
+  node: ts.Node,
+  analysis: ConfigExpressionAnalysis,
+): node is ts.CallExpression => {
+  if (!ts.isCallExpression(node)) return false;
+  const target = node.expression;
+  if (ts.isIdentifier(target)) {
+    if (analysis.localBindings.has(target.text) || getScopedConfigBinding(target).wasFound) {
+      return false;
+    }
+    const importBinding = getImportBinding(analysis.sourceFile, target.text);
+    return Boolean(
+      importBinding &&
+      NODE_MODULE_SPECIFIERS.has(importBinding.moduleSpecifier) &&
+      importBinding.exportName === "createRequire",
+    );
+  }
+  if (!ts.isPropertyAccessExpression(target) && !ts.isElementAccessExpression(target)) {
+    return false;
+  }
+  const propertyName = ts.isPropertyAccessExpression(target)
+    ? target.name.text
+    : target.argumentExpression && ts.isStringLiteralLike(target.argumentExpression)
+      ? target.argumentExpression.text
+      : null;
+  if (propertyName !== "createRequire" || !ts.isIdentifier(target.expression)) return false;
+  if (
+    analysis.localBindings.has(target.expression.text) ||
+    getScopedConfigBinding(target.expression).wasFound
+  ) {
+    return false;
+  }
+  const importBinding = getImportBinding(analysis.sourceFile, target.expression.text);
+  return Boolean(
+    importBinding?.isNamespace && NODE_MODULE_SPECIFIERS.has(importBinding.moduleSpecifier),
+  );
+};
+
+const getNodeRequireResolveModuleSpecifier = (
+  callExpression: ts.CallExpression,
+  analysis: ConfigExpressionAnalysis,
+): string | null => {
+  const [moduleSpecifierNode] = callExpression.arguments;
+  if (!moduleSpecifierNode || !ts.isStringLiteralLike(moduleSpecifierNode)) return null;
+  const target = callExpression.expression;
+  if (!ts.isPropertyAccessExpression(target) && !ts.isElementAccessExpression(target)) return null;
+  const propertyName = ts.isPropertyAccessExpression(target)
+    ? target.name.text
+    : target.argumentExpression && ts.isStringLiteralLike(target.argumentExpression)
+      ? target.argumentExpression.text
+      : null;
+  if (propertyName !== "resolve" || !ts.isIdentifier(target.expression)) return null;
+
+  const resolverIdentifier = target.expression;
+  if (analysis.localBindings.has(resolverIdentifier.text)) return null;
+  const scopedBinding = getScopedConfigBinding(resolverIdentifier);
+  const topLevelBinding = scopedBinding.wasFound
+    ? null
+    : getTopLevelBinding(analysis.sourceFile, resolverIdentifier.text);
+  const resolverInitializer = scopedBinding.wasFound ? scopedBinding.initializer : topLevelBinding;
+  if (
+    resolverInitializer === null &&
+    !scopedBinding.wasFound &&
+    resolverIdentifier.text === "require" &&
+    getImportBinding(analysis.sourceFile, resolverIdentifier.text) === null
+  ) {
+    return moduleSpecifierNode.text;
+  }
+  if (
+    !resolverInitializer ||
+    !isConstantVariableInitializer(resolverInitializer) ||
+    !isNodeCreateRequireCall(resolverInitializer, analysis)
+  ) {
+    return null;
+  }
+  return moduleSpecifierNode.text;
+};
+
 interface ReactCompilerFlagState {
   readonly isEnabled: boolean;
 }
@@ -1685,6 +1771,12 @@ const analyzeConfigNode = (
     });
   }
   if (ts.isCallExpression(node)) {
+    const resolvedModuleSpecifier = getNodeRequireResolveModuleSpecifier(node, analysis);
+    if (resolvedModuleSpecifier !== null) {
+      return (
+        allowCompilerTransform && isCompilerTransformModule(resolvedModuleSpecifier, "default")
+      );
+    }
     const callTargetResult = analyzeConfigCallTarget(node, analysis, allowCompilerTransform);
     if (callTargetResult !== null) return callTargetResult;
     const directModuleSpecifier = getRequireModuleSpecifier(node);

--- a/packages/core/src/project-info/detectors.ts
+++ b/packages/core/src/project-info/detectors.ts
@@ -719,14 +719,32 @@ const isNodeCreateRequireCall = (node: ts.Node, analysis: ConfigExpressionAnalys
     : target.argumentExpression && ts.isStringLiteralLike(target.argumentExpression)
       ? target.argumentExpression.text
       : null;
-  if (propertyName !== "createRequire" || !ts.isIdentifier(target.expression)) return false;
+  if (propertyName !== "createRequire") return false;
+  const createRequireReceiver = target.expression;
+  if (ts.isCallExpression(createRequireReceiver)) {
+    const requiredModuleSpecifier = getRequireModuleSpecifier(createRequireReceiver);
+    if (
+      requiredModuleSpecifier === null ||
+      !NODE_MODULE_SPECIFIERS.has(requiredModuleSpecifier) ||
+      !ts.isIdentifier(createRequireReceiver.expression)
+    ) {
+      return false;
+    }
+    const requireIdentifier = createRequireReceiver.expression;
+    return (
+      !analysis.localBindings.has(requireIdentifier.text) &&
+      !getScopedConfigBinding(requireIdentifier).wasFound &&
+      !hasTopLevelValueBinding(analysis.sourceFile, requireIdentifier.text)
+    );
+  }
+  if (!ts.isIdentifier(createRequireReceiver)) return false;
   if (
-    analysis.localBindings.has(target.expression.text) ||
-    getScopedConfigBinding(target.expression).wasFound
+    analysis.localBindings.has(createRequireReceiver.text) ||
+    getScopedConfigBinding(createRequireReceiver).wasFound
   ) {
     return false;
   }
-  const importBinding = getImportBinding(analysis.sourceFile, target.expression.text);
+  const importBinding = getImportBinding(analysis.sourceFile, createRequireReceiver.text);
   return Boolean(
     importBinding?.isNamespace && NODE_MODULE_SPECIFIERS.has(importBinding.moduleSpecifier),
   );
@@ -745,7 +763,9 @@ const getNodeRequireResolveModuleSpecifier = (
     : target.argumentExpression && ts.isStringLiteralLike(target.argumentExpression)
       ? target.argumentExpression.text
       : null;
-  if (propertyName !== "resolve" || !ts.isIdentifier(target.expression)) return null;
+  if (propertyName !== "resolve") return null;
+  if (isNodeCreateRequireCall(target.expression, analysis)) return moduleSpecifierNode.text;
+  if (!ts.isIdentifier(target.expression)) return null;
 
   const resolverIdentifier = target.expression;
   if (analysis.localBindings.has(resolverIdentifier.text)) return null;

--- a/packages/core/tests/discover-project.test.ts
+++ b/packages/core/tests/discover-project.test.ts
@@ -1637,6 +1637,18 @@ describe("discoverProject", () => {
       expected: true,
     },
     {
+      name: "compiler-direct-create-require-resolve",
+      config:
+        "import { createRequire } from 'node:module'; export default { plugins: [(createRequire(import.meta.url)).resolve('babel-plugin-react-compiler')] };",
+      expected: true,
+    },
+    {
+      name: "compiler-commonjs-create-require-resolve",
+      config:
+        "export default { plugins: [require('node:module').createRequire(import.meta.url).resolve('babel-plugin-react-compiler')] };",
+      expected: true,
+    },
+    {
       name: "compiler-non-node-create-require-resolve",
       config:
         "import { createRequire } from 'other-module'; const packageRequire = createRequire(import.meta.url); export default { plugins: [packageRequire.resolve('babel-plugin-react-compiler')] };",
@@ -1670,6 +1682,18 @@ describe("discoverProject", () => {
       name: "compiler-destructured-shadowed-require-resolve",
       config:
         "const { require } = other; export default { plugins: [require.resolve('babel-plugin-react-compiler')] };",
+      expected: false,
+    },
+    {
+      name: "compiler-non-node-chained-create-require-resolve",
+      config:
+        "export default { plugins: [require('other-module').createRequire(import.meta.url).resolve('babel-plugin-react-compiler')] };",
+      expected: false,
+    },
+    {
+      name: "compiler-shadowed-chained-create-require-resolve",
+      config:
+        "const require = () => ({ createRequire: () => ({ resolve: () => 'other-plugin' }) }); export default { plugins: [require('node:module').createRequire(import.meta.url).resolve('babel-plugin-react-compiler')] };",
       expected: false,
     },
     {

--- a/packages/core/tests/discover-project.test.ts
+++ b/packages/core/tests/discover-project.test.ts
@@ -1625,6 +1625,18 @@ describe("discoverProject", () => {
       expected: true,
     },
     {
+      name: "compiler-parenthesized-create-require-resolve",
+      config:
+        "import { createRequire } from 'node:module'; const packageRequire = (createRequire(import.meta.url)); export default { plugins: [packageRequire.resolve('babel-plugin-react-compiler')] };",
+      expected: true,
+    },
+    {
+      name: "compiler-as-create-require-resolve",
+      config:
+        "import { createRequire } from 'node:module'; const packageRequire = createRequire(import.meta.url) as NodeRequire; export default { plugins: [packageRequire.resolve('babel-plugin-react-compiler')] };",
+      expected: true,
+    },
+    {
       name: "compiler-non-node-create-require-resolve",
       config:
         "import { createRequire } from 'other-module'; const packageRequire = createRequire(import.meta.url); export default { plugins: [packageRequire.resolve('babel-plugin-react-compiler')] };",
@@ -1640,6 +1652,24 @@ describe("discoverProject", () => {
       name: "compiler-shadowed-require-resolve",
       config:
         "const require = { resolve: () => 'other-plugin' }; export default { plugins: [require.resolve('babel-plugin-react-compiler')] };",
+      expected: false,
+    },
+    {
+      name: "compiler-class-shadowed-require-resolve",
+      config:
+        "class require { static resolve() { return 'other-plugin'; } } export default { plugins: [require.resolve('babel-plugin-react-compiler')] };",
+      expected: false,
+    },
+    {
+      name: "compiler-uninitialized-let-shadowed-require-resolve",
+      config:
+        "let require; export default { plugins: [require.resolve('babel-plugin-react-compiler')] };",
+      expected: false,
+    },
+    {
+      name: "compiler-destructured-shadowed-require-resolve",
+      config:
+        "const { require } = other; export default { plugins: [require.resolve('babel-plugin-react-compiler')] };",
       expected: false,
     },
     {

--- a/packages/core/tests/discover-project.test.ts
+++ b/packages/core/tests/discover-project.test.ts
@@ -1602,6 +1602,71 @@ describe("discoverProject", () => {
       expected: true,
     },
     {
+      name: "compiler-global-require-resolve",
+      config: "export default { plugins: [require.resolve('babel-plugin-react-compiler')] };",
+      expected: true,
+    },
+    {
+      name: "compiler-node-create-require-resolve",
+      config:
+        "import { createRequire } from 'node:module'; const packageRequire = createRequire(import.meta.url); export default { plugins: [packageRequire.resolve('babel-plugin-react-compiler')] };",
+      expected: true,
+    },
+    {
+      name: "compiler-aliased-create-require-resolve",
+      config:
+        "import { createRequire as makeRequire } from 'module'; const packageRequire = makeRequire(import.meta.url); const compiler = packageRequire.resolve('babel-plugin-react-compiler'); export default { plugins: [[compiler, {}]] };",
+      expected: true,
+    },
+    {
+      name: "compiler-namespace-create-require-resolve",
+      config:
+        "import * as nodeModule from 'node:module'; const packageRequire = nodeModule.createRequire(import.meta.url); export default { plugins: [packageRequire.resolve('babel-plugin-react-compiler')] };",
+      expected: true,
+    },
+    {
+      name: "compiler-non-node-create-require-resolve",
+      config:
+        "import { createRequire } from 'other-module'; const packageRequire = createRequire(import.meta.url); export default { plugins: [packageRequire.resolve('babel-plugin-react-compiler')] };",
+      expected: false,
+    },
+    {
+      name: "compiler-mutable-create-require-resolve",
+      config:
+        "import { createRequire } from 'node:module'; let packageRequire = createRequire(import.meta.url); export default { plugins: [packageRequire.resolve('babel-plugin-react-compiler')] };",
+      expected: false,
+    },
+    {
+      name: "compiler-shadowed-require-resolve",
+      config:
+        "const require = { resolve: () => 'other-plugin' }; export default { plugins: [require.resolve('babel-plugin-react-compiler')] };",
+      expected: false,
+    },
+    {
+      name: "compiler-parameter-shadowed-require-resolve",
+      config:
+        "const makeConfig = (require) => ({ plugins: [require.resolve('babel-plugin-react-compiler')] }); export default makeConfig(otherResolver);",
+      expected: false,
+    },
+    {
+      name: "compiler-import-shadowed-require-resolve",
+      config:
+        "import require from 'other-module'; export default { plugins: [require.resolve('babel-plugin-react-compiler')] };",
+      expected: false,
+    },
+    {
+      name: "compiler-parameter-shadowed-create-require",
+      config:
+        "import { createRequire } from 'node:module'; const makeConfig = (createRequire) => { const packageRequire = createRequire(import.meta.url); return { plugins: [packageRequire.resolve('babel-plugin-react-compiler')] }; }; export default makeConfig(otherFactory);",
+      expected: false,
+    },
+    {
+      name: "compiler-unused-create-require-resolve",
+      config:
+        "import { createRequire } from 'node:module'; const packageRequire = createRequire(import.meta.url); const compiler = packageRequire.resolve('babel-plugin-react-compiler'); export default { plugins: ['other-plugin'] };",
+      expected: false,
+    },
+    {
       name: "destructured-vite-preset-require",
       config:
         "const { reactCompilerPreset } = require('@vitejs/plugin-react'); module.exports = { plugins: [reactCompilerPreset()] };",

--- a/packages/react-doctor/tests/regressions/react-compiler-context-provider.test.ts
+++ b/packages/react-doctor/tests/regressions/react-compiler-context-provider.test.ts
@@ -1,0 +1,94 @@
+import * as fs from "node:fs";
+import os from "node:os";
+import * as path from "node:path";
+import { afterAll, describe, expect, it } from "vite-plus/test";
+import { discoverProject, runOxlint } from "@react-doctor/core";
+import type { ProjectInfo } from "@react-doctor/core";
+import { setupReactProject } from "./_helpers.js";
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "rd-react-compiler-context-"));
+
+const providerSource = `
+import { createContext, useContext, useState } from "react";
+import type { ReactNode } from "react";
+
+interface AppStateContextValue {
+  readonly presentationMode: boolean;
+  readonly setPresentationMode: (active: boolean) => void;
+}
+
+const AppStateContext = createContext<AppStateContextValue>({
+  presentationMode: false,
+  setPresentationMode: () => {},
+});
+
+export const AppStateProvider = ({ children }: { children: ReactNode }) => {
+  const [presentationModeActive, setPresentationModeActive] = useState(false);
+  const contextValue: AppStateContextValue = {
+    presentationMode: presentationModeActive,
+    setPresentationMode: setPresentationModeActive,
+  };
+
+  return <AppStateContext.Provider value={contextValue}>{children}</AppStateContext.Provider>;
+};
+
+export const useAppState = () => useContext(AppStateContext);
+`;
+
+const compilerConfigSource = `
+import { createRequire } from "node:module";
+
+const packageRequire = createRequire(import.meta.url);
+const reactCompilerPlugin = packageRequire.resolve("babel-plugin-react-compiler");
+
+export default {
+  plugins: [
+    {
+      babel: {
+        plugins: [[reactCompilerPlugin, { target: "19" }]],
+      },
+    },
+  ],
+};
+`;
+
+afterAll(() => {
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+});
+
+const getContextProviderDiagnostics = async (
+  project: ProjectInfo,
+): Promise<Awaited<ReturnType<typeof runOxlint>>> => {
+  const diagnostics = await runOxlint({
+    rootDirectory: project.rootDirectory,
+    project,
+  });
+  return diagnostics.filter(
+    (diagnostic) => diagnostic.rule === "context-provider-value-from-unmemoized-local-literal",
+  );
+};
+
+describe("issue #1448: compiler-gated context provider diagnostics", () => {
+  it("reports the provider without an active compiler transform", async () => {
+    const projectDirectory = setupReactProject(tempRoot, "without-react-compiler", {
+      files: { "src/app-state-provider.tsx": providerSource },
+    });
+    const project = discoverProject(projectDirectory);
+
+    expect(project.hasReactCompiler).toBe(false);
+    expect(await getContextProviderDiagnostics(project)).toHaveLength(1);
+  });
+
+  it("suppresses the provider when createRequire resolves the compiler transform", async () => {
+    const projectDirectory = setupReactProject(tempRoot, "with-react-compiler", {
+      files: {
+        "src/app-state-provider.tsx": providerSource,
+        "vite.config.ts": compilerConfigSource,
+      },
+    });
+    const project = discoverProject(projectDirectory);
+
+    expect(project.hasReactCompiler).toBe(true);
+    expect(await getContextProviderDiagnostics(project)).toEqual([]);
+  });
+});

--- a/packages/react-doctor/tests/regressions/scan-resilience.test.ts
+++ b/packages/react-doctor/tests/regressions/scan-resilience.test.ts
@@ -598,6 +598,7 @@ describe("issue #141: oxlint config must not reference unloaded plugins", () => 
       ["react-doctor/jsx-no-new-function-as-prop", "warn"],
       ["react-doctor/jsx-no-jsx-as-prop", "warn"],
       ["react-doctor/jsx-no-constructed-context-values", "warn"],
+      ["react-doctor/context-provider-value-from-unmemoized-local-literal", "warn"],
       ["react-doctor/no-inline-prop-on-memo-component", "warn"],
       ["react-doctor/no-effect-with-fresh-deps", "error"],
       ["react-doctor/prefer-module-scope-pure-function", "warn"],


### PR DESCRIPTION
## Summary

- detect `babel-plugin-react-compiler` when config files reference it through global `require.resolve()`
- recognize `require.resolve()` from Node `createRequire()` named, aliased, and namespace imports
- recognize direct and CommonJS-chained Node `createRequire().resolve()` expressions
- unwrap transparent JavaScript and TypeScript wrappers around `createRequire()` initializers
- reject mutable, shadowed, unused, and non-Node resolver lookalikes, including class, uninitialized, and destructured `require` bindings
- verify the full project discovery → capability gate → oxlint config → diagnostic suppression path with an issue-shaped context provider

## Root cause addressed

The rule already has the correct `disabledWhen: ["react-compiler"]` gate, but project discovery did not recognize compiler transforms resolved through Node's `require.resolve()` APIs. That left `hasReactCompiler` false and kept the rule enabled for those configuration forms.

Issue #1448 does not yet include the reporter's build configuration, so this PR deliberately references rather than closes it until the candidate package is verified against that project.

## Impact

Projects using these valid React Compiler configuration forms no longer receive compiler-redundant context provider warnings. Merely installing the compiler package still does not count as activation.

Refs #1448.

## Eval results

Daytona parity could not run because `DAYTONA_API_KEY` is unavailable in this environment. The bounded local RDE fallback is also unavailable because its checkout requires `AXIOM_DATASET` and `AXIOM_TOKEN`. No parity result is claimed.

As a bounded real-world fallback, eight active open-source React Compiler configurations were checked before and after the change. Two `createRequire().resolve()` configurations were missed before the change; all eight are detected afterward.

## Validation

- `nr test`
- `nr lint`
- `nr typecheck`
- `nr format`
- `nr smoke:json-report`
- focused project discovery tests: 296 passed
- focused rule tests: 91 passed
- focused CLI regression tests: 41 passed
- end-to-end regression: the issue-shaped provider reports once without compiler evidence and is suppressed with a `createRequire().resolve()` compiler config

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes static analysis in project discovery that gates many lint rules; incorrect detection could hide real issues or leave false positives, but scope is limited to config parsing with extensive negative tests.
> 
> **Overview**
> **Project discovery** now treats active React Compiler transforms as enabled when config references `babel-plugin-react-compiler` through Node **`require.resolve()`**, including resolvers from **`createRequire`** (`module` / `node:module`) with aliased, namespace, chained, and lightly wrapped call forms.
> 
> The static analyzer adds guards so **shadowed**, **mutable**, **unused**, or **non-Node** resolver patterns do not flip **`hasReactCompiler`**, and top-level binding checks cover **destructured** names. That drives the existing **`react-compiler`** capability gate so compiler-redundant rules (e.g. **`context-provider-value-from-unmemoized-local-literal`**) stay off when the transform is actually wired in configs like **`createRequire(import.meta.url).resolve(...)`**.
> 
> Coverage is expanded with discovery fixtures and an end-to-end regression for issue **#1448**-shaped Vite configs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14959affd72a2432b0b8556d12696402519c07dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->