### PR TITLE
RDFPFN792026: preserve copied external subscription snapshots

### DIFF
--- a/.changeset/quiet-media-queries-report.md
+++ b/.changeset/quiet-media-queries-report.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Avoid reporting parent notifications that forward an immutable snapshot from an imported external-subscription hook after also copying it into a comparison ref.

--- a/packages/fuzz/corpus/regressions/no-pass-data-to-parent--external-snapshot-comparison-ref.tsx
+++ b/packages/fuzz/corpus/regressions/no-pass-data-to-parent--external-snapshot-comparison-ref.tsx
@@ -1,0 +1,31 @@
+// rule: no-pass-data-to-parent
+// verdict: pass
+// weakness: external-state-origin-through-comparison-ref
+// source: react-bench write-react-azouaoui-med-react-pro-sidebar q35NJos
+
+import { useEffect, useRef } from "react";
+import { useMediaQuery } from "../hooks/useMediaQuery";
+
+interface SidebarProps {
+  breakPoint: string;
+  onBreakPoint?: (broken: boolean) => void;
+}
+
+export const Sidebar = ({ breakPoint, onBreakPoint }: SidebarProps) => {
+  const broken = useMediaQuery(`(max-width: ${breakPoint})`);
+  const previousBrokenRef = useRef(broken);
+  const hasReportedRef = useRef(false);
+
+  useEffect(() => {
+    if (previousBrokenRef.current === broken) return;
+    previousBrokenRef.current = broken;
+    if (!hasReportedRef.current) {
+      hasReportedRef.current = true;
+      if (broken) onBreakPoint?.(true);
+      return;
+    }
+    onBreakPoint?.(broken);
+  }, [broken, onBreakPoint]);
+
+  return null;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.regressions.test.ts
@@ -127,6 +127,34 @@ describe("no-pass-data-to-parent — regressions", () => {
       expect(result.diagnostics).toEqual([]);
     });
 
+    it("stays silent when an imported media-query snapshot is copied into a comparison ref", () => {
+      const result = runRule(
+        noPassDataToParent,
+        `import React from "react";
+        import { useMediaQuery } from "../hooks/useMediaQuery";
+
+        const Sidebar = ({ breakPoint, onBreakPoint }) => {
+          const broken = useMediaQuery(\`(max-width: \${breakPoint})\`);
+          const previousBrokenRef = React.useRef(broken);
+          const hasReportedRef = React.useRef(false);
+
+          React.useEffect(() => {
+            if (previousBrokenRef.current === broken) return;
+            previousBrokenRef.current = broken;
+            if (!hasReportedRef.current) {
+              hasReportedRef.current = true;
+              if (broken) onBreakPoint?.(true);
+              return;
+            }
+            onBreakPoint?.(broken);
+          }, [broken, onBreakPoint]);
+          return null;
+        };`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
     it("stays silent for a direct imported visibility result", () => {
       const result = runRule(
         noPassDataToParent,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.ts
@@ -1206,8 +1206,7 @@ const isExternalSubscriptionHookResultRef = (analysis: ProgramAnalysis, ref: Ref
       if (isNodeOfType(declarator.id, "Identifier")) {
         return (
           EXTERNAL_SUBSCRIPTION_PRIMITIVE_RESULT_HOOK_NAMES.has(hookName) &&
-          ref.resolved &&
-          !hasUnsafeExternalSubscriptionBindingUse(analysis, ref.resolved)
+          !hasMutableBindingWrite(ref)
         );
       }
       const bindingIdentifier = def.name as unknown as EsTreeNode;


### PR DESCRIPTION
## Why

`no-pass-data-to-parent` still reported an immutable `useMediaQuery` snapshot when the component also copied that snapshot into a ref to compare subscription transitions. The parent cannot own this child subscription, so the live rule contract classifies the notification as valid external-system synchronization.

Harbor job `d8321254-7c6a-44d0-8feb-a55a682eeb80` archived two affected React Pro Sidebar findings. Prior provenance work already suppresses the callback-ref variant on current main; this PR removes the one remaining b135 false positive.

Before:

```tsx
const broken = useMediaQuery(query);
const previousBrokenRef = useRef(broken);

useEffect(() => {
  if (previousBrokenRef.current === broken) return;
  previousBrokenRef.current = broken;
  onBreakPoint?.(broken);
}, [broken, onBreakPoint]);
```

After: the direct immutable imported external-subscription snapshot remains recognized even when it is also copied into a comparison ref. Reassigned aliases and local/shadowed hook lookalikes remain diagnosed.

## What changed

- prove direct primitive external-subscription results from their immutable binding instead of treating downstream comparison-ref copies as mutation
- add the exact media-query transition regression and a permanent fuzz corpus fixture
- retain adversarial true positives for reassigned aliases, derived mutable values, lookalike hooks, and mutable object results
- add a patch changeset for `oxlint-plugin-react-doctor`

## Eval results

The local RDE sample could not classify current reports because the RDE checkout at `64b96b941603f91a0a38ef7d6ddd8c969035e351` expects schema version 1 while current React Doctor emits schema version 3.

Harbor replay evidence:

| Evidence | Archived 0.9.2 | b135 main | This PR |
| --- | ---: | ---: | ---: |
| q35NJos direct callback | 1 | 1 | 0 |
| xNVgkiw callback ref | 1 | 0 | 0 |
| Total | 2 | 1 | 0 |

Artifact: `/tmp/reactbench-no-pass-data-to-parent-current-main-replay-419de3ef3.json` (`sha256:0dad1ab055593fde9333c021d65657e40ed3bcbd96411513632eb4381a4146ac`).

## Test plan

- `nr -C packages/oxlint-plugin-react-doctor test` — 957 files, 24,795 passed / 201 skipped
- `nr -C packages/fuzz test` — 192 passed / 782 skipped
- `CI=1 FUZZ_RULE=no-pass-data-to-parent FUZZ_STRICT=1 FUZZ_ITERATIONS=500 FUZZ_PRINT_STATS=1 nr fuzz` — passed
- `nr test` — all workspace test tasks passed
- `nr build` — 9/9 tasks passed
- `nr lint` — passed with existing corpus warnings
- `nr typecheck` — 11/11 tasks passed
- `nr format:check` — passed
- `nr smoke:json-report` — passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow lint-rule heuristic change with targeted regression and fuzz coverage; no runtime or security impact.
> 
> **Overview**
> Fixes a **false positive** in `no-pass-data-to-parent` when a component forwards an immutable snapshot from an imported primitive external-subscription hook (e.g. `useMediaQuery`) to a parent after also seeding a **comparison ref** to detect transitions (`previousBrokenRef.current = broken`).
> 
> For direct primitive hook results, safe external-subscription recognition now hinges on **no mutable writes to the binding** (`!hasMutableBindingWrite(ref)`), instead of treating downstream comparison-ref updates as unsafe subscription binding use. Reassigned aliases, derived mutable values, hook lookalikes, and ambiguous object results should still be reported.
> 
> Adds a regression test and a fuzz corpus fixture for the React Pro Sidebar media-query shape, plus a patch changeset for `oxlint-plugin-react-doctor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 419de3ef35cbeeae259550adcbb76d1e4d8024f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->