### PR TITLE
RDFPFN792026: recognize mounted callback-ref state

### DIFF
--- a/.changeset/calm-mounted-container.md
+++ b/.changeset/calm-mounted-container.md
@@ -2,4 +2,4 @@
 "oxlint-plugin-react-doctor": patch
 ---
 
-Recognize DOM nodes stored by callback refs as post-mount state sources.
+Recognize callback-ref values and measured DOM state paired with mount flags as post-mount state sources.

--- a/.changeset/calm-mounted-container.md
+++ b/.changeset/calm-mounted-container.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Recognize DOM nodes stored by callback refs as post-mount state sources.

--- a/packages/fuzz/corpus/regressions/no-did-mount-set-state--callback-ref-container.tsx
+++ b/packages/fuzz/corpus/regressions/no-did-mount-set-state--callback-ref-container.tsx
@@ -1,0 +1,24 @@
+// rule: no-did-mount-set-state
+// weakness: post-mount-callback-ref
+// source: ReactBench fix-react-rdh-hacker0x01-react-d__3UEZkbb
+// verdict: pass
+
+import { Component } from "react";
+
+class Calendar extends Component {
+  monthContainer = undefined;
+
+  setMonthContainerRef = (element) => {
+    this.monthContainer = element ?? undefined;
+  };
+
+  componentDidMount() {
+    if (this.props.showTimeSelect) {
+      this.setState({ monthContainer: this.monthContainer });
+    }
+  }
+
+  render() {
+    return <div ref={this.setMonthContainerRef} />;
+  }
+}

--- a/packages/fuzz/corpus/regressions/no-did-mount-set-state--forwarded-ref-wrapper.tsx
+++ b/packages/fuzz/corpus/regressions/no-did-mount-set-state--forwarded-ref-wrapper.tsx
@@ -1,0 +1,22 @@
+// rule: no-did-mount-set-state
+// weakness: wrapper-transparency
+// source: PR #1506 Bugbot review
+// verdict: pass
+
+import { Component } from "react";
+
+class Calendar extends Component {
+  monthContainer = undefined;
+
+  setMonthContainerRef = (element) => {
+    this.monthContainer = element ?? undefined;
+  };
+
+  componentDidMount() {
+    this.setState({ monthContainer: this.monthContainer });
+  }
+
+  render() {
+    return <div ref={(element) => this.setMonthContainerRef(element)} />;
+  }
+}

--- a/packages/fuzz/corpus/regressions/no-did-mount-set-state--iife-callback-ref-measurement.tsx
+++ b/packages/fuzz/corpus/regressions/no-did-mount-set-state--iife-callback-ref-measurement.tsx
@@ -1,0 +1,25 @@
+// rule: no-did-mount-set-state
+// weakness: immediate-execution
+// source: PR #1506 Bugbot review
+// verdict: pass
+
+import { Component } from "react";
+
+class Calendar extends Component {
+  monthContainer = undefined;
+
+  setMonthContainerRef = (element) => {
+    this.monthContainer = element ?? undefined;
+  };
+
+  componentDidMount() {
+    (() => {
+      const height = this.monthContainer.clientHeight;
+      this.setState({ height });
+    })();
+  }
+
+  render() {
+    return <div ref={this.setMonthContainerRef} />;
+  }
+}

--- a/packages/fuzz/corpus/regressions/no-did-mount-set-state--measured-width-mount-flag.tsx
+++ b/packages/fuzz/corpus/regressions/no-did-mount-set-state--measured-width-mount-flag.tsx
@@ -1,0 +1,19 @@
+// rule: no-did-mount-set-state
+// weakness: post-mount-source
+// source: ReactBench relax/relax@75943ce5e9c4ce8f503398487b35f89cf4974d7e
+// verdict: pass
+
+import { Component } from "react";
+import { findDOMNode } from "react-dom";
+
+class Image extends Component {
+  componentDidMount() {
+    const dom = findDOMNode(this);
+    const rect = dom.getBoundingClientRect();
+    const width = Math.round(rect.right - rect.left);
+    this.setState({
+      mounted: true,
+      width,
+    });
+  }
+}

--- a/packages/fuzz/corpus/regressions/no-did-mount-set-state--nested-class-callback-ref.tsx
+++ b/packages/fuzz/corpus/regressions/no-did-mount-set-state--nested-class-callback-ref.tsx
@@ -1,0 +1,29 @@
+// rule: no-did-mount-set-state
+// weakness: control-flow
+// source: Cursor Bugbot PR #1506
+// verdict: pass
+
+import { Component } from "react";
+
+class Calendar extends Component {
+  monthContainer = undefined;
+
+  setMonthContainerRef = (element) => {
+    this.monthContainer = element ?? undefined;
+  };
+
+  componentDidMount() {
+    this.setState({ monthContainer: this.monthContainer });
+  }
+
+  render() {
+    class NestedCalendar {
+      readHandler() {
+        const instance = this;
+        return instance.setMonthContainerRef;
+      }
+    }
+
+    return <div ref={this.setMonthContainerRef} />;
+  }
+}

--- a/packages/fuzz/corpus/regressions/no-did-mount-set-state--ref-height-mount-flag.tsx
+++ b/packages/fuzz/corpus/regressions/no-did-mount-set-state--ref-height-mount-flag.tsx
@@ -1,0 +1,22 @@
+// rule: no-did-mount-set-state
+// weakness: post-mount-source
+// source: ReactBench sneljo1/auryo@5180622e43d236feaebd00013f3d78e93f02cac1
+// verdict: pass
+
+import React from "react";
+
+class ToggleMore extends React.PureComponent {
+  overflow = React.createRef();
+
+  componentDidMount() {
+    if (this.overflow.current) {
+      const height = this.overflow.current.clientHeight;
+      if (height > this.state.checkHeight && !this.state.overflow) {
+        this.setState({
+          overflow: true,
+          max: height,
+        });
+      }
+    }
+  }
+}

--- a/packages/fuzz/corpus/regressions/no-did-mount-set-state--synchronous-callback-ref-map.tsx
+++ b/packages/fuzz/corpus/regressions/no-did-mount-set-state--synchronous-callback-ref-map.tsx
@@ -1,0 +1,23 @@
+// rule: no-did-mount-set-state
+// weakness: control-flow
+// source: Cursor Bugbot PR #1506
+// verdict: pass
+
+import { Component } from "react";
+
+class Gallery extends Component {
+  measuredElement = undefined;
+
+  setMeasuredElementRef = (element) => {
+    this.measuredElement = element ?? undefined;
+  };
+
+  componentDidMount() {
+    const elements = [0].map(() => this.measuredElement);
+    this.setState({ elements });
+  }
+
+  render() {
+    return <div ref={this.setMeasuredElementRef} />;
+  }
+}

--- a/packages/fuzz/corpus/regressions/no-did-mount-set-state--synchronous-span-measurement.tsx
+++ b/packages/fuzz/corpus/regressions/no-did-mount-set-state--synchronous-span-measurement.tsx
@@ -1,0 +1,25 @@
+// rule: no-did-mount-set-state
+// weakness: control-flow
+// source: ReactBench justinrhodes1/react-power-tooltip@fb2df8120e0d64ed81c53fcaaef845157f1a9e0c
+// verdict: pass
+
+import React, { Component } from "react";
+
+class TextBox extends Component {
+  componentDidMount() {
+    const heights = Object.keys(this.spanHeights).map((key) => this.spanHeights[key].clientHeight);
+    const firstH = heights[0];
+    const lastH = heights[heights.length - 1];
+    const totH = heights.reduce((accumulator, currentValue) => accumulator + currentValue, 0);
+    this.setState({ totH, firstH, lastH });
+  }
+
+  render() {
+    this.spanHeights = {};
+    return React.Children.map(this.props.children, (child, index) =>
+      React.cloneElement(child, {
+        ref: (span) => (this.spanHeights[`span${index + 1}`] = span),
+      }),
+    );
+  }
+}

--- a/packages/fuzz/corpus/true-positives/no-did-mount-set-state--aliased-handler-invocation.tsx
+++ b/packages/fuzz/corpus/true-positives/no-did-mount-set-state--aliased-handler-invocation.tsx
@@ -1,0 +1,24 @@
+// rule: no-did-mount-set-state
+// weakness: alias-guard
+// source: PR #1506 Bugbot review
+// verdict: fail
+
+import { Component } from "react";
+
+class Calendar extends Component {
+  monthContainer = undefined;
+
+  setMonthContainerRef = (element) => {
+    this.monthContainer = element ?? undefined;
+  };
+
+  componentDidMount() {
+    const instance = this;
+    instance.setMonthContainerRef(this.props.monthContainer);
+    this.setState({ monthContainer: this.monthContainer });
+  }
+
+  render() {
+    return <div ref={this.setMonthContainerRef} />;
+  }
+}

--- a/packages/fuzz/corpus/true-positives/no-did-mount-set-state--callback-ref-with-competing-writer.tsx
+++ b/packages/fuzz/corpus/true-positives/no-did-mount-set-state--callback-ref-with-competing-writer.tsx
@@ -1,0 +1,31 @@
+// rule: no-did-mount-set-state
+// weakness: post-mount-callback-ref
+// source: adversarial audit of ReactBench fix-react-rdh-hacker0x01-react-d__3UEZkbb
+// verdict: fail
+
+import { Component } from "react";
+
+class Calendar extends Component {
+  monthContainer = undefined;
+
+  setMonthContainerRef = (element) => {
+    this.monthContainer = element ?? undefined;
+  };
+
+  replaceMonthContainer = (value) => {
+    this.monthContainer = value;
+  };
+
+  componentDidMount() {
+    this.setState({ monthContainer: this.monthContainer });
+  }
+
+  render() {
+    return (
+      <>
+        <div ref={this.setMonthContainerRef} />
+        <button onClick={() => this.replaceMonthContainer(this.props.value)}>Replace</button>
+      </>
+    );
+  }
+}

--- a/packages/fuzz/corpus/true-positives/no-did-mount-set-state--nested-captured-alias-writer.tsx
+++ b/packages/fuzz/corpus/true-positives/no-did-mount-set-state--nested-captured-alias-writer.tsx
@@ -1,0 +1,28 @@
+// rule: no-did-mount-set-state
+// weakness: control-flow
+// source: Cursor Bugbot PR #1506
+// verdict: fail
+
+import { Component } from "react";
+
+class Calendar extends Component {
+  monthContainer = undefined;
+
+  setMonthContainerRef = (element) => {
+    this.monthContainer = element ?? undefined;
+  };
+
+  render() {
+    const calendar = this;
+    class NestedCalendar {
+      overwriteMonthContainer(value) {
+        calendar.monthContainer = value;
+      }
+    }
+    return <div ref={this.setMonthContainerRef} />;
+  }
+
+  componentDidMount() {
+    this.setState({ monthContainer: this.monthContainer });
+  }
+}

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.regressions.test.ts
@@ -722,6 +722,125 @@ describe("react-builtins/no-did-mount-set-state — regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("stays silent on rendered span heights mapped from Object.keys", () => {
+    const result = runRule(
+      noDidMountSetState,
+      `
+      import React, { Component } from "react";
+      class TextBox extends Component {
+        componentDidMount() {
+          const heights = Object.keys(this.spanHeights)
+            .map((key) => this.spanHeights[key].clientHeight);
+          const firstH = heights[0];
+          const lastH = heights[heights.length - 1];
+          const totH = heights.reduce(
+            (accumulator, currentValue) => accumulator + currentValue,
+            0,
+          );
+          this.setState({ totH, firstH, lastH });
+        }
+        render() {
+          this.spanHeights = {};
+          return React.Children.map(this.props.children, (child, index) =>
+            React.cloneElement(child, {
+              ref: (span) => (this.spanHeights[\`span\${index + 1}\`] = span),
+            }),
+          );
+        }
+      }
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent on a mounted flag paired with a rendered DOM width", () => {
+    const result = runRule(
+      noDidMountSetState,
+      `
+      import { Component } from "react";
+      import { findDOMNode } from "react-dom";
+      class Image extends Component {
+        componentDidMount() {
+          const dom = findDOMNode(this);
+          const rect = dom.getBoundingClientRect();
+          const width = Math.round(rect.right - rect.left);
+          this.setState({
+            mounted: true,
+            width,
+          });
+        }
+      }
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent on an overflow flag paired with a createRef height", () => {
+    const result = runRule(
+      noDidMountSetState,
+      `
+      import React from "react";
+      class ToggleMore extends React.PureComponent {
+        overflow = React.createRef();
+        componentDidMount() {
+          if (this.overflow.current) {
+            const height = this.overflow.current.clientHeight;
+            if (height > this.state.checkHeight && !this.state.overflow) {
+              this.setState({
+                overflow: true,
+                max: height,
+              });
+            }
+          }
+        }
+      }
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it.each([
+    `this.props.elements.map((element) => element.clientHeight)`,
+    `this.props.deferredMap((element) => element.clientHeight)`,
+  ])("still flags post-mount-looking reads inside an unproven callback host: %s", (value) => {
+    const result = runRule(
+      noDidMountSetState,
+      `
+      import { Component } from "react";
+      class Gallery extends Component {
+        componentDidMount() {
+          const heights = ${value};
+          this.setState({ heights });
+        }
+      }
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a mount flag paired with a prop-derived value", () => {
+    const result = runRule(
+      noDidMountSetState,
+      `
+      import { Component } from "react";
+      class Image extends Component {
+        componentDidMount() {
+          this.setState({
+            mounted: true,
+            width: this.props.width,
+          });
+        }
+      }
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("ignores nested class aliases and callback-ref handler reads", () => {
     const result = runRule(
       noDidMountSetState,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.regressions.test.ts
@@ -145,6 +145,54 @@ describe("react-builtins/no-did-mount-set-state — regressions", () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("stays silent when callback-ref fields reach state through lifecycle locals", () => {
+    const result = runRule(
+      noDidMountSetState,
+      `
+      import { Component } from "react";
+      class Calendar extends Component {
+        monthContainer = undefined;
+        setMonthContainerRef = (element) => {
+          this.monthContainer = element ?? undefined;
+        };
+        componentDidMount() {
+          const monthContainer = this.monthContainer;
+          const layout = { monthContainer };
+          this.setState({ monthContainer: layout.monthContainer });
+        }
+        render() {
+          return <div ref={this.setMonthContainerRef} />;
+        }
+      }
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays silent when an exclusively callback-ref-owned field starts as void zero", () => {
+    const result = runRule(
+      noDidMountSetState,
+      `
+      import { Component } from "react";
+      class Calendar extends Component {
+        monthContainer = void 0;
+        setMonthContainerRef = (element) => {
+          this.monthContainer = element ?? undefined;
+        };
+        componentDidMount() {
+          this.setState({ monthContainer: this.monthContainer });
+        }
+        render() {
+          return <div ref={this.setMonthContainerRef} />;
+        }
+      }
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("still flags a class field written by a callback that is not used as a ref", () => {
     const result = runRule(
       noDidMountSetState,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.regressions.test.ts
@@ -494,6 +494,8 @@ describe("react-builtins/no-did-mount-set-state — regressions", () => {
     `this["monthContainer"] = element ?? undefined;`,
     `Object.assign(this, { monthContainer: element });`,
     `Reflect.set(this, "monthContainer", element);`,
+    `const MutationObject = Object; MutationObject.assign(this, { monthContainer: element });`,
+    `const MutationReflect = Reflect; MutationReflect.set(this, "monthContainer", element);`,
   ])("stays silent when the callback ref writes its field through %s", (refWrite) => {
     const result = runRule(
       noDidMountSetState,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.regressions.test.ts
@@ -568,6 +568,60 @@ describe("react-builtins/no-did-mount-set-state — regressions", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("still flags a callback-ref handler invoked with a prop value", () => {
+    const result = runRule(
+      noDidMountSetState,
+      `
+      import { Component } from "react";
+      class Calendar extends Component {
+        monthContainer = undefined;
+        setMonthContainerRef = (element) => {
+          this.monthContainer = element ?? undefined;
+        };
+        componentDidMount() {
+          this.setMonthContainerRef(this.props.monthContainer);
+          this.setState({ monthContainer: this.monthContainer });
+        }
+        render() {
+          return <div ref={this.setMonthContainerRef} />;
+        }
+      }
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it.each([
+    `instance.monthContainer = value;`,
+    `Object.assign(instance, { monthContainer: value });`,
+  ])("still flags a competing writer through a this alias: %s", (competingWrite) => {
+    const result = runRule(
+      noDidMountSetState,
+      `
+      import { Component } from "react";
+      class Calendar extends Component {
+        monthContainer = undefined;
+        setMonthContainerRef = (element) => {
+          this.monthContainer = element ?? undefined;
+        };
+        overrideMonthContainer = (value) => {
+          const instance = this;
+          ${competingWrite}
+        };
+        componentDidMount() {
+          this.setState({ monthContainer: this.monthContainer });
+        }
+        render() {
+          return <div ref={this.setMonthContainerRef} />;
+        }
+      }
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("still flags a nested post-mount update in disallow-in-func mode", () => {
     const result = runRule(
       noDidMountSetState,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.regressions.test.ts
@@ -271,6 +271,40 @@ describe("react-builtins/no-did-mount-set-state — regressions", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it.each([`this["monthContainer"] = value;`, `this[this.props.fieldName] = value;`])(
+    "still flags a callback-ref field with the competing writer %s",
+    (competingWrite) => {
+      const result = runRule(
+        noDidMountSetState,
+        `
+      import { Component } from "react";
+      class Calendar extends Component {
+        monthContainer = undefined;
+        setMonthContainerRef = (element) => {
+          this.monthContainer = element ?? undefined;
+        };
+        overrideMonthContainer = (value) => {
+          ${competingWrite}
+        };
+        componentDidMount() {
+          this.setState({ monthContainer: this.monthContainer });
+        }
+        render() {
+          return (
+            <>
+              <div ref={this.setMonthContainerRef} />
+              <button onClick={() => this.overrideMonthContainer(this.props.value)}>Set</button>
+            </>
+          );
+        }
+      }
+      `,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    },
+  );
+
   it("still flags a callback-ref field initialized from props", () => {
     const result = runRule(
       noDidMountSetState,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.regressions.test.ts
@@ -490,6 +490,34 @@ describe("react-builtins/no-did-mount-set-state — regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("still flags a nested competing writer inside a callback-ref mutation call", () => {
+    const result = runRule(
+      noDidMountSetState,
+      `
+      import { Component } from "react";
+      class Calendar extends Component {
+        monthContainer = undefined;
+        setMonthContainerRef = (element) => {
+          Object.assign(this, {
+            monthContainer: element,
+            overwriteLater: () => {
+              this.monthContainer = this.props.fallbackContainer;
+            },
+          });
+        };
+        componentDidMount() {
+          this.setState({ monthContainer: this.monthContainer });
+        }
+        render() {
+          return <div ref={this.setMonthContainerRef} />;
+        }
+      }
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it.each([
     `this["monthContainer"] = element ?? undefined;`,
     `Object.assign(this, { monthContainer: element });`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.regressions.test.ts
@@ -271,12 +271,19 @@ describe("react-builtins/no-did-mount-set-state — regressions", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
-  it.each([`this["monthContainer"] = value;`, `this[this.props.fieldName] = value;`])(
-    "still flags a callback-ref field with the competing writer %s",
-    (competingWrite) => {
-      const result = runRule(
-        noDidMountSetState,
-        `
+  it.each([
+    `this["monthContainer"] = value;`,
+    `this[this.props.fieldName] = value;`,
+    `Object.assign(this, { monthContainer: value });`,
+    `Object.defineProperty(this, "monthContainer", { value });`,
+    `Object.defineProperties(this, { monthContainer: { value } });`,
+    `Reflect.set(this, "monthContainer", value);`,
+    `Reflect.defineProperty(this, "monthContainer", { value });`,
+    `Reflect.deleteProperty(this, "monthContainer");`,
+  ])("still flags a callback-ref field with the competing writer %s", (competingWrite) => {
+    const result = runRule(
+      noDidMountSetState,
+      `
       import { Component } from "react";
       class Calendar extends Component {
         monthContainer = undefined;
@@ -299,11 +306,10 @@ describe("react-builtins/no-did-mount-set-state — regressions", () => {
         }
       }
       `,
-      );
-      expect(result.parseErrors).toEqual([]);
-      expect(result.diagnostics).toHaveLength(1);
-    },
-  );
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
 
   it("still flags a callback-ref field initialized from props", () => {
     const result = runRule(

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.regressions.test.ts
@@ -870,6 +870,113 @@ describe("react-builtins/no-did-mount-set-state — regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("still flags a callback-ref field written through a captured alias in a nested class", () => {
+    const result = runRule(
+      noDidMountSetState,
+      `
+      import { Component } from "react";
+      class Calendar extends Component {
+        monthContainer = undefined;
+        setMonthContainerRef = (element) => {
+          this.monthContainer = element ?? undefined;
+        };
+        render() {
+          const calendar = this;
+          class NestedCalendar {
+            overwriteMonthContainer(value) {
+              calendar.monthContainer = value;
+            }
+          }
+          return <div ref={this.setMonthContainerRef} />;
+        }
+        componentDidMount() {
+          this.setState({ monthContainer: this.monthContainer });
+        }
+      }
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("ignores a same-named field written through a nested class instance", () => {
+    const result = runRule(
+      noDidMountSetState,
+      `
+      import { Component } from "react";
+      class Calendar extends Component {
+        monthContainer = undefined;
+        setMonthContainerRef = (element) => {
+          this.monthContainer = element ?? undefined;
+        };
+        render() {
+          class NestedCalendar {
+            overwriteMonthContainer(value) {
+              this.monthContainer = value;
+            }
+          }
+          return <div ref={this.setMonthContainerRef} />;
+        }
+        componentDidMount() {
+          this.setState({ monthContainer: this.monthContainer });
+        }
+      }
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent when a synchronous map returns callback-ref measurements", () => {
+    const result = runRule(
+      noDidMountSetState,
+      `
+      import { Component } from "react";
+      class Gallery extends Component {
+        measuredElement = undefined;
+        setMeasuredElementRef = (element) => {
+          this.measuredElement = element ?? undefined;
+        };
+        componentDidMount() {
+          const elements = [0].map(() => this.measuredElement);
+          this.setState({ elements });
+        }
+        render() {
+          return <div ref={this.setMeasuredElementRef} />;
+        }
+      }
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still flags callback-ref reads inside an unproven map callback", () => {
+    const result = runRule(
+      noDidMountSetState,
+      `
+      import { Component } from "react";
+      class Gallery extends Component {
+        measuredElement = undefined;
+        setMeasuredElementRef = (element) => {
+          this.measuredElement = element ?? undefined;
+        };
+        componentDidMount() {
+          const heights = this.props.collection.map(
+            () => this.measuredElement.clientHeight,
+          );
+          this.setState({ heights });
+        }
+        render() {
+          return <div ref={this.setMeasuredElementRef} />;
+        }
+      }
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("still flags a callback-ref handler invoked with a prop value", () => {
     const result = runRule(
       noDidMountSetState,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.regressions.test.ts
@@ -1001,6 +1001,159 @@ describe("react-builtins/no-did-mount-set-state — regressions", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("stays silent on callback-ref measurements captured inside a synchronous IIFE", () => {
+    const result = runRule(
+      noDidMountSetState,
+      `
+      import { Component } from "react";
+      class Calendar extends Component {
+        monthContainer = undefined;
+        setMonthContainerRef = (element) => {
+          this.monthContainer = element ?? undefined;
+        };
+        componentDidMount() {
+          (() => {
+            const height = this.monthContainer.clientHeight;
+            this.setState({ height });
+          })();
+        }
+        render() {
+          return <div ref={this.setMonthContainerRef} />;
+        }
+      }
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still flags prop-derived locals captured inside a synchronous IIFE", () => {
+    const result = runRule(
+      noDidMountSetState,
+      `
+      import { Component } from "react";
+      class Calendar extends Component {
+        componentDidMount() {
+          (() => {
+            const height = this.props.height;
+            this.setState({ height });
+          })();
+        }
+        render() {
+          return <div />;
+        }
+      }
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a callback-ref handler invoked through a this alias", () => {
+    const result = runRule(
+      noDidMountSetState,
+      `
+      import { Component } from "react";
+      class Calendar extends Component {
+        monthContainer = undefined;
+        setMonthContainerRef = (element) => {
+          this.monthContainer = element ?? undefined;
+        };
+        componentDidMount() {
+          const instance = this;
+          instance.setMonthContainerRef(this.props.monthContainer);
+          this.setState({ monthContainer: this.monthContainer });
+        }
+        render() {
+          return <div ref={this.setMonthContainerRef} />;
+        }
+      }
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays silent when a callback-ref handler is referenced through a this alias", () => {
+    const result = runRule(
+      noDidMountSetState,
+      `
+      import { Component } from "react";
+      class Calendar extends Component {
+        monthContainer = undefined;
+        setMonthContainerRef = (element) => {
+          this.monthContainer = element ?? undefined;
+        };
+        componentDidMount() {
+          this.setState({ monthContainer: this.monthContainer });
+        }
+        render() {
+          const instance = this;
+          return (
+            <>
+              <div ref={this.setMonthContainerRef} />
+              <div ref={instance.setMonthContainerRef} />
+            </>
+          );
+        }
+      }
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent when a JSX ref wrapper forwards its element to a callback-ref handler", () => {
+    const result = runRule(
+      noDidMountSetState,
+      `
+      import { Component } from "react";
+      class Calendar extends Component {
+        monthContainer = undefined;
+        setMonthContainerRef = (element) => {
+          this.monthContainer = element ?? undefined;
+        };
+        componentDidMount() {
+          this.setState({ monthContainer: this.monthContainer });
+        }
+        render() {
+          return <div ref={(element) => this.setMonthContainerRef(element)} />;
+        }
+      }
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still flags a JSX ref wrapper that does not forward the callback element", () => {
+    const result = runRule(
+      noDidMountSetState,
+      `
+      import { Component } from "react";
+      class Calendar extends Component {
+        monthContainer = undefined;
+        setMonthContainerRef = (element) => {
+          this.monthContainer = element ?? undefined;
+        };
+        componentDidMount() {
+          this.setState({ monthContainer: this.monthContainer });
+        }
+        render() {
+          return (
+            <>
+              <div ref={this.setMonthContainerRef} />
+              <div ref={() => this.setMonthContainerRef(this.props.monthContainer)} />
+            </>
+          );
+        }
+      }
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("still flags a destructured callback-ref handler invoked with a prop value", () => {
     const result = runRule(
       noDidMountSetState,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.regressions.test.ts
@@ -440,6 +440,78 @@ describe("react-builtins/no-did-mount-set-state — regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("stays silent when an invoked lifecycle helper reads the callback-ref field", () => {
+    const result = runRule(
+      noDidMountSetState,
+      `
+      import { Component } from "react";
+      class Calendar extends Component {
+        monthContainer = undefined;
+        setMonthContainerRef = (element) => {
+          this.monthContainer = element ?? undefined;
+        };
+        componentDidMount() {
+          const readMonthContainer = () => this.monthContainer;
+          const monthContainer = readMonthContainer();
+          this.setState({ monthContainer });
+        }
+        render() {
+          return <div ref={this.setMonthContainerRef} />;
+        }
+      }
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent when the sole callback ref also writes through Object.assign", () => {
+    const result = runRule(
+      noDidMountSetState,
+      `
+      import { Component } from "react";
+      class Calendar extends Component {
+        monthContainer = undefined;
+        setMonthContainerRef = (element) => {
+          this.monthContainer = element ?? undefined;
+          Object.assign(this, { monthContainer: element });
+        };
+        componentDidMount() {
+          this.setState({ monthContainer: this.monthContainer });
+        }
+        render() {
+          return <div ref={this.setMonthContainerRef} />;
+        }
+      }
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent when the payload reads a static bracket callback-ref field", () => {
+    const result = runRule(
+      noDidMountSetState,
+      `
+      import { Component } from "react";
+      class Calendar extends Component {
+        monthContainer = undefined;
+        setMonthContainerRef = (element) => {
+          this.monthContainer = element ?? undefined;
+        };
+        componentDidMount() {
+          this.setState({ monthContainer: this["monthContainer"] });
+        }
+        render() {
+          return <div ref={this.setMonthContainerRef} />;
+        }
+      }
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   // setState after an await in an async componentDidMount is the
   // promise-buried case the doc says must not fire in "allowed" mode
   // (dtale NetworkDisplay).

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.regressions.test.ts
@@ -98,6 +98,154 @@ describe("react-builtins/no-did-mount-set-state — regressions", () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("stays silent when storing a DOM node supplied by a named callback ref", () => {
+    const result = runRule(
+      noDidMountSetState,
+      `
+      import { Component } from "react";
+      class Calendar extends Component {
+        state = { monthContainer: undefined };
+        monthContainer = undefined;
+        setMonthContainerRef = (element) => {
+          this.monthContainer = element ?? undefined;
+        };
+        componentDidMount() {
+          if (this.props.showTimeSelect) {
+            this.setState({ monthContainer: this.monthContainer });
+          }
+        }
+        render() {
+          return <div ref={this.setMonthContainerRef} />;
+        }
+      }
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays silent when storing a DOM node supplied by an inline callback ref", () => {
+    const result = runRule(
+      noDidMountSetState,
+      `
+      import { Component } from "react";
+      class Calendar extends Component {
+        state = { monthContainer: undefined };
+        monthContainer = undefined;
+        componentDidMount() {
+          this.setState({ monthContainer: this.monthContainer });
+        }
+        render() {
+          return <div ref={(element) => (this.monthContainer = element ?? undefined)} />;
+        }
+      }
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still flags a class field written by a callback that is not used as a ref", () => {
+    const result = runRule(
+      noDidMountSetState,
+      `
+      import { Component } from "react";
+      class Calendar extends Component {
+        monthContainer = undefined;
+        setMonthContainer = (value) => {
+          this.monthContainer = value ?? undefined;
+        };
+        componentDidMount() {
+          this.setState({ monthContainer: this.monthContainer });
+        }
+        render() {
+          return <button onClick={this.setMonthContainer}>Set</button>;
+        }
+      }
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a different class field when the component owns a callback ref", () => {
+    const result = runRule(
+      noDidMountSetState,
+      `
+      import { Component } from "react";
+      class Calendar extends Component {
+        monthContainer = undefined;
+        selection = undefined;
+        setSelectionRef = (element) => {
+          this.selection = element ?? undefined;
+        };
+        componentDidMount() {
+          this.setState({ monthContainer: this.monthContainer });
+        }
+        render() {
+          return <div ref={this.setSelectionRef} />;
+        }
+      }
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a callback-ref field that has another writer", () => {
+    const result = runRule(
+      noDidMountSetState,
+      `
+      import { Component } from "react";
+      class Calendar extends Component {
+        monthContainer = undefined;
+        setMonthContainerRef = (element) => {
+          this.monthContainer = element ?? undefined;
+        };
+        overrideMonthContainer = (value) => {
+          this.monthContainer = value;
+        };
+        componentDidMount() {
+          this.setState({ monthContainer: this.monthContainer });
+        }
+        render() {
+          return (
+            <>
+              <div ref={this.setMonthContainerRef} />
+              <button onClick={() => this.overrideMonthContainer(this.props.value)}>Set</button>
+            </>
+          );
+        }
+      }
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a callback-ref field initialized from props", () => {
+    const result = runRule(
+      noDidMountSetState,
+      `
+      import { Component } from "react";
+      class Calendar extends Component {
+        monthContainer = this.props.initialContainer;
+        setMonthContainerRef = (element) => {
+          this.monthContainer = element ?? undefined;
+        };
+        componentDidMount() {
+          this.setState({ monthContainer: this.monthContainer });
+        }
+        render() {
+          return <div ref={this.setMonthContainerRef} />;
+        }
+      }
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   // setState after an await in an async componentDidMount is the
   // promise-buried case the doc says must not fire in "allowed" mode
   // (dtale NetworkDisplay).

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.regressions.test.ts
@@ -359,6 +359,87 @@ describe("react-builtins/no-did-mount-set-state — regressions", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("still flags when a nested payload callback reads the ref field", () => {
+    const result = runRule(
+      noDidMountSetState,
+      `
+      import { Component } from "react";
+      class Calendar extends Component {
+        monthContainer = undefined;
+        setMonthContainerRef = (element) => {
+          this.monthContainer = element ?? undefined;
+        };
+        componentDidMount() {
+          this.setState({
+            selectedDate: this.props.selectedDate,
+            getContainer: () => this.monthContainer,
+          });
+        }
+        render() {
+          return <div ref={this.setMonthContainerRef} />;
+        }
+      }
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags when a nested function shadows the lifecycle local", () => {
+    const result = runRule(
+      noDidMountSetState,
+      `
+      import { Component } from "react";
+      class Calendar extends Component {
+        monthContainer = undefined;
+        setMonthContainerRef = (element) => {
+          this.monthContainer = element ?? undefined;
+        };
+        componentDidMount() {
+          const container = this.props.initialContainer;
+          const readLater = () => {
+            const container = this.monthContainer;
+            return container;
+          };
+          this.setState({ container, readLater });
+        }
+        render() {
+          return <div ref={this.setMonthContainerRef} />;
+        }
+      }
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays silent when one callback ref assigns its field in separate branches", () => {
+    const result = runRule(
+      noDidMountSetState,
+      `
+      import { Component } from "react";
+      class Calendar extends Component {
+        monthContainer = undefined;
+        setMonthContainerRef = (element) => {
+          if (element) {
+            this.monthContainer = element;
+          } else {
+            this.monthContainer = element;
+          }
+        };
+        componentDidMount() {
+          this.setState({ monthContainer: this.monthContainer });
+        }
+        render() {
+          return <div ref={this.setMonthContainerRef} />;
+        }
+      }
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   // setState after an await in an async componentDidMount is the
   // promise-buried case the doc says must not fire in "allowed" mode
   // (dtale NetworkDisplay).

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.regressions.test.ts
@@ -542,6 +542,65 @@ describe("react-builtins/no-did-mount-set-state — regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("still flags a mixed payload with callback-ref and pre-mount values", () => {
+    const result = runRule(
+      noDidMountSetState,
+      `
+      import { Component } from "react";
+      class Calendar extends Component {
+        monthContainer = undefined;
+        setMonthContainerRef = (element) => {
+          this.monthContainer = element ?? undefined;
+        };
+        componentDidMount() {
+          this.setState({
+            monthContainer: this.monthContainer,
+            selected: this.props.selected,
+          });
+        }
+        render() {
+          return <div ref={this.setMonthContainerRef} />;
+        }
+      }
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a nested post-mount update in disallow-in-func mode", () => {
+    const result = runRule(
+      noDidMountSetState,
+      `
+      import { Component } from "react";
+      class Calendar extends Component {
+        monthContainer = undefined;
+        setMonthContainerRef = (element) => {
+          this.monthContainer = element ?? undefined;
+        };
+        componentDidMount() {
+          const updateMonthContainer = () => {
+            this.setState({ monthContainer: this.monthContainer });
+          };
+          updateMonthContainer();
+        }
+        render() {
+          return <div ref={this.setMonthContainerRef} />;
+        }
+      }
+      `,
+      {
+        settings: {
+          "react-doctor": {
+            noDidMountSetState: { mode: "disallow-in-func" },
+          },
+        },
+      },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   // setState after an await in an async componentDidMount is the
   // promise-buried case the doc says must not fire in "allowed" mode
   // (dtale NetworkDisplay).

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.regressions.test.ts
@@ -568,6 +568,133 @@ describe("react-builtins/no-did-mount-set-state — regressions", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it.each([
+    `this.monthContainer || this.props.fallbackContainer`,
+    `this.props.useMountedContainer ? this.monthContainer : this.props.fallbackContainer`,
+  ])("still flags a callback-ref value mixed with pre-mount input: %s", (value) => {
+    const result = runRule(
+      noDidMountSetState,
+      `
+      import { Component } from "react";
+      class Calendar extends Component {
+        monthContainer = undefined;
+        setMonthContainerRef = (element) => {
+          this.monthContainer = element ?? undefined;
+        };
+        componentDidMount() {
+          this.setState({ monthContainer: ${value} });
+        }
+        render() {
+          return <div ref={this.setMonthContainerRef} />;
+        }
+      }
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a lifecycle local mixing callback-ref and pre-mount values", () => {
+    const result = runRule(
+      noDidMountSetState,
+      `
+      import { Component } from "react";
+      class Calendar extends Component {
+        monthContainer = undefined;
+        setMonthContainerRef = (element) => {
+          this.monthContainer = element ?? undefined;
+        };
+        componentDidMount() {
+          const monthContainer = this.monthContainer ?? this.props.fallbackContainer;
+          this.setState({ monthContainer });
+        }
+        render() {
+          return <div ref={this.setMonthContainerRef} />;
+        }
+      }
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a local helper mixing callback-ref and pre-mount values", () => {
+    const result = runRule(
+      noDidMountSetState,
+      `
+      import { Component } from "react";
+      class Calendar extends Component {
+        monthContainer = undefined;
+        setMonthContainerRef = (element) => {
+          this.monthContainer = element ?? undefined;
+        };
+        componentDidMount() {
+          const readMonthContainer = () =>
+            this.monthContainer ?? this.props.fallbackContainer;
+          this.setState({ monthContainer: readMonthContainer() });
+        }
+        render() {
+          return <div ref={this.setMonthContainerRef} />;
+        }
+      }
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays silent when a callback-ref value has only a literal fallback", () => {
+    const result = runRule(
+      noDidMountSetState,
+      `
+      import { Component } from "react";
+      class Calendar extends Component {
+        monthContainer = undefined;
+        setMonthContainerRef = (element) => {
+          this.monthContainer = element ?? undefined;
+        };
+        componentDidMount() {
+          this.setState({ monthContainer: this.monthContainer ?? null });
+        }
+        render() {
+          return <div ref={this.setMonthContainerRef} />;
+        }
+      }
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("ignores nested class aliases and callback-ref handler reads", () => {
+    const result = runRule(
+      noDidMountSetState,
+      `
+      import { Component } from "react";
+      class Calendar extends Component {
+        monthContainer = undefined;
+        setMonthContainerRef = (element) => {
+          this.monthContainer = element ?? undefined;
+        };
+        componentDidMount() {
+          this.setState({ monthContainer: this.monthContainer });
+        }
+        render() {
+          class NestedCalendar {
+            readHandler() {
+              const instance = this;
+              return instance.setMonthContainerRef;
+            }
+          }
+          return <div ref={this.setMonthContainerRef} />;
+        }
+      }
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("still flags a callback-ref handler invoked with a prop value", () => {
     const result = runRule(
       noDidMountSetState,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.regressions.test.ts
@@ -519,6 +519,34 @@ describe("react-builtins/no-did-mount-set-state — regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it.each([
+    `instance.monthContainer = element ?? undefined;`,
+    `Object.assign(instance, { monthContainer: element });`,
+    `Reflect.set(instance, "monthContainer", element);`,
+  ])("stays silent when a callback ref writes through a this alias: %s", (refWrite) => {
+    const result = runRule(
+      noDidMountSetState,
+      `
+      import { Component } from "react";
+      class Calendar extends Component {
+        monthContainer = undefined;
+        setMonthContainerRef = (element) => {
+          const instance = this;
+          ${refWrite}
+        };
+        componentDidMount() {
+          this.setState({ monthContainer: this.monthContainer });
+        }
+        render() {
+          return <div ref={this.setMonthContainerRef} />;
+        }
+      }
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("stays silent when the payload reads a static bracket callback-ref field", () => {
     const result = runRule(
       noDidMountSetState,
@@ -717,6 +745,60 @@ describe("react-builtins/no-did-mount-set-state — regressions", () => {
     );
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a destructured callback-ref handler invoked with a prop value", () => {
+    const result = runRule(
+      noDidMountSetState,
+      `
+      import { Component } from "react";
+      class Calendar extends Component {
+        monthContainer = undefined;
+        setMonthContainerRef = (element) => {
+          this.monthContainer = element ?? undefined;
+        };
+        componentDidMount() {
+          const { setMonthContainerRef } = this;
+          setMonthContainerRef(this.props.monthContainer);
+          this.setState({ monthContainer: this.monthContainer });
+        }
+        render() {
+          return <div ref={this.setMonthContainerRef} />;
+        }
+      }
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays silent when a destructured callback-ref handler is only used as a ref", () => {
+    const result = runRule(
+      noDidMountSetState,
+      `
+      import { Component } from "react";
+      class Calendar extends Component {
+        monthContainer = undefined;
+        setMonthContainerRef = (element) => {
+          this.monthContainer = element ?? undefined;
+        };
+        componentDidMount() {
+          this.setState({ monthContainer: this.monthContainer });
+        }
+        render() {
+          const { setMonthContainerRef } = this;
+          return (
+            <>
+              <div ref={this.setMonthContainerRef} />
+              <div ref={setMonthContainerRef} />
+            </>
+          );
+        }
+      }
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
   });
 
   it.each([

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.regressions.test.ts
@@ -275,6 +275,7 @@ describe("react-builtins/no-did-mount-set-state — regressions", () => {
     `this["monthContainer"] = value;`,
     `this[this.props.fieldName] = value;`,
     `Object.assign(this, { monthContainer: value });`,
+    `const MutationObject = Object; MutationObject.assign(this, { monthContainer: value });`,
     `Object.defineProperty(this, "monthContainer", { value });`,
     `Object.defineProperties(this, { monthContainer: { value } });`,
     `Reflect.set(this, "monthContainer", value);`,
@@ -475,6 +476,33 @@ describe("react-builtins/no-did-mount-set-state — regressions", () => {
         setMonthContainerRef = (element) => {
           this.monthContainer = element ?? undefined;
           Object.assign(this, { monthContainer: element });
+        };
+        componentDidMount() {
+          this.setState({ monthContainer: this.monthContainer });
+        }
+        render() {
+          return <div ref={this.setMonthContainerRef} />;
+        }
+      }
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it.each([
+    `this["monthContainer"] = element ?? undefined;`,
+    `Object.assign(this, { monthContainer: element });`,
+    `Reflect.set(this, "monthContainer", element);`,
+  ])("stays silent when the callback ref writes its field through %s", (refWrite) => {
+    const result = runRule(
+      noDidMountSetState,
+      `
+      import { Component } from "react";
+      class Calendar extends Component {
+        monthContainer = undefined;
+        setMonthContainerRef = (element) => {
+          ${refWrite}
         };
         componentDidMount() {
           this.setState({ monthContainer: this.monthContainer });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.regressions.test.ts
@@ -334,6 +334,31 @@ describe("react-builtins/no-did-mount-set-state — regressions", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("still flags when only the setState completion callback reads the ref field", () => {
+    const result = runRule(
+      noDidMountSetState,
+      `
+      import { Component } from "react";
+      class Calendar extends Component {
+        monthContainer = undefined;
+        setMonthContainerRef = (element) => {
+          this.monthContainer = element ?? undefined;
+        };
+        componentDidMount() {
+          this.setState({ selectedDate: this.props.selectedDate }, () => {
+            positionTimeList(this.monthContainer);
+          });
+        }
+        render() {
+          return <div ref={this.setMonthContainerRef} />;
+        }
+      }
+      `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   // setState after an await in an async componentDidMount is the
   // promise-buried case the doc says must not fire in "allowed" mode
   // (dtale NetworkDisplay).

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.ts
@@ -139,15 +139,19 @@ const containsPostMountSource = (node: EsTreeNode, scopes: ScopeAnalysis): boole
 const containsCallbackRefField = (
   node: EsTreeNode,
   callbackRefFieldNames: ReadonlySet<string>,
+  scopes: ScopeAnalysis,
 ): boolean => {
   let didFindCallbackRefField = false;
   walkAst(node, (descendant) => {
-    if (
-      descendant !== node &&
-      isFunctionLike(descendant) &&
-      !isImmediatelyInvokedFunction(descendant)
-    ) {
-      return false;
+    if (descendant !== node && isFunctionLike(descendant)) {
+      const parent = descendant.parent;
+      if (
+        !isImmediatelyInvokedFunction(descendant) &&
+        (!isNodeOfType(parent, "CallExpression") ||
+          !isSynchronousIteratorCall(parent, descendant, scopes))
+      ) {
+        return false;
+      }
     }
     const fieldName = getStaticThisFieldName(descendant);
     if (fieldName && callbackRefFieldNames.has(fieldName)) {
@@ -312,6 +316,31 @@ const functionReturnsCallbackRefDerivedValue = (
   return evidence.hasCallbackRefValue && !evidence.hasDynamicValue;
 };
 
+const synchronousIteratorResultDerivesFromCallbackRef = (
+  node: EsTreeNode,
+  callbackRefFieldNames: ReadonlySet<string>,
+  scopes: ScopeAnalysis,
+): boolean => {
+  const candidate = stripParenExpression(node);
+  if (!isNodeOfType(candidate, "CallExpression")) return false;
+  const callee = stripParenExpression(candidate.callee);
+  if (
+    isNodeOfType(callee, "MemberExpression") &&
+    getStaticPropertyKeyName(callee, { allowComputedString: true }) === "forEach"
+  ) {
+    return false;
+  }
+  return candidate.arguments.some((argument) => {
+    if (isNodeOfType(argument, "SpreadElement")) return false;
+    const callback = stripParenExpression(argument);
+    return (
+      isFunctionLike(callback) &&
+      isSynchronousIteratorCall(candidate, callback, scopes) &&
+      functionReturnsCallbackRefDerivedValue(callback.body, callbackRefFieldNames)
+    );
+  });
+};
+
 const collectReferencedNames = (node: EsTreeNode, into: Set<string>): void => {
   walkAst(node, (descendant) => {
     if (!isNodeOfType(descendant, "Identifier")) return;
@@ -362,6 +391,7 @@ const expressionCallsPostMountHelper = (
     const doesFunctionReadCallbackRefField = containsCallbackRefField(
       functionBody,
       callbackRefFieldNames,
+      scopes,
     );
     if (
       (doesFunctionReadCallbackRefField
@@ -431,10 +461,12 @@ const argumentDerivesFromPostMountSource = (
     const doesExpressionReadCallbackRefField = containsCallbackRefField(
       expression,
       callbackRefFieldNames,
+      scopes,
     );
     if (
       (doesExpressionReadCallbackRefField
-        ? isCallbackRefDerivedValue(expression, callbackRefFieldNames)
+        ? isCallbackRefDerivedValue(expression, callbackRefFieldNames) ||
+          synchronousIteratorResultDerivesFromCallbackRef(expression, callbackRefFieldNames, scopes)
         : containsPostMountSource(expression, scopes)) ||
       expressionCallsPostMountHelper(expression, localFunctions, callbackRefFieldNames, scopes)
     ) {
@@ -453,10 +485,16 @@ const argumentDerivesFromPostMountSource = (
       const doesInitializerReadCallbackRefField = containsCallbackRefField(
         initializer,
         callbackRefFieldNames,
+        scopes,
       );
       if (
         (doesInitializerReadCallbackRefField
-          ? isCallbackRefDerivedValue(initializer, callbackRefFieldNames)
+          ? isCallbackRefDerivedValue(initializer, callbackRefFieldNames) ||
+            synchronousIteratorResultDerivesFromCallbackRef(
+              initializer,
+              callbackRefFieldNames,
+              scopes,
+            )
           : containsPostMountSource(initializer, scopes)) ||
         expressionCallsPostMountHelper(initializer, localFunctions, callbackRefFieldNames, scopes)
       ) {
@@ -519,10 +557,15 @@ const objectExpressionMayDefineField = (node: EsTreeNode, fieldName: string): bo
   });
 };
 
-const isThisOrAlias = (node: EsTreeNode, thisAliasNames: ReadonlySet<string>): boolean => {
+const isThisOrAlias = (
+  node: EsTreeNode,
+  thisAliasNames: ReadonlySet<string>,
+  classNode?: EsTreeNode,
+): boolean => {
   const candidate = stripParenExpression(node);
   return (
-    isNodeOfType(candidate, "ThisExpression") ||
+    (isNodeOfType(candidate, "ThisExpression") &&
+      (!classNode || findEnclosingClass(candidate) === classNode)) ||
     (isNodeOfType(candidate, "Identifier") && thisAliasNames.has(candidate.name))
   );
 };
@@ -532,6 +575,7 @@ const callMayWriteThisField = (
   fieldName: string,
   receiverKinds: ReadonlyMap<string, "object" | "reflect">,
   thisAliasNames: ReadonlySet<string>,
+  classNode: EsTreeNode,
 ): boolean => {
   const callee = stripParenExpression(callExpression.callee);
   if (!isNodeOfType(callee, "MemberExpression")) return false;
@@ -545,7 +589,7 @@ const callMayWriteThisField = (
     target && !isNodeOfType(target, "SpreadElement")
       ? stripParenExpression(target as EsTreeNode)
       : null;
-  if (!unwrappedTarget || !isThisOrAlias(unwrappedTarget, thisAliasNames)) {
+  if (!unwrappedTarget || !isThisOrAlias(unwrappedTarget, thisAliasNames, classNode)) {
     return false;
   }
   if (receiverKind === "object" && methodName === "assign") {
@@ -709,13 +753,8 @@ const hasExclusiveCallbackRefFieldWrite = (
   let didFindUnsafeWrite = false;
   walkAst(classNode, (node) => {
     if (
-      node !== classNode &&
-      (isNodeOfType(node, "ClassDeclaration") || isNodeOfType(node, "ClassExpression"))
-    ) {
-      return false;
-    }
-    if (
       isNodeOfType(node, "PropertyDefinition") &&
+      findEnclosingClass(node) === classNode &&
       node.static !== true &&
       getStaticPropertyKeyName(node, { allowComputedString: true }) === fieldName &&
       !isUndefinedOrNull(node.value as EsTreeNode | null | undefined)
@@ -725,7 +764,7 @@ const hasExclusiveCallbackRefFieldWrite = (
     }
     if (
       isNodeOfType(node, "CallExpression") &&
-      callMayWriteThisField(node, fieldName, receiverKinds, thisAliasNames)
+      callMayWriteThisField(node, fieldName, receiverKinds, thisAliasNames, classNode)
     ) {
       const writerFunction = getEnclosingWriterFunction(node, classNode);
       if (!writerFunction) {
@@ -746,7 +785,7 @@ const hasExclusiveCallbackRefFieldWrite = (
     const unwrappedAssignmentTarget = stripParenExpression(assignmentTarget);
     if (
       !isNodeOfType(unwrappedAssignmentTarget, "MemberExpression") ||
-      !isThisOrAlias(unwrappedAssignmentTarget.object as EsTreeNode, thisAliasNames)
+      !isThisOrAlias(unwrappedAssignmentTarget.object as EsTreeNode, thisAliasNames, classNode)
     ) {
       return;
     }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.ts
@@ -205,6 +205,65 @@ const isUndefinedOrNull = (node: EsTreeNode | null | undefined): boolean => {
   );
 };
 
+const objectExpressionMayDefineField = (node: EsTreeNode, fieldName: string): boolean => {
+  const candidate = stripParenExpression(node);
+  if (!isNodeOfType(candidate, "ObjectExpression")) return true;
+  return candidate.properties.some((property) => {
+    if (!isNodeOfType(property, "Property")) return true;
+    const propertyName = getStaticPropertyKeyName(property, { allowComputedString: true });
+    return propertyName === null || propertyName === fieldName;
+  });
+};
+
+const callMayWriteThisField = (
+  callExpression: EsTreeNodeOfType<"CallExpression">,
+  fieldName: string,
+): boolean => {
+  const callee = stripParenExpression(callExpression.callee);
+  if (!isNodeOfType(callee, "MemberExpression")) return false;
+  const receiver = stripParenExpression(callee.object as EsTreeNode);
+  if (!isNodeOfType(receiver, "Identifier")) return false;
+  const methodName = getStaticPropertyKeyName(callee, { allowComputedString: true });
+  const [target, propertyOrSource, ...remainingArguments] = callExpression.arguments;
+  if (
+    !target ||
+    isNodeOfType(target, "SpreadElement") ||
+    !isNodeOfType(stripParenExpression(target as EsTreeNode), "ThisExpression")
+  ) {
+    return false;
+  }
+  if (receiver.name === "Object" && methodName === "assign") {
+    const sources = [propertyOrSource, ...remainingArguments];
+    return sources.some(
+      (source) =>
+        !source ||
+        isNodeOfType(source, "SpreadElement") ||
+        objectExpressionMayDefineField(source as EsTreeNode, fieldName),
+    );
+  }
+  if (receiver.name === "Object" && methodName === "defineProperties") {
+    return (
+      !propertyOrSource ||
+      isNodeOfType(propertyOrSource, "SpreadElement") ||
+      objectExpressionMayDefineField(propertyOrSource as EsTreeNode, fieldName)
+    );
+  }
+  if (
+    (receiver.name === "Object" && methodName === "defineProperty") ||
+    (receiver.name === "Reflect" &&
+      (methodName === "defineProperty" || methodName === "deleteProperty" || methodName === "set"))
+  ) {
+    if (!propertyOrSource || isNodeOfType(propertyOrSource, "SpreadElement")) return true;
+    const propertyName = stripParenExpression(propertyOrSource as EsTreeNode);
+    return (
+      !isNodeOfType(propertyName, "Literal") ||
+      typeof propertyName.value !== "string" ||
+      propertyName.value === fieldName
+    );
+  }
+  return false;
+};
+
 const hasExclusiveCallbackRefFieldWrite = (classNode: EsTreeNode, fieldName: string): boolean => {
   if (fieldName.startsWith("#")) return false;
   let assignmentCount = 0;
@@ -222,6 +281,10 @@ const hasExclusiveCallbackRefFieldWrite = (classNode: EsTreeNode, fieldName: str
       getStaticPropertyKeyName(node, { allowComputedString: true }) === fieldName &&
       !isUndefinedOrNull(node.value as EsTreeNode | null | undefined)
     ) {
+      didFindUnsafeWrite = true;
+      return false;
+    }
+    if (isNodeOfType(node, "CallExpression") && callMayWriteThisField(node, fieldName)) {
       didFindUnsafeWrite = true;
       return false;
     }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.ts
@@ -5,11 +5,12 @@ import { findEnclosingClass } from "../../utils/find-enclosing-class.js";
 import { getNodeStartIndex } from "../../utils/get-node-start-index.js";
 import { getStaticPropertyKeyName } from "../../utils/get-static-property-key-name.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
+import { isImmediatelyInvokedFunction } from "../../utils/is-immediately-invoked-function.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isSetStateCallInLifecycle } from "../../utils/is-set-state-in-lifecycle.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import { walkAst } from "../../utils/walk-ast.js";
-import { getCallbackRefFieldNames, getThisFieldName } from "./no-did-update-set-state.js";
+import { getCallbackRefFieldNames } from "./no-did-update-set-state.js";
 
 const LIFECYCLE_NAMES = new Set(["componentDidMount"]);
 const MESSAGE =
@@ -73,11 +74,28 @@ const POST_MOUNT_MEMBER_NAMES = new Set([
 ]);
 const OBSERVER_CONSTRUCTOR_PATTERN = /Observer$/;
 
+const getStaticThisFieldName = (node: EsTreeNode): string | null => {
+  const candidate = stripParenExpression(node);
+  if (
+    !isNodeOfType(candidate, "MemberExpression") ||
+    !isNodeOfType(stripParenExpression(candidate.object as EsTreeNode), "ThisExpression")
+  ) {
+    return null;
+  }
+  return getStaticPropertyKeyName(candidate, { allowComputedString: true });
+};
+
 const containsPostMountSource = (node: EsTreeNode): boolean => {
   let didFindSource = false;
   walkAst(node, (descendant) => {
     if (didFindSource) return false;
-    if (descendant !== node && isFunctionLike(descendant)) return false;
+    if (
+      descendant !== node &&
+      isFunctionLike(descendant) &&
+      !isImmediatelyInvokedFunction(descendant)
+    ) {
+      return false;
+    }
     if (
       isNodeOfType(descendant, "NewExpression") &&
       isNodeOfType(descendant.callee, "Identifier") &&
@@ -105,8 +123,14 @@ const containsCallbackRefField = (
 ): boolean => {
   let didFindCallbackRefField = false;
   walkAst(node, (descendant) => {
-    if (descendant !== node && isFunctionLike(descendant)) return false;
-    const fieldName = getThisFieldName(descendant);
+    if (
+      descendant !== node &&
+      isFunctionLike(descendant) &&
+      !isImmediatelyInvokedFunction(descendant)
+    ) {
+      return false;
+    }
+    const fieldName = getStaticThisFieldName(descendant);
     if (fieldName && callbackRefFieldNames.has(fieldName)) {
       didFindCallbackRefField = true;
       return false;
@@ -138,6 +162,47 @@ const collectReferencedNames = (node: EsTreeNode, into: Set<string>): void => {
   });
 };
 
+const expressionCallsPostMountHelper = (
+  node: EsTreeNode,
+  localFunctions: ReadonlyMap<string, EsTreeNode>,
+  callbackRefFieldNames: ReadonlySet<string>,
+  visitedFunctionNames: ReadonlySet<string> = new Set(),
+): boolean => {
+  let didFindPostMountHelper = false;
+  walkAst(node, (descendant) => {
+    if (didFindPostMountHelper) return false;
+    if (
+      descendant !== node &&
+      isFunctionLike(descendant) &&
+      !isImmediatelyInvokedFunction(descendant)
+    ) {
+      return false;
+    }
+    if (!isNodeOfType(descendant, "CallExpression")) return;
+    const callee = stripParenExpression(descendant.callee);
+    if (!isNodeOfType(callee, "Identifier") || visitedFunctionNames.has(callee.name)) return;
+    const localFunction = localFunctions.get(callee.name);
+    if (!localFunction) return;
+    const functionBody = (localFunction as { body?: EsTreeNode }).body;
+    if (!functionBody) return;
+    const nextVisitedFunctionNames = new Set([...visitedFunctionNames, callee.name]);
+    if (
+      containsPostMountSource(functionBody) ||
+      containsCallbackRefField(functionBody, callbackRefFieldNames) ||
+      expressionCallsPostMountHelper(
+        functionBody,
+        localFunctions,
+        callbackRefFieldNames,
+        nextVisitedFunctionNames,
+      )
+    ) {
+      didFindPostMountHelper = true;
+      return false;
+    }
+  });
+  return didFindPostMountHelper;
+};
+
 // True when the setState argument reads a post-mount-only source directly,
 // or references a local declared in the lifecycle body whose initializer
 // (transitively) does — `const el = this.ref.current; const z = calc(el);
@@ -153,16 +218,40 @@ const argumentDerivesFromPostMountSource = (
   if (containsCallbackRefField(argumentNode, callbackRefFieldNames)) return true;
 
   const localInitializers = new Map<string, EsTreeNode>();
+  const localFunctions = new Map<string, EsTreeNode>();
+  const ambiguousLocalNames = new Set<string>();
+  const registerLocalBinding = (name: string, initializer: EsTreeNode): void => {
+    if (ambiguousLocalNames.has(name)) return;
+    if (localInitializers.has(name)) {
+      ambiguousLocalNames.add(name);
+      localInitializers.delete(name);
+      localFunctions.delete(name);
+      return;
+    }
+    localInitializers.set(name, initializer);
+    if (isFunctionLike(stripParenExpression(initializer))) {
+      localFunctions.set(name, initializer);
+    }
+  };
   walkAst(lifecycleFunction, (descendant) => {
-    if (descendant !== lifecycleFunction && isFunctionLike(descendant)) return false;
     if (
       isNodeOfType(descendant, "VariableDeclarator") &&
       isNodeOfType(descendant.id, "Identifier") &&
       descendant.init
     ) {
-      localInitializers.set(descendant.id.name, descendant.init);
+      registerLocalBinding(descendant.id.name, descendant.init);
+    } else if (
+      descendant !== lifecycleFunction &&
+      isNodeOfType(descendant, "FunctionDeclaration") &&
+      descendant.id
+    ) {
+      registerLocalBinding(descendant.id.name, descendant);
     }
+    if (descendant !== lifecycleFunction && isFunctionLike(descendant)) return false;
   });
+  if (expressionCallsPostMountHelper(argumentNode, localFunctions, callbackRefFieldNames)) {
+    return true;
+  }
   if (localInitializers.size === 0) return false;
 
   const reachedNames = new Set<string>();
@@ -176,7 +265,8 @@ const argumentDerivesFromPostMountSource = (
     if (isFunctionLike(stripParenExpression(initializer))) continue;
     if (
       containsPostMountSource(initializer) ||
-      containsCallbackRefField(initializer, callbackRefFieldNames)
+      containsCallbackRefField(initializer, callbackRefFieldNames) ||
+      expressionCallsPostMountHelper(initializer, localFunctions, callbackRefFieldNames)
     ) {
       return true;
     }
@@ -266,6 +356,14 @@ const callMayWriteThisField = (
   return false;
 };
 
+const getEnclosingWriterFunction = (node: EsTreeNode, classNode: EsTreeNode): EsTreeNode | null => {
+  let ancestor: EsTreeNode | null | undefined = node.parent;
+  while (ancestor && ancestor !== classNode && !isFunctionLike(ancestor)) {
+    ancestor = ancestor.parent;
+  }
+  return ancestor && ancestor !== classNode ? ancestor : null;
+};
+
 const hasExclusiveCallbackRefFieldWrite = (classNode: EsTreeNode, fieldName: string): boolean => {
   if (fieldName.startsWith("#")) return false;
   const writerFunctions = new Set<EsTreeNode>();
@@ -287,7 +385,12 @@ const hasExclusiveCallbackRefFieldWrite = (classNode: EsTreeNode, fieldName: str
       return false;
     }
     if (isNodeOfType(node, "CallExpression") && callMayWriteThisField(node, fieldName)) {
-      didFindUnsafeWrite = true;
+      const writerFunction = getEnclosingWriterFunction(node, classNode);
+      if (!writerFunction) {
+        didFindUnsafeWrite = true;
+        return false;
+      }
+      writerFunctions.add(writerFunction);
       return false;
     }
     const assignmentTarget =
@@ -316,11 +419,8 @@ const hasExclusiveCallbackRefFieldWrite = (classNode: EsTreeNode, fieldName: str
       return false;
     }
     if (assignmentFieldName !== fieldName) return;
-    let writerFunction: EsTreeNode | null | undefined = node.parent;
-    while (writerFunction && writerFunction !== classNode && !isFunctionLike(writerFunction)) {
-      writerFunction = writerFunction.parent;
-    }
-    if (!writerFunction || writerFunction === classNode) {
+    const writerFunction = getEnclosingWriterFunction(node, classNode);
+    if (!writerFunction) {
       didFindUnsafeWrite = true;
       return false;
     }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.ts
@@ -232,7 +232,25 @@ const hasExclusiveCallbackRefFieldWrite = (classNode: EsTreeNode, fieldName: str
         node.operator === "delete" &&
         (node.argument as EsTreeNode)) ||
       null;
-    if (!assignmentTarget || getThisFieldName(assignmentTarget) !== fieldName) return;
+    if (!assignmentTarget) return;
+    const unwrappedAssignmentTarget = stripParenExpression(assignmentTarget);
+    if (
+      !isNodeOfType(unwrappedAssignmentTarget, "MemberExpression") ||
+      !isNodeOfType(
+        stripParenExpression(unwrappedAssignmentTarget.object as EsTreeNode),
+        "ThisExpression",
+      )
+    ) {
+      return;
+    }
+    const assignmentFieldName = getStaticPropertyKeyName(unwrappedAssignmentTarget, {
+      allowComputedString: true,
+    });
+    if (!assignmentFieldName) {
+      didFindUnsafeWrite = true;
+      return false;
+    }
+    if (assignmentFieldName !== fieldName) return;
     assignmentCount += 1;
   });
   return !didFindUnsafeWrite && assignmentCount === 1;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.ts
@@ -307,14 +307,46 @@ const objectExpressionMayDefineField = (node: EsTreeNode, fieldName: string): bo
   });
 };
 
+const collectMutationReceiverKinds = (
+  classNode: EsTreeNode,
+): ReadonlyMap<string, "object" | "reflect"> => {
+  const receiverKinds = new Map<string, "object" | "reflect">([
+    ["Object", "object"],
+    ["Reflect", "reflect"],
+  ]);
+  let didAddReceiver = true;
+  while (didAddReceiver) {
+    didAddReceiver = false;
+    walkAst(classNode, (node) => {
+      if (
+        !isNodeOfType(node, "VariableDeclarator") ||
+        !isNodeOfType(node.id, "Identifier") ||
+        !node.init
+      ) {
+        return;
+      }
+      const initializer = stripParenExpression(node.init);
+      if (!isNodeOfType(initializer, "Identifier")) return;
+      const receiverKind = receiverKinds.get(initializer.name);
+      if (!receiverKind || receiverKinds.has(node.id.name)) return;
+      receiverKinds.set(node.id.name, receiverKind);
+      didAddReceiver = true;
+    });
+  }
+  return receiverKinds;
+};
+
 const callMayWriteThisField = (
   callExpression: EsTreeNodeOfType<"CallExpression">,
   fieldName: string,
+  receiverKinds: ReadonlyMap<string, "object" | "reflect">,
 ): boolean => {
   const callee = stripParenExpression(callExpression.callee);
   if (!isNodeOfType(callee, "MemberExpression")) return false;
   const receiver = stripParenExpression(callee.object as EsTreeNode);
   if (!isNodeOfType(receiver, "Identifier")) return false;
+  const receiverKind = receiverKinds.get(receiver.name);
+  if (!receiverKind) return false;
   const methodName = getStaticPropertyKeyName(callee, { allowComputedString: true });
   const [target, propertyOrSource, ...remainingArguments] = callExpression.arguments;
   if (
@@ -324,7 +356,7 @@ const callMayWriteThisField = (
   ) {
     return false;
   }
-  if (receiver.name === "Object" && methodName === "assign") {
+  if (receiverKind === "object" && methodName === "assign") {
     const sources = [propertyOrSource, ...remainingArguments];
     return sources.some(
       (source) =>
@@ -333,7 +365,7 @@ const callMayWriteThisField = (
         objectExpressionMayDefineField(source as EsTreeNode, fieldName),
     );
   }
-  if (receiver.name === "Object" && methodName === "defineProperties") {
+  if (receiverKind === "object" && methodName === "defineProperties") {
     return (
       !propertyOrSource ||
       isNodeOfType(propertyOrSource, "SpreadElement") ||
@@ -341,8 +373,8 @@ const callMayWriteThisField = (
     );
   }
   if (
-    (receiver.name === "Object" && methodName === "defineProperty") ||
-    (receiver.name === "Reflect" &&
+    (receiverKind === "object" && methodName === "defineProperty") ||
+    (receiverKind === "reflect" &&
       (methodName === "defineProperty" || methodName === "deleteProperty" || methodName === "set"))
   ) {
     if (!propertyOrSource || isNodeOfType(propertyOrSource, "SpreadElement")) return true;
@@ -366,6 +398,7 @@ const getEnclosingWriterFunction = (node: EsTreeNode, classNode: EsTreeNode): Es
 
 const hasExclusiveCallbackRefFieldWrite = (classNode: EsTreeNode, fieldName: string): boolean => {
   if (fieldName.startsWith("#")) return false;
+  const receiverKinds = collectMutationReceiverKinds(classNode);
   const writerFunctions = new Set<EsTreeNode>();
   let didFindUnsafeWrite = false;
   walkAst(classNode, (node) => {
@@ -384,7 +417,10 @@ const hasExclusiveCallbackRefFieldWrite = (classNode: EsTreeNode, fieldName: str
       didFindUnsafeWrite = true;
       return false;
     }
-    if (isNodeOfType(node, "CallExpression") && callMayWriteThisField(node, fieldName)) {
+    if (
+      isNodeOfType(node, "CallExpression") &&
+      callMayWriteThisField(node, fieldName, receiverKinds)
+    ) {
       const writerFunction = getEnclosingWriterFunction(node, classNode);
       if (!writerFunction) {
         didFindUnsafeWrite = true;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.ts
@@ -718,7 +718,7 @@ const hasExclusiveCallbackRefFieldWrite = (
         return false;
       }
       writerFunctions.add(writerFunction);
-      return false;
+      return;
     }
     const assignmentTarget =
       (isNodeOfType(node, "AssignmentExpression") && (node.left as EsTreeNode)) ||

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.ts
@@ -153,6 +153,159 @@ const containsCallbackRefField = (
   return didFindCallbackRefField;
 };
 
+interface CallbackRefValueEvidence {
+  hasCallbackRefValue: boolean;
+  hasDynamicValue: boolean;
+}
+
+const combineCallbackRefValueEvidence = (
+  nodes: readonly EsTreeNode[],
+  callbackRefFieldNames: ReadonlySet<string>,
+): CallbackRefValueEvidence =>
+  nodes.reduce<CallbackRefValueEvidence>(
+    (evidence, node) => {
+      const nodeEvidence = collectCallbackRefValueEvidence(node, callbackRefFieldNames);
+      return {
+        hasCallbackRefValue: evidence.hasCallbackRefValue || nodeEvidence.hasCallbackRefValue,
+        hasDynamicValue: evidence.hasDynamicValue || nodeEvidence.hasDynamicValue,
+      };
+    },
+    { hasCallbackRefValue: false, hasDynamicValue: false },
+  );
+
+const collectCallbackRefValueEvidence = (
+  node: EsTreeNode,
+  callbackRefFieldNames: ReadonlySet<string>,
+): CallbackRefValueEvidence => {
+  const candidate = stripParenExpression(node);
+  const callbackRefFieldName = getStaticThisFieldName(candidate);
+  if (callbackRefFieldName && callbackRefFieldNames.has(callbackRefFieldName)) {
+    return { hasCallbackRefValue: true, hasDynamicValue: false };
+  }
+  if (isNodeOfType(candidate, "Literal")) {
+    return { hasCallbackRefValue: false, hasDynamicValue: false };
+  }
+  if (isNodeOfType(candidate, "Identifier")) {
+    return {
+      hasCallbackRefValue: false,
+      hasDynamicValue: candidate.name !== "undefined",
+    };
+  }
+  if (isNodeOfType(candidate, "UnaryExpression") || isNodeOfType(candidate, "AwaitExpression")) {
+    return collectCallbackRefValueEvidence(candidate.argument, callbackRefFieldNames);
+  }
+  if (isNodeOfType(candidate, "BinaryExpression") || isNodeOfType(candidate, "LogicalExpression")) {
+    return combineCallbackRefValueEvidence(
+      [candidate.left, candidate.right],
+      callbackRefFieldNames,
+    );
+  }
+  if (isNodeOfType(candidate, "ConditionalExpression")) {
+    return combineCallbackRefValueEvidence(
+      [candidate.test, candidate.consequent, candidate.alternate],
+      callbackRefFieldNames,
+    );
+  }
+  if (isNodeOfType(candidate, "SequenceExpression")) {
+    const finalExpression = candidate.expressions.at(-1);
+    return finalExpression
+      ? collectCallbackRefValueEvidence(finalExpression, callbackRefFieldNames)
+      : { hasCallbackRefValue: false, hasDynamicValue: true };
+  }
+  if (isNodeOfType(candidate, "TemplateLiteral")) {
+    return combineCallbackRefValueEvidence(candidate.expressions, callbackRefFieldNames);
+  }
+  if (isNodeOfType(candidate, "ArrayExpression")) {
+    const elementNodes: EsTreeNode[] = [];
+    for (const element of candidate.elements) {
+      if (!element || isNodeOfType(element, "SpreadElement")) {
+        return { hasCallbackRefValue: false, hasDynamicValue: true };
+      }
+      elementNodes.push(element);
+    }
+    return combineCallbackRefValueEvidence(elementNodes, callbackRefFieldNames);
+  }
+  if (isNodeOfType(candidate, "ObjectExpression")) {
+    const valueNodes: EsTreeNode[] = [];
+    for (const property of candidate.properties) {
+      if (!isNodeOfType(property, "Property") || property.kind !== "init") {
+        return { hasCallbackRefValue: false, hasDynamicValue: true };
+      }
+      if (property.computed === true) valueNodes.push(property.key as EsTreeNode);
+      valueNodes.push(property.value as EsTreeNode);
+    }
+    return combineCallbackRefValueEvidence(valueNodes, callbackRefFieldNames);
+  }
+  if (isNodeOfType(candidate, "MemberExpression")) {
+    const objectEvidence = collectCallbackRefValueEvidence(
+      candidate.object as EsTreeNode,
+      callbackRefFieldNames,
+    );
+    if (!objectEvidence.hasCallbackRefValue || objectEvidence.hasDynamicValue) {
+      return { hasCallbackRefValue: false, hasDynamicValue: true };
+    }
+    if (candidate.computed !== true) return objectEvidence;
+    const propertyEvidence = collectCallbackRefValueEvidence(
+      candidate.property as EsTreeNode,
+      callbackRefFieldNames,
+    );
+    return {
+      hasCallbackRefValue: true,
+      hasDynamicValue: propertyEvidence.hasDynamicValue,
+    };
+  }
+  if (isNodeOfType(candidate, "CallExpression") || isNodeOfType(candidate, "NewExpression")) {
+    const argumentNodes: EsTreeNode[] = [];
+    for (const argument of candidate.arguments) {
+      if (isNodeOfType(argument, "SpreadElement")) {
+        return { hasCallbackRefValue: false, hasDynamicValue: true };
+      }
+      argumentNodes.push(argument as EsTreeNode);
+    }
+    const argumentEvidence = combineCallbackRefValueEvidence(argumentNodes, callbackRefFieldNames);
+    const callee = stripParenExpression(candidate.callee);
+    if (!isNodeOfType(callee, "MemberExpression")) return argumentEvidence;
+    const receiverEvidence = collectCallbackRefValueEvidence(
+      callee.object as EsTreeNode,
+      callbackRefFieldNames,
+    );
+    if (!receiverEvidence.hasCallbackRefValue || receiverEvidence.hasDynamicValue) {
+      return argumentEvidence;
+    }
+    return {
+      hasCallbackRefValue: true,
+      hasDynamicValue: argumentEvidence.hasDynamicValue,
+    };
+  }
+  return { hasCallbackRefValue: false, hasDynamicValue: true };
+};
+
+const isCallbackRefDerivedValue = (
+  node: EsTreeNode,
+  callbackRefFieldNames: ReadonlySet<string>,
+): boolean => {
+  const evidence = collectCallbackRefValueEvidence(node, callbackRefFieldNames);
+  return evidence.hasCallbackRefValue && !evidence.hasDynamicValue;
+};
+
+const functionReturnsCallbackRefDerivedValue = (
+  functionBody: EsTreeNode,
+  callbackRefFieldNames: ReadonlySet<string>,
+): boolean => {
+  if (!isNodeOfType(functionBody, "BlockStatement")) {
+    return isCallbackRefDerivedValue(functionBody, callbackRefFieldNames);
+  }
+  const returnValueNodes: EsTreeNode[] = [];
+  walkAst(functionBody, (node) => {
+    if (node !== functionBody && isFunctionLike(node)) return false;
+    if (isNodeOfType(node, "ReturnStatement") && node.argument) {
+      returnValueNodes.push(node.argument);
+    }
+  });
+  const evidence = combineCallbackRefValueEvidence(returnValueNodes, callbackRefFieldNames);
+  return evidence.hasCallbackRefValue && !evidence.hasDynamicValue;
+};
+
 const collectReferencedNames = (node: EsTreeNode, into: Set<string>): void => {
   walkAst(node, (descendant) => {
     if (!isNodeOfType(descendant, "Identifier")) return;
@@ -199,9 +352,14 @@ const expressionCallsPostMountHelper = (
     const functionBody = (localFunction as { body?: EsTreeNode }).body;
     if (!functionBody) return;
     const nextVisitedFunctionNames = new Set([...visitedFunctionNames, callee.name]);
+    const doesFunctionReadCallbackRefField = containsCallbackRefField(
+      functionBody,
+      callbackRefFieldNames,
+    );
     if (
-      containsPostMountSource(functionBody) ||
-      containsCallbackRefField(functionBody, callbackRefFieldNames) ||
+      (doesFunctionReadCallbackRefField
+        ? functionReturnsCallbackRefDerivedValue(functionBody, callbackRefFieldNames)
+        : containsPostMountSource(functionBody)) ||
       expressionCallsPostMountHelper(
         functionBody,
         localFunctions,
@@ -261,9 +419,14 @@ const argumentDerivesFromPostMountSource = (
     if (descendant !== lifecycleFunction && isFunctionLike(descendant)) return false;
   });
   const doesExpressionDeriveFromPostMountSource = (expression: EsTreeNode): boolean => {
+    const doesExpressionReadCallbackRefField = containsCallbackRefField(
+      expression,
+      callbackRefFieldNames,
+    );
     if (
-      containsPostMountSource(expression) ||
-      containsCallbackRefField(expression, callbackRefFieldNames) ||
+      (doesExpressionReadCallbackRefField
+        ? isCallbackRefDerivedValue(expression, callbackRefFieldNames)
+        : containsPostMountSource(expression)) ||
       expressionCallsPostMountHelper(expression, localFunctions, callbackRefFieldNames)
     ) {
       return true;
@@ -278,9 +441,14 @@ const argumentDerivesFromPostMountSource = (
       const initializer = localInitializers.get(name);
       if (!initializer) continue;
       if (isFunctionLike(stripParenExpression(initializer))) continue;
+      const doesInitializerReadCallbackRefField = containsCallbackRefField(
+        initializer,
+        callbackRefFieldNames,
+      );
       if (
-        containsPostMountSource(initializer) ||
-        containsCallbackRefField(initializer, callbackRefFieldNames) ||
+        (doesInitializerReadCallbackRefField
+          ? isCallbackRefDerivedValue(initializer, callbackRefFieldNames)
+          : containsPostMountSource(initializer)) ||
         expressionCallsPostMountHelper(initializer, localFunctions, callbackRefFieldNames)
       ) {
         return true;
@@ -402,6 +570,12 @@ const collectThisAliasNames = (classNode: EsTreeNode): ReadonlySet<string> => {
   while (didAddAlias) {
     didAddAlias = false;
     walkAst(classNode, (node) => {
+      if (
+        node !== classNode &&
+        (isNodeOfType(node, "ClassDeclaration") || isNodeOfType(node, "ClassExpression"))
+      ) {
+        return false;
+      }
       if (
         !isNodeOfType(node, "VariableDeclarator") ||
         !isNodeOfType(node.id, "Identifier") ||
@@ -529,6 +703,12 @@ const hasExclusiveCallbackRefFieldWrite = (classNode: EsTreeNode, fieldName: str
   if (!writerMemberName) return true;
   let didFindNonRefUsage = false;
   walkAst(classNode, (node) => {
+    if (
+      node !== classNode &&
+      (isNodeOfType(node, "ClassDeclaration") || isNodeOfType(node, "ClassExpression"))
+    ) {
+      return false;
+    }
     if (getStaticThisFieldName(node) === writerMemberName && !isInsideRefAttribute(node)) {
       didFindNonRefUsage = true;
       return false;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.ts
@@ -98,6 +98,22 @@ const containsPostMountSource = (node: EsTreeNode): boolean => {
   return didFindSource;
 };
 
+const containsCallbackRefField = (
+  node: EsTreeNode,
+  callbackRefFieldNames: ReadonlySet<string>,
+): boolean => {
+  let didFindCallbackRefField = false;
+  walkAst(node, (descendant) => {
+    const fieldName = getThisFieldName(descendant);
+    if (fieldName && callbackRefFieldNames.has(fieldName)) {
+      didFindCallbackRefField = true;
+      return false;
+    }
+    return undefined;
+  });
+  return didFindCallbackRefField;
+};
+
 const collectReferencedNames = (node: EsTreeNode, into: Set<string>): void => {
   walkAst(node, (descendant) => {
     if (!isNodeOfType(descendant, "Identifier")) return;
@@ -132,16 +148,8 @@ const argumentDerivesFromPostMountSource = (
   const argumentNodes = setStateCall.arguments ?? [];
   if (argumentNodes.length === 0) return false;
   if (argumentNodes.some((argument) => containsPostMountSource(argument))) return true;
-  for (const argument of argumentNodes) {
-    let didFindCallbackRefField = false;
-    walkAst(argument, (descendant) => {
-      const fieldName = getThisFieldName(descendant);
-      if (fieldName && callbackRefFieldNames.has(fieldName)) {
-        didFindCallbackRefField = true;
-        return false;
-      }
-    });
-    if (didFindCallbackRefField) return true;
+  if (argumentNodes.some((argument) => containsCallbackRefField(argument, callbackRefFieldNames))) {
+    return true;
   }
 
   const localInitializers = new Map<string, EsTreeNode>();
@@ -164,7 +172,12 @@ const argumentDerivesFromPostMountSource = (
     if (name === undefined) break;
     const initializer = localInitializers.get(name);
     if (!initializer) continue;
-    if (containsPostMountSource(initializer)) return true;
+    if (
+      containsPostMountSource(initializer) ||
+      containsCallbackRefField(initializer, callbackRefFieldNames)
+    ) {
+      return true;
+    }
     const referencedNames = new Set<string>();
     collectReferencedNames(initializer, referencedNames);
     for (const referencedName of referencedNames) {
@@ -179,9 +192,16 @@ const argumentDerivesFromPostMountSource = (
 const isUndefinedOrNull = (node: EsTreeNode | null | undefined): boolean => {
   if (!node) return true;
   const value = stripParenExpression(node);
+  const voidOperand = isNodeOfType(value, "UnaryExpression")
+    ? stripParenExpression(value.argument)
+    : null;
   return (
     (isNodeOfType(value, "Identifier") && value.name === "undefined") ||
-    (isNodeOfType(value, "Literal") && value.value === null)
+    (isNodeOfType(value, "Literal") && value.value === null) ||
+    (isNodeOfType(value, "UnaryExpression") &&
+      value.operator === "void" &&
+      isNodeOfType(voidOperand, "Literal") &&
+      voidOperand.value === 0)
   );
 };
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.ts
@@ -1,12 +1,15 @@
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findEnclosingClass } from "../../utils/find-enclosing-class.js";
 import { getNodeStartIndex } from "../../utils/get-node-start-index.js";
+import { getStaticPropertyKeyName } from "../../utils/get-static-property-key-name.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isSetStateCallInLifecycle } from "../../utils/is-set-state-in-lifecycle.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import { walkAst } from "../../utils/walk-ast.js";
+import { getCallbackRefFieldNames, getThisFieldName } from "./no-did-update-set-state.js";
 
 const LIFECYCLE_NAMES = new Set(["componentDidMount"]);
 const MESSAGE =
@@ -124,10 +127,22 @@ const collectReferencedNames = (node: EsTreeNode, into: Set<string>): void => {
 const argumentDerivesFromPostMountSource = (
   setStateCall: EsTreeNodeOfType<"CallExpression">,
   lifecycleFunction: EsTreeNode,
+  callbackRefFieldNames: ReadonlySet<string>,
 ): boolean => {
   const argumentNodes = setStateCall.arguments ?? [];
   if (argumentNodes.length === 0) return false;
   if (argumentNodes.some((argument) => containsPostMountSource(argument))) return true;
+  for (const argument of argumentNodes) {
+    let didFindCallbackRefField = false;
+    walkAst(argument, (descendant) => {
+      const fieldName = getThisFieldName(descendant);
+      if (fieldName && callbackRefFieldNames.has(fieldName)) {
+        didFindCallbackRefField = true;
+        return false;
+      }
+    });
+    if (didFindCallbackRefField) return true;
+  }
 
   const localInitializers = new Map<string, EsTreeNode>();
   walkAst(lifecycleFunction, (descendant) => {
@@ -159,6 +174,48 @@ const argumentDerivesFromPostMountSource = (
     }
   }
   return false;
+};
+
+const isUndefinedOrNull = (node: EsTreeNode | null | undefined): boolean => {
+  if (!node) return true;
+  const value = stripParenExpression(node);
+  return (
+    (isNodeOfType(value, "Identifier") && value.name === "undefined") ||
+    (isNodeOfType(value, "Literal") && value.value === null)
+  );
+};
+
+const hasExclusiveCallbackRefFieldWrite = (classNode: EsTreeNode, fieldName: string): boolean => {
+  if (fieldName.startsWith("#")) return false;
+  let assignmentCount = 0;
+  let didFindUnsafeWrite = false;
+  walkAst(classNode, (node) => {
+    if (
+      node !== classNode &&
+      (isNodeOfType(node, "ClassDeclaration") || isNodeOfType(node, "ClassExpression"))
+    ) {
+      return false;
+    }
+    if (
+      isNodeOfType(node, "PropertyDefinition") &&
+      node.static !== true &&
+      getStaticPropertyKeyName(node, { allowComputedString: true }) === fieldName &&
+      !isUndefinedOrNull(node.value as EsTreeNode | null | undefined)
+    ) {
+      didFindUnsafeWrite = true;
+      return false;
+    }
+    const assignmentTarget =
+      (isNodeOfType(node, "AssignmentExpression") && (node.left as EsTreeNode)) ||
+      (isNodeOfType(node, "UpdateExpression") && (node.argument as EsTreeNode)) ||
+      (isNodeOfType(node, "UnaryExpression") &&
+        node.operator === "delete" &&
+        (node.argument as EsTreeNode)) ||
+      null;
+    if (!assignmentTarget || getThisFieldName(assignmentTarget) !== fieldName) return;
+    assignmentCount += 1;
+  });
+  return !didFindUnsafeWrite && assignmentCount === 1;
 };
 
 // A setState after an `await` in an async componentDidMount is the
@@ -231,7 +288,24 @@ export const noDidMountSetState = defineRule({
         const lifecycleFunction = getEnclosingLifecycleFunction(node);
         if (lifecycleFunction) {
           if (isAfterAwaitInAsyncLifecycle(node, lifecycleFunction)) return;
-          if (argumentDerivesFromPostMountSource(node, lifecycleFunction)) return;
+          const enclosingClass = findEnclosingClass(lifecycleFunction);
+          const callbackRefFieldNames = getCallbackRefFieldNames(enclosingClass, context.scopes);
+          const exclusivelyRefOwnedFieldNames = enclosingClass
+            ? new Set(
+                [...callbackRefFieldNames].filter((fieldName) =>
+                  hasExclusiveCallbackRefFieldWrite(enclosingClass, fieldName),
+                ),
+              )
+            : new Set<string>();
+          if (
+            argumentDerivesFromPostMountSource(
+              node,
+              lifecycleFunction,
+              exclusivelyRefOwnedFieldNames,
+            )
+          ) {
+            return;
+          }
         }
         context.report({ node: node.callee, message: MESSAGE });
       },

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.ts
@@ -1,5 +1,6 @@
 import { defineRule } from "../../utils/define-rule.js";
 import { collectMutationReceiverKinds } from "../../utils/collect-mutation-receiver-kinds.js";
+import type { ScopeAnalysis, SymbolDescriptor } from "../../semantic/scope-analysis.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { findEnclosingClass } from "../../utils/find-enclosing-class.js";
@@ -632,7 +633,60 @@ const getWriterMemberName = (writerFunction: EsTreeNode): string | null => {
   return getStaticPropertyKeyName(parent, { allowComputedString: true });
 };
 
-const hasExclusiveCallbackRefFieldWrite = (classNode: EsTreeNode, fieldName: string): boolean => {
+const isInsideNode = (node: EsTreeNode, ancestorNode: EsTreeNode): boolean => {
+  let ancestor: EsTreeNode | null | undefined = node;
+  while (ancestor) {
+    if (ancestor === ancestorNode) return true;
+    ancestor = ancestor.parent;
+  }
+  return false;
+};
+
+const getDestructuredThisMemberSymbols = (
+  classNode: EsTreeNode,
+  memberName: string,
+  thisAliasNames: ReadonlySet<string>,
+  scopes: ScopeAnalysis,
+): readonly SymbolDescriptor[] => {
+  const symbols: SymbolDescriptor[] = [];
+  walkAst(classNode, (node) => {
+    if (
+      node !== classNode &&
+      (isNodeOfType(node, "ClassDeclaration") || isNodeOfType(node, "ClassExpression"))
+    ) {
+      return false;
+    }
+    if (
+      !isNodeOfType(node, "VariableDeclarator") ||
+      !isNodeOfType(node.id, "ObjectPattern") ||
+      !node.init ||
+      !isThisOrAlias(node.init, thisAliasNames)
+    ) {
+      return;
+    }
+    for (const property of node.id.properties) {
+      if (
+        !isNodeOfType(property, "Property") ||
+        getStaticPropertyKeyName(property, { allowComputedString: true }) !== memberName
+      ) {
+        continue;
+      }
+      const bindingIdentifier = isNodeOfType(property.value, "AssignmentPattern")
+        ? property.value.left
+        : property.value;
+      if (!isNodeOfType(bindingIdentifier, "Identifier")) continue;
+      const symbol = scopes.symbolFor(bindingIdentifier);
+      if (symbol) symbols.push(symbol);
+    }
+  });
+  return symbols;
+};
+
+const hasExclusiveCallbackRefFieldWrite = (
+  classNode: EsTreeNode,
+  fieldName: string,
+  scopes: ScopeAnalysis,
+): boolean => {
   if (fieldName.startsWith("#")) return false;
   const receiverKinds = collectMutationReceiverKinds(classNode);
   const thisAliasNames = collectThisAliasNames(classNode);
@@ -714,7 +768,25 @@ const hasExclusiveCallbackRefFieldWrite = (classNode: EsTreeNode, fieldName: str
       return false;
     }
   });
-  return !didFindNonRefUsage;
+  if (didFindNonRefUsage) return false;
+  const destructuredHandlerSymbols = getDestructuredThisMemberSymbols(
+    classNode,
+    writerMemberName,
+    thisAliasNames,
+    scopes,
+  );
+  if (
+    destructuredHandlerSymbols.some((symbol) =>
+      symbol.references.some(
+        (reference) =>
+          !isInsideNode(reference.identifier, symbol.declarationNode) &&
+          !isInsideRefAttribute(reference.identifier),
+      ),
+    )
+  ) {
+    return false;
+  }
+  return true;
 };
 
 // A setState after an `await` in an async componentDidMount is the
@@ -800,7 +872,7 @@ export const noDidMountSetState = defineRule({
           const exclusivelyRefOwnedFieldNames = enclosingClass
             ? new Set(
                 [...callbackRefFieldNames].filter((fieldName) =>
-                  hasExclusiveCallbackRefFieldWrite(enclosingClass, fieldName),
+                  hasExclusiveCallbackRefFieldWrite(enclosingClass, fieldName, context.scopes),
                 ),
               )
             : new Set<string>();

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.ts
@@ -145,12 +145,10 @@ const argumentDerivesFromPostMountSource = (
   lifecycleFunction: EsTreeNode,
   callbackRefFieldNames: ReadonlySet<string>,
 ): boolean => {
-  const argumentNodes = setStateCall.arguments ?? [];
-  if (argumentNodes.length === 0) return false;
-  if (argumentNodes.some((argument) => containsPostMountSource(argument))) return true;
-  if (argumentNodes.some((argument) => containsCallbackRefField(argument, callbackRefFieldNames))) {
-    return true;
-  }
+  const argumentNode = setStateCall.arguments[0];
+  if (!argumentNode || isNodeOfType(argumentNode, "SpreadElement")) return false;
+  if (containsPostMountSource(argumentNode)) return true;
+  if (containsCallbackRefField(argumentNode, callbackRefFieldNames)) return true;
 
   const localInitializers = new Map<string, EsTreeNode>();
   walkAst(lifecycleFunction, (descendant) => {
@@ -165,7 +163,7 @@ const argumentDerivesFromPostMountSource = (
   if (localInitializers.size === 0) return false;
 
   const reachedNames = new Set<string>();
-  for (const argument of argumentNodes) collectReferencedNames(argument, reachedNames);
+  collectReferencedNames(argumentNode, reachedNames);
   const pendingNames = [...reachedNames];
   while (pendingNames.length > 0) {
     const name = pendingNames.pop();

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.ts
@@ -77,6 +77,7 @@ const containsPostMountSource = (node: EsTreeNode): boolean => {
   let didFindSource = false;
   walkAst(node, (descendant) => {
     if (didFindSource) return false;
+    if (descendant !== node && isFunctionLike(descendant)) return false;
     if (
       isNodeOfType(descendant, "NewExpression") &&
       isNodeOfType(descendant.callee, "Identifier") &&
@@ -104,6 +105,7 @@ const containsCallbackRefField = (
 ): boolean => {
   let didFindCallbackRefField = false;
   walkAst(node, (descendant) => {
+    if (descendant !== node && isFunctionLike(descendant)) return false;
     const fieldName = getThisFieldName(descendant);
     if (fieldName && callbackRefFieldNames.has(fieldName)) {
       didFindCallbackRefField = true;
@@ -152,6 +154,7 @@ const argumentDerivesFromPostMountSource = (
 
   const localInitializers = new Map<string, EsTreeNode>();
   walkAst(lifecycleFunction, (descendant) => {
+    if (descendant !== lifecycleFunction && isFunctionLike(descendant)) return false;
     if (
       isNodeOfType(descendant, "VariableDeclarator") &&
       isNodeOfType(descendant.id, "Identifier") &&
@@ -170,6 +173,7 @@ const argumentDerivesFromPostMountSource = (
     if (name === undefined) break;
     const initializer = localInitializers.get(name);
     if (!initializer) continue;
+    if (isFunctionLike(stripParenExpression(initializer))) continue;
     if (
       containsPostMountSource(initializer) ||
       containsCallbackRefField(initializer, callbackRefFieldNames)
@@ -264,7 +268,7 @@ const callMayWriteThisField = (
 
 const hasExclusiveCallbackRefFieldWrite = (classNode: EsTreeNode, fieldName: string): boolean => {
   if (fieldName.startsWith("#")) return false;
-  let assignmentCount = 0;
+  const writerFunctions = new Set<EsTreeNode>();
   let didFindUnsafeWrite = false;
   walkAst(classNode, (node) => {
     if (
@@ -312,9 +316,17 @@ const hasExclusiveCallbackRefFieldWrite = (classNode: EsTreeNode, fieldName: str
       return false;
     }
     if (assignmentFieldName !== fieldName) return;
-    assignmentCount += 1;
+    let writerFunction: EsTreeNode | null | undefined = node.parent;
+    while (writerFunction && writerFunction !== classNode && !isFunctionLike(writerFunction)) {
+      writerFunction = writerFunction.parent;
+    }
+    if (!writerFunction || writerFunction === classNode) {
+      didFindUnsafeWrite = true;
+      return false;
+    }
+    writerFunctions.add(writerFunction);
   });
-  return !didFindUnsafeWrite && assignmentCount === 1;
+  return !didFindUnsafeWrite && writerFunctions.size === 1;
 };
 
 // A setState after an `await` in an async componentDidMount is the

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.ts
@@ -6,6 +6,7 @@ import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { findEnclosingClass } from "../../utils/find-enclosing-class.js";
 import { getNodeStartIndex } from "../../utils/get-node-start-index.js";
 import { getStaticPropertyKeyName } from "../../utils/get-static-property-key-name.js";
+import { getStaticThisOrAliasFieldName } from "../../utils/get-static-this-or-alias-field-name.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isImmediatelyInvokedFunction } from "../../utils/is-immediately-invoked-function.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
@@ -455,7 +456,13 @@ const argumentDerivesFromPostMountSource = (
     ) {
       registerLocalBinding(descendant.id.name, descendant);
     }
-    if (descendant !== lifecycleFunction && isFunctionLike(descendant)) return false;
+    if (
+      descendant !== lifecycleFunction &&
+      isFunctionLike(descendant) &&
+      !isImmediatelyInvokedFunction(descendant)
+    ) {
+      return false;
+    }
   });
   const doesExpressionDeriveFromPostMountSource = (expression: EsTreeNode): boolean => {
     const doesExpressionReadCallbackRefField = containsCallbackRefField(
@@ -666,15 +673,54 @@ const getEnclosingWriterFunction = (node: EsTreeNode, classNode: EsTreeNode): Es
   return ancestor && ancestor !== classNode ? ancestor : null;
 };
 
-const isInsideRefAttribute = (node: EsTreeNode): boolean => {
+const isDirectRefWrapperHandlerUse = (
+  node: EsTreeNode,
+  wrapperFunction: EsTreeNode,
+  scopes: ScopeAnalysis,
+): boolean => {
+  const parameters = (wrapperFunction as { params?: EsTreeNode[] }).params ?? [];
+  const firstParameter = parameters[0];
+  if (!firstParameter) return false;
+  const parameterIdentifier = isNodeOfType(firstParameter, "AssignmentPattern")
+    ? firstParameter.left
+    : firstParameter;
+  if (!isNodeOfType(parameterIdentifier, "Identifier")) return false;
+  const parameterSymbolId = scopes.symbolFor(parameterIdentifier)?.id;
+  if (parameterSymbolId === undefined) return false;
   let ancestor: EsTreeNode | null | undefined = node.parent;
-  while (ancestor && !isFunctionLike(ancestor)) {
+  while (ancestor && ancestor !== wrapperFunction) {
+    if (isFunctionLike(ancestor)) return false;
+    if (
+      isNodeOfType(ancestor, "CallExpression") &&
+      isInsideNode(node, ancestor.callee as EsTreeNode)
+    ) {
+      const [forwardedValue] = ancestor.arguments;
+      if (!forwardedValue || isNodeOfType(forwardedValue, "SpreadElement")) return false;
+      const unwrappedValue = stripParenExpression(forwardedValue as EsTreeNode);
+      return (
+        isNodeOfType(unwrappedValue, "Identifier") &&
+        scopes.symbolFor(unwrappedValue)?.id === parameterSymbolId
+      );
+    }
+    ancestor = ancestor.parent;
+  }
+  return false;
+};
+
+const isInsideRefAttribute = (node: EsTreeNode, scopes: ScopeAnalysis): boolean => {
+  let wrapperFunction: EsTreeNode | null = null;
+  let ancestor: EsTreeNode | null | undefined = node.parent;
+  while (ancestor) {
+    if (isFunctionLike(ancestor)) {
+      if (wrapperFunction) return false;
+      wrapperFunction = ancestor;
+    }
     if (
       isNodeOfType(ancestor, "JSXAttribute") &&
       isNodeOfType(ancestor.name, "JSXIdentifier") &&
       ancestor.name.name === "ref"
     ) {
-      return true;
+      return !wrapperFunction || isDirectRefWrapperHandlerUse(node, wrapperFunction, scopes);
     }
     ancestor = ancestor.parent;
   }
@@ -817,7 +863,10 @@ const hasExclusiveCallbackRefFieldWrite = (
     ) {
       return false;
     }
-    if (getStaticThisFieldName(node) === writerMemberName && !isInsideRefAttribute(node)) {
+    if (
+      getStaticThisOrAliasFieldName(node, thisAliasNames, classNode) === writerMemberName &&
+      !isInsideRefAttribute(node, scopes)
+    ) {
       didFindNonRefUsage = true;
       return false;
     }
@@ -834,7 +883,7 @@ const hasExclusiveCallbackRefFieldWrite = (
       symbol.references.some(
         (reference) =>
           !isInsideNode(reference.identifier, symbol.declarationNode) &&
-          !isInsideRefAttribute(reference.identifier),
+          !isInsideRefAttribute(reference.identifier, scopes),
       ),
     )
   ) {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.ts
@@ -10,6 +10,7 @@ import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isImmediatelyInvokedFunction } from "../../utils/is-immediately-invoked-function.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isSetStateCallInLifecycle } from "../../utils/is-set-state-in-lifecycle.js";
+import { isSynchronousIteratorCall } from "../../utils/is-synchronous-iterator-callback.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import { walkAst } from "../../utils/walk-ast.js";
 import { getCallbackRefFieldNames } from "./no-did-update-set-state.js";
@@ -54,17 +55,18 @@ const isInsideNestedLifecycleFunction = (
 // right after mount is the deliberate two-pass render pattern (hydration
 // gates, enter animations): the second render IS the point, and no initial
 // state or getDerivedStateFromProps can replace it.
+const isMountFlagProperty = (property: EsTreeNode): boolean =>
+  isNodeOfType(property, "Property") &&
+  property.kind === "init" &&
+  property.computed !== true &&
+  isNodeOfType(property.value, "Literal") &&
+  property.value.value === true;
+
 const isMountFlagArgument = (argument: EsTreeNode | undefined): boolean => {
   if (!argument || !isNodeOfType(argument, "ObjectExpression")) return false;
   const properties = argument.properties ?? [];
   if (properties.length === 0) return false;
-  return properties.every(
-    (property) =>
-      isNodeOfType(property, "Property") &&
-      property.computed !== true &&
-      isNodeOfType(property.value, "Literal") &&
-      property.value.value === true,
-  );
+  return properties.every(isMountFlagProperty);
 };
 
 // Sources whose values genuinely cannot exist before mount — the doc's
@@ -99,16 +101,19 @@ const getStaticThisFieldName = (node: EsTreeNode): string | null => {
   return getStaticPropertyKeyName(candidate, { allowComputedString: true });
 };
 
-const containsPostMountSource = (node: EsTreeNode): boolean => {
+const containsPostMountSource = (node: EsTreeNode, scopes: ScopeAnalysis): boolean => {
   let didFindSource = false;
   walkAst(node, (descendant) => {
     if (didFindSource) return false;
-    if (
-      descendant !== node &&
-      isFunctionLike(descendant) &&
-      !isImmediatelyInvokedFunction(descendant)
-    ) {
-      return false;
+    if (descendant !== node && isFunctionLike(descendant)) {
+      const parent = descendant.parent;
+      if (
+        !isImmediatelyInvokedFunction(descendant) &&
+        (!isNodeOfType(parent, "CallExpression") ||
+          !isSynchronousIteratorCall(parent, descendant, scopes))
+      ) {
+        return false;
+      }
     }
     if (
       isNodeOfType(descendant, "NewExpression") &&
@@ -333,6 +338,7 @@ const expressionCallsPostMountHelper = (
   node: EsTreeNode,
   localFunctions: ReadonlyMap<string, EsTreeNode>,
   callbackRefFieldNames: ReadonlySet<string>,
+  scopes: ScopeAnalysis,
   visitedFunctionNames: ReadonlySet<string> = new Set(),
 ): boolean => {
   let didFindPostMountHelper = false;
@@ -360,11 +366,12 @@ const expressionCallsPostMountHelper = (
     if (
       (doesFunctionReadCallbackRefField
         ? functionReturnsCallbackRefDerivedValue(functionBody, callbackRefFieldNames)
-        : containsPostMountSource(functionBody)) ||
+        : containsPostMountSource(functionBody, scopes)) ||
       expressionCallsPostMountHelper(
         functionBody,
         localFunctions,
         callbackRefFieldNames,
+        scopes,
         nextVisitedFunctionNames,
       )
     ) {
@@ -383,6 +390,7 @@ const argumentDerivesFromPostMountSource = (
   setStateCall: EsTreeNodeOfType<"CallExpression">,
   lifecycleFunction: EsTreeNode,
   callbackRefFieldNames: ReadonlySet<string>,
+  scopes: ScopeAnalysis,
 ): boolean => {
   const argumentNode = setStateCall.arguments[0];
   if (!argumentNode || isNodeOfType(argumentNode, "SpreadElement")) return false;
@@ -427,8 +435,8 @@ const argumentDerivesFromPostMountSource = (
     if (
       (doesExpressionReadCallbackRefField
         ? isCallbackRefDerivedValue(expression, callbackRefFieldNames)
-        : containsPostMountSource(expression)) ||
-      expressionCallsPostMountHelper(expression, localFunctions, callbackRefFieldNames)
+        : containsPostMountSource(expression, scopes)) ||
+      expressionCallsPostMountHelper(expression, localFunctions, callbackRefFieldNames, scopes)
     ) {
       return true;
     }
@@ -449,8 +457,8 @@ const argumentDerivesFromPostMountSource = (
       if (
         (doesInitializerReadCallbackRefField
           ? isCallbackRefDerivedValue(initializer, callbackRefFieldNames)
-          : containsPostMountSource(initializer)) ||
-        expressionCallsPostMountHelper(initializer, localFunctions, callbackRefFieldNames)
+          : containsPostMountSource(initializer, scopes)) ||
+        expressionCallsPostMountHelper(initializer, localFunctions, callbackRefFieldNames, scopes)
       ) {
         return true;
       }
@@ -470,12 +478,19 @@ const argumentDerivesFromPostMountSource = (
     return doesExpressionDeriveFromPostMountSource(statePayload);
   }
   if (statePayload.properties.length === 0) return false;
-  return statePayload.properties.every(
-    (property) =>
-      isNodeOfType(property, "Property") &&
-      property.kind === "init" &&
-      doesExpressionDeriveFromPostMountSource(property.value as EsTreeNode),
-  );
+  let hasPostMountValue = false;
+  for (const property of statePayload.properties) {
+    if (isMountFlagProperty(property)) continue;
+    if (
+      !isNodeOfType(property, "Property") ||
+      property.kind !== "init" ||
+      !doesExpressionDeriveFromPostMountSource(property.value as EsTreeNode)
+    ) {
+      return false;
+    }
+    hasPostMountValue = true;
+  }
+  return hasPostMountValue;
 };
 
 const isUndefinedOrNull = (node: EsTreeNode | null | undefined): boolean => {
@@ -881,6 +896,7 @@ export const noDidMountSetState = defineRule({
               node,
               lifecycleFunction,
               exclusivelyRefOwnedFieldNames,
+              context.scopes,
             )
           ) {
             return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.ts
@@ -1,4 +1,5 @@
 import { defineRule } from "../../utils/define-rule.js";
+import { collectMutationReceiverKinds } from "../../utils/collect-mutation-receiver-kinds.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { findEnclosingClass } from "../../utils/find-enclosing-class.js";
@@ -305,35 +306,6 @@ const objectExpressionMayDefineField = (node: EsTreeNode, fieldName: string): bo
     const propertyName = getStaticPropertyKeyName(property, { allowComputedString: true });
     return propertyName === null || propertyName === fieldName;
   });
-};
-
-const collectMutationReceiverKinds = (
-  classNode: EsTreeNode,
-): ReadonlyMap<string, "object" | "reflect"> => {
-  const receiverKinds = new Map<string, "object" | "reflect">([
-    ["Object", "object"],
-    ["Reflect", "reflect"],
-  ]);
-  let didAddReceiver = true;
-  while (didAddReceiver) {
-    didAddReceiver = false;
-    walkAst(classNode, (node) => {
-      if (
-        !isNodeOfType(node, "VariableDeclarator") ||
-        !isNodeOfType(node.id, "Identifier") ||
-        !node.init
-      ) {
-        return;
-      }
-      const initializer = stripParenExpression(node.init);
-      if (!isNodeOfType(initializer, "Identifier")) return;
-      const receiverKind = receiverKinds.get(initializer.name);
-      if (!receiverKind || receiverKinds.has(node.id.name)) return;
-      receiverKinds.set(node.id.name, receiverKind);
-      didAddReceiver = true;
-    });
-  }
-  return receiverKinds;
 };
 
 const callMayWriteThisField = (

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.ts
@@ -37,6 +37,18 @@ const getEnclosingLifecycleFunction = (setStateCall: EsTreeNode): EsTreeNode | n
   return null;
 };
 
+const isInsideNestedLifecycleFunction = (
+  setStateCall: EsTreeNode,
+  lifecycleFunction: EsTreeNode,
+): boolean => {
+  let ancestor: EsTreeNode | null | undefined = setStateCall.parent;
+  while (ancestor && ancestor !== lifecycleFunction) {
+    if (isFunctionLike(ancestor)) return true;
+    ancestor = ancestor.parent;
+  }
+  return false;
+};
+
 // `this.setState({ hasMounted: true })` — flipping a boolean flag to `true`
 // right after mount is the deliberate two-pass render pattern (hydration
 // gates, enter animations): the second render IS the point, and no initial
@@ -215,8 +227,6 @@ const argumentDerivesFromPostMountSource = (
 ): boolean => {
   const argumentNode = setStateCall.arguments[0];
   if (!argumentNode || isNodeOfType(argumentNode, "SpreadElement")) return false;
-  if (containsPostMountSource(argumentNode)) return true;
-  if (containsCallbackRefField(argumentNode, callbackRefFieldNames)) return true;
 
   const localInitializers = new Map<string, EsTreeNode>();
   const localFunctions = new Map<string, EsTreeNode>();
@@ -250,36 +260,53 @@ const argumentDerivesFromPostMountSource = (
     }
     if (descendant !== lifecycleFunction && isFunctionLike(descendant)) return false;
   });
-  if (expressionCallsPostMountHelper(argumentNode, localFunctions, callbackRefFieldNames)) {
-    return true;
-  }
-  if (localInitializers.size === 0) return false;
-
-  const reachedNames = new Set<string>();
-  collectReferencedNames(argumentNode, reachedNames);
-  const pendingNames = [...reachedNames];
-  while (pendingNames.length > 0) {
-    const name = pendingNames.pop();
-    if (name === undefined) break;
-    const initializer = localInitializers.get(name);
-    if (!initializer) continue;
-    if (isFunctionLike(stripParenExpression(initializer))) continue;
+  const doesExpressionDeriveFromPostMountSource = (expression: EsTreeNode): boolean => {
     if (
-      containsPostMountSource(initializer) ||
-      containsCallbackRefField(initializer, callbackRefFieldNames) ||
-      expressionCallsPostMountHelper(initializer, localFunctions, callbackRefFieldNames)
+      containsPostMountSource(expression) ||
+      containsCallbackRefField(expression, callbackRefFieldNames) ||
+      expressionCallsPostMountHelper(expression, localFunctions, callbackRefFieldNames)
     ) {
       return true;
     }
-    const referencedNames = new Set<string>();
-    collectReferencedNames(initializer, referencedNames);
-    for (const referencedName of referencedNames) {
-      if (reachedNames.has(referencedName)) continue;
-      reachedNames.add(referencedName);
-      pendingNames.push(referencedName);
+    if (localInitializers.size === 0) return false;
+    const reachedNames = new Set<string>();
+    collectReferencedNames(expression, reachedNames);
+    const pendingNames = [...reachedNames];
+    while (pendingNames.length > 0) {
+      const name = pendingNames.pop();
+      if (name === undefined) break;
+      const initializer = localInitializers.get(name);
+      if (!initializer) continue;
+      if (isFunctionLike(stripParenExpression(initializer))) continue;
+      if (
+        containsPostMountSource(initializer) ||
+        containsCallbackRefField(initializer, callbackRefFieldNames) ||
+        expressionCallsPostMountHelper(initializer, localFunctions, callbackRefFieldNames)
+      ) {
+        return true;
+      }
+      const referencedNames = new Set<string>();
+      collectReferencedNames(initializer, referencedNames);
+      for (const referencedName of referencedNames) {
+        if (reachedNames.has(referencedName)) continue;
+        reachedNames.add(referencedName);
+        pendingNames.push(referencedName);
+      }
     }
+    return false;
+  };
+
+  const statePayload = stripParenExpression(argumentNode as EsTreeNode);
+  if (!isNodeOfType(statePayload, "ObjectExpression")) {
+    return doesExpressionDeriveFromPostMountSource(statePayload);
   }
-  return false;
+  if (statePayload.properties.length === 0) return false;
+  return statePayload.properties.every(
+    (property) =>
+      isNodeOfType(property, "Property") &&
+      property.kind === "init" &&
+      doesExpressionDeriveFromPostMountSource(property.value as EsTreeNode),
+  );
 };
 
 const isUndefinedOrNull = (node: EsTreeNode | null | undefined): boolean => {
@@ -503,8 +530,16 @@ export const noDidMountSetState = defineRule({
           disallowInNestedFunctions: mode === "disallow-in-func",
         });
         if (!shouldFlag) return;
-        if (isMountFlagArgument(node.arguments?.[0])) return;
         const lifecycleFunction = getEnclosingLifecycleFunction(node);
+        if (
+          lifecycleFunction &&
+          mode === "disallow-in-func" &&
+          isInsideNestedLifecycleFunction(node, lifecycleFunction)
+        ) {
+          context.report({ node: node.callee, message: MESSAGE });
+          return;
+        }
+        if (isMountFlagArgument(node.arguments?.[0])) return;
         if (lifecycleFunction) {
           if (isAfterAwaitInAsyncLifecycle(node, lifecycleFunction)) return;
           const enclosingClass = findEnclosingClass(lifecycleFunction);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-mount-set-state.ts
@@ -335,10 +335,19 @@ const objectExpressionMayDefineField = (node: EsTreeNode, fieldName: string): bo
   });
 };
 
+const isThisOrAlias = (node: EsTreeNode, thisAliasNames: ReadonlySet<string>): boolean => {
+  const candidate = stripParenExpression(node);
+  return (
+    isNodeOfType(candidate, "ThisExpression") ||
+    (isNodeOfType(candidate, "Identifier") && thisAliasNames.has(candidate.name))
+  );
+};
+
 const callMayWriteThisField = (
   callExpression: EsTreeNodeOfType<"CallExpression">,
   fieldName: string,
   receiverKinds: ReadonlyMap<string, "object" | "reflect">,
+  thisAliasNames: ReadonlySet<string>,
 ): boolean => {
   const callee = stripParenExpression(callExpression.callee);
   if (!isNodeOfType(callee, "MemberExpression")) return false;
@@ -348,11 +357,11 @@ const callMayWriteThisField = (
   if (!receiverKind) return false;
   const methodName = getStaticPropertyKeyName(callee, { allowComputedString: true });
   const [target, propertyOrSource, ...remainingArguments] = callExpression.arguments;
-  if (
-    !target ||
-    isNodeOfType(target, "SpreadElement") ||
-    !isNodeOfType(stripParenExpression(target as EsTreeNode), "ThisExpression")
-  ) {
+  const unwrappedTarget =
+    target && !isNodeOfType(target, "SpreadElement")
+      ? stripParenExpression(target as EsTreeNode)
+      : null;
+  if (!unwrappedTarget || !isThisOrAlias(unwrappedTarget, thisAliasNames)) {
     return false;
   }
   if (receiverKind === "object" && methodName === "assign") {
@@ -387,6 +396,34 @@ const callMayWriteThisField = (
   return false;
 };
 
+const collectThisAliasNames = (classNode: EsTreeNode): ReadonlySet<string> => {
+  const thisAliasNames = new Set<string>();
+  let didAddAlias = true;
+  while (didAddAlias) {
+    didAddAlias = false;
+    walkAst(classNode, (node) => {
+      if (
+        !isNodeOfType(node, "VariableDeclarator") ||
+        !isNodeOfType(node.id, "Identifier") ||
+        !node.init
+      ) {
+        return;
+      }
+      const initializer = stripParenExpression(node.init);
+      if (
+        !isNodeOfType(initializer, "ThisExpression") &&
+        (!isNodeOfType(initializer, "Identifier") || !thisAliasNames.has(initializer.name))
+      ) {
+        return;
+      }
+      if (thisAliasNames.has(node.id.name)) return;
+      thisAliasNames.add(node.id.name);
+      didAddAlias = true;
+    });
+  }
+  return thisAliasNames;
+};
+
 const getEnclosingWriterFunction = (node: EsTreeNode, classNode: EsTreeNode): EsTreeNode | null => {
   let ancestor: EsTreeNode | null | undefined = node.parent;
   while (ancestor && ancestor !== classNode && !isFunctionLike(ancestor)) {
@@ -395,9 +432,36 @@ const getEnclosingWriterFunction = (node: EsTreeNode, classNode: EsTreeNode): Es
   return ancestor && ancestor !== classNode ? ancestor : null;
 };
 
+const isInsideRefAttribute = (node: EsTreeNode): boolean => {
+  let ancestor: EsTreeNode | null | undefined = node.parent;
+  while (ancestor && !isFunctionLike(ancestor)) {
+    if (
+      isNodeOfType(ancestor, "JSXAttribute") &&
+      isNodeOfType(ancestor.name, "JSXIdentifier") &&
+      ancestor.name.name === "ref"
+    ) {
+      return true;
+    }
+    ancestor = ancestor.parent;
+  }
+  return false;
+};
+
+const getWriterMemberName = (writerFunction: EsTreeNode): string | null => {
+  const parent = writerFunction.parent;
+  if (
+    !parent ||
+    (!isNodeOfType(parent, "MethodDefinition") && !isNodeOfType(parent, "PropertyDefinition"))
+  ) {
+    return null;
+  }
+  return getStaticPropertyKeyName(parent, { allowComputedString: true });
+};
+
 const hasExclusiveCallbackRefFieldWrite = (classNode: EsTreeNode, fieldName: string): boolean => {
   if (fieldName.startsWith("#")) return false;
   const receiverKinds = collectMutationReceiverKinds(classNode);
+  const thisAliasNames = collectThisAliasNames(classNode);
   const writerFunctions = new Set<EsTreeNode>();
   let didFindUnsafeWrite = false;
   walkAst(classNode, (node) => {
@@ -418,7 +482,7 @@ const hasExclusiveCallbackRefFieldWrite = (classNode: EsTreeNode, fieldName: str
     }
     if (
       isNodeOfType(node, "CallExpression") &&
-      callMayWriteThisField(node, fieldName, receiverKinds)
+      callMayWriteThisField(node, fieldName, receiverKinds, thisAliasNames)
     ) {
       const writerFunction = getEnclosingWriterFunction(node, classNode);
       if (!writerFunction) {
@@ -439,10 +503,7 @@ const hasExclusiveCallbackRefFieldWrite = (classNode: EsTreeNode, fieldName: str
     const unwrappedAssignmentTarget = stripParenExpression(assignmentTarget);
     if (
       !isNodeOfType(unwrappedAssignmentTarget, "MemberExpression") ||
-      !isNodeOfType(
-        stripParenExpression(unwrappedAssignmentTarget.object as EsTreeNode),
-        "ThisExpression",
-      )
+      !isThisOrAlias(unwrappedAssignmentTarget.object as EsTreeNode, thisAliasNames)
     ) {
       return;
     }
@@ -461,7 +522,19 @@ const hasExclusiveCallbackRefFieldWrite = (classNode: EsTreeNode, fieldName: str
     }
     writerFunctions.add(writerFunction);
   });
-  return !didFindUnsafeWrite && writerFunctions.size === 1;
+  if (didFindUnsafeWrite || writerFunctions.size !== 1) return false;
+  const [writerFunction] = writerFunctions;
+  if (!writerFunction) return false;
+  const writerMemberName = getWriterMemberName(writerFunction);
+  if (!writerMemberName) return true;
+  let didFindNonRefUsage = false;
+  walkAst(classNode, (node) => {
+    if (getStaticThisFieldName(node) === writerMemberName && !isInsideRefAttribute(node)) {
+      didFindNonRefUsage = true;
+      return false;
+    }
+  });
+  return !didFindNonRefUsage;
 };
 
 // A setState after an `await` in an async componentDidMount is the

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-update-set-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-update-set-state.ts
@@ -1,5 +1,6 @@
 import { collectPatternNames } from "../../utils/collect-pattern-names.js";
 import { collectReferenceIdentifierNames } from "../../utils/collect-reference-identifier-names.js";
+import { collectMutationReceiverKinds } from "../../utils/collect-mutation-receiver-kinds.js";
 import { areExpressionsStructurallyEqual } from "../../utils/are-expressions-structurally-equal.js";
 import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
 import { defineRule } from "../../utils/define-rule.js";
@@ -331,6 +332,7 @@ const getCallbackRefAssignedFields = (
   if (parameterSymbolId === undefined) return new Set();
   const body = (callback as { body?: EsTreeNode }).body;
   if (!body) return new Set();
+  const receiverKinds = collectMutationReceiverKinds(callback);
   const assignedFieldNames = new Set<string>();
   walkAst(body, (node) => {
     if (
@@ -366,6 +368,8 @@ const getCallbackRefAssignedFields = (
     if (!isNodeOfType(callee, "MemberExpression")) return;
     const receiver = stripParenExpression(callee.object as EsTreeNode);
     if (!isNodeOfType(receiver, "Identifier")) return;
+    const receiverKind = receiverKinds.get(receiver.name);
+    if (!receiverKind) return;
     const methodName = getStaticPropertyKeyName(callee, { allowComputedString: true });
     const [target, propertyOrSource, assignedValue, ...remainingArguments] = node.arguments;
     if (
@@ -375,7 +379,7 @@ const getCallbackRefAssignedFields = (
     ) {
       return;
     }
-    if (receiver.name === "Object" && methodName === "assign") {
+    if (receiverKind === "object" && methodName === "assign") {
       for (const source of [propertyOrSource, assignedValue, ...remainingArguments]) {
         if (!source || isNodeOfType(source, "SpreadElement")) continue;
         const objectExpression = stripParenExpression(source as EsTreeNode);
@@ -394,7 +398,7 @@ const getCallbackRefAssignedFields = (
       return;
     }
     if (
-      receiver.name === "Reflect" &&
+      receiverKind === "reflect" &&
       methodName === "set" &&
       propertyOrSource &&
       !isNodeOfType(propertyOrSource, "SpreadElement")

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-update-set-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-update-set-state.ts
@@ -333,6 +333,57 @@ const getCallbackRefAssignedFields = (
   const body = (callback as { body?: EsTreeNode }).body;
   if (!body) return new Set();
   const receiverKinds = collectMutationReceiverKinds(callback);
+  const thisAliasNames = new Set<string>();
+  let didAddThisAlias = true;
+  while (didAddThisAlias) {
+    didAddThisAlias = false;
+    walkAst(body, (node) => {
+      if (
+        node !== body &&
+        ((FUNCTION_NODE_TYPES.has(node.type) && !isImmediatelyInvokedFunction(node)) ||
+          CLASS_NODE_TYPES.has(node.type))
+      ) {
+        return false;
+      }
+      if (
+        !isNodeOfType(node, "VariableDeclarator") ||
+        !isNodeOfType(node.id, "Identifier") ||
+        !node.init
+      ) {
+        return;
+      }
+      const initializer = stripParenExpression(node.init);
+      if (
+        !isNodeOfType(initializer, "ThisExpression") &&
+        (!isNodeOfType(initializer, "Identifier") || !thisAliasNames.has(initializer.name))
+      ) {
+        return;
+      }
+      if (thisAliasNames.has(node.id.name)) return;
+      thisAliasNames.add(node.id.name);
+      didAddThisAlias = true;
+    });
+  }
+  const isThisOrAlias = (node: EsTreeNode): boolean => {
+    const candidate = stripParenExpression(node);
+    return (
+      isNodeOfType(candidate, "ThisExpression") ||
+      (isNodeOfType(candidate, "Identifier") && thisAliasNames.has(candidate.name))
+    );
+  };
+  const getThisOrAliasFieldName = (node: EsTreeNode): string | null => {
+    const candidate = stripParenExpression(node);
+    if (
+      !isNodeOfType(candidate, "MemberExpression") ||
+      !isThisOrAlias(candidate.object as EsTreeNode)
+    ) {
+      return null;
+    }
+    if (isNodeOfType(candidate.property, "PrivateIdentifier")) {
+      return `#${candidate.property.name}`;
+    }
+    return getStaticPropertyKeyName(candidate, { allowComputedString: true });
+  };
   const assignedFieldNames = new Set<string>();
   walkAst(body, (node) => {
     if (
@@ -350,7 +401,7 @@ const getCallbackRefAssignedFields = (
         (node.argument as EsTreeNode)) ||
       null;
     if (assignmentTarget) {
-      const fieldName = getThisFieldName(assignmentTarget);
+      const fieldName = getThisOrAliasFieldName(assignmentTarget);
       if (!fieldName) return;
       if (
         isNodeOfType(node, "AssignmentExpression") &&
@@ -372,11 +423,7 @@ const getCallbackRefAssignedFields = (
     if (!receiverKind) return;
     const methodName = getStaticPropertyKeyName(callee, { allowComputedString: true });
     const [target, propertyOrSource, assignedValue, ...remainingArguments] = node.arguments;
-    if (
-      !target ||
-      isNodeOfType(target, "SpreadElement") ||
-      !isNodeOfType(stripParenExpression(target as EsTreeNode), "ThisExpression")
-    ) {
+    if (!target || isNodeOfType(target, "SpreadElement") || !isThisOrAlias(target as EsTreeNode)) {
       return;
     }
     if (receiverKind === "object" && methodName === "assign") {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-update-set-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-update-set-state.ts
@@ -281,12 +281,14 @@ export const getThisFieldName = (node: EsTreeNode): string | null => {
   const unwrappedNode = stripParenExpression(node);
   if (
     !isNodeOfType(unwrappedNode, "MemberExpression") ||
-    unwrappedNode.computed === true ||
     !isNodeOfType(stripParenExpression(unwrappedNode.object as EsTreeNode), "ThisExpression")
   ) {
     return null;
   }
-  return getMemberIdentity(unwrappedNode.property);
+  if (isNodeOfType(unwrappedNode.property, "PrivateIdentifier")) {
+    return `#${unwrappedNode.property.name}`;
+  }
+  return getStaticPropertyKeyName(unwrappedNode, { allowComputedString: true });
 };
 
 const isUndefinedIdentifier = (node: EsTreeNode): boolean => {
@@ -345,18 +347,70 @@ const getCallbackRefAssignedFields = (
         node.operator === "delete" &&
         (node.argument as EsTreeNode)) ||
       null;
-    if (!assignmentTarget) return;
-    const fieldName = getThisFieldName(assignmentTarget);
-    if (!fieldName) return;
-    if (
-      isNodeOfType(node, "AssignmentExpression") &&
-      node.operator === "=" &&
-      isDirectRefParameterValue(node.right as EsTreeNode, parameterSymbolId, scopes)
-    ) {
-      assignedFieldNames.add(fieldName);
+    if (assignmentTarget) {
+      const fieldName = getThisFieldName(assignmentTarget);
+      if (!fieldName) return;
+      if (
+        isNodeOfType(node, "AssignmentExpression") &&
+        node.operator === "=" &&
+        isDirectRefParameterValue(node.right as EsTreeNode, parameterSymbolId, scopes)
+      ) {
+        assignedFieldNames.add(fieldName);
+        return;
+      }
+      assignedFieldNames.delete(fieldName);
       return;
     }
-    assignedFieldNames.delete(fieldName);
+    if (!isNodeOfType(node, "CallExpression")) return;
+    const callee = stripParenExpression(node.callee);
+    if (!isNodeOfType(callee, "MemberExpression")) return;
+    const receiver = stripParenExpression(callee.object as EsTreeNode);
+    if (!isNodeOfType(receiver, "Identifier")) return;
+    const methodName = getStaticPropertyKeyName(callee, { allowComputedString: true });
+    const [target, propertyOrSource, assignedValue, ...remainingArguments] = node.arguments;
+    if (
+      !target ||
+      isNodeOfType(target, "SpreadElement") ||
+      !isNodeOfType(stripParenExpression(target as EsTreeNode), "ThisExpression")
+    ) {
+      return;
+    }
+    if (receiver.name === "Object" && methodName === "assign") {
+      for (const source of [propertyOrSource, assignedValue, ...remainingArguments]) {
+        if (!source || isNodeOfType(source, "SpreadElement")) continue;
+        const objectExpression = stripParenExpression(source as EsTreeNode);
+        if (!isNodeOfType(objectExpression, "ObjectExpression")) continue;
+        for (const property of objectExpression.properties) {
+          if (!isNodeOfType(property, "Property")) continue;
+          const propertyName = getStaticPropertyKeyName(property, { allowComputedString: true });
+          if (!propertyName) continue;
+          if (isDirectRefParameterValue(property.value as EsTreeNode, parameterSymbolId, scopes)) {
+            assignedFieldNames.add(propertyName);
+          } else {
+            assignedFieldNames.delete(propertyName);
+          }
+        }
+      }
+      return;
+    }
+    if (
+      receiver.name === "Reflect" &&
+      methodName === "set" &&
+      propertyOrSource &&
+      !isNodeOfType(propertyOrSource, "SpreadElement")
+    ) {
+      const propertyNameNode = stripParenExpression(propertyOrSource as EsTreeNode);
+      const propertyName =
+        isNodeOfType(propertyNameNode, "Literal") && typeof propertyNameNode.value === "string"
+          ? propertyNameNode.value
+          : null;
+      if (!propertyName || !assignedValue || isNodeOfType(assignedValue, "SpreadElement")) return;
+      if (isDirectRefParameterValue(assignedValue as EsTreeNode, parameterSymbolId, scopes)) {
+        assignedFieldNames.add(propertyName);
+      } else {
+        assignedFieldNames.delete(propertyName);
+      }
+    }
   });
   return assignedFieldNames;
 };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-update-set-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-update-set-state.ts
@@ -277,7 +277,7 @@ const isHistoricalToCurrentTransitionGuard = (
   );
 };
 
-const getThisFieldName = (node: EsTreeNode): string | null => {
+export const getThisFieldName = (node: EsTreeNode): string | null => {
   const unwrappedNode = stripParenExpression(node);
   if (
     !isNodeOfType(unwrappedNode, "MemberExpression") ||
@@ -433,7 +433,7 @@ const collectCallbackRefFieldsFromExpression = (
   }
 };
 
-const getCallbackRefFieldNames = (
+export const getCallbackRefFieldNames = (
   classNode: EsTreeNode | null,
   scopes: ScopeAnalysis,
 ): ReadonlySet<string> => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-update-set-state.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-did-update-set-state.ts
@@ -8,6 +8,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { findEnclosingClass } from "../../utils/find-enclosing-class.js";
 import { getStaticPropertyKeyName } from "../../utils/get-static-property-key-name.js";
+import { getStaticThisOrAliasFieldName } from "../../utils/get-static-this-or-alias-field-name.js";
 import { getPropertyKeyName } from "../../utils/get-property-key-name.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isImmediatelyInvokedFunction } from "../../utils/is-immediately-invoked-function.js";
@@ -320,6 +321,8 @@ const isDirectRefParameterValue = (
 const getCallbackRefAssignedFields = (
   callback: EsTreeNode,
   scopes: ScopeAnalysis,
+  classNode: EsTreeNode | null = null,
+  visitedHandlerNames: ReadonlySet<string> = new Set(),
 ): ReadonlySet<string> => {
   const parameters = (callback as { params?: EsTreeNode[] }).params ?? [];
   const firstParameter = parameters[0];
@@ -417,6 +420,30 @@ const getCallbackRefAssignedFields = (
     if (!isNodeOfType(node, "CallExpression")) return;
     const callee = stripParenExpression(node.callee);
     if (!isNodeOfType(callee, "MemberExpression")) return;
+    const handlerName = getStaticThisOrAliasFieldName(callee, thisAliasNames);
+    const [forwardedValue] = node.arguments;
+    if (
+      classNode &&
+      handlerName &&
+      !visitedHandlerNames.has(handlerName) &&
+      forwardedValue &&
+      !isNodeOfType(forwardedValue, "SpreadElement") &&
+      isDirectRefParameterValue(forwardedValue as EsTreeNode, parameterSymbolId, scopes)
+    ) {
+      const handler = getClassMemberCallback(classNode, handlerName);
+      if (handler) {
+        const nextVisitedHandlerNames = new Set([...visitedHandlerNames, handlerName]);
+        for (const fieldName of getCallbackRefAssignedFields(
+          handler,
+          scopes,
+          classNode,
+          nextVisitedHandlerNames,
+        )) {
+          assignedFieldNames.add(fieldName);
+        }
+      }
+      return;
+    }
     const receiver = stripParenExpression(callee.object as EsTreeNode);
     if (!isNodeOfType(receiver, "Identifier")) return;
     const receiverKind = receiverKinds.get(receiver.name);
@@ -490,7 +517,7 @@ const collectCallbackRefFieldsFromExpression = (
 ): void => {
   const unwrappedExpression = stripParenExpression(expression);
   if (FUNCTION_NODE_TYPES.has(unwrappedExpression.type)) {
-    for (const fieldName of getCallbackRefAssignedFields(unwrappedExpression, scopes)) {
+    for (const fieldName of getCallbackRefAssignedFields(unwrappedExpression, scopes, classNode)) {
       fieldNames.add(fieldName);
     }
     return;
@@ -499,7 +526,7 @@ const collectCallbackRefFieldsFromExpression = (
   if (handlerName) {
     const callback = getClassMemberCallback(classNode, handlerName);
     if (callback) {
-      for (const fieldName of getCallbackRefAssignedFields(callback, scopes)) {
+      for (const fieldName of getCallbackRefAssignedFields(callback, scopes, classNode)) {
         fieldNames.add(fieldName);
       }
     }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/collect-mutation-receiver-kinds.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/collect-mutation-receiver-kinds.ts
@@ -1,0 +1,33 @@
+import type { EsTreeNode } from "./es-tree-node.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+import { stripParenExpression } from "./strip-paren-expression.js";
+import { walkAst } from "./walk-ast.js";
+
+export interface MutationReceiverKinds extends ReadonlyMap<string, "object" | "reflect"> {}
+
+export const collectMutationReceiverKinds = (rootNode: EsTreeNode): MutationReceiverKinds => {
+  const receiverKinds = new Map<string, "object" | "reflect">([
+    ["Object", "object"],
+    ["Reflect", "reflect"],
+  ]);
+  let didAddReceiver = true;
+  while (didAddReceiver) {
+    didAddReceiver = false;
+    walkAst(rootNode, (node) => {
+      if (
+        !isNodeOfType(node, "VariableDeclarator") ||
+        !isNodeOfType(node.id, "Identifier") ||
+        !node.init
+      ) {
+        return;
+      }
+      const initializer = stripParenExpression(node.init);
+      if (!isNodeOfType(initializer, "Identifier")) return;
+      const receiverKind = receiverKinds.get(initializer.name);
+      if (!receiverKind || receiverKinds.has(node.id.name)) return;
+      receiverKinds.set(node.id.name, receiverKind);
+      didAddReceiver = true;
+    });
+  }
+  return receiverKinds;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-static-this-or-alias-field-name.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-static-this-or-alias-field-name.ts
@@ -1,0 +1,24 @@
+import type { EsTreeNode } from "./es-tree-node.js";
+import { findEnclosingClass } from "./find-enclosing-class.js";
+import { getStaticPropertyKeyName } from "./get-static-property-key-name.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+import { stripParenExpression } from "./strip-paren-expression.js";
+
+export const getStaticThisOrAliasFieldName = (
+  node: EsTreeNode,
+  thisAliasNames: ReadonlySet<string>,
+  classNode?: EsTreeNode,
+): string | null => {
+  const candidate = stripParenExpression(node);
+  if (!isNodeOfType(candidate, "MemberExpression")) return null;
+  const receiver = stripParenExpression(candidate.object as EsTreeNode);
+  const isClassThis =
+    isNodeOfType(receiver, "ThisExpression") &&
+    (!classNode || findEnclosingClass(receiver) === classNode);
+  const isThisAlias = isNodeOfType(receiver, "Identifier") && thisAliasNames.has(receiver.name);
+  if (!isClassThis && !isThisAlias) return null;
+  if (isNodeOfType(candidate.property, "PrivateIdentifier")) {
+    return `#${candidate.property.name}`;
+  }
+  return getStaticPropertyKeyName(candidate, { allowComputedString: true });
+};


### PR DESCRIPTION
## Summary
- recognize class fields populated exclusively by React callback refs as post-mount-only values
- keep competing writers, prop-derived initializers, unrelated fields, and non-ref callbacks diagnosed
- add exact ReactBench regression coverage, adversarial fuzz controls, and a patch changeset

## ReactBench evidence
- Harbor trial: `fix-react-rdh-hacker0x01-react-d__3UEZkbb`
- exact source: `src/calendar.fixed.tsx`, SHA-256 `27a8167b55ebee6356e592910bfadd074778dc5501b48cf2daebb6437188ef5c`
- live contract reserves mount-time state for values that cannot exist before mount, such as measured DOM state
- baseline `b1352a2`: 1 `no-did-mount-set-state` diagnostic, 0 parse errors
- branch `c24ae9f02`: 0 diagnostics, 0 parse errors
- baseline artifact SHA-256: `1f7669460a6b0d4c3e8f53709ee13c1ee2f338488e05a40219984f0d07cd3123`
- head artifact SHA-256: `641ccb5ae7368a671b053dbfb1f738eb044f450900be386faab0e0864977618f`

## Validation
- plugin suite: 957 files, 24,800 passed, 201 skipped
- fuzz verdict suite: 192 passed, 782 skipped
- strict targeted fuzz: 500 iterations
- typecheck: 16/16 tasks
- lint, format check, build (9/9), JSON smoke: green

This PR is intentionally not authorized for merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large static-analysis changes to a widely used lint rule; incorrect exemptions could hide real extra-render issues, though coverage is heavy on regressions and fuzz corpora.
> 
> **Overview**
> **`no-did-mount-set-state`** now treats more mount-time `setState` as intentional when state comes from values that only exist after render.
> 
> The rule skips diagnostics when the payload is built from **class fields written only by JSX callback refs** (including forwarded ref wrappers, `Object.assign`/`Reflect` writes, and lifecycle locals), or from **DOM measurements** (with IIFEs and proven-synchronous `map` callbacks). **Boolean mount flags** (`true`) may sit alongside measured fields in the same object without blocking the exemption.
> 
> It still reports competing writers, prop-fed handlers, mixed pre-mount props, and nested `setState` under **`disallow-in-func`**. Shared helpers were added or extended (`getCallbackRefFieldNames`, mutation-receiver tracking), plus fuzz corpus cases and a large regression suite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f227c112a79b212768a5e9d969650c44705dd14a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->