### PR TITLE
RDFPFN792026: skip root test-prefixed security fixtures

### DIFF
--- a/.changeset/calm-test-sinks.md
+++ b/.changeset/calm-test-sinks.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Skip root test-prefixed JavaScript and TypeScript files in production security scans.

--- a/packages/fuzz/corpus/test-dangerous-html-sink--root-test-prefix.tsx
+++ b/packages/fuzz/corpus/test-dangerous-html-sink--root-test-prefix.tsx
@@ -1,0 +1,7 @@
+// rule: dangerous-html-sink
+// weakness: test-path-classification
+// source: ReactBench test-katex-error.tsx exact replay
+
+export const Fixture = ({ html }: { html: string }) => (
+  <span dangerouslySetInnerHTML={{ __html: html }} />
+);

--- a/packages/fuzz/corpus/true-positives/dangerous-html-sink--nested-test-prefix.tsx
+++ b/packages/fuzz/corpus/true-positives/dangerous-html-sink--nested-test-prefix.tsx
@@ -1,0 +1,7 @@
+// rule: dangerous-html-sink
+// weakness: test-path-classification
+// source: adversarial audit of ReactBench test-katex-error.tsx
+
+export const Preview = ({ html }: { html: string }) => (
+  <span dangerouslySetInnerHTML={{ __html: html }} />
+);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/security-scan.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/security-scan.ts
@@ -19,7 +19,7 @@ export const SERVER_CONTEXT_PATTERN =
   /(?:^|\/)(?:api|backend|server|servers|middleware|route|routes|functions|lambdas|workers)(?:\/|$)|(?:^|\/)[^/]+\.server\.[cm]?[jt]sx?$/i;
 
 export const TEST_CONTEXT_PATTERN =
-  /(?:^|\/)(?:__fixtures__|__mocks__|__tests__|__integration__|fixtures|mocks|test|tests|testdata|test-data|e2e|playwright|cypress|specs?)(?:\/|$)|\.(?:test|spec|e2e|e2e-spec|integration-test|fixture|fixtures|stories|story)\.[cm]?[jt]sx?$|(?:^|\/)(?:playwright|cypress|vitest|jest|karma)[^/]*\.conf(?:ig)?\.[cm]?[jt]s$|(?:^|\/)(?:test_[^/]+|[^/]+_test|conftest)\.py$|\.env\.[^/]*(?:test|e2e)[^/]*$/i;
+  /(?:^|\/)(?:__fixtures__|__mocks__|__tests__|__integration__|fixtures|mocks|test|tests|testdata|test-data|e2e|playwright|cypress|specs?)(?:\/|$)|^(?:test|spec)-[^/]+\.[cm]?[jt]sx?$|\.(?:test|spec|e2e|e2e-spec|integration-test|fixture|fixtures|stories|story)\.[cm]?[jt]sx?$|(?:^|\/)(?:playwright|cypress|vitest|jest|karma)[^/]*\.conf(?:ig)?\.[cm]?[jt]s$|(?:^|\/)(?:test_[^/]+|[^/]+_test|conftest)\.py$|\.env\.[^/]*(?:test|e2e)[^/]*$/i;
 
 // Bundler / framework build configs (`vite.config.ts`, `next.config.mjs`,
 // `webpack.config.js`, …) execute in Node at build time and are never

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/dangerous-html-sink.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/dangerous-html-sink.regressions.test.ts
@@ -3,6 +3,34 @@ import { runScanRule } from "../../../test-utils/run-scan-rule.js";
 import { dangerousHtmlSink } from "./dangerous-html-sink.js";
 
 describe("security-scan/dangerous-html-sink — regressions", () => {
+  it("stays silent on a root test-prefixed KaTeX error fixture", () => {
+    const findings = runScanRule(dangerousHtmlSink, {
+      relativePath: "test-katex-error.tsx",
+      content: `import katex from "katex";
+        const renderMath = (math: string) => {
+          try {
+            return katex.renderToString(math, { throwOnError: false });
+          } catch (error) {
+            return String(error);
+          }
+        };
+        export const Fixture = ({ children }: Props) => (
+          <span dangerouslySetInnerHTML={{ __html: renderMath(String(children)) }} />
+        );`,
+    });
+    expect(findings).toHaveLength(0);
+  });
+
+  it("still scans a test-prefixed production source below src", () => {
+    const findings = runScanRule(dangerousHtmlSink, {
+      relativePath: "src/test-user-content.tsx",
+      content: `export const Preview = ({ html }: Props) => (
+        <span dangerouslySetInnerHTML={{ __html: html }} />
+      );`,
+    });
+    expect(findings).toHaveLength(1);
+  });
+
   it("stays silent on an empty-string innerHTML clear", () => {
     const findings = runScanRule(dangerousHtmlSink, {
       relativePath: "src/components/tooltip.ts",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/utils/is-production-source-path.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/utils/is-production-source-path.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vite-plus/test";
+import { isProductionSourcePath } from "./is-production-source-path.js";
+
+describe("isProductionSourcePath", () => {
+  it("excludes root test-prefixed source files", () => {
+    expect(isProductionSourcePath("test-katex-error.tsx")).toBe(false);
+    expect(isProductionSourcePath("spec-parser.ts")).toBe(false);
+  });
+
+  it("keeps nested test-prefixed production source files", () => {
+    expect(isProductionSourcePath("src/test-user-content.tsx")).toBe(true);
+    expect(isProductionSourcePath("components/spec-preview.jsx")).toBe(true);
+  });
+
+  it("keeps production files whose names merely contain test", () => {
+    expect(isProductionSourcePath("src/components/testimonials.tsx")).toBe(true);
+    expect(isProductionSourcePath("src/latest-release.ts")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- classify root `test-*` and `spec-*` JavaScript/TypeScript files as test context for production security scans
- preserve scanning for nested production files such as `src/test-user-content.tsx`
- add exact ReactBench regression coverage, adversarial controls, fuzz corpus entries, and a patch changeset

## ReactBench evidence
- source: Harbor job `d8321254-7c6a-44d0-8feb-a55a682eeb80`, `test-katex-error.tsx`
- updated live rule contract excludes test source from `dangerous-html-sink`
- baseline `b1352a2`: 1 `dangerous-html-sink` diagnostic at line 23
- branch `b8704b120`: 0 diagnostics
- nested production control `src/test-user-content.tsx`: 1 diagnostic retained
- baseline JSON SHA-256: `b2a5ae32137ca346dafc0b8edf5f184b29228a76e293dd62849817e063c6deb4`
- branch JSON SHA-256: `5e981639c10df493e90aee68caf8ef421c747e1f6af384b9cebbcce3aa7385c6`

## Validation
- plugin suite: 958 files, 24,799 passed, 201 skipped
- fuzz verdict suite: 192 passed, 782 skipped
- strict targeted fuzz: 500 iterations
- typecheck: 16/16 tasks
- lint, format check, build (9/9), JSON smoke: green

This PR is intentionally not authorized for merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broadens test-path classification for all rules using `TEST_CONTEXT_PATTERN`, which could miss issues in misnamed root-level production files while fixing benchmark false positives.
> 
> **Overview**
> **Production security scans** now treat **root-level** `test-*` and `spec-*` JavaScript/TypeScript files as test context (via an added alternation on shared `TEST_CONTEXT_PATTERN`), so rules such as `dangerous-html-sink` no longer flag fixtures like `test-katex-error.tsx`.
> 
> **Nested** sources with the same naming pattern (e.g. `src/test-user-content.tsx`) and names that only *contain* `test` (e.g. `testimonials.tsx`) **stay in production scope**.
> 
> Adds ReactBench-style regression tests, `isProductionSourcePath` unit coverage, fuzz corpus entries for root vs nested cases, and a patch changeset for `oxlint-plugin-react-doctor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8704b12034b771f5746b634e3af1a566095920a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->