### PR TITLE
RDFPFN792026: gate exhaustive deps custom Hook analysis

### DIFF
--- a/.changeset/quiet-custom-hooks.md
+++ b/.changeset/quiet-custom-hooks.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Keep `exhaustive-deps` quiet for unconfigured custom Hooks without dependency arrays.

--- a/packages/fuzz/corpus/regressions/exhaustive-deps--unconfigured-stable-callback-hook.tsx
+++ b/packages/fuzz/corpus/regressions/exhaustive-deps--unconfigured-stable-callback-hook.tsx
@@ -1,0 +1,48 @@
+// rule: exhaustive-deps
+// verdict: pass
+// weakness: framework-gating
+// source: React Bench write-react-xr843-fojin-775__6TM24iQ
+
+import { useCallback, useEffect, useRef } from "react";
+
+const useStableCallback = <Arguments extends unknown[], Result>(
+  callback: (...argumentsForCallback: Arguments) => Result,
+) => {
+  const callbackRef = useRef(callback);
+  useEffect(() => {
+    callbackRef.current = callback;
+  }, [callback]);
+  return useCallback(
+    (...argumentsForCallback: Arguments) => callbackRef.current(...argumentsForCallback),
+    [],
+  );
+};
+
+interface ChatProps {
+  readonly cite: (message: string) => void;
+  readonly rate: (message: string) => void;
+  readonly retry: (message: string) => void;
+  readonly send: (message: string) => void;
+  readonly share: (message: string) => void;
+}
+
+export const Chat = ({ send, share, retry, cite, rate }: ChatProps) => {
+  const sendMessage = useStableCallback((message: string) => send(message));
+  const shareMessage = useStableCallback((message: string) => share(message));
+  const retryMessage = useStableCallback((message: string) => retry(message));
+  const citeMessage = useStableCallback((message: string) => cite(message));
+  const rateMessage = useStableCallback((message: string) => rate(message));
+  return (
+    <button
+      onClick={() => {
+        sendMessage("send");
+        shareMessage("share");
+        retryMessage("retry");
+        citeMessage("cite");
+        rateMessage("rate");
+      }}
+    >
+      Run callbacks
+    </button>
+  );
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/custom-hook-forwarded-fresh-deps.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/custom-hook-forwarded-fresh-deps.regressions.test.ts
@@ -37,7 +37,19 @@ const defaultFreshnessRuleCases: ForwardedFreshRuleCase[] = [
 ];
 
 const runRuleWithFilename = (rule: Rule, code: string, filename: string) =>
-  runRule(rule, code, { filename });
+  runRule(rule, code, {
+    filename,
+    settings:
+      rule === exhaustiveDeps
+        ? {
+            "react-doctor": {
+              exhaustiveDeps: {
+                additionalHooks: "^use",
+              },
+            },
+          }
+        : undefined,
+  });
 
 describe("custom Hook forwarded fresh dependencies", () => {
   let temporaryDirectory = "";

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.regressions.test.ts
@@ -7,6 +7,34 @@ import { exhaustiveDeps } from "./exhaustive-deps.js";
 import { clearExhaustiveDepsSuppressionCache } from "./exhaustive-deps-suppression.js";
 
 describe("react-builtins/exhaustive-deps — regressions", () => {
+  it("does not analyze unconfigured custom callback Hooks without dependency arrays", () => {
+    const code = `
+      import { useCallback, useEffect, useRef } from "react";
+
+      const useStableCallback = (callback) => {
+        const callbackRef = useRef(callback);
+        useEffect(() => {
+          callbackRef.current = callback;
+        }, [callback]);
+        return useCallback((...argumentsForCallback) => {
+          return callbackRef.current(...argumentsForCallback);
+        }, []);
+      };
+
+      const Chat = ({ send, share, retry, cite, rate }) => {
+        const sendMessage = useStableCallback((message) => send(message));
+        const shareMessage = useStableCallback((message) => share(message));
+        const retryMessage = useStableCallback((message) => retry(message));
+        const citeMessage = useStableCallback((message) => cite(message));
+        const rateMessage = useStableCallback((message) => rate(message));
+        return null;
+      };
+    `;
+    const result = runRule(exhaustiveDeps, code);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it.each([
     [
       "a shadowing local",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.ts
@@ -1691,6 +1691,9 @@ If the missing value is recreated every render, move it inside the hook or stabi
 
     return {
       CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+        const hookName = getHookName(node.callee, context.scopes);
+        if (!hookName || !isHookOfInterest(hookName, node.callee)) return;
+
         for (const finding of findForwardedFreshHookDependencies(
           node,
           context,
@@ -1702,8 +1705,6 @@ If the missing value is recreated every render, move it inside the hook or stabi
           });
         }
 
-        const hookName = getHookName(node.callee, context.scopes);
-        if (!hookName || !isHookOfInterest(hookName, node.callee)) return;
         if (
           HOOKS_REQUIRING_DEPS_MATCH.has(hookName) &&
           !isReactApiCall(node, HOOKS_REQUIRING_DEPS_MATCH, context.scopes, {


### PR DESCRIPTION
## Why

React Bench trial `write-react-xr843-fojin-775__6TM24iQ` exposed five false positives from `exhaustive-deps`. A local `useStableCallback(callback)` Hook intentionally has no dependency-array argument, but forwarded-fresh-dependency analysis ran before the rule checked whether the Hook was built in or explicitly configured.

The current rule contract only analyzes supported React Hooks and custom Hooks matched by `settings.react-doctor.exhaustiveDeps.additionalHooks`.

## What

- Gate forwarded-fresh analysis behind the existing supported/configured Hook check
- Preserve configured custom-Hook findings with explicit `additionalHooks` settings in the adversarial regression suite
- Add the exact five-call false-positive shape and a fuzz corpus fixture
- Add a patch changeset

## Evaluation

- Exact Harbor source SHA-256: `81603737422ffd2fd724be0b3028bfdcbf09e3c1d7c5ff864abe60d8575a9f5a`
- Baseline `b1352a2be4baf42962b1624151b7382fc09dc3ca`: 5 target diagnostics
- Head `5ada632c8`: 0 target diagnostics, 0 parse errors
- Baseline artifact SHA-256: `eaa75429c1ca4f86bb5c7c38bf12975a6deead83ecf9075303fe8ee8d1c7abf1`
- Head artifact SHA-256: `53df14688d21b9a589e2a25c7b482970b861ab3ea7382a9ffe750e971ab38b90`

The live RDE sample runner currently rejects the repository's schemaVersion 3 reports because its checkout expects schemaVersion 1, so this PR uses the exact Harbor file replay plus rule-level and fuzz validation.

## Tests

- `nr test` (15/15 tasks; plugin 24,795 tests and CLI 2,346 tests passed)
- `nr build`
- `nr lint`
- `nr typecheck`
- `nr format:check`
- `nr smoke:json-report`
- `FUZZ_RULE=exhaustive-deps FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small ordering change in lint rule gating with targeted regressions; behavior tightens to match the documented hook configuration contract.
> 
> **Overview**
> Fixes false positives where **`exhaustive-deps`** reported forwarded-unstable dependencies on **local custom Hooks** (e.g. `useStableCallback`) that intentionally omit a dependency-array argument and are **not** listed in `settings.react-doctor.exhaustiveDeps.additionalHooks`.
> 
> In **`exhaustive-deps.ts`**, **`findForwardedFreshHookDependencies`** now runs only **after** resolving the hook name and passing the existing **`isHookOfInterest`** check (built-in React hooks or **`additionalHooks`** matches). Unconfigured `use*` helpers are no longer analyzed for forwarded-fresh deps.
> 
> Regression coverage adds the React Bench **`useStableCallback` / Chat** shape (rule test + fuzz corpus **`verdict: pass`**). The custom-hook forwarded-fresh suite passes **`additionalHooks: "^use"`** when exercising **`exhaustive-deps`** so configured custom-hook findings stay enforced.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ada632c86dd5ed5fd0971620cb37d2d9fd49033. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Exact current-main parity

The full scoped matrix is bound to the PR's live GitHub state:

- current `main`: `6b64dfaf9e973139d1df2d09f405c9d916e158a3`
- PR head: `5ada632c86dd5ed5fd0971620cb37d2d9fd49033`
- prospective merge: `003ea89edf27843d3cc14cd5ff94ce15c77fae22`
- evaluation: `de00d4ee-f196-45f3-9012-c1c45e7e1dfb`
- projects: 2,000 / 2,000, zero skipped and zero failed
- scoped rule: `react-doctor/exhaustive-deps`
- comparator: 1 added diagnostic unit, 350 removed diagnostic units

Exact source reconstruction classified 347 removed units as intended false-positive removals: 339 canonical identities across 253 pinned source files, 114 repositories, and 91 distinct unconfigured custom `use*` callees. None is a supported built-in dependency Hook. There are zero confirmed false negatives, zero candidate false positives, and zero reconstruction failures.

The remaining four units are frozen project-root persistence gaps, not detector regressions:

- `pinterest/gestalt`, root `.`, `docs/pages/index.tsx:10:6`: matrix `1 -> 2`; exact root replay was base `[1, 1]`, candidate `[1, 1]`, so the base artifact omitted the repository-root occurrence.
- `huozhi/codice`, root `site`, `site/app/studio/canvas-view.tsx:74:6`: matrix `2 -> 1`; exact isolated-root replay was base `[0, 0]`, candidate `[0, 0]`, so the base-only nested occurrence is overlapping-root persistence noise. Whole-workspace replay also toggled this identity between two occurrences and zero at the same candidate ref.
- `serafimcloud/21st`, root `apps/web`, `apps/web/components/ui/multiselect.tsx:330:8`: matrix `2 -> 1`; exact root replay was base `[1, 1]`, candidate `[1, 1]`, so the candidate artifact omitted the nested-root occurrence.
- `serafimcloud/21st`, root `apps/web`, `apps/web/components/ui/multiselect.tsx:356:8`: matrix `2 -> 1`; exact root replay was base `[1, 1]`, candidate `[1, 1]`, so the candidate artifact omitted the nested-root occurrence.

Frozen artifacts:

- base NDJSON SHA-256: `7e22605a84ef17853e0f2a748fc6fe2a11e3a1a0180ef190f25671f26140f4ee`
- candidate NDJSON SHA-256: `d018514c04f366f14df2fb49053f30a5549310e2f693d88bf39331ecd1832846`
- comparator SHA-256: `63c6bb192455ff5ea60416bca65b6d8bf9a0732ff1455bdcda867480b228de89`
- exact adjudication SHA-256: `8f8d72e2958f708ee58f76525b40704f639f1f9857101f213afa933c7f459e74`
- deterministic root replay SHA-256: `c2c2cb9620ba1349901363926f06e5e036c90b2fba511609236ece8e827ecbc5`
