### PR TITLE
RDFPFN792026: recognize terminal promise recovery catches

### DIFF
--- a/.changeset/calm-catches-recover.md
+++ b/.changeset/calm-catches-recover.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Recognize terminal promise catch blocks that recover effect state.

--- a/packages/fuzz/corpus/regressions/no-promise-then-side-effect-in-effect-without-catch--fulfilled-promise-return.tsx
+++ b/packages/fuzz/corpus/regressions/no-promise-then-side-effect-in-effect-without-catch--fulfilled-promise-return.tsx
@@ -1,0 +1,20 @@
+// rule: no-promise-then-side-effect-in-effect-without-catch
+// verdict: pass
+// weakness: control-flow, promise-assimilation
+// source: Cursor Bugbot review on PR #1496
+import { useEffect, useState } from "react";
+
+export const Profile = ({ source }) => {
+  const [, setProfile] = useState(null);
+
+  useEffect(() => {
+    fetch("/api/profile")
+      .then(setProfile)
+      .catch(() => {
+        setProfile(source.fallback);
+        return Promise.resolve(null);
+      });
+  }, [source]);
+
+  return null;
+};

--- a/packages/fuzz/corpus/regressions/no-promise-then-side-effect-in-effect-without-catch--non-thenable-return.tsx
+++ b/packages/fuzz/corpus/regressions/no-promise-then-side-effect-in-effect-without-catch--non-thenable-return.tsx
@@ -1,0 +1,21 @@
+// rule: no-promise-then-side-effect-in-effect-without-catch
+// verdict: pass
+// weakness: control-flow
+// source: Cursor Bugbot review on PR #1496
+import { useEffect, useState } from "react";
+
+export const Profile = ({ source }) => {
+  const [, setProfile] = useState(null);
+  const fallback = null;
+
+  useEffect(() => {
+    fetch("/api/profile")
+      .then(setProfile)
+      .catch(() => {
+        setProfile(source.fallback);
+        return fallback;
+      });
+  }, [source]);
+
+  return null;
+};

--- a/packages/fuzz/corpus/regressions/no-promise-then-side-effect-in-effect-without-catch--terminal-recovery-block.tsx
+++ b/packages/fuzz/corpus/regressions/no-promise-then-side-effect-in-effect-without-catch--terminal-recovery-block.tsx
@@ -1,0 +1,31 @@
+// rule: no-promise-then-side-effect-in-effect-without-catch
+// weakness: control-flow
+// source: ReactBench fix-react-rdh-sofn-xyz-mailing-s__fJkiZQQ
+import { useEffect, useRef, useState } from "react";
+
+export const ApiKeys = ({ updateAlert }) => {
+  const [tasks, setTasks] = useState([]);
+  const [, setApiKeys] = useState([]);
+  const latestSuccessfulRefreshIdRef = useRef(0);
+
+  useEffect(() => {
+    const refreshId = 1;
+    const triggerIds = [1];
+    fetch("/api/apiKeys")
+      .then((response) => response.json())
+      .then((json) => {
+        setTasks((previous) => previous.map((task) => ({ ...task, status: "success" })));
+        if (refreshId > latestSuccessfulRefreshIdRef.current) {
+          latestSuccessfulRefreshIdRef.current = refreshId;
+          setApiKeys(json.apiKeys);
+        }
+        updateAlert(Math.max(...triggerIds), false);
+      })
+      .catch(() => {
+        setTasks((previous) => previous.map((task) => ({ ...task, status: "error" })));
+        updateAlert(Math.max(...triggerIds), true);
+      });
+  }, [tasks, updateAlert]);
+
+  return null;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-promise-then-side-effect-in-effect-without-catch.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-promise-then-side-effect-in-effect-without-catch.test.ts
@@ -810,6 +810,61 @@ describe("no-promise-then-side-effect-in-effect-without-catch audit regressions"
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("accepts terminal block catches that return known non-thenable values", () => {
+    const validSources = [
+      `const C = ({ source }) => {
+        const [, setValue] = useState();
+        useEffect(() => {
+          fetch("/x").then(setValue).catch(() => {
+            setValue(source.fallback);
+            return undefined;
+          });
+        }, [source]);
+      };`,
+      `const C = ({ source }) => {
+        const [, setValue] = useState();
+        useEffect(() => {
+          fetch("/x").then(setValue).catch(() => {
+            setValue(source.fallback);
+            return null;
+          });
+        }, [source]);
+      };`,
+      `const C = ({ source }) => {
+        const [, setValue] = useState();
+        const fallback = null;
+        useEffect(() => {
+          fetch("/x").then(setValue).catch(() => {
+            setValue(source.fallback);
+            return fallback;
+          });
+        }, [source]);
+      };`,
+    ];
+    for (const source of validSources) {
+      expect(runRule(noPromiseThenSideEffectInEffectWithoutCatch, source).diagnostics).toHaveLength(
+        0,
+      );
+    }
+  });
+
+  it("continues to flag terminal block catches that may return a thenable", () => {
+    const result = runRule(
+      noPromiseThenSideEffectInEffectWithoutCatch,
+      `const C = ({ source }) => {
+        const [, setValue] = useState();
+        const fallback = source.fallback;
+        useEffect(() => {
+          fetch("/x").then(setValue).catch(() => {
+            setValue(source.value);
+            return fallback;
+          });
+        }, [source]);
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("accepts rejection handlers with simple non-throwing arguments", () => {
     const validSources = [
       `const C = () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-promise-then-side-effect-in-effect-without-catch.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-promise-then-side-effect-in-effect-without-catch.test.ts
@@ -810,7 +810,7 @@ describe("no-promise-then-side-effect-in-effect-without-catch audit regressions"
     expect(result.diagnostics).toHaveLength(0);
   });
 
-  it("accepts terminal block catches that return known non-thenable values", () => {
+  it("accepts terminal block catches that return known non-rejecting values", () => {
     const validSources = [
       `const C = ({ source }) => {
         const [, setValue] = useState();
@@ -840,6 +840,25 @@ describe("no-promise-then-side-effect-in-effect-without-catch audit regressions"
           });
         }, [source]);
       };`,
+      `const C = ({ source }) => {
+        const [, setValue] = useState();
+        useEffect(() => {
+          fetch("/x").then(setValue).catch(() => {
+            setValue(source.fallback);
+            return Promise.resolve(null);
+          });
+        }, [source]);
+      };`,
+      `const C = ({ source }) => {
+        const [, setValue] = useState();
+        const fallback = undefined;
+        useEffect(() => {
+          fetch("/x").then(setValue).catch(() => {
+            setValue(source.fallback);
+            return Promise.resolve(fallback);
+          });
+        }, [source]);
+      };`,
     ];
     for (const source of validSources) {
       expect(runRule(noPromiseThenSideEffectInEffectWithoutCatch, source).diagnostics).toHaveLength(
@@ -848,9 +867,8 @@ describe("no-promise-then-side-effect-in-effect-without-catch audit regressions"
     }
   });
 
-  it("continues to flag terminal block catches that may return a thenable", () => {
-    const result = runRule(
-      noPromiseThenSideEffectInEffectWithoutCatch,
+  it("continues to flag terminal block catches that may reject", () => {
+    const invalidSources = [
       `const C = ({ source }) => {
         const [, setValue] = useState();
         const fallback = source.fallback;
@@ -861,8 +879,40 @@ describe("no-promise-then-side-effect-in-effect-without-catch audit regressions"
           });
         }, [source]);
       };`,
-    );
-    expect(result.diagnostics).toHaveLength(1);
+      `const C = ({ source }) => {
+        const [, setValue] = useState();
+        useEffect(() => {
+          fetch("/x").then(setValue).catch(() => {
+            setValue(source.value);
+            return Promise.resolve(source.fallback);
+          });
+        }, [source]);
+      };`,
+      `const C = ({ source }) => {
+        const [, setValue] = useState();
+        useEffect(() => {
+          fetch("/x").then(setValue).catch(() => {
+            setValue(source.value);
+            return Promise.reject(null);
+          });
+        }, [source]);
+      };`,
+      `const Promise = { resolve: () => fetch("/fallback") };
+      const C = ({ source }) => {
+        const [, setValue] = useState();
+        useEffect(() => {
+          fetch("/x").then(setValue).catch(() => {
+            setValue(source.value);
+            return Promise.resolve(null);
+          });
+        }, [source]);
+      };`,
+    ];
+    for (const source of invalidSources) {
+      expect(runRule(noPromiseThenSideEffectInEffectWithoutCatch, source).diagnostics).toHaveLength(
+        1,
+      );
+    }
   });
 
   it("accepts rejection handlers with simple non-throwing arguments", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-promise-then-side-effect-in-effect-without-catch.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-promise-then-side-effect-in-effect-without-catch.test.ts
@@ -221,6 +221,46 @@ describe("no-promise-then-side-effect-in-effect-without-catch", () => {
     }
   });
 
+  it("does not flag the ReactBench task refresh chain with a terminal catch", () => {
+    const result = runRule(
+      noPromiseThenSideEffectInEffectWithoutCatch,
+      `const C = () => {
+        const [tasks, setTasks] = useState([]);
+        const [, setApiKeys] = useState([]);
+        const latestSuccessfulRefreshIdRef = useRef(0);
+        const updateAlert = (id, isError) => {};
+        useEffect(() => {
+          const refreshId = 1;
+          const triggerIds = [1];
+          fetch("/api/apiKeys")
+            .then((response) => {
+              if (!response.ok) throw new Error("not ok");
+              return response.json();
+            })
+            .then((json) => {
+              setTasks((previous) =>
+                previous.map((task) => ({ ...task, status: "success" })),
+              );
+              if (refreshId > latestSuccessfulRefreshIdRef.current) {
+                latestSuccessfulRefreshIdRef.current = refreshId;
+                setApiKeys(json.apiKeys);
+              }
+              updateAlert(Math.max(...triggerIds), false);
+            })
+            .catch(() => {
+              setTasks((previous) =>
+                previous.map((task) => ({ ...task, status: "error" })),
+              );
+              updateAlert(Math.max(...triggerIds), true);
+            });
+        }, [tasks, updateAlert]);
+      };`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("does not flag a catch handler that returns a fulfilled promise", () => {
     const result = runRule(
       noPromiseThenSideEffectInEffectWithoutCatch,
@@ -744,26 +784,30 @@ describe("no-promise-then-side-effect-in-effect-without-catch audit regressions"
     expect(result.diagnostics).toHaveLength(0);
   });
 
-  it("requires rejection handlers to avoid potentially throwing member reads", () => {
-    const invalidSources = [
+  it("still requires a then rejection handler to avoid potentially throwing member reads", () => {
+    const result = runRule(
+      noPromiseThenSideEffectInEffectWithoutCatch,
       `const C = ({ source }) => {
         const [, setValue] = useState();
         useEffect(() => {
           fetch("/x").then(setValue, () => console.log(source.throwingGetter));
         }, [source]);
       };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("accepts a terminal block catch that performs state recovery from a member value", () => {
+    const result = runRule(
+      noPromiseThenSideEffectInEffectWithoutCatch,
       `const C = ({ source }) => {
         const [, setValue] = useState();
         useEffect(() => {
           fetch("/x").then(setValue).catch(() => { setValue(source.throwingGetter); });
         }, [source]);
       };`,
-    ];
-    for (const source of invalidSources) {
-      expect(runRule(noPromiseThenSideEffectInEffectWithoutCatch, source).diagnostics).toHaveLength(
-        1,
-      );
-    }
+    );
+    expect(result.diagnostics).toHaveLength(0);
   });
 
   it("accepts rejection handlers with simple non-throwing arguments", () => {
@@ -834,7 +878,7 @@ describe("no-promise-then-side-effect-in-effect-without-catch audit regressions"
     }
   });
 
-  it("requires a callable, non-rethrowing rejection handler", () => {
+  it("requires a callable rejection handler that does not explicitly rethrow", () => {
     const invalidSources = [
       `const C = () => { const [, setValue] = useState(); useEffect(() => { fetch("/x").then(setValue).catch(); }, []); };`,
       `const C = () => { const [, setValue] = useState(); useEffect(() => { fetch("/x").then(setValue).catch(undefined); }, []); };`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-promise-then-side-effect-in-effect-without-catch.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-promise-then-side-effect-in-effect-without-catch.ts
@@ -160,6 +160,51 @@ const handlerHasPotentiallyThrowingMemberRead = (
   return hasPotentiallyThrowingMemberRead;
 };
 
+const hasRejectionHandler = (
+  chain: EsTreeNode,
+  argument: EsTreeNode | undefined,
+  context: RuleContext,
+  allowTerminalCatchBlock: boolean,
+): boolean => {
+  if (!argument) return false;
+  if (
+    !handlerHasPotentiallyThrowingMemberRead(argument, context) &&
+    (chainCarriesRejectionHandler(chain, context.scopes) ||
+      isKnownNonRejectingHandler(argument, context))
+  ) {
+    return true;
+  }
+  if (!allowTerminalCatchBlock) return false;
+  const candidate = stripParenExpression(argument);
+  const handler = isNodeOfType(candidate, "Identifier")
+    ? resolveExactLocalFunction(candidate, context.scopes)
+    : candidate;
+  if (!handler || !isFunctionLike(handler)) {
+    return (
+      isNodeOfType(candidate, "MemberExpression") ||
+      (isNodeOfType(candidate, "Identifier") && candidate.name !== "undefined")
+    );
+  }
+  if (!isNodeOfType(handler.body, "BlockStatement")) return false;
+  let doesExplicitlyReject = false;
+  walkOwnFunctionScope(handler, (child: EsTreeNode) => {
+    if (doesExplicitlyReject) return false;
+    if (isNodeOfType(child, "ThrowStatement") || isNodeOfType(child, "AwaitExpression")) {
+      doesExplicitlyReject = true;
+      return false;
+    }
+    if (
+      isNodeOfType(child, "ReturnStatement") &&
+      child.argument &&
+      !isDefinitelyNonThenableValue(child.argument)
+    ) {
+      doesExplicitlyReject = true;
+      return false;
+    }
+  });
+  return !doesExplicitlyReject;
+};
+
 const walkPromiseChain = (chainExpression: EsTreeNode, context: RuleContext): PromiseChainWalk => {
   let cursor = stripParenExpression(chainExpression);
   let hasCatch = false;
@@ -179,15 +224,18 @@ const walkPromiseChain = (chainExpression: EsTreeNode, context: RuleContext): Pr
       methodName === "catch"
         ? (cursor.arguments[0] as EsTreeNode | undefined)
         : (cursor.arguments[1] as EsTreeNode | undefined);
-    const hasAbsorbingRejectionHandler =
-      !handlerHasPotentiallyThrowingMemberRead(rejectionHandlerArgument, context) &&
-      (chainCarriesRejectionHandler(cursor, context.scopes) ||
-        isKnownNonRejectingHandler(rejectionHandlerArgument, context));
-    if (!didReachTerminalThen && methodName === "catch" && hasAbsorbingRejectionHandler) {
+    if (
+      !didReachTerminalThen &&
+      methodName === "catch" &&
+      hasRejectionHandler(cursor, rejectionHandlerArgument, context, true)
+    ) {
       hasCatch = true;
     }
     if (methodName === "then") {
-      if (!didReachTerminalThen && hasAbsorbingRejectionHandler) {
+      if (
+        !didReachTerminalThen &&
+        hasRejectionHandler(cursor, rejectionHandlerArgument, context, false)
+      ) {
         hasRejectionHandlerArgument = true;
       }
       didReachTerminalThen = true;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-promise-then-side-effect-in-effect-without-catch.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-promise-then-side-effect-in-effect-without-catch.ts
@@ -48,13 +48,32 @@ interface ResolvedInitiator {
   initiator: EsTreeNode;
   hasUpstreamRejectionHandling: boolean;
 }
-const isKnownNonThenableHandlerReturn = (
+const isKnownNonRejectingHandlerReturn = (
   expression: EsTreeNode,
   context: RuleContext,
   visitedBindingIdentifiers = new Set<EsTreeNode>(),
 ): boolean => {
   const strippedExpression = stripParenExpression(expression);
   if (isDefinitelyNonThenableValue(strippedExpression)) return true;
+  if (
+    isNodeOfType(strippedExpression, "CallExpression") &&
+    isNodeOfType(strippedExpression.callee, "MemberExpression")
+  ) {
+    const receiver = stripParenExpression(strippedExpression.callee.object);
+    if (
+      isNodeOfType(receiver, "Identifier") &&
+      receiver.name === "Promise" &&
+      context.scopes.isGlobalReference(receiver) &&
+      getStaticPropertyName(strippedExpression.callee) === "resolve"
+    ) {
+      const resolvedValue = strippedExpression.arguments[0];
+      return (
+        !resolvedValue ||
+        (!isNodeOfType(resolvedValue, "SpreadElement") &&
+          isKnownNonRejectingHandlerReturn(resolvedValue, context, visitedBindingIdentifiers))
+      );
+    }
+  }
   if (!isNodeOfType(strippedExpression, "Identifier")) return false;
   if (
     strippedExpression.name === "undefined" &&
@@ -67,7 +86,8 @@ const isKnownNonThenableHandlerReturn = (
   visitedBindingIdentifiers.add(symbol.bindingIdentifier);
   const initializer = getDirectUnreassignedInitializer(symbol);
   return Boolean(
-    initializer && isKnownNonThenableHandlerReturn(initializer, context, visitedBindingIdentifiers),
+    initializer &&
+    isKnownNonRejectingHandlerReturn(initializer, context, visitedBindingIdentifiers),
   );
 };
 const isKnownNonRejectingHandler = (
@@ -91,7 +111,7 @@ const isKnownNonRejectingHandler = (
     if (
       isNodeOfType(child, "ReturnStatement") &&
       child.argument &&
-      !isKnownNonThenableHandlerReturn(child.argument, context)
+      !isKnownNonRejectingHandlerReturn(child.argument, context)
     ) {
       const returnedExpression = stripParenExpression(child.argument);
       if (!isNodeOfType(returnedExpression, "CallExpression")) {
@@ -196,7 +216,7 @@ const hasRejectionHandler = (
     if (
       isNodeOfType(child, "ReturnStatement") &&
       child.argument &&
-      !isKnownNonThenableHandlerReturn(child.argument, context)
+      !isKnownNonRejectingHandlerReturn(child.argument, context)
     ) {
       doesExplicitlyReject = true;
       return false;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-promise-then-side-effect-in-effect-without-catch.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-promise-then-side-effect-in-effect-without-catch.ts
@@ -196,7 +196,7 @@ const hasRejectionHandler = (
     if (
       isNodeOfType(child, "ReturnStatement") &&
       child.argument &&
-      !isDefinitelyNonThenableValue(child.argument)
+      !isKnownNonThenableHandlerReturn(child.argument, context)
     ) {
       doesExplicitlyReject = true;
       return false;


### PR DESCRIPTION
## Summary
- recognize terminal `.catch(() => { ... })` recovery blocks even when their state-recovery work includes member reads or application callbacks
- retain diagnostics for explicit throws, `await`, and returned possibly-thenable values
- add the exact ReactBench mailing/settings regression plus a fuzz corpus case

## ReactBench evidence
- unit: `fix-react-rdh-sofn-xyz-mailing-s__fJkiZQQ` / `no-promise-then-side-effect-in-effect-without-catch` / `src/pages/settings.tsx`
- baseline at `b1352a2be`: 1 exact-line diagnostic, 0 parse errors
- this head: 0 diagnostics, 0 parse errors
- replay artifact: `/tmp/reactbench-promise-catch-exact-replay.json`
- replay SHA-256: `e5a5ab1212faf855e6e59b41788c5ceda4a264564d4fcc21e8a7fe3dd9bbe4b6`

## Validation
- focused + full plugin suite: 24,796 passed / 201 skipped
- fuzz: 500 strict iterations; regression corpus: 192 passed / 782 skipped
- full repository tests: all 15 tasks passed
- lint, typecheck, format check, plugin build, JSON-report smoke: passed
- RDE unavailable locally (`AXIOM_DATASET` unset)
- Daytona parity unavailable locally (`DAYTONA_API_KEY` unset)

## Contract
A terminal catch handler absorbs the upstream rejection unless the handler explicitly throws, awaits, or returns a possibly thenable value. The stricter existing proof remains in place for `.then(success, onRejected)` and expression-bodied handlers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes static analysis behavior for a correctness lint rule—mostly reducing false positives, with some risk of under-reporting if terminal catch detection is too permissive.
> 
> **Overview**
> Updates **`no-promise-then-side-effect-in-effect-without-catch`** so terminal **`.catch(() => { ... })`** blocks count as rejection handling when they perform state recovery (including member reads and non-setter calls), while **`.then(success, onRejected)`** stays on the stricter path.
> 
> Rejection proof is centralized in **`hasRejectionHandler`**, with a relaxed mode only for terminal **`.catch`**: block bodies are accepted unless they explicitly throw, **`await`**, or return a possibly-rejecting value. **`isKnownNonRejectingHandlerReturn`** now treats **`Promise.resolve(...)`** as safe when the resolved value is already known non-rejecting.
> 
> Adds unit tests, fuzz regression cases, and a patch changeset for **`oxlint-plugin-react-doctor`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83a9619d2fd20fa23f265c61e4946497d3fc7d21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->