### PR TITLE
fix: detect React Compiler through dependency configs

### DIFF
--- a/.changeset/resolve-compiler-config-packages.md
+++ b/.changeset/resolve-compiler-config-packages.md
@@ -1,0 +1,6 @@
+---
+"@react-doctor/core": patch
+"react-doctor": patch
+---
+
+Detect active React Compiler transforms imported recursively from dependency packages.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,6 +29,7 @@
     "effect": "4.0.0-beta.70",
     "eslint-plugin-react-hooks": "^7.1.1",
     "jiti": "^2.7.0",
+    "oxc-resolver": "^11.24.2",
     "oxlint": ">=1.74.0 <1.75.0",
     "oxlint-plugin-react-doctor": "workspace:*",
     "picomatch": "^4.0.4",

--- a/packages/core/src/project-info/detectors.ts
+++ b/packages/core/src/project-info/detectors.ts
@@ -2168,19 +2168,21 @@ const hasCompilerInConfigFile = (filePath: string): boolean =>
 const hasCompilerInConfigFiles = (directory: string, filenames: string[]): boolean =>
   filenames.some((filename) => hasCompilerInConfigFile(path.join(directory, filename)));
 
-const hasCompilerInPackageJsonConfig = (packageJson: PackageJson): boolean =>
-  isPlainObject(packageJson.babel) &&
-  analyzeConfigSourceFileExport(
-    ts.parseJsonText("package.json", JSON.stringify(packageJson.babel)),
-    "package.json#babel",
+const hasCompilerInPackageJsonConfig = (directory: string, packageJson: PackageJson): boolean => {
+  if (!isPlainObject(packageJson.babel)) return false;
+  const packageJsonPath = path.join(directory, "package.json");
+  return analyzeConfigSourceFileExport(
+    ts.parseJsonText(packageJsonPath, JSON.stringify(packageJson.babel)),
+    packageJsonPath,
     "default",
     false,
     0,
     new Set<string>(),
   );
+};
 
 const hasCompilerConfiguration = (directory: string, packageJson: PackageJson): boolean =>
-  hasCompilerInPackageJsonConfig(packageJson) ||
+  hasCompilerInPackageJsonConfig(directory, packageJson) ||
   hasCompilerInConfigFiles(directory, REACT_COMPILER_CONFIG_FILENAMES);
 
 const hasCompilerConfigurationInAncestors = (directory: string): boolean => {
@@ -2193,7 +2195,7 @@ const hasCompilerConfigurationInAncestors = (directory: string): boolean => {
       ? readPackageJson(ancestorPackagePath)
       : {};
     if (
-      hasCompilerInPackageJsonConfig(ancestorPackageJson) ||
+      hasCompilerInPackageJsonConfig(ancestorDirectory, ancestorPackageJson) ||
       hasCompilerInConfigFiles(ancestorDirectory, BABEL_CONFIG_FILENAMES)
     ) {
       return true;

--- a/packages/core/src/project-info/detectors.ts
+++ b/packages/core/src/project-info/detectors.ts
@@ -27,8 +27,10 @@ interface TsConfigShape {
   readonly compilerOptions: TsConfigCompilerOptions;
 }
 
-const isRelativeExtendsValue = (extendsValue: string): boolean =>
-  extendsValue.startsWith("./") || extendsValue.startsWith("../") || path.isAbsolute(extendsValue);
+const isLocalModuleSpecifier = (moduleSpecifier: string): boolean =>
+  moduleSpecifier.startsWith("./") ||
+  moduleSpecifier.startsWith("../") ||
+  path.isAbsolute(moduleSpecifier);
 
 const ensureJsonExtension = (filePath: string): string =>
   path.extname(filePath) === "" ? `${filePath}.json` : filePath;
@@ -56,7 +58,7 @@ const resolvePackageExtendsPath = (
 };
 
 const resolveExtendsPath = (extendsValue: string, fromConfigDirectory: string): string | null => {
-  if (isRelativeExtendsValue(extendsValue)) {
+  if (isLocalModuleSpecifier(extendsValue)) {
     return ensureJsonExtension(path.resolve(fromConfigDirectory, extendsValue));
   }
 
@@ -395,6 +397,15 @@ const resolveImportedConfigFile = (
   fromFilePath: string,
   moduleSpecifier: string,
 ): string | null => {
+  if (!isLocalModuleSpecifier(moduleSpecifier)) {
+    try {
+      const resolvedPath = createRequire(fromFilePath).resolve(moduleSpecifier);
+      return isFile(resolvedPath) ? resolvedPath : null;
+    } catch {
+      return null;
+    }
+  }
+
   const unresolvedPath = path.resolve(path.dirname(fromFilePath), moduleSpecifier);
   const extension = path.extname(unresolvedPath);
   const candidatePaths = extension
@@ -467,6 +478,14 @@ interface ConfigExpressionAnalysis {
   readonly visitedNodes: Set<string>;
   readonly localBindings: ReadonlyMap<string, ts.Expression | null>;
   readonly activeFunctions: ReadonlySet<number>;
+}
+
+interface AnalyzeImportedConfigOptions {
+  readonly analysis: ConfigExpressionAnalysis;
+  readonly moduleSpecifier: string;
+  readonly exportName: string;
+  readonly allowCompilerTransform: boolean;
+  readonly argumentsList?: readonly ts.Expression[];
 }
 
 interface ScopedConfigBinding {
@@ -1433,6 +1452,27 @@ const analyzeConfigFunction = (
   return hasCompiler;
 };
 
+const analyzeImportedConfig = ({
+  analysis,
+  moduleSpecifier,
+  exportName,
+  allowCompilerTransform,
+  argumentsList,
+}: AnalyzeImportedConfigOptions): boolean => {
+  const importedFilePath = resolveImportedConfigFile(analysis.filePath, moduleSpecifier);
+  return Boolean(
+    importedFilePath &&
+    analyzeConfigModuleExport(
+      importedFilePath,
+      exportName,
+      allowCompilerTransform,
+      analysis.importDepth + 1,
+      analysis.visitedModules,
+      argumentsList,
+    ),
+  );
+};
+
 const analyzeConfigIdentifier = (
   identifier: ts.Identifier,
   analysis: ConfigExpressionAnalysis,
@@ -1499,21 +1539,12 @@ const analyzeConfigIdentifier = (
     ) {
       return true;
     }
-    if (!importBinding.moduleSpecifier.startsWith(".")) return false;
-    const importedFilePath = resolveImportedConfigFile(
-      analysis.filePath,
-      importBinding.moduleSpecifier,
-    );
-    return Boolean(
-      importedFilePath &&
-      analyzeConfigModuleExport(
-        importedFilePath,
-        importBinding.exportName,
-        allowCompilerTransform,
-        analysis.importDepth + 1,
-        analysis.visitedModules,
-      ),
-    );
+    return analyzeImportedConfig({
+      analysis,
+      moduleSpecifier: importBinding.moduleSpecifier,
+      exportName: importBinding.exportName,
+      allowCompilerTransform,
+    });
   }
   const topLevelBinding = getTopLevelBinding(analysis.sourceFile, identifier.text);
   return Boolean(
@@ -1550,39 +1581,45 @@ const analyzeConfigCallTarget = (
       (getScopedConfigBinding(target.expression.expression).wasFound ||
         hasTopLevelValueBinding(analysis.sourceFile, "require"));
     if (isRequireShadowed) return false;
-    if (!requiredModuleSpecifier.startsWith(".")) return null;
-    const importedFilePath = resolveImportedConfigFile(analysis.filePath, requiredModuleSpecifier);
-    return Boolean(
-      importedFilePath &&
-      analyzeConfigModuleExport(
-        importedFilePath,
-        propertyName,
-        allowCompilerTransform,
-        analysis.importDepth + 1,
-        analysis.visitedModules,
-        callExpression.arguments,
-      ),
-    );
+    const hasCompilerTransform = analyzeImportedConfig({
+      analysis,
+      moduleSpecifier: requiredModuleSpecifier,
+      exportName: propertyName,
+      allowCompilerTransform,
+      argumentsList: callExpression.arguments,
+    });
+    if (isLocalModuleSpecifier(requiredModuleSpecifier) || hasCompilerTransform) {
+      return hasCompilerTransform;
+    }
+    return null;
   }
 
   if (!ts.isIdentifier(target.expression)) return null;
+  if (
+    analysis.localBindings.has(target.expression.text) ||
+    getScopedConfigBinding(target.expression).wasFound
+  ) {
+    return null;
+  }
   const importBinding = getImportBinding(analysis.sourceFile, target.expression.text);
-  if (importBinding?.isNamespace && importBinding.moduleSpecifier.startsWith(".")) {
-    const importedFilePath = resolveImportedConfigFile(
-      analysis.filePath,
-      importBinding.moduleSpecifier,
-    );
-    return Boolean(
-      importedFilePath &&
-      analyzeConfigModuleExport(
-        importedFilePath,
-        propertyName,
-        allowCompilerTransform,
-        analysis.importDepth + 1,
-        analysis.visitedModules,
-        callExpression.arguments,
-      ),
-    );
+  if (importBinding?.isNamespace) {
+    if (
+      allowCompilerTransform &&
+      isCompilerTransformModule(importBinding.moduleSpecifier, propertyName)
+    ) {
+      return true;
+    }
+    const hasCompilerTransform = analyzeImportedConfig({
+      analysis,
+      moduleSpecifier: importBinding.moduleSpecifier,
+      exportName: propertyName,
+      allowCompilerTransform,
+      argumentsList: callExpression.arguments,
+    });
+    if (isLocalModuleSpecifier(importBinding.moduleSpecifier) || hasCompilerTransform) {
+      return hasCompilerTransform;
+    }
+    return null;
   }
 
   const selectedProperty = getSelectedObjectProperty(target.expression, propertyName, analysis);
@@ -1673,24 +1710,14 @@ const analyzeConfigNode = (
         }
         const propertyAllowsCompilerTransform =
           propertyName === "plugins" || propertyName === "presets";
-        if (
-          propertyName === "extends" &&
-          ts.isStringLiteralLike(property.initializer) &&
-          property.initializer.text.startsWith(".")
-        ) {
-          const extendedFilePath = resolveImportedConfigFile(
-            analysis.filePath,
-            property.initializer.text,
-          );
+        if (propertyName === "extends" && ts.isStringLiteralLike(property.initializer)) {
           if (
-            extendedFilePath &&
-            analyzeConfigModuleExport(
-              extendedFilePath,
-              "default",
-              false,
-              analysis.importDepth + 1,
-              analysis.visitedModules,
-            )
+            analyzeImportedConfig({
+              analysis,
+              moduleSpecifier: property.initializer.text,
+              exportName: "default",
+              allowCompilerTransform: false,
+            })
           ) {
             return true;
           }
@@ -1818,43 +1845,36 @@ const analyzeConfigNode = (
     if (directModuleSpecifier && !isRequireShadowed) {
       if (allowCompilerTransform && isCompilerTransformModule(directModuleSpecifier, "default"))
         return true;
-      if (directModuleSpecifier.startsWith(".")) {
-        const importedFilePath = resolveImportedConfigFile(
-          analysis.filePath,
-          directModuleSpecifier,
-        );
-        if (
-          importedFilePath &&
-          analyzeConfigModuleExport(
-            importedFilePath,
-            "default",
-            allowCompilerTransform,
-            analysis.importDepth + 1,
-            analysis.visitedModules,
-          )
-        ) {
-          return true;
-        }
+      if (
+        analyzeImportedConfig({
+          analysis,
+          moduleSpecifier: directModuleSpecifier,
+          exportName: "default",
+          allowCompilerTransform,
+        })
+      ) {
+        return true;
       }
     }
     if (ts.isIdentifier(node.expression)) {
       const importBinding = getImportBinding(analysis.sourceFile, node.expression.text);
-      if (importBinding?.moduleSpecifier.startsWith(".")) {
-        const importedFilePath = resolveImportedConfigFile(
-          analysis.filePath,
-          importBinding.moduleSpecifier,
-        );
-        return Boolean(
-          importedFilePath &&
-          analyzeConfigModuleExport(
-            importedFilePath,
-            importBinding.exportName,
-            allowCompilerTransform,
-            analysis.importDepth + 1,
-            analysis.visitedModules,
-            node.arguments,
-          ),
-        );
+      if (importBinding) {
+        if (
+          allowCompilerTransform &&
+          isCompilerTransformModule(importBinding.moduleSpecifier, importBinding.exportName)
+        ) {
+          return true;
+        }
+        const hasCompilerTransform = analyzeImportedConfig({
+          analysis,
+          moduleSpecifier: importBinding.moduleSpecifier,
+          exportName: importBinding.exportName,
+          allowCompilerTransform,
+          argumentsList: node.arguments,
+        });
+        if (isLocalModuleSpecifier(importBinding.moduleSpecifier) || hasCompilerTransform) {
+          return hasCompilerTransform;
+        }
       }
       const topLevelBinding = getTopLevelBinding(analysis.sourceFile, node.expression.text);
       if (
@@ -1879,21 +1899,15 @@ const analyzeConfigNode = (
         (getScopedConfigBinding(node.expression.expression).wasFound ||
           hasTopLevelValueBinding(analysis.sourceFile, "require"));
       if (isRequireShadowed) return false;
-      if (requiredModuleSpecifier.startsWith(".")) {
-        const importedFilePath = resolveImportedConfigFile(
-          analysis.filePath,
-          requiredModuleSpecifier,
-        );
-        return Boolean(
-          importedFilePath &&
-          analyzeConfigModuleExport(
-            importedFilePath,
-            node.name.text,
-            allowCompilerTransform,
-            analysis.importDepth + 1,
-            analysis.visitedModules,
-          ),
-        );
+      if (
+        analyzeImportedConfig({
+          analysis,
+          moduleSpecifier: requiredModuleSpecifier,
+          exportName: node.name.text,
+          allowCompilerTransform,
+        })
+      ) {
+        return true;
       }
       return (
         allowCompilerTransform && isCompilerTransformModule(requiredModuleSpecifier, node.name.text)
@@ -1914,23 +1928,15 @@ const analyzeConfigNode = (
         ) {
           return true;
         }
-        if (importBinding.moduleSpecifier.startsWith(".")) {
-          const importedFilePath = resolveImportedConfigFile(
-            analysis.filePath,
-            importBinding.moduleSpecifier,
-          );
-          if (
-            importedFilePath &&
-            analyzeConfigModuleExport(
-              importedFilePath,
-              node.name.text,
-              allowCompilerTransform,
-              analysis.importDepth + 1,
-              analysis.visitedModules,
-            )
-          ) {
-            return true;
-          }
+        if (
+          analyzeImportedConfig({
+            analysis,
+            moduleSpecifier: importBinding.moduleSpecifier,
+            exportName: node.name.text,
+            allowCompilerTransform,
+          })
+        ) {
+          return true;
         }
         return false;
       }
@@ -1956,22 +1962,12 @@ const analyzeConfigNode = (
         ) {
           return true;
         }
-        if (importBinding.moduleSpecifier.startsWith(".")) {
-          const importedFilePath = resolveImportedConfigFile(
-            analysis.filePath,
-            importBinding.moduleSpecifier,
-          );
-          return Boolean(
-            importedFilePath &&
-            analyzeConfigModuleExport(
-              importedFilePath,
-              node.argumentExpression.text,
-              allowCompilerTransform,
-              analysis.importDepth + 1,
-              analysis.visitedModules,
-            ),
-          );
-        }
+        return analyzeImportedConfig({
+          analysis,
+          moduleSpecifier: importBinding.moduleSpecifier,
+          exportName: node.argumentExpression.text,
+          allowCompilerTransform,
+        });
       }
       const selectedProperty = getSelectedObjectProperty(
         node.expression,

--- a/packages/core/src/project-info/detectors.ts
+++ b/packages/core/src/project-info/detectors.ts
@@ -62,7 +62,10 @@ const resolvePackageExtendsPath = (
 
 const resolveExtendsPath = (extendsValue: string, fromConfigDirectory: string): string | null => {
   if (isLocalModuleSpecifier(extendsValue)) {
-    return ensureJsonExtension(path.resolve(fromConfigDirectory, extendsValue));
+    const resolvedPath = path.resolve(fromConfigDirectory, extendsValue);
+    if (isFile(resolvedPath)) return resolvedPath;
+    const directoryConfigPath = path.join(resolvedPath, TSCONFIG_FILENAME);
+    return isFile(directoryConfigPath) ? directoryConfigPath : ensureJsonExtension(resolvedPath);
   }
 
   return resolvePackageExtendsPath(extendsValue, fromConfigDirectory);
@@ -1593,7 +1596,8 @@ const analyzeConfigCallTarget = (
     const isRequireShadowed =
       ts.isCallExpression(target.expression) &&
       ts.isIdentifier(target.expression.expression) &&
-      (getScopedConfigBinding(target.expression.expression).wasFound ||
+      (analysis.localBindings.has(target.expression.expression.text) ||
+        getScopedConfigBinding(target.expression.expression).wasFound ||
         hasTopLevelValueBinding(analysis.sourceFile, "require"));
     if (isRequireShadowed) return false;
     const hasCompilerTransform = analyzeImportedConfig({
@@ -1610,13 +1614,12 @@ const analyzeConfigCallTarget = (
   }
 
   if (!ts.isIdentifier(target.expression)) return null;
-  if (
+  const isTargetShadowed =
     analysis.localBindings.has(target.expression.text) ||
-    getScopedConfigBinding(target.expression).wasFound
-  ) {
-    return null;
-  }
-  const importBinding = getImportBinding(analysis.sourceFile, target.expression.text);
+    getScopedConfigBinding(target.expression).wasFound;
+  const importBinding = isTargetShadowed
+    ? null
+    : getImportBinding(analysis.sourceFile, target.expression.text);
   if (importBinding?.isNamespace) {
     if (
       allowCompilerTransform &&
@@ -1916,7 +1919,8 @@ const analyzeConfigNode = (
       const isRequireShadowed =
         ts.isCallExpression(node.expression) &&
         ts.isIdentifier(node.expression.expression) &&
-        (getScopedConfigBinding(node.expression.expression).wasFound ||
+        (analysis.localBindings.has(node.expression.expression.text) ||
+          getScopedConfigBinding(node.expression.expression).wasFound ||
           hasTopLevelValueBinding(analysis.sourceFile, "require"));
       if (isRequireShadowed) return false;
       if (

--- a/packages/core/src/project-info/detectors.ts
+++ b/packages/core/src/project-info/detectors.ts
@@ -1476,18 +1476,16 @@ const analyzeImportedConfig = ({
   exportName,
   allowCompilerTransform,
   argumentsList,
-}: AnalyzeImportedConfigOptions): boolean => {
+}: AnalyzeImportedConfigOptions): boolean | null => {
   const importedFilePath = resolveImportedConfigFile(analysis.filePath, moduleSpecifier);
-  return Boolean(
-    importedFilePath &&
-    analyzeConfigModuleExport(
-      importedFilePath,
-      exportName,
-      allowCompilerTransform,
-      analysis.importDepth + 1,
-      analysis.visitedModules,
-      argumentsList,
-    ),
+  if (!importedFilePath) return null;
+  return analyzeConfigModuleExport(
+    importedFilePath,
+    exportName,
+    allowCompilerTransform,
+    analysis.importDepth + 1,
+    analysis.visitedModules,
+    argumentsList,
   );
 };
 
@@ -1557,12 +1555,14 @@ const analyzeConfigIdentifier = (
     ) {
       return true;
     }
-    return analyzeImportedConfig({
-      analysis,
-      moduleSpecifier: importBinding.moduleSpecifier,
-      exportName: importBinding.exportName,
-      allowCompilerTransform,
-    });
+    return Boolean(
+      analyzeImportedConfig({
+        analysis,
+        moduleSpecifier: importBinding.moduleSpecifier,
+        exportName: importBinding.exportName,
+        allowCompilerTransform,
+      }),
+    );
   }
   const topLevelBinding = getTopLevelBinding(analysis.sourceFile, identifier.text);
   return Boolean(
@@ -1583,6 +1583,33 @@ const analyzeConfigCallTarget = (
   allowCompilerTransform: boolean,
 ): boolean | null => {
   const target = callExpression.expression;
+  const callableRequiredModuleSpecifier = getRequireModuleSpecifier(target);
+  if (callableRequiredModuleSpecifier !== null) {
+    const isRequireShadowed =
+      ts.isCallExpression(target) &&
+      ts.isIdentifier(target.expression) &&
+      (analysis.localBindings.has(target.expression.text) ||
+        getScopedConfigBinding(target.expression).wasFound ||
+        hasTopLevelValueBinding(analysis.sourceFile, "require"));
+    if (isRequireShadowed) return false;
+    if (
+      allowCompilerTransform &&
+      isCompilerTransformModule(callableRequiredModuleSpecifier, "default")
+    ) {
+      return true;
+    }
+    const hasCompilerTransform = analyzeImportedConfig({
+      analysis,
+      moduleSpecifier: callableRequiredModuleSpecifier,
+      exportName: "default",
+      allowCompilerTransform,
+      argumentsList: callExpression.arguments,
+    });
+    if (isLocalModuleSpecifier(callableRequiredModuleSpecifier) || hasCompilerTransform !== null) {
+      return Boolean(hasCompilerTransform);
+    }
+    return null;
+  }
   if (!ts.isPropertyAccessExpression(target) && !ts.isElementAccessExpression(target)) return null;
   const propertyName = ts.isPropertyAccessExpression(target)
     ? target.name.text
@@ -1607,8 +1634,8 @@ const analyzeConfigCallTarget = (
       allowCompilerTransform,
       argumentsList: callExpression.arguments,
     });
-    if (isLocalModuleSpecifier(requiredModuleSpecifier) || hasCompilerTransform) {
-      return hasCompilerTransform;
+    if (isLocalModuleSpecifier(requiredModuleSpecifier) || hasCompilerTransform !== null) {
+      return Boolean(hasCompilerTransform);
     }
     return null;
   }
@@ -1634,8 +1661,8 @@ const analyzeConfigCallTarget = (
       allowCompilerTransform,
       argumentsList: callExpression.arguments,
     });
-    if (isLocalModuleSpecifier(importBinding.moduleSpecifier) || hasCompilerTransform) {
-      return hasCompilerTransform;
+    if (isLocalModuleSpecifier(importBinding.moduleSpecifier) || hasCompilerTransform !== null) {
+      return Boolean(hasCompilerTransform);
     }
     return null;
   }
@@ -1894,8 +1921,11 @@ const analyzeConfigNode = (
             allowCompilerTransform,
             argumentsList: node.arguments,
           });
-          if (isLocalModuleSpecifier(importBinding.moduleSpecifier) || hasCompilerTransform) {
-            return hasCompilerTransform;
+          if (
+            isLocalModuleSpecifier(importBinding.moduleSpecifier) ||
+            hasCompilerTransform !== null
+          ) {
+            return Boolean(hasCompilerTransform);
           }
         }
       }
@@ -2006,12 +2036,14 @@ const analyzeConfigNode = (
         ) {
           return true;
         }
-        return analyzeImportedConfig({
-          analysis,
-          moduleSpecifier: importBinding.moduleSpecifier,
-          exportName: node.argumentExpression.text,
-          allowCompilerTransform,
-        });
+        return Boolean(
+          analyzeImportedConfig({
+            analysis,
+            moduleSpecifier: importBinding.moduleSpecifier,
+            exportName: node.argumentExpression.text,
+            allowCompilerTransform,
+          }),
+        );
       }
       const selectedProperty = getSelectedObjectProperty(
         node.expression,

--- a/packages/core/src/project-info/detectors.ts
+++ b/packages/core/src/project-info/detectors.ts
@@ -1627,6 +1627,12 @@ const analyzeConfigCallTarget = (
         getScopedConfigBinding(target.expression.expression).wasFound ||
         hasTopLevelValueBinding(analysis.sourceFile, "require"));
     if (isRequireShadowed) return false;
+    if (
+      allowCompilerTransform &&
+      isCompilerTransformModule(requiredModuleSpecifier, propertyName)
+    ) {
+      return true;
+    }
     const hasCompilerTransform = analyzeImportedConfig({
       analysis,
       moduleSpecifier: requiredModuleSpecifier,

--- a/packages/core/src/project-info/detectors.ts
+++ b/packages/core/src/project-info/detectors.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import { createRequire } from "node:module";
 import * as path from "node:path";
+import { ResolverFactory } from "oxc-resolver";
 import ts from "typescript";
 import {
   ES2023_YEAR,
@@ -28,6 +29,8 @@ interface TsConfigShape {
 }
 
 const isLocalModuleSpecifier = (moduleSpecifier: string): boolean =>
+  moduleSpecifier === "." ||
+  moduleSpecifier === ".." ||
   moduleSpecifier.startsWith("./") ||
   moduleSpecifier.startsWith("../") ||
   path.isAbsolute(moduleSpecifier);
@@ -356,6 +359,11 @@ const REACT_COMPILER_CONFIG_SOURCE_EXTENSIONS = [
   ".json",
 ];
 
+const REACT_COMPILER_CONFIG_RESOLVER = new ResolverFactory({
+  conditionNames: ["import", "require", "node", "default"],
+  extensions: REACT_COMPILER_CONFIG_SOURCE_EXTENSIONS,
+});
+
 // `output: "export"` (static HTML export) in next.config.*. The leading
 // `(?:^|[^.\w])` boundary keeps it from matching a nested/namespaced key like
 // `experimental.output` or `outputFileTracingRoot`.
@@ -398,6 +406,13 @@ const resolveImportedConfigFile = (
   moduleSpecifier: string,
 ): string | null => {
   if (!isLocalModuleSpecifier(moduleSpecifier)) {
+    try {
+      const resolvedPath = REACT_COMPILER_CONFIG_RESOLVER.resolveFileSync(
+        fromFilePath,
+        moduleSpecifier,
+      ).path;
+      if (resolvedPath && isFile(resolvedPath)) return resolvedPath;
+    } catch {}
     try {
       const resolvedPath = createRequire(fromFilePath).resolve(moduleSpecifier);
       return isFile(resolvedPath) ? resolvedPath : null;
@@ -1857,23 +1872,28 @@ const analyzeConfigNode = (
       }
     }
     if (ts.isIdentifier(node.expression)) {
-      const importBinding = getImportBinding(analysis.sourceFile, node.expression.text);
-      if (importBinding) {
-        if (
-          allowCompilerTransform &&
-          isCompilerTransformModule(importBinding.moduleSpecifier, importBinding.exportName)
-        ) {
-          return true;
-        }
-        const hasCompilerTransform = analyzeImportedConfig({
-          analysis,
-          moduleSpecifier: importBinding.moduleSpecifier,
-          exportName: importBinding.exportName,
-          allowCompilerTransform,
-          argumentsList: node.arguments,
-        });
-        if (isLocalModuleSpecifier(importBinding.moduleSpecifier) || hasCompilerTransform) {
-          return hasCompilerTransform;
+      if (
+        !analysis.localBindings.has(node.expression.text) &&
+        !getScopedConfigBinding(node.expression).wasFound
+      ) {
+        const importBinding = getImportBinding(analysis.sourceFile, node.expression.text);
+        if (importBinding) {
+          if (
+            allowCompilerTransform &&
+            isCompilerTransformModule(importBinding.moduleSpecifier, importBinding.exportName)
+          ) {
+            return true;
+          }
+          const hasCompilerTransform = analyzeImportedConfig({
+            analysis,
+            moduleSpecifier: importBinding.moduleSpecifier,
+            exportName: importBinding.exportName,
+            allowCompilerTransform,
+            argumentsList: node.arguments,
+          });
+          if (isLocalModuleSpecifier(importBinding.moduleSpecifier) || hasCompilerTransform) {
+            return hasCompilerTransform;
+          }
         }
       }
       const topLevelBinding = getTopLevelBinding(analysis.sourceFile, node.expression.text);
@@ -1914,10 +1934,17 @@ const analyzeConfigNode = (
       );
     }
     if (ts.isIdentifier(node.expression)) {
-      if (analysis.localBindings.has(node.expression.text)) {
-        const localInitializer = analysis.localBindings.get(node.expression.text);
+      if (
+        analysis.localBindings.has(node.expression.text) ||
+        getScopedConfigBinding(node.expression).wasFound
+      ) {
+        const selectedProperty = getSelectedObjectProperty(
+          node.expression,
+          node.name.text,
+          analysis,
+        );
         return Boolean(
-          localInitializer && analyzeConfigNode(localInitializer, analysis, allowCompilerTransform),
+          selectedProperty && analyzeConfigNode(selectedProperty, analysis, allowCompilerTransform),
         );
       }
       const importBinding = getImportBinding(analysis.sourceFile, node.expression.text);
@@ -1954,6 +1981,19 @@ const analyzeConfigNode = (
     ts.isStringLiteralLike(node.argumentExpression)
   ) {
     if (ts.isIdentifier(node.expression)) {
+      if (
+        analysis.localBindings.has(node.expression.text) ||
+        getScopedConfigBinding(node.expression).wasFound
+      ) {
+        const selectedProperty = getSelectedObjectProperty(
+          node.expression,
+          node.argumentExpression.text,
+          analysis,
+        );
+        return Boolean(
+          selectedProperty && analyzeConfigNode(selectedProperty, analysis, allowCompilerTransform),
+        );
+      }
       const importBinding = getImportBinding(analysis.sourceFile, node.expression.text);
       if (importBinding?.isNamespace) {
         if (

--- a/packages/core/tests/detect-pre-es2023-target.test.ts
+++ b/packages/core/tests/detect-pre-es2023-target.test.ts
@@ -111,6 +111,28 @@ describe("detectPreES2023Target", () => {
     expect(detectPreES2023Target(path.join(projectDirectory, "apps", "web"))).toBe(true);
   });
 
+  it("inherits target from a parent directory through an exact dot-dot extends", () => {
+    const projectDirectory = setupProject("dot-dot-extends", {
+      "apps/tsconfig.json": writeTsConfig({ compilerOptions: { target: "es2022" } }),
+      "apps/web/tsconfig.json": writeTsConfig({ extends: ".." }),
+    });
+
+    expect(detectPreES2023Target(path.join(projectDirectory, "apps", "web"))).toBe(true);
+  });
+
+  it("inherits target from the current directory through an exact dot extends", () => {
+    const projectDirectory = setupProject("dot-extends", {
+      "tsconfig.json": writeTsConfig({
+        files: [],
+        references: [{ path: "./app/tsconfig.build.json" }],
+      }),
+      "app/tsconfig.json": writeTsConfig({ compilerOptions: { target: "es2022" } }),
+      "app/tsconfig.build.json": writeTsConfig({ extends: "." }),
+    });
+
+    expect(detectPreES2023Target(projectDirectory)).toBe(true);
+  });
+
   it("lets child compiler options override inherited target", () => {
     const projectDirectory = setupProject("child-target-override", {
       "tsconfig.base.json": writeTsConfig({ compilerOptions: { target: "es2022" } }),

--- a/packages/core/tests/discover-project.test.ts
+++ b/packages/core/tests/discover-project.test.ts
@@ -1577,6 +1577,39 @@ describe("discoverProject", () => {
     expect(discoverProject(projectDirectory).hasReactCompiler).toBe(false);
   });
 
+  it.each([
+    {
+      name: "babel-plugin-default",
+      packageName: "babel-plugin-react-compiler",
+      config: "module.exports = { plugins: [require('babel-plugin-react-compiler').default()] };",
+    },
+    {
+      name: "vite-react-preset",
+      packageName: "@vitejs/plugin-react",
+      config:
+        "module.exports = { plugins: [require('@vitejs/plugin-react').reactCompilerPreset()] };",
+    },
+  ])("detects $name when the compiler package resolves", (testCase) => {
+    const projectDirectory = path.join(tempDirectory, `resolved-${testCase.name}`);
+    const packageDirectory = path.join(projectDirectory, "node_modules", testCase.packageName);
+    fs.mkdirSync(packageDirectory, { recursive: true });
+    fs.writeFileSync(
+      path.join(projectDirectory, "package.json"),
+      JSON.stringify({
+        name: `resolved-${testCase.name}`,
+        dependencies: { react: "^19.0.0" },
+      }),
+    );
+    fs.writeFileSync(path.join(projectDirectory, "vite.config.ts"), testCase.config);
+    fs.writeFileSync(
+      path.join(packageDirectory, "package.json"),
+      JSON.stringify({ name: testCase.packageName, main: "./index.js" }),
+    );
+    fs.writeFileSync(path.join(packageDirectory, "index.js"), "module.exports = {};\n");
+
+    expect(discoverProject(projectDirectory).hasReactCompiler).toBe(true);
+  });
+
   it("detects React Compiler through an import-only package export", () => {
     const projectDirectory = path.join(tempDirectory, "import-only-package-react-compiler");
     const configDirectory = path.join(

--- a/packages/core/tests/discover-project.test.ts
+++ b/packages/core/tests/discover-project.test.ts
@@ -1443,6 +1443,99 @@ describe("discoverProject", () => {
     expect(discoverProject(projectDirectory).hasReactCompiler).toBe(true);
   });
 
+  it("detects React Compiler through recursively imported dependency packages", () => {
+    const projectDirectory = path.join(tempDirectory, "dependency-package-react-compiler");
+    const buildConfigDirectory = path.join(
+      projectDirectory,
+      "node_modules",
+      "@fixture",
+      "build-config",
+    );
+    const compilerConfigDirectory = path.join(
+      projectDirectory,
+      "node_modules",
+      "@fixture",
+      "compiler-config",
+    );
+    fs.mkdirSync(buildConfigDirectory, { recursive: true });
+    fs.mkdirSync(compilerConfigDirectory, { recursive: true });
+    fs.writeFileSync(
+      path.join(projectDirectory, "package.json"),
+      JSON.stringify({
+        name: "dependency-package-react-compiler",
+        dependencies: { react: "^19.0.0" },
+        devDependencies: { "@fixture/build-config": "workspace:*" },
+      }),
+    );
+    fs.writeFileSync(
+      path.join(projectDirectory, "vite.config.ts"),
+      "import buildConfig from '@fixture/build-config';\nexport default buildConfig;\n",
+    );
+    fs.writeFileSync(
+      path.join(buildConfigDirectory, "package.json"),
+      JSON.stringify({
+        name: "@fixture/build-config",
+        exports: "./index.js",
+        dependencies: { "@fixture/compiler-config": "workspace:*" },
+      }),
+    );
+    fs.writeFileSync(
+      path.join(buildConfigDirectory, "index.js"),
+      "import compilerConfig from '@fixture/compiler-config';\nexport default compilerConfig;\n",
+    );
+    fs.writeFileSync(
+      path.join(compilerConfigDirectory, "package.json"),
+      JSON.stringify({
+        name: "@fixture/compiler-config",
+        exports: "./index.js",
+        dependencies: { "babel-plugin-react-compiler": "^1.0.0" },
+      }),
+    );
+    fs.writeFileSync(
+      path.join(compilerConfigDirectory, "index.js"),
+      "export default { plugins: ['babel-plugin-react-compiler'] };\n",
+    );
+
+    expect(discoverProject(projectDirectory).hasReactCompiler).toBe(true);
+  });
+
+  it("does not infer React Compiler from an unused transitive dependency", () => {
+    const projectDirectory = path.join(tempDirectory, "unused-dependency-package-react-compiler");
+    const buildConfigDirectory = path.join(
+      projectDirectory,
+      "node_modules",
+      "@fixture",
+      "plain-build-config",
+    );
+    fs.mkdirSync(buildConfigDirectory, { recursive: true });
+    fs.writeFileSync(
+      path.join(projectDirectory, "package.json"),
+      JSON.stringify({
+        name: "unused-dependency-package-react-compiler",
+        dependencies: { react: "^19.0.0" },
+        devDependencies: { "@fixture/plain-build-config": "workspace:*" },
+      }),
+    );
+    fs.writeFileSync(
+      path.join(projectDirectory, "vite.config.ts"),
+      "import buildConfig from '@fixture/plain-build-config';\nexport default buildConfig;\n",
+    );
+    fs.writeFileSync(
+      path.join(buildConfigDirectory, "package.json"),
+      JSON.stringify({
+        name: "@fixture/plain-build-config",
+        exports: "./index.js",
+        dependencies: { "babel-plugin-react-compiler": "^1.0.0" },
+      }),
+    );
+    fs.writeFileSync(
+      path.join(buildConfigDirectory, "index.js"),
+      "export default { plugins: ['other-plugin'] };\n",
+    );
+
+    expect(discoverProject(projectDirectory).hasReactCompiler).toBe(false);
+  });
+
   const reactCompilerDetectionCases: ReactCompilerDetectionCase[] = [
     {
       name: "property-key-collision",

--- a/packages/core/tests/discover-project.test.ts
+++ b/packages/core/tests/discover-project.test.ts
@@ -1673,6 +1673,12 @@ describe("discoverProject", () => {
       expected: false,
     },
     {
+      name: "parameter-shadowed-require-member-call",
+      config:
+        "const make = (require) => ({ plugins: [require('babel-plugin-react-compiler').default()] }); export default make(other);",
+      expected: false,
+    },
+    {
       name: "shadowed-vite-namespace",
       config:
         "import * as viteReact from '@vitejs/plugin-react'; const make = (viteReact) => ({ plugins: [viteReact.reactCompilerPreset()] }); export default make(other);",
@@ -2187,6 +2193,12 @@ describe("discoverProject", () => {
       name: "local-method-helper-enabled-argument",
       config:
         "const helper = { make(reactCompiler) { return { reactCompiler }; } }; export default helper.make(true);",
+      expected: true,
+    },
+    {
+      name: "scoped-method-helper-enabled-argument",
+      config:
+        "const make = () => { const helper = { make(reactCompiler) { return { reactCompiler }; } }; return helper.make(true); }; export default make();",
       expected: true,
     },
     {

--- a/packages/core/tests/discover-project.test.ts
+++ b/packages/core/tests/discover-project.test.ts
@@ -1527,6 +1527,56 @@ describe("discoverProject", () => {
     expect(discoverProject(projectDirectory).hasReactCompiler).toBe(true);
   });
 
+  it.each([
+    {
+      name: "default-import",
+      config: "import make from '@fixture/config'; export default make(false);",
+      entryFilename: "index.js",
+      entrySource: "export default (reactCompiler) => ({ reactCompiler });",
+    },
+    {
+      name: "namespace-import",
+      config: "import * as helper from '@fixture/config'; export default helper.make(false);",
+      entryFilename: "index.js",
+      entrySource: "export const make = (reactCompiler) => ({ reactCompiler });",
+    },
+    {
+      name: "commonjs-member",
+      config: "module.exports = require('@fixture/config').make(false);",
+      entryFilename: "index.cjs",
+      entrySource: "exports.make = (reactCompiler) => ({ reactCompiler });",
+    },
+    {
+      name: "commonjs-callable",
+      config: "module.exports = require('@fixture/config')(false);",
+      entryFilename: "index.cjs",
+      entrySource: "module.exports = (reactCompiler) => ({ reactCompiler });",
+    },
+  ])("preserves disabled arguments for $name package helpers", (testCase) => {
+    const projectDirectory = path.join(tempDirectory, `disabled-package-helper-${testCase.name}`);
+    const configDirectory = path.join(projectDirectory, "node_modules", "@fixture", "config");
+    fs.mkdirSync(configDirectory, { recursive: true });
+    fs.writeFileSync(
+      path.join(projectDirectory, "package.json"),
+      JSON.stringify({
+        name: `disabled-package-helper-${testCase.name}`,
+        dependencies: { react: "^19.0.0" },
+        devDependencies: { "@fixture/config": "workspace:*" },
+      }),
+    );
+    fs.writeFileSync(path.join(projectDirectory, "vite.config.ts"), testCase.config);
+    fs.writeFileSync(
+      path.join(configDirectory, "package.json"),
+      JSON.stringify({
+        name: "@fixture/config",
+        exports: `./${testCase.entryFilename}`,
+      }),
+    );
+    fs.writeFileSync(path.join(configDirectory, testCase.entryFilename), testCase.entrySource);
+
+    expect(discoverProject(projectDirectory).hasReactCompiler).toBe(false);
+  });
+
   it("detects React Compiler through an import-only package export", () => {
     const projectDirectory = path.join(tempDirectory, "import-only-package-react-compiler");
     const configDirectory = path.join(

--- a/packages/core/tests/discover-project.test.ts
+++ b/packages/core/tests/discover-project.test.ts
@@ -1499,6 +1499,80 @@ describe("discoverProject", () => {
     expect(discoverProject(projectDirectory).hasReactCompiler).toBe(true);
   });
 
+  it("detects React Compiler through an import-only package export", () => {
+    const projectDirectory = path.join(tempDirectory, "import-only-package-react-compiler");
+    const configDirectory = path.join(
+      projectDirectory,
+      "node_modules",
+      "@fixture",
+      "import-only-config",
+    );
+    fs.mkdirSync(configDirectory, { recursive: true });
+    fs.writeFileSync(
+      path.join(projectDirectory, "package.json"),
+      JSON.stringify({
+        name: "import-only-package-react-compiler",
+        dependencies: { react: "^19.0.0" },
+        devDependencies: { "@fixture/import-only-config": "workspace:*" },
+      }),
+    );
+    fs.writeFileSync(
+      path.join(projectDirectory, "vite.config.ts"),
+      "import config from '@fixture/import-only-config';\nexport default config;\n",
+    );
+    fs.writeFileSync(
+      path.join(configDirectory, "package.json"),
+      JSON.stringify({
+        name: "@fixture/import-only-config",
+        type: "module",
+        exports: { import: "./index.js" },
+      }),
+    );
+    fs.writeFileSync(
+      path.join(configDirectory, "index.js"),
+      "export default { plugins: ['babel-plugin-react-compiler'] };\n",
+    );
+
+    expect(discoverProject(projectDirectory).hasReactCompiler).toBe(true);
+  });
+
+  it.each([
+    { name: "dot", moduleSpecifier: ".", entryPath: "entry.js" },
+    { name: "dot-dot", moduleSpecifier: "..", entryPath: "nested/entry.js" },
+  ])("detects React Compiler through an exact $name config import", (testCase) => {
+    const projectDirectory = path.join(tempDirectory, `${testCase.name}-specifier-react-compiler`);
+    const configDirectory = path.join(
+      projectDirectory,
+      "node_modules",
+      "@fixture",
+      `${testCase.name}-config`,
+    );
+    fs.mkdirSync(path.dirname(path.join(configDirectory, testCase.entryPath)), {
+      recursive: true,
+    });
+    fs.writeFileSync(
+      path.join(projectDirectory, "package.json"),
+      JSON.stringify({
+        name: `${testCase.name}-specifier-react-compiler`,
+        dependencies: { react: "^19.0.0" },
+      }),
+    );
+    fs.writeFileSync(
+      path.join(projectDirectory, "vite.config.ts"),
+      `import config from './node_modules/@fixture/${testCase.name}-config/${testCase.entryPath}';\nexport default config;\n`,
+    );
+    fs.writeFileSync(
+      path.join(configDirectory, testCase.entryPath),
+      `import config from '${testCase.moduleSpecifier}';\nexport default config;\n`,
+    );
+    fs.writeFileSync(
+      path.join(configDirectory, "index.js"),
+      "export default { plugins: ['babel-plugin-react-compiler'] };\n",
+    );
+
+    expect(discoverProject(projectDirectory).hasReactCompiler).toBe(true);
+  });
+
   it("does not infer React Compiler from an unused transitive dependency", () => {
     const projectDirectory = path.join(tempDirectory, "unused-dependency-package-react-compiler");
     const buildConfigDirectory = path.join(
@@ -1602,6 +1676,24 @@ describe("discoverProject", () => {
       name: "shadowed-vite-namespace",
       config:
         "import * as viteReact from '@vitejs/plugin-react'; const make = (viteReact) => ({ plugins: [viteReact.reactCompilerPreset()] }); export default make(other);",
+      expected: false,
+    },
+    {
+      name: "shadowed-direct-compiler-call",
+      config:
+        "import { reactCompilerPreset } from '@vitejs/plugin-react'; const make = (reactCompilerPreset) => ({ plugins: [reactCompilerPreset()] }); export default make(other);",
+      expected: false,
+    },
+    {
+      name: "shadowed-compiler-property",
+      config:
+        "import * as viteReact from '@vitejs/plugin-react'; const make = () => { const viteReact = other; return { plugins: [viteReact.reactCompilerPreset] }; }; export default make();",
+      expected: false,
+    },
+    {
+      name: "shadowed-compiler-element",
+      config:
+        "import * as viteReact from '@vitejs/plugin-react'; const make = () => { const viteReact = other; return { plugins: [viteReact['reactCompilerPreset']] }; }; export default make();",
       expected: false,
     },
     {

--- a/packages/core/tests/discover-project.test.ts
+++ b/packages/core/tests/discover-project.test.ts
@@ -1499,6 +1499,34 @@ describe("discoverProject", () => {
     expect(discoverProject(projectDirectory).hasReactCompiler).toBe(true);
   });
 
+  it("detects React Compiler extended from a package.json Babel config", () => {
+    const projectDirectory = path.join(tempDirectory, "package-json-babel-package-config");
+    const configDirectory = path.join(projectDirectory, "node_modules", "@fixture", "babel-config");
+    fs.mkdirSync(configDirectory, { recursive: true });
+    fs.writeFileSync(
+      path.join(projectDirectory, "package.json"),
+      JSON.stringify({
+        name: "package-json-babel-package-config",
+        dependencies: { react: "^19.0.0" },
+        devDependencies: { "@fixture/babel-config": "workspace:*" },
+        babel: { extends: "@fixture/babel-config" },
+      }),
+    );
+    fs.writeFileSync(
+      path.join(configDirectory, "package.json"),
+      JSON.stringify({
+        name: "@fixture/babel-config",
+        exports: "./index.json",
+      }),
+    );
+    fs.writeFileSync(
+      path.join(configDirectory, "index.json"),
+      JSON.stringify({ plugins: ["babel-plugin-react-compiler"] }),
+    );
+
+    expect(discoverProject(projectDirectory).hasReactCompiler).toBe(true);
+  });
+
   it("detects React Compiler through an import-only package export", () => {
     const projectDirectory = path.join(tempDirectory, "import-only-package-react-compiler");
     const configDirectory = path.join(

--- a/packages/react-doctor/package.json
+++ b/packages/react-doctor/package.json
@@ -68,6 +68,7 @@
     "ink-spinner": "^5.0.0",
     "jiti": "^2.7.0",
     "magicast": "^0.5.3",
+    "oxc-resolver": "^11.24.2",
     "oxlint": ">=1.74.0 <1.75.0",
     "oxlint-plugin-react-doctor": "workspace:*",
     "prompts": "^2.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -279,6 +279,9 @@ importers:
       magicast:
         specifier: ^0.5.3
         version: 0.5.3
+      oxc-resolver:
+        specifier: ^11.24.2
+        version: 11.24.2
       oxlint:
         specifier: '>=1.74.0 <1.75.0'
         version: 1.74.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.1.20(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.22.4)(typescript@5.9.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0))(yaml@2.9.0))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,6 +88,9 @@ importers:
       jiti:
         specifier: ^2.7.0
         version: 2.7.0
+      oxc-resolver:
+        specifier: ^11.24.2
+        version: 11.24.2
       oxlint:
         specifier: '>=1.74.0 <1.75.0'
         version: 1.74.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.1.20(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.22.4)(typescript@6.0.3)(vite@7.3.1(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.22.4)(yaml@2.9.0))(yaml@2.9.0))


### PR DESCRIPTION
## Why

React Doctor only followed local files when analyzing active React Compiler configuration. Monorepos that import shared build configuration from workspace or dependency packages could therefore leave `hasReactCompiler` false and receive diagnostics for work the compiler already handles.

Before, a config import chain stopped at the first package specifier. After, project discovery follows the active exported config through normal Node/workspace package resolution, including nested dependency packages. A package that merely declares `babel-plugin-react-compiler` without using it in the selected config still does not count as compiler activation.

Follow-up to #1448.

## What changed

- resolve package specifiers in the existing bounded recursive config analyzer
- follow default, named, namespace, CommonJS, and `extends` config paths through dependency packages
- preserve shadowing and unused-transitive-dependency false-positive guards
- resolve import-only package exports and exact `.` / `..` config imports
- declare the resolver runtime dependency in the published CLI package
- add positive and negative recursive package-chain regression coverage
- add a patch changeset for `@react-doctor/core` and `react-doctor`

## Eval results

Daytona processed all 2,000 baseline repositories, but 20 timed out after three attempts. The parity validator rejected the resulting partial baseline, so the candidate pass was not run and no parity result is claimed.

The changed-scope React Doctor regression scan reports no findings and scores 100/100.

## Test plan

- `nr build` — passed
- `nr -C packages/core test tests/discover-project.test.ts tests/detect-pre-es2023-target.test.ts` — 330 passed
- `nr test` — passed
- `nr lint` — passed with existing fuzz-fixture warnings only
- `nr typecheck` — 16 tasks passed
- `nr format:check` — passed
- `nr smoke:json-report` — passed
- `nr check:published-deps` — all 5 published packages passed
- `nlx react-doctor@latest --verbose --scope changed` — no issues, 100/100

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how hasReactCompiler is inferred for all projects, which gates diagnostics; scope is bounded and heavily tested but false positives/negatives on exotic configs remain possible.
> 
> **Overview**
> **Project discovery** now follows **active** React Compiler configuration through **workspace and npm package imports**, not only relative files—so monorepos that re-export shared build configs should get `hasReactCompiler` right and avoid redundant diagnostics.
> 
> The bounded config AST analyzer uses **`oxc-resolver`** (plus `createRequire` fallback) for package specifiers, with a shared **`analyzeImportedConfig`** path for default/named/namespace/CommonJS/`extends` chains. **Shadowing** and **unused transitive dependency** behavior are tightened; **`tsconfig` extends** also accepts exact **`.`** / **`..`** directory specifiers. **`package.json#babel`** analysis resolves extends using the real package path.
> 
> Adds **`oxc-resolver`** to **`@react-doctor/core`** and **`react-doctor`**, plus broad regression tests for nested dependency chains and negative cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69b9e233017b43a65c730b0bac88cb56c8f9143c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->