### PR TITLE
RDFPFN792026 Narrow repeated array lookup diagnostics

### DIFF
--- a/.changeset/tiny-sets-smile.md
+++ b/.changeset/tiny-sets-smile.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Avoid array-lookup reports for fresh array transforms and generated rest helpers with only small fixed omission lists.

--- a/packages/fuzz/corpus/regressions/js-set-map-lookups--small-rest-and-fresh-array.ts
+++ b/packages/fuzz/corpus/regressions/js-set-map-lookups--small-rest-and-fresh-array.ts
@@ -1,0 +1,30 @@
+// rule: js-set-map-lookups
+// weakness: small-collection-and-fresh-allocation
+// source: ReactBench RDFPFN792026 replay
+
+interface LookupRow {
+  value: string;
+}
+
+var __rest =
+  (this && this.__rest) ||
+  function (source, excluded) {
+    var target = {};
+    for (var property in source) {
+      if (
+        Object.prototype.hasOwnProperty.call(source, property) &&
+        excluded.indexOf(property) < 0
+      ) {
+        target[property] = source[property];
+      }
+    }
+    return target;
+  };
+
+export const omitSmallFixedLists = (first, second) => [
+  __rest(first, ["children", "className"]),
+  __rest(second, ["disabled"]),
+];
+
+export const retainFreshMatches = (rows: LookupRow[], selectedValues: string[]) =>
+  rows.filter((row) => selectedValues.filter(Boolean).includes(row.value));

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-set-map-lookups-reactbench-regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-set-map-lookups-reactbench-regressions.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { jsSetMapLookups } from "./js-set-map-lookups.js";
+
+const runLookupRule = (source: string) => runRule(jsSetMapLookups, source);
+
+const expectNoDiagnostics = (source: string): void => {
+  const result = runLookupRule(source);
+  expect(result.parseErrors).toEqual([]);
+  expect(result.diagnostics).toEqual([]);
+};
+
+const expectDiagnostic = (source: string): void => {
+  const result = runLookupRule(source);
+  expect(result.parseErrors).toEqual([]);
+  expect(result.diagnostics.length).toBeGreaterThan(0);
+};
+
+describe("js-set-map-lookups — ReactBench regressions", () => {
+  it("stays silent for a transpiled rest helper whose call sites omit only small fixed lists", () => {
+    expectNoDiagnostics(`
+      var __rest = (this && this.__rest) || function (source, excluded) {
+        var target = {};
+        for (var property in source) {
+          if (Object.prototype.hasOwnProperty.call(source, property) && excluded.indexOf(property) < 0) {
+            target[property] = source[property];
+          }
+        }
+        return target;
+      };
+      const first = __rest(props, ["children", "className"]);
+      const second = __rest(options, ["disabled"]);
+    `);
+  });
+
+  it("reports a transpiled rest helper when any omission list is larger than the cutoff", () => {
+    expectDiagnostic(`
+      var __rest = (this && this.__rest) || function (source, excluded) {
+        var target = {};
+        for (var property in source) {
+          if (Object.prototype.hasOwnProperty.call(source, property) && excluded.indexOf(property) < 0) {
+            target[property] = source[property];
+          }
+        }
+        return target;
+      };
+      const rest = __rest(props, ["a", "b", "c", "d", "e", "f", "g", "h", "i"]);
+    `);
+  });
+
+  it("reports a transpiled rest helper with an unproven omission list", () => {
+    expectDiagnostic(`
+      var __rest = (this && this.__rest) || function (source, excluded) {
+        var target = {};
+        for (var property in source) {
+          if (Object.prototype.hasOwnProperty.call(source, property) && excluded.indexOf(property) < 0) {
+            target[property] = source[property];
+          }
+        }
+        return target;
+      };
+      const rest = __rest(props, excludedKeys);
+    `);
+  });
+
+  it("stays silent when an array transform rebuilds the receiver in every iteration", () => {
+    expectNoDiagnostics(`
+      const selectedValues: string[] = [];
+      const rows: Array<{ value: string }> = [];
+      const matchingRows = rows.filter((row) =>
+        selectedValues.filter(Boolean).includes(row.value)
+      );
+    `);
+  });
+
+  it("reports an unproven userland transform method that can return a cached large array", () => {
+    expectDiagnostic(`
+      const cachedValues = ["a", "b", "c", "d", "e", "f", "g", "h", "i"];
+      const cache = { filter: () => cachedValues };
+      const matchingRows = rows.filter((row) => cache.filter().includes(row.value));
+    `);
+  });
+
+  it("stays silent for proven string receivers that previously looked like arrays", () => {
+    expectNoDiagnostics(`
+      const matchingRows = rows.filter((row) =>
+        text.slice(row.offset).includes(row.query) ||
+        (row.title || "").includes(row.query)
+      );
+    `);
+  });
+
+  it.each([
+    "buildRowSearchText(row)",
+    "hastClassName(row)",
+    "parseFilterTokens(row)",
+    "sectionTitle",
+  ])("reports an unproven receiver named like a string or fresh array: %s", (receiver) => {
+    expectDiagnostic(`
+      const matchingRows = rows.filter((row) => ${receiver}.includes(row.value));
+    `);
+  });
+
+  it.each(["conflicts", "categories", "excludeKeys"])(
+    "reports an unproven stable array named %s",
+    (arrayName) => {
+      expectDiagnostic(`
+        function findMatches(rows: string[], ${arrayName}: string[]) {
+          return rows.filter((row) => ${arrayName}.includes(row));
+        }
+      `);
+    },
+  );
+
+  it("reports a stable large array reused across repeated lookups", () => {
+    expectDiagnostic(`
+      const allowedValues = ["a", "b", "c", "d", "e", "f", "g", "h", "i"];
+      const matchingRows = rows.filter((row) => allowedValues.includes(row.value));
+    `);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-set-map-lookups-reactbench-regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-set-map-lookups-reactbench-regressions.test.ts
@@ -48,6 +48,21 @@ describe("js-set-map-lookups — ReactBench regressions", () => {
     `);
   });
 
+  it("stays silent for an empty transpiled rest omission list", () => {
+    expectNoDiagnostics(`
+      var __rest = (this && this.__rest) || function (source, excluded) {
+        var target = {};
+        for (var property in source) {
+          if (Object.prototype.hasOwnProperty.call(source, property) && excluded.indexOf(property) < 0) {
+            target[property] = source[property];
+          }
+        }
+        return target;
+      };
+      const rest = __rest(props, []);
+    `);
+  });
+
   it("reports a transpiled rest helper with an unproven omission list", () => {
     expectDiagnostic(`
       var __rest = (this && this.__rest) || function (source, excluded) {
@@ -73,6 +88,16 @@ describe("js-set-map-lookups — ReactBench regressions", () => {
     `);
   });
 
+  it("stays silent through transparent wrappers on proven fresh arrays", () => {
+    expectNoDiagnostics(`
+      const selectedValues: string[] = [];
+      const rows: Array<{ value: string }> = [];
+      const matchingRows = rows.filter((row) =>
+        (selectedValues as string[]).filter(Boolean).includes(row.value)
+      );
+    `);
+  });
+
   it("reports an unproven userland transform method that can return a cached large array", () => {
     expectDiagnostic(`
       const cachedValues = ["a", "b", "c", "d", "e", "f", "g", "h", "i"];
@@ -86,6 +111,16 @@ describe("js-set-map-lookups — ReactBench regressions", () => {
       const matchingRows = rows.filter((row) =>
         text.slice(row.offset).includes(row.query) ||
         (row.title || "").includes(row.query)
+      );
+    `);
+  });
+
+  it("stays silent through transparent wrappers on proven strings", () => {
+    expectNoDiagnostics(`
+      const rows: Array<{ offset: number; query: string }> = [];
+      const text: string | null = "content";
+      const matchingRows = rows.filter((row) =>
+        text!.slice(row.offset).includes(row.query)
       );
     `);
   });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-set-map-lookups.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-set-map-lookups.ts
@@ -1,9 +1,11 @@
 import { LOOP_TYPES } from "../../constants/js.js";
 import { SMALL_LITERAL_ARRAY_MAX_ELEMENTS } from "../../constants/thresholds.js";
+import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
 import { collectPatternNames } from "../../utils/collect-pattern-names.js";
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
 import { findProgramRoot } from "../../utils/find-program-root.js";
 import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
 import { getRangeStart } from "../../utils/get-range-start.js";
@@ -97,6 +99,7 @@ const STRING_TYPED_PROPERTY_NAMES: ReadonlySet<string> = new Set([
   "label",
   "slug",
   "prefix",
+  "__html",
 ]);
 
 // Identifier suffix conventions whose binding is overwhelmingly a
@@ -237,6 +240,16 @@ const STRING_TYPED_IDENTIFIER_NAMES: ReadonlySet<string> = new Set([
 
 const STRING_RETURNING_CALLEE_PREFIX_PATTERN = /^(?:normalize|format|stringify|serialize)/;
 
+const FRESH_ARRAY_METHOD_NAMES: ReadonlySet<string> = new Set([
+  "concat",
+  "filter",
+  "flat",
+  "flatMap",
+  "map",
+  "slice",
+  "split",
+]);
+
 // HACK: returns true when the receiver of `.includes()` / `.indexOf()`
 // is obviously a string, so the Set rewrite suggestion doesn't apply.
 const isLikelyStringReceiver = (receiver: EsTreeNode | null | undefined): boolean => {
@@ -264,6 +277,15 @@ const isLikelyStringReceiver = (receiver: EsTreeNode | null | undefined): boolea
     isNodeOfType(receiver, "CallExpression") &&
     isNodeOfType(receiver.callee, "Identifier") &&
     STRING_RETURNING_CALLEE_PREFIX_PATTERN.test(receiver.callee.name)
+  ) {
+    return true;
+  }
+  if (
+    isNodeOfType(receiver, "CallExpression") &&
+    isNodeOfType(receiver.callee, "MemberExpression") &&
+    isNodeOfType(receiver.callee.property, "Identifier") &&
+    (receiver.callee.property.name === "concat" || receiver.callee.property.name === "slice") &&
+    isLikelyStringReceiver(receiver.callee.object)
   ) {
     return true;
   }
@@ -304,7 +326,68 @@ const isLikelyStringReceiver = (receiver: EsTreeNode | null | undefined): boolea
       isLikelyStringReceiver(receiver.consequent) && isLikelyStringReceiver(receiver.alternate)
     );
   }
+  if (isNodeOfType(receiver, "LogicalExpression")) {
+    return isLikelyStringReceiver(receiver.left) && isLikelyStringReceiver(receiver.right);
+  }
   return false;
+};
+
+const isFreshArrayReceiver = (receiver: EsTreeNode): boolean => {
+  if (
+    !isNodeOfType(receiver, "CallExpression") ||
+    !isNodeOfType(receiver.callee, "MemberExpression") ||
+    !isNodeOfType(receiver.callee.property, "Identifier")
+  ) {
+    return false;
+  }
+  if (!FRESH_ARRAY_METHOD_NAMES.has(receiver.callee.property.name)) return false;
+  if (receiver.callee.property.name === "split") {
+    return isLikelyStringReceiver(receiver.callee.object);
+  }
+  return (
+    isKnownNativeArrayReceiver(receiver.callee.object) ||
+    isFreshArrayReceiver(receiver.callee.object)
+  );
+};
+
+const isTypeScriptRestHelperLookup = (
+  lookupCall: EsTreeNode,
+  receiver: EsTreeNode,
+  scopes: ScopeAnalysis,
+): boolean => {
+  if (!isNodeOfType(receiver, "Identifier")) return false;
+  const enclosingFunction = findEnclosingFunction(lookupCall);
+  if (
+    !isNodeOfType(enclosingFunction, "FunctionExpression") ||
+    !isNodeOfType(enclosingFunction.params?.[1], "Identifier") ||
+    enclosingFunction.params[1].name !== receiver.name
+  ) {
+    return false;
+  }
+  let bindingIdentifier: EsTreeNode | null = null;
+  let ancestor: EsTreeNode | null | undefined = enclosingFunction.parent;
+  while (ancestor && !isFunctionLike(ancestor)) {
+    if (
+      isNodeOfType(ancestor, "VariableDeclarator") &&
+      isNodeOfType(ancestor.id, "Identifier") &&
+      ancestor.id.name === "__rest"
+    ) {
+      bindingIdentifier = ancestor.id;
+      break;
+    }
+    ancestor = ancestor.parent;
+  }
+  if (!bindingIdentifier) return false;
+  const helperSymbol = scopes.symbolFor(bindingIdentifier);
+  if (!helperSymbol || helperSymbol.references.length === 0) return false;
+  return helperSymbol.references.every((reference) => {
+    const callExpression = reference.identifier.parent;
+    return (
+      isNodeOfType(callExpression, "CallExpression") &&
+      callExpression.callee === reference.identifier &&
+      isSmallInlineLiteralArray(callExpression.arguments?.[1])
+    );
+  });
 };
 
 // `lines[i]` / `tokens[cursor]` — indexing into an array by a numeric
@@ -1606,6 +1689,8 @@ export const jsSetMapLookups = defineRule({
         return;
       }
       if (isLikelyStringReceiver(receiver)) return;
+      if (isFreshArrayReceiver(receiver)) return;
+      if (isTypeScriptRestHelperLookup(node, receiver, context.scopes)) return;
       if (isSmallInlineLiteralArray(receiver)) return;
       if (isScreamingSnakeCaseConstantReceiver(receiver)) return;
       if (isSmallFixedListMember(receiver)) return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-set-map-lookups.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-set-map-lookups.ts
@@ -254,6 +254,8 @@ const FRESH_ARRAY_METHOD_NAMES: ReadonlySet<string> = new Set([
 // is obviously a string, so the Set rewrite suggestion doesn't apply.
 const isLikelyStringReceiver = (receiver: EsTreeNode | null | undefined): boolean => {
   if (!receiver) return false;
+  const unwrappedReceiver = stripParenExpression(receiver);
+  if (unwrappedReceiver !== receiver) return isLikelyStringReceiver(unwrappedReceiver);
   if (isNodeOfType(receiver, "Literal") && typeof receiver.value === "string") return true;
   if (isNodeOfType(receiver, "TemplateLiteral")) return true;
   if (
@@ -333,6 +335,8 @@ const isLikelyStringReceiver = (receiver: EsTreeNode | null | undefined): boolea
 };
 
 const isFreshArrayReceiver = (receiver: EsTreeNode): boolean => {
+  const unwrappedReceiver = stripParenExpression(receiver);
+  if (unwrappedReceiver !== receiver) return isFreshArrayReceiver(unwrappedReceiver);
   if (
     !isNodeOfType(receiver, "CallExpression") ||
     !isNodeOfType(receiver.callee, "MemberExpression") ||
@@ -344,9 +348,18 @@ const isFreshArrayReceiver = (receiver: EsTreeNode): boolean => {
   if (receiver.callee.property.name === "split") {
     return isLikelyStringReceiver(receiver.callee.object);
   }
+  const sourceReceiver = stripParenExpression(receiver.callee.object);
+  return isKnownNativeArrayReceiver(sourceReceiver) || isFreshArrayReceiver(sourceReceiver);
+};
+
+const isSmallRestHelperOmissionList = (node: EsTreeNode | undefined): boolean => {
+  if (!node) return false;
+  const candidate = stripParenExpression(node);
+  if (!isNodeOfType(candidate, "ArrayExpression")) return false;
+  const elements = candidate.elements ?? [];
   return (
-    isKnownNativeArrayReceiver(receiver.callee.object) ||
-    isFreshArrayReceiver(receiver.callee.object)
+    elements.length <= SMALL_LITERAL_ARRAY_MAX_ELEMENTS &&
+    elements.every((element) => element === null || !isNodeOfType(element, "SpreadElement"))
   );
 };
 
@@ -385,7 +398,7 @@ const isTypeScriptRestHelperLookup = (
     return (
       isNodeOfType(callExpression, "CallExpression") &&
       callExpression.callee === reference.identifier &&
-      isSmallInlineLiteralArray(callExpression.arguments?.[1])
+      isSmallRestHelperOmissionList(callExpression.arguments?.[1])
     );
   });
 };


### PR DESCRIPTION
## Why

ReactBench archived 493 `js-set-map-lookups` positive-delta units as false positives. Replaying the canonical patches against current `main` showed that only 100 are safely closable under the live rule contract without identifier or callee-name guesses:

- 5 lookups have structurally proven string receivers.
- 95 generated TypeScript `__rest` helper diagnostics have only same-file literal omission callsites at or below the eight-item cutoff.
- 393 diagnostics remain reported: 53 are confirmed true positives because a same-file helper callsite passes 10–39 omission keys, and 340 have runtime sizes that cannot be proven statically and remain contract-subjective.

Terra's 32 archived units remain reported. Thirty are correlated variants of the same Freecut hotkey-editor task/file, and none has static size proof; receiver-name suppression would hide adversarial large arrays.

## What changed

- Recognize independently proven string slices/concatenations and string-backed logical expressions.
- Recognize fresh standard array transforms only when their receiver is itself proven native/fresh.
- Suppress generated `__rest` helper lookups only when every resolved same-file callsite supplies a literal omission list of at most eight elements.
- Add adversarial regressions for large arrays named `conflicts`, `categories`, and `excludeKeys`, cached userland transform results, large/unproven helper callsites, and string cases.
- Add a strict-fuzz regression corpus and a patch changeset.

## Replay evidence

- Clean current-main replay: 493 reported, 0 suppressed; SHA-256 `e51458da2b742fb74eb51e71529be5035c7549c399387f4755f02f3df5ffe785`.
- Validated post-edit replay: 493 total, 100 suppressed, 393 retained, 0 parse errors across 321 files / 232 trials; SHA-256 `f1f140135050763bbba441107c00770680cc1f39e51cfddadce4b425d848a6cd`.
- Final A/B/C partition: A=5 structural strings, B=95 callsite-proven small helpers, C=393 retained; SHA-256 `2e7a2f1ec58192cdee16dbb9f98f8c349baa9f42ae45a618c2a2007d250a43cc`.
- Helper evidence: all 53 retained helper units have at least one literal callsite over the cutoff; 0 are retained only because callsites are unavailable; SHA-256 `097ee2531076a6bbf54d7fee7612436911de901213b851d520da30c5f45e6cc1`.

## Validation

- `nr format`
- `nr lint`
- `nr typecheck`
- `nr test` — all 15 tasks passed; plugin 958 files / 25,009 tests, CLI 226 files / 2,373 tests
- `nr smoke:json-report` — schema v3 smoke passed
- `FUZZ_RULE=js-set-map-lookups FUZZ_ITERATIONS=500 FUZZ_STRICT=1 FUZZ_PRINT_STATS=1 nr -C packages/fuzz fuzz`
- Truffler pre/post symbol searches found no reusable duplicate.

Local RDE was attempted and blocked by the eval runner's schema-version mismatch (`Expected 1, got 3`). Daytona parity could not run because `DAYTONA_API_KEY` is unavailable in this environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes heuristic suppression in a widely used lint rule; mistakes could hide real repeated lookups, though adversarial cases (large arrays, cached transforms, unproven receivers) remain covered by tests.
> 
> **Overview**
> Tightens **`js-set-map-lookups`** so ReactBench-style false positives are suppressed without hiding large or unproven array membership checks.
> 
> **String receivers:** Parentheses are peeled before classification; string-backed `concat`/`slice` chains and `&&`/`||` operands count as strings; `__html` is treated as a string-typed property.
> 
> **Fresh arrays:** `.includes`/`.indexOf` on receivers from standard transforms (`filter`, `map`, `slice`, string `split`, etc.) are skipped when the chain is rooted in a proven native or recursively fresh array—e.g. `selectedValues.filter(Boolean).includes(...)` inside a loop.
> 
> **TypeScript `__rest`:** Scope analysis finds generated helpers whose second parameter uses `excluded.indexOf`; diagnostics are suppressed only when every same-file `__rest` call passes a literal omission list of at most eight elements (no spreads). Large lists, dynamic lists, and non-helper patterns still report.
> 
> Adds ReactBench regression tests, a fuzz corpus sample, and a patch changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0633368f9c1e30ab978f4ff7c4922237f31dd55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->