### PR TITLE
RDFPFN792026: recognize compound stale-request guards

### DIFF
--- a/.changeset/calm-awaits-guard.md
+++ b/.changeset/calm-awaits-guard.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Recognize compound and local stale-request guards after awaited effect work while rejecting mutated guards and conditional cleanup evidence.

--- a/packages/fuzz/corpus/regressions/no-set-state-after-await-in-effect--compound-cleanup-guard.tsx
+++ b/packages/fuzz/corpus/regressions/no-set-state-after-await-in-effect--compound-cleanup-guard.tsx
@@ -1,0 +1,35 @@
+// rule: no-set-state-after-await-in-effect
+// weakness: control-flow
+// source: ReactBench fix-react-rdh-appflowy-io-appflowy-web-documenthistorymodal
+import { useEffect, useRef, useState } from "react";
+
+export const Preview = ({ loadPreview, selectedVersionId, viewId }) => {
+  const [, setActiveDoc] = useState(null);
+  const activeViewIdRef = useRef(viewId);
+  const selectedVersionIdRef = useRef(selectedVersionId);
+
+  useEffect(() => {
+    let cancelled = false;
+    const requestViewId = viewId;
+    const previewVersionId = selectedVersionId;
+    const isCurrentRequest = () =>
+      !cancelled &&
+      activeViewIdRef.current === requestViewId &&
+      selectedVersionIdRef.current === previewVersionId;
+
+    void (async () => {
+      const document = await loadPreview(requestViewId, previewVersionId);
+      if (!isCurrentRequest()) {
+        document?.destroy();
+        return;
+      }
+      setActiveDoc(document);
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [loadPreview, selectedVersionId, viewId]);
+
+  return null;
+};

--- a/packages/fuzz/corpus/regressions/no-set-state-after-await-in-effect--conditional-call-site.tsx
+++ b/packages/fuzz/corpus/regressions/no-set-state-after-await-in-effect--conditional-call-site.tsx
@@ -1,0 +1,48 @@
+// rule: no-set-state-after-await-in-effect
+// weakness: conditional-invocation-path
+import { useEffect, useState } from "react";
+
+interface ConditionalLoaderProps {
+  enabled: boolean;
+  id: string;
+}
+
+export const DirectConditionalLoader = ({ enabled, id }: ConditionalLoaderProps) => {
+  const [, setValue] = useState<string>();
+  useEffect(() => {
+    let cancelled = false;
+    const run = async () => {
+      const value = await load(id);
+      if (cancelled) return;
+      setValue(value);
+    };
+    if (enabled) void run();
+    if (!enabled) return;
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled, id]);
+  return null;
+};
+
+export const NestedConditionalLoader = ({ enabled, id }: ConditionalLoaderProps) => {
+  const [, setValue] = useState<string>();
+  useEffect(() => {
+    let cancelled = false;
+    const run = async () => {
+      const value = await load(id);
+      if (cancelled) return;
+      setValue(value);
+    };
+    const innerStart = () => run();
+    const start = () => {
+      if (enabled) innerStart();
+    };
+    start();
+    if (!enabled) return;
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled, id]);
+  return null;
+};

--- a/packages/fuzz/corpus/regressions/no-set-state-after-await-in-effect--no-op-effect-path.tsx
+++ b/packages/fuzz/corpus/regressions/no-set-state-after-await-in-effect--no-op-effect-path.tsx
@@ -1,0 +1,26 @@
+// rule: no-set-state-after-await-in-effect
+// weakness: control-flow
+// source: PR #1499 Daytona parity, 53 candidate-introduced false positives
+import { useEffect, useState } from "react";
+
+export const User = ({ enabled, userId }) => {
+  const [, setUser] = useState(null);
+
+  useEffect(() => {
+    if (!enabled) return;
+    let cancelled = false;
+
+    const run = async () => {
+      const user = await loadUser(userId);
+      if (cancelled) return;
+      setUser(user);
+    };
+
+    run();
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled, userId]);
+
+  return null;
+};

--- a/packages/fuzz/corpus/true-positives/no-set-state-after-await-in-effect--conditional-wrapper.tsx
+++ b/packages/fuzz/corpus/true-positives/no-set-state-after-await-in-effect--conditional-wrapper.tsx
@@ -1,0 +1,34 @@
+// rule: no-set-state-after-await-in-effect
+// weakness: conditional-wrapper
+import { useEffect, useState } from "react";
+
+export const ConditionalStart = ({ enabled, id }: { enabled: boolean; id: string }) => {
+  const [, setValue] = useState<string>();
+  useEffect(() => {
+    const run = async () => {
+      const value = await load(id);
+      setValue(value);
+    };
+    const start = () => {
+      if (enabled) void run();
+    };
+    start();
+  }, [enabled, id]);
+  return null;
+};
+
+export const MixedStarts = ({ enabled, id }: { enabled: boolean; id: string }) => {
+  const [, setValue] = useState<string>();
+  useEffect(() => {
+    const run = async () => {
+      const value = await load(id);
+      setValue(value);
+    };
+    const start = () => {
+      if (enabled) void run();
+    };
+    start();
+    void run();
+  }, [enabled, id]);
+  return null;
+};

--- a/packages/fuzz/corpus/true-positives/no-set-state-after-await-in-effect--conditional-wrapper.tsx
+++ b/packages/fuzz/corpus/true-positives/no-set-state-after-await-in-effect--conditional-wrapper.tsx
@@ -32,3 +32,25 @@ export const MixedStarts = ({ enabled, id }: { enabled: boolean; id: string }) =
   }, [enabled, id]);
   return null;
 };
+
+export const ConditionalCleanupBypass = ({ enabled, id }: { enabled: boolean; id: string }) => {
+  const [, setValue] = useState<string>();
+  useEffect(() => {
+    let cancelled = false;
+    const run = async () => {
+      const value = await load(id);
+      if (cancelled) return;
+      setValue(value);
+    };
+    const start = () => {
+      if (enabled) void run();
+    };
+    start();
+    if (enabled) return;
+    void run();
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled, id]);
+  return null;
+};

--- a/packages/fuzz/corpus/true-positives/no-set-state-after-await-in-effect--mutable-helper.tsx
+++ b/packages/fuzz/corpus/true-positives/no-set-state-after-await-in-effect--mutable-helper.tsx
@@ -1,0 +1,31 @@
+// rule: no-set-state-after-await-in-effect
+// weakness: mutable-helper
+import { useEffect, useState } from "react";
+
+interface LoaderProps {
+  id: string;
+}
+
+export const LetLoader = ({ id }: LoaderProps) => {
+  const [, setValue] = useState<string>();
+  useEffect(() => {
+    let load = async () => {
+      await fetch(`/value/${id}`);
+      setValue(id);
+    };
+    void load();
+  }, [id]);
+  return null;
+};
+
+export const VarLoader = ({ id }: LoaderProps) => {
+  const [, setValue] = useState<string>();
+  useEffect(() => {
+    var load = async function () {
+      await fetch(`/value/${id}`);
+      setValue(id);
+    };
+    void load();
+  }, [id]);
+  return null;
+};

--- a/packages/fuzz/corpus/true-positives/no-set-state-after-await-in-effect--mutated-guards.tsx
+++ b/packages/fuzz/corpus/true-positives/no-set-state-after-await-in-effect--mutated-guards.tsx
@@ -1,0 +1,56 @@
+// rule: no-set-state-after-await-in-effect
+// weakness: mutated-guard
+import { useEffect, useRef, useState } from "react";
+
+export const HelperReset = ({ id }: { id: string }) => {
+  const [, setValue] = useState<string>();
+  useEffect(() => {
+    let cancelled = false;
+    const resetCancellation = () => {
+      cancelled = false;
+    };
+    const run = async () => {
+      const value = await load(id);
+      resetCancellation();
+      if (cancelled) return;
+      setValue(value);
+    };
+    void run();
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+  return null;
+};
+
+export const SequenceReset = ({ id }: { id: string }) => {
+  const [, setValue] = useState<string>();
+  const requestIdRef = useRef(0);
+  useEffect(() => {
+    const requestId = ++requestIdRef.current;
+    const run = async () => {
+      const value = await load(id);
+      requestIdRef.current = requestId;
+      if (requestId !== requestIdRef.current) return;
+      setValue(value);
+    };
+    void run();
+  }, [id]);
+  return null;
+};
+
+export const ConditionalAbort = ({ id, shouldAbort }: { id: string; shouldAbort: boolean }) => {
+  const [, setValue] = useState<string>();
+  useEffect(() => {
+    const controller = new AbortController();
+    const run = async () => {
+      const value = await load(id, { signal: controller.signal });
+      setValue(value);
+    };
+    void run();
+    return () => {
+      if (shouldAbort) controller.abort();
+    };
+  }, [id, shouldAbort]);
+  return null;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-set-state-after-await-in-effect.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-set-state-after-await-in-effect.test.ts
@@ -831,6 +831,104 @@ describe("no-set-state-after-await-in-effect", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("does not stop before cancellation actions after cleanup try statements", () => {
+    const guardedState = runRule(
+      noSetStateAfterAwaitInEffect,
+      `const C = ({ id }) => {
+        const [, setValue] = useState();
+        useEffect(() => {
+          let cancelled = false;
+          const run = async () => {
+            await load(id);
+            if (cancelled) return;
+            setValue(id);
+          };
+          run();
+          return () => {
+            try {
+              logCleanup(id);
+            } catch {}
+            cancelled = true;
+          };
+        }, [id]);
+      };`,
+    );
+    const abortedRequest = runRule(
+      noSetStateAfterAwaitInEffect,
+      `const C = ({ url }) => {
+        const [, setValue] = useState();
+        useEffect(() => {
+          const controller = new AbortController();
+          const run = async () => {
+            const value = await load(url, { signal: controller.signal });
+            setValue(value);
+          };
+          run();
+          return () => {
+            try {
+              logCleanup(url);
+            } finally {
+              recordCleanup(url);
+            }
+            controller.abort();
+          };
+        }, [url]);
+      };`,
+    );
+    expect(guardedState.diagnostics).toHaveLength(0);
+    expect(abortedRequest.diagnostics).toHaveLength(0);
+  });
+
+  it("does not treat cleanup actions after abrupt try exits as unconditional", () => {
+    const returned = runRule(
+      noSetStateAfterAwaitInEffect,
+      `const C = ({ id, skip }) => {
+        const [, setValue] = useState();
+        useEffect(() => {
+          let cancelled = false;
+          const run = async () => {
+            await load(id);
+            if (cancelled) return;
+            setValue(id);
+          };
+          run();
+          return () => {
+            try {
+              if (skip) return;
+            } finally {
+              recordCleanup(id);
+            }
+            cancelled = true;
+          };
+        }, [id, skip]);
+      };`,
+    );
+    const thrown = runRule(
+      noSetStateAfterAwaitInEffect,
+      `const C = ({ url, fail }) => {
+        const [, setValue] = useState();
+        useEffect(() => {
+          const controller = new AbortController();
+          const run = async () => {
+            const value = await load(url, { signal: controller.signal });
+            setValue(value);
+          };
+          run();
+          return () => {
+            try {
+              if (fail) throw new Error("cleanup failed");
+            } finally {
+              recordCleanup(url);
+            }
+            controller.abort();
+          };
+        }, [fail, url]);
+      };`,
+    );
+    expect(returned.diagnostics).toHaveLength(1);
+    expect(thrown.diagnostics).toHaveLength(1);
+  });
+
   it("flags when only one possible cleanup aborts the request", () => {
     const result = runRule(
       noSetStateAfterAwaitInEffect,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-set-state-after-await-in-effect.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-set-state-after-await-in-effect.test.ts
@@ -989,6 +989,65 @@ describe("no-set-state-after-await-in-effect", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("accepts equivalent cancellation writes from every cleanup return", () => {
+    const result = runRule(
+      noSetStateAfterAwaitInEffect,
+      `const ImageViewer = ({ filePath, reloadKey }) => {
+        const [, setImage] = useState();
+        useEffect(() => {
+          let cancelled = false;
+          if (readCache(filePath) && reloadKey === 0) {
+            return () => {
+              cancelled = true;
+            };
+          }
+          const load = async () => {
+            try {
+              const loaded = await preloadImage(filePath);
+              if (cancelled) return;
+              setImage(loaded);
+            } catch (error) {
+              if (cancelled) return;
+              setImage(null);
+            }
+          };
+          load();
+          return () => {
+            cancelled = true;
+          };
+        }, [filePath, reloadKey]);
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("requires every cleanup return to write the cancellation guard", () => {
+    const result = runRule(
+      noSetStateAfterAwaitInEffect,
+      `const ImageViewer = ({ filePath, reloadKey }) => {
+        const [, setImage] = useState();
+        useEffect(() => {
+          let cancelled = false;
+          if (readCache(filePath) && reloadKey === 0) {
+            return () => {
+              recordCacheHit();
+            };
+          }
+          const load = async () => {
+            const loaded = await preloadImage(filePath);
+            if (cancelled) return;
+            setImage(loaded);
+          };
+          load();
+          return () => {
+            cancelled = true;
+          };
+        }, [filePath, reloadKey]);
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("flags an external-store dependency without a cancellation guard", () => {
     const result = runRule(
       noSetStateAfterAwaitInEffect,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-set-state-after-await-in-effect.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-set-state-after-await-in-effect.test.ts
@@ -320,6 +320,171 @@ describe("no-set-state-after-await-in-effect", () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("preserves conditional gates across nested wrappers", () => {
+    const safeResult = runRule(
+      noSetStateAfterAwaitInEffect,
+      `const C = ({ enabled, userId }) => {
+        const [, setUser] = useState(null);
+        useEffect(() => {
+          let cancelled = false;
+          const run = async () => {
+            const user = await load(userId);
+            if (cancelled) return;
+            setUser(user);
+          };
+          const innerStart = () => run();
+          const start = () => {
+            if (enabled) innerStart();
+          };
+          start();
+          if (!enabled) return;
+          return () => { cancelled = true; };
+        }, [enabled, userId]);
+      };`,
+    );
+    const bypassResult = runRule(
+      noSetStateAfterAwaitInEffect,
+      `const C = ({ enabled, skipCleanup, userId }) => {
+        const [, setUser] = useState(null);
+        useEffect(() => {
+          let cancelled = false;
+          const run = async () => {
+            const user = await load(userId);
+            if (cancelled) return;
+            setUser(user);
+          };
+          const innerStart = () => run();
+          const start = () => {
+            if (enabled) innerStart();
+          };
+          start();
+          if (enabled && skipCleanup) return;
+          return () => { cancelled = true; };
+        }, [enabled, skipCleanup, userId]);
+      };`,
+    );
+    expect(safeResult.diagnostics).toHaveLength(0);
+    expect(bypassResult.diagnostics).toHaveLength(1);
+  });
+
+  it("correlates direct and wrapped conditional effect call sites with cleanup exits", () => {
+    const directResult = runRule(
+      noSetStateAfterAwaitInEffect,
+      `const C = ({ enabled, userId }) => {
+        const [, setUser] = useState(null);
+        useEffect(() => {
+          let cancelled = false;
+          const run = async () => {
+            const user = await load(userId);
+            if (cancelled) return;
+            setUser(user);
+          };
+          if (enabled) run();
+          if (!enabled) return;
+          return () => { cancelled = true; };
+        }, [enabled, userId]);
+      };`,
+    );
+    const wrappedResult = runRule(
+      noSetStateAfterAwaitInEffect,
+      `const C = ({ enabled, userId }) => {
+        const [, setUser] = useState(null);
+        useEffect(() => {
+          let cancelled = false;
+          const run = async () => {
+            const user = await load(userId);
+            if (cancelled) return;
+            setUser(user);
+          };
+          const start = () => run();
+          if (enabled) start();
+          if (!enabled) return;
+          return () => { cancelled = true; };
+        }, [enabled, userId]);
+      };`,
+    );
+    const bypassResult = runRule(
+      noSetStateAfterAwaitInEffect,
+      `const C = ({ enabled, skipCleanup, userId }) => {
+        const [, setUser] = useState(null);
+        useEffect(() => {
+          let cancelled = false;
+          const run = async () => {
+            const user = await load(userId);
+            if (cancelled) return;
+            setUser(user);
+          };
+          if (enabled) run();
+          if (enabled && skipCleanup) return;
+          return () => { cancelled = true; };
+        }, [enabled, skipCleanup, userId]);
+      };`,
+    );
+    expect(directResult.diagnostics).toHaveLength(0);
+    expect(wrappedResult.diagnostics).toHaveLength(0);
+    expect(bypassResult.diagnostics).toHaveLength(1);
+  });
+
+  it("bounds conditional invocation analysis on diamond wrapper graphs", () => {
+    const diamondDepth = 30;
+    const wrapperDeclarations = Array.from({ length: diamondDepth }, (_, wrapperIndex) =>
+      wrapperIndex === 0
+        ? "const start0 = () => run();"
+        : `const start${wrapperIndex} = () => {
+            if (enabled) start${wrapperIndex - 1}();
+            if (enabled) start${wrapperIndex - 1}();
+          };`,
+    ).join("\n");
+    const result = runRule(
+      noSetStateAfterAwaitInEffect,
+      `const C = ({ enabled, userId }) => {
+        const [, setUser] = useState(null);
+        useEffect(() => {
+          let cancelled = false;
+          const run = async () => {
+            const user = await load(userId);
+            if (cancelled) return;
+            setUser(user);
+          };
+          ${wrapperDeclarations}
+          start${diamondDepth - 1}();
+          if (!enabled) return;
+          return () => { cancelled = true; };
+        }, [enabled, userId]);
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not cache incomplete reachability across recursive wrapper cycles", () => {
+    const result = runRule(
+      noSetStateAfterAwaitInEffect,
+      `const C = ({ enabled, userId }) => {
+        const [, setUser] = useState(null);
+        useEffect(() => {
+          let cancelled = false;
+          const run = async () => {
+            const user = await load(userId);
+            if (cancelled) return;
+            setUser(user);
+          };
+          const a = (depth) => {
+            if (depth > 0) b(depth - 1);
+            else run();
+          };
+          const b = (depth) => a(depth);
+          if (enabled) {
+            a(0);
+            return () => { cancelled = true; };
+          }
+          b(0);
+          return;
+        }, [enabled, userId]);
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("reports conditionally invoked async work without a matching cleanup guard", () => {
     const conditionalResult = runRule(
       noSetStateAfterAwaitInEffect,
@@ -399,6 +564,31 @@ describe("no-set-state-after-await-in-effect", () => {
           if (skipCleanup) return;
           return () => { cancelled = true; };
         }, [enabled, skipCleanup, userId]);
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("requires cleanup for conditional starts before a guarded unconditional start", () => {
+    const result = runRule(
+      noSetStateAfterAwaitInEffect,
+      `const C = ({ enabled, userId }) => {
+        const [, setUser] = useState(null);
+        useEffect(() => {
+          let cancelled = false;
+          const run = async () => {
+            const user = await load(userId);
+            if (cancelled) return;
+            setUser(user);
+          };
+          const start = () => {
+            if (enabled) run();
+          };
+          start();
+          if (enabled) return;
+          run();
+          return () => { cancelled = true; };
+        }, [enabled, userId]);
       };`,
     );
     expect(result.diagnostics).toHaveLength(1);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-set-state-after-await-in-effect.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-set-state-after-await-in-effect.test.ts
@@ -256,6 +256,175 @@ describe("no-set-state-after-await-in-effect", () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("does not require cleanup on effect paths that return before starting async work", () => {
+    const directResult = runRule(
+      noSetStateAfterAwaitInEffect,
+      `const C = ({ enabled, userId }) => {
+        const [, setUser] = useState(null);
+        useEffect(() => {
+          if (!enabled) return;
+          let cancelled = false;
+          const run = async () => {
+            const user = await load(userId);
+            if (cancelled) return;
+            setUser(user);
+          };
+          run();
+          return () => { cancelled = true; };
+        }, [enabled, userId]);
+      };`,
+    );
+    const nestedResult = runRule(
+      noSetStateAfterAwaitInEffect,
+      `const C = ({ enabled, userId }) => {
+        const [, setUser] = useState(null);
+        useEffect(() => {
+          if (!enabled) return;
+          let cancelled = false;
+          const run = async () => {
+            const user = await load(userId);
+            if (cancelled) return;
+            setUser(user);
+          };
+          const start = () => run();
+          start();
+          return () => { cancelled = true; };
+        }, [enabled, userId]);
+      };`,
+    );
+    expect(directResult.diagnostics).toHaveLength(0);
+    expect(nestedResult.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when a wrapper conditionally starts the guarded async work", () => {
+    const result = runRule(
+      noSetStateAfterAwaitInEffect,
+      `const C = ({ enabled, userId }) => {
+        const [, setUser] = useState(null);
+        useEffect(() => {
+          let cancelled = false;
+          const run = async () => {
+            const user = await load(userId);
+            if (cancelled) return;
+            setUser(user);
+          };
+          const start = () => {
+            if (enabled) run();
+          };
+          start();
+          if (!enabled) return;
+          return () => { cancelled = true; };
+        }, [enabled, userId]);
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not require cleanup before a guarded async promise callback is registered", () => {
+    const result = runRule(
+      noSetStateAfterAwaitInEffect,
+      `const C = ({ enabled, userId }) => {
+        const [, setUser] = useState(null);
+        useEffect(() => {
+          if (!enabled) return;
+          let cancelled = false;
+          loadRequest(userId).then(async (request) => {
+            const user = await request.read();
+            if (cancelled) return;
+            setUser(user);
+          });
+          return () => { cancelled = true; };
+        }, [enabled, userId]);
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("ignores cleanup functions returned before async work starts", () => {
+    const result = runRule(
+      noSetStateAfterAwaitInEffect,
+      `const C = ({ cached, userId }) => {
+        const [, setUser] = useState(null);
+        useEffect(() => {
+          let cancelled = false;
+          if (cached) return () => recordCacheHit();
+          const run = async () => {
+            const user = await load(userId);
+            if (cancelled) return;
+            setUser(user);
+          };
+          run();
+          return () => { cancelled = true; };
+        }, [cached, userId]);
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still requires cleanup on every path after async work starts", () => {
+    const directResult = runRule(
+      noSetStateAfterAwaitInEffect,
+      `const C = ({ skipCleanup, userId }) => {
+        const [, setUser] = useState(null);
+        useEffect(() => {
+          let cancelled = false;
+          const run = async () => {
+            const user = await load(userId);
+            if (cancelled) return;
+            setUser(user);
+          };
+          run();
+          if (skipCleanup) return;
+          return () => { cancelled = true; };
+        }, [skipCleanup, userId]);
+      };`,
+    );
+    const nestedResult = runRule(
+      noSetStateAfterAwaitInEffect,
+      `const C = ({ skipCleanup, userId }) => {
+        const [, setUser] = useState(null);
+        useEffect(() => {
+          let cancelled = false;
+          const run = async () => {
+            const user = await load(userId);
+            if (cancelled) return;
+            setUser(user);
+          };
+          const start = () => run();
+          start();
+          if (skipCleanup) return;
+          return () => { cancelled = true; };
+        }, [skipCleanup, userId]);
+      };`,
+    );
+    expect(directResult.diagnostics).toHaveLength(1);
+    expect(nestedResult.diagnostics).toHaveLength(1);
+  });
+
+  it("still requires cleanup after every invocation site", () => {
+    const result = runRule(
+      noSetStateAfterAwaitInEffect,
+      `const C = ({ startWithoutCleanup, userId }) => {
+        const [, setUser] = useState(null);
+        useEffect(() => {
+          let cancelled = false;
+          const run = async () => {
+            const user = await load(userId);
+            if (cancelled) return;
+            setUser(user);
+          };
+          if (startWithoutCleanup) {
+            run();
+            return;
+          }
+          run();
+          return () => { cancelled = true; };
+        }, [startWithoutCleanup, userId]);
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("does not flag cleanup-backed local request predicates", () => {
     const result = runRule(
       noSetStateAfterAwaitInEffect,
@@ -1028,17 +1197,17 @@ describe("no-set-state-after-await-in-effect", () => {
         const [, setImage] = useState();
         useEffect(() => {
           let cancelled = false;
-          if (readCache(filePath) && reloadKey === 0) {
-            return () => {
-              recordCacheHit();
-            };
-          }
           const load = async () => {
             const loaded = await preloadImage(filePath);
             if (cancelled) return;
             setImage(loaded);
           };
           load();
+          if (readCache(filePath) && reloadKey === 0) {
+            return () => {
+              recordCacheHit();
+            };
+          }
           return () => {
             cancelled = true;
           };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-set-state-after-await-in-effect.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-set-state-after-await-in-effect.test.ts
@@ -689,6 +689,44 @@ describe("no-set-state-after-await-in-effect", () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("does not flag compound sequence guards that use loose equality", () => {
+    const mismatchResult = runRule(
+      noSetStateAfterAwaitInEffect,
+      `let sequence = 0;
+       const C = ({ id }) => {
+         const [, setValue] = useState();
+         const isClosedRef = useRef(false);
+         useEffect(() => {
+           const requestSequence = ++sequence;
+           const run = async () => {
+             const value = await load(id);
+             if (requestSequence != sequence || isClosedRef.current) return;
+             setValue(value);
+           };
+           run();
+         }, [id]);
+       };`,
+    );
+    const currentResult = runRule(
+      noSetStateAfterAwaitInEffect,
+      `let sequence = 0;
+       const C = ({ id }) => {
+         const [, setValue] = useState();
+         const isOpenRef = useRef(true);
+         useEffect(() => {
+           const requestSequence = ++sequence;
+           const run = async () => {
+             const value = await load(id);
+             if (isOpenRef.current && requestSequence == sequence) setValue(value);
+           };
+           run();
+         }, [id]);
+       };`,
+    );
+    expect(mismatchResult.diagnostics).toHaveLength(0);
+    expect(currentResult.diagnostics).toHaveLength(0);
+  });
+
   it("does not flag a setter that is not bound to useState/useReducer", () => {
     const result = runRule(
       noSetStateAfterAwaitInEffect,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-set-state-after-await-in-effect.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-set-state-after-await-in-effect.test.ts
@@ -231,6 +231,464 @@ describe("no-set-state-after-await-in-effect", () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("does not flag cleanup-backed compound stale-request guards", () => {
+    const result = runRule(
+      noSetStateAfterAwaitInEffect,
+      `
+      const C = ({ userId }) => {
+        const [user, setUser] = useState(null);
+        const activeUserIdRef = useRef(userId);
+        activeUserIdRef.current = userId;
+        useEffect(() => {
+          let cancelled = false;
+          const requestUserId = userId;
+          const run = async () => {
+            const loadedUser = await load(requestUserId);
+            if (cancelled || activeUserIdRef.current !== requestUserId) return;
+            setUser(loadedUser);
+          };
+          run();
+          return () => { cancelled = true; };
+        }, [userId]);
+      };
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag cleanup-backed local request predicates", () => {
+    const result = runRule(
+      noSetStateAfterAwaitInEffect,
+      `
+      const C = ({ userId }) => {
+        const [user, setUser] = useState(null);
+        const activeUserIdRef = useRef(userId);
+        activeUserIdRef.current = userId;
+        useEffect(() => {
+          let cancelled = false;
+          const requestUserId = userId;
+          const isCurrentRequest = () =>
+            !cancelled && activeUserIdRef.current === requestUserId;
+          const run = async () => {
+            const loadedUser = await load(requestUserId);
+            if (isCurrentRequest()) setUser(loadedUser);
+          };
+          run();
+          return () => { cancelled = true; };
+        }, [userId]);
+      };
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still flags a setter reached before a cleanup-backed stale-request guard", () => {
+    const result = runRule(
+      noSetStateAfterAwaitInEffect,
+      `
+      const C = ({ userId }) => {
+        const [user, setUser] = useState(null);
+        useEffect(() => {
+          let cancelled = false;
+          const run = async () => {
+            const loadedUser = await load(userId);
+            if (!loadedUser) {
+              setUser(null);
+              return;
+            }
+            if (cancelled) return;
+            setUser(loadedUser);
+          };
+          run();
+          return () => { cancelled = true; };
+        }, [userId]);
+      };
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags compound conditions that cleanup cannot force", () => {
+    const invalidSources = [
+      `const C = ({ userId, isWrongUser }) => {
+        const [, setUser] = useState(null);
+        useEffect(() => {
+          let cancelled = false;
+          const run = async () => {
+            const loadedUser = await load(userId);
+            if (cancelled && isWrongUser) return;
+            setUser(loadedUser);
+          };
+          run();
+          return () => { cancelled = true; };
+        }, [isWrongUser, userId]);
+      };`,
+      `const C = ({ userId, isCurrentUser }) => {
+        const [, setUser] = useState(null);
+        useEffect(() => {
+          let cancelled = false;
+          const run = async () => {
+            const loadedUser = await load(userId);
+            if (!cancelled || isCurrentUser) setUser(loadedUser);
+          };
+          run();
+          return () => { cancelled = true; };
+        }, [isCurrentUser, userId]);
+      };`,
+    ];
+    for (const source of invalidSources) {
+      expect(runRule(noSetStateAfterAwaitInEffect, source).diagnostics).toHaveLength(1);
+    }
+  });
+
+  it("still flags unsound local and sequence guard lookalikes", () => {
+    const invalidSources = [
+      `const C = ({ userId }) => {
+        const [, setUser] = useState(null);
+        useEffect(() => {
+          let cancelled = false;
+          function* isCurrentRequest() {
+            return !cancelled;
+          }
+          const run = async () => {
+            const loadedUser = await load(userId);
+            if (isCurrentRequest()) setUser(loadedUser);
+          };
+          run();
+          return () => { cancelled = true; };
+        }, [userId]);
+      };`,
+      `const C = ({ userId }) => {
+        const [, setUser] = useState(null);
+        const requestIdRef = useRef(0);
+        useEffect(() => {
+          const requestId = ++requestIdRef.current;
+          const run = async () => {
+            const loadedUser = await load(userId);
+            const requestId = requestIdRef.current;
+            if (requestId === requestIdRef.current) setUser(loadedUser);
+          };
+          run();
+        }, [userId]);
+      };`,
+      `const C = ({ userId }) => {
+        const [, setUser] = useState(null);
+        useEffect(() => {
+          let cancelled = false;
+          const isCurrentRequest = () => !cancelled;
+          const run = async () => {
+            const loadedUser = await load(userId);
+            cancelled = false;
+            if (isCurrentRequest()) setUser(loadedUser);
+          };
+          run();
+          return () => { cancelled = true; };
+        }, [userId]);
+      };`,
+      `const C = ({ userId }) => {
+        const [, setUser] = useState(null);
+        useEffect(() => {
+          let cancelled = false;
+          const resetCancellation = () => {
+            cancelled = false;
+            return false;
+          };
+          const run = async () => {
+            const loadedUser = await load(userId);
+            if (resetCancellation() || cancelled) return;
+            setUser(loadedUser);
+          };
+          run();
+          return () => { cancelled = true; };
+        }, [userId]);
+      };`,
+      `const C = ({ userId }) => {
+        const [, setUser] = useState(null);
+        useEffect(() => {
+          let cancelled = false;
+          const resetCancellation = () => {
+            cancelled = false;
+            return true;
+          };
+          const run = async () => {
+            const loadedUser = await load(userId);
+            if (resetCancellation() && !cancelled) setUser(loadedUser);
+          };
+          run();
+          return () => { cancelled = true; };
+        }, [userId]);
+      };`,
+      `const C = ({ userId }) => {
+        const [, setUser] = useState(null);
+        useEffect(() => {
+          let cancelled = false;
+          const disruptCancellation = {
+            get current() {
+              cancelled = false;
+              return false;
+            },
+          };
+          const run = async () => {
+            const loadedUser = await load(userId);
+            if (disruptCancellation.current || cancelled) return;
+            setUser(loadedUser);
+          };
+          run();
+          return () => { cancelled = true; };
+        }, [userId]);
+      };`,
+      `const C = ({ userId }) => {
+        const [, setUser] = useState(null);
+        useEffect(() => {
+          let cancelled = false;
+          const resetCancellation = () => {
+            cancelled = false;
+          };
+          const run = async () => {
+            const loadedUser = await load(userId);
+            resetCancellation();
+            if (cancelled) return;
+            setUser(loadedUser);
+          };
+          run();
+          return () => { cancelled = true; };
+        }, [userId]);
+      };`,
+      `const C = ({ userId }) => {
+        const [, setUser] = useState(null);
+        const requestIdRef = useRef(0);
+        useEffect(() => {
+          const requestId = ++requestIdRef.current;
+          const run = async () => {
+            const loadedUser = await load(userId);
+            requestIdRef.current = requestId;
+            if (requestId !== requestIdRef.current) return;
+            setUser(loadedUser);
+          };
+          run();
+        }, [userId]);
+      };`,
+      `const C = ({ userId }) => {
+        const [, setUser] = useState(null);
+        const requestIdRef = useRef(0);
+        useEffect(() => {
+          const requestId = ++requestIdRef.current;
+          const resetRequestId = () => {
+            requestIdRef.current = requestId;
+          };
+          const run = async () => {
+            const loadedUser = await load(userId);
+            resetRequestId();
+            if (requestId !== requestIdRef.current) return;
+            setUser(loadedUser);
+          };
+          run();
+        }, [userId]);
+      };`,
+      `const C = ({ userId, mode }) => {
+        const [, setUser] = useState(null);
+        useEffect(() => {
+          let cancelled = false;
+          const run = async () => {
+            const loadedUser = await load(userId);
+            if (cancelled) return;
+            setUser(loadedUser);
+          };
+          run();
+          if (mode) return () => { cancelled = false; };
+          return () => { cancelled = true; };
+        }, [mode, userId]);
+      };`,
+      `const C = ({ userId }) => {
+        const [, setUser] = useState(null);
+        useEffect(() => {
+          let cancelled = false;
+          const run = async () => {
+            const loadedUser = await load(userId);
+            [cancelled] = [false];
+            if (cancelled) return;
+            setUser(loadedUser);
+          };
+          run();
+          return () => { cancelled = true; };
+        }, [userId]);
+      };`,
+      `const C = ({ userId }) => {
+        const [, setUser] = useState(null);
+        const requestIdRef = useRef(0);
+        useEffect(() => {
+          const requestId = ++requestIdRef.current;
+          const run = async () => {
+            const loadedUser = await load(userId);
+            [requestIdRef.current] = [requestId];
+            if (requestId !== requestIdRef.current) return;
+            setUser(loadedUser);
+          };
+          run();
+        }, [userId]);
+      };`,
+      `const C = ({ userId }) => {
+        const [, setUser] = useState(null);
+        useEffect(() => {
+          let cancelled = false;
+          const run = async () => {
+            const loadedUser = await load(userId);
+            [loadedUser].forEach(() => {
+              cancelled = false;
+            });
+            if (cancelled) return;
+            setUser(loadedUser);
+          };
+          run();
+          return () => { cancelled = true; };
+        }, [userId]);
+      };`,
+      `const C = ({ mode, userId }) => {
+        const [, setUser] = useState(null);
+        useEffect(() => {
+          let cancelled = false;
+          const run = async () => {
+            const loadedUser = await load(userId);
+            if (cancelled) return;
+            setUser(loadedUser);
+          };
+          run();
+          return () => {
+            if (mode) return;
+            cancelled = true;
+          };
+        }, [mode, userId]);
+      };`,
+      `const C = ({ userId }) => {
+        const [, setUser] = useState(null);
+        useEffect(() => {
+          let cancelled = false;
+          const run = async () => {
+            const loadedUser = await load(userId);
+            for (cancelled of [false]) {}
+            if (cancelled) return;
+            setUser(loadedUser);
+          };
+          run();
+          return () => { cancelled = true; };
+        }, [userId]);
+      };`,
+      `const C = ({ userId }) => {
+        const [, setUser] = useState(null);
+        const requestIdRef = useRef(0);
+        useEffect(() => {
+          const requestId = ++requestIdRef.current;
+          const run = async () => {
+            const loadedUser = await load(userId);
+            for (requestIdRef.current of [requestId]) {}
+            if (requestId !== requestIdRef.current) return;
+            setUser(loadedUser);
+          };
+          run();
+        }, [userId]);
+      };`,
+      `const C = ({ userId }) => {
+        const [, setUser] = useState(null);
+        const cancelledRef = useRef(false);
+        useEffect(() => {
+          const run = async () => {
+            const loadedUser = await load(userId);
+            delete cancelledRef.current;
+            if (cancelledRef.current) return;
+            setUser(loadedUser);
+          };
+          run();
+          return () => { cancelledRef.current = true; };
+        }, [userId]);
+      };`,
+      `const C = ({ userId }) => {
+        const [, setUser] = useState(null);
+        const cancelledRef = useRef(false);
+        useEffect(() => {
+          const run = async () => {
+            const loadedUser = await load(userId);
+            Object.assign(cancelledRef, { current: false });
+            if (cancelledRef.current) return;
+            setUser(loadedUser);
+          };
+          run();
+          return () => { cancelledRef.current = true; };
+        }, [userId]);
+      };`,
+      `const C = ({ userId }) => {
+        const [, setUser] = useState(null);
+        const cancelledRef = useRef(false);
+        useEffect(() => {
+          const run = async () => {
+            const loadedUser = await load(userId);
+            Reflect.set(cancelledRef, "current", false);
+            if (cancelledRef.current) return;
+            setUser(loadedUser);
+          };
+          run();
+          return () => { cancelledRef.current = true; };
+        }, [userId]);
+      };`,
+      `const C = ({ userId }) => {
+        const [, setUser] = useState(null);
+        const cancelledRef = useRef(false);
+        const cancellationAlias = cancelledRef;
+        useEffect(() => {
+          const run = async () => {
+            const loadedUser = await load(userId);
+            cancellationAlias.current = false;
+            if (cancelledRef.current) return;
+            setUser(loadedUser);
+          };
+          run();
+          return () => { cancelledRef.current = true; };
+        }, [cancellationAlias, cancelledRef, userId]);
+      };`,
+      `const C = ({ userId }) => {
+        const [, setUser] = useState(null);
+        const requestIdRef = useRef(0);
+        const requestAlias = requestIdRef;
+        useEffect(() => {
+          const requestId = ++requestIdRef.current;
+          const run = async () => {
+            const loadedUser = await load(userId);
+            requestAlias.current = requestId;
+            if (requestId !== requestIdRef.current) return;
+            setUser(loadedUser);
+          };
+          run();
+        }, [requestAlias, requestIdRef, userId]);
+      };`,
+    ];
+    for (const source of invalidSources) {
+      expect(runRule(noSetStateAfterAwaitInEffect, source).diagnostics).toHaveLength(1);
+    }
+  });
+
+  it("does not flag compound sequence guards", () => {
+    const result = runRule(
+      noSetStateAfterAwaitInEffect,
+      `
+      const C = ({ userId, open }) => {
+        const [user, setUser] = useState(null);
+        const requestIdRef = useRef(0);
+        const openRef = useRef(open);
+        openRef.current = open;
+        useEffect(() => {
+          const requestId = ++requestIdRef.current;
+          const run = async () => {
+            const loadedUser = await load(userId);
+            if (requestId !== requestIdRef.current || !openRef.current) return;
+            setUser(loadedUser);
+          };
+          run();
+        }, [userId]);
+      };
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("does not flag a setter that is not bound to useState/useReducer", () => {
     const result = runRule(
       noSetStateAfterAwaitInEffect,
@@ -348,6 +806,51 @@ describe("no-set-state-after-await-in-effect", () => {
       `,
     );
     expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags when AbortController cleanup is conditional", () => {
+    const result = runRule(
+      noSetStateAfterAwaitInEffect,
+      `
+      const C = ({ url, shouldAbort }) => {
+        const [data, setData] = useState(null);
+        useEffect(() => {
+          const controller = new AbortController();
+          const run = async () => {
+            const res = await fetch(url, { signal: controller.signal });
+            setData(res);
+          };
+          run();
+          return () => {
+            if (shouldAbort) controller.abort();
+          };
+        }, [shouldAbort, url]);
+      };
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags when only one possible cleanup aborts the request", () => {
+    const result = runRule(
+      noSetStateAfterAwaitInEffect,
+      `
+      const C = ({ mode, url }) => {
+        const [data, setData] = useState(null);
+        useEffect(() => {
+          const controller = new AbortController();
+          const run = async () => {
+            const res = await fetch(url, { signal: controller.signal });
+            setData(res);
+          };
+          run();
+          if (mode) return () => {};
+          return () => controller.abort();
+        }, [mode, url]);
+      };
+      `,
+    );
+    expect(result.diagnostics).toHaveLength(1);
   });
 
   it("flags an external-store dependency without a cancellation guard", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-set-state-after-await-in-effect.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-set-state-after-await-in-effect.test.ts
@@ -320,6 +320,90 @@ describe("no-set-state-after-await-in-effect", () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("reports conditionally invoked async work without a matching cleanup guard", () => {
+    const conditionalResult = runRule(
+      noSetStateAfterAwaitInEffect,
+      `const C = ({ enabled, userId }) => {
+        const [, setUser] = useState(null);
+        useEffect(() => {
+          const run = async () => {
+            const user = await load(userId);
+            setUser(user);
+          };
+          const start = () => {
+            if (enabled) run();
+          };
+          start();
+        }, [enabled, userId]);
+      };`,
+    );
+    const unrelatedCleanupResult = runRule(
+      noSetStateAfterAwaitInEffect,
+      `const C = ({ enabled, userId }) => {
+        const [, setUser] = useState(null);
+        useEffect(() => {
+          const run = async () => {
+            const user = await load(userId);
+            setUser(user);
+          };
+          const start = () => {
+            if (enabled) run();
+          };
+          start();
+          return () => recordCleanup();
+        }, [enabled, userId]);
+      };`,
+    );
+    const uncoveredGuardResult = runRule(
+      noSetStateAfterAwaitInEffect,
+      `const C = ({ enabled, skipCleanup, userId }) => {
+        const [, setUser] = useState(null);
+        useEffect(() => {
+          let cancelled = false;
+          const run = async () => {
+            const user = await load(userId);
+            if (cancelled) return;
+            setUser(user);
+          };
+          const start = () => {
+            if (enabled) run();
+          };
+          start();
+          if (enabled && skipCleanup) return;
+          return () => { cancelled = true; };
+        }, [enabled, skipCleanup, userId]);
+      };`,
+    );
+    expect(conditionalResult.diagnostics).toHaveLength(1);
+    expect(unrelatedCleanupResult.diagnostics).toHaveLength(1);
+    expect(uncoveredGuardResult.diagnostics).toHaveLength(1);
+  });
+
+  it("does not let a conditional invocation suppress an unsafe unconditional invocation", () => {
+    const result = runRule(
+      noSetStateAfterAwaitInEffect,
+      `const C = ({ enabled, skipCleanup, userId }) => {
+        const [, setUser] = useState(null);
+        useEffect(() => {
+          let cancelled = false;
+          const run = async () => {
+            const user = await load(userId);
+            if (cancelled) return;
+            setUser(user);
+          };
+          const start = () => {
+            if (enabled) run();
+          };
+          start();
+          run();
+          if (skipCleanup) return;
+          return () => { cancelled = true; };
+        }, [enabled, skipCleanup, userId]);
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("does not require cleanup before a guarded async promise callback is registered", () => {
     const result = runRule(
       noSetStateAfterAwaitInEffect,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-set-state-after-await-in-effect.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-set-state-after-await-in-effect.test.ts
@@ -296,6 +296,252 @@ describe("no-set-state-after-await-in-effect", () => {
     expect(nestedResult.diagnostics).toHaveLength(0);
   });
 
+  it("resolves unreassigned let and var async helpers invoked by an effect", () => {
+    const letResult = runRule(
+      noSetStateAfterAwaitInEffect,
+      `const C = ({ userId }) => {
+        const [, setUser] = useState(null);
+        useEffect(() => {
+          let run = async () => {
+            const user = await load(userId);
+            setUser(user);
+          };
+          run();
+        }, [userId]);
+      };`,
+    );
+    const varResult = runRule(
+      noSetStateAfterAwaitInEffect,
+      `const C = ({ userId }) => {
+        const [, setUser] = useState(null);
+        useEffect(() => {
+          var run = async function () {
+            const user = await load(userId);
+            setUser(user);
+          };
+          run();
+        }, [userId]);
+      };`,
+    );
+    expect(letResult.diagnostics).toHaveLength(1);
+    expect(varResult.diagnostics).toHaveLength(1);
+  });
+
+  it("does not attribute a call to a let-bound helper replaced before invocation", () => {
+    const result = runRule(
+      noSetStateAfterAwaitInEffect,
+      `const C = ({ userId }) => {
+        const [, setUser] = useState(null);
+        useEffect(() => {
+          let run = async () => {
+            const user = await load(userId);
+            setUser(user);
+          };
+          run = () => {};
+          run();
+        }, [userId]);
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("requires a mutable helper initializer to execute before invocation", () => {
+    const letResult = runRule(
+      noSetStateAfterAwaitInEffect,
+      `const C = ({ userId }) => {
+        const [, setUser] = useState(null);
+        useEffect(() => {
+          run();
+          let run = async () => {
+            const user = await load(userId);
+            setUser(user);
+          };
+        }, [userId]);
+      };`,
+    );
+    const varResult = runRule(
+      noSetStateAfterAwaitInEffect,
+      `const C = ({ userId }) => {
+        const [, setUser] = useState(null);
+        useEffect(() => {
+          run();
+          var run = async () => {
+            const user = await load(userId);
+            setUser(user);
+          };
+        }, [userId]);
+      };`,
+    );
+    expect(letResult.diagnostics).toHaveLength(0);
+    expect(varResult.diagnostics).toHaveLength(0);
+  });
+
+  it("keeps reassigned mutable helpers outside the initialized-helper contract", () => {
+    const laterWriteResult = runRule(
+      noSetStateAfterAwaitInEffect,
+      `const C = ({ userId }) => {
+        const [, setUser] = useState(null);
+        useEffect(() => {
+          let run = async () => {
+            const user = await load(userId);
+            setUser(user);
+          };
+          run();
+          run = () => {};
+        }, [userId]);
+      };`,
+    );
+    const unreachableWriteResult = runRule(
+      noSetStateAfterAwaitInEffect,
+      `const C = ({ userId }) => {
+        const [, setUser] = useState(null);
+        useEffect(() => {
+          let run = async () => {
+            const user = await load(userId);
+            setUser(user);
+          };
+          const replace = () => {
+            run = () => {};
+          };
+          run();
+        }, [userId]);
+      };`,
+    );
+    expect(laterWriteResult.diagnostics).toHaveLength(0);
+    expect(unreachableWriteResult.diagnostics).toHaveLength(0);
+  });
+
+  it("tracks mutable helpers through wrappers and component scope", () => {
+    const sources = [
+      `const C = ({ userId }) => {
+        const [, setUser] = useState(null);
+        useEffect(() => {
+          let run = async () => { await load(userId); setUser(userId); };
+          const start = () => run();
+          start();
+        }, [userId]);
+      };`,
+      `const C = ({ userId }) => {
+        const [, setUser] = useState(null);
+        let run = async () => { await load(userId); setUser(userId); };
+        useEffect(() => { run(); }, [userId]);
+      };`,
+      `const C = ({ userId }) => {
+        const [, setUser] = useState(null);
+        useEffect(() => { run(); }, [userId]);
+        var run = async () => { await load(userId); setUser(userId); };
+      };`,
+    ];
+    expect(
+      sources.map((source) => runRule(noSetStateAfterAwaitInEffect, source).diagnostics.length),
+    ).toEqual([1, 1, 1]);
+  });
+
+  it("requires nested mutable helpers to initialize before their wrapper declaration", () => {
+    const sources = [
+      `const C = ({ userId }) => {
+        const [, setUser] = useState(null);
+        useEffect(() => {
+          const start = () => run();
+          start();
+          let run = async () => { await load(userId); setUser(userId); };
+        }, [userId]);
+      };`,
+      `const C = ({ userId }) => {
+        const [, setUser] = useState(null);
+        useEffect(() => {
+          const start = () => run();
+          let run = async () => { await load(userId); setUser(userId); };
+          start();
+        }, [userId]);
+      };`,
+    ];
+    for (const source of sources) {
+      expect(runRule(noSetStateAfterAwaitInEffect, source).diagnostics).toHaveLength(0);
+    }
+  });
+
+  it("keeps assigned mutable helpers outside the initialized-helper contract", () => {
+    const sources = [
+      `const C = ({ userId }) => {
+        const [, setUser] = useState(null);
+        useEffect(() => {
+          let run;
+          run = async () => { await load(userId); setUser(userId); };
+          run();
+        }, [userId]);
+      };`,
+      `const C = ({ enabled, userId }) => {
+        const [, setUser] = useState(null);
+        useEffect(() => {
+          let run;
+          if (enabled) run = async () => { await load(userId); setUser(userId); };
+          run();
+        }, [enabled, userId]);
+      };`,
+      `const C = ({ enabled, userId }) => {
+        const [, setUser] = useState(null);
+        useEffect(() => {
+          let run = async () => { await load(userId); setUser(userId); };
+          if (enabled) run = () => {};
+          run();
+        }, [enabled, userId]);
+      };`,
+    ];
+    for (const source of sources) {
+      expect(runRule(noSetStateAfterAwaitInEffect, source).diagnostics).toHaveLength(0);
+    }
+  });
+
+  it("tracks initialized mutable helpers through const aliases but not assignment IIFEs", () => {
+    const aliasResult = runRule(
+      noSetStateAfterAwaitInEffect,
+      `const C = ({ userId }) => {
+        const [, setUser] = useState(null);
+        useEffect(() => {
+          let run = async () => { await load(userId); setUser(userId); };
+          const start = run;
+          start();
+        }, [userId]);
+      };`,
+    );
+    const assignmentIifeResult = runRule(
+      noSetStateAfterAwaitInEffect,
+      `const C = ({ userId }) => {
+        const [, setUser] = useState(null);
+        useEffect(() => {
+          let run;
+          (run = async () => { await load(userId); setUser(userId); })();
+        }, [userId]);
+      };`,
+    );
+    expect(aliasResult.diagnostics).toHaveLength(1);
+    expect(assignmentIifeResult.diagnostics).toHaveLength(0);
+  });
+
+  it("bounds initialized mutable helper discovery across wide wrapper graphs", () => {
+    const helpers = Array.from(
+      { length: 400 },
+      (_, helperIndex) => `
+        let run${helperIndex} = async () => {
+          await load(userId);
+          setUser(userId);
+        };
+        const start${helperIndex} = () => run${helperIndex}();
+        start${helperIndex}();`,
+    ).join("\n");
+    const result = runRule(
+      noSetStateAfterAwaitInEffect,
+      `const C = ({ userId }) => {
+        const [, setUser] = useState(null);
+        useEffect(() => {
+          ${helpers}
+        }, [userId]);
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("stays quiet when a wrapper conditionally starts the guarded async work", () => {
     const result = runRule(
       noSetStateAfterAwaitInEffect,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-set-state-after-await-in-effect.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-set-state-after-await-in-effect.ts
@@ -1,10 +1,12 @@
 import { EFFECT_HOOK_NAMES } from "../../constants/react.js";
 import { areNodesOnExclusiveConditionalBranches } from "../../utils/are-nodes-on-exclusive-conditional-branches.js";
 import { areNodesOnContradictoryGuardBranches } from "../../utils/are-nodes-on-contradictory-guard-branches.js";
-import { collectEffectInvokedFunctions } from "../../utils/collect-effect-invoked-functions.js";
+import { canNodeReachLaterNodeWithinFunction } from "../../utils/can-node-reach-later-node-within-function.js";
+import { getPromiseChainCallForCallback } from "../../utils/collect-effect-invoked-functions.js";
 import { collectFunctionReturnStatements } from "../../utils/collect-function-return-statements.js";
 import { resolveCleanupFunctions } from "../../utils/collect-returned-cleanup-functions.js";
 import { defineRule } from "../../utils/define-rule.js";
+import { doNodesCoverEveryPathAfterNode } from "../../utils/do-nodes-cover-every-path-after-node.js";
 import { doNodesCoverEveryPathFromFunctionEntry } from "../../utils/do-nodes-cover-every-path-from-function-entry.js";
 import { getEffectCallback } from "../../utils/get-effect-callback.js";
 import { getReactUseCallbackCall } from "../../utils/get-react-use-callback-call.js";
@@ -169,10 +171,110 @@ const walkWithoutNestedFunctions = (
   });
 };
 
-const getCleanupFunctionsOnEveryPath = (
-  effectCallback: EsTreeNode,
+const collectDirectlyInvokedFunctions = (
+  call: EsTreeNodeOfType<"CallExpression">,
   context: RuleContext,
 ): EsTreeNode[] => {
+  const functions = new Set<EsTreeNode>();
+  const callee = stripParenExpression(call.callee);
+  if (isFunctionLike(callee)) {
+    functions.add(callee);
+  } else if (isNodeOfType(callee, "Identifier")) {
+    const resolvedFunction = resolveExactLocalFunction(callee, context.scopes);
+    if (resolvedFunction && isFunctionLike(resolvedFunction)) functions.add(resolvedFunction);
+  }
+  for (const argument of call.arguments ?? []) {
+    const callback = stripParenExpression(argument);
+    if (isFunctionLike(callback) && getPromiseChainCallForCallback(callback) === call) {
+      functions.add(callback);
+    }
+  }
+  return [...functions];
+};
+
+const collectTransitivelyInvokedFunctions = (
+  rootFunction: EsTreeNode,
+  context: RuleContext,
+): Set<EsTreeNode> => {
+  const invokedFunctions = new Set([rootFunction]);
+  const pendingFunctions = [rootFunction];
+  while (pendingFunctions.length > 0) {
+    const currentFunction = pendingFunctions.pop();
+    if (!currentFunction) break;
+    walkOwnFunctionScope(currentFunction, (candidate: EsTreeNode) => {
+      if (!isNodeOfType(candidate, "CallExpression")) return;
+      for (const invokedFunction of collectDirectlyInvokedFunctions(candidate, context)) {
+        if (invokedFunctions.has(invokedFunction)) continue;
+        invokedFunctions.add(invokedFunction);
+        pendingFunctions.push(invokedFunction);
+      }
+    });
+  }
+  return invokedFunctions;
+};
+
+const doesFunctionInvokeTargetOnEveryPath = (
+  rootFunction: EsTreeNode,
+  targetFunction: EsTreeNode,
+  context: RuleContext,
+  visitedFunctions: Set<EsTreeNode>,
+): boolean => {
+  if (rootFunction === targetFunction) return true;
+  if (visitedFunctions.has(rootFunction)) return false;
+  visitedFunctions.add(rootFunction);
+  const invocationSites: EsTreeNode[] = [];
+  walkOwnFunctionScope(rootFunction, (candidate: EsTreeNode) => {
+    if (!isNodeOfType(candidate, "CallExpression")) return;
+    const invokesTarget = collectDirectlyInvokedFunctions(candidate, context).some(
+      (invokedFunction) =>
+        doesFunctionInvokeTargetOnEveryPath(
+          invokedFunction,
+          targetFunction,
+          context,
+          new Set(visitedFunctions),
+        ),
+    );
+    if (invokesTarget) invocationSites.push(candidate);
+  });
+  return doNodesCoverEveryPathFromFunctionEntry(rootFunction, invocationSites, context);
+};
+
+const collectEffectInvocationAnchors = (
+  effectCallback: EsTreeNode,
+  invokedFunction: EsTreeNode,
+  context: RuleContext,
+): EsTreeNode[] | null => {
+  const anchors = new Set<EsTreeNode>();
+  let hasConditionalWrapperInvocation = false;
+  walkOwnFunctionScope(effectCallback, (candidate: EsTreeNode) => {
+    if (!isNodeOfType(candidate, "CallExpression")) return;
+    const directlyInvokedFunctions = collectDirectlyInvokedFunctions(candidate, context);
+    const canInvokeTarget = directlyInvokedFunctions.some((directlyInvokedFunction) =>
+      collectTransitivelyInvokedFunctions(directlyInvokedFunction, context).has(invokedFunction),
+    );
+    if (!canInvokeTarget) return;
+    const alwaysInvokesTarget = directlyInvokedFunctions.some((directlyInvokedFunction) =>
+      doesFunctionInvokeTargetOnEveryPath(
+        directlyInvokedFunction,
+        invokedFunction,
+        context,
+        new Set(),
+      ),
+    );
+    if (alwaysInvokesTarget) {
+      anchors.add(candidate);
+    } else {
+      hasConditionalWrapperInvocation = true;
+    }
+  });
+  return hasConditionalWrapperInvocation ? null : [...anchors];
+};
+
+const collectCleanupFunctionsAfterInvocations = (
+  effectCallback: EsTreeNode,
+  invokedFunction: EsTreeNode,
+  context: RuleContext,
+): EsTreeNode[] | null => {
   if (!isFunctionLike(effectCallback)) return [];
   if (!isNodeOfType(effectCallback.body, "BlockStatement")) {
     return resolveCleanupFunctions(effectCallback.body, effectCallback, context.scopes);
@@ -188,16 +290,37 @@ const getCleanupFunctionsOnEveryPath = (
       return cleanupFunctions.length > 0 ? [{ cleanupFunctions, returnStatement }] : [];
     },
   );
-  if (
-    !doNodesCoverEveryPathFromFunctionEntry(
-      effectCallback,
-      cleanupReturns.map(({ returnStatement }) => returnStatement),
-      context,
-    )
-  ) {
-    return [];
+  const invocationAnchors = collectEffectInvocationAnchors(
+    effectCallback,
+    invokedFunction,
+    context,
+  );
+  if (invocationAnchors === null) return null;
+  if (invocationAnchors.length === 0) return [];
+  const reachableCleanupReturns = new Set<(typeof cleanupReturns)[number]>();
+  for (const invocationAnchor of invocationAnchors) {
+    const cleanupReturnsAfterInvocation = cleanupReturns.filter(({ returnStatement }) =>
+      canNodeReachLaterNodeWithinFunction(
+        invocationAnchor,
+        returnStatement,
+        effectCallback,
+        context,
+      ),
+    );
+    if (
+      !doNodesCoverEveryPathAfterNode(
+        invocationAnchor,
+        cleanupReturnsAfterInvocation.map(({ returnStatement }) => returnStatement),
+        context,
+      )
+    ) {
+      return [];
+    }
+    for (const cleanupReturn of cleanupReturnsAfterInvocation) {
+      reachableCleanupReturns.add(cleanupReturn);
+    }
   }
-  return cleanupReturns.flatMap(({ cleanupFunctions }) => cleanupFunctions);
+  return [...reachableCleanupReturns].flatMap(({ cleanupFunctions }) => cleanupFunctions);
 };
 
 const collectUnconditionalCleanupActions = (
@@ -239,43 +362,41 @@ const collectUnconditionalCleanupActions = (
 };
 
 const collectCleanupGuardWrites = (
-  effectCallback: EsTreeNode,
+  cleanupFunctions: EsTreeNode[],
   context: RuleContext,
 ): Map<string, boolean> => {
-  const cleanupWriteMaps = getCleanupFunctionsOnEveryPath(effectCallback, context).map(
-    (cleanupFunction) => {
-      const writes = new Map<string, boolean>();
-      if (!isFunctionLike(cleanupFunction)) return writes;
-      const recordAssignment = (candidate: EsTreeNode): void => {
-        const expression = isNodeOfType(candidate, "ExpressionStatement")
-          ? (candidate.expression as EsTreeNode)
-          : candidate;
-        const assignedValue = isNodeOfType(expression, "AssignmentExpression")
-          ? stripParenExpression(expression.right)
-          : null;
-        if (
-          !isNodeOfType(expression, "AssignmentExpression") ||
-          expression.operator !== "=" ||
-          !isNodeOfType(assignedValue, "Literal") ||
-          typeof assignedValue.value !== "boolean"
-        ) {
-          return;
-        }
-        const targetKey = serializeReferenceKey({
-          node: expression.left,
-          scopes: context.scopes,
-        });
-        if (targetKey) writes.set(targetKey, assignedValue.value);
-      };
-      const body = cleanupFunction.body;
-      if (isNodeOfType(body, "BlockStatement")) {
-        collectUnconditionalCleanupActions(body.body as EsTreeNode[], recordAssignment);
-      } else if (body) {
-        recordAssignment(body);
+  const cleanupWriteMaps = cleanupFunctions.map((cleanupFunction) => {
+    const writes = new Map<string, boolean>();
+    if (!isFunctionLike(cleanupFunction)) return writes;
+    const recordAssignment = (candidate: EsTreeNode): void => {
+      const expression = isNodeOfType(candidate, "ExpressionStatement")
+        ? (candidate.expression as EsTreeNode)
+        : candidate;
+      const assignedValue = isNodeOfType(expression, "AssignmentExpression")
+        ? stripParenExpression(expression.right)
+        : null;
+      if (
+        !isNodeOfType(expression, "AssignmentExpression") ||
+        expression.operator !== "=" ||
+        !isNodeOfType(assignedValue, "Literal") ||
+        typeof assignedValue.value !== "boolean"
+      ) {
+        return;
       }
-      return writes;
-    },
-  );
+      const targetKey = serializeReferenceKey({
+        node: expression.left,
+        scopes: context.scopes,
+      });
+      if (targetKey) writes.set(targetKey, assignedValue.value);
+    };
+    const body = cleanupFunction.body;
+    if (isNodeOfType(body, "BlockStatement")) {
+      collectUnconditionalCleanupActions(body.body as EsTreeNode[], recordAssignment);
+    } else if (body) {
+      recordAssignment(body);
+    }
+    return writes;
+  });
   const [firstWrites, ...remainingWrites] = cleanupWriteMaps;
   const writes = new Map<string, boolean>();
   if (!firstWrites) return writes;
@@ -288,38 +409,33 @@ const collectCleanupGuardWrites = (
 };
 
 const collectCleanupAbortedControllers = (
-  effectCallback: EsTreeNode,
+  cleanupFunctions: EsTreeNode[],
   context: RuleContext,
 ): Set<string> => {
-  const cleanupControllerSets = getCleanupFunctionsOnEveryPath(effectCallback, context).map(
-    (cleanupFunction) => {
-      const controllerKeys = new Set<string>();
-      if (!isFunctionLike(cleanupFunction)) return controllerKeys;
-      const recordAbort = (candidate: EsTreeNode): void => {
-        const expression = isNodeOfType(candidate, "ExpressionStatement")
-          ? candidate.expression
-          : candidate;
-        if (!isNodeOfType(expression, "CallExpression")) return;
-        const callee = stripParenExpression(expression.callee);
-        if (
-          !isNodeOfType(callee, "MemberExpression") ||
-          getStaticPropertyName(callee) !== "abort"
-        ) {
-          return;
-        }
-        const receiver = stripParenExpression(callee.object);
-        const receiverKey = serializeReferenceKey({ node: receiver, scopes: context.scopes });
-        if (receiverKey) controllerKeys.add(receiverKey);
-      };
-      const body = cleanupFunction.body;
-      if (isNodeOfType(body, "BlockStatement")) {
-        collectUnconditionalCleanupActions(body.body as EsTreeNode[], recordAbort);
-      } else if (body) {
-        recordAbort(body);
+  const cleanupControllerSets = cleanupFunctions.map((cleanupFunction) => {
+    const controllerKeys = new Set<string>();
+    if (!isFunctionLike(cleanupFunction)) return controllerKeys;
+    const recordAbort = (candidate: EsTreeNode): void => {
+      const expression = isNodeOfType(candidate, "ExpressionStatement")
+        ? candidate.expression
+        : candidate;
+      if (!isNodeOfType(expression, "CallExpression")) return;
+      const callee = stripParenExpression(expression.callee);
+      if (!isNodeOfType(callee, "MemberExpression") || getStaticPropertyName(callee) !== "abort") {
+        return;
       }
-      return controllerKeys;
-    },
-  );
+      const receiver = stripParenExpression(callee.object);
+      const receiverKey = serializeReferenceKey({ node: receiver, scopes: context.scopes });
+      if (receiverKey) controllerKeys.add(receiverKey);
+    };
+    const body = cleanupFunction.body;
+    if (isNodeOfType(body, "BlockStatement")) {
+      collectUnconditionalCleanupActions(body.body as EsTreeNode[], recordAbort);
+    } else if (body) {
+      recordAbort(body);
+    }
+    return controllerKeys;
+  });
   const [firstControllerKeys, ...remainingControllerSets] = cleanupControllerSets;
   const controllerKeys = new Set<string>();
   if (!firstControllerKeys) return controllerKeys;
@@ -1080,34 +1196,6 @@ const analyzeAsyncStatements = (
   return { states, hasUnsafeSetter: false };
 };
 
-const collectInvokedAsyncFunctions = (
-  effectCallback: EsTreeNode,
-  context: RuleContext,
-): Set<EsTreeNode> => {
-  const invokedFunctions = collectEffectInvokedFunctions(effectCallback, context.scopes);
-  const pendingFunctions = [...invokedFunctions];
-  while (pendingFunctions.length > 0) {
-    const currentFunction = pendingFunctions.pop();
-    if (!currentFunction) break;
-    walkOwnFunctionScope(currentFunction, (child: EsTreeNode) => {
-      if (!isNodeOfType(child, "CallExpression")) return;
-      const callee = stripParenExpression(child.callee);
-      if (!isNodeOfType(callee, "Identifier")) return;
-      const resolvedFunction = resolveExactLocalFunction(callee, context.scopes);
-      if (
-        !resolvedFunction ||
-        !isFunctionLike(resolvedFunction) ||
-        invokedFunctions.has(resolvedFunction)
-      ) {
-        return;
-      }
-      invokedFunctions.add(resolvedFunction);
-      pendingFunctions.push(resolvedFunction);
-    });
-  }
-  return invokedFunctions;
-};
-
 const hasUnsafePostAwaitSetter = (
   asyncFunction: EsTreeNode,
   effectCallback: EsTreeNode,
@@ -1116,7 +1204,13 @@ const hasUnsafePostAwaitSetter = (
   if (!isFunctionLike(asyncFunction) || !asyncFunction.async) return false;
   const firstSuspensionStart = findFirstSuspensionStart(asyncFunction);
   if (firstSuspensionStart === null) return false;
-  const cleanupWrites = collectCleanupGuardWrites(effectCallback, context);
+  const cleanupFunctions = collectCleanupFunctionsAfterInvocations(
+    effectCallback,
+    asyncFunction,
+    context,
+  );
+  if (cleanupFunctions === null) return false;
+  const cleanupWrites = collectCleanupGuardWrites(cleanupFunctions, context);
   const postSuspensionWrites = collectPostSuspensionWrittenReferenceKeys(
     asyncFunction,
     firstSuspensionStart,
@@ -1128,7 +1222,7 @@ const hasUnsafePostAwaitSetter = (
     }
   }
   const declaredControllers = collectAbortControllerKeys(effectCallback, context);
-  const abortedControllers = collectCleanupAbortedControllers(effectCallback, context);
+  const abortedControllers = collectCleanupAbortedControllers(cleanupFunctions, context);
   const abortProtectedControllers = new Set(
     [...declaredControllers].filter((controllerName) => abortedControllers.has(controllerName)),
   );
@@ -1186,7 +1280,7 @@ export const noSetStateAfterAwaitInEffect = defineRule({
       if (dependencyArray && hasOnlyStableIdentityDependencies({ dependencyArray, context })) {
         return;
       }
-      for (const asyncFunction of collectInvokedAsyncFunctions(callback, context)) {
+      for (const asyncFunction of collectTransitivelyInvokedFunctions(callback, context)) {
         if (
           asyncFunction !== callback &&
           hasUnsafePostAwaitSetter(asyncFunction, callback, context)

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-set-state-after-await-in-effect.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-set-state-after-await-in-effect.ts
@@ -7,11 +7,16 @@ import { collectFunctionReturnStatements } from "../../utils/collect-function-re
 import { resolveCleanupFunctions } from "../../utils/collect-returned-cleanup-functions.js";
 import { defineRule } from "../../utils/define-rule.js";
 import { doNodesCoverEveryPathAfterNode } from "../../utils/do-nodes-cover-every-path-after-node.js";
+import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
 import { getEffectCallback } from "../../utils/get-effect-callback.js";
 import { getReactUseCallbackCall } from "../../utils/get-react-use-callback-call.js";
 import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
+import { resolveStaticLocalCallFunction } from "../../utils/get-order-independent-local-function.js";
+import { canNodeExecuteBefore } from "../../utils/has-static-property-write-before.js";
 import { isEarlyExitStatement } from "../../utils/is-early-exit-statement.js";
+import { isAstDescendant } from "../../utils/is-ast-descendant.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
+import { isNodeReachableWithinFunction } from "../../utils/is-node-reachable-within-function.js";
 import { isReactApiCall } from "../../utils/is-react-api-call.js";
 import { isReactHookResultReference } from "../../utils/is-react-hook-result-reference.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
@@ -170,6 +175,52 @@ const walkWithoutNestedFunctions = (
   });
 };
 
+const findContainingEffectCallback = (
+  functionNode: EsTreeNode,
+  context: RuleContext,
+): EsTreeNode | null => {
+  let currentFunction: EsTreeNode | null = functionNode;
+  while (currentFunction) {
+    const parent = currentFunction.parent;
+    if (
+      parent &&
+      isNodeOfType(parent, "CallExpression") &&
+      getEffectCallback(parent) === currentFunction &&
+      isReactApiCall(parent, EFFECT_HOOK_NAMES, context.scopes, {
+        allowGlobalReactNamespace: true,
+        allowUnboundBareCalls: true,
+      })
+    ) {
+      return currentFunction;
+    }
+    currentFunction = findEnclosingFunction(currentFunction);
+  }
+  return null;
+};
+
+const doesMutableInitializerExecuteBeforeCall = (
+  declarationNode: EsTreeNode,
+  call: EsTreeNode,
+  context: RuleContext,
+): boolean => {
+  const declarationFunction = findEnclosingFunction(declarationNode);
+  const callFunction = findEnclosingFunction(call);
+  if (!declarationFunction || !callFunction) return false;
+  if (declarationFunction === callFunction) {
+    return canNodeExecuteBefore(declarationNode, call, context.scopes);
+  }
+  const effectCallback = findContainingEffectCallback(callFunction, context);
+  if (
+    effectCallback &&
+    declarationFunction !== effectCallback &&
+    isAstDescendant(effectCallback, declarationFunction)
+  ) {
+    return isNodeReachableWithinFunction(declarationNode, context);
+  }
+  if (!isAstDescendant(callFunction, declarationFunction)) return false;
+  return declarationNode.range[0] < callFunction.range[0];
+};
+
 const collectDirectlyInvokedFunctions = (
   call: EsTreeNodeOfType<"CallExpression">,
   context: RuleContext,
@@ -179,8 +230,21 @@ const collectDirectlyInvokedFunctions = (
   if (isFunctionLike(callee)) {
     functions.add(callee);
   } else if (isNodeOfType(callee, "Identifier")) {
-    const resolvedFunction = resolveExactLocalFunction(callee, context.scopes);
-    if (resolvedFunction && isFunctionLike(resolvedFunction)) functions.add(resolvedFunction);
+    const symbol = context.scopes.symbolFor(callee);
+    const resolvedFunction = resolveStaticLocalCallFunction(call, context.scopes);
+    const isMutableBinding = symbol?.kind === "let" || symbol?.kind === "var";
+    const isImmutableInPractice = Boolean(
+      !isMutableBinding || symbol?.references.every((reference) => reference.flag === "read"),
+    );
+    const didInitializerExecuteBeforeCall =
+      !isMutableBinding ||
+      Boolean(
+        symbol?.initializer &&
+        doesMutableInitializerExecuteBeforeCall(symbol.declarationNode, call, context),
+      );
+    if (resolvedFunction && isImmutableInPractice && didInitializerExecuteBeforeCall) {
+      functions.add(resolvedFunction);
+    }
   }
   for (const argument of call.arguments ?? []) {
     const callback = stripParenExpression(argument);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-set-state-after-await-in-effect.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-set-state-after-await-in-effect.ts
@@ -205,6 +205,44 @@ const getUnconditionalCleanupFunction = (
   return cleanupReturn.cleanupFunctions[0] ?? null;
 };
 
+const collectUnconditionalCleanupActions = (
+  statements: EsTreeNode[],
+  recordAction: (candidate: EsTreeNode) => void,
+): boolean => {
+  for (const statement of statements) {
+    if (isNodeOfType(statement, "ExpressionStatement")) {
+      recordAction(statement);
+      continue;
+    }
+    if (isNodeOfType(statement, "BlockStatement")) {
+      if (!collectUnconditionalCleanupActions(statement.body as EsTreeNode[], recordAction)) {
+        return false;
+      }
+      continue;
+    }
+    if (isNodeOfType(statement, "TryStatement")) {
+      if (statement.finalizer) {
+        collectUnconditionalCleanupActions(statement.finalizer.body as EsTreeNode[], recordAction);
+      }
+      let hasAbruptExit = false;
+      walkAst(statement, (candidate: EsTreeNode) => {
+        if (candidate !== statement && isFunctionLike(candidate)) return false;
+        if (
+          isNodeOfType(candidate, "ReturnStatement") ||
+          isNodeOfType(candidate, "ThrowStatement")
+        ) {
+          hasAbruptExit = true;
+        }
+        return undefined;
+      });
+      if (hasAbruptExit) return false;
+      continue;
+    }
+    return false;
+  }
+  return true;
+};
+
 const collectCleanupGuardWrites = (
   effectCallback: EsTreeNode,
   context: RuleContext,
@@ -228,26 +266,11 @@ const collectCleanupGuardWrites = (
     const targetKey = serializeReferenceKey({ node: expression.left, scopes: context.scopes });
     if (targetKey) writes.set(targetKey, assignedValue.value);
   };
-  const collectUnconditionalWrites = (statements: EsTreeNode[]): boolean => {
-    for (const statement of statements) {
-      if (isNodeOfType(statement, "ExpressionStatement")) {
-        recordAssignment(statement);
-      } else if (isNodeOfType(statement, "BlockStatement")) {
-        if (!collectUnconditionalWrites(statement.body as EsTreeNode[])) return false;
-      } else if (isNodeOfType(statement, "TryStatement") && statement.finalizer) {
-        collectUnconditionalWrites(statement.finalizer.body as EsTreeNode[]);
-        return false;
-      } else {
-        return false;
-      }
-    }
-    return true;
-  };
   const cleanupFunction = getUnconditionalCleanupFunction(effectCallback, context);
   if (cleanupFunction && isFunctionLike(cleanupFunction)) {
     const body = cleanupFunction.body;
     if (isNodeOfType(body, "BlockStatement")) {
-      collectUnconditionalWrites(body.body as EsTreeNode[]);
+      collectUnconditionalCleanupActions(body.body as EsTreeNode[], recordAssignment);
     } else if (body) {
       recordAssignment(body);
     }
@@ -273,26 +296,11 @@ const collectCleanupAbortedControllers = (
     const receiverKey = serializeReferenceKey({ node: receiver, scopes: context.scopes });
     if (receiverKey) controllerKeys.add(receiverKey);
   };
-  const collectUnconditionalAborts = (statements: EsTreeNode[]): boolean => {
-    for (const statement of statements) {
-      if (isNodeOfType(statement, "ExpressionStatement")) {
-        recordAbort(statement);
-      } else if (isNodeOfType(statement, "BlockStatement")) {
-        if (!collectUnconditionalAborts(statement.body as EsTreeNode[])) return false;
-      } else if (isNodeOfType(statement, "TryStatement") && statement.finalizer) {
-        collectUnconditionalAborts(statement.finalizer.body as EsTreeNode[]);
-        return false;
-      } else {
-        return false;
-      }
-    }
-    return true;
-  };
   const cleanupFunction = getUnconditionalCleanupFunction(effectCallback, context);
   if (cleanupFunction && isFunctionLike(cleanupFunction)) {
     const body = cleanupFunction.body;
     if (isNodeOfType(body, "BlockStatement")) {
-      collectUnconditionalAborts(body.body as EsTreeNode[]);
+      collectUnconditionalCleanupActions(body.body as EsTreeNode[], recordAbort);
     } else if (body) {
       recordAbort(body);
     }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-set-state-after-await-in-effect.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-set-state-after-await-in-effect.ts
@@ -5,12 +5,12 @@ import { collectEffectInvokedFunctions } from "../../utils/collect-effect-invoke
 import { collectFunctionReturnStatements } from "../../utils/collect-function-return-statements.js";
 import { resolveCleanupFunctions } from "../../utils/collect-returned-cleanup-functions.js";
 import { defineRule } from "../../utils/define-rule.js";
+import { doNodesCoverEveryPathFromFunctionEntry } from "../../utils/do-nodes-cover-every-path-from-function-entry.js";
 import { getEffectCallback } from "../../utils/get-effect-callback.js";
 import { getReactUseCallbackCall } from "../../utils/get-react-use-callback-call.js";
 import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
 import { isEarlyExitStatement } from "../../utils/is-early-exit-statement.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
-import { isNodeOnUnconditionalPath } from "../../utils/is-node-on-unconditional-path.js";
 import { isReactApiCall } from "../../utils/is-react-api-call.js";
 import { isReactHookResultReference } from "../../utils/is-react-hook-result-reference.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
@@ -169,18 +169,13 @@ const walkWithoutNestedFunctions = (
   });
 };
 
-const getUnconditionalCleanupFunction = (
+const getCleanupFunctionsOnEveryPath = (
   effectCallback: EsTreeNode,
   context: RuleContext,
-): EsTreeNode | null => {
-  if (!isFunctionLike(effectCallback)) return null;
+): EsTreeNode[] => {
+  if (!isFunctionLike(effectCallback)) return [];
   if (!isNodeOfType(effectCallback.body, "BlockStatement")) {
-    const cleanupFunctions = resolveCleanupFunctions(
-      effectCallback.body,
-      effectCallback,
-      context.scopes,
-    );
-    return cleanupFunctions.length === 1 ? (cleanupFunctions[0] ?? null) : null;
+    return resolveCleanupFunctions(effectCallback.body, effectCallback, context.scopes);
   }
   const cleanupReturns = collectFunctionReturnStatements(effectCallback).flatMap(
     (returnStatement) => {
@@ -193,16 +188,16 @@ const getUnconditionalCleanupFunction = (
       return cleanupFunctions.length > 0 ? [{ cleanupFunctions, returnStatement }] : [];
     },
   );
-  if (cleanupReturns.length !== 1) return null;
-  const cleanupReturn = cleanupReturns[0];
   if (
-    !cleanupReturn ||
-    cleanupReturn.cleanupFunctions.length !== 1 ||
-    !isNodeOnUnconditionalPath(cleanupReturn.returnStatement, effectCallback)
+    !doNodesCoverEveryPathFromFunctionEntry(
+      effectCallback,
+      cleanupReturns.map(({ returnStatement }) => returnStatement),
+      context,
+    )
   ) {
-    return null;
+    return [];
   }
-  return cleanupReturn.cleanupFunctions[0] ?? null;
+  return cleanupReturns.flatMap(({ cleanupFunctions }) => cleanupFunctions);
 };
 
 const collectUnconditionalCleanupActions = (
@@ -247,32 +242,46 @@ const collectCleanupGuardWrites = (
   effectCallback: EsTreeNode,
   context: RuleContext,
 ): Map<string, boolean> => {
+  const cleanupWriteMaps = getCleanupFunctionsOnEveryPath(effectCallback, context).map(
+    (cleanupFunction) => {
+      const writes = new Map<string, boolean>();
+      if (!isFunctionLike(cleanupFunction)) return writes;
+      const recordAssignment = (candidate: EsTreeNode): void => {
+        const expression = isNodeOfType(candidate, "ExpressionStatement")
+          ? (candidate.expression as EsTreeNode)
+          : candidate;
+        const assignedValue = isNodeOfType(expression, "AssignmentExpression")
+          ? stripParenExpression(expression.right)
+          : null;
+        if (
+          !isNodeOfType(expression, "AssignmentExpression") ||
+          expression.operator !== "=" ||
+          !isNodeOfType(assignedValue, "Literal") ||
+          typeof assignedValue.value !== "boolean"
+        ) {
+          return;
+        }
+        const targetKey = serializeReferenceKey({
+          node: expression.left,
+          scopes: context.scopes,
+        });
+        if (targetKey) writes.set(targetKey, assignedValue.value);
+      };
+      const body = cleanupFunction.body;
+      if (isNodeOfType(body, "BlockStatement")) {
+        collectUnconditionalCleanupActions(body.body as EsTreeNode[], recordAssignment);
+      } else if (body) {
+        recordAssignment(body);
+      }
+      return writes;
+    },
+  );
+  const [firstWrites, ...remainingWrites] = cleanupWriteMaps;
   const writes = new Map<string, boolean>();
-  const recordAssignment = (candidate: EsTreeNode): void => {
-    const expression = isNodeOfType(candidate, "ExpressionStatement")
-      ? (candidate.expression as EsTreeNode)
-      : candidate;
-    const assignedValue = isNodeOfType(expression, "AssignmentExpression")
-      ? stripParenExpression(expression.right)
-      : null;
-    if (
-      !isNodeOfType(expression, "AssignmentExpression") ||
-      expression.operator !== "=" ||
-      !isNodeOfType(assignedValue, "Literal") ||
-      typeof assignedValue.value !== "boolean"
-    ) {
-      return;
-    }
-    const targetKey = serializeReferenceKey({ node: expression.left, scopes: context.scopes });
-    if (targetKey) writes.set(targetKey, assignedValue.value);
-  };
-  const cleanupFunction = getUnconditionalCleanupFunction(effectCallback, context);
-  if (cleanupFunction && isFunctionLike(cleanupFunction)) {
-    const body = cleanupFunction.body;
-    if (isNodeOfType(body, "BlockStatement")) {
-      collectUnconditionalCleanupActions(body.body as EsTreeNode[], recordAssignment);
-    } else if (body) {
-      recordAssignment(body);
+  if (!firstWrites) return writes;
+  for (const [targetKey, value] of firstWrites) {
+    if (remainingWrites.every((candidateWrites) => candidateWrites.get(targetKey) === value)) {
+      writes.set(targetKey, value);
     }
   }
   return writes;
@@ -282,27 +291,41 @@ const collectCleanupAbortedControllers = (
   effectCallback: EsTreeNode,
   context: RuleContext,
 ): Set<string> => {
+  const cleanupControllerSets = getCleanupFunctionsOnEveryPath(effectCallback, context).map(
+    (cleanupFunction) => {
+      const controllerKeys = new Set<string>();
+      if (!isFunctionLike(cleanupFunction)) return controllerKeys;
+      const recordAbort = (candidate: EsTreeNode): void => {
+        const expression = isNodeOfType(candidate, "ExpressionStatement")
+          ? candidate.expression
+          : candidate;
+        if (!isNodeOfType(expression, "CallExpression")) return;
+        const callee = stripParenExpression(expression.callee);
+        if (
+          !isNodeOfType(callee, "MemberExpression") ||
+          getStaticPropertyName(callee) !== "abort"
+        ) {
+          return;
+        }
+        const receiver = stripParenExpression(callee.object);
+        const receiverKey = serializeReferenceKey({ node: receiver, scopes: context.scopes });
+        if (receiverKey) controllerKeys.add(receiverKey);
+      };
+      const body = cleanupFunction.body;
+      if (isNodeOfType(body, "BlockStatement")) {
+        collectUnconditionalCleanupActions(body.body as EsTreeNode[], recordAbort);
+      } else if (body) {
+        recordAbort(body);
+      }
+      return controllerKeys;
+    },
+  );
+  const [firstControllerKeys, ...remainingControllerSets] = cleanupControllerSets;
   const controllerKeys = new Set<string>();
-  const recordAbort = (candidate: EsTreeNode): void => {
-    const expression = isNodeOfType(candidate, "ExpressionStatement")
-      ? candidate.expression
-      : candidate;
-    if (!isNodeOfType(expression, "CallExpression")) return;
-    const callee = stripParenExpression(expression.callee);
-    if (!isNodeOfType(callee, "MemberExpression") || getStaticPropertyName(callee) !== "abort") {
-      return;
-    }
-    const receiver = stripParenExpression(callee.object);
-    const receiverKey = serializeReferenceKey({ node: receiver, scopes: context.scopes });
-    if (receiverKey) controllerKeys.add(receiverKey);
-  };
-  const cleanupFunction = getUnconditionalCleanupFunction(effectCallback, context);
-  if (cleanupFunction && isFunctionLike(cleanupFunction)) {
-    const body = cleanupFunction.body;
-    if (isNodeOfType(body, "BlockStatement")) {
-      collectUnconditionalCleanupActions(body.body as EsTreeNode[], recordAbort);
-    } else if (body) {
-      recordAbort(body);
+  if (!firstControllerKeys) return controllerKeys;
+  for (const controllerKey of firstControllerKeys) {
+    if (remainingControllerSets.every((candidateKeys) => candidateKeys.has(controllerKey))) {
+      controllerKeys.add(controllerKey);
     }
   }
   return controllerKeys;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-set-state-after-await-in-effect.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-set-state-after-await-in-effect.ts
@@ -2,16 +2,19 @@ import { EFFECT_HOOK_NAMES } from "../../constants/react.js";
 import { areNodesOnExclusiveConditionalBranches } from "../../utils/are-nodes-on-exclusive-conditional-branches.js";
 import { areNodesOnContradictoryGuardBranches } from "../../utils/are-nodes-on-contradictory-guard-branches.js";
 import { collectEffectInvokedFunctions } from "../../utils/collect-effect-invoked-functions.js";
-import { collectReturnedCleanupFunctions } from "../../utils/collect-returned-cleanup-functions.js";
+import { collectFunctionReturnStatements } from "../../utils/collect-function-return-statements.js";
+import { resolveCleanupFunctions } from "../../utils/collect-returned-cleanup-functions.js";
 import { defineRule } from "../../utils/define-rule.js";
 import { getEffectCallback } from "../../utils/get-effect-callback.js";
 import { getReactUseCallbackCall } from "../../utils/get-react-use-callback-call.js";
 import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
 import { isEarlyExitStatement } from "../../utils/is-early-exit-statement.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
+import { isNodeOnUnconditionalPath } from "../../utils/is-node-on-unconditional-path.js";
 import { isReactApiCall } from "../../utils/is-react-api-call.js";
 import { isReactHookResultReference } from "../../utils/is-react-hook-result-reference.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { resolveConstIdentifierAlias } from "../../utils/resolve-const-identifier-alias.js";
 import { resolveExactLocalFunction } from "../../utils/resolve-exact-local-function.js";
 import { serializeReferenceKey } from "../../utils/serialize-reference-key.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
@@ -166,6 +169,42 @@ const walkWithoutNestedFunctions = (
   });
 };
 
+const getUnconditionalCleanupFunction = (
+  effectCallback: EsTreeNode,
+  context: RuleContext,
+): EsTreeNode | null => {
+  if (!isFunctionLike(effectCallback)) return null;
+  if (!isNodeOfType(effectCallback.body, "BlockStatement")) {
+    const cleanupFunctions = resolveCleanupFunctions(
+      effectCallback.body,
+      effectCallback,
+      context.scopes,
+    );
+    return cleanupFunctions.length === 1 ? (cleanupFunctions[0] ?? null) : null;
+  }
+  const cleanupReturns = collectFunctionReturnStatements(effectCallback).flatMap(
+    (returnStatement) => {
+      if (!returnStatement.argument) return [];
+      const cleanupFunctions = resolveCleanupFunctions(
+        returnStatement.argument as EsTreeNode,
+        returnStatement,
+        context.scopes,
+      );
+      return cleanupFunctions.length > 0 ? [{ cleanupFunctions, returnStatement }] : [];
+    },
+  );
+  if (cleanupReturns.length !== 1) return null;
+  const cleanupReturn = cleanupReturns[0];
+  if (
+    !cleanupReturn ||
+    cleanupReturn.cleanupFunctions.length !== 1 ||
+    !isNodeOnUnconditionalPath(cleanupReturn.returnStatement, effectCallback)
+  ) {
+    return null;
+  }
+  return cleanupReturn.cleanupFunctions[0] ?? null;
+};
+
 const collectCleanupGuardWrites = (
   effectCallback: EsTreeNode,
   context: RuleContext,
@@ -189,19 +228,23 @@ const collectCleanupGuardWrites = (
     const targetKey = serializeReferenceKey({ node: expression.left, scopes: context.scopes });
     if (targetKey) writes.set(targetKey, assignedValue.value);
   };
-  const collectUnconditionalWrites = (statements: EsTreeNode[]): void => {
+  const collectUnconditionalWrites = (statements: EsTreeNode[]): boolean => {
     for (const statement of statements) {
       if (isNodeOfType(statement, "ExpressionStatement")) {
         recordAssignment(statement);
       } else if (isNodeOfType(statement, "BlockStatement")) {
-        collectUnconditionalWrites(statement.body as EsTreeNode[]);
+        if (!collectUnconditionalWrites(statement.body as EsTreeNode[])) return false;
       } else if (isNodeOfType(statement, "TryStatement") && statement.finalizer) {
         collectUnconditionalWrites(statement.finalizer.body as EsTreeNode[]);
+        return false;
+      } else {
+        return false;
       }
     }
+    return true;
   };
-  for (const cleanupFunction of collectReturnedCleanupFunctions(effectCallback)) {
-    if (!isFunctionLike(cleanupFunction)) continue;
+  const cleanupFunction = getUnconditionalCleanupFunction(effectCallback, context);
+  if (cleanupFunction && isFunctionLike(cleanupFunction)) {
     const body = cleanupFunction.body;
     if (isNodeOfType(body, "BlockStatement")) {
       collectUnconditionalWrites(body.body as EsTreeNode[]);
@@ -217,17 +260,42 @@ const collectCleanupAbortedControllers = (
   context: RuleContext,
 ): Set<string> => {
   const controllerKeys = new Set<string>();
-  for (const cleanupFunction of collectReturnedCleanupFunctions(effectCallback)) {
-    walkOwnFunctionScope(cleanupFunction, (child: EsTreeNode) => {
-      if (!isNodeOfType(child, "CallExpression")) return;
-      const callee = stripParenExpression(child.callee);
-      if (!isNodeOfType(callee, "MemberExpression") || getStaticPropertyName(callee) !== "abort") {
-        return;
+  const recordAbort = (candidate: EsTreeNode): void => {
+    const expression = isNodeOfType(candidate, "ExpressionStatement")
+      ? candidate.expression
+      : candidate;
+    if (!isNodeOfType(expression, "CallExpression")) return;
+    const callee = stripParenExpression(expression.callee);
+    if (!isNodeOfType(callee, "MemberExpression") || getStaticPropertyName(callee) !== "abort") {
+      return;
+    }
+    const receiver = stripParenExpression(callee.object);
+    const receiverKey = serializeReferenceKey({ node: receiver, scopes: context.scopes });
+    if (receiverKey) controllerKeys.add(receiverKey);
+  };
+  const collectUnconditionalAborts = (statements: EsTreeNode[]): boolean => {
+    for (const statement of statements) {
+      if (isNodeOfType(statement, "ExpressionStatement")) {
+        recordAbort(statement);
+      } else if (isNodeOfType(statement, "BlockStatement")) {
+        if (!collectUnconditionalAborts(statement.body as EsTreeNode[])) return false;
+      } else if (isNodeOfType(statement, "TryStatement") && statement.finalizer) {
+        collectUnconditionalAborts(statement.finalizer.body as EsTreeNode[]);
+        return false;
+      } else {
+        return false;
       }
-      const receiver = stripParenExpression(callee.object);
-      const receiverKey = serializeReferenceKey({ node: receiver, scopes: context.scopes });
-      if (receiverKey) controllerKeys.add(receiverKey);
-    });
+    }
+    return true;
+  };
+  const cleanupFunction = getUnconditionalCleanupFunction(effectCallback, context);
+  if (cleanupFunction && isFunctionLike(cleanupFunction)) {
+    const body = cleanupFunction.body;
+    if (isNodeOfType(body, "BlockStatement")) {
+      collectUnconditionalAborts(body.body as EsTreeNode[]);
+    } else if (body) {
+      recordAbort(body);
+    }
   }
   return controllerKeys;
 };
@@ -285,42 +353,188 @@ const awaitUsesAbortedControllerSignal = (
   return usesSignal;
 };
 
-const getCleanupBackedGuard = (
-  test: EsTreeNode,
-  cleanupWrites: ReadonlyMap<string, boolean>,
+const getLocalPredicateExpression = (
+  expression: EsTreeNode,
   context: RuleContext,
-): string | null => {
-  const inner = stripParenExpression(test);
-  const isNegated = isNodeOfType(inner, "UnaryExpression") && inner.operator === "!";
-  const target = isNegated ? stripParenExpression(inner.argument) : inner;
-  const targetKey = serializeReferenceKey({ node: target, scopes: context.scopes });
-  if (!targetKey) return null;
-  const cleanupValue = cleanupWrites.get(targetKey);
-  if (cleanupValue === undefined) return null;
-  const exitsWhenValue = !isNegated;
-  return cleanupValue === exitsWhenValue ? targetKey : null;
+): { predicate: EsTreeNode; returnedExpression: EsTreeNode } | null => {
+  const candidate = stripParenExpression(expression);
+  if (
+    !isNodeOfType(candidate, "CallExpression") ||
+    candidate.arguments.length !== 0 ||
+    !isNodeOfType(candidate.callee, "Identifier")
+  ) {
+    return null;
+  }
+  const predicate = resolveExactLocalFunction(candidate.callee, context.scopes);
+  if (
+    !predicate ||
+    !isFunctionLike(predicate) ||
+    predicate.async ||
+    predicate.generator ||
+    predicate.params.length !== 0
+  ) {
+    return null;
+  }
+  const returnedExpression = isNodeOfType(predicate.body, "BlockStatement")
+    ? predicate.body.body.length === 1 &&
+      isNodeOfType(predicate.body.body[0], "ReturnStatement") &&
+      predicate.body.body[0].argument
+      ? predicate.body.body[0].argument
+      : null
+    : predicate.body;
+  return returnedExpression ? { predicate, returnedExpression } : null;
 };
 
-const getCleanupBackedProceedGuard = (
+const isSideEffectFreeGuardExpression = (
+  expression: EsTreeNode,
+  context: RuleContext,
+  visitedPredicates = new Set<EsTreeNode>(),
+): boolean => {
+  const candidate = stripParenExpression(expression);
+  if (isNodeOfType(candidate, "Identifier") || isNodeOfType(candidate, "Literal")) {
+    return true;
+  }
+  if (isNodeOfType(candidate, "MemberExpression")) {
+    return (
+      getStaticPropertyName(candidate) === "current" &&
+      isNodeOfType(stripParenExpression(candidate.object), "Identifier") &&
+      isReactHookResultReference(
+        stripParenExpression(candidate.object),
+        REF_HOOKS,
+        null,
+        context.scopes,
+      )
+    );
+  }
+  if (isNodeOfType(candidate, "UnaryExpression") && candidate.operator === "!") {
+    return isSideEffectFreeGuardExpression(candidate.argument, context, visitedPredicates);
+  }
+  if (
+    isNodeOfType(candidate, "BinaryExpression") &&
+    (candidate.operator === "===" || candidate.operator === "!==")
+  ) {
+    return (
+      isSideEffectFreeGuardExpression(candidate.left, context, visitedPredicates) &&
+      isSideEffectFreeGuardExpression(candidate.right, context, visitedPredicates)
+    );
+  }
+  if (isNodeOfType(candidate, "LogicalExpression")) {
+    return (
+      isSideEffectFreeGuardExpression(candidate.left, context, visitedPredicates) &&
+      isSideEffectFreeGuardExpression(candidate.right, context, visitedPredicates)
+    );
+  }
+  const localPredicate = getLocalPredicateExpression(candidate, context);
+  if (!localPredicate || visitedPredicates.has(localPredicate.predicate)) return false;
+  visitedPredicates.add(localPredicate.predicate);
+  const isSideEffectFree = isSideEffectFreeGuardExpression(
+    localPredicate.returnedExpression,
+    context,
+    visitedPredicates,
+  );
+  visitedPredicates.delete(localPredicate.predicate);
+  return isSideEffectFree;
+};
+
+const doesBooleanExpressionForceValue = (
+  expression: EsTreeNode,
+  expectedValue: boolean,
+  resolveAtomicValue: (candidate: EsTreeNode, expectedAtomicValue: boolean) => boolean,
+  context: RuleContext,
+  visitedPredicates = new Set<EsTreeNode>(),
+): boolean => {
+  const candidate = stripParenExpression(expression);
+  if (isNodeOfType(candidate, "UnaryExpression") && candidate.operator === "!") {
+    return doesBooleanExpressionForceValue(
+      candidate.argument,
+      !expectedValue,
+      resolveAtomicValue,
+      context,
+      visitedPredicates,
+    );
+  }
+  if (isNodeOfType(candidate, "LogicalExpression")) {
+    if (!isSideEffectFreeGuardExpression(candidate, context)) return false;
+    const leftForcesValue = doesBooleanExpressionForceValue(
+      candidate.left,
+      expectedValue,
+      resolveAtomicValue,
+      context,
+      visitedPredicates,
+    );
+    const rightForcesValue = doesBooleanExpressionForceValue(
+      candidate.right,
+      expectedValue,
+      resolveAtomicValue,
+      context,
+      visitedPredicates,
+    );
+    if (candidate.operator === "&&") {
+      return expectedValue
+        ? leftForcesValue && rightForcesValue
+        : leftForcesValue || rightForcesValue;
+    }
+    if (candidate.operator === "||") {
+      return expectedValue
+        ? leftForcesValue || rightForcesValue
+        : leftForcesValue && rightForcesValue;
+    }
+  }
+  const localPredicate = getLocalPredicateExpression(candidate, context);
+  if (localPredicate && !visitedPredicates.has(localPredicate.predicate)) {
+    visitedPredicates.add(localPredicate.predicate);
+    const doesPredicateForceValue = doesBooleanExpressionForceValue(
+      localPredicate.returnedExpression,
+      expectedValue,
+      resolveAtomicValue,
+      context,
+      visitedPredicates,
+    );
+    visitedPredicates.delete(localPredicate.predicate);
+    return doesPredicateForceValue;
+  }
+  return resolveAtomicValue(candidate, expectedValue);
+};
+
+const doesCleanupForceGuardValue = (
   test: EsTreeNode,
+  expectedValue: boolean,
   cleanupWrites: ReadonlyMap<string, boolean>,
   context: RuleContext,
-): string | null => {
-  const inner = stripParenExpression(test);
-  const isNegated = isNodeOfType(inner, "UnaryExpression") && inner.operator === "!";
-  const target = isNegated ? stripParenExpression(inner.argument) : inner;
-  const targetKey = serializeReferenceKey({ node: target, scopes: context.scopes });
-  if (!targetKey) return null;
-  const cleanupValue = cleanupWrites.get(targetKey);
-  if (cleanupValue === undefined) return null;
-  const proceedsWhenValue = !isNegated;
-  return cleanupValue !== proceedsWhenValue ? targetKey : null;
-};
+): boolean =>
+  doesBooleanExpressionForceValue(
+    test,
+    expectedValue,
+    (candidate, expectedAtomicValue) => {
+      const targetKey = serializeReferenceKey({ node: candidate, scopes: context.scopes });
+      const cleanupValue = targetKey ? cleanupWrites.get(targetKey) : undefined;
+      return cleanupValue === expectedAtomicValue;
+    },
+    context,
+  );
 
 interface SequenceSnapshot {
   counterKey: string;
-  start: number;
 }
+
+interface PostSuspensionWrites {
+  objectKeys: Set<string>;
+  referenceKeys: Set<string>;
+}
+
+const serializeCanonicalReferenceKey = (node: EsTreeNode, context: RuleContext): string | null => {
+  const candidate = stripParenExpression(node);
+  if (isNodeOfType(candidate, "Identifier")) {
+    const symbol = resolveConstIdentifierAlias(candidate, context.scopes);
+    return symbol
+      ? serializeReferenceKey({ node: symbol.bindingIdentifier, scopes: context.scopes })
+      : serializeReferenceKey({ node: candidate, scopes: context.scopes });
+  }
+  if (!isNodeOfType(candidate, "MemberExpression")) return null;
+  const receiverKey = serializeCanonicalReferenceKey(candidate.object, context);
+  const propertyName = getStaticPropertyName(candidate);
+  return receiverKey && propertyName ? `${receiverKey}.${propertyName}` : null;
+};
 
 const collectSequenceSnapshots = (
   root: EsTreeNode,
@@ -347,40 +561,182 @@ const collectSequenceSnapshots = (
     });
     const start = (child as { start?: unknown }).start;
     if (counterKey && typeof start === "number" && start < firstSuspensionStart) {
-      snapshots.set(child.id.name, { counterKey, start });
+      const snapshotKey = serializeReferenceKey({ node: child.id, scopes: context.scopes });
+      if (snapshotKey) snapshots.set(snapshotKey, { counterKey });
     }
   });
   return snapshots;
 };
 
-const isSequenceGuard = (
+const collectPostSuspensionWrittenReferenceKeys = (
+  asyncFunction: EsTreeNode,
+  firstSuspensionStart: number,
+  context: RuleContext,
+): PostSuspensionWrites => {
+  const mutatedObjectKeys = new Set<string>();
+  const writtenReferenceKeys = new Set<string>();
+  const visitedFunctions = new Set<EsTreeNode>();
+  const collectWriteTarget = (target: EsTreeNode): void => {
+    const candidate = stripParenExpression(target);
+    if (isNodeOfType(candidate, "ArrayPattern")) {
+      for (const element of candidate.elements) {
+        if (element) collectWriteTarget(element);
+      }
+      return;
+    }
+    if (isNodeOfType(candidate, "ObjectPattern")) {
+      for (const property of candidate.properties) {
+        if (isNodeOfType(property, "Property")) {
+          collectWriteTarget(property.value);
+        } else if (isNodeOfType(property, "RestElement")) {
+          collectWriteTarget(property.argument);
+        }
+      }
+      return;
+    }
+    if (isNodeOfType(candidate, "AssignmentPattern")) {
+      collectWriteTarget(candidate.left);
+      return;
+    }
+    if (isNodeOfType(candidate, "RestElement")) {
+      collectWriteTarget(candidate.argument);
+      return;
+    }
+    const targetKey = serializeReferenceKey({ node: candidate, scopes: context.scopes });
+    if (targetKey) writtenReferenceKeys.add(targetKey);
+    const canonicalTargetKey = serializeCanonicalReferenceKey(candidate, context);
+    if (canonicalTargetKey) writtenReferenceKeys.add(canonicalTargetKey);
+  };
+  const collectWrites = (root: EsTreeNode, minimumStart: number | null): void => {
+    walkOwnFunctionScope(root, (child: EsTreeNode) => {
+      const start = (child as { start?: unknown }).start;
+      if (minimumStart !== null && (typeof start !== "number" || start <= minimumStart)) return;
+      const writeTarget = isNodeOfType(child, "AssignmentExpression")
+        ? child.left
+        : isNodeOfType(child, "UpdateExpression")
+          ? child.argument
+          : isNodeOfType(child, "UnaryExpression") && child.operator === "delete"
+            ? child.argument
+            : (isNodeOfType(child, "ForInStatement") || isNodeOfType(child, "ForOfStatement")) &&
+                !isNodeOfType(child.left, "VariableDeclaration")
+              ? child.left
+              : null;
+      if (writeTarget) collectWriteTarget(writeTarget);
+      if (!isNodeOfType(child, "CallExpression")) return;
+      const callee = stripParenExpression(child.callee);
+      if (isNodeOfType(callee, "MemberExpression")) {
+        const receiver = stripParenExpression(callee.object);
+        const methodName = getStaticPropertyName(callee);
+        const isObjectMutation =
+          isNodeOfType(receiver, "Identifier") &&
+          receiver.name === "Object" &&
+          context.scopes.isGlobalReference(receiver) &&
+          (methodName === "assign" ||
+            methodName === "defineProperties" ||
+            methodName === "defineProperty");
+        const isReflectMutation =
+          isNodeOfType(receiver, "Identifier") &&
+          receiver.name === "Reflect" &&
+          context.scopes.isGlobalReference(receiver) &&
+          (methodName === "defineProperty" ||
+            methodName === "deleteProperty" ||
+            methodName === "set");
+        const mutationTarget = isObjectMutation || isReflectMutation ? child.arguments[0] : null;
+        if (mutationTarget && !isNodeOfType(mutationTarget, "SpreadElement")) {
+          const targetKey = serializeReferenceKey({
+            node: mutationTarget,
+            scopes: context.scopes,
+          });
+          if (targetKey) mutatedObjectKeys.add(targetKey);
+          const canonicalTargetKey = serializeCanonicalReferenceKey(mutationTarget, context);
+          if (canonicalTargetKey) mutatedObjectKeys.add(canonicalTargetKey);
+        }
+      }
+      const invokedFunctions = [
+        resolveExactLocalFunction(child.callee, context.scopes),
+        ...child.arguments.map((argument) =>
+          isNodeOfType(argument, "SpreadElement")
+            ? null
+            : resolveExactLocalFunction(argument, context.scopes),
+        ),
+      ];
+      for (const invokedFunction of invokedFunctions) {
+        if (
+          !invokedFunction ||
+          !isFunctionLike(invokedFunction) ||
+          invokedFunction.generator ||
+          visitedFunctions.has(invokedFunction)
+        ) {
+          continue;
+        }
+        visitedFunctions.add(invokedFunction);
+        collectWrites(invokedFunction, null);
+      }
+    });
+  };
+  visitedFunctions.add(asyncFunction);
+  collectWrites(asyncFunction, firstSuspensionStart);
+  return { objectKeys: mutatedObjectKeys, referenceKeys: writtenReferenceKeys };
+};
+
+const doesPostSuspensionWriteReference = (
+  referenceKey: string,
+  postSuspensionWrites: PostSuspensionWrites,
+): boolean => {
+  if (postSuspensionWrites.referenceKeys.has(referenceKey)) return true;
+  for (const objectKey of postSuspensionWrites.objectKeys) {
+    if (referenceKey === objectKey || referenceKey.startsWith(`${objectKey}.`)) return true;
+  }
+  return false;
+};
+
+const isSequenceComparison = (
   test: EsTreeNode,
+  expectedValue: boolean,
   sequenceSnapshots: ReadonlyMap<string, SequenceSnapshot>,
   context: RuleContext,
 ): boolean => {
   const inner = stripParenExpression(test);
   if (
     !isNodeOfType(inner, "BinaryExpression") ||
-    (inner.operator !== "!=" && inner.operator !== "!==")
+    !["==", "===", "!=", "!=="].includes(inner.operator)
   ) {
     return false;
   }
+  const comparisonValue = inner.operator === "!=" || inner.operator === "!==";
+  if (comparisonValue !== expectedValue) return false;
   const left = stripParenExpression(inner.left);
   const right = stripParenExpression(inner.right);
   if (isNodeOfType(left, "Identifier")) {
-    const snapshot = sequenceSnapshots.get(left.name);
+    const leftKey = serializeReferenceKey({ node: left, scopes: context.scopes });
+    const snapshot = leftKey ? sequenceSnapshots.get(leftKey) : undefined;
     if (snapshot?.counterKey === serializeReferenceKey({ node: right, scopes: context.scopes })) {
       return true;
     }
   }
   if (isNodeOfType(right, "Identifier")) {
-    const snapshot = sequenceSnapshots.get(right.name);
+    const rightKey = serializeReferenceKey({ node: right, scopes: context.scopes });
+    const snapshot = rightKey ? sequenceSnapshots.get(rightKey) : undefined;
     if (snapshot?.counterKey === serializeReferenceKey({ node: left, scopes: context.scopes })) {
       return true;
     }
   }
   return false;
 };
+
+const doesSequenceMismatchForceGuardValue = (
+  test: EsTreeNode,
+  expectedValue: boolean,
+  sequenceSnapshots: ReadonlyMap<string, SequenceSnapshot>,
+  context: RuleContext,
+): boolean =>
+  doesBooleanExpressionForceValue(
+    test,
+    expectedValue,
+    (candidate, expectedAtomicValue) =>
+      isSequenceComparison(candidate, expectedAtomicValue, sequenceSnapshots, context),
+    context,
+  );
 
 interface AsyncPathState {
   didSuspend: boolean;
@@ -513,19 +869,40 @@ const analyzeAsyncStatements = (
       if (tested.hasUnsafeSetter) return tested;
       states = tested.states;
       if (!statement.alternate && isEarlyExitStatement(statement.consequent)) {
-        const guardKey = getCleanupBackedGuard(statement.test, cleanupWrites, context);
-        const isLatestSequenceGuard = isSequenceGuard(statement.test, sequenceSnapshots, context);
-        if (guardKey || isLatestSequenceGuard) {
+        const doesCleanupForceExit = doesCleanupForceGuardValue(
+          statement.test,
+          true,
+          cleanupWrites,
+          context,
+        );
+        const doesSequenceMismatchForceExit = doesSequenceMismatchForceGuardValue(
+          statement.test,
+          true,
+          sequenceSnapshots,
+          context,
+        );
+        if (doesCleanupForceExit || doesSequenceMismatchForceExit) {
           states = states.map((state) => ({
             ...state,
             hasDominatingGuard:
               state.hasDominatingGuard ||
-              (state.didSuspend && Boolean(guardKey || isLatestSequenceGuard)),
+              (state.didSuspend && (doesCleanupForceExit || doesSequenceMismatchForceExit)),
           }));
           continue;
         }
       }
-      const proceedGuard = getCleanupBackedProceedGuard(statement.test, cleanupWrites, context);
+      const doesCleanupPreventProceed = doesCleanupForceGuardValue(
+        statement.test,
+        false,
+        cleanupWrites,
+        context,
+      );
+      const doesSequenceMismatchPreventProceed = doesSequenceMismatchForceGuardValue(
+        statement.test,
+        false,
+        sequenceSnapshots,
+        context,
+      );
       const consequent = analyzeAsyncStatements(
         isNodeOfType(statement.consequent, "BlockStatement")
           ? (statement.consequent.body as EsTreeNode[])
@@ -533,7 +910,8 @@ const analyzeAsyncStatements = (
         states.map((state) => ({
           ...state,
           hasDominatingGuard:
-            state.hasDominatingGuard || (state.didSuspend && Boolean(proceedGuard)),
+            state.hasDominatingGuard ||
+            (state.didSuspend && (doesCleanupPreventProceed || doesSequenceMismatchPreventProceed)),
         })),
         context,
         cleanupWrites,
@@ -708,6 +1086,16 @@ const hasUnsafePostAwaitSetter = (
   const firstSuspensionStart = findFirstSuspensionStart(asyncFunction);
   if (firstSuspensionStart === null) return false;
   const cleanupWrites = collectCleanupGuardWrites(effectCallback, context);
+  const postSuspensionWrites = collectPostSuspensionWrittenReferenceKeys(
+    asyncFunction,
+    firstSuspensionStart,
+    context,
+  );
+  for (const targetKey of cleanupWrites.keys()) {
+    if (doesPostSuspensionWriteReference(targetKey, postSuspensionWrites)) {
+      cleanupWrites.delete(targetKey);
+    }
+  }
   const declaredControllers = collectAbortControllerKeys(effectCallback, context);
   const abortedControllers = collectCleanupAbortedControllers(effectCallback, context);
   const abortProtectedControllers = new Set(
@@ -717,6 +1105,11 @@ const hasUnsafePostAwaitSetter = (
     ...collectSequenceSnapshots(effectCallback, firstSuspensionStart, context),
     ...collectSequenceSnapshots(asyncFunction, firstSuspensionStart, context),
   ]);
+  for (const [snapshotKey, snapshot] of sequenceSnapshots) {
+    if (doesPostSuspensionWriteReference(snapshot.counterKey, postSuspensionWrites)) {
+      sequenceSnapshots.delete(snapshotKey);
+    }
+  }
   const body = asyncFunction.body;
   const statements = isNodeOfType(body, "BlockStatement")
     ? (body.body as EsTreeNode[])

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-set-state-after-await-in-effect.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-set-state-after-await-in-effect.ts
@@ -239,13 +239,52 @@ const doesFunctionInvokeTargetOnEveryPath = (
   return doNodesCoverEveryPathFromFunctionEntry(rootFunction, invocationSites, context);
 };
 
+const collectTargetInvocationSites = (
+  rootFunction: EsTreeNode,
+  targetFunction: EsTreeNode,
+  context: RuleContext,
+  visitedFunctions: Set<EsTreeNode>,
+): EsTreeNode[] => {
+  if (visitedFunctions.has(rootFunction)) return [];
+  visitedFunctions.add(rootFunction);
+  const invocationSites = new Set<EsTreeNode>();
+  walkOwnFunctionScope(rootFunction, (candidate: EsTreeNode) => {
+    if (!isNodeOfType(candidate, "CallExpression")) return;
+    for (const invokedFunction of collectDirectlyInvokedFunctions(candidate, context)) {
+      if (invokedFunction === targetFunction) {
+        invocationSites.add(candidate);
+        continue;
+      }
+      for (const invocationSite of collectTargetInvocationSites(
+        invokedFunction,
+        targetFunction,
+        context,
+        new Set(visitedFunctions),
+      )) {
+        invocationSites.add(invocationSite);
+      }
+    }
+  });
+  return [...invocationSites];
+};
+
+interface ConditionalEffectInvocationAnchor {
+  anchor: EsTreeNode;
+  targetInvocationSites: EsTreeNode[];
+}
+
+interface EffectInvocationAnchors {
+  conditional: ConditionalEffectInvocationAnchor[];
+  unconditional: EsTreeNode[];
+}
+
 const collectEffectInvocationAnchors = (
   effectCallback: EsTreeNode,
   invokedFunction: EsTreeNode,
   context: RuleContext,
-): EsTreeNode[] | null => {
-  const anchors = new Set<EsTreeNode>();
-  let hasConditionalWrapperInvocation = false;
+): EffectInvocationAnchors => {
+  const conditional = new Map<EsTreeNode, ConditionalEffectInvocationAnchor>();
+  const unconditional = new Set<EsTreeNode>();
   walkOwnFunctionScope(effectCallback, (candidate: EsTreeNode) => {
     if (!isNodeOfType(candidate, "CallExpression")) return;
     const directlyInvokedFunctions = collectDirectlyInvokedFunctions(candidate, context);
@@ -262,58 +301,97 @@ const collectEffectInvocationAnchors = (
       ),
     );
     if (alwaysInvokesTarget) {
-      anchors.add(candidate);
+      unconditional.add(candidate);
     } else {
-      hasConditionalWrapperInvocation = true;
+      const targetInvocationSites = directlyInvokedFunctions.flatMap((directlyInvokedFunction) =>
+        collectTargetInvocationSites(directlyInvokedFunction, invokedFunction, context, new Set()),
+      );
+      conditional.set(candidate, { anchor: candidate, targetInvocationSites });
     }
   });
-  return hasConditionalWrapperInvocation ? null : [...anchors];
+  return {
+    conditional: [...conditional.values()],
+    unconditional: [...unconditional],
+  };
 };
 
 const collectCleanupFunctionsAfterInvocations = (
   effectCallback: EsTreeNode,
   invokedFunction: EsTreeNode,
   context: RuleContext,
-): EsTreeNode[] | null => {
+): EsTreeNode[] => {
   if (!isFunctionLike(effectCallback)) return [];
   if (!isNodeOfType(effectCallback.body, "BlockStatement")) {
     return resolveCleanupFunctions(effectCallback.body, effectCallback, context.scopes);
   }
-  const cleanupReturns = collectFunctionReturnStatements(effectCallback).flatMap(
-    (returnStatement) => {
-      if (!returnStatement.argument) return [];
-      const cleanupFunctions = resolveCleanupFunctions(
-        returnStatement.argument as EsTreeNode,
-        returnStatement,
-        context.scopes,
-      );
-      return cleanupFunctions.length > 0 ? [{ cleanupFunctions, returnStatement }] : [];
-    },
-  );
+  const returnStatements = collectFunctionReturnStatements(effectCallback);
+  const cleanupReturns = returnStatements.flatMap((returnStatement) => {
+    if (!returnStatement.argument) return [];
+    const cleanupFunctions = resolveCleanupFunctions(
+      returnStatement.argument as EsTreeNode,
+      returnStatement,
+      context.scopes,
+    );
+    return cleanupFunctions.length > 0 ? [{ cleanupFunctions, returnStatement }] : [];
+  });
   const invocationAnchors = collectEffectInvocationAnchors(
     effectCallback,
     invokedFunction,
     context,
   );
-  if (invocationAnchors === null) return null;
-  if (invocationAnchors.length === 0) return [];
   const reachableCleanupReturns = new Set<(typeof cleanupReturns)[number]>();
-  for (const invocationAnchor of invocationAnchors) {
-    const cleanupReturnsAfterInvocation = cleanupReturns.filter(({ returnStatement }) =>
-      canNodeReachLaterNodeWithinFunction(
-        invocationAnchor,
-        returnStatement,
-        effectCallback,
-        context,
-      ),
+  if (invocationAnchors.unconditional.length > 0) {
+    for (const invocationAnchor of invocationAnchors.unconditional) {
+      const cleanupReturnsAfterInvocation = cleanupReturns.filter(({ returnStatement }) =>
+        canNodeReachLaterNodeWithinFunction(
+          invocationAnchor,
+          returnStatement,
+          effectCallback,
+          context,
+        ),
+      );
+      if (
+        !doNodesCoverEveryPathAfterNode(
+          invocationAnchor,
+          cleanupReturnsAfterInvocation.map(({ returnStatement }) => returnStatement),
+          context,
+        )
+      ) {
+        return [];
+      }
+      for (const cleanupReturn of cleanupReturnsAfterInvocation) {
+        reachableCleanupReturns.add(cleanupReturn);
+      }
+    }
+    return [...reachableCleanupReturns].flatMap(({ cleanupFunctions }) => cleanupFunctions);
+  }
+  if (invocationAnchors.conditional.length === 0) return [];
+  for (const { anchor, targetInvocationSites } of invocationAnchors.conditional) {
+    if (targetInvocationSites.length === 0) return [];
+    const returnsAfterInvocation = returnStatements.filter((returnStatement) =>
+      canNodeReachLaterNodeWithinFunction(anchor, returnStatement, effectCallback, context),
     );
-    if (
-      !doNodesCoverEveryPathAfterNode(
-        invocationAnchor,
-        cleanupReturnsAfterInvocation.map(({ returnStatement }) => returnStatement),
-        context,
-      )
-    ) {
+    if (!doNodesCoverEveryPathAfterNode(anchor, returnsAfterInvocation, context)) return [];
+    const cleanupReturnsAfterInvocation = cleanupReturns.filter(({ returnStatement }) =>
+      returnsAfterInvocation.includes(returnStatement),
+    );
+    const cleanupReturnStatements = new Set(
+      cleanupReturnsAfterInvocation.map(({ returnStatement }) => returnStatement),
+    );
+    const returnsWithoutCleanup = returnsAfterInvocation.filter(
+      (returnStatement) => !cleanupReturnStatements.has(returnStatement),
+    );
+    const areNoCleanupReturnsExclusiveWithInvocations = returnsWithoutCleanup.every(
+      (returnStatement) =>
+        targetInvocationSites.every((targetInvocationSite) =>
+          areNodesOnContradictoryGuardBranches(
+            targetInvocationSite,
+            returnStatement,
+            context.scopes,
+          ),
+        ),
+    );
+    if (!areNoCleanupReturnsExclusiveWithInvocations) {
       return [];
     }
     for (const cleanupReturn of cleanupReturnsAfterInvocation) {
@@ -1209,7 +1287,6 @@ const hasUnsafePostAwaitSetter = (
     asyncFunction,
     context,
   );
-  if (cleanupFunctions === null) return false;
   const cleanupWrites = collectCleanupGuardWrites(cleanupFunctions, context);
   const postSuspensionWrites = collectPostSuspensionWrittenReferenceKeys(
     asyncFunction,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-set-state-after-await-in-effect.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-set-state-after-await-in-effect.ts
@@ -419,7 +419,7 @@ const isSideEffectFreeGuardExpression = (
   }
   if (
     isNodeOfType(candidate, "BinaryExpression") &&
-    (candidate.operator === "===" || candidate.operator === "!==")
+    ["==", "===", "!=", "!=="].includes(candidate.operator)
   ) {
     return (
       isSideEffectFreeGuardExpression(candidate.left, context, visitedPredicates) &&

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-set-state-after-await-in-effect.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-set-state-after-await-in-effect.ts
@@ -7,7 +7,6 @@ import { collectFunctionReturnStatements } from "../../utils/collect-function-re
 import { resolveCleanupFunctions } from "../../utils/collect-returned-cleanup-functions.js";
 import { defineRule } from "../../utils/define-rule.js";
 import { doNodesCoverEveryPathAfterNode } from "../../utils/do-nodes-cover-every-path-after-node.js";
-import { doNodesCoverEveryPathFromFunctionEntry } from "../../utils/do-nodes-cover-every-path-from-function-entry.js";
 import { getEffectCallback } from "../../utils/get-effect-callback.js";
 import { getReactUseCallbackCall } from "../../utils/get-react-use-callback-call.js";
 import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
@@ -213,106 +212,75 @@ const collectTransitivelyInvokedFunctions = (
   return invokedFunctions;
 };
 
-const doesFunctionInvokeTargetOnEveryPath = (
+const doesFunctionTransitivelyInvokeTarget = (
   rootFunction: EsTreeNode,
   targetFunction: EsTreeNode,
   context: RuleContext,
-  visitedFunctions: Set<EsTreeNode>,
+  memoizedResults: Map<EsTreeNode, boolean>,
 ): boolean => {
-  if (rootFunction === targetFunction) return true;
-  if (visitedFunctions.has(rootFunction)) return false;
-  visitedFunctions.add(rootFunction);
-  const invocationSites: EsTreeNode[] = [];
-  walkOwnFunctionScope(rootFunction, (candidate: EsTreeNode) => {
-    if (!isNodeOfType(candidate, "CallExpression")) return;
-    const invokesTarget = collectDirectlyInvokedFunctions(candidate, context).some(
-      (invokedFunction) =>
-        doesFunctionInvokeTargetOnEveryPath(
-          invokedFunction,
-          targetFunction,
-          context,
-          new Set(visitedFunctions),
-        ),
-    );
-    if (invokesTarget) invocationSites.push(candidate);
-  });
-  return doNodesCoverEveryPathFromFunctionEntry(rootFunction, invocationSites, context);
+  const memoizedResult = memoizedResults.get(rootFunction);
+  if (memoizedResult !== undefined) return memoizedResult;
+  const doesInvokeTarget = collectTransitivelyInvokedFunctions(rootFunction, context).has(
+    targetFunction,
+  );
+  memoizedResults.set(rootFunction, doesInvokeTarget);
+  return doesInvokeTarget;
 };
 
-const collectTargetInvocationSites = (
-  rootFunction: EsTreeNode,
+const doFunctionsHaveUnguardedTargetInvocationPath = (
+  rootFunctions: EsTreeNode[],
   targetFunction: EsTreeNode,
+  noCleanupReturn: EsTreeNode,
   context: RuleContext,
-  visitedFunctions: Set<EsTreeNode>,
-): EsTreeNode[] => {
-  if (visitedFunctions.has(rootFunction)) return [];
-  visitedFunctions.add(rootFunction);
-  const invocationSites = new Set<EsTreeNode>();
-  walkOwnFunctionScope(rootFunction, (candidate: EsTreeNode) => {
-    if (!isNodeOfType(candidate, "CallExpression")) return;
-    for (const invokedFunction of collectDirectlyInvokedFunctions(candidate, context)) {
-      if (invokedFunction === targetFunction) {
-        invocationSites.add(candidate);
-        continue;
+): boolean => {
+  const visitedFunctions = new Set<EsTreeNode>();
+  const pendingFunctions = [...rootFunctions];
+  while (pendingFunctions.length > 0) {
+    const currentFunction = pendingFunctions.pop();
+    if (!currentFunction) break;
+    if (currentFunction === targetFunction) return true;
+    if (visitedFunctions.has(currentFunction)) continue;
+    visitedFunctions.add(currentFunction);
+    walkOwnFunctionScope(currentFunction, (candidate: EsTreeNode) => {
+      if (
+        !isNodeOfType(candidate, "CallExpression") ||
+        areNodesOnContradictoryGuardBranches(candidate, noCleanupReturn, context.scopes)
+      ) {
+        return;
       }
-      for (const invocationSite of collectTargetInvocationSites(
-        invokedFunction,
-        targetFunction,
-        context,
-        new Set(visitedFunctions),
-      )) {
-        invocationSites.add(invocationSite);
-      }
-    }
-  });
-  return [...invocationSites];
+      pendingFunctions.push(...collectDirectlyInvokedFunctions(candidate, context));
+    });
+  }
+  return false;
 };
 
-interface ConditionalEffectInvocationAnchor {
+interface EffectInvocationAnchor {
   anchor: EsTreeNode;
-  targetInvocationSites: EsTreeNode[];
-}
-
-interface EffectInvocationAnchors {
-  conditional: ConditionalEffectInvocationAnchor[];
-  unconditional: EsTreeNode[];
+  targetReachableFunctions: EsTreeNode[];
 }
 
 const collectEffectInvocationAnchors = (
   effectCallback: EsTreeNode,
   invokedFunction: EsTreeNode,
   context: RuleContext,
-): EffectInvocationAnchors => {
-  const conditional = new Map<EsTreeNode, ConditionalEffectInvocationAnchor>();
-  const unconditional = new Set<EsTreeNode>();
+): EffectInvocationAnchor[] => {
+  const invocationAnchors: EffectInvocationAnchor[] = [];
+  const targetReachability = new Map<EsTreeNode, boolean>();
   walkOwnFunctionScope(effectCallback, (candidate: EsTreeNode) => {
     if (!isNodeOfType(candidate, "CallExpression")) return;
-    const directlyInvokedFunctions = collectDirectlyInvokedFunctions(candidate, context);
-    const canInvokeTarget = directlyInvokedFunctions.some((directlyInvokedFunction) =>
-      collectTransitivelyInvokedFunctions(directlyInvokedFunction, context).has(invokedFunction),
+    const targetReachableFunctions = collectDirectlyInvokedFunctions(candidate, context).filter(
+      (directlyInvokedFunction) =>
+        doesFunctionTransitivelyInvokeTarget(
+          directlyInvokedFunction,
+          invokedFunction,
+          context,
+          targetReachability,
+        ),
     );
-    if (!canInvokeTarget) return;
-    const alwaysInvokesTarget = directlyInvokedFunctions.some((directlyInvokedFunction) =>
-      doesFunctionInvokeTargetOnEveryPath(
-        directlyInvokedFunction,
-        invokedFunction,
-        context,
-        new Set(),
-      ),
-    );
-    if (alwaysInvokesTarget) {
-      unconditional.add(candidate);
-    } else {
-      const targetInvocationSites = directlyInvokedFunctions.flatMap((directlyInvokedFunction) =>
-        collectTargetInvocationSites(directlyInvokedFunction, invokedFunction, context, new Set()),
-      );
-      conditional.set(candidate, { anchor: candidate, targetInvocationSites });
-    }
+    if (targetReachableFunctions.length === 0) return;
+    invocationAnchors.push({ anchor: candidate, targetReachableFunctions });
   });
-  return {
-    conditional: [...conditional.values()],
-    unconditional: [...unconditional],
-  };
+  return invocationAnchors;
 };
 
 const collectCleanupFunctionsAfterInvocations = (
@@ -340,34 +308,7 @@ const collectCleanupFunctionsAfterInvocations = (
     context,
   );
   const reachableCleanupReturns = new Set<(typeof cleanupReturns)[number]>();
-  if (invocationAnchors.unconditional.length > 0) {
-    for (const invocationAnchor of invocationAnchors.unconditional) {
-      const cleanupReturnsAfterInvocation = cleanupReturns.filter(({ returnStatement }) =>
-        canNodeReachLaterNodeWithinFunction(
-          invocationAnchor,
-          returnStatement,
-          effectCallback,
-          context,
-        ),
-      );
-      if (
-        !doNodesCoverEveryPathAfterNode(
-          invocationAnchor,
-          cleanupReturnsAfterInvocation.map(({ returnStatement }) => returnStatement),
-          context,
-        )
-      ) {
-        return [];
-      }
-      for (const cleanupReturn of cleanupReturnsAfterInvocation) {
-        reachableCleanupReturns.add(cleanupReturn);
-      }
-    }
-    return [...reachableCleanupReturns].flatMap(({ cleanupFunctions }) => cleanupFunctions);
-  }
-  if (invocationAnchors.conditional.length === 0) return [];
-  for (const { anchor, targetInvocationSites } of invocationAnchors.conditional) {
-    if (targetInvocationSites.length === 0) return [];
+  for (const { anchor, targetReachableFunctions } of invocationAnchors) {
     const returnsAfterInvocation = returnStatements.filter((returnStatement) =>
       canNodeReachLaterNodeWithinFunction(anchor, returnStatement, effectCallback, context),
     );
@@ -382,14 +323,17 @@ const collectCleanupFunctionsAfterInvocations = (
       (returnStatement) => !cleanupReturnStatements.has(returnStatement),
     );
     const areNoCleanupReturnsExclusiveWithInvocations = returnsWithoutCleanup.every(
-      (returnStatement) =>
-        targetInvocationSites.every((targetInvocationSite) =>
-          areNodesOnContradictoryGuardBranches(
-            targetInvocationSite,
-            returnStatement,
-            context.scopes,
-          ),
-        ),
+      (returnStatement) => {
+        if (areNodesOnContradictoryGuardBranches(anchor, returnStatement, context.scopes)) {
+          return true;
+        }
+        return !doFunctionsHaveUnguardedTargetInvocationPath(
+          targetReachableFunctions,
+          invokedFunction,
+          returnStatement,
+          context,
+        );
+      },
     );
     if (!areNoCleanupReturnsExclusiveWithInvocations) {
       return [];


### PR DESCRIPTION
## Summary

- recognize cancellation guards composed with `&&`, `||`, negation, local zero-argument predicates, and stale-request sequence comparisons
- require unconditional cleanup evidence and invalidate guard proofs after post-suspension writes, helper/callback mutations, destructuring, loop writes, deletes, and object mutation APIs
- add focused adversarial coverage plus fuzz regression and true-positive corpus entries

## ReactBench evidence

- audited all 14 historical `no-set-state-after-await-in-effect` diagnostics from the AppFlowy trials
- exact replay suppresses all 13 verified false positives
- exact replay retains the one verified true positive (`W3oL3cJ`)
- replay result: 13 suppressed / 1 retained / 0 mismatches / 0 parse failures
- immutable replay SHA-256: `51a409b03785b98fbc8470ab02ad66460fe59b0304a6223020b6d66b131b8f60`

## Validation

- focused rule suite: 74/74
- plugin suite: 24,802 passed, 201 skipped
- full repository suite: 15/15 tasks passed
- fuzz regression suite: 192/192
- strict fuzzing: 500 cases passed
- `nr lint`
- `nr typecheck`
- `nr format:check`
- `nr smoke:json-report`

RDE and Daytona parity could not run because the required Axiom and Daytona credentials are not present in this environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large control-flow changes in a widely used lint rule; misclassification could hide real stale-setState bugs or spam false positives, though coverage is extensive.
> 
> **Overview**
> **`no-set-state-after-await-in-effect`** is tightened so fewer real-world stale-request patterns are false positives, while guard/cleanup proofs stay conservative.
> 
> The rule now treats **compound and local predicates** (logical combinations, zero-arg helpers like `isCurrentRequest()`, ref equality, sequence counters with `==`/`===`) as valid post-`await` guards when they align with effect cleanup. **Cleanup is tied to invocation**: only returns reachable after async work starts count, every such path must register equivalent cancellation/`abort`, and early returns before async work (e.g. `if (!enabled) return`) do not require cleanup. **Invocation tracking** follows transitively invoked helpers, including initialized `let`/`var` async functions, with ordering and reassignment checks so replaced helpers are not attributed.
> 
> **Guard proofs are invalidated** when cancellation or sequence state is written after the first `await` (assignments, destructuring, loops, `delete`, `Object`/`Reflect` mutations, conditional cleanup, partial `AbortController` abort). Conditional starts through wrappers must still pair with cleanup on all paths that can run async work.
> 
> Adds a large focused test suite, fuzz **regression** corpus (AppFlowy-style compound guards, conditional call sites, early-exit paths), and **true-positive** corpus (conditional wrappers, mutable helpers, mutated guards). Patch changeset for `oxlint-plugin-react-doctor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4413c474289acc2e4ea10e6cf8995dcb610e5b7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Final cached Daytona parity

- immutable base: `6b64dfaf9e973139d1df2d09f405c9d916e158a3`
- PR head: `4413c474289acc2e4ea10e6cf8995dcb610e5b7d`
- prospective merge: `8e9811bcad29016c785e34718841b188f0d528f7`
- compared: 2,000 / 2,000 projects; 0 failures; 0 skipped
- diagnostics: 2,198 baseline / 2,198 candidate / 2,193 unchanged / +5 / -5
- additions: 5 confirmed true positives; 0 false positives
- removals: 5 confirmed baseline false positives and intended removals; 0 false negatives
- reconciliation: 0 location movements, 0 persistence gaps, 0 reconstruction failures, 0 blockers
- cleanup: task-scoped Daytona sandbox/snapshot cleanup completed twice; the second pass confirmed no task-owned resource remained

### Immutable artifact hashes

- `base-pr-1499-final-scoped.ndjson`: `210a64183a9f20a0b39760aabc181aaee7d4715d7d487b6cb42ecb71ff98c048`
- `pr-1499-final-4413-candidate.ndjson`: `e1e5eb35047952c90e7fcec25974d7ad4af07232631ba8ffb61a1657d030f16d`
- `pr-1499-final-4413-parity.json`: `aa1abc9e69d599c58206566fd0c4b6ba61deeb99dc09ce6c655042834df6877d`
- `pr-1499-final-4413-impact.json`: `a03cfc87163089a7857385bc0f9317962fefcabd0a6ce900ad9b316b1ad9acaa`
- prospective-merge rule source: `87d44b5066942068c5f19d02bdf2ef3b9d9a553cafa3eacff81f2d4371f225ed`

### Added-diagnostic evidence hashes

- `added/classifications.json`: `d233ef13e5f9ff832e4d7f19c6e4144dde1e93b1a42d9706f79774246832446b`
- `added/evidence.md`: `3892469354ad0703dd529e4635e36567410725159e72ce4762cf7ed8becb8b5d`
- `added/verification.json`: `806e1b7fec3873e73b61372969a12cba3894870b116412e6e8b392753a9e9e7b`
- `added/SHA256SUMS`: `601fdb9f723a8dd9e0f01dfe4c88db7280643e529772e42875c33511cf9876ed`

### Removed-diagnostic evidence hashes

- `removed/classifications.json`: `e3eb7eee1767120dcda56b89da21a2cd8e3e0775f9a8167a46b01e4b1e768c6e`
- `removed/evidence.md`: `0bb3110a9a393a5901945df30db8623f4e931cefa4dc7092ddd231e36b55cc81`
- `removed/SHA256SUMS`: `a4074efcde897a66ed3a02822b2fa049b7d73573770260e0f8df63198a45fc5a`