### PR TITLE
perf(rules): fingerprint Next.js async API manifest

### DIFF
--- a/.changeset/nextjs-manifest-fingerprint.md
+++ b/.changeset/nextjs-manifest-fingerprint.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Cache Next.js async dynamic API diagnostics against the owning package manifest.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/cross-file-dependencies.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/cross-file-dependencies.test.ts
@@ -326,6 +326,30 @@ describe("forwarded Hook dependency collectors", () => {
 });
 
 describe("nextjs collectors", () => {
+  it("records the owning package manifest for the async dynamic API wrapper gate", () => {
+    writeFixtureFile(
+      "package.json",
+      `{ "dependencies": { "next": "^15.0.0", "react": "^19.0.0" } }\n`,
+    );
+    const pagePath = writeFixtureFile(
+      "app/page.tsx",
+      `import { cookies } from "next/headers";
+export default function Page() {
+  return cookies().get("session");
+}
+`,
+    );
+
+    for (const trace of [
+      collectFor(pagePath, ["nextjs-async-dynamic-api-not-awaited"]),
+      collectFor(pagePath, ["nextjs-async-dynamic-api-not-awaited"]),
+    ]) {
+      expect(trace).not.toBeNull();
+      expect(trace?.contentPaths.has(fixturePath("package.json"))).toBe(true);
+      expect(trace?.existencePaths.has(fixturePath("app/package.json"))).toBe(true);
+    }
+  });
+
   it("records ancestor layout probes for a page file only", () => {
     writeFixtureFile("app/layout.tsx", "export default ({ children }) => children;\n");
     const pagePath = writeFixtureFile("app/products/page.tsx", "export default () => <div />;\n");

--- a/packages/oxlint-plugin-react-doctor/src/plugin/cross-file-dependencies.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/cross-file-dependencies.ts
@@ -427,6 +427,7 @@ export const CROSS_FILE_DEPENDENCY_COLLECTORS: ReadonlyMap<string, CrossFileDepe
     ["client-passive-event-listeners", collectEffectValueHelperDependencies],
     ["exhaustive-deps", collectForwardedHookDependencies],
     ["no-barrel-import", collectNoBarrelImportDependencies],
+    ["nextjs-async-dynamic-api-not-awaited", collectNearestManifestDependencies],
     ["nextjs-missing-metadata", collectNextjsMissingMetadataDependencies],
     ["nextjs-no-use-search-params-without-suspense", collectNextjsSearchParamsDependencies],
     ["no-dynamic-import-path", collectNearestManifestDependencies],
@@ -466,7 +467,6 @@ export const CROSS_FILE_DEPENDENCY_COLLECTORS: ReadonlyMap<string, CrossFileDepe
  * partition), forcing a conscious classification.
  */
 export const UNBOUNDED_CROSS_FILE_RULE_IDS: ReadonlySet<string> = new Set([
-  "nextjs-async-dynamic-api-not-awaited",
   "nextjs-no-img-element",
   "no-loading-flag-reset-outside-finally",
   "only-export-components",


### PR DESCRIPTION
## What changed

`nextjs-async-dynamic-api-not-awaited` now fingerprints the nearest package manifest instead of being classified as globally unbounded for sidecar caching.

## Why

The rule wrapper reads only the owning package manifest to determine its Next.js gate. Recording that bounded dependency lets unchanged files reuse cached diagnostics without sacrificing correctness when Next.js metadata changes.

## Regression review

- records both the nested manifest existence probe and owning package.json content
- repeats collection to cover memoized manifest lookup
- keeps project-wide rules without a sound bound in the unbounded set
- complete plugin suite: 24,795 passed, 201 skipped
- full repository tests, lint, typecheck, formatting, JSON-report smoke test all pass
- React Doctor changed-scope scan: 100/100, no issues
- patch changeset included

This PR is independent and targets `main`.