### PR TITLE
RDFPFN792026: avoid no-flush-sync Awareness false positives

### DIFF
--- a/.changeset/tidy-editors-sync.md
+++ b/.changeset/tidy-editors-sync.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Avoid `no-flush-sync` false positives for Softmaple Awareness integrations that synchronize editor selections with committed text.

--- a/packages/fuzz/corpus/regressions/no-flush-sync--awareness-guarded-selection-restore.tsx
+++ b/packages/fuzz/corpus/regressions/no-flush-sync--awareness-guarded-selection-restore.tsx
@@ -1,0 +1,22 @@
+// rule: no-flush-sync
+// weakness: library-idiom
+// source: react-bench write-react-softmaple-softmaple q73E2SU
+
+import { useTextareaSelectionSync } from "@softmaple/awareness/hooks";
+import { flushSync } from "react-dom";
+
+export const commitRemoteOperations = (
+  textarea: HTMLTextAreaElement,
+  operations: readonly unknown[],
+): void => {
+  const selectionSync = useTextareaSelectionSync({ current: textarea });
+  const selection = selectionSync.captureSelection();
+  const mergedText = readRemoteText();
+  flushSync(() => {
+    setText(mergedText);
+  });
+  if (!selection || operations.length === 0) {
+    return;
+  }
+  selectionSync.restoreSelection(selection);
+};

--- a/packages/fuzz/corpus/regressions/no-flush-sync--awareness-inline-selection-restore.tsx
+++ b/packages/fuzz/corpus/regressions/no-flush-sync--awareness-inline-selection-restore.tsx
@@ -1,0 +1,15 @@
+// rule: no-flush-sync
+// weakness: library-idiom
+// source: react-bench write-react-softmaple-softmaple jGcM6e2
+
+import { useTextareaSelectionSync } from "@softmaple/awareness/hooks";
+import { flushSync } from "react-dom";
+
+export const runReplicaChange = (textarea: HTMLTextAreaElement): void => {
+  const selectionSync = useTextareaSelectionSync({ current: textarea });
+  const selection = selectionSync.captureSelection();
+  flushSync(() => {
+    setText(readRemoteText());
+    selectionSync.restoreSelection(selection);
+  });
+};

--- a/packages/fuzz/corpus/regressions/no-flush-sync--awareness-operation-handoff.tsx
+++ b/packages/fuzz/corpus/regressions/no-flush-sync--awareness-operation-handoff.tsx
@@ -1,0 +1,15 @@
+// rule: no-flush-sync
+// weakness: library-idiom
+// source: react-bench write-react-softmaple-softmaple pdH5s6A
+
+import type { PositionOperation } from "@softmaple/awareness/mapping";
+import { flushSync } from "react-dom";
+
+export const applyRemoteEvents = (operations: PositionOperation[]): void => {
+  flushSync(() => {
+    setSynced({
+      text: readRemoteText(),
+      remoteOperations: operations,
+    });
+  });
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/view-transitions/no-flush-sync.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/view-transitions/no-flush-sync.regressions.test.ts
@@ -66,6 +66,86 @@ const useShakaControl = () => {
     );
   });
 
+  it("stays silent when an awareness hook restores a committed selection", () => {
+    expectPass(
+      `import { useTextareaSelectionSync } from "@softmaple/awareness/hooks";
+import { flushSync } from "react-dom";
+const runReplicaChange = (localSync, localSelection) => {
+  flushSync(() => {
+    setLocalText(localReplica.getText());
+    localSync.restoreSelection(localSelection);
+  });
+};`,
+    );
+  });
+
+  it("stays silent when awareness operations cross a committed render boundary", () => {
+    expectPass(
+      `import type { PositionOperation } from "@softmaple/awareness/mapping";
+import { flushSync } from "react-dom";
+const applyRemoteEvents = (operations: PositionOperation[]) => {
+  flushSync(() => {
+    setSynced({
+      text: replica.getText(),
+      remoteOperations: operations,
+    });
+  });
+};`,
+    );
+  });
+
+  it("stays silent when awareness restores a selection after commit guards", () => {
+    expectPass(
+      `import { useTextareaSelectionSync } from "@softmaple/awareness/hooks";
+import { flushSync } from "react-dom";
+const commitRemoteOperations = (selectionSync, selectionBefore, operations) => {
+  const mergedText = replica.getText();
+  flushSync(() => {
+    setText(mergedText);
+  });
+  if (!selectionBefore || operations.length === 0) {
+    return;
+  }
+  const textarea = textareaRef.current;
+  if (!textarea || textarea.value !== mergedText) {
+    return;
+  }
+  selectionSync.restoreSelection(
+    mapSelectionThroughOperations(selectionBefore, operations),
+  );
+};`,
+    );
+  });
+
+  it("still flags synchronous loading state before async work", () => {
+    expectFail(
+      `import { flushSync } from "react-dom";
+const confirmDelete = async () => {
+  flushSync(() => setDeleteInProgress(true));
+  try {
+    await deleteDecision();
+  } finally {
+    setDeleteInProgress(false);
+  }
+};`,
+    );
+  });
+
+  it("still flags loading state in a file that only imports awareness types", () => {
+    expectFail(
+      `import type { PositionOperation } from "@softmaple/awareness/mapping";
+import { flushSync } from "react-dom";
+const confirmDelete = async (operations: PositionOperation[]) => {
+  flushSync(() => setDeleteInProgress(true));
+  try {
+    await deleteDecision(operations);
+  } finally {
+    setDeleteInProgress(false);
+  }
+};`,
+    );
+  });
+
   // FP anchor (marigold ToastProvider): flushSync inside
   // startViewTransition is the sanctioned pairing — it doesn't skip the
   // transition, it drives it.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/view-transitions/no-flush-sync.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/view-transitions/no-flush-sync.ts
@@ -15,6 +15,13 @@ import { walkAst } from "../../utils/walk-ast.js";
 const IMPERATIVE_DOM_LIBRARY_SOURCE_PATTERN =
   /^(?:@floating-ui\/|@popperjs\/|react-popper$|popper\.js$|shaka-player)/;
 
+const AWARENESS_LIBRARY_SOURCE_PATTERN = /^@softmaple\/awareness\/(?:hooks|mapping)$/;
+
+const AWARENESS_SELECTION_SIGNAL_NAMES: ReadonlySet<string> = new Set([
+  "remoteOperations",
+  "restoreSelection",
+]);
+
 // DOM reads that only make sense against a committed tree. `flushSync`
 // followed by (or wrapped around) one of these is the documented
 // exemption: a third-party/imperative consumer measuring fresh layout.
@@ -234,15 +241,56 @@ const findProgram = (node: EsTreeNode): EsTreeNode | null => {
   return null;
 };
 
-const importsImperativeDomLibrary = (program: EsTreeNode): boolean => {
-  for (const stmt of (program as { body?: EsTreeNode[] }).body ?? []) {
-    if (!isNodeOfType(stmt, "ImportDeclaration")) continue;
-    const source = stmt.source?.value;
-    if (typeof source === "string" && IMPERATIVE_DOM_LIBRARY_SOURCE_PATTERN.test(source)) {
+const importsLibraryMatching = (program: EsTreeNode, sourcePattern: RegExp): boolean => {
+  for (const statement of (program as { body?: EsTreeNode[] }).body ?? []) {
+    if (!isNodeOfType(statement, "ImportDeclaration")) continue;
+    const source = statement.source?.value;
+    if (typeof source === "string" && sourcePattern.test(source)) {
       return true;
     }
   }
   return false;
+};
+
+const subtreeUsesAwarenessSelection = (root: EsTreeNode | null | undefined): boolean => {
+  if (!root) return false;
+  let found = false;
+  walkAst(root, (child: EsTreeNode) => {
+    if (isNodeOfType(child, "Identifier") && AWARENESS_SELECTION_SIGNAL_NAMES.has(child.name)) {
+      found = true;
+      return false;
+    }
+  });
+  return found;
+};
+
+const enclosingFunctionUsesAwarenessSelection = (node: EsTreeNode): boolean => {
+  let cursor: EsTreeNode | null | undefined = node.parent;
+  while (cursor) {
+    if (isFunctionLike(cursor)) {
+      const body = (cursor as { body?: EsTreeNode | null }).body;
+      return subtreeUsesAwarenessSelection(body);
+    }
+    cursor = cursor.parent ?? null;
+  }
+  return false;
+};
+
+const hasAwarenessSelectionFlushSyncCall = (program: EsTreeNode, localName: string): boolean => {
+  if (!importsLibraryMatching(program, AWARENESS_LIBRARY_SOURCE_PATTERN)) return false;
+  let found = false;
+  walkAst(program, (child: EsTreeNode) => {
+    if (
+      isNodeOfType(child, "CallExpression") &&
+      isNodeOfType(child.callee, "Identifier") &&
+      child.callee.name === localName &&
+      enclosingFunctionUsesAwarenessSelection(child)
+    ) {
+      found = true;
+      return false;
+    }
+  });
+  return found;
 };
 
 // A justified call keeps the import regardless of the file's other call
@@ -301,10 +349,11 @@ export const noFlushSync = defineRule({
 
         const program = findProgram(node as EsTreeNode);
         if (program) {
-          if (importsImperativeDomLibrary(program)) return;
+          if (importsLibraryMatching(program, IMPERATIVE_DOM_LIBRARY_SOURCE_PATTERN)) return;
           const localName = isNodeOfType(specifier.local, "Identifier")
             ? specifier.local.name
             : "flushSync";
+          if (hasAwarenessSelectionFlushSyncCall(program, localName)) return;
           if (hasExemptFlushSyncCall(program, localName)) return;
         }
 


### PR DESCRIPTION
## Why

Three Harbor trials in Softmaple use `flushSync` as React's documented imperative-integration escape hatch: commit collaborative text before Awareness restores or remaps the textarea selection. Current main reports each use as `react-doctor/no-flush-sync` even though replacing it with a transition would break the committed-DOM boundary.

Confirmed trials:

- `write-react-softmaple-softmaple__jGcM6e2`
- `write-react-softmaple-softmaple__pdH5s6A`
- `write-react-softmaple-softmaple__q73E2SU`

## What changed

- Recognize the exact `@softmaple/awareness/hooks` and `/mapping` integrations only when the same enclosing function contains a selection synchronization signal (`restoreSelection` or `remoteOperations`).
- Keep unrelated loading-state `flushSync` calls reportable even when the file imports an Awareness type.
- Add one minimized fuzz regression per confirmed false positive and a patch changeset.

## Exact replay

Reconstructed all three trials from Softmaple base `19f8db643b50d8d3224820613fe388279205bf26` plus each Harbor `verifier/model.patch`, with React Doctor scan caching disabled.

| Revision | jGcM6e2 | pdH5s6A | q73E2SU |
| --- | ---: | ---: | ---: |
| current main `b1352a2be4baf42962b1624151b7382fc09dc3ca` | 1 | 1 | 1 |
| candidate `6649f943d00d2a166aeff3c853d468bafe1cf79c` | 0 | 0 | 0 |

Evidence hashes:

- baseline aggregate: `56a25390d74900827da13b2dc9656c489a447033624a0054a6ef7405681d8fa0`
- jGcM6e2 candidate JSON: `49bc6f2d4eb086535e206ac24c6f4216ac1e81044cf85175928c0e4ac8eb6ef9`
- pdH5s6A candidate JSON: `5bf7f819f1fda0b4270b573fdeec360ce53fff1c21fc900fca1660e2853ab39b`
- q73E2SU candidate JSON: `708510aee236a965c7f6848df1d705d39114472e6a679778e1d475d3acaf868c`

The CrowdSec async loading-state shape (`flushSync(() => setDeleteInProgress(true))`) remains a true positive, including the adversarial mixed Awareness-type-import variant.

## Validation

- `nr test` — 15/15 tasks green; plugin: 957 files, 24,799 passed, 201 skipped
- `nr typecheck`
- `nr lint` — green with existing corpus warnings
- `nr build`
- `nr format:check`
- `nr smoke:json-report`
- `FUZZ_RULE=no-flush-sync FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz`
- exact three-trial Harbor replay, cache disabled: 3 → 0

A targeted local RDE sample was attempted, but the checked-out eval runner decodes JSON report schema v1 while this CLI emits schema v3, so it rejected every candidate report before scoring. This PR does not claim RDE sample evidence from that incompatible run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-only heuristic change with explicit guards; no runtime or security impact.
> 
> **Overview**
> **`no-flush-sync`** no longer reports `@softmaple/awareness` integrations that commit remote text before restoring or remapping editor selection.
> 
> The rule skips the import diagnostic when the file imports `@softmaple/awareness/hooks` or `/mapping` and a `flushSync` call sits in the same enclosing function as selection-sync signals (`restoreSelection` or `remoteOperations`). Imperative-DOM import detection is generalized via `importsLibraryMatching`. Unrelated patterns—e.g. `flushSync` for loading state with only an Awareness type import—still fail.
> 
> Adds three fuzz regression fixtures and regression tests for the exempt and still-flagged cases, plus a patch changeset for `oxlint-plugin-react-doctor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6649f943d00d2a166aeff3c853d468bafe1cf79c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Final current-main parity

The immutable 2,000-project matrix replay is complete against current main `6b64dfaf9e973139d1df2d09f405c9d916e158a3` and prospective merge commit `32937002b269d2bdcc9423cecb8a8b04e7878234`. Both candidate and scoped shared-base artifacts contain 2,000/2,000 records with zero skipped projects. The exact `react-doctor/no-flush-sync` comparison is `+0/-0`, with 1,284 unchanged diagnostic identities.

- candidate NDJSON SHA-256: `1bf382a1ff1bb47cf5b4926d03a828c11dff44db8920d95d9a2c209175c4460b`
- shared scoped-base NDJSON SHA-256: `1501643bf3b616e7bcad2c060f81195461551778b0d43d6f44b8826c913f429d`
- parity JSON SHA-256: `6ac72d02984fa08e11af635d0f36322754c7b97d46c7dce627fff684b9f0434f`
- evaluator source SHA-256: `7dcb7c25d0608f37151cd4354d708f14980876a5463fcea95d4ad4d3f9f21c40`
- corpus manifest SHA-256: `ff8f5bfca41e411d4ad16b57d69c90c5a7b723ea6190f5ef94052af64af02b01`

Daytona cleanup for the matrix group was independently verified twice at zero sandboxes with the exact snapshot absent.
