### PR TITLE
RDFPFN792026: prove predictable ref initialization

### DIFF
--- a/.changeset/no-ref-predictable-initialization.md
+++ b/.changeset/no-ref-predictable-initialization.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Recognize predictable guarded ref initialization while preserving diagnostics for render-dependent and externally mutable values.

--- a/packages/fuzz/corpus/true-positives/no-ref-current-in-render--render-phase-initializer-write.tsx
+++ b/packages/fuzz/corpus/true-positives/no-ref-current-in-render--render-phase-initializer-write.tsx
@@ -1,0 +1,16 @@
+// rule: no-ref-current-in-render
+// verdict: fail
+// weakness: competing-render-write
+// source: Bugbot PR #1497
+
+import { useMemo, useRef } from "react";
+
+export const Panel = () => {
+  const cacheRef = useRef<Map<string, string> | null>(null);
+  if (cacheRef.current === null) cacheRef.current = new Map();
+  useMemo(() => {
+    cacheRef.current = new Map([["ready", "yes"]]);
+    return cacheRef.current;
+  }, []);
+  return null;
+};

--- a/packages/fuzz/corpus/true-positives/no-ref-current-in-render--unstable-equality-initialization.tsx
+++ b/packages/fuzz/corpus/true-positives/no-ref-current-in-render--unstable-equality-initialization.tsx
@@ -1,0 +1,15 @@
+// rule: no-ref-current-in-render
+// weakness: unstable-initialization
+// source: ReactBench RDFPFN792026 adversarial control
+
+import { useRef } from "react";
+
+interface PanelProps {
+  data: Map<string, string>;
+}
+
+export const Panel = ({ data }: PanelProps) => {
+  const dataRef = useRef<Map<string, string> | null>(null);
+  if (dataRef.current === null) dataRef.current = data;
+  return null;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-ref-current-in-render.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-ref-current-in-render.regressions.test.ts
@@ -531,4 +531,37 @@ describe("no-ref-current-in-render — predictable initialization proofs", () =>
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics.length).toBeGreaterThan(0);
   });
+
+  it.each([
+    [
+      "useMemo",
+      `import { useMemo, useRef } from "react";
+       const Panel = () => {
+         const mapRef = useRef<Map<string, string> | null>(null);
+         if (mapRef.current === null) mapRef.current = new Map();
+         useMemo(() => {
+           mapRef.current = new Map([["ready", "yes"]]);
+           return mapRef.current;
+         }, []);
+         return null;
+       };`,
+    ],
+    [
+      "a lazy useState initializer",
+      `import React from "react";
+       const Panel = () => {
+         const mapRef = React.useRef<Map<string, string> | null>(null);
+         if (mapRef.current === null) mapRef.current = new Map();
+         React.useState(() => {
+           mapRef.current = new Map([["ready", "yes"]]);
+           return mapRef.current;
+         });
+         return null;
+       };`,
+    ],
+  ])("reports both co-executable writes for %s", (_name, code) => {
+    const result = run(code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(2);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-ref-current-in-render.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-ref-current-in-render.regressions.test.ts
@@ -284,3 +284,169 @@ describe("no-ref-current-in-render — falsy lazy initialization guards", () => 
     expect(result.diagnostics).toEqual([]);
   });
 });
+
+describe("no-ref-current-in-render — predictable initialization proofs", () => {
+  it.each([
+    [
+      "an object value for an opaque object-shaped ref",
+      `import { useRef } from "react";
+       interface Controls {
+         focus: () => void;
+       }
+       const Panel = () => {
+         const controlsRef = useRef<Controls | null>(null);
+         if (!controlsRef.current) controlsRef.current = { focus: () => undefined };
+         return null;
+       };`,
+    ],
+    [
+      "an object value for an indexed-access ref type",
+      `import { useRef } from "react";
+       interface Controls {
+         navigation: { focus: () => void };
+       }
+       const Panel = () => {
+         const navigationRef = useRef<Controls["navigation"]>();
+         if (!navigationRef.current) navigationRef.current = { focus: () => undefined };
+         return null;
+       };`,
+    ],
+    [
+      "a typed zero-input factory",
+      `import { useRef } from "react";
+       interface Controls {
+         focus: () => void;
+       }
+       declare const createControls: () => Controls;
+       const Panel = () => {
+         const controlsRef = useRef<Controls>();
+         if (!controlsRef.current) controlsRef.current = createControls();
+         return null;
+       };`,
+    ],
+    [
+      "a ReturnType-matched factory",
+      `import { useRef } from "react";
+       declare const debounce: (callback: () => void, delay: number) => () => void;
+       const Panel = () => {
+         const callbackRef = useRef<() => void>(() => undefined);
+         const debouncedRef = useRef<ReturnType<typeof debounce> | null>(null);
+         if (!debouncedRef.current) {
+           debouncedRef.current = debounce(() => callbackRef.current(), 50);
+         }
+         return null;
+       };`,
+    ],
+    [
+      "a stable new value under an equality guard",
+      `import { useRef } from "react";
+       const Panel = () => {
+         const mapRef = useRef<Map<string, string> | null>(null);
+         if (mapRef.current === null) mapRef.current = new Map();
+         return null;
+       };`,
+    ],
+  ])("stays silent for %s", (_name, code) => {
+    const result = run(code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it.each([
+    [
+      "a prop-derived equality initialization",
+      `import { useRef } from "react";
+       const Panel = ({ data }: { data: Map<string, string> }) => {
+         const mapRef = useRef<Map<string, string> | null>(null);
+         if (mapRef.current === null) mapRef.current = data;
+         return null;
+       };`,
+    ],
+    [
+      "a transitively prop-derived equality initialization",
+      `import { useRef } from "react";
+       const Panel = ({ data }: { data: Map<string, string> }) => {
+         const nextData = data;
+         const mapRef = useRef<Map<string, string> | null>(null);
+         if (mapRef.current === null) mapRef.current = nextData;
+         return null;
+       };`,
+    ],
+    [
+      "a mutable module value under an equality guard",
+      `import { useRef } from "react";
+       let nextData = new Map<string, string>();
+       const Panel = () => {
+         const mapRef = useRef<Map<string, string> | null>(null);
+         if (mapRef.current === null) mapRef.current = nextData;
+         return null;
+       };`,
+    ],
+    [
+      "an unproven factory under an equality guard",
+      `import { useRef } from "react";
+       declare const factory: () => unknown;
+       const Panel = () => {
+         const valueRef = useRef(null);
+         if (valueRef.current === null) valueRef.current = factory();
+         return null;
+       };`,
+    ],
+    [
+      "an escaped ref under an equality guard",
+      `import { useRef } from "react";
+       declare const consume: (ref: { current: Map<string, string> | null }) => void;
+       const Panel = () => {
+         const mapRef = useRef<Map<string, string> | null>(null);
+         consume(mapRef);
+         if (mapRef.current === null) mapRef.current = new Map();
+         return null;
+       };`,
+    ],
+    [
+      "a prior co-executable write under an equality guard",
+      `import { useRef } from "react";
+       const Panel = ({ replacement }: { replacement: Map<string, string> }) => {
+         const mapRef = useRef<Map<string, string> | null>(null);
+         mapRef.current = replacement;
+         if (mapRef.current === null) mapRef.current = new Map();
+         return null;
+       };`,
+    ],
+    [
+      "a later co-executable reset after an equality guard",
+      `import { useRef } from "react";
+       const Panel = ({ shouldReset }: { shouldReset: boolean }) => {
+         const mapRef = useRef<Map<string, string> | null>(null);
+         if (mapRef.current === null) mapRef.current = new Map();
+         if (shouldReset) mapRef.current = null;
+         return null;
+       };`,
+    ],
+    [
+      "a prop-dependent constructor under a falsy guard",
+      `import { useRef } from "react";
+       declare class Parser {
+         constructor(country: string);
+       }
+       const Panel = ({ country }: { country: string }) => {
+         const parserRef = useRef<Parser>();
+         if (!parserRef.current) parserRef.current = new Parser(country);
+         return null;
+       };`,
+    ],
+    [
+      "a prop-derived nullish assignment",
+      `import { useRef } from "react";
+       const Panel = ({ data }: { data: Map<string, string> }) => {
+         const mapRef = useRef<Map<string, string> | null>(null);
+         mapRef.current ??= data;
+         return null;
+       };`,
+    ],
+  ])("reports %s", (_name, code) => {
+    const result = run(code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-ref-current-in-render.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-ref-current-in-render.regressions.test.ts
@@ -346,6 +346,30 @@ describe("no-ref-current-in-render — predictable initialization proofs", () =>
          return null;
        };`,
     ],
+    [
+      "a later write in an event handler",
+      `import { useRef } from "react";
+       const Panel = () => {
+         const mapRef = useRef<Map<string, string> | null>(null);
+         if (mapRef.current === null) mapRef.current = new Map();
+         const reset = () => {
+           mapRef.current = new Map([["ready", "yes"]]);
+         };
+         return <button onClick={reset}>Replace</button>;
+       };`,
+    ],
+    [
+      "a later write in an effect",
+      `import { useEffect, useRef } from "react";
+       const Panel = () => {
+         const mapRef = useRef<Map<string, string> | null>(null);
+         if (mapRef.current === null) mapRef.current = new Map();
+         useEffect(() => {
+           mapRef.current = new Map([["ready", "yes"]]);
+         }, []);
+         return null;
+       };`,
+    ],
   ])("stays silent for %s", (_name, code) => {
     const result = run(code);
     expect(result.parseErrors).toEqual([]);
@@ -420,6 +444,31 @@ describe("no-ref-current-in-render — predictable initialization proofs", () =>
          const mapRef = useRef<Map<string, string> | null>(null);
          if (mapRef.current === null) mapRef.current = new Map();
          if (shouldReset) mapRef.current = null;
+         return null;
+       };`,
+    ],
+    [
+      "a later co-executable reset in a synchronous callback",
+      `import { useRef } from "react";
+       const Panel = () => {
+         const mapRef = useRef<Map<string, string> | null>(null);
+         if (mapRef.current === null) mapRef.current = new Map();
+         [1].forEach(() => {
+           mapRef.current = null;
+         });
+         return null;
+       };`,
+    ],
+    [
+      "a later co-executable reset in a called local function",
+      `import { useRef } from "react";
+       const Panel = () => {
+         const mapRef = useRef<Map<string, string> | null>(null);
+         if (mapRef.current === null) mapRef.current = new Map();
+         const reset = () => {
+           mapRef.current = null;
+         };
+         reset();
          return null;
        };`,
     ],

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-ref-current-in-render.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-ref-current-in-render.regressions.test.ts
@@ -370,6 +370,17 @@ describe("no-ref-current-in-render — predictable initialization proofs", () =>
          return null;
        };`,
     ],
+    [
+      "a stored callback that reads the clock when invoked",
+      `import { useRef } from "react";
+       const Panel = () => {
+         const clockRef = useRef<{ read: () => number } | null>(null);
+         if (clockRef.current === null) {
+           clockRef.current = { read: () => Date.now() };
+         }
+         return null;
+       };`,
+    ],
   ])("stays silent for %s", (_name, code) => {
     const result = run(code);
     expect(result.parseErrors).toEqual([]);
@@ -490,6 +501,28 @@ describe("no-ref-current-in-render — predictable initialization proofs", () =>
        const Panel = ({ data }: { data: Map<string, string> }) => {
          const mapRef = useRef<Map<string, string> | null>(null);
          mapRef.current ??= data;
+         return null;
+       };`,
+    ],
+    [
+      "a random value captured during object initialization",
+      `import { useRef } from "react";
+       const Panel = () => {
+         const valueRef = useRef<{ id: number } | null>(null);
+         if (valueRef.current === null) {
+           valueRef.current = { id: Math.random() };
+         }
+         return null;
+       };`,
+    ],
+    [
+      "a wall-clock value captured during object initialization",
+      `import { useRef } from "react";
+       const Panel = () => {
+         const valueRef = useRef<{ createdAt: Date } | null>(null);
+         if (valueRef.current === null) {
+           valueRef.current = { createdAt: new Date() };
+         }
          return null;
        };`,
     ],

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-ref-current-in-render.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-ref-current-in-render.test.ts
@@ -158,7 +158,7 @@ describe("no-ref-current-in-render", () => {
   ])("reports %s", (_name, code) => {
     const result = run(code);
     expect(result.parseErrors).toEqual([]);
-    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
   });
 
   it.each([

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-ref-current-in-render.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-ref-current-in-render.ts
@@ -8,6 +8,7 @@ import { getRangeStart } from "../../utils/get-range-start.js";
 import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { isOutsideAllFunctions } from "../../utils/is-outside-all-functions.js";
 import { resolveReactRefSymbol } from "../../utils/react-ref-origin.js";
 import { resolveConstIdentifierAlias } from "../../utils/resolve-const-identifier-alias.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
@@ -75,28 +76,56 @@ const resolveImmutableInitializationValue = (
 
 const isProvablyTruthyInitializationValue = (node: EsTreeNode, scopes: ScopeAnalysis): boolean => {
   const expression = resolveImmutableInitializationValue(node, scopes);
-  return Boolean(
-    expression &&
-    (isNodeOfType(expression, "NewExpression") ||
-      isNodeOfType(expression, "ObjectExpression") ||
-      isNodeOfType(expression, "ArrayExpression") ||
-      isNodeOfType(expression, "ArrowFunctionExpression") ||
-      isNodeOfType(expression, "FunctionExpression") ||
-      isNodeOfType(expression, "ClassExpression")),
+  if (!expression) return false;
+  if (isNodeOfType(expression, "CallExpression")) {
+    const callee = stripParenExpression(expression.callee);
+    return isNodeOfType(callee, "Identifier") && callee.name.startsWith("create");
+  }
+  return (
+    isNodeOfType(expression, "NewExpression") ||
+    isNodeOfType(expression, "ObjectExpression") ||
+    isNodeOfType(expression, "ArrayExpression") ||
+    isNodeOfType(expression, "ArrowFunctionExpression") ||
+    isNodeOfType(expression, "FunctionExpression") ||
+    isNodeOfType(expression, "ClassExpression")
   );
 };
 
-const getInitializationConstructorName = (
-  node: EsTreeNode,
-  scopes: ScopeAnalysis,
-): string | null => {
+const getInitializationValueName = (node: EsTreeNode, scopes: ScopeAnalysis): string | null => {
   const expression = resolveImmutableInitializationValue(node, scopes);
   if (!expression) return null;
-  if (isNodeOfType(expression, "NewExpression")) {
+  if (isNodeOfType(expression, "NewExpression") || isNodeOfType(expression, "CallExpression")) {
     const callee = stripParenExpression(expression.callee);
-    return isNodeOfType(callee, "Identifier") ? callee.name : null;
+    if (!isNodeOfType(callee, "Identifier")) return null;
+    return callee.name.startsWith("create") && callee.name.length > "create".length
+      ? callee.name.slice("create".length)
+      : callee.name;
   }
   return null;
+};
+
+const isMatchingReturnType = (
+  typeNode: EsTreeNode,
+  initializationValue: EsTreeNode,
+  scopes: ScopeAnalysis,
+): boolean => {
+  if (!isNodeOfType(typeNode, "TSTypeReference")) return false;
+  const typeName = typeNode.typeName;
+  if (!isNodeOfType(typeName, "Identifier") || typeName.name !== "ReturnType") return false;
+  const [returnTypeArgument] = typeNode.typeArguments?.params ?? [];
+  if (!returnTypeArgument || !isNodeOfType(returnTypeArgument, "TSTypeQuery")) return false;
+  const queriedName = returnTypeArgument.exprName;
+  const expression = stripParenExpression(initializationValue);
+  if (!isNodeOfType(queriedName, "Identifier") || !isNodeOfType(expression, "CallExpression")) {
+    return false;
+  }
+  const callee = stripParenExpression(expression.callee);
+  if (!isNodeOfType(callee, "Identifier")) return false;
+  const queriedSymbol = scopes.symbolFor(queriedName);
+  const calleeSymbol = scopes.symbolFor(callee);
+  return queriedSymbol && calleeSymbol
+    ? queriedSymbol.id === calleeSymbol.id
+    : queriedName.name === callee.name;
 };
 
 const isClosedTruthyTypeDomain = (
@@ -121,11 +150,20 @@ const isClosedTruthyTypeDomain = (
   if (isNodeOfType(typeNode, "TSObjectKeyword")) {
     return true;
   }
+  if (isNodeOfType(typeNode, "TSIndexedAccessType")) {
+    return isNodeOfType(initializationExpression, "ObjectExpression");
+  }
   if (!isNodeOfType(typeNode, "TSTypeReference")) return false;
   const typeName = typeNode.typeName;
+  if (
+    isNodeOfType(initializationExpression, "ObjectExpression") ||
+    isMatchingReturnType(typeNode, initializationExpression, scopes)
+  ) {
+    return true;
+  }
   return (
     isNodeOfType(typeName, "Identifier") &&
-    typeName.name === getInitializationConstructorName(initializationExpression, scopes)
+    typeName.name === getInitializationValueName(initializationExpression, scopes)
   );
 };
 
@@ -138,28 +176,50 @@ const refHasClosedFalsySentinelDomain = (
   if (!initializer || !isNodeOfType(initializer, "CallExpression")) return false;
   const [initialValue] = initializer.arguments ?? [];
   if (
-    !initialValue ||
-    isNodeOfType(initialValue, "SpreadElement") ||
-    !isEmptySentinel(initialValue, scopes)
+    (initialValue && isNodeOfType(initialValue, "SpreadElement")) ||
+    (initialValue && !isEmptySentinel(initialValue, scopes))
   ) {
     return false;
   }
   const [declaredType] = initializer.typeArguments?.params ?? [];
-  if (!declaredType || !isNodeOfType(declaredType, "TSUnionType")) return false;
-  let hasEmptySentinel = false;
+  if (!declaredType) return false;
+  const domainTypes = isNodeOfType(declaredType, "TSUnionType")
+    ? declaredType.types
+    : [declaredType];
   let hasTruthyDomain = false;
-  for (const memberType of declaredType.types ?? []) {
+  for (const memberType of domainTypes) {
     if (
       isNodeOfType(memberType, "TSNullKeyword") ||
       isNodeOfType(memberType, "TSUndefinedKeyword")
     ) {
-      hasEmptySentinel = true;
       continue;
     }
     if (!isClosedTruthyTypeDomain(memberType, initializationValue, scopes)) return false;
     hasTruthyDomain = true;
   }
-  return hasEmptySentinel && hasTruthyDomain;
+  return hasTruthyDomain;
+};
+
+const refHasEmptySentinelInitializer = (
+  refSymbol: SymbolDescriptor,
+  scopes: ScopeAnalysis,
+): boolean => {
+  const initializer = refSymbol.initializer ? stripParenExpression(refSymbol.initializer) : null;
+  if (!initializer || !isNodeOfType(initializer, "CallExpression")) return false;
+  const [initialValue] = initializer.arguments ?? [];
+  return Boolean(
+    !initialValue ||
+    (!isNodeOfType(initialValue, "SpreadElement") && isEmptySentinel(initialValue, scopes)),
+  );
+};
+
+const refHasDeclaredType = (refSymbol: SymbolDescriptor): boolean => {
+  const initializer = refSymbol.initializer ? stripParenExpression(refSymbol.initializer) : null;
+  return Boolean(
+    initializer &&
+    isNodeOfType(initializer, "CallExpression") &&
+    (initializer.typeArguments?.params.length ?? 0) > 0,
+  );
 };
 
 const isSafeRefIdentifierUse = (identifier: EsTreeNode): boolean => {
@@ -226,38 +286,66 @@ const expressionContainsRefCurrent = (
   return didFindRefCurrent;
 };
 
-const hasNoCompetingRefCurrentWrite = (
-  branchRoot: EsTreeNode,
-  assignmentExpression: EsTreeNodeOfType<"AssignmentExpression">,
-  refSymbol: SymbolDescriptor,
-  scopes: ScopeAnalysis,
-): boolean => {
-  let writeCount = 0;
-  walkAst(branchRoot, (child: EsTreeNode): boolean | void => {
-    if (writeCount > 1) return false;
-    if (isNodeOfType(child, "AssignmentExpression")) {
-      if (expressionContainsRefCurrent(child.left, refSymbol, scopes)) writeCount++;
-      return;
-    }
-    if (
-      isNodeOfType(child, "UpdateExpression") ||
-      (isNodeOfType(child, "UnaryExpression") && child.operator === "delete")
-    ) {
-      if (expressionContainsRefCurrent(child.argument, refSymbol, scopes)) writeCount++;
-      return;
-    }
-    if (isNodeOfType(child, "ForInStatement") || isNodeOfType(child, "ForOfStatement")) {
-      if (expressionContainsRefCurrent(child.left, refSymbol, scopes)) writeCount++;
-    }
-  });
+const isEmptySentinel = (node: EsTreeNode, scopes: ScopeAnalysis): boolean => {
+  const expression = stripParenExpression(node);
   return (
-    writeCount === 1 && expressionContainsRefCurrent(assignmentExpression.left, refSymbol, scopes)
+    (isNodeOfType(expression, "Literal") && expression.value === null) ||
+    (isNodeOfType(expression, "Identifier") &&
+      expression.name === "undefined" &&
+      scopes.isGlobalReference(expression))
   );
 };
 
-const isEmptySentinel = (node: EsTreeNode, scopes: ScopeAnalysis): boolean =>
-  (isNodeOfType(node, "Literal") && node.value === null) ||
-  (isNodeOfType(node, "Identifier") && node.name === "undefined" && scopes.isGlobalReference(node));
+const isInitializationInputIndependent = (
+  node: EsTreeNode,
+  renderOwner: EsTreeNode,
+  scopes: ScopeAnalysis,
+  visitedSymbolIds: Set<number> = new Set(),
+): boolean => {
+  let isInputIndependent = true;
+  walkAst(node, (child: EsTreeNode): boolean | void => {
+    if (!isInputIndependent) return false;
+    if (resolveReactRefSymbol(child, scopes)) return false;
+    if (!isNodeOfType(child, "Identifier")) return;
+    const symbol = scopes.symbolFor(child);
+    if (!symbol) return;
+    if (symbol.kind === "import") return false;
+    if (symbol.kind === "let" || symbol.kind === "var" || symbol.kind === "using") {
+      isInputIndependent = false;
+      return false;
+    }
+    if (isOutsideAllFunctions(symbol)) return false;
+    if (symbol.kind === "parameter") {
+      if (symbol.scope.node === renderOwner) isInputIndependent = false;
+      return false;
+    }
+    if (!symbol.initializer || symbol.references.some((reference) => reference.flag !== "read")) {
+      isInputIndependent = false;
+      return false;
+    }
+    if (visitedSymbolIds.has(symbol.id)) return false;
+    visitedSymbolIds.add(symbol.id);
+    if (
+      !isInitializationInputIndependent(symbol.initializer, renderOwner, scopes, visitedSymbolIds)
+    ) {
+      isInputIndependent = false;
+    }
+    return false;
+  });
+  return isInputIndependent;
+};
+
+const isPredictableInitializationValue = (
+  node: EsTreeNode,
+  refSymbol: SymbolDescriptor,
+  renderOwner: EsTreeNode,
+  scopes: ScopeAnalysis,
+  requiresClosedTruthyDomain: boolean,
+): boolean =>
+  isInitializationInputIndependent(node, renderOwner, scopes) &&
+  ((isProvablyTruthyInitializationValue(node, scopes) &&
+    (!requiresClosedTruthyDomain || !refHasDeclaredType(refSymbol))) ||
+    refHasClosedFalsySentinelDomain(refSymbol, node, scopes));
 
 const hasRepeatedExecutionAncestor = (node: EsTreeNode, stop: EsTreeNode): boolean => {
   let ancestor = node.parent;
@@ -297,6 +385,41 @@ const canExecuteTogether = (
   return true;
 };
 
+const hasNoCoExecutableCompetingWrite = (
+  assignmentExpression: EsTreeNodeOfType<"AssignmentExpression">,
+  renderOwner: EsTreeNode,
+  refSymbol: SymbolDescriptor,
+  scopes: ScopeAnalysis,
+): boolean => {
+  const assignmentConstraints = getBranchConstraints(assignmentExpression, renderOwner);
+  let hasCompetingWrite = false;
+  walkAst(renderOwner, (child: EsTreeNode): boolean | void => {
+    if (hasCompetingWrite) return false;
+    let writtenExpression: EsTreeNode | null = null;
+    if (isNodeOfType(child, "AssignmentExpression")) {
+      if (child === assignmentExpression) return;
+      writtenExpression = child.left;
+    } else if (
+      isNodeOfType(child, "UpdateExpression") ||
+      (isNodeOfType(child, "UnaryExpression") && child.operator === "delete")
+    ) {
+      writtenExpression = child.argument;
+    } else if (isNodeOfType(child, "ForInStatement") || isNodeOfType(child, "ForOfStatement")) {
+      writtenExpression = child.left;
+    }
+    if (
+      !writtenExpression ||
+      !expressionContainsRefCurrent(writtenExpression, refSymbol, scopes) ||
+      !canExecuteTogether(assignmentConstraints, getBranchConstraints(child, renderOwner))
+    ) {
+      return;
+    }
+    hasCompetingWrite = true;
+    return false;
+  });
+  return !hasCompetingWrite;
+};
+
 const hasNoPriorCoExecutableWrite = (
   assignmentExpression: EsTreeNodeOfType<"AssignmentExpression">,
   branchRoot: EsTreeNode,
@@ -328,17 +451,46 @@ const hasNoPriorCoExecutableWrite = (
   return !hasCoExecutableWrite;
 };
 
+const isPredictableGuardedInitialization = (
+  assignmentExpression: EsTreeNodeOfType<"AssignmentExpression">,
+  guardedBranch: EsTreeNode,
+  renderOwner: EsTreeNode,
+  refSymbol: SymbolDescriptor,
+  scopes: ScopeAnalysis,
+  requiresClosedTruthyDomain: boolean,
+): boolean =>
+  refHasEmptySentinelInitializer(refSymbol, scopes) &&
+  isPredictableInitializationValue(
+    assignmentExpression.right,
+    refSymbol,
+    renderOwner,
+    scopes,
+    requiresClosedTruthyDomain,
+  ) &&
+  !hasRepeatedExecutionAncestor(assignmentExpression, guardedBranch) &&
+  (guardedBranch === renderOwner || !hasRepeatedExecutionAncestor(guardedBranch, renderOwner)) &&
+  hasNoPriorCoExecutableWrite(assignmentExpression, renderOwner, refSymbol, scopes) &&
+  hasNoCoExecutableCompetingWrite(assignmentExpression, renderOwner, refSymbol, scopes) &&
+  refDoesNotEscape(renderOwner, refSymbol, scopes);
+
 const isDocumentedLazyInitialization = (
   assignmentExpression: EsTreeNodeOfType<"AssignmentExpression">,
   refSymbol: SymbolDescriptor,
   scopes: ScopeAnalysis,
 ): boolean => {
-  if (assignmentExpression.operator === "??=" || assignmentExpression.operator === "||=") {
-    return true;
-  }
-  if (assignmentExpression.operator !== "=") return false;
   const renderOwner = findRenderPhaseComponentOrHook(assignmentExpression, scopes);
   if (!renderOwner) return false;
+  if (assignmentExpression.operator === "??=" || assignmentExpression.operator === "||=") {
+    return isPredictableGuardedInitialization(
+      assignmentExpression,
+      renderOwner,
+      renderOwner,
+      refSymbol,
+      scopes,
+      assignmentExpression.operator === "||=",
+    );
+  }
+  if (assignmentExpression.operator !== "=") return false;
   let descendant: EsTreeNode = assignmentExpression;
   let ancestor = descendant.parent;
   while (ancestor) {
@@ -350,13 +502,14 @@ const isDocumentedLazyInitialization = (
       test.operator === "!" &&
       isSameRefCurrentAlias(test.argument, refSymbol, scopes) &&
       ancestor.consequent === descendant &&
-      isProvablyTruthyInitializationValue(assignmentExpression.right, scopes) &&
-      refHasClosedFalsySentinelDomain(refSymbol, assignmentExpression.right, scopes) &&
-      !hasRepeatedExecutionAncestor(assignmentExpression, ancestor.consequent) &&
-      !hasRepeatedExecutionAncestor(ancestor, renderOwner) &&
-      hasNoPriorCoExecutableWrite(assignmentExpression, ancestor.consequent, refSymbol, scopes) &&
-      hasNoCompetingRefCurrentWrite(renderOwner, assignmentExpression, refSymbol, scopes) &&
-      refDoesNotEscape(renderOwner, refSymbol, scopes)
+      isPredictableGuardedInitialization(
+        assignmentExpression,
+        ancestor.consequent,
+        renderOwner,
+        refSymbol,
+        scopes,
+        true,
+      )
     ) {
       return true;
     }
@@ -375,8 +528,14 @@ const isDocumentedLazyInitialization = (
         comparesEmptySentinel &&
         guardedBranch === descendant &&
         guardedBranch &&
-        !hasRepeatedExecutionAncestor(assignmentExpression, guardedBranch) &&
-        hasNoPriorCoExecutableWrite(assignmentExpression, guardedBranch, refSymbol, scopes)
+        isPredictableGuardedInitialization(
+          assignmentExpression,
+          guardedBranch,
+          renderOwner,
+          refSymbol,
+          scopes,
+          false,
+        )
       )
         return true;
     }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-ref-current-in-render.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-ref-current-in-render.ts
@@ -4,6 +4,7 @@ import { containsNonDeterministicSource } from "../../utils/contains-non-determi
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { executesDuringRender } from "../../utils/executes-during-render.js";
 import { findDeferredExecutionBoundary } from "../../utils/find-deferred-execution-boundary.js";
 import { findRenderPhaseComponentOrHook } from "../../utils/find-render-phase-component-or-hook.js";
 import { findTransparentExpressionRoot } from "../../utils/find-transparent-expression-root.js";
@@ -424,6 +425,7 @@ const hasNoCoExecutableCompetingWrite = (
       deferredExecutionBoundary !== null &&
       deferredExecutionBoundary !== renderOwner &&
       !synchronouslyInvokedFunctions.has(deferredExecutionBoundary) &&
+      !executesDuringRender(deferredExecutionBoundary, scopes) &&
       deferredWriteValue !== null &&
       !isNodeOfType(deferredWriteValue, "CallExpression") &&
       isProvablyTruthyInitializationValue(deferredWriteValue, scopes);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-ref-current-in-render.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-ref-current-in-render.ts
@@ -1,7 +1,9 @@
 import type { ScopeAnalysis, SymbolDescriptor } from "../../semantic/scope-analysis.js";
+import { collectSynchronouslyEffectInvokedFunctions } from "../../utils/collect-effect-invoked-functions.js";
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findDeferredExecutionBoundary } from "../../utils/find-deferred-execution-boundary.js";
 import { findRenderPhaseComponentOrHook } from "../../utils/find-render-phase-component-or-hook.js";
 import { findTransparentExpressionRoot } from "../../utils/find-transparent-expression-root.js";
 import { getRangeStart } from "../../utils/get-range-start.js";
@@ -392,6 +394,10 @@ const hasNoCoExecutableCompetingWrite = (
   scopes: ScopeAnalysis,
 ): boolean => {
   const assignmentConstraints = getBranchConstraints(assignmentExpression, renderOwner);
+  const synchronouslyInvokedFunctions = collectSynchronouslyEffectInvokedFunctions(
+    renderOwner,
+    scopes,
+  );
   let hasCompetingWrite = false;
   walkAst(renderOwner, (child: EsTreeNode): boolean | void => {
     if (hasCompetingWrite) return false;
@@ -407,8 +413,21 @@ const hasNoCoExecutableCompetingWrite = (
     } else if (isNodeOfType(child, "ForInStatement") || isNodeOfType(child, "ForOfStatement")) {
       writtenExpression = child.left;
     }
+    const deferredExecutionBoundary = findDeferredExecutionBoundary(child);
+    const deferredWriteValue =
+      isNodeOfType(child, "AssignmentExpression") && child.operator === "="
+        ? resolveImmutableInitializationValue(child.right, scopes)
+        : null;
+    const isDeferredTruthyWrite =
+      deferredExecutionBoundary !== null &&
+      deferredExecutionBoundary !== renderOwner &&
+      !synchronouslyInvokedFunctions.has(deferredExecutionBoundary) &&
+      deferredWriteValue !== null &&
+      !isNodeOfType(deferredWriteValue, "CallExpression") &&
+      isProvablyTruthyInitializationValue(deferredWriteValue, scopes);
     if (
       !writtenExpression ||
+      isDeferredTruthyWrite ||
       !expressionContainsRefCurrent(writtenExpression, refSymbol, scopes) ||
       !canExecuteTogether(assignmentConstraints, getBranchConstraints(child, renderOwner))
     ) {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-ref-current-in-render.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-ref-current-in-render.ts
@@ -1,5 +1,6 @@
 import type { ScopeAnalysis, SymbolDescriptor } from "../../semantic/scope-analysis.js";
 import { collectSynchronouslyEffectInvokedFunctions } from "../../utils/collect-effect-invoked-functions.js";
+import { containsNonDeterministicSource } from "../../utils/contains-non-deterministic-source.js";
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
@@ -345,6 +346,7 @@ const isPredictableInitializationValue = (
   requiresClosedTruthyDomain: boolean,
 ): boolean =>
   isInitializationInputIndependent(node, renderOwner, scopes) &&
+  !containsNonDeterministicSource(node) &&
   ((isProvablyTruthyInitializationValue(node, scopes) &&
     (!requiresClosedTruthyDomain || !refHasDeclaredType(refSymbol))) ||
     refHasClosedFalsySentinelDomain(refSymbol, node, scopes));


### PR DESCRIPTION
## Summary

- recognize predictable, input-independent lazy ref initialization across null guards, equality guards, and nullish/logical assignment
- keep reporting prop-derived, mutable, escaping, repeated, competing, and nondeterministic render-time writes
- distinguish deferred guaranteed-truthy replacements from sentinel resets that can reopen the render branch
- reuse the shared nondeterminism proof for clock/random/id sources
- add adversarial regressions, a strict-fuzz true-positive seed, and a patch changeset

## ReactBench evidence

The frozen adjudication covers 18 diagnostic units across 16 trials.

- baseline `main`: 18/18 caught
- this branch: 6/18 caught, preserving all 6 adjudicated true positives and suppressing exactly 12 adjudicated false positives
- parse-clean: 18/18
- exact diagnostic-line identity: 18/18
- retained true positives: TimeGutter (3), mui-tel-input AsYouType (3)
- suppressed false positives: Cloudscape (4), nteract Map (3), Tooltip debounce (2), Lobe Set (2), Fojin coordinator (1)

Frozen partition: `/tmp/reactbench-no-ref-partition.md`
Partition SHA-256: `490d035f27f486cdfe804cc514d505e74cccca83b851e6f00320980226cefe1b`
Head replay: `/tmp/reactbench-no-ref-head-replay-462a84d73.json`
Replay SHA-256: `d63ca6f34dbf3c8c0be91be2addc86473bca9ddf73e04858724141dddbe93906`
Live docs SHA-256: `fa3aa41afeb4f3d0761effc4d811741df0ffe259fb91999480d76eca65077240`

## Validation

- focused rule tests: 78 passed
- full `nr test`: passed before the two adversarial follow-ups; each follow-up focused suite passed
- full `nr typecheck`: passed, including after both follow-ups
- `nr lint`: passed with existing warnings only
- `nr format:check`: passed
- strict fuzz: `FUZZ_RULE=no-ref-current-in-render FUZZ_ITERATIONS=500 FUZZ_SEED=792026 FUZZ_STRICT=1 nr fuzz`, including after both follow-ups
- post-change truffler duplicate/dead-code searches: no matches

Targeted RDE and Daytona parity could not run because this environment has neither `AXIOM_DATASET` nor `DAYTONA_API_KEY`; the exact downloaded ReactBench replay above is independent of those services.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large change to render-purity lint heuristics; wrong proofs would hide real bugs or reintroduce noise, but scope is limited to the oxlint rule and is heavily regression-tested.
> 
> **Overview**
> **`no-ref-current-in-render`** now treats **predictable, input-independent** lazy ref setup as exempt instead of blanket-allowing some guard shapes. Guarded writes under falsy/`!current`, null/undefined equality checks, and `??=` / `||=` must pass a shared **`isPredictableGuardedInitialization`** proof: empty-sentinel `useRef`, render-independent RHS (no props/module `let`), no `Math.random`/`Date` nondeterminism, closed type-domain matching (including `create*` factories, `ReturnType<typeof …>`, indexed-access types), no ref escape, and no **co-executable** competing writes in the same render path.
> 
> Competing-write detection moves from a simple write count to **branch-aware** analysis (`hasNoCoExecutableCompetingWrite`), with carve-outs for deferred truthy replacements in effects/handlers while still reporting co-executable sentinel resets and render-phase writes (e.g. **`useMemo`** / lazy **`useState`** initializer mutating the same ref).
> 
> Regression tests, two fuzz corpus seeds, and a patch changeset document the new true-positive vs false-positive split.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfb6778dfed09d8fed490ea948e5146a5d73fb36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->