### PR TITLE
RDFPFN792026: respect dynamic Intl utility inputs

### DIFF
--- a/.changeset/quiet-formatters-rest.md
+++ b/.changeset/quiet-formatters-rest.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Avoid reporting Intl formatters in plain utilities when their locale or options come from caller input.

--- a/packages/core/tests/fixtures/basic-react/src/new-rules.tsx
+++ b/packages/core/tests/fixtures/basic-react/src/new-rules.tsx
@@ -35,8 +35,8 @@ export const cachePropertyAccessHotLoop = (items: Item[]): number => {
 export const lengthCheckFirst = (a: number[], b: number[]): boolean =>
   a.every((value, index) => value === b[index]);
 
-export const intlInRender = (amount: number, locale: string): string => {
-  const formatter = new Intl.NumberFormat(locale, { style: "currency", currency: "USD" });
+export const intlInRender = (amount: number): string => {
+  const formatter = new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" });
   return formatter.format(amount);
 };
 

--- a/packages/fuzz/corpus/regressions/js-hoist-intl--dynamic-locale-utility.ts
+++ b/packages/fuzz/corpus/regressions/js-hoist-intl--dynamic-locale-utility.ts
@@ -1,0 +1,17 @@
+// verdict: pass
+// rule: js-hoist-intl
+// weakness: framework-gating
+// source: ReactBench Cloudscape format-date-localized
+
+export const formatDateLocalized = ({ date, locale }: { date: Date; locale?: string }) => {
+  const formattedDate = new Intl.DateTimeFormat(locale, {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  }).format(date);
+  const formattedTime = new Intl.DateTimeFormat(locale, {
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(date);
+  return `${formattedDate} ${formattedTime}`;
+};

--- a/packages/fuzz/corpus/true-positives/js-hoist-intl--static-locale-utility.ts
+++ b/packages/fuzz/corpus/true-positives/js-hoist-intl--static-locale-utility.ts
@@ -1,0 +1,10 @@
+// verdict: fail
+// rule: js-hoist-intl
+// weakness: framework-gating
+// source: React Doctor adversarial control
+
+export const formatAmount = (value: number) =>
+  new Intl.NumberFormat("en-US", {
+    currency: "USD",
+    style: "currency",
+  }).format(value);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness-fixtures.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness-fixtures.ts
@@ -392,7 +392,7 @@ export const livenessFixtures: Readonly<Record<string, LivenessFixture>> = {
     code: "const result = items.map((item) => item.value).filter(Boolean);",
   },
   "js-hoist-intl": {
-    code: "function fmt(locale, n) { return new Intl.NumberFormat(locale).format(n); }",
+    code: 'function fmt(n) { return new Intl.NumberFormat("en-US").format(n); }',
   },
   "js-hoist-regexp": {
     code: 'for (const line of lines) { const m = new RegExp("\\\\d+", "i"); m.test(line); }',

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-hoist-intl.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-hoist-intl.regressions.test.ts
@@ -12,10 +12,10 @@ describe("js-performance/js-hoist-intl — regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
-  it("still flags an unconditional Intl allocation in a function body", () => {
+  it("still flags an unconditional Intl allocation with a static locale", () => {
     const result = runRule(
       jsHoistIntl,
-      `function fmt(locale, n) { return new Intl.NumberFormat(locale).format(n); }`,
+      `function fmt(n) { return new Intl.NumberFormat("en-US").format(n); }`,
     );
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics.length).toBeGreaterThan(0);
@@ -131,7 +131,7 @@ function getFormatter(locale) {
     expect(result.diagnostics).toEqual([]);
   });
 
-  it("still flags an allocation guarded by an unrelated `.includes` if-test (no cache write)", () => {
+  it("stays silent on dynamic utility input behind a branch", () => {
     const result = runRule(
       jsHoistIntl,
       `function formatPrice(label, value, locale) {
@@ -142,7 +142,7 @@ function getFormatter(locale) {
 }`,
     );
     expect(result.parseErrors).toEqual([]);
-    expect(result.diagnostics.length).toBeGreaterThan(0);
+    expect(result.diagnostics).toEqual([]);
   });
 
   it("still flags a `.set` that stores the formatted string, not the formatter", () => {
@@ -217,6 +217,67 @@ function getFormatter(locale) {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("stays silent when a plain utility formats with its caller locale", () => {
+    const result = runRule(
+      jsHoistIntl,
+      `function formatDateLocalized({ date, locale }) {
+  const value = new Date(date);
+  const month = new Intl.DateTimeFormat(locale, {
+    month: "long",
+    year: "numeric",
+  }).format(value);
+  const fullDate = new Intl.DateTimeFormat(locale, {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  }).format(value);
+  const time = new Intl.DateTimeFormat(locale, {
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(value);
+  return { month, fullDate, time };
+}`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent on the emitted Cloudscape utility with a locale alias", () => {
+    const result = runRule(
+      jsHoistIntl,
+      `function formatDateLocalized(_a) {
+  var date = _a.date, locale = _a.locale;
+  var month = new Intl.DateTimeFormat(locale, {
+    month: "long",
+    year: "numeric",
+  }).format(date);
+  var fullDate = new Intl.DateTimeFormat(locale, {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  }).format(date);
+  var time = new Intl.DateTimeFormat(locale, {
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(date);
+  return { month: month, fullDate: fullDate, time: time };
+}`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent on aliased destructured locale and direct options parameters", () => {
+    const result = runRule(
+      jsHoistIntl,
+      `function formatAmount({ locale: language }, value, options) {
+  return new Intl.NumberFormat(language, options).format(value);
+}`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("still flags a component spreading a props options object", () => {
     const result = runRule(
       jsHoistIntl,
@@ -224,6 +285,42 @@ function getFormatter(locale) {
   const text = new Intl.NumberFormat(locale, { ...options }).format(value);
   return text;
 };`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("still flags a Hook using a dynamic locale outside useMemo", () => {
+    const result = runRule(
+      jsHoistIntl,
+      `function useFormattedDate(locale, value) {
+  return new Intl.DateTimeFormat(locale).format(value);
+}`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("still flags a parameter-shadowing static locale", () => {
+    const result = runRule(
+      jsHoistIntl,
+      `function formatAmount(locale, value) {
+  {
+    const locale = "en-US";
+    return new Intl.NumberFormat(locale).format(value);
+  }
+}`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("still flags a dynamic locale inside a nested hot callback", () => {
+    const result = runRule(
+      jsHoistIntl,
+      `function formatAmounts(locale, values) {
+  return values.map((value) => new Intl.NumberFormat(locale).format(value));
+}`,
     );
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics.length).toBeGreaterThan(0);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-hoist-intl.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-hoist-intl.ts
@@ -1,8 +1,8 @@
-import { collectPatternNames } from "../../utils/collect-pattern-names.js";
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
 import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
+import { getRootIdentifier } from "../../utils/get-root-identifier.js";
 import { getRootIdentifierName } from "../../utils/get-root-identifier-name.js";
 import { isAstDescendant } from "../../utils/is-ast-descendant.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
@@ -226,32 +226,80 @@ const getFunctionName = (functionNode: EsTreeNode): string | null => {
   return null;
 };
 
-// A named plain utility that MERGES a caller-supplied options parameter
-// into the Intl config (`new Intl.NumberFormat(locale, { …defaults,
-// ...options })`): the arbitrary options object cannot be used as a cache
-// key, so neither hoisting nor a keyed memo applies — the doc's "per-call
-// dynamic input that can't be cached" false-positive condition. A bare
-// locale parameter stays flagged: a `Map` keyed by locale is the
-// documented fix for that shape.
-const isUncacheableOptionsMergeUtility = (node: EsTreeNodeOfType<"NewExpression">): boolean => {
+const doesIdentifierResolveToFunctionParameter = (
+  identifier: EsTreeNodeOfType<"Identifier">,
+  enclosingFunction: EsTreeNodeOfType<
+    "ArrowFunctionExpression" | "FunctionExpression" | "FunctionDeclaration"
+  >,
+): boolean => {
+  const visitedBindings = new Set<EsTreeNode>();
+  let currentIdentifier: EsTreeNodeOfType<"Identifier"> | null = identifier;
+  while (currentIdentifier) {
+    const binding = findVariableInitializer(currentIdentifier, currentIdentifier.name, {
+      preferInitializerBeforeReference: true,
+    });
+    if (!binding || visitedBindings.has(binding.bindingIdentifier)) return false;
+    if (
+      (enclosingFunction.params ?? []).some(
+        (parameter) =>
+          binding.bindingIdentifier === parameter ||
+          isAstDescendant(binding.bindingIdentifier, parameter),
+      )
+    ) {
+      return true;
+    }
+    if (!binding.initializer) return false;
+
+    visitedBindings.add(binding.bindingIdentifier);
+    currentIdentifier = getRootIdentifier(binding.initializer);
+  }
+  return false;
+};
+
+const isIdentifierValueReference = (identifier: EsTreeNodeOfType<"Identifier">): boolean => {
+  const parent = identifier.parent;
+  if (!parent) return true;
+  if (
+    isNodeOfType(parent, "MemberExpression") &&
+    parent.property === identifier &&
+    !parent.computed
+  ) {
+    return false;
+  }
+  if (
+    isNodeOfType(parent, "Property") &&
+    parent.key === identifier &&
+    parent.value !== identifier &&
+    !parent.computed
+  ) {
+    return false;
+  }
+  return true;
+};
+
+const hasDynamicIntlUtilityArguments = (node: EsTreeNodeOfType<"NewExpression">): boolean => {
   const enclosingFunction = findEnclosingFunction(node);
   if (!enclosingFunction || !isFunctionLike(enclosingFunction)) return false;
   const functionName = getFunctionName(enclosingFunction);
   if (!functionName || isComponentOrHookName(functionName)) return false;
-  const parameterNames = new Set<string>();
-  for (const parameter of enclosingFunction.params ?? []) {
-    collectPatternNames(parameter, parameterNames);
+
+  let didReferenceParameter = false;
+  for (const argument of node.arguments ?? []) {
+    walkAst(argument, (candidate: EsTreeNode) => {
+      if (didReferenceParameter) return false;
+      if (candidate !== argument && isFunctionLike(candidate)) return false;
+      if (!isNodeOfType(candidate, "Identifier")) return;
+      if (
+        isIdentifierValueReference(candidate) &&
+        doesIdentifierResolveToFunctionParameter(candidate, enclosingFunction)
+      ) {
+        didReferenceParameter = true;
+        return false;
+      }
+    });
+    if (didReferenceParameter) return true;
   }
-  if (parameterNames.size === 0) return false;
-  return (node.arguments ?? []).some((argument) => {
-    if (!isNodeOfType(argument, "ObjectExpression")) return false;
-    return (argument.properties ?? []).some(
-      (property) =>
-        isNodeOfType(property, "SpreadElement") &&
-        isNodeOfType(property.argument, "Identifier") &&
-        parameterNames.has(property.argument.name),
-    );
-  });
+  return false;
 };
 
 const isIntlNewExpression = (node: EsTreeNode, context: RuleContext): boolean => {
@@ -327,7 +375,7 @@ export const jsHoistIntl = defineRule({
       if (!inFunctionBody) return;
       if (isInsideCacheMemo(node)) return;
       if (isDiscardedProbeInsideTry(node)) return;
-      if (isUncacheableOptionsMergeUtility(node)) return;
+      if (hasDynamicIntlUtilityArguments(node)) return;
 
       const className =
         isNodeOfType(node.callee, "MemberExpression") &&


### PR DESCRIPTION
## Why

ReactBench trial `fix-react-cloudscape-design-comp__gJBeG5i` exposed three `js-hoist-intl` false positives in Cloudscape’s `formatDateLocalized` helper. Its locale is caller-provided, so hoisting a singleton formatter would capture the wrong locale. This matches the live rule documentation’s dynamic-input exception.

## What

- suppress plain named utilities only when an actual Intl constructor argument resolves to that utility’s parameter
- follow destructured and emitted alias bindings such as `_a.locale`
- preserve diagnostics for static utilities, React components/Hooks, shadowed static values, and nested hot callbacks
- add exact regression coverage, fuzz pass/fail seeds, liveness updates, and a patch changeset

## Eval evidence

- exact ReactBench replay before: 3 diagnostics on exact source lines
- exact ReactBench replay after: 0 diagnostics, 0 parse errors, 3/3 exact source matches
- adversarial controls after: static utility 1, dynamic component 1, nested hot callback 1
- head replay artifact SHA-256: `01e563bc6c53d5635b5dcf97363901fe00d4b98b510f0c244d1b4ec9c09ded9c`

## Validation

- `nr test` — 15/15 workspace tasks green
- `nr typecheck`
- `nr lint`
- `nr format:check`
- `nr smoke:json-report`
- focused `vercel-skill-parity.test.ts` — 21/21
- strict targeted fuzz — 500 iterations
- full plugin suite — 25,001 tests (24,800 passed, 201 skipped)

Daytona/RDE remote parity could not start locally because `DAYTONA_API_KEY` and `AXIOM_DATASET` are absent; exact stored-trial replay and local gates are included above.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-rule precision change in oxlint-plugin-react-doctor with extensive regression and fuzz coverage; no runtime product or security impact.
> 
> **Overview**
> **`js-hoist-intl`** no longer nags **plain named utilities** when `new Intl.*` uses **caller-driven** locale or options. The old exemption only covered **object spreads** of an `options` parameter; it now walks **all constructor arguments** and skips reporting when a **value reference** traces back to a **function parameter** (including destructuring, renames like `locale: language`, and emitted aliases such as `_a.locale`).
> 
> **React components, hooks, static-locale utilities, shadowed “static” locales, and hot nested callbacks** still get diagnostics. Regression tests, fuzz pass/fail seeds, liveness fixtures, and a patch changeset document the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9a447685fee27361c73092852340cbc7b78f921. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->