### PR TITLE
RDFPFN792026: treat custom Hook calls as opaque

### DIFF
--- a/.changeset/tidy-dogs-listen.md
+++ b/.changeset/tidy-dogs-listen.md
@@ -1,0 +1,6 @@
+---
+"oxlint-plugin-react-doctor": patch
+"eslint-plugin-react-doctor": patch
+---
+
+Treat custom Hook calls as opaque in `no-effect-with-fresh-deps`.

--- a/packages/core/tests/cross-file-rule-ids.test.ts
+++ b/packages/core/tests/cross-file-rule-ids.test.ts
@@ -175,7 +175,6 @@ describe("CROSS_FILE_RULE_IDS", () => {
       "no-derived-state",
       "no-derived-state-effect",
       "no-dynamic-import-path",
-      "no-effect-with-fresh-deps",
       "no-event-handler",
       "no-full-lodash-import",
       "no-hydration-branch-on-browser-global",

--- a/packages/fuzz/corpus/regressions/custom-hook-forwarded-fresh-deps--overwritten-object.tsx
+++ b/packages/fuzz/corpus/regressions/custom-hook-forwarded-fresh-deps--overwritten-object.tsx
@@ -1,4 +1,4 @@
-// rule: exhaustive-deps, no-effect-with-fresh-deps
+// rule: exhaustive-deps
 // weakness: overwritten-object-property
 // source: adversarial review of React Bench validation
 

--- a/packages/fuzz/corpus/regressions/custom-hook-forwarded-fresh-deps--spread-argument.tsx
+++ b/packages/fuzz/corpus/regressions/custom-hook-forwarded-fresh-deps--spread-argument.tsx
@@ -1,4 +1,4 @@
-// rule: exhaustive-deps, no-effect-with-fresh-deps, rerender-memo-with-default-value
+// rule: exhaustive-deps, rerender-memo-with-default-value
 // weakness: spread-argument-arity
 // source: adversarial review of React Bench validation
 

--- a/packages/fuzz/corpus/regressions/no-effect-with-fresh-deps--custom-hook-call-opaque.tsx
+++ b/packages/fuzz/corpus/regressions/no-effect-with-fresh-deps--custom-hook-call-opaque.tsx
@@ -1,0 +1,38 @@
+// rule: no-effect-with-fresh-deps
+// verdict: pass
+// weakness: library-idiom
+// source: React Bench write-react-xr843-fojin-775__6TM24iQ and write-react-softmaple-softmaple__mGtA7Dm
+
+import { useCallback, useEffect, useRef } from "react";
+
+interface SubscriptionOptions {
+  readonly onValue: () => void;
+}
+
+interface SubscriberProps {
+  readonly onValue: () => void;
+}
+
+const useStableCallback = <Arguments extends unknown[], Result>(
+  callback: (...arguments_: Arguments) => Result,
+): ((...arguments_: Arguments) => Result) => {
+  const callbackRef = useRef(callback);
+  useEffect(() => {
+    callbackRef.current = callback;
+  }, [callback]);
+  return useCallback((...arguments_: Arguments) => callbackRef.current(...arguments_), []);
+};
+
+const useSubscription = (options: SubscriptionOptions): void => {
+  const optionsRef = useRef(options);
+  useEffect(() => {
+    optionsRef.current = options;
+  }, [options]);
+  useEffect(() => subscribe(() => optionsRef.current.onValue()), []);
+};
+
+export const Subscriber = ({ onValue }: SubscriberProps) => {
+  const stableCallback = useStableCallback(() => onValue());
+  useSubscription({ onValue: stableCallback });
+  return null;
+};

--- a/packages/fuzz/corpus/true-positives/custom-hook-forwarded-fresh-deps.tsx
+++ b/packages/fuzz/corpus/true-positives/custom-hook-forwarded-fresh-deps.tsx
@@ -1,4 +1,4 @@
-// rule: exhaustive-deps, no-effect-with-fresh-deps, rerender-memo-with-default-value
+// rule: exhaustive-deps, rerender-memo-with-default-value
 // weakness: custom-hook-forwarded-fresh-deps
 // source: React Bench write-react-mezzanine-ui-mezzani__BH7ZFrC
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/cross-file-rule-ids.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/cross-file-rule-ids.ts
@@ -60,7 +60,6 @@ export const CROSS_FILE_RULE_IDS: ReadonlySet<string> = new Set([
   "no-derived-state",
   "no-derived-state-effect",
   "no-event-handler",
-  "no-effect-with-fresh-deps",
   "no-initialize-state",
   "no-mutating-reducer-state",
   "only-export-components",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/cross-file-dependencies.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/cross-file-dependencies.test.ts
@@ -280,11 +280,7 @@ export const App = ({ items }) => {
 });
 
 describe("forwarded Hook dependency collectors", () => {
-  const affectedRuleIds = [
-    "exhaustive-deps",
-    "no-effect-with-fresh-deps",
-    "rerender-memo-with-default-value",
-  ];
+  const affectedRuleIds = ["exhaustive-deps", "rerender-memo-with-default-value"];
 
   it("records direct and nested imported Hook modules for every affected rule", () => {
     writeFixtureFile(

--- a/packages/oxlint-plugin-react-doctor/src/plugin/cross-file-dependencies.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/cross-file-dependencies.ts
@@ -440,7 +440,6 @@ export const CROSS_FILE_DEPENDENCY_COLLECTORS: ReadonlyMap<string, CrossFileDepe
     ["no-derived-state", collectEffectValueHelperDependencies],
     ["no-derived-state-effect", collectEffectValueHelperDependencies],
     ["no-event-handler", collectEffectValueHelperDependencies],
-    ["no-effect-with-fresh-deps", collectForwardedHookDependencies],
     ["no-initialize-state", collectEffectValueHelperDependencies],
     ["no-mutating-reducer-state", collectMutatingReducerDependencies],
     ["no-unguarded-browser-global-at-module-scope", collectBrowserGuardDependencies],

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/custom-hook-forwarded-fresh-deps.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/custom-hook-forwarded-fresh-deps.regressions.test.ts
@@ -6,7 +6,6 @@ import { runRule } from "../../test-utils/run-rule.js";
 import type { Rule } from "../utils/rule.js";
 import { rerenderMemoWithDefaultValue } from "./performance/rerender-memo-with-default-value.js";
 import { exhaustiveDeps } from "./react-builtins/exhaustive-deps.js";
-import { noEffectWithFreshDeps } from "./state-and-effects/no-effect-with-fresh-deps.js";
 
 interface ForwardedFreshRuleCase {
   readonly expectedMessageFragment: string;
@@ -15,11 +14,6 @@ interface ForwardedFreshRuleCase {
 }
 
 const callerFreshnessRuleCases: ForwardedFreshRuleCase[] = [
-  {
-    expectedMessageFragment: "dependency inside this custom Hook changes every render",
-    name: "no-effect-with-fresh-deps",
-    rule: noEffectWithFreshDeps,
-  },
   {
     expectedMessageFragment: "reaches a Hook dependency inside this custom Hook",
     name: "exhaustive-deps",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-with-fresh-deps.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-with-fresh-deps.test.ts
@@ -302,6 +302,78 @@ describe("no-effect-with-fresh-deps", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("does NOT trace fresh callback arguments into a custom Hook", () => {
+    const result = runRule(
+      noEffectWithFreshDeps,
+      `
+      import { useCallback, useEffect, useRef } from "react";
+
+      const useStableCallback = (fn) => {
+        const callbackRef = useRef(fn);
+        useEffect(() => {
+          callbackRef.current = fn;
+        }, [fn]);
+        return useCallback((...args) => callbackRef.current(...args), []);
+      };
+
+      function Component({ send, retry }) {
+        useStableCallback(() => send("one"));
+        useStableCallback(() => send("two"));
+        useStableCallback(() => retry());
+        useStableCallback(async () => send("three"));
+        useStableCallback((value) => send(value));
+        return null;
+      }
+    `,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does NOT trace fresh options into a custom Hook that copies them into a ref", () => {
+    const result = runRule(
+      noEffectWithFreshDeps,
+      `
+      import { useEffect, useRef } from "react";
+
+      const useSubscription = (options) => {
+        const optionsRef = useRef(options);
+        useEffect(() => {
+          optionsRef.current = options;
+        }, [options]);
+        useEffect(() => subscribe(() => optionsRef.current.onValue()), []);
+      };
+
+      function Component({ onValue }) {
+        useSubscription({ onValue });
+        return null;
+      }
+    `,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still flags direct fresh dependencies inside a custom Hook", () => {
+    const result = runRule(
+      noEffectWithFreshDeps,
+      `
+      import { useEffect } from "react";
+
+      const useSubscription = (value) => {
+        const options = { value };
+        useEffect(() => subscribe(options), [options]);
+      };
+    `,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("options");
+  });
+
   it("does NOT flag a destructured prop with an array default", () => {
     const result = runRule(
       noEffectWithFreshDeps,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-with-fresh-deps.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-with-fresh-deps.ts
@@ -1,9 +1,8 @@
-import { EFFECT_HOOK_NAMES, HOOKS_WITH_DEPS } from "../../constants/react.js";
+import { HOOKS_WITH_DEPS } from "../../constants/react.js";
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
-import { findForwardedFreshHookDependencies } from "../../utils/find-forwarded-fresh-hook-dependencies.js";
 import { isReactHookCall } from "../../utils/is-react-hook-call.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
@@ -138,13 +137,6 @@ export const noEffectWithFreshDeps = defineRule({
     "Move the value inside the hook body and depend on its simple inputs instead, or wrap it in useMemo / useCallback so it stays the same between renders.",
   create: (context: RuleContext) => ({
     CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
-      for (const finding of findForwardedFreshHookDependencies(node, context, EFFECT_HOOK_NAMES)) {
-        context.report({
-          node: finding.reportNode,
-          message: `A dependency inside this custom Hook changes every render because \`${finding.bindingName}\` is a new ${finding.kind} built fresh each time.`,
-        });
-      }
-
       if (!isReactHookCall(node, HOOKS_WITH_DEPS, context.scopes)) return;
       const args = node.arguments ?? [];
       if (args.length < 2) return;


### PR DESCRIPTION
## Why

no-effect-with-fresh-deps promises syntactic, same-scope freshness detection. Its forwarded custom-Hook analysis crossed an opaque call boundary and treated intentionally fresh callback and options arguments as Effect dependencies, causing six confirmed React Bench false positives.

The current rule documentation explicitly classifies every CallExpression, including custom Hooks, as opaque.

## What changed

- stop propagating caller argument freshness through custom Hook calls for no-effect-with-fresh-deps
- remove this rule from cross-file dependency collection while preserving exhaustive-deps and rerender-memo-with-default-value forwarding
- add Harbor-derived regression coverage for stable callback and ref-copy subscription idioms
- retain a true-positive test for fresh dependencies created directly inside a custom Hook
- add a strict fuzz regression and patch changeset

## Harbor replay

Exact reconstructed post-patch sources from:

- write-react-xr843-fojin-775__6TM24iQ
- write-react-softmaple-softmaple__mGtA7Dm

Baseline: 6 diagnostics (5 callback arguments, 1 options object)
Head: 0 diagnostics

Artifacts:

- baseline SHA-256: 8f10c97c568815e23a985c3f92b656086ab1d0cfcda9d879b96893b5b432ece9
- head SHA-256: 17648bc905af2bd756ce5fca04c6763b5b248dd00724185416c2f0c36ed61d51

## Validation

- full workspace tests: 15/15 tasks
- plugin: 957 files, 24,778 passed, 201 skipped
- core: 131 files, 1,794 passed
- CLI: 226 files passed, 2 skipped; 2,346 tests passed, 27 skipped
- strict targeted fuzz: 500 iterations
- typecheck: 16/16 tasks
- build: 9/9 tasks
- smoke JSON report
- lint
- format check
- exact Harbor replay: 6 -> 0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted lint-rule behavior change with tests and fuzz regressions; no auth, data, or runtime path changes.
> 
> **Overview**
> **`no-effect-with-fresh-deps`** no longer follows caller arguments through custom Hook calls. It only checks freshness in the same scope (inline deps and local bindings), matching the documented rule that **CallExpression**s—including custom Hooks—are opaque.
> 
> Removed the forwarded custom-Hook path (`findForwardedFreshHookDependencies`) and dropped the rule from **cross-file** rule IDs and dependency collectors, since it no longer reads other files. **`exhaustive-deps`** and **`rerender-memo-with-default-value`** still use forwarded Hook analysis.
> 
> Added tests and fuzz regressions for stable-callback and options-via-ref subscription patterns (Harbor false positives), and kept coverage for fresh values created **inside** a custom Hook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb076d5d933df9b6a4230acc06ac265cd6effe7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->