### PR TITLE
fix: detect React Compiler through bundled config wrappers

### DIFF
--- a/.changeset/bright-configs-smile.md
+++ b/.changeset/bright-configs-smile.md
@@ -1,0 +1,6 @@
+---
+"@react-doctor/core": patch
+"react-doctor": patch
+---
+
+Detect React Compiler transforms passed through bundled config wrappers such as Vite's `defineConfig`.

--- a/packages/core/src/project-info/detectors.ts
+++ b/packages/core/src/project-info/detectors.ts
@@ -489,13 +489,23 @@ interface ConfigImportBinding {
   readonly isNamespace: boolean;
 }
 
+interface ConfigExpressionReference {
+  readonly expression: ts.Expression | null;
+  readonly analysis: ConfigExpressionAnalysis;
+}
+
+interface ConfigPropertyReference {
+  readonly node: ts.Expression | ts.MethodDeclaration;
+  readonly analysis: ConfigExpressionAnalysis;
+}
+
 interface ConfigExpressionAnalysis {
   readonly filePath: string;
   readonly sourceFile: ts.SourceFile;
   readonly importDepth: number;
   readonly visitedModules: ReadonlySet<string>;
   readonly visitedNodes: Set<string>;
-  readonly localBindings: ReadonlyMap<string, ts.Expression | null>;
+  readonly localBindings: ReadonlyMap<string, ConfigExpressionReference>;
   readonly activeFunctions: ReadonlySet<number>;
 }
 
@@ -655,14 +665,17 @@ const getTopLevelBinding = (
 const getFunctionLocalBindings = (
   functionNode: ts.FunctionLikeDeclaration,
   argumentsList: readonly ts.Expression[],
-): Map<string, ts.Expression | null> => {
-  const localBindings = new Map<string, ts.Expression | null>();
+  argumentAnalysis: ConfigExpressionAnalysis,
+  functionAnalysis: ConfigExpressionAnalysis,
+): Map<string, ConfigExpressionReference> => {
+  const localBindings = new Map<string, ConfigExpressionReference>();
   functionNode.parameters.forEach((parameter, parameterIndex) => {
     if (ts.isIdentifier(parameter.name)) {
-      localBindings.set(
-        parameter.name.text,
-        argumentsList[parameterIndex] ?? parameter.initializer ?? null,
-      );
+      const argument = argumentsList[parameterIndex];
+      localBindings.set(parameter.name.text, {
+        expression: argument ?? parameter.initializer ?? null,
+        analysis: argument ? argumentAnalysis : functionAnalysis,
+      });
     }
   });
   return localBindings;
@@ -958,9 +971,13 @@ const getStaticConfigValueState = (
   }
   if (ts.isIdentifier(unwrappedExpression)) {
     if (analysis.localBindings.has(unwrappedExpression.text)) {
-      const localInitializer = analysis.localBindings.get(unwrappedExpression.text);
-      return localInitializer
-        ? getStaticConfigValueState(localInitializer, analysis, nextVisitedExpressions)
+      const localReference = analysis.localBindings.get(unwrappedExpression.text);
+      return localReference?.expression
+        ? getStaticConfigValueState(
+            localReference.expression,
+            localReference.analysis,
+            nextVisitedExpressions,
+          )
         : null;
     }
     const topLevelBinding = getTopLevelBinding(analysis.sourceFile, unwrappedExpression.text);
@@ -1064,9 +1081,13 @@ const getReactCompilerFlagState = (
       };
     }
     if (analysis.localBindings.has(unwrappedExpression.text)) {
-      const localInitializer = analysis.localBindings.get(unwrappedExpression.text);
-      return localInitializer
-        ? getReactCompilerFlagState(localInitializer, analysis, nextVisitedExpressions)
+      const localReference = analysis.localBindings.get(unwrappedExpression.text);
+      return localReference?.expression
+        ? getReactCompilerFlagState(
+            localReference.expression,
+            localReference.analysis,
+            nextVisitedExpressions,
+          )
         : null;
     }
     const topLevelBinding = getTopLevelBinding(analysis.sourceFile, unwrappedExpression.text);
@@ -1102,7 +1123,7 @@ const getSelectedObjectProperty = (
   propertyName: string,
   analysis: ConfigExpressionAnalysis,
   visitedExpressions: Set<ts.Expression> = new Set(),
-): ts.Expression | ts.MethodDeclaration | null => {
+): ConfigPropertyReference | null => {
   let resolvedExpression = expression;
   while (
     ts.isParenthesizedExpression(resolvedExpression) ||
@@ -1117,9 +1138,14 @@ const getSelectedObjectProperty = (
   visitedExpressions.add(resolvedExpression);
   if (ts.isIdentifier(resolvedExpression)) {
     if (analysis.localBindings.has(resolvedExpression.text)) {
-      const localInitializer = analysis.localBindings.get(resolvedExpression.text);
-      return localInitializer
-        ? getSelectedObjectProperty(localInitializer, propertyName, analysis, visitedExpressions)
+      const localReference = analysis.localBindings.get(resolvedExpression.text);
+      return localReference?.expression
+        ? getSelectedObjectProperty(
+            localReference.expression,
+            propertyName,
+            localReference.analysis,
+            visitedExpressions,
+          )
         : null;
     }
     const scopedBinding = getScopedConfigBinding(resolvedExpression);
@@ -1144,13 +1170,13 @@ const getSelectedObjectProperty = (
       ts.isPropertyAssignment(property) &&
       getStaticPropertyName(property.name) === propertyName
     ) {
-      return property.initializer;
+      return { node: property.initializer, analysis };
     }
     if (ts.isMethodDeclaration(property) && getStaticPropertyName(property.name) === propertyName) {
-      return property;
+      return { node: property, analysis };
     }
     if (ts.isShorthandPropertyAssignment(property) && property.name.text === propertyName) {
-      return property.name;
+      return { node: property.name, analysis };
     }
     if (ts.isSpreadAssignment(property)) {
       const spreadProperty = getSelectedObjectProperty(
@@ -1182,9 +1208,13 @@ const configExpressionMayDefineProperty = (
   }
   if (ts.isIdentifier(resolvedExpression)) {
     if (analysis.localBindings.has(resolvedExpression.text)) {
-      const localInitializer = analysis.localBindings.get(resolvedExpression.text);
-      return localInitializer
-        ? configExpressionMayDefineProperty(localInitializer, propertyName, analysis)
+      const localReference = analysis.localBindings.get(resolvedExpression.text);
+      return localReference?.expression
+        ? configExpressionMayDefineProperty(
+            localReference.expression,
+            propertyName,
+            localReference.analysis,
+          )
         : true;
     }
     const scopedBinding = getScopedConfigBinding(resolvedExpression);
@@ -1395,6 +1425,7 @@ const analyzeConfigModuleExport = (
   importDepth: number,
   visitedModules: ReadonlySet<string>,
   argumentsList: readonly ts.Expression[] = [],
+  argumentAnalysis?: ConfigExpressionAnalysis,
 ): boolean => {
   if (!isFile(filePath) || importDepth > REACT_COMPILER_CONFIG_IMPORT_MAX_DEPTH) return false;
   const moduleVisitKey = `${filePath}:${exportName}:${allowCompilerTransform}`;
@@ -1410,6 +1441,7 @@ const analyzeConfigModuleExport = (
     importDepth,
     nextVisitedModules,
     argumentsList,
+    argumentAnalysis,
   );
 };
 
@@ -1421,6 +1453,7 @@ const analyzeConfigSourceFileExport = (
   importDepth: number,
   visitedModules: ReadonlySet<string>,
   argumentsList: readonly ts.Expression[] = [],
+  argumentAnalysis?: ConfigExpressionAnalysis,
 ): boolean => {
   const analysis: ConfigExpressionAnalysis = {
     filePath,
@@ -1428,16 +1461,59 @@ const analyzeConfigSourceFileExport = (
     importDepth,
     visitedModules,
     visitedNodes: new Set<string>(),
-    localBindings: new Map<string, ts.Expression | null>(),
+    localBindings: new Map<string, ConfigExpressionReference>(),
     activeFunctions: new Set<number>(),
   };
+  const resolvedArgumentAnalysis = argumentAnalysis ?? analysis;
   const exportedConfigNodes = getExportedConfigNodes(sourceFile, exportName);
   return (
-    exportedConfigNodes.some((node) =>
-      ts.isArrowFunction(node) || ts.isFunctionExpression(node) || ts.isFunctionDeclaration(node)
-        ? analyzeConfigFunction(node, analysis, allowCompilerTransform, argumentsList)
-        : analyzeConfigNode(node, analysis, allowCompilerTransform),
-    ) ||
+    exportedConfigNodes.some((node) => {
+      if (
+        ts.isArrowFunction(node) ||
+        ts.isFunctionExpression(node) ||
+        ts.isFunctionDeclaration(node)
+      ) {
+        return analyzeConfigFunction(
+          node,
+          analysis,
+          allowCompilerTransform,
+          argumentsList,
+          resolvedArgumentAnalysis,
+        );
+      }
+      if (argumentsList.length > 0 && ts.isIdentifier(node)) {
+        const topLevelBinding = getTopLevelBinding(sourceFile, node.text);
+        if (topLevelBinding && ts.isFunctionLike(topLevelBinding)) {
+          return analyzeConfigFunction(
+            topLevelBinding,
+            analysis,
+            allowCompilerTransform,
+            argumentsList,
+            resolvedArgumentAnalysis,
+          );
+        }
+        const importBinding = getImportBinding(sourceFile, node.text);
+        if (importBinding) {
+          const importedFilePath = resolveImportedConfigFile(
+            filePath,
+            importBinding.moduleSpecifier,
+          );
+          return Boolean(
+            importedFilePath &&
+            analyzeConfigModuleExport(
+              importedFilePath,
+              importBinding.exportName,
+              allowCompilerTransform,
+              importDepth + 1,
+              visitedModules,
+              argumentsList,
+              resolvedArgumentAnalysis,
+            ),
+          );
+        }
+      }
+      return analyzeConfigNode(node, analysis, allowCompilerTransform);
+    }) ||
     getReExportedConfigModules(sourceFile, exportName).some((binding) => {
       if (exportedConfigNodes.length > 0 && binding.isNamespace) return false;
       const importedFilePath = resolveImportedConfigFile(filePath, binding.moduleSpecifier);
@@ -1450,6 +1526,7 @@ const analyzeConfigSourceFileExport = (
           importDepth + 1,
           visitedModules,
           argumentsList,
+          resolvedArgumentAnalysis,
         ),
       );
     })
@@ -1461,6 +1538,7 @@ const analyzeConfigFunction = (
   analysis: ConfigExpressionAnalysis,
   allowCompilerTransform: boolean,
   argumentsList: readonly ts.Expression[] = [],
+  argumentAnalysis: ConfigExpressionAnalysis = analysis,
 ): boolean => {
   if (!functionNode.body) return false;
   if (analysis.activeFunctions.has(functionNode.pos)) return false;
@@ -1469,7 +1547,12 @@ const analyzeConfigFunction = (
   const functionAnalysis: ConfigExpressionAnalysis = {
     ...analysis,
     visitedNodes: new Set<string>(),
-    localBindings: getFunctionLocalBindings(functionNode, argumentsList),
+    localBindings: getFunctionLocalBindings(
+      functionNode,
+      argumentsList,
+      argumentAnalysis,
+      analysis,
+    ),
     activeFunctions,
   };
   if (!ts.isBlock(functionNode.body)) {
@@ -1504,6 +1587,7 @@ const analyzeImportedConfig = ({
     analysis.importDepth + 1,
     analysis.visitedModules,
     argumentsList,
+    analysis,
   );
 };
 
@@ -1540,12 +1624,12 @@ const analyzeConfigIdentifier = (
   if (assignedPlugins.wasFound) overriddenPropertyNames.add("plugins");
   if (assignedPresets.wasFound) overriddenPropertyNames.add("presets");
   if (analysis.localBindings.has(identifier.text)) {
-    const localInitializer = analysis.localBindings.get(identifier.text);
+    const localReference = analysis.localBindings.get(identifier.text);
     return Boolean(
-      localInitializer &&
+      localReference?.expression &&
       analyzeConfigNode(
-        localInitializer,
-        analysis,
+        localReference.expression,
+        localReference.analysis,
         allowCompilerTransform,
         isCompilerTransformCollection,
         overriddenPropertyNames,
@@ -1693,14 +1777,15 @@ const analyzeConfigCallTarget = (
 
   const selectedProperty = getSelectedObjectProperty(target.expression, propertyName, analysis);
   if (selectedProperty === null) return null;
-  return ts.isFunctionLike(selectedProperty)
+  return ts.isFunctionLike(selectedProperty.node)
     ? analyzeConfigFunction(
-        selectedProperty,
-        analysis,
+        selectedProperty.node,
+        selectedProperty.analysis,
         allowCompilerTransform,
         callExpression.arguments,
+        analysis,
       )
-    : analyzeConfigNode(selectedProperty, analysis, allowCompilerTransform);
+    : analyzeConfigNode(selectedProperty.node, selectedProperty.analysis, allowCompilerTransform);
 };
 
 const analyzeConfigNode = (
@@ -2002,7 +2087,12 @@ const analyzeConfigNode = (
           analysis,
         );
         return Boolean(
-          selectedProperty && analyzeConfigNode(selectedProperty, analysis, allowCompilerTransform),
+          selectedProperty &&
+          analyzeConfigNode(
+            selectedProperty.node,
+            selectedProperty.analysis,
+            allowCompilerTransform,
+          ),
         );
       }
       const importBinding = getImportBinding(analysis.sourceFile, node.expression.text);
@@ -2027,7 +2117,11 @@ const analyzeConfigNode = (
       }
       const selectedProperty = getSelectedObjectProperty(node.expression, node.name.text, analysis);
       if (selectedProperty) {
-        return analyzeConfigNode(selectedProperty, analysis, allowCompilerTransform);
+        return analyzeConfigNode(
+          selectedProperty.node,
+          selectedProperty.analysis,
+          allowCompilerTransform,
+        );
       }
       return false;
     }
@@ -2049,7 +2143,12 @@ const analyzeConfigNode = (
           analysis,
         );
         return Boolean(
-          selectedProperty && analyzeConfigNode(selectedProperty, analysis, allowCompilerTransform),
+          selectedProperty &&
+          analyzeConfigNode(
+            selectedProperty.node,
+            selectedProperty.analysis,
+            allowCompilerTransform,
+          ),
         );
       }
       const importBinding = getImportBinding(analysis.sourceFile, node.expression.text);
@@ -2075,7 +2174,11 @@ const analyzeConfigNode = (
         analysis,
       );
       if (selectedProperty) {
-        return analyzeConfigNode(selectedProperty, analysis, allowCompilerTransform);
+        return analyzeConfigNode(
+          selectedProperty.node,
+          selectedProperty.analysis,
+          allowCompilerTransform,
+        );
       }
       return false;
     }

--- a/packages/core/tests/discover-project.test.ts
+++ b/packages/core/tests/discover-project.test.ts
@@ -2551,9 +2551,11 @@ describe("discoverProject", () => {
     expect(projectInfo.hasReactCompilerLintPlugin).toBe(true);
   });
 
-  it("detects the Vite 6 React Compiler preset", () => {
+  it("detects the official Vite 8 React Compiler preset through defineConfig re-exports", () => {
     const projectDirectory = path.join(tempDirectory, "vite-react-compiler-preset");
-    fs.mkdirSync(projectDirectory, { recursive: true });
+    const viteDirectory = path.join(projectDirectory, "node_modules", "vite");
+    const viteChunksDirectory = path.join(viteDirectory, "chunks");
+    fs.mkdirSync(viteChunksDirectory, { recursive: true });
     fs.writeFileSync(
       path.join(projectDirectory, "package.json"),
       JSON.stringify({
@@ -2562,17 +2564,87 @@ describe("discoverProject", () => {
         devDependencies: {
           "@rolldown/plugin-babel": "^0.2.0",
           "@vitejs/plugin-react": "^6.0.0",
+          vite: "^8.1.0",
         },
       }),
     );
     fs.writeFileSync(
+      path.join(viteDirectory, "package.json"),
+      JSON.stringify({
+        name: "vite",
+        type: "module",
+        exports: "./index.js",
+      }),
+    );
+    fs.writeFileSync(
+      path.join(viteDirectory, "index.js"),
+      "import { d as defineConfig } from './chunks/config.js';\nexport { defineConfig };\n",
+    );
+    fs.writeFileSync(
+      path.join(viteChunksDirectory, "config.js"),
+      "const defineConfig = (config) => config;\nexport { defineConfig as d };\n",
+    );
+    fs.writeFileSync(
       path.join(projectDirectory, "vite.config.ts"),
-      "import react, { reactCompilerPreset } from '@vitejs/plugin-react';\nimport babel from '@rolldown/plugin-babel';\nexport default { plugins: [react(), babel({ presets: [reactCompilerPreset()] })] };\n",
+      "import { defineConfig } from 'vite';\nimport react, { reactCompilerPreset } from '@vitejs/plugin-react';\nimport babel from '@rolldown/plugin-babel';\nexport default defineConfig({ plugins: [react(), babel({ presets: [reactCompilerPreset()] })] });\n",
     );
 
     const projectInfo = discoverProject(projectDirectory);
     expect(projectInfo.hasReactCompiler).toBe(true);
   });
+
+  it.each([
+    { wrapperName: "withNextConfig", argument: "nextConfig", expected: true },
+    { wrapperName: "selectNextConfig", argument: "{ config: nextConfig }", expected: true },
+    { wrapperName: "withoutNextConfig", argument: "nextConfig", expected: false },
+  ])(
+    "preserves caller imports through bundled Next.js wrappers: $wrapperName",
+    ({ wrapperName, argument, expected }) => {
+      const projectDirectory = path.join(tempDirectory, `nextjs-bundled-wrapper-${wrapperName}`);
+      const wrapperDirectory = path.join(
+        projectDirectory,
+        "node_modules",
+        "@fixture",
+        "next-wrapper",
+      );
+      const wrapperChunksDirectory = path.join(wrapperDirectory, "chunks");
+      fs.mkdirSync(wrapperChunksDirectory, { recursive: true });
+      fs.writeFileSync(
+        path.join(projectDirectory, "package.json"),
+        JSON.stringify({
+          name: `nextjs-bundled-wrapper-${wrapperName}`,
+          dependencies: { next: "^16.0.0", react: "^19.0.0" },
+          devDependencies: { "@fixture/next-wrapper": "workspace:*" },
+        }),
+      );
+      fs.writeFileSync(
+        path.join(wrapperDirectory, "package.json"),
+        JSON.stringify({
+          name: "@fixture/next-wrapper",
+          type: "module",
+          exports: "./index.js",
+        }),
+      );
+      fs.writeFileSync(
+        path.join(wrapperDirectory, "index.js"),
+        "import { a as withNextConfig, b as selectNextConfig, c as withoutNextConfig } from './chunks/config.js';\nexport { withNextConfig, selectNextConfig, withoutNextConfig };\n",
+      );
+      fs.writeFileSync(
+        path.join(wrapperChunksDirectory, "config.js"),
+        "const withNextConfig = (config) => config;\nconst selectNextConfig = (options) => options.config;\nconst withoutNextConfig = () => ({ turbopack: {} });\nexport { withNextConfig as a, selectNextConfig as b, withoutNextConfig as c };\n",
+      );
+      fs.writeFileSync(
+        path.join(projectDirectory, "compiler-config.ts"),
+        "export default { reactCompiler: { compilationMode: 'annotation' }, turbopack: { rules: {} } };\n",
+      );
+      fs.writeFileSync(
+        path.join(projectDirectory, "next.config.ts"),
+        `import { ${wrapperName} } from '@fixture/next-wrapper';\nimport nextConfig from './compiler-config';\nexport default ${wrapperName}(${argument});\n`,
+      );
+
+      expect(discoverProject(projectDirectory).hasReactCompiler).toBe(expected);
+    },
+  );
 
   it("detects the Rsbuild React Compiler transform", () => {
     const projectDirectory = path.join(tempDirectory, "rsbuild-react-compiler");


### PR DESCRIPTION
## Summary

- preserve the originating config analysis context when arguments cross imported wrapper functions and re-export aliases
- detect Vite 8's official `defineConfig()` + `reactCompilerPreset()` setup
- cover wrapped Next.js configs alongside Turbopack, nested config selection, and wrappers that discard the supplied config
- add a patch changeset

Fixes #1468.

## Root cause

The detector could resolve `defineConfig` into Vite's bundled package implementation, but arguments forwarded through that re-export chain were analyzed against Vite's source file. Imports owned by the user's config, including `reactCompilerPreset`, were therefore no longer resolvable.

The fix carries each bound expression's originating analysis context through calls and selected object properties. This follows the actual wrapper implementation instead of treating every `defineConfig`-shaped call as transparent, preserving the negative case where a wrapper discards the compiler-enabled config.

## Product brief

- **Job:** accurately identify active React Compiler transforms so compiler-gated diagnostics match the user's build
- **Reuse:** extend the existing recursive config expression analyzer; no new public option or report field
- **Metric:** reuse the existing anonymized `project.reactCompiler` telemetry dimension
- **Compatibility:** behavior-only patch; JSON schema remains unchanged

## Validation

- `nr test`
- `nr typecheck`
- `nr lint`
- `nr format:check`
- `nr smoke:json-report`
- `react-doctor --verbose --scope changed` — 100/100, no issues

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches recursive static analysis in project discovery; incorrect heuristics could mis-gate compiler-related diagnostics, but scope is limited to detection logic with expanded fixture tests.
> 
> **Overview**
> **React Compiler detection** now follows config arguments through bundled wrapper functions (Vite `defineConfig`, Next.js-style helpers) instead of analyzing them only inside the wrapper package, so user-owned imports like `reactCompilerPreset` and `reactCompiler` flags resolve correctly.
> 
> The config analyzer threads **originating analysis context** with each bound expression (`ConfigExpressionReference` / `ConfigPropertyReference`), including when crossing imported re-exports and function parameters. Wrappers that **discard** the passed config still evaluate as no compiler.
> 
> Tests cover Vite 8 `defineConfig` + `reactCompilerPreset`, and parameterized Next.js bundled wrappers (pass-through, nested selection, discard). Patch changeset for `@react-doctor/core` and `react-doctor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8613eb003f83e414e2298eb31447b89b13d842e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->