### PR TITLE
RDFPFN792026 Prove effect cleanup lifecycle ownership

### DIFF
--- a/.changeset/quiet-lifecycles-clean.md
+++ b/.changeset/quiet-lifecycles-clean.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Recognize source-proven listener and timer teardown across stable aliases, local loops, and callback-ref replacement.

--- a/packages/fuzz/corpus/regressions/effect-needs-cleanup--reactbench-lifecycle-equivalence.tsx
+++ b/packages/fuzz/corpus/regressions/effect-needs-cleanup--reactbench-lifecycle-equivalence.tsx
@@ -1,0 +1,31 @@
+// verdict: pass
+// rule: effect-needs-cleanup
+// weakness: stable capture aliases, replayed target loops, and callback-ref replacement
+// source: react-bench job d8321254-7c6a-44d0-8feb-a55a682eeb80
+import { useCallback, useEffect, useRef } from "react";
+
+export const LifecycleEquivalence = ({ first, second, onWheel }) => {
+  const nodeRef = useRef<HTMLElement | null>(null);
+  const setNode = useCallback(
+    (node: HTMLElement | null) => {
+      const previous = nodeRef.current;
+      if (previous && previous !== node) {
+        previous.removeEventListener("wheel", onWheel);
+      }
+      nodeRef.current = node;
+      if (node) node.addEventListener("wheel", onWheel, { passive: false });
+    },
+    [onWheel],
+  );
+
+  useEffect(() => {
+    const targets = [first, second];
+    const options = { passive: false };
+    for (const target of targets) target.addEventListener("wheel", onWheel, options);
+    return () => {
+      for (const target of targets) target.removeEventListener("wheel", onWheel);
+    };
+  }, [first, onWheel, second]);
+
+  return <button ref={setNode} />;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup-reactbench-regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup-reactbench-regressions.test.ts
@@ -1,0 +1,602 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { effectNeedsCleanup } from "./effect-needs-cleanup.js";
+
+describe("effect-needs-cleanup React Bench regressions", () => {
+  it("accepts a stable passive options alias with default capture", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+export const WheelTarget = ({ node }) => {
+  useEffect(() => {
+    const handler = () => undefined;
+    const options = { passive: false };
+    node.addEventListener("wheel", handler, options);
+    return () => node.removeEventListener("wheel", handler);
+  }, [node]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("keeps a stable options alias with mismatched capture", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+export const WheelTarget = ({ node }) => {
+  useEffect(() => {
+    const handler = () => undefined;
+    const options = { capture: true, passive: false };
+    node.addEventListener("wheel", handler, options);
+    return () => node.removeEventListener("wheel", handler);
+  }, [node]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("accepts immutable equivalent event listener options aliases", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+export const WheelTarget = ({ node }) => {
+  useEffect(() => {
+    const handler = () => undefined;
+    const addOptions = { capture: true };
+    const removeOptions = { capture: true };
+    node.addEventListener("wheel", handler, addOptions);
+    return () => node.removeEventListener("wheel", handler, removeOptions);
+  }, [node]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("keeps a mutated removal options alias", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+export const WheelTarget = ({ node }) => {
+  useEffect(() => {
+    const handler = () => undefined;
+    const addOptions = { capture: true };
+    const removeOptions = { capture: true };
+    node.addEventListener("wheel", handler, addOptions);
+    removeOptions.capture = false;
+    return () => node.removeEventListener("wheel", handler, removeOptions);
+  }, [node]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("keeps a mutated registration options alias", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+export const WheelTarget = ({ node }) => {
+  useEffect(() => {
+    const handler = () => undefined;
+    const addOptions = { capture: true };
+    const removeOptions = { capture: false };
+    node.addEventListener("wheel", handler, addOptions);
+    addOptions.capture = false;
+    return () => node.removeEventListener("wheel", handler, removeOptions);
+  }, [node]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("keeps a mutated event listener options alias chain", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+export const WheelTarget = ({ node }) => {
+  useEffect(() => {
+    const handler = () => undefined;
+    const addBase = { capture: true };
+    const removeBase = { capture: true };
+    const addAlias = addBase;
+    const removeAlias = removeBase;
+    node.addEventListener("wheel", handler, addAlias);
+    removeBase.capture = false;
+    return () => node.removeEventListener("wheel", handler, removeAlias);
+  }, [node]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("keeps immutable event listener options alias chains unproven", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+export const WheelTarget = ({ node }) => {
+  useEffect(() => {
+    const handler = () => undefined;
+    const addBase = { capture: true };
+    const removeBase = { capture: true };
+    const addAlias = addBase;
+    const removeAlias = removeBase;
+    node.addEventListener("wheel", handler, addAlias);
+    return () => node.removeEventListener("wheel", handler, removeAlias);
+  }, [node]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("accepts cleanup across exhaustive local target loops", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+export const WheelTargets = ({ first, second }) => {
+  useEffect(() => {
+    const targets = [first, second];
+    const handler = () => undefined;
+    for (const target of targets) {
+      target.addEventListener("wheel", handler, { passive: false });
+    }
+    return () => {
+      for (const target of targets) {
+        target.removeEventListener("wheel", handler);
+      }
+    };
+  }, [first, second]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("keeps cleanup that drops a local target before release", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+export const WheelTargets = ({ first, second }) => {
+  useEffect(() => {
+    const targets = [first, second];
+    const handler = () => undefined;
+    for (const target of targets) {
+      target.addEventListener("wheel", handler);
+    }
+    targets.shift();
+    return () => {
+      for (const target of targets) {
+        target.removeEventListener("wheel", handler);
+      }
+    };
+  }, [first, second]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("accepts exact unary listener cleanup", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+export const LegacySubscription = ({ source }) => {
+  useEffect(() => {
+    const handler = () => undefined;
+    source.addListener(handler);
+    return () => source.removeListener(handler);
+  }, [source]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("keeps unary listener cleanup with a different handler", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+export const LegacySubscription = ({ source }) => {
+  useEffect(() => {
+    const handler = () => undefined;
+    const otherHandler = () => undefined;
+    source.addListener(handler);
+    return () => source.removeListener(otherHandler);
+  }, [source]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("accepts a typed timer handle released on unmount", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+export const DelayedTask = () => {
+  useEffect(() => {
+    const timer = setTimeout(task, 10) as unknown as number;
+    return () => clearTimeout(timer);
+  }, []);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("keeps a typed timer handle when cleanup releases another handle", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+export const DelayedTask = () => {
+  useEffect(() => {
+    const timer = setTimeout(task, 10) as unknown as number;
+    const otherTimer = 1;
+    return () => clearTimeout(otherTimer);
+  }, []);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("accepts same-node-aware JSX callback-ref replacement", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useCallback, useRef } from "react";
+export const WheelTarget = ({ onWheel }) => {
+  const nodeRef = useRef(null);
+  const setNode = useCallback((node) => {
+    const previous = nodeRef.current;
+    if (previous && previous !== node) {
+      previous.removeEventListener("wheel", onWheel);
+    }
+    nodeRef.current = node;
+    if (node) node.addEventListener("wheel", onWheel, { passive: false });
+  }, [onWheel]);
+  return <button ref={setNode} />;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("keeps same-node-aware callback-ref cleanup with a different target", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useCallback, useRef } from "react";
+export const WheelTarget = ({ onWheel }) => {
+  const nodeRef = useRef(null);
+  const setNode = useCallback((node) => {
+    const previous = nodeRef.current;
+    if (previous && previous !== node) {
+      window.removeEventListener("wheel", onWheel);
+    }
+    nodeRef.current = node;
+    if (node) node.addEventListener("wheel", onWheel, { passive: false });
+  }, [onWheel]);
+  return <button ref={setNode} />;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports an unowned one-shot timer in an effect-invoked callback", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useCallback, useEffect } from "react";
+export const DelayedSubscription = ({ delay, subscribe }) => {
+  const start = useCallback(() => {
+    setTimeout(subscribe, delay);
+  }, [delay, subscribe]);
+  useEffect(() => {
+    start();
+  }, [start]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("keeps an event-only guarded timer exempt when the effect call omits the event", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+export const DelayedAction = () => {
+  const handle = (event?: Event) => {
+    if (!event) return;
+    setTimeout(() => undefined, 100);
+  };
+  useEffect(() => {
+    handle();
+  }, []);
+  return <button onClick={handle}>Start</button>;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("keeps a statically unreachable timer exempt in an effect-invoked callback", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+export const DelayedAction = () => {
+  const start = () => {
+    if (false) setTimeout(() => undefined, 100);
+  };
+  useEffect(() => {
+    start();
+  }, []);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("keeps a timer exempt when the effect invocation is statically unreachable", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+export const DelayedAction = () => {
+  const start = () => setTimeout(() => undefined, 100);
+  useEffect(() => {
+    if (false) start();
+  }, []);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("reports a timer when an early return can skip the effect invocation", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+export const DelayedAction = ({ enabled }) => {
+  const start = () => setTimeout(() => undefined, 100);
+  useEffect(() => {
+    if (!enabled) return;
+    start();
+  }, [enabled]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports a timer behind a dynamic condition in an effect-invoked callback", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+export const DelayedAction = ({ enabled }) => {
+  const start = () => {
+    if (enabled) setTimeout(() => undefined, 100);
+  };
+  useEffect(() => {
+    start();
+  }, [enabled]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("accepts an effect-invoked callback whose timer is released", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useCallback, useEffect, useRef } from "react";
+export const DelayedSubscription = ({ delay, subscribe }) => {
+  const timerRef = useRef(null);
+  const start = useCallback(() => {
+    timerRef.current = setTimeout(subscribe, delay);
+  }, [delay, subscribe]);
+  useEffect(() => {
+    start();
+    return () => clearTimeout(timerRef.current);
+  }, [start]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("keeps an event-only callback one-shot timer exempt", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useCallback } from "react";
+export const DelayedAction = ({ delay, action }) => {
+  const start = useCallback(() => {
+    setTimeout(action, delay);
+  }, [action, delay]);
+  return <button onClick={start}>Start</button>;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("keeps statically unreachable retained resources quiet", () => {
+    const timerResult = runRule(
+      effectNeedsCleanup,
+      `const TimerRef = ({ task }) => {
+  const callbackRef = () => {
+    if (false) setInterval(task, 10);
+  };
+  return <div ref={callbackRef} />;
+};`,
+    );
+    const subscriptionResult = runRule(
+      effectNeedsCleanup,
+      `const SubscriptionRef = ({ source }) => {
+  const callbackRef = () => {
+    if (false) source.subscribe(() => undefined);
+  };
+  return <div ref={callbackRef} />;
+};`,
+    );
+    const listenerResult = runRule(
+      effectNeedsCleanup,
+      `const ListenerRef = ({ node, handler }) => {
+  const callbackRef = () => {
+    if (false) node.addEventListener("focus", handler);
+  };
+  return <div ref={callbackRef} />;
+};`,
+    );
+    expect(timerResult.diagnostics).toHaveLength(0);
+    expect(subscriptionResult.diagnostics).toHaveLength(0);
+    expect(listenerResult.diagnostics).toHaveLength(0);
+  });
+
+  it("reports dynamically conditional retained resources", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `const TimerRef = ({ enabled, task }) => {
+  const callbackRef = () => {
+    if (enabled) setInterval(task, 10);
+  };
+  return <div ref={callbackRef} />;
+};`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports direct effect-owned timers in parameterized callbacks", () => {
+    const requiredResult = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+const Delayed = ({ task }) => {
+  const start = (delay) => setTimeout(task, delay);
+  useEffect(() => {
+    start(10);
+  }, []);
+  return null;
+};`,
+    );
+    const defaultResult = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+const Delayed = ({ task }) => {
+  const start = (delay = 10) => setTimeout(task, delay);
+  useEffect(() => {
+    start();
+  }, []);
+  return null;
+};`,
+    );
+    const restResult = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+const Delayed = ({ task }) => {
+  const start = (...delays) => setTimeout(task, delays[0]);
+  useEffect(() => {
+    start(10);
+  }, []);
+  return null;
+};`,
+    );
+    expect(requiredResult.diagnostics).toHaveLength(1);
+    expect(defaultResult.diagnostics).toHaveLength(1);
+    expect(restResult.diagnostics).toHaveLength(1);
+  });
+
+  it("reports effect-owned timers invoked by synchronous array iterators", () => {
+    const forEachResult = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+const Delayed = ({ items, task }) => {
+  const start = (item) => setTimeout(() => task(item), 10);
+  useEffect(() => {
+    items.forEach(start);
+  }, [items]);
+  return null;
+};`,
+    );
+    const mapResult = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+const Delayed = ({ items, task }) => {
+  const start = (item) => setTimeout(() => task(item), 10);
+  useEffect(() => {
+    items.map(start);
+  }, [items]);
+  return null;
+};`,
+    );
+    expect(forEachResult.diagnostics).toHaveLength(1);
+    expect(mapResult.diagnostics).toHaveLength(1);
+  });
+
+  it("keeps deferred callback handoffs exempt", () => {
+    const promiseResult = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+const Delayed = ({ promise, task }) => {
+  const start = (value) => setTimeout(() => task(value), 10);
+  useEffect(() => {
+    promise.then(start);
+  }, [promise]);
+  return null;
+};`,
+    );
+    const listenerResult = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+const Delayed = ({ target, task }) => {
+  const start = (event) => setTimeout(() => task(event), 10);
+  useEffect(() => {
+    target.addEventListener("click", start);
+    return () => target.removeEventListener("click", start);
+  }, [target]);
+  return null;
+};`,
+    );
+    expect(promiseResult.diagnostics).toHaveLength(0);
+    expect(listenerResult.diagnostics).toHaveLength(0);
+  });
+
+  it("does not attribute a different helper invocation to the timer owner", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+const Delayed = ({ task }) => {
+  const start = (event) => {
+    if (!event) return;
+    setTimeout(() => task(event), 10);
+  };
+  const initialize = () => undefined;
+  useEffect(() => {
+    initialize();
+  }, []);
+  return <button onClick={start}>Start</button>;
+};`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup-reactbench-regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup-reactbench-regressions.test.ts
@@ -526,6 +526,140 @@ const Delayed = ({ task }) => {
     expect(restResult.diagnostics).toHaveLength(1);
   });
 
+  it("uses direct invocation arguments to resolve conditional effect-owned timers", () => {
+    const trueResult = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+const Delayed = ({ task }) => {
+  const start = (enabled) => {
+    if (enabled) setTimeout(task, 10);
+  };
+  useEffect(() => {
+    start(true);
+  }, []);
+  return null;
+};`,
+    );
+    const dynamicResult = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+const Delayed = ({ enabled, task }) => {
+  const start = (shouldStart) => {
+    if (shouldStart) setTimeout(task, 10);
+  };
+  useEffect(() => {
+    start(enabled);
+  }, [enabled]);
+  return null;
+};`,
+    );
+    const defaultTrueResult = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+const Delayed = ({ task }) => {
+  const start = (enabled = true) => {
+    if (enabled) setTimeout(task, 10);
+  };
+  useEffect(() => {
+    start();
+  }, []);
+  return null;
+};`,
+    );
+    const falseResult = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+const Delayed = ({ task }) => {
+  const start = (enabled) => {
+    if (enabled) setTimeout(task, 10);
+  };
+  useEffect(() => {
+    start(false);
+  }, []);
+  return null;
+};`,
+    );
+    const omittedOptionalResult = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+const Delayed = ({ task }) => {
+  const start = (event) => {
+    if (event) setTimeout(task, 10);
+  };
+  useEffect(() => {
+    start();
+  }, []);
+  return null;
+};`,
+    );
+    expect(trueResult.diagnostics).toHaveLength(1);
+    expect(dynamicResult.diagnostics).toHaveLength(1);
+    expect(defaultTrueResult.diagnostics).toHaveLength(1);
+    expect(falseResult.diagnostics).toHaveLength(0);
+    expect(omittedOptionalResult.diagnostics).toHaveLength(0);
+  });
+
+  it("reports when any effect invocation can reach a conditional timer", () => {
+    const mixedInvocationResult = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+const Delayed = ({ task }) => {
+  const start = (enabled) => {
+    if (enabled) setTimeout(task, 10);
+  };
+  useEffect(() => {
+    start(false);
+    start(true);
+  }, []);
+  return null;
+};`,
+    );
+    const reassignedParameterResult = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+const Delayed = ({ task }) => {
+  const start = (enabled) => {
+    enabled = true;
+    if (enabled) setTimeout(task, 10);
+  };
+  useEffect(() => {
+    start(false);
+  }, []);
+  return null;
+};`,
+    );
+    const invertedFalseResult = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+const Delayed = ({ task }) => {
+  const start = (disabled) => {
+    if (!disabled) setTimeout(task, 10);
+  };
+  useEffect(() => {
+    start(false);
+  }, []);
+  return null;
+};`,
+    );
+    const invertedTrueResult = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+const Delayed = ({ task }) => {
+  const start = (disabled) => {
+    if (!disabled) setTimeout(task, 10);
+  };
+  useEffect(() => {
+    start(true);
+  }, []);
+  return null;
+};`,
+    );
+    expect(mixedInvocationResult.diagnostics).toHaveLength(1);
+    expect(reassignedParameterResult.diagnostics).toHaveLength(1);
+    expect(invertedFalseResult.diagnostics).toHaveLength(1);
+    expect(invertedTrueResult.diagnostics).toHaveLength(0);
+  });
+
   it("reports effect-owned timers invoked by synchronous array iterators", () => {
     const forEachResult = runRule(
       effectNeedsCleanup,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -35,6 +35,7 @@ import { getFunctionBindingIdentifier } from "../../utils/get-function-binding-n
 import { getRangeStart } from "../../utils/get-range-start.js";
 import { getStaticPropertyKeyName } from "../../utils/get-static-property-key-name.js";
 import { isEventHandlerAttribute } from "../../utils/is-event-handler-attribute.js";
+import { isAstNode } from "../../utils/is-ast-node.js";
 import { isAstDescendant } from "../../utils/is-ast-descendant.js";
 import { getProvenDomEventTargetPrototypeOwnerNames } from "../../utils/is-proven-browser-api-receiver.js";
 import { isReactHookName } from "../../utils/is-react-hook-name.js";
@@ -61,7 +62,10 @@ import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isNodeReachableWithinFunction } from "../../utils/is-node-reachable-within-function.js";
 import { isProvenNonThrowingBuiltInCall } from "../../utils/is-proven-non-throwing-built-in-call.js";
-import { isSynchronousIteratorCallback } from "../../utils/is-synchronous-iterator-callback.js";
+import {
+  isSynchronousIteratorCallback,
+  isSynchronousIteratorCallbackCall,
+} from "../../utils/is-synchronous-iterator-callback.js";
 import { isWithinAssignmentTarget } from "../../utils/is-within-assignment-target.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import type { SymbolDescriptor } from "../../semantic/scope-analysis.js";
@@ -324,17 +328,61 @@ const resolveEventListenerCaptureValueIdentityKey = (
     : null;
 };
 
+const resolveReadOnlyEventListenerOptions = (
+  optionsNode: EsTreeNode,
+  context: RuleContext,
+): EsTreeNode | null => {
+  const unwrappedOptions = stripParenExpression(optionsNode);
+  if (!isNodeOfType(unwrappedOptions, "Identifier")) {
+    return resolveStableValue(unwrappedOptions, context);
+  }
+  const optionsSymbol = context.scopes.symbolFor(unwrappedOptions);
+  const initializer = optionsSymbol?.initializer
+    ? stripParenExpression(optionsSymbol.initializer)
+    : null;
+  if (!optionsSymbol || !initializer) {
+    return resolveStableValue(unwrappedOptions, context);
+  }
+  if (!isNodeOfType(initializer, "ObjectExpression")) {
+    if (isNodeOfType(initializer, "Identifier") || isNodeOfType(initializer, "MemberExpression")) {
+      return null;
+    }
+    return resolveStableValue(unwrappedOptions, context);
+  }
+  if (optionsSymbol.kind !== "const") return null;
+  const hasOnlyEventListenerOptionUses = optionsSymbol.references.every((reference) => {
+    if (reference.flag !== "read" || isWithinAssignmentTarget(reference.identifier)) return false;
+    const referenceRoot = findTransparentExpressionRoot(reference.identifier);
+    const callNode = referenceRoot.parent;
+    if (
+      !isNodeOfType(callNode, "CallExpression") ||
+      callNode.arguments[EVENT_LISTENER_HANDLER_ARGUMENT_INDEX + 1] !== referenceRoot
+    ) {
+      return false;
+    }
+    const callee = stripParenExpression(callNode.callee);
+    if (!isNodeOfType(callee, "MemberExpression")) return false;
+    const methodName = getStaticPropertyKeyName(callee);
+    return methodName === "addEventListener" || methodName === "removeEventListener";
+  });
+  return hasOnlyEventListenerOptionUses ? initializer : null;
+};
+
 const resolveEventListenerCaptureIdentityKey = (
   optionsNode: EsTreeNode | null | undefined,
   context: RuleContext,
   allowOpaqueOptionsIdentity: boolean,
 ): string | null => {
-  const capture = resolveEventListenerCapture(optionsNode, {
+  const stableOptionsNode = optionsNode
+    ? resolveReadOnlyEventListenerOptions(optionsNode, context)
+    : null;
+  if (optionsNode && !stableOptionsNode) return null;
+  const capture = resolveEventListenerCapture(stableOptionsNode, {
     allowIndeterminateEntries: true,
   });
   if (capture !== null) return `capture:${String(capture)}`;
-  if (!optionsNode) return null;
-  const unwrappedOptions = stripParenExpression(optionsNode);
+  if (!stableOptionsNode) return null;
+  const unwrappedOptions = stripParenExpression(stableOptionsNode);
   if (!isNodeOfType(unwrappedOptions, "ObjectExpression")) {
     const optionsKey = allowOpaqueOptionsIdentity
       ? resolveEventListenerCaptureValueIdentityKey(unwrappedOptions, context)
@@ -406,12 +454,8 @@ const doEventListenerCapturesMatch = (
 };
 
 const findAssignedResourceKey = (resourceNode: EsTreeNode, context: RuleContext): string | null => {
-  let currentNode = resourceNode;
-  let parentNode = currentNode.parent;
-  while (isNodeOfType(parentNode, "ChainExpression")) {
-    currentNode = parentNode;
-    parentNode = currentNode.parent;
-  }
+  const currentNode = findTransparentExpressionRoot(resourceNode);
+  const parentNode = currentNode.parent;
   if (isNodeOfType(parentNode, "VariableDeclarator") && parentNode.init === currentNode) {
     return resolveExpressionKey(parentNode.id, context);
   }
@@ -920,6 +964,34 @@ const resolveIteratorCollectionKey = (
     }
   }
   return null;
+};
+
+const resolveReceiverIteratorCollectionKey = (
+  expression: EsTreeNode | null | undefined,
+  context: RuleContext,
+): string | null => {
+  if (!expression) return null;
+  const unwrappedExpression = stripParenExpression(expression);
+  if (!isNodeOfType(unwrappedExpression, "Identifier")) return null;
+  const forOfStatement = findForOfStatementForIteratorExpression(unwrappedExpression, context);
+  const collectionExpression = forOfStatement?.right;
+  if (!collectionExpression) return null;
+  const collectionIdentifier = stripParenExpression(collectionExpression);
+  if (
+    !isNodeOfType(collectionIdentifier, "Identifier") ||
+    !isPrivatePlainConstIdentifier(collectionIdentifier, context)
+  ) {
+    return null;
+  }
+  const collectionSymbol = context.scopes.symbolFor(collectionIdentifier);
+  const initializer = collectionSymbol?.initializer
+    ? stripParenExpression(collectionSymbol.initializer)
+    : null;
+  return collectionSymbol &&
+    isNodeOfType(initializer, "ArrayExpression") &&
+    hasOnlyReplayableCollectionReferences(collectionIdentifier, context, new Set())
+    ? `symbol:${collectionSymbol.id}`
+    : null;
 };
 
 const isStableLoopReceiver = (
@@ -2778,6 +2850,49 @@ const isFunctionUsedAsReactRef = (functionNode: EsTreeNode, context: RuleContext
   isFunctionForwardedToReactRef(functionNode, context) ||
   isFunctionReturnedFromReactHook(functionNode, context, true);
 
+const findCallbackRefReplacementReleaseGuard = (
+  releaseCall: EsTreeNode,
+  ownerFunction: EsTreeNode,
+  releaseReceiverKey: string,
+  registrationReceiverKey: string,
+  context: RuleContext,
+): EsTreeNodeOfType<"IfStatement"> | null => {
+  let descendant = releaseCall;
+  let ancestor = descendant.parent;
+  while (ancestor && ancestor !== ownerFunction) {
+    if (
+      isNodeOfType(ancestor, "IfStatement") &&
+      ancestor.consequent === descendant &&
+      ancestor.alternate === null
+    ) {
+      const test = stripParenExpression(ancestor.test);
+      if (!isNodeOfType(test, "LogicalExpression") || test.operator !== "&&") return null;
+      const operands = [stripParenExpression(test.left), stripParenExpression(test.right)];
+      const hasLiveReceiverTest = operands.some((operand) =>
+        doesTestRequireLiveExpressionKey(operand, releaseReceiverKey, context),
+      );
+      const hasDifferentReceiverTest = operands.some((operand) => {
+        if (
+          !isNodeOfType(operand, "BinaryExpression") ||
+          (operand.operator !== "!==" && operand.operator !== "!=")
+        ) {
+          return false;
+        }
+        const leftKey = resolveExpressionKey(operand.left, context);
+        const rightKey = resolveExpressionKey(operand.right, context);
+        return (
+          (leftKey === releaseReceiverKey && rightKey === registrationReceiverKey) ||
+          (rightKey === releaseReceiverKey && leftKey === registrationReceiverKey)
+        );
+      });
+      return hasLiveReceiverTest && hasDifferentReceiverTest ? ancestor : null;
+    }
+    descendant = ancestor;
+    ancestor = descendant.parent;
+  }
+  return null;
+};
+
 const isReactRefListenerReplacementRelease = (
   releaseCall: EsTreeNodeOfType<"CallExpression">,
   usage: SubscribeLikeUsage,
@@ -2850,6 +2965,13 @@ const isReactRefListenerReplacementRelease = (
   });
   const releaseAnchor =
     findLiveExpressionGuardForRelease(releaseCall, usageFunction, releaseReceiverKey, context) ??
+    findCallbackRefReplacementReleaseGuard(
+      releaseCall,
+      usageFunction,
+      releaseReceiverKey,
+      registrationReceiverKey,
+      context,
+    ) ??
     releaseCall;
   const safeOwnershipAssignments = matchingOwnershipAssignments.filter((assignment) =>
     doMatchingNodesCoverEveryPathBeforeUsage(assignment, [releaseAnchor], usageFunction, context),
@@ -3197,26 +3319,25 @@ const doesReleaseCallMatchUsage = (
     return true;
   }
   if (
-    usage.registrationVerbName === "addListener" &&
-    isNodeOfType(usage.node, "CallExpression") &&
-    usage.node.arguments?.length === UNARY_LISTENER_ARGUMENT_COUNT
-  ) {
-    return (
-      isProvenLegacyMediaQueryListMethodCall(usage.node, "addListener", context) &&
-      releaseVerbName === "removeListener" &&
-      isProvenLegacyMediaQueryListMethodCall(callNode, "removeListener", context) &&
-      usage.receiverKey !== null &&
-      resolveStableMediaQueryListenerIdentityKey(callee.object, context) === usage.receiverKey &&
-      usage.handlerKey !== null &&
-      resolveStableMediaQueryListenerIdentityKey(callNode.arguments?.[0], context) ===
-        usage.handlerKey
-    );
-  }
-  if (
     releaseVerbName === "abort" &&
     isRetainedAbortControllerRefRelease(callee.object, usage, context)
   ) {
     return true;
+  }
+  if (
+    usage.registrationVerbName === "addListener" &&
+    releaseVerbName === "removeListener" &&
+    isNodeOfType(usage.node, "CallExpression") &&
+    usage.node.arguments?.length === UNARY_LISTENER_ARGUMENT_COUNT
+  ) {
+    if (callNode.arguments?.length !== UNARY_LISTENER_ARGUMENT_COUNT) return false;
+    const registrationHandler = resolveStableValue(usage.node.arguments[0], context);
+    if (
+      !isProvenLegacyMediaQueryListMethodCall(usage.node, "addListener", context) &&
+      !isFunctionLike(registrationHandler)
+    ) {
+      return false;
+    }
   }
   if (
     usage.registrationVerbName === "addEventListener" &&
@@ -3240,7 +3361,25 @@ const doesReleaseCallMatchUsage = (
     !hasSafeForEachProjectionCleanup(usage.node, callNode, context)
   )
     return false;
-  if (usage.receiverKey === null || releaseReceiverKey !== usage.receiverKey) return false;
+  const registrationCallee = isNodeOfType(usage.node, "CallExpression")
+    ? stripParenExpression(usage.node.callee)
+    : null;
+  const registrationReceiverCollectionKey = isNodeOfType(registrationCallee, "MemberExpression")
+    ? resolveReceiverIteratorCollectionKey(registrationCallee.object, context)
+    : null;
+  const releaseReceiverCollectionKeyForPair = resolveReceiverIteratorCollectionKey(
+    callee.object,
+    context,
+  );
+  const hasMatchingIteratorReceivers =
+    registrationReceiverCollectionKey !== null &&
+    registrationReceiverCollectionKey === releaseReceiverCollectionKeyForPair;
+  if (
+    !hasMatchingIteratorReceivers &&
+    (usage.receiverKey === null || releaseReceiverKey !== usage.receiverKey)
+  ) {
+    return false;
+  }
   if (
     usage.registrationVerbName === "subscribe" &&
     (releaseVerbName === "unsubscribe" || releaseVerbName === "unsub") &&
@@ -3348,7 +3487,7 @@ const doesReleaseCallMatchUsage = (
       : callNode.arguments?.[EVENT_LISTENER_HANDLER_ARGUMENT_INDEX];
     if (!releaseHandler) return releaseVerbName === "off";
     const expectedHandlerKey = usesUnaryListenerSignatureForCalls
-      ? usage.eventKey
+      ? (usage.handlerKey ?? usage.eventKey)
       : usage.handlerKey;
     const registrationHandler = isNodeOfType(usage.node, "CallExpression")
       ? usage.node.arguments?.[
@@ -4385,6 +4524,7 @@ const findRetainedFunctionLeak = (
   walkAst(body, (child: EsTreeNode) => {
     if (leak !== null) return false;
     if (isFunctionLike(child)) return false;
+    if (!isNodeReachableWithinFunction(child, context)) return false;
 
     if (
       isSocketConstruction(child) &&
@@ -4878,6 +5018,48 @@ const isInlineRetainedHandlerFunction = (
   return isPassedInline && findRenderPhaseComponentOrHook(parentNode, context.scopes) !== null;
 };
 
+const isDirectlyInvokedByEffect = (retainedFunction: EsTreeNode, context: RuleContext): boolean => {
+  if (!isFunctionLike(retainedFunction)) return false;
+  const componentFunction = findEnclosingFunction(retainedFunction);
+  if (!componentFunction || !isFunctionLike(componentFunction)) return false;
+  let isInvoked = false;
+  walkAst(componentFunction.body, (child: EsTreeNode) => {
+    if (isInvoked) return false;
+    if (
+      !isNodeOfType(child, "CallExpression") ||
+      findEnclosingFunction(child) !== componentFunction ||
+      !isReactHookCall(child, CLEANUP_EFFECT_HOOK_NAMES, context.scopes)
+    ) {
+      return;
+    }
+    const effectCallback = getEffectCallback(child);
+    if (!effectCallback || !isFunctionLike(effectCallback)) return;
+    walkAst(effectCallback.body, (effectChild: EsTreeNode) => {
+      if (isInvoked) return false;
+      if (effectChild !== effectCallback.body && isFunctionLike(effectChild)) return false;
+      if (
+        !isNodeOfType(effectChild, "CallExpression") ||
+        !isNodeReachableWithinFunction(effectChild, context)
+      ) {
+        return;
+      }
+      const isDirectInvocation =
+        resolveRefOwnedCleanupFunction(effectChild.callee, context) === retainedFunction;
+      const isSynchronousIteratorInvocation = effectChild.arguments.some(
+        (argument) =>
+          isAstNode(argument) &&
+          resolveRefOwnedCleanupFunction(argument, context) === retainedFunction &&
+          isSynchronousIteratorCallbackCall(effectChild, argument),
+      );
+      if (isDirectInvocation || isSynchronousIteratorInvocation) {
+        isInvoked = true;
+        return false;
+      }
+    });
+  });
+  return isInvoked;
+};
+
 export const effectNeedsCleanup = defineRule({
   id: "effect-needs-cleanup",
   title: "Effect subscription or timer never cleaned up",
@@ -4891,6 +5073,7 @@ export const effectNeedsCleanup = defineRule({
       if (!refEffectUsage && !isPotentiallyReachableFunction(retainedFunction, context)) {
         return;
       }
+      const isEffectInvoked = isDirectlyInvokedByEffect(retainedFunction, context);
       const leak = findRetainedFunctionLeak(
         retainedFunction,
         context,
@@ -4901,9 +5084,22 @@ export const effectNeedsCleanup = defineRule({
               includeOneShotTimers: true,
               requireCallableReturnedResource: true,
             }
-          : undefined,
+          : isEffectInvoked
+            ? {
+                allowReturnedTimerEscape: false,
+                includeOneShotTimers: true,
+              }
+            : undefined,
       );
       if (!leak) return;
+      if (
+        isEffectInvoked &&
+        leak.resourceName === "setTimeout" &&
+        (!isNodeReachableWithinFunction(leak.node, context) ||
+          (retainedFunction.params.length > 0 && !context.cfg.isUnconditionalFromEntry(leak.node)))
+      ) {
+        return;
+      }
       const resourceNoun = RESOURCE_NOUN_BY_KIND[leak.kind];
       context.report({
         node: leak.node,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -35,6 +35,7 @@ import { getFunctionBindingIdentifier } from "../../utils/get-function-binding-n
 import { getRangeStart } from "../../utils/get-range-start.js";
 import { getStaticPropertyKeyName } from "../../utils/get-static-property-key-name.js";
 import { isEventHandlerAttribute } from "../../utils/is-event-handler-attribute.js";
+import { isEarlyExitStatement } from "../../utils/is-early-exit-statement.js";
 import { isAstNode } from "../../utils/is-ast-node.js";
 import { isAstDescendant } from "../../utils/is-ast-descendant.js";
 import { getProvenDomEventTargetPrototypeOwnerNames } from "../../utils/is-proven-browser-api-receiver.js";
@@ -5018,13 +5019,275 @@ const isInlineRetainedHandlerFunction = (
   return isPassedInline && findRenderPhaseComponentOrHook(parentNode, context.scopes) !== null;
 };
 
-const isDirectlyInvokedByEffect = (retainedFunction: EsTreeNode, context: RuleContext): boolean => {
-  if (!isFunctionLike(retainedFunction)) return false;
+interface EffectRetainedInvocation {
+  call: EsTreeNodeOfType<"CallExpression">;
+  isDirect: boolean;
+}
+
+interface InvocationArgumentValue {
+  isDefinitelyUndefined: boolean;
+  truthiness: "falsy" | "truthy" | "unknown";
+}
+
+const readInvocationArgumentValue = (
+  expression: EsTreeNode | null,
+  context: RuleContext,
+): InvocationArgumentValue => {
+  if (!expression) return { isDefinitelyUndefined: true, truthiness: "falsy" };
+  const target = stripParenExpression(expression);
+  if (isNodeOfType(target, "Literal")) {
+    return {
+      isDefinitelyUndefined: false,
+      truthiness: target.value ? "truthy" : "falsy",
+    };
+  }
+  if (
+    isNodeOfType(target, "Identifier") &&
+    target.name === "undefined" &&
+    context.scopes.isGlobalReference(target)
+  ) {
+    return { isDefinitelyUndefined: true, truthiness: "falsy" };
+  }
+  if (isNodeOfType(target, "UnaryExpression") && target.operator === "void") {
+    return { isDefinitelyUndefined: true, truthiness: "falsy" };
+  }
+  if (
+    isNodeOfType(target, "ArrayExpression") ||
+    isNodeOfType(target, "ArrowFunctionExpression") ||
+    isNodeOfType(target, "ClassExpression") ||
+    isNodeOfType(target, "FunctionExpression") ||
+    isNodeOfType(target, "NewExpression") ||
+    isNodeOfType(target, "ObjectExpression")
+  ) {
+    return { isDefinitelyUndefined: false, truthiness: "truthy" };
+  }
+  return { isDefinitelyUndefined: false, truthiness: "unknown" };
+};
+
+const readInvocationConditionTruthiness = (
+  expression: EsTreeNode,
+  parameterValues: ReadonlyMap<number, InvocationArgumentValue>,
+  context: RuleContext,
+): InvocationArgumentValue["truthiness"] => {
+  const target = stripParenExpression(expression);
+  const atomicValue = readInvocationArgumentValue(target, context);
+  if (atomicValue.truthiness !== "unknown") return atomicValue.truthiness;
+  if (isNodeOfType(target, "Identifier")) {
+    const symbol = context.scopes.symbolFor(target);
+    return symbol ? (parameterValues.get(symbol.id)?.truthiness ?? "unknown") : "unknown";
+  }
+  if (isNodeOfType(target, "UnaryExpression") && target.operator === "!") {
+    const argumentTruthiness = readInvocationConditionTruthiness(
+      target.argument as EsTreeNode,
+      parameterValues,
+      context,
+    );
+    return argumentTruthiness === "truthy"
+      ? "falsy"
+      : argumentTruthiness === "falsy"
+        ? "truthy"
+        : "unknown";
+  }
+  if (isNodeOfType(target, "LogicalExpression")) {
+    const leftTruthiness = readInvocationConditionTruthiness(
+      target.left as EsTreeNode,
+      parameterValues,
+      context,
+    );
+    const rightTruthiness = readInvocationConditionTruthiness(
+      target.right as EsTreeNode,
+      parameterValues,
+      context,
+    );
+    if (target.operator === "&&") {
+      if (leftTruthiness === "falsy" || rightTruthiness === "falsy") return "falsy";
+      return leftTruthiness === "truthy" && rightTruthiness === "truthy" ? "truthy" : "unknown";
+    }
+    if (target.operator === "||") {
+      if (leftTruthiness === "truthy" || rightTruthiness === "truthy") return "truthy";
+      return leftTruthiness === "falsy" && rightTruthiness === "falsy" ? "falsy" : "unknown";
+    }
+    return "unknown";
+  }
+  if (isNodeOfType(target, "ConditionalExpression")) {
+    const testTruthiness = readInvocationConditionTruthiness(
+      target.test as EsTreeNode,
+      parameterValues,
+      context,
+    );
+    if (testTruthiness === "truthy") {
+      return readInvocationConditionTruthiness(
+        target.consequent as EsTreeNode,
+        parameterValues,
+        context,
+      );
+    }
+    if (testTruthiness === "falsy") {
+      return readInvocationConditionTruthiness(
+        target.alternate as EsTreeNode,
+        parameterValues,
+        context,
+      );
+    }
+    const consequentTruthiness = readInvocationConditionTruthiness(
+      target.consequent as EsTreeNode,
+      parameterValues,
+      context,
+    );
+    const alternateTruthiness = readInvocationConditionTruthiness(
+      target.alternate as EsTreeNode,
+      parameterValues,
+      context,
+    );
+    return consequentTruthiness === alternateTruthiness ? consequentTruthiness : "unknown";
+  }
+  if (
+    isNodeOfType(target, "CallExpression") &&
+    isNodeOfType(target.callee, "Identifier") &&
+    target.callee.name === "Boolean" &&
+    context.scopes.isGlobalReference(target.callee) &&
+    target.arguments[0] &&
+    isAstNode(target.arguments[0])
+  ) {
+    return readInvocationConditionTruthiness(
+      target.arguments[0] as EsTreeNode,
+      parameterValues,
+      context,
+    );
+  }
+  return "unknown";
+};
+
+const getInvocationParameterValues = (
+  retainedFunction: EsTreeNode,
+  invocation: EffectRetainedInvocation,
+  leakNode: EsTreeNode,
+  context: RuleContext,
+): ReadonlyMap<number, InvocationArgumentValue> => {
+  const parameterValues = new Map<number, InvocationArgumentValue>();
+  if (!isFunctionLike(retainedFunction) || !invocation.isDirect) return parameterValues;
+  for (const [parameterIndex, parameter] of retainedFunction.params.entries()) {
+    const argument = invocation.call.arguments[parameterIndex];
+    const argumentExpression = argument && isAstNode(argument) ? (argument as EsTreeNode) : null;
+    let parameterIdentifier: EsTreeNode | null = null;
+    let parameterValue = readInvocationArgumentValue(argumentExpression, context);
+    if (isNodeOfType(parameter, "Identifier")) {
+      parameterIdentifier = parameter;
+    } else if (
+      isNodeOfType(parameter, "AssignmentPattern") &&
+      isNodeOfType(parameter.left, "Identifier")
+    ) {
+      parameterIdentifier = parameter.left;
+      if (parameterValue.isDefinitelyUndefined) {
+        parameterValue = readInvocationArgumentValue(parameter.right as EsTreeNode, context);
+      }
+    } else if (
+      isNodeOfType(parameter, "RestElement") &&
+      isNodeOfType(parameter.argument, "Identifier")
+    ) {
+      parameterIdentifier = parameter.argument;
+      parameterValue = { isDefinitelyUndefined: false, truthiness: "truthy" };
+    }
+    if (!parameterIdentifier) continue;
+    const parameterSymbol = context.scopes.symbolFor(parameterIdentifier);
+    if (!parameterSymbol) continue;
+    const isWrittenBeforeLeak = parameterSymbol.references.some(
+      (reference) => reference.flag !== "read" && reference.identifier.range[0] < leakNode.range[0],
+    );
+    parameterValues.set(
+      parameterSymbol.id,
+      isWrittenBeforeLeak
+        ? { isDefinitelyUndefined: false, truthiness: "unknown" }
+        : parameterValue,
+    );
+  }
+  return parameterValues;
+};
+
+const isLeakPathDisabledForInvocation = (
+  retainedFunction: EsTreeNode,
+  leakNode: EsTreeNode,
+  invocation: EffectRetainedInvocation,
+  context: RuleContext,
+): boolean => {
+  if (!invocation.isDirect) return false;
+  const parameterValues = getInvocationParameterValues(
+    retainedFunction,
+    invocation,
+    leakNode,
+    context,
+  );
+  let child = leakNode;
+  let ancestor = leakNode.parent ?? null;
+  while (ancestor && ancestor !== retainedFunction) {
+    if (isNodeOfType(ancestor, "BlockStatement")) {
+      const childIndex = ancestor.body.findIndex((statement) => statement === child);
+      for (const precedingStatement of ancestor.body.slice(0, childIndex)) {
+        if (
+          !isNodeOfType(precedingStatement, "IfStatement") ||
+          precedingStatement.alternate ||
+          !isEarlyExitStatement(precedingStatement.consequent)
+        ) {
+          continue;
+        }
+        const guardTruthiness = readInvocationConditionTruthiness(
+          precedingStatement.test as EsTreeNode,
+          parameterValues,
+          context,
+        );
+        if (guardTruthiness === "truthy") return true;
+      }
+    }
+    let requiredTruthiness: InvocationArgumentValue["truthiness"] | null = null;
+    let condition: EsTreeNode | null = null;
+    if (isNodeOfType(ancestor, "IfStatement")) {
+      condition = ancestor.test as EsTreeNode;
+      requiredTruthiness = ancestor.consequent === child ? "truthy" : "falsy";
+    } else if (isNodeOfType(ancestor, "ConditionalExpression")) {
+      condition = ancestor.test as EsTreeNode;
+      requiredTruthiness = ancestor.consequent === child ? "truthy" : "falsy";
+    } else if (
+      isNodeOfType(ancestor, "LogicalExpression") &&
+      ancestor.right === child &&
+      ancestor.operator !== "??"
+    ) {
+      condition = ancestor.left as EsTreeNode;
+      requiredTruthiness = ancestor.operator === "&&" ? "truthy" : "falsy";
+    } else if (
+      (isNodeOfType(ancestor, "WhileStatement") || isNodeOfType(ancestor, "DoWhileStatement")) &&
+      ancestor.body === child
+    ) {
+      condition = ancestor.test as EsTreeNode;
+      requiredTruthiness = "truthy";
+    } else if (isNodeOfType(ancestor, "ForStatement") && ancestor.body === child && ancestor.test) {
+      condition = ancestor.test as EsTreeNode;
+      requiredTruthiness = "truthy";
+    }
+    if (condition && requiredTruthiness) {
+      const conditionTruthiness = readInvocationConditionTruthiness(
+        condition,
+        parameterValues,
+        context,
+      );
+      if (conditionTruthiness !== "unknown" && conditionTruthiness !== requiredTruthiness) {
+        return true;
+      }
+    }
+    child = ancestor;
+    ancestor = ancestor.parent ?? null;
+  }
+  return false;
+};
+
+const getEffectRetainedInvocations = (
+  retainedFunction: EsTreeNode,
+  context: RuleContext,
+): EffectRetainedInvocation[] => {
+  if (!isFunctionLike(retainedFunction)) return [];
   const componentFunction = findEnclosingFunction(retainedFunction);
-  if (!componentFunction || !isFunctionLike(componentFunction)) return false;
-  let isInvoked = false;
+  if (!componentFunction || !isFunctionLike(componentFunction)) return [];
+  const invocations: EffectRetainedInvocation[] = [];
   walkAst(componentFunction.body, (child: EsTreeNode) => {
-    if (isInvoked) return false;
     if (
       !isNodeOfType(child, "CallExpression") ||
       findEnclosingFunction(child) !== componentFunction ||
@@ -5035,7 +5298,6 @@ const isDirectlyInvokedByEffect = (retainedFunction: EsTreeNode, context: RuleCo
     const effectCallback = getEffectCallback(child);
     if (!effectCallback || !isFunctionLike(effectCallback)) return;
     walkAst(effectCallback.body, (effectChild: EsTreeNode) => {
-      if (isInvoked) return false;
       if (effectChild !== effectCallback.body && isFunctionLike(effectChild)) return false;
       if (
         !isNodeOfType(effectChild, "CallExpression") ||
@@ -5051,13 +5313,11 @@ const isDirectlyInvokedByEffect = (retainedFunction: EsTreeNode, context: RuleCo
           resolveRefOwnedCleanupFunction(argument, context) === retainedFunction &&
           isSynchronousIteratorCallbackCall(effectChild, argument),
       );
-      if (isDirectInvocation || isSynchronousIteratorInvocation) {
-        isInvoked = true;
-        return false;
-      }
+      if (isDirectInvocation) invocations.push({ call: effectChild, isDirect: true });
+      if (isSynchronousIteratorInvocation) invocations.push({ call: effectChild, isDirect: false });
     });
   });
-  return isInvoked;
+  return invocations;
 };
 
 export const effectNeedsCleanup = defineRule({
@@ -5073,7 +5333,8 @@ export const effectNeedsCleanup = defineRule({
       if (!refEffectUsage && !isPotentiallyReachableFunction(retainedFunction, context)) {
         return;
       }
-      const isEffectInvoked = isDirectlyInvokedByEffect(retainedFunction, context);
+      const effectInvocations = getEffectRetainedInvocations(retainedFunction, context);
+      const isEffectInvoked = effectInvocations.length > 0;
       const leak = findRetainedFunctionLeak(
         retainedFunction,
         context,
@@ -5096,7 +5357,12 @@ export const effectNeedsCleanup = defineRule({
         isEffectInvoked &&
         leak.resourceName === "setTimeout" &&
         (!isNodeReachableWithinFunction(leak.node, context) ||
-          (retainedFunction.params.length > 0 && !context.cfg.isUnconditionalFromEntry(leak.node)))
+          (isFunctionLike(retainedFunction) &&
+            retainedFunction.params.length > 0 &&
+            !context.cfg.isUnconditionalFromEntry(leak.node) &&
+            effectInvocations.every((invocation) =>
+              isLeakPathDisabledForInvocation(retainedFunction, leak.node, invocation, context),
+            )))
       ) {
         return;
       }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-synchronous-iterator-callback.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-synchronous-iterator-callback.ts
@@ -256,9 +256,10 @@ export const isSynchronousIteratorCall = (
   );
 };
 
-export const isSynchronousIteratorCallback = (functionNode: EsTreeNode): boolean => {
-  const callNode = functionNode.parent;
-  if (!isNodeOfType(callNode, "CallExpression")) return false;
+export const isSynchronousIteratorCallbackCall = (
+  callNode: EsTreeNodeOfType<"CallExpression">,
+  callbackArgument: EsTreeNode,
+): boolean => {
   const callee = stripParenExpression(callNode.callee);
   if (
     !isNodeOfType(callee, "MemberExpression") ||
@@ -272,10 +273,18 @@ export const isSynchronousIteratorCallback = (functionNode: EsTreeNode): boolean
     callee.object.name === "Array" &&
     callee.property.name === "from"
   ) {
-    return callNode.arguments[1] === functionNode;
+    return callNode.arguments[1] === callbackArgument;
   }
   return (
     SYNCHRONOUS_ITERATOR_METHOD_NAMES.has(callee.property.name) &&
-    callNode.arguments[0] === functionNode
+    callNode.arguments[0] === callbackArgument
+  );
+};
+
+export const isSynchronousIteratorCallback = (functionNode: EsTreeNode): boolean => {
+  const callNode = functionNode.parent;
+  return Boolean(
+    isNodeOfType(callNode, "CallExpression") &&
+    isSynchronousIteratorCallbackCall(callNode, functionNode),
   );
 };


### PR DESCRIPTION
## Summary

- prove exact listener teardown through stable capture aliases, exhaustive local receiver loops, unary listener pairs, and callback-ref replacement
- preserve diagnostics for all contract-subjective split-lifecycle cases and direct effect timers
- detect one-shot timers in callbacks synchronously invoked by an effect
- add React Bench regressions, near-miss controls, a strict fuzz corpus case, and a patch changeset

## React Bench audit

- updated docs contract: `effect-needs-cleanup`
- archived confirmed-FP units: 128
- final adjudication: 12 confirmed FP, 82 confirmed TP, 34 contract-subjective
- replay after fix: 12 suppressed, 116 retained, 0 parse failures
- separate confirmed FN: 1, now reported
- Terra: both archived cases are direct effect timers and remain reported as true positives
- Sol: its archived case remains reported as contract-subjective

Artifacts:

- partition SHA-256: `a70787e869bce08af432ab558cb3e220eac0797cde237107247d1486caecd908`
- replay SHA-256: `fe0c64d6e8ae9060ef88fc382d33abb46673099a06f3c43af4d8319560b99b8a`
- updated model ledger SHA-256: `5bb9e22d8d79aae8fcc5cabf966aa3e7337475f6479b4777c93d5a4ba2c9dde2`

## Validation

- `nr build`
- `nr format:check`
- `nr lint`
- `nr typecheck`
- `nr test --concurrency=1`
- `nr smoke:json-report`
- strict fuzz: 500 iterations, seed 792026, invariants and strict mode enabled
- post-edit truffler searches found no duplicate helper

RDE is blocked in the local eval checkout by its required but unset `AXIOM_DATASET` schema field. Daytona parity is blocked because `DAYTONA_API_KEY` is unavailable in this environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large static-analysis changes to a core lint rule can shift diagnostic volume (fewer FPs, new timer reports); behavior is heavily regression-tested but edge cases in condition/truthiness folding remain possible.
> 
> **Overview**
> Strengthens **`effect-needs-cleanup`** so source-proven teardown is recognized in more real React patterns, cutting React Bench false positives while keeping strict cases reported.
> 
> **Listener / subscription pairing** now treats read-only `const` options objects used only on `addEventListener` / `removeEventListener` as stable for capture matching, pairs **add/remove across the same local `for…of` over a private const array**, accepts **unary `addListener` / `removeListener`** when the handler is proven (not only legacy media-query paths), and credits **callback-ref replacement** guarded by `previous && previous !== node` before `removeEventListener`.
> 
> **Timers in helpers called from effects** are analyzed when a `useCallback` (or similar) is synchronously invoked from an effect: one-shot `setTimeout` leaks are reported unless cleanup exists, with **argument-aware condition folding** (e.g. `start(false)` vs `start(true)`), guards for unreachable paths, and reporting for **`forEach` / `map`** iterator handoffs while **promise / deferred** paths stay exempt. Leak scanning also skips unreachable AST nodes.
> 
> Adds a **React Bench regression suite**, a **fuzz corpus** pass case, and a patch **changeset** for `oxlint-plugin-react-doctor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 569dba0bc7df61ed1dab7cd276683cc4d077c939. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->