### PR TITLE
feat: add missing scripts and path containment rules

### DIFF
--- a/.changeset/breezy-canyons-fix.md
+++ b/.changeset/breezy-canyons-fix.md
@@ -1,0 +1,6 @@
+---
+"oxlint-plugin-react-doctor": patch
+"react-doctor": patch
+---
+
+Detect TanStack Start root documents that omit client scripts and unsafe filesystem containment checks that compare resolved paths with a bare string prefix.

--- a/packages/fuzz/corpus/regressions/tanstack-start-missing-scripts--body-script-value/__root.tsx
+++ b/packages/fuzz/corpus/regressions/tanstack-start-missing-scripts--body-script-value/__root.tsx
@@ -1,0 +1,15 @@
+// rule: tanstack-start-missing-scripts
+// weakness: wrapper-transparency
+// source: Bugbot review of PR #1451
+import { createRootRoute, Scripts } from "@tanstack/react-router";
+
+export const Route = createRootRoute({
+  component: () => {
+    const scripts = <Scripts />;
+    return (
+      <html>
+        <body>{scripts}</body>
+      </html>
+    );
+  },
+});

--- a/packages/fuzz/corpus/regressions/tanstack-start-missing-scripts--default-import/__root.tsx
+++ b/packages/fuzz/corpus/regressions/tanstack-start-missing-scripts--default-import/__root.tsx
@@ -1,0 +1,15 @@
+// rule: tanstack-start-missing-scripts
+// weakness: import-alias
+// source: Bugbot review of PR #1451
+import Scripts from "@/router-components";
+import { createRootRoute } from "@tanstack/react-router";
+
+export const Route = createRootRoute({
+  component: () => (
+    <html>
+      <body>
+        <Scripts />
+      </body>
+    </html>
+  ),
+});

--- a/packages/fuzz/corpus/regressions/tanstack-start-missing-scripts--unowned-body/__root.tsx
+++ b/packages/fuzz/corpus/regressions/tanstack-start-missing-scripts--unowned-body/__root.tsx
@@ -1,0 +1,16 @@
+// rule: tanstack-start-missing-scripts
+// weakness: framework-gating
+// source: Bugbot review of PR #1451
+import { createRootRoute } from "@tanstack/react-router";
+
+const DemoDocument = () => (
+  <html>
+    <body>Demo</body>
+  </html>
+);
+
+export const Route = createRootRoute({
+  component: () => <main>Home</main>,
+});
+
+export { DemoDocument };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness-fixtures.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness-fixtures.ts
@@ -820,6 +820,10 @@ export const livenessFixtures: Readonly<Record<string, LivenessFixture>> = {
     code: 'const fn = new Function("return 1");',
     filePath: "src/run.ts",
   },
+  "no-path-prefix-containment": {
+    code: 'import path from "node:path";\nconst candidatePath = path.resolve(rootDirectory, requestedPath);\nconst isInside = candidatePath.startsWith(rootDirectory);',
+    filePath: "src/files.ts",
+  },
   "no-event-handler": {
     code: "function Form() {\n        const [submitted, setSubmitted] = useState(false);\n        const [data, setData] = useState(null);\n        useEffect(() => {\n          if (submitted) {\n            submitData(data);\n            window.scrollTo(0, 0);\n          }\n        }, [submitted]);\n        return <button onClick={() => setSubmitted(true)}>go</button>;\n      }",
   },
@@ -1761,6 +1765,10 @@ export const livenessFixtures: Readonly<Record<string, LivenessFixture>> = {
     code: "createFileRoute('/x')({ loader: async () => { const a = await fetchA(); const b = await fetchB(); return { a, b }; } });",
   },
   "tanstack-start-missing-head-content": {
+    code: "export const Route = createRootRoute({\n  component: () => (\n    <html>\n      <head />\n      <body />\n    </html>\n  ),\n});",
+    filePath: "src/routes/__root.tsx",
+  },
+  "tanstack-start-missing-scripts": {
     code: "export const Route = createRootRoute({\n  component: () => (\n    <html>\n      <head />\n      <body />\n    </html>\n  ),\n});",
     filePath: "src/routes/__root.tsx",
   },

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
@@ -381,6 +381,7 @@ import { noOversizedLongHeading } from "./rules/design/no-oversized-long-heading
 import { noOverwideTextMeasure } from "./rules/design/no-overwide-text-measure.js";
 import { noPassDataToParent } from "./rules/state-and-effects/no-pass-data-to-parent.js";
 import { noPassLiveStateToParent } from "./rules/state-and-effects/no-pass-live-state-to-parent.js";
+import { noPathPrefixContainment } from "./rules/security/no-path-prefix-containment.js";
 import { noPermanentWillChange } from "./rules/performance/no-permanent-will-change.js";
 import { noPillNavigationCount } from "./rules/design/no-pill-navigation-count.js";
 import { noPlaceholderOnlyField } from "./rules/a11y/no-placeholder-only-field.js";
@@ -706,6 +707,7 @@ import { tabindexNoPositive } from "./rules/a11y/tabindex-no-positive.js";
 import { tanstackStartGetMutation } from "./rules/tanstack-start/tanstack-start-get-mutation.js";
 import { tanstackStartLoaderParallelFetch } from "./rules/tanstack-start/tanstack-start-loader-parallel-fetch.js";
 import { tanstackStartMissingHeadContent } from "./rules/tanstack-start/tanstack-start-missing-head-content.js";
+import { tanstackStartMissingScripts } from "./rules/tanstack-start/tanstack-start-missing-scripts.js";
 import { tanstackStartNoAnchorElement } from "./rules/tanstack-start/tanstack-start-no-anchor-element.js";
 import { tanstackStartNoDirectFetchInLoader } from "./rules/tanstack-start/tanstack-start-no-direct-fetch-in-loader.js";
 import { tanstackStartNoDynamicServerFnImport } from "./rules/tanstack-start/tanstack-start-no-dynamic-server-fn-import.js";
@@ -5249,6 +5251,17 @@ export const reactDoctorRules = [
     },
   },
   {
+    key: "react-doctor/no-path-prefix-containment",
+    id: "no-path-prefix-containment",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noPathPrefixContainment,
+      framework: "global",
+      category: "Security",
+    },
+  },
+  {
     key: "react-doctor/no-permanent-will-change",
     id: "no-permanent-will-change",
     source: "react-doctor",
@@ -9270,6 +9283,17 @@ export const reactDoctorRules = [
     originallyExternal: false,
     rule: {
       ...tanstackStartMissingHeadContent,
+      framework: "tanstack-start",
+      category: "Bugs",
+    },
+  },
+  {
+    key: "react-doctor/tanstack-start-missing-scripts",
+    id: "tanstack-start-missing-scripts",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...tanstackStartMissingScripts,
       framework: "tanstack-start",
       category: "Bugs",
     },

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/no-path-prefix-containment.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/no-path-prefix-containment.test.ts
@@ -48,6 +48,25 @@ describe("security/no-path-prefix-containment", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("flags unchanged mutable root bindings", () => {
+    const result = runPathPrefixRule(`
+      import path from "node:path";
+
+      let firstRootDirectory;
+      firstRootDirectory = process.cwd();
+      const firstCandidatePath = path.resolve(firstRootDirectory, requestedPath);
+      const firstIsInside = firstCandidatePath.startsWith(firstRootDirectory);
+
+      var secondRootDirectory;
+      secondRootDirectory = process.cwd();
+      const secondCandidatePath = path.resolve(secondRootDirectory, requestedPath);
+      const secondIsInside = secondCandidatePath.startsWith(secondRootDirectory);
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
   it("allows path.relative containment checks", () => {
     const result = runPathPrefixRule(`
       import path from "node:path";
@@ -172,6 +191,20 @@ describe("security/no-path-prefix-containment", () => {
 
       let candidatePath = path.resolve(rootDirectory, requestedPath);
       candidatePath = normalize(candidatePath);
+      const isInside = candidatePath.startsWith(rootDirectory);
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("ignores roots reassigned after candidate resolution", () => {
+    const result = runPathPrefixRule(`
+      import path from "node:path";
+
+      let rootDirectory = process.cwd();
+      const candidatePath = path.resolve(rootDirectory, requestedPath);
+      rootDirectory = otherRootDirectory;
       const isInside = candidatePath.startsWith(rootDirectory);
     `);
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/no-path-prefix-containment.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/no-path-prefix-containment.test.ts
@@ -91,6 +91,34 @@ describe("security/no-path-prefix-containment", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("flags bare prefixes when resolve receives a separator-suffixed root", () => {
+    const result = runPathPrefixRule(`
+      import path from "node:path";
+
+      const candidatePath = path.resolve(rootDirectory + path.sep, requestedPath);
+      const isInside = candidatePath.startsWith(rootDirectory);
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags template and literal separator-suffixed resolve roots", () => {
+    const result = runPathPrefixRule(`
+      import path from "node:path";
+
+      const templateCandidate = path.resolve(\`\${rootDirectory}/\`, requestedPath);
+      const templateIsInside = templateCandidate.startsWith(rootDirectory);
+      const separatorCandidate = path.resolve(\`\${rootDirectory}\${path.sep}\`, requestedPath);
+      const separatorIsInside = separatorCandidate.startsWith(rootDirectory);
+      const literalCandidate = path.resolve("/srv/uploads/", requestedPath);
+      const literalIsInside = literalCandidate.startsWith("/srv/uploads");
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(3);
+  });
+
   it("allows static root paths that end at a separator boundary", () => {
     const result = runPathPrefixRule(`
       import path from "node:path";

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/no-path-prefix-containment.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/no-path-prefix-containment.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noPathPrefixContainment } from "./no-path-prefix-containment.js";
+
+const runPathPrefixRule = (code: string) =>
+  runRule(noPathPrefixContainment, code, { filename: "src/files.ts" });
+
+describe("security/no-path-prefix-containment", () => {
+  it("flags namespace path.resolve results checked with the bare root prefix", () => {
+    const result = runPathPrefixRule(`
+      import * as path from "node:path";
+
+      export const readProjectFile = (rootDirectory, requestedPath) => {
+        const candidatePath = path.resolve(rootDirectory, requestedPath);
+        if (!candidatePath.startsWith(rootDirectory)) throw new Error("Outside project");
+        return candidatePath;
+      };
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags named resolve imports and direct call receivers", () => {
+    const result = runPathPrefixRule(`
+      import { resolve as resolvePath } from "path";
+
+      export const isInside = (rootDirectory, requestedPath) =>
+        resolvePath(rootDirectory, requestedPath).startsWith(rootDirectory);
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags stable aliases of the candidate and root", () => {
+    const result = runPathPrefixRule(`
+      import path from "node:path";
+
+      const rootDirectory = process.cwd();
+      const containmentRoot = rootDirectory;
+      const candidatePath = path.resolve(rootDirectory, requestedPath);
+      const resolvedCandidatePath = candidatePath;
+      const isInside = resolvedCandidatePath.startsWith(containmentRoot);
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("allows path.relative containment checks", () => {
+    const result = runPathPrefixRule(`
+      import path from "node:path";
+
+      const relativePath = path.relative(rootDirectory, candidatePath);
+      const isInside =
+        relativePath === "" ||
+        (!relativePath.startsWith(\`..\${path.sep}\`) &&
+          relativePath !== ".." &&
+          !path.isAbsolute(relativePath));
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("allows separator-aware prefix checks", () => {
+    const result = runPathPrefixRule(`
+      import path from "node:path";
+
+      const candidatePath = path.resolve(rootDirectory, requestedPath);
+      const isInside =
+        candidatePath === rootDirectory ||
+        candidatePath.startsWith(rootDirectory + path.sep);
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("allows separator-aware roots passed through stable aliases", () => {
+    const result = runPathPrefixRule(`
+      import path from "node:path";
+
+      const containmentPrefix = rootDirectory + path.sep;
+      const candidatePath = path.resolve(containmentPrefix, requestedPath);
+      const isInside = candidatePath.startsWith(containmentPrefix);
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("allows static root paths that end at a separator boundary", () => {
+    const result = runPathPrefixRule(`
+      import path from "node:path";
+
+      const candidatePath = path.resolve("/srv/uploads/", requestedPath);
+      const isInside = candidatePath.startsWith("/srv/uploads/");
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("ignores startsWith checks that use a non-default offset", () => {
+    const result = runPathPrefixRule(`
+      import path from "node:path";
+
+      const candidatePath = path.resolve(rootDirectory, requestedPath);
+      const hasNestedPrefix = candidatePath.startsWith(rootDirectory, rootDirectory.length);
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("allows ordinary string and URL prefix checks", () => {
+    const result = runPathPrefixRule(`
+      const hasApiPrefix = pathname.startsWith("/api/");
+      const isSecure = url.startsWith("https://");
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("ignores shadowed path objects", () => {
+    const result = runPathPrefixRule(`
+      const path = {
+        resolve: (rootDirectory, requestedPath) => rootDirectory + requestedPath,
+      };
+      const candidatePath = path.resolve(rootDirectory, requestedPath);
+      const isInside = candidatePath.startsWith(rootDirectory);
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("ignores reassigned candidate aliases", () => {
+    const result = runPathPrefixRule(`
+      import path from "node:path";
+
+      let candidatePath = path.resolve(rootDirectory, requestedPath);
+      candidatePath = normalize(candidatePath);
+      const isInside = candidatePath.startsWith(rootDirectory);
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("ignores a different comparison root", () => {
+    const result = runPathPrefixRule(`
+      import path from "node:path";
+
+      const candidatePath = path.resolve(rootDirectory, requestedPath);
+      const isInside = candidatePath.startsWith(otherRootDirectory);
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("ignores dynamic startsWith property access", () => {
+    const result = runPathPrefixRule(`
+      import path from "node:path";
+
+      const candidatePath = path.resolve(rootDirectory, requestedPath);
+      const methodName = "startsWith";
+      const isInside = candidatePath[methodName](rootDirectory);
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/no-path-prefix-containment.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/no-path-prefix-containment.ts
@@ -5,6 +5,7 @@ import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { getDirectUnreassignedInitializer } from "../../utils/get-direct-unreassigned-initializer.js";
 import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
 import { getStaticStringExpression } from "../../utils/get-static-string-expression.js";
+import { hasBindingWriteBetween } from "../../utils/has-binding-write-between.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { resolveImportedApiReference } from "../../utils/resolve-imported-api-reference.js";
 import type { RuleContext } from "../../utils/rule-context.js";
@@ -39,17 +40,30 @@ const areSameStableExpressions = (
     resolveStableExpression(secondExpression, context),
     {
       areIdentifiersEqual: (firstIdentifier, secondIdentifier) => {
+        if (
+          !isNodeOfType(firstIdentifier, "Identifier") ||
+          !isNodeOfType(secondIdentifier, "Identifier")
+        ) {
+          return false;
+        }
         const firstSymbol = context.scopes.symbolFor(firstIdentifier);
         const secondSymbol = context.scopes.symbolFor(secondIdentifier);
         if (firstSymbol || secondSymbol) {
-          return (
-            firstSymbol === secondSymbol &&
-            Boolean(firstSymbol?.references.every((reference) => reference.flag === "read"))
+          if (!firstSymbol || firstSymbol !== secondSymbol) return false;
+          const earlierIdentifier =
+            firstIdentifier.range[0] <= secondIdentifier.range[0]
+              ? firstIdentifier
+              : secondIdentifier;
+          const laterIdentifier =
+            earlierIdentifier === firstIdentifier ? secondIdentifier : firstIdentifier;
+          return !hasBindingWriteBetween(
+            earlierIdentifier,
+            earlierIdentifier,
+            laterIdentifier,
+            context.scopes,
           );
         }
         return (
-          isNodeOfType(firstIdentifier, "Identifier") &&
-          isNodeOfType(secondIdentifier, "Identifier") &&
           firstIdentifier.name === secondIdentifier.name &&
           context.scopes.isGlobalReference(firstIdentifier) &&
           context.scopes.isGlobalReference(secondIdentifier)

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/no-path-prefix-containment.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/no-path-prefix-containment.ts
@@ -4,6 +4,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { getDirectUnreassignedInitializer } from "../../utils/get-direct-unreassigned-initializer.js";
 import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
+import { getStaticStringExpression } from "../../utils/get-static-string-expression.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { resolveImportedApiReference } from "../../utils/resolve-imported-api-reference.js";
 import type { RuleContext } from "../../utils/rule-context.js";
@@ -105,6 +106,61 @@ const hasPathSeparatorSuffix = (expression: EsTreeNode, context: RuleContext): b
   return Boolean(trailingExpression && isPathSeparatorExpression(trailingExpression, context));
 };
 
+const isPathSeparatorSuffixedVersionOf = (
+  suffixedExpression: EsTreeNode,
+  bareExpression: EsTreeNode,
+  context: RuleContext,
+): boolean => {
+  const resolvedSuffixedExpression = resolveStableExpression(suffixedExpression, context);
+  const resolvedBareExpression = resolveStableExpression(bareExpression, context);
+  const suffixedStaticValue = getStaticStringExpression(resolvedSuffixedExpression);
+  const bareStaticValue = getStaticStringExpression(resolvedBareExpression);
+  if (suffixedStaticValue !== null && bareStaticValue !== null) {
+    return [...PATH_SEPARATORS].some(
+      (separator) => suffixedStaticValue === `${bareStaticValue}${separator}`,
+    );
+  }
+  if (
+    isNodeOfType(resolvedSuffixedExpression, "BinaryExpression") &&
+    resolvedSuffixedExpression.operator === "+" &&
+    isPathSeparatorExpression(resolvedSuffixedExpression.right, context)
+  ) {
+    return areSameStableExpressions(resolvedSuffixedExpression.left, bareExpression, context);
+  }
+  if (!isNodeOfType(resolvedSuffixedExpression, "TemplateLiteral")) return false;
+  const trailingQuasi = resolvedSuffixedExpression.quasis.at(-1);
+  const trailingText = trailingQuasi?.value.cooked ?? trailingQuasi?.value.raw ?? "";
+  if (
+    resolvedSuffixedExpression.expressions.length === 1 &&
+    resolvedSuffixedExpression.quasis.length === 2 &&
+    (resolvedSuffixedExpression.quasis[0]?.value.cooked ??
+      resolvedSuffixedExpression.quasis[0]?.value.raw ??
+      "") === "" &&
+    PATH_SEPARATORS.has(trailingText)
+  ) {
+    const baseExpression = resolvedSuffixedExpression.expressions[0];
+    return Boolean(
+      baseExpression && areSameStableExpressions(baseExpression, bareExpression, context),
+    );
+  }
+  if (
+    resolvedSuffixedExpression.expressions.length !== 2 ||
+    resolvedSuffixedExpression.quasis.some(
+      (quasi) => (quasi.value.cooked ?? quasi.value.raw ?? "") !== "",
+    )
+  ) {
+    return false;
+  }
+  const baseExpression = resolvedSuffixedExpression.expressions[0];
+  const separatorExpression = resolvedSuffixedExpression.expressions[1];
+  return Boolean(
+    baseExpression &&
+    separatorExpression &&
+    isPathSeparatorExpression(separatorExpression, context) &&
+    areSameStableExpressions(baseExpression, bareExpression, context),
+  );
+};
+
 export const noPathPrefixContainment = defineRule({
   id: "no-path-prefix-containment",
   title: "Path containment check uses a string prefix",
@@ -128,7 +184,12 @@ export const noPathPrefixContainment = defineRule({
       if (!resolvedPathCall || resolvedPathCall.arguments.length < 2) return;
       const rootExpression = resolvedPathCall.arguments[0];
       if (!rootExpression || isNodeOfType(rootExpression, "SpreadElement")) return;
-      if (!areSameStableExpressions(rootExpression, prefixExpression, context)) return;
+      if (
+        !areSameStableExpressions(rootExpression, prefixExpression, context) &&
+        !isPathSeparatorSuffixedVersionOf(rootExpression, prefixExpression, context)
+      ) {
+        return;
+      }
 
       context.report({
         node,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/no-path-prefix-containment.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security/no-path-prefix-containment.ts
@@ -1,0 +1,140 @@
+import { areExpressionsStructurallyEqual } from "../../utils/are-expressions-structurally-equal.js";
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { getDirectUnreassignedInitializer } from "../../utils/get-direct-unreassigned-initializer.js";
+import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { resolveImportedApiReference } from "../../utils/resolve-imported-api-reference.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+import type { RuleVisitors } from "../../utils/rule-visitors.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+
+const PATH_MODULES = new Set(["node:path", "path"]);
+const PATH_SEPARATORS = new Set(["/", "\\"]);
+
+const resolveStableExpression = (
+  expression: EsTreeNode,
+  context: RuleContext,
+  visitedSymbolIds = new Set<number>(),
+): EsTreeNode => {
+  const unwrappedExpression = stripParenExpression(expression);
+  if (!isNodeOfType(unwrappedExpression, "Identifier")) return unwrappedExpression;
+  const symbol = context.scopes.symbolFor(unwrappedExpression);
+  if (!symbol || visitedSymbolIds.has(symbol.id)) return unwrappedExpression;
+  const initializer = getDirectUnreassignedInitializer(symbol);
+  if (!initializer) return unwrappedExpression;
+  visitedSymbolIds.add(symbol.id);
+  return resolveStableExpression(initializer, context, visitedSymbolIds);
+};
+
+const areSameStableExpressions = (
+  firstExpression: EsTreeNode,
+  secondExpression: EsTreeNode,
+  context: RuleContext,
+): boolean =>
+  areExpressionsStructurallyEqual(
+    resolveStableExpression(firstExpression, context),
+    resolveStableExpression(secondExpression, context),
+    {
+      areIdentifiersEqual: (firstIdentifier, secondIdentifier) => {
+        const firstSymbol = context.scopes.symbolFor(firstIdentifier);
+        const secondSymbol = context.scopes.symbolFor(secondIdentifier);
+        if (firstSymbol || secondSymbol) {
+          return (
+            firstSymbol === secondSymbol &&
+            Boolean(firstSymbol?.references.every((reference) => reference.flag === "read"))
+          );
+        }
+        return (
+          isNodeOfType(firstIdentifier, "Identifier") &&
+          isNodeOfType(secondIdentifier, "Identifier") &&
+          firstIdentifier.name === secondIdentifier.name &&
+          context.scopes.isGlobalReference(firstIdentifier) &&
+          context.scopes.isGlobalReference(secondIdentifier)
+        );
+      },
+    },
+  );
+
+const getResolvedPathCall = (
+  expression: EsTreeNode,
+  context: RuleContext,
+): EsTreeNodeOfType<"CallExpression"> | null => {
+  const resolvedExpression = resolveStableExpression(expression, context);
+  if (!isNodeOfType(resolvedExpression, "CallExpression")) return null;
+  const importedApi = resolveImportedApiReference(resolvedExpression.callee, context.scopes);
+  if (
+    !importedApi ||
+    !PATH_MODULES.has(importedApi.source) ||
+    importedApi.importedName !== "resolve"
+  ) {
+    return null;
+  }
+  return resolvedExpression;
+};
+
+const isPathSeparatorExpression = (expression: EsTreeNode, context: RuleContext): boolean => {
+  const resolvedExpression = resolveStableExpression(expression, context);
+  if (isNodeOfType(resolvedExpression, "Literal") && typeof resolvedExpression.value === "string") {
+    return PATH_SEPARATORS.has(resolvedExpression.value);
+  }
+  const importedApi = resolveImportedApiReference(resolvedExpression, context.scopes);
+  return Boolean(
+    importedApi && PATH_MODULES.has(importedApi.source) && importedApi.importedName === "sep",
+  );
+};
+
+const hasPathSeparatorSuffix = (expression: EsTreeNode, context: RuleContext): boolean => {
+  const resolvedExpression = resolveStableExpression(expression, context);
+  if (isNodeOfType(resolvedExpression, "Literal") && typeof resolvedExpression.value === "string") {
+    return [...PATH_SEPARATORS].some((separator) => resolvedExpression.value.endsWith(separator));
+  }
+  if (isNodeOfType(resolvedExpression, "BinaryExpression")) {
+    return (
+      resolvedExpression.operator === "+" &&
+      isPathSeparatorExpression(resolvedExpression.right, context)
+    );
+  }
+  if (!isNodeOfType(resolvedExpression, "TemplateLiteral")) return false;
+  const trailingQuasi = resolvedExpression.quasis.at(-1);
+  const trailingText = trailingQuasi?.value.cooked ?? trailingQuasi?.value.raw ?? "";
+  if ([...PATH_SEPARATORS].some((separator) => trailingText.endsWith(separator))) return true;
+  if (trailingText !== "") return false;
+  const trailingExpression = resolvedExpression.expressions.at(-1);
+  return Boolean(trailingExpression && isPathSeparatorExpression(trailingExpression, context));
+};
+
+export const noPathPrefixContainment = defineRule({
+  id: "no-path-prefix-containment",
+  title: "Path containment check uses a string prefix",
+  tags: ["test-noise"],
+  severity: "warn",
+  recommendation:
+    "Use `path.relative(root, candidate)` and reject `..` or absolute results instead of comparing path strings with the bare root prefix.",
+  create: (context: RuleContext): RuleVisitors => ({
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+      if (
+        !isNodeOfType(node.callee, "MemberExpression") ||
+        getStaticPropertyName(node.callee) !== "startsWith"
+      ) {
+        return;
+      }
+      if (node.arguments.length !== 1) return;
+      const prefixExpression = node.arguments?.[0];
+      if (!prefixExpression || isNodeOfType(prefixExpression, "SpreadElement")) return;
+      if (hasPathSeparatorSuffix(prefixExpression, context)) return;
+      const resolvedPathCall = getResolvedPathCall(node.callee.object, context);
+      if (!resolvedPathCall || resolvedPathCall.arguments.length < 2) return;
+      const rootExpression = resolvedPathCall.arguments[0];
+      if (!rootExpression || isNodeOfType(rootExpression, "SpreadElement")) return;
+      if (!areSameStableExpressions(rootExpression, prefixExpression, context)) return;
+
+      context.report({
+        node,
+        message:
+          "A bare path string prefix also accepts sibling paths such as `<root>-backup`. Use a boundary-aware path containment check.",
+      });
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-start/tanstack-start-missing-scripts.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-start/tanstack-start-missing-scripts.test.ts
@@ -45,6 +45,63 @@ describe("tanstack-start/missing-scripts", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("flags root routes created through aliased imports", () => {
+    const result = runMissingScriptsRule(`
+      import { createRootRoute as makeRootRoute } from "@tanstack/react-router";
+
+      export const Route = makeRootRoute({
+        component: () => (
+          <html>
+            <body>
+              <main>Home</main>
+            </body>
+          </html>
+        ),
+      });
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags root routes created through namespace imports", () => {
+    const result = runMissingScriptsRule(`
+      import * as TanStackRouter from "@tanstack/react-router";
+
+      export const Route = TanStackRouter.createRootRoute({
+        component: () => (
+          <html>
+            <body>
+              <main>Home</main>
+            </body>
+          </html>
+        ),
+      });
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags root routes configured through stable options bindings", () => {
+    const result = runMissingScriptsRule(`
+      const routeOptions = {
+        component: () => (
+          <html>
+            <body>
+              <main>Home</main>
+            </body>
+          </html>
+        ),
+      };
+
+      export const Route = createRootRoute(routeOptions);
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("flags shell components with document bodies missing Scripts", () => {
     const result = runMissingScriptsRule(`
       const RootDocument = ({ children }) => (

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-start/tanstack-start-missing-scripts.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-start/tanstack-start-missing-scripts.test.ts
@@ -269,6 +269,25 @@ describe("tanstack-start/missing-scripts", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("allows default Scripts imports from project barrels", () => {
+    const result = runMissingScriptsRule(`
+      import Scripts from "@/router-components";
+
+      export const Route = createRootRoute({
+        component: () => (
+          <html>
+            <body>
+              <Scripts />
+            </body>
+          </html>
+        ),
+      });
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("allows TanStack Router namespace usage", () => {
     const result = runMissingScriptsRule(`
       import * as TanStackRouter from "@tanstack/react-router";

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-start/tanstack-start-missing-scripts.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-start/tanstack-start-missing-scripts.test.ts
@@ -148,6 +148,54 @@ describe("tanstack-start/missing-scripts", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("allows nested local wrappers that render Scripts", () => {
+    const result = runMissingScriptsRule(`
+      import { Scripts } from "@tanstack/react-router";
+
+      const AppScripts = () => <Scripts />;
+      const AppShell = () => <AppScripts />;
+
+      export const Route = createRootRoute({
+        component: () => (
+          <html>
+            <body>
+              <AppShell />
+            </body>
+          </html>
+        ),
+      });
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("keeps Scripts aliases scoped to their bindings", () => {
+    const result = runMissingScriptsRule(`
+      import { Scripts } from "@tanstack/react-router";
+
+      const AppScripts = () => <main>Home</main>;
+
+      const NestedScope = () => {
+        const AppScripts = Scripts;
+        return <AppScripts />;
+      };
+
+      export const Route = createRootRoute({
+        component: () => (
+          <html>
+            <body>
+              <AppScripts />
+            </body>
+          </html>
+        ),
+      });
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("does not accept unrelated custom body children as proof", () => {
     const result = runMissingScriptsRule(`
       const AppShell = () => <main>Home</main>;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-start/tanstack-start-missing-scripts.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-start/tanstack-start-missing-scripts.test.ts
@@ -45,6 +45,91 @@ describe("tanstack-start/missing-scripts", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("flags shell components with document bodies missing Scripts", () => {
+    const result = runMissingScriptsRule(`
+      const RootDocument = ({ children }) => (
+        <html>
+          <body>{children}</body>
+        </html>
+      );
+
+      export const Route = createRootRoute({
+        component: () => <Outlet />,
+        shellComponent: RootDocument,
+      });
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("allows shell components that render Scripts", () => {
+    const result = runMissingScriptsRule(`
+      import { Scripts } from "@tanstack/react-router";
+
+      const RootDocument = ({ children }) => (
+        <html>
+          <body>
+            {children}
+            <Scripts />
+          </body>
+        </html>
+      );
+
+      export const Route = createRootRoute({
+        component: () => <Outlet />,
+        shellComponent: RootDocument,
+      });
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("flags class root components with document bodies missing Scripts", () => {
+    const result = runMissingScriptsRule(`
+      class RootComponent extends React.Component {
+        render() {
+          return (
+            <html>
+              <body>
+                <main>Home</main>
+              </body>
+            </html>
+          );
+        }
+      }
+
+      export const Route = createRootRoute({
+        component: RootComponent,
+      });
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags inline class root components with document bodies missing Scripts", () => {
+    const result = runMissingScriptsRule(`
+      export const Route = createRootRoute({
+        component: class extends React.Component {
+          render() {
+            return (
+              <html>
+                <body>
+                  <main>Home</main>
+                </body>
+              </html>
+            );
+          }
+        },
+      });
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("allows direct Scripts usage inside the document body", () => {
     const result = runMissingScriptsRule(`
       import { Scripts } from "@tanstack/react-router";

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-start/tanstack-start-missing-scripts.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-start/tanstack-start-missing-scripts.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { tanstackStartMissingScripts } from "./tanstack-start-missing-scripts.js";
+
+const ROOT_ROUTE_FILENAME = "src/routes/__root.tsx";
+
+const runMissingScriptsRule = (code: string, filename = ROOT_ROUTE_FILENAME) =>
+  runRule(tanstackStartMissingScripts, code, { filename });
+
+describe("tanstack-start/missing-scripts", () => {
+  it("flags root route document bodies without Scripts", () => {
+    const result = runMissingScriptsRule(`
+      export const Route = createRootRoute({
+        component: () => (
+          <html>
+            <head />
+            <body>
+              <main>Home</main>
+            </body>
+          </html>
+        ),
+      });
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("allows direct Scripts usage inside the document body", () => {
+    const result = runMissingScriptsRule(`
+      import { Scripts } from "@tanstack/react-router";
+
+      export const Route = createRootRoute({
+        component: () => (
+          <html>
+            <body>
+              <main>Home</main>
+              <Scripts />
+            </body>
+          </html>
+        ),
+      });
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("flags Scripts rendered outside the document body", () => {
+    const result = runMissingScriptsRule(`
+      import { Scripts } from "@tanstack/react-router";
+
+      export const Route = createRootRoute({
+        component: () => (
+          <>
+            <Scripts />
+            <html>
+              <body />
+            </html>
+          </>
+        ),
+      });
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("allows aliased Scripts imports from project barrels", () => {
+    const result = runMissingScriptsRule(`
+      import { Scripts as RouterScripts } from "@/router-components";
+
+      export const Route = createRootRoute({
+        component: () => (
+          <html>
+            <body>
+              <RouterScripts />
+            </body>
+          </html>
+        ),
+      });
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("allows TanStack Router namespace usage", () => {
+    const result = runMissingScriptsRule(`
+      import * as TanStackRouter from "@tanstack/react-router";
+
+      export const Route = createRootRoute({
+        component: () => (
+          <html>
+            <body>
+              <TanStackRouter.Scripts />
+            </body>
+          </html>
+        ),
+      });
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("allows local wrapper components that render Scripts", () => {
+    const result = runMissingScriptsRule(`
+      import { Scripts } from "@tanstack/react-router";
+
+      const AppScripts = () => <Scripts />;
+
+      export const Route = createRootRoute({
+        component: () => (
+          <html>
+            <body>
+              <AppScripts />
+            </body>
+          </html>
+        ),
+      });
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("allows wrappers declared after the root route", () => {
+    const result = runMissingScriptsRule(`
+      import { Scripts } from "@tanstack/react-router";
+
+      export const Route = createRootRoute({
+        component: () => (
+          <html>
+            <body>
+              <AppScripts />
+            </body>
+          </html>
+        ),
+      });
+
+      function AppScripts() {
+        return <Scripts />;
+      }
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not accept unrelated custom body children as proof", () => {
+    const result = runMissingScriptsRule(`
+      const AppShell = () => <main>Home</main>;
+
+      export const Route = createRootRoute({
+        component: () => (
+          <html>
+            <body>
+              <AppShell />
+            </body>
+          </html>
+        ),
+      });
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays quiet when the root route does not own the document body", () => {
+    const result = runMissingScriptsRule(`
+      export const Route = createRootRoute({
+        component: () => <Outlet />,
+      });
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays quiet outside TanStack root route files", () => {
+    const result = runMissingScriptsRule(
+      `
+        export const Page = () => (
+          <html>
+            <body />
+          </html>
+        );
+      `,
+      "src/routes/index.tsx",
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-start/tanstack-start-missing-scripts.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-start/tanstack-start-missing-scripts.test.ts
@@ -26,6 +26,25 @@ describe("tanstack-start/missing-scripts", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("flags named root components passed to contextual route factories", () => {
+    const result = runMissingScriptsRule(`
+      const RootComponent = () => (
+        <html>
+          <body>
+            <main>Home</main>
+          </body>
+        </html>
+      );
+
+      export const Route = createRootRouteWithContext<AppContext>()({
+        component: RootComponent,
+      });
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("allows direct Scripts usage inside the document body", () => {
     const result = runMissingScriptsRule(`
       import { Scripts } from "@tanstack/react-router";
@@ -39,6 +58,29 @@ describe("tanstack-start/missing-scripts", () => {
             </body>
           </html>
         ),
+      });
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("allows Scripts values rendered inside the document body", () => {
+    const result = runMissingScriptsRule(`
+      import { Scripts } from "@tanstack/react-router";
+
+      export const Route = createRootRoute({
+        component: () => {
+          const scripts = <Scripts />;
+          return (
+            <html>
+              <body>
+                <main>Home</main>
+                {scripts}
+              </body>
+            </html>
+          );
+        },
       });
     `);
 
@@ -217,6 +259,25 @@ describe("tanstack-start/missing-scripts", () => {
 
   it("stays quiet when the root route does not own the document body", () => {
     const result = runMissingScriptsRule(`
+      export const Route = createRootRoute({
+        component: () => <Outlet />,
+      });
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("ignores document bodies outside the configured root component", () => {
+    const result = runMissingScriptsRule(`
+      const DemoDocument = () => (
+        <html>
+          <body>
+            <main>Demo</main>
+          </body>
+        </html>
+      );
+
       export const Route = createRootRoute({
         component: () => <Outlet />,
       });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-start/tanstack-start-missing-scripts.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-start/tanstack-start-missing-scripts.ts
@@ -1,0 +1,215 @@
+import { TANSTACK_ROOT_ROUTE_FILE_PATTERN } from "../../constants/tanstack.js";
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+import type { RuleVisitors } from "../../utils/rule-visitors.js";
+
+const TANSTACK_ROUTER_PACKAGE = "@tanstack/react-router";
+const SCRIPTS_COMPONENT_NAME = "Scripts";
+const DOCUMENT_BODY_ELEMENT_NAME = "body";
+
+const getJsxMemberRootName = (node: EsTreeNodeOfType<"JSXMemberExpression">): string | null => {
+  if (isNodeOfType(node.object, "JSXIdentifier")) return node.object.name;
+  if (isNodeOfType(node.object, "JSXMemberExpression")) return getJsxMemberRootName(node.object);
+  return null;
+};
+
+const getJsxMemberPropertyName = (node: EsTreeNodeOfType<"JSXMemberExpression">): string | null =>
+  isNodeOfType(node.property, "JSXIdentifier") ? node.property.name : null;
+
+const getMemberRootName = (node: EsTreeNodeOfType<"MemberExpression">): string | null => {
+  if (isNodeOfType(node.object, "Identifier")) return node.object.name;
+  if (isNodeOfType(node.object, "MemberExpression")) return getMemberRootName(node.object);
+  return null;
+};
+
+const getMemberPropertyName = (node: EsTreeNodeOfType<"MemberExpression">): string | null =>
+  isNodeOfType(node.property, "Identifier") ? node.property.name : null;
+
+const isDocumentBodyElement = (node: EsTreeNode): boolean =>
+  isNodeOfType(node, "JSXElement") &&
+  isNodeOfType(node.openingElement.name, "JSXIdentifier") &&
+  node.openingElement.name.name === DOCUMENT_BODY_ELEMENT_NAME;
+
+const isInsideDocumentBodyElement = (node: EsTreeNode): boolean => {
+  let currentNode = node.parent;
+  while (currentNode) {
+    if (isDocumentBodyElement(currentNode)) return true;
+    currentNode = currentNode.parent;
+  }
+  return false;
+};
+
+const getEnclosingComponentName = (node: EsTreeNode): string | null => {
+  let currentNode = node.parent;
+  while (currentNode) {
+    if (isNodeOfType(currentNode, "FunctionDeclaration")) {
+      return isNodeOfType(currentNode.id, "Identifier") ? currentNode.id.name : null;
+    }
+    if (
+      isNodeOfType(currentNode, "ArrowFunctionExpression") ||
+      isNodeOfType(currentNode, "FunctionExpression")
+    ) {
+      const parentNode = currentNode.parent;
+      if (
+        parentNode &&
+        isNodeOfType(parentNode, "VariableDeclarator") &&
+        isNodeOfType(parentNode.id, "Identifier")
+      ) {
+        return parentNode.id.name;
+      }
+      return null;
+    }
+    currentNode = currentNode.parent;
+  }
+  return null;
+};
+
+export const tanstackStartMissingScripts = defineRule({
+  id: "tanstack-start-missing-scripts",
+  title: "Root route missing Scripts",
+  tags: ["test-noise"],
+  requires: ["tanstack-start"],
+  severity: "warn",
+  recommendation:
+    "Render `<Scripts />` near the end of `<body>` in your __root route so TanStack Start can load client-side JavaScript.",
+  create: (context: RuleContext): RuleVisitors => {
+    if (!TANSTACK_ROOT_ROUTE_FILE_PATTERN.test(context.filename ?? "")) return {};
+
+    let hasDocumentBodyElement = false;
+    let hasScriptsInsideBody = false;
+    const scriptsComponentNames = new Set([SCRIPTS_COMPONENT_NAME]);
+    const tanstackRouterNamespaceNames = new Set<string>();
+    const bodyChildComponentNames = new Set<string>();
+    const scriptsWrapperComponentNames = new Set<string>();
+
+    const collectImportBindings = (node: EsTreeNode): void => {
+      if (!isNodeOfType(node, "ImportDeclaration")) return;
+      const isTanstackRouterImport = node.source.value === TANSTACK_ROUTER_PACKAGE;
+      for (const specifier of node.specifiers ?? []) {
+        if (isTanstackRouterImport && isNodeOfType(specifier, "ImportNamespaceSpecifier")) {
+          tanstackRouterNamespaceNames.add(specifier.local.name);
+          continue;
+        }
+        if (
+          isNodeOfType(specifier, "ImportSpecifier") &&
+          isNodeOfType(specifier.imported, "Identifier") &&
+          specifier.imported.name === SCRIPTS_COMPONENT_NAME
+        ) {
+          scriptsComponentNames.add(specifier.local.name);
+        }
+      }
+    };
+
+    const collectVariableAlias = (node: EsTreeNode): boolean => {
+      if (
+        !isNodeOfType(node, "VariableDeclarator") ||
+        !isNodeOfType(node.id, "Identifier") ||
+        !node.init
+      ) {
+        return false;
+      }
+      if (isNodeOfType(node.init, "Identifier")) {
+        if (scriptsComponentNames.has(node.init.name)) {
+          const previousSize = scriptsComponentNames.size;
+          scriptsComponentNames.add(node.id.name);
+          return scriptsComponentNames.size !== previousSize;
+        }
+        if (tanstackRouterNamespaceNames.has(node.init.name)) {
+          const previousSize = tanstackRouterNamespaceNames.size;
+          tanstackRouterNamespaceNames.add(node.id.name);
+          return tanstackRouterNamespaceNames.size !== previousSize;
+        }
+        return false;
+      }
+      if (!isNodeOfType(node.init, "MemberExpression")) return false;
+      const rootName = getMemberRootName(node.init);
+      const propertyName = getMemberPropertyName(node.init);
+      if (
+        !rootName ||
+        !tanstackRouterNamespaceNames.has(rootName) ||
+        propertyName !== SCRIPTS_COMPONENT_NAME
+      ) {
+        return false;
+      }
+      const previousSize = scriptsComponentNames.size;
+      scriptsComponentNames.add(node.id.name);
+      return scriptsComponentNames.size !== previousSize;
+    };
+
+    const isScriptsElementName = (name: EsTreeNodeOfType<"JSXOpeningElement">["name"]): boolean => {
+      if (isNodeOfType(name, "JSXIdentifier")) return scriptsComponentNames.has(name.name);
+      if (!isNodeOfType(name, "JSXMemberExpression")) return false;
+      const rootName = getJsxMemberRootName(name);
+      return Boolean(
+        rootName &&
+        tanstackRouterNamespaceNames.has(rootName) &&
+        getJsxMemberPropertyName(name) === SCRIPTS_COMPONENT_NAME,
+      );
+    };
+
+    return {
+      Program(node: EsTreeNodeOfType<"Program">) {
+        for (const statement of node.body ?? []) collectImportBindings(statement);
+        const variableDeclarators = (node.body ?? [])
+          .filter((statement) => isNodeOfType(statement, "VariableDeclaration"))
+          .flatMap((statement) => statement.declarations ?? []);
+        let didCollectAlias = false;
+        do {
+          didCollectAlias = false;
+          for (const variableDeclarator of variableDeclarators) {
+            didCollectAlias = collectVariableAlias(variableDeclarator) || didCollectAlias;
+          }
+        } while (didCollectAlias);
+      },
+      ImportDeclaration(node: EsTreeNodeOfType<"ImportDeclaration">) {
+        collectImportBindings(node);
+      },
+      VariableDeclarator(node: EsTreeNodeOfType<"VariableDeclarator">) {
+        collectVariableAlias(node);
+      },
+      JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
+        if (
+          isNodeOfType(node.name, "JSXIdentifier") &&
+          node.name.name === DOCUMENT_BODY_ELEMENT_NAME
+        ) {
+          hasDocumentBodyElement = true;
+          return;
+        }
+
+        const isInsideBody = isInsideDocumentBodyElement(node);
+        if (isScriptsElementName(node.name)) {
+          if (isInsideBody) {
+            hasScriptsInsideBody = true;
+            return;
+          }
+          const wrapperComponentName = getEnclosingComponentName(node);
+          if (wrapperComponentName) scriptsWrapperComponentNames.add(wrapperComponentName);
+          return;
+        }
+
+        if (
+          isInsideBody &&
+          isNodeOfType(node.name, "JSXIdentifier") &&
+          node.name.name.charAt(0) === node.name.name.charAt(0).toUpperCase()
+        ) {
+          bodyChildComponentNames.add(node.name.name);
+        }
+      },
+      "Program:exit"(programNode: EsTreeNode) {
+        const hasScriptsWrapperInsideBody = [...bodyChildComponentNames].some((componentName) =>
+          scriptsWrapperComponentNames.has(componentName),
+        );
+        if (hasDocumentBodyElement && !hasScriptsInsideBody && !hasScriptsWrapperInsideBody) {
+          context.report({
+            node: programNode,
+            message:
+              "Without <Scripts /> inside <body>, the __root route does not load TanStack Start's client-side JavaScript.",
+          });
+        }
+      },
+    };
+  },
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-start/tanstack-start-missing-scripts.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-start/tanstack-start-missing-scripts.ts
@@ -10,18 +10,24 @@ const TANSTACK_ROUTER_PACKAGE = "@tanstack/react-router";
 const SCRIPTS_COMPONENT_NAME = "Scripts";
 const DOCUMENT_BODY_ELEMENT_NAME = "body";
 
-const getJsxMemberRootName = (node: EsTreeNodeOfType<"JSXMemberExpression">): string | null => {
-  if (isNodeOfType(node.object, "JSXIdentifier")) return node.object.name;
-  if (isNodeOfType(node.object, "JSXMemberExpression")) return getJsxMemberRootName(node.object);
+const getJsxMemberRootIdentifier = (
+  node: EsTreeNodeOfType<"JSXMemberExpression">,
+): EsTreeNodeOfType<"JSXIdentifier"> | null => {
+  if (isNodeOfType(node.object, "JSXIdentifier")) return node.object;
+  if (isNodeOfType(node.object, "JSXMemberExpression")) {
+    return getJsxMemberRootIdentifier(node.object);
+  }
   return null;
 };
 
 const getJsxMemberPropertyName = (node: EsTreeNodeOfType<"JSXMemberExpression">): string | null =>
   isNodeOfType(node.property, "JSXIdentifier") ? node.property.name : null;
 
-const getMemberRootName = (node: EsTreeNodeOfType<"MemberExpression">): string | null => {
-  if (isNodeOfType(node.object, "Identifier")) return node.object.name;
-  if (isNodeOfType(node.object, "MemberExpression")) return getMemberRootName(node.object);
+const getMemberRootIdentifier = (
+  node: EsTreeNodeOfType<"MemberExpression">,
+): EsTreeNodeOfType<"Identifier"> | null => {
+  if (isNodeOfType(node.object, "Identifier")) return node.object;
+  if (isNodeOfType(node.object, "MemberExpression")) return getMemberRootIdentifier(node.object);
   return null;
 };
 
@@ -42,11 +48,13 @@ const isInsideDocumentBodyElement = (node: EsTreeNode): boolean => {
   return false;
 };
 
-const getEnclosingComponentName = (node: EsTreeNode): string | null => {
+const getEnclosingComponentIdentifier = (
+  node: EsTreeNode,
+): EsTreeNodeOfType<"Identifier"> | null => {
   let currentNode = node.parent;
   while (currentNode) {
     if (isNodeOfType(currentNode, "FunctionDeclaration")) {
-      return isNodeOfType(currentNode.id, "Identifier") ? currentNode.id.name : null;
+      return isNodeOfType(currentNode.id, "Identifier") ? currentNode.id : null;
     }
     if (
       isNodeOfType(currentNode, "ArrowFunctionExpression") ||
@@ -58,7 +66,7 @@ const getEnclosingComponentName = (node: EsTreeNode): string | null => {
         isNodeOfType(parentNode, "VariableDeclarator") &&
         isNodeOfType(parentNode.id, "Identifier")
       ) {
-        return parentNode.id.name;
+        return parentNode.id;
       }
       return null;
     }
@@ -66,6 +74,9 @@ const getEnclosingComponentName = (node: EsTreeNode): string | null => {
   }
   return null;
 };
+
+const getBindingDeclaration = (node: EsTreeNode, context: RuleContext): EsTreeNode | null =>
+  context.scopes.symbolFor(node)?.declarationNode ?? null;
 
 export const tanstackStartMissingScripts = defineRule({
   id: "tanstack-start-missing-scripts",
@@ -80,17 +91,19 @@ export const tanstackStartMissingScripts = defineRule({
 
     let hasDocumentBodyElement = false;
     let hasScriptsInsideBody = false;
-    const scriptsComponentNames = new Set([SCRIPTS_COMPONENT_NAME]);
-    const tanstackRouterNamespaceNames = new Set<string>();
-    const bodyChildComponentNames = new Set<string>();
-    const scriptsWrapperComponentNames = new Set<string>();
+    const scriptsComponentDeclarations = new Set<EsTreeNode>();
+    const tanstackRouterNamespaceDeclarations = new Set<EsTreeNode>();
+    const bodyChildComponentDeclarations = new Set<EsTreeNode>();
+    const scriptsWrapperComponentDeclarations = new Set<EsTreeNode>();
+    const componentDependencyDeclarations = new Map<EsTreeNode, Set<EsTreeNode>>();
 
     const collectImportBindings = (node: EsTreeNode): void => {
       if (!isNodeOfType(node, "ImportDeclaration")) return;
       const isTanstackRouterImport = node.source.value === TANSTACK_ROUTER_PACKAGE;
       for (const specifier of node.specifiers ?? []) {
         if (isTanstackRouterImport && isNodeOfType(specifier, "ImportNamespaceSpecifier")) {
-          tanstackRouterNamespaceNames.add(specifier.local.name);
+          const namespaceDeclaration = getBindingDeclaration(specifier.local, context);
+          if (namespaceDeclaration) tanstackRouterNamespaceDeclarations.add(namespaceDeclaration);
           continue;
         }
         if (
@@ -98,7 +111,10 @@ export const tanstackStartMissingScripts = defineRule({
           isNodeOfType(specifier.imported, "Identifier") &&
           specifier.imported.name === SCRIPTS_COMPONENT_NAME
         ) {
-          scriptsComponentNames.add(specifier.local.name);
+          const scriptsComponentDeclaration = getBindingDeclaration(specifier.local, context);
+          if (scriptsComponentDeclaration) {
+            scriptsComponentDeclarations.add(scriptsComponentDeclaration);
+          }
         }
       }
     };
@@ -111,41 +127,58 @@ export const tanstackStartMissingScripts = defineRule({
       ) {
         return false;
       }
+      const aliasDeclaration = getBindingDeclaration(node.id, context);
+      if (!aliasDeclaration) return false;
       if (isNodeOfType(node.init, "Identifier")) {
-        if (scriptsComponentNames.has(node.init.name)) {
-          const previousSize = scriptsComponentNames.size;
-          scriptsComponentNames.add(node.id.name);
-          return scriptsComponentNames.size !== previousSize;
+        const initializerDeclaration = getBindingDeclaration(node.init, context);
+        if (initializerDeclaration && scriptsComponentDeclarations.has(initializerDeclaration)) {
+          const previousSize = scriptsComponentDeclarations.size;
+          scriptsComponentDeclarations.add(aliasDeclaration);
+          return scriptsComponentDeclarations.size !== previousSize;
         }
-        if (tanstackRouterNamespaceNames.has(node.init.name)) {
-          const previousSize = tanstackRouterNamespaceNames.size;
-          tanstackRouterNamespaceNames.add(node.id.name);
-          return tanstackRouterNamespaceNames.size !== previousSize;
+        if (
+          initializerDeclaration &&
+          tanstackRouterNamespaceDeclarations.has(initializerDeclaration)
+        ) {
+          const previousSize = tanstackRouterNamespaceDeclarations.size;
+          tanstackRouterNamespaceDeclarations.add(aliasDeclaration);
+          return tanstackRouterNamespaceDeclarations.size !== previousSize;
         }
         return false;
       }
       if (!isNodeOfType(node.init, "MemberExpression")) return false;
-      const rootName = getMemberRootName(node.init);
+      const rootIdentifier = getMemberRootIdentifier(node.init);
+      const rootDeclaration = rootIdentifier
+        ? getBindingDeclaration(rootIdentifier, context)
+        : null;
       const propertyName = getMemberPropertyName(node.init);
       if (
-        !rootName ||
-        !tanstackRouterNamespaceNames.has(rootName) ||
+        !rootDeclaration ||
+        !tanstackRouterNamespaceDeclarations.has(rootDeclaration) ||
         propertyName !== SCRIPTS_COMPONENT_NAME
       ) {
         return false;
       }
-      const previousSize = scriptsComponentNames.size;
-      scriptsComponentNames.add(node.id.name);
-      return scriptsComponentNames.size !== previousSize;
+      const previousSize = scriptsComponentDeclarations.size;
+      scriptsComponentDeclarations.add(aliasDeclaration);
+      return scriptsComponentDeclarations.size !== previousSize;
     };
 
     const isScriptsElementName = (name: EsTreeNodeOfType<"JSXOpeningElement">["name"]): boolean => {
-      if (isNodeOfType(name, "JSXIdentifier")) return scriptsComponentNames.has(name.name);
+      if (isNodeOfType(name, "JSXIdentifier")) {
+        const componentDeclaration = getBindingDeclaration(name, context);
+        return componentDeclaration
+          ? scriptsComponentDeclarations.has(componentDeclaration)
+          : name.name === SCRIPTS_COMPONENT_NAME;
+      }
       if (!isNodeOfType(name, "JSXMemberExpression")) return false;
-      const rootName = getJsxMemberRootName(name);
+      const rootIdentifier = getJsxMemberRootIdentifier(name);
+      const rootDeclaration = rootIdentifier
+        ? getBindingDeclaration(rootIdentifier, context)
+        : null;
       return Boolean(
-        rootName &&
-        tanstackRouterNamespaceNames.has(rootName) &&
+        rootDeclaration &&
+        tanstackRouterNamespaceDeclarations.has(rootDeclaration) &&
         getJsxMemberPropertyName(name) === SCRIPTS_COMPONENT_NAME,
       );
     };
@@ -185,23 +218,46 @@ export const tanstackStartMissingScripts = defineRule({
             hasScriptsInsideBody = true;
             return;
           }
-          const wrapperComponentName = getEnclosingComponentName(node);
-          if (wrapperComponentName) scriptsWrapperComponentNames.add(wrapperComponentName);
+          const wrapperComponentIdentifier = getEnclosingComponentIdentifier(node);
+          const wrapperComponentDeclaration = wrapperComponentIdentifier
+            ? getBindingDeclaration(wrapperComponentIdentifier, context)
+            : null;
+          if (wrapperComponentDeclaration) {
+            scriptsWrapperComponentDeclarations.add(wrapperComponentDeclaration);
+          }
           return;
         }
 
-        if (
-          isInsideBody &&
-          isNodeOfType(node.name, "JSXIdentifier") &&
-          node.name.name.charAt(0) === node.name.name.charAt(0).toUpperCase()
-        ) {
-          bodyChildComponentNames.add(node.name.name);
-        }
+        if (!isNodeOfType(node.name, "JSXIdentifier")) return;
+        const childComponentDeclaration = getBindingDeclaration(node.name, context);
+        if (!childComponentDeclaration) return;
+        if (isInsideBody) bodyChildComponentDeclarations.add(childComponentDeclaration);
+
+        const enclosingComponentIdentifier = getEnclosingComponentIdentifier(node);
+        const enclosingComponentDeclaration = enclosingComponentIdentifier
+          ? getBindingDeclaration(enclosingComponentIdentifier, context)
+          : null;
+        if (!enclosingComponentDeclaration) return;
+        const dependencyDeclarations =
+          componentDependencyDeclarations.get(enclosingComponentDeclaration) ??
+          new Set<EsTreeNode>();
+        dependencyDeclarations.add(childComponentDeclaration);
+        componentDependencyDeclarations.set(enclosingComponentDeclaration, dependencyDeclarations);
       },
       "Program:exit"(programNode: EsTreeNode) {
-        const hasScriptsWrapperInsideBody = [...bodyChildComponentNames].some((componentName) =>
-          scriptsWrapperComponentNames.has(componentName),
-        );
+        const reachableComponentDeclarations = new Set(bodyChildComponentDeclarations);
+        let hasScriptsWrapperInsideBody = false;
+        for (const componentDeclaration of reachableComponentDeclarations) {
+          if (scriptsWrapperComponentDeclarations.has(componentDeclaration)) {
+            hasScriptsWrapperInsideBody = true;
+            break;
+          }
+          for (const dependencyDeclaration of componentDependencyDeclarations.get(
+            componentDeclaration,
+          ) ?? []) {
+            reachableComponentDeclarations.add(dependencyDeclaration);
+          }
+        }
         if (hasDocumentBodyElement && !hasScriptsInsideBody && !hasScriptsWrapperInsideBody) {
           context.report({
             node: programNode,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-start/tanstack-start-missing-scripts.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-start/tanstack-start-missing-scripts.ts
@@ -156,9 +156,17 @@ export const tanstackStartMissingScripts = defineRule({
       if (!isNodeOfType(node, "ImportDeclaration")) return;
       const isTanstackRouterImport = node.source.value === TANSTACK_ROUTER_PACKAGE;
       for (const specifier of node.specifiers ?? []) {
+        const bindingDeclaration = getBindingDeclaration(specifier.local, context);
+        if (!bindingDeclaration) continue;
+        if (
+          isNodeOfType(specifier, "ImportDefaultSpecifier") &&
+          specifier.local.name === SCRIPTS_COMPONENT_NAME
+        ) {
+          scriptsComponentDeclarations.add(bindingDeclaration);
+          continue;
+        }
         if (isTanstackRouterImport && isNodeOfType(specifier, "ImportNamespaceSpecifier")) {
-          const namespaceDeclaration = getBindingDeclaration(specifier.local, context);
-          if (namespaceDeclaration) tanstackRouterNamespaceDeclarations.add(namespaceDeclaration);
+          tanstackRouterNamespaceDeclarations.add(bindingDeclaration);
           continue;
         }
         if (
@@ -167,8 +175,6 @@ export const tanstackStartMissingScripts = defineRule({
         ) {
           continue;
         }
-        const bindingDeclaration = getBindingDeclaration(specifier.local, context);
-        if (!bindingDeclaration) continue;
         if (specifier.imported.name === SCRIPTS_COMPONENT_NAME) {
           scriptsComponentDeclarations.add(bindingDeclaration);
         }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-start/tanstack-start-missing-scripts.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-start/tanstack-start-missing-scripts.ts
@@ -8,6 +8,7 @@ import { getClassBindingSymbol } from "../../utils/get-class-binding-symbol.js";
 import { getStaticPropertyKeyName } from "../../utils/get-static-property-key-name.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { resolveStableOptionsObject } from "../../utils/resolve-stable-options-object.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import type { RuleVisitors } from "../../utils/rule-visitors.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
@@ -20,7 +21,7 @@ const TANSTACK_ROOT_ROUTE_FACTORY_NAMES = new Set([
 const SCRIPTS_COMPONENT_NAME = "Scripts";
 const DOCUMENT_BODY_ELEMENT_NAME = "body";
 const CLASS_RENDER_METHOD_NAME = "render";
-const ROOT_DOCUMENT_COMPONENT_PROPERTY_NAMES = new Set(["component", "shellComponent"]);
+const ROOT_DOCUMENT_COMPONENT_PROPERTY_NAMES = ["component", "shellComponent"];
 
 const getJsxMemberRootIdentifier = (
   node: EsTreeNodeOfType<"JSXMemberExpression">,
@@ -125,25 +126,6 @@ const getEnclosingVariableDeclaration = (
 const getBindingDeclaration = (node: EsTreeNode, context: RuleContext): EsTreeNode | null =>
   context.scopes.symbolFor(node)?.declarationNode ?? null;
 
-const isRootRouteFactoryCall = (node: EsTreeNodeOfType<"CallExpression">): boolean => {
-  let callee = stripParenExpression(node.callee);
-  while (isNodeOfType(callee, "CallExpression")) {
-    callee = stripParenExpression(callee.callee);
-  }
-  return isNodeOfType(callee, "Identifier") && TANSTACK_ROOT_ROUTE_FACTORY_NAMES.has(callee.name);
-};
-
-const isRootRouteOptionsObject = (node: EsTreeNodeOfType<"ObjectExpression">): boolean => {
-  const expressionRoot = findTransparentExpressionRoot(node);
-  const parentNode = expressionRoot.parent;
-  return Boolean(
-    parentNode &&
-    isNodeOfType(parentNode, "CallExpression") &&
-    parentNode.arguments.some((argument) => argument === expressionRoot) &&
-    isRootRouteFactoryCall(parentNode),
-  );
-};
-
 export const tanstackStartMissingScripts = defineRule({
   id: "tanstack-start-missing-scripts",
   title: "Root route missing Scripts",
@@ -157,6 +139,7 @@ export const tanstackStartMissingScripts = defineRule({
 
     const scriptsComponentDeclarations = new Set<EsTreeNode>();
     const tanstackRouterNamespaceDeclarations = new Set<EsTreeNode>();
+    const rootRouteFactoryDeclarations = new Set<EsTreeNode>();
     const configuredRootComponentDeclarations = new Set<EsTreeNode>();
     const documentBodyElements = new Set<EsTreeNodeOfType<"JSXElement">>();
     const scriptsInsideBodyElements = new Set<EsTreeNodeOfType<"JSXElement">>();
@@ -179,14 +162,21 @@ export const tanstackStartMissingScripts = defineRule({
           continue;
         }
         if (
-          isNodeOfType(specifier, "ImportSpecifier") &&
-          isNodeOfType(specifier.imported, "Identifier") &&
-          specifier.imported.name === SCRIPTS_COMPONENT_NAME
+          !isNodeOfType(specifier, "ImportSpecifier") ||
+          !isNodeOfType(specifier.imported, "Identifier")
         ) {
-          const scriptsComponentDeclaration = getBindingDeclaration(specifier.local, context);
-          if (scriptsComponentDeclaration) {
-            scriptsComponentDeclarations.add(scriptsComponentDeclaration);
-          }
+          continue;
+        }
+        const bindingDeclaration = getBindingDeclaration(specifier.local, context);
+        if (!bindingDeclaration) continue;
+        if (specifier.imported.name === SCRIPTS_COMPONENT_NAME) {
+          scriptsComponentDeclarations.add(bindingDeclaration);
+        }
+        if (
+          isTanstackRouterImport &&
+          TANSTACK_ROOT_ROUTE_FACTORY_NAMES.has(specifier.imported.name)
+        ) {
+          rootRouteFactoryDeclarations.add(bindingDeclaration);
         }
       }
     };
@@ -203,10 +193,11 @@ export const tanstackStartMissingScripts = defineRule({
       if (!aliasDeclaration) return false;
       if (isNodeOfType(node.init, "Identifier")) {
         const initializerDeclaration = getBindingDeclaration(node.init, context);
+        let didCollectAlias = false;
         if (initializerDeclaration && scriptsComponentDeclarations.has(initializerDeclaration)) {
           const previousSize = scriptsComponentDeclarations.size;
           scriptsComponentDeclarations.add(aliasDeclaration);
-          return scriptsComponentDeclarations.size !== previousSize;
+          didCollectAlias = scriptsComponentDeclarations.size !== previousSize;
         }
         if (
           initializerDeclaration &&
@@ -214,9 +205,15 @@ export const tanstackStartMissingScripts = defineRule({
         ) {
           const previousSize = tanstackRouterNamespaceDeclarations.size;
           tanstackRouterNamespaceDeclarations.add(aliasDeclaration);
-          return tanstackRouterNamespaceDeclarations.size !== previousSize;
+          didCollectAlias =
+            tanstackRouterNamespaceDeclarations.size !== previousSize || didCollectAlias;
         }
-        return false;
+        if (initializerDeclaration && rootRouteFactoryDeclarations.has(initializerDeclaration)) {
+          const previousSize = rootRouteFactoryDeclarations.size;
+          rootRouteFactoryDeclarations.add(aliasDeclaration);
+          didCollectAlias = rootRouteFactoryDeclarations.size !== previousSize || didCollectAlias;
+        }
+        return didCollectAlias;
       }
       if (!isNodeOfType(node.init, "MemberExpression")) return false;
       const rootIdentifier = getMemberRootIdentifier(node.init);
@@ -224,16 +221,20 @@ export const tanstackStartMissingScripts = defineRule({
         ? getBindingDeclaration(rootIdentifier, context)
         : null;
       const propertyName = getMemberPropertyName(node.init);
-      if (
-        !rootDeclaration ||
-        !tanstackRouterNamespaceDeclarations.has(rootDeclaration) ||
-        propertyName !== SCRIPTS_COMPONENT_NAME
-      ) {
+      if (!rootDeclaration || !tanstackRouterNamespaceDeclarations.has(rootDeclaration)) {
         return false;
       }
-      const previousSize = scriptsComponentDeclarations.size;
-      scriptsComponentDeclarations.add(aliasDeclaration);
-      return scriptsComponentDeclarations.size !== previousSize;
+      if (propertyName === SCRIPTS_COMPONENT_NAME) {
+        const previousSize = scriptsComponentDeclarations.size;
+        scriptsComponentDeclarations.add(aliasDeclaration);
+        return scriptsComponentDeclarations.size !== previousSize;
+      }
+      if (propertyName && TANSTACK_ROOT_ROUTE_FACTORY_NAMES.has(propertyName)) {
+        const previousSize = rootRouteFactoryDeclarations.size;
+        rootRouteFactoryDeclarations.add(aliasDeclaration);
+        return rootRouteFactoryDeclarations.size !== previousSize;
+      }
+      return false;
     };
 
     const isScriptsElementName = (name: EsTreeNodeOfType<"JSXOpeningElement">["name"]): boolean => {
@@ -253,6 +254,48 @@ export const tanstackStartMissingScripts = defineRule({
         tanstackRouterNamespaceDeclarations.has(rootDeclaration) &&
         getJsxMemberPropertyName(name) === SCRIPTS_COMPONENT_NAME,
       );
+    };
+
+    const isRootRouteFactoryCall = (node: EsTreeNodeOfType<"CallExpression">): boolean => {
+      let callee = stripParenExpression(node.callee);
+      while (isNodeOfType(callee, "CallExpression")) {
+        callee = stripParenExpression(callee.callee);
+      }
+      if (isNodeOfType(callee, "Identifier")) {
+        const factoryDeclaration = getBindingDeclaration(callee, context);
+        return factoryDeclaration
+          ? rootRouteFactoryDeclarations.has(factoryDeclaration)
+          : TANSTACK_ROOT_ROUTE_FACTORY_NAMES.has(callee.name);
+      }
+      if (!isNodeOfType(callee, "MemberExpression")) return false;
+      const rootIdentifier = getMemberRootIdentifier(callee);
+      const rootDeclaration = rootIdentifier
+        ? getBindingDeclaration(rootIdentifier, context)
+        : null;
+      const propertyName = getMemberPropertyName(callee);
+      return Boolean(
+        rootDeclaration &&
+        tanstackRouterNamespaceDeclarations.has(rootDeclaration) &&
+        propertyName &&
+        TANSTACK_ROOT_ROUTE_FACTORY_NAMES.has(propertyName),
+      );
+    };
+
+    const collectConfiguredRootComponent = (componentValue: EsTreeNode): void => {
+      const unwrappedComponentValue = stripParenExpression(componentValue);
+      if (isFunctionLike(unwrappedComponentValue)) {
+        configuredRootComponentDeclarations.add(unwrappedComponentValue);
+        return;
+      }
+      if (isNodeOfType(unwrappedComponentValue, "ClassExpression")) {
+        configuredRootComponentDeclarations.add(
+          getClassComponentDeclaration(unwrappedComponentValue, context),
+        );
+        return;
+      }
+      if (!isNodeOfType(unwrappedComponentValue, "Identifier")) return;
+      const componentDeclaration = getBindingDeclaration(unwrappedComponentValue, context);
+      if (componentDeclaration) configuredRootComponentDeclarations.add(componentDeclaration);
     };
 
     return {
@@ -275,31 +318,27 @@ export const tanstackStartMissingScripts = defineRule({
       VariableDeclarator(node: EsTreeNodeOfType<"VariableDeclarator">) {
         collectVariableAlias(node);
       },
-      Property(node: EsTreeNodeOfType<"Property">) {
-        const propertyName = getStaticPropertyKeyName(node, { allowComputedString: true });
-        if (
-          !propertyName ||
-          !ROOT_DOCUMENT_COMPONENT_PROPERTY_NAMES.has(propertyName) ||
-          !isNodeOfType(node.parent, "ObjectExpression") ||
-          !isRootRouteOptionsObject(node.parent)
-        ) {
-          return;
-        }
-        const componentValue = stripParenExpression(node.value);
-        if (isFunctionLike(componentValue)) {
-          configuredRootComponentDeclarations.add(componentValue);
-          return;
-        }
-        if (isNodeOfType(componentValue, "ClassExpression")) {
-          configuredRootComponentDeclarations.add(
-            getClassComponentDeclaration(componentValue, context),
-          );
-          return;
-        }
-        if (!isNodeOfType(componentValue, "Identifier")) return;
-        const componentDeclaration = getBindingDeclaration(componentValue, context);
-        if (componentDeclaration) {
-          configuredRootComponentDeclarations.add(componentDeclaration);
+      CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+        if (!isRootRouteFactoryCall(node)) return;
+        const optionsArgument = node.arguments[0];
+        if (!optionsArgument || isNodeOfType(optionsArgument, "SpreadElement")) return;
+        const optionsObject = resolveStableOptionsObject(
+          optionsArgument,
+          ROOT_DOCUMENT_COMPONENT_PROPERTY_NAMES,
+          context.scopes,
+          node,
+        );
+        if (!optionsObject) return;
+        for (const property of optionsObject.properties) {
+          if (
+            !isNodeOfType(property, "Property") ||
+            !ROOT_DOCUMENT_COMPONENT_PROPERTY_NAMES.includes(
+              getStaticPropertyKeyName(property, { allowComputedString: true }) ?? "",
+            )
+          ) {
+            continue;
+          }
+          collectConfiguredRootComponent(property.value);
         }
       },
       JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-start/tanstack-start-missing-scripts.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-start/tanstack-start-missing-scripts.ts
@@ -2,13 +2,22 @@ import { TANSTACK_ROOT_ROUTE_FILE_PATTERN } from "../../constants/tanstack.js";
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findTransparentExpressionRoot } from "../../utils/find-transparent-expression-root.js";
+import { getStaticPropertyKeyName } from "../../utils/get-static-property-key-name.js";
+import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import type { RuleVisitors } from "../../utils/rule-visitors.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 
 const TANSTACK_ROUTER_PACKAGE = "@tanstack/react-router";
+const TANSTACK_ROOT_ROUTE_FACTORY_NAMES = new Set([
+  "createRootRoute",
+  "createRootRouteWithContext",
+]);
 const SCRIPTS_COMPONENT_NAME = "Scripts";
 const DOCUMENT_BODY_ELEMENT_NAME = "body";
+const ROOT_COMPONENT_PROPERTY_NAME = "component";
 
 const getJsxMemberRootIdentifier = (
   node: EsTreeNodeOfType<"JSXMemberExpression">,
@@ -34,42 +43,62 @@ const getMemberRootIdentifier = (
 const getMemberPropertyName = (node: EsTreeNodeOfType<"MemberExpression">): string | null =>
   isNodeOfType(node.property, "Identifier") ? node.property.name : null;
 
-const isDocumentBodyElement = (node: EsTreeNode): boolean =>
+const isDocumentBodyElement = (node: EsTreeNode): node is EsTreeNodeOfType<"JSXElement"> =>
   isNodeOfType(node, "JSXElement") &&
   isNodeOfType(node.openingElement.name, "JSXIdentifier") &&
   node.openingElement.name.name === DOCUMENT_BODY_ELEMENT_NAME;
 
-const isInsideDocumentBodyElement = (node: EsTreeNode): boolean => {
+const getEnclosingDocumentBodyElement = (
+  node: EsTreeNode,
+): EsTreeNodeOfType<"JSXElement"> | null => {
   let currentNode = node.parent;
   while (currentNode) {
-    if (isDocumentBodyElement(currentNode)) return true;
+    if (isDocumentBodyElement(currentNode)) return currentNode;
     currentNode = currentNode.parent;
   }
-  return false;
+  return null;
 };
 
-const getEnclosingComponentIdentifier = (
+const getEnclosingComponentDeclaration = (
   node: EsTreeNode,
-): EsTreeNodeOfType<"Identifier"> | null => {
+  context: RuleContext,
+): EsTreeNode | null => {
   let currentNode = node.parent;
   while (currentNode) {
     if (isNodeOfType(currentNode, "FunctionDeclaration")) {
-      return isNodeOfType(currentNode.id, "Identifier") ? currentNode.id : null;
+      return currentNode;
     }
     if (
       isNodeOfType(currentNode, "ArrowFunctionExpression") ||
       isNodeOfType(currentNode, "FunctionExpression")
     ) {
-      const parentNode = currentNode.parent;
+      const parentNode = findTransparentExpressionRoot(currentNode).parent;
       if (
         parentNode &&
         isNodeOfType(parentNode, "VariableDeclarator") &&
         isNodeOfType(parentNode.id, "Identifier")
       ) {
-        return parentNode.id;
+        return context.scopes.symbolFor(parentNode.id)?.declarationNode ?? null;
       }
-      return null;
+      return currentNode;
     }
+    currentNode = currentNode.parent;
+  }
+  return null;
+};
+
+const getEnclosingVariableDeclaration = (
+  node: EsTreeNode,
+): EsTreeNodeOfType<"VariableDeclarator"> | null => {
+  let currentNode = node.parent;
+  while (currentNode) {
+    if (
+      isNodeOfType(currentNode, "VariableDeclarator") &&
+      isNodeOfType(currentNode.id, "Identifier")
+    ) {
+      return currentNode;
+    }
+    if (isFunctionLike(currentNode)) return null;
     currentNode = currentNode.parent;
   }
   return null;
@@ -77,6 +106,25 @@ const getEnclosingComponentIdentifier = (
 
 const getBindingDeclaration = (node: EsTreeNode, context: RuleContext): EsTreeNode | null =>
   context.scopes.symbolFor(node)?.declarationNode ?? null;
+
+const isRootRouteFactoryCall = (node: EsTreeNodeOfType<"CallExpression">): boolean => {
+  let callee = stripParenExpression(node.callee);
+  while (isNodeOfType(callee, "CallExpression")) {
+    callee = stripParenExpression(callee.callee);
+  }
+  return isNodeOfType(callee, "Identifier") && TANSTACK_ROOT_ROUTE_FACTORY_NAMES.has(callee.name);
+};
+
+const isRootRouteOptionsObject = (node: EsTreeNodeOfType<"ObjectExpression">): boolean => {
+  const expressionRoot = findTransparentExpressionRoot(node);
+  const parentNode = expressionRoot.parent;
+  return Boolean(
+    parentNode &&
+    isNodeOfType(parentNode, "CallExpression") &&
+    parentNode.arguments.some((argument) => argument === expressionRoot) &&
+    isRootRouteFactoryCall(parentNode),
+  );
+};
 
 export const tanstackStartMissingScripts = defineRule({
   id: "tanstack-start-missing-scripts",
@@ -89,13 +137,19 @@ export const tanstackStartMissingScripts = defineRule({
   create: (context: RuleContext): RuleVisitors => {
     if (!TANSTACK_ROOT_ROUTE_FILE_PATTERN.test(context.filename ?? "")) return {};
 
-    let hasDocumentBodyElement = false;
-    let hasScriptsInsideBody = false;
     const scriptsComponentDeclarations = new Set<EsTreeNode>();
     const tanstackRouterNamespaceDeclarations = new Set<EsTreeNode>();
-    const bodyChildComponentDeclarations = new Set<EsTreeNode>();
+    const configuredRootComponentDeclarations = new Set<EsTreeNode>();
+    const documentBodyElements = new Set<EsTreeNodeOfType<"JSXElement">>();
+    const scriptsInsideBodyElements = new Set<EsTreeNodeOfType<"JSXElement">>();
+    const scriptsValueDeclarations = new Set<EsTreeNode>();
     const scriptsWrapperComponentDeclarations = new Set<EsTreeNode>();
     const componentDependencyDeclarations = new Map<EsTreeNode, Set<EsTreeNode>>();
+    const bodyChildComponentDeclarations = new Map<
+      EsTreeNodeOfType<"JSXElement">,
+      Set<EsTreeNode>
+    >();
+    const bodyExpressionDeclarations = new Map<EsTreeNodeOfType<"JSXElement">, Set<EsTreeNode>>();
 
     const collectImportBindings = (node: EsTreeNode): void => {
       if (!isNodeOfType(node, "ImportDeclaration")) return;
@@ -203,25 +257,46 @@ export const tanstackStartMissingScripts = defineRule({
       VariableDeclarator(node: EsTreeNodeOfType<"VariableDeclarator">) {
         collectVariableAlias(node);
       },
+      Property(node: EsTreeNodeOfType<"Property">) {
+        if (
+          getStaticPropertyKeyName(node, { allowComputedString: true }) !==
+            ROOT_COMPONENT_PROPERTY_NAME ||
+          !isNodeOfType(node.parent, "ObjectExpression") ||
+          !isRootRouteOptionsObject(node.parent)
+        ) {
+          return;
+        }
+        const componentValue = stripParenExpression(node.value);
+        if (isFunctionLike(componentValue)) {
+          configuredRootComponentDeclarations.add(componentValue);
+          return;
+        }
+        if (!isNodeOfType(componentValue, "Identifier")) return;
+        const componentDeclaration = getBindingDeclaration(componentValue, context);
+        if (componentDeclaration) {
+          configuredRootComponentDeclarations.add(componentDeclaration);
+        }
+      },
       JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
+        const enclosingBodyElement = getEnclosingDocumentBodyElement(node);
         if (
           isNodeOfType(node.name, "JSXIdentifier") &&
           node.name.name === DOCUMENT_BODY_ELEMENT_NAME
         ) {
-          hasDocumentBodyElement = true;
+          if (enclosingBodyElement) documentBodyElements.add(enclosingBodyElement);
           return;
         }
 
-        const isInsideBody = isInsideDocumentBodyElement(node);
         if (isScriptsElementName(node.name)) {
-          if (isInsideBody) {
-            hasScriptsInsideBody = true;
+          const scriptsValueDeclaration = getEnclosingVariableDeclaration(node);
+          if (scriptsValueDeclaration) {
+            scriptsValueDeclarations.add(scriptsValueDeclaration);
+          }
+          if (enclosingBodyElement) {
+            scriptsInsideBodyElements.add(enclosingBodyElement);
             return;
           }
-          const wrapperComponentIdentifier = getEnclosingComponentIdentifier(node);
-          const wrapperComponentDeclaration = wrapperComponentIdentifier
-            ? getBindingDeclaration(wrapperComponentIdentifier, context)
-            : null;
+          const wrapperComponentDeclaration = getEnclosingComponentDeclaration(node, context);
           if (wrapperComponentDeclaration) {
             scriptsWrapperComponentDeclarations.add(wrapperComponentDeclaration);
           }
@@ -231,12 +306,14 @@ export const tanstackStartMissingScripts = defineRule({
         if (!isNodeOfType(node.name, "JSXIdentifier")) return;
         const childComponentDeclaration = getBindingDeclaration(node.name, context);
         if (!childComponentDeclaration) return;
-        if (isInsideBody) bodyChildComponentDeclarations.add(childComponentDeclaration);
+        if (enclosingBodyElement) {
+          const bodyChildDeclarations =
+            bodyChildComponentDeclarations.get(enclosingBodyElement) ?? new Set<EsTreeNode>();
+          bodyChildDeclarations.add(childComponentDeclaration);
+          bodyChildComponentDeclarations.set(enclosingBodyElement, bodyChildDeclarations);
+        }
 
-        const enclosingComponentIdentifier = getEnclosingComponentIdentifier(node);
-        const enclosingComponentDeclaration = enclosingComponentIdentifier
-          ? getBindingDeclaration(enclosingComponentIdentifier, context)
-          : null;
+        const enclosingComponentDeclaration = getEnclosingComponentDeclaration(node, context);
         if (!enclosingComponentDeclaration) return;
         const dependencyDeclarations =
           componentDependencyDeclarations.get(enclosingComponentDeclaration) ??
@@ -244,26 +321,71 @@ export const tanstackStartMissingScripts = defineRule({
         dependencyDeclarations.add(childComponentDeclaration);
         componentDependencyDeclarations.set(enclosingComponentDeclaration, dependencyDeclarations);
       },
+      JSXExpressionContainer(node: EsTreeNodeOfType<"JSXExpressionContainer">) {
+        const enclosingBodyElement = getEnclosingDocumentBodyElement(node);
+        if (!enclosingBodyElement || !isNodeOfType(node.expression, "Identifier")) return;
+        const expressionDeclaration = getBindingDeclaration(node.expression, context);
+        if (!expressionDeclaration) return;
+        const expressionDeclarations =
+          bodyExpressionDeclarations.get(enclosingBodyElement) ?? new Set<EsTreeNode>();
+        expressionDeclarations.add(expressionDeclaration);
+        bodyExpressionDeclarations.set(enclosingBodyElement, expressionDeclarations);
+      },
       "Program:exit"(programNode: EsTreeNode) {
-        const reachableComponentDeclarations = new Set(bodyChildComponentDeclarations);
-        let hasScriptsWrapperInsideBody = false;
-        for (const componentDeclaration of reachableComponentDeclarations) {
-          if (scriptsWrapperComponentDeclarations.has(componentDeclaration)) {
-            hasScriptsWrapperInsideBody = true;
-            break;
-          }
+        const reachableRootComponentDeclarations = new Set(configuredRootComponentDeclarations);
+        for (const componentDeclaration of reachableRootComponentDeclarations) {
           for (const dependencyDeclaration of componentDependencyDeclarations.get(
             componentDeclaration,
           ) ?? []) {
-            reachableComponentDeclarations.add(dependencyDeclaration);
+            reachableRootComponentDeclarations.add(dependencyDeclaration);
           }
         }
-        if (hasDocumentBodyElement && !hasScriptsInsideBody && !hasScriptsWrapperInsideBody) {
+
+        for (const documentBodyElement of documentBodyElements) {
+          const bodyOwnerDeclaration = getEnclosingComponentDeclaration(
+            documentBodyElement,
+            context,
+          );
+          if (
+            !bodyOwnerDeclaration ||
+            !reachableRootComponentDeclarations.has(bodyOwnerDeclaration)
+          ) {
+            continue;
+          }
+          if (scriptsInsideBodyElements.has(documentBodyElement)) continue;
+          const renderedExpressionDeclarations =
+            bodyExpressionDeclarations.get(documentBodyElement) ?? [];
+          if (
+            [...renderedExpressionDeclarations].some((declaration) =>
+              scriptsValueDeclarations.has(declaration),
+            )
+          ) {
+            continue;
+          }
+
+          const reachableBodyChildDeclarations = new Set(
+            bodyChildComponentDeclarations.get(documentBodyElement) ?? [],
+          );
+          let hasScriptsWrapperInsideBody = false;
+          for (const componentDeclaration of reachableBodyChildDeclarations) {
+            if (scriptsWrapperComponentDeclarations.has(componentDeclaration)) {
+              hasScriptsWrapperInsideBody = true;
+              break;
+            }
+            for (const dependencyDeclaration of componentDependencyDeclarations.get(
+              componentDeclaration,
+            ) ?? []) {
+              reachableBodyChildDeclarations.add(dependencyDeclaration);
+            }
+          }
+          if (hasScriptsWrapperInsideBody) continue;
+
           context.report({
             node: programNode,
             message:
               "Without <Scripts /> inside <body>, the __root route does not load TanStack Start's client-side JavaScript.",
           });
+          return;
         }
       },
     };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-start/tanstack-start-missing-scripts.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-start/tanstack-start-missing-scripts.ts
@@ -2,7 +2,9 @@ import { TANSTACK_ROOT_ROUTE_FILE_PATTERN } from "../../constants/tanstack.js";
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findEnclosingClass } from "../../utils/find-enclosing-class.js";
 import { findTransparentExpressionRoot } from "../../utils/find-transparent-expression-root.js";
+import { getClassBindingSymbol } from "../../utils/get-class-binding-symbol.js";
 import { getStaticPropertyKeyName } from "../../utils/get-static-property-key-name.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
@@ -17,7 +19,8 @@ const TANSTACK_ROOT_ROUTE_FACTORY_NAMES = new Set([
 ]);
 const SCRIPTS_COMPONENT_NAME = "Scripts";
 const DOCUMENT_BODY_ELEMENT_NAME = "body";
-const ROOT_COMPONENT_PROPERTY_NAME = "component";
+const CLASS_RENDER_METHOD_NAME = "render";
+const ROOT_DOCUMENT_COMPONENT_PROPERTY_NAMES = new Set(["component", "shellComponent"]);
 
 const getJsxMemberRootIdentifier = (
   node: EsTreeNodeOfType<"JSXMemberExpression">,
@@ -59,6 +62,11 @@ const getEnclosingDocumentBodyElement = (
   return null;
 };
 
+const getClassComponentDeclaration = (
+  node: EsTreeNodeOfType<"ClassDeclaration" | "ClassExpression">,
+  context: RuleContext,
+): EsTreeNode => getClassBindingSymbol(node, context.scopes)?.declarationNode ?? node;
+
 const getEnclosingComponentDeclaration = (
   node: EsTreeNode,
   context: RuleContext,
@@ -73,6 +81,16 @@ const getEnclosingComponentDeclaration = (
       isNodeOfType(currentNode, "FunctionExpression")
     ) {
       const parentNode = findTransparentExpressionRoot(currentNode).parent;
+      if (
+        parentNode &&
+        (isNodeOfType(parentNode, "MethodDefinition") ||
+          isNodeOfType(parentNode, "PropertyDefinition")) &&
+        getStaticPropertyKeyName(parentNode, { allowComputedString: true }) ===
+          CLASS_RENDER_METHOD_NAME
+      ) {
+        const classNode = findEnclosingClass(parentNode);
+        if (classNode) return getClassComponentDeclaration(classNode, context);
+      }
       if (
         parentNode &&
         isNodeOfType(parentNode, "VariableDeclarator") &&
@@ -258,9 +276,10 @@ export const tanstackStartMissingScripts = defineRule({
         collectVariableAlias(node);
       },
       Property(node: EsTreeNodeOfType<"Property">) {
+        const propertyName = getStaticPropertyKeyName(node, { allowComputedString: true });
         if (
-          getStaticPropertyKeyName(node, { allowComputedString: true }) !==
-            ROOT_COMPONENT_PROPERTY_NAME ||
+          !propertyName ||
+          !ROOT_DOCUMENT_COMPONENT_PROPERTY_NAMES.has(propertyName) ||
           !isNodeOfType(node.parent, "ObjectExpression") ||
           !isRootRouteOptionsObject(node.parent)
         ) {
@@ -269,6 +288,12 @@ export const tanstackStartMissingScripts = defineRule({
         const componentValue = stripParenExpression(node.value);
         if (isFunctionLike(componentValue)) {
           configuredRootComponentDeclarations.add(componentValue);
+          return;
+        }
+        if (isNodeOfType(componentValue, "ClassExpression")) {
+          configuredRootComponentDeclarations.add(
+            getClassComponentDeclaration(componentValue, context),
+          );
           return;
         }
         if (!isNodeOfType(componentValue, "Identifier")) return;


### PR DESCRIPTION
## Why

TanStack Start root documents can silently omit the client script loader, and filesystem containment checks based on a bare string prefix accept sibling paths such as `<root>-backup`.

## What changed

- add `tanstack-start-missing-scripts`, including import aliases, namespace usage, body placement, and local wrapper handling
- add `no-path-prefix-containment` with Node `path.resolve` provenance and stable-alias tracking
- preserve `path.relative`, separator-aware prefixes, ordinary string prefixes, shadowed imports, reassigned candidates, and dynamic computed access
- add adversarial unit tests, liveness fixtures, generated registry entries, and a patch changeset

## Validation

- `nr test`
- `nr lint` (existing fixture warnings only)
- `nr typecheck`
- `nr format:check`
- `nr smoke:json-report`
- 500 strict fuzz iterations per new rule
- direct cached-corpus check: confirmed one true positive in Twenty and one clean TanStack root in Builder.io

## Parity

Daytona baseline attempted against base `b1b62db71d43b6d34ca5108f5598b9e2f6392f91` over 2,000 pinned project roots at concurrency 10. It completed 1,345/2,000 (67.3%) and failed 655 after all retries:

- 635 evaluation time budget exhausted
- 13 invalid JSON reports
- 7 command execution timeouts

The strict baseline validator exited 1, so the candidate revision and comparison were intentionally not run. Comparator and validator unit suites passed (31/31). Local artifacts are preserved under `tmp/parity-pr-1451-0eca8598/`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New static analysis only—no runtime behavior changes—but the path-containment rule targets security-sensitive filesystem checks and the Scripts rule is a large AST pass that could false-positive on unusual root layouts.
> 
> **Overview**
> Adds two new **react-doctor** lint rules and wires them through the registry, liveness fixtures, fuzz regressions, and a patch changeset.
> 
> **`tanstack-start-missing-scripts`** (TanStack Start) flags `__root` routes whose configured `component` or `shellComponent` renders a document `<body>` without TanStack Router’s `<Scripts />` inside it. Detection follows import aliases, namespace access, JSX variables, and local wrappers that ultimately render `Scripts`, and it stays quiet when the root route does not own the document.
> 
> **`no-path-prefix-containment`** (Security, global) reports `path.resolve(...)` results checked with a bare `startsWith(root)` prefix. It allows separator-aware prefixes, `path.relative`-style checks, and ordinary non-path string prefixes, while tracking stable identifier aliases and ignoring shadowed `path` imports and reassigned bindings.
> 
> Each rule ships with broad unit tests; three fuzz corpus cases cover known weaknesses for the Scripts rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41036eb9eacdafb1727aff6ac1d007392ec97593. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->