### PR TITLE
RDFPFN792026: recognize guarded loading finalizers

### DIFF
--- a/.changeset/calm-loading-owners.md
+++ b/.changeset/calm-loading-owners.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Avoid loading-reset false positives when a `finally` reset is guarded by the current async operation or a cleanup-backed mounted ref.

--- a/packages/fuzz/corpus/regressions/no-loading-flag-reset-outside-finally--guarded-finalizer-before-later-await.tsx
+++ b/packages/fuzz/corpus/regressions/no-loading-flag-reset-outside-finally--guarded-finalizer-before-later-await.tsx
@@ -1,0 +1,25 @@
+// rule: no-loading-flag-reset-outside-finally
+// weakness: control-flow
+// source: Cursor Bugbot PR #1494
+// verdict: pass
+
+import { useRef, useState } from "react";
+
+export const FeedButton = () => {
+  const [isFeedPending, setFeedPending] = useState(false);
+  const ownerRef = useRef<object | null>(null);
+
+  const load = async () => {
+    const token = {};
+    ownerRef.current = token;
+    setFeedPending(true);
+    try {
+      prepareFeed();
+    } finally {
+      if (ownerRef.current === token) setFeedPending(false);
+    }
+    await fetch("/feed/more");
+  };
+
+  return <button onClick={() => void load()}>{isFeedPending ? "Loading" : "Load"}</button>;
+};

--- a/packages/fuzz/corpus/regressions/no-loading-flag-reset-outside-finally--latest-operation-owner.tsx
+++ b/packages/fuzz/corpus/regressions/no-loading-flag-reset-outside-finally--latest-operation-owner.tsx
@@ -1,0 +1,23 @@
+// rule: no-loading-flag-reset-outside-finally
+// weakness: alias-guard
+// source: React Bench RDFPFN792026 claude-view PermissionCard
+import { useRef, useState } from "react";
+
+export const PermissionCard = () => {
+  const [, setDeliveryPending] = useState(false);
+  const activeRequestIdRef = useRef(0);
+  const requestSequenceRef = useRef(0);
+
+  const deliver = async () => {
+    const requestId = ++requestSequenceRef.current;
+    activeRequestIdRef.current = requestId;
+    setDeliveryPending(true);
+    try {
+      await fetch("/deliver");
+    } finally {
+      if (activeRequestIdRef.current === requestId) setDeliveryPending(false);
+    }
+  };
+
+  return <button onClick={() => void deliver()}>Deliver</button>;
+};

--- a/packages/fuzz/corpus/regressions/no-loading-flag-reset-outside-finally--separate-sequence-ref-write.tsx
+++ b/packages/fuzz/corpus/regressions/no-loading-flag-reset-outside-finally--separate-sequence-ref-write.tsx
@@ -1,0 +1,34 @@
+// rule: no-loading-flag-reset-outside-finally
+// weakness: control-flow
+// source: Cursor Bugbot PR #1494
+// verdict: pass
+
+import { useRef, useState } from "react";
+
+export const DeliveryButton = () => {
+  const [isDeliveryPending, setDeliveryPending] = useState(false);
+  const ownerRef = useRef(0);
+  const sequenceRef = useRef(0);
+
+  const reserveSequence = () => {
+    sequenceRef.current += 1;
+  };
+
+  const deliver = async () => {
+    const token = ++sequenceRef.current;
+    ownerRef.current = token;
+    setDeliveryPending(true);
+    try {
+      await fetch("/deliver");
+    } finally {
+      if (ownerRef.current === token) setDeliveryPending(false);
+    }
+  };
+
+  return (
+    <>
+      <button onClick={reserveSequence}>Reserve</button>
+      <button onClick={() => void deliver()}>{isDeliveryPending ? "Sending" : "Send"}</button>
+    </>
+  );
+};

--- a/packages/fuzz/corpus/regressions/no-loading-flag-reset-outside-finally--sibling-effect-mounted-ref.tsx
+++ b/packages/fuzz/corpus/regressions/no-loading-flag-reset-outside-finally--sibling-effect-mounted-ref.tsx
@@ -1,0 +1,27 @@
+// rule: no-loading-flag-reset-outside-finally
+// weakness: control-flow
+// source: React Bench RDFPFN792026 claude-view PermissionCard
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export const PermissionCard = () => {
+  const [, setPending] = useState(false);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const deliver = useCallback(async () => {
+    setPending(true);
+    try {
+      await fetch("/deliver");
+    } finally {
+      if (mountedRef.current) setPending(false);
+    }
+  }, []);
+
+  return <button onClick={() => void deliver()}>Deliver</button>;
+};

--- a/packages/fuzz/corpus/true-positives/no-loading-flag-reset-outside-finally--nested-loader-outer-owner-write.tsx
+++ b/packages/fuzz/corpus/true-positives/no-loading-flag-reset-outside-finally--nested-loader-outer-owner-write.tsx
@@ -1,0 +1,31 @@
+// rule: no-loading-flag-reset-outside-finally
+// weakness: control-flow
+// source: Cursor Bugbot PR #1494
+// verdict: fail
+
+import { useEffect, useRef, useState } from "react";
+
+export const DeliveryStatus = () => {
+  const [isDeliveryPending, setDeliveryPending] = useState(false);
+  const ownerRef = useRef<object | null>(null);
+
+  const cancel = () => {
+    ownerRef.current = null;
+  };
+
+  useEffect(() => {
+    const deliver = async () => {
+      const token = {};
+      ownerRef.current = token;
+      setDeliveryPending(true);
+      try {
+        await fetch("/deliver");
+      } finally {
+        if (ownerRef.current === token) setDeliveryPending(false);
+      }
+    };
+    void deliver();
+  }, []);
+
+  return <button onClick={cancel}>{isDeliveryPending ? "Cancel" : "Idle"}</button>;
+};

--- a/packages/fuzz/corpus/true-positives/no-loading-flag-reset-outside-finally--ownership-claim-after-loading.tsx
+++ b/packages/fuzz/corpus/true-positives/no-loading-flag-reset-outside-finally--ownership-claim-after-loading.tsx
@@ -1,0 +1,24 @@
+// rule: no-loading-flag-reset-outside-finally
+// weakness: control-flow
+// source: Cursor Bugbot PR #1494
+// verdict: fail
+
+import { useRef, useState } from "react";
+
+export const DeliveryButton = () => {
+  const [isDeliveryPending, setDeliveryPending] = useState(false);
+  const ownerRef = useRef<object | null>(null);
+
+  const deliver = async () => {
+    const token = {};
+    setDeliveryPending(true);
+    ownerRef.current = token;
+    try {
+      await fetch("/deliver");
+    } finally {
+      if (ownerRef.current === token) setDeliveryPending(false);
+    }
+  };
+
+  return <button onClick={() => void deliver()}>{isDeliveryPending ? "Sending" : "Send"}</button>;
+};

--- a/packages/fuzz/corpus/true-positives/no-loading-flag-reset-outside-finally--ref-snapshot-is-not-ownership.tsx
+++ b/packages/fuzz/corpus/true-positives/no-loading-flag-reset-outside-finally--ref-snapshot-is-not-ownership.tsx
@@ -1,0 +1,25 @@
+// rule: no-loading-flag-reset-outside-finally
+// weakness: control-flow
+// source: Cursor Bugbot PR #1494
+// verdict: fail
+
+import { useRef, useState } from "react";
+
+export const RefreshButton = () => {
+  const [isRefreshPending, setRefreshPending] = useState(false);
+  const ownerRef = useRef(0);
+
+  const refresh = async () => {
+    const owner = ownerRef.current;
+    setRefreshPending(true);
+    try {
+      await fetch("/refresh");
+    } finally {
+      if (ownerRef.current === owner) setRefreshPending(false);
+    }
+  };
+
+  return (
+    <button onClick={() => void refresh()}>{isRefreshPending ? "Refreshing" : "Refresh"}</button>
+  );
+};

--- a/packages/fuzz/corpus/true-positives/no-loading-flag-reset-outside-finally--stale-ordered-guard.tsx
+++ b/packages/fuzz/corpus/true-positives/no-loading-flag-reset-outside-finally--stale-ordered-guard.tsx
@@ -1,0 +1,25 @@
+// rule: no-loading-flag-reset-outside-finally
+// weakness: control-flow
+// source: Cursor Bugbot PR #1494
+// verdict: fail
+
+import { useRef, useState } from "react";
+
+export const FeedButton = () => {
+  const [isFeedPending, setFeedPending] = useState(false);
+  const latestStartedRef = useRef(0);
+  const sequenceRef = useRef(0);
+
+  const load = async () => {
+    const requestId = ++sequenceRef.current;
+    latestStartedRef.current = requestId;
+    setFeedPending(true);
+    try {
+      await fetch("/feed");
+    } finally {
+      if (requestId <= latestStartedRef.current) setFeedPending(false);
+    }
+  };
+
+  return <button onClick={() => void load()}>{isFeedPending ? "Loading" : "Load"}</button>;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-loading-flag-reset-outside-finally.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-loading-flag-reset-outside-finally.test.ts
@@ -493,6 +493,52 @@ describe("no-loading-flag-reset-outside-finally", () => {
     }
   });
 
+  it("does not treat a ref snapshot as an ownership claim", () => {
+    const result = runRule(
+      noLoadingFlagResetOutsideFinally,
+      `import { useRef, useState } from "react";
+       const Preview = () => {
+         const [, setIsLoading] = useState(false);
+         const ownerRef = useRef(0);
+         const load = async () => {
+           const token = ownerRef.current;
+           setIsLoading(true);
+           try { await fetchFeed(); }
+           finally {
+             if (ownerRef.current === token) setIsLoading(false);
+           }
+         };
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("accepts a ref snapshot backed by a synchronous single-flight claim", () => {
+    const result = runRule(
+      noLoadingFlagResetOutsideFinally,
+      `import { useRef, useState } from "react";
+       const Preview = () => {
+         const [, setIsLoading] = useState(false);
+         const ownerRef = useRef(0);
+         const inFlightRef = useRef(false);
+         const load = async () => {
+           if (inFlightRef.current) return;
+           inFlightRef.current = true;
+           const token = ownerRef.current;
+           setIsLoading(true);
+           try { await fetchFeed(); }
+           finally {
+             if (ownerRef.current === token) {
+               inFlightRef.current = false;
+               setIsLoading(false);
+             }
+           }
+         };
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("accepts an ownership claim aligned with the loading path", () => {
     const result = runRule(
       noLoadingFlagResetOutsideFinally,
@@ -518,7 +564,8 @@ describe("no-loading-flag-reset-outside-finally", () => {
   });
 
   it("accepts a committed effect invalidation paired with the same reset", () => {
-    const sources = [
+    const result = runRule(
+      noLoadingFlagResetOutsideFinally,
       `import { useEffect, useRef, useState } from "react";
        const Preview = ({ requestId }) => {
          const [, setIsLoading] = useState(false);
@@ -536,27 +583,8 @@ describe("no-loading-flag-reset-outside-finally", () => {
            }
          };
        };`,
-      `import { useEffect, useRef, useState } from "react";
-       const Preview = ({ requestId }) => {
-         const [, setIsLoading] = useState(false);
-         const sequenceRef = useRef(0);
-         useEffect(() => {
-           setIsLoading(false);
-           sequenceRef.current += 1;
-         }, [requestId]);
-         const load = async () => {
-           const sequence = sequenceRef.current;
-           setIsLoading(true);
-           try { await fetchFeed(); }
-           finally {
-             if (sequenceRef.current === sequence) setIsLoading(false);
-           }
-         };
-       };`,
-    ];
-    for (const source of sources) {
-      expect(runRule(noLoadingFlagResetOutsideFinally, source).diagnostics).toHaveLength(0);
-    }
+    );
+    expect(result.diagnostics).toHaveLength(0);
   });
 
   it("rejects an effect invalidation that is not paired with the same reset", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-loading-flag-reset-outside-finally.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-loading-flag-reset-outside-finally.test.ts
@@ -586,6 +586,81 @@ describe("no-loading-flag-reset-outside-finally", () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("accepts a guarded finalizer before a later risky await", () => {
+    const sources = [
+      `import { useRef, useState } from "react";
+       const Preview = () => {
+         const [, setIsLoading] = useState(false);
+         const ownerRef = useRef(null);
+         const load = async () => {
+           const token = {};
+           ownerRef.current = token;
+           setIsLoading(true);
+           try { prepareFeed(); }
+           finally {
+             if (ownerRef.current === token) setIsLoading(false);
+           }
+           await fetchMore();
+         };
+       };`,
+      `import { useEffect, useRef, useState } from "react";
+       const Preview = () => {
+         const [, setIsLoading] = useState(false);
+         const mountedRef = useRef(true);
+         useEffect(() => () => { mountedRef.current = false; }, []);
+         const load = async () => {
+           setIsLoading(true);
+           try { prepareFeed(); }
+           finally {
+             if (mountedRef.current) setIsLoading(false);
+           }
+           await fetchMore();
+         };
+       };`,
+    ];
+    for (const source of sources) {
+      expect(runRule(noLoadingFlagResetOutsideFinally, source).diagnostics).toHaveLength(0);
+    }
+  });
+
+  it("rejects ordered guards that stay true for stale operations", () => {
+    const sources = [
+      `import { useRef, useState } from "react";
+       const Preview = () => {
+         const [, setIsLoading] = useState(false);
+         const latestStartedRef = useRef(0);
+         const sequenceRef = useRef(0);
+         const load = async () => {
+           const requestId = ++sequenceRef.current;
+           latestStartedRef.current = requestId;
+           setIsLoading(true);
+           try { await fetchFeed(); }
+           finally {
+             if (requestId <= latestStartedRef.current) setIsLoading(false);
+           }
+         };
+       };`,
+      `import { useRef, useState } from "react";
+       const Preview = () => {
+         const [, setIsLoading] = useState(false);
+         const latestStartedRef = useRef(0);
+         const sequenceRef = useRef(0);
+         const load = async () => {
+           const requestId = ++sequenceRef.current;
+           latestStartedRef.current = requestId;
+           setIsLoading(true);
+           try { await fetchFeed(); }
+           finally {
+             if (latestStartedRef.current >= requestId) setIsLoading(false);
+           }
+         };
+       };`,
+    ];
+    for (const source of sources) {
+      expect(runRule(noLoadingFlagResetOutsideFinally, source).diagnostics).toHaveLength(1);
+    }
+  });
+
   it("checks ownership writes outside an enclosing effect callback", () => {
     const result = runRule(
       noLoadingFlagResetOutsideFinally,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-loading-flag-reset-outside-finally.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-loading-flag-reset-outside-finally.test.ts
@@ -179,6 +179,481 @@ describe("no-loading-flag-reset-outside-finally", () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("stays quiet for a sibling effect cleanup lifecycle guard in finally", () => {
+    const result = runRule(
+      noLoadingFlagResetOutsideFinally,
+      `import { useCallback, useEffect, useRef, useState } from "react";
+       const Preview = () => {
+         const [, setIsLoading] = useState(false);
+         const mountedRef = useRef(true);
+         useEffect(() => {
+           mountedRef.current = true;
+           return () => { mountedRef.current = false; };
+         }, []);
+         const load = useCallback(async () => {
+           setIsLoading(true);
+           try { await fetchFeed(); }
+           finally { if (mountedRef.current) setIsLoading(false); }
+         }, []);
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when only the latest async operation owns the final reset", () => {
+    const sources = [
+      `import { useRef, useState } from "react";
+       const Preview = () => {
+         const [, setIsLoading] = useState(false);
+         const requestIdRef = useRef(0);
+         const requestSequenceRef = useRef(0);
+         const load = async () => {
+           const requestId = ++requestSequenceRef.current;
+           requestIdRef.current = requestId;
+           setIsLoading(true);
+           try { await fetchFeed(); }
+           finally {
+             if (requestIdRef.current === requestId) setIsLoading(false);
+           }
+         };
+       };`,
+      `import { useRef, useState } from "react";
+       const Preview = () => {
+         const [, setIsLoading] = useState(false);
+         const requestIdRef = useRef(0);
+         const requestSequenceRef = useRef(0);
+         const attemptRef = useRef(0);
+         const load = async () => {
+           const requestId = ++requestSequenceRef.current;
+           requestIdRef.current = requestId;
+           const attempt = ++attemptRef.current;
+           setIsLoading(true);
+           try { await fetchFeed(); }
+           finally {
+             if (requestIdRef.current === requestId && attemptRef.current === attempt) {
+               setIsLoading(false);
+             }
+           }
+         };
+       };`,
+      `import { useRef, useState } from "react";
+       const Preview = () => {
+         const [, setIsLoading] = useState(false);
+         const latestStartedRef = useRef(0);
+         const requestSequenceRef = useRef(0);
+         const load = async () => {
+           const requestId = ++requestSequenceRef.current;
+           latestStartedRef.current = requestId;
+           setIsLoading(true);
+           try { await fetchFeed(); }
+           finally {
+             if (requestId >= latestStartedRef.current) setIsLoading(false);
+           }
+         };
+       };`,
+      `import { useRef, useState } from "react";
+       const Preview = () => {
+         const [, setIsLoading] = useState(false);
+         const ownerRef = useRef(null);
+         const load = async () => {
+           const token = {};
+           ownerRef.current = token;
+           setIsLoading(true);
+           try { await fetchFeed(); }
+           finally {
+             if (ownerRef.current === token) setIsLoading(false);
+           }
+         };
+       };`,
+    ];
+    for (const source of sources) {
+      expect(runRule(noLoadingFlagResetOutsideFinally, source).diagnostics).toHaveLength(0);
+    }
+  });
+
+  it("requires a proven current-operation ownership guard around a final reset", () => {
+    const sources = [
+      `import { useRef, useState } from "react";
+       const Preview = () => {
+         const [, setIsLoading] = useState(false);
+         const latestStartedRef = useRef(0);
+         const load = async (requestId) => {
+           setIsLoading(true);
+           try { await fetchFeed(); }
+           finally {
+             if (requestId <= latestStartedRef.current) setIsLoading(false);
+           }
+         };
+       };`,
+      `import { useRef, useState } from "react";
+       const Preview = () => {
+         const [, setIsLoading] = useState(false);
+         const statusRef = useRef("ready");
+         const load = async () => {
+           setIsLoading(true);
+           try { await fetchFeed(); }
+           finally {
+             if (statusRef.current === "ready") setIsLoading(false);
+           }
+         };
+       };`,
+      `import { useState } from "react";
+       const useRef = (value) => ({ current: value });
+       const Preview = () => {
+         const [, setIsLoading] = useState(false);
+         const requestRef = useRef("");
+         const load = async (requestId) => {
+           setIsLoading(true);
+           try { await fetchFeed(); }
+           finally {
+             if (requestRef.current === requestId) setIsLoading(false);
+           }
+         };
+       };`,
+      `import { useRef, useState } from "react";
+       const Preview = () => {
+         const [, setIsLoading] = useState(false);
+         const requestRef = useRef("");
+         const load = async () => {
+           let requestId = "first";
+           setIsLoading(true);
+           await fetchFeed();
+           requestId = "second";
+           try { await fetchMore(); }
+           finally {
+             if (requestRef.current === requestId) setIsLoading(false);
+           }
+         };
+       };`,
+      `import { useRef, useState } from "react";
+       const Preview = () => {
+         const [, setIsLoading] = useState(false);
+         const ownerRef = useRef("different");
+         const load = async () => {
+           const token = "never";
+           setIsLoading(true);
+           try { await fetchFeed(); }
+           finally {
+             if (ownerRef.current === token) setIsLoading(false);
+           }
+         };
+       };`,
+      `import { useRef, useState } from "react";
+       const Preview = () => {
+         const [, setIsLoading] = useState(false);
+         const ownerRef = useRef("");
+         const load = async (token) => {
+           ownerRef.current = token;
+           setIsLoading(true);
+           try { await fetchFeed(); }
+           finally {
+             if (ownerRef.current === token) setIsLoading(false);
+           }
+         };
+       };`,
+      `import { useRef, useState } from "react";
+       const Preview = () => {
+         const [, setIsLoading] = useState(false);
+         const latestStartedRef = useRef(0);
+         const load = async (requestId) => {
+           latestStartedRef.current = requestId;
+           setIsLoading(true);
+           try { await fetchFeed(); }
+           finally {
+             if (requestId >= latestStartedRef.current) setIsLoading(false);
+           }
+         };
+       };`,
+      `import { useRef, useState } from "react";
+       const Preview = () => {
+         const [, setIsLoading] = useState(false);
+         const ownerRef = useRef("");
+         const load = async (token) => {
+           setIsLoading(true);
+           try {
+             await fetchFeed();
+             ownerRef.current = token;
+           } finally {
+             if (ownerRef.current === token) setIsLoading(false);
+           }
+         };
+       };`,
+      `import { useRef, useState } from "react";
+       const Preview = () => {
+         const [, setIsLoading] = useState(false);
+         const ownerRef = useRef("");
+         const load = async (token) => {
+           const claim = () => { ownerRef.current = token; };
+           setIsLoading(true);
+           try { await fetchFeed(); }
+           finally {
+             if (ownerRef.current === token) setIsLoading(false);
+           }
+         };
+       };`,
+      `import { useRef, useState } from "react";
+       const Preview = () => {
+         const [, setIsLoading] = useState(false);
+         const ownerRef = useRef("");
+         const load = async (token, shouldClaim) => {
+           if (shouldClaim) ownerRef.current = token;
+           setIsLoading(true);
+           try { await fetchFeed(); }
+           finally {
+             if (ownerRef.current === token) setIsLoading(false);
+           }
+         };
+       };`,
+      `import { useRef, useState } from "react";
+       const Preview = () => {
+         const [, setIsLoading] = useState(false);
+         const ownerRef = useRef(0);
+         const sequenceRef = useRef(0);
+         const overwriteOwner = () => { ownerRef.current = 0; };
+         const load = async () => {
+           const token = ++sequenceRef.current;
+           ownerRef.current = token;
+           setIsLoading(true);
+           try { await fetchFeed(); }
+           finally {
+             if (ownerRef.current === token) setIsLoading(false);
+           }
+         };
+       };`,
+      `import { useRef, useState } from "react";
+       const Preview = () => {
+         const [, setIsLoading] = useState(false);
+         const ownerRef = useRef(0);
+         const sequenceRef = useRef(0);
+         const load = async () => {
+           const token = ++sequenceRef.current;
+           ownerRef.current = token;
+           mightThrow();
+           setIsLoading(true);
+           try { await fetchFeed(); }
+           finally {
+             if (ownerRef.current === token) setIsLoading(false);
+           }
+         };
+       };`,
+    ];
+    for (const [sourceIndex, source] of sources.entries()) {
+      expect(
+        runRule(noLoadingFlagResetOutsideFinally, source).diagnostics,
+        `source ${sourceIndex}`,
+      ).toHaveLength(1);
+    }
+  });
+
+  it("accepts an ownership claim aligned with the loading path", () => {
+    const result = runRule(
+      noLoadingFlagResetOutsideFinally,
+      `import { useRef, useState } from "react";
+       const Preview = () => {
+         const [, setIsLoading] = useState(false);
+         const ownerRef = useRef(0);
+         const sequenceRef = useRef(0);
+         const load = async (shouldLoad) => {
+           if (shouldLoad) {
+             const token = ++sequenceRef.current;
+             ownerRef.current = token;
+             setIsLoading(true);
+             try { await fetchFeed(); }
+             finally {
+               if (ownerRef.current === token) setIsLoading(false);
+             }
+           }
+         };
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("accepts a committed effect invalidation paired with the same reset", () => {
+    const sources = [
+      `import { useEffect, useRef, useState } from "react";
+       const Preview = ({ requestId }) => {
+         const [, setIsLoading] = useState(false);
+         const attemptRef = useRef(0);
+         useEffect(() => {
+           attemptRef.current += 1;
+           setIsLoading(false);
+         }, [requestId]);
+         const load = async () => {
+           const attempt = ++attemptRef.current;
+           setIsLoading(true);
+           try { await fetchFeed(); }
+           finally {
+             if (attemptRef.current === attempt) setIsLoading(false);
+           }
+         };
+       };`,
+      `import { useEffect, useRef, useState } from "react";
+       const Preview = ({ requestId }) => {
+         const [, setIsLoading] = useState(false);
+         const sequenceRef = useRef(0);
+         useEffect(() => {
+           setIsLoading(false);
+           sequenceRef.current += 1;
+         }, [requestId]);
+         const load = async () => {
+           const sequence = sequenceRef.current;
+           setIsLoading(true);
+           try { await fetchFeed(); }
+           finally {
+             if (sequenceRef.current === sequence) setIsLoading(false);
+           }
+         };
+       };`,
+    ];
+    for (const source of sources) {
+      expect(runRule(noLoadingFlagResetOutsideFinally, source).diagnostics).toHaveLength(0);
+    }
+  });
+
+  it("rejects an effect invalidation that is not paired with the same reset", () => {
+    const sources = [
+      `import { useEffect, useRef, useState } from "react";
+       const Preview = ({ requestId }) => {
+         const [, setIsLoading] = useState(false);
+         const attemptRef = useRef(0);
+         useEffect(() => {
+           attemptRef.current += 1;
+         }, [requestId]);
+         const load = async () => {
+           const attempt = ++attemptRef.current;
+           setIsLoading(true);
+           try { await fetchFeed(); }
+           finally {
+             if (attemptRef.current === attempt) setIsLoading(false);
+           }
+         };
+       };`,
+      `import { useEffect, useRef, useState } from "react";
+       const Preview = ({ requestId, shouldReset }) => {
+         const [, setIsLoading] = useState(false);
+         const attemptRef = useRef(0);
+         useEffect(() => {
+           attemptRef.current += 1;
+           if (shouldReset) setIsLoading(false);
+         }, [requestId, shouldReset]);
+         const load = async () => {
+           const attempt = ++attemptRef.current;
+           setIsLoading(true);
+           try { await fetchFeed(); }
+           finally {
+             if (attemptRef.current === attempt) setIsLoading(false);
+           }
+         };
+       };`,
+    ];
+    for (const source of sources) {
+      expect(runRule(noLoadingFlagResetOutsideFinally, source).diagnostics).toHaveLength(1);
+    }
+  });
+
+  it("composes lifecycle and claimed-ownership finalizer guards", () => {
+    const sources = [
+      `import { useEffect, useRef, useState } from "react";
+       const Preview = () => {
+         const [, setIsLoading] = useState(false);
+         const mountedRef = useRef(true);
+         const ownerRef = useRef(0);
+         const sequenceRef = useRef(0);
+         useEffect(() => () => { mountedRef.current = false; }, []);
+         const load = async () => {
+           const token = ++sequenceRef.current;
+           ownerRef.current = token;
+           setIsLoading(true);
+           try { await fetchFeed(); }
+           finally {
+             if (mountedRef.current && ownerRef.current === token) setIsLoading(false);
+           }
+         };
+       };`,
+      `import { useEffect, useRef, useState } from "react";
+       const Preview = () => {
+         const [, setIsLoading] = useState(false);
+         const mountedRef = useRef(true);
+         const ownerRef = useRef(0);
+         const sequenceRef = useRef(0);
+         useEffect(() => () => { mountedRef.current = false; }, []);
+         const load = async () => {
+           const token = ++sequenceRef.current;
+           ownerRef.current = token;
+           setIsLoading(true);
+           try { await fetchFeed(); }
+           finally {
+             if (!mountedRef.current) return;
+             if (ownerRef.current !== token) return;
+             setIsLoading(false);
+           }
+         };
+       };`,
+      `import { useEffect, useRef, useState } from "react";
+       const Preview = () => {
+         const [, setIsLoading] = useState(false);
+         const mountedRef = useRef(true);
+         const ownerRef = useRef(0);
+         const sequenceRef = useRef(0);
+         useEffect(() => () => { mountedRef.current = false; }, []);
+         const load = async () => {
+           const token = ++sequenceRef.current;
+           ownerRef.current = token;
+           setIsLoading(true);
+           try { await fetchFeed(); }
+           finally {
+             if (!mountedRef.current || ownerRef.current !== token) return;
+             setIsLoading(false);
+           }
+         };
+       };`,
+    ];
+    for (const source of sources) {
+      expect(runRule(noLoadingFlagResetOutsideFinally, source).diagnostics).toHaveLength(0);
+    }
+  });
+
+  it("rejects unknown finalizer guard conjuncts and exits", () => {
+    const sources = [
+      `import { useRef, useState } from "react";
+       const Preview = () => {
+         const [, setIsLoading] = useState(false);
+         const ownerRef = useRef(0);
+         const sequenceRef = useRef(0);
+         const load = async (shouldReset) => {
+           const token = ++sequenceRef.current;
+           ownerRef.current = token;
+           setIsLoading(true);
+           try { await fetchFeed(); }
+           finally {
+             if (ownerRef.current === token && shouldReset) setIsLoading(false);
+           }
+         };
+       };`,
+      `import { useRef, useState } from "react";
+       const Preview = () => {
+         const [, setIsLoading] = useState(false);
+         const ownerRef = useRef(0);
+         const sequenceRef = useRef(0);
+         const load = async (shouldSkip) => {
+           const token = ++sequenceRef.current;
+           ownerRef.current = token;
+           setIsLoading(true);
+           try { await fetchFeed(); }
+           finally {
+             if (shouldSkip) return;
+             if (ownerRef.current !== token) return;
+             setIsLoading(false);
+           }
+         };
+       };`,
+    ];
+    for (const source of sources) {
+      expect(runRule(noLoadingFlagResetOutsideFinally, source).diagnostics).toHaveLength(1);
+    }
+  });
+
   it("flags a conditional finally reset without a matching effect cleanup guard", () => {
     const result = runRule(
       noLoadingFlagResetOutsideFinally,
@@ -281,6 +756,30 @@ describe("no-loading-flag-reset-outside-finally", () => {
            load();
            return () => { mountedRef.current = false; };
          }, []);
+       };`,
+      `import { useEffect, useRef, useState } from "react";
+       const Preview = () => {
+         const [, setIsLoading] = useState(false);
+         const mountedRef = useRef(true);
+         useEffect(() => () => { mountedRef.current = false; }, []);
+         mountedRef.current = false;
+         const load = async () => {
+           setIsLoading(true);
+           try { await fetchFeed(); }
+           finally { if (mountedRef.current) setIsLoading(false); }
+         };
+       };`,
+      `import { useEffect, useRef, useState } from "react";
+       const Preview = () => {
+         const [, setIsLoading] = useState(false);
+         const mountedRef = useRef(true);
+         useEffect(() => () => { mountedRef.current = false; }, []);
+         const disable = () => { mountedRef.current = false; };
+         const load = async () => {
+           setIsLoading(true);
+           try { await fetchFeed(); }
+           finally { if (mountedRef.current) setIsLoading(false); }
+         };
        };`,
     ];
     for (const source of sources) {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-loading-flag-reset-outside-finally.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-loading-flag-reset-outside-finally.test.ts
@@ -445,6 +445,54 @@ describe("no-loading-flag-reset-outside-finally", () => {
     }
   });
 
+  it("requires an ownership claim to execute before the loading setter", () => {
+    const sources = [
+      `import { useRef, useState } from "react";
+       const Preview = () => {
+         const [, setIsLoading] = useState(false);
+         const ownerRef = useRef(null);
+         const load = async () => {
+           const token = {};
+           setIsLoading(true);
+           ownerRef.current = token;
+           try { await fetchFeed(); }
+           finally {
+             if (ownerRef.current === token) setIsLoading(false);
+           }
+         };
+       };`,
+      `import { useRef, useState } from "react";
+       const Preview = () => {
+         const [, setIsLoading] = useState(false);
+         const latestStartedRef = useRef(0);
+         const load = async () => {
+           setIsLoading(true);
+           const requestId = ++latestStartedRef.current;
+           try { await fetchFeed(); }
+           finally {
+             if (requestId >= latestStartedRef.current) setIsLoading(false);
+           }
+         };
+       };`,
+      `import { useRef, useState } from "react";
+       const Preview = () => {
+         const [, setIsLoading] = useState(false);
+         const ownerRef = useRef(null);
+         const load = async () => {
+           const token = {};
+           ownerRef.current = (setIsLoading(true), token);
+           try { await fetchFeed(); }
+           finally {
+             if (ownerRef.current === token) setIsLoading(false);
+           }
+         };
+       };`,
+    ];
+    for (const source of sources) {
+      expect(runRule(noLoadingFlagResetOutsideFinally, source).diagnostics).toHaveLength(1);
+    }
+  });
+
   it("accepts an ownership claim aligned with the loading path", () => {
     const result = runRule(
       noLoadingFlagResetOutsideFinally,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-loading-flag-reset-outside-finally.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-loading-flag-reset-outside-finally.test.ts
@@ -563,6 +563,54 @@ describe("no-loading-flag-reset-outside-finally", () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("accepts unrelated writes to a separate ownership token sequence", () => {
+    const result = runRule(
+      noLoadingFlagResetOutsideFinally,
+      `import { useRef, useState } from "react";
+       const Preview = () => {
+         const [, setIsLoading] = useState(false);
+         const ownerRef = useRef(0);
+         const sequenceRef = useRef(0);
+         const reserveSequence = () => { sequenceRef.current += 1; };
+         const load = async () => {
+           const token = ++sequenceRef.current;
+           ownerRef.current = token;
+           setIsLoading(true);
+           try { await fetchFeed(); }
+           finally {
+             if (ownerRef.current === token) setIsLoading(false);
+           }
+         };
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("checks ownership writes outside an enclosing effect callback", () => {
+    const result = runRule(
+      noLoadingFlagResetOutsideFinally,
+      `import { useEffect, useRef, useState } from "react";
+       const Preview = () => {
+         const [, setIsLoading] = useState(false);
+         const ownerRef = useRef(null);
+         const cancel = () => { ownerRef.current = null; };
+         useEffect(() => {
+           const load = async () => {
+             const token = {};
+             ownerRef.current = token;
+             setIsLoading(true);
+             try { await fetchFeed(); }
+             finally {
+               if (ownerRef.current === token) setIsLoading(false);
+             }
+           };
+           void load();
+         }, []);
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("accepts a committed effect invalidation paired with the same reset", () => {
     const result = runRule(
       noLoadingFlagResetOutsideFinally,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-loading-flag-reset-outside-finally.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-loading-flag-reset-outside-finally.ts
@@ -1835,7 +1835,7 @@ const getOwningFunction = (functionNode: EsTreeNode): EsTreeNode => {
   let ownerFunction = functionNode;
   let cursor: EsTreeNode | null | undefined = functionNode.parent;
   while (cursor) {
-    if (isFunctionLike(cursor)) return cursor;
+    if (isFunctionLike(cursor)) ownerFunction = cursor;
     cursor = cursor.parent ?? null;
   }
   return ownerFunction;
@@ -2092,25 +2092,27 @@ const findOwnershipClaim = (
       scopes: context.scopes,
     });
     if (!generationKey) return null;
-    const ownerFunction = getOwningFunction(functionNode);
-    let didFindOtherGenerationWrite = false;
-    walkAst(ownerFunction, (candidate) => {
-      if (didFindOtherGenerationWrite || candidate === tokenInitializer) return;
-      const writeTarget = isNodeOfType(candidate, "AssignmentExpression")
-        ? candidate.left
-        : isNodeOfType(candidate, "UpdateExpression") ||
-            (isNodeOfType(candidate, "UnaryExpression") && candidate.operator === "delete")
-          ? candidate.argument
-          : null;
-      if (
-        writeTarget &&
-        serializeReferenceKey({ node: writeTarget, scopes: context.scopes }) === generationKey &&
-        !isEffectInvalidationPairedWithReset(candidate, truthySets, context)
-      ) {
-        didFindOtherGenerationWrite = true;
-      }
-    });
-    if (didFindOtherGenerationWrite) return null;
+    if (generationKey === refKey) {
+      const ownerFunction = getOwningFunction(functionNode);
+      let didFindOtherGenerationWrite = false;
+      walkAst(ownerFunction, (candidate) => {
+        if (didFindOtherGenerationWrite || candidate === tokenInitializer) return;
+        const writeTarget = isNodeOfType(candidate, "AssignmentExpression")
+          ? candidate.left
+          : isNodeOfType(candidate, "UpdateExpression") ||
+              (isNodeOfType(candidate, "UnaryExpression") && candidate.operator === "delete")
+            ? candidate.argument
+            : null;
+        if (
+          writeTarget &&
+          serializeReferenceKey({ node: writeTarget, scopes: context.scopes }) === generationKey &&
+          !isEffectInvalidationPairedWithReset(candidate, truthySets, context)
+        ) {
+          didFindOtherGenerationWrite = true;
+        }
+      });
+      if (didFindOtherGenerationWrite) return null;
+    }
   }
   walkOwnFunctionScope(functionNode, (candidate) => {
     if (!isNodeOfType(candidate, "AssignmentExpression") || candidate.operator !== "=") return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-loading-flag-reset-outside-finally.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-loading-flag-reset-outside-finally.ts
@@ -2091,8 +2091,7 @@ const findOwnershipClaim = (
       node: tokenInitializer.argument,
       scopes: context.scopes,
     });
-    if (!generationKey) return null;
-    if (generationKey === refKey) {
+    if (generationKey && generationKey === refKey) {
       const ownerFunction = getOwningFunction(functionNode);
       let didFindOtherGenerationWrite = false;
       walkAst(ownerFunction, (candidate) => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-loading-flag-reset-outside-finally.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-loading-flag-reset-outside-finally.ts
@@ -1138,6 +1138,100 @@ const isCancellationGuardTest = (test: EsTreeNode): boolean => {
   return matches;
 };
 
+interface AsyncOwnershipComparison {
+  refCurrent: EsTreeNodeOfType<"MemberExpression">;
+  token: EsTreeNodeOfType<"Identifier">;
+  mode: "owns" | "lost";
+  isOrdered: boolean;
+}
+
+const getReactRefCurrent = (
+  expression: EsTreeNode,
+  context: RuleContext,
+): EsTreeNodeOfType<"MemberExpression"> | null => {
+  const stripped = stripParenExpression(expression);
+  if (
+    !isNodeOfType(stripped, "MemberExpression") ||
+    getStaticPropertyName(stripped) !== "current"
+  ) {
+    return null;
+  }
+  const receiver = stripParenExpression(stripped.object);
+  if (!isNodeOfType(receiver, "Identifier")) return null;
+  const binding = findVariableInitializer(receiver, receiver.name);
+  const initializer = binding?.initializer ? stripParenExpression(binding.initializer) : null;
+  return initializer &&
+    isNodeOfType(initializer, "CallExpression") &&
+    isReactApiCall(initializer, USE_REF_HOOK_NAMES, context.scopes, {
+      allowGlobalReactNamespace: true,
+      allowUnboundBareCalls: true,
+    })
+    ? stripped
+    : null;
+};
+
+const getStableOwnershipToken = (
+  expression: EsTreeNode,
+  context: RuleContext,
+): EsTreeNodeOfType<"Identifier"> | null => {
+  const stripped = stripParenExpression(expression);
+  if (!isNodeOfType(stripped, "Identifier")) return null;
+  const symbol = context.scopes.symbolFor(stripped);
+  const initializer = symbol?.initializer ? stripParenExpression(symbol.initializer) : null;
+  const isStableAsyncIdentity =
+    Boolean(initializer && isNodeOfType(initializer, "ObjectExpression")) ||
+    Boolean(initializer && getReactRefCurrent(initializer, context)) ||
+    Boolean(
+      initializer &&
+      isNodeOfType(initializer, "UpdateExpression") &&
+      initializer.operator === "++" &&
+      getReactRefCurrent(initializer.argument, context),
+    );
+  return symbol &&
+    symbol.kind === "const" &&
+    symbol.references.every((reference) => reference.flag === "read") &&
+    isStableAsyncIdentity
+    ? stripped
+    : null;
+};
+
+const getAsyncOwnershipComparison = (
+  test: EsTreeNode,
+  context: RuleContext,
+): AsyncOwnershipComparison | null => {
+  const stripped = stripParenExpression(test);
+  if (!isNodeOfType(stripped, "BinaryExpression")) return null;
+  const leftRef = getReactRefCurrent(stripped.left, context);
+  const rightRef = getReactRefCurrent(stripped.right, context);
+  const leftToken = getStableOwnershipToken(stripped.left, context);
+  const rightToken = getStableOwnershipToken(stripped.right, context);
+  if (stripped.operator === "===" || stripped.operator === "==") {
+    if (leftRef && rightToken) {
+      return { refCurrent: leftRef, token: rightToken, mode: "owns", isOrdered: false };
+    }
+    if (rightRef && leftToken) {
+      return { refCurrent: rightRef, token: leftToken, mode: "owns", isOrdered: false };
+    }
+    return null;
+  }
+  if (stripped.operator === "!==" || stripped.operator === "!=") {
+    if (leftRef && rightToken) {
+      return { refCurrent: leftRef, token: rightToken, mode: "lost", isOrdered: false };
+    }
+    if (rightRef && leftToken) {
+      return { refCurrent: rightRef, token: leftToken, mode: "lost", isOrdered: false };
+    }
+    return null;
+  }
+  if (stripped.operator === "<=" && leftRef && rightToken) {
+    return { refCurrent: leftRef, token: rightToken, mode: "owns", isOrdered: true };
+  }
+  if (stripped.operator === ">=" && rightRef && leftToken) {
+    return { refCurrent: rightRef, token: leftToken, mode: "owns", isOrdered: true };
+  }
+  return null;
+};
+
 interface CatchPathState {
   isCleared: boolean;
   isCancellationPath: boolean;
@@ -1673,10 +1767,250 @@ const isInsideTryFinalizer = (
   return false;
 };
 
+interface BlockEntry {
+  block: EsTreeNodeOfType<"BlockStatement">;
+  entry: EsTreeNode;
+}
+
+const getDirectBlockEntry = (node: EsTreeNode, functionNode: EsTreeNode): BlockEntry | null => {
+  let entry = node;
+  let cursor: EsTreeNode | null | undefined = node.parent;
+  while (cursor && cursor !== functionNode) {
+    if (isNodeOfType(cursor, "BlockStatement")) return { block: cursor, entry };
+    entry = cursor;
+    cursor = cursor.parent ?? null;
+  }
+  return null;
+};
+
+const claimPrecedesTruthySet = (
+  claimNode: EsTreeNode,
+  truthySet: SetterCall,
+  firstRiskyAwait: AwaitSite,
+  functionNode: EsTreeNode,
+  context: RuleContext,
+): boolean => {
+  const claimStart = getNodeStart(claimNode);
+  if (
+    claimStart === null ||
+    claimStart >= firstRiskyAwait.start ||
+    truthySet.start >= firstRiskyAwait.start
+  ) {
+    return false;
+  }
+  const claimEntry = getDirectBlockEntry(claimNode, functionNode);
+  const truthyEntry = getDirectBlockEntry(truthySet.node, functionNode);
+  if (!claimEntry || !truthyEntry || claimEntry.block !== truthyEntry.block) return false;
+  let claimCursor: EsTreeNode | null | undefined = claimNode.parent;
+  while (claimCursor && claimCursor !== claimEntry.block) {
+    if (
+      isNodeOfType(claimCursor, "IfStatement") ||
+      isNodeOfType(claimCursor, "SwitchCase") ||
+      isNodeOfType(claimCursor, "ConditionalExpression") ||
+      isNodeOfType(claimCursor, "LogicalExpression") ||
+      isNodeOfType(claimCursor, "ForStatement") ||
+      isNodeOfType(claimCursor, "ForInStatement") ||
+      isNodeOfType(claimCursor, "ForOfStatement") ||
+      isNodeOfType(claimCursor, "WhileStatement") ||
+      isNodeOfType(claimCursor, "DoWhileStatement")
+    ) {
+      return false;
+    }
+    claimCursor = claimCursor.parent ?? null;
+  }
+  const claimIndex = claimEntry.block.body.findIndex((statement) => statement === claimEntry.entry);
+  const truthyIndex = claimEntry.block.body.findIndex(
+    (statement) => statement === truthyEntry.entry,
+  );
+  if (claimIndex === -1 || truthyIndex === -1) return false;
+  if (claimIndex === truthyIndex) return true;
+  const firstIndex = Math.min(claimIndex, truthyIndex);
+  const lastIndex = Math.max(claimIndex, truthyIndex);
+  return claimEntry.block.body
+    .slice(firstIndex + 1, lastIndex)
+    .every(
+      (statement) =>
+        !subtreeHasAbruptSynchronousOperation(statement as EsTreeNode, functionNode, context),
+    );
+};
+
+const getOwningFunction = (functionNode: EsTreeNode): EsTreeNode => {
+  let ownerFunction = functionNode;
+  let cursor: EsTreeNode | null | undefined = functionNode.parent;
+  while (cursor) {
+    if (isFunctionLike(cursor)) return cursor;
+    cursor = cursor.parent ?? null;
+  }
+  return ownerFunction;
+};
+
+const isEffectInvalidationPairedWithReset = (
+  writeNode: EsTreeNode,
+  truthySets: ReadonlyArray<SetterCall>,
+  context: RuleContext,
+): boolean => {
+  const truthyCall = truthySets[0]?.node;
+  if (!truthyCall || !isNodeOfType(truthyCall, "CallExpression")) return false;
+  const setter = getSetterBooleanValue(truthyCall, context);
+  if (!setter) return false;
+  let effectCallback: EsTreeNode | null | undefined = writeNode.parent;
+  while (effectCallback && !isFunctionLike(effectCallback)) {
+    effectCallback = effectCallback.parent ?? null;
+  }
+  if (!effectCallback || !isEffectCallback(effectCallback, context)) return false;
+  if (!isUnconditionallyExecutedWithinFunction(writeNode, effectCallback, context)) return false;
+  const writeEntry = getDirectBlockEntry(writeNode, effectCallback);
+  if (!writeEntry) return false;
+  let isPaired = false;
+  walkOwnFunctionScope(effectCallback, (candidate) => {
+    if (isPaired || !isNodeOfType(candidate, "CallExpression")) return;
+    const candidateSetter = getSetterBooleanValue(candidate, context);
+    if (
+      candidateSetter?.setterKey !== setter.setterKey ||
+      candidateSetter.value ||
+      !isUnconditionallyExecutedWithinFunction(candidate, effectCallback, context)
+    ) {
+      return;
+    }
+    const resetEntry = getDirectBlockEntry(candidate, effectCallback);
+    if (!resetEntry || resetEntry.block !== writeEntry.block) return;
+    const writeIndex = writeEntry.block.body.findIndex(
+      (statement) => statement === writeEntry.entry,
+    );
+    const resetIndex = resetEntry.block.body.findIndex(
+      (statement) => statement === resetEntry.entry,
+    );
+    if (writeIndex === -1 || resetIndex === -1) return;
+    if (resetIndex <= writeIndex) {
+      isPaired = true;
+      return false;
+    }
+    isPaired = writeEntry.block.body
+      .slice(writeIndex + 1, resetIndex)
+      .every(
+        (statement) =>
+          !subtreeHasAbruptSynchronousOperation(statement as EsTreeNode, effectCallback, context),
+      );
+    return isPaired ? false : undefined;
+  });
+  return isPaired;
+};
+
+const findOwnershipClaim = (
+  comparison: AsyncOwnershipComparison,
+  functionNode: EsTreeNode,
+  truthySets: ReadonlyArray<SetterCall>,
+  firstRiskyAwait: AwaitSite,
+  context: RuleContext,
+): EsTreeNode | null => {
+  const refKey = serializeReferenceKey({
+    node: comparison.refCurrent,
+    scopes: context.scopes,
+  });
+  const tokenKey = serializeReferenceKey({ node: comparison.token, scopes: context.scopes });
+  if (!refKey || !tokenKey) return null;
+  const candidates: EsTreeNode[] = [];
+  const tokenSymbol = context.scopes.symbolFor(comparison.token);
+  const tokenInitializer = tokenSymbol?.initializer
+    ? stripParenExpression(tokenSymbol.initializer)
+    : null;
+  if (comparison.isOrdered && !isNodeOfType(tokenInitializer, "UpdateExpression")) return null;
+  if (
+    tokenInitializer &&
+    isNodeOfType(tokenInitializer, "UpdateExpression") &&
+    tokenInitializer.operator === "++" &&
+    serializeReferenceKey({ node: tokenInitializer.argument, scopes: context.scopes }) === refKey
+  ) {
+    candidates.push(tokenInitializer);
+  }
+  if (
+    tokenInitializer &&
+    getReactRefCurrent(tokenInitializer, context) &&
+    serializeReferenceKey({ node: tokenInitializer, scopes: context.scopes }) === refKey
+  ) {
+    candidates.push(tokenInitializer);
+  }
+  if (tokenInitializer && isNodeOfType(tokenInitializer, "UpdateExpression")) {
+    const generationKey = serializeReferenceKey({
+      node: tokenInitializer.argument,
+      scopes: context.scopes,
+    });
+    if (!generationKey) return null;
+    const ownerFunction = getOwningFunction(functionNode);
+    let didFindOtherGenerationWrite = false;
+    walkAst(ownerFunction, (candidate) => {
+      if (didFindOtherGenerationWrite || candidate === tokenInitializer) return;
+      const writeTarget = isNodeOfType(candidate, "AssignmentExpression")
+        ? candidate.left
+        : isNodeOfType(candidate, "UpdateExpression") ||
+            (isNodeOfType(candidate, "UnaryExpression") && candidate.operator === "delete")
+          ? candidate.argument
+          : null;
+      if (
+        writeTarget &&
+        serializeReferenceKey({ node: writeTarget, scopes: context.scopes }) === generationKey &&
+        !isEffectInvalidationPairedWithReset(candidate, truthySets, context)
+      ) {
+        didFindOtherGenerationWrite = true;
+      }
+    });
+    if (didFindOtherGenerationWrite) return null;
+  }
+  walkOwnFunctionScope(functionNode, (candidate) => {
+    if (!isNodeOfType(candidate, "AssignmentExpression") || candidate.operator !== "=") return;
+    if (
+      serializeReferenceKey({ node: candidate.left, scopes: context.scopes }) === refKey &&
+      serializeReferenceKey({ node: candidate.right, scopes: context.scopes }) === tokenKey
+    ) {
+      candidates.push(candidate);
+    }
+  });
+  const claim = candidates.find((candidate) =>
+    truthySets.some((truthySet) =>
+      claimPrecedesTruthySet(candidate, truthySet, firstRiskyAwait, functionNode, context),
+    ),
+  );
+  if (!claim) return null;
+  let didFindOtherWrite = false;
+  walkAst(getOwningFunction(functionNode), (candidate) => {
+    if (didFindOtherWrite || candidate === claim) return;
+    const writeTarget = isNodeOfType(candidate, "AssignmentExpression")
+      ? candidate.left
+      : isNodeOfType(candidate, "UpdateExpression") ||
+          (isNodeOfType(candidate, "UnaryExpression") && candidate.operator === "delete")
+        ? candidate.argument
+        : null;
+    if (
+      writeTarget &&
+      serializeReferenceKey({ node: writeTarget, scopes: context.scopes }) === refKey &&
+      !isEffectInvalidationPairedWithReset(candidate, truthySets, context)
+    ) {
+      didFindOtherWrite = true;
+    }
+  });
+  return didFindOtherWrite ? null : claim;
+};
+
+const isClaimedOwnershipComparison = (
+  test: EsTreeNode,
+  expectedMode: AsyncOwnershipComparison["mode"],
+  functionNode: EsTreeNode,
+  truthySets: ReadonlyArray<SetterCall>,
+  firstRiskyAwait: AwaitSite,
+  context: RuleContext,
+): boolean => {
+  const comparison = getAsyncOwnershipComparison(test, context);
+  return Boolean(
+    comparison &&
+    comparison.mode === expectedMode &&
+    findOwnershipClaim(comparison, functionNode, truthySets, firstRiskyAwait, context),
+  );
+};
+
 const hasLifecycleGuardWriteOutsideCleanup = (
   effectCallback: EsTreeNode,
   guardKey: string,
-  acceptedCleanupAssignments: ReadonlySet<EsTreeNode>,
+  acceptedAssignments: ReadonlySet<EsTreeNode>,
   context: RuleContext,
 ): boolean => {
   let didFindOtherWrite = false;
@@ -1685,7 +2019,7 @@ const hasLifecycleGuardWriteOutsideCleanup = (
     if (isNodeOfType(candidate, "AssignmentExpression")) {
       if (
         serializeReferenceKey({ node: candidate.left, scopes: context.scopes }) === guardKey &&
-        !acceptedCleanupAssignments.has(candidate)
+        !acceptedAssignments.has(candidate)
       ) {
         didFindOtherWrite = true;
         return false;
@@ -1704,83 +2038,241 @@ const hasLifecycleGuardWriteOutsideCleanup = (
   return didFindOtherWrite;
 };
 
-const isResetGuardedByCleanupBackedLifecycle = (
-  resetNode: EsTreeNode,
+const collectCleanupBackedLifecycleAssignments = (
+  effectCallback: EsTreeNode,
+  guardKey: string,
+  context: RuleContext,
+): ReadonlySet<EsTreeNode> | null => {
+  const acceptedAssignments = new Set<EsTreeNode>();
+  for (const cleanupFunction of collectReturnedCleanupFunctions(effectCallback, context.scopes)) {
+    walkOwnFunctionScope(cleanupFunction, (cleanupNode) => {
+      const assignedValue = isNodeOfType(cleanupNode, "AssignmentExpression")
+        ? stripParenExpression(cleanupNode.right)
+        : null;
+      if (
+        !isNodeOfType(cleanupNode, "AssignmentExpression") ||
+        cleanupNode.operator !== "=" ||
+        !isNodeOfType(assignedValue, "Literal") ||
+        assignedValue.value !== false ||
+        serializeReferenceKey({ node: cleanupNode.left, scopes: context.scopes }) !== guardKey ||
+        !isUnconditionallyExecutedWithinFunction(cleanupNode, cleanupFunction, context)
+      ) {
+        return;
+      }
+      acceptedAssignments.add(cleanupNode);
+    });
+  }
+  if (acceptedAssignments.size === 0) return null;
+  walkOwnFunctionScope(effectCallback, (effectNode) => {
+    const assignedValue = isNodeOfType(effectNode, "AssignmentExpression")
+      ? stripParenExpression(effectNode.right)
+      : null;
+    if (
+      isNodeOfType(effectNode, "AssignmentExpression") &&
+      effectNode.operator === "=" &&
+      isNodeOfType(assignedValue, "Literal") &&
+      assignedValue.value === true &&
+      serializeReferenceKey({ node: effectNode.left, scopes: context.scopes }) === guardKey &&
+      isUnconditionallyExecutedWithinFunction(effectNode, effectCallback, context)
+    ) {
+      acceptedAssignments.add(effectNode);
+    }
+  });
+  return acceptedAssignments;
+};
+
+const isEffectCallback = (node: EsTreeNode, context: RuleContext): boolean => {
+  const callbackRoot = findTransparentExpressionRoot(node);
+  const callbackCall = callbackRoot.parent;
+  return Boolean(
+    callbackCall &&
+    isNodeOfType(callbackCall, "CallExpression") &&
+    callbackCall.arguments[0] === callbackRoot &&
+    isReactApiCall(callbackCall, EFFECT_HOOK_NAMES, context.scopes, {
+      allowGlobalReactNamespace: true,
+      allowUnboundBareCalls: true,
+    }),
+  );
+};
+
+const isCleanupBackedLifecycleGuard = (
+  guardExpression: EsTreeNode,
   functionNode: EsTreeNode,
   context: RuleContext,
 ): boolean => {
+  const guardKey = serializeReferenceKey({ node: guardExpression, scopes: context.scopes });
+  if (!guardKey || !isInitiallyActiveLifecycleGuard(guardExpression, context)) return false;
+  let ownerFunction: EsTreeNode | null | undefined = functionNode.parent;
+  while (ownerFunction && !isFunctionLike(ownerFunction)) {
+    ownerFunction = ownerFunction.parent ?? null;
+  }
+  if (!ownerFunction) return false;
+  const effectCallbacks: EsTreeNode[] = [];
+  if (isEffectCallback(ownerFunction, context)) effectCallbacks.push(ownerFunction);
+  walkOwnFunctionScope(ownerFunction, (candidate) => {
+    if (!isNodeOfType(candidate, "CallExpression")) return;
+    if (
+      !isReactApiCall(candidate, EFFECT_HOOK_NAMES, context.scopes, {
+        allowGlobalReactNamespace: true,
+        allowUnboundBareCalls: true,
+      })
+    ) {
+      return;
+    }
+    const effectCallback = candidate.arguments[0];
+    if (effectCallback && isFunctionLike(effectCallback)) effectCallbacks.push(effectCallback);
+  });
+  const acceptedAssignments = new Set<EsTreeNode>();
+  for (const effectCallback of effectCallbacks) {
+    const effectAssignments = collectCleanupBackedLifecycleAssignments(
+      effectCallback,
+      guardKey,
+      context,
+    );
+    if (!effectAssignments) continue;
+    for (const assignment of effectAssignments) acceptedAssignments.add(assignment);
+  }
+  return Boolean(
+    acceptedAssignments.size > 0 &&
+    !hasLifecycleGuardWriteOutsideCleanup(ownerFunction, guardKey, acceptedAssignments, context),
+  );
+};
+
+interface FinalizerGuardExpressions {
+  positive: EsTreeNode[];
+  negative: EsTreeNode[];
+}
+
+const collectLogicalOperands = (expression: EsTreeNode, operator: "&&" | "||"): EsTreeNode[] => {
+  const stripped = stripParenExpression(expression);
+  if (isNodeOfType(stripped, "LogicalExpression") && stripped.operator === operator) {
+    return [
+      ...collectLogicalOperands(stripped.left, operator),
+      ...collectLogicalOperands(stripped.right, operator),
+    ];
+  }
+  return [stripped];
+};
+
+const isUnconditionalReturnBranch = (statement: EsTreeNode): boolean => {
+  if (isNodeOfType(statement, "ReturnStatement")) return true;
+  return Boolean(
+    isNodeOfType(statement, "BlockStatement") &&
+    statement.body.length === 1 &&
+    isNodeOfType(statement.body[0] as EsTreeNode, "ReturnStatement"),
+  );
+};
+
+const collectFinalizerGuardExpressions = (
+  resetNode: EsTreeNode,
+  protectingTry: EsTreeNodeOfType<"TryStatement">,
+): FinalizerGuardExpressions | null => {
+  const positive: EsTreeNode[] = [];
+  const negative: EsTreeNode[] = [];
   let child = resetNode;
   let cursor: EsTreeNode | null | undefined = resetNode.parent;
-  let guardKey: string | null = null;
-  let guardExpression: EsTreeNode | null = null;
-  while (cursor && cursor !== functionNode) {
-    if (
-      isNodeOfType(cursor, "IfStatement") &&
-      cursor.consequent === child &&
-      cursor.alternate === null
+  while (cursor && cursor !== protectingTry) {
+    if (isNodeOfType(cursor, "IfStatement")) {
+      if (cursor.consequent !== child || cursor.alternate !== null) return null;
+      positive.push(...collectLogicalOperands(cursor.test, "&&"));
+    } else if (isNodeOfType(cursor, "LogicalExpression")) {
+      if (cursor.operator !== "&&" || cursor.right !== child) return null;
+      positive.push(...collectLogicalOperands(cursor.left, "&&"));
+    } else if (isNodeOfType(cursor, "BlockStatement")) {
+      const childIndex = cursor.body.findIndex((statement) => statement === child);
+      if (childIndex !== -1) {
+        for (const statement of cursor.body.slice(0, childIndex)) {
+          if (
+            !isNodeOfType(statement, "IfStatement") ||
+            statement.alternate !== null ||
+            !isUnconditionalReturnBranch(statement.consequent)
+          ) {
+            continue;
+          }
+          negative.push(...collectLogicalOperands(statement.test, "||"));
+        }
+      }
+    } else if (
+      isNodeOfType(cursor, "SwitchCase") ||
+      isNodeOfType(cursor, "ConditionalExpression") ||
+      isNodeOfType(cursor, "ForStatement") ||
+      isNodeOfType(cursor, "ForInStatement") ||
+      isNodeOfType(cursor, "ForOfStatement") ||
+      isNodeOfType(cursor, "WhileStatement") ||
+      isNodeOfType(cursor, "DoWhileStatement")
     ) {
-      guardExpression = cursor.test;
-      guardKey = serializeReferenceKey({ node: cursor.test, scopes: context.scopes });
-      break;
+      return null;
     }
     child = cursor;
     cursor = cursor.parent ?? null;
   }
-  if (!guardKey || !guardExpression || !isInitiallyActiveLifecycleGuard(guardExpression, context)) {
-    return false;
-  }
+  return cursor === protectingTry && positive.length + negative.length > 0
+    ? { positive, negative }
+    : null;
+};
 
-  cursor = functionNode.parent;
-  while (cursor) {
-    if (isFunctionLike(cursor)) {
-      const callbackRoot = findTransparentExpressionRoot(cursor);
-      const callbackCall = callbackRoot.parent;
-      const isEffectCallback = Boolean(
-        callbackCall &&
-        isNodeOfType(callbackCall, "CallExpression") &&
-        callbackCall.arguments[0] === callbackRoot &&
-        isReactApiCall(callbackCall, EFFECT_HOOK_NAMES, context.scopes, {
-          allowGlobalReactNamespace: true,
-          allowUnboundBareCalls: true,
-        }),
-      );
-      if (isEffectCallback) {
-        const acceptedCleanupAssignments = new Set<EsTreeNode>();
-        for (const cleanupFunction of collectReturnedCleanupFunctions(cursor, context.scopes)) {
-          walkOwnFunctionScope(cleanupFunction, (cleanupNode) => {
-            const assignedValue = isNodeOfType(cleanupNode, "AssignmentExpression")
-              ? stripParenExpression(cleanupNode.right)
-              : null;
-            if (
-              !isNodeOfType(cleanupNode, "AssignmentExpression") ||
-              cleanupNode.operator !== "=" ||
-              !isNodeOfType(assignedValue, "Literal") ||
-              assignedValue.value !== false ||
-              serializeReferenceKey({ node: cleanupNode.left, scopes: context.scopes }) !==
-                guardKey ||
-              !isUnconditionallyExecutedWithinFunction(cleanupNode, cleanupFunction, context)
-            ) {
-              return;
-            }
-            acceptedCleanupAssignments.add(cleanupNode);
-          });
-        }
-        if (
-          acceptedCleanupAssignments.size > 0 &&
-          !hasLifecycleGuardWriteOutsideCleanup(
-            cursor,
-            guardKey,
-            acceptedCleanupAssignments,
-            context,
-          )
-        ) {
-          return true;
-        }
-      }
-    }
-    cursor = cursor.parent ?? null;
+const isPositiveFinalizerGuard = (
+  expression: EsTreeNode,
+  functionNode: EsTreeNode,
+  truthySets: ReadonlyArray<SetterCall>,
+  firstRiskyAwait: AwaitSite,
+  context: RuleContext,
+): boolean =>
+  isCleanupBackedLifecycleGuard(expression, functionNode, context) ||
+  isClaimedOwnershipComparison(
+    expression,
+    "owns",
+    functionNode,
+    truthySets,
+    firstRiskyAwait,
+    context,
+  );
+
+const isNegativeFinalizerGuard = (
+  expression: EsTreeNode,
+  functionNode: EsTreeNode,
+  truthySets: ReadonlyArray<SetterCall>,
+  firstRiskyAwait: AwaitSite,
+  context: RuleContext,
+): boolean => {
+  const stripped = stripParenExpression(expression);
+  if (isNodeOfType(stripped, "UnaryExpression") && stripped.operator === "!") {
+    return isPositiveFinalizerGuard(
+      stripped.argument,
+      functionNode,
+      truthySets,
+      firstRiskyAwait,
+      context,
+    );
   }
-  return false;
+  return isClaimedOwnershipComparison(
+    stripped,
+    "lost",
+    functionNode,
+    truthySets,
+    firstRiskyAwait,
+    context,
+  );
+};
+
+const isFinalizerResetProvablyGuarded = (
+  resetNode: EsTreeNode,
+  protectingTry: EsTreeNodeOfType<"TryStatement">,
+  functionNode: EsTreeNode,
+  truthySets: ReadonlyArray<SetterCall>,
+  firstRiskyAwait: AwaitSite,
+  context: RuleContext,
+): boolean => {
+  const guards = collectFinalizerGuardExpressions(resetNode, protectingTry);
+  return Boolean(
+    guards &&
+    guards.positive.every((guard) =>
+      isPositiveFinalizerGuard(guard, functionNode, truthySets, firstRiskyAwait, context),
+    ) &&
+    guards.negative.every((guard) =>
+      isNegativeFinalizerGuard(guard, functionNode, truthySets, firstRiskyAwait, context),
+    ),
+  );
 };
 
 const isAwaitInsideProtectedTry = (
@@ -1919,17 +2411,32 @@ const analyzeFunction = (functionNode: EsTreeNode, context: RuleContext): void =
         ),
     );
     if (riskyAwaitsWithTruthySet.length === 0) continue;
-    const conditionalExceptionalResets = calls.filter(
-      (call) =>
-        !call.value &&
-        call.context !== "plain" &&
-        !call.isUnconditional &&
-        call.protectingTry !== null &&
-        !(
-          isInsideTryFinalizer(call.node, call.protectingTry) &&
-          isResetGuardedByCleanupBackedLifecycle(call.node, functionNode, context)
-        ),
-    );
+    const conditionalExceptionalResets = calls.filter((call) => {
+      if (
+        call.value ||
+        call.context === "plain" ||
+        call.isUnconditional ||
+        call.protectingTry === null
+      ) {
+        return false;
+      }
+      const protectingTry = call.protectingTry;
+      if (!isInsideTryFinalizer(call.node, protectingTry)) return true;
+      const firstRiskyAwait = riskyAwaitsWithTruthySet.find((awaitSite) =>
+        isAwaitInsideProtectedTry(awaitSite.node, protectingTry),
+      );
+      return !(
+        firstRiskyAwait &&
+        isFinalizerResetProvablyGuarded(
+          call.node,
+          protectingTry,
+          functionNode,
+          truthySets,
+          firstRiskyAwait,
+          context,
+        )
+      );
+    });
     for (const reset of conditionalExceptionalResets) {
       const catchHandler = reset.protectingTry?.handler;
       if (

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-loading-flag-reset-outside-finally.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-loading-flag-reset-outside-finally.ts
@@ -1893,11 +1893,162 @@ const isEffectInvalidationPairedWithReset = (
   return isPaired;
 };
 
+const isUnconditionalReturnBranch = (statement: EsTreeNode): boolean => {
+  if (isNodeOfType(statement, "ReturnStatement")) return true;
+  return Boolean(
+    isNodeOfType(statement, "BlockStatement") &&
+    statement.body.length === 1 &&
+    isNodeOfType(statement.body[0] as EsTreeNode, "ReturnStatement"),
+  );
+};
+
+const findSingleFlightSnapshotClaim = (
+  tokenInitializer: EsTreeNode,
+  functionNode: EsTreeNode,
+  truthySets: ReadonlyArray<SetterCall>,
+  firstRiskyAwait: AwaitSite,
+  resetNode: EsTreeNode,
+  context: RuleContext,
+): EsTreeNode | null => {
+  const snapshotEntry = getDirectBlockEntry(tokenInitializer, functionNode);
+  const resetEntry = getDirectBlockEntry(resetNode, functionNode);
+  if (!snapshotEntry || !resetEntry) return null;
+  const claimCandidates: EsTreeNodeOfType<"AssignmentExpression">[] = [];
+  const releaseCandidates: EsTreeNodeOfType<"AssignmentExpression">[] = [];
+  walkOwnFunctionScope(functionNode, (candidate) => {
+    if (
+      !isNodeOfType(candidate, "AssignmentExpression") ||
+      candidate.operator !== "=" ||
+      !getReactRefCurrent(candidate.left, context)
+    ) {
+      return;
+    }
+    const assignedValue = stripParenExpression(candidate.right);
+    if (!isNodeOfType(assignedValue, "Literal") || typeof assignedValue.value !== "boolean") {
+      return;
+    }
+    const candidateKey = serializeReferenceKey({
+      node: candidate.left,
+      scopes: context.scopes,
+    });
+    if (!candidateKey) return;
+    if (!assignedValue.value) {
+      const candidateEntry = getDirectBlockEntry(candidate, functionNode);
+      if (candidateEntry?.block === resetEntry.block) releaseCandidates.push(candidate);
+      return;
+    }
+    if (
+      !truthySets.some((truthySet) =>
+        claimPrecedesTruthySet(candidate, truthySet, firstRiskyAwait, functionNode, context),
+      )
+    ) {
+      return;
+    }
+    const candidateEntry = getDirectBlockEntry(candidate, functionNode);
+    if (!candidateEntry || candidateEntry.block !== snapshotEntry.block) return;
+    const candidateIndex = candidateEntry.block.body.findIndex(
+      (statement) => statement === candidateEntry.entry,
+    );
+    const snapshotIndex = candidateEntry.block.body.findIndex(
+      (statement) => statement === snapshotEntry.entry,
+    );
+    if (candidateIndex === -1 || snapshotIndex === -1 || candidateIndex >= snapshotIndex) return;
+    const guardIndex = candidateEntry.block.body.findLastIndex((statement, statementIndex) => {
+      if (
+        statementIndex >= candidateIndex ||
+        !isNodeOfType(statement, "IfStatement") ||
+        statement.alternate !== null ||
+        !isUnconditionalReturnBranch(statement.consequent)
+      ) {
+        return false;
+      }
+      return (
+        serializeReferenceKey({
+          node: stripParenExpression(statement.test),
+          scopes: context.scopes,
+        }) === candidateKey
+      );
+    });
+    if (
+      guardIndex === -1 ||
+      !candidateEntry.block.body
+        .slice(guardIndex + 1, candidateIndex)
+        .every(
+          (statement) =>
+            !subtreeHasAbruptSynchronousOperation(statement as EsTreeNode, functionNode, context),
+        )
+    ) {
+      return;
+    }
+    claimCandidates.push(candidate);
+  });
+  const claim = claimCandidates.find((claimCandidate) => {
+    const candidateKey = serializeReferenceKey({
+      node: claimCandidate.left,
+      scopes: context.scopes,
+    });
+    return releaseCandidates.some(
+      (releaseCandidate) =>
+        serializeReferenceKey({
+          node: releaseCandidate.left,
+          scopes: context.scopes,
+        }) === candidateKey,
+    );
+  });
+  if (!claim) return null;
+  const claimKey = serializeReferenceKey({ node: claim.left, scopes: context.scopes });
+  const release = releaseCandidates.find(
+    (releaseCandidate) =>
+      serializeReferenceKey({
+        node: releaseCandidate.left,
+        scopes: context.scopes,
+      }) === claimKey,
+  );
+  if (!claimKey || !release) return null;
+  const releaseEntry = getDirectBlockEntry(release, functionNode);
+  if (!releaseEntry || releaseEntry.block !== resetEntry.block) return null;
+  const releaseIndex = resetEntry.block.body.findIndex(
+    (statement) => statement === releaseEntry.entry,
+  );
+  const resetIndex = resetEntry.block.body.findIndex((statement) => statement === resetEntry.entry);
+  if (
+    releaseIndex === -1 ||
+    resetIndex === -1 ||
+    !resetEntry.block.body
+      .slice(Math.min(releaseIndex, resetIndex) + 1, Math.max(releaseIndex, resetIndex))
+      .every(
+        (statement) =>
+          !subtreeHasAbruptSynchronousOperation(statement as EsTreeNode, functionNode, context),
+      )
+  ) {
+    return null;
+  }
+  let didFindUnsafeWrite = false;
+  walkAst(getOwningFunction(functionNode), (candidate) => {
+    if (didFindUnsafeWrite || candidate === claim || candidate === release) return;
+    const writeTarget = isNodeOfType(candidate, "AssignmentExpression")
+      ? candidate.left
+      : isNodeOfType(candidate, "UpdateExpression") ||
+          (isNodeOfType(candidate, "UnaryExpression") && candidate.operator === "delete")
+        ? candidate.argument
+        : null;
+    if (
+      writeTarget &&
+      serializeReferenceKey({ node: writeTarget, scopes: context.scopes }) === claimKey &&
+      !isEffectInvalidationPairedWithReset(candidate, truthySets, context)
+    ) {
+      didFindUnsafeWrite = true;
+    }
+  });
+  return didFindUnsafeWrite ? null : claim;
+};
+
 const findOwnershipClaim = (
   comparison: AsyncOwnershipComparison,
   functionNode: EsTreeNode,
   truthySets: ReadonlyArray<SetterCall>,
   firstRiskyAwait: AwaitSite,
+  resetNode: EsTreeNode,
   context: RuleContext,
 ): EsTreeNode | null => {
   const refKey = serializeReferenceKey({
@@ -1925,7 +2076,15 @@ const findOwnershipClaim = (
     getReactRefCurrent(tokenInitializer, context) &&
     serializeReferenceKey({ node: tokenInitializer, scopes: context.scopes }) === refKey
   ) {
-    candidates.push(tokenInitializer);
+    const singleFlightClaim = findSingleFlightSnapshotClaim(
+      tokenInitializer,
+      functionNode,
+      truthySets,
+      firstRiskyAwait,
+      resetNode,
+      context,
+    );
+    if (singleFlightClaim) candidates.push(singleFlightClaim);
   }
   if (tokenInitializer && isNodeOfType(tokenInitializer, "UpdateExpression")) {
     const generationKey = serializeReferenceKey({
@@ -1994,13 +2153,14 @@ const isClaimedOwnershipComparison = (
   functionNode: EsTreeNode,
   truthySets: ReadonlyArray<SetterCall>,
   firstRiskyAwait: AwaitSite,
+  resetNode: EsTreeNode,
   context: RuleContext,
 ): boolean => {
   const comparison = getAsyncOwnershipComparison(test, context);
   return Boolean(
     comparison &&
     comparison.mode === expectedMode &&
-    findOwnershipClaim(comparison, functionNode, truthySets, firstRiskyAwait, context),
+    findOwnershipClaim(comparison, functionNode, truthySets, firstRiskyAwait, resetNode, context),
   );
 };
 
@@ -2151,15 +2311,6 @@ const collectLogicalOperands = (expression: EsTreeNode, operator: "&&" | "||"): 
   return [stripped];
 };
 
-const isUnconditionalReturnBranch = (statement: EsTreeNode): boolean => {
-  if (isNodeOfType(statement, "ReturnStatement")) return true;
-  return Boolean(
-    isNodeOfType(statement, "BlockStatement") &&
-    statement.body.length === 1 &&
-    isNodeOfType(statement.body[0] as EsTreeNode, "ReturnStatement"),
-  );
-};
-
 const collectFinalizerGuardExpressions = (
   resetNode: EsTreeNode,
   protectingTry: EsTreeNodeOfType<"TryStatement">,
@@ -2210,6 +2361,7 @@ const collectFinalizerGuardExpressions = (
 
 const isPositiveFinalizerGuard = (
   expression: EsTreeNode,
+  resetNode: EsTreeNode,
   functionNode: EsTreeNode,
   truthySets: ReadonlyArray<SetterCall>,
   firstRiskyAwait: AwaitSite,
@@ -2222,11 +2374,13 @@ const isPositiveFinalizerGuard = (
     functionNode,
     truthySets,
     firstRiskyAwait,
+    resetNode,
     context,
   );
 
 const isNegativeFinalizerGuard = (
   expression: EsTreeNode,
+  resetNode: EsTreeNode,
   functionNode: EsTreeNode,
   truthySets: ReadonlyArray<SetterCall>,
   firstRiskyAwait: AwaitSite,
@@ -2236,6 +2390,7 @@ const isNegativeFinalizerGuard = (
   if (isNodeOfType(stripped, "UnaryExpression") && stripped.operator === "!") {
     return isPositiveFinalizerGuard(
       stripped.argument,
+      resetNode,
       functionNode,
       truthySets,
       firstRiskyAwait,
@@ -2248,6 +2403,7 @@ const isNegativeFinalizerGuard = (
     functionNode,
     truthySets,
     firstRiskyAwait,
+    resetNode,
     context,
   );
 };
@@ -2264,10 +2420,24 @@ const isFinalizerResetProvablyGuarded = (
   return Boolean(
     guards &&
     guards.positive.every((guard) =>
-      isPositiveFinalizerGuard(guard, functionNode, truthySets, firstRiskyAwait, context),
+      isPositiveFinalizerGuard(
+        guard,
+        resetNode,
+        functionNode,
+        truthySets,
+        firstRiskyAwait,
+        context,
+      ),
     ) &&
     guards.negative.every((guard) =>
-      isNegativeFinalizerGuard(guard, functionNode, truthySets, firstRiskyAwait, context),
+      isNegativeFinalizerGuard(
+        guard,
+        resetNode,
+        functionNode,
+        truthySets,
+        firstRiskyAwait,
+        context,
+      ),
     ),
   );
 };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-loading-flag-reset-outside-finally.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-loading-flag-reset-outside-finally.ts
@@ -1822,12 +1822,9 @@ const claimPrecedesTruthySet = (
   const truthyIndex = claimEntry.block.body.findIndex(
     (statement) => statement === truthyEntry.entry,
   );
-  if (claimIndex === -1 || truthyIndex === -1) return false;
-  if (claimIndex === truthyIndex) return true;
-  const firstIndex = Math.min(claimIndex, truthyIndex);
-  const lastIndex = Math.max(claimIndex, truthyIndex);
+  if (claimIndex === -1 || truthyIndex === -1 || claimIndex >= truthyIndex) return false;
   return claimEntry.block.body
-    .slice(firstIndex + 1, lastIndex)
+    .slice(claimIndex + 1, truthyIndex)
     .every(
       (statement) =>
         !subtreeHasAbruptSynchronousOperation(statement as EsTreeNode, functionNode, context),


### PR DESCRIPTION
## Why

React Doctor reports guarded finally resets as success-only loading resets even when a locally unique async-operation token or cleanup-backed mounted ref proves that the finalizer is safe.

## What changed

- recognize locally unique ownership tokens that are synchronously claimed before the risky await
- require ownership claims to precede `setLoading(true)` and reject unclaimed ref snapshots
- accept snapshot guards only when backed by a synchronous single-flight claim and paired release
- scan ownership writes across the complete enclosing lexical function scope while keeping separate sequence generators independent
- recognize committed effect invalidations only when paired with an unconditional reset of the same loading setter
- recognize cleanup-backed mounted refs while rejecting render-phase identities, mutable external request fields, branch-only resets, sibling writes, and stale ordered guards
- add focused adversarial tests, eight fuzz regression/true-positive fixtures, and a patch changeset

## ReactBench replay

The same 30 diagnostic units now partition as 7 proven false positives suppressed and 23 retained true positives reported. Bugbot exposed that one prior false-positive adjudication already had `setRefreshPending(true)` before its ownership token claim; that unit is now correctly reclassified as a true positive. All other 29 outcomes are unchanged.

Artifact: /tmp/reactbench-no-loading-finalizer-claim-order-replay-strict-7-23-5e03f5931.json
SHA-256: 2a17839263b53a9a3641815a16417719e834e138c638605a361c55d821385174

## Validation

- nr format
- nr lint (passes with repository baseline warnings)
- nr typecheck
- nr format:check
- nr test: all 15 tasks passed
- nr smoke:json-report
- nr -C packages/oxlint-plugin-react-doctor test src/plugin/rules/state-and-effects/no-loading-flag-reset-outside-finally.test.ts: 164 passed
- nr -C packages/oxlint-plugin-react-doctor test: 24,809 passed, 201 skipped
- nr -C packages/fuzz test: 192 passed, 782 skipped
- FUZZ_RULE=no-loading-flag-reset-outside-finally FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz
- nlx react-doctor@latest --verbose --scope changed: 100/100, no issues
- truffler post-change dedup searches: no competing helper matched

Local RDE is currently blocked before diagnostic ingestion because the latest eval checkout expects JSON schemaVersion 1 while current React Doctor emits schemaVersion 3.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes static analysis heuristics for a widely used lint rule; behavior shifts on edge cases (claim order, ordered guards, effect pairing) but is heavily test- and fuzz-backed.
> 
> **Overview**
> Tightens **`no-loading-flag-reset-outside-finally`** so conditional **`finally`** loading resets are not reported when the guard is provably tied to the current async work or a cleanup-backed mounted ref.
> 
> The rule now walks **`if` / `&&` / early-return** guard structure around the reset and accepts only **lifecycle guards** (effect cleanup–backed `mountedRef`, including sibling effects) and **claimed-ownership** checks (`ref.current === token`, request-id equality, ordered `>=` latest-start patterns). Ownership must be **synchronously claimed before** `setLoading(true)`; ref snapshots, claims after loading, stale `<=` ordered guards, outer-scope owner writes, and unpaired effect invalidation still **flag**.
> 
> Guarded finalizers that run **before a later risky `await`** outside the `try` are treated as safe. Implementation adds ownership-claim analysis across the enclosing lexical scope, single-flight snapshot exceptions, and pairs effect invalidation with an unconditional reset of the same setter.
> 
> Ships a **patch changeset**, **eight fuzz corpus fixtures**, and a large expansion of rule unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e03f593179fc76a75e642a3ccca75002aab1471. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->