### PR TITLE
test: add regression tests for React Compiler detection with @rolldown/plugin-babel

### DIFF
--- a/.changeset/test-react-compiler-rolldown.md
+++ b/.changeset/test-react-compiler-rolldown.md
@@ -1,0 +1,5 @@
+---
+"@react-doctor/core": patch
+---
+
+Add regression tests for React Compiler detection with @rolldown/plugin-babel. The detection logic already correctly handles reactCompilerPreset() with @rolldown/plugin-babel (working in 0.9.2), but these tests prevent future regressions.

--- a/packages/core/tests/discover-project.test.ts
+++ b/packages/core/tests/discover-project.test.ts
@@ -2574,6 +2574,87 @@ describe("discoverProject", () => {
     expect(projectInfo.hasReactCompiler).toBe(true);
   });
 
+  it("detects the Vite 6 React Compiler preset with defineConfig wrapper (issue #1468)", () => {
+    const projectDirectory = path.join(tempDirectory, "vite-react-compiler-preset-defineconfig");
+    fs.mkdirSync(projectDirectory, { recursive: true });
+    fs.writeFileSync(
+      path.join(projectDirectory, "package.json"),
+      JSON.stringify({
+        name: "vite-react-compiler-preset-defineconfig",
+        dependencies: { react: "19.2.3" },
+        devDependencies: {
+          "vite": "^8.1.0",
+          "@vitejs/plugin-react": "^6.0.1",
+          "@rolldown/plugin-babel": "^0.2.3",
+          "babel-plugin-react-compiler": "^1.0.0",
+        },
+      }),
+    );
+    fs.writeFileSync(
+      path.join(projectDirectory, "vite.config.ts"),
+      "import babel from '@rolldown/plugin-babel';\nimport react, { reactCompilerPreset } from '@vitejs/plugin-react';\nimport { defineConfig } from 'vite';\n\nexport default defineConfig({\n  plugins: [\n    react(),\n    babel({\n      presets: [reactCompilerPreset()],\n    }),\n  ],\n});\n",
+    );
+
+    const projectInfo = discoverProject(projectDirectory);
+    expect(projectInfo.hasReactCompiler).toBe(true);
+  });
+
+  it("detects the Vite 6 React Compiler preset with various file extensions", () => {
+    [".js", ".mjs", ".ts"].forEach((extension) => {
+      const projectDirectory = path.join(
+        tempDirectory,
+        `vite-react-compiler-preset-${extension.slice(1)}`,
+      );
+      fs.mkdirSync(projectDirectory, { recursive: true });
+      fs.writeFileSync(
+        path.join(projectDirectory, "package.json"),
+        JSON.stringify({
+          name: `vite-react-compiler-preset-${extension.slice(1)}`,
+          dependencies: { react: "^19.0.0" },
+          devDependencies: {
+            "vite": "^8.1.0",
+            "@vitejs/plugin-react": "^6.0.1",
+            "@rolldown/plugin-babel": "^0.2.3",
+          },
+        }),
+      );
+      fs.writeFileSync(
+        path.join(projectDirectory, `vite.config${extension}`),
+        "import babel from '@rolldown/plugin-babel';\nimport react, { reactCompilerPreset } from '@vitejs/plugin-react';\nimport { defineConfig } from 'vite';\n\nexport default defineConfig({\n  plugins: [\n    react(),\n    babel({\n      presets: [reactCompilerPreset()],\n    }),\n  ],\n});\n",
+      );
+
+      const projectInfo = discoverProject(projectDirectory);
+      expect(projectInfo.hasReactCompiler).toBe(true);
+    });
+  });
+
+  it("detects the Vite 6 React Compiler preset without babel-plugin-react-compiler listed", () => {
+    const projectDirectory = path.join(
+      tempDirectory,
+      "vite-react-compiler-preset-no-babel-plugin",
+    );
+    fs.mkdirSync(projectDirectory, { recursive: true });
+    fs.writeFileSync(
+      path.join(projectDirectory, "package.json"),
+      JSON.stringify({
+        name: "vite-react-compiler-preset-no-babel-plugin",
+        dependencies: { react: "19.2.3" },
+        devDependencies: {
+          "vite": "^8.1.0",
+          "@vitejs/plugin-react": "^6.0.1",
+          "@rolldown/plugin-babel": "^0.2.3",
+        },
+      }),
+    );
+    fs.writeFileSync(
+      path.join(projectDirectory, "vite.config.ts"),
+      "import babel from '@rolldown/plugin-babel';\nimport react, { reactCompilerPreset } from '@vitejs/plugin-react';\nimport { defineConfig } from 'vite';\n\nexport default defineConfig({\n  plugins: [\n    react(),\n    babel({\n      presets: [reactCompilerPreset()],\n    }),\n  ],\n});\n",
+    );
+
+    const projectInfo = discoverProject(projectDirectory);
+    expect(projectInfo.hasReactCompiler).toBe(true);
+  });
+
   it("detects the Rsbuild React Compiler transform", () => {
     const projectDirectory = path.join(tempDirectory, "rsbuild-react-compiler");
     fs.mkdirSync(projectDirectory, { recursive: true });

--- a/packages/core/tests/discover-project.test.ts
+++ b/packages/core/tests/discover-project.test.ts
@@ -2583,7 +2583,7 @@ describe("discoverProject", () => {
         name: "vite-react-compiler-preset-defineconfig",
         dependencies: { react: "19.2.3" },
         devDependencies: {
-          "vite": "^8.1.0",
+          vite: "^8.1.0",
           "@vitejs/plugin-react": "^6.0.1",
           "@rolldown/plugin-babel": "^0.2.3",
           "babel-plugin-react-compiler": "^1.0.0",
@@ -2612,7 +2612,7 @@ describe("discoverProject", () => {
           name: `vite-react-compiler-preset-${extension.slice(1)}`,
           dependencies: { react: "^19.0.0" },
           devDependencies: {
-            "vite": "^8.1.0",
+            vite: "^8.1.0",
             "@vitejs/plugin-react": "^6.0.1",
             "@rolldown/plugin-babel": "^0.2.3",
           },
@@ -2629,10 +2629,7 @@ describe("discoverProject", () => {
   });
 
   it("detects the Vite 6 React Compiler preset without babel-plugin-react-compiler listed", () => {
-    const projectDirectory = path.join(
-      tempDirectory,
-      "vite-react-compiler-preset-no-babel-plugin",
-    );
+    const projectDirectory = path.join(tempDirectory, "vite-react-compiler-preset-no-babel-plugin");
     fs.mkdirSync(projectDirectory, { recursive: true });
     fs.writeFileSync(
       path.join(projectDirectory, "package.json"),
@@ -2640,7 +2637,7 @@ describe("discoverProject", () => {
         name: "vite-react-compiler-preset-no-babel-plugin",
         dependencies: { react: "19.2.3" },
         devDependencies: {
-          "vite": "^8.1.0",
+          vite: "^8.1.0",
           "@vitejs/plugin-react": "^6.0.1",
           "@rolldown/plugin-babel": "^0.2.3",
         },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds regression tests for React Compiler detection when using `reactCompilerPreset()` with `@rolldown/plugin-babel` in Vite configurations.

## Context

Issue #1468 reported that React Doctor 0.9.2 reports `hasReactCompiler: false` when using the official React Compiler configuration with `@rolldown/plugin-babel` and `reactCompilerPreset()`.

## Investigation

After thorough investigation and testing, I found that **the detection logic already works correctly** in 0.9.2. The Vite 6 `reactCompilerPreset()` detection was added in commit 0b0b5ac52 (2026-07-20) and is included in the 0.9.2 release (2026-07-28).

All test cases pass, including:
- `defineConfig` wrapper (exact configuration from #1468)
- Various file extensions (.js, .mjs, .ts)
- Configuration without `babel-plugin-react-compiler` explicitly listed

## Changes

This PR adds comprehensive regression tests to prevent future issues:
1. Test with `defineConfig` wrapper (the exact case from #1468)
2. Test with multiple file extensions
3. Test without `babel-plugin-react-compiler` in dependencies

## Testing

All 320 tests in `discover-project.test.ts` pass, including the 3 new regression tests.

Since this PR only adds tests without modifying any detection logic, no parity run is needed - diagnostics are unchanged.

Closes #1468
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b6a636e4-6ab2-4911-a4d3-1301cae47dc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b6a636e4-6ab2-4911-a4d3-1301cae47dc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

