### PR TITLE
[8/11] refactor(cli): migrate core imports to local facades

### DIFF
--- a/packages/react-doctor/src/cli/commands/rules.ts
+++ b/packages/react-doctor/src/cli/commands/rules.ts
@@ -1,6 +1,8 @@
 import * as path from "node:path";
-import { buildRuleDocsUrl, highlighter, validateConfigTypes } from "@react-doctor/core";
-import type { ReactDoctorConfig, RuleSeverityOverride } from "@react-doctor/core";
+import { validateConfigTypes } from "../../core/core-configuration.js";
+import type { ReactDoctorConfig, RuleSeverityOverride } from "../../core/core-configuration.js";
+import { highlighter } from "../../core/core-presentation.js";
+import { buildRuleDocsUrl } from "../../core/core-product.js";
 import { cliLogger as logger } from "../utils/cli-logger.js";
 import { METRIC } from "../utils/constants.js";
 import { recordCount } from "../utils/record-metric.js";

--- a/packages/react-doctor/src/cli/index.ts
+++ b/packages/react-doctor/src/cli/index.ts
@@ -1,5 +1,6 @@
 import { Command, Option } from "commander";
-import { CANONICAL_GITHUB_URL, CI_URL, highlighter } from "@react-doctor/core";
+import { highlighter } from "../core/core-presentation.js";
+import { CANONICAL_GITHUB_URL, CI_URL } from "../core/core-product.js";
 import { flushSentry, initializeSentry } from "../instrument.js";
 import { ciConfigAction, ciInstallAction, ciUpgradeAction } from "./commands/ci.js";
 import { designAction } from "./commands/design.js";

--- a/packages/react-doctor/src/cli/ink/components/diagnostic-detail.tsx
+++ b/packages/react-doctor/src/cli/ink/components/diagnostic-detail.tsx
@@ -1,5 +1,5 @@
-import { getCategoryImpact } from "@react-doctor/core";
 import { Box, Text } from "ink";
+import { getCategoryImpact } from "../../../core/core-presentation.js";
 import { useMemo } from "react";
 import { buildCodeFrame } from "../../utils/build-code-frame.js";
 import { TUI_DETAIL_INDENT_COLUMNS } from "../../utils/constants.js";

--- a/packages/react-doctor/src/cli/ink/components/project-select.tsx
+++ b/packages/react-doctor/src/cli/ink/components/project-select.tsx
@@ -2,7 +2,7 @@ import path from "node:path";
 import figures from "figures";
 import { Box, Text, useInput } from "ink";
 import { useMemo, useState } from "react";
-import type { WorkspacePackage } from "@react-doctor/core";
+import type { WorkspacePackage } from "../../../core/core-types.js";
 import {
   TUI_PRINTABLE_ASCII_MIN_CODE_POINT,
   TUI_PROJECT_SELECT_CHROME_ROWS,

--- a/packages/react-doctor/src/cli/ink/components/report.tsx
+++ b/packages/react-doctor/src/cli/ink/components/report.tsx
@@ -1,6 +1,6 @@
 import { Box, Text, useInput } from "ink";
 import { useEffect, useMemo, useRef } from "react";
-import type { ScoreResult } from "@react-doctor/core";
+import type { ScoreResult } from "../../../core/core-types.js";
 import type { CliAgentId } from "../../utils/launch-agent.js";
 import {
   METRIC,

--- a/packages/react-doctor/src/cli/ink/components/scanning.tsx
+++ b/packages/react-doctor/src/cli/ink/components/scanning.tsx
@@ -1,6 +1,6 @@
 import { Box, Text } from "ink";
 import Spinner from "ink-spinner";
-import type { Diagnostic as LiveDiagnostic } from "@react-doctor/core/schemas";
+import type { LiveDiagnostic } from "../../../core/core-reporting.js";
 import { formatDiagnosticSite } from "../../utils/format-diagnostic-site.js";
 import { severityVariant } from "../lib/severity-variants.js";
 

--- a/packages/react-doctor/src/cli/ink/components/score-header.tsx
+++ b/packages/react-doctor/src/cli/ink/components/score-header.tsx
@@ -1,7 +1,8 @@
 import { Box, Text, useStdout } from "ink";
 import { useMemo } from "react";
-import { PERFECT_SCORE, SCORE_BAR_WIDTH_CHARS, TOP_ERRORS_DISPLAY_COUNT } from "@react-doctor/core";
-import type { ScoreResult } from "@react-doctor/core";
+import { SCORE_BAR_WIDTH_CHARS } from "../../../core/core-presentation.js";
+import { PERFECT_SCORE, TOP_ERRORS_DISPLAY_COUNT } from "../../../core/core-score.js";
+import type { ScoreResult } from "../../../core/core-types.js";
 import { doctorFace } from "../../utils/doctor-face.js";
 import {
   TUI_HORIZONTAL_PADDING_COLUMNS,

--- a/packages/react-doctor/src/cli/ink/lib/diagnostic-list-entries.ts
+++ b/packages/react-doctor/src/cli/ink/lib/diagnostic-list-entries.ts
@@ -1,4 +1,4 @@
-import { DIAGNOSTIC_CATEGORY_BUCKETS } from "@react-doctor/core";
+import { DIAGNOSTIC_CATEGORY_BUCKETS } from "../../../core/core-diagnostic-semantics.js";
 import type { DiagnosticRow } from "./diagnostic-rows.js";
 
 export interface DiagnosticHeaderEntry {

--- a/packages/react-doctor/src/cli/ink/lib/diagnostic-rows.ts
+++ b/packages/react-doctor/src/cli/ink/lib/diagnostic-rows.ts
@@ -1,4 +1,4 @@
-import type { Diagnostic, ScoreResult } from "@react-doctor/core";
+import type { Diagnostic, ScoreResult } from "../../../core/core-types.js";
 import {
   buildRulePriorityMap,
   buildSortedRuleGroups,

--- a/packages/react-doctor/src/cli/ink/lib/score-color.ts
+++ b/packages/react-doctor/src/cli/ink/lib/score-color.ts
@@ -1,4 +1,4 @@
-import { SCORE_GOOD_THRESHOLD, SCORE_OK_THRESHOLD } from "@react-doctor/core";
+import { SCORE_GOOD_THRESHOLD, SCORE_OK_THRESHOLD } from "../../../core/core-score.js";
 
 export const scoreColorName = (score: number): string => {
   if (score >= SCORE_GOOD_THRESHOLD) return "green";

--- a/packages/react-doctor/src/cli/ink/scan-bridge-layers.ts
+++ b/packages/react-doctor/src/cli/ink/scan-bridge-layers.ts
@@ -1,7 +1,7 @@
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
-import { Progress, Reporter } from "@react-doctor/core";
-import type { ProgressHandle } from "@react-doctor/core";
+import { Progress, Reporter } from "../../core/core-runtime.js";
+import type { ProgressHandle } from "../../core/core-types.js";
 import type { ScanStore } from "./scan-store.js";
 
 export const reporterLayerForStore = (store: ScanStore): Layer.Layer<Reporter> =>

--- a/packages/react-doctor/src/cli/ink/scan-store.ts
+++ b/packages/react-doctor/src/cli/ink/scan-store.ts
@@ -1,8 +1,8 @@
-import type { Diagnostic, ScoreResult } from "@react-doctor/core";
+import type { Diagnostic, ScoreResult } from "../../core/core-types.js";
 // The live feed carries diagnostics exactly as `Reporter.emit` produces them
 // (the schema class), which differs from the index `Diagnostic` type only in
 // nested-array readonly-ness. The settled `report` keeps the index type.
-import type { Diagnostic as LiveDiagnostic } from "@react-doctor/core/schemas";
+import type { LiveDiagnostic } from "../../core/core-reporting.js";
 
 import { TUI_LIVE_FEED_MAX_ENTRIES } from "../utils/constants.js";
 import type { CliAgentId } from "../utils/launch-agent.js";

--- a/packages/react-doctor/src/cli/utils/apply-color-preference.ts
+++ b/packages/react-doctor/src/cli/utils/apply-color-preference.ts
@@ -1,4 +1,4 @@
-import { setColorEnabled } from "@react-doctor/core";
+import { setColorEnabled } from "../../core/core-presentation.js";
 
 /**
  * Resolve an explicit color preference from `--color` / `--no-color` or the

--- a/packages/react-doctor/src/cli/utils/apply-observability.ts
+++ b/packages/react-doctor/src/cli/utils/apply-observability.ts
@@ -1,7 +1,7 @@
 import * as Sentry from "@sentry/node";
 import * as Effect from "effect/Effect";
 import * as Tracer from "effect/Tracer";
-import { layerOtlp } from "@react-doctor/core";
+import { layerOtlp } from "../../core/core-runtime.js";
 import { TRACE_FLAG_SAMPLED } from "./constants.js";
 import { makeSentryTracer } from "./sentry-tracer.js";
 

--- a/packages/react-doctor/src/cli/utils/ask-add-to-github-actions.ts
+++ b/packages/react-doctor/src/cli/utils/ask-add-to-github-actions.ts
@@ -1,4 +1,5 @@
-import { GITHUB_ACTIONS_SETUP_URL, highlighter } from "@react-doctor/core";
+import { highlighter } from "../../core/core-presentation.js";
+import { GITHUB_ACTIONS_SETUP_URL } from "../../core/core-product.js";
 import { cliLogger as logger } from "./cli-logger.js";
 import { CI_TRUST_COMPANIES } from "./constants.js";
 import { openUrl } from "./open-url.js";

--- a/packages/react-doctor/src/cli/utils/box-text.ts
+++ b/packages/react-doctor/src/cli/utils/box-text.ts
@@ -1,4 +1,4 @@
-import { highlighter } from "@react-doctor/core";
+import { highlighter } from "../../core/core-presentation.js";
 
 // The ANSI escape introducer (built from its char code so the SGR patterns
 // below don't embed a control character in a regex literal).

--- a/packages/react-doctor/src/cli/utils/build-code-frame.ts
+++ b/packages/react-doctor/src/cli/utils/build-code-frame.ts
@@ -4,7 +4,7 @@ import {
   CODE_FRAME_LINES_ABOVE,
   CODE_FRAME_LINES_BELOW,
   CODE_FRAME_MAX_LINE_LENGTH_CHARS,
-} from "@react-doctor/core";
+} from "../../core/core-presentation.js";
 import { resolveAbsolutePath } from "./resolve-absolute-path.js";
 
 interface CodeFrameInput {

--- a/packages/react-doctor/src/cli/utils/build-diagnostic-issue-url.ts
+++ b/packages/react-doctor/src/cli/utils/build-diagnostic-issue-url.ts
@@ -1,5 +1,5 @@
-import { CANONICAL_GITHUB_URL } from "@react-doctor/core";
-import type { Diagnostic } from "@react-doctor/core";
+import { CANONICAL_GITHUB_URL } from "../../core/core-product.js";
+import type { Diagnostic } from "../../core/core-types.js";
 
 interface BuildDiagnosticIssueUrlInput {
   readonly diagnostic: Diagnostic;

--- a/packages/react-doctor/src/cli/utils/build-handoff-payload.ts
+++ b/packages/react-doctor/src/cli/utils/build-handoff-payload.ts
@@ -1,5 +1,5 @@
-import { TOP_ERRORS_DISPLAY_COUNT } from "@react-doctor/core";
-import type { Diagnostic } from "@react-doctor/core";
+import { TOP_ERRORS_DISPLAY_COUNT } from "../../core/core-score.js";
+import type { Diagnostic } from "../../core/core-types.js";
 import { HANDOFF_MAX_FILES_PER_RULE } from "./constants.js";
 import {
   buildSortedRuleGroups,

--- a/packages/react-doctor/src/cli/utils/build-no-score-message.ts
+++ b/packages/react-doctor/src/cli/utils/build-no-score-message.ts
@@ -1,4 +1,4 @@
-import { ENTERPRISE_CONTACT_URL } from "@react-doctor/core";
+import { ENTERPRISE_CONTACT_URL } from "../../core/core-product.js";
 
 const ENTERPRISE_CONTACT_HINT = `Want something custom to your company? Contact us at ${ENTERPRISE_CONTACT_URL}.`;
 

--- a/packages/react-doctor/src/cli/utils/build-run-context.ts
+++ b/packages/react-doctor/src/cli/utils/build-run-context.ts
@@ -1,4 +1,5 @@
-import { resolveLintBatchOrdering, scrubSensitivePaths } from "@react-doctor/core";
+import { scrubSensitivePaths } from "../../core/core-primitives.js";
+import { resolveLintBatchOrdering } from "../../core/core-scan-cache.js";
 import { detectTerminalKind } from "./detect-terminal-kind.js";
 import {
   detectCiEventName,

--- a/packages/react-doctor/src/cli/utils/build-section-divider.ts
+++ b/packages/react-doctor/src/cli/utils/build-section-divider.ts
@@ -1,4 +1,4 @@
-import { highlighter } from "@react-doctor/core";
+import { highlighter } from "../../core/core-presentation.js";
 import { resolveMeasureWidth } from "./resolve-measure-width.js";
 
 const DIVIDER_INDENT = "  ";

--- a/packages/react-doctor/src/cli/utils/build-sentry-project-context.ts
+++ b/packages/react-doctor/src/cli/utils/build-sentry-project-context.ts
@@ -1,4 +1,4 @@
-import type { ProjectInfo } from "@react-doctor/core";
+import type { ProjectInfo } from "../../core/core-types.js";
 
 export interface SentryProjectContext {
   // Low-cardinality, searchable signals (framework, React major, capabilities)

--- a/packages/react-doctor/src/cli/utils/ci/ci-provider.ts
+++ b/packages/react-doctor/src/cli/utils/ci/ci-provider.ts
@@ -1,4 +1,4 @@
-import type { BlockingLevel, ScopeValue } from "@react-doctor/core";
+import type { BlockingLevel, ScopeValue } from "../../../core/core-types.js";
 
 // One CI backend React Doctor can scaffold and manage. GitHub Actions is the
 // fully supported provider; GitLab CI is a gate-only scaffold (no PR-opening,

--- a/packages/react-doctor/src/cli/utils/ci/manage-ci.ts
+++ b/packages/react-doctor/src/cli/utils/ci/manage-ci.ts
@@ -1,6 +1,7 @@
 import * as path from "node:path";
 import * as fs from "node:fs";
-import { CI_URL, GITHUB_ACTIONS_SETUP_URL, highlighter } from "@react-doctor/core";
+import { highlighter } from "../../../core/core-presentation.js";
+import { CI_URL, GITHUB_ACTIONS_SETUP_URL } from "../../../core/core-product.js";
 import { cliLogger as logger } from "../cli-logger.js";
 import { METRIC } from "../constants.js";
 import { detectDefaultBranch } from "../detect-default-branch.js";

--- a/packages/react-doctor/src/cli/utils/cli-logger.ts
+++ b/packages/react-doctor/src/cli/utils/cli-logger.ts
@@ -1,6 +1,6 @@
 import * as Console from "effect/Console";
 import * as Effect from "effect/Effect";
-import { highlighter } from "@react-doctor/core";
+import { highlighter } from "../../core/core-presentation.js";
 
 /**
  * Thin synchronous façade over Effect's `Console` module. Used by

--- a/packages/react-doctor/src/cli/utils/cli-migrations.ts
+++ b/packages/react-doctor/src/cli/utils/cli-migrations.ts
@@ -1,4 +1,5 @@
-import { findLegacyConfig, toRelativePath } from "@react-doctor/core";
+import { findLegacyConfig } from "../../core/core-configuration.js";
+import { toRelativePath } from "../../core/core-primitives.js";
 import { cliLogger as logger } from "./cli-logger.js";
 import { type CliStateOptions } from "./cli-state-store.js";
 import { type Migration, type MigrationResult, runMigrations } from "./cli-lifecycle.js";

--- a/packages/react-doctor/src/cli/utils/colorize-by-score.ts
+++ b/packages/react-doctor/src/cli/utils/colorize-by-score.ts
@@ -1,4 +1,5 @@
-import { highlighter, SCORE_GOOD_THRESHOLD, SCORE_OK_THRESHOLD } from "@react-doctor/core";
+import { highlighter } from "../../core/core-presentation.js";
+import { SCORE_GOOD_THRESHOLD, SCORE_OK_THRESHOLD } from "../../core/core-score.js";
 
 export const colorizeByScore = (text: string, score: number): string => {
   if (score >= SCORE_GOOD_THRESHOLD) return highlighter.success(text);

--- a/packages/react-doctor/src/cli/utils/compute-score-projection.ts
+++ b/packages/react-doctor/src/cli/utils/compute-score-projection.ts
@@ -1,5 +1,5 @@
-import { calculateScore, TOP_ERRORS_DISPLAY_COUNT } from "@react-doctor/core";
-import type { Diagnostic, ScoreResult } from "@react-doctor/core";
+import { calculateScore, TOP_ERRORS_DISPLAY_COUNT } from "../../core/core-score.js";
+import type { Diagnostic, ScoreResult } from "../../core/core-types.js";
 import { buildRulePriorityMap } from "./diagnostic-grouping.js";
 import { getTopErrorRuleKeys } from "./render-diagnostics.js";
 

--- a/packages/react-doctor/src/cli/utils/count-unique-scanned-files.ts
+++ b/packages/react-doctor/src/cli/utils/count-unique-scanned-files.ts
@@ -1,4 +1,4 @@
-import type { InspectResult } from "@react-doctor/core";
+import type { InspectResult } from "../../core/core-types.js";
 
 export const countUniqueScannedFiles = (results: ReadonlyArray<InspectResult>): number => {
   const uniqueScannedFilePaths = new Set<string>();

--- a/packages/react-doctor/src/cli/utils/diagnostic-grouping.ts
+++ b/packages/react-doctor/src/cli/utils/diagnostic-grouping.ts
@@ -1,11 +1,11 @@
 import {
-  buildRuleDocsUrl,
-  groupBy,
   hasPublishedFixRecipe,
   MIGRATION_SCALE_RULE_FILE_COUNT,
   MIN_SHARED_FIX_SITE_COUNT,
-} from "@react-doctor/core";
-import type { Diagnostic, ScoreResult } from "@react-doctor/core";
+} from "../../core/core-presentation.js";
+import { groupBy } from "../../core/core-diagnostic-semantics.js";
+import { buildRuleDocsUrl } from "../../core/core-product.js";
+import type { Diagnostic, ScoreResult } from "../../core/core-types.js";
 
 // Ordering / formatting helpers shared by the diagnostics renderer, the
 // agent-handoff payload builder, and the on-disk diagnostics writer — so

--- a/packages/react-doctor/src/cli/utils/diagnostic-intersects-line-ranges.ts
+++ b/packages/react-doctor/src/cli/utils/diagnostic-intersects-line-ranges.ts
@@ -1,4 +1,4 @@
-import type { Diagnostic } from "@react-doctor/core";
+import type { Diagnostic } from "../../core/core-types.js";
 
 export const diagnosticIntersectsLineRanges = (
   diagnostic: Diagnostic,

--- a/packages/react-doctor/src/cli/utils/doctor-face.ts
+++ b/packages/react-doctor/src/cli/utils/doctor-face.ts
@@ -1,4 +1,4 @@
-import { SCORE_GOOD_THRESHOLD, SCORE_OK_THRESHOLD } from "@react-doctor/core";
+import { SCORE_GOOD_THRESHOLD, SCORE_OK_THRESHOLD } from "../../core/core-score.js";
 
 export const doctorFace = (score: number): readonly [string, string] => {
   if (score >= SCORE_GOOD_THRESHOLD) return ["◠ ◠", " ▽ "];

--- a/packages/react-doctor/src/cli/utils/filter-diagnostics-by-categories.ts
+++ b/packages/react-doctor/src/cli/utils/filter-diagnostics-by-categories.ts
@@ -1,4 +1,4 @@
-import type { Diagnostic } from "@react-doctor/core";
+import type { Diagnostic } from "../../core/core-types.js";
 
 export const filterDiagnosticsByCategories = (
   diagnostics: ReadonlyArray<Diagnostic>,

--- a/packages/react-doctor/src/cli/utils/get-staged-files.ts
+++ b/packages/react-doctor/src/cli/utils/get-staged-files.ts
@@ -1,6 +1,8 @@
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
-import { Git, StagedFiles, messageFromUnknown, type StagedSnapshot } from "@react-doctor/core";
+import { messageFromUnknown } from "../../core/core-errors.js";
+import { Git, StagedFiles } from "../../core/core-runtime.js";
+import type { StagedSnapshot } from "../../core/core-types.js";
 import { cliLogger } from "./cli-logger.js";
 
 const stagedFilesLayer = StagedFiles.layerNode.pipe(Layer.provide(Git.layerNode));

--- a/packages/react-doctor/src/cli/utils/handoff-to-agent.ts
+++ b/packages/react-doctor/src/cli/utils/handoff-to-agent.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import { getSkillAgentConfig } from "agent-install";
-import type { Diagnostic } from "@react-doctor/core";
-import { highlighter } from "@react-doctor/core";
+import type { Diagnostic } from "../../core/core-types.js";
+import { highlighter } from "../../core/core-presentation.js";
 import { buildHandoffPayload } from "./build-handoff-payload.js";
 import { cliLogger as logger } from "./cli-logger.js";
 import { detectLaunchableAgents } from "./detect-launchable-agents.js";

--- a/packages/react-doctor/src/cli/utils/has-lint-hard-failure.ts
+++ b/packages/react-doctor/src/cli/utils/has-lint-hard-failure.ts
@@ -1,4 +1,4 @@
-import type { InspectResult } from "@react-doctor/core";
+import type { InspectResult } from "../../core/core-types.js";
 
 // `skippedChecks` carries "lint" only when the whole lint pass failed
 // (`didLintFail` in core's `build-skipped-checks`): an engine, plugin, or

--- a/packages/react-doctor/src/cli/utils/install-agent-hooks.ts
+++ b/packages/react-doctor/src/cli/utils/install-agent-hooks.ts
@@ -1,6 +1,6 @@
 import * as path from "node:path";
 import type { SkillAgentType } from "agent-install";
-import { isErrnoException } from "@react-doctor/core";
+import { isErrnoException } from "../../core/core-errors.js";
 import { AGENT_HOOK_TIMEOUT_SECONDS } from "./constants.js";
 import * as fs from "node:fs";
 import { CliInputError } from "./cli-input-error.js";

--- a/packages/react-doctor/src/cli/utils/install-git-hook-file.ts
+++ b/packages/react-doctor/src/cli/utils/install-git-hook-file.ts
@@ -4,7 +4,6 @@ import * as fs from "node:fs";
 import {
   ensureTrailingNewline,
   LEGACY_HOOK_RUNNER_RELATIVE_PATH,
-  NON_BLOCKING_REACT_DOCTOR_COMMAND,
   REACT_DOCTOR_COMMAND,
   runGit,
 } from "./git-hook-shared.js";
@@ -129,5 +128,3 @@ export const installDirectGitHook = (options: InstallGitHookOptions): InstallGit
     status: didHookExist ? "updated" : "created",
   };
 };
-
-export { NON_BLOCKING_REACT_DOCTOR_COMMAND, REACT_DOCTOR_COMMAND };

--- a/packages/react-doctor/src/cli/utils/install-react-doctor.ts
+++ b/packages/react-doctor/src/cli/utils/install-react-doctor.ts
@@ -9,7 +9,8 @@ import {
   SKILL_MANIFEST_FILE,
   type SkillAgentType,
 } from "agent-install";
-import { highlighter, SKILL_NAME } from "@react-doctor/core";
+import { highlighter } from "../../core/core-presentation.js";
+import { SKILL_NAME } from "../../core/core-product.js";
 import { cliLogger as logger } from "./cli-logger.js";
 import { computeDefaultSelectedAgents, detectAvailableAgents } from "./detect-agents.js";
 import { readInstallAgents, rememberInstallAgents } from "./install-agents-preference.js";

--- a/packages/react-doctor/src/cli/utils/is-environment-error.ts
+++ b/packages/react-doctor/src/cli/utils/is-environment-error.ts
@@ -1,4 +1,4 @@
-import { isErrnoException, messageFromUnknown } from "@react-doctor/core";
+import { isErrnoException, messageFromUnknown } from "../../core/core-errors.js";
 
 // Filesystem conditions React Doctor cannot fix: a full or read-only disk, a
 // failing disk, denied permissions, or a path blocked by an existing file.

--- a/packages/react-doctor/src/cli/utils/is-expected-user-error.ts
+++ b/packages/react-doctor/src/cli/utils/is-expected-user-error.ts
@@ -1,4 +1,4 @@
-import { isProjectDiscoveryError, isReactDoctorError } from "@react-doctor/core";
+import { isProjectDiscoveryError, isReactDoctorError } from "../../core/core-errors.js";
 import { CliInputError } from "./cli-input-error.js";
 import { isEnvironmentError } from "./is-environment-error.js";
 

--- a/packages/react-doctor/src/cli/utils/is-inspect-result-complete.ts
+++ b/packages/react-doctor/src/cli/utils/is-inspect-result-complete.ts
@@ -1,5 +1,5 @@
-import { isScanComplete } from "@react-doctor/core";
-import type { InspectResult } from "@react-doctor/core";
+import { isScanComplete } from "../../core/core-reporting.js";
+import type { InspectResult } from "../../core/core-types.js";
 
 export const isInspectResultComplete = (result: InspectResult): boolean =>
   isScanComplete({

--- a/packages/react-doctor/src/cli/utils/is-share-opted-out.ts
+++ b/packages/react-doctor/src/cli/utils/is-share-opted-out.ts
@@ -1,4 +1,4 @@
-import type { ReactDoctorConfig } from "@react-doctor/core";
+import type { ReactDoctorConfig } from "../../core/core-configuration.js";
 
 // A scanned project as the aggregate share gate sees it: only its merged
 // (root + module) config matters.

--- a/packages/react-doctor/src/cli/utils/json-mode.ts
+++ b/packages/react-doctor/src/cli/utils/json-mode.ts
@@ -1,8 +1,8 @@
 import { performance } from "node:perf_hooks";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { buildJsonReportError } from "@react-doctor/core";
-import type { JsonReport, JsonReportMode } from "@react-doctor/core";
+import { buildJsonReportError } from "../../core/core-reporting.js";
+import type { JsonReport, JsonReportMode } from "../../core/core-reporting.js";
 import { INTERNAL_ERROR_JSON_FALLBACK } from "./constants.js";
 import { makeNoopConsole } from "./noop-console.js";
 import { VERSION } from "./version.js";

--- a/packages/react-doctor/src/cli/utils/materialize-baseline-files.ts
+++ b/packages/react-doctor/src/cli/utils/materialize-baseline-files.ts
@@ -1,10 +1,10 @@
 import * as Effect from "effect/Effect";
+import { Git } from "../../core/core-runtime.js";
+import type { MaterializedTree } from "../../core/core-types.js";
 import {
   GIT_SHOW_MAX_BUFFER_BYTES,
-  Git,
-  type MaterializedTree,
   materializeSourceTree,
-} from "@react-doctor/core";
+} from "../../core/core-version-control.js";
 import { isMaterializableGitSource } from "./is-materializable-git-source.js";
 
 export interface BaselineMaterializedTree extends MaterializedTree {

--- a/packages/react-doctor/src/cli/utils/migrate-legacy-config.ts
+++ b/packages/react-doctor/src/cli/utils/migrate-legacy-config.ts
@@ -1,5 +1,5 @@
 import * as path from "node:path";
-import type { LegacyConfigLocation } from "@react-doctor/core";
+import type { LegacyConfigLocation } from "../../core/core-types.js";
 import { readObjectFile } from "./read-object-file.js";
 import { serializeTsObjectLiteral } from "./serialize-ts-object-literal.js";
 import * as fs from "node:fs";

--- a/packages/react-doctor/src/cli/utils/onboarding-state.ts
+++ b/packages/react-doctor/src/cli/utils/onboarding-state.ts
@@ -1,4 +1,4 @@
-import { type CliStateOptions, ONBOARDING_EVENT, getCliStatePath } from "./cli-state-store.js";
+import { type CliStateOptions, ONBOARDING_EVENT } from "./cli-state-store.js";
 import { type Gate, isGatePending, recordGate } from "./cli-lifecycle.js";
 
 // The first-run onboarding reveal, expressed as a global gate: it fires once
@@ -6,8 +6,6 @@ import { type Gate, isGatePending, recordGate } from "./cli-lifecycle.js";
 // flip `scope` to "project" (and pass `{ projectRoot }` through) — the gate
 // machinery supports both with no other change.
 export const ONBOARDING_GATE: Gate = { id: ONBOARDING_EVENT, scope: "global" };
-
-export const getOnboardingConfigPath = getCliStatePath;
 
 // `isGatePending` defaults to "not pending" on an unreadable store, so this
 // fails safe to "already onboarded" — a broken config dir never replays the

--- a/packages/react-doctor/src/cli/utils/parse-staged-snapshot-divergences.ts
+++ b/packages/react-doctor/src/cli/utils/parse-staged-snapshot-divergences.ts
@@ -1,5 +1,5 @@
 import * as path from "node:path";
-import { STAGED_FILES_PROJECT_CONFIG_FILENAMES } from "@react-doctor/core";
+import { STAGED_FILES_PROJECT_CONFIG_FILENAMES } from "../../core/core-version-control.js";
 import { STAGED_SNAPSHOT_ADDITIONAL_CONFIG_FILENAMES } from "./constants.js";
 
 const SNAPSHOT_CONFIG_FILENAMES = new Set<string>([

--- a/packages/react-doctor/src/cli/utils/print-branded-header.ts
+++ b/packages/react-doctor/src/cli/utils/print-branded-header.ts
@@ -1,6 +1,6 @@
 import * as Console from "effect/Console";
 import * as Effect from "effect/Effect";
-import { highlighter } from "@react-doctor/core";
+import { highlighter } from "../../core/core-presentation.js";
 import { VERSION } from "./version.js";
 
 /**

--- a/packages/react-doctor/src/cli/utils/print-debug-trace.ts
+++ b/packages/react-doctor/src/cli/utils/print-debug-trace.ts
@@ -1,5 +1,5 @@
 import * as Sentry from "@sentry/node";
-import { highlighter } from "@react-doctor/core";
+import { highlighter } from "../../core/core-presentation.js";
 import { getLastRunTraceId } from "./active-run-trace.js";
 
 /**

--- a/packages/react-doctor/src/cli/utils/project-manifest-changed.ts
+++ b/packages/react-doctor/src/cli/utils/project-manifest-changed.ts
@@ -1,4 +1,4 @@
-import type { DiffInfo } from "@react-doctor/core";
+import type { DiffInfo } from "../../core/core-types.js";
 import { resolveProjectRelativeDirectory } from "./resolve-project-relative-directory.js";
 import { toForwardSlashes } from "./path-format.js";
 

--- a/packages/react-doctor/src/cli/utils/prompts.ts
+++ b/packages/react-doctor/src/cli/utils/prompts.ts
@@ -1,6 +1,6 @@
 import { createRequire } from "node:module";
 import basePrompts, { type PromptObject, type Answers } from "prompts";
-import type { PromptMultiselectContext } from "@react-doctor/core";
+import type { PromptMultiselectContext } from "../../core/core-types.js";
 import { cliLogger as logger } from "./cli-logger.js";
 import { shouldAutoSelectCurrentChoice } from "./should-auto-select-current-choice.js";
 import { shouldSelectAllChoices } from "./should-select-all-choices.js";

--- a/packages/react-doctor/src/cli/utils/read-changed-files-from.ts
+++ b/packages/react-doctor/src/cli/utils/read-changed-files-from.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { isErrnoException } from "@react-doctor/core";
+import { isErrnoException } from "../../core/core-errors.js";
 import { CliInputError } from "./cli-input-error.js";
 import { toForwardSlashes } from "./path-format.js";
 

--- a/packages/react-doctor/src/cli/utils/read-diagnostic-evidence.ts
+++ b/packages/react-doctor/src/cli/utils/read-diagnostic-evidence.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
-import { listSourceFiles } from "@react-doctor/core";
-import type { Diagnostic } from "@react-doctor/core";
+import type { Diagnostic } from "../../core/core-types.js";
+import { listSourceFiles } from "../../core/core-project-discovery.js";
 import ts from "typescript";
 
 interface CreateDiagnosticEvidenceReaderOptions {

--- a/packages/react-doctor/src/cli/utils/read-object-file.ts
+++ b/packages/react-doctor/src/cli/utils/read-object-file.ts
@@ -1,6 +1,6 @@
 import { parseJSON5 } from "confbox";
-import { isPlainObject } from "@react-doctor/core";
 import * as fs from "node:fs";
+import { isPlainObject } from "../../core/core-primitives.js";
 
 /**
  * Reads a JSON / JSONC file as a plain object, or `null` when it is missing,

--- a/packages/react-doctor/src/cli/utils/read-source-line.ts
+++ b/packages/react-doctor/src/cli/utils/read-source-line.ts
@@ -1,4 +1,4 @@
-import { createNodeReadFileLinesSync } from "@react-doctor/core";
+import { createNodeReadFileLinesSync } from "../../core/core-presentation.js";
 
 /**
  * Builds a cached `(filePath, line) -> source text` reader rooted at

--- a/packages/react-doctor/src/cli/utils/render-agent-guidance.ts
+++ b/packages/react-doctor/src/cli/utils/render-agent-guidance.ts
@@ -1,6 +1,6 @@
 import * as Console from "effect/Console";
 import * as Effect from "effect/Effect";
-import { highlighter } from "@react-doctor/core";
+import { highlighter } from "../../core/core-presentation.js";
 
 const AGENT_GUIDANCE_LINES = [
   "Treat React Doctor diagnostics as starting hypotheses. Read the relevant code before confirming or suppressing each finding.",

--- a/packages/react-doctor/src/cli/utils/render-multi-project-summary.ts
+++ b/packages/react-doctor/src/cli/utils/render-multi-project-summary.ts
@@ -1,7 +1,7 @@
 import * as Console from "effect/Console";
 import * as Effect from "effect/Effect";
-import { highlighter } from "@react-doctor/core";
-import type { Diagnostic, InspectResult, ScoreResult } from "@react-doctor/core";
+import { highlighter } from "../../core/core-presentation.js";
+import type { Diagnostic, InspectResult, ScoreResult } from "../../core/core-types.js";
 import { colorizeByScore } from "./colorize-by-score.js";
 import { countUniqueScannedFiles } from "./count-unique-scanned-files.js";
 import { scoreBandLabel } from "./score-band-label.js";

--- a/packages/react-doctor/src/cli/utils/render-project-detection.ts
+++ b/packages/react-doctor/src/cli/utils/render-project-detection.ts
@@ -1,5 +1,6 @@
 import * as Effect from "effect/Effect";
-import type { ProjectInfo, ReactDoctorConfig } from "@react-doctor/core";
+import type { ReactDoctorConfig } from "../../core/core-configuration.js";
+import type { ProjectInfo } from "../../core/core-types.js";
 
 export interface PrintProjectDetectionInput {
   readonly projectInfo: ProjectInfo;

--- a/packages/react-doctor/src/cli/utils/render-rule-catalog.ts
+++ b/packages/react-doctor/src/cli/utils/render-rule-catalog.ts
@@ -1,5 +1,6 @@
-import { buildRuleDocsUrl, highlighter } from "@react-doctor/core";
-import type { RuleSeverityOverride } from "@react-doctor/core";
+import type { RuleSeverityOverride } from "../../core/core-configuration.js";
+import { highlighter } from "../../core/core-presentation.js";
+import { buildRuleDocsUrl } from "../../core/core-product.js";
 import type { RuleCatalogEntry } from "./rule-catalog.js";
 import type { EffectiveRuleSeverity } from "./resolve-effective-rule-severity.js";
 

--- a/packages/react-doctor/src/cli/utils/render-score-header.ts
+++ b/packages/react-doctor/src/cli/utils/render-score-header.ts
@@ -1,7 +1,8 @@
 import * as Console from "effect/Console";
 import * as Effect from "effect/Effect";
-import { highlighter, PERFECT_SCORE, SCORE_BAR_WIDTH_CHARS } from "@react-doctor/core";
-import type { ScoreResult } from "@react-doctor/core";
+import { highlighter, SCORE_BAR_WIDTH_CHARS } from "../../core/core-presentation.js";
+import { PERFECT_SCORE } from "../../core/core-score.js";
+import type { ScoreResult } from "../../core/core-types.js";
 import { colorizeByScore } from "./colorize-by-score.js";
 import { doctorFace } from "./doctor-face.js";
 import {

--- a/packages/react-doctor/src/cli/utils/render-welcome.ts
+++ b/packages/react-doctor/src/cli/utils/render-welcome.ts
@@ -1,5 +1,5 @@
 import * as Effect from "effect/Effect";
-import { highlighter } from "@react-doctor/core";
+import { highlighter } from "../../core/core-presentation.js";
 import {
   RIGHT_EDGE_SAFETY_COLUMNS,
   WELCOME_EXPLANATION_HOLD_MS,

--- a/packages/react-doctor/src/cli/utils/report-error.ts
+++ b/packages/react-doctor/src/cli/utils/report-error.ts
@@ -1,5 +1,5 @@
 import * as Sentry from "@sentry/node";
-import { isReactDoctorError } from "@react-doctor/core";
+import { isReactDoctorError } from "../../core/core-errors.js";
 import { getActiveRunTrace, recordRunTraceId } from "./active-run-trace.js";
 import { buildSentryScope } from "./build-sentry-scope.js";
 import { METRIC, SENTRY_FLUSH_TIMEOUT_MS } from "./constants.js";

--- a/packages/react-doctor/src/cli/utils/resolve-blocking-level.ts
+++ b/packages/react-doctor/src/cli/utils/resolve-blocking-level.ts
@@ -1,4 +1,5 @@
-import type { BlockingLevel, ReactDoctorConfig } from "@react-doctor/core";
+import type { ReactDoctorConfig } from "../../core/core-configuration.js";
+import type { BlockingLevel } from "../../core/core-types.js";
 import { cliLogger as logger } from "./cli-logger.js";
 import type { InspectFlags } from "./inspect-flags.js";
 

--- a/packages/react-doctor/src/cli/utils/resolve-cli-categories.ts
+++ b/packages/react-doctor/src/cli/utils/resolve-cli-categories.ts
@@ -1,4 +1,4 @@
-import { DIAGNOSTIC_CATEGORY_BUCKETS } from "@react-doctor/core";
+import { DIAGNOSTIC_CATEGORY_BUCKETS } from "../../core/core-diagnostic-semantics.js";
 import { CliInputError } from "./cli-input-error.js";
 
 const categoryByLowercase = new Map(

--- a/packages/react-doctor/src/cli/utils/resolve-cli-inspect-options.ts
+++ b/packages/react-doctor/src/cli/utils/resolve-cli-inspect-options.ts
@@ -1,4 +1,5 @@
-import type { InspectOptions, ReactDoctorConfig } from "@react-doctor/core";
+import type { ReactDoctorConfig } from "../../core/core-configuration.js";
+import type { InspectOptions } from "../../core/core-types.js";
 import type { InspectFlags } from "./inspect-flags.js";
 import { isCiEnvironment } from "./is-ci-environment.js";
 import { pickBlockingLevel } from "./resolve-blocking-level.js";

--- a/packages/react-doctor/src/cli/utils/resolve-effective-rule-severity.ts
+++ b/packages/react-doctor/src/cli/utils/resolve-effective-rule-severity.ts
@@ -1,9 +1,9 @@
 import {
   COMPILER_CLEANUP_BUCKET,
   COMPILER_CLEANUP_RULE_KEYS,
-  getEquivalentRuleKeys,
-} from "@react-doctor/core";
-import type { ReactDoctorConfig, RuleSeverityOverride } from "@react-doctor/core";
+} from "../../core/core-configuration.js";
+import type { ReactDoctorConfig, RuleSeverityOverride } from "../../core/core-configuration.js";
+import { getEquivalentRuleKeys } from "../../core/core-diagnostic-semantics.js";
 import type { RuleCatalogEntry } from "./rule-catalog.js";
 
 export type EffectiveSeveritySource = "rule" | "category" | "bucket" | "tag" | "default";

--- a/packages/react-doctor/src/cli/utils/resolve-max-duration-flag.ts
+++ b/packages/react-doctor/src/cli/utils/resolve-max-duration-flag.ts
@@ -1,4 +1,4 @@
-import { MILLISECONDS_PER_SECOND } from "@react-doctor/core";
+import { MILLISECONDS_PER_SECOND } from "../../core/core-runtime.js";
 import { cliLogger as logger } from "./cli-logger.js";
 
 // `--max-duration <seconds>` → milliseconds, or `undefined` when unset. An

--- a/packages/react-doctor/src/cli/utils/resolve-measure-width.ts
+++ b/packages/react-doctor/src/cli/utils/resolve-measure-width.ts
@@ -1,4 +1,4 @@
-import { OUTPUT_MEASURE_WIDTH_CHARS } from "@react-doctor/core";
+import { OUTPUT_MEASURE_WIDTH_CHARS } from "../../core/core-presentation.js";
 import { MIN_MEASURE_WIDTH_CHARS } from "./constants.js";
 
 interface ResolveClampedWidthInput {

--- a/packages/react-doctor/src/cli/utils/resolve-oxlint-node.ts
+++ b/packages/react-doctor/src/cli/utils/resolve-oxlint-node.ts
@@ -1,11 +1,11 @@
 import * as Console from "effect/Console";
 import * as Effect from "effect/Effect";
 import {
-  highlighter,
   NodeResolver,
   OXLINT_NODE_REQUIREMENT,
   OXLINT_RECOMMENDED_NODE_MAJOR,
-} from "@react-doctor/core";
+} from "../../core/core-runtime.js";
+import { highlighter } from "../../core/core-presentation.js";
 import { prompts } from "./prompts.js";
 
 const consoleWarn = (message: string): Effect.Effect<void> =>

--- a/packages/react-doctor/src/cli/utils/resolve-parallel-flag.ts
+++ b/packages/react-doctor/src/cli/utils/resolve-parallel-flag.ts
@@ -1,4 +1,4 @@
-import { MIN_SCAN_CONCURRENCY } from "@react-doctor/core";
+import { MIN_SCAN_CONCURRENCY } from "../../core/core-runtime.js";
 
 /**
  * Maps the `--no-parallel` flag to an `InspectOptions.concurrency` value.

--- a/packages/react-doctor/src/cli/utils/resolve-project-diff-include-paths.ts
+++ b/packages/react-doctor/src/cli/utils/resolve-project-diff-include-paths.ts
@@ -1,4 +1,4 @@
-import type { ChangedFileLineRanges, DiffInfo } from "@react-doctor/core";
+import type { ChangedFileLineRanges, DiffInfo } from "../../core/core-types.js";
 import { resolveProjectRelativeDirectory } from "./resolve-project-relative-directory.js";
 import { toForwardSlashes } from "./path-format.js";
 import { resolveProjectSourceFilePaths } from "./resolve-project-source-file-paths.js";

--- a/packages/react-doctor/src/cli/utils/resolve-project-source-file-paths.ts
+++ b/packages/react-doctor/src/cli/utils/resolve-project-source-file-paths.ts
@@ -1,4 +1,4 @@
-import { filterSourceFiles } from "@react-doctor/core";
+import { filterSourceFiles } from "../../core/core-project-discovery.js";
 import { toForwardSlashes } from "./path-format.js";
 import { resolveProjectRelativeDirectory } from "./resolve-project-relative-directory.js";
 

--- a/packages/react-doctor/src/cli/utils/resolve-scope.ts
+++ b/packages/react-doctor/src/cli/utils/resolve-scope.ts
@@ -1,5 +1,6 @@
-import { filterSourceFiles } from "@react-doctor/core";
-import type { DiffInfo, ReactDoctorConfig, ScopeValue } from "@react-doctor/core";
+import type { ReactDoctorConfig } from "../../core/core-configuration.js";
+import { filterSourceFiles } from "../../core/core-project-discovery.js";
+import type { DiffInfo, ScopeValue } from "../../core/core-types.js";
 import { cliLogger as logger } from "./cli-logger.js";
 import type { InspectFlags } from "./inspect-flags.js";
 import { prompts } from "./prompts.js";

--- a/packages/react-doctor/src/cli/utils/rule-catalog.ts
+++ b/packages/react-doctor/src/cli/utils/rule-catalog.ts
@@ -1,5 +1,5 @@
 import { REACT_DOCTOR_RULES } from "oxlint-plugin-react-doctor";
-import { isSameRuleKey } from "@react-doctor/core";
+import { isSameRuleKey } from "../../core/core-diagnostic-semantics.js";
 import type { RuleSeverity } from "oxlint-plugin-react-doctor";
 
 export interface RuleCatalogEntry {

--- a/packages/react-doctor/src/cli/utils/run-explain.ts
+++ b/packages/react-doctor/src/cli/utils/run-explain.ts
@@ -1,7 +1,9 @@
-import { highlighter, toRelativePath } from "@react-doctor/core";
+import type { ReactDoctorConfig } from "../../core/core-configuration.js";
+import { highlighter } from "../../core/core-presentation.js";
+import { toRelativePath } from "../../core/core-primitives.js";
 import { cliLogger as logger } from "./cli-logger.js";
 import { inspect } from "../../inspect.js";
-import type { Diagnostic, InspectOptions, ReactDoctorConfig } from "@react-doctor/core";
+import type { Diagnostic, InspectOptions } from "../../core/core-types.js";
 import { buildCodeFrame } from "./build-code-frame.js";
 import { buildDiagnosticIssueUrl } from "./build-diagnostic-issue-url.js";
 import { findOwningProjectDirectory } from "./find-owning-project.js";

--- a/packages/react-doctor/src/cli/utils/score-band-label.ts
+++ b/packages/react-doctor/src/cli/utils/score-band-label.ts
@@ -1,4 +1,4 @@
-import { SCORE_GOOD_THRESHOLD, SCORE_OK_THRESHOLD } from "@react-doctor/core";
+import { SCORE_GOOD_THRESHOLD, SCORE_OK_THRESHOLD } from "../../core/core-score.js";
 
 export const scoreBandLabel = (score: number): string => {
   if (score >= SCORE_GOOD_THRESHOLD) return "Great";

--- a/packages/react-doctor/src/cli/utils/scrub-sentry-event.ts
+++ b/packages/react-doctor/src/cli/utils/scrub-sentry-event.ts
@@ -1,5 +1,5 @@
 import type { Event } from "@sentry/node";
-import { scrubSensitivePaths } from "@react-doctor/core";
+import { scrubSensitivePaths } from "../../core/core-primitives.js";
 import { anonymizeInPlace, anonymizeText } from "./anonymize-text.js";
 
 /**

--- a/packages/react-doctor/src/cli/utils/serialize-ts-object-literal.ts
+++ b/packages/react-doctor/src/cli/utils/serialize-ts-object-literal.ts
@@ -1,4 +1,4 @@
-import { isPlainObject } from "@react-doctor/core";
+import { isPlainObject } from "../../core/core-primitives.js";
 
 // A key that can appear unquoted in a TS object literal. Anything else
 // (e.g. "react-doctor/no-danger") is quoted via JSON.stringify.

--- a/packages/react-doctor/src/cli/utils/set-up-github-actions.ts
+++ b/packages/react-doctor/src/cli/utils/set-up-github-actions.ts
@@ -1,4 +1,5 @@
-import { CI_URL, highlighter } from "@react-doctor/core";
+import { highlighter } from "../../core/core-presentation.js";
+import { CI_URL } from "../../core/core-product.js";
 import { cliLogger as logger } from "./cli-logger.js";
 import { detectDefaultBranch } from "./detect-default-branch.js";
 import {

--- a/packages/react-doctor/src/cli/utils/should-auto-select-current-choice.ts
+++ b/packages/react-doctor/src/cli/utils/should-auto-select-current-choice.ts
@@ -1,4 +1,4 @@
-import type { PromptMultiselectChoiceState } from "@react-doctor/core";
+import type { PromptMultiselectChoiceState } from "../../core/core-types.js";
 
 export const shouldAutoSelectCurrentChoice = (
   choiceStates: PromptMultiselectChoiceState[],

--- a/packages/react-doctor/src/cli/utils/should-block-ci.ts
+++ b/packages/react-doctor/src/cli/utils/should-block-ci.ts
@@ -1,4 +1,4 @@
-import type { BlockingLevel, Diagnostic } from "@react-doctor/core";
+import type { BlockingLevel, Diagnostic } from "../../core/core-types.js";
 
 // Whether the scan should block CI (exit non-zero) at the given threshold:
 // `none` never blocks, `warning` blocks on any diagnostic, `error` blocks only

--- a/packages/react-doctor/src/cli/utils/should-fail-scan-gate.ts
+++ b/packages/react-doctor/src/cli/utils/should-fail-scan-gate.ts
@@ -1,4 +1,4 @@
-import type { BlockingLevel } from "@react-doctor/core";
+import type { BlockingLevel } from "../../core/core-types.js";
 import { filterScansForSurface, type SurfaceFilterableScan } from "./filter-scans-for-surface.js";
 import { hasLintHardFailure } from "./has-lint-hard-failure.js";
 import { shouldBlockCi } from "./should-block-ci.js";

--- a/packages/react-doctor/src/cli/utils/should-select-all-choices.ts
+++ b/packages/react-doctor/src/cli/utils/should-select-all-choices.ts
@@ -1,4 +1,4 @@
-import type { PromptMultiselectChoiceState } from "@react-doctor/core";
+import type { PromptMultiselectChoiceState } from "../../core/core-types.js";
 
 export const shouldSelectAllChoices = (choiceStates: PromptMultiselectChoiceState[]): boolean => {
   const enabledChoiceStates = choiceStates.filter((choiceState) => !choiceState.disabled);

--- a/packages/react-doctor/src/cli/utils/spinner.ts
+++ b/packages/react-doctor/src/cli/utils/spinner.ts
@@ -1,5 +1,5 @@
 import ora from "ora";
-import { SPINNER_INDENT_CHARS } from "@react-doctor/core";
+import { SPINNER_INDENT_CHARS } from "../../core/core-presentation.js";
 import { isSpinnerInteractive } from "./is-spinner-interactive.js";
 
 let isSilent = false;

--- a/packages/react-doctor/src/cli/utils/update-rule-config.ts
+++ b/packages/react-doctor/src/cli/utils/update-rule-config.ts
@@ -1,5 +1,5 @@
-import { getEquivalentRuleKeys } from "@react-doctor/core";
-import type { ReactDoctorConfig, RuleSeverityOverride } from "@react-doctor/core";
+import type { ReactDoctorConfig, RuleSeverityOverride } from "../../core/core-configuration.js";
+import { getEquivalentRuleKeys } from "../../core/core-diagnostic-semantics.js";
 
 /**
  * Sets a per-rule severity, replacing any existing entry for the same

--- a/packages/react-doctor/src/cli/utils/validate-mode-flags.ts
+++ b/packages/react-doctor/src/cli/utils/validate-mode-flags.ts
@@ -1,4 +1,4 @@
-import type { ScopeValue } from "@react-doctor/core";
+import type { ScopeValue } from "../../core/core-types.js";
 import { CliInputError } from "./cli-input-error.js";
 import type { InspectFlags } from "./inspect-flags.js";
 

--- a/packages/react-doctor/src/cli/utils/warn-ai-training-environment.ts
+++ b/packages/react-doctor/src/cli/utils/warn-ai-training-environment.ts
@@ -1,4 +1,5 @@
-import { detectAiTrainingEnvironment, highlighter } from "@react-doctor/core";
+import { highlighter } from "../../core/core-presentation.js";
+import { detectAiTrainingEnvironment } from "../../core/core-runtime.js";
 import { METRIC } from "./constants.js";
 import { recordCount } from "./record-metric.js";
 

--- a/packages/react-doctor/src/cli/utils/warn-deprecated-fail-on.ts
+++ b/packages/react-doctor/src/cli/utils/warn-deprecated-fail-on.ts
@@ -1,4 +1,4 @@
-import type { ReactDoctorConfig } from "@react-doctor/core";
+import type { ReactDoctorConfig } from "../../core/core-configuration.js";
 import { cliLogger as logger } from "./cli-logger.js";
 import type { InspectFlags } from "./inspect-flags.js";
 

--- a/packages/react-doctor/src/cli/utils/with-sentry-run-span.ts
+++ b/packages/react-doctor/src/cli/utils/with-sentry-run-span.ts
@@ -1,5 +1,5 @@
 import * as Sentry from "@sentry/node";
-import type { ProjectInfo } from "@react-doctor/core";
+import type { ProjectInfo } from "../../core/core-types.js";
 import { isSentryTracingEnabled } from "../../instrument.js";
 import { recordRunTraceId, setActiveRunTrace } from "./active-run-trace.js";
 import { buildSentryScope } from "./build-sentry-scope.js";

--- a/packages/react-doctor/src/cli/utils/write-diagnostics-directory.ts
+++ b/packages/react-doctor/src/cli/utils/write-diagnostics-directory.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { tmpdir } from "node:os";
-import type { Diagnostic } from "@react-doctor/core";
+import type { Diagnostic } from "../../core/core-types.js";
 import { buildSortedRuleGroups } from "./diagnostic-grouping.js";
 import { formatRuleSummary } from "./render-diagnostics.js";
 import * as fs from "node:fs";


### PR DESCRIPTION
Part 8 of 11. Review this PR against `codex/internal-architecture-07-cli-workflows`.

## What changed

- Mechanically migrates CLI and Ink imports from broad core imports to the local core facade modules.
- Removes one now-redundant direct import path.

## Why

This completes the adapter boundary introduced in Part 6 without mixing mechanical import churn into the workflow review.

## Impact

No runtime behavior change. The diff is intentionally import-only and separately reviewable.

## Validation

- Full workspace typecheck at this exact commit
- 11 core facade/source-boundary tests
- Changed-scope React Doctor scan: 100/100

## Stack

Review only each PR's diff against its base branch. Merge in order.

1. [#1463 — Git service decomposition](https://github.com/millionco/react-doctor/pull/1463)
2. [#1478 — Core execution pipeline](https://github.com/millionco/react-doctor/pull/1478)
3. [#1479 — Workspace package graph](https://github.com/millionco/react-doctor/pull/1479)
4. [#1480 — Package-aware rules](https://github.com/millionco/react-doctor/pull/1480)
5. [#1487 — Private evaluator parity](https://github.com/millionco/react-doctor/pull/1487)
6. [#1482 — API/LSP adapter facades](https://github.com/millionco/react-doctor/pull/1482)
7. [#1483 — CLI workflow decomposition](https://github.com/millionco/react-doctor/pull/1483)
8. [#1481 — CLI facade import migration](https://github.com/millionco/react-doctor/pull/1481)
9. [#1484 — Architecture and compatibility gates](https://github.com/millionco/react-doctor/pull/1484)
10. [#1485 — Shared deslop cycle traversal](https://github.com/millionco/react-doctor/pull/1485)
11. [#1486 — Architecture docs and skill sync](https://github.com/millionco/react-doctor/pull/1486)