### PR TITLE
RDFPFN792026 detect dynamic array index keys

### DIFF
--- a/.changeset/brave-index-keys.md
+++ b/.changeset/brave-index-keys.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Detect index keys in dynamic React child arrays and data-indexed while loops.

--- a/packages/fuzz/corpus/true-positives/no-array-index-as-key--dynamic-react-children.tsx
+++ b/packages/fuzz/corpus/true-positives/no-array-index-as-key--dynamic-react-children.tsx
@@ -1,0 +1,10 @@
+// rule: no-array-index-as-key
+// weakness: wrapper-transparency
+// source: ReactBench write-react-docusaurus-tabs-1173
+
+import { Children, Fragment, type ReactNode } from "react";
+
+export const TabChildren = ({ children }: { children: ReactNode }) => {
+  const normalized = Children.toArray(children);
+  return normalized.map((child, index) => <Fragment key={index}>{child}</Fragment>);
+};

--- a/packages/fuzz/corpus/true-positives/no-array-index-as-key--while-loop-data-index.tsx
+++ b/packages/fuzz/corpus/true-positives/no-array-index-as-key--while-loop-data-index.tsx
@@ -1,0 +1,20 @@
+// rule: no-array-index-as-key
+// weakness: control-flow
+// source: ReactBench fix-react-rdh-pedropalau-react-b
+
+interface Photo {
+  photo: string;
+}
+
+export const preloadPhotos = (photos: Photo[], activePhotoIndex: number, preloadSize: number) => {
+  const nodes = [];
+  let loaded = 0;
+  let index = activePhotoIndex;
+  while (index < photos.length && loaded < preloadSize) {
+    const photo = photos[index];
+    nodes.push(<img key={index} src={photo.photo} alt="" />);
+    index += 1;
+    loaded += 1;
+  }
+  return nodes;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-array-index-as-key.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-array-index-as-key.regressions.test.ts
@@ -804,6 +804,420 @@ const Table = () => (
       expect(result.parseErrors).toEqual([]);
       expect(result.diagnostics).toEqual([]);
     });
+
+    it("flags fragments wrapping dynamic React.Children entries", () => {
+      const result = runRule(
+        noArrayIndexAsKey,
+        `const TabContent = ({ children }) => {
+  const childArray = React.Children.toArray(children).filter(Boolean);
+  return childArray.map((child, index) => (
+    <React.Fragment key={index}>{child}</React.Fragment>
+  ));
+};
+`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    });
+
+    it("flags fragments wrapping aliased named Children entries", () => {
+      const result = runRule(
+        noArrayIndexAsKey,
+        `import { Children as ReactChildren } from "react";
+const TabContent = ({ children }) => {
+  const childArray = ReactChildren.toArray(children);
+  return childArray.map((child, index) => (
+    <Fragment key={index}>{child}</Fragment>
+  ));
+};
+`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    });
+
+    it("flags fragments wrapping conditionally normalized React children", () => {
+      const result = runRule(
+        noArrayIndexAsKey,
+        `const TabContent = ({ children }) => {
+  const childItems = (Array.isArray(children) ? children : [children]).filter(Boolean);
+  return childItems.map((child, i) => <Fragment key={i}>{child}</Fragment>);
+};
+`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    });
+
+    it("stays silent on conditionally normalized text and value inputs", () => {
+      const valuesResult = runRule(
+        noArrayIndexAsKey,
+        `const ValueRows = ({ values }) => {
+  const normalized = Array.isArray(values) ? values : [values];
+  return normalized.map((value, index) => (
+    <Fragment key={index}>{value}</Fragment>
+  ));
+};
+`,
+      );
+      const textResult = runRule(
+        noArrayIndexAsKey,
+        `const TextRows = (text) => {
+  const normalized = Array.isArray(text) ? text : [text];
+  return normalized.map((part, index) => (
+    <Fragment key={index}>{part}</Fragment>
+  ));
+};
+`,
+      );
+      expect(valuesResult.parseErrors).toEqual([]);
+      expect(textResult.parseErrors).toEqual([]);
+      expect(valuesResult.diagnostics).toEqual([]);
+      expect(textResult.diagnostics).toEqual([]);
+    });
+
+    it("stays silent on shadowed React and Array lookalikes", () => {
+      const reactResult = runRule(
+        noArrayIndexAsKey,
+        `const React = { Children: { toArray: (value) => value } };
+const TextRun = ({ children }) =>
+  React.Children.toArray(children).map((child, index) => (
+    <React.Fragment key={index}>{child}</React.Fragment>
+  ));
+`,
+      );
+      const arrayResult = runRule(
+        noArrayIndexAsKey,
+        `const Array = { isArray: () => true };
+const TextRun = ({ children }) => {
+  const items = Array.isArray(children) ? children : [children];
+  return items.map((child, index) => (
+    <Fragment key={index}>{child}</Fragment>
+  ));
+};
+`,
+      );
+      expect(reactResult.parseErrors).toEqual([]);
+      expect(arrayResult.parseErrors).toEqual([]);
+      expect(reactResult.diagnostics).toEqual([]);
+      expect(arrayResult.diagnostics).toEqual([]);
+    });
+
+    it("flags fragments wrapping dynamically accumulated React children", () => {
+      const result = runRule(
+        noArrayIndexAsKey,
+        `const TabContent = ({ children }) => {
+  const childArray = React.Children.toArray(children);
+  const toRender = [];
+  for (const child of childArray) {
+    if (isPanel(child)) toRender.push(<Panel>{child}</Panel>);
+    else toRender.push(child);
+  }
+  return toRender.map((child, i) => (
+    <React.Fragment key={i}>{child}</React.Fragment>
+  ));
+};
+`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    });
+
+    it("stays silent on fragments wrapping accumulated text", () => {
+      const result = runRule(
+        noArrayIndexAsKey,
+        `const Labels = ({ values }) => {
+  const labels = [];
+  for (const value of values) labels.push(value.label);
+  return labels.map((label, index) => (
+    <Fragment key={index}>{label}</Fragment>
+  ));
+};
+`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it("stays silent on text derived from accumulated React children", () => {
+      const result = runRule(
+        noArrayIndexAsKey,
+        `const Labels = ({ children }) => {
+  const childArray = React.Children.toArray(children);
+  const labels = [];
+  for (const child of childArray) labels.push(child.props.label);
+  return labels.map((label, index) => (
+    <Fragment key={index}>{label}</Fragment>
+  ));
+};
+`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it("stays silent on fragments wrapping static accumulated JSX", () => {
+      const result = runRule(
+        noArrayIndexAsKey,
+        `const LoadingRows = ({ count }) => {
+  const rows = [];
+  for (let index = 0; index < count; index += 1) {
+    rows.push(<Skeleton />);
+  }
+  return rows.map((row, index) => (
+    <Fragment key={index}>{row}</Fragment>
+  ));
+};
+`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it("stays silent on a self-fed empty-array accumulator", () => {
+      const result = runRule(
+        noArrayIndexAsKey,
+        `const Rows = () => {
+  const rows = [];
+  for (const row of rows) rows.push(row);
+  return rows.map((row, index) => (
+    <Fragment key={index}>{row}</Fragment>
+  ));
+};
+`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it("flags loop counters bounded by non-identifier length receivers", () => {
+      const callResult = runRule(
+        noArrayIndexAsKey,
+        `const Rows = () => {
+  const rows = [];
+  for (let index = 0; index < getItems().length; index += 1) {
+    rows.push(<Row key={index} />);
+  }
+  return rows;
+};
+`,
+      );
+      const memberResult = runRule(
+        noArrayIndexAsKey,
+        `class Rows extends React.Component {
+  render() {
+    const rows = [];
+    for (let index = 0; index < this.items.length; index += 1) {
+      rows.push(<Row key={index} />);
+    }
+    return rows;
+  }
+}
+`,
+      );
+      expect(callResult.parseErrors).toEqual([]);
+      expect(memberResult.parseErrors).toEqual([]);
+      expect(callResult.diagnostics).toHaveLength(1);
+      expect(memberResult.diagnostics).toHaveLength(1);
+    });
+
+    it("stays silent when an unrelated length read does not bound the counter", () => {
+      const forResult = runRule(
+        noArrayIndexAsKey,
+        `const Rows = ({ items }) => {
+  const rows = [];
+  for (let index = 0; index < 5 && items.length > 0; index += 1) {
+    rows.push(<Row key={index} />);
+  }
+  return rows;
+};
+`,
+      );
+      const whileResult = runRule(
+        noArrayIndexAsKey,
+        `const Rows = ({ items }) => {
+  const rows = [];
+  let index = 0;
+  while (index < 5 && items.length > 0) {
+    rows.push(<Row key={index} />);
+    index += 1;
+  }
+  return rows;
+};
+`,
+      );
+      expect(forResult.parseErrors).toEqual([]);
+      expect(whileResult.parseErrors).toEqual([]);
+      expect(forResult.diagnostics).toEqual([]);
+      expect(whileResult.diagnostics).toEqual([]);
+    });
+
+    it("correlates identical member-chain collections without crossing collection paths", () => {
+      const sameCollectionResult = runRule(
+        noArrayIndexAsKey,
+        `const Gallery = ({ state }) => {
+  const rows = [];
+  let index = 0;
+  while (index < state.photos.length) {
+    const photo = state.photos[index];
+    rows.push(
+      <div aria-hidden>
+        <img key={index} src={photo.url} />
+      </div>,
+    );
+    index += 1;
+  }
+  return rows;
+};
+`,
+      );
+      const differentCollectionResult = runRule(
+        noArrayIndexAsKey,
+        `const Gallery = ({ photos, state }) => {
+  const rows = [];
+  let index = 0;
+  while (index < photos.length) {
+    const photo = state.photos[index];
+    rows.push(
+      <div aria-hidden>
+        <img key={index} src={photo.url} />
+      </div>,
+    );
+    index += 1;
+  }
+  return rows;
+};
+`,
+      );
+      expect(sameCollectionResult.parseErrors).toEqual([]);
+      expect(differentCollectionResult.parseErrors).toEqual([]);
+      expect(sameCollectionResult.diagnostics).toHaveLength(1);
+      expect(differentCollectionResult.diagnostics).toEqual([]);
+    });
+
+    it("flags stateless wrappers around cast dynamic React children", () => {
+      const result = runRule(
+        noArrayIndexAsKey,
+        `const TabContent = ({ children }) => {
+  const normalized = React.Children.toArray(children);
+  return normalized.map((child, idx) => (
+    <div key={idx}>{child as React.ReactNode}</div>
+  ));
+};
+`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    });
+
+    it("stays silent on bare text items inside fragments", () => {
+      const result = runRule(
+        noArrayIndexAsKey,
+        `const TextRun = ({ parts }) =>
+  parts.map((part, index) => (
+    <Fragment key={index}>
+      {index > 0 ? " and " : null}
+      {part}
+    </Fragment>
+  ));
+`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it("stays silent on fragment-wrapped static placeholders", () => {
+      const result = runRule(
+        noArrayIndexAsKey,
+        `const LoadingRows = ({ count }) =>
+  Array.from({ length: count }, (_, index) => (
+    <Fragment key={index}>
+      <Skeleton />
+    </Fragment>
+  ));
+`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+  });
+
+  describe("data-indexed while-loop counters", () => {
+    it("flags a mutable counter used to select array entries", () => {
+      const result = runRule(
+        noArrayIndexAsKey,
+        `const Gallery = ({ photos, activePhotoIndex, preloadSize }) => {
+  let counter = 1;
+  let index = activePhotoIndex;
+  const preloadPhotos = [];
+  while (index < photos.length && counter <= preloadSize) {
+    const photo = photos[index];
+    preloadPhotos.push(
+      <img key={index} src={photo.photo} alt="" aria-hidden="true" />,
+    );
+    index += 1;
+    counter += 1;
+  }
+  return preloadPhotos;
+};
+`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    });
+
+    it("stays silent on count-only placeholder while loops", () => {
+      const result = runRule(
+        noArrayIndexAsKey,
+        `const LoadingRows = ({ count }) => {
+  let index = 0;
+  const rows = [];
+  while (index < count) {
+    rows.push(<Skeleton key={index} />);
+    index += 1;
+  }
+  return rows;
+};
+`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it("stays silent when a while-loop key is not used to select array data", () => {
+      const result = runRule(
+        noArrayIndexAsKey,
+        `const SelectedPane = ({ selectedIndex }) => {
+  let index = selectedIndex;
+  while (shouldRender(index)) {
+    return <Pane key={index} selectedIndex={index} />;
+  }
+  return null;
+};
+`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it("stays silent when a while-loop reads an unrelated collection", () => {
+      const result = runRule(
+        noArrayIndexAsKey,
+        `const Gallery = ({ photos, bounds, selectedIndex }) => {
+  let index = selectedIndex;
+  const rows = [];
+  while (index < bounds.length) {
+    const photo = photos[index];
+    rows.push(<img key={index} src={photo.url} alt="" />);
+    index += 1;
+  }
+  return rows;
+};
+`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
   });
 
   describe("entries() tuples still resolve as positional indexes", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-array-index-as-key.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-array-index-as-key.regressions.test.ts
@@ -836,6 +836,21 @@ const TabContent = ({ children }) => {
       expect(result.diagnostics).toHaveLength(1);
     });
 
+    it("stays silent when React.Children.toArray normalizes ordinary data", () => {
+      const result = runRule(
+        noArrayIndexAsKey,
+        `const DataRows = ({ items }) => {
+  const rows = React.Children.toArray(items);
+  return rows.map((row, index) => (
+    <Fragment key={index}>{row}</Fragment>
+  ));
+};
+`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
     it("flags fragments wrapping conditionally normalized React children", () => {
       const result = runRule(
         noArrayIndexAsKey,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-array-index-as-key.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-array-index-as-key.regressions.test.ts
@@ -851,11 +851,41 @@ const TabContent = ({ children }) => {
       expect(result.diagnostics).toEqual([]);
     });
 
+    it("flags React.Children.toArray through a transparent children wrapper", () => {
+      const result = runRule(
+        noArrayIndexAsKey,
+        `const TabContent = ({ children }) => {
+  const childArray = React.Children.toArray(children as React.ReactNode);
+  return childArray.map((child, index) => (
+    <Fragment key={index}>{child}</Fragment>
+  ));
+};
+`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    });
+
     it("flags fragments wrapping conditionally normalized React children", () => {
       const result = runRule(
         noArrayIndexAsKey,
         `const TabContent = ({ children }) => {
   const childItems = (Array.isArray(children) ? children : [children]).filter(Boolean);
+  return childItems.map((child, i) => <Fragment key={i}>{child}</Fragment>);
+};
+`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    });
+
+    it("flags conditionally normalized React children through a transparent wrapper", () => {
+      const result = runRule(
+        noArrayIndexAsKey,
+        `const TabContent = ({ children }) => {
+  const childItems = (Array.isArray(children as React.ReactNode)
+    ? children
+    : [children]).filter(Boolean);
   return childItems.map((child, i) => <Fragment key={i}>{child}</Fragment>);
 };
 `,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-array-index-as-key.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-array-index-as-key.ts
@@ -1,4 +1,5 @@
 import { INDEX_PARAMETER_NAMES } from "../../constants/react.js";
+import { areExpressionsStructurallyEqual } from "../../utils/are-expressions-structurally-equal.js";
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { RuleContext } from "../../utils/rule-context.js";
@@ -7,6 +8,7 @@ import { findSameFileTypeDeclarations } from "../../utils/find-same-file-type-de
 import { getRootIdentifierName } from "../../utils/get-root-identifier-name.js";
 import { collectPatternNames } from "../../utils/collect-pattern-names.js";
 import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
+import { getImportBindingForName } from "../../utils/find-import-source-for-name.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isConstDeclaredBinding } from "../../utils/is-const-declared-binding.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
@@ -862,6 +864,171 @@ const isLoopCounterDeclarator = (
   return isBindingReassignedOrMutated(referenceNode, indexName);
 };
 
+const findEnclosingWhileLoop = (
+  node: EsTreeNode,
+): EsTreeNodeOfType<"WhileStatement"> | EsTreeNodeOfType<"DoWhileStatement"> | null => {
+  let current = node.parent;
+  while (current) {
+    if (isNodeOfType(current, "WhileStatement") || isNodeOfType(current, "DoWhileStatement")) {
+      return current;
+    }
+    if (isFunctionLike(current) || isNodeOfType(current, "Program")) return null;
+    current = current.parent;
+  }
+  return null;
+};
+
+const isStaticMemberChain = (expression: EsTreeNode): boolean => {
+  const candidate = stripParenExpression(expression);
+  if (isNodeOfType(candidate, "Identifier") || isNodeOfType(candidate, "ThisExpression")) {
+    return true;
+  }
+  return Boolean(
+    isNodeOfType(candidate, "MemberExpression") &&
+    !candidate.computed &&
+    isNodeOfType(candidate.property, "Identifier") &&
+    isStaticMemberChain(candidate.object),
+  );
+};
+
+const findLengthBoundCollections = (expression: EsTreeNode): EsTreeNode[] => {
+  const collections: EsTreeNode[] = [];
+  walkAst(expression, (child: EsTreeNode): boolean | void => {
+    if (
+      isNodeOfType(child, "MemberExpression") &&
+      !child.computed &&
+      isStaticMemberChain(child.object) &&
+      isNodeOfType(child.property, "Identifier") &&
+      child.property.name === "length"
+    ) {
+      collections.push(child.object);
+    }
+  });
+  return collections;
+};
+
+const areSameBoundStaticMemberChains = (first: EsTreeNode, second: EsTreeNode): boolean =>
+  isStaticMemberChain(first) &&
+  isStaticMemberChain(second) &&
+  areExpressionsStructurallyEqual(first, second, {
+    areIdentifiersEqual: (firstIdentifier, secondIdentifier) => {
+      if (
+        !isNodeOfType(firstIdentifier, "Identifier") ||
+        !isNodeOfType(secondIdentifier, "Identifier") ||
+        firstIdentifier.name !== secondIdentifier.name
+      ) {
+        return false;
+      }
+      const firstBinding = findVariableInitializer(firstIdentifier, firstIdentifier.name);
+      const secondBinding = findVariableInitializer(secondIdentifier, secondIdentifier.name);
+      return firstBinding?.bindingIdentifier === secondBinding?.bindingIdentifier;
+    },
+  });
+
+const RELATIONAL_BOUND_OPERATORS = new Set(["<", "<=", ">", ">="]);
+
+const loopTestBoundsCounterByLength = (
+  expression: EsTreeNode,
+  indexName: string,
+  bindingIdentifier: EsTreeNode,
+): boolean => {
+  const readsCounter = (candidate: EsTreeNode): boolean => {
+    let didReadCounter = false;
+    walkAst(candidate, (child: EsTreeNode): boolean | void => {
+      if (didReadCounter) return false;
+      if (
+        isNodeOfType(child, "Identifier") &&
+        child.name === indexName &&
+        findVariableInitializer(child, indexName)?.bindingIdentifier === bindingIdentifier
+      ) {
+        didReadCounter = true;
+        return false;
+      }
+    });
+    return didReadCounter;
+  };
+  const readsLength = (candidate: EsTreeNode): boolean => {
+    let didReadLength = false;
+    walkAst(candidate, (child: EsTreeNode): boolean | void => {
+      if (didReadLength) return false;
+      if (
+        isNodeOfType(child, "MemberExpression") &&
+        !child.computed &&
+        isNodeOfType(child.property, "Identifier") &&
+        child.property.name === "length"
+      ) {
+        didReadLength = true;
+        return false;
+      }
+    });
+    return didReadLength;
+  };
+  let didFindLengthBound = false;
+  walkAst(expression, (child: EsTreeNode): boolean | void => {
+    if (didFindLengthBound) return false;
+    if (
+      !isNodeOfType(child, "BinaryExpression") ||
+      !RELATIONAL_BOUND_OPERATORS.has(child.operator)
+    ) {
+      return;
+    }
+    if (
+      (readsCounter(child.left) && readsLength(child.right)) ||
+      (readsCounter(child.right) && readsLength(child.left))
+    ) {
+      didFindLengthBound = true;
+      return false;
+    }
+  });
+  return didFindLengthBound;
+};
+
+const isDataIndexedWhileLoopCounter = (
+  referenceNode: EsTreeNode,
+  bindingIdentifier: EsTreeNode,
+  indexName: string,
+): boolean => {
+  if (!INDEX_PARAMETER_NAMES.has(indexName)) return false;
+  const loop = findEnclosingWhileLoop(referenceNode);
+  if (!loop) return false;
+  let doesTestReadCounter = false;
+  walkAst(loop.test, (child: EsTreeNode): boolean | void => {
+    if (doesTestReadCounter) return false;
+    if (!isNodeOfType(child, "Identifier") || child.name !== indexName) return;
+    if (findVariableInitializer(child, indexName)?.bindingIdentifier === bindingIdentifier) {
+      doesTestReadCounter = true;
+      return false;
+    }
+  });
+  if (!doesTestReadCounter) return false;
+  const lengthBoundCollections = findLengthBoundCollections(loop.test);
+  if (lengthBoundCollections.length === 0) return false;
+  let didFindIndexedCollectionRead = false;
+  walkAst(loop.body, (child: EsTreeNode): boolean | void => {
+    if (didFindIndexedCollectionRead) return false;
+    if (isFunctionLike(child)) return false;
+    if (
+      !isNodeOfType(child, "MemberExpression") ||
+      !child.computed ||
+      !isNodeOfType(child.property, "Identifier") ||
+      child.property.name !== indexName
+    ) {
+      return;
+    }
+    const binding = findVariableInitializer(child.property, indexName);
+    if (
+      binding?.bindingIdentifier === bindingIdentifier &&
+      lengthBoundCollections.some((collection) =>
+        areSameBoundStaticMemberChains(collection, child.object),
+      )
+    ) {
+      didFindIndexedCollectionRead = true;
+      return false;
+    }
+  });
+  return didFindIndexedCollectionRead;
+};
+
 interface PositionalIndexBinding {
   // The `.map` / `.flatMap` / `.forEach` / `Array.from` call whose
   // callback binds the index, when the index came from one.
@@ -873,6 +1040,7 @@ interface PositionalIndexBinding {
   // Slot of the index parameter within `bindingFunction`, or null when
   // the index isn't a direct parameter (entries tuples, counters).
   indexParameterPosition: number | null;
+  isDataIndexedLoopCounter?: boolean;
 }
 
 interface PositionalIndexUse {
@@ -953,6 +1121,16 @@ const resolvePositionalIndexBinding = (
     declarator.id === binding.bindingIdentifier &&
     declarator.init
   ) {
+    if (
+      isDataIndexedWhileLoopCounter(identifierNode, binding.bindingIdentifier, identifierNode.name)
+    ) {
+      return {
+        iteratorCall: null,
+        bindingFunction: null,
+        indexParameterPosition: null,
+        isDataIndexedLoopCounter: true,
+      };
+    }
     const initializer = stripParenExpression(declarator.init);
     if (isNodeOfType(initializer, "Literal") && typeof initializer.value === "number") {
       if (!INDEX_PARAMETER_NAMES.has(identifierNode.name)) return null;
@@ -1003,6 +1181,206 @@ const iteratorCallExemptsIndexKey = (iteratorCall: EsTreeNodeOfType<"CallExpress
     isStaticDefaultLiteralReceiver(receiver) ||
     isStringDerivedReceiver(receiver)
   );
+};
+
+const isReactNamespaceIdentifier = (node: EsTreeNode): boolean => {
+  if (!isNodeOfType(node, "Identifier")) return false;
+  const importBinding = getImportBindingForName(node, node.name);
+  const visibleBinding = findVariableInitializer(node, node.name);
+  if (!importBinding) return node.name === "React" && !visibleBinding;
+  return (
+    visibleBinding?.initializer?.type.startsWith("Import") === true &&
+    importBinding.source === "react" &&
+    (importBinding.isNamespace || importBinding.exportedName === "default")
+  );
+};
+
+const isReactChildrenObject = (node: EsTreeNode): boolean => {
+  const candidate = stripParenExpression(node);
+  if (isNodeOfType(candidate, "Identifier")) {
+    const importBinding = getImportBindingForName(candidate, candidate.name);
+    const visibleBinding = findVariableInitializer(candidate, candidate.name);
+    return Boolean(
+      visibleBinding?.initializer?.type === "ImportSpecifier" &&
+      importBinding?.source === "react" &&
+      importBinding.exportedName === "Children",
+    );
+  }
+  return Boolean(
+    isNodeOfType(candidate, "MemberExpression") &&
+    !candidate.computed &&
+    isReactNamespaceIdentifier(candidate.object) &&
+    isNodeOfType(candidate.property, "Identifier") &&
+    candidate.property.name === "Children",
+  );
+};
+
+const isReactChildrenToArrayCall = (node: EsTreeNode): boolean => {
+  const candidate = stripParenExpression(node);
+  return Boolean(
+    isNodeOfType(candidate, "CallExpression") &&
+    isNodeOfType(candidate.callee, "MemberExpression") &&
+    !candidate.callee.computed &&
+    isReactChildrenObject(candidate.callee.object) &&
+    isNodeOfType(candidate.callee.property, "Identifier") &&
+    candidate.callee.property.name === "toArray",
+  );
+};
+
+const isSameIdentifier = (first: EsTreeNode, second: EsTreeNode): boolean => {
+  const firstIdentifier = stripParenExpression(first);
+  const secondIdentifier = stripParenExpression(second);
+  if (
+    !isNodeOfType(firstIdentifier, "Identifier") ||
+    !isNodeOfType(secondIdentifier, "Identifier") ||
+    firstIdentifier.name !== secondIdentifier.name
+  ) {
+    return false;
+  }
+  const firstBinding = findVariableInitializer(firstIdentifier, firstIdentifier.name);
+  const secondBinding = findVariableInitializer(secondIdentifier, secondIdentifier.name);
+  return firstBinding?.bindingIdentifier === secondBinding?.bindingIdentifier;
+};
+
+const isReactChildrenArrayNormalization = (node: EsTreeNode): boolean => {
+  const candidate = stripParenExpression(node);
+  if (!isNodeOfType(candidate, "ConditionalExpression")) return false;
+  const test = stripParenExpression(candidate.test);
+  if (
+    !isNodeOfType(test, "CallExpression") ||
+    !isNodeOfType(test.callee, "MemberExpression") ||
+    test.callee.computed ||
+    !isNodeOfType(test.callee.object, "Identifier") ||
+    test.callee.object.name !== "Array" ||
+    findVariableInitializer(test.callee.object, "Array") ||
+    !isNodeOfType(test.callee.property, "Identifier") ||
+    test.callee.property.name !== "isArray"
+  ) {
+    return false;
+  }
+  const testedValue = test.arguments?.[0];
+  if (!testedValue || !isNodeOfType(testedValue, "Identifier")) return false;
+  const testedBinding = findVariableInitializer(testedValue, testedValue.name);
+  if (
+    testedValue.name !== "children" ||
+    !testedBinding ||
+    !findEnclosingParameter(testedBinding.bindingIdentifier)
+  ) {
+    return false;
+  }
+  const branchWrapsTestedValue = (branch: EsTreeNode): boolean => {
+    const unwrappedBranch = stripParenExpression(branch);
+    return (
+      isNodeOfType(unwrappedBranch, "ArrayExpression") &&
+      unwrappedBranch.elements?.length === 1 &&
+      Boolean(
+        unwrappedBranch.elements[0] && isSameIdentifier(unwrappedBranch.elements[0], testedValue),
+      )
+    );
+  };
+  return (
+    (isSameIdentifier(candidate.consequent, testedValue) &&
+      branchWrapsTestedValue(candidate.alternate)) ||
+    (isSameIdentifier(candidate.alternate, testedValue) &&
+      branchWrapsTestedValue(candidate.consequent))
+  );
+};
+
+const isMutatedEmptyArrayBinding = (
+  identifierNode: EsTreeNodeOfType<"Identifier">,
+  depth: number,
+): boolean => {
+  const binding = findVariableInitializer(identifierNode, identifierNode.name);
+  const initializer = binding?.initializer ? stripParenExpression(binding.initializer) : null;
+  if (
+    !binding ||
+    !initializer ||
+    !isNodeOfType(initializer, "ArrayExpression") ||
+    initializer.elements?.length !== 0
+  ) {
+    return false;
+  }
+  const program = findProgramRoot(identifierNode);
+  if (!program) return false;
+  let didFindReactChildPush = false;
+  walkAst(program, (child: EsTreeNode): boolean | void => {
+    if (didFindReactChildPush) return false;
+    if (
+      !isNodeOfType(child, "CallExpression") ||
+      !isNodeOfType(child.callee, "MemberExpression") ||
+      child.callee.computed ||
+      !isNodeOfType(child.callee.object, "Identifier") ||
+      child.callee.object.name !== identifierNode.name ||
+      !isNodeOfType(child.callee.property, "Identifier") ||
+      child.callee.property.name !== "push"
+    ) {
+      return;
+    }
+    const receiverBinding = findVariableInitializer(child.callee.object, identifierNode.name);
+    if (
+      receiverBinding?.bindingIdentifier === binding.bindingIdentifier &&
+      (child.arguments ?? []).some((argument) => {
+        const candidate = stripParenExpression(argument);
+        const canCarryReactChild =
+          isNodeOfType(candidate, "Identifier") ||
+          isNodeOfType(candidate, "JSXElement") ||
+          isNodeOfType(candidate, "JSXFragment");
+        if (!canCarryReactChild) return false;
+        let doesCarryReactChild = false;
+        walkAst(candidate, (argumentChild: EsTreeNode): boolean | void => {
+          if (doesCarryReactChild) return false;
+          if (!isNodeOfType(argumentChild, "Identifier")) return;
+          const argumentBinding = findVariableInitializer(argumentChild, argumentChild.name);
+          const declarator = argumentBinding?.bindingIdentifier.parent;
+          const declaration = declarator?.parent;
+          const forOfStatement = declaration?.parent;
+          if (
+            declarator &&
+            isNodeOfType(declarator, "VariableDeclarator") &&
+            declaration &&
+            isNodeOfType(declaration, "VariableDeclaration") &&
+            forOfStatement &&
+            isNodeOfType(forOfStatement, "ForOfStatement") &&
+            forOfStatement.left === declaration &&
+            isDynamicReactChildrenExpression(forOfStatement.right, depth + 1)
+          ) {
+            doesCarryReactChild = true;
+            return false;
+          }
+        });
+        return doesCarryReactChild;
+      })
+    ) {
+      didFindReactChildPush = true;
+      return false;
+    }
+  });
+  return didFindReactChildPush;
+};
+
+const isDynamicReactChildrenExpression = (expression: EsTreeNode, depth: number): boolean => {
+  if (depth > TYPE_RESOLUTION_DEPTH_LIMIT) return false;
+  const candidate = stripParenExpression(expression);
+  if (isReactChildrenToArrayCall(candidate) || isReactChildrenArrayNormalization(candidate)) {
+    return true;
+  }
+  if (isNodeOfType(candidate, "Identifier")) {
+    if (isMutatedEmptyArrayBinding(candidate, depth)) return true;
+    const binding = findVariableInitializer(candidate, candidate.name);
+    return Boolean(
+      binding?.initializer && isDynamicReactChildrenExpression(binding.initializer, depth + 1),
+    );
+  }
+  if (
+    isNodeOfType(candidate, "CallExpression") &&
+    isNodeOfType(candidate.callee, "MemberExpression") &&
+    !candidate.callee.computed &&
+    isNodeOfType(candidate.callee.property, "Identifier") &&
+    candidate.callee.property.name === "filter"
+  ) {
+    return isDynamicReactChildrenExpression(candidate.callee.object, depth + 1);
+  }
+  return false;
 };
 
 // The key expression as a template literal — directly, or laundered one
@@ -1092,49 +1470,39 @@ const findBareItemNamesReferencedByTemplate = (
   return referencedItemNames;
 };
 
-const forLoopTestReadsDataLength = (test: EsTreeNode): boolean => {
-  let didFindLengthRead = false;
-  walkAst(test, (child: EsTreeNode): boolean | void => {
-    if (didFindLengthRead) return false;
-    if (
-      isNodeOfType(child, "MemberExpression") &&
-      isNodeOfType(child.property, "Identifier") &&
-      child.property.name === "length"
-    ) {
-      didFindLengthRead = true;
-      return false;
-    }
-  });
-  return didFindLengthRead;
-};
-
 // `for (let i = 0; i < count; i++) { children.push(<Col key={i} />) }` is
 // the imperative twin of the exempt `Array.from({length: count}).map(…)`
 // placeholder — the counter has no identity beyond its position.
-const isNumericForLoopCounter = (attributeNode: EsTreeNode, indexName: string): boolean => {
+const isNumericPlaceholderLoopCounter = (attributeNode: EsTreeNode, indexName: string): boolean => {
   const binding = findVariableInitializer(attributeNode, indexName);
   if (!binding) return false;
   const declarator = binding.bindingIdentifier.parent;
   if (!declarator || !isNodeOfType(declarator, "VariableDeclarator")) return false;
   const declaration = declarator.parent;
   if (!declaration || !isNodeOfType(declaration, "VariableDeclaration")) return false;
-  const forStatement = declaration.parent;
   if (
-    !forStatement ||
-    !isNodeOfType(forStatement, "ForStatement") ||
-    forStatement.init !== declaration ||
     !declarator.init ||
     !isNodeOfType(declarator.init, "Literal") ||
     typeof declarator.init.value !== "number"
   ) {
     return false;
   }
+  const forStatement = declaration.parent;
+  if (
+    forStatement &&
+    isNodeOfType(forStatement, "ForStatement") &&
+    forStatement.init === declaration
+  ) {
+    return !(
+      forStatement.test &&
+      loopTestBoundsCounterByLength(forStatement.test, indexName, binding.bindingIdentifier)
+    );
+  }
+  const whileLoop = findEnclosingWhileLoop(attributeNode);
+  if (!whileLoop) return false;
   // `for (let i = 0; i < items.length; i++)` walks real list data — the
   // items carry identity, so an index key there still breaks on reorder.
-  if (forStatement.test && forLoopTestReadsDataLength(forStatement.test as EsTreeNode)) {
-    return false;
-  }
-  return true;
+  return !loopTestBoundsCounterByLength(whileLoop.test, indexName, binding.bindingIdentifier);
 };
 
 const EMPTY_NAME_SET: ReadonlySet<string> = new Set();
@@ -1193,6 +1561,7 @@ const fragmentHasStatefulChildren = (
   openingElement: EsTreeNode,
   itemNames: ReadonlySet<string>,
   derivedNames: ReadonlySet<string>,
+  areBareItemsDynamicReactChildren: boolean,
 ): boolean => {
   const jsxElement = openingElement.parent;
   if (!jsxElement || !isNodeOfType(jsxElement, "JSXElement")) return false;
@@ -1203,7 +1572,9 @@ const fragmentHasStatefulChildren = (
   // elements appear, bare item reads are treated conservatively again.
   const bareIdentifierNames = hasTopLevelElementChildren
     ? derivedNames
-    : new Set([...derivedNames, ...itemNames]);
+    : areBareItemsDynamicReactChildren
+      ? derivedNames
+      : new Set([...derivedNames, ...itemNames]);
   return children.some((child) =>
     containsStatefulDescendant(child, {
       memberRootNames: itemNames,
@@ -1212,6 +1583,19 @@ const fragmentHasStatefulChildren = (
       callCalleeRootNames: itemNames,
     }),
   );
+};
+
+const elementHasDirectItemChild = (
+  openingElement: EsTreeNode,
+  itemNames: ReadonlySet<string>,
+): boolean => {
+  const jsxElement = openingElement.parent;
+  if (!jsxElement || !isNodeOfType(jsxElement, "JSXElement")) return false;
+  return (jsxElement.children ?? []).some((child) => {
+    if (!isNodeOfType(child, "JSXExpressionContainer")) return false;
+    const expression = stripParenExpression(child.expression);
+    return isNodeOfType(expression, "Identifier") && itemNames.has(expression.name);
+  });
 };
 
 // A callback that conditionally skips rows (`if (…) return null`)
@@ -1294,7 +1678,7 @@ export const noArrayIndexAsKey = defineRule({
       const indexUse = findPositionalIndexUse(node.value.expression, 0);
       if (!indexUse) return;
       const indexName = indexUse.identifier.name;
-      if (isNumericForLoopCounter(node, indexName)) return;
+      if (isNumericPlaceholderLoopCounter(node, indexName)) return;
       if (
         indexUse.binding.iteratorCall &&
         iteratorCallExemptsIndexKey(indexUse.binding.iteratorCall)
@@ -1308,12 +1692,20 @@ export const noArrayIndexAsKey = defineRule({
       ) {
         return;
       }
-      if (hasAriaHiddenAncestor(node)) return;
+      if (hasAriaHiddenAncestor(node) && !indexUse.binding.isDataIndexedLoopCounter) {
+        return;
+      }
 
       const itemNames = findIteratorItemNamesOfBinding(indexUse.binding);
       const derivedNames = collectDerivedRowContentNames(
         indexUse.binding.bindingFunction,
         itemNames,
+      );
+      const iteratorCallee = indexUse.binding.iteratorCall?.callee;
+      const hasDynamicReactChildren = Boolean(
+        iteratorCallee &&
+        isNodeOfType(iteratorCallee, "MemberExpression") &&
+        isDynamicReactChildrenExpression(iteratorCallee.object, 0),
       );
 
       const openingElement = node.parent;
@@ -1321,7 +1713,16 @@ export const noArrayIndexAsKey = defineRule({
         const elementName = openingElement.name as EsTreeNode;
         if (isNodeOfType(elementName, "JSXIdentifier")) {
           if (elementName.name === "Fragment") {
-            if (!fragmentHasStatefulChildren(openingElement, itemNames, derivedNames)) return;
+            if (
+              !fragmentHasStatefulChildren(
+                openingElement,
+                itemNames,
+                derivedNames,
+                hasDynamicReactChildren,
+              )
+            ) {
+              return;
+            }
           } else if (PURE_SVG_PRIMITIVE_TAGS.has(elementName.name)) {
             // Pure SVG primitives (`<g>`, `<path>`, …) only re-diff
             // attributes on reorder — no observable consequence, UNLESS
@@ -1342,13 +1743,15 @@ export const noArrayIndexAsKey = defineRule({
               const primitiveItemNames = keyTemplate
                 ? findBareItemNamesReferencedByTemplate(keyTemplate, itemNames)
                 : EMPTY_NAME_SET;
-              const isStateful = containsStatefulDescendant(jsxElement as EsTreeNode, {
-                memberRootNames: isInlineTextRun ? itemNames : EMPTY_NAME_SET,
-                bareIdentifierNames:
-                  primitiveItemNames.size > 0
-                    ? new Set([...derivedNames, ...primitiveItemNames])
-                    : derivedNames,
-              });
+              const isStateful =
+                (hasDynamicReactChildren && elementHasDirectItemChild(openingElement, itemNames)) ||
+                containsStatefulDescendant(jsxElement, {
+                  memberRootNames: isInlineTextRun ? itemNames : EMPTY_NAME_SET,
+                  bareIdentifierNames:
+                    primitiveItemNames.size > 0
+                      ? new Set([...derivedNames, ...primitiveItemNames])
+                      : derivedNames,
+                });
               if (!isStateful) return;
             }
           }
@@ -1359,7 +1762,12 @@ export const noArrayIndexAsKey = defineRule({
           isNodeOfType(elementName.property, "JSXIdentifier") &&
           elementName.object.name === "React" &&
           elementName.property.name === "Fragment" &&
-          !fragmentHasStatefulChildren(openingElement, itemNames, derivedNames)
+          !fragmentHasStatefulChildren(
+            openingElement,
+            itemNames,
+            derivedNames,
+            hasDynamicReactChildren,
+          )
         ) {
           return;
         }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-array-index-as-key.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-array-index-as-key.ts
@@ -1217,14 +1217,26 @@ const isReactChildrenObject = (node: EsTreeNode): boolean => {
 
 const isReactChildrenToArrayCall = (node: EsTreeNode): boolean => {
   const candidate = stripParenExpression(node);
-  return Boolean(
-    isNodeOfType(candidate, "CallExpression") &&
-    isNodeOfType(candidate.callee, "MemberExpression") &&
-    !candidate.callee.computed &&
-    isReactChildrenObject(candidate.callee.object) &&
-    isNodeOfType(candidate.callee.property, "Identifier") &&
-    candidate.callee.property.name === "toArray",
-  );
+  if (
+    !isNodeOfType(candidate, "CallExpression") ||
+    !isNodeOfType(candidate.callee, "MemberExpression") ||
+    candidate.callee.computed ||
+    !isReactChildrenObject(candidate.callee.object) ||
+    !isNodeOfType(candidate.callee.property, "Identifier") ||
+    candidate.callee.property.name !== "toArray"
+  ) {
+    return false;
+  }
+  const normalizedValue = candidate.arguments?.[0];
+  if (
+    !normalizedValue ||
+    !isNodeOfType(normalizedValue, "Identifier") ||
+    normalizedValue.name !== "children"
+  ) {
+    return false;
+  }
+  const normalizedBinding = findVariableInitializer(normalizedValue, normalizedValue.name);
+  return Boolean(normalizedBinding && findEnclosingParameter(normalizedBinding.bindingIdentifier));
 };
 
 const isSameIdentifier = (first: EsTreeNode, second: EsTreeNode): boolean => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-array-index-as-key.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-array-index-as-key.ts
@@ -1227,7 +1227,8 @@ const isReactChildrenToArrayCall = (node: EsTreeNode): boolean => {
   ) {
     return false;
   }
-  const normalizedValue = candidate.arguments?.[0];
+  const normalizedValueNode = candidate.arguments?.[0];
+  const normalizedValue = normalizedValueNode ? stripParenExpression(normalizedValueNode) : null;
   if (
     !normalizedValue ||
     !isNodeOfType(normalizedValue, "Identifier") ||
@@ -1270,8 +1271,10 @@ const isReactChildrenArrayNormalization = (node: EsTreeNode): boolean => {
   ) {
     return false;
   }
-  const testedValue = test.arguments?.[0];
-  if (!testedValue || !isNodeOfType(testedValue, "Identifier")) return false;
+  const testedValueNode = test.arguments?.[0];
+  if (!testedValueNode) return false;
+  const testedValue = stripParenExpression(testedValueNode);
+  if (!isNodeOfType(testedValue, "Identifier")) return false;
   const testedBinding = findVariableInitializer(testedValue, testedValue.name);
   if (
     testedValue.name !== "children" ||


### PR DESCRIPTION
Catches positional React keys that previously escaped `no-array-index-as-key` when dynamic children were wrapped in fragments or selected by a while-loop counter.

Before:

```tsx
const items = React.Children.toArray(children);
return items.map((child, index) => <Fragment key={index}>{child}</Fragment>);
```

```tsx
while (index < photos.length) {
  const photo = photos[index];
  nodes.push(<img key={index} src={photo.url} />);
  index += 1;
}
```

After: both shapes report the existing stable-key recommendation.

Precision boundaries:
- proves `React.Children.toArray` or the equivalent `Array.isArray(children) ? children : [children]` normalization, including named aliases
- requires the normalized `children` binding to originate from a function parameter
- follows accumulators only when pushed values reference an item iterated from a proven React-children source
- correlates a while-loop length bound and indexed read to the same collection and counter binding
- preserves static `Array.from`/`new Array` placeholders, count-only loops, bare text fragments, static JSX accumulators, `aria-hidden` measurement lists, shadowed globals, self-fed accumulators, and unrelated collections
- keeps the detector aligned with the live JSX `key={...}` rule contract; `cloneElement` configuration keys remain out of scope

ReactBench replay against the exact canonical patched files:
- D7DxAbF: 0 -> 2
- fQWEcdE: 0 -> 1
- uMikaLw: 0 -> 1
- ZVe5ePb: 0 -> 2
- NskERiX: 1 -> 2, adding the while-loop miss

This catches all 7 confirmed in-contract residual units. The previously counted `cloneElement` cases were reclassified against the updated live rule documentation and removed from both the implementation and the benchmark FN total.

Validation:
- full repository test: 15/15 tasks passed
- oxlint plugin: 24,810 passed, 201 skipped
- fuzz corpus: 192 passed, 782 skipped
- strict targeted fuzz: 500 iterations passed
- lint, typecheck, format check, and JSON report smoke passed
- exact canonical ReactBench replay catches all 7 in-contract residual units

Local RDE setup and build completed, but the run could not start because `AXIOM_DATASET` and `AXIOM_TOKEN` are unavailable in this environment. Daytona parity could not start because `DAYTONA_API_KEY` is unavailable.

A patch changeset is included.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-only correctness tightening in the oxlint plugin with broad regression tests; no runtime app or auth/data-path changes.
> 
> **Overview**
> Extends **`no-array-index-as-key`** so positional keys that used to slip through are reported, with a patch changeset and fuzz true-positive fixtures.
> 
> **Dynamic React children:** The rule now treats iterators over proven `children` sources (`React.Children.toArray`, `Array.isArray(children) ? children : [children]`, accumulators fed from those loops) as identity-bearing lists. Index keys on **Fragment** wrappers and thin wrappers around each child are flagged even when the fragment exemption would have stayed quiet before.
> 
> **While / for loops:** Counters bounded by a `.length` on the same collection used for `collection[index]` are classified as data-indexed loop counters (`isDataIndexedLoopCounter`), including while loops. Placeholder loops (`index < count`) stay exempt via **`loopTestBoundsCounterByLength`** replacing the old coarse “any `.length` in the test” check. **`aria-hidden`** no longer suppresses diagnostics for these data-indexed cases.
> 
> Regression and fuzz coverage document the new positives and unchanged silences (shadowed `React`/`Array`, plain data normalization, skeleton loops, mismatched collection paths).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e0fe72e4d6383e58e7b76b06878b50df98a56a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->