### PR TITLE
Fix Tailwind arbitrary length regex crash

### DIFF
--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-decorative-radial-spotlight.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/no-decorative-radial-spotlight.test.ts
@@ -126,6 +126,7 @@ describe("no-decorative-radial-spotlight", () => {
           <div className="fixed inset-x-0 inset-y-0 top-1 bg-[radial-gradient(circle,rgba(14,165,233,0.2),transparent)]" />
           <div className="fixed inset-x-0 inset-y-0 !top-1 bg-[radial-gradient(circle,rgba(14,165,233,0.2),transparent)]" />
           <div className="fixed inset-0 -top-1 bg-[radial-gradient(circle,rgba(14,165,233,0.2),transparent)]" />
+          <div className="absolute top-[-10%] h-[40vw] w-[40vw] bg-[radial-gradient(circle,rgba(14,165,233,0.2),transparent)]" />
           <div className="fixed inset-x-0 inset-y-0 bg-[radial-gradient(circle,rgba(14,165,233,0.2),transparent)]" style={{ top: 1 }} />
           <div className="fixed inset-x-0 bg-[radial-gradient(circle,rgba(14,165,233,0.2),transparent)]" />
           <div style={{ position: "fixed", top: 0, right: 0, bottom: 0, left: 1, backgroundImage: "radial-gradient(circle, rgb(37 99 235 / 20%), transparent)" }} />

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/utils/parse-static-tailwind-length-px.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/utils/parse-static-tailwind-length-px.test.ts
@@ -16,6 +16,7 @@ describe("parseStaticTailwindLengthPx", () => {
   it("rejects unrelated, dynamic, negative, and unitless arbitrary values", () => {
     expect(parseStaticTailwindLengthPx("h-7", "w")).toBeNull();
     expect(parseStaticTailwindLengthPx("w-[var(--width)]", "w")).toBeNull();
+    expect(parseStaticTailwindLengthPx("top-[-10%]", "top-[")).toBeNull();
     expect(parseStaticTailwindLengthPx("-w-2", "w")).toBeNull();
     expect(parseStaticTailwindLengthPx("w-[8]", "w")).toBeNull();
   });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/utils/parse-static-tailwind-length-px.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/design/utils/parse-static-tailwind-length-px.ts
@@ -1,16 +1,17 @@
 import { ROOT_FONT_SIZE_PX, TAILWIND_SPACING_UNIT_PX } from "../../../constants/design.js";
 
 export const parseStaticTailwindLengthPx = (utility: string, prefix: string): number | null => {
-  if (utility === `${prefix}-px`) return 1;
-  const arbitraryMatch = utility.match(
-    new RegExp(`^${prefix}-\\[(?:length:)?(\\d+(?:\\.\\d*)?|\\.\\d+)(px|rem)\\]$`, "i"),
-  );
+  const prefixWithSeparator = `${prefix}-`;
+  if (!utility.startsWith(prefixWithSeparator)) return null;
+  const value = utility.slice(prefixWithSeparator.length);
+  if (value === "px") return 1;
+  const arbitraryMatch = value.match(/^\[(?:length:)?(\d+(?:\.\d*)?|\.\d+)(px|rem)\]$/i);
   if (arbitraryMatch) {
     const numericValue = Number.parseFloat(arbitraryMatch[1]);
     return arbitraryMatch[2].toLowerCase() === "rem"
       ? numericValue * ROOT_FONT_SIZE_PX
       : numericValue;
   }
-  const scaleMatch = utility.match(new RegExp(`^${prefix}-(\\d+(?:\\.\\d*)?|\\.\\d+)$`));
+  const scaleMatch = value.match(/^(\d+(?:\.\d*)?|\.\d+)$/);
   return scaleMatch ? Number.parseFloat(scaleMatch[1]) * TAILWIND_SPACING_UNIT_PX : null;
 };


### PR DESCRIPTION
## What changed

- parse Tailwind length utilities after removing the literal prefix instead of interpolating the prefix into a dynamic regular expression
- keep unsupported arbitrary negative percentages conservative without throwing
- cover the real `top-[-10%]` crash shape at both utility and rule level

## Why

Parity for #1454 found `trykimu/videoeditor` produced an incomplete JSON report because `no-decorative-radial-spotlight` derived `top-[` as a prefix and constructed an unterminated character class. The fixed build emits a complete parser-valid report for the same pinned repository.

## Validation

- focused rule and utility tests
- strict 500-iteration rule fuzz
- full test suite
- lint
- typecheck
- format
- JSON report smoke test
- React Doctor changed-scope scan: 100/100
- local reproduction on `trykimu/videoeditor@e10879152dfed4a340d62a55f6e341e9e1938be5`: complete report, no skipped checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to a design-rule utility with explicit regression tests; behavior for valid lengths is preserved while invalid arbitrary values fail safely.
> 
> **Overview**
> Fixes a **crash in React Doctor** when `no-decorative-radial-spotlight` parses classes like `top-[-10%]`. Prefix extraction could yield `top-[`, which was interpolated into a dynamic `RegExp` and produced an **invalid character class**, aborting the scan and yielding incomplete JSON reports.
> 
> **`parseStaticTailwindLengthPx`** now strips the literal `prefix-` with string operations and matches only the suffix (`px`, scale numbers, or `[…px|rem]` arbitrary values). Unsupported shapes such as **negative percentage arbitraries** return `null` instead of throwing.
> 
> Tests add the **`top-[-10%]`** / `top-[` utility case and a rule fixture with `absolute top-[-10%] h-[40vw] w-[40vw]` to confirm the spotlight rule stays conservative and does not regress.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d30fec5afe11b64547e87e5356d0f054b8708756. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->