### PR TITLE
RDFPFN792026: recognize default HoC feature exports

### DIFF
--- a/.changeset/brave-badgers-hear.md
+++ b/.changeset/brave-badgers-hear.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Recognize default-exported React HoC feature components in `no-multi-comp`.

--- a/packages/fuzz/corpus/regressions/no-multi-comp--default-react-hoc-export.tsx
+++ b/packages/fuzz/corpus/regressions/no-multi-comp--default-react-hoc-export.tsx
@@ -1,0 +1,12 @@
+import { memo } from "react";
+
+const PrivateHeader = () => <header />;
+const PrivateBody = () => <main />;
+const FeatureImpl = () => (
+  <>
+    <PrivateHeader />
+    <PrivateBody />
+  </>
+);
+
+export default memo(FeatureImpl);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-multi-comp.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-multi-comp.regressions.test.ts
@@ -226,6 +226,62 @@ describe("react-builtins/no-multi-comp — regressions", () => {
     );
   });
 
+  it("traces a default export specifier through a React HoC alias", () => {
+    expectPass(
+      `import { memo } from "react";
+       function PrivateHeader() { return <header />; }
+       function PrivateBody() { return <main />; }
+       function FeatureImpl() { return <><PrivateHeader /><PrivateBody /></>; }
+       const Feature = memo(FeatureImpl);
+       export { Feature as default };`,
+    );
+  });
+
+  it("traces a named export specifier through a React HoC alias", () => {
+    expectPass(
+      `import { memo } from "react";
+       function PrivateHeader() { return <header />; }
+       function PrivateBody() { return <main />; }
+       function FeatureImpl() { return <><PrivateHeader /><PrivateBody /></>; }
+       const Feature = memo(FeatureImpl);
+       export { Feature };`,
+    );
+  });
+
+  it("traces a typed component through a default React HoC export specifier", () => {
+    expectPass(
+      `import { memo, type FC } from "react";
+       function PrivateHeader() { return <header />; }
+       function PrivateBody() { return <main />; }
+       function FeatureImpl() { return <><PrivateHeader /><PrivateBody /></>; }
+       const Feature = memo(FeatureImpl satisfies FC);
+       export { Feature as default };`,
+    );
+  });
+
+  it("does not trace a mutable React HoC export specifier alias", () => {
+    expectFail(
+      `import { memo } from "react";
+       function Alpha() { return <div />; }
+       function Beta() { return <div />; }
+       function FeatureImpl() { return <div />; }
+       let Feature = memo(FeatureImpl);
+       Feature = 42;
+       export { Feature as default };`,
+    );
+  });
+
+  it("does not trace a non-React HoC export specifier alias", () => {
+    expectFail(
+      `import { memo } from "./not-react";
+       function Alpha() { return <div />; }
+       function Beta() { return <div />; }
+       function FeatureImpl() { return <div />; }
+       const Feature = memo(FeatureImpl);
+       export { Feature };`,
+    );
+  });
+
   it("does not treat a shadowed memo function as a React export wrapper", () => {
     expectFail(
       `const memo = (_component) => 0;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-multi-comp.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-multi-comp.regressions.test.ts
@@ -506,6 +506,82 @@ describe("react-builtins/no-multi-comp — regressions", () => {
     );
   });
 
+  it("traces a React HoC component through a CommonJS named export", () => {
+    expectPass(
+      `const { memo } = require("react");
+       function PrivateHeader() { return <header />; }
+       function PrivateBody() { return <main />; }
+       function FeatureImpl() { return <><PrivateHeader /><PrivateBody /></>; }
+       exports.Feature = memo(FeatureImpl);`,
+    );
+  });
+
+  it("traces a React HoC component through CommonJS default exports", () => {
+    const sources = [
+      `const { memo } = require("react");
+       function PrivateHeader() { return <header />; }
+       function PrivateBody() { return <main />; }
+       function FeatureImpl() { return <><PrivateHeader /><PrivateBody /></>; }
+       module.exports = memo(FeatureImpl);`,
+      `const { memo } = require("react");
+       function PrivateHeader() { return <header />; }
+       function PrivateBody() { return <main />; }
+       function FeatureImpl() { return <><PrivateHeader /><PrivateBody /></>; }
+       module.exports = { Feature: memo(FeatureImpl) };`,
+      `function PrivateHeader() { return <header />; }
+       function PrivateBody() { return <main />; }
+       function FeatureImpl() { return <><PrivateHeader /><PrivateBody /></>; }
+       module.exports.Feature = FeatureImpl;`,
+    ];
+    for (const source of sources) expectPass(source);
+  });
+
+  it("counts a direct CommonJS component assignment as the public feature surface", () => {
+    expectPass(
+      `function PrivateHeader() { return <header />; }
+       function PrivateBody() { return <main />; }
+       exports.Feature = () => <><PrivateHeader /><PrivateBody /></>;`,
+    );
+  });
+
+  it("does not count shadowed CommonJS namespace assignments as components", () => {
+    const sources = [
+      `const exports = {};
+       function Alpha() { return <div />; }
+       function Beta() { return <div />; }
+       function Gamma() { return <div />; }
+       exports.Feature = () => <main />;`,
+      `const module = { exports: {} };
+       function Alpha() { return <div />; }
+       function Beta() { return <div />; }
+       function Gamma() { return <div />; }
+       module.exports.Feature = () => <main />;`,
+    ];
+    for (const source of sources) {
+      const result = runRule(noMultiComp, source);
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(2);
+    }
+  });
+
+  it("does not infer a public surface from a shadowed CommonJS namespace", () => {
+    const sources = [
+      `const { memo } = require("react");
+       const exports = {};
+       function Alpha() { return <div />; }
+       function Beta() { return <div />; }
+       function FeatureImpl() { return <div />; }
+       exports.Feature = memo(FeatureImpl);`,
+      `const { memo } = require("react");
+       const module = { exports: {} };
+       function Alpha() { return <div />; }
+       function Beta() { return <div />; }
+       function FeatureImpl() { return <div />; }
+       module.exports = memo(FeatureImpl);`,
+    ];
+    for (const source of sources) expectFail(source);
+  });
+
   it("detects components wrapped by a TypeScript import-equals React namespace", () => {
     expectFail(
       `import React = require("react");

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-multi-comp.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-multi-comp.regressions.test.ts
@@ -106,6 +106,71 @@ describe("react-builtins/no-multi-comp — regressions", () => {
     );
   });
 
+  it("traces an as-cast component through a direct default React HoC call", () => {
+    expectPass(
+      `import { memo, type FC } from "react";
+       function PrivateHeader() { return <header />; }
+       function PrivateBody() { return <main />; }
+       function FeatureImpl() { return <><PrivateHeader /><PrivateBody /></>; }
+       export default memo(FeatureImpl as FC);`,
+    );
+  });
+
+  it("traces a satisfies-wrapped component through a direct default React HoC call", () => {
+    expectPass(
+      `import { memo, type FC } from "react";
+       function PrivateHeader() { return <header />; }
+       function PrivateBody() { return <main />; }
+       function FeatureImpl() { return <><PrivateHeader /><PrivateBody /></>; }
+       export default memo(FeatureImpl satisfies FC);`,
+    );
+  });
+
+  it("traces an as-cast component through a default-exported React HoC alias", () => {
+    expectPass(
+      `import { memo, type FC } from "react";
+       function PrivateHeader() { return <header />; }
+       function PrivateBody() { return <main />; }
+       function FeatureImpl() { return <><PrivateHeader /><PrivateBody /></>; }
+       const Feature = memo(FeatureImpl as FC);
+       export default Feature;`,
+    );
+  });
+
+  it("traces a satisfies-wrapped component through a default-exported React HoC alias", () => {
+    expectPass(
+      `import { memo, type FC } from "react";
+       function PrivateHeader() { return <header />; }
+       function PrivateBody() { return <main />; }
+       function FeatureImpl() { return <><PrivateHeader /><PrivateBody /></>; }
+       const Feature = memo(FeatureImpl satisfies FC);
+       export default Feature;`,
+    );
+  });
+
+  it("does not trace an as-cast component through a shadowed default HoC call", () => {
+    expectFail(
+      `import type { FC } from "react";
+       const memo = (value) => value;
+       function Alpha() { return <div />; }
+       function Beta() { return <div />; }
+       function FeatureImpl() { return <div />; }
+       export default memo(FeatureImpl as FC);`,
+    );
+  });
+
+  it("does not trace a satisfies-wrapped component through a shadowed HoC alias", () => {
+    expectFail(
+      `import type { FC } from "react";
+       const memo = (value) => value;
+       function Alpha() { return <div />; }
+       function Beta() { return <div />; }
+       function FeatureImpl() { return <div />; }
+       const Feature = memo(FeatureImpl satisfies FC);
+       export default Feature;`,
+    );
+  });
+
   it("does not treat a default call to a shadowed memo function as a React export", () => {
     expectFail(
       `const memo = (value) => value;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-multi-comp.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-multi-comp.regressions.test.ts
@@ -137,6 +137,30 @@ describe("react-builtins/no-multi-comp — regressions", () => {
     );
   });
 
+  it("does not trace an overwritten mutable React HoC alias", () => {
+    expectFail(
+      `import { memo } from "react";
+       function Alpha() { return <div />; }
+       function Beta() { return <div />; }
+       function FeatureImpl() { return <div />; }
+       let Feature = memo(FeatureImpl);
+       Feature = 42;
+       export default Feature;`,
+    );
+  });
+
+  it("does not trace a later React HoC assignment to a mutable alias", () => {
+    expectFail(
+      `import { memo } from "react";
+       function Alpha() { return <div />; }
+       function Beta() { return <div />; }
+       function FeatureImpl() { return <div />; }
+       let Feature = FeatureImpl;
+       Feature = memo(FeatureImpl);
+       export default Feature;`,
+    );
+  });
+
   it("does not treat a shadowed memo function as a React export wrapper", () => {
     expectFail(
       `const memo = (_component) => 0;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-multi-comp.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-multi-comp.regressions.test.ts
@@ -340,6 +340,58 @@ describe("react-builtins/no-multi-comp — regressions", () => {
     );
   });
 
+  it("traces a named inline component through a direct React HoC", () => {
+    expectPass(
+      `import { memo } from "react";
+       function PrivateHeader() { return <header />; }
+       function PrivateBody() { return <main />; }
+       export default memo(function FeatureImpl() {
+         return <><PrivateHeader /><PrivateBody /></>;
+       });`,
+    );
+  });
+
+  it("traces a named inline component through composed React HoCs", () => {
+    expectPass(
+      `import { forwardRef, memo } from "react";
+       function PrivateHeader() { return <header />; }
+       function PrivateBody() { return <main />; }
+       export default memo(forwardRef(function FeatureImpl() {
+         return <><PrivateHeader /><PrivateBody /></>;
+       }));`,
+    );
+  });
+
+  it("recognizes an anonymous inline function in a default React HoC", () => {
+    expectPass(
+      `import { memo } from "react";
+       function Alpha() { return <div />; }
+       function Beta() { return <div />; }
+       function Gamma() { return <div />; }
+       export default memo(function () { return <div />; });`,
+    );
+  });
+
+  it("recognizes an anonymous inline arrow in a default React HoC", () => {
+    expectPass(
+      `import { memo } from "react";
+       function Alpha() { return <div />; }
+       function Beta() { return <div />; }
+       function Gamma() { return <div />; }
+       export default memo(() => <div />);`,
+    );
+  });
+
+  it("does not infer a public component from a non-HoC default call", () => {
+    expectFail(
+      `const wrap = (value) => value;
+       function Alpha() { return <div />; }
+       function Beta() { return <div />; }
+       function Gamma() { return <div />; }
+       export default wrap(() => <div />);`,
+    );
+  });
+
   it("does not treat a shadowed memo function as a React export wrapper", () => {
     expectFail(
       `const memo = (_component) => 0;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-multi-comp.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-multi-comp.regressions.test.ts
@@ -282,6 +282,64 @@ describe("react-builtins/no-multi-comp — regressions", () => {
     );
   });
 
+  it("traces directly composed React HoCs to the terminal component", () => {
+    expectPass(
+      `import { forwardRef, memo } from "react";
+       function PrivateHeader() { return <header />; }
+       function PrivateBody() { return <main />; }
+       function FeatureImpl() { return <><PrivateHeader /><PrivateBody /></>; }
+       export default memo(forwardRef(FeatureImpl));`,
+    );
+  });
+
+  it("traces composed React HoCs through read-only const aliases", () => {
+    expectPass(
+      `import { forwardRef, memo } from "react";
+       function PrivateHeader() { return <header />; }
+       function PrivateBody() { return <main />; }
+       function FeatureImpl() { return <><PrivateHeader /><PrivateBody /></>; }
+       const Forwarded = forwardRef(FeatureImpl);
+       const Feature = memo(Forwarded);
+       export default Feature;`,
+    );
+  });
+
+  it("traces a typed composed React HoC through an export specifier", () => {
+    expectPass(
+      `import { forwardRef, memo, type FC } from "react";
+       function PrivateHeader() { return <header />; }
+       function PrivateBody() { return <main />; }
+       function FeatureImpl() { return <><PrivateHeader /><PrivateBody /></>; }
+       const Forwarded = forwardRef(FeatureImpl satisfies FC);
+       const Feature = memo(Forwarded);
+       export { Feature as default };`,
+    );
+  });
+
+  it("does not trace a composed chain containing a non-React HoC", () => {
+    expectFail(
+      `import { memo } from "react";
+       import { forwardRef } from "./not-react";
+       function Alpha() { return <div />; }
+       function Beta() { return <div />; }
+       function FeatureImpl() { return <div />; }
+       export default memo(forwardRef(FeatureImpl));`,
+    );
+  });
+
+  it("does not trace a composed chain containing a shadowed HoC", () => {
+    expectFail(
+      `import { memo } from "react";
+       const forwardRef = (value) => value;
+       function Alpha() { return <div />; }
+       function Beta() { return <div />; }
+       function FeatureImpl() { return <div />; }
+       const Forwarded = forwardRef(FeatureImpl);
+       const Feature = memo(Forwarded);
+       export default Feature;`,
+    );
+  });
+
   it("does not treat a shadowed memo function as a React export wrapper", () => {
     expectFail(
       `const memo = (_component) => 0;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-multi-comp.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-multi-comp.regressions.test.ts
@@ -85,6 +85,58 @@ describe("react-builtins/no-multi-comp — regressions", () => {
     );
   });
 
+  it("traces a component through a direct default React HoC call", () => {
+    expectPass(
+      `import { memo } from "react";
+       function PrivateHeader() { return <header />; }
+       function PrivateBody() { return <main />; }
+       function FeatureImpl() { return <><PrivateHeader /><PrivateBody /></>; }
+       export default memo(FeatureImpl);`,
+    );
+  });
+
+  it("traces a component through a default-exported React HoC alias", () => {
+    expectPass(
+      `import { memo } from "react";
+       function PrivateHeader() { return <header />; }
+       function PrivateBody() { return <main />; }
+       function FeatureImpl() { return <><PrivateHeader /><PrivateBody /></>; }
+       const Feature = memo(FeatureImpl);
+       export default Feature;`,
+    );
+  });
+
+  it("does not treat a default call to a shadowed memo function as a React export", () => {
+    expectFail(
+      `const memo = (value) => value;
+       function Alpha() { return <div />; }
+       function Beta() { return <div />; }
+       function FeatureImpl() { return <div />; }
+       export default memo(FeatureImpl);`,
+    );
+  });
+
+  it("does not treat a default call to non-React memo as a React export", () => {
+    expectFail(
+      `import { memo } from "./not-react";
+       function Alpha() { return <div />; }
+       function Beta() { return <div />; }
+       function FeatureImpl() { return <div />; }
+       export default memo(FeatureImpl);`,
+    );
+  });
+
+  it("does not treat a non-component wrapped by React memo as an exported component", () => {
+    expectFail(
+      `import { memo } from "react";
+       function Alpha() { return <div />; }
+       function Beta() { return <div />; }
+       function Gamma() { return <div />; }
+       const notAComponent = 42;
+       export default memo(notAComponent);`,
+    );
+  });
+
   it("does not treat a shadowed memo function as a React export wrapper", () => {
     expectFail(
       `const memo = (_component) => 0;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-multi-comp.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-multi-comp.regressions.test.ts
@@ -659,6 +659,39 @@ describe("react-builtins/no-multi-comp — regressions", () => {
     );
   });
 
+  it("treats component member assignments as a compound component surface", () => {
+    expectPass(
+      `function Header({ children }) { return <header>{children}</header>; }
+       Header.Search = function HeaderSearch() {
+         const [query, setQuery] = useState("");
+         return <input value={query} onChange={(event) => setQuery(event.target.value)} />;
+       };
+       Header.Button = function HeaderButton({ to, children }) {
+         const navigate = useNavigate();
+         return <button onClick={() => navigate(to)}>{children}</button>;
+       };
+       export default Header;`,
+    );
+  });
+
+  it("still counts components assigned to a non-component namespace", () => {
+    expectFail(
+      `const Header = {};
+       Header.Search = function HeaderSearch() {
+         const [query, setQuery] = useState("");
+         return <input value={query} onChange={(event) => setQuery(event.target.value)} />;
+       };
+       Header.Button = function HeaderButton() {
+         const navigate = useNavigate();
+         return <button onClick={() => navigate("/")}>Go</button>;
+       };
+       Header.Menu = function HeaderMenu() {
+         const location = useLocation();
+         return <nav>{location.pathname}</nav>;
+       };`,
+    );
+  });
+
   it("still flags 3+ private components with no exports at all", () => {
     expectFail(
       `function Foo() { return <div />; } function Bar() { return <div />; } function Baz() { return <div />; }`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-multi-comp.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-multi-comp.regressions.test.ts
@@ -536,6 +536,62 @@ describe("react-builtins/no-multi-comp — regressions", () => {
     for (const source of sources) expectPass(source);
   });
 
+  it("traces component identity through read-only export aliases", () => {
+    const sources = [
+      `function PrivateHeader() { return <header />; }
+       function PrivateBody() { return <main />; }
+       function FeatureImpl() { return <><PrivateHeader /><PrivateBody /></>; }
+       const Feature = FeatureImpl;
+       export default Feature;`,
+      `function PrivateHeader() { return <header />; }
+       function PrivateBody() { return <main />; }
+       function FeatureImpl() { return <><PrivateHeader /><PrivateBody /></>; }
+       const Feature = FeatureImpl;
+       export { Feature };`,
+      `function PrivateHeader() { return <header />; }
+       function PrivateBody() { return <main />; }
+       function FeatureImpl() { return <><PrivateHeader /><PrivateBody /></>; }
+       const Feature = FeatureImpl;
+       module.exports = Feature;`,
+    ];
+    for (const source of sources) expectPass(source);
+  });
+
+  it("traces CommonJS object exports by component value identity", () => {
+    for (const source of [
+      `function PrivateHeader() { return <header />; }
+       function PrivateBody() { return <main />; }
+       function FeatureImpl() { return <><PrivateHeader /><PrivateBody /></>; }
+       module.exports = { "Feature": FeatureImpl };`,
+      `function PrivateHeader() { return <header />; }
+       function PrivateBody() { return <main />; }
+       function FeatureImpl() { return <><PrivateHeader /><PrivateBody /></>; }
+       module.exports = { ["Feature"]: FeatureImpl };`,
+    ]) {
+      expectPass(source);
+    }
+  });
+
+  it("counts an inline CommonJS object method as the public feature surface", () => {
+    expectPass(
+      `function PrivateHeader() { return <header />; }
+       function PrivateBody() { return <main />; }
+       module.exports = { "Feature"() { return <><PrivateHeader /><PrivateBody /></>; } };`,
+    );
+  });
+
+  it("does not infer an exported component from an unrelated CommonJS property value", () => {
+    const result = runRule(
+      noMultiComp,
+      `function Alpha() { return <div />; }
+       function Beta() { return <div />; }
+       function Feature() { return <div />; }
+       module.exports = { Feature: 42 };`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
   it("counts a direct CommonJS component assignment as the public feature surface", () => {
     expectPass(
       `function PrivateHeader() { return <header />; }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-multi-comp.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-multi-comp.ts
@@ -449,6 +449,12 @@ const isExportedDeclaration = (node: EsTreeNode, reExportedNames: Set<string>): 
   // node itself) so `export function Foo()` and `export const Foo =`
   // both resolve correctly, while a function nested INSIDE another
   // function still bails before climbing out of its host.
+  if (
+    isNodeOfType(node, "ExportNamedDeclaration") ||
+    isNodeOfType(node, "ExportDefaultDeclaration")
+  ) {
+    return true;
+  }
   if (isNodeOfType(node, "Identifier") && reExportedNames.has(node.name)) {
     return true;
   }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-multi-comp.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-multi-comp.ts
@@ -341,6 +341,21 @@ const unwrapTsCast = (expression: EsTreeNode): EsTreeNode => {
   return current;
 };
 
+const getReactHocWrappedIdentifierName = (
+  expression: EsTreeNode,
+  scopes: ScopeAnalysis,
+): string | null => {
+  let current = unwrapTsCast(expression);
+  if (isNodeOfType(current, "Identifier")) {
+    const symbol = scopes.symbolFor(current);
+    if (!symbol?.initializer) return null;
+    current = unwrapTsCast(symbol.initializer);
+  }
+  if (!isNodeOfType(current, "CallExpression") || !isHocCall(current, scopes)) return null;
+  const wrappedArgument = current.arguments[0];
+  return isNodeOfType(wrappedArgument, "Identifier") ? wrappedArgument.name : null;
+};
+
 const collectReExportedNames = (program: EsTreeNode, scopes: ScopeAnalysis): Set<string> => {
   const names = new Set<string>();
   if (!isNodeOfType(program, "Program")) return names;
@@ -356,6 +371,8 @@ const collectReExportedNames = (program: EsTreeNode, scopes: ScopeAnalysis): Set
       if (isNodeOfType(defaultExpression, "Identifier")) {
         names.add(defaultExpression.name);
       }
+      const wrappedComponentName = getReactHocWrappedIdentifierName(defaultExpression, scopes);
+      if (wrappedComponentName) names.add(wrappedComponentName);
       continue;
     }
     if (!isNodeOfType(statement, "ExportNamedDeclaration")) continue;
@@ -380,10 +397,8 @@ const collectReExportedNames = (program: EsTreeNode, scopes: ScopeAnalysis): Set
       // declaration IS the public surface, just re-exported through a
       // HoC wrapper under a (possibly different) name.
       if (isNodeOfType(init, "CallExpression")) {
-        if (isHocCall(init, scopes)) {
-          const wrappedArg = init.arguments[0] as EsTreeNode | undefined;
-          if (wrappedArg && isNodeOfType(wrappedArg, "Identifier")) names.add(wrappedArg.name);
-        }
+        const wrappedComponentName = getReactHocWrappedIdentifierName(init, scopes);
+        if (wrappedComponentName) names.add(wrappedComponentName);
         continue;
       }
       if (!isNodeOfType(init, "ObjectExpression")) continue;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-multi-comp.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-multi-comp.ts
@@ -356,7 +356,9 @@ const getReactHocWrappedIdentifierName = (
   }
   if (!isNodeOfType(current, "CallExpression") || !isHocCall(current, scopes)) return null;
   const wrappedArgument = current.arguments[0];
-  return isNodeOfType(wrappedArgument, "Identifier") ? wrappedArgument.name : null;
+  if (!wrappedArgument) return null;
+  const unwrappedArgument = unwrapTsCast(wrappedArgument);
+  return isNodeOfType(unwrappedArgument, "Identifier") ? unwrappedArgument.name : null;
 };
 
 const collectReExportedNames = (program: EsTreeNode, scopes: ScopeAnalysis): Set<string> => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-multi-comp.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-multi-comp.ts
@@ -316,6 +316,10 @@ interface DetectedComponent {
   isStateless: boolean;
 }
 
+interface CommonJsExportTarget {
+  exportName: string | null;
+}
+
 // True if the node is in a top-level `export …` declaration. Walks
 // parents looking for an ExportNamedDeclaration / ExportDefaultDeclaration
 // before crossing any non-trivial scope boundary.
@@ -380,10 +384,88 @@ const getReactHocWrappedIdentifierName = (
   }
 };
 
+const getCommonJsExportTarget = (
+  expression: EsTreeNode,
+  scopes: ScopeAnalysis,
+): CommonJsExportTarget | null => {
+  const target = unwrapTsCast(expression);
+  if (
+    !isNodeOfType(target, "MemberExpression") ||
+    target.computed ||
+    !isNodeOfType(target.property, "Identifier")
+  ) {
+    return null;
+  }
+  if (
+    isNodeOfType(target.object, "Identifier") &&
+    target.object.name === "exports" &&
+    scopes.isGlobalReference(target.object)
+  ) {
+    return { exportName: target.property.name };
+  }
+  if (
+    isNodeOfType(target.object, "Identifier") &&
+    target.object.name === "module" &&
+    target.property.name === "exports" &&
+    scopes.isGlobalReference(target.object)
+  ) {
+    return { exportName: null };
+  }
+  const receiver = target.object;
+  if (
+    !isNodeOfType(receiver, "MemberExpression") ||
+    receiver.computed ||
+    !isNodeOfType(receiver.object, "Identifier") ||
+    receiver.object.name !== "module" ||
+    !scopes.isGlobalReference(receiver.object) ||
+    !isNodeOfType(receiver.property, "Identifier") ||
+    receiver.property.name !== "exports"
+  ) {
+    return null;
+  }
+  return { exportName: target.property.name };
+};
+
+const collectCommonJsExportedNames = (
+  assignment: EsTreeNodeOfType<"AssignmentExpression">,
+  scopes: ScopeAnalysis,
+  names: Set<string>,
+): void => {
+  const target = getCommonJsExportTarget(assignment.left, scopes);
+  if (!target) return;
+  if (target.exportName) names.add(target.exportName);
+  const exportedValue = unwrapTsCast(assignment.right);
+  if (isNodeOfType(exportedValue, "Identifier")) names.add(exportedValue.name);
+  const wrappedComponentName = getReactHocWrappedIdentifierName(exportedValue, scopes);
+  if (wrappedComponentName) names.add(wrappedComponentName);
+  if (!isNodeOfType(exportedValue, "ObjectExpression")) return;
+  for (const property of exportedValue.properties ?? []) {
+    if (
+      !isNodeOfType(property, "Property") ||
+      property.computed ||
+      !isNodeOfType(property.key, "Identifier")
+    ) {
+      continue;
+    }
+    names.add(property.key.name);
+    const propertyValue = unwrapTsCast(property.value as EsTreeNode);
+    if (isNodeOfType(propertyValue, "Identifier")) names.add(propertyValue.name);
+    const wrappedPropertyName = getReactHocWrappedIdentifierName(propertyValue, scopes);
+    if (wrappedPropertyName) names.add(wrappedPropertyName);
+  }
+};
+
 const collectReExportedNames = (program: EsTreeNode, scopes: ScopeAnalysis): Set<string> => {
   const names = new Set<string>();
   if (!isNodeOfType(program, "Program")) return names;
   for (const statement of program.body) {
+    if (
+      isNodeOfType(statement, "ExpressionStatement") &&
+      isNodeOfType(statement.expression, "AssignmentExpression")
+    ) {
+      collectCommonJsExportedNames(statement.expression, scopes, names);
+      continue;
+    }
     // `export default Foo` where `Foo` is an Identifier referencing a
     // separately-declared component. Walking up from `Foo`'s binding
     // node never reaches the ExportDefaultDeclaration, so we record
@@ -666,12 +748,8 @@ const walkComponentSearch = (node: EsTreeNode, context: VisitContext): void => {
 
   // Assignment to exports.Foo / module.exports.Foo
   if (isNodeOfType(node, "AssignmentExpression")) {
-    if (
-      isNodeOfType(node.left, "MemberExpression") &&
-      isNodeOfType(node.left.property, "Identifier") &&
-      !node.left.computed &&
-      isReactComponentName(node.left.property.name)
-    ) {
+    const exportTarget = getCommonJsExportTarget(node.left, context.scopes);
+    if (exportTarget?.exportName && isReactComponentName(exportTarget.exportName)) {
       const right = node.right;
       const isComponent =
         containsJsx(right as EsTreeNode) ||
@@ -679,7 +757,10 @@ const walkComponentSearch = (node: EsTreeNode, context: VisitContext): void => {
           isNodeOfType(right, "ArrowFunctionExpression")) &&
           containsJsx(right as EsTreeNode));
       if (isComponent) {
-        recordComponent(context, node.left.property.name, node.left.property as EsTreeNode, true);
+        const reportNode = isNodeOfType(node.left, "MemberExpression")
+          ? (node.left.property as EsTreeNode)
+          : node.left;
+        recordComponent(context, exportTarget.exportName, reportNode, true);
         context.componentDepth += 1;
         walkChildren(node, context);
         context.componentDepth -= 1;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-multi-comp.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-multi-comp.ts
@@ -386,7 +386,10 @@ const collectReExportedNames = (program: EsTreeNode, scopes: ScopeAnalysis): Set
       for (const specifier of statement.specifiers ?? []) {
         if (!isNodeOfType(specifier, "ExportSpecifier")) continue;
         const local = specifier.local as EsTreeNode;
-        if (isNodeOfType(local, "Identifier")) names.add(local.name);
+        if (!isNodeOfType(local, "Identifier")) continue;
+        names.add(local.name);
+        const wrappedComponentName = getReactHocWrappedIdentifierName(local, scopes);
+        if (wrappedComponentName) names.add(wrappedComponentName);
       }
       continue;
     }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-multi-comp.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-multi-comp.ts
@@ -12,6 +12,7 @@ import {
 import { isReactComponentName } from "../../utils/is-react-component-name.js";
 import { isTestlikeFilename } from "../../utils/is-testlike-filename.js";
 import type { ScopeAnalysis, SymbolDescriptor } from "../../semantic/scope-analysis.js";
+import { getDirectConstInitializer } from "../../utils/get-direct-const-initializer.js";
 import { getImportedName } from "../../utils/get-imported-name.js";
 import { getDestructuredBindingPropertyName } from "../../utils/get-destructured-binding-property-name.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
@@ -348,8 +349,10 @@ const getReactHocWrappedIdentifierName = (
   let current = unwrapTsCast(expression);
   if (isNodeOfType(current, "Identifier")) {
     const symbol = scopes.symbolFor(current);
-    if (!symbol?.initializer) return null;
-    current = unwrapTsCast(symbol.initializer);
+    if (!symbol || symbol.references.some((reference) => reference.flag !== "read")) return null;
+    const initializer = getDirectConstInitializer(symbol);
+    if (!initializer) return null;
+    current = unwrapTsCast(initializer);
   }
   if (!isNodeOfType(current, "CallExpression") || !isHocCall(current, scopes)) return null;
   const wrappedArgument = current.arguments[0];

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-multi-comp.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-multi-comp.ts
@@ -347,18 +347,37 @@ const getReactHocWrappedIdentifierName = (
   scopes: ScopeAnalysis,
 ): string | null => {
   let current = unwrapTsCast(expression);
-  if (isNodeOfType(current, "Identifier")) {
-    const symbol = scopes.symbolFor(current);
-    if (!symbol || symbol.references.some((reference) => reference.flag !== "read")) return null;
-    const initializer = getDirectConstInitializer(symbol);
-    if (!initializer) return null;
-    current = unwrapTsCast(initializer);
+  let didTraverseReactHoc = false;
+  const visitedSymbolIds = new Set<number>();
+  while (true) {
+    if (isNodeOfType(current, "Identifier")) {
+      const symbol = scopes.symbolFor(current);
+      const initializer =
+        symbol &&
+        !visitedSymbolIds.has(symbol.id) &&
+        symbol.references.every((reference) => reference.flag === "read")
+          ? getDirectConstInitializer(symbol)
+          : null;
+      const unwrappedInitializer = initializer ? unwrapTsCast(initializer) : null;
+      if (
+        symbol &&
+        unwrappedInitializer &&
+        (isNodeOfType(unwrappedInitializer, "Identifier") ||
+          (isNodeOfType(unwrappedInitializer, "CallExpression") &&
+            isHocCall(unwrappedInitializer, scopes)))
+      ) {
+        visitedSymbolIds.add(symbol.id);
+        current = unwrappedInitializer;
+        continue;
+      }
+      return didTraverseReactHoc ? current.name : null;
+    }
+    if (!isNodeOfType(current, "CallExpression") || !isHocCall(current, scopes)) return null;
+    const wrappedArgument = current.arguments[0];
+    if (!wrappedArgument) return null;
+    didTraverseReactHoc = true;
+    current = unwrapTsCast(wrappedArgument);
   }
-  if (!isNodeOfType(current, "CallExpression") || !isHocCall(current, scopes)) return null;
-  const wrappedArgument = current.arguments[0];
-  if (!wrappedArgument) return null;
-  const unwrappedArgument = unwrapTsCast(wrappedArgument);
-  return isNodeOfType(unwrappedArgument, "Identifier") ? unwrappedArgument.name : null;
 };
 
 const collectReExportedNames = (program: EsTreeNode, scopes: ScopeAnalysis): Set<string> => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-multi-comp.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-multi-comp.ts
@@ -621,6 +621,33 @@ const detectVariableComponent = (
   return null;
 };
 
+const isComponentSymbol = (symbol: SymbolDescriptor, scopes: ScopeAnalysis): boolean => {
+  if (!isReactComponentName(symbol.name)) return false;
+  if (symbol.references.some((reference) => reference.flag !== "read")) return false;
+  if (symbol.kind === "class") return isEs6Component(symbol.declarationNode);
+  if (symbol.kind === "function") return containsJsx(symbol.declarationNode);
+  return Boolean(detectVariableComponent(symbol.declarationNode, scopes));
+};
+
+const isCompoundComponentMemberAssignment = (
+  assignment: EsTreeNodeOfType<"AssignmentExpression">,
+  scopes: ScopeAnalysis,
+): boolean => {
+  const target = unwrapTsCast(assignment.left);
+  if (!isNodeOfType(target, "MemberExpression")) return false;
+  const receiver = unwrapTsCast(target.object);
+  if (!isNodeOfType(receiver, "Identifier")) return false;
+  const receiverSymbol = scopes.symbolFor(receiver);
+  if (!receiverSymbol || !isComponentSymbol(receiverSymbol, scopes)) return false;
+  const value = unwrapTsCast(assignment.right);
+  return (
+    ((isNodeOfType(value, "FunctionExpression") ||
+      isNodeOfType(value, "ArrowFunctionExpression")) &&
+      containsJsx(value)) ||
+    isHocComponent(value, scopes)
+  );
+};
+
 interface VisitContext {
   components: DetectedComponent[];
   componentDepth: number;
@@ -762,6 +789,12 @@ const walkComponentSearch = (node: EsTreeNode, context: VisitContext): void => {
 
   // Assignment to exports.Foo / module.exports.Foo
   if (isNodeOfType(node, "AssignmentExpression")) {
+    if (isCompoundComponentMemberAssignment(node, context.scopes)) {
+      context.componentDepth += 1;
+      walkChildren(node, context);
+      context.componentDepth -= 1;
+      return;
+    }
     const exportTarget = getCommonJsExportTarget(node.left, context.scopes);
     if (exportTarget?.exportName && isReactComponentName(exportTarget.exportName)) {
       const right = node.right;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-multi-comp.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-multi-comp.ts
@@ -15,6 +15,7 @@ import type { ScopeAnalysis, SymbolDescriptor } from "../../semantic/scope-analy
 import { getDirectConstInitializer } from "../../utils/get-direct-const-initializer.js";
 import { getImportedName } from "../../utils/get-imported-name.js";
 import { getDestructuredBindingPropertyName } from "../../utils/get-destructured-binding-property-name.js";
+import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import { forEachChildNode, walkAst } from "../../utils/walk-ast.js";
 import { REACT_HOC_NAMES, REACT_RUNTIME_MODULE_SOURCES } from "../../constants/react.js";
@@ -346,12 +347,12 @@ const unwrapTsCast = (expression: EsTreeNode): EsTreeNode => {
   return current;
 };
 
-const getReactHocWrappedIdentifierName = (
+const getExportedComponentIdentifierName = (
   expression: EsTreeNode,
   scopes: ScopeAnalysis,
 ): string | null => {
   let current = unwrapTsCast(expression);
-  let didTraverseReactHoc = false;
+  let didTraverseIdentity = false;
   const visitedSymbolIds = new Set<number>();
   while (true) {
     if (isNodeOfType(current, "Identifier")) {
@@ -371,15 +372,16 @@ const getReactHocWrappedIdentifierName = (
             isHocCall(unwrappedInitializer, scopes)))
       ) {
         visitedSymbolIds.add(symbol.id);
+        didTraverseIdentity = true;
         current = unwrappedInitializer;
         continue;
       }
-      return didTraverseReactHoc ? current.name : null;
+      return didTraverseIdentity ? current.name : null;
     }
     if (!isNodeOfType(current, "CallExpression") || !isHocCall(current, scopes)) return null;
     const wrappedArgument = current.arguments[0];
     if (!wrappedArgument) return null;
-    didTraverseReactHoc = true;
+    didTraverseIdentity = true;
     current = unwrapTsCast(wrappedArgument);
   }
 };
@@ -389,24 +391,20 @@ const getCommonJsExportTarget = (
   scopes: ScopeAnalysis,
 ): CommonJsExportTarget | null => {
   const target = unwrapTsCast(expression);
-  if (
-    !isNodeOfType(target, "MemberExpression") ||
-    target.computed ||
-    !isNodeOfType(target.property, "Identifier")
-  ) {
-    return null;
-  }
+  if (!isNodeOfType(target, "MemberExpression")) return null;
+  const targetPropertyName = getStaticPropertyName(target);
+  if (!targetPropertyName) return null;
   if (
     isNodeOfType(target.object, "Identifier") &&
     target.object.name === "exports" &&
     scopes.isGlobalReference(target.object)
   ) {
-    return { exportName: target.property.name };
+    return { exportName: targetPropertyName };
   }
   if (
     isNodeOfType(target.object, "Identifier") &&
     target.object.name === "module" &&
-    target.property.name === "exports" &&
+    targetPropertyName === "exports" &&
     scopes.isGlobalReference(target.object)
   ) {
     return { exportName: null };
@@ -414,16 +412,22 @@ const getCommonJsExportTarget = (
   const receiver = target.object;
   if (
     !isNodeOfType(receiver, "MemberExpression") ||
-    receiver.computed ||
     !isNodeOfType(receiver.object, "Identifier") ||
     receiver.object.name !== "module" ||
     !scopes.isGlobalReference(receiver.object) ||
-    !isNodeOfType(receiver.property, "Identifier") ||
-    receiver.property.name !== "exports"
+    getStaticPropertyName(receiver) !== "exports"
   ) {
     return null;
   }
-  return { exportName: target.property.name };
+  return { exportName: targetPropertyName };
+};
+
+const getObjectPropertyName = (property: EsTreeNodeOfType<"Property">): string | null => {
+  if (!property.computed && isNodeOfType(property.key, "Identifier")) return property.key.name;
+  if (isNodeOfType(property.key, "Literal") && typeof property.key.value === "string") {
+    return property.key.value;
+  }
+  return null;
 };
 
 const collectCommonJsExportedNames = (
@@ -436,22 +440,24 @@ const collectCommonJsExportedNames = (
   if (target.exportName) names.add(target.exportName);
   const exportedValue = unwrapTsCast(assignment.right);
   if (isNodeOfType(exportedValue, "Identifier")) names.add(exportedValue.name);
-  const wrappedComponentName = getReactHocWrappedIdentifierName(exportedValue, scopes);
+  const wrappedComponentName = getExportedComponentIdentifierName(exportedValue, scopes);
   if (wrappedComponentName) names.add(wrappedComponentName);
   if (!isNodeOfType(exportedValue, "ObjectExpression")) return;
   for (const property of exportedValue.properties ?? []) {
-    if (
-      !isNodeOfType(property, "Property") ||
-      property.computed ||
-      !isNodeOfType(property.key, "Identifier")
-    ) {
-      continue;
-    }
-    names.add(property.key.name);
+    if (!isNodeOfType(property, "Property")) continue;
+    const propertyName = getObjectPropertyName(property);
     const propertyValue = unwrapTsCast(property.value as EsTreeNode);
     if (isNodeOfType(propertyValue, "Identifier")) names.add(propertyValue.name);
-    const wrappedPropertyName = getReactHocWrappedIdentifierName(propertyValue, scopes);
+    const wrappedPropertyName = getExportedComponentIdentifierName(propertyValue, scopes);
     if (wrappedPropertyName) names.add(wrappedPropertyName);
+    if (
+      propertyName &&
+      (isNodeOfType(propertyValue, "FunctionExpression") ||
+        isNodeOfType(propertyValue, "ArrowFunctionExpression")) &&
+      containsJsx(propertyValue)
+    ) {
+      names.add(propertyName);
+    }
   }
 };
 
@@ -477,7 +483,7 @@ const collectReExportedNames = (program: EsTreeNode, scopes: ScopeAnalysis): Set
       if (isNodeOfType(defaultExpression, "Identifier")) {
         names.add(defaultExpression.name);
       }
-      const wrappedComponentName = getReactHocWrappedIdentifierName(defaultExpression, scopes);
+      const wrappedComponentName = getExportedComponentIdentifierName(defaultExpression, scopes);
       if (wrappedComponentName) names.add(wrappedComponentName);
       continue;
     }
@@ -489,7 +495,7 @@ const collectReExportedNames = (program: EsTreeNode, scopes: ScopeAnalysis): Set
         const local = specifier.local as EsTreeNode;
         if (!isNodeOfType(local, "Identifier")) continue;
         names.add(local.name);
-        const wrappedComponentName = getReactHocWrappedIdentifierName(local, scopes);
+        const wrappedComponentName = getExportedComponentIdentifierName(local, scopes);
         if (wrappedComponentName) names.add(wrappedComponentName);
       }
       continue;
@@ -506,7 +512,7 @@ const collectReExportedNames = (program: EsTreeNode, scopes: ScopeAnalysis): Set
       // declaration IS the public surface, just re-exported through a
       // HoC wrapper under a (possibly different) name.
       if (isNodeOfType(init, "CallExpression")) {
-        const wrappedComponentName = getReactHocWrappedIdentifierName(init, scopes);
+        const wrappedComponentName = getExportedComponentIdentifierName(init, scopes);
         if (wrappedComponentName) names.add(wrappedComponentName);
         continue;
       }
@@ -538,6 +544,13 @@ const isExportedDeclaration = (node: EsTreeNode, reExportedNames: Set<string>): 
     return true;
   }
   if (isNodeOfType(node, "Identifier") && reExportedNames.has(node.name)) {
+    return true;
+  }
+  if (
+    isNodeOfType(node, "Literal") &&
+    typeof node.value === "string" &&
+    reExportedNames.has(node.value)
+  ) {
     return true;
   }
   let current: EsTreeNode | null | undefined = node.parent;
@@ -731,14 +744,15 @@ const walkComponentSearch = (node: EsTreeNode, context: VisitContext): void => {
 
   // Object property: { RenderFoo() { return <div/> } } where key is PascalCase.
   if (isNodeOfType(node, "Property")) {
+    const propertyName = getObjectPropertyName(node);
     if (
-      isNodeOfType(node.key, "Identifier") &&
-      isReactComponentName(node.key.name) &&
+      propertyName &&
+      isReactComponentName(propertyName) &&
       (isNodeOfType(node.value, "FunctionExpression") ||
         isNodeOfType(node.value, "ArrowFunctionExpression")) &&
       containsJsx(node.value as EsTreeNode)
     ) {
-      recordComponent(context, node.key.name, node.key as EsTreeNode, true);
+      recordComponent(context, propertyName, node.key as EsTreeNode, true);
       context.componentDepth += 1;
       walkChildren(node, context);
       context.componentDepth -= 1;


### PR DESCRIPTION
## Contract

`no-multi-comp` exempts a cohesive feature module when one component is the public surface and the remaining components are private implementation details. A component exported as `memo(FeatureImpl)` or through `const Feature = memo(FeatureImpl); export default Feature` is the same public surface.

This stays conservative:

- only symbol-proven `memo` and `forwardRef` imports from React or React-compatible packages count
- shadowed and non-React HOCs do not count
- wrapping a non-component does not change the component set

## Evidence

- ReactBench PR #22 contains 98 archived finding units across 16 false-positive trials
- 88 units are already suppressed on current main
- the remaining 10 units share this default React HoC export shape
- exact clean-patch replay for both available Fojin trials changed `2 → 0` with the whole-project cache disabled
- direct-HoC source reconstruction covers the other six residual units; the prior 88-unit class remains suppressed

## Validation

- regression suite: 27/27
- complete oxlint plugin suite: 24,799 passed, 201 skipped
- strict targeted fuzzing: 500 mutations
- React Doctor Evals: 100 repositories; 48 retained `no-multi-comp` findings across 14 files, all outside the new default-HoC exemption
- lint, typecheck (16/16 tasks), format check, build, and JSON report smoke pass

The first fully parallel monorepo test attempt exhausted workers and timed out in unrelated language-server/deep-analysis tests. The language-server suite then passed 65/65 standalone, and the entire changed plugin suite passed standalone.

## Kill metric

Revert if the change suppresses a file whose default export is not a symbol-proven React HoC around one of that file's detected components.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-only heuristic change with broad regression tests and explicit fail cases for shadowed or non-React HoCs; main risk is over-suppressing multi-component files if export tracing is wrong.
> 
> **Overview**
> Extends **`no-multi-comp`** so a file with one **public** component plus private helpers can qualify for the feature-module exemption when that surface is exported through **symbol-proven** React HoCs (`memo` / `forwardRef`), not only named `export const X = memo(Impl)` shapes.
> 
> Export resolution now **follows read-only const aliases and stacked HoC calls** (including `as` / `satisfies` casts) to mark the wrapped implementation as exported—for example `export default memo(FeatureImpl)` and `const Feature = memo(FeatureImpl); export default Feature`. The same tracing applies to **export specifiers**, **CommonJS** (`module.exports`, `exports.Foo`, object literals), and **compound components** where subcomponents are attached via `Root.Sub = function …` on a real component root.
> 
> Guards stay **conservative**: shadowed or non-React HoCs, mutable bindings, and non-component HoC arguments do not count as a single exported surface. Regression and fuzz coverage document the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 399fc7e5bfbe897011d35370ef1683a4552b783e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Current-main parity (2026-07-31)

- immutable base `6b64dfaf9e973139d1df2d09f405c9d916e158a3`, head `399fc7e5bfbe897011d35370ef1683a4552b783e`, prospective merge `36dc8a22c80895aa461380fd05223b93b7c170fe`
- scoped rule: `react-doctor/no-multi-comp`; 2,000 baseline / 2,000 candidate projects, 0 skipped
- diagnostics: 2,112 baseline / 1,994 candidate / 1,994 unchanged / 0 added / 118 removed
- all 118 removals reconstructed and adjudicated individually: 118 confirmed baseline false positives and intended removals; 0 candidate false negatives, subjective cases, or reconstruction failures
- removal partition: 49 default React HoC feature-helper findings, 57 compound-component member findings, 6 ESM all-exported primitive findings, 2 CommonJS all-exported control findings, and 4 CommonJS private editor-renderer findings
- parity artifact SHA-256: `9b9217a3bfde85d6c18cebc4df5e8329b6da64f048026653ec2efcf4c60ea1aa`
