### PR TITLE
RDFPFN792026: detect unescaped RegExp path segments

### DIFF
--- a/.changeset/fuzzy-folders-wave.md
+++ b/.changeset/fuzzy-folders-wave.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Detect unescaped dynamic folder path segments in anchored `RegExp` patterns.

--- a/packages/fuzz/corpus/true-positives/no-unescaped-dynamic-string-in-regexp--path-segment.ts
+++ b/packages/fuzz/corpus/true-positives/no-unescaped-dynamic-string-in-regexp--path-segment.ts
@@ -1,0 +1,7 @@
+// rule: no-unescaped-dynamic-string-in-regexp
+// verdict: fail
+// weakness: name-heuristic
+// source: ReactBench RDFPFN792026 dynamic RegExp false-negative audit
+
+export const stripRootDirectory = (relativePath: string, directorySegment: string): string =>
+  relativePath.replace(new RegExp(`^${directorySegment}/`), "");

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-unescaped-dynamic-string-in-regexp.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-unescaped-dynamic-string-in-regexp.test.ts
@@ -55,9 +55,11 @@ describe("no-unescaped-dynamic-string-in-regexp", () => {
       const second = new RegExp(\`^\${rootName}/\`);
       const third = new RegExp(\`^\${currentRootFolder}/\`);
       const fourth = new RegExp(\`^\${topLevelName}/\`);
-      const fifth = new RegExp(\`^\${directorySegment}/\`);`,
+      const fifth = new RegExp(\`^\${directorySegment}/\`);
+      const sixth = new RegExp(\`^\${resourceFolder}/\`);
+      const seventh = new RegExp(\`^\${PathSource}/\`);`,
     );
-    expect(result.diagnostics).toHaveLength(5);
+    expect(result.diagnostics).toHaveLength(7);
   });
 
   it("does not flag path-like identifiers outside anchored path-prefix patterns", () => {
@@ -88,6 +90,27 @@ describe("no-unescaped-dynamic-string-in-regexp", () => {
       `const first = new RegExp(\`^\${escapeRegExp(rootFolderName)}/\`);
       const escapedRootFolderName = RegExp.escape(rootFolderName);
       const second = new RegExp(\`^\${escapedRootFolderName}/\`);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags an anchored path alias when one conditional branch is unescaped", () => {
+    const result = runRule(
+      noUnescapedDynamicStringInRegexp,
+      `const escapedRootFolder = escapeRegExp(rootFolder);
+      const pathPrefix = shouldEscape ? escapedRootFolder : untrustedValue;
+      const matcher = new RegExp(\`^\${pathPrefix}/\`);`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag an anchored path alias when every conditional branch is escaped", () => {
+    const result = runRule(
+      noUnescapedDynamicStringInRegexp,
+      `const escapedRootFolder = escapeRegExp(rootFolder);
+      const sanitizedFallbackFolder = RegExp.escape(fallbackFolder);
+      const pathPrefix = useFallback ? sanitizedFallbackFolder : escapedRootFolder;
+      const matcher = new RegExp(\`^\${pathPrefix}/\`);`,
     );
     expect(result.diagnostics).toHaveLength(0);
   });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-unescaped-dynamic-string-in-regexp.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-unescaped-dynamic-string-in-regexp.test.ts
@@ -32,6 +32,66 @@ describe("no-unescaped-dynamic-string-in-regexp", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("flags an unescaped root folder name in an anchored path pattern", () => {
+    const result = runRule(
+      noUnescapedDynamicStringInRegexp,
+      "const prefix = new RegExp(`^${rootFolderName}/`);",
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags the compiled concat form of an unescaped root folder name", () => {
+    const result = runRule(
+      noUnescapedDynamicStringInRegexp,
+      `const prefix = new RegExp("^".concat(rootFolderName, "/"));`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags semantic path-segment identifier variants in anchored path patterns", () => {
+    const result = runRule(
+      noUnescapedDynamicStringInRegexp,
+      `const first = new RegExp(\`^\${topLevelFolderName}/\`);
+      const second = new RegExp(\`^\${rootName}/\`);
+      const third = new RegExp(\`^\${currentRootFolder}/\`);
+      const fourth = new RegExp(\`^\${topLevelName}/\`);
+      const fifth = new RegExp(\`^\${directorySegment}/\`);`,
+    );
+    expect(result.diagnostics).toHaveLength(5);
+  });
+
+  it("does not flag path-like identifiers outside anchored path-prefix patterns", () => {
+    const result = runRule(
+      noUnescapedDynamicStringInRegexp,
+      `const namedPattern = new RegExp(rootName);
+      const exactPattern = new RegExp(\`^\${topLevelName}$\`);
+      const reorderedPattern = new RegExp(\`/\${directorySegment}^\`);
+      const nestedFragments = new RegExp(
+        \`\${makePrefix("^")}\${directorySegment}\${makeSuffix("/")}\`,
+      );`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not treat author-named regex sources as literal path segments", () => {
+    const result = runRule(
+      noUnescapedDynamicStringInRegexp,
+      `const first = new RegExp(\`^\${rootPattern}/\`);
+      const second = new RegExp(\`^\${pathRegexSource}/\`);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag escaped folder-root identifiers", () => {
+    const result = runRule(
+      noUnescapedDynamicStringInRegexp,
+      `const first = new RegExp(\`^\${escapeRegExp(rootFolderName)}/\`);
+      const escapedRootFolderName = RegExp.escape(rootFolderName);
+      const second = new RegExp(\`^\${escapedRootFolderName}/\`);`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("flags a highlight prop passed to RegExp without new", () => {
     const result = runRule(noUnescapedDynamicStringInRegexp, `const re = RegExp(highlight, 'gi');`);
     expect(result.diagnostics).toHaveLength(1);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-unescaped-dynamic-string-in-regexp.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-unescaped-dynamic-string-in-regexp.ts
@@ -32,7 +32,7 @@ const TEST_CONTEXT_FILE_PATTERN =
 // stay quiet. `term(?!in)` keeps `searchTerm` while excluding
 // `terminalSequence` / `terminate`-shaped names.
 const SEARCH_TERM_NAME_PATTERN = /search|query|highlight|filter|term(?!in)|keyword/i;
-const REGEX_SOURCE_NAME_PATTERN = /pattern|regex|regexp|source/i;
+const REGEX_SOURCE_WORDS = ["pattern", "regex", "regexp"];
 
 // An escape helper applied to the value makes the pattern safe. Also treat
 // `.replace(...)` / `.replaceAll(...)` as author-driven sanitization.
@@ -352,11 +352,11 @@ const isTypePositionIdentifier = (identifier: EsTreeNode): boolean => {
 };
 
 const identifierNameHasPathSegmentSemantics = (identifierName: string): boolean => {
-  if (REGEX_SOURCE_NAME_PATTERN.test(identifierName)) return false;
   const identifierWords = identifierName
     .replaceAll(/([a-z0-9])([A-Z])/g, "$1 $2")
     .split(/[\s_]+/)
     .map((word) => word.toLowerCase());
+  if (identifierWords.some((word) => REGEX_SOURCE_WORDS.includes(word))) return false;
   return (
     identifierWords.some((word) => ["path", "folder", "directory", "root"].includes(word)) ||
     (identifierWords.includes("top") && identifierWords.includes("level"))
@@ -456,12 +456,48 @@ const compositeInitializerResolvesEscaped = (
   regexpObjectSymbolIds: ReadonlySet<number>,
   globalRegExpObjectNames: ReadonlySet<string>,
 ): boolean => {
+  if (isNodeOfType(strippedInitializer, "ConditionalExpression")) {
+    return [strippedInitializer.consequent, strippedInitializer.alternate].every((branch) =>
+      initializerLooksEscaped(
+        branch,
+        remainingHops,
+        scopes,
+        regexpObjectSymbolIds,
+        globalRegExpObjectNames,
+      ),
+    );
+  }
+  if (
+    isNodeOfType(strippedInitializer, "BinaryExpression") ||
+    isNodeOfType(strippedInitializer, "LogicalExpression")
+  ) {
+    return [strippedInitializer.left, strippedInitializer.right].every((operand) =>
+      initializerLooksEscaped(
+        operand,
+        remainingHops,
+        scopes,
+        regexpObjectSymbolIds,
+        globalRegExpObjectNames,
+      ),
+    );
+  }
+  if (isNodeOfType(strippedInitializer, "TemplateLiteral")) {
+    return strippedInitializer.expressions.every((expression) =>
+      initializerLooksEscaped(
+        expression,
+        remainingHops,
+        scopes,
+        regexpObjectSymbolIds,
+        globalRegExpObjectNames,
+      ),
+    );
+  }
   let didResolveAnyLeafEscaped = false;
   for (const leafIdentifier of collectLeafIdentifiers(strippedInitializer)) {
     if (
       identifierResolvesToEscapedValue(
         leafIdentifier,
-        remainingHops,
+        remainingHops - 1,
         scopes,
         regexpObjectSymbolIds,
         globalRegExpObjectNames,
@@ -514,7 +550,7 @@ const initializerLooksEscaped = (
     }
     return compositeInitializerResolvesEscaped(
       strippedInitializer,
-      remainingHops - 1,
+      remainingHops,
       scopes,
       regexpObjectSymbolIds,
       globalRegExpObjectNames,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-unescaped-dynamic-string-in-regexp.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-unescaped-dynamic-string-in-regexp.ts
@@ -32,6 +32,7 @@ const TEST_CONTEXT_FILE_PATTERN =
 // stay quiet. `term(?!in)` keeps `searchTerm` while excluding
 // `terminalSequence` / `terminate`-shaped names.
 const SEARCH_TERM_NAME_PATTERN = /search|query|highlight|filter|term(?!in)|keyword/i;
+const REGEX_SOURCE_NAME_PATTERN = /pattern|regex|regexp|source/i;
 
 // An escape helper applied to the value makes the pattern safe. Also treat
 // `.replace(...)` / `.replaceAll(...)` as author-driven sanitization.
@@ -350,23 +351,91 @@ const isTypePositionIdentifier = (identifier: EsTreeNode): boolean => {
   return false;
 };
 
-const collectRawSearchTermIdentifiers = (
+const identifierNameHasPathSegmentSemantics = (identifierName: string): boolean => {
+  if (REGEX_SOURCE_NAME_PATTERN.test(identifierName)) return false;
+  const identifierWords = identifierName
+    .replaceAll(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .split(/[\s_]+/)
+    .map((word) => word.toLowerCase());
+  return (
+    identifierWords.some((word) => ["path", "folder", "directory", "root"].includes(word)) ||
+    (identifierWords.includes("top") && identifierWords.includes("level"))
+  );
+};
+
+const flattenPatternParts = (expression: EsTreeNode): Array<string | EsTreeNode> | null => {
+  const inner = stripParenExpression(expression);
+  const staticValue = literalStringValue(inner);
+  if (staticValue !== null) return [staticValue];
+  if (isNodeOfType(inner, "Identifier")) return [inner];
+  if (isNodeOfType(inner, "TemplateLiteral")) {
+    const parts: Array<string | EsTreeNode> = [];
+    for (let index = 0; index < inner.quasis.length; index += 1) {
+      const quasi = inner.quasis[index];
+      if (quasi) parts.push(quasi.value.cooked ?? quasi.value.raw);
+      const templateExpression = inner.expressions[index];
+      if (templateExpression) parts.push(stripParenExpression(templateExpression));
+    }
+    return parts;
+  }
+  if (isNodeOfType(inner, "BinaryExpression") && inner.operator === "+") {
+    const leftParts = flattenPatternParts(inner.left);
+    const rightParts = flattenPatternParts(inner.right);
+    return leftParts && rightParts ? [...leftParts, ...rightParts] : null;
+  }
+  if (
+    isNodeOfType(inner, "CallExpression") &&
+    isNodeOfType(inner.callee, "MemberExpression") &&
+    getStaticPropertyName(inner.callee) === "concat"
+  ) {
+    const receiverParts = flattenPatternParts(inner.callee.object);
+    if (!receiverParts) return null;
+    const parts = [...receiverParts];
+    for (const argument of inner.arguments) {
+      if (isNodeOfType(argument, "SpreadElement")) return null;
+      const argumentParts = flattenPatternParts(argument);
+      if (!argumentParts) return null;
+      parts.push(...argumentParts);
+    }
+    return parts;
+  }
+  return null;
+};
+
+const isIdentifierAnAnchoredPathSegment = (
+  argument: EsTreeNode,
+  identifier: EsTreeNodeOfType<"Identifier">,
+): boolean => {
+  if (!identifierNameHasPathSegmentSemantics(identifier.name)) return false;
+  const parts = flattenPatternParts(argument);
+  if (!parts) return false;
+  const identifierPartIndex = parts.findIndex((part) => part === identifier);
+  if (identifierPartIndex < 0) return false;
+  const precedingParts = parts.slice(0, identifierPartIndex);
+  if (precedingParts.some((part) => typeof part !== "string")) return false;
+  const staticPrefix = precedingParts.join("");
+  const followingPart = parts[identifierPartIndex + 1];
+  return staticPrefix === "^" && typeof followingPart === "string" && followingPart.startsWith("/");
+};
+
+const collectRawDynamicLiteralIdentifiers = (
   argument: EsTreeNode,
 ): EsTreeNodeOfType<"Identifier">[] => {
-  const rawSearchTermIdentifiers: EsTreeNodeOfType<"Identifier">[] = [];
+  const rawDynamicLiteralIdentifiers: EsTreeNodeOfType<"Identifier">[] = [];
   walkAst(argument, (child: EsTreeNode) => {
     if (isEscapingCall(child) || isRegexSourceAccess(child)) return false;
     if (isLiteralReturningGetterCall(child)) return false;
     if (
       isNodeOfType(child, "Identifier") &&
-      SEARCH_TERM_NAME_PATTERN.test(child.name) &&
+      (SEARCH_TERM_NAME_PATTERN.test(child.name) ||
+        isIdentifierAnAnchoredPathSegment(argument, child)) &&
       !isPropertyNamePosition(child) &&
       !isTypePositionIdentifier(child)
     ) {
-      rawSearchTermIdentifiers.push(child);
+      rawDynamicLiteralIdentifiers.push(child);
     }
   });
-  return rawSearchTermIdentifiers;
+  return rawDynamicLiteralIdentifiers;
 };
 
 const collectLeafIdentifiers = (node: EsTreeNode): EsTreeNodeOfType<"Identifier">[] => {
@@ -819,7 +888,7 @@ export const noUnescapedDynamicStringInRegexp = defineRule({
   category: "Correctness",
   tags: ["test-noise"],
   recommendation:
-    "A search/filter/highlight term dropped straight into `new RegExp(...)` lets its regex metacharacters act as operators, so a user typing `.` or `(` over-matches or throws. Escape the value with an `escapeRegExp` helper before constructing the pattern.",
+    "A dynamic literal string such as a search term or path segment dropped straight into `new RegExp(...)` lets its regex metacharacters act as operators, so values containing `.` or `(` over-match or throw. Escape the value with an `escapeRegExp` helper before constructing the pattern.",
   create: (context: RuleContext): RuleVisitors => {
     if (TEST_CONTEXT_FILE_PATTERN.test(context.filename ?? "")) return {};
     let regexpObjectIndex: RegExpObjectIndex | null = null;
@@ -838,8 +907,8 @@ export const noUnescapedDynamicStringInRegexp = defineRule({
         regexpObjectIndex = buildRegExpObjectIndex(programRoot, context.scopes);
       }
       const currentRegExpObjectIndex = regexpObjectIndex;
-      const rawSearchTermIdentifiers = collectRawSearchTermIdentifiers(firstArgument);
-      const hasUnescapedSearchTerm = rawSearchTermIdentifiers.some(
+      const rawDynamicLiteralIdentifiers = collectRawDynamicLiteralIdentifiers(firstArgument);
+      const hasUnescapedDynamicLiteral = rawDynamicLiteralIdentifiers.some(
         (identifier) =>
           !identifierResolvesToEscapedValue(
             identifier,
@@ -851,11 +920,11 @@ export const noUnescapedDynamicStringInRegexp = defineRule({
           !isShapeTestedByDominatingGuard(node, identifier, context.scopes) &&
           !isParameterFedOnlyMetacharacterFreeLiterals(identifier, context.scopes),
       );
-      if (!hasUnescapedSearchTerm) return;
+      if (!hasUnescapedDynamicLiteral) return;
       context.report({
         node,
         message:
-          "This builds a `RegExp` from a dynamic search/filter term without escaping it, so regex metacharacters in the value act as operators and over-match or throw. Escape the value with an `escapeRegExp` helper first.",
+          "This builds a `RegExp` from a dynamic literal string without escaping it, so regex metacharacters in the value act as operators and over-match or throw. Escape the value with an `escapeRegExp` helper first.",
       });
     };
     return {


### PR DESCRIPTION
## Why

ReactBench exposed 27 missed diagnostics where a dynamic root-folder segment was interpolated into an anchored `RegExp`:

```ts
new RegExp(`^${rootFolderName}/`)
```

Folder names can contain regex metacharacters, so the pattern can over-match or throw unless the segment is escaped.

## What changed

- recognize path-segment identifiers only in the narrow anchored `^<segment>/` shape
- preserve source order through templates, string concatenation, and compiled `.concat(...)` forms
- exclude author-named regex sources and keep escaped values quiet
- add adversarial positives, negatives, a true-positive fuzz corpus case, and a patch changeset

## Validation

- `nr test`: 15/15 tasks passed
- `nr lint`: passed with existing warnings only
- `nr typecheck`: 16/16 tasks passed
- `nr format:check`: passed
- `nr smoke:json-report`: passed (schemaVersion 3)
- strict target fuzz: 500 iterations, 1/1 passed
- local RDE: 99/99 roots across 12 repositories, zero target-rule diagnostics

`DAYTONA_API_KEY` is not available in this environment, so PR parity could not be run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-rule heuristic extension with broad negative tests; no runtime app or auth/data-path changes.
> 
> **Overview**
> Extends **`no-unescaped-dynamic-string-in-regexp`** so it catches dynamic **folder/path segment** names in the narrow **`^<segment>/`** shape (e.g. `` new RegExp(`^${rootFolderName}/`) ``), not only search/query-style identifiers.
> 
> The rule **flattens** template literals, `+` concatenation, and **`.concat(...)`** to verify the anchor and trailing slash, uses **name heuristics** for path/folder/directory/root (and excludes names like `rootPattern`), and **tightens escape resolution** for conditionals, templates, and composite initializers. User-facing copy now mentions path segments as well as search terms.
> 
> Adds **unit tests**, a **fuzz true-positive** corpus case, and a **patch changeset** for `oxlint-plugin-react-doctor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8eb1ad3b356c99def0310c89f7885662edd6b29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->