### PR TITLE
fix: honor project scope in Git hook scans

### DIFF
--- a/.changeset/git-dir-scoped-scan.md
+++ b/.changeset/git-dir-scoped-scan.md
@@ -1,0 +1,5 @@
+---
+"@react-doctor/core": patch
+---
+
+Clear inherited `GIT_DIR` from nested Git commands so scoped scans launched by Git hooks respect their working directory, while preserving `GIT_INDEX_FILE` and the rest of the environment.

--- a/.changeset/staged-honors-config-projects.md
+++ b/.changeset/staged-honors-config-projects.md
@@ -1,0 +1,10 @@
+---
+"@react-doctor/core": patch
+"react-doctor": patch
+---
+
+`--staged` now honors `--project` and the config's `projects` field, so a monorepo pre-commit scan stops reporting clean with every React rule gated off. Each selected package brings its own `package.json` / `tsconfig` / config into the staged snapshot, and every staged path belongs to exactly one package. Selecting a package also makes the `--json` report package-scoped, so `packageRoot` is no longer always the report's `directory`; diagnostic ids are unchanged, so baselines still match.
+
+Selecting several packages prints the aggregate project summary rather than a single-scan report, notes how many staged files fell outside the selected projects, and writes `--output-dir` on a quiet (`--json` / `--score`) run where it previously wrote nothing.
+
+Failures stay out of the committer's way. A `projects` entry that no longer resolves, or that points outside the scanned tree, warns and falls back to a root scan rather than blocking every commit; an explicit `--project` still fails, since it was typed this run. A staged run whose git index cannot be read fails rather than treating it as empty, but individual paths that cannot be snapshotted are reported and skipped, and when nothing is left to scan the run warns and exits 0 — nobody can act on an oversized blob mid-commit, and failing would only send them to `--no-verify`.

--- a/docs/json-report.md
+++ b/docs/json-report.md
@@ -33,6 +33,12 @@ uses `mode: "baseline"` and includes the optional `baseline` block. Consumers
 must not infer coverage from an empty `diagnostics` array: use each project's
 `complete` and `analyzedFiles` fields.
 
+A `mode: "staged"` report's projects are the packages `--project` or the config's
+`projects` field selected. Whenever that resolves anywhere but the scan root —
+including a single package — `packageRoot` is not the report's `directory` and
+that project's paths are relative to its own `packageRoot`. Diagnostic ids stay
+relative to the report root, so they remain stable across both shapes.
+
 Baseline comparison identifies a finding by its plugin/rule, diagnostic
 message, and normalized diagnosed source range. The identity is independent of
 file and line, so unchanged findings remain pre-existing after a rename or

--- a/packages/core/src/materialize-source-tree.ts
+++ b/packages/core/src/materialize-source-tree.ts
@@ -37,6 +37,12 @@ export const materializeSourceTree = (input: {
   readonly files: ReadonlyArray<string>;
   readonly tempDirectory: string;
   readonly readContent: (relativePath: string) => Effect.Effect<string | null, ReactDoctorError>;
+  /**
+   * Tree-relative subdirectories that are themselves project roots (a
+   * monorepo's packages). Their config files are copied too, so each one
+   * resolves its own React version, tsconfig, and lint config.
+   */
+  readonly configSubdirectories?: ReadonlyArray<string>;
 }): Effect.Effect<MaterializedTree, ReactDoctorError> =>
   Effect.gen(function* () {
     const materializedFiles: string[] = [];
@@ -60,11 +66,15 @@ export const materializeSourceTree = (input: {
       materializedFiles.push(relativePath);
     }
     yield* Effect.sync(() => {
-      for (const configFilename of STAGED_FILES_PROJECT_CONFIG_FILENAMES) {
-        const sourcePath = path.join(input.directory, configFilename);
-        const targetPath = path.join(resolvedTempDirectory, configFilename);
-        if (fs.existsSync(sourcePath) && !fs.existsSync(targetPath)) {
-          fs.cpSync(sourcePath, targetPath);
+      for (const subdirectory of ["", ...(input.configSubdirectories ?? [])]) {
+        for (const configFilename of STAGED_FILES_PROJECT_CONFIG_FILENAMES) {
+          const sourcePath = path.join(input.directory, subdirectory, configFilename);
+          const targetPath = path.resolve(resolvedTempDirectory, subdirectory, configFilename);
+          if (!isPathInsideDirectory(targetPath, resolvedTempDirectory)) continue;
+          if (fs.existsSync(sourcePath) && !fs.existsSync(targetPath)) {
+            fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+            fs.cpSync(sourcePath, targetPath);
+          }
         }
       }
     });

--- a/packages/core/src/services/git.ts
+++ b/packages/core/src/services/git.ts
@@ -327,10 +327,13 @@ export class Git extends Context.Service<
       readonly directory: string;
       readonly ref: string;
     }) => Effect.Effect<GitBaselineDiffPlan | null, ReactDoctorError>;
-    /** Files staged for commit (null-separated, `--diff-filter=ACMR`). */
+    /**
+     * Files staged for commit (null-separated, `--diff-filter=ACMR`);
+     * `null` when git could not read the index, `[]` when nothing is staged.
+     */
     readonly stagedFilePaths: (
       directory: string,
-    ) => Effect.Effect<ReadonlyArray<string>, ReactDoctorError>;
+    ) => Effect.Effect<ReadonlyArray<string> | null, ReactDoctorError>;
     /** `git show :<path>` contents; `null` when the file isn't in the index. */
     readonly showStagedContent: (
       directory: string,
@@ -443,7 +446,13 @@ export class Git extends Context.Service<
               // default; ChildProcess's option flips the polarity.)
               ChildProcess.make(input.command, [...input.args], {
                 cwd: input.directory,
-                env: input.env,
+                env:
+                  input.command === "git"
+                    ? {
+                        ...input.env,
+                        GIT_DIR: undefined,
+                      }
+                    : input.env,
                 extendEnv: true,
               }),
             );
@@ -906,7 +915,7 @@ export class Git extends Context.Service<
             "--relative",
           ]).pipe(
             Effect.map((result) => {
-              if (result.status !== 0) return [] as ReadonlyArray<string>;
+              if (result.status !== 0) return null;
               return splitNullSeparated(result.stdout);
             }),
           ),

--- a/packages/core/src/services/staged-files.ts
+++ b/packages/core/src/services/staged-files.ts
@@ -10,6 +10,11 @@ import { Git } from "./git.js";
 export interface StagedSnapshot {
   readonly tempDirectory: string;
   readonly stagedFiles: ReadonlyArray<string>;
+  /**
+   * Staged paths that never made it into the snapshot — unreadable from the
+   * index, or refused for resolving outside the temp tree.
+   */
+  readonly unmaterializedFiles: ReadonlyArray<string>;
   readonly cleanup: () => void;
 }
 
@@ -31,10 +36,11 @@ export class StagedFiles extends Context.Service<
     /**
      * Discovers source files staged for commit (lintable staged paths
      * from `git diff --cached` — JS/TS/HTML minus generated bundles).
+     * `null` when git could not read the index; `[]` when nothing is staged.
      */
     readonly discoverSourceFiles: (
       directory: string,
-    ) => Effect.Effect<ReadonlyArray<string>, ReactDoctorError>;
+    ) => Effect.Effect<ReadonlyArray<string> | null, ReactDoctorError>;
     /**
      * Materializes the supplied staged files into `tempDirectory`,
      * preserving the project layout and the well-known project config
@@ -46,6 +52,7 @@ export class StagedFiles extends Context.Service<
       readonly directory: string;
       readonly stagedFiles: ReadonlyArray<string>;
       readonly tempDirectory: string;
+      readonly configSubdirectories?: ReadonlyArray<string>;
     }) => Effect.Effect<StagedSnapshot, ReactDoctorError>;
   }
 >()("react-doctor/StagedFiles") {
@@ -56,10 +63,12 @@ export class StagedFiles extends Context.Service<
       return StagedFiles.of({
         discoverSourceFiles: (directory) =>
           git.stagedFilePaths(directory).pipe(
-            Effect.map((entries) => entries.filter(isLintableSourceFile)),
+            Effect.map((entries) =>
+              entries === null ? null : entries.filter(isLintableSourceFile),
+            ),
             Effect.withSpan("StagedFiles.discoverSourceFiles"),
           ),
-        materialize: ({ directory, stagedFiles, tempDirectory }) =>
+        materialize: ({ directory, stagedFiles, tempDirectory, configSubdirectories }) =>
           // Per-file git failures (missing binary, buffer overflow, spawn
           // errors) must NOT sink the whole snapshot — `materializeSourceTree`
           // folds each read failure to `null` and skips that path, so the
@@ -68,6 +77,7 @@ export class StagedFiles extends Context.Service<
             directory,
             files: stagedFiles,
             tempDirectory,
+            configSubdirectories,
             readContent: (relativePath) =>
               git.showStagedContent(directory, relativePath, {
                 maxBufferBytes: GIT_SHOW_MAX_BUFFER_BYTES,
@@ -78,6 +88,7 @@ export class StagedFiles extends Context.Service<
                 ({
                   tempDirectory: tree.tempDirectory,
                   stagedFiles: tree.materializedFiles,
+                  unmaterializedFiles: tree.unmaterializedFiles,
                   cleanup: tree.cleanup,
                 }) satisfies StagedSnapshot,
             ),
@@ -104,6 +115,7 @@ export class StagedFiles extends Context.Service<
           Effect.succeed({
             tempDirectory,
             stagedFiles: snapshot.materializedFiles ?? snapshot.sourceFiles ?? [],
+            unmaterializedFiles: [],
             cleanup: () => {
               /* test snapshot does not own any disk state */
             },

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -296,11 +296,17 @@ export interface ReactDoctorConfig {
    * Entries resolve exactly like `--project` values: workspace package
    * names (or directory basenames) first, then directory paths relative to
    * the scanned root. `"*"` selects every discovered workspace project.
-   * Invalid entries fail the run with the same error as the flag.
+   * Invalid entries fail the run with the same error as the flag — except
+   * under `--staged`, where they warn and fall back to a single scan at the
+   * root, because `--staged` runs in a commit hook and a stale entry there
+   * would block every commit.
    *
    * Precedence: an explicit `--project` flag overrides this list. Only the
    * config at the invocation root is consulted — `projects` inside a
-   * module's own config is ignored (modules can't redirect the scan).
+   * module's own config is ignored (modules can't redirect the scan). Under
+   * `--staged` this list applies only when you invoke react-doctor from the
+   * directory that declared it, so a per-package or positional run does not
+   * resolve an ancestor's entries against the package.
    */
   projects?: string[];
   textComponents?: string[];

--- a/packages/core/tests/materialize-source-tree.test.ts
+++ b/packages/core/tests/materialize-source-tree.test.ts
@@ -35,4 +35,48 @@ describe("materializeSourceTree", () => {
     expect(fs.existsSync(path.join(tempDirectory, "src/present.ts"))).toBe(true);
     expect(fs.existsSync(path.resolve(tempDirectory, "..", "escape.ts"))).toBe(false);
   });
+
+  it("copies project-config files for each requested subdirectory", async () => {
+    // The source and the snapshot need different parents. As siblings, a `..`
+    // subdirectory resolves to the same path from both, so the escape assertion
+    // would hold whether or not the containment guard exists.
+    const sourceParent = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-source-parent-"));
+    const snapshotParent = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-snapshot-parent-"));
+    const sourceDirectory = path.join(sourceParent, "repo");
+    const snapshotDirectory = path.join(snapshotParent, "snapshot");
+    fs.mkdirSync(path.join(sourceDirectory, "packages/app/src"), { recursive: true });
+    fs.mkdirSync(snapshotDirectory, { recursive: true });
+    fs.writeFileSync(path.join(sourceDirectory, "package.json"), '{"name":"root"}\n');
+    fs.writeFileSync(
+      path.join(sourceDirectory, "packages/app/package.json"),
+      '{"name":"app","dependencies":{"react":"19"}}\n',
+    );
+    // The escape source exists and is readable, so only the containment guard
+    // can keep it out of the snapshot.
+    fs.mkdirSync(path.join(sourceParent, "escape"), { recursive: true });
+    fs.writeFileSync(path.join(sourceParent, "escape/package.json"), '{"name":"escaped"}\n');
+
+    try {
+      await Effect.runPromise(
+        materializeSourceTree({
+          directory: sourceDirectory,
+          files: ["packages/app/src/app.tsx"],
+          tempDirectory: snapshotDirectory,
+          readContent: () => Effect.succeed("export const App = () => null;\n"),
+          configSubdirectories: ["packages/app", "../escape"],
+        }),
+      );
+
+      expect(fs.readFileSync(path.join(snapshotDirectory, "package.json"), "utf8")).toContain(
+        "root",
+      );
+      expect(
+        fs.readFileSync(path.join(snapshotDirectory, "packages/app/package.json"), "utf8"),
+      ).toContain('"react"');
+      expect(fs.existsSync(path.join(snapshotParent, "escape/package.json"))).toBe(false);
+    } finally {
+      fs.rmSync(sourceParent, { recursive: true, force: true });
+      fs.rmSync(snapshotParent, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/core/tests/regressions/issue-1501-git-dir-scoped-scan.test.ts
+++ b/packages/core/tests/regressions/issue-1501-git-dir-scoped-scan.test.ts
@@ -1,0 +1,164 @@
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as Effect from "effect/Effect";
+import { afterAll, describe, expect, it } from "vite-plus/test";
+import { Git } from "@react-doctor/core";
+
+const runNode = <Value>(program: Effect.Effect<Value, unknown, Git>): Promise<Value> =>
+  Effect.runPromise(program.pipe(Effect.provide(Git.layerNode)));
+
+interface GitEnvironmentInput<Value> {
+  readonly gitDirectory: string;
+  readonly gitIndexFile?: string;
+  readonly run: () => Promise<Value>;
+}
+
+const withGitEnvironment = async <Value>(input: GitEnvironmentInput<Value>): Promise<Value> => {
+  const originalGitDirectory = process.env.GIT_DIR;
+  const originalGitIndexFile = process.env.GIT_INDEX_FILE;
+  process.env.GIT_DIR = input.gitDirectory;
+  if (input.gitIndexFile !== undefined) process.env.GIT_INDEX_FILE = input.gitIndexFile;
+  try {
+    return await input.run();
+  } finally {
+    if (originalGitDirectory === undefined) delete process.env.GIT_DIR;
+    else process.env.GIT_DIR = originalGitDirectory;
+    if (originalGitIndexFile === undefined) delete process.env.GIT_INDEX_FILE;
+    else process.env.GIT_INDEX_FILE = originalGitIndexFile;
+  }
+};
+
+const setupLinkedWorktreeRepo = (): { mainRepoPath: string; linkedWorktreePath: string } => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "rd-1501-"));
+  const mainRepoPath = path.join(tempRoot, "main-repo");
+  const linkedWorktreePath = path.join(tempRoot, "linked-worktree");
+  const gitEnvironment = { ...process.env, GIT_DIR: mainRepoPath };
+
+  execFileSync("git", ["init"], { cwd: tempRoot, stdio: "ignore" });
+  fs.renameSync(path.join(tempRoot, ".git"), path.join(tempRoot, "main-repo"));
+
+  fs.mkdirSync(path.join(mainRepoPath, "webapp"), { recursive: true });
+  fs.writeFileSync(path.join(mainRepoPath, "webapp", "index.html"), "<html></html>");
+  fs.writeFileSync(path.join(mainRepoPath, "webapp", "app.js"), "console.log('app');");
+
+  execFileSync("git", ["config", "user.email", "test@example.com"], {
+    cwd: mainRepoPath,
+    env: gitEnvironment,
+    stdio: "ignore",
+  });
+  execFileSync("git", ["config", "user.name", "Test User"], {
+    cwd: mainRepoPath,
+    env: gitEnvironment,
+    stdio: "ignore",
+  });
+  execFileSync("git", ["add", "."], {
+    cwd: mainRepoPath,
+    env: gitEnvironment,
+    stdio: "ignore",
+  });
+  execFileSync("git", ["commit", "-m", "initial"], {
+    cwd: mainRepoPath,
+    env: gitEnvironment,
+    stdio: "ignore",
+  });
+
+  execFileSync("git", ["worktree", "add", linkedWorktreePath, "-b", "feature"], {
+    cwd: mainRepoPath,
+    env: gitEnvironment,
+    stdio: "ignore",
+  });
+
+  fs.writeFileSync(path.join(linkedWorktreePath, "webapp", "app.js"), "console.log('modified');");
+
+  return { mainRepoPath, linkedWorktreePath };
+};
+
+const testRepo = setupLinkedWorktreeRepo();
+
+afterAll(() => {
+  fs.rmSync(path.dirname(testRepo.mainRepoPath), { recursive: true, force: true });
+});
+
+describe("issue #1501: scoped scans fail inside Git hooks when GIT_DIR is set", () => {
+  it("returns paths relative to the scoped directory when GIT_DIR is set", async () => {
+    const webappPath = path.join(testRepo.linkedWorktreePath, "webapp");
+    const result = await withGitEnvironment({
+      gitDirectory: testRepo.mainRepoPath,
+      run: () =>
+        runNode(
+          Effect.gen(function* () {
+            const git = yield* Git;
+            return yield* git.diffSelection({
+              directory: webappPath,
+              explicitBaseBranch: "HEAD",
+            });
+          }),
+        ),
+    });
+
+    expect(result).not.toBeNull();
+    if (result !== null) {
+      expect(result.changedFiles).toEqual(["app.js"]);
+    }
+  });
+
+  it("does not return repository-root paths when scanning a subdirectory with GIT_DIR set", async () => {
+    const webappPath = path.join(testRepo.linkedWorktreePath, "webapp");
+    const result = await withGitEnvironment({
+      gitDirectory: testRepo.mainRepoPath,
+      run: () =>
+        runNode(
+          Effect.gen(function* () {
+            const git = yield* Git;
+            return yield* git.diffSelection({
+              directory: webappPath,
+              explicitBaseBranch: "HEAD",
+            });
+          }),
+        ),
+    });
+
+    if (result !== null) {
+      for (const filePath of result.changedFiles) {
+        expect(filePath).not.toContain("webapp/");
+        expect(path.isAbsolute(filePath)).toBe(false);
+      }
+    }
+  });
+
+  it("preserves GIT_INDEX_FILE when clearing GIT_DIR", async () => {
+    const webappPath = path.join(testRepo.linkedWorktreePath, "webapp");
+    const customIndexPath = path.join(path.dirname(testRepo.mainRepoPath), "custom-index");
+    const customIndexEnvironment = {
+      ...process.env,
+      GIT_DIR: undefined,
+      GIT_INDEX_FILE: customIndexPath,
+    };
+    execFileSync("git", ["read-tree", "HEAD"], {
+      cwd: testRepo.linkedWorktreePath,
+      env: customIndexEnvironment,
+      stdio: "ignore",
+    });
+    execFileSync("git", ["add", "webapp/app.js"], {
+      cwd: testRepo.linkedWorktreePath,
+      env: customIndexEnvironment,
+      stdio: "ignore",
+    });
+
+    const stagedFiles = await withGitEnvironment({
+      gitDirectory: testRepo.mainRepoPath,
+      gitIndexFile: customIndexPath,
+      run: () =>
+        runNode(
+          Effect.gen(function* () {
+            const git = yield* Git;
+            return yield* git.stagedFilePaths(webappPath);
+          }),
+        ),
+    });
+
+    expect(stagedFiles).toEqual(["app.js"]);
+  });
+});

--- a/packages/react-doctor/src/cli/commands/inspect.ts
+++ b/packages/react-doctor/src/cli/commands/inspect.ts
@@ -97,6 +97,7 @@ interface CompletedScan {
 }
 
 interface StagedProjectScanContext {
+  readonly projectDirectory: string;
   readonly scanDirectory: string;
   /** `scanDirectory` relative to the scan root; empty when they're the same. */
   readonly treeRelativeDirectory: string;
@@ -460,6 +461,7 @@ export const inspectAction = async (
         // index is keyed to the root, so there is nothing for it to scan.
         if (treeRelativeDirectory === null) return null;
         return {
+          projectDirectory,
           scanDirectory,
           treeRelativeDirectory,
           projectConfig:
@@ -592,15 +594,24 @@ export const inspectAction = async (
         recordCount(METRIC.stagedPerProject, 1, { projectCount: stagedProjectScans.length });
       }
       const tempDirectory = fs.mkdtempSync(path.join(tmpdir(), STAGED_FILES_TEMP_DIR_PREFIX));
+      const configSubdirectories = new Set<string>();
+      for (const projectScan of stagedProjectScans) {
+        configSubdirectories.add(projectScan.treeRelativeDirectory);
+        const projectRelativeDirectory = resolveProjectRelativeDirectory(
+          resolvedDirectory,
+          projectScan.projectDirectory,
+        );
+        if (projectRelativeDirectory !== null) {
+          configSubdirectories.add(projectRelativeDirectory);
+        }
+      }
       // If materialization throws before `snapshot.cleanup` is wired up, remove
       // the temp dir we just created so it can't leak.
       const snapshot = await materializeStagedFiles({
         directory: resolvedDirectory,
         stagedFiles: selectedStagedFiles,
         tempDirectory,
-        configSubdirectories: stagedProjectScans.map(
-          (projectScan) => projectScan.treeRelativeDirectory,
-        ),
+        configSubdirectories: [...configSubdirectories],
       }).catch((error: unknown) => {
         fs.rmSync(tempDirectory, { recursive: true, force: true });
         throw error;

--- a/packages/react-doctor/src/cli/commands/inspect.ts
+++ b/packages/react-doctor/src/cli/commands/inspect.ts
@@ -5,13 +5,11 @@ import * as Effect from "effect/Effect";
 import * as fs from "node:fs";
 import {
   buildJsonReport,
-  DEFAULT_PROJECT_SCAN_CONCURRENCY,
   getBaselineDiffPlan,
   getChangedLineRanges,
   getDiffInfo,
   hasReactRuntime,
   highlighter,
-  mapWithConcurrency,
   mergeReactDoctorConfigs,
   resolveScanTarget,
   toRelativePath,
@@ -70,11 +68,16 @@ import {
 } from "../utils/resolve-project-diff-include-paths.js";
 import { resolveProjectSourceFilePaths } from "../utils/resolve-project-source-file-paths.js";
 import { runExplain } from "../utils/run-explain.js";
+import { runProjectScanBatch } from "../utils/run-project-scan-batch.js";
 import { projectManifestChanged } from "../utils/project-manifest-changed.js";
 import { filterScansForSurface } from "../utils/filter-scans-for-surface.js";
 import { selectProjects } from "../utils/select-projects.js";
+import {
+  STAGED_PROJECT_FALLBACK_HINT,
+  selectStagedProjects,
+} from "../utils/select-staged-projects.js";
 import { resolveProjectRelativeDirectory } from "../utils/resolve-project-relative-directory.js";
-import { isSpinnerSilent, setSpinnerSilent, spinner } from "../utils/spinner.js";
+import { spinner } from "../utils/spinner.js";
 import { shouldFailScanGate } from "../utils/should-fail-scan-gate.js";
 import { shouldSkipPrompts } from "../utils/should-skip-prompts.js";
 import { warnDeprecatedFailOn } from "../utils/warn-deprecated-fail-on.js";
@@ -90,6 +93,25 @@ interface CompletedScan {
   // The merged (root + module) config the scan ran under — surface
   // filtering of its diagnostics must use this, not the root config.
   config: ReactDoctorConfig | null;
+  frameSourceRoot?: string;
+}
+
+interface StagedProjectScanContext {
+  readonly scanDirectory: string;
+  /** `scanDirectory` relative to the scan root; empty when they're the same. */
+  readonly treeRelativeDirectory: string;
+  readonly projectConfig: ReactDoctorConfig | null;
+  readonly projectConfigSourceDirectory: string | null;
+}
+
+interface StagedProjectScan extends StagedProjectScanContext {
+  /**
+   * The staged paths this project owns, relative to the **scan root** (the
+   * space `git diff --cached --relative` reports and the snapshot mirrors).
+   * Each staged path belongs to exactly one project, so nested packages never
+   * scan the same file twice.
+   */
+  readonly stagedFiles: ReadonlyArray<string>;
 }
 
 const filterCompletedScansByCategories = (
@@ -370,8 +392,31 @@ export const inspectAction = async (
     const skipPrompts = shouldSkipPrompts({ yes: flags.yes, json: flags.json });
 
     if (flags.staged) {
-      const stagedFiles = await getStagedSourceFiles(resolvedDirectory);
-      if (stagedFiles.length === 0) {
+      // `--staged` scans the index. `--project`, or `doctor.config`'s
+      // `projects`, names the packages that own the staged paths, so each one
+      // materializes its own config and keeps its React identity. With neither,
+      // one scan at the scan root.
+      const hasConfigProjects = (userConfig?.projects ?? []).some(
+        (projectName) => projectName.trim().length > 0,
+      );
+      // `projects` entries resolve against the scan root, not the directory that
+      // declared them, so they only apply when react-doctor was invoked from the
+      // config's own directory. Without this a per-package or positional run
+      // would resolve an ancestor config's entries against the package.
+      const configProjectsApply =
+        hasConfigProjects && scanTarget.requestedDirectory === scanTarget.configSourceDirectory;
+      const projectDirectories = await selectStagedProjects({
+        rootDirectory: resolvedDirectory,
+        projectFlag: flags.project,
+        configProjects: configProjectsApply ? userConfig?.projects : undefined,
+      });
+
+      // Nothing to scan is not a failure: `--staged` is wired into commit hooks
+      // and `lint-staged`, so it must not fail a commit that stages no source.
+      const reportNothingToScan = (input: {
+        readonly reason: string;
+        readonly severity?: "dim" | "warn";
+      }): void => {
         if (isJsonMode) {
           writeJsonReport(
             buildJsonReport({
@@ -384,30 +429,145 @@ export const inspectAction = async (
             }),
           );
         } else if (!isScoreOnly) {
-          logger.dim("No staged source files found.");
+          if (input.severity === "warn") {
+            logger.warn(input.reason);
+            logger.break();
+          } else {
+            logger.dim(input.reason);
+          }
         }
+      };
+
+      const rootStagedFiles = await getStagedSourceFiles(resolvedDirectory);
+      if (rootStagedFiles.length === 0) {
+        reportNothingToScan({ reason: "No staged source files found." });
         return;
       }
 
+      const buildProjectScanContext = async (
+        projectDirectory: string,
+      ): Promise<StagedProjectScanContext | null> => {
+        const projectScanTarget =
+          projectDirectory === resolvedDirectory
+            ? scanTarget
+            : await resolveScanTarget(projectDirectory, { allowAmbiguous: true });
+        const scanDirectory = projectScanTarget.resolvedDirectory;
+        const treeRelativeDirectory = resolveProjectRelativeDirectory(
+          resolvedDirectory,
+          scanDirectory,
+        );
+        // A project outside the scan root owns none of the index paths — the
+        // index is keyed to the root, so there is nothing for it to scan.
+        if (treeRelativeDirectory === null) return null;
+        return {
+          scanDirectory,
+          treeRelativeDirectory,
+          projectConfig:
+            projectDirectory === resolvedDirectory
+              ? userConfig
+              : mergeReactDoctorConfigs(userConfig, projectScanTarget.userConfig ?? undefined),
+          // `plugins` is override-wins in the merge, so relative entries must
+          // resolve against the config file that supplied them.
+          projectConfigSourceDirectory:
+            projectScanTarget.userConfig?.plugins === undefined
+              ? scanTarget.configSourceDirectory
+              : projectScanTarget.configSourceDirectory,
+        };
+      };
+
+      const projectScanContexts: StagedProjectScanContext[] = [];
+      const seenScanDirectories = new Set<string>();
+      for (const projectDirectory of projectDirectories) {
+        const projectScanContext = await buildProjectScanContext(projectDirectory);
+        if (projectScanContext === null) {
+          // An explicit `--project` naming an outside directory is a mistake
+          // worth failing on; a config entry falls back with the others below.
+          if (flags.project) {
+            throw new CliInputError(
+              `Project "${toRelativePath(projectDirectory, resolvedDirectory)}" is outside ${resolvedDirectory}, so it holds none of the staged files. Run --staged from a directory that contains the project.`,
+            );
+          }
+          continue;
+        }
+        // Two entries can name one directory — as spellings of the same package,
+        // or via a `rootDir` redirect onto a shared target. Scanning it twice
+        // doubles its diagnostics into the summary, the report, and the gate.
+        if (seenScanDirectories.has(projectScanContext.scanDirectory)) continue;
+        seenScanDirectories.add(projectScanContext.scanDirectory);
+        projectScanContexts.push(projectScanContext);
+      }
+
+      // Every configured project resolved outside the scan root, so none of them
+      // can own an index path. Falling through would scan nothing and report
+      // "no staged files in the selected projects" — a clean gate for a reason
+      // that is really a misconfiguration. Warn and scan the root instead, the
+      // same way an unresolvable entry does.
+      if (projectScanContexts.length === 0) {
+        logger.warn(
+          `No configured project is inside ${resolvedDirectory}. ${STAGED_PROJECT_FALLBACK_HINT}`,
+        );
+        logger.break();
+        const rootScanContext = await buildProjectScanContext(resolvedDirectory);
+        if (rootScanContext !== null) projectScanContexts.push(rootScanContext);
+      }
+
+      // Assign each staged path to exactly one project, deepest first, so a
+      // nested package claims its own files before its parent does.
+      // Among the ancestors of one staged path, a longer tree-relative directory
+      // is always the deeper one.
+      const contextsByLongestPathFirst = [...projectScanContexts].sort(
+        (left, right) => right.treeRelativeDirectory.length - left.treeRelativeDirectory.length,
+      );
+      const ownedStagedFiles = new Map<string, string[]>();
+      for (const stagedFile of rootStagedFiles) {
+        const owner = contextsByLongestPathFirst.find(
+          (context) =>
+            context.treeRelativeDirectory.length === 0 ||
+            stagedFile.startsWith(`${context.treeRelativeDirectory}/`),
+        );
+        if (owner === undefined) continue;
+        const ownedFiles = ownedStagedFiles.get(owner.scanDirectory);
+        if (ownedFiles === undefined) ownedStagedFiles.set(owner.scanDirectory, [stagedFile]);
+        else ownedFiles.push(stagedFile);
+      }
+
+      const stagedProjectScans: StagedProjectScan[] = [];
+      for (const projectScanContext of projectScanContexts) {
+        const projectStagedFiles = ownedStagedFiles.get(projectScanContext.scanDirectory);
+        if (projectStagedFiles === undefined) continue;
+        stagedProjectScans.push({ ...projectScanContext, stagedFiles: projectStagedFiles });
+      }
+
+      if (stagedProjectScans.length === 0) {
+        reportNothingToScan({ reason: "No staged source files in the selected projects." });
+        return;
+      }
+
+      // Ownership is exclusive, so this is already duplicate-free. Everything
+      // downstream works from it rather than the whole index: `showStagedContent`
+      // spawns one `git show` per file, so an unowned path would cost a
+      // subprocess to write bytes no scan reads.
+      const selectedStagedFiles = stagedProjectScans.flatMap(
+        (projectScan) => projectScan.stagedFiles,
+      );
+      const stagedFileCount = selectedStagedFiles.length;
+      const unselectedStagedFileCount = rootStagedFiles.length - stagedFileCount;
       if (!isQuiet) {
-        logger.log(`Scanning ${highlighter.info(`${stagedFiles.length}`)} staged files...`);
+        logger.log(`Scanning ${highlighter.info(`${stagedFileCount}`)} staged files...`);
+        // Staged paths outside the selected projects are out of scope, not
+        // missed — a plain scan would skip them too. Say so anyway, so the
+        // count above can't read as the whole staged set.
+        if (unselectedStagedFileCount > 0) {
+          logger.dim(
+            `${unselectedStagedFileCount} more staged file${unselectedStagedFileCount === 1 ? "" : "s"} outside the selected projects.`,
+          );
+        }
         logger.break();
       }
 
-      const tempDirectory = fs.mkdtempSync(path.join(tmpdir(), STAGED_FILES_TEMP_DIR_PREFIX));
-      // If materialization throws before `snapshot.cleanup` is wired up,
-      // remove the temp dir we just created so it can't leak.
-      const snapshot = await materializeStagedFiles(
-        resolvedDirectory,
-        stagedFiles,
-        tempDirectory,
-      ).catch((error: unknown) => {
-        fs.rmSync(tempDirectory, { recursive: true, force: true });
-        throw error;
-      });
-      // `--staged --scope lines`: only report issues on the staged hunks. The
-      // index diff (`--cached`) is keyed by the same relative paths the staged
-      // snapshot mirrors, so the ranges match the scan's diagnostics. A `null`
+      // `--staged --scope lines`: only report issues on the staged hunks. Ranges
+      // are computed once at the scan root (repo-relative paths), then re-keyed
+      // per project so they match project-relative diagnostic paths. A `null`
       // result (git diff failed) degrades to file-level rather than hiding
       // everything behind an empty filter.
       const stagedWantsLines = resolveScope(flags, userConfig).scope === "lines";
@@ -415,7 +575,7 @@ export const inspectAction = async (
         ? await getChangedLineRanges({
             directory: resolvedDirectory,
             cached: true,
-            files: snapshot.stagedFiles,
+            files: selectedStagedFiles,
           })
         : null;
       if (stagedWantsLines && stagedLineRanges === null && !isQuiet) {
@@ -424,50 +584,188 @@ export const inspectAction = async (
         );
         logger.break();
       }
-      try {
-        const scanResult = await inspect(snapshot.tempDirectory, {
+
+      // Every run that scans a package rather than the scan root, whether it
+      // selected one or several — a single selected package is the whole feature
+      // working, so gating this on more than one would hide the common case.
+      if (stagedProjectScans.some((projectScan) => projectScan.treeRelativeDirectory.length > 0)) {
+        recordCount(METRIC.stagedPerProject, 1, { projectCount: stagedProjectScans.length });
+      }
+      const tempDirectory = fs.mkdtempSync(path.join(tmpdir(), STAGED_FILES_TEMP_DIR_PREFIX));
+      // If materialization throws before `snapshot.cleanup` is wired up, remove
+      // the temp dir we just created so it can't leak.
+      const snapshot = await materializeStagedFiles({
+        directory: resolvedDirectory,
+        stagedFiles: selectedStagedFiles,
+        tempDirectory,
+        configSubdirectories: stagedProjectScans.map(
+          (projectScan) => projectScan.treeRelativeDirectory,
+        ),
+      }).catch((error: unknown) => {
+        fs.rmSync(tempDirectory, { recursive: true, force: true });
+        throw error;
+      });
+      const materializedStagedFiles = new Set(snapshot.stagedFiles);
+      // A project whose own staged files could not be snapshotted is dropped,
+      // not failed — see the empty case below for why none of the causes may
+      // block a commit.
+      const stagedProjectRuns = stagedProjectScans
+        .map((projectScan) => ({
+          projectScan,
+          includePaths: resolveProjectSourceFilePaths(
+            resolvedDirectory,
+            projectScan.scanDirectory,
+            projectScan.stagedFiles.filter((stagedFile) => materializedStagedFiles.has(stagedFile)),
+          ),
+        }))
+        .filter((projectRun) => projectRun.includePaths.length > 0);
+      // Derived from the projects that survived the drop above, not the ones
+      // selected: a lone survivor renders inline like any single-project scan
+      // instead of being suppressed in favour of an aggregate summary of one.
+      const isMultiProject = stagedProjectRuns.length > 1;
+      // Nothing at all came out of the index. An unreadable index already failed
+      // upstream — the divergence guard runs `git status` before any of this, and
+      // `getStagedSourceFiles` throws when `git diff --cached` reports failure —
+      // so what is left here is an oversized blob (`GIT_SHOW_MAX_BUFFER_BYTES`),
+      // a transient `git show` failure, or a path the snapshot refused. The
+      // committer can act on none of them, and failing would only teach them to
+      // reach for `--no-verify`, which drops every other hook with it. Warn and
+      // let the commit through. Nothing owns the snapshot yet, so tear it down.
+      if (stagedProjectRuns.length === 0) {
+        snapshot.cleanup();
+        reportNothingToScan({
+          reason: `Could not read any of the ${stagedFileCount} staged file${stagedFileCount === 1 ? "" : "s"} out of the index, so nothing was scanned. An unusually large staged file is the usual cause.`,
+          severity: "warn",
+        });
+        return;
+      }
+      if (snapshot.unmaterializedFiles.length > 0 && !isQuiet) {
+        // "not snapshotted", not "unreadable": the set also holds paths the
+        // snapshot refused because they resolved outside the temp tree.
+        const stagedFileLabel = `staged file${stagedFileCount === 1 ? "" : "s"}`;
+        logger.warn(
+          `Skipped ${snapshot.unmaterializedFiles.length} of ${stagedFileCount} ${stagedFileLabel}; they could not be snapshotted from the index.`,
+        );
+        logger.break();
+      }
+
+      const scanStagedProject = async (
+        projectRun: (typeof stagedProjectRuns)[number],
+      ): Promise<CompletedScan> => {
+        const { projectScan, includePaths } = projectRun;
+        const projectTempDirectory = path.join(
+          snapshot.tempDirectory,
+          projectScan.treeRelativeDirectory,
+        );
+        const scanResult = await inspect(projectTempDirectory, {
           ...scanOptions,
           deadlineEpochMs: scanDeadlineEpochMs,
-          includePaths: snapshot.stagedFiles,
-          configOverride: userConfig,
+          includePaths: [...includePaths],
+          configOverride: projectScan.projectConfig,
           // Resolve `config.plugins` from the real config directory — the
           // staged temp snapshot has no node_modules or plugin files, so
           // anchoring resolution there silently drops every custom plugin
           // from pre-commit scans.
-          configSourceDirectory: scanTarget.configSourceDirectory ?? undefined,
-          changedLineRanges: stagedLineRanges ?? undefined,
+          configSourceDirectory: projectScan.projectConfigSourceDirectory ?? undefined,
+          changedLineRanges:
+            stagedLineRanges === null
+              ? undefined
+              : resolveProjectChangedLineRanges(
+                  resolvedDirectory,
+                  projectScan.scanDirectory,
+                  stagedLineRanges,
+                ),
+          suppressRendering: isMultiProject,
+          concurrentScan: isMultiProject,
         });
 
         const remappedDiagnostics = scanResult.diagnostics.map((diagnostic) => ({
           ...diagnostic,
           filePath: path.isAbsolute(diagnostic.filePath)
-            ? diagnostic.filePath.replaceAll(snapshot.tempDirectory, () => resolvedDirectory)
+            ? diagnostic.filePath.replaceAll(projectTempDirectory, () => projectScan.scanDirectory)
             : diagnostic.filePath,
         }));
-        const remappedInspectResult: InspectResult = {
-          ...scanResult,
-          diagnostics: remappedDiagnostics,
-          project: { ...scanResult.project, rootDirectory: resolvedDirectory },
+        return {
+          directory: projectScan.scanDirectory,
+          result: {
+            ...scanResult,
+            diagnostics: remappedDiagnostics,
+            project: { ...scanResult.project, rootDirectory: projectScan.scanDirectory },
+          },
+          config: projectScan.projectConfig,
+          // `rootDirectory` is rewritten above so the report and the summary
+          // name real paths, but the scanned bytes are in the snapshot — code
+          // frames must read there or they show worktree lines at index
+          // numbers.
+          frameSourceRoot: projectTempDirectory,
         };
+      };
 
-        finalizeScans({
-          completedScans: [
-            { directory: resolvedDirectory, result: remappedInspectResult, config: userConfig },
-          ],
-          mode: "staged",
-          diff: null,
-          baselineIntended: false,
-          isJsonMode,
-          isScoreOnly,
-          flags,
-          categoryFilters,
-          userConfig,
-          resolvedDirectory,
-          startTime,
-        });
+      const stagedBatch = await runProjectScanBatch({
+        projects: stagedProjectRuns,
+        isQuiet,
+        isSilent: scanOptions.silent === true,
+        scanProject: scanStagedProject,
+      }).catch((error: unknown) => {
+        snapshot.cleanup();
+        throw error;
+      });
+      const completedScans = stagedBatch.completedScans;
+
+      // The snapshot has to outlive rendering: code frames read the scanned
+      // bytes out of it, so tearing it down first would silently degrade every
+      // frame to a bare `file:line`.
+      try {
+        if (!isQuiet && isMultiProject) {
+          const showShareLink =
+            !isShareOptedOut(completedScans, scanOptions.noScore) && !scanOptions.isCi;
+          await Effect.runPromise(
+            printMultiProjectSummary({
+              completedScans,
+              categoryFilters,
+              verbose: Boolean(flags.verbose),
+              outputDirectory: flags.outputDir,
+              isOffline: !showShareLink,
+              projectName: path.basename(resolvedDirectory),
+              totalElapsedMilliseconds: stagedBatch.elapsedMilliseconds,
+            }),
+          );
+        }
+
+        // `inspect()` dumps for a single scan, and the multi-project summary for
+        // a non-quiet monorepo scan. A quiet monorepo scan (`--json` /
+        // `--score`) has neither: rendering is suppressed and the summary is
+        // gated off, so without this `--output-dir` silently writes nothing.
+        if (flags.outputDir && isMultiProject && isQuiet) {
+          await Effect.runPromise(
+            printDiagnosticsDump(
+              filterDiagnosticsByCategories(
+                filterScansForSurface(completedScans, scanOptions.outputSurface ?? "cli"),
+                categoryFilters,
+              ),
+              flags.outputDir,
+              false,
+              "stderr",
+            ),
+          );
+        }
       } finally {
         snapshot.cleanup();
       }
+
+      finalizeScans({
+        completedScans,
+        mode: "staged",
+        diff: null,
+        baselineIntended: false,
+        isJsonMode,
+        isScoreOnly,
+        flags,
+        categoryFilters,
+        userConfig,
+        resolvedDirectory,
+        startTime,
+      });
       return;
     }
 
@@ -611,7 +909,6 @@ export const inspectAction = async (
       logger.break();
     }
 
-    const completedScans: CompletedScan[] = [];
     const isMultiProject = projectDirectories.length > 1;
 
     const scanProject = async (projectDirectory: string): Promise<CompletedScan | null> => {
@@ -730,43 +1027,13 @@ export const inspectAction = async (
       return { directory: scanDirectory, result: scanResult, config: projectConfig };
     };
 
-    // Multi-project scans run through the same bounded pool as
-    // `diagnose({ projects })` — per-project rendering is suppressed in favor
-    // of the aggregate summary, so concurrent scans don't garble output.
-    // Single-project runs keep their inline rendering on the same path.
-    const scanLoopStartTime = performance.now();
-    const projectCount = projectDirectories.length;
-    const batchSpinner =
-      isMultiProject && !isQuiet ? spinner(`Scanning ${projectCount} projects…`).start() : null;
-    // Concurrent pool members skip the per-scan toggle of the module-level
-    // spinner-silent flag (overlapping save/restore pairs would race), so
-    // the pool owner silences spinners once around the whole batch.
-    const ownsBatchSpinnerSilence = isMultiProject && scanOptions.silent === true;
-    const wasSpinnerSilent = isSpinnerSilent();
-    if (ownsBatchSpinnerSilence) setSpinnerSilent(true);
-    let finishedProjectCount = 0;
-    let scanOutcomes: ReadonlyArray<CompletedScan | null>;
-    try {
-      scanOutcomes = await mapWithConcurrency(
-        projectDirectories,
-        isMultiProject ? DEFAULT_PROJECT_SCAN_CONCURRENCY : 1,
-        async (projectDirectory) => {
-          const scanOutcome = await scanProject(projectDirectory);
-          finishedProjectCount += 1;
-          batchSpinner?.update(
-            `Scanning ${projectCount} projects… (${finishedProjectCount}/${projectCount})`,
-          );
-          return scanOutcome;
-        },
-      );
-    } finally {
-      if (ownsBatchSpinnerSilence) setSpinnerSilent(wasSpinnerSilent);
-      batchSpinner?.stop();
-    }
-    for (const scanOutcome of scanOutcomes) {
-      if (scanOutcome === null) continue;
-      completedScans.push(scanOutcome);
-    }
+    const projectBatch = await runProjectScanBatch({
+      projects: projectDirectories,
+      isQuiet,
+      isSilent: scanOptions.silent === true,
+      scanProject,
+    });
+    const completedScans = projectBatch.completedScans;
 
     if (!isQuiet && isMultiProject && completedScans.length > 0) {
       const showShareLink =
@@ -779,7 +1046,7 @@ export const inspectAction = async (
           outputDirectory: flags.outputDir,
           isOffline: !showShareLink,
           projectName: path.basename(resolvedDirectory),
-          totalElapsedMilliseconds: performance.now() - scanLoopStartTime,
+          totalElapsedMilliseconds: projectBatch.elapsedMilliseconds,
         }),
       );
     }

--- a/packages/react-doctor/src/cli/index.ts
+++ b/packages/react-doctor/src/cli/index.ts
@@ -227,7 +227,10 @@ const program = new Command()
     "--no-telemetry",
     "alias for --no-score (skip the score API, share URL, and crash reporting)",
   )
-  .option("--staged", "scan only staged (git index) files for pre-commit hooks")
+  .option(
+    "--staged",
+    "scan only staged (git index) files for pre-commit hooks (honors --project and config `projects`; exits 0 when nothing is staged)",
+  )
   .option(
     "--max-duration <seconds>",
     "scan time budget for the whole run, shared across workspace projects: past it, remaining lint batches and dead-code are skipped and partial results are reported (skipped files are listed in the JSON report)",

--- a/packages/react-doctor/src/cli/utils/constants.ts
+++ b/packages/react-doctor/src/cli/utils/constants.ts
@@ -262,6 +262,11 @@ export const METRIC = {
   cliError: "cli.error",
   cliEnvironmentError: "cli.env_error",
   stagedSnapshotDivergence: "staged.snapshot_divergence",
+  // The kill metric for per-package `--staged` scanning: one count per run that
+  // scanned a package instead of the scan root, with how many in an attribute.
+  // If it never fires, no repository points `--staged` at its packages and the
+  // ownership map earns nothing.
+  stagedPerProject: "staged.per_project",
   projectDetected: "project.detected",
   projectPathSelected: "project.path_selected",
   projectConfigSelected: "project.config_selected",

--- a/packages/react-doctor/src/cli/utils/filter-scans-for-surface.ts
+++ b/packages/react-doctor/src/cli/utils/filter-scans-for-surface.ts
@@ -15,6 +15,13 @@ export interface SurfaceFilterableScan {
    * exactly as they would to a standalone scan of that module.
    */
   readonly config: ReactDoctorConfig | null;
+  /**
+   * Where to read source from when rendering a code frame, when that is not
+   * `result.project.rootDirectory`. A `--staged` scan runs against a snapshot
+   * of the index, so the worktree copy can differ from what was scanned —
+   * reading it would print the wrong lines under index line numbers.
+   */
+  readonly frameSourceRoot?: string;
 }
 
 export const filterScansForSurface = (

--- a/packages/react-doctor/src/cli/utils/get-staged-files.ts
+++ b/packages/react-doctor/src/cli/utils/get-staged-files.ts
@@ -2,44 +2,57 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import { Git, StagedFiles, messageFromUnknown, type StagedSnapshot } from "@react-doctor/core";
 import { cliLogger } from "./cli-logger.js";
+import { CliInputError } from "./cli-input-error.js";
 
 const stagedFilesLayer = StagedFiles.layerNode.pipe(Layer.provide(Git.layerNode));
 
 export const getStagedSourceFiles = async (directory: string): Promise<string[]> => {
+  let stagedSourceFiles: ReadonlyArray<string> | null;
   try {
-    const files = await Effect.runPromise(
+    stagedSourceFiles = await Effect.runPromise(
       Effect.gen(function* () {
         const stagedFiles = yield* StagedFiles;
         return yield* stagedFiles.discoverSourceFiles(directory);
       }).pipe(Effect.provide(stagedFilesLayer)),
     );
-    return [...files];
   } catch (error) {
     cliLogger.warn(`Failed to discover staged files: ${messageFromUnknown(error)}`);
     return [];
   }
+  // `null` means git ran and reported a failure. `--staged` gates a commit, so
+  // an unread index must not arrive here as an empty one — that passes the gate
+  // without scanning anything.
+  if (stagedSourceFiles === null) {
+    throw new CliInputError(
+      "Could not read the git index to list staged files. Check that git can read the index in this directory.",
+    );
+  }
+  return [...stagedSourceFiles];
 };
 
 interface MaterializeResult {
   tempDirectory: string;
   stagedFiles: string[];
+  unmaterializedFiles: string[];
   cleanup: () => void;
 }
 
-export const materializeStagedFiles = async (
-  directory: string,
-  stagedFiles: string[],
-  tempDirectory: string,
-): Promise<MaterializeResult> => {
+export const materializeStagedFiles = async (input: {
+  readonly directory: string;
+  readonly stagedFiles: ReadonlyArray<string>;
+  readonly tempDirectory: string;
+  readonly configSubdirectories?: ReadonlyArray<string>;
+}): Promise<MaterializeResult> => {
   const snapshot: StagedSnapshot = await Effect.runPromise(
     Effect.gen(function* () {
       const staged = yield* StagedFiles;
-      return yield* staged.materialize({ directory, stagedFiles, tempDirectory });
+      return yield* staged.materialize(input);
     }).pipe(Effect.provide(stagedFilesLayer)),
   );
   return {
     tempDirectory: snapshot.tempDirectory,
     stagedFiles: [...snapshot.stagedFiles],
+    unmaterializedFiles: [...snapshot.unmaterializedFiles],
     cleanup: snapshot.cleanup,
   };
 };

--- a/packages/react-doctor/src/cli/utils/render-diagnostics.ts
+++ b/packages/react-doctor/src/cli/utils/render-diagnostics.ts
@@ -1,6 +1,7 @@
 import isUnicodeSupported from "is-unicode-supported";
 import * as Console from "effect/Console";
 import * as Effect from "effect/Effect";
+import * as path from "node:path";
 import {
   CODE_FRAME_BATCH_MAX_SPAN_LINES,
   CODE_FRAME_LINES_ABOVE,
@@ -325,11 +326,18 @@ const formatClusterLocation = (
 const buildDiagnosticClusterLines = (
   cluster: DiagnosticCluster,
   resolveSourceRoot: SourceRootResolver,
+  resolveFrameSourceRoot: SourceRootResolver,
   renderCodeFrame: boolean,
   hyperlinks: boolean,
 ): ReadonlyArray<string> => {
   const lead = cluster.diagnostics[0]!;
   const isMultiSite = cluster.diagnostics.length > 1;
+  const sourceRoot = resolveSourceRoot(lead);
+  const frameSourceRoot = resolveFrameSourceRoot(lead);
+  const frameFilePath =
+    path.isAbsolute(lead.filePath) && sourceRoot !== frameSourceRoot
+      ? path.relative(sourceRoot, lead.filePath)
+      : lead.filePath;
   const lines: string[] = [
     "",
     highlighter.gray(
@@ -338,11 +346,11 @@ const buildDiagnosticClusterLines = (
   ];
   const codeFrame = renderCodeFrame
     ? buildCodeFrame({
-        filePath: lead.filePath,
+        filePath: frameFilePath,
         line: cluster.startLine,
         column: isMultiSite ? 0 : lead.column,
         endLine: isMultiSite ? cluster.endLine : undefined,
-        rootDirectory: resolveSourceRoot(lead),
+        rootDirectory: frameSourceRoot,
       })
     : null;
   if (codeFrame) {
@@ -371,6 +379,7 @@ const buildRuleDetailBlock = (
   ruleKey: string,
   ruleDiagnostics: Diagnostic[],
   resolveSourceRoot: SourceRootResolver,
+  resolveFrameSourceRoot: SourceRootResolver,
   renderEverySite: boolean,
   isAgentEnvironment: boolean,
   hyperlinks: boolean,
@@ -461,7 +470,13 @@ const buildRuleDetailBlock = (
   if (!skipSharedLocation) {
     for (const cluster of clusterNearbyDiagnostics(sites)) {
       lines.push(
-        ...buildDiagnosticClusterLines(cluster, resolveSourceRoot, renderCodeFrame, hyperlinks),
+        ...buildDiagnosticClusterLines(
+          cluster,
+          resolveSourceRoot,
+          resolveFrameSourceRoot,
+          renderCodeFrame,
+          hyperlinks,
+        ),
       );
     }
   }
@@ -579,6 +594,7 @@ interface TopErrorsSection {
 const buildTopErrorsSection = (
   diagnostics: Diagnostic[],
   resolveSourceRoot: SourceRootResolver,
+  resolveFrameSourceRoot: SourceRootResolver,
   hyperlinks: boolean,
   rulePriority?: ReadonlyMap<string, number>,
 ): TopErrorsSection => {
@@ -602,6 +618,7 @@ const buildTopErrorsSection = (
         ruleKey,
         ruleDiagnostics,
         resolveSourceRoot,
+        resolveFrameSourceRoot,
         false,
         false,
         hyperlinks,
@@ -663,11 +680,9 @@ export interface DiagnosticsOnboarding {
 export const printDiagnostics = (
   diagnostics: Diagnostic[],
   isVerbose: boolean,
-  // The directory each diagnostic's relative `filePath` is resolved
-  // against for the inline code frame. A bare string works for a
-  // single-project scan; multi-project scans pass a resolver so each
-  // diagnostic reads from its own project root (their relative paths
-  // would otherwise miss against a single shared root → no frame).
+  // The directory each diagnostic's relative `filePath` is reported from.
+  // A bare string works for a single-project scan; multi-project scans pass
+  // a resolver so hyperlinks target the diagnostic's own project.
   sourceRoot: string | SourceRootResolver,
   // Score-API rule priorities (see `buildRulePriorityMap`). When present,
   // rule groups, categories, and the top-errors selection order
@@ -686,6 +701,9 @@ export const printDiagnostics = (
   // output stays plain text (and tests render deterministically); the CLI turns
   // it on only for capable, human-driven terminals (see supports-hyperlinks).
   hyperlinks = false,
+  // Staged scans report worktree paths while their frames must read the index
+  // snapshot. Other scans use `sourceRoot` for both.
+  frameSourceRoot: string | SourceRootResolver = sourceRoot,
 ): Effect.Effect<void> =>
   Effect.gen(function* () {
     // The beat played before each top-error block reveals; a no-op off onboarding.
@@ -693,6 +711,8 @@ export const printDiagnostics = (
     const animateCountUp = onboarding.animateCountUp ?? false;
     const resolveSourceRoot: SourceRootResolver =
       typeof sourceRoot === "function" ? sourceRoot : () => sourceRoot;
+    const resolveFrameSourceRoot: SourceRootResolver =
+      typeof frameSourceRoot === "function" ? frameSourceRoot : () => frameSourceRoot;
 
     // Detail block leads (the most actionable content — the specific
     // errors to fix). The category breakdown + total then land BELOW it as
@@ -708,6 +728,7 @@ export const printDiagnostics = (
       const topErrors = buildTopErrorsSection(
         diagnostics,
         resolveSourceRoot,
+        resolveFrameSourceRoot,
         hyperlinks,
         rulePriority,
       );
@@ -720,6 +741,7 @@ export const printDiagnostics = (
           ruleKey,
           ruleDiagnostics,
           resolveSourceRoot,
+          resolveFrameSourceRoot,
           true,
           isAgentEnvironment,
           hyperlinks,

--- a/packages/react-doctor/src/cli/utils/render-multi-project-summary.ts
+++ b/packages/react-doctor/src/cli/utils/render-multi-project-summary.ts
@@ -100,13 +100,14 @@ export const printMultiProjectSummary = (input: MultiProjectSummaryInput): Effec
       scoreDiagnostics.has(diagnostic),
     );
 
-    // Each diagnostic's `filePath` is relative to its own project root,
-    // so the code-frame renderer needs to resolve per-diagnostic rather
-    // than against one shared root (there isn't one across projects).
+    // Each diagnostic belongs to a different project root, and staged code
+    // frames may come from a separate index snapshot.
     const projectRootByDiagnostic = new WeakMap<Diagnostic, string>();
+    const frameSourceRootByDiagnostic = new WeakMap<Diagnostic, string>();
     for (const scan of completedScans) {
       for (const diagnostic of scan.result.diagnostics) {
-        projectRootByDiagnostic.set(
+        projectRootByDiagnostic.set(diagnostic, scan.result.project.rootDirectory);
+        frameSourceRootByDiagnostic.set(
           diagnostic,
           scan.frameSourceRoot ?? scan.result.project.rootDirectory,
         );
@@ -114,6 +115,8 @@ export const printMultiProjectSummary = (input: MultiProjectSummaryInput): Effec
     }
     const resolveDiagnosticSourceRoot = (diagnostic: Diagnostic): string =>
       projectRootByDiagnostic.get(diagnostic) ?? "";
+    const resolveDiagnosticFrameSourceRoot = (diagnostic: Diagnostic): string =>
+      frameSourceRootByDiagnostic.get(diagnostic) ?? resolveDiagnosticSourceRoot(diagnostic);
 
     // Single aggregate scan line in place of the per-project spinner
     // success lines (suppressed via `suppressScanSummary`). Scans run
@@ -137,6 +140,7 @@ export const printMultiProjectSummary = (input: MultiProjectSummaryInput): Effec
         isCodingAgentEnvironment(),
         { animateCountUp: animateRender },
         shouldRenderHyperlinks(process.stdout),
+        resolveDiagnosticFrameSourceRoot,
       );
     }
 

--- a/packages/react-doctor/src/cli/utils/render-multi-project-summary.ts
+++ b/packages/react-doctor/src/cli/utils/render-multi-project-summary.ts
@@ -106,7 +106,10 @@ export const printMultiProjectSummary = (input: MultiProjectSummaryInput): Effec
     const projectRootByDiagnostic = new WeakMap<Diagnostic, string>();
     for (const scan of completedScans) {
       for (const diagnostic of scan.result.diagnostics) {
-        projectRootByDiagnostic.set(diagnostic, scan.result.project.rootDirectory);
+        projectRootByDiagnostic.set(
+          diagnostic,
+          scan.frameSourceRoot ?? scan.result.project.rootDirectory,
+        );
       }
     }
     const resolveDiagnosticSourceRoot = (diagnostic: Diagnostic): string =>

--- a/packages/react-doctor/src/cli/utils/run-project-scan-batch.ts
+++ b/packages/react-doctor/src/cli/utils/run-project-scan-batch.ts
@@ -1,0 +1,53 @@
+import { performance } from "node:perf_hooks";
+import { DEFAULT_PROJECT_SCAN_CONCURRENCY, mapWithConcurrency } from "@react-doctor/core";
+import { isSpinnerSilent, setSpinnerSilent, spinner } from "./spinner.js";
+
+/**
+ * Run one scan per project through the same bounded pool as
+ * `diagnose({ projects })`, with the batch spinner and its progress counter.
+ *
+ * Pool members must not toggle the module-level spinner-silent flag themselves —
+ * overlapping save/restore pairs would race — so the batch owns that toggle once
+ * around the whole run.
+ *
+ * A `scanProject` that returns `null` drops the project from the results: diff
+ * mode skips projects with no changed source.
+ */
+export const runProjectScanBatch = async <Project, Scan>(input: {
+  readonly projects: ReadonlyArray<Project>;
+  readonly isQuiet: boolean;
+  readonly isSilent: boolean;
+  readonly scanProject: (project: Project) => Promise<Scan | null>;
+}): Promise<{ completedScans: Scan[]; elapsedMilliseconds: number }> => {
+  const startTime = performance.now();
+  const projectCount = input.projects.length;
+  const isMultiProject = projectCount > 1;
+  const batchSpinner =
+    isMultiProject && !input.isQuiet ? spinner(`Scanning ${projectCount} projects…`).start() : null;
+  const ownsBatchSpinnerSilence = isMultiProject && input.isSilent;
+  const wasSpinnerSilent = isSpinnerSilent();
+  if (ownsBatchSpinnerSilence) setSpinnerSilent(true);
+  let finishedProjectCount = 0;
+  let scanOutcomes: ReadonlyArray<Scan | null>;
+  try {
+    scanOutcomes = await mapWithConcurrency(
+      input.projects,
+      isMultiProject ? DEFAULT_PROJECT_SCAN_CONCURRENCY : 1,
+      async (project) => {
+        const scanOutcome = await input.scanProject(project);
+        finishedProjectCount += 1;
+        batchSpinner?.update(
+          `Scanning ${projectCount} projects… (${finishedProjectCount}/${projectCount})`,
+        );
+        return scanOutcome;
+      },
+    );
+  } finally {
+    if (ownsBatchSpinnerSilence) setSpinnerSilent(wasSpinnerSilent);
+    batchSpinner?.stop();
+  }
+  return {
+    completedScans: scanOutcomes.filter((scanOutcome): scanOutcome is Scan => scanOutcome !== null),
+    elapsedMilliseconds: performance.now() - startTime,
+  };
+};

--- a/packages/react-doctor/src/cli/utils/select-staged-projects.ts
+++ b/packages/react-doctor/src/cli/utils/select-staged-projects.ts
@@ -1,0 +1,37 @@
+import { cliLogger as logger } from "./cli-logger.js";
+import { CliInputError } from "./cli-input-error.js";
+import { selectProjects } from "./select-projects.js";
+
+/**
+ * Appended to the reason a `--staged` run could not scan per package. Shared so
+ * both fallback sites word it identically.
+ */
+export const STAGED_PROJECT_FALLBACK_HINT =
+  "Scanning the staged files at the scan root instead — fix the `projects` entries in your config to scan per package.";
+
+/**
+ * Resolve the project directories a `--staged` scan owns. The interactive picker
+ * is always skipped: a commit hook has nobody to answer it.
+ */
+export const selectStagedProjects = async (input: {
+  readonly rootDirectory: string;
+  readonly projectFlag: string | undefined;
+  readonly configProjects: readonly string[] | undefined;
+}): Promise<string[]> => {
+  if (input.projectFlag) {
+    return selectProjects(input.rootDirectory, input.projectFlag, true, undefined);
+  }
+  if (input.configProjects === undefined) return [input.rootDirectory];
+  try {
+    return await selectProjects(input.rootDirectory, undefined, true, input.configProjects);
+  } catch (error) {
+    // Only a `CliInputError` — the "entry does not resolve" case. Everything
+    // else propagates: an environment failure (permission denied, a path
+    // blocked by a file) would otherwise degrade to a root-only scan and
+    // report the vacuous clean scan this whole change exists to prevent.
+    if (!(error instanceof CliInputError)) throw error;
+    logger.warn(`${error.message} ${STAGED_PROJECT_FALLBACK_HINT}`);
+    logger.break();
+    return [input.rootDirectory];
+  }
+};

--- a/packages/react-doctor/tests/inspect-action-staged-guard.test.ts
+++ b/packages/react-doctor/tests/inspect-action-staged-guard.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import type { InspectResult } from "@react-doctor/core";
 import { inspectAction } from "../src/cli/commands/inspect.js";
 import { CliInputError } from "../src/cli/utils/cli-input-error.js";
+import { cliLogger } from "../src/cli/utils/cli-logger.js";
 import { handleUserError } from "../src/cli/utils/handle-error.js";
 import { inspect } from "../src/inspect.js";
 
@@ -92,16 +93,19 @@ const getLastCliInputErrorMessage = (): string => {
   return error instanceof CliInputError ? error.message : "";
 };
 
-describe("inspectAction staged snapshot guard", () => {
-  afterEach(() => {
-    vi.clearAllMocks();
-    Object.assign(console, originalConsoleMethods);
-    process.exitCode = undefined;
-    for (const temporaryDirectory of temporaryDirectories.splice(0)) {
-      fs.rmSync(temporaryDirectory, { recursive: true, force: true });
-    }
-  });
+afterEach(() => {
+  // `clearAllMocks` clears calls but leaves `vi.spyOn` installed, so the
+  // cliLogger spies below would stay live for every later test in this file.
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+  Object.assign(console, originalConsoleMethods);
+  process.exitCode = undefined;
+  for (const temporaryDirectory of temporaryDirectories.splice(0)) {
+    fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+  }
+});
 
+describe("inspectAction staged snapshot guard", () => {
   it("rejects a staged scan when tracked configuration diverges from the index", async () => {
     const directory = createDirectory("rd-staged-guard-");
     writeReactProject(directory);
@@ -176,5 +180,422 @@ describe("inspectAction staged snapshot guard", () => {
     expect(report.mode).toBe("staged");
     expect(report.ok).toBe(false);
     expect(report.error.name).toBe("CliInputError");
+  });
+});
+
+describe("inspectAction staged multi-project", () => {
+  // The `vi.mock` factory already builds a full InspectResult keyed off the
+  // directory it is handed. Tests that only need to observe the temp tree
+  // delegate to it instead of restating all of ProjectInfo.
+  const getDefaultInspect = () => {
+    const runDefaultInspect = vi.mocked(inspect).getMockImplementation();
+    if (runDefaultInspect === undefined) throw new Error("inspect mock has no implementation");
+    return runDefaultInspect;
+  };
+
+  const writeMonorepoWithoutRootReact = (directory: string): string => {
+    const appDirectory = path.join(directory, "packages/app");
+    fs.mkdirSync(path.join(appDirectory, "src"), { recursive: true });
+    fs.writeFileSync(
+      path.join(directory, "package.json"),
+      '{"name":"monorepo-root","private":true}\n',
+    );
+    fs.writeFileSync(path.join(directory, "pnpm-workspace.yaml"), "packages:\n  - 'packages/*'\n");
+    fs.writeFileSync(
+      path.join(directory, "doctor.config.json"),
+      `${JSON.stringify({ projects: ["packages/app"], noScore: true })}\n`,
+    );
+    fs.writeFileSync(
+      path.join(appDirectory, "package.json"),
+      '{"name":"app","dependencies":{"react":"19"}}\n',
+    );
+    fs.writeFileSync(path.join(appDirectory, "src/app.tsx"), "export const App = () => null;\n");
+    return appDirectory;
+  };
+
+  it("materializes staged files under each selected package so React rules see package identity", async () => {
+    const directory = createDirectory("rd-staged-projects-");
+    const appDirectory = writeMonorepoWithoutRootReact(directory);
+    initializeRepository(directory);
+
+    fs.writeFileSync(path.join(appDirectory, "src/app.tsx"), "export const App = () => <div />;\n");
+    runGit(directory, ["add", "packages/app/src/app.tsx"]);
+
+    // Capture the temp tree during inspect — cleanup runs in a finally after
+    // the mock returns, so post-call reads of the temp dir are empty.
+    const runDefaultInspect = getDefaultInspect();
+    let materializedPackageJson = "";
+    let materializedAppSourceExists = false;
+    vi.mocked(inspect).mockImplementationOnce(async (tempDirectory, options) => {
+      materializedPackageJson = fs.readFileSync(path.join(tempDirectory, "package.json"), "utf8");
+      materializedAppSourceExists = fs.existsSync(path.join(tempDirectory, "src/app.tsx"));
+      return runDefaultInspect(tempDirectory, options);
+    });
+
+    await inspectAction(directory, { staged: true, lint: false, yes: true });
+
+    expect(handleUserError).not.toHaveBeenCalled();
+    expect(inspect).toHaveBeenCalledTimes(1);
+    const [, options] = vi.mocked(inspect).mock.calls[0] ?? [];
+    expect(options?.includePaths).toEqual(["src/app.tsx"]);
+    expect(materializedPackageJson).toContain('"react"');
+    expect(materializedPackageJson).not.toContain("monorepo-root");
+    expect(materializedAppSourceExists).toBe(true);
+  });
+
+  it("falls back to the scan root when config projects is absent", async () => {
+    const directory = createDirectory("rd-staged-root-fallback-");
+    const appDirectory = path.join(directory, "packages/app");
+    fs.mkdirSync(path.join(appDirectory, "src"), { recursive: true });
+    fs.writeFileSync(
+      path.join(directory, "package.json"),
+      '{"name":"monorepo-root","private":true}\n',
+    );
+    fs.writeFileSync(path.join(directory, "pnpm-workspace.yaml"), "packages:\n  - 'packages/*'\n");
+    fs.writeFileSync(
+      path.join(appDirectory, "package.json"),
+      '{"name":"app","dependencies":{"react":"19"}}\n',
+    );
+    fs.writeFileSync(path.join(appDirectory, "src/app.tsx"), "export const App = () => null;\n");
+    initializeRepository(directory);
+
+    fs.writeFileSync(path.join(appDirectory, "src/app.tsx"), "export const App = () => <div />;\n");
+    runGit(directory, ["add", "packages/app/src/app.tsx"]);
+
+    const runDefaultInspect = getDefaultInspect();
+    let materializedPackageJson = "";
+    vi.mocked(inspect).mockImplementationOnce(async (tempDirectory, options) => {
+      materializedPackageJson = fs.readFileSync(path.join(tempDirectory, "package.json"), "utf8");
+      return runDefaultInspect(tempDirectory, options);
+    });
+
+    await inspectAction(directory, { staged: true, lint: false, yes: true });
+
+    expect(inspect).toHaveBeenCalledTimes(1);
+    const [, options] = vi.mocked(inspect).mock.calls[0] ?? [];
+    // Today's root scan: paths stay repo-relative under the monorepo root.
+    expect(options?.includePaths).toEqual(["packages/app/src/app.tsx"]);
+    expect(materializedPackageJson).toContain("monorepo-root");
+    expect(materializedPackageJson).not.toContain('"react"');
+  });
+
+  it("lets --project override the config projects under --staged", async () => {
+    const directory = createDirectory("rd-staged-project-flag-wins-");
+    const appDirectory = path.join(directory, "packages/app");
+    const otherDirectory = path.join(directory, "packages/other");
+    fs.mkdirSync(path.join(appDirectory, "src"), { recursive: true });
+    fs.mkdirSync(path.join(otherDirectory, "src"), { recursive: true });
+    fs.writeFileSync(
+      path.join(directory, "package.json"),
+      '{"name":"monorepo-root","private":true}\n',
+    );
+    fs.writeFileSync(path.join(directory, "pnpm-workspace.yaml"), "packages:\n  - 'packages/*'\n");
+    fs.writeFileSync(
+      path.join(directory, "doctor.config.json"),
+      `${JSON.stringify({ projects: ["packages/app"], noScore: true })}\n`,
+    );
+    for (const packageDirectory of [appDirectory, otherDirectory]) {
+      fs.writeFileSync(
+        path.join(packageDirectory, "package.json"),
+        `{"name":"${path.basename(packageDirectory)}","dependencies":{"react":"19"}}\n`,
+      );
+      fs.writeFileSync(
+        path.join(packageDirectory, "src/app.tsx"),
+        "export const App = () => null;\n",
+      );
+    }
+    initializeRepository(directory);
+
+    for (const packageDirectory of [appDirectory, otherDirectory]) {
+      fs.writeFileSync(
+        path.join(packageDirectory, "src/app.tsx"),
+        "export const App = () => <div />;\n",
+      );
+    }
+    runGit(directory, ["add", "packages/app/src/app.tsx", "packages/other/src/app.tsx"]);
+
+    await inspectAction(directory, {
+      staged: true,
+      project: "packages/other",
+      lint: false,
+      yes: true,
+    });
+
+    expect(handleUserError).not.toHaveBeenCalled();
+    expect(inspect).toHaveBeenCalledTimes(1);
+    const [scanDirectory] = vi.mocked(inspect).mock.calls[0] ?? [];
+    expect(scanDirectory).toContain(path.join("packages", "other"));
+  });
+
+  it("skips selected packages with no staged source files", async () => {
+    const directory = createDirectory("rd-staged-skip-empty-");
+    const appDirectory = path.join(directory, "packages/app");
+    const otherDirectory = path.join(directory, "packages/other");
+    fs.mkdirSync(path.join(appDirectory, "src"), { recursive: true });
+    fs.mkdirSync(path.join(otherDirectory, "src"), { recursive: true });
+    fs.writeFileSync(
+      path.join(directory, "package.json"),
+      '{"name":"monorepo-root","private":true}\n',
+    );
+    fs.writeFileSync(path.join(directory, "pnpm-workspace.yaml"), "packages:\n  - 'packages/*'\n");
+    fs.writeFileSync(
+      path.join(directory, "doctor.config.json"),
+      `${JSON.stringify({ projects: ["packages/app", "packages/other"], noScore: true })}\n`,
+    );
+    fs.writeFileSync(
+      path.join(appDirectory, "package.json"),
+      '{"name":"app","dependencies":{"react":"19"}}\n',
+    );
+    fs.writeFileSync(
+      path.join(otherDirectory, "package.json"),
+      '{"name":"other","dependencies":{"react":"19"}}\n',
+    );
+    fs.writeFileSync(path.join(appDirectory, "src/app.tsx"), "export const App = () => null;\n");
+    fs.writeFileSync(
+      path.join(otherDirectory, "src/other.tsx"),
+      "export const Other = () => null;\n",
+    );
+    initializeRepository(directory);
+
+    fs.writeFileSync(path.join(appDirectory, "src/app.tsx"), "export const App = () => <div />;\n");
+    runGit(directory, ["add", "packages/app/src/app.tsx"]);
+
+    await inspectAction(directory, { staged: true, lint: false, yes: true });
+
+    expect(inspect).toHaveBeenCalledTimes(1);
+    const [, options] = vi.mocked(inspect).mock.calls[0] ?? [];
+    expect(options?.includePaths).toEqual(["src/app.tsx"]);
+  });
+
+  it("ignores an ancestor config's projects entry that resolves inside the target package", async () => {
+    const directory = createDirectory("rd-staged-package-target-");
+    const appDirectory = writeMonorepoWithoutRootReact(directory);
+    // `"src"` does resolve from inside `packages/app`, so without the
+    // requested-is-config-source guard the ancestor's entry would make
+    // `packages/app/src` the scan root instead of the package itself. An entry
+    // that fails to resolve cannot tell the guard apart from the fallback.
+    fs.writeFileSync(
+      path.join(directory, "doctor.config.json"),
+      `${JSON.stringify({ projects: ["src"], noScore: true })}\n`,
+    );
+    initializeRepository(directory);
+
+    fs.writeFileSync(path.join(appDirectory, "src/app.tsx"), "export const App = () => <div />;\n");
+    runGit(directory, ["add", "packages/app/src/app.tsx"]);
+    const warn = vi.spyOn(cliLogger, "warn").mockImplementation(() => {});
+
+    await inspectAction(appDirectory, { staged: true, lint: false, yes: true });
+
+    expect(handleUserError).not.toHaveBeenCalled();
+    expect(inspect).toHaveBeenCalledTimes(1);
+    const [scanDirectory, options] = vi.mocked(inspect).mock.calls[0] ?? [];
+    expect(path.basename(String(scanDirectory))).not.toBe("src");
+    expect(options?.includePaths).toEqual(["src/app.tsx"]);
+    // The guard skipped the entry outright; it did not resolve it and fall back.
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  const writeTwoPackageMonorepo = (
+    directory: string,
+    configProjects: ReadonlyArray<string>,
+  ): { appDirectory: string; otherDirectory: string } => {
+    const appDirectory = path.join(directory, "packages/app");
+    const otherDirectory = path.join(directory, "packages/other");
+    for (const [packageDirectory, packageName] of [
+      [appDirectory, "app"],
+      [otherDirectory, "other"],
+    ] as const) {
+      fs.mkdirSync(path.join(packageDirectory, "src"), { recursive: true });
+      fs.writeFileSync(
+        path.join(packageDirectory, "package.json"),
+        `{"name":"${packageName}","dependencies":{"react":"19"}}\n`,
+      );
+      fs.writeFileSync(
+        path.join(packageDirectory, `src/${packageName}.tsx`),
+        "export const Component = () => null;\n",
+      );
+    }
+    fs.writeFileSync(
+      path.join(directory, "package.json"),
+      '{"name":"monorepo-root","private":true}\n',
+    );
+    fs.writeFileSync(path.join(directory, "pnpm-workspace.yaml"), "packages:\n  - 'packages/*'\n");
+    fs.writeFileSync(
+      path.join(directory, "doctor.config.json"),
+      `${JSON.stringify({ projects: [...configProjects], noScore: true })}\n`,
+    );
+    return { appDirectory, otherDirectory };
+  };
+
+  const getIncludePathsByScanDirectory = (): Record<string, ReadonlyArray<string> | undefined> => {
+    // Pool order is nondeterministic, so key by the temp root each scan got
+    // rather than by call index.
+    const includePathsByDirectory: Record<string, ReadonlyArray<string> | undefined> = {};
+    for (const [scanDirectory, options] of vi.mocked(inspect).mock.calls) {
+      includePathsByDirectory[path.basename(scanDirectory)] = options?.includePaths;
+    }
+    return includePathsByDirectory;
+  };
+
+  it("scans every selected package that has staged files, each from its own package root", async () => {
+    const directory = createDirectory("rd-staged-two-packages-");
+    const { appDirectory, otherDirectory } = writeTwoPackageMonorepo(directory, [
+      "packages/app",
+      "packages/other",
+    ]);
+    initializeRepository(directory);
+
+    fs.writeFileSync(path.join(appDirectory, "src/app.tsx"), "export const App = () => <div />;\n");
+    fs.writeFileSync(
+      path.join(otherDirectory, "src/other.tsx"),
+      "export const Other = () => <span />;\n",
+    );
+    runGit(directory, ["add", "packages/app/src/app.tsx", "packages/other/src/other.tsx"]);
+
+    const runDefaultInspect = getDefaultInspect();
+    const materializedPackageNames: string[] = [];
+    // Two queued one-shot implementations rather than a persistent one: a
+    // persistent `mockImplementation` would outlive `vi.clearAllMocks()` and
+    // leak into the tests below. Both are identical, so pool order is moot.
+    const captureMaterializedPackageName = async (
+      tempDirectory: string,
+      options: Parameters<typeof inspect>[1],
+    ) => {
+      materializedPackageNames.push(
+        JSON.parse(fs.readFileSync(path.join(tempDirectory, "package.json"), "utf8")).name,
+      );
+      return runDefaultInspect(tempDirectory, options);
+    };
+    vi.mocked(inspect)
+      .mockImplementationOnce(captureMaterializedPackageName)
+      .mockImplementationOnce(captureMaterializedPackageName);
+
+    await inspectAction(directory, { staged: true, lint: false, yes: true });
+
+    expect(handleUserError).not.toHaveBeenCalled();
+    expect(inspect).toHaveBeenCalledTimes(2);
+    // Each scan is rooted at its own package, so React identity is per package
+    // rather than the React-less monorepo root's.
+    expect([...materializedPackageNames].sort()).toEqual(["app", "other"]);
+    expect(getIncludePathsByScanDirectory()).toEqual({
+      app: ["src/app.tsx"],
+      other: ["src/other.tsx"],
+    });
+  });
+
+  it("claims each staged file once when a package and its parent are both selected", async () => {
+    const directory = createDirectory("rd-staged-nested-");
+    const appDirectory = path.join(directory, "packages/app");
+    const innerDirectory = path.join(appDirectory, "inner");
+    fs.mkdirSync(path.join(innerDirectory, "src"), { recursive: true });
+    fs.mkdirSync(path.join(appDirectory, "src"), { recursive: true });
+    fs.writeFileSync(
+      path.join(directory, "package.json"),
+      '{"name":"monorepo-root","private":true}\n',
+    );
+    fs.writeFileSync(path.join(directory, "pnpm-workspace.yaml"), "packages:\n  - 'packages/*'\n");
+    fs.writeFileSync(
+      path.join(directory, "doctor.config.json"),
+      `${JSON.stringify({
+        // The same package three ways, plus a nested one: aliases must collapse
+        // and the nested package must claim its own file.
+        projects: ["packages/app", "./packages/app", "packages/app/inner"],
+        noScore: true,
+      })}\n`,
+    );
+    fs.writeFileSync(
+      path.join(appDirectory, "package.json"),
+      '{"name":"app","dependencies":{"react":"19"}}\n',
+    );
+    fs.writeFileSync(
+      path.join(innerDirectory, "package.json"),
+      '{"name":"inner","dependencies":{"react":"19"}}\n',
+    );
+    fs.writeFileSync(path.join(appDirectory, "src/app.tsx"), "export const App = () => null;\n");
+    fs.writeFileSync(
+      path.join(innerDirectory, "src/inner.tsx"),
+      "export const Inner = () => null;\n",
+    );
+    initializeRepository(directory);
+
+    fs.writeFileSync(path.join(appDirectory, "src/app.tsx"), "export const App = () => <div />;\n");
+    fs.writeFileSync(
+      path.join(innerDirectory, "src/inner.tsx"),
+      "export const Inner = () => <div />;\n",
+    );
+    runGit(directory, ["add", "packages/app/src/app.tsx", "packages/app/inner/src/inner.tsx"]);
+
+    await inspectAction(directory, { staged: true, lint: false, yes: true });
+
+    expect(handleUserError).not.toHaveBeenCalled();
+    // Two projects, not three: the alias collapsed. And `inner/src/inner.tsx`
+    // belongs to `inner` alone, so it is never scanned twice.
+    expect(inspect).toHaveBeenCalledTimes(2);
+    expect(getIncludePathsByScanDirectory()).toEqual({
+      app: ["src/app.tsx"],
+      inner: ["src/inner.tsx"],
+    });
+  });
+
+  it("reports staged files outside the selected projects and still exits clean", async () => {
+    const directory = createDirectory("rd-staged-unselected-");
+    const { appDirectory, otherDirectory } = writeTwoPackageMonorepo(directory, ["packages/app"]);
+    initializeRepository(directory);
+
+    fs.writeFileSync(path.join(appDirectory, "src/app.tsx"), "export const App = () => <div />;\n");
+    fs.writeFileSync(
+      path.join(otherDirectory, "src/other.tsx"),
+      "export const Other = () => <span />;\n",
+    );
+    runGit(directory, ["add", "packages/app/src/app.tsx", "packages/other/src/other.tsx"]);
+
+    const dimMessages: string[] = [];
+    vi.spyOn(cliLogger, "dim").mockImplementation((message: string) => {
+      dimMessages.push(message);
+    });
+
+    await inspectAction(directory, { staged: true, lint: false, yes: true });
+
+    // Out of scope, not missed — a plain scan would skip it too — so this stays
+    // exit 0. It must not pass in silence, though.
+    expect(handleUserError).not.toHaveBeenCalled();
+    expect(process.exitCode).toBeUndefined();
+    expect(inspect).toHaveBeenCalledTimes(1);
+    expect(dimMessages.join("\n")).toContain("1 more staged file outside the selected projects");
+  });
+
+  it("warns and scans the root when a config projects entry no longer resolves", async () => {
+    const directory = createDirectory("rd-staged-stale-entry-");
+    const appDirectory = path.join(directory, "packages/app");
+    fs.mkdirSync(path.join(appDirectory, "src"), { recursive: true });
+    fs.writeFileSync(path.join(directory, "package.json"), '{"dependencies":{"react":"19"}}\n');
+    fs.writeFileSync(path.join(directory, "pnpm-workspace.yaml"), "packages:\n  - 'packages/*'\n");
+    fs.writeFileSync(
+      path.join(directory, "doctor.config.json"),
+      `${JSON.stringify({ projects: ["packages/renamed-away"], noScore: true })}\n`,
+    );
+    fs.writeFileSync(
+      path.join(appDirectory, "package.json"),
+      '{"name":"app","dependencies":{"react":"19"}}\n',
+    );
+    fs.writeFileSync(path.join(appDirectory, "src/app.tsx"), "export const App = () => null;\n");
+    initializeRepository(directory);
+
+    fs.writeFileSync(path.join(appDirectory, "src/app.tsx"), "export const App = () => <div />;\n");
+    runGit(directory, ["add", "packages/app/src/app.tsx"]);
+
+    const warnMessages: string[] = [];
+    vi.spyOn(cliLogger, "warn").mockImplementation((message: string) => {
+      warnMessages.push(message);
+    });
+
+    await inspectAction(directory, { staged: true, lint: false, yes: true });
+
+    // A stale entry must not block every commit — `--staged` runs in a hook.
+    expect(handleUserError).not.toHaveBeenCalled();
+    expect(inspect).toHaveBeenCalledTimes(1);
+    expect(warnMessages.join("\n")).toContain("packages/renamed-away");
+    const [, options] = vi.mocked(inspect).mock.calls[0] ?? [];
+    expect(options?.includePaths).toEqual(["packages/app/src/app.tsx"]);
   });
 });

--- a/packages/react-doctor/tests/inspect-action-staged-materialize.test.ts
+++ b/packages/react-doctor/tests/inspect-action-staged-materialize.test.ts
@@ -1,0 +1,224 @@
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import type { InspectResult } from "@react-doctor/core";
+import { inspectAction } from "../src/cli/commands/inspect.js";
+import { cliLogger } from "../src/cli/utils/cli-logger.js";
+import { handleUserError } from "../src/cli/utils/handle-error.js";
+import { getStagedSourceFiles, materializeStagedFiles } from "../src/cli/utils/get-staged-files.js";
+import { inspect } from "../src/inspect.js";
+import { buildTestProject } from "./regressions/_helpers.js";
+
+vi.mock("../src/cli/utils/handle-error.js", () => ({
+  buildErrorIssueUrl: vi.fn(() => ""),
+  handleError: vi.fn(),
+  handleUserError: vi.fn(),
+}));
+
+vi.mock("../src/inspect.js", () => ({ inspect: vi.fn() }));
+
+vi.mock("../src/cli/utils/get-staged-files.js", () => ({
+  getStagedSourceFiles: vi.fn(),
+  materializeStagedFiles: vi.fn(),
+}));
+
+const temporaryDirectories: string[] = [];
+
+const createDirectory = (prefix: string): string => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  temporaryDirectories.push(directory);
+  return directory;
+};
+
+const buildInspectResult = (rootDirectory: string): InspectResult => ({
+  diagnostics: [],
+  score: null,
+  skippedChecks: [],
+  project: buildTestProject({ rootDirectory }),
+  elapsedMilliseconds: 1,
+});
+
+const initializeRepository = (directory: string): void => {
+  const runGit = (args: ReadonlyArray<string>): void => {
+    execFileSync("git", [...args], { cwd: directory });
+  };
+  runGit(["init", "-q", "-b", "main"]);
+  runGit(["config", "user.email", "test@example.com"]);
+  runGit(["config", "user.name", "test"]);
+  runGit(["config", "commit.gpgsign", "false"]);
+  runGit(["add", "."]);
+  runGit(["commit", "-q", "-m", "init"]);
+};
+
+const writeReactRepository = (directory: string): void => {
+  fs.mkdirSync(path.join(directory, "src"), { recursive: true });
+  fs.writeFileSync(path.join(directory, "package.json"), '{"dependencies":{"react":"19"}}\n');
+  fs.writeFileSync(path.join(directory, "src/app.tsx"), "export const App = () => null;\n");
+  initializeRepository(directory);
+};
+
+describe("inspectAction staged materialization", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+    process.exitCode = undefined;
+    for (const temporaryDirectory of temporaryDirectories.splice(0)) {
+      fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+    }
+  });
+
+  it("warns without blocking the commit when no staged file could be read out of the index", async () => {
+    const directory = createDirectory("rd-staged-materialize-empty-");
+    writeReactRepository(directory);
+    const warn = vi.spyOn(cliLogger, "warn").mockImplementation(() => {});
+    vi.spyOn(cliLogger, "break").mockImplementation(() => {});
+    vi.mocked(getStagedSourceFiles).mockResolvedValue(["src/app.tsx"]);
+    vi.mocked(materializeStagedFiles).mockImplementation(
+      async ({ stagedFiles, tempDirectory }) => ({
+        tempDirectory,
+        stagedFiles: [],
+        unmaterializedFiles: [...stagedFiles],
+        cleanup: () => fs.rmSync(tempDirectory, { recursive: true, force: true }),
+      }),
+    );
+
+    await inspectAction(directory, { staged: true, lint: false, yes: true });
+
+    expect(inspect).not.toHaveBeenCalled();
+    expect(handleUserError).not.toHaveBeenCalled();
+    expect(process.exitCode).not.toBe(1);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("Could not read any of the 1 staged file "),
+    );
+  });
+
+  it("warns and keeps scanning when only some staged files could be read", async () => {
+    const directory = createDirectory("rd-staged-materialize-partial-");
+    writeReactRepository(directory);
+    const warn = vi.spyOn(cliLogger, "warn").mockImplementation(() => {});
+    vi.spyOn(cliLogger, "break").mockImplementation(() => {});
+    vi.mocked(getStagedSourceFiles).mockResolvedValue(["src/app.tsx", "src/gone.tsx"]);
+    vi.mocked(materializeStagedFiles).mockImplementation(async ({ tempDirectory }) => ({
+      tempDirectory,
+      stagedFiles: ["src/app.tsx"],
+      unmaterializedFiles: ["src/gone.tsx"],
+      cleanup: () => fs.rmSync(tempDirectory, { recursive: true, force: true }),
+    }));
+    vi.mocked(inspect).mockImplementation(async (scanDirectory) =>
+      buildInspectResult(scanDirectory),
+    );
+
+    await inspectAction(directory, { staged: true, lint: false, yes: true });
+
+    expect(handleUserError).not.toHaveBeenCalled();
+    expect(inspect).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("Skipped 1 of 2 staged files"));
+  });
+
+  it("materializes only the staged files the selected projects own", async () => {
+    const directory = createDirectory("rd-staged-owned-only-");
+    for (const packageName of ["app", "other"]) {
+      const packageDirectory = path.join(directory, "packages", packageName);
+      fs.mkdirSync(path.join(packageDirectory, "src"), { recursive: true });
+      fs.writeFileSync(
+        path.join(packageDirectory, "package.json"),
+        `{"name":"${packageName}","dependencies":{"react":"19"}}\n`,
+      );
+      fs.writeFileSync(
+        path.join(packageDirectory, `src/${packageName}.tsx`),
+        "export const Component = () => null;\n",
+      );
+    }
+    fs.writeFileSync(
+      path.join(directory, "package.json"),
+      '{"name":"monorepo-root","private":true}\n',
+    );
+    fs.writeFileSync(path.join(directory, "pnpm-workspace.yaml"), "packages:\n  - 'packages/*'\n");
+    fs.writeFileSync(
+      path.join(directory, "doctor.config.json"),
+      `${JSON.stringify({ projects: ["packages/app"], noScore: true })}\n`,
+    );
+    initializeRepository(directory);
+    const warn = vi.spyOn(cliLogger, "warn").mockImplementation(() => {});
+    vi.spyOn(cliLogger, "break").mockImplementation(() => {});
+    vi.mocked(getStagedSourceFiles).mockResolvedValue([
+      "packages/app/src/app.tsx",
+      "packages/other/src/other.tsx",
+    ]);
+    vi.mocked(materializeStagedFiles).mockImplementation(
+      async ({ stagedFiles, tempDirectory }) => ({
+        tempDirectory,
+        stagedFiles: [],
+        unmaterializedFiles: [...stagedFiles],
+        cleanup: () => fs.rmSync(tempDirectory, { recursive: true, force: true }),
+      }),
+    );
+
+    await inspectAction(directory, { staged: true, lint: false, yes: true });
+
+    // `other` is staged but unselected, so it never reaches the snapshot —
+    // `git show` costs a subprocess per file and nothing would read those bytes.
+    const [materializeInput] = vi.mocked(materializeStagedFiles).mock.calls[0] ?? [];
+    expect(materializeInput?.stagedFiles).toEqual(["packages/app/src/app.tsx"]);
+    // And the failure count is out of the owned files, not the whole index.
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("Could not read any of the 1 staged file "),
+    );
+  });
+
+  it("skips a package whose staged files could not be snapshotted and scans its sibling", async () => {
+    const directory = createDirectory("rd-staged-materialize-one-package-");
+    for (const packageName of ["app", "other"]) {
+      const packageDirectory = path.join(directory, "packages", packageName);
+      fs.mkdirSync(path.join(packageDirectory, "src"), { recursive: true });
+      fs.writeFileSync(
+        path.join(packageDirectory, "package.json"),
+        `{"name":"${packageName}","dependencies":{"react":"19"}}\n`,
+      );
+      fs.writeFileSync(
+        path.join(packageDirectory, `src/${packageName}.tsx`),
+        "export const Component = () => null;\n",
+      );
+    }
+    fs.writeFileSync(
+      path.join(directory, "package.json"),
+      '{"name":"monorepo-root","private":true}\n',
+    );
+    fs.writeFileSync(path.join(directory, "pnpm-workspace.yaml"), "packages:\n  - 'packages/*'\n");
+    fs.writeFileSync(
+      path.join(directory, "doctor.config.json"),
+      `${JSON.stringify({ projects: ["packages/app", "packages/other"], noScore: true })}\n`,
+    );
+    initializeRepository(directory);
+    const warn = vi.spyOn(cliLogger, "warn").mockImplementation(() => {});
+    vi.spyOn(cliLogger, "break").mockImplementation(() => {});
+    vi.mocked(getStagedSourceFiles).mockResolvedValue([
+      "packages/app/src/app.tsx",
+      "packages/other/src/other.tsx",
+    ]);
+    // Only `app` comes out of the index. `other` must be dropped, not scanned
+    // against an empty tree — and not turned into a failed commit either, since
+    // an unreadable blob is not something the committer can act on.
+    vi.mocked(materializeStagedFiles).mockImplementation(async ({ tempDirectory }) => ({
+      tempDirectory,
+      stagedFiles: ["packages/app/src/app.tsx"],
+      unmaterializedFiles: ["packages/other/src/other.tsx"],
+      cleanup: () => fs.rmSync(tempDirectory, { recursive: true, force: true }),
+    }));
+    vi.mocked(inspect).mockImplementation(async (scanDirectory) =>
+      buildInspectResult(scanDirectory),
+    );
+
+    await inspectAction(directory, { staged: true, lint: false, yes: true });
+
+    expect(handleUserError).not.toHaveBeenCalled();
+    expect(inspect).toHaveBeenCalledTimes(1);
+    const [scanDirectory, options] = vi.mocked(inspect).mock.calls[0] ?? [];
+    expect(path.basename(String(scanDirectory))).toBe("app");
+    expect(options?.includePaths).toEqual(["src/app.tsx"]);
+    // The drop is reported, so a partially-snapshotted run cannot read as clean.
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("Skipped 1 of 2 staged files"));
+  });
+});

--- a/packages/react-doctor/tests/inspect-action-staged-materialize.test.ts
+++ b/packages/react-doctor/tests/inspect-action-staged-materialize.test.ts
@@ -168,6 +168,48 @@ describe("inspectAction staged materialization", () => {
     );
   });
 
+  it("materializes package config when rootDir redirects the scan directory", async () => {
+    const directory = createDirectory("rd-staged-root-dir-config-");
+    const packageDirectory = path.join(directory, "packages", "app");
+    fs.mkdirSync(path.join(packageDirectory, "src"), { recursive: true });
+    fs.writeFileSync(
+      path.join(packageDirectory, "package.json"),
+      '{"name":"app","dependencies":{"react":"19"}}\n',
+    );
+    fs.writeFileSync(
+      path.join(packageDirectory, "doctor.config.json"),
+      `${JSON.stringify({ rootDir: "src" })}\n`,
+    );
+    fs.writeFileSync(
+      path.join(packageDirectory, "src/app.tsx"),
+      "export const App = () => null;\n",
+    );
+    fs.writeFileSync(
+      path.join(directory, "package.json"),
+      '{"name":"monorepo-root","private":true}\n',
+    );
+    fs.writeFileSync(path.join(directory, "pnpm-workspace.yaml"), "packages:\n  - 'packages/*'\n");
+    fs.writeFileSync(
+      path.join(directory, "doctor.config.json"),
+      `${JSON.stringify({ projects: ["packages/app"], noScore: true })}\n`,
+    );
+    initializeRepository(directory);
+    vi.mocked(getStagedSourceFiles).mockResolvedValue(["packages/app/src/app.tsx"]);
+    vi.mocked(materializeStagedFiles).mockImplementation(
+      async ({ stagedFiles, tempDirectory }) => ({
+        tempDirectory,
+        stagedFiles: [],
+        unmaterializedFiles: [...stagedFiles],
+        cleanup: () => fs.rmSync(tempDirectory, { recursive: true, force: true }),
+      }),
+    );
+
+    await inspectAction(directory, { staged: true, lint: false, yes: true });
+
+    const [materializeInput] = vi.mocked(materializeStagedFiles).mock.calls[0] ?? [];
+    expect(materializeInput?.configSubdirectories).toEqual(["packages/app/src", "packages/app"]);
+  });
+
   it("skips a package whose staged files could not be snapshotted and scans its sibling", async () => {
     const directory = createDirectory("rd-staged-materialize-one-package-");
     for (const packageName of ["app", "other"]) {

--- a/packages/react-doctor/tests/regressions/scan-resilience.test.ts
+++ b/packages/react-doctor/tests/regressions/scan-resilience.test.ts
@@ -311,7 +311,11 @@ describe("issue #115: --staged uses git INDEX content, not working tree", () => 
     expect(stagedFiles).toEqual(["src/App.tsx"]);
 
     const tempDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "rd-staged-snapshot-"));
-    const snapshot = await materializeStagedFiles(repoDir, stagedFiles, tempDirectory);
+    const snapshot = await materializeStagedFiles({
+      directory: repoDir,
+      stagedFiles,
+      tempDirectory,
+    });
     try {
       const snapshotted = fs.readFileSync(
         path.join(snapshot.tempDirectory, "src", "App.tsx"),
@@ -330,6 +334,30 @@ describe("issue #115: --staged uses git INDEX content, not working tree", () => 
     writeJson(path.join(repoDir, "package.json"), { name: "empty-staged" });
     initGitRepo(repoDir);
     await expect(getStagedSourceFiles(repoDir)).resolves.toEqual([]);
+  });
+});
+
+describe("getStagedSourceFiles separates an unreadable index from an empty one", () => {
+  it("throws instead of returning [] when git cannot read the index", async () => {
+    const repoDir = path.join(tempRoot, "staged-unreadable-index");
+    fs.mkdirSync(repoDir, { recursive: true });
+    writeJson(path.join(repoDir, "package.json"), { name: "unreadable-index" });
+    fs.writeFileSync(path.join(repoDir, "app.tsx"), "export const App = () => <div />;\n");
+    initGitRepo(repoDir);
+
+    // A corrupt index makes `git diff --cached` exit non-zero. Returning `[]`
+    // there is indistinguishable from "nothing staged", which passes a
+    // pre-commit gate without scanning anything.
+    const corruptIndexPath = path.join(repoDir, "corrupt-index");
+    fs.writeFileSync(corruptIndexPath, "not-a-git-index");
+    const previousIndexFile = process.env.GIT_INDEX_FILE;
+    process.env.GIT_INDEX_FILE = corruptIndexPath;
+    try {
+      await expect(getStagedSourceFiles(repoDir)).rejects.toThrow(/Could not read the git index/);
+    } finally {
+      if (previousIndexFile === undefined) delete process.env.GIT_INDEX_FILE;
+      else process.env.GIT_INDEX_FILE = previousIndexFile;
+    }
   });
 });
 

--- a/packages/react-doctor/tests/render-multi-project-summary.test.ts
+++ b/packages/react-doctor/tests/render-multi-project-summary.test.ts
@@ -1,3 +1,6 @@
+import * as fs from "node:fs";
+import os from "node:os";
+import * as path from "node:path";
 import * as Effect from "effect/Effect";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import type { Diagnostic, InspectResult, ProjectInfo, ReactDoctorConfig } from "@react-doctor/core";
@@ -188,5 +191,81 @@ describe("printMultiProjectSummary score projection", () => {
     const [topErrorSource, rescoreSource] = mockedComputeProjectedScore.mock.calls[0];
     expect(topErrorSource).toEqual([highProductionDiagnostic]);
     expect(rescoreSource).toEqual([lowProductionDiagnostic]);
+  });
+});
+
+describe("printMultiProjectSummary code frames", () => {
+  const temporaryDirectories: string[] = [];
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    for (const temporaryDirectory of temporaryDirectories.splice(0)) {
+      fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+    }
+  });
+
+  const writeSourceTree = (marker: string): string => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "rd-frame-root-"));
+    temporaryDirectories.push(directory);
+    fs.mkdirSync(path.join(directory, "src"), { recursive: true });
+    fs.writeFileSync(path.join(directory, "src/App.tsx"), `export const ${marker} = 1;\n`);
+    return directory;
+  };
+
+  const renderFramedOutput = async (scanOverrides: {
+    rootDirectory: string;
+    frameSourceRoot?: string;
+  }): Promise<string> => {
+    const lines: string[] = [];
+    vi.spyOn(console, "log").mockImplementation((line?: unknown) => {
+      lines.push(String(line ?? ""));
+    });
+    const framedScan = {
+      config: null,
+      frameSourceRoot: scanOverrides.frameSourceRoot,
+      result: {
+        diagnostics: [buildDiagnostic({ filePath: "src/App.tsx", line: 1, column: 14 })],
+        score: { score: 40, label: "Needs work" },
+        skippedChecks: [],
+        project: { ...buildProject("app"), rootDirectory: scanOverrides.rootDirectory },
+        elapsedMilliseconds: 10,
+        scannedFileCount: 1,
+        analyzedFiles: ["src/App.tsx"],
+      } satisfies InspectResult,
+    };
+    await Effect.runPromise(
+      printMultiProjectSummary({
+        completedScans: [framedScan, buildScan("other", 80, [highProductionDiagnostic])],
+        verbose: true,
+        isOffline: true,
+        projectName: "workspace",
+        totalElapsedMilliseconds: 20,
+      }),
+    );
+    return lines.join("\n");
+  };
+
+  // `--staged` scans a snapshot of the index but reports real package paths, so
+  // the frame has to come from the snapshot. Reading the worktree would print
+  // whatever is uncommitted under index-derived line numbers.
+  it("reads the frame from frameSourceRoot rather than the reported project root", async () => {
+    const worktreeDirectory = writeSourceTree("FROM_WORKTREE");
+    const snapshotDirectory = writeSourceTree("FROM_SNAPSHOT");
+
+    const output = await renderFramedOutput({
+      rootDirectory: worktreeDirectory,
+      frameSourceRoot: snapshotDirectory,
+    });
+
+    expect(output).toContain("FROM_SNAPSHOT");
+    expect(output).not.toContain("FROM_WORKTREE");
+  });
+
+  it("falls back to the project root when no frameSourceRoot is set", async () => {
+    const worktreeDirectory = writeSourceTree("FROM_WORKTREE");
+
+    const output = await renderFramedOutput({ rootDirectory: worktreeDirectory });
+
+    expect(output).toContain("FROM_WORKTREE");
   });
 });

--- a/packages/react-doctor/tests/render-multi-project-summary.test.ts
+++ b/packages/react-doctor/tests/render-multi-project-summary.test.ts
@@ -215,6 +215,7 @@ describe("printMultiProjectSummary code frames", () => {
   const renderFramedOutput = async (scanOverrides: {
     rootDirectory: string;
     frameSourceRoot?: string;
+    filePath?: string;
   }): Promise<string> => {
     const lines: string[] = [];
     vi.spyOn(console, "log").mockImplementation((line?: unknown) => {
@@ -224,7 +225,13 @@ describe("printMultiProjectSummary code frames", () => {
       config: null,
       frameSourceRoot: scanOverrides.frameSourceRoot,
       result: {
-        diagnostics: [buildDiagnostic({ filePath: "src/App.tsx", line: 1, column: 14 })],
+        diagnostics: [
+          buildDiagnostic({
+            filePath: scanOverrides.filePath ?? "src/App.tsx",
+            line: 1,
+            column: 14,
+          }),
+        ],
         score: { score: 40, label: "Needs work" },
         skippedChecks: [],
         project: { ...buildProject("app"), rootDirectory: scanOverrides.rootDirectory },
@@ -255,6 +262,7 @@ describe("printMultiProjectSummary code frames", () => {
     const output = await renderFramedOutput({
       rootDirectory: worktreeDirectory,
       frameSourceRoot: snapshotDirectory,
+      filePath: path.join(worktreeDirectory, "src/App.tsx"),
     });
 
     expect(output).toContain("FROM_SNAPSHOT");


### PR DESCRIPTION
## Why

`react-doctor --staged` ignored both `--project` and config `projects`. In a monorepo whose root package does not depend on React, that meant a pre-commit scan could gate every React rule off, report clean, and exit 0 even when a selected package had error-level findings.

Scoped scans launched from Git hooks could also inherit `GIT_DIR`. Nested Git commands then ignored the scan `cwd`, returned repository-root paths, and failed when the requested project lived in a subdirectory.

Before: staged monorepo scans could report a false clean result, while scoped hook scans could fail with paths outside their project.

After: staged scans use the selected packages and their own project metadata, and nested Git commands respect the scoped working directory without losing the hook's custom index.

Closes #1500
Closes #1501

## What changed

- resolve `--project` and config `projects` for `--staged`, with explicit-project errors and safe config fallback behavior
- assign every staged path to exactly one selected project, including nested workspaces and `rootDir` redirects
- materialize each selected package's manifest, TypeScript config, and lint config into the staged snapshot
- keep staged snapshots alive through code-frame rendering so frames reflect index contents rather than unstaged worktree edits
- preserve multi-project summaries, quiet `--output-dir` dumps, package-scoped JSON reports, and stable diagnostic identities
- distinguish an unreadable Git index from an empty index while skipping individual files that cannot be snapshotted
- clear inherited `GIT_DIR` only for nested Git commands while preserving `GIT_INDEX_FILE` and the rest of the environment
- add `staged.per_project` telemetry, JSON report documentation, and patch changesets for `@react-doctor/core` and `react-doctor`
- add regression coverage for project selection, ownership, materialization, fallbacks, output, code frames, unreadable indexes, and linked-worktree Git-hook environments

## Eval results

RDE/parity was not run because this changes CLI and Git orchestration, not lint detector behavior.

## Test plan

- `nr test` — passed
- `nr lint` — passed (existing fuzz-corpus warnings only)
- `nr typecheck` — passed
- `nr format:check` — passed
- `nr smoke:json-report` — passed (`schemaVersion=3`)
- `nlx react-doctor@latest --verbose --scope changed` — 100/100, no issues

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches pre-commit gating, git subprocess env, and large `inspect.ts` staged flow; behavior is heavily tested but mis-scoping could still affect monorepo hooks.
> 
> **Overview**
> Fixes monorepo pre-commit scans that reported **clean** because `--staged` ignored `--project` and config **`projects`**, so React rules were gated off at a non-React root. **`--staged`** now resolves the same project selection as full scans, assigns each staged path to **one** package (deepest wins), materializes **per-package** `package.json` / tsconfig / lint config into the index snapshot, and runs **one inspect per selected package** with package-scoped JSON (`packageRoot`) while keeping diagnostic ids stable.
> 
> **Hook-oriented behavior:** unreadable git index **fails** instead of looking empty; per-file snapshot failures **warn** and skip; nothing left to scan **warns and exits 0**. Stale config `projects` entries **warn and fall back** to a root scan; explicit **`--project`** still errors. Multi-package staged runs get the **aggregate summary**, counts for staged files outside selected projects, **`--output-dir`** on quiet runs, and code frames read the **index snapshot** (`frameSourceRoot`) not the dirty worktree.
> 
> **Git in hooks:** nested **`git`** spawns clear inherited **`GIT_DIR`** so scoped cwd/`--relative` paths work (e.g. linked worktrees), while **`GIT_INDEX_FILE`** is preserved. **`materializeSourceTree`** gains **`configSubdirectories`** for monorepo config copy with zip-slip guards. Shared **`runProjectScanBatch`** refactors multi-project scan orchestration for staged and non-staged paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 627f9f9291021d6b127f26f68405a0f96f9833a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->