### PR TITLE
RDFPFN792026: preserve ordered async traversal output

### DIFF
--- a/.changeset/tidy-files-listen.md
+++ b/.changeset/tidy-files-listen.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Avoid reporting intentionally sequential async traversal that appends await-derived values to an ordered output array.

--- a/packages/fuzz/corpus/regressions/async-await-in-loop--await-derived-ordered-output.ts
+++ b/packages/fuzz/corpus/regressions/async-await-in-loop--await-derived-ordered-output.ts
@@ -1,0 +1,28 @@
+// rule: async-await-in-loop
+// weakness: cross-function-data-flow
+// source: React Bench fix-react-same-recursive-file-drop
+// verdict: pass
+
+interface Entry {
+  children: Entry[];
+  isFile: boolean;
+}
+
+const collectFiles = async (entry: Entry, files: File[]): Promise<void> => {
+  if (entry.isFile) {
+    const file = await readFile(entry);
+    files.push(file);
+    return;
+  }
+  for (const child of entry.children) {
+    await collectFiles(child, files);
+  }
+};
+
+export const readDroppedFiles = async (entries: Entry[]): Promise<File[]> => {
+  const files: File[] = [];
+  for (const entry of entries) {
+    await collectFiles(entry, files);
+  }
+  return files;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/async-await-in-loop.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/async-await-in-loop.regressions.test.ts
@@ -133,6 +133,132 @@ describe("js-performance/async-await-in-loop — regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("stays silent when an awaited local helper appends to a passed output array", () => {
+    const result = runRule(
+      asyncAwaitInLoop,
+      `const collect = async (entry, files) => { files.push(await read(entry)); }; async function load(entries) { const files = []; for (const entry of entries) { await collect(entry, files); } return files; }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent when a later assignment carries the awaited value into the ordered output", () => {
+    const result = runRule(
+      asyncAwaitInLoop,
+      `const collect = async (entry, files) => { let copy; const file = await read(entry); copy = file; files.push(copy); }; async function load(entries) { const files = []; for (const entry of entries) { await collect(entry, files); } return files; }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent when an awaited local helper appends through a defaulted output parameter", () => {
+    const result = runRule(
+      asyncAwaitInLoop,
+      `const collect = async (entry, files = []) => { files.push(await read(entry)); }; async function load(entries) { const files = []; for (const entry of entries) { await collect(entry, files); } return files; }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent when an awaited local helper appends to a captured output array", () => {
+    const result = runRule(
+      asyncAwaitInLoop,
+      `async function load(entries) { const files = []; const collect = async (entry) => { files.push(await read(entry)); }; for (const entry of entries) { await collect(entry); } return files; }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still flags an awaited helper when its caller-local output has no order-observing escape", () => {
+    const result = runRule(
+      asyncAwaitInLoop,
+      `const collect = async (entry, files) => { files.push(await read(entry)); }; async function load(entries) { const files = []; for (const entry of entries) { await collect(entry, files); } consumeAsSet(files); }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("still flags when the only return of the output is inside a nested callback", () => {
+    const result = runRule(
+      asyncAwaitInLoop,
+      `const collect = async (entry, files) => { files.push(await read(entry)); }; async function load(entries) { const files = []; for (const entry of entries) { await collect(entry, files); } consume(files.map(() => { return files; })); }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("still flags a captured output array with no order-observing escape", () => {
+    const result = runRule(
+      asyncAwaitInLoop,
+      `async function load(entries) { const files = []; const collect = async (entry) => { files.push(await read(entry)); }; for (const entry of entries) { await collect(entry); } consumeAsSet(files); }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("still flags an append that reads a shadowing binding instead of the awaited value", () => {
+    const result = runRule(
+      asyncAwaitInLoop,
+      `const collect = async (entry, files) => { const file = await read(entry); { const file = entry; files.push(file); } }; async function load(entries) { const files = []; for (const entry of entries) { await collect(entry, files); } return files; }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("stays silent when a recursive awaited helper appends an await-derived file in traversal order", () => {
+    const result = runRule(
+      asyncAwaitInLoop,
+      `const collect = async (entry, files) => { if (entry.isFile) { const file = await read(entry); files.push(withPath(file)); return; } for (const child of entry.children) { await collect(child, files); } }; async function load(entries) { const files = []; for (const entry of entries) { await collect(entry, files); } return files; }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still flags a helper that pushes before awaiting independent work", () => {
+    const result = runRule(
+      asyncAwaitInLoop,
+      `const collect = async (entry, files) => { files.push(entry); await send(entry); }; async function load(entries) { const files = []; for (const entry of entries) { await collect(entry, files); } return files; }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("still flags a helper that sets distinct map keys after awaiting", () => {
+    const result = runRule(
+      asyncAwaitInLoop,
+      `const collect = async (entry, files) => { const file = await read(entry); files.set(entry.id, file); }; async function load(entries) { const files = new Map(); for (const entry of entries) { await collect(entry, files); } return files; }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("still flags an external append unrelated to the awaited result", () => {
+    const result = runRule(
+      asyncAwaitInLoop,
+      `const collect = async (entry, files) => { await send(entry); files.push(entry); }; async function load(entries) { const files = []; for (const entry of entries) { await collect(entry, files); } return files; }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("still flags an awaited local helper that only appends to its own local array", () => {
+    const result = runRule(
+      asyncAwaitInLoop,
+      `const collect = async (entry) => { const files = []; files.push(await read(entry)); return files; }; async function load(entries) { for (const entry of entries) { await collect(entry); } }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("still flags an awaited local helper that only reads a passed output array", () => {
+    const result = runRule(
+      asyncAwaitInLoop,
+      `const collect = async (entry, files) => read(entry, files.length); async function load(entries) { const files = []; for (const entry of entries) { await collect(entry, files); } return files; }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
   it("still flags independent awaits in a loop", () => {
     const result = runRule(
       asyncAwaitInLoop,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/async-await-in-loop.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/async-await-in-loop.ts
@@ -1,11 +1,20 @@
 import { INTENTIONAL_SEQUENCING_CALLEE_NAMES, LOOP_TYPES } from "../../constants/js.js";
+import type {
+  ScopeAnalysis,
+  ScopeDescriptor,
+  SymbolDescriptor,
+} from "../../semantic/scope-analysis.js";
 import { collectReferenceIdentifierNames } from "../../utils/collect-reference-identifier-names.js";
 import { containsDirectAwait } from "../../utils/contains-direct-await.js";
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { findTransparentExpressionRoot } from "../../utils/find-transparent-expression-root.js";
-import { getOrderIndependentLocalFunction } from "../../utils/get-order-independent-local-function.js";
+import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
+import {
+  getOrderIndependentLocalFunction,
+  resolveStaticLocalCallFunction,
+} from "../../utils/get-order-independent-local-function.js";
 import { hasPossibleStaticMemberCallWrite } from "../../utils/has-static-property-write-before.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isInlineFunctionExpression } from "../../utils/is-inline-function-expression.js";
@@ -14,6 +23,7 @@ import type { RuleContext } from "../../utils/rule-context.js";
 import { walkAst } from "../../utils/walk-ast.js";
 
 const LOOP_STATEMENT_TYPES: ReadonlySet<string> = new Set(LOOP_TYPES);
+const ORDERED_OUTPUT_INSERTION_METHOD_NAMES = new Set(["push", "unshift"]);
 
 const findFirstAwaitOutsideNestedFunctions = (
   block: EsTreeNode,
@@ -138,11 +148,227 @@ const isAwaitingManualPromiseWait = (awaitNode: EsTreeNode): boolean => {
   return isWaitLike;
 };
 
+const getRootObjectIdentifierName = (node: EsTreeNode | null | undefined): string | null => {
+  let current: EsTreeNode | null | undefined = node;
+  while (isNodeOfType(current, "MemberExpression")) {
+    current = current.object;
+  }
+  return isNodeOfType(current, "Identifier") ? current.name : null;
+};
+
+const isScopeWithinFunction = (
+  candidateScope: ScopeDescriptor,
+  functionScope: ScopeDescriptor,
+): boolean => {
+  let currentScope: typeof candidateScope | null = candidateScope;
+  while (currentScope) {
+    if (currentScope === functionScope) return true;
+    currentScope = currentScope.parent;
+  }
+  return false;
+};
+
+const isSymbolDirectlyReturned = (
+  symbol: SymbolDescriptor,
+  callerFunction: EsTreeNode | null,
+): boolean =>
+  Boolean(callerFunction) &&
+  symbol.references.some((reference) => {
+    const expressionRoot = findTransparentExpressionRoot(reference.identifier);
+    const parent = expressionRoot.parent;
+    return (
+      isNodeOfType(parent, "ReturnStatement") &&
+      parent.argument === expressionRoot &&
+      findEnclosingFunction(parent) === callerFunction
+    );
+  });
+
+const collectPatternBindingSymbolIds = (
+  pattern: EsTreeNode,
+  scopes: ScopeAnalysis,
+  target: Set<number>,
+): void => {
+  if (isNodeOfType(pattern, "Identifier")) {
+    const symbol = scopes.symbolFor(pattern);
+    if (symbol) target.add(symbol.id);
+    return;
+  }
+  if (isNodeOfType(pattern, "ObjectPattern")) {
+    for (const property of pattern.properties ?? []) {
+      if (isNodeOfType(property, "Property") && property.value) {
+        collectPatternBindingSymbolIds(property.value, scopes, target);
+      } else if (isNodeOfType(property, "RestElement") && property.argument) {
+        collectPatternBindingSymbolIds(property.argument, scopes, target);
+      }
+    }
+    return;
+  }
+  if (isNodeOfType(pattern, "ArrayPattern")) {
+    for (const element of pattern.elements ?? []) {
+      if (element) collectPatternBindingSymbolIds(element, scopes, target);
+    }
+    return;
+  }
+  if (isNodeOfType(pattern, "AssignmentPattern") && pattern.left) {
+    collectPatternBindingSymbolIds(pattern.left, scopes, target);
+  }
+};
+
+const collectReferencedSymbolIds = (expression: EsTreeNode, scopes: ScopeAnalysis): Set<number> => {
+  const referencedSymbolIds = new Set<number>();
+  walkAst(expression, (child: EsTreeNode): boolean | void => {
+    if (child !== expression && isFunctionLike(child)) return false;
+    if (!isNodeOfType(child, "Identifier")) return;
+    const symbol = scopes.symbolFor(child);
+    if (symbol) referencedSymbolIds.add(symbol.id);
+  });
+  return referencedSymbolIds;
+};
+
+const collectAwaitDerivedSymbolIds = (block: EsTreeNode, scopes: ScopeAnalysis): Set<number> => {
+  const awaitDerivedSymbolIds = new Set<number>();
+  const bindingDependencies: Array<{
+    declaredSymbolId: number;
+    referencedSymbolIds: Set<number>;
+  }> = [];
+  walkAst(block, (child: EsTreeNode): boolean | void => {
+    if (child !== block && isFunctionLike(child)) return false;
+    if (isNodeOfType(child, "VariableDeclarator") && child.id && child.init) {
+      const declaredSymbolIds = new Set<number>();
+      collectPatternBindingSymbolIds(child.id, scopes, declaredSymbolIds);
+      if (containsDirectAwait(child.init)) {
+        for (const symbolId of declaredSymbolIds) awaitDerivedSymbolIds.add(symbolId);
+      }
+      const referencedSymbolIds = collectReferencedSymbolIds(child.init, scopes);
+      for (const declaredSymbolId of declaredSymbolIds) {
+        bindingDependencies.push({ declaredSymbolId, referencedSymbolIds });
+      }
+      return;
+    }
+    if (isNodeOfType(child, "AssignmentExpression") && child.left) {
+      const assignedSymbolIds = new Set<number>();
+      collectPatternBindingSymbolIds(child.left, scopes, assignedSymbolIds);
+      if (containsDirectAwait(child.right)) {
+        for (const symbolId of assignedSymbolIds) awaitDerivedSymbolIds.add(symbolId);
+      }
+      const referencedSymbolIds = collectReferencedSymbolIds(child.right, scopes);
+      for (const assignedSymbolId of assignedSymbolIds) {
+        bindingDependencies.push({
+          declaredSymbolId: assignedSymbolId,
+          referencedSymbolIds,
+        });
+      }
+    }
+  });
+  let didGrow = true;
+  while (didGrow) {
+    didGrow = false;
+    for (const { declaredSymbolId, referencedSymbolIds } of bindingDependencies) {
+      if (awaitDerivedSymbolIds.has(declaredSymbolId)) continue;
+      for (const referencedSymbolId of referencedSymbolIds) {
+        if (!awaitDerivedSymbolIds.has(referencedSymbolId)) continue;
+        awaitDerivedSymbolIds.add(declaredSymbolId);
+        didGrow = true;
+        break;
+      }
+    }
+  }
+  return awaitDerivedSymbolIds;
+};
+
+const getSimpleParameterIdentifier = (parameter: EsTreeNode): EsTreeNode | null => {
+  if (isNodeOfType(parameter, "Identifier")) return parameter;
+  if (isNodeOfType(parameter, "AssignmentPattern") && isNodeOfType(parameter.left, "Identifier")) {
+    return parameter.left;
+  }
+  return null;
+};
+
+const doesAwaitedLocalCallInsertAwaitDerivedOutput = (
+  awaitNode: EsTreeNode,
+  context: RuleContext,
+): boolean => {
+  if (!isNodeOfType(awaitNode, "AwaitExpression")) return false;
+  const callExpression = awaitNode.argument;
+  if (!isNodeOfType(callExpression, "CallExpression")) return false;
+  const localFunction = resolveStaticLocalCallFunction(callExpression, context.scopes);
+  if (!isFunctionLike(localFunction)) return false;
+  const callerFunction = findEnclosingFunction(callExpression);
+  const functionScope = context.scopes.ownScopeFor(localFunction);
+  if (!functionScope) return false;
+  const awaitDerivedSymbolIds = collectAwaitDerivedSymbolIds(localFunction.body, context.scopes);
+  const externallyReachableParameterSymbolIds = new Set<number>();
+  for (const [parameterIndex, parameter] of localFunction.params.entries()) {
+    const parameterIdentifier = getSimpleParameterIdentifier(parameter);
+    if (!parameterIdentifier) continue;
+    const argument = callExpression.arguments[parameterIndex];
+    if (!isNodeOfType(argument, "Identifier")) continue;
+    const parameterSymbol = context.scopes.symbolFor(parameterIdentifier);
+    const argumentSymbol = context.scopes.symbolFor(argument);
+    if (
+      parameterSymbol &&
+      argumentSymbol &&
+      (isSymbolDirectlyReturned(argumentSymbol, callerFunction) ||
+        argumentSymbol.id === parameterSymbol.id)
+    ) {
+      externallyReachableParameterSymbolIds.add(parameterSymbol.id);
+    }
+  }
+  let doesInsertAwaitDerivedOutput = false;
+  walkAst(localFunction.body, (child: EsTreeNode): boolean | void => {
+    if (doesInsertAwaitDerivedOutput) return false;
+    if (child !== localFunction.body && isFunctionLike(child)) return false;
+    if (!isNodeOfType(child, "CallExpression")) return;
+    const callee = child.callee;
+    if (
+      !isNodeOfType(callee, "MemberExpression") ||
+      callee.computed ||
+      !isNodeOfType(callee.property, "Identifier") ||
+      !ORDERED_OUTPUT_INSERTION_METHOD_NAMES.has(callee.property.name)
+    ) {
+      return;
+    }
+    let doesMutationConsumeAwaitedValue = false;
+    for (const mutationArgument of child.arguments ?? []) {
+      if (containsDirectAwait(mutationArgument)) {
+        doesMutationConsumeAwaitedValue = true;
+        break;
+      }
+      const referencedSymbolIds = collectReferencedSymbolIds(mutationArgument, context.scopes);
+      for (const referencedSymbolId of referencedSymbolIds) {
+        if (awaitDerivedSymbolIds.has(referencedSymbolId)) {
+          doesMutationConsumeAwaitedValue = true;
+          break;
+        }
+      }
+      if (doesMutationConsumeAwaitedValue) break;
+    }
+    if (!doesMutationConsumeAwaitedValue) return;
+    let receiverIdentifier: EsTreeNode | null = callee.object;
+    while (isNodeOfType(receiverIdentifier, "MemberExpression")) {
+      receiverIdentifier = receiverIdentifier.object;
+    }
+    if (!isNodeOfType(receiverIdentifier, "Identifier")) return;
+    const receiverSymbol = context.scopes.symbolFor(receiverIdentifier);
+    if (
+      receiverSymbol &&
+      (externallyReachableParameterSymbolIds.has(receiverSymbol.id) ||
+        (!isScopeWithinFunction(receiverSymbol.scope, functionScope) &&
+          isSymbolDirectlyReturned(receiverSymbol, callerFunction)))
+    ) {
+      doesInsertAwaitDerivedOutput = true;
+      return false;
+    }
+  });
+  return doesInsertAwaitDerivedOutput;
+};
+
 const isIntentionallySequentialAwait = (awaitNode: EsTreeNode, context: RuleContext): boolean =>
   isAwaitingPossiblyMutatedMemberCall(awaitNode, context) ||
   isAwaitingSleepLikeCall(awaitNode, context) ||
   isAwaitingPromiseConcurrencyCall(awaitNode) ||
-  isAwaitingManualPromiseWait(awaitNode);
+  isAwaitingManualPromiseWait(awaitNode) ||
+  doesAwaitedLocalCallInsertAwaitDerivedOutput(awaitNode, context);
 
 const collectPatternIdentifiers = (pattern: EsTreeNode, target: Set<string>): void => {
   if (isNodeOfType(pattern, "Identifier")) {
@@ -427,14 +653,6 @@ const loopBodyHasAwaitDependentEarlyExit = (
     }
   });
   return hasAwaitDependentExit;
-};
-
-const getRootObjectIdentifierName = (node: EsTreeNode | null | undefined): string | null => {
-  let current: EsTreeNode | null | undefined = node;
-  while (isNodeOfType(current, "MemberExpression")) {
-    current = current.object;
-  }
-  return isNodeOfType(current, "Identifier") ? current.name : null;
 };
 
 const MUTATING_ARRAY_METHOD_NAMES = new Set([...ARRAY_MUTATION_METHOD_NAMES, "pop", "shift"]);


### PR DESCRIPTION
## Summary

- Suppress `async-await-in-loop` only when an awaited same-file helper inserts an await-derived value into an externally reachable ordered array.
- Preserve diagnostics for pre-await output writes, unrelated post-await writes, distinct-key Map updates, and helper-local output.
- Add focused regressions, a fuzz corpus fixture, and a patch changeset.

## ReactBench evidence

- Current main baseline: 479/479 archived family units projected residual from 2/2 frozen trial examples; 3 diagnostics across those examples.
- This branch: 0 diagnostics across both exact patched trial replays.
- Live docs contract: false positive only when iterations must complete in order for correctness.
- Frozen validation artifact: `/tmp/reactbench-async-await-in-loop-post-edit-validation.json` SHA-256 `8b5b26d37213433dd4f8740b7db919b1276c299615b5bd4699dfc98dcb1902ef`.

## Validation

- Focused rule tests: 60 passed
- Full repository tests: 15/15 tasks passed
- Strict target fuzz: 500 iterations passed
- RDE: 99 project-root records across 12 repositories; 233 retained target diagnostics in 171 files
- Lint: passed with existing warnings
- Typecheck: 16/16 tasks passed
- Format check: passed
- JSON report smoke: passed, schemaVersion 3

## Parity

PR parity was not run because `DAYTONA_API_KEY` is unavailable in this environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds non-trivial cross-function data-flow heuristics to a widely used lint rule; false negatives/positives are possible but bounded by extensive regression tests.
> 
> **Overview**
> Extends **`async-await-in-loop`** so loops that **`await` same-file helpers** are treated as **intentionally sequential** when those helpers **`push`/`unshift` values derived from `await`** into an **ordered output array** the caller returns (or passes in and returns).
> 
> The new path uses scope analysis to trace **await-derived bindings** (including assignments), resolve **static local callees**, and require the mutation receiver to be an **externally reachable** output—not helper-local arrays, **Map** keyed writes, **pre-await** pushes, or pushes of **unrelated** values. **Recursive traversal** and **captured** output arrays are covered; cases where order does not matter (e.g. **`consumeAsSet`**) still **diagnose**.
> 
> Adds **regression tests**, a **fuzz corpus** fixture for recursive file-drop collection, and a **patch changeset**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd4dc202ada1205f7c0ae9643b5020105f55420f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->