### PR TITLE
RDFPFN792026: trace hydration branches through rendered values

### DIFF
--- a/.changeset/hydration-browser-provenance.md
+++ b/.changeset/hydration-browser-provenance.md
@@ -1,0 +1,6 @@
+---
+"oxlint-plugin-react-doctor": patch
+"react-doctor": patch
+---
+
+Detect browser-dependent hydration branches through render-time helpers, mutable aliases, state initializers, and compiled React output.

--- a/packages/fuzz/corpus/regressions/no-hydration-branch-on-browser-global--duplicated-predicate-comparison.tsx
+++ b/packages/fuzz/corpus/regressions/no-hydration-branch-on-browser-global--duplicated-predicate-comparison.tsx
@@ -22,3 +22,12 @@ export const BitwiseComparisons = () => {
   const combined = (typeof window === "undefined") | (typeof window !== "undefined");
   return masked || combined ? <Same /> : <Different />;
 };
+
+export const AliasComparisons = () => {
+  const isServer = typeof window === "undefined";
+  const serverAlias = isServer;
+  const zero = 0;
+  const stable = serverAlias === isServer;
+  const primitive = isServer === zero;
+  return stable || primitive ? <Same /> : <Different />;
+};

--- a/packages/fuzz/corpus/regressions/no-hydration-branch-on-browser-global--duplicated-predicate-comparison.tsx
+++ b/packages/fuzz/corpus/regressions/no-hydration-branch-on-browser-global--duplicated-predicate-comparison.tsx
@@ -31,3 +31,11 @@ export const AliasComparisons = () => {
   const primitive = isServer === zero;
   return stable || primitive ? <Same /> : <Different />;
 };
+
+export const MutableAliasComparisons = () => {
+  let isServer = false;
+  if (typeof window === "undefined") isServer = true;
+  const equal = isServer === isServer;
+  const unequal = isServer !== isServer;
+  return equal || unequal ? <Same /> : <Different />;
+};

--- a/packages/fuzz/corpus/regressions/no-hydration-branch-on-browser-global--duplicated-predicate-comparison.tsx
+++ b/packages/fuzz/corpus/regressions/no-hydration-branch-on-browser-global--duplicated-predicate-comparison.tsx
@@ -8,3 +8,17 @@ export const Page = () => {
   const stable = (typeof window === "undefined") === (typeof window === "undefined");
   return stable ? <Same /> : <Different />;
 };
+
+export const PrimitiveComparisons = () => {
+  const zero = (typeof window === "undefined") === 0;
+  const empty = (typeof window === "undefined") === "";
+  const nullable = (typeof window === "undefined") === null;
+  const missing = (typeof window === "undefined") === undefined;
+  return zero || empty || nullable || missing ? <Same /> : <Different />;
+};
+
+export const BitwiseComparisons = () => {
+  const masked = (typeof window === "undefined") & 0;
+  const combined = (typeof window === "undefined") | (typeof window !== "undefined");
+  return masked || combined ? <Same /> : <Different />;
+};

--- a/packages/fuzz/corpus/regressions/no-hydration-branch-on-browser-global--duplicated-predicate-comparison.tsx
+++ b/packages/fuzz/corpus/regressions/no-hydration-branch-on-browser-global--duplicated-predicate-comparison.tsx
@@ -1,0 +1,10 @@
+// rule: no-hydration-branch-on-browser-global
+// weakness: boolean-comparison
+// source: adversarial review
+
+import React from "react";
+
+export const Page = () => {
+  const stable = (typeof window === "undefined") === (typeof window === "undefined");
+  return stable ? <Same /> : <Different />;
+};

--- a/packages/fuzz/corpus/regressions/no-hydration-branch-on-browser-global--mount-gated-probe.tsx
+++ b/packages/fuzz/corpus/regressions/no-hydration-branch-on-browser-global--mount-gated-probe.tsx
@@ -1,0 +1,14 @@
+// rule: no-hydration-branch-on-browser-global
+// weakness: control-flow
+// source: ReactBench hydration audit retractions
+
+import { useMemo, useState } from "react";
+
+export const Background = () => {
+  const [mounted] = useState(false);
+  const playable = useMemo(() => {
+    if (typeof document === "undefined") return false;
+    return Boolean(document.createElement("video"));
+  }, []);
+  return mounted && playable ? <video /> : <img alt="" />;
+};

--- a/packages/fuzz/corpus/regressions/no-hydration-branch-on-browser-global--render-flow-equivalence.tsx
+++ b/packages/fuzz/corpus/regressions/no-hydration-branch-on-browser-global--render-flow-equivalence.tsx
@@ -1,0 +1,31 @@
+// rule: no-hydration-branch-on-browser-global
+// weakness: reachability
+// source: adversarial review
+
+import React, { useEffect, useState } from "react";
+
+export const DeadWrite = () => {
+  let show = false;
+  if (typeof window !== "undefined") {
+    if (false) show = true;
+  }
+  return show ? <Client /> : <Server />;
+};
+
+const useRuntime = () => {
+  const [runtime] = useState(typeof window === "undefined" ? "server" : "client");
+  return { runtime };
+};
+
+export const MountGatedConsumer = () => {
+  const { runtime } = useRuntime();
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+  if (!mounted) return null;
+  return runtime ? <Client /> : <Server />;
+};
+
+export const SuppressedConsumer = () => {
+  const { runtime } = useRuntime();
+  return <span suppressHydrationWarning>{runtime}</span>;
+};

--- a/packages/fuzz/corpus/regressions/no-hydration-branch-on-browser-global--render-flow-equivalence.tsx
+++ b/packages/fuzz/corpus/regressions/no-hydration-branch-on-browser-global--render-flow-equivalence.tsx
@@ -29,3 +29,25 @@ export const SuppressedConsumer = () => {
   const { runtime } = useRuntime();
   return <span suppressHydrationWarning>{runtime}</span>;
 };
+
+export const DeadConditionalArms = () => {
+  const consequent = false ? typeof window !== "undefined" : false;
+  const alternate = true ? false : typeof window !== "undefined";
+  return consequent || alternate ? <Client /> : <Server />;
+};
+
+export const StaticallyOverwritten = () => {
+  let show = false;
+  if (typeof window !== "undefined") show = true;
+  if (true) show = false;
+  return show ? <Client /> : <Server />;
+};
+
+export const StableHelperWrite = () => {
+  let show = false;
+  const preserve = () => {
+    show = false;
+  };
+  if (typeof window !== "undefined") preserve();
+  return show ? <Client /> : <Server />;
+};

--- a/packages/fuzz/corpus/regressions/no-hydration-branch-on-browser-global--unrendered-hook-state.tsx
+++ b/packages/fuzz/corpus/regressions/no-hydration-branch-on-browser-global--unrendered-hook-state.tsx
@@ -1,0 +1,10 @@
+// rule: no-hydration-branch-on-browser-global
+// weakness: dataflow
+// source: ReactBench hydration audit
+
+import { useState } from "react";
+
+export const useMetadata = () => {
+  const [runtime] = useState(typeof window === "undefined" ? "server" : "client");
+  return { runtime };
+};

--- a/packages/fuzz/corpus/true-positives/no-hydration-branch-on-browser-global--adversarial-flow.tsx
+++ b/packages/fuzz/corpus/true-positives/no-hydration-branch-on-browser-global--adversarial-flow.tsx
@@ -1,0 +1,30 @@
+// rule: no-hydration-branch-on-browser-global
+// weakness: dataflow
+// source: adversarial review
+
+import { useState } from "react";
+
+const useRuntime = () => {
+  const [runtime] = useState(typeof window === "undefined" ? "server" : "client");
+  return [runtime] as const;
+};
+
+const renderContent = () => (typeof window !== "undefined" ? <Client /> : <Server />);
+
+export const Page = ({ enabled }: { enabled: boolean }) => {
+  let show = false;
+  const enable = () => {
+    show = true;
+  };
+  if (typeof window !== "undefined") enable();
+  const [runtime] = useRuntime();
+  const possibleNaN = enabled ? (typeof window !== "undefined" ? Number("x") : 0) : 0;
+  return (
+    <main>
+      {show ? <Client /> : <Server />}
+      {runtime ? <Client /> : <Server />}
+      {possibleNaN === possibleNaN ? <Same /> : <Different />}
+      {renderContent()}
+    </main>
+  );
+};

--- a/packages/fuzz/corpus/true-positives/no-hydration-branch-on-browser-global--react-bench-flows.tsx
+++ b/packages/fuzz/corpus/true-positives/no-hydration-branch-on-browser-global--react-bench-flows.tsx
@@ -1,0 +1,20 @@
+// rule: no-hydration-branch-on-browser-global
+// weakness: dataflow
+// source: ReactBench hydration audit
+
+import { useMemo } from "react";
+
+export const Background = ({ candidate }: { candidate: boolean }) => {
+  const playable = useMemo(() => {
+    let result = false;
+    if (candidate && typeof document !== "undefined") {
+      try {
+        result = document.createElement("video").canPlayType("video/mp4") !== "";
+      } catch {
+        result = false;
+      }
+    }
+    return { playable: result };
+  }, [candidate]).playable;
+  return playable ? <video /> : <img alt="" />;
+};

--- a/packages/fuzz/corpus/true-positives/no-hydration-branch-on-browser-global--rendered-local-factory.tsx
+++ b/packages/fuzz/corpus/true-positives/no-hydration-branch-on-browser-global--rendered-local-factory.tsx
@@ -1,0 +1,18 @@
+// rule: no-hydration-branch-on-browser-global
+// weakness: provenance
+// source: ReactBench hydration audit
+
+import React from "react";
+
+const renderer = {
+  createElement: (value: string) => value,
+};
+
+export const Page = () =>
+  React.createElement(
+    "main",
+    null,
+    typeof window === "undefined"
+      ? renderer.createElement("server")
+      : renderer.createElement("client"),
+  );

--- a/packages/fuzz/corpus/true-positives/no-hydration-branch-on-browser-global--shadowed-render-bindings.tsx
+++ b/packages/fuzz/corpus/true-positives/no-hydration-branch-on-browser-global--shadowed-render-bindings.tsx
@@ -1,0 +1,14 @@
+// rule: no-hydration-branch-on-browser-global
+// weakness: binding-identity
+// source: adversarial review
+
+import React from "react";
+
+export const Page = () => {
+  if (typeof window !== "undefined") {
+    const label = "client";
+    return <div title={label}>{label}</div>;
+  }
+  const label = "server";
+  return <div title={label}>{label}</div>;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-hydration-branch-on-browser-global.react-bench.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-hydration-branch-on-browser-global.react-bench.regressions.test.ts
@@ -54,7 +54,7 @@ describe("no-hydration-branch-on-browser-global — ReactBench regressions", () 
       `,
     ],
     [
-      "returned custom-hook state",
+      "local rendered custom-hook state",
       `
         import { useState } from "react";
         export const useRegistration = () => {
@@ -62,6 +62,10 @@ describe("no-hydration-branch-on-browser-global — ReactBench regressions", () 
             typeof window === "undefined" ? { type: "primary" } : null,
           );
           return { registration };
+        };
+        export const Page = () => {
+          const { registration } = useRegistration();
+          return registration ? <Primary /> : <Pending />;
         };
       `,
     ],
@@ -99,6 +103,34 @@ describe("no-hydration-branch-on-browser-global — ReactBench regressions", () 
             return <img alt="" />;
           };
           return <main>{renderMedia()}</main>;
+        };
+      `,
+    ],
+    [
+      "a createElement lookalike rendered by React",
+      `
+        import React from "react";
+        const renderer = { createElement: () => "not React" };
+        export const Page = ({ ready }) =>
+          React.createElement(
+            "main",
+            null,
+            ready && typeof window !== "undefined" && renderer.createElement(),
+          );
+      `,
+    ],
+    [
+      "a shadowed React factory returned by a component",
+      `
+        import { useState } from "react";
+        const React = {
+          createElement: (value) => value === "server" ? "server" : "client",
+        };
+        export const Page = () => {
+          useState(false);
+          return typeof window === "undefined"
+            ? React.createElement("server")
+            : React.createElement("client");
         };
       `,
     ],
@@ -173,7 +205,7 @@ describe("no-hydration-branch-on-browser-global — ReactBench regressions", () 
       `,
     ],
     [
-      "a returned state value used only as metadata",
+      "a custom hook state value returned without a local rendered consumer",
       `
         import { useState } from "react";
         export const useMetadata = () => {
@@ -240,12 +272,14 @@ describe("no-hydration-branch-on-browser-global — ReactBench regressions", () 
       `
         import React from "react";
         const renderer = { createElement: () => "not React" };
-        export const Page = ({ ready }) =>
-          React.createElement(
-            "main",
-            null,
-            ready && typeof window !== "undefined" && renderer.createElement(),
-          );
+        export const Page = () => {
+          const metadata =
+            typeof window === "undefined"
+              ? renderer.createElement("server")
+              : renderer.createElement("client");
+          log(metadata);
+          return React.createElement("main", null, "stable");
+        };
       `,
     ],
     [
@@ -255,9 +289,11 @@ describe("no-hydration-branch-on-browser-global — ReactBench regressions", () 
         const React = { createElement: () => "not React" };
         export const Page = () => {
           useState(false);
-          return typeof window === "undefined"
+          const metadata = typeof window === "undefined"
             ? React.createElement("server")
             : React.createElement("client");
+          log(metadata);
+          return <Stable />;
         };
       `,
     ],

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-hydration-branch-on-browser-global.react-bench.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-hydration-branch-on-browser-global.react-bench.regressions.test.ts
@@ -333,6 +333,38 @@ describe("no-hydration-branch-on-browser-global — ReactBench regressions", () 
         };
       `,
     ],
+    ...[["0"], ['""'], ["null"], ["undefined"]].map(([value]) => [
+      `strict browser predicate comparison with ${value}`,
+      `
+        import React from "react";
+        export const Page = () => {
+          const stable = (typeof window === "undefined") === ${value};
+          return stable ? <Same /> : <Different />;
+        };
+      `,
+    ]),
+    [
+      "a browser predicate masked by bitwise and",
+      `
+        import React from "react";
+        export const Page = () => {
+          const stable = (typeof window === "undefined") & 0;
+          return stable ? <Same /> : <Different />;
+        };
+      `,
+    ],
+    [
+      "inverse browser predicates combined by bitwise or",
+      `
+        import React from "react";
+        export const Page = () => {
+          const stable =
+            (typeof window === "undefined") |
+            (typeof window !== "undefined");
+          return stable ? <Same /> : <Different />;
+        };
+      `,
+    ],
   ])("stays quiet for %s", (_name, code) => {
     const result = run(code);
     expect(result.parseErrors).toEqual([]);
@@ -344,6 +376,11 @@ describe("no-hydration-branch-on-browser-global — ReactBench regressions", () 
     [
       "a nested browser predicate compared with false",
       `((typeof window === "undefined") === true) === false`,
+    ],
+    ["a browser predicate loosely compared with zero", `(typeof window === "undefined") == 0`],
+    [
+      "a Boolean-wrapped browser predicate compared with false",
+      `Boolean(typeof window === "undefined") === false`,
     ],
   ])("reports %s", (_name, condition) => {
     const result = run(`

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-hydration-branch-on-browser-global.react-bench.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-hydration-branch-on-browser-global.react-bench.regressions.test.ts
@@ -399,7 +399,245 @@ describe("no-hydration-branch-on-browser-global — ReactBench regressions", () 
         };
       `,
     ],
+    ...["===", "!=="].map((operator) => [
+      `mutable browser alias self-${operator === "===" ? "equality" : "inequality"}`,
+      `
+        import React from "react";
+        export const Page = () => {
+          let isServer = false;
+          if (typeof window === "undefined") isServer = true;
+          const stable = isServer ${operator} isServer;
+          return stable ? <Same /> : <Different />;
+        };
+      `,
+    ]),
   ])("stays quiet for %s", (_name, code) => {
+    const result = run(code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it.each([
+    [
+      "a dynamically nested browser write",
+      `
+        import React from "react";
+        export const Page = ({ enabled }) => {
+          let show = false;
+          if (typeof window !== "undefined") {
+            if (enabled) show = true;
+          }
+          return show ? <Client /> : <Server />;
+        };
+      `,
+    ],
+    [
+      "a browser write from a shadowed same-name binding",
+      `
+        import React from "react";
+        export const Page = () => {
+          const value = false;
+          let show = value;
+          if (typeof window !== "undefined") {
+            const value = true;
+            show = value;
+          }
+          return show ? <Client /> : <Server />;
+        };
+      `,
+    ],
+    ...["false", "reset"].map((condition) => [
+      `a browser write followed by a ${condition} conditional overwrite`,
+      `
+        import React from "react";
+        export const Page = ({ reset }) => {
+          let show = false;
+          if (typeof window !== "undefined") show = true;
+          if (${condition}) show = false;
+          return show ? <Client /> : <Server />;
+        };
+      `,
+    ]),
+    [
+      "shadowed branch-local return conditions",
+      `
+        import React from "react";
+        export const Page = () => {
+          if (typeof window !== "undefined") {
+            const ready = true;
+            if (ready) return <Primary />;
+            return <Fallback />;
+          } else {
+            const ready = false;
+            if (ready) return <Primary />;
+            return <Fallback />;
+          }
+        };
+      `,
+    ],
+    [
+      "shadowed JSX child bindings",
+      `
+        import React from "react";
+        export const Page = () => {
+          if (typeof window !== "undefined") {
+            const label = "client";
+            return <div>{label}</div>;
+          } else {
+            const label = "server";
+            return <div>{label}</div>;
+          }
+        };
+      `,
+    ],
+    [
+      "shadowed JSX attribute bindings",
+      `
+        import React from "react";
+        export const Page = () => {
+          if (typeof window !== "undefined") {
+            const label = "client";
+            return <div title={label} />;
+          } else {
+            const label = "server";
+            return <div title={label} />;
+          }
+        };
+      `,
+    ],
+    [
+      "a structurally rendered suppressed custom-hook value",
+      `
+        import React, { useState } from "react";
+        const useRuntime = () => {
+          const [runtime] = useState(
+            typeof window === "undefined" ? "server" : "client",
+          );
+          return { runtime };
+        };
+        export const Page = () => {
+          const { runtime } = useRuntime();
+          return (
+            <span suppressHydrationWarning>
+              {runtime ? <Client /> : <Server />}
+            </span>
+          );
+        };
+      `,
+    ],
+  ])("reports adversarial %s", (_name, code) => {
+    const result = run(code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it.each([
+    [
+      "a statically unreachable browser write",
+      `
+        import React from "react";
+        export const Page = () => {
+          let show = false;
+          if (typeof window !== "undefined") {
+            if (false) show = true;
+          }
+          return show ? <Client /> : <Server />;
+        };
+      `,
+    ],
+    [
+      "a browser write preserving the same binding",
+      `
+        import React from "react";
+        export const Page = () => {
+          const value = false;
+          let show = value;
+          if (typeof window !== "undefined") show = value;
+          return show ? <Client /> : <Server />;
+        };
+      `,
+    ],
+    [
+      "same-binding equivalent return trees",
+      `
+        import React from "react";
+        export const Page = () => {
+          const ready = true;
+          if (typeof window !== "undefined") {
+            if (ready) return <Primary />;
+            return <Fallback />;
+          } else {
+            if (ready) return <Primary />;
+            return <Fallback />;
+          }
+        };
+      `,
+    ],
+    [
+      "same-binding equivalent JSX children and attributes",
+      `
+        import React from "react";
+        export const Page = () => {
+          const label = "same";
+          if (typeof window !== "undefined") {
+            return <div title={label}>{label}</div>;
+          }
+          return <div title={label}>{label}</div>;
+        };
+      `,
+    ],
+    [
+      "a mount-gated custom-hook consumer",
+      `
+        import React, { useEffect, useState } from "react";
+        const useRuntime = () => {
+          const [runtime] = useState(
+            typeof window === "undefined" ? "server" : "client",
+          );
+          return { runtime };
+        };
+        export const Page = () => {
+          const { runtime } = useRuntime();
+          const [mounted, setMounted] = useState(false);
+          useEffect(() => setMounted(true), []);
+          if (!mounted) return null;
+          return runtime ? <Client /> : <Server />;
+        };
+      `,
+    ],
+    [
+      "suppressed custom-hook text",
+      `
+        import React, { useState } from "react";
+        const useRuntime = () => {
+          const [runtime] = useState(
+            typeof window === "undefined" ? "server" : "client",
+          );
+          return { runtime };
+        };
+        export const Page = () => {
+          const { runtime } = useRuntime();
+          return <span suppressHydrationWarning>{runtime}</span>;
+        };
+      `,
+    ],
+    [
+      "suppressed custom-hook attribute",
+      `
+        import React, { useState } from "react";
+        const useRuntime = () => {
+          const [runtime] = useState(
+            typeof window === "undefined" ? "server" : "client",
+          );
+          return { runtime };
+        };
+        export const Page = () => {
+          const { runtime } = useRuntime();
+          return <span suppressHydrationWarning title={runtime} />;
+        };
+      `,
+    ],
+  ])("stays quiet for adversarial %s", (_name, code) => {
     const result = run(code);
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toHaveLength(0);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-hydration-branch-on-browser-global.react-bench.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-hydration-branch-on-browser-global.react-bench.regressions.test.ts
@@ -1,0 +1,269 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noHydrationBranchOnBrowserGlobal } from "./no-hydration-branch-on-browser-global.js";
+
+const run = (code: string, filename = "src/background.tsx") =>
+  runRule(noHydrationBranchOnBrowserGlobal, code, { filename });
+
+describe("no-hydration-branch-on-browser-global — ReactBench regressions", () => {
+  it.each([
+    [
+      "try/catch return flow",
+      `
+        import { useMemo } from "react";
+        export const Background = ({ candidate }) => {
+          const playable = useMemo(() => {
+            if (!candidate) return false;
+            if (typeof document === "undefined") return false;
+            try {
+              return document.createElement("video").canPlayType("video/mp4") !== "";
+            } catch {
+              return false;
+            }
+          }, [candidate]);
+          return playable ? <video /> : <img alt="" />;
+        };
+      `,
+    ],
+    [
+      "mutable render state",
+      `
+        import { useState } from "react";
+        export const Background = ({ candidate }) => {
+          const [failed] = useState(false);
+          let playable = candidate;
+          if (candidate && typeof document !== "undefined") {
+            if (!document.createElement("video").canPlayType("video/mp4")) playable = false;
+          }
+          return playable && !failed ? <video /> : <img alt="" />;
+        };
+      `,
+    ],
+    [
+      "useMemo object return",
+      `
+        import { useMemo } from "react";
+        export const Background = ({ candidate }) => {
+          const { playable } = useMemo(() => {
+            let result = false;
+            if (candidate && typeof document !== "undefined") result = true;
+            return { playable: result };
+          }, [candidate]);
+          return playable ? <video /> : <img alt="" />;
+        };
+      `,
+    ],
+    [
+      "returned custom-hook state",
+      `
+        import { useState } from "react";
+        export const useRegistration = () => {
+          const [registration] = useState(
+            typeof window === "undefined" ? { type: "primary" } : null,
+          );
+          return { registration };
+        };
+      `,
+    ],
+    [
+      "hookless imported React component",
+      `
+        import React from "react";
+        export const Skeleton = ({ registered }) => (
+          <main>{typeof window === "undefined" || registered ? <Ready /> : null}</main>
+        );
+      `,
+    ],
+    [
+      "forwardRef component",
+      `
+        import React from "react";
+        export const Skeleton = React.forwardRef(({ ready }, ref) => {
+          const server = typeof window === "undefined";
+          return <main ref={ref}>{ready || server ? <Ready /> : null}</main>;
+        });
+      `,
+    ],
+    [
+      "local render helper",
+      `
+        import { useMemo } from "react";
+        export const Background = () => {
+          const { playable } = useMemo(() => {
+            let result = false;
+            if (typeof document !== "undefined") result = true;
+            return { playable: result };
+          }, []);
+          const renderMedia = () => {
+            if (playable) return <video />;
+            return <img alt="" />;
+          };
+          return <main>{renderMedia()}</main>;
+        };
+      `,
+    ],
+    [
+      "compiled createElement output",
+      `
+        var react_1 = require("react");
+        function BreadcrumbsSlot(props) {
+          var isSSR = typeof window === "undefined";
+          return react_1.createElement(
+            "main",
+            null,
+            props.breadcrumbs && !isSSR && react_1.createElement("div", null),
+          );
+        }
+      `,
+    ],
+  ])("reports %s", (_name, code) => {
+    const result = run(code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it.each([
+    ["52u5oWQ", "hasMounted", "document", "document.createElement"],
+    ["8VLeaNy", "mounted", "document", "document.createElement"],
+    ["HBuH2VG", "mounted", "document", "document.createElement"],
+    ["NLWHX7b", "hasMounted", "window", "window.document"],
+    ["tonnDnH", "mounted", "window", "window.document"],
+    ["VzG9Zow", "hasMounted", "document", "document.createElement"],
+  ])(
+    "stays quiet for mount-gated ReactBench retraction %s",
+    (_trial, mountedName, browserGlobal, browserValue) => {
+      const result = run(`
+        import { useMemo, useState } from "react";
+        export const Background = ({ candidate }) => {
+          const [${mountedName}] = useState(false);
+          const playable = useMemo(() => {
+            if (typeof ${browserGlobal} === "undefined") return false;
+            return Boolean(${browserValue});
+          }, [candidate]);
+          return ${mountedName} && playable ? <video /> : <img alt="" />;
+        };
+      `);
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(0);
+    },
+  );
+
+  it.each([
+    [
+      "an overwritten mutable alias",
+      `
+        import React from "react";
+        export const Page = () => {
+          let browser = false;
+          if (typeof window !== "undefined") browser = true;
+          browser = false;
+          return browser ? <Client /> : <Server />;
+        };
+      `,
+    ],
+    [
+      "equivalent mutable assignments",
+      `
+        import React from "react";
+        export const Page = () => {
+          let browser = false;
+          if (typeof document !== "undefined") browser = false;
+          return browser ? <Client /> : <Server />;
+        };
+      `,
+    ],
+    [
+      "a returned state value used only as metadata",
+      `
+        import { useState } from "react";
+        export const useMetadata = () => {
+          const [runtime] = useState(
+            typeof window === "undefined" ? "server" : "client",
+          );
+          log(runtime);
+          return { stable: true };
+        };
+      `,
+    ],
+    [
+      "a browser-guarded write unrelated to the returned symbol",
+      `
+        import { useMemo } from "react";
+        export const Page = () => {
+          const stable = useMemo(() => {
+            let probe = false;
+            const rendered = true;
+            if (typeof document !== "undefined") probe = true;
+            log(probe);
+            return { rendered };
+          }, []).rendered;
+          return stable ? <Stable /> : null;
+        };
+      `,
+    ],
+    [
+      "a lazy browser initializer whose state is never rendered",
+      `
+        import { useState } from "react";
+        export const Page = () => {
+          const [runtime] = useState(() => {
+            if (typeof window === "undefined") return "server";
+            return "client";
+          });
+          log(runtime);
+          return <Stable />;
+        };
+      `,
+    ],
+    [
+      "a React import in a non-component utility",
+      `
+        import React from "react";
+        export const readRuntime = () =>
+          typeof window === "undefined" ? "server" : "client";
+      `,
+    ],
+    [
+      "a local helper called outside render",
+      `
+        import { useEffect } from "react";
+        export const Page = () => {
+          const readRuntime = () =>
+            typeof document === "undefined" ? "server" : "client";
+          useEffect(() => log(readRuntime()), []);
+          return <Stable />;
+        };
+      `,
+    ],
+    [
+      "a createElement lookalike",
+      `
+        import React from "react";
+        const renderer = { createElement: () => "not React" };
+        export const Page = ({ ready }) =>
+          React.createElement(
+            "main",
+            null,
+            ready && typeof window !== "undefined" && renderer.createElement(),
+          );
+      `,
+    ],
+    [
+      "a shadowed React namespace",
+      `
+        import { useState } from "react";
+        const React = { createElement: () => "not React" };
+        export const Page = () => {
+          useState(false);
+          return typeof window === "undefined"
+            ? React.createElement("server")
+            : React.createElement("client");
+        };
+      `,
+    ],
+  ])("stays quiet for %s", (_name, code) => {
+    const result = run(code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-hydration-branch-on-browser-global.react-bench.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-hydration-branch-on-browser-global.react-bench.regressions.test.ts
@@ -297,9 +297,63 @@ describe("no-hydration-branch-on-browser-global — ReactBench regressions", () 
         };
       `,
     ],
+    [
+      "equal duplicated browser predicates",
+      `
+        import React from "react";
+        export const Page = () => {
+          const stable =
+            (typeof window === "undefined") ===
+            (typeof window === "undefined");
+          return stable ? <Same /> : <Different />;
+        };
+      `,
+    ],
+    [
+      "unequal duplicated browser predicates",
+      `
+        import React from "react";
+        export const Page = () => {
+          const stable =
+            (typeof window === "undefined") !==
+            (typeof window === "undefined");
+          return stable ? <Same /> : <Different />;
+        };
+      `,
+    ],
+    [
+      "nested equal duplicated browser comparisons",
+      `
+        import React from "react";
+        export const Page = () => {
+          const stable =
+            ((typeof window === "undefined") === true) ===
+            ((typeof window === "undefined") === true);
+          return stable ? <Same /> : <Different />;
+        };
+      `,
+    ],
   ])("stays quiet for %s", (_name, code) => {
     const result = run(code);
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it.each([
+    ["a browser predicate compared with false", `(typeof window === "undefined") === false`],
+    [
+      "a nested browser predicate compared with false",
+      `((typeof window === "undefined") === true) === false`,
+    ],
+  ])("reports %s", (_name, condition) => {
+    const result = run(`
+      import React from "react";
+      export const Page = () => {
+        const unstable = ${condition};
+        return unstable ? <Client /> : <Server />;
+      };
+    `);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
   });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-hydration-branch-on-browser-global.react-bench.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-hydration-branch-on-browser-global.react-bench.regressions.test.ts
@@ -365,6 +365,40 @@ describe("no-hydration-branch-on-browser-global — ReactBench regressions", () 
         };
       `,
     ],
+    [
+      "equal aliased browser predicates",
+      `
+        import React from "react";
+        export const Page = () => {
+          const isServer = typeof window === "undefined";
+          const stable = isServer === isServer;
+          return stable ? <Same /> : <Different />;
+        };
+      `,
+    ],
+    [
+      "a strict browser predicate comparison with an aliased zero",
+      `
+        import React from "react";
+        export const Page = () => {
+          const zero = 0;
+          const stable = (typeof window === "undefined") === zero;
+          return stable ? <Same /> : <Different />;
+        };
+      `,
+    ],
+    [
+      "equal boolean aliases of a browser predicate",
+      `
+        import React from "react";
+        export const Page = () => {
+          const isServer = typeof window === "undefined";
+          const serverAlias = isServer;
+          const stable = serverAlias === isServer;
+          return stable ? <Same /> : <Different />;
+        };
+      `,
+    ],
   ])("stays quiet for %s", (_name, code) => {
     const result = run(code);
     expect(result.parseErrors).toEqual([]);
@@ -381,6 +415,13 @@ describe("no-hydration-branch-on-browser-global — ReactBench regressions", () 
     [
       "a Boolean-wrapped browser predicate compared with false",
       `Boolean(typeof window === "undefined") === false`,
+    ],
+    [
+      "an aliased browser predicate compared with false",
+      `(() => {
+        const isServer = typeof window === "undefined";
+        return isServer === false;
+      })()`,
     ],
   ])("reports %s", (_name, condition) => {
     const result = run(`

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-hydration-branch-on-browser-global.react-bench.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-hydration-branch-on-browser-global.react-bench.regressions.test.ts
@@ -54,6 +54,20 @@ describe("no-hydration-branch-on-browser-global — ReactBench regressions", () 
       `,
     ],
     [
+      "useMemo object property access",
+      `
+        import { useMemo } from "react";
+        export const Background = () => {
+          const playable = useMemo(() => {
+            let result = false;
+            if (typeof document !== "undefined") result = true;
+            return { playable: result };
+          }, []).playable;
+          return playable ? <video /> : <img alt="" />;
+        };
+      `,
+    ],
+    [
       "local rendered custom-hook state",
       `
         import { useState } from "react";
@@ -66,6 +80,71 @@ describe("no-hydration-branch-on-browser-global — ReactBench regressions", () 
         export const Page = () => {
           const { registration } = useRegistration();
           return registration ? <Primary /> : <Pending />;
+        };
+      `,
+    ],
+    [
+      "direct custom-hook state return",
+      `
+        import { useState } from "react";
+        const useRuntime = () => {
+          const [runtime] = useState(
+            typeof window === "undefined" ? "server" : "client",
+          );
+          return runtime;
+        };
+        export const Page = () => {
+          const runtime = useRuntime();
+          return runtime ? <Client /> : <Server />;
+        };
+      `,
+    ],
+    [
+      "tuple custom-hook state return",
+      `
+        import { useState } from "react";
+        const useRuntime = () => {
+          const [runtime] = useState(
+            typeof window === "undefined" ? "server" : "client",
+          );
+          return [runtime] as const;
+        };
+        export const Page = () => {
+          const [runtime] = useRuntime();
+          return runtime ? <Client /> : <Server />;
+        };
+      `,
+    ],
+    [
+      "custom-hook result member consumer",
+      `
+        import { useState } from "react";
+        const useRuntime = () => {
+          const [runtime] = useState(
+            typeof window === "undefined" ? "server" : "client",
+          );
+          return { runtime };
+        };
+        export const Page = () => {
+          const result = useRuntime();
+          return result.runtime ? <Client /> : <Server />;
+        };
+      `,
+    ],
+    [
+      "aliased custom-hook result member consumer",
+      `
+        import { useState } from "react";
+        const useRuntime = () => {
+          const [runtime] = useState(
+            typeof window === "undefined" ? "server" : "client",
+          );
+          return { runtime };
+        };
+        export const Page = () => {
+          const result = useRuntime();
+          const mode = result.runtime;
+          return mode ? <Client /> : <Server />;
         };
       `,
     ],
@@ -104,6 +183,15 @@ describe("no-hydration-branch-on-browser-global — ReactBench regressions", () 
           };
           return <main>{renderMedia()}</main>;
         };
+      `,
+    ],
+    [
+      "a browser branch inside a directly rendered local helper",
+      `
+        import React from "react";
+        const renderContent = () =>
+          typeof window !== "undefined" ? <Client /> : <Server />;
+        export const Page = () => <div>{renderContent()}</div>;
       `,
     ],
     [
@@ -264,6 +352,46 @@ describe("no-hydration-branch-on-browser-global — ReactBench regressions", () 
             typeof document === "undefined" ? "server" : "client";
           useEffect(() => log(readRuntime()), []);
           return <Stable />;
+        };
+      `,
+    ],
+    [
+      "an unused local render helper",
+      `
+        import React from "react";
+        export const Page = () => {
+          const renderContent = () =>
+            typeof window !== "undefined" ? <Client /> : <Server />;
+          log(renderContent);
+          return <Stable />;
+        };
+      `,
+    ],
+    [
+      "a stored state-writing callback",
+      `
+        import React from "react";
+        export const Page = () => {
+          let show = false;
+          const enable = () => {
+            show = true;
+          };
+          if (typeof window !== "undefined") log(enable);
+          return show ? <Client /> : <Server />;
+        };
+      `,
+    ],
+    [
+      "a browser-guarded helper write preserving the initial value",
+      `
+        import React from "react";
+        export const Page = () => {
+          let show = false;
+          const preserve = () => {
+            show = false;
+          };
+          if (typeof window !== "undefined") preserve();
+          return show ? <Client /> : <Server />;
         };
       `,
     ],
@@ -432,6 +560,55 @@ describe("no-hydration-branch-on-browser-global — ReactBench regressions", () 
       `,
     ],
     [
+      "a browser-guarded local helper invocation that writes rendered state",
+      `
+        import React from "react";
+        export const Page = () => {
+          let show = false;
+          const enable = () => {
+            show = true;
+          };
+          if (typeof window !== "undefined") enable();
+          return show ? <Client /> : <Server />;
+        };
+      `,
+    ],
+    [
+      "unrelated browser-derived values compared for equality",
+      `
+        import React from "react";
+        export const Page = () => {
+          const client =
+            typeof window !== "undefined" ? readClientFlag() : false;
+          const server =
+            typeof window === "undefined" ? readServerFlag() : false;
+          return client === server ? <Same /> : <Different />;
+        };
+      `,
+    ],
+    [
+      "a browser-derived possible NaN compared with itself",
+      `
+        import React from "react";
+        export const Page = () => {
+          const value =
+            typeof window !== "undefined" ? Number("x") : 0;
+          return value === value ? <Same /> : <Different />;
+        };
+      `,
+    ],
+    [
+      "a browser predicate in a dynamically selected conditional arm",
+      `
+        import React from "react";
+        export const Page = ({ enabled }) => {
+          const value =
+            enabled ? typeof window !== "undefined" : false;
+          return value ? <Client /> : <Server />;
+        };
+      `,
+    ],
+    [
       "a browser write from a shadowed same-name binding",
       `
         import React from "react";
@@ -546,6 +723,67 @@ describe("no-hydration-branch-on-browser-global — ReactBench regressions", () 
       `,
     ],
     [
+      "a stable property beside an unstable memo property",
+      `
+        import { useMemo } from "react";
+        export const Page = () => {
+          const stable = useMemo(() => ({
+            stable: false,
+            runtime: typeof window !== "undefined",
+          }), []).stable;
+          return stable ? <Client /> : <Server />;
+        };
+      `,
+    ],
+    [
+      "an equivalent browser-guarded memo write",
+      `
+        import { useMemo } from "react";
+        export const Page = () => {
+          const { stable } = useMemo(() => {
+            let stable = false;
+            if (typeof window !== "undefined") stable = false;
+            return { stable };
+          }, []);
+          return stable ? <Client /> : <Server />;
+        };
+      `,
+    ],
+    [
+      "a browser predicate in the dead consequent of a conditional",
+      `
+        import React from "react";
+        export const Page = () => {
+          const value =
+            false ? typeof window !== "undefined" : false;
+          return value ? <Client /> : <Server />;
+        };
+      `,
+    ],
+    [
+      "a browser predicate in the dead alternate of a conditional",
+      `
+        import React from "react";
+        export const Page = () => {
+          const value =
+            true ? false : typeof window !== "undefined";
+          return value ? <Client /> : <Server />;
+        };
+      `,
+    ],
+    [
+      "a browser write followed by a statically unconditional overwrite",
+      `
+        import React from "react";
+        export const Page = () => {
+          let show = false;
+          if (typeof window !== "undefined") show = true;
+          if (true) show = false;
+          return show ? <Client /> : <Server />;
+        };
+      `,
+    ],
+    [
       "a browser write preserving the same binding",
       `
         import React from "react";
@@ -602,6 +840,58 @@ describe("no-hydration-branch-on-browser-global — ReactBench regressions", () 
           useEffect(() => setMounted(true), []);
           if (!mounted) return null;
           return runtime ? <Client /> : <Server />;
+        };
+      `,
+    ],
+    [
+      "an unused direct custom-hook state return",
+      `
+        import React, { useState } from "react";
+        const useRuntime = () => {
+          const [runtime] = useState(
+            typeof window === "undefined" ? "server" : "client",
+          );
+          return runtime;
+        };
+        export const Page = () => {
+          const runtime = useRuntime();
+          log(runtime);
+          return <Stable />;
+        };
+      `,
+    ],
+    [
+      "a mount-gated tuple custom-hook consumer",
+      `
+        import React, { useEffect, useState } from "react";
+        const useRuntime = () => {
+          const [runtime] = useState(
+            typeof window === "undefined" ? "server" : "client",
+          );
+          return [runtime] as const;
+        };
+        export const Page = () => {
+          const [runtime] = useRuntime();
+          const [mounted, setMounted] = useState(false);
+          useEffect(() => setMounted(true), []);
+          if (!mounted) return null;
+          return runtime ? <Client /> : <Server />;
+        };
+      `,
+    ],
+    [
+      "a suppressed custom-hook member consumer",
+      `
+        import React, { useState } from "react";
+        const useRuntime = () => {
+          const [runtime] = useState(
+            typeof window === "undefined" ? "server" : "client",
+          );
+          return { runtime };
+        };
+        export const Page = () => {
+          const result = useRuntime();
+          return <span suppressHydrationWarning>{result.runtime}</span>;
         };
       `,
     ],
@@ -667,6 +957,70 @@ describe("no-hydration-branch-on-browser-global — ReactBench regressions", () 
       export const Page = () => {
         const unstable = ${condition};
         return unstable ? <Client /> : <Server />;
+      };
+    `);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it.each([
+    [
+      "an as-wrapped rendered local helper",
+      `const renderContent = (() =>
+        typeof window !== "undefined" ? <Client /> : <Server />
+      ) as () => React.ReactNode;`,
+    ],
+    [
+      "a satisfies-wrapped rendered local helper",
+      `const renderContent = (() =>
+        typeof window !== "undefined" ? <Client /> : <Server />
+      ) satisfies () => React.ReactNode;`,
+    ],
+  ])("reports %s", (_name, helperDeclaration) => {
+    const result = run(`
+      import React from "react";
+      ${helperDeclaration}
+      export const Page = () => <main>{renderContent()}</main>;
+    `);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays quiet for a nested uninvoked browser-guarded writer", () => {
+    const result = run(`
+      import React from "react";
+      export const Page = () => {
+        const visible = React.useMemo(() => {
+          let nextVisible = false;
+          if (typeof window !== "undefined") {
+            const neverRun = () => {
+              nextVisible = true;
+            };
+          }
+          return nextVisible;
+        }, []);
+        return visible ? <Client /> : <Server />;
+      };
+    `);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("reports a nested invoked browser-guarded writer", () => {
+    const result = run(`
+      import React from "react";
+      export const Page = () => {
+        const visible = React.useMemo(() => {
+          let nextVisible = false;
+          if (typeof window !== "undefined") {
+            const enable = () => {
+              nextVisible = true;
+            };
+            enable();
+          }
+          return nextVisible;
+        }, []);
+        return visible ? <Client /> : <Server />;
       };
     `);
     expect(result.parseErrors).toEqual([]);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-hydration-branch-on-browser-global.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-hydration-branch-on-browser-global.ts
@@ -55,6 +55,11 @@ interface HydrationStatementResult {
   readonly value: boolean | null;
 }
 
+interface HydrationPrimitiveResult {
+  readonly kind: "boolean" | "null" | "number" | "string" | "undefined";
+  readonly value: boolean | null | number | string | undefined;
+}
+
 const findGuardingIfStatements = (
   node: EsTreeNode,
   functionBoundary: EsTreeNode,
@@ -311,6 +316,125 @@ const readLogicalConditionResult = (
   return null;
 };
 
+const areLooselyEqualPrimitiveResults = (
+  left: HydrationPrimitiveResult,
+  right: HydrationPrimitiveResult,
+): boolean => {
+  if (left.kind === right.kind) return left.value === right.value;
+  if (
+    (left.kind === "null" && right.kind === "undefined") ||
+    (left.kind === "undefined" && right.kind === "null")
+  ) {
+    return true;
+  }
+  if (left.kind === "boolean") {
+    return areLooselyEqualPrimitiveResults({ kind: "number", value: left.value ? 1 : 0 }, right);
+  }
+  if (right.kind === "boolean") {
+    return areLooselyEqualPrimitiveResults(left, {
+      kind: "number",
+      value: right.value ? 1 : 0,
+    });
+  }
+  if (left.kind === "number" && right.kind === "string") {
+    return left.value === Number(right.value);
+  }
+  if (left.kind === "string" && right.kind === "number") {
+    return Number(left.value) === right.value;
+  }
+  return false;
+};
+
+const readHydrationPrimitiveResult = (
+  expression: EsTreeNode,
+  context: RuleContext,
+  runtime: "client" | "server",
+  state: HydrationResolutionState,
+): HydrationPrimitiveResult | null => {
+  const unwrappedExpression = stripParenExpression(expression);
+  const predicateMatch = matchBrowserPredicate(unwrappedExpression, context);
+  if (predicateMatch) {
+    return { kind: "boolean", value: predicateMatch[`${runtime}Result`] };
+  }
+  if (isNodeOfType(unwrappedExpression, "Literal")) {
+    const value = unwrappedExpression.value;
+    if (value === null) return { kind: "null", value };
+    if (typeof value === "boolean") return { kind: "boolean", value };
+    if (typeof value === "number") return { kind: "number", value };
+    if (typeof value === "string") return { kind: "string", value };
+    return null;
+  }
+  if (
+    isNodeOfType(unwrappedExpression, "Identifier") &&
+    unwrappedExpression.name === "undefined" &&
+    context.scopes.isGlobalReference(unwrappedExpression)
+  ) {
+    return { kind: "undefined", value: undefined };
+  }
+  if (
+    isNodeOfType(unwrappedExpression, "UnaryExpression") &&
+    unwrappedExpression.operator === "!"
+  ) {
+    const argumentResult = readHydrationConditionResult(
+      unwrappedExpression.argument,
+      context,
+      runtime,
+      state,
+    );
+    return argumentResult === null ? null : { kind: "boolean", value: !argumentResult };
+  }
+  if (isNodeOfType(unwrappedExpression, "BinaryExpression")) {
+    const leftResult = readHydrationPrimitiveResult(
+      unwrappedExpression.left,
+      context,
+      runtime,
+      state,
+    );
+    const rightResult = readHydrationPrimitiveResult(
+      unwrappedExpression.right,
+      context,
+      runtime,
+      state,
+    );
+    if (!leftResult || !rightResult) return null;
+    if (unwrappedExpression.operator === "===" || unwrappedExpression.operator === "!==") {
+      const areEqual =
+        leftResult.kind === rightResult.kind && leftResult.value === rightResult.value;
+      return {
+        kind: "boolean",
+        value: unwrappedExpression.operator === "===" ? areEqual : !areEqual,
+      };
+    }
+    if (unwrappedExpression.operator === "==" || unwrappedExpression.operator === "!=") {
+      const areEqual = areLooselyEqualPrimitiveResults(leftResult, rightResult);
+      return {
+        kind: "boolean",
+        value: unwrappedExpression.operator === "==" ? areEqual : !areEqual,
+      };
+    }
+  }
+  if (isNodeOfType(unwrappedExpression, "CallExpression")) {
+    const callArguments = unwrappedExpression.arguments ?? [];
+    const callee = stripParenExpression(unwrappedExpression.callee);
+    if (
+      isNodeOfType(callee, "Identifier") &&
+      callee.name === "Boolean" &&
+      context.scopes.isGlobalReference(callee) &&
+      callArguments.length === 1 &&
+      !isNodeOfType(callArguments[0], "SpreadElement")
+    ) {
+      const argumentResult = readHydrationConditionResult(
+        callArguments[0],
+        context,
+        runtime,
+        state,
+      );
+      return argumentResult === null ? null : { kind: "boolean", value: argumentResult };
+    }
+  }
+  return null;
+};
+
 const readHydrationConditionResult = (
   expression: EsTreeNode,
   context: RuleContext,
@@ -401,26 +525,8 @@ const readHydrationConditionResult = (
     });
   }
   if (isNodeOfType(unwrappedExpression, "BinaryExpression")) {
-    const leftResult = readHydrationConditionResult(
-      unwrappedExpression.left,
-      context,
-      runtime,
-      state,
-    );
-    const rightResult = readHydrationConditionResult(
-      unwrappedExpression.right,
-      context,
-      runtime,
-      state,
-    );
-    if (leftResult === null || rightResult === null) return null;
-    if (unwrappedExpression.operator === "===" || unwrappedExpression.operator === "==") {
-      return leftResult === rightResult;
-    }
-    if (unwrappedExpression.operator === "!==" || unwrappedExpression.operator === "!=") {
-      return leftResult !== rightResult;
-    }
-    return null;
+    const result = readHydrationPrimitiveResult(unwrappedExpression, context, runtime, state);
+    return result?.kind === "boolean" && typeof result.value === "boolean" ? result.value : null;
   }
   if (
     isNodeOfType(unwrappedExpression, "UnaryExpression") &&
@@ -720,6 +826,14 @@ const matchHydrationConditionInternal = (
     );
   }
   if (isNodeOfType(unwrappedExpression, "BinaryExpression")) {
+    if (
+      unwrappedExpression.operator !== "===" &&
+      unwrappedExpression.operator !== "!==" &&
+      unwrappedExpression.operator !== "==" &&
+      unwrappedExpression.operator !== "!="
+    ) {
+      return null;
+    }
     const nestedMatch =
       matchHydrationConditionInternal(unwrappedExpression.left, context, state) ??
       matchHydrationConditionInternal(unwrappedExpression.right, context, state);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-hydration-branch-on-browser-global.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-hydration-branch-on-browser-global.ts
@@ -371,6 +371,28 @@ const readHydrationPrimitiveResult = (
   ) {
     return { kind: "undefined", value: undefined };
   }
+  if (isNodeOfType(unwrappedExpression, "Identifier")) {
+    const symbol = context.scopes.symbolFor(unwrappedExpression);
+    const parameterValue = symbol ? state.parameterValuesBySymbolId.get(symbol.id) : null;
+    if (symbol && parameterValue && !state.visitedSymbolIds.has(symbol.id)) {
+      state.visitedSymbolIds.add(symbol.id);
+      const result = readHydrationPrimitiveResult(parameterValue, context, runtime, state);
+      state.visitedSymbolIds.delete(symbol.id);
+      return result;
+    }
+    if (
+      symbol &&
+      symbol.kind === "const" &&
+      symbol.initializer &&
+      symbol.references.every((reference) => reference.flag === "read") &&
+      !state.visitedSymbolIds.has(symbol.id)
+    ) {
+      state.visitedSymbolIds.add(symbol.id);
+      const result = readHydrationPrimitiveResult(symbol.initializer, context, runtime, state);
+      state.visitedSymbolIds.delete(symbol.id);
+      return result;
+    }
+  }
   if (
     isNodeOfType(unwrappedExpression, "UnaryExpression") &&
     unwrappedExpression.operator === "!"

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-hydration-branch-on-browser-global.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-hydration-branch-on-browser-global.ts
@@ -6,6 +6,7 @@ import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
 import { findEnclosingJsxOpeningElement } from "../../utils/find-enclosing-jsx-opening-element.js";
 import { findRenderPhaseComponentOrHook } from "../../utils/find-render-phase-component-or-hook.js";
 import { flattenJsxName } from "../../utils/flatten-jsx-name.js";
+import { getDirectFunctionBindingIdentifier } from "../../utils/get-direct-function-binding-identifier.js";
 import { hasClientRenderEvidence } from "../../utils/has-client-render-evidence.js";
 import { hasDirective } from "../../utils/has-directive.js";
 import { hasEmailTemplateImport } from "../../utils/has-email-template-import.js";
@@ -61,6 +62,11 @@ interface HydrationPrimitiveResult {
   readonly value: boolean | null | number | string | undefined;
 }
 
+interface ReturnedStatePath {
+  readonly kind: "direct" | "index" | "property";
+  readonly key: string | null;
+}
+
 const findGuardingIfStatements = (
   node: EsTreeNode,
   functionBoundary: EsTreeNode,
@@ -96,6 +102,7 @@ const collectWrittenSymbols = (
 ): ReadonlySet<SymbolDescriptor> => {
   const writtenSymbols = new Set<SymbolDescriptor>();
   walkAst(node, (childNode) => {
+    if (childNode !== node && isFunctionLike(childNode)) return false;
     if (!isNodeOfType(childNode, "Identifier")) return;
     const reference = scopes.referenceFor(childNode);
     if (!reference || reference.flag === "read" || !reference.resolvedSymbol) return;
@@ -159,10 +166,38 @@ const isWriteOverwrittenBefore = (
       reference.identifier !== writeIdentifier &&
       !isDescendantOf(reference.identifier, guardingIfStatement) &&
       isNodeReachableWithinFunction(reference.identifier, context) &&
-      context.cfg.isUnconditionalFromEntry(reference.identifier) &&
+      isUnconditionalOrStaticallySelected(reference.identifier, context) &&
       getNodeStartIndex(reference.identifier) > getNodeStartIndex(writeIdentifier) &&
       getNodeStartIndex(reference.identifier) < getNodeStartIndex(readIdentifier),
   );
+
+const isUnconditionalOrStaticallySelected = (node: EsTreeNode, context: RuleContext): boolean => {
+  if (context.cfg.isUnconditionalFromEntry(node)) return true;
+  let currentNode = node;
+  let outermostStaticIfStatement: EsTreeNodeOfType<"IfStatement"> | null = null;
+  let parentNode = currentNode.parent;
+  while (parentNode) {
+    if (isFunctionLike(parentNode)) break;
+    if (isNodeOfType(parentNode, "IfStatement")) {
+      const staticResult = readInitialStateBoolean(parentNode.test, context.scopes);
+      let selectedBranch: EsTreeNode | null = null;
+      if (staticResult === true) selectedBranch = parentNode.consequent;
+      if (staticResult === false) selectedBranch = parentNode.alternate;
+      if (
+        !selectedBranch ||
+        (currentNode !== selectedBranch && !isDescendantOf(currentNode, selectedBranch))
+      ) {
+        return false;
+      }
+      outermostStaticIfStatement = parentNode;
+    }
+    currentNode = parentNode;
+    parentNode = currentNode.parent;
+  }
+  return Boolean(
+    outermostStaticIfStatement && context.cfg.isUnconditionalFromEntry(outermostStaticIfStatement),
+  );
+};
 
 const containsExplicitReactRuntimeReference = (
   node: EsTreeNode,
@@ -201,11 +236,7 @@ const findComponentRenderingLocalFunctionResult = (
   functionNode: EsTreeNode,
   scopes: ScopeAnalysis,
 ): EsTreeNode | null => {
-  const bindingIdentifier = isNodeOfType(functionNode, "FunctionDeclaration")
-    ? functionNode.id
-    : isNodeOfType(functionNode.parent, "VariableDeclarator")
-      ? functionNode.parent.id
-      : null;
+  const bindingIdentifier = getDirectFunctionBindingIdentifier(functionNode);
   if (!isNodeOfType(bindingIdentifier, "Identifier")) return null;
   const functionSymbol = scopes.symbolFor(bindingIdentifier);
   if (!functionSymbol) return null;
@@ -721,6 +752,151 @@ const doHelperReturnValuesDiffer = (
   );
 };
 
+const isExpressionProvablyReflexive = (
+  expression: EsTreeNode,
+  context: RuleContext,
+  visitedSymbolIds = new Set<number>(),
+): boolean => {
+  const unwrappedExpression = stripParenExpression(expression);
+  if (matchBrowserPredicate(unwrappedExpression, context)) return true;
+  if (isNodeOfType(unwrappedExpression, "Literal")) {
+    return (
+      typeof unwrappedExpression.value !== "number" || !Number.isNaN(unwrappedExpression.value)
+    );
+  }
+  if (
+    isNodeOfType(unwrappedExpression, "Identifier") &&
+    unwrappedExpression.name === "undefined" &&
+    context.scopes.isGlobalReference(unwrappedExpression)
+  ) {
+    return true;
+  }
+  if (isNodeOfType(unwrappedExpression, "Identifier")) {
+    const symbol = context.scopes.symbolFor(unwrappedExpression);
+    if (!symbol || visitedSymbolIds.has(symbol.id) || !symbol.initializer) return false;
+    visitedSymbolIds.add(symbol.id);
+    const assignedValues = symbol.references
+      .filter((reference) => reference.flag !== "read")
+      .map((reference) => getAssignedValue(reference.identifier));
+    const isReflexive =
+      isExpressionProvablyReflexive(symbol.initializer, context, visitedSymbolIds) &&
+      assignedValues.every((assignedValue) =>
+        Boolean(
+          assignedValue && isExpressionProvablyReflexive(assignedValue, context, visitedSymbolIds),
+        ),
+      );
+    visitedSymbolIds.delete(symbol.id);
+    return isReflexive;
+  }
+  if (isNodeOfType(unwrappedExpression, "ConditionalExpression")) {
+    return (
+      isExpressionProvablyReflexive(unwrappedExpression.consequent, context, visitedSymbolIds) &&
+      isExpressionProvablyReflexive(unwrappedExpression.alternate, context, visitedSymbolIds)
+    );
+  }
+  if (
+    isNodeOfType(unwrappedExpression, "UnaryExpression") &&
+    (unwrappedExpression.operator === "!" ||
+      unwrappedExpression.operator === "typeof" ||
+      unwrappedExpression.operator === "void")
+  ) {
+    return true;
+  }
+  if (isNodeOfType(unwrappedExpression, "BinaryExpression")) {
+    return (
+      unwrappedExpression.operator === "===" ||
+      unwrappedExpression.operator === "!==" ||
+      unwrappedExpression.operator === "==" ||
+      unwrappedExpression.operator === "!="
+    );
+  }
+  if (
+    isNodeOfType(unwrappedExpression, "ArrayExpression") ||
+    isNodeOfType(unwrappedExpression, "ObjectExpression") ||
+    isNodeOfType(unwrappedExpression, "FunctionExpression") ||
+    isNodeOfType(unwrappedExpression, "ArrowFunctionExpression") ||
+    isNodeOfType(unwrappedExpression, "TemplateLiteral")
+  ) {
+    return true;
+  }
+  if (!isNodeOfType(unwrappedExpression, "CallExpression")) return false;
+  const callee = stripParenExpression(unwrappedExpression.callee);
+  return (
+    isNodeOfType(callee, "Identifier") &&
+    callee.name === "Boolean" &&
+    context.scopes.isGlobalReference(callee)
+  );
+};
+
+const getReturnedObjectPropertyValues = (
+  node: EsTreeNode,
+  propertyName: string,
+  scopes: ScopeAnalysis,
+): ReadonlyArray<EsTreeNode> => {
+  if (isNodeOfType(node, "ReturnStatement")) {
+    return node.argument
+      ? getReturnedObjectPropertyValues(node.argument, propertyName, scopes)
+      : [];
+  }
+  if (isNodeOfType(node, "ObjectExpression")) {
+    return node.properties.flatMap((property) =>
+      isNodeOfType(property, "Property") &&
+      property.kind === "init" &&
+      getResolvedStaticPropertyName(property, scopes) === propertyName
+        ? [property.value]
+        : [],
+    );
+  }
+  if (isNodeOfType(node, "IfStatement")) {
+    return [
+      ...getReturnedObjectPropertyValues(node.consequent, propertyName, scopes),
+      ...(node.alternate
+        ? getReturnedObjectPropertyValues(node.alternate, propertyName, scopes)
+        : []),
+    ];
+  }
+  if (isNodeOfType(node, "TryStatement")) {
+    return [
+      ...getReturnedObjectPropertyValues(node.block, propertyName, scopes),
+      ...(node.handler
+        ? getReturnedObjectPropertyValues(node.handler.body, propertyName, scopes)
+        : []),
+      ...(node.finalizer
+        ? getReturnedObjectPropertyValues(node.finalizer, propertyName, scopes)
+        : []),
+    ];
+  }
+  if (!isNodeOfType(node, "BlockStatement")) return [];
+  const propertyValues: Array<EsTreeNode> = [];
+  for (const childStatement of node.body) {
+    propertyValues.push(...getReturnedObjectPropertyValues(childStatement, propertyName, scopes));
+    if (statementAlwaysExits(childStatement)) break;
+  }
+  return propertyValues;
+};
+
+const matchHydrationFunctionPropertyResult = (
+  functionNode: EsTreeNode,
+  propertyName: string,
+  context: RuleContext,
+  state: HydrationResolutionState,
+): HydrationConditionMatch | null => {
+  if (!isFunctionLike(functionNode) || state.visitedFunctionNodes.has(functionNode)) return null;
+  state.visitedFunctionNodes.add(functionNode);
+  const propertyValues = getReturnedObjectPropertyValues(
+    functionNode.body,
+    propertyName,
+    context.scopes,
+  );
+  let match: HydrationConditionMatch | null = null;
+  for (const propertyValue of propertyValues) {
+    match = matchHydrationConditionInternal(propertyValue, context, state);
+    if (match) break;
+  }
+  state.visitedFunctionNodes.delete(functionNode);
+  return match;
+};
+
 const matchHydrationConditionInternal = (
   expression: EsTreeNode,
   context: RuleContext,
@@ -777,6 +953,69 @@ const matchHydrationConditionInternal = (
           }
         }
       }
+      const readingFunction = findEnclosingFunction(unwrappedExpression);
+      for (const reference of symbol.references) {
+        if (reference.flag === "read") continue;
+        const writingFunction = findEnclosingFunction(reference.identifier);
+        if (
+          !readingFunction ||
+          !isFunctionLike(writingFunction) ||
+          writingFunction === readingFunction ||
+          writingFunction.async ||
+          writingFunction.params.length > 0 ||
+          (isNodeOfType(writingFunction, "FunctionDeclaration") && writingFunction.generator) ||
+          (isNodeOfType(writingFunction, "FunctionExpression") && writingFunction.generator)
+        ) {
+          continue;
+        }
+        const assignedValue = getAssignedValue(reference.identifier);
+        if (
+          symbol.initializer &&
+          assignedValue &&
+          areExpressionsStructurallyEqual(symbol.initializer, assignedValue) &&
+          doEquivalentExpressionBindingsMatch(symbol.initializer, assignedValue, context.scopes)
+        ) {
+          continue;
+        }
+        const functionBinding = getDirectFunctionBindingIdentifier(writingFunction);
+        if (!isNodeOfType(functionBinding, "Identifier")) continue;
+        const functionSymbol = context.scopes.symbolFor(functionBinding);
+        if (!functionSymbol) continue;
+        for (const functionReference of functionSymbol.references) {
+          const callExpression = functionReference.identifier.parent;
+          if (
+            !isNodeOfType(callExpression, "CallExpression") ||
+            callExpression.callee !== functionReference.identifier ||
+            (callExpression.arguments ?? []).length > 0 ||
+            findEnclosingFunction(callExpression) !== readingFunction ||
+            !isNodeReachableWithinFunction(callExpression, context) ||
+            getNodeStartIndex(callExpression) >= getNodeStartIndex(unwrappedExpression)
+          ) {
+            continue;
+          }
+          for (const guardingIfStatement of findGuardingIfStatements(
+            callExpression,
+            readingFunction,
+          )) {
+            if (
+              isWriteOverwrittenBefore(
+                symbol,
+                callExpression,
+                guardingIfStatement,
+                unwrappedExpression,
+                context,
+              )
+            ) {
+              continue;
+            }
+            const match = matchHydrationConditionInternal(guardingIfStatement.test, context, state);
+            if (match) {
+              state.visitedSymbolIds.delete(symbol.id);
+              return match;
+            }
+          }
+        }
+      }
       state.visitedSymbolIds.delete(symbol.id);
     }
     if (
@@ -792,6 +1031,34 @@ const matchHydrationConditionInternal = (
     const match = matchHydrationConditionInternal(symbol.initializer, context, state);
     state.visitedSymbolIds.delete(symbol.id);
     return match;
+  }
+  if (isNodeOfType(unwrappedExpression, "MemberExpression")) {
+    const propertyName = getResolvedStaticPropertyName(unwrappedExpression, context.scopes, {
+      allowConstNumericLiteral: true,
+      stringifyNonStringLiterals: true,
+    });
+    const object = stripParenExpression(unwrappedExpression.object);
+    if (propertyName === null || !isNodeOfType(object, "CallExpression")) return null;
+    const callArguments = object.arguments ?? [];
+    if (
+      isReactApiCall(object, "useMemo", context.scopes, {
+        allowGlobalReactNamespace: true,
+        resolveNamedAliases: true,
+      })
+    ) {
+      const callbackArgument = callArguments[0];
+      if (!callbackArgument || isNodeOfType(callbackArgument, "SpreadElement")) return null;
+      const callbackFunction = resolveExactLocalFunction(callbackArgument, context.scopes);
+      return isFunctionLike(callbackFunction) && callbackFunction.params.length === 0
+        ? matchHydrationFunctionPropertyResult(callbackFunction, propertyName, context, state)
+        : null;
+    }
+    const helperFunction = resolveExactLocalFunction(object.callee, context.scopes);
+    return isFunctionLike(helperFunction) &&
+      helperFunction.params.length === 0 &&
+      callArguments.length === 0
+      ? matchHydrationFunctionPropertyResult(helperFunction, propertyName, context, state)
+      : null;
   }
   if (isNodeOfType(unwrappedExpression, "CallExpression")) {
     const callArguments = unwrappedExpression.arguments ?? [];
@@ -862,7 +1129,16 @@ const matchHydrationConditionInternal = (
     return matchHydrationConditionInternal(unwrappedExpression.argument, context, state);
   }
   if (isNodeOfType(unwrappedExpression, "ConditionalExpression")) {
+    const staticTestResult = readInitialStateBoolean(unwrappedExpression.test, context.scopes);
+    if (staticTestResult !== null) {
+      return matchHydrationConditionInternal(
+        staticTestResult ? unwrappedExpression.consequent : unwrappedExpression.alternate,
+        context,
+        state,
+      );
+    }
     return (
+      matchHydrationConditionInternal(unwrappedExpression.test, context, state) ??
       matchHydrationConditionInternal(unwrappedExpression.consequent, context, state) ??
       matchHydrationConditionInternal(unwrappedExpression.alternate, context, state)
     );
@@ -895,7 +1171,17 @@ const matchHydrationConditionInternal = (
     if (clientResult !== null && serverResult !== null) {
       return clientResult !== serverResult ? nestedMatch : null;
     }
-    return Boolean(leftMatch) === Boolean(rightMatch) ? null : nestedMatch;
+    return leftMatch &&
+      rightMatch &&
+      areExpressionsStructurallyEqual(unwrappedExpression.left, unwrappedExpression.right) &&
+      doEquivalentExpressionBindingsMatch(
+        unwrappedExpression.left,
+        unwrappedExpression.right,
+        context.scopes,
+      ) &&
+      isExpressionProvablyReflexive(unwrappedExpression.left, context)
+      ? null
+      : nestedMatch;
   }
   if (
     !isNodeOfType(unwrappedExpression, "LogicalExpression") ||
@@ -945,8 +1231,10 @@ const matchHydrationReturningStatement = (
         ...(statement.alternate ? collectWrittenSymbols(statement.alternate, context.scopes) : []),
       ]);
       if (
-        [...writtenSymbols].some((symbol) =>
-          followingReturnedValues.some((value) => doesNodeReadSymbol(value, symbol)),
+        [...writtenSymbols].some(
+          (symbol) =>
+            !doesGuardPreserveInitialSymbolValue(symbol, statement, context.scopes) &&
+            followingReturnedValues.some((value) => doesNodeReadSymbol(value, symbol)),
         )
       ) {
         return conditionMatch;
@@ -1274,13 +1562,6 @@ const findUseStateBindingSymbol = (
   return null;
 };
 
-const getFunctionBindingIdentifier = (functionNode: EsTreeNode): EsTreeNode | null =>
-  isNodeOfType(functionNode, "FunctionDeclaration")
-    ? functionNode.id
-    : isNodeOfType(functionNode.parent, "VariableDeclarator")
-      ? functionNode.parent.id
-      : null;
-
 const doesReferenceControlStructuralRenderedValue = (referenceIdentifier: EsTreeNode): boolean => {
   let currentNode = referenceIdentifier;
   let parentNode = currentNode.parent;
@@ -1309,6 +1590,169 @@ const doesReferenceControlStructuralRenderedValue = (referenceIdentifier: EsTree
   return false;
 };
 
+const isRenderedHydrationConsumer = (
+  node: EsTreeNode,
+  producerHookNode: EsTreeNode,
+  scopes: ScopeAnalysis,
+): boolean => {
+  const renderingComponent = findRenderPhaseComponentOrHook(node, scopes);
+  return Boolean(
+    renderingComponent &&
+    renderingComponent !== producerHookNode &&
+    isInRenderedOutput(node, renderingComponent, scopes) &&
+    !isGatedByFalsyInitialState(node, scopes) &&
+    !isAfterClientOnlyEarlyReturn(node, renderingComponent, scopes) &&
+    (!hasSuppressHydrationWarningAttribute(findEnclosingJsxOpeningElement(node)) ||
+      doesReferenceControlStructuralRenderedValue(node)),
+  );
+};
+
+const doesConsumerExpressionReachRenderedOutput = (
+  node: EsTreeNode,
+  producerHookNode: EsTreeNode,
+  scopes: ScopeAnalysis,
+  visitedSymbolIds: Set<number>,
+): boolean => {
+  if (isRenderedHydrationConsumer(node, producerHookNode, scopes)) return true;
+  const parentNode = node.parent;
+  if (
+    !isNodeOfType(parentNode, "VariableDeclarator") ||
+    parentNode.init !== node ||
+    !isNodeOfType(parentNode.id, "Identifier")
+  ) {
+    return false;
+  }
+  const aliasSymbol = scopes.symbolFor(parentNode.id);
+  if (!aliasSymbol || visitedSymbolIds.has(aliasSymbol.id)) return false;
+  visitedSymbolIds.add(aliasSymbol.id);
+  const doesReachRenderedOutput = aliasSymbol.references.some((reference) =>
+    doesConsumerExpressionReachRenderedOutput(
+      reference.identifier,
+      producerHookNode,
+      scopes,
+      visitedSymbolIds,
+    ),
+  );
+  visitedSymbolIds.delete(aliasSymbol.id);
+  return doesReachRenderedOutput;
+};
+
+const doesConsumerBindingReachRenderedOutput = (
+  bindingIdentifier: EsTreeNode,
+  producerHookNode: EsTreeNode,
+  scopes: ScopeAnalysis,
+): boolean => {
+  if (!isNodeOfType(bindingIdentifier, "Identifier")) return false;
+  const consumerSymbol = scopes.symbolFor(bindingIdentifier);
+  if (!consumerSymbol) return false;
+  return consumerSymbol.references.some((reference) =>
+    doesConsumerExpressionReachRenderedOutput(
+      reference.identifier,
+      producerHookNode,
+      scopes,
+      new Set([consumerSymbol.id]),
+    ),
+  );
+};
+
+const getReturnedStatePaths = (
+  returnedValue: EsTreeNode,
+  stateSymbol: SymbolDescriptor,
+  scopes: ScopeAnalysis,
+): ReadonlyArray<ReturnedStatePath> => {
+  const unwrappedValue = stripParenExpression(returnedValue);
+  if (isNodeOfType(unwrappedValue, "ObjectExpression")) {
+    return unwrappedValue.properties.flatMap((property) => {
+      if (
+        !isNodeOfType(property, "Property") ||
+        property.kind !== "init" ||
+        !doesNodeReadSymbol(property.value, stateSymbol)
+      ) {
+        return [];
+      }
+      const propertyName = getResolvedStaticPropertyName(property, scopes);
+      return propertyName === null ? [] : [{ kind: "property", key: propertyName }];
+    });
+  }
+  if (isNodeOfType(unwrappedValue, "ArrayExpression")) {
+    return (unwrappedValue.elements ?? []).flatMap((element, index) =>
+      element && isAstNode(element) && doesNodeReadSymbol(element, stateSymbol)
+        ? [{ kind: "index", key: String(index) }]
+        : [],
+    );
+  }
+  return doesNodeReadSymbol(unwrappedValue, stateSymbol) ? [{ kind: "direct", key: null }] : [];
+};
+
+const doesCallResultPathReachRenderedOutput = (
+  callExpression: EsTreeNode,
+  returnedStatePath: ReturnedStatePath,
+  producerHookNode: EsTreeNode,
+  scopes: ScopeAnalysis,
+): boolean => {
+  const callParent = callExpression.parent;
+  if (returnedStatePath.kind === "direct") {
+    return doesConsumerExpressionReachRenderedOutput(
+      callExpression,
+      producerHookNode,
+      scopes,
+      new Set(),
+    );
+  }
+  if (
+    isNodeOfType(callParent, "MemberExpression") &&
+    callParent.object === callExpression &&
+    getResolvedStaticPropertyName(callParent, scopes, {
+      allowConstNumericLiteral: true,
+      stringifyNonStringLiterals: true,
+    }) === returnedStatePath.key
+  ) {
+    return doesConsumerExpressionReachRenderedOutput(
+      callParent,
+      producerHookNode,
+      scopes,
+      new Set(),
+    );
+  }
+  if (!isNodeOfType(callParent, "VariableDeclarator") || callParent.init !== callExpression) {
+    return false;
+  }
+  if (returnedStatePath.kind === "property" && isNodeOfType(callParent.id, "ObjectPattern")) {
+    return callParent.id.properties.some(
+      (property) =>
+        isNodeOfType(property, "Property") &&
+        getResolvedStaticPropertyName(property, scopes) === returnedStatePath.key &&
+        doesConsumerBindingReachRenderedOutput(property.value, producerHookNode, scopes),
+    );
+  }
+  if (returnedStatePath.kind === "index" && isNodeOfType(callParent.id, "ArrayPattern")) {
+    const element = callParent.id.elements?.[Number(returnedStatePath.key)];
+    return Boolean(
+      element && doesConsumerBindingReachRenderedOutput(element, producerHookNode, scopes),
+    );
+  }
+  if (!isNodeOfType(callParent.id, "Identifier")) return false;
+  const resultSymbol = scopes.symbolFor(callParent.id);
+  if (!resultSymbol) return false;
+  return resultSymbol.references.some((reference) => {
+    const memberExpression = reference.identifier.parent;
+    return Boolean(
+      isNodeOfType(memberExpression, "MemberExpression") &&
+      memberExpression.object === reference.identifier &&
+      getResolvedStaticPropertyName(memberExpression, scopes, {
+        allowConstNumericLiteral: true,
+        stringifyNonStringLiterals: true,
+      }) === returnedStatePath.key &&
+      doesConsumerExpressionReachRenderedOutput(
+        memberExpression,
+        producerHookNode,
+        scopes,
+        new Set([resultSymbol.id]),
+      ),
+    );
+  });
+};
+
 const isReturnedUseStateInitializerRendered = (
   node: EsTreeNode,
   componentOrHookNode: EsTreeNode,
@@ -1320,73 +1764,29 @@ const isReturnedUseStateInitializerRendered = (
   const returnedValues = isNodeOfType(componentOrHookNode.body, "BlockStatement")
     ? getReturnedValues(componentOrHookNode.body)
     : [componentOrHookNode.body];
-  const returnedPropertyNames = new Set<string>();
-  for (const returnedValue of returnedValues) {
-    const unwrappedValue = stripParenExpression(returnedValue);
-    if (!isNodeOfType(unwrappedValue, "ObjectExpression")) continue;
-    for (const property of unwrappedValue.properties) {
-      if (
-        isNodeOfType(property, "Property") &&
-        property.kind === "init" &&
-        doesNodeReadSymbol(property.value, stateSymbol)
-      ) {
-        const propertyName = getResolvedStaticPropertyName(property, scopes);
-        if (propertyName !== null) returnedPropertyNames.add(propertyName);
-      }
-    }
-  }
-  if (returnedPropertyNames.size === 0) return false;
-  const functionBinding = getFunctionBindingIdentifier(componentOrHookNode);
+  const returnedStatePaths = returnedValues.flatMap((returnedValue) =>
+    getReturnedStatePaths(returnedValue, stateSymbol, scopes),
+  );
+  if (returnedStatePaths.length === 0) return false;
+  const functionBinding = getDirectFunctionBindingIdentifier(componentOrHookNode);
   if (!isNodeOfType(functionBinding, "Identifier")) return false;
   const functionSymbol = scopes.symbolFor(functionBinding);
   if (!functionSymbol) return false;
-  for (const functionReference of functionSymbol.references) {
+  return functionSymbol.references.some((functionReference) => {
     const callExpression = functionReference.identifier.parent;
-    if (
-      !isNodeOfType(callExpression, "CallExpression") ||
-      callExpression.callee !== functionReference.identifier ||
-      !isNodeOfType(callExpression.parent, "VariableDeclarator") ||
-      !isNodeOfType(callExpression.parent.id, "ObjectPattern")
-    ) {
-      continue;
-    }
-    for (const property of callExpression.parent.id.properties) {
-      if (
-        !isNodeOfType(property, "Property") ||
-        !returnedPropertyNames.has(getResolvedStaticPropertyName(property, scopes) ?? "") ||
-        !isNodeOfType(property.value, "Identifier")
-      ) {
-        continue;
-      }
-      const consumerSymbol = scopes.symbolFor(property.value);
-      if (
-        consumerSymbol?.references.some((consumerReference) => {
-          const renderingComponent = findRenderPhaseComponentOrHook(
-            consumerReference.identifier,
-            scopes,
-          );
-          return Boolean(
-            renderingComponent &&
-            renderingComponent !== componentOrHookNode &&
-            isInRenderedOutput(consumerReference.identifier, renderingComponent, scopes) &&
-            !isGatedByFalsyInitialState(consumerReference.identifier, scopes) &&
-            !isAfterClientOnlyEarlyReturn(
-              consumerReference.identifier,
-              renderingComponent,
-              scopes,
-            ) &&
-            (!hasSuppressHydrationWarningAttribute(
-              findEnclosingJsxOpeningElement(consumerReference.identifier),
-            ) ||
-              doesReferenceControlStructuralRenderedValue(consumerReference.identifier)),
-          );
-        })
-      ) {
-        return true;
-      }
-    }
-  }
-  return false;
+    return Boolean(
+      isNodeOfType(callExpression, "CallExpression") &&
+      callExpression.callee === functionReference.identifier &&
+      returnedStatePaths.some((returnedStatePath) =>
+        doesCallResultPathReachRenderedOutput(
+          callExpression,
+          returnedStatePath,
+          componentOrHookNode,
+          scopes,
+        ),
+      ),
+    );
+  });
 };
 
 const findFollowingReturnedValues = (
@@ -1536,6 +1936,12 @@ export const noHydrationBranchOnBrowserGlobal = defineRule({
           ? findComponentRenderingLocalFunctionResult(enclosingFunction, context.scopes)
           : null);
       if (!componentOrHookNode) return;
+      const hasRenderedLocalFunctionConsumer = Boolean(
+        enclosingFunction &&
+        enclosingFunction !== componentOrHookNode &&
+        findComponentRenderingLocalFunctionResult(enclosingFunction, context.scopes) ===
+          componentOrHookNode,
+      );
       if (
         !hasClientRenderEvidence(componentOrHookNode, fileHasUseClientDirective) &&
         !fileHasExplicitReactRuntimeReference
@@ -1544,7 +1950,8 @@ export const noHydrationBranchOnBrowserGlobal = defineRule({
       }
       if (
         requiresRenderedContext &&
-        !isInRenderedOutput(conditionNode, componentOrHookNode, context.scopes)
+        !isInRenderedOutput(conditionNode, componentOrHookNode, context.scopes) &&
+        !hasRenderedLocalFunctionConsumer
       )
         return;
       if (

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-hydration-branch-on-browser-global.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-hydration-branch-on-browser-global.ts
@@ -19,6 +19,7 @@ import { getNodeStartIndex } from "../../utils/get-node-start-index.js";
 import { getResolvedStaticPropertyName } from "../../utils/get-resolved-static-property-name.js";
 import { isEventHandlerAttribute } from "../../utils/is-event-handler-attribute.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { isNodeReachableWithinFunction } from "../../utils/is-node-reachable-within-function.js";
 import { isReactApiCall } from "../../utils/is-react-api-call.js";
 import { classifyReactNativeFileTarget } from "../../utils/is-react-native-file.js";
 import { isTestlikeFilename } from "../../utils/is-testlike-filename.js";
@@ -124,8 +125,10 @@ const getAssignedValue = (identifier: EsTreeNode): EsTreeNode | null => {
 const doesGuardPreserveInitialSymbolValue = (
   symbol: SymbolDescriptor,
   guardingIfStatement: EsTreeNodeOfType<"IfStatement">,
+  scopes: ScopeAnalysis,
 ): boolean => {
-  if (!symbol.initializer) return false;
+  const initialValue = symbol.initializer;
+  if (!initialValue) return false;
   const guardedWrites = symbol.references.filter(
     (reference) =>
       reference.flag !== "read" && isDescendantOf(reference.identifier, guardingIfStatement),
@@ -135,7 +138,9 @@ const doesGuardPreserveInitialSymbolValue = (
     guardedWrites.every((reference) => {
       const assignedValue = getAssignedValue(reference.identifier);
       return Boolean(
-        assignedValue && areExpressionsStructurallyEqual(symbol.initializer, assignedValue),
+        assignedValue &&
+        areExpressionsStructurallyEqual(initialValue, assignedValue) &&
+        doEquivalentExpressionBindingsMatch(initialValue, assignedValue, scopes),
       );
     })
   );
@@ -146,12 +151,15 @@ const isWriteOverwrittenBefore = (
   writeIdentifier: EsTreeNode,
   guardingIfStatement: EsTreeNodeOfType<"IfStatement">,
   readIdentifier: EsTreeNode,
+  context: RuleContext,
 ): boolean =>
   symbol.references.some(
     (reference) =>
       reference.flag !== "read" &&
       reference.identifier !== writeIdentifier &&
       !isDescendantOf(reference.identifier, guardingIfStatement) &&
+      isNodeReachableWithinFunction(reference.identifier, context) &&
+      context.cfg.isUnconditionalFromEntry(reference.identifier) &&
       getNodeStartIndex(reference.identifier) > getNodeStartIndex(writeIdentifier) &&
       getNodeStartIndex(reference.identifier) < getNodeStartIndex(readIdentifier),
   );
@@ -649,23 +657,33 @@ const doEquivalentExpressionBindingsMatch = (
     const rightSymbol = scopes.symbolFor(right);
     return leftSymbol || rightSymbol ? leftSymbol?.id === rightSymbol?.id : true;
   }
-  if (isNodeOfType(left, "MemberExpression") && isNodeOfType(right, "MemberExpression")) {
-    return (
-      doEquivalentExpressionBindingsMatch(left.object, right.object, scopes) &&
-      (!left.computed || doEquivalentExpressionBindingsMatch(left.property, right.property, scopes))
-    );
-  }
-  if (isNodeOfType(left, "CallExpression") && isNodeOfType(right, "CallExpression")) {
-    const rightArguments = right.arguments ?? [];
-    return (
-      doEquivalentExpressionBindingsMatch(left.callee, right.callee, scopes) &&
-      (left.arguments ?? []).every((argument, index) => {
-        const rightArgument = rightArguments[index];
-        return Boolean(
-          rightArgument && doEquivalentExpressionBindingsMatch(argument, rightArgument, scopes),
-        );
-      })
-    );
+  const rightEntries = new Map(Object.entries(right));
+  for (const [key, leftValue] of Object.entries(left)) {
+    if (key === "parent") continue;
+    const rightValue = rightEntries.get(key);
+    if (isAstNode(leftValue)) {
+      if (
+        !isAstNode(rightValue) ||
+        !doEquivalentExpressionBindingsMatch(leftValue, rightValue, scopes)
+      ) {
+        return false;
+      }
+      continue;
+    }
+    if (!Array.isArray(leftValue)) continue;
+    if (!Array.isArray(rightValue)) return false;
+    const leftNodes = leftValue.filter(isAstNode);
+    const rightNodes = rightValue.filter(isAstNode);
+    if (
+      leftNodes.length !== rightNodes.length ||
+      leftNodes.some(
+        (leftNode, index) =>
+          !rightNodes[index] ||
+          !doEquivalentExpressionBindingsMatch(leftNode, rightNodes[index], scopes),
+      )
+    ) {
+      return false;
+    }
   }
   return true;
 };
@@ -733,6 +751,7 @@ const matchHydrationConditionInternal = (
       }
       for (const reference of symbol.references) {
         if (reference.flag === "read") continue;
+        if (!isNodeReachableWithinFunction(reference.identifier, context)) continue;
         const enclosingFunction = findEnclosingFunction(reference.identifier);
         if (!enclosingFunction) continue;
         for (const guardingIfStatement of findGuardingIfStatements(
@@ -740,12 +759,13 @@ const matchHydrationConditionInternal = (
           enclosingFunction,
         )) {
           if (
-            doesGuardPreserveInitialSymbolValue(symbol, guardingIfStatement) ||
+            doesGuardPreserveInitialSymbolValue(symbol, guardingIfStatement, context.scopes) ||
             isWriteOverwrittenBefore(
               symbol,
               reference.identifier,
               guardingIfStatement,
               unwrappedExpression,
+              context,
             )
           ) {
             continue;
@@ -856,9 +876,9 @@ const matchHydrationConditionInternal = (
     ) {
       return null;
     }
-    const nestedMatch =
-      matchHydrationConditionInternal(unwrappedExpression.left, context, state) ??
-      matchHydrationConditionInternal(unwrappedExpression.right, context, state);
+    const leftMatch = matchHydrationConditionInternal(unwrappedExpression.left, context, state);
+    const rightMatch = matchHydrationConditionInternal(unwrappedExpression.right, context, state);
+    const nestedMatch = leftMatch ?? rightMatch;
     if (!nestedMatch) return null;
     const clientResult = readHydrationConditionResult(
       unwrappedExpression,
@@ -872,9 +892,10 @@ const matchHydrationConditionInternal = (
       "server",
       state,
     );
-    return clientResult !== null && serverResult !== null && clientResult === serverResult
-      ? null
-      : nestedMatch;
+    if (clientResult !== null && serverResult !== null) {
+      return clientResult !== serverResult ? nestedMatch : null;
+    }
+    return Boolean(leftMatch) === Boolean(rightMatch) ? null : nestedMatch;
   }
   if (
     !isNodeOfType(unwrappedExpression, "LogicalExpression") ||
@@ -985,18 +1006,24 @@ const matchHydrationCondition = (
 const areNodeArraysEquivalent = (
   leftNodes: ReadonlyArray<EsTreeNode>,
   rightNodes: ReadonlyArray<EsTreeNode>,
+  scopes: ScopeAnalysis,
 ): boolean =>
   leftNodes.length === rightNodes.length &&
-  leftNodes.every((leftNode, index) => areRenderedBranchesEquivalent(leftNode, rightNodes[index]));
+  leftNodes.every((leftNode, index) =>
+    areRenderedBranchesEquivalent(leftNode, rightNodes[index], scopes),
+  );
 
 const areRenderedBranchesEquivalent = (
   leftNode: EsTreeNode | null | undefined,
   rightNode: EsTreeNode | null | undefined,
+  scopes: ScopeAnalysis,
 ): boolean => {
   if (!leftNode || !rightNode) return leftNode === rightNode;
   const left = stripParenExpression(leftNode);
   const right = stripParenExpression(rightNode);
-  if (areExpressionsStructurallyEqual(left, right)) return true;
+  if (areExpressionsStructurallyEqual(left, right)) {
+    return doEquivalentExpressionBindingsMatch(left, right, scopes);
+  }
   if (left.type !== right.type) return false;
   if (isNodeOfType(left, "JSXText") && isNodeOfType(right, "JSXText")) {
     return left.value === right.value;
@@ -1008,26 +1035,32 @@ const areRenderedBranchesEquivalent = (
     if (!isAstNode(left.expression) || !isAstNode(right.expression)) {
       return left.expression.type === right.expression.type;
     }
-    return areRenderedBranchesEquivalent(left.expression, right.expression);
+    return areRenderedBranchesEquivalent(left.expression, right.expression, scopes);
   }
   if (isNodeOfType(left, "JSXElement") && isNodeOfType(right, "JSXElement")) {
     if (flattenJsxName(left.openingElement.name) !== flattenJsxName(right.openingElement.name)) {
       return false;
     }
-    if (!areNodeArraysEquivalent(left.openingElement.attributes, right.openingElement.attributes)) {
+    if (
+      !areNodeArraysEquivalent(
+        left.openingElement.attributes,
+        right.openingElement.attributes,
+        scopes,
+      )
+    ) {
       return false;
     }
-    return areNodeArraysEquivalent(left.children, right.children);
+    return areNodeArraysEquivalent(left.children, right.children, scopes);
   }
   if (isNodeOfType(left, "JSXFragment") && isNodeOfType(right, "JSXFragment")) {
-    return areNodeArraysEquivalent(left.children, right.children);
+    return areNodeArraysEquivalent(left.children, right.children, scopes);
   }
   if (isNodeOfType(left, "JSXAttribute") && isNodeOfType(right, "JSXAttribute")) {
     if (flattenJsxName(left.name) !== flattenJsxName(right.name)) return false;
-    return areRenderedBranchesEquivalent(left.value, right.value);
+    return areRenderedBranchesEquivalent(left.value, right.value, scopes);
   }
   if (isNodeOfType(left, "JSXSpreadAttribute") && isNodeOfType(right, "JSXSpreadAttribute")) {
-    return areRenderedBranchesEquivalent(left.argument, right.argument);
+    return areRenderedBranchesEquivalent(left.argument, right.argument, scopes);
   }
   if (isNodeOfType(left, "TemplateLiteral") && isNodeOfType(right, "TemplateLiteral")) {
     if (left.quasis.length !== right.quasis.length) return false;
@@ -1040,7 +1073,7 @@ const areRenderedBranchesEquivalent = (
     ) {
       return false;
     }
-    return areNodeArraysEquivalent(left.expressions, right.expressions);
+    return areNodeArraysEquivalent(left.expressions, right.expressions, scopes);
   }
   return false;
 };
@@ -1248,6 +1281,34 @@ const getFunctionBindingIdentifier = (functionNode: EsTreeNode): EsTreeNode | nu
       ? functionNode.parent.id
       : null;
 
+const doesReferenceControlStructuralRenderedValue = (referenceIdentifier: EsTreeNode): boolean => {
+  let currentNode = referenceIdentifier;
+  let parentNode = currentNode.parent;
+  while (parentNode) {
+    if (
+      isNodeOfType(parentNode, "ConditionalExpression") &&
+      parentNode.test === currentNode &&
+      (isStructuralRenderedValue(parentNode.consequent) ||
+        isStructuralRenderedValue(parentNode.alternate))
+    ) {
+      return true;
+    }
+    if (
+      isNodeOfType(parentNode, "LogicalExpression") &&
+      parentNode.left === currentNode &&
+      isStructuralRenderedValue(parentNode.right)
+    ) {
+      return true;
+    }
+    if (isNodeOfType(parentNode, "JSXExpressionContainer") || isFunctionLike(parentNode)) {
+      return false;
+    }
+    currentNode = parentNode;
+    parentNode = currentNode.parent;
+  }
+  return false;
+};
+
 const isReturnedUseStateInitializerRendered = (
   node: EsTreeNode,
   componentOrHookNode: EsTreeNode,
@@ -1307,7 +1368,17 @@ const isReturnedUseStateInitializerRendered = (
           return Boolean(
             renderingComponent &&
             renderingComponent !== componentOrHookNode &&
-            isInRenderedOutput(consumerReference.identifier, renderingComponent, scopes),
+            isInRenderedOutput(consumerReference.identifier, renderingComponent, scopes) &&
+            !isGatedByFalsyInitialState(consumerReference.identifier, scopes) &&
+            !isAfterClientOnlyEarlyReturn(
+              consumerReference.identifier,
+              renderingComponent,
+              scopes,
+            ) &&
+            (!hasSuppressHydrationWarningAttribute(
+              findEnclosingJsxOpeningElement(consumerReference.identifier),
+            ) ||
+              doesReferenceControlStructuralRenderedValue(consumerReference.identifier)),
           );
         })
       ) {
@@ -1336,29 +1407,32 @@ const findFollowingReturnedValues = (
 const areConditionExpressionsEquivalent = (
   leftExpression: EsTreeNode,
   rightExpression: EsTreeNode,
+  scopes: ScopeAnalysis,
 ): boolean => {
   const left = stripParenExpression(leftExpression);
   const right = stripParenExpression(rightExpression);
-  if (areExpressionsStructurallyEqual(left, right)) return true;
+  if (areExpressionsStructurallyEqual(left, right)) {
+    return doEquivalentExpressionBindingsMatch(left, right, scopes);
+  }
   if (left.type !== right.type) return false;
   if (isNodeOfType(left, "UnaryExpression") && isNodeOfType(right, "UnaryExpression")) {
     return (
       left.operator === right.operator &&
-      areConditionExpressionsEquivalent(left.argument, right.argument)
+      areConditionExpressionsEquivalent(left.argument, right.argument, scopes)
     );
   }
   if (isNodeOfType(left, "LogicalExpression") && isNodeOfType(right, "LogicalExpression")) {
     return (
       left.operator === right.operator &&
-      areConditionExpressionsEquivalent(left.left, right.left) &&
-      areConditionExpressionsEquivalent(left.right, right.right)
+      areConditionExpressionsEquivalent(left.left, right.left, scopes) &&
+      areConditionExpressionsEquivalent(left.right, right.right, scopes)
     );
   }
   if (isNodeOfType(left, "BinaryExpression") && isNodeOfType(right, "BinaryExpression")) {
     return (
       left.operator === right.operator &&
-      areConditionExpressionsEquivalent(left.left, right.left) &&
-      areConditionExpressionsEquivalent(left.right, right.right)
+      areConditionExpressionsEquivalent(left.left, right.left, scopes) &&
+      areConditionExpressionsEquivalent(left.right, right.right, scopes)
     );
   }
   return false;
@@ -1367,19 +1441,20 @@ const areConditionExpressionsEquivalent = (
 const areReturnTreesEquivalent = (
   leftStatement: EsTreeNode | null | undefined,
   rightStatement: EsTreeNode | null | undefined,
+  scopes: ScopeAnalysis,
 ): boolean => {
   if (!leftStatement || !rightStatement) return leftStatement === rightStatement;
   if (
     isNodeOfType(leftStatement, "ReturnStatement") &&
     isNodeOfType(rightStatement, "ReturnStatement")
   ) {
-    return areRenderedBranchesEquivalent(leftStatement.argument, rightStatement.argument);
+    return areRenderedBranchesEquivalent(leftStatement.argument, rightStatement.argument, scopes);
   }
   if (isNodeOfType(leftStatement, "IfStatement") && isNodeOfType(rightStatement, "IfStatement")) {
     return (
-      areConditionExpressionsEquivalent(leftStatement.test, rightStatement.test) &&
-      areReturnTreesEquivalent(leftStatement.consequent, rightStatement.consequent) &&
-      areReturnTreesEquivalent(leftStatement.alternate, rightStatement.alternate)
+      areConditionExpressionsEquivalent(leftStatement.test, rightStatement.test, scopes) &&
+      areReturnTreesEquivalent(leftStatement.consequent, rightStatement.consequent, scopes) &&
+      areReturnTreesEquivalent(leftStatement.alternate, rightStatement.alternate, scopes)
     );
   }
   if (
@@ -1397,7 +1472,7 @@ const areReturnTreesEquivalent = (
   return (
     leftReturningStatements.length === rightReturningStatements.length &&
     leftReturningStatements.every((statement, index) =>
-      areReturnTreesEquivalent(statement, rightReturningStatements[index]),
+      areReturnTreesEquivalent(statement, rightReturningStatements[index], scopes),
     )
   );
 };
@@ -1451,7 +1526,9 @@ export const noHydrationBranchOnBrowserGlobal = defineRule({
       if (!conditionMatch) return;
       const { predicateMatch, predicateNode } = conditionMatch;
       if (reportedNodes.has(predicateNode)) return;
-      if (rightBranch && areRenderedBranchesEquivalent(leftBranch, rightBranch)) return;
+      if (rightBranch && areRenderedBranchesEquivalent(leftBranch, rightBranch, context.scopes)) {
+        return;
+      }
       const enclosingFunction = findEnclosingFunction(conditionNode);
       const componentOrHookNode =
         findRenderPhaseComponentOrHook(conditionNode, context.scopes) ??
@@ -1537,7 +1614,12 @@ export const noHydrationBranchOnBrowserGlobal = defineRule({
         reportHydrationBranch(node, renderedValue, null, true);
       },
       IfStatement(node: EsTreeNodeOfType<"IfStatement">) {
-        if (node.alternate && areReturnTreesEquivalent(node.consequent, node.alternate)) return;
+        if (
+          node.alternate &&
+          areReturnTreesEquivalent(node.consequent, node.alternate, context.scopes)
+        ) {
+          return;
+        }
         const consequentValues = getReturnedValues(node.consequent);
         const alternateValues = node.alternate
           ? getReturnedValues(node.alternate)

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-hydration-branch-on-browser-global.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-hydration-branch-on-browser-global.ts
@@ -16,6 +16,7 @@ import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isGatedByFalsyInitialState } from "../../utils/is-gated-by-falsy-initial-state.js";
 import { isGeneratedImageRenderContext } from "../../utils/is-generated-image-render-context.js";
 import { getNodeStartIndex } from "../../utils/get-node-start-index.js";
+import { getResolvedStaticPropertyName } from "../../utils/get-resolved-static-property-name.js";
 import { isEventHandlerAttribute } from "../../utils/is-event-handler-attribute.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isReactApiCall } from "../../utils/is-react-api-call.js";
@@ -930,7 +931,7 @@ const findRenderedValueInAndBranch = (
   scopes: ScopeAnalysis,
 ): EsTreeNode | null => {
   const unwrappedNode = stripParenExpression(node);
-  if (isRenderedValue(unwrappedNode, scopes)) return unwrappedNode;
+  if (isPotentiallyRenderedValue(unwrappedNode, scopes)) return unwrappedNode;
   if (!isNodeOfType(unwrappedNode, "LogicalExpression") || unwrappedNode.operator !== "&&") {
     return null;
   }
@@ -983,47 +984,6 @@ const isInRenderedOutput = (
   return false;
 };
 
-const isReturnedUseStateInitializer = (
-  node: EsTreeNode,
-  componentOrHookNode: EsTreeNode,
-  scopes: ScopeAnalysis,
-): boolean => {
-  let currentNode = node.parent;
-  while (currentNode && currentNode !== componentOrHookNode) {
-    if (
-      isNodeOfType(currentNode, "CallExpression") &&
-      isReactApiCall(currentNode, "useState", scopes, {
-        allowGlobalReactNamespace: true,
-        resolveNamedAliases: true,
-      }) &&
-      isNodeOfType(currentNode.parent, "VariableDeclarator") &&
-      isNodeOfType(currentNode.parent.id, "ArrayPattern")
-    ) {
-      const stateBinding = currentNode.parent.id.elements?.[0];
-      if (!isNodeOfType(stateBinding, "Identifier")) return false;
-      const stateSymbol = scopes.symbolFor(stateBinding);
-      if (!stateSymbol) return false;
-      return stateSymbol.references.some((reference) => {
-        let referenceParent = reference.identifier.parent;
-        while (referenceParent && referenceParent !== componentOrHookNode) {
-          if (
-            isNodeOfType(referenceParent, "ReturnStatement") &&
-            findEnclosingFunction(referenceParent) === componentOrHookNode
-          ) {
-            return true;
-          }
-          if (isFunctionLike(referenceParent)) return false;
-          referenceParent = referenceParent.parent;
-        }
-        return false;
-      });
-    }
-    if (isFunctionLike(currentNode)) return false;
-    currentNode = currentNode.parent;
-  }
-  return false;
-};
-
 const getReturnedValues = (statement: EsTreeNode | null | undefined): ReadonlyArray<EsTreeNode> => {
   if (!statement) return [];
   if (isNodeOfType(statement, "ReturnStatement")) {
@@ -1046,6 +1006,143 @@ const getReturnedValues = (statement: EsTreeNode | null | undefined): ReadonlyAr
     if (statementAlwaysExits(childStatement)) break;
   }
   return returnedValues;
+};
+
+const isPotentiallyRenderedValueInternal = (
+  node: EsTreeNode,
+  scopes: ScopeAnalysis,
+  visitedFunctionNodes: Set<EsTreeNode>,
+): boolean => {
+  const unwrappedNode = stripParenExpression(node);
+  if (isRenderedValue(unwrappedNode, scopes)) return true;
+  if (isNodeOfType(unwrappedNode, "ConditionalExpression")) {
+    return (
+      isPotentiallyRenderedValueInternal(unwrappedNode.consequent, scopes, visitedFunctionNodes) &&
+      isPotentiallyRenderedValueInternal(unwrappedNode.alternate, scopes, visitedFunctionNodes)
+    );
+  }
+  if (isNodeOfType(unwrappedNode, "LogicalExpression")) {
+    return isPotentiallyRenderedValueInternal(unwrappedNode.right, scopes, visitedFunctionNodes);
+  }
+  if (!isNodeOfType(unwrappedNode, "CallExpression")) return false;
+  const calledFunction = resolveExactLocalFunction(unwrappedNode.callee, scopes);
+  if (!isFunctionLike(calledFunction) || visitedFunctionNodes.has(calledFunction)) return false;
+  visitedFunctionNodes.add(calledFunction);
+  const returnedValues = isNodeOfType(calledFunction.body, "BlockStatement")
+    ? getReturnedValues(calledFunction.body)
+    : [calledFunction.body];
+  const isPotentiallyRendered =
+    returnedValues.length > 0 &&
+    returnedValues.every((returnedValue) =>
+      isPotentiallyRenderedValueInternal(returnedValue, scopes, visitedFunctionNodes),
+    );
+  visitedFunctionNodes.delete(calledFunction);
+  return isPotentiallyRendered;
+};
+
+const isPotentiallyRenderedValue = (node: EsTreeNode, scopes: ScopeAnalysis): boolean =>
+  isPotentiallyRenderedValueInternal(node, scopes, new Set());
+
+const findUseStateBindingSymbol = (
+  node: EsTreeNode,
+  componentOrHookNode: EsTreeNode,
+  scopes: ScopeAnalysis,
+): SymbolDescriptor | null => {
+  let currentNode = node.parent;
+  while (currentNode && currentNode !== componentOrHookNode) {
+    if (
+      isNodeOfType(currentNode, "CallExpression") &&
+      isReactApiCall(currentNode, "useState", scopes, {
+        allowGlobalReactNamespace: true,
+        resolveNamedAliases: true,
+      }) &&
+      isNodeOfType(currentNode.parent, "VariableDeclarator") &&
+      isNodeOfType(currentNode.parent.id, "ArrayPattern")
+    ) {
+      const stateBinding = currentNode.parent.id.elements?.[0];
+      return isNodeOfType(stateBinding, "Identifier") ? scopes.symbolFor(stateBinding) : null;
+    }
+    if (isFunctionLike(currentNode)) return null;
+    currentNode = currentNode.parent;
+  }
+  return null;
+};
+
+const getFunctionBindingIdentifier = (functionNode: EsTreeNode): EsTreeNode | null =>
+  isNodeOfType(functionNode, "FunctionDeclaration")
+    ? functionNode.id
+    : isNodeOfType(functionNode.parent, "VariableDeclarator")
+      ? functionNode.parent.id
+      : null;
+
+const isReturnedUseStateInitializerRendered = (
+  node: EsTreeNode,
+  componentOrHookNode: EsTreeNode,
+  scopes: ScopeAnalysis,
+): boolean => {
+  if (!isFunctionLike(componentOrHookNode)) return false;
+  const stateSymbol = findUseStateBindingSymbol(node, componentOrHookNode, scopes);
+  if (!stateSymbol) return false;
+  const returnedValues = isNodeOfType(componentOrHookNode.body, "BlockStatement")
+    ? getReturnedValues(componentOrHookNode.body)
+    : [componentOrHookNode.body];
+  const returnedPropertyNames = new Set<string>();
+  for (const returnedValue of returnedValues) {
+    const unwrappedValue = stripParenExpression(returnedValue);
+    if (!isNodeOfType(unwrappedValue, "ObjectExpression")) continue;
+    for (const property of unwrappedValue.properties) {
+      if (
+        isNodeOfType(property, "Property") &&
+        property.kind === "init" &&
+        doesNodeReadSymbol(property.value, stateSymbol)
+      ) {
+        const propertyName = getResolvedStaticPropertyName(property, scopes);
+        if (propertyName !== null) returnedPropertyNames.add(propertyName);
+      }
+    }
+  }
+  if (returnedPropertyNames.size === 0) return false;
+  const functionBinding = getFunctionBindingIdentifier(componentOrHookNode);
+  if (!isNodeOfType(functionBinding, "Identifier")) return false;
+  const functionSymbol = scopes.symbolFor(functionBinding);
+  if (!functionSymbol) return false;
+  for (const functionReference of functionSymbol.references) {
+    const callExpression = functionReference.identifier.parent;
+    if (
+      !isNodeOfType(callExpression, "CallExpression") ||
+      callExpression.callee !== functionReference.identifier ||
+      !isNodeOfType(callExpression.parent, "VariableDeclarator") ||
+      !isNodeOfType(callExpression.parent.id, "ObjectPattern")
+    ) {
+      continue;
+    }
+    for (const property of callExpression.parent.id.properties) {
+      if (
+        !isNodeOfType(property, "Property") ||
+        !returnedPropertyNames.has(getResolvedStaticPropertyName(property, scopes) ?? "") ||
+        !isNodeOfType(property.value, "Identifier")
+      ) {
+        continue;
+      }
+      const consumerSymbol = scopes.symbolFor(property.value);
+      if (
+        consumerSymbol?.references.some((consumerReference) => {
+          const renderingComponent = findRenderPhaseComponentOrHook(
+            consumerReference.identifier,
+            scopes,
+          );
+          return Boolean(
+            renderingComponent &&
+            renderingComponent !== componentOrHookNode &&
+            isInRenderedOutput(consumerReference.identifier, renderingComponent, scopes),
+          );
+        })
+      ) {
+        return true;
+      }
+    }
+  }
+  return false;
 };
 
 const findFollowingReturnedValues = (
@@ -1175,7 +1272,7 @@ export const noHydrationBranchOnBrowserGlobal = defineRule({
       leftBranch: EsTreeNode,
       rightBranch: EsTreeNode | null,
       requiresRenderedContext: boolean,
-      allowsReturnedStateInitializer = false,
+      hasProvenRenderedConsumer = false,
     ): void => {
       const conditionMatch = matchHydrationCondition(conditionNode, context);
       if (!conditionMatch) return;
@@ -1201,9 +1298,14 @@ export const noHydrationBranchOnBrowserGlobal = defineRule({
       )
         return;
       if (
-        !allowsReturnedStateInitializer &&
-        !isRenderedValue(leftBranch, context.scopes) &&
-        (!rightBranch || !isRenderedValue(rightBranch, context.scopes))
+        !hasProvenRenderedConsumer &&
+        !(requiresRenderedContext
+          ? isPotentiallyRenderedValue(leftBranch, context.scopes)
+          : isRenderedValue(leftBranch, context.scopes)) &&
+        (!rightBranch ||
+          !(requiresRenderedContext
+            ? isPotentiallyRenderedValue(rightBranch, context.scopes)
+            : isRenderedValue(rightBranch, context.scopes)))
       ) {
         const attribute = findEnclosingJsxAttribute(conditionNode);
         if (!attribute || isEventHandlerAttribute(attribute)) return;
@@ -1245,7 +1347,7 @@ export const noHydrationBranchOnBrowserGlobal = defineRule({
         const componentOrHookNode = findRenderPhaseComponentOrHook(node, context.scopes);
         if (
           componentOrHookNode &&
-          isReturnedUseStateInitializer(node, componentOrHookNode, context.scopes)
+          isReturnedUseStateInitializerRendered(node, componentOrHookNode, context.scopes)
         ) {
           reportHydrationBranch(node.test, node.consequent, node.alternate, false, true);
         }
@@ -1255,7 +1357,7 @@ export const noHydrationBranchOnBrowserGlobal = defineRule({
         const renderedValue =
           node.operator === "&&"
             ? findRenderedValueInAndBranch(node.right, context.scopes)
-            : isRenderedValue(node.right, context.scopes)
+            : isPotentiallyRenderedValue(node.right, context.scopes)
               ? node.right
               : null;
         if (!renderedValue) return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-hydration-branch-on-browser-global.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-hydration-branch-on-browser-global.ts
@@ -400,6 +400,28 @@ const readHydrationConditionResult = (
       parameterValuesBySymbolId,
     });
   }
+  if (isNodeOfType(unwrappedExpression, "BinaryExpression")) {
+    const leftResult = readHydrationConditionResult(
+      unwrappedExpression.left,
+      context,
+      runtime,
+      state,
+    );
+    const rightResult = readHydrationConditionResult(
+      unwrappedExpression.right,
+      context,
+      runtime,
+      state,
+    );
+    if (leftResult === null || rightResult === null) return null;
+    if (unwrappedExpression.operator === "===" || unwrappedExpression.operator === "==") {
+      return leftResult === rightResult;
+    }
+    if (unwrappedExpression.operator === "!==" || unwrappedExpression.operator === "!=") {
+      return leftResult !== rightResult;
+    }
+    return null;
+  }
   if (
     isNodeOfType(unwrappedExpression, "UnaryExpression") &&
     unwrappedExpression.operator === "!"
@@ -698,10 +720,25 @@ const matchHydrationConditionInternal = (
     );
   }
   if (isNodeOfType(unwrappedExpression, "BinaryExpression")) {
-    return (
+    const nestedMatch =
       matchHydrationConditionInternal(unwrappedExpression.left, context, state) ??
-      matchHydrationConditionInternal(unwrappedExpression.right, context, state)
+      matchHydrationConditionInternal(unwrappedExpression.right, context, state);
+    if (!nestedMatch) return null;
+    const clientResult = readHydrationConditionResult(
+      unwrappedExpression,
+      context,
+      "client",
+      state,
     );
+    const serverResult = readHydrationConditionResult(
+      unwrappedExpression,
+      context,
+      "server",
+      state,
+    );
+    return clientResult !== null && serverResult !== null && clientResult === serverResult
+      ? null
+      : nestedMatch;
   }
   if (
     !isNodeOfType(unwrappedExpression, "LogicalExpression") ||

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-hydration-branch-on-browser-global.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-hydration-branch-on-browser-global.ts
@@ -1,4 +1,5 @@
 import { areExpressionsStructurallyEqual } from "../../utils/are-expressions-structurally-equal.js";
+import { REACT_RUNTIME_MODULE_SOURCES } from "../../constants/react.js";
 import { defineRule } from "../../utils/define-rule.js";
 import { executesDuringRender } from "../../utils/executes-during-render.js";
 import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
@@ -14,6 +15,7 @@ import { isAfterClientOnlyEarlyReturn } from "../../utils/is-after-client-only-e
 import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isGatedByFalsyInitialState } from "../../utils/is-gated-by-falsy-initial-state.js";
 import { isGeneratedImageRenderContext } from "../../utils/is-generated-image-render-context.js";
+import { getNodeStartIndex } from "../../utils/get-node-start-index.js";
 import { isEventHandlerAttribute } from "../../utils/is-event-handler-attribute.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isReactApiCall } from "../../utils/is-react-api-call.js";
@@ -23,7 +25,8 @@ import { readInitialStateBoolean } from "../../utils/read-initial-state-boolean.
 import { resolveExactLocalFunction } from "../../utils/resolve-exact-local-function.js";
 import { statementAlwaysExits } from "../../utils/statement-always-exits.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
-import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
+import { walkAst } from "../../utils/walk-ast.js";
+import type { ScopeAnalysis, SymbolDescriptor } from "../../semantic/scope-analysis.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import type { RuleContext } from "../../utils/rule-context.js";
@@ -50,6 +53,163 @@ interface HydrationStatementResult {
   readonly didReturn: boolean;
   readonly value: boolean | null;
 }
+
+const findGuardingIfStatements = (
+  node: EsTreeNode,
+  functionBoundary: EsTreeNode,
+): ReadonlyArray<EsTreeNodeOfType<"IfStatement">> => {
+  const guardingIfStatements: Array<EsTreeNodeOfType<"IfStatement">> = [];
+  let currentNode = node.parent;
+  while (currentNode && currentNode !== functionBoundary) {
+    if (isNodeOfType(currentNode, "IfStatement")) guardingIfStatements.push(currentNode);
+    currentNode = currentNode.parent;
+  }
+  return guardingIfStatements;
+};
+
+const doesNodeReadSymbol = (node: EsTreeNode, symbol: SymbolDescriptor): boolean => {
+  let doesReadSymbol = false;
+  walkAst(node, (childNode) => {
+    if (
+      isNodeOfType(childNode, "Identifier") &&
+      symbol.references.some(
+        (reference) => reference.identifier === childNode && reference.flag !== "write",
+      )
+    ) {
+      doesReadSymbol = true;
+      return false;
+    }
+  });
+  return doesReadSymbol;
+};
+
+const collectWrittenSymbols = (
+  node: EsTreeNode,
+  scopes: ScopeAnalysis,
+): ReadonlySet<SymbolDescriptor> => {
+  const writtenSymbols = new Set<SymbolDescriptor>();
+  walkAst(node, (childNode) => {
+    if (!isNodeOfType(childNode, "Identifier")) return;
+    const reference = scopes.referenceFor(childNode);
+    if (!reference || reference.flag === "read" || !reference.resolvedSymbol) return;
+    writtenSymbols.add(reference.resolvedSymbol);
+  });
+  return writtenSymbols;
+};
+
+const isDescendantOf = (node: EsTreeNode, ancestorNode: EsTreeNode): boolean => {
+  let currentNode = node.parent;
+  while (currentNode) {
+    if (currentNode === ancestorNode) return true;
+    currentNode = currentNode.parent;
+  }
+  return false;
+};
+
+const getAssignedValue = (identifier: EsTreeNode): EsTreeNode | null => {
+  const assignmentExpression = identifier.parent;
+  return isNodeOfType(assignmentExpression, "AssignmentExpression") &&
+    assignmentExpression.operator === "=" &&
+    assignmentExpression.left === identifier
+    ? assignmentExpression.right
+    : null;
+};
+
+const doesGuardPreserveInitialSymbolValue = (
+  symbol: SymbolDescriptor,
+  guardingIfStatement: EsTreeNodeOfType<"IfStatement">,
+): boolean => {
+  if (!symbol.initializer) return false;
+  const guardedWrites = symbol.references.filter(
+    (reference) =>
+      reference.flag !== "read" && isDescendantOf(reference.identifier, guardingIfStatement),
+  );
+  return (
+    guardedWrites.length > 0 &&
+    guardedWrites.every((reference) => {
+      const assignedValue = getAssignedValue(reference.identifier);
+      return Boolean(
+        assignedValue && areExpressionsStructurallyEqual(symbol.initializer, assignedValue),
+      );
+    })
+  );
+};
+
+const isWriteOverwrittenBefore = (
+  symbol: SymbolDescriptor,
+  writeIdentifier: EsTreeNode,
+  guardingIfStatement: EsTreeNodeOfType<"IfStatement">,
+  readIdentifier: EsTreeNode,
+): boolean =>
+  symbol.references.some(
+    (reference) =>
+      reference.flag !== "read" &&
+      reference.identifier !== writeIdentifier &&
+      !isDescendantOf(reference.identifier, guardingIfStatement) &&
+      getNodeStartIndex(reference.identifier) > getNodeStartIndex(writeIdentifier) &&
+      getNodeStartIndex(reference.identifier) < getNodeStartIndex(readIdentifier),
+  );
+
+const containsExplicitReactRuntimeReference = (
+  node: EsTreeNode,
+  scopes: ScopeAnalysis,
+): boolean => {
+  let hasRuntimeReference = false;
+  walkAst(node, (childNode) => {
+    if (
+      isNodeOfType(childNode, "ImportDeclaration") &&
+      typeof childNode.source.value === "string" &&
+      REACT_RUNTIME_MODULE_SOURCES.has(childNode.source.value)
+    ) {
+      hasRuntimeReference = true;
+      return false;
+    }
+    if (!isNodeOfType(childNode, "CallExpression")) return;
+    const callArguments = childNode.arguments ?? [];
+    const sourceArgument = callArguments[0];
+    if (
+      !isNodeOfType(childNode.callee, "Identifier") ||
+      childNode.callee.name !== "require" ||
+      !scopes.isGlobalReference(childNode.callee) ||
+      !isNodeOfType(sourceArgument, "Literal") ||
+      typeof sourceArgument.value !== "string" ||
+      !REACT_RUNTIME_MODULE_SOURCES.has(sourceArgument.value)
+    ) {
+      return;
+    }
+    hasRuntimeReference = true;
+    return false;
+  });
+  return hasRuntimeReference;
+};
+
+const findComponentRenderingLocalFunctionResult = (
+  functionNode: EsTreeNode,
+  scopes: ScopeAnalysis,
+): EsTreeNode | null => {
+  const bindingIdentifier = isNodeOfType(functionNode, "FunctionDeclaration")
+    ? functionNode.id
+    : isNodeOfType(functionNode.parent, "VariableDeclarator")
+      ? functionNode.parent.id
+      : null;
+  if (!isNodeOfType(bindingIdentifier, "Identifier")) return null;
+  const functionSymbol = scopes.symbolFor(bindingIdentifier);
+  if (!functionSymbol) return null;
+  for (const reference of functionSymbol.references) {
+    const callExpression = reference.identifier.parent;
+    if (
+      !isNodeOfType(callExpression, "CallExpression") ||
+      callExpression.callee !== reference.identifier
+    ) {
+      continue;
+    }
+    const componentOrHookNode = findRenderPhaseComponentOrHook(callExpression, scopes);
+    if (componentOrHookNode && isInRenderedOutput(callExpression, componentOrHookNode, scopes)) {
+      return componentOrHookNode;
+    }
+  }
+  return null;
+};
 
 const evaluateEquality = (operator: string, left: string, right: string): boolean | null => {
   if (operator === "===" || operator === "==") return left === right;
@@ -410,6 +570,45 @@ const matchHydrationConditionInternal = (
       return match;
     }
     if (
+      symbol &&
+      (symbol.kind === "let" || symbol.kind === "var") &&
+      !state.visitedSymbolIds.has(symbol.id)
+    ) {
+      state.visitedSymbolIds.add(symbol.id);
+      if (symbol.initializer && symbol.references.every((reference) => reference.flag === "read")) {
+        const match = matchHydrationConditionInternal(symbol.initializer, context, state);
+        state.visitedSymbolIds.delete(symbol.id);
+        return match;
+      }
+      for (const reference of symbol.references) {
+        if (reference.flag === "read") continue;
+        const enclosingFunction = findEnclosingFunction(reference.identifier);
+        if (!enclosingFunction) continue;
+        for (const guardingIfStatement of findGuardingIfStatements(
+          reference.identifier,
+          enclosingFunction,
+        )) {
+          if (
+            doesGuardPreserveInitialSymbolValue(symbol, guardingIfStatement) ||
+            isWriteOverwrittenBefore(
+              symbol,
+              reference.identifier,
+              guardingIfStatement,
+              unwrappedExpression,
+            )
+          ) {
+            continue;
+          }
+          const match = matchHydrationConditionInternal(guardingIfStatement.test, context, state);
+          if (match) {
+            state.visitedSymbolIds.delete(symbol.id);
+            return match;
+          }
+        }
+      }
+      state.visitedSymbolIds.delete(symbol.id);
+    }
+    if (
       !symbol ||
       symbol.kind !== "const" ||
       !symbol.initializer ||
@@ -425,6 +624,19 @@ const matchHydrationConditionInternal = (
   }
   if (isNodeOfType(unwrappedExpression, "CallExpression")) {
     const callArguments = unwrappedExpression.arguments ?? [];
+    if (
+      isReactApiCall(unwrappedExpression, "useState", context.scopes, {
+        allowGlobalReactNamespace: true,
+        resolveNamedAliases: true,
+      })
+    ) {
+      const initialState = callArguments[0];
+      if (!initialState || isNodeOfType(initialState, "SpreadElement")) return null;
+      const lazyInitializer = resolveExactLocalFunction(initialState, context.scopes);
+      return isFunctionLike(lazyInitializer) && lazyInitializer.params.length === 0
+        ? matchHydrationFunctionResult(lazyInitializer, context, state)
+        : matchHydrationConditionInternal(initialState, context, state);
+    }
     if (
       isReactApiCall(unwrappedExpression, "useMemo", context.scopes, {
         allowGlobalReactNamespace: true,
@@ -478,6 +690,18 @@ const matchHydrationConditionInternal = (
   ) {
     return matchHydrationConditionInternal(unwrappedExpression.argument, context, state);
   }
+  if (isNodeOfType(unwrappedExpression, "ConditionalExpression")) {
+    return (
+      matchHydrationConditionInternal(unwrappedExpression.consequent, context, state) ??
+      matchHydrationConditionInternal(unwrappedExpression.alternate, context, state)
+    );
+  }
+  if (isNodeOfType(unwrappedExpression, "BinaryExpression")) {
+    return (
+      matchHydrationConditionInternal(unwrappedExpression.left, context, state) ??
+      matchHydrationConditionInternal(unwrappedExpression.right, context, state)
+    );
+  }
   if (
     !isNodeOfType(unwrappedExpression, "LogicalExpression") ||
     (unwrappedExpression.operator !== "&&" && unwrappedExpression.operator !== "||")
@@ -519,10 +743,35 @@ const matchHydrationReturningStatement = (
     ) {
       return conditionMatch;
     }
+    if (conditionMatch) {
+      const followingReturnedValues = findFollowingReturnedValues(statement);
+      const writtenSymbols = new Set([
+        ...collectWrittenSymbols(statement.consequent, context.scopes),
+        ...(statement.alternate ? collectWrittenSymbols(statement.alternate, context.scopes) : []),
+      ]);
+      if (
+        [...writtenSymbols].some((symbol) =>
+          followingReturnedValues.some((value) => doesNodeReadSymbol(value, symbol)),
+        )
+      ) {
+        return conditionMatch;
+      }
+    }
     return (
       matchHydrationReturningStatement(statement.consequent, context, state) ??
       (statement.alternate
         ? matchHydrationReturningStatement(statement.alternate, context, state)
+        : null)
+    );
+  }
+  if (isNodeOfType(statement, "TryStatement")) {
+    return (
+      matchHydrationReturningStatement(statement.block, context, state) ??
+      (statement.handler
+        ? matchHydrationReturningStatement(statement.handler.body, context, state)
+        : null) ??
+      (statement.finalizer
+        ? matchHydrationReturningStatement(statement.finalizer, context, state)
         : null)
     );
   }
@@ -622,7 +871,43 @@ const areRenderedBranchesEquivalent = (
   return false;
 };
 
-const isRenderedValue = (node: EsTreeNode): boolean => {
+const isProvenReactCreateElementCall = (node: EsTreeNode, scopes: ScopeAnalysis): boolean => {
+  if (
+    isReactApiCall(node, "createElement", scopes, {
+      allowGlobalReactNamespace: true,
+      resolveNamedAliases: true,
+    })
+  ) {
+    return true;
+  }
+  if (!isNodeOfType(node, "CallExpression")) return false;
+  const callee = stripParenExpression(node.callee);
+  if (
+    !isNodeOfType(callee, "MemberExpression") ||
+    callee.computed ||
+    !isNodeOfType(callee.property, "Identifier") ||
+    callee.property.name !== "createElement"
+  ) {
+    return false;
+  }
+  const receiver = stripParenExpression(callee.object);
+  const namespaceIdentifier =
+    isNodeOfType(receiver, "MemberExpression") &&
+    !receiver.computed &&
+    isNodeOfType(receiver.property, "Identifier") &&
+    receiver.property.name === "default"
+      ? stripParenExpression(receiver.object)
+      : receiver;
+  if (!isNodeOfType(namespaceIdentifier, "Identifier")) return false;
+  const namespaceSymbol = scopes.symbolFor(namespaceIdentifier);
+  return Boolean(
+    namespaceSymbol?.initializer &&
+    namespaceSymbol.references.every((reference) => reference.flag === "read") &&
+    containsExplicitReactRuntimeReference(namespaceSymbol.initializer, scopes),
+  );
+};
+
+const isRenderedValue = (node: EsTreeNode, scopes: ScopeAnalysis): boolean => {
   const unwrappedNode = stripParenExpression(node);
   if (isNodeOfType(unwrappedNode, "Literal")) {
     return (
@@ -635,16 +920,21 @@ const isRenderedValue = (node: EsTreeNode): boolean => {
   if (isNodeOfType(unwrappedNode, "TemplateLiteral")) {
     return unwrappedNode.expressions.length > 0 || unwrappedNode.quasis[0]?.value.cooked !== "";
   }
+  if (isNodeOfType(unwrappedNode, "CallExpression"))
+    return isProvenReactCreateElementCall(unwrappedNode, scopes);
   return isNodeOfType(unwrappedNode, "JSXElement") || isNodeOfType(unwrappedNode, "JSXFragment");
 };
 
-const findRenderedValueInAndBranch = (node: EsTreeNode): EsTreeNode | null => {
+const findRenderedValueInAndBranch = (
+  node: EsTreeNode,
+  scopes: ScopeAnalysis,
+): EsTreeNode | null => {
   const unwrappedNode = stripParenExpression(node);
-  if (isRenderedValue(unwrappedNode)) return unwrappedNode;
+  if (isRenderedValue(unwrappedNode, scopes)) return unwrappedNode;
   if (!isNodeOfType(unwrappedNode, "LogicalExpression") || unwrappedNode.operator !== "&&") {
     return null;
   }
-  return findRenderedValueInAndBranch(unwrappedNode.right);
+  return findRenderedValueInAndBranch(unwrappedNode.right, scopes);
 };
 
 const findEnclosingJsxAttribute = (node: EsTreeNode): EsTreeNodeOfType<"JSXAttribute"> | null => {
@@ -693,6 +983,47 @@ const isInRenderedOutput = (
   return false;
 };
 
+const isReturnedUseStateInitializer = (
+  node: EsTreeNode,
+  componentOrHookNode: EsTreeNode,
+  scopes: ScopeAnalysis,
+): boolean => {
+  let currentNode = node.parent;
+  while (currentNode && currentNode !== componentOrHookNode) {
+    if (
+      isNodeOfType(currentNode, "CallExpression") &&
+      isReactApiCall(currentNode, "useState", scopes, {
+        allowGlobalReactNamespace: true,
+        resolveNamedAliases: true,
+      }) &&
+      isNodeOfType(currentNode.parent, "VariableDeclarator") &&
+      isNodeOfType(currentNode.parent.id, "ArrayPattern")
+    ) {
+      const stateBinding = currentNode.parent.id.elements?.[0];
+      if (!isNodeOfType(stateBinding, "Identifier")) return false;
+      const stateSymbol = scopes.symbolFor(stateBinding);
+      if (!stateSymbol) return false;
+      return stateSymbol.references.some((reference) => {
+        let referenceParent = reference.identifier.parent;
+        while (referenceParent && referenceParent !== componentOrHookNode) {
+          if (
+            isNodeOfType(referenceParent, "ReturnStatement") &&
+            findEnclosingFunction(referenceParent) === componentOrHookNode
+          ) {
+            return true;
+          }
+          if (isFunctionLike(referenceParent)) return false;
+          referenceParent = referenceParent.parent;
+        }
+        return false;
+      });
+    }
+    if (isFunctionLike(currentNode)) return false;
+    currentNode = currentNode.parent;
+  }
+  return false;
+};
+
 const getReturnedValues = (statement: EsTreeNode | null | undefined): ReadonlyArray<EsTreeNode> => {
   if (!statement) return [];
   if (isNodeOfType(statement, "ReturnStatement")) {
@@ -700,6 +1031,13 @@ const getReturnedValues = (statement: EsTreeNode | null | undefined): ReadonlyAr
   }
   if (isNodeOfType(statement, "IfStatement")) {
     return [...getReturnedValues(statement.consequent), ...getReturnedValues(statement.alternate)];
+  }
+  if (isNodeOfType(statement, "TryStatement")) {
+    return [
+      ...getReturnedValues(statement.block),
+      ...getReturnedValues(statement.handler?.body),
+      ...getReturnedValues(statement.finalizer),
+    ];
   }
   if (!isNodeOfType(statement, "BlockStatement")) return [];
   const returnedValues: Array<EsTreeNode> = [];
@@ -828,6 +1166,7 @@ export const noHydrationBranchOnBrowserGlobal = defineRule({
     if (isTestlikeFilename(context.filename)) return {};
     if (classifyReactNativeFileTarget(context) === "react-native") return {};
     let fileHasUseClientDirective = false;
+    let fileHasExplicitReactRuntimeReference = false;
     let fileIsEmailTemplate = false;
     const reportedNodes = new Set<EsTreeNode>();
 
@@ -836,21 +1175,36 @@ export const noHydrationBranchOnBrowserGlobal = defineRule({
       leftBranch: EsTreeNode,
       rightBranch: EsTreeNode | null,
       requiresRenderedContext: boolean,
+      allowsReturnedStateInitializer = false,
     ): void => {
       const conditionMatch = matchHydrationCondition(conditionNode, context);
       if (!conditionMatch) return;
       const { predicateMatch, predicateNode } = conditionMatch;
       if (reportedNodes.has(predicateNode)) return;
       if (rightBranch && areRenderedBranchesEquivalent(leftBranch, rightBranch)) return;
-      const componentOrHookNode = findRenderPhaseComponentOrHook(conditionNode, context.scopes);
+      const enclosingFunction = findEnclosingFunction(conditionNode);
+      const componentOrHookNode =
+        findRenderPhaseComponentOrHook(conditionNode, context.scopes) ??
+        (enclosingFunction
+          ? findComponentRenderingLocalFunctionResult(enclosingFunction, context.scopes)
+          : null);
       if (!componentOrHookNode) return;
-      if (!hasClientRenderEvidence(componentOrHookNode, fileHasUseClientDirective)) return;
+      if (
+        !hasClientRenderEvidence(componentOrHookNode, fileHasUseClientDirective) &&
+        !fileHasExplicitReactRuntimeReference
+      ) {
+        return;
+      }
       if (
         requiresRenderedContext &&
         !isInRenderedOutput(conditionNode, componentOrHookNode, context.scopes)
       )
         return;
-      if (!isRenderedValue(leftBranch) && (!rightBranch || !isRenderedValue(rightBranch))) {
+      if (
+        !allowsReturnedStateInitializer &&
+        !isRenderedValue(leftBranch, context.scopes) &&
+        (!rightBranch || !isRenderedValue(rightBranch, context.scopes))
+      ) {
         const attribute = findEnclosingJsxAttribute(conditionNode);
         if (!attribute || isEventHandlerAttribute(attribute)) return;
       }
@@ -880,17 +1234,28 @@ export const noHydrationBranchOnBrowserGlobal = defineRule({
     return {
       Program(node: EsTreeNodeOfType<"Program">) {
         fileHasUseClientDirective = hasDirective(node, "use client");
+        fileHasExplicitReactRuntimeReference = containsExplicitReactRuntimeReference(
+          node,
+          context.scopes,
+        );
         fileIsEmailTemplate = hasEmailTemplateImport(node);
       },
       ConditionalExpression(node: EsTreeNodeOfType<"ConditionalExpression">) {
         reportHydrationBranch(node.test, node.consequent, node.alternate, true);
+        const componentOrHookNode = findRenderPhaseComponentOrHook(node, context.scopes);
+        if (
+          componentOrHookNode &&
+          isReturnedUseStateInitializer(node, componentOrHookNode, context.scopes)
+        ) {
+          reportHydrationBranch(node.test, node.consequent, node.alternate, false, true);
+        }
       },
       LogicalExpression(node: EsTreeNodeOfType<"LogicalExpression">) {
         if (node.operator !== "&&" && node.operator !== "||") return;
         const renderedValue =
           node.operator === "&&"
-            ? findRenderedValueInAndBranch(node.right)
-            : isRenderedValue(node.right)
+            ? findRenderedValueInAndBranch(node.right, context.scopes)
+            : isRenderedValue(node.right, context.scopes)
               ? node.right
               : null;
         if (!renderedValue) return;
@@ -903,19 +1268,28 @@ export const noHydrationBranchOnBrowserGlobal = defineRule({
           ? getReturnedValues(node.alternate)
           : findFollowingReturnedValues(node);
         if (consequentValues.length === 0 || alternateValues.length === 0) return;
-        const componentOrHookNode = findRenderPhaseComponentOrHook(node.test, context.scopes);
-        if (!componentOrHookNode) return;
         const enclosingFunction = findEnclosingFunction(node);
+        const componentOrHookNode =
+          findRenderPhaseComponentOrHook(node.test, context.scopes) ??
+          (enclosingFunction
+            ? findComponentRenderingLocalFunctionResult(enclosingFunction, context.scopes)
+            : null);
+        if (!componentOrHookNode) return;
         if (
           enclosingFunction !== componentOrHookNode &&
           (!enclosingFunction ||
-            !isInRenderedOutput(enclosingFunction, componentOrHookNode, context.scopes))
+            (!isInRenderedOutput(enclosingFunction, componentOrHookNode, context.scopes) &&
+              findComponentRenderingLocalFunctionResult(enclosingFunction, context.scopes) !==
+                componentOrHookNode))
         ) {
           return;
         }
         for (const consequentValue of consequentValues) {
           for (const alternateValue of alternateValues) {
-            if (!isRenderedValue(consequentValue) && !isRenderedValue(alternateValue)) {
+            if (
+              !isRenderedValue(consequentValue, context.scopes) &&
+              !isRenderedValue(alternateValue, context.scopes)
+            ) {
               continue;
             }
             reportHydrationBranch(node.test, consequentValue, alternateValue, false);


### PR DESCRIPTION
## Why

ReactBench exposed browser-global hydration branches that the rule missed when the predicate flowed through mutable aliases, local helpers, memoized objects, hook state, or compiled `createElement` output.

## What

- trace browser-global predicates through render-phase helper and state flows
- recognize rendered local factory results without treating lookalike factories as React provenance
- require a same-file rendered consumer before reporting a browser-derived custom-hook initializer
- keep mount-gated probes and equivalent initial output quiet
- add ReactBench regression and fuzz coverage

## ReactBench evidence

- live-doc contract: 42 source-provable units
- exact replay: 42/42 caught
- excluded: six initially-false mount gates and one cross-file-only hook consumer (`ivEkXud`)
- parse errors: 0
- reconstructed-source mismatches: 0

The `ivEkXud` hook initializer is intentionally not reported from its standalone source file. Its rendered consumer appears only in a separate patched file, so this file-local rule cannot prove the hydration mismatch.

## Test plan

- `nr test` in `packages/oxlint-plugin-react-doctor`: 958 files, 24,819 passed, 201 skipped
- `FUZZ_RULE=no-hydration-branch-on-browser-global FUZZ_ITERATIONS=500 FUZZ_SEED=792026 nr fuzz`
- `nr typecheck` in the plugin and fuzz packages
- `nr lint`
- `nr format:check`
- `nr smoke:json-report`

The root test/typecheck orchestration was also attempted. Unrelated workers exhausted the shared runner after the affected packages had passed; the isolated affected-package gates are green.

Local RDE could not start because `AXIOM_DATASET` is not configured.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large, intricate changes to a correctness lint rule’s static analysis; behavior shifts on many edge cases, though scope is limited to the plugin and tests.
> 
> **Overview**
> Extends **`no-hydration-branch-on-browser-global`** so browser-global predicates are tracked through render-time helpers, mutable aliases, **`useState`/`useMemo`** flows, custom-hook return paths, and compiled **`createElement`** output—not only direct JSX conditionals.
> 
> **Predicate resolution** now follows **`let`/`var`** writes guarded by browser checks (including nested helper invocations), **`useMemo`** object properties, lazy **`useState`** initializers, and equality/bitwise forms that still differ by runtime; reflexive or duplicated-predicate comparisons are suppressed.
> 
> **Reporting gates** require a same-file rendered consumer for hook-returned browser state, treat locally invoked render helpers as in-output, and distinguish real React **`createElement`** from lookalike factories via explicit runtime **`require`/import** provenance. **Equivalence** checks use binding-aware structural comparison so shadowed branch-local JSX and mount-gated or **`suppressHydrationWarning`** consumers stay quiet when output is effectively stable.
> 
> Adds a large ReactBench regression suite and fuzz corpus cases for true positives and false-positive retractions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cc9aeba70bc9f48735fa96a0fa22f80eeb052d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->