### PR TITLE
RDFPFN792026: preserve Next.js page prop serialization

### DIFF
--- a/.changeset/quiet-page-props.md
+++ b/.changeset/quiet-page-props.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Avoid flagging intentional JSON normalization at Next.js Pages Router props boundaries.

--- a/packages/fuzz/corpus/regressions/no-json-parse-stringify-clone--nextjs-page-props/pages/settings.tsx
+++ b/packages/fuzz/corpus/regressions/no-json-parse-stringify-clone--nextjs-page-props/pages/settings.tsx
@@ -1,0 +1,15 @@
+// rule: no-json-parse-stringify-clone
+// weakness: framework-gating
+// source: ReactBench RDFPFN792026 exact 15-unit false-positive partition
+
+export const getServerSideProps = withSessionSsr(async ({ req }) => {
+  const apiKeys = await loadApiKeys();
+  const jsonSafeUser = JSON.parse(JSON.stringify(req.session.user));
+  const serializedUser = jsonSafeUser;
+  return {
+    props: {
+      user: serializedUser,
+      apiKeys: JSON.parse(JSON.stringify(apiKeys)),
+    },
+  };
+});

--- a/packages/fuzz/corpus/regressions/no-json-parse-stringify-clone--nextjs-page-props/pages/settings.tsx
+++ b/packages/fuzz/corpus/regressions/no-json-parse-stringify-clone--nextjs-page-props/pages/settings.tsx
@@ -1,6 +1,6 @@
 // rule: no-json-parse-stringify-clone
-// weakness: framework-gating
-// source: ReactBench RDFPFN792026 exact 15-unit false-positive partition
+// weakness: framework-gating, control-flow, transparent-wrapper
+// source: ReactBench RDFPFN792026 exact 15-unit false-positive partition; Bugbot PR #1498
 
 export const getServerSideProps = withSessionSsr(async ({ req }) => {
   const apiKeys = await loadApiKeys();
@@ -13,3 +13,12 @@ export const getServerSideProps = withSessionSsr(async ({ req }) => {
     },
   };
 });
+
+export const getStaticProps = async ({ missing }) =>
+  missing
+    ? { notFound: true }
+    : ({
+        props: {
+          apiKeys: JSON.parse(JSON.stringify(loadApiKeys())),
+        },
+      } satisfies GetStaticPropsResult);

--- a/packages/fuzz/corpus/regressions/no-json-parse-stringify-clone--opaque-returned-props/pages/settings.tsx
+++ b/packages/fuzz/corpus/regressions/no-json-parse-stringify-clone--opaque-returned-props/pages/settings.tsx
@@ -1,0 +1,10 @@
+// rule: no-json-parse-stringify-clone
+// weakness: framework-gating, opacity
+// source: Bugbot PR #1498
+// verdict: fail
+
+export const getServerSideProps = async () => ({
+  props: {
+    state: consume(JSON.parse(JSON.stringify(state))),
+  },
+});

--- a/packages/fuzz/corpus/regressions/no-json-parse-stringify-clone--opaque-returned-props/pages/settings.tsx
+++ b/packages/fuzz/corpus/regressions/no-json-parse-stringify-clone--opaque-returned-props/pages/settings.tsx
@@ -3,8 +3,12 @@
 // source: Bugbot PR #1498
 // verdict: fail
 
-export const getServerSideProps = async () => ({
-  props: {
-    state: consume(JSON.parse(JSON.stringify(state))),
-  },
-});
+export const getServerSideProps = async () => {
+  const serializedState = JSON.parse(JSON.stringify(state));
+  return {
+    props: {
+      serializedState,
+      escaped: consume(serializedState),
+    },
+  };
+};

--- a/packages/fuzz/corpus/regressions/no-json-parse-stringify-clone--props-binding/pages/settings.tsx
+++ b/packages/fuzz/corpus/regressions/no-json-parse-stringify-clone--props-binding/pages/settings.tsx
@@ -1,0 +1,11 @@
+// rule: no-json-parse-stringify-clone
+// weakness: framework-gating, props-binding
+// source: Bugbot PR #1498
+// verdict: pass
+
+export const getServerSideProps = async () => {
+  const pageProps = {
+    nested: [{ state: JSON.parse(JSON.stringify(state)) }],
+  };
+  return { props: pageProps };
+};

--- a/packages/fuzz/corpus/regressions/no-json-parse-stringify-clone--returned-page-result/pages/settings.tsx
+++ b/packages/fuzz/corpus/regressions/no-json-parse-stringify-clone--returned-page-result/pages/settings.tsx
@@ -1,0 +1,11 @@
+// rule: no-json-parse-stringify-clone
+// weakness: framework-gating, returned-binding
+// source: Bugbot PR #1498
+// verdict: pass
+
+export const getServerSideProps = async ({ missing }) => {
+  const response = missing
+    ? { notFound: true }
+    : { props: { state: JSON.parse(JSON.stringify(state)) } };
+  return response;
+};

--- a/packages/fuzz/corpus/true-positives/no-json-parse-stringify-clone--nested-binding/pages/settings.tsx
+++ b/packages/fuzz/corpus/true-positives/no-json-parse-stringify-clone--nested-binding/pages/settings.tsx
@@ -1,0 +1,13 @@
+// rule: no-json-parse-stringify-clone
+// weakness: binding-provenance, escape-analysis
+// source: Bugbot PR #1498
+// verdict: fail
+
+export const getServerSideProps = async () => {
+  const serializedState = (() => {
+    const workingCopy = JSON.parse(JSON.stringify(state));
+    mutate(workingCopy);
+    return workingCopy;
+  })();
+  return { props: { serializedState } };
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-json-parse-stringify-clone.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-json-parse-stringify-clone.test.ts
@@ -352,6 +352,46 @@ describe("no-json-parse-stringify-clone", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("still flags a clone passed through an opaque directly returned props value", () => {
+    const result = runRule(
+      noJsonParseStringifyClone,
+      `
+      export const getServerSideProps = async () => {
+        return {
+          props: {
+            state: consume(JSON.parse(JSON.stringify(state))),
+          },
+        };
+      };
+      `,
+      { filename: "/repo/src/pages/settings.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a mutated IIFE clone inside directly returned props", () => {
+    const result = runRule(
+      noJsonParseStringifyClone,
+      `
+      export const getServerSideProps = async () => {
+        return {
+          props: {
+            state: (() => {
+              const workingCopy = JSON.parse(JSON.stringify(state));
+              mutate(workingCopy);
+              return workingCopy;
+            })(),
+          },
+        };
+      };
+      `,
+      { filename: "/repo/src/pages/settings.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("still flags a nested IIFE clone binding that is mutated before page serialization", () => {
     const result = runRule(
       noJsonParseStringifyClone,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-json-parse-stringify-clone.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-json-parse-stringify-clone.test.ts
@@ -271,6 +271,76 @@ describe("no-json-parse-stringify-clone", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("does not flag JSON normalization in a returned page-result binding", () => {
+    const result = runRule(
+      noJsonParseStringifyClone,
+      `
+      export const getServerSideProps = async ({ missing }) => {
+        const response = missing
+          ? { notFound: true }
+          : { props: { state: JSON.parse(JSON.stringify(state)) } };
+        return response;
+      };
+      `,
+      { filename: "/repo/src/pages/settings.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still flags a nested helper clone that is mutated before page serialization", () => {
+    const result = runRule(
+      noJsonParseStringifyClone,
+      `
+      export const getServerSideProps = async () => {
+        const buildState = () => {
+          const workingCopy = JSON.parse(JSON.stringify(state));
+          mutate(workingCopy);
+          return workingCopy;
+        };
+        return { props: { state: buildState() } };
+      };
+      `,
+      { filename: "/repo/src/pages/settings.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a nested IIFE clone binding that is mutated before page serialization", () => {
+    const result = runRule(
+      noJsonParseStringifyClone,
+      `
+      export const getServerSideProps = async () => {
+        const serializedState = (() => {
+          const workingCopy = JSON.parse(JSON.stringify(state));
+          mutate(workingCopy);
+          return workingCopy;
+        })();
+        return { props: { serializedState } };
+      };
+      `,
+      { filename: "/repo/src/pages/settings.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a clone passed through an opaque initializer before page serialization", () => {
+    const result = runRule(
+      noJsonParseStringifyClone,
+      `
+      export const getServerSideProps = async () => {
+        const serializedState = consume(JSON.parse(JSON.stringify(state)));
+        return { props: { serializedState } };
+      };
+      `,
+      { filename: "/repo/src/pages/settings.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("still flags redundant JSON normalization before an API response", () => {
     const result = runRule(
       noJsonParseStringifyClone,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-json-parse-stringify-clone.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-json-parse-stringify-clone.test.ts
@@ -150,9 +150,7 @@ describe("no-json-parse-stringify-clone", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
-  // sofn-xyz/mailing settings: both
-  // mined clones inside getServerSideProps props MUST keep firing.
-  it("flags both clones in a getServerSideProps props object", () => {
+  it("does not flag JSON normalization in a getServerSideProps props object", () => {
     const result = runRule(
       noJsonParseStringifyClone,
       `
@@ -168,8 +166,154 @@ describe("no-json-parse-stringify-clone", () => {
         };
       });
       `,
+      { filename: "/repo/src/pages/settings.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag an aliased JSON normalization returned from getServerSideProps", () => {
+    const result = runRule(
+      noJsonParseStringifyClone,
+      `
+      export const getServerSideProps = withSessionSsr(async ({ req }) => {
+        const normalizedUser = (() => {
+          try {
+            return JSON.parse(JSON.stringify(req.session.user));
+          } catch {
+            return {};
+          }
+        })();
+        const serializedUser = normalizedUser;
+        return { props: { user: serializedUser } };
+      });
+      `,
+      { filename: "/repo/src/pages/settings.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag JSON normalization returned from getStaticProps", () => {
+    const result = runRule(
+      noJsonParseStringifyClone,
+      `
+      export async function getStaticProps() {
+        const articles = await loadArticles();
+        return { ["props"]: { articles: JSON.parse(JSON.stringify(articles)) } };
+      }
+      `,
+      { filename: "/repo/pages/index.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still flags redundant JSON normalization before an API response", () => {
+    const result = runRule(
+      noJsonParseStringifyClone,
+      `
+      export default async function handler(req, res) {
+        const apiKey = await prisma.apiKey.create();
+        const apiKeys = await prisma.apiKey.findMany();
+        res.status(201).json({ apiKey: JSON.parse(JSON.stringify(apiKey)) });
+        const serializedApiKeys = JSON.parse(JSON.stringify(apiKeys));
+        res.status(200).json({ apiKeys: serializedApiKeys });
+      }
+      `,
+      { filename: "/repo/src/pages/api/apiKeys/index.ts" },
     );
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toHaveLength(2);
+  });
+
+  it("still flags a clone not returned in Next.js page props", () => {
+    const result = runRule(
+      noJsonParseStringifyClone,
+      `
+      export const getServerSideProps = async () => {
+        const workingCopy = JSON.parse(JSON.stringify(state));
+        mutate(workingCopy);
+        return { props: { state } };
+      };
+      `,
+      { filename: "/repo/src/pages/settings.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a clone in a non-exported getServerSideProps lookalike", () => {
+    const result = runRule(
+      noJsonParseStringifyClone,
+      `
+      const getServerSideProps = async () => ({
+        props: { state: JSON.parse(JSON.stringify(state)) },
+      });
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not flag a separately exported page-data boundary", () => {
+    const result = runRule(
+      noJsonParseStringifyClone,
+      `
+      const loadPage = async () => ({
+        props: { state: JSON.parse(JSON.stringify(state)) },
+      });
+      export { loadPage as getServerSideProps };
+      `,
+      { filename: "/repo/src/pages/settings.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still flags a clone that is mutated before being returned in page props", () => {
+    const result = runRule(
+      noJsonParseStringifyClone,
+      `
+      export const getServerSideProps = async () => {
+        const workingCopy = JSON.parse(JSON.stringify(state));
+        mutate(workingCopy);
+        return { props: { workingCopy } };
+      };
+      `,
+      { filename: "/repo/src/pages/settings.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a clone that escapes before being returned in page props", () => {
+    const result = runRule(
+      noJsonParseStringifyClone,
+      `
+      export const getServerSideProps = async () => {
+        const serializedState = JSON.parse(JSON.stringify(state));
+        recordSnapshot(serializedState);
+        return { props: { serializedState } };
+      };
+      `,
+      { filename: "/repo/src/pages/settings.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a page-data lookalike outside a Next.js pages directory", () => {
+    const result = runRule(
+      noJsonParseStringifyClone,
+      `
+      export const getServerSideProps = async () => ({
+        props: { state: JSON.parse(JSON.stringify(state)) },
+      });
+      `,
+      { filename: "/repo/src/server/load-state.ts" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
   });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-json-parse-stringify-clone.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-json-parse-stringify-clone.test.ts
@@ -288,6 +288,34 @@ describe("no-json-parse-stringify-clone", () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("does not flag JSON normalization nested in a returned props binding", () => {
+    const validSources = [
+      `
+      export const getServerSideProps = async () => {
+        const props = {
+          state: JSON.parse(JSON.stringify(state)),
+        };
+        return { props };
+      };
+      `,
+      `
+      export const getServerSideProps = async () => {
+        const pageProps = {
+          nested: [{ state: JSON.parse(JSON.stringify(state)) }],
+        };
+        return { props: pageProps };
+      };
+      `,
+    ];
+    for (const source of validSources) {
+      const result = runRule(noJsonParseStringifyClone, source, {
+        filename: "/repo/src/pages/settings.tsx",
+      });
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(0);
+    }
+  });
+
   it("still flags a nested helper clone that is mutated before page serialization", () => {
     const result = runRule(
       noJsonParseStringifyClone,
@@ -299,6 +327,23 @@ describe("no-json-parse-stringify-clone", () => {
           return workingCopy;
         };
         return { props: { state: buildState() } };
+      };
+      `,
+      { filename: "/repo/src/pages/settings.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a clone passed through an opaque nested props value", () => {
+    const result = runRule(
+      noJsonParseStringifyClone,
+      `
+      export const getServerSideProps = async () => {
+        const props = {
+          state: consume(JSON.parse(JSON.stringify(state))),
+        };
+        return { props };
       };
       `,
       { filename: "/repo/src/pages/settings.tsx" },

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-json-parse-stringify-clone.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-json-parse-stringify-clone.test.ts
@@ -370,6 +370,26 @@ describe("no-json-parse-stringify-clone", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("still flags a props binding that also escapes through an opaque sibling value", () => {
+    const result = runRule(
+      noJsonParseStringifyClone,
+      `
+      export const getServerSideProps = async () => {
+        const serializedState = JSON.parse(JSON.stringify(state));
+        return {
+          props: {
+            serializedState,
+            escaped: consume(serializedState),
+          },
+        };
+      };
+      `,
+      { filename: "/repo/src/pages/settings.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("still flags a mutated IIFE clone inside directly returned props", () => {
     const result = runRule(
       noJsonParseStringifyClone,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-json-parse-stringify-clone.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-json-parse-stringify-clone.test.ts
@@ -209,6 +209,68 @@ describe("no-json-parse-stringify-clone", () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("does not flag JSON normalization in a conditional page-data return", () => {
+    const result = runRule(
+      noJsonParseStringifyClone,
+      `
+      export const getServerSideProps = async ({ preferProps }) => {
+        return preferProps
+          ? { props: { state: JSON.parse(JSON.stringify(state)) } }
+          : { redirect: { destination: "/", permanent: false } };
+      };
+
+      export async function getStaticProps({ missing }) {
+        return missing
+          ? { notFound: true }
+          : { props: { state: JSON.parse(JSON.stringify(state)) } };
+      }
+      `,
+      { filename: "/repo/src/pages/settings.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag JSON normalization in a typed concise page-data return", () => {
+    const result = runRule(
+      noJsonParseStringifyClone,
+      `
+      export const getServerSideProps = (
+        async () =>
+          ({
+            props: { state: JSON.parse(JSON.stringify(state)) },
+          } as GetServerSidePropsResult)
+      ) satisfies GetServerSideProps;
+
+      export const getStaticProps = async () =>
+        ({
+          props: { state: JSON.parse(JSON.stringify(state)) },
+        } satisfies GetStaticPropsResult);
+      `,
+      { filename: "/repo/src/pages/settings.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still flags a clone in a conditional props object that is not returned", () => {
+    const result = runRule(
+      noJsonParseStringifyClone,
+      `
+      export const getServerSideProps = async ({ missing }) => {
+        const response = missing
+          ? { notFound: true }
+          : { props: { state: JSON.parse(JSON.stringify(state)) } };
+        consume(response);
+        return { props: { state } };
+      };
+      `,
+      { filename: "/repo/src/pages/settings.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("still flags redundant JSON normalization before an API response", () => {
     const result = runRule(
       noJsonParseStringifyClone,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-json-parse-stringify-clone.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-json-parse-stringify-clone.ts
@@ -163,7 +163,36 @@ const findConditionalReturnExpressionRoot = (node: EsTreeNode): EsTreeNode => {
   return expressionRoot;
 };
 
-const isInsideReturnedNextjsProps = (node: EsTreeNode, pageDataFunction: EsTreeNode): boolean => {
+const isReturnedPageDataResultBinding = (
+  returnExpression: EsTreeNode,
+  pageDataFunction: EsTreeNode,
+  context: RuleContext,
+): boolean => {
+  const declarator = returnExpression.parent;
+  if (
+    !isNodeOfType(declarator, "VariableDeclarator") ||
+    declarator.init !== returnExpression ||
+    !isNodeOfType(declarator.id, "Identifier") ||
+    findEnclosingFunction(declarator) !== pageDataFunction
+  ) {
+    return false;
+  }
+  const bindingSymbol = context.scopes.symbolFor(declarator.id);
+  if (!bindingSymbol || bindingSymbol.references.length !== 1) return false;
+  const referenceRoot = findTransparentExpressionRoot(bindingSymbol.references[0].identifier);
+  const returnStatement = referenceRoot.parent;
+  return (
+    isNodeOfType(returnStatement, "ReturnStatement") &&
+    returnStatement.argument === referenceRoot &&
+    findEnclosingFunction(returnStatement) === pageDataFunction
+  );
+};
+
+const isInsideReturnedNextjsProps = (
+  node: EsTreeNode,
+  pageDataFunction: EsTreeNode,
+  context: RuleContext,
+): boolean => {
   let cursor: EsTreeNode | null | undefined = node.parent;
   while (cursor && cursor !== pageDataFunction) {
     if (
@@ -187,25 +216,53 @@ const isInsideReturnedNextjsProps = (node: EsTreeNode, pageDataFunction: EsTreeN
       ) {
         return true;
       }
+      if (isReturnedPageDataResultBinding(returnExpression, pageDataFunction, context)) return true;
     }
     cursor = cursor.parent ?? null;
   }
   return false;
 };
 
-const findPageDataResultBinding = (
+const isExpressionReturnedByFunction = (node: EsTreeNode, functionNode: EsTreeNode): boolean => {
+  const returnExpression = findConditionalReturnExpressionRoot(node);
+  if (
+    isNodeOfType(functionNode, "ArrowFunctionExpression") &&
+    !isNodeOfType(functionNode.body, "BlockStatement")
+  ) {
+    return stripParenExpression(functionNode.body) === stripParenExpression(returnExpression);
+  }
+  const returnStatement = returnExpression.parent;
+  return (
+    isNodeOfType(returnStatement, "ReturnStatement") &&
+    returnStatement.argument === returnExpression &&
+    findEnclosingFunction(returnStatement) === functionNode
+  );
+};
+
+const isValueForwardedToBindingInitializer = (
   node: EsTreeNode,
-  pageDataFunction: EsTreeNode,
-): EsTreeNodeOfType<"Identifier"> | null => {
+  bindingInitializer: EsTreeNode,
+): boolean => {
+  const directValue = findConditionalReturnExpressionRoot(node);
+  if (stripParenExpression(bindingInitializer) === stripParenExpression(directValue)) return true;
+  const initializer = stripParenExpression(bindingInitializer);
+  if (!isNodeOfType(initializer, "CallExpression")) return false;
+  const callee = stripParenExpression(initializer.callee);
+  return isFunctionLike(callee) && isExpressionReturnedByFunction(node, callee);
+};
+
+const findPageDataResultBinding = (node: EsTreeNode): EsTreeNodeOfType<"Identifier"> | null => {
   let cursor: EsTreeNode | null | undefined = node.parent;
-  while (cursor && cursor !== pageDataFunction) {
-    if (
-      isNodeOfType(cursor, "VariableDeclarator") &&
-      cursor.init &&
-      isNodeOfType(cursor.id, "Identifier") &&
-      findEnclosingFunction(cursor) === pageDataFunction
-    ) {
-      return cursor.id;
+  while (cursor) {
+    if (isNodeOfType(cursor, "VariableDeclarator")) {
+      if (
+        cursor.init &&
+        isNodeOfType(cursor.id, "Identifier") &&
+        isValueForwardedToBindingInitializer(node, cursor.init)
+      ) {
+        return cursor.id;
+      }
+      return null;
     }
     cursor = cursor.parent ?? null;
   }
@@ -218,8 +275,8 @@ const isUsedToSerializeNextjsPageProps = (node: EsTreeNode, context: RuleContext
   }
   const pageDataFunction = findEnclosingNextjsPageDataFunction(node);
   if (!pageDataFunction) return false;
-  if (isInsideReturnedNextjsProps(node, pageDataFunction)) return true;
-  const bindingIdentifier = findPageDataResultBinding(node, pageDataFunction);
+  if (isInsideReturnedNextjsProps(node, pageDataFunction, context)) return true;
+  const bindingIdentifier = findPageDataResultBinding(node);
   const bindingSymbol = bindingIdentifier ? context.scopes.symbolFor(bindingIdentifier) : null;
   if (!bindingSymbol) return false;
   const aliasSymbols = collectConstAliasSymbols(bindingSymbol, context.scopes);
@@ -228,7 +285,7 @@ const isUsedToSerializeNextjsPageProps = (node: EsTreeNode, context: RuleContext
   for (const aliasSymbol of aliasSymbols) {
     for (const reference of aliasSymbol.references) {
       if (findEnclosingFunction(reference.identifier) !== pageDataFunction) return false;
-      if (isInsideReturnedNextjsProps(reference.identifier, pageDataFunction)) {
+      if (isInsideReturnedNextjsProps(reference.identifier, pageDataFunction, context)) {
         hasPagePropsReference = true;
         continue;
       }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-json-parse-stringify-clone.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-json-parse-stringify-clone.ts
@@ -188,6 +188,56 @@ const isReturnedPageDataResultBinding = (
   );
 };
 
+const isSameShorthandPropertyValue = (
+  node: EsTreeNode,
+  property: EsTreeNodeOfType<"Property">,
+): boolean =>
+  property.shorthand &&
+  isNodeOfType(node, "Identifier") &&
+  isNodeOfType(property.value, "Identifier") &&
+  node.name === property.value.name;
+
+const isValueForwardedThroughLiteralStructure = (
+  node: EsTreeNode,
+  structure: EsTreeNode,
+): boolean => {
+  const strippedNode = stripParenExpression(node);
+  const strippedStructure = stripParenExpression(structure);
+  if (strippedNode === strippedStructure) return true;
+  if (isNodeOfType(strippedStructure, "ConditionalExpression")) {
+    return (
+      isValueForwardedThroughLiteralStructure(strippedNode, strippedStructure.consequent) ||
+      isValueForwardedThroughLiteralStructure(strippedNode, strippedStructure.alternate)
+    );
+  }
+  if (isNodeOfType(strippedStructure, "ArrayExpression")) {
+    return strippedStructure.elements.some(
+      (element) =>
+        element &&
+        !isNodeOfType(element, "SpreadElement") &&
+        isValueForwardedThroughLiteralStructure(strippedNode, element),
+    );
+  }
+  if (!isNodeOfType(strippedStructure, "ObjectExpression")) return false;
+  return strippedStructure.properties.some((property) => {
+    if (isNodeOfType(property, "SpreadElement")) {
+      return isValueForwardedThroughLiteralStructure(strippedNode, property.argument);
+    }
+    if (!isNodeOfType(property, "Property")) return false;
+    if (isValueForwardedThroughLiteralStructure(strippedNode, property.value)) return true;
+    return isSameShorthandPropertyValue(strippedNode, property);
+  });
+};
+
+const isValueForwardedToPropertyValue = (
+  node: EsTreeNode,
+  property: EsTreeNodeOfType<"Property">,
+): boolean => {
+  const directValue = findConditionalReturnExpressionRoot(node);
+  if (isValueForwardedThroughLiteralStructure(directValue, property.value)) return true;
+  return isSameShorthandPropertyValue(directValue, property);
+};
+
 const isInsideReturnedNextjsProps = (
   node: EsTreeNode,
   pageDataFunction: EsTreeNode,
@@ -197,7 +247,8 @@ const isInsideReturnedNextjsProps = (
   while (cursor && cursor !== pageDataFunction) {
     if (
       isNodeOfType(cursor, "Property") &&
-      getStaticPropertyKeyName(cursor, { allowComputedString: true }) === "props"
+      getStaticPropertyKeyName(cursor, { allowComputedString: true }) === "props" &&
+      isValueForwardedToPropertyValue(node, cursor)
     ) {
       const propertyContainer = cursor.parent;
       if (!propertyContainer) return false;
@@ -237,39 +288,6 @@ const isExpressionReturnedByFunction = (node: EsTreeNode, functionNode: EsTreeNo
     returnStatement.argument === returnExpression &&
     findEnclosingFunction(returnStatement) === functionNode
   );
-};
-
-const isValueForwardedThroughLiteralStructure = (
-  node: EsTreeNode,
-  structure: EsTreeNode,
-): boolean => {
-  const strippedNode = stripParenExpression(node);
-  const strippedStructure = stripParenExpression(structure);
-  if (strippedNode === strippedStructure) return true;
-  if (isNodeOfType(strippedStructure, "ConditionalExpression")) {
-    return (
-      isValueForwardedThroughLiteralStructure(strippedNode, strippedStructure.consequent) ||
-      isValueForwardedThroughLiteralStructure(strippedNode, strippedStructure.alternate)
-    );
-  }
-  if (isNodeOfType(strippedStructure, "ArrayExpression")) {
-    return strippedStructure.elements.some(
-      (element) =>
-        element &&
-        !isNodeOfType(element, "SpreadElement") &&
-        isValueForwardedThroughLiteralStructure(strippedNode, element),
-    );
-  }
-  if (!isNodeOfType(strippedStructure, "ObjectExpression")) return false;
-  return strippedStructure.properties.some((property) => {
-    if (isNodeOfType(property, "SpreadElement")) {
-      return isValueForwardedThroughLiteralStructure(strippedNode, property.argument);
-    }
-    return (
-      isNodeOfType(property, "Property") &&
-      isValueForwardedThroughLiteralStructure(strippedNode, property.value)
-    );
-  });
 };
 
 const isValueForwardedToBindingInitializer = (

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-json-parse-stringify-clone.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-json-parse-stringify-clone.ts
@@ -1,9 +1,18 @@
 import { defineRule } from "../../utils/define-rule.js";
+import { collectConstAliasSymbols } from "../../utils/collect-const-alias-symbols.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
+import { findExportedValue } from "../../utils/find-exported-value.js";
+import { findTransparentExpressionRoot } from "../../utils/find-transparent-expression-root.js";
+import { getStaticPropertyKeyName } from "../../utils/get-static-property-key-name.js";
+import { isAstDescendant } from "../../utils/is-ast-descendant.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
+import { isInProjectDirectory } from "../../utils/is-in-project-directory.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isReactComponentName } from "../../utils/is-react-component-name.js";
+import { NEXTJS_PAGE_DATA_EXPORT_NAMES } from "../../utils/nextjs-page-data-export-names.js";
+import type { RuleContext } from "../../utils/rule-context.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 
 const MESSAGE =
@@ -121,6 +130,111 @@ const isInsideSnapshotHelper = (node: EsTreeNode): boolean => {
   return false;
 };
 
+const findEnclosingNextjsPageDataFunction = (node: EsTreeNode): EsTreeNode | null => {
+  let outermostFunction: EsTreeNode | null = null;
+  let cursor: EsTreeNode | null | undefined = node.parent;
+  while (cursor) {
+    if (isFunctionLike(cursor)) outermostFunction = cursor;
+    if (isNodeOfType(cursor, "Program")) {
+      if (!outermostFunction) return null;
+      for (const exportName of NEXTJS_PAGE_DATA_EXPORT_NAMES) {
+        const exportedValue = findExportedValue(cursor, exportName);
+        if (exportedValue && isAstDescendant(outermostFunction, exportedValue)) {
+          return outermostFunction;
+        }
+      }
+      return null;
+    }
+    cursor = cursor.parent ?? null;
+  }
+  return null;
+};
+
+const isInsideReturnedNextjsProps = (node: EsTreeNode, pageDataFunction: EsTreeNode): boolean => {
+  let cursor: EsTreeNode | null | undefined = node.parent;
+  while (cursor && cursor !== pageDataFunction) {
+    if (
+      isNodeOfType(cursor, "Property") &&
+      getStaticPropertyKeyName(cursor, { allowComputedString: true }) === "props"
+    ) {
+      const propertyContainer = cursor.parent;
+      if (!propertyContainer) return false;
+      const returnedObject = findTransparentExpressionRoot(propertyContainer);
+      const returnStatement = returnedObject.parent;
+      if (
+        isNodeOfType(returnStatement, "ReturnStatement") &&
+        findEnclosingFunction(returnStatement) === pageDataFunction
+      ) {
+        return true;
+      }
+      if (
+        isNodeOfType(pageDataFunction, "ArrowFunctionExpression") &&
+        !isNodeOfType(pageDataFunction.body, "BlockStatement") &&
+        stripParenExpression(pageDataFunction.body) === returnedObject
+      ) {
+        return true;
+      }
+    }
+    cursor = cursor.parent ?? null;
+  }
+  return false;
+};
+
+const findPageDataResultBinding = (
+  node: EsTreeNode,
+  pageDataFunction: EsTreeNode,
+): EsTreeNodeOfType<"Identifier"> | null => {
+  let cursor: EsTreeNode | null | undefined = node.parent;
+  while (cursor && cursor !== pageDataFunction) {
+    if (
+      isNodeOfType(cursor, "VariableDeclarator") &&
+      cursor.init &&
+      isNodeOfType(cursor.id, "Identifier") &&
+      findEnclosingFunction(cursor) === pageDataFunction
+    ) {
+      return cursor.id;
+    }
+    cursor = cursor.parent ?? null;
+  }
+  return null;
+};
+
+const isUsedToSerializeNextjsPageProps = (node: EsTreeNode, context: RuleContext): boolean => {
+  if (!isInProjectDirectory(context, "pages") || isInProjectDirectory(context, "pages/api")) {
+    return false;
+  }
+  const pageDataFunction = findEnclosingNextjsPageDataFunction(node);
+  if (!pageDataFunction) return false;
+  if (isInsideReturnedNextjsProps(node, pageDataFunction)) return true;
+  const bindingIdentifier = findPageDataResultBinding(node, pageDataFunction);
+  const bindingSymbol = bindingIdentifier ? context.scopes.symbolFor(bindingIdentifier) : null;
+  if (!bindingSymbol) return false;
+  const aliasSymbols = collectConstAliasSymbols(bindingSymbol, context.scopes);
+  const aliasSymbolIds = new Set(aliasSymbols.map((aliasSymbol) => aliasSymbol.id));
+  let hasPagePropsReference = false;
+  for (const aliasSymbol of aliasSymbols) {
+    for (const reference of aliasSymbol.references) {
+      if (findEnclosingFunction(reference.identifier) !== pageDataFunction) return false;
+      if (isInsideReturnedNextjsProps(reference.identifier, pageDataFunction)) {
+        hasPagePropsReference = true;
+        continue;
+      }
+      const referenceRoot = findTransparentExpressionRoot(reference.identifier);
+      const declarator = referenceRoot.parent;
+      if (
+        isNodeOfType(declarator, "VariableDeclarator") &&
+        declarator.init === referenceRoot &&
+        isNodeOfType(declarator.id, "Identifier")
+      ) {
+        const aliasSymbolForReference = context.scopes.symbolFor(declarator.id);
+        if (aliasSymbolForReference && aliasSymbolIds.has(aliasSymbolForReference.id)) continue;
+      }
+      return false;
+    }
+  }
+  return hasPagePropsReference;
+};
+
 export const noJsonParseStringifyClone = defineRule({
   id: "no-json-parse-stringify-clone",
   title: "JSON parse/stringify deep clone",
@@ -148,6 +262,7 @@ export const noJsonParseStringifyClone = defineRule({
       if (isInsideSnapshotHelper(node)) return;
       if (isAssignedToNormalizationBinding(node)) return;
       if (isCatchParameterRoundTrip(firstArgument)) return;
+      if (isUsedToSerializeNextjsPageProps(node, context)) return;
       context.report({ node, message: MESSAGE });
     },
   }),

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-json-parse-stringify-clone.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-json-parse-stringify-clone.ts
@@ -239,12 +239,45 @@ const isExpressionReturnedByFunction = (node: EsTreeNode, functionNode: EsTreeNo
   );
 };
 
+const isValueForwardedThroughLiteralStructure = (
+  node: EsTreeNode,
+  structure: EsTreeNode,
+): boolean => {
+  const strippedNode = stripParenExpression(node);
+  const strippedStructure = stripParenExpression(structure);
+  if (strippedNode === strippedStructure) return true;
+  if (isNodeOfType(strippedStructure, "ConditionalExpression")) {
+    return (
+      isValueForwardedThroughLiteralStructure(strippedNode, strippedStructure.consequent) ||
+      isValueForwardedThroughLiteralStructure(strippedNode, strippedStructure.alternate)
+    );
+  }
+  if (isNodeOfType(strippedStructure, "ArrayExpression")) {
+    return strippedStructure.elements.some(
+      (element) =>
+        element &&
+        !isNodeOfType(element, "SpreadElement") &&
+        isValueForwardedThroughLiteralStructure(strippedNode, element),
+    );
+  }
+  if (!isNodeOfType(strippedStructure, "ObjectExpression")) return false;
+  return strippedStructure.properties.some((property) => {
+    if (isNodeOfType(property, "SpreadElement")) {
+      return isValueForwardedThroughLiteralStructure(strippedNode, property.argument);
+    }
+    return (
+      isNodeOfType(property, "Property") &&
+      isValueForwardedThroughLiteralStructure(strippedNode, property.value)
+    );
+  });
+};
+
 const isValueForwardedToBindingInitializer = (
   node: EsTreeNode,
   bindingInitializer: EsTreeNode,
 ): boolean => {
   const directValue = findConditionalReturnExpressionRoot(node);
-  if (stripParenExpression(bindingInitializer) === stripParenExpression(directValue)) return true;
+  if (isValueForwardedThroughLiteralStructure(directValue, bindingInitializer)) return true;
   const initializer = stripParenExpression(bindingInitializer);
   if (!isNodeOfType(initializer, "CallExpression")) return false;
   const callee = stripParenExpression(initializer.callee);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-json-parse-stringify-clone.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-json-parse-stringify-clone.ts
@@ -150,6 +150,19 @@ const findEnclosingNextjsPageDataFunction = (node: EsTreeNode): EsTreeNode | nul
   return null;
 };
 
+const findConditionalReturnExpressionRoot = (node: EsTreeNode): EsTreeNode => {
+  let expressionRoot = findTransparentExpressionRoot(node);
+  while (
+    expressionRoot.parent &&
+    isNodeOfType(expressionRoot.parent, "ConditionalExpression") &&
+    (expressionRoot.parent.consequent === expressionRoot ||
+      expressionRoot.parent.alternate === expressionRoot)
+  ) {
+    expressionRoot = findTransparentExpressionRoot(expressionRoot.parent);
+  }
+  return expressionRoot;
+};
+
 const isInsideReturnedNextjsProps = (node: EsTreeNode, pageDataFunction: EsTreeNode): boolean => {
   let cursor: EsTreeNode | null | undefined = node.parent;
   while (cursor && cursor !== pageDataFunction) {
@@ -159,8 +172,8 @@ const isInsideReturnedNextjsProps = (node: EsTreeNode, pageDataFunction: EsTreeN
     ) {
       const propertyContainer = cursor.parent;
       if (!propertyContainer) return false;
-      const returnedObject = findTransparentExpressionRoot(propertyContainer);
-      const returnStatement = returnedObject.parent;
+      const returnExpression = findConditionalReturnExpressionRoot(propertyContainer);
+      const returnStatement = returnExpression.parent;
       if (
         isNodeOfType(returnStatement, "ReturnStatement") &&
         findEnclosingFunction(returnStatement) === pageDataFunction
@@ -170,7 +183,7 @@ const isInsideReturnedNextjsProps = (node: EsTreeNode, pageDataFunction: EsTreeN
       if (
         isNodeOfType(pageDataFunction, "ArrowFunctionExpression") &&
         !isNodeOfType(pageDataFunction.body, "BlockStatement") &&
-        stripParenExpression(pageDataFunction.body) === returnedObject
+        stripParenExpression(pageDataFunction.body) === stripParenExpression(returnExpression)
       ) {
         return true;
       }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-json-parse-stringify-clone.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-json-parse-stringify-clone.ts
@@ -191,11 +191,7 @@ const isReturnedPageDataResultBinding = (
 const isSameShorthandPropertyValue = (
   node: EsTreeNode,
   property: EsTreeNodeOfType<"Property">,
-): boolean =>
-  property.shorthand &&
-  isNodeOfType(node, "Identifier") &&
-  isNodeOfType(property.value, "Identifier") &&
-  node.name === property.value.name;
+): boolean => property.shorthand && (node === property.key || node === property.value);
 
 const isValueForwardedThroughLiteralStructure = (
   node: EsTreeNode,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-derived-use-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-derived-use-state.ts
@@ -9,6 +9,7 @@ import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isReactHookCall } from "../../utils/is-react-hook-call.js";
 import { isInitialOnlyPropName } from "../../utils/is-initial-only-prop-name.js";
 import { isReactHookName } from "../../utils/is-react-hook-name.js";
+import { NEXTJS_PAGE_DATA_EXPORT_NAMES } from "../../utils/nextjs-page-data-export-names.js";
 import { walkAst } from "../../utils/walk-ast.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { RuleContext } from "../../utils/rule-context.js";
@@ -289,8 +290,6 @@ const isDraftCommittedToParent = (
   });
   return isCommitted;
 };
-
-const NEXTJS_PAGE_DATA_EXPORT_NAMES = new Set(["getServerSideProps", "getStaticProps"]);
 
 // A Next.js pages-router page gets its props from getServerSideProps /
 // getStaticProps: they are fixed for the page instance (navigation

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/nextjs-page-data-export-names.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/nextjs-page-data-export-names.ts
@@ -1,0 +1,4 @@
+export const NEXTJS_PAGE_DATA_EXPORT_NAMES: ReadonlySet<string> = new Set([
+  "getServerSideProps",
+  "getStaticProps",
+]);


### PR DESCRIPTION
## Why

`JSON.parse(JSON.stringify(value))` is intentional at Next.js Pages Router prop boundaries: it converts values such as `Date` into the JSON-safe representation that `getServerSideProps` and `getStaticProps` require. Replacing it with `structuredClone` preserves values that Next.js rejects. This produced 15 false positives across 20 ReactBench trials, including all three Terra findings.

## What changed

- suppress the diagnostic only inside exported `getServerSideProps` or `getStaticProps` values in non-API `pages` files
- follow safe const aliases into returned `props` while retaining diagnostics when the value is mutated, escapes, or is used outside that boundary
- support direct, wrapped, and separate export-specifier forms without suppressing non-Next lookalikes
- add focused regression and fuzz-corpus coverage plus a patch changeset
- share the existing Next.js page-data export-name set instead of duplicating it

## Eval results

Exact ReactBench replay: 29/29 expectations matched — 15 confirmed Pages-props false positives removed and 14 API `res.json` true positives retained. All three Terra units are in the removed false-positive partition.

Local RDE was attempted against 100 roots; 98 completed attempts were rejected before ingestion because the eval checkout requires JSON `schemaVersion: 1` while current React Doctor emits `schemaVersion: 3`. Pull-request parity is pending because `DAYTONA_API_KEY` is not available in this environment.

## Test plan

- `nr test` — changed plugin suite passed; broad parallel run hit three unrelated timeout flakes, all passing on isolated rerun
- `nr -C packages/api test -- tests/diagnose.test.ts` — 19 passed
- `nr -C packages/react-doctor test -- tests/install-react-doctor.test.ts tests/github-action-comment.test.ts` — 2,346 passed, 27 skipped
- `nr typecheck` — 16 tasks passed
- `nr lint` — passed with existing warnings
- `nr format:check` — passed
- `nr smoke:json-report` — passed, schemaVersion 3
- strict fuzz: `FUZZ_RULE=no-json-parse-stringify-clone FUZZ_STRICT=1 FUZZ_ITERATIONS=500` — passed for seeds 1 and 42

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Linter behavior change with non-trivial AST escape analysis; mis-gating could hide real performance issues in page loaders or reintroduce false positives, but scope is limited to Pages Router data exports and tests are extensive.
> 
> **Overview**
> Stops **`no-json-parse-stringify-clone`** from reporting `JSON.parse(JSON.stringify(...))` when it is used to make values JSON-safe for **Next.js Pages Router** `getServerSideProps` / `getStaticProps` returns in `pages/` (not `pages/api`).
> 
> The rule adds **`isUsedToSerializeNextjsPageProps`**: it recognizes exported page-data handlers (including re-exports), follows values into returned **`props`** (direct returns, conditionals, typed returns, and const-alias chains), and still **flags** clones that are mutated, escape via opaque calls, are built but not returned, or appear outside real page boundaries.
> 
> **`NEXTJS_PAGE_DATA_EXPORT_NAMES`** is extracted to a shared util and wired into **`no-derived-use-state`** instead of a local duplicate. Fuzz regressions and a large unit-test matrix cover pass/fail cases; changeset is a patch on `oxlint-plugin-react-doctor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e489cb89b8fbdf44ca544a5216e268496ad1bac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->