### PR TITLE
RDFPFN792026: recognize controlled local state fallbacks

### DIFF
--- a/.changeset/tidy-controlled-fallbacks.md
+++ b/.changeset/tidy-controlled-fallbacks.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Avoid reporting intentional uncontrolled state selected as the fallback to a controlled prop.

--- a/packages/fuzz/corpus/regressions/no-derived-use-state--controlled-local-fallback.tsx
+++ b/packages/fuzz/corpus/regressions/no-derived-use-state--controlled-local-fallback.tsx
@@ -1,0 +1,19 @@
+// rule: no-derived-useState
+// weakness: control-flow
+// source: ReactBench fix-react-rdh-nteract-semiotic-a__BTorRet
+// verdict: pass
+import { useCallback, useState } from "react";
+
+export const ControlledTree = ({ tree, activeId: controlledActiveId }) => {
+  const [internalActiveId, setInternalActiveId] = useState(tree.id);
+  const isControlled = controlledActiveId !== undefined;
+  const activeId = isControlled ? controlledActiveId : internalActiveId;
+  const selectItem = useCallback(
+    (item) => {
+      if (!isControlled) setInternalActiveId(item.id);
+    },
+    [isControlled],
+  );
+
+  return <Tree activeId={activeId} onSelect={selectItem} />;
+};

--- a/packages/fuzz/corpus/true-positives/no-derived-use-state--unrelated-conditional.tsx
+++ b/packages/fuzz/corpus/true-positives/no-derived-use-state--unrelated-conditional.tsx
@@ -1,0 +1,12 @@
+// rule: no-derived-useState
+// weakness: control-flow
+// source: adversarial validation of controlled local fallback
+// verdict: fail
+import { useState } from "react";
+
+export const Profile = ({ name, nickname, showNickname }) => {
+  const [displayName, setDisplayName] = useState(name);
+  const visibleName = showNickname ? nickname : displayName;
+
+  return <input value={visibleName} onChange={(event) => setDisplayName(event.target.value)} />;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-derived-use-state.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-derived-use-state.regressions.test.ts
@@ -266,6 +266,20 @@ describe("no-derived-useState — regressions", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("does not treat a wrapped prop re-seed as a user edit", () => {
+    const result = runRule(
+      noDerivedUseState,
+      `function Profile({ name, value: controlledValue }) {
+        const [internalValue, setInternalValue] = useState(name);
+        const value = controlledValue ?? internalValue;
+        const reset = () => setInternalValue(name as string);
+        return <button onClick={reset}>{value}</button>;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("does not treat a shadowed state name as the controlled fallback", () => {
     const result = runRule(
       noDerivedUseState,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-derived-use-state.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-derived-use-state.regressions.test.ts
@@ -202,6 +202,85 @@ describe("no-derived-useState — regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("stays silent on a user-editable fallback behind a controlled prop", () => {
+    const result = runRule(
+      noDerivedUseState,
+      `function AccessibleTree({ tree, activeId: controlledActiveId }) {
+        const [internalActiveId, setInternalActiveId] = useState(tree.id);
+        const isControlled = controlledActiveId !== undefined;
+        const activeId = isControlled
+          ? (controlledActiveId as string)
+          : (internalActiveId satisfies string);
+        const selectItem = useCallback((item) => {
+          if (!isControlled) setInternalActiveId(item.id);
+        }, [isControlled]);
+        return <Tree activeId={activeId} onSelect={selectItem} />;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent on a nullish controlled prop with a user-editable local fallback", () => {
+    const result = runRule(
+      noDerivedUseState,
+      `function Select({ sourceValue, value: controlledValue }) {
+        const [internalValue, setInternalValue] = useState(sourceValue);
+        const value = controlledValue ?? internalValue;
+        return <input value={value} onChange={(event) => setInternalValue(event.target.value)} />;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("flags a conditional prop copy that is only updated by a non-handler hook", () => {
+    const result = runRule(
+      noDerivedUseState,
+      `function Profile({ name, preferredName, usePreferredName }) {
+        const [displayName, setDisplayName] = useState(name);
+        const visibleName = usePreferredName ? preferredName : displayName;
+        useInterval(() => setDisplayName(name), 1000);
+        return <span>{visibleName}</span>;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not infer uncontrolled intent from an unrelated conditional alone", () => {
+    const result = runRule(
+      noDerivedUseState,
+      `function Profile({ name, nickname, showNickname }) {
+        const [displayName, setDisplayName] = useState(name);
+        const visibleName = showNickname ? nickname : displayName;
+        return (
+          <input
+            value={visibleName}
+            onChange={(event) => setDisplayName(event.target.value)}
+          />
+        );
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not treat a shadowed state name as the controlled fallback", () => {
+    const result = runRule(
+      noDerivedUseState,
+      `function Profile({ name, preferredName, usePreferredName }) {
+        const [displayName, setDisplayName] = useState(name);
+        const renderValue = (displayName) =>
+          usePreferredName ? preferredName : displayName;
+        const onChange = (event) => setDisplayName(event.target.value);
+        return <input value={renderValue('preview')} onChange={onChange} />;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("stays silent on snapshot-named state (previous / preserved / debounced)", () => {
     const result = runRule(
       noDerivedUseState,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-derived-use-state.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-derived-use-state.regressions.test.ts
@@ -280,6 +280,25 @@ describe("no-derived-useState — regressions", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("does not infer a controlled fallback from inside a nested handler", () => {
+    const result = runRule(
+      noDerivedUseState,
+      `function Profile({ name, value: controlledValue }) {
+        const [internalValue, setInternalValue] = useState(name);
+        const logValue = () => console.log(controlledValue ?? internalValue);
+        return (
+          <input
+            value={internalValue}
+            onClick={logValue}
+            onChange={(event) => setInternalValue(event.target.value)}
+          />
+        );
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("does not treat a shadowed state name as the controlled fallback", () => {
     const result = runRule(
       noDerivedUseState,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-derived-use-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-derived-use-state.ts
@@ -36,6 +36,7 @@ const isInitialOnlySeedName = (propName: string): boolean =>
 // "staleness" is the feature, not a bug.
 const SNAPSHOT_STATE_NAME_PATTERN =
   /^(initial|previous|prev|preserved|saved|original|cached|snapshot|prior|debounced|deferred)([A-Z_]|$)/;
+const INTERNAL_STATE_NAME_PATTERN = /^(internal|uncontrolled)([A-Z_]|$)/;
 
 const getStateSetterName = (useStateCall: EsTreeNodeOfType<"CallExpression">): string | null => {
   const declarator = useStateCall.parent;
@@ -357,6 +358,86 @@ const isInRenderScope = (node: EsTreeNode, componentFunction: EsTreeNode): boole
   return true;
 };
 
+const isReferenceToBinding = (
+  reference: EsTreeNode,
+  bindingIdentifier: EsTreeNode,
+  context: RuleContext,
+): boolean => {
+  if (!isNodeOfType(reference, "Identifier")) return false;
+  const bindingSymbol = context.scopes.symbolFor(bindingIdentifier);
+  if (!bindingSymbol) return false;
+  const referenceSymbol = context.scopes.referenceFor(reference)?.resolvedSymbol;
+  return referenceSymbol?.id === bindingSymbol.id;
+};
+
+const isControlledPropFallbackExpression = (
+  expression: EsTreeNode,
+  stateBinding: EsTreeNode,
+  isPropName: IsPropNameFn,
+  context: RuleContext,
+): boolean => {
+  if (isNodeOfType(expression, "ConditionalExpression")) {
+    const consequent = unwrapInitializerSeed(expression.consequent);
+    const alternate = unwrapInitializerSeed(expression.alternate);
+    return (
+      (isReferenceToBinding(consequent, stateBinding, context) &&
+        isPropDerivedArgument(alternate, isPropName)) ||
+      (isPropDerivedArgument(consequent, isPropName) &&
+        isReferenceToBinding(alternate, stateBinding, context))
+    );
+  }
+  return (
+    isNodeOfType(expression, "LogicalExpression") &&
+    expression.operator === "??" &&
+    isPropDerivedArgument(unwrapInitializerSeed(expression.left), isPropName) &&
+    isReferenceToBinding(unwrapInitializerSeed(expression.right), stateBinding, context)
+  );
+};
+
+const isUserEditableControlledFallback = (
+  useStateCall: EsTreeNodeOfType<"CallExpression">,
+  isPropName: IsPropNameFn,
+  context: RuleContext,
+): boolean => {
+  const declarator = useStateCall.parent;
+  if (!isNodeOfType(declarator, "VariableDeclarator")) return false;
+  if (!isNodeOfType(declarator.id, "ArrayPattern")) return false;
+  const stateBinding = declarator.id.elements?.[0];
+  const setterBinding = declarator.id.elements?.[1];
+  if (!isNodeOfType(stateBinding, "Identifier") || !isNodeOfType(setterBinding, "Identifier")) {
+    return false;
+  }
+  if (!INTERNAL_STATE_NAME_PATTERN.test(stateBinding.name)) return false;
+  const componentFunction = findEnclosingFunction(useStateCall);
+  if (!componentFunction) return false;
+
+  let hasControlledFallback = false;
+  let hasUserEdit = false;
+  walkAst(componentFunction, (child) => {
+    if (child !== componentFunction && isFunctionLike(child)) {
+      return;
+    }
+    if (
+      !hasControlledFallback &&
+      (isNodeOfType(child, "ConditionalExpression") || isNodeOfType(child, "LogicalExpression")) &&
+      isControlledPropFallbackExpression(child, stateBinding, isPropName, context)
+    ) {
+      hasControlledFallback = true;
+    }
+  });
+  walkAst(componentFunction, (child) => {
+    if (hasUserEdit) return false;
+    if (!isNodeOfType(child, "CallExpression")) return;
+    if (!isReferenceToBinding(child.callee, setterBinding, context)) return;
+    if (!isHandlerShapedReseed(child, componentFunction)) return;
+    const setterArgument = child.arguments?.[0];
+    if (!setterArgument || isPropDerivedArgument(setterArgument, isPropName)) return;
+    hasUserEdit = true;
+    return false;
+  });
+  return hasControlledFallback && hasUserEdit;
+};
+
 // Two exemptions, one walk (they look for the same prop-derived setter call
 // and differ only in where it sits):
 //   - Draft buffer: the re-seed lives in a NESTED handler (e.g.
@@ -456,6 +537,7 @@ export const noDerivedUseState = defineRule({
         const reportStalePropCopy = (propName: string): void => {
           if (isIntentionalSnapshotState(node)) return;
           if (hasSessionDismissProp(propStackTracker.getCurrentPropNames())) return;
+          if (isUserEditableControlledFallback(node, propStackTracker.isPropName, context)) return;
           if (isDraftReseedOrRenderAdjusted(node, propStackTracker.isPropName)) return;
           if (isEffectDrivenResync(node)) return;
           if (isNextjsDataFetchingPage(node)) return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-derived-use-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-derived-use-state.ts
@@ -431,7 +431,12 @@ const isUserEditableControlledFallback = (
     if (!isReferenceToBinding(child.callee, setterBinding, context)) return;
     if (!isHandlerShapedReseed(child, componentFunction)) return;
     const setterArgument = child.arguments?.[0];
-    if (!setterArgument || isPropDerivedArgument(setterArgument, isPropName)) return;
+    if (
+      !setterArgument ||
+      isPropDerivedArgument(unwrapInitializerSeed(setterArgument), isPropName)
+    ) {
+      return;
+    }
     hasUserEdit = true;
     return false;
   });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-derived-use-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-derived-use-state.ts
@@ -415,7 +415,7 @@ const isUserEditableControlledFallback = (
   let hasUserEdit = false;
   walkAst(componentFunction, (child) => {
     if (child !== componentFunction && isFunctionLike(child)) {
-      return;
+      return false;
     }
     if (
       !hasControlledFallback &&


### PR DESCRIPTION
## Why

`no-derived-useState` reports intentionally uncontrolled state when a component also accepts a controlled override. In the ReactBench Nteract trial, `internalActiveId` is initialized from the tree root, selected only when `controlledActiveId` is absent, and updated by the tree's selection handler. The refreshed rule contract explicitly exempts this one-time uncontrolled initialization.

Before:

```tsx
const [internalActiveId, setInternalActiveId] = useState(tree.id);
const activeId = isControlled ? controlledActiveId : internalActiveId;
```

React Doctor reports the `useState(tree.id)` call even though the local state is the component's editable uncontrolled fallback.

After this change, the rule suppresses that diagnostic only when all of these are proven:

- the state binding is explicitly named `internal*` or `uncontrolled*`
- a render-time conditional or `??` chooses between a prop and that exact state binding
- a handler updates the exact setter from a non-prop value

## What changed

- recognize scope-resolved controlled/local fallback selections, including transparent TypeScript wrappers
- preserve diagnostics for unrelated conditionals, effect-driven writes, shadowed bindings, and ordinary stale prop copies
- add focused and fuzz regression/true-positive coverage
- add a patch changeset for `oxlint-plugin-react-doctor`

## Eval results

Local RDE could not start because `AXIOM_DATASET` is absent. Daytona PR parity is also unavailable because `DAYTONA_API_KEY` is absent.

The exact reconstructed ReactBench trial replays from one diagnostic on `b1352a2be` to zero on this branch with zero parse errors:

- `/tmp/reactbench-no-derived-use-state-controlled-fallback-replay.json`
- SHA-256 `a52a99aab17139dd7433ab844068ea189e920b9a9c05306148d0b38a9f731051`

## Test plan

- `nr test -- src/plugin/rules/state-and-effects/no-derived-use-state.regressions.test.ts` from the plugin package — 25,000 tests passed, 201 skipped
- `FUZZ_RULE=no-derived-useState FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz` — passed
- `nr test` from the fuzz package — 192 passed, 782 skipped
- `nr typecheck` — 16/16 tasks passed
- `nr lint` — passed with existing warnings
- `nr format` and `nr format:check` — passed
- `nr build` — 9/9 tasks passed
- `nr smoke:json-report` — passed
- isolated language-server rerun after a concurrent full-suite timeout — 65/65 passed

The first concurrent full-repository test attempt timed out in three unrelated suites after resource starvation. The changed plugin subsequently passed all 25,000 tests, and the timed-out language-server package passed 65/65 in isolation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-rule heuristic change with broad regression and fuzz coverage; no runtime or security impact.
> 
> **Overview**
> **`no-derived-useState`** no longer flags `useState` seeds when the component implements an intentional **controlled prop + local uncontrolled fallback** (e.g. `internalActiveId` with `activeId = isControlled ? controlledActiveId : internalActiveId`).
> 
> The rule skips the diagnostic only when it can prove all of: state is named `internal*` or `uncontrolled*`, a render-time `?:` or `??` picks between a prop and that state binding (scope-resolved, including TS wrappers), and a handler-shaped setter call updates state from a **non-prop** value. Unrelated conditionals, prop-only re-seeds, nested-handler fallbacks, and shadowed names still report.
> 
> Adds regression/fuzz corpus cases and a patch changeset for `oxlint-plugin-react-doctor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bbbfd7204e10b8475f7a8a564fc116d36df4a64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->