### PR TITLE
RDFPFN792026: recognize conditional focus forwarding wrappers

### DIFF
--- a/.changeset/friendly-focus-wrappers.md
+++ b/.changeset/friendly-focus-wrappers.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Avoid reporting conditional wrappers whose click handler only forwards focus to a queried control.

--- a/packages/fuzz/corpus/regressions/click-events-have-key-events--conditional-focus-forwarding.tsx
+++ b/packages/fuzz/corpus/regressions/click-events-have-key-events--conditional-focus-forwarding.tsx
@@ -1,0 +1,23 @@
+// rule: click-events-have-key-events
+// weakness: focus-forwarding-wrapper
+// source: ReactBench write-react-automattic-vip-desig__eF5Ecq5
+// verdict: pass
+
+interface FieldProps {
+  forLabel: string;
+  variant: string;
+}
+
+export const Field = ({ forLabel, variant }: FieldProps) => {
+  const handleContainerClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (event.target.closest(".chip")) return;
+    const input = globalThis.document.querySelector(`#${forLabel}`);
+    input?.focus();
+  };
+
+  return (
+    <div onClick={variant === "chips" ? handleContainerClick : undefined}>
+      <Autocomplete id={forLabel} />
+    </div>
+  );
+};

--- a/packages/fuzz/corpus/true-positives/click-events-have-key-events--guarded-hidden-input-click.tsx
+++ b/packages/fuzz/corpus/true-positives/click-events-have-key-events--guarded-hidden-input-click.tsx
@@ -1,0 +1,18 @@
+// rule: click-events-have-key-events
+// weakness: focus-forwarding-wrapper
+// source: adversarial audit of ReactBench write-react-automattic-vip-desig__eF5Ecq5
+// verdict: fail
+
+interface UploadProps {
+  enabled: boolean;
+  inputRef: React.RefObject<HTMLInputElement | null>;
+}
+
+export const Upload = ({ enabled, inputRef }: UploadProps) => {
+  const handleContainerClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (event.target.closest(".chip")) return;
+    inputRef.current?.click();
+  };
+
+  return <div onClick={enabled ? handleContainerClick : undefined}>Upload</div>;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/click-events-have-key-events.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/click-events-have-key-events.regressions.test.ts
@@ -24,6 +24,155 @@ describe("a11y/click-events-have-key-events regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("does not flag a conditional wrapper handler that only forwards focus", () => {
+    const result = runRule(
+      clickEventsHaveKeyEvents,
+      `export const Field = ({ variant, forLabel }) => {
+        const handleContainerClick = (event) => {
+          if (event.target.closest(".chip")) return;
+          const input = globalThis.document.querySelector(\`#\${forLabel}\`);
+          input?.focus();
+        };
+        return (
+          <div onClick={variant === "chips" ? handleContainerClick : undefined}>
+            <Autocomplete id={forLabel} />
+          </div>
+        );
+      };`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not flag a typed focus-forwarding handler in the nullish-first branch form", () => {
+    const result = runRule(
+      clickEventsHaveKeyEvents,
+      `export const Field = ({ enabled, forLabel }) => {
+        const handleContainerClick = (event) => {
+          if (event.target.closest(".chip")) return;
+          const input = document.getElementById(forLabel);
+          input?.focus();
+        };
+        return (
+          <div
+            onClick={
+              enabled
+                ? undefined
+                : (handleContainerClick as React.MouseEventHandler<HTMLDivElement>)
+            }
+          />
+        );
+      };`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still flags a guarded focus handler that performs another action", () => {
+    const result = runRule(
+      clickEventsHaveKeyEvents,
+      `export const Field = ({ forLabel, submit }) => {
+        const handleContainerClick = (event) => {
+          if (event.target.closest(".chip")) return;
+          const input = document.querySelector(\`#\${forLabel}\`);
+          input?.focus();
+          submit();
+        };
+        return <div onClick={handleContainerClick} />;
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags an early guard whose return expression performs an action", () => {
+    const result = runRule(
+      clickEventsHaveKeyEvents,
+      `export const Field = ({ forLabel, submit }) => {
+        const handleContainerClick = (event) => {
+          if (event.target.closest(".chip")) return submit();
+          const input = document.querySelector(\`#\${forLabel}\`);
+          input?.focus();
+        };
+        return <div onClick={handleContainerClick} />;
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags an early guard whose closest receiver performs an action", () => {
+    const result = runRule(
+      clickEventsHaveKeyEvents,
+      `export const Field = ({ forLabel, getTarget }) => {
+        const handleContainerClick = () => {
+          if (getTarget().closest(".chip")) return;
+          const input = document.querySelector(\`#\${forLabel}\`);
+          input?.focus();
+        };
+        return <div onClick={handleContainerClick} />;
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a focus handler whose selector construction can run code", () => {
+    const result = runRule(
+      clickEventsHaveKeyEvents,
+      `export const Field = ({ buildSelector }) => {
+        const handleContainerClick = () => {
+          const input = document.querySelector(buildSelector());
+          input?.focus();
+        };
+        return <div onClick={handleContainerClick} />;
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a focus handler that queries through a shadowed document", () => {
+    const result = runRule(
+      clickEventsHaveKeyEvents,
+      `export const Field = ({ document, forLabel }) => {
+        const handleContainerClick = () => {
+          const input = document.querySelector(\`#\${forLabel}\`);
+          input?.focus();
+        };
+        return <div onClick={handleContainerClick} />;
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a conditional handler when the other branch is actionable", () => {
+    const result = runRule(
+      clickEventsHaveKeyEvents,
+      `export const Field = ({ shouldFocus, inputRef, open }) => (
+        <div onClick={shouldFocus ? () => inputRef.current?.focus() : open} />
+      );`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not treat a shadowed undefined handler as a nullish branch", () => {
+    const result = runRule(
+      clickEventsHaveKeyEvents,
+      `export const Field = ({ shouldFocus, inputRef, undefined }) => (
+        <div onClick={shouldFocus ? () => inputRef.current?.focus() : undefined} />
+      );`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a conditional handler that clicks a hidden input", () => {
+    const result = runRule(
+      clickEventsHaveKeyEvents,
+      `export const Upload = ({ enabled, inputRef }) => (
+        <div onClick={enabled ? () => inputRef.current?.click() : undefined} />
+      );`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("does not flag a named same-file propagation-guard handler", () => {
     const result = runRule(
       clickEventsHaveKeyEvents,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/click-events-have-key-events.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/click-events-have-key-events.regressions.test.ts
@@ -571,4 +571,25 @@ describe("a11y/click-events-have-key-events regressions", () => {
     );
     expect(result.diagnostics).toEqual([]);
   });
+
+  it.each(["input!.focus();", "(input as HTMLElement).focus();", "(input)?.focus();"])(
+    "does not flag conditional focus forwarding through %s",
+    (focusStatement) => {
+      const result = runRule(
+        clickEventsHaveKeyEvents,
+        `const Cell = ({ event }) => (
+        <div
+          onClick={event.target.closest("button") ? null : () => {
+            if (event.target.closest("button")) return;
+            const input = document.querySelector("input");
+            ${focusStatement}
+          }}
+        >
+          Label
+        </div>
+      );`,
+      );
+      expect(result.diagnostics).toEqual([]);
+    },
+  );
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/click-events-have-key-events.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/click-events-have-key-events.ts
@@ -314,10 +314,11 @@ const isFocusCallOnVariable = (statement: EsTreeNode, variableName: string): boo
   const expression = stripParenExpression(statement.expression as EsTreeNode);
   if (!isNodeOfType(expression, "CallExpression")) return false;
   const callee = stripParenExpression(expression.callee);
+  if (!isNodeOfType(callee, "MemberExpression")) return false;
+  const receiver = stripParenExpression(callee.object as EsTreeNode);
   return (
-    isNodeOfType(callee, "MemberExpression") &&
-    isNodeOfType(callee.object, "Identifier") &&
-    callee.object.name === variableName &&
+    isNodeOfType(receiver, "Identifier") &&
+    receiver.name === variableName &&
     isNodeOfType(callee.property, "Identifier") &&
     callee.property.name === "focus" &&
     expression.arguments.length === 0

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/click-events-have-key-events.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/click-events-have-key-events.ts
@@ -9,6 +9,7 @@ import { hasKeyboardActivatableDescendant } from "../../utils/has-keyboard-activ
 import { hasJsxPropIgnoreCase } from "../../utils/has-jsx-prop-ignore-case.js";
 import { isHiddenFromScreenReader } from "../../utils/is-hidden-from-screen-reader.js";
 import { isInteractiveElement } from "../../utils/is-interactive-element.js";
+import { isNullishExpression } from "../../utils/is-nullish-expression.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isPresentationRole } from "../../utils/is-presentation-role.js";
 import { isPureEventBlockerHandler } from "../../utils/is-pure-event-blocker-handler.js";
@@ -156,6 +157,8 @@ const FOCUS_FORWARDING_METHOD_NAMES: ReadonlySet<string> = new Set([
   "preventDefault",
   "stopImmediatePropagation",
 ]);
+const DOM_QUERY_METHOD_NAMES: ReadonlySet<string> = new Set(["getElementById", "querySelector"]);
+const GLOBAL_OBJECT_NAMES: ReadonlySet<string> = new Set(["global", "globalThis", "window"]);
 
 const isFocusForwardingCall = (node: EsTreeNode | null | undefined): boolean => {
   if (!node) return false;
@@ -165,6 +168,24 @@ const isFocusForwardingCall = (node: EsTreeNode | null | undefined): boolean => 
   if (!isNodeOfType(callee, "MemberExpression")) return false;
   if (!isNodeOfType(callee.property, "Identifier")) return false;
   return FOCUS_FORWARDING_METHOD_NAMES.has(callee.property.name);
+};
+
+const isGlobalDocumentExpression = (expression: EsTreeNode, scopes: ScopeAnalysis): boolean => {
+  const candidate = stripParenExpression(expression);
+  if (isNodeOfType(candidate, "Identifier")) {
+    return candidate.name === "document" && scopes.isGlobalReference(candidate);
+  }
+  if (
+    !isNodeOfType(candidate, "MemberExpression") ||
+    !isNodeOfType(candidate.object, "Identifier") ||
+    !isNodeOfType(candidate.property, "Identifier") ||
+    candidate.property.name !== "document"
+  ) {
+    return false;
+  }
+  return (
+    GLOBAL_OBJECT_NAMES.has(candidate.object.name) && scopes.isGlobalReference(candidate.object)
+  );
 };
 
 const isFocusForwardingFunctionBody = (body: EsTreeNode | null | undefined): boolean => {
@@ -182,17 +203,29 @@ const isFocusForwardingFunctionBody = (body: EsTreeNode | null | undefined): boo
   return false;
 };
 
-const resolveHandlerFunction = (attribute: EsTreeNodeOfType<"JSXAttribute">): EsTreeNode | null => {
+const resolveHandlerFunction = (
+  attribute: EsTreeNodeOfType<"JSXAttribute">,
+):
+  | EsTreeNodeOfType<"ArrowFunctionExpression">
+  | EsTreeNodeOfType<"FunctionExpression">
+  | EsTreeNodeOfType<"FunctionDeclaration">
+  | null => {
   if (!attribute.value || !isNodeOfType(attribute.value, "JSXExpressionContainer")) return null;
   return resolveHandlerFunctionExpression(attribute.value.expression as EsTreeNode);
 };
 
-const resolveHandlerFunctionExpression = (handlerExpression: EsTreeNode): EsTreeNode | null => {
-  let expression = handlerExpression;
+const resolveHandlerFunctionExpression = (
+  handlerExpression: EsTreeNode,
+):
+  | EsTreeNodeOfType<"ArrowFunctionExpression">
+  | EsTreeNodeOfType<"FunctionExpression">
+  | EsTreeNodeOfType<"FunctionDeclaration">
+  | null => {
+  let expression = stripParenExpression(handlerExpression);
   if (isNodeOfType(expression, "Identifier")) {
     const binding = findVariableInitializer(expression, expression.name);
     if (!binding?.initializer) return null;
-    expression = binding.initializer;
+    expression = stripParenExpression(binding.initializer);
   }
   if (
     isNodeOfType(expression, "ArrowFunctionExpression") ||
@@ -204,14 +237,136 @@ const resolveHandlerFunctionExpression = (handlerExpression: EsTreeNode): EsTree
   return null;
 };
 
+const isEmptyReturn = (statement: EsTreeNode): boolean =>
+  isNodeOfType(statement, "ReturnStatement") && statement.argument === null;
+
+const isClosestEarlyReturn = (statement: EsTreeNode): boolean => {
+  if (!isNodeOfType(statement, "IfStatement") || statement.alternate) return false;
+  const consequent = statement.consequent;
+  const hasEmptyReturn = isNodeOfType(consequent, "BlockStatement")
+    ? consequent.body.length === 1 && isEmptyReturn(consequent.body[0] as EsTreeNode)
+    : isEmptyReturn(consequent);
+  if (!hasEmptyReturn) return false;
+  const test = stripParenExpression(statement.test);
+  const call = isNodeOfType(test, "ChainExpression") ? test.expression : test;
+  if (!isNodeOfType(call, "CallExpression") || call.arguments.length !== 1) return false;
+  const callee = stripParenExpression(call.callee);
+  const receiver = isNodeOfType(callee, "MemberExpression")
+    ? stripParenExpression(callee.object as EsTreeNode)
+    : null;
+  return (
+    isNodeOfType(callee, "MemberExpression") &&
+    isNodeOfType(callee.property, "Identifier") &&
+    callee.property.name === "closest" &&
+    isNodeOfType(receiver, "MemberExpression") &&
+    isNodeOfType(receiver.object, "Identifier") &&
+    isNodeOfType(receiver.property, "Identifier") &&
+    receiver.property.name === "target" &&
+    isNodeOfType(call.arguments[0], "Literal") &&
+    typeof call.arguments[0].value === "string"
+  );
+};
+
+const isStaticSelectorExpression = (expression: EsTreeNode): boolean => {
+  const candidate = stripParenExpression(expression);
+  if (isNodeOfType(candidate, "Identifier") || isNodeOfType(candidate, "Literal")) return true;
+  return (
+    isNodeOfType(candidate, "TemplateLiteral") &&
+    candidate.expressions.every((innerExpression) =>
+      isStaticSelectorExpression(innerExpression as EsTreeNode),
+    )
+  );
+};
+
+const getDomQueryVariableName = (statement: EsTreeNode, scopes: ScopeAnalysis): string | null => {
+  if (
+    !isNodeOfType(statement, "VariableDeclaration") ||
+    statement.kind !== "const" ||
+    statement.declarations.length !== 1
+  ) {
+    return null;
+  }
+  const declaration = statement.declarations[0];
+  if (!declaration || !isNodeOfType(declaration.id, "Identifier") || !declaration.init) return null;
+  const initializer = stripParenExpression(declaration.init);
+  if (
+    !isNodeOfType(initializer, "CallExpression") ||
+    initializer.arguments.length !== 1 ||
+    isNodeOfType(initializer.arguments[0], "SpreadElement") ||
+    !isStaticSelectorExpression(initializer.arguments[0] as EsTreeNode)
+  ) {
+    return null;
+  }
+  const callee = stripParenExpression(initializer.callee);
+  if (
+    !isNodeOfType(callee, "MemberExpression") ||
+    !isNodeOfType(callee.property, "Identifier") ||
+    !DOM_QUERY_METHOD_NAMES.has(callee.property.name) ||
+    !isGlobalDocumentExpression(callee.object as EsTreeNode, scopes)
+  ) {
+    return null;
+  }
+  return declaration.id.name;
+};
+
+const isFocusCallOnVariable = (statement: EsTreeNode, variableName: string): boolean => {
+  if (!isNodeOfType(statement, "ExpressionStatement")) return false;
+  const expression = stripParenExpression(statement.expression as EsTreeNode);
+  if (!isNodeOfType(expression, "CallExpression")) return false;
+  const callee = stripParenExpression(expression.callee);
+  return (
+    isNodeOfType(callee, "MemberExpression") &&
+    isNodeOfType(callee.object, "Identifier") &&
+    callee.object.name === variableName &&
+    isNodeOfType(callee.property, "Identifier") &&
+    callee.property.name === "focus" &&
+    expression.arguments.length === 0
+  );
+};
+
+const isConditionalFocusForwardingHandler = (
+  attribute: EsTreeNodeOfType<"JSXAttribute">,
+  scopes: ScopeAnalysis,
+): boolean => {
+  if (!attribute.value || !isNodeOfType(attribute.value, "JSXExpressionContainer")) return false;
+  const expression = stripParenExpression(attribute.value.expression as EsTreeNode);
+  if (!isNodeOfType(expression, "ConditionalExpression")) return false;
+  const consequent = stripParenExpression(expression.consequent as EsTreeNode);
+  const alternate = stripParenExpression(expression.alternate as EsTreeNode);
+  const nullishBranch = isNullishExpression(consequent) ? consequent : alternate;
+  if (
+    !isNullishExpression(nullishBranch) ||
+    (isNodeOfType(nullishBranch, "Identifier") && !scopes.isGlobalReference(nullishBranch))
+  ) {
+    return false;
+  }
+  const handlerExpression = nullishBranch === consequent ? alternate : consequent;
+  const handlerFunction = resolveHandlerFunctionExpression(handlerExpression);
+  if (!handlerFunction || !isNodeOfType(handlerFunction.body, "BlockStatement")) return false;
+  const [guard, query, focus, ...rest] = handlerFunction.body.body;
+  if (!guard || !query || !focus || rest.length > 0 || !isClosestEarlyReturn(guard as EsTreeNode)) {
+    return false;
+  }
+  const queryVariableName = getDomQueryVariableName(query as EsTreeNode, scopes);
+  return Boolean(
+    queryVariableName && isFocusCallOnVariable(focus as EsTreeNode, queryVariableName),
+  );
+};
+
 // `onClick={() => inputRef.current?.focus()}` (and same-file named
 // handlers with that shape) only forward focus to a real control
 // keyboard users already reach via Tab — the wrapper isn't a
 // keyboard-inaccessible action.
-const isFocusForwardingHandler = (attribute: EsTreeNodeOfType<"JSXAttribute">): boolean => {
+const isFocusForwardingHandler = (
+  attribute: EsTreeNodeOfType<"JSXAttribute">,
+  scopes: ScopeAnalysis,
+): boolean => {
+  if (isConditionalFocusForwardingHandler(attribute, scopes)) return true;
   const handlerFunction = resolveHandlerFunction(attribute);
-  if (!handlerFunction) return false;
-  return isFocusForwardingFunctionBody((handlerFunction as { body?: EsTreeNode }).body ?? null);
+  return Boolean(
+    handlerFunction &&
+    isFocusForwardingFunctionBody((handlerFunction as { body?: EsTreeNode }).body ?? null),
+  );
 };
 
 // Items of ARIA composite widgets receive keyboard interaction from the
@@ -342,7 +497,7 @@ export const clickEventsHaveKeyEvents = defineRule({
           return;
         }
         if (onClick && isPureEventBlockerHandler(onClick)) return;
-        if (onClick && isFocusForwardingHandler(onClick)) return;
+        if (onClick && isFocusForwardingHandler(onClick, context.scopes)) return;
         const spreadHandlerFunction = spreadOnClickExpression
           ? resolveHandlerFunctionExpression(spreadOnClickExpression)
           : null;


### PR DESCRIPTION
## Summary

- suppress `click-events-have-key-events` only for a conditional wrapper whose enabled handler has an empty `.closest()` guard, one global DOM query, and `.focus()` on that queried binding
- preserve diagnostics for extra actions, hidden-input `.click()`, shadowed globals, side-effectful guards/selectors, and two actionable conditional branches
- add verdict-checked fuzz seeds and a patch changeset

## ReactBench evidence

- Harbor job: `d8321254-7c6a-44d0-8feb-a55a682eeb80`
- trial: `write-react-automattic-vip-desig__eF5Ecq5`
- exact reconstructed full-file replay: current main 1 diagnostic, this head 0, zero parse errors
- artifact: `/tmp/reactbench-click-events-automattic-exact-replay-e5dc3946c.json`
- SHA-256: `86dc5c1af5633c220d73e05360fbf665b5d22db55eeeb50d92046fd06494d2ea`

## Validation

- plugin suite: 957 files, 24,804 passed, 201 skipped
- fuzz corpus: 192 passed, 782 skipped; declared pass/fail verdicts preserved
- strict fuzz: 500 iterations, seed 792026
- root typecheck: 16/16 tasks
- lint, format check, build, JSON smoke: pass
- root test attempt was resource-starved after 953 plugin files passed: unrelated Vitest workers failed to start/terminate and unrelated CLI/core tests timed out; the complete 957-file plugin suite subsequently passed cleanly

RDE and Daytona parity are blocked because `AXIOM_TOKEN` and `DAYTONA_API_KEY` are not available in this environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> A11y lint heuristic refinement with broad regression and fuzz coverage; no runtime or security surface beyond fewer warnings on a narrow AST pattern.
> 
> **Overview**
> Narrows **`click-events-have-key-events`** false positives when `onClick` is a ternary whose active branch only moves focus to an already-focusable control (e.g. chip-field wrappers).
> 
> The rule now treats **`onClick={cond ? handler : undefined}`** (and the reversed nullish branch) as safe when the handler body matches a fixed shape: an empty **`event.target.closest(...)`** early return, one **`document` / `globalThis.document`** `querySelector` / `getElementById` with a static selector, then **`.focus()`** on that binding. Handler resolution also strips parentheses and requires global **`undefined`** (not a shadowed prop).
> 
> Diagnostics are **unchanged** for extra side effects after focus, actionable guard returns, non-`event.target` `.closest()`, dynamic selectors, shadowed `document`, mixed actionable ternary branches, and conditional wrappers that call **`.click()`** on a hidden input.
> 
> Adds regression tests, fuzz corpus pass/fail seeds, and a patch changeset for **`oxlint-plugin-react-doctor`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c975b16243bd124d9fdc4afc45979e06b903d955. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->