### PR TITLE
RDFPFN792026: preserve guarded createRef persistence

### DIFF
--- a/.changeset/guarded-create-ref-persistence.md
+++ b/.changeset/guarded-create-ref-persistence.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Keep `no-create-ref-in-function-component` quiet when `createRef()` values are initialized once behind a stable `useRef().current` guard.

--- a/packages/fuzz/corpus/regressions/no-create-ref-in-function-component--guarded-use-ref-persistence.tsx
+++ b/packages/fuzz/corpus/regressions/no-create-ref-in-function-component--guarded-use-ref-persistence.tsx
@@ -1,0 +1,32 @@
+// rule: no-create-ref-in-function-component
+// verdict: pass
+// weakness: control-flow
+// source: React Bench fix-react-cloudscape-design-comp__mun7kHG
+
+import { createRef, useRef } from "react";
+
+const Navigation = ({ focusControl }: { focusControl: unknown }) => (
+  <div data-has-focus-control={Boolean(focusControl)} />
+);
+
+export const PendingNavigation = () => {
+  const focusControlRef = useRef<{
+    refs: {
+      toggle: ReturnType<typeof createRef>;
+      close: ReturnType<typeof createRef>;
+      slider: ReturnType<typeof createRef>;
+    };
+  }>();
+
+  if (!focusControlRef.current) {
+    focusControlRef.current = {
+      refs: {
+        toggle: createRef(),
+        close: createRef(),
+        slider: createRef(),
+      },
+    };
+  }
+
+  return <Navigation focusControl={focusControlRef.current} />;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/__fixtures__/create-ref-guarded-reactbench.txt
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/__fixtures__/create-ref-guarded-reactbench.txt
@@ -1,0 +1,200 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React, { createRef, useRef } from 'react';
+import clsx from 'clsx';
+
+import { AppLayoutBuiltInErrorBoundary } from '../../../error-boundary/internal';
+import { createWidgetizedComponent } from '../../../internal/widgets';
+import { ActiveDrawersContext } from '../../utils/visibility-context';
+import { AppLayoutGlobalAiDrawerImplementation } from '../drawer/global-ai-drawer';
+import { AppLayoutInternals } from '../interfaces';
+import { AppLayoutNavigationImplementation as AppLayoutNavigation } from '../navigation';
+import { SkeletonPartProps } from '../skeleton/interfaces';
+import { BeforeMainSlotSkeleton } from '../skeleton/skeleton-parts';
+import { getPropsToMerge, mergeProps } from '../state/props-merger';
+import { AppLayoutToolbarImplementation as AppLayoutToolbar } from '../toolbar';
+
+import sharedStyles from '../../resize/styles.css.js';
+import styles from '../skeleton/styles.css.js';
+
+const FALLBACK_VERTICAL_OFFSETS = { toolbar: 0, notifications: 0, header: 0, drawers: 0 };
+const noop = () => {};
+
+export const BeforeMainSlotImplementationInternal = ({
+  toolbarProps,
+  appLayoutState,
+  appLayoutProps,
+  registered,
+}: SkeletonPartProps) => {
+  const wasAiDrawerOpenRef = useRef(false);
+  // Created once and reused for as long as the real widget state isn't ready yet, so the fallback
+  // appLayoutInternals object below doesn't force ref reattachment on every render.
+  const fallbackNavigationFocusControlRef = useRef<AppLayoutInternals['navigationFocusControl']>();
+  if (!fallbackNavigationFocusControlRef.current) {
+    fallbackNavigationFocusControlRef.current = {
+      refs: { toggle: createRef(), close: createRef(), slider: createRef() },
+      setFocus: noop,
+      loseFocus: noop,
+    };
+  }
+
+  const widgetizedState = appLayoutState.widgetizedState;
+  // toolbarProps is only populated once multi-layout registration resolves, which never happens
+  // during SSR (and briefly on the client before the registration effect runs). Falling back to
+  // this instance's own props keeps the toolbar/breadcrumbs/trigger rendering instead of waiting.
+  // Once actually registered, toolbarProps must be trusted as-is (including null), since a
+  // registered non-primary instance deliberately stays out of the shared toolbar so it doesn't
+  // duplicate the primary instance's.
+  const effectiveToolbarProps = registered
+    ? toolbarProps
+    : mergeProps(getPropsToMerge(appLayoutProps, appLayoutState), []);
+
+  const activeDrawer = widgetizedState?.activeDrawer;
+  const navigationOpen = widgetizedState ? widgetizedState.navigationOpen : !!effectiveToolbarProps?.navigationOpen;
+  const navigation = widgetizedState
+    ? widgetizedState.navigation
+    : appLayoutProps.navigationHide
+      ? null
+      : (appLayoutProps.navigation ?? <></>);
+  const expandedDrawerId = widgetizedState?.expandedDrawerId ?? null;
+  const setExpandedDrawerId = widgetizedState?.setExpandedDrawerId;
+  const navigationAnimationDisabled = widgetizedState ? widgetizedState.navigationAnimationDisabled : true;
+  const activeAiDrawerId = widgetizedState?.activeAiDrawerId;
+  const aiDrawerExpandedMode = widgetizedState ? widgetizedState.aiDrawerExpandedMode : false;
+  const aiDrawer = widgetizedState?.aiDrawer;
+  const activeAiDrawerSize = widgetizedState?.activeAiDrawerSize;
+  const minAiDrawerSize = widgetizedState?.minAiDrawerSize;
+  const maxAiDrawerSize = widgetizedState?.maxAiDrawerSize;
+  const onActiveAiDrawerResize = widgetizedState?.onActiveAiDrawerResize;
+  const aiDrawerFocusControl = widgetizedState?.aiDrawerFocusControl;
+  const ariaLabels = widgetizedState ? widgetizedState.ariaLabels : appLayoutProps.ariaLabels;
+  const isMobile = widgetizedState ? widgetizedState.isMobile : false;
+  const drawersOpenQueue = widgetizedState?.drawersOpenQueue;
+  const onActiveAiDrawerChange = widgetizedState?.onActiveAiDrawerChange;
+  const activeAiDrawer = widgetizedState?.activeAiDrawer;
+  const bottomDrawerReportedSize = widgetizedState?.bottomDrawerReportedSize;
+  const featureNotificationsProps = widgetizedState?.featureNotificationsProps;
+
+  const drawerExpandedMode = !!expandedDrawerId;
+  const toolsOpen = !!activeDrawer;
+  // Must use `toolbarProps` because all layouts have to apply this mode, not just the one with toolbar
+  const drawerExpandedModeInChildLayout = !!toolbarProps?.expandedDrawerId;
+  const { __embeddedViewMode: embeddedViewMode } = appLayoutProps as any;
+
+  // The toolbar and navigation below are always rendered through their real implementation (never
+  // swapped out for a separate skeleton component) so that once the widget state becomes ready,
+  // React updates their existing DOM in place instead of replacing it. Before that, this fallback
+  // subset of appLayoutInternals (derived straight from props) stands in for the real widget state.
+  const fallbackAppLayoutInternals: Pick<
+    AppLayoutInternals,
+    | 'ariaLabels'
+    | 'breadcrumbs'
+    | 'discoveredBreadcrumbs'
+    | 'verticalOffsets'
+    | 'isMobile'
+    | 'setToolbarHeight'
+    | 'aiDrawer'
+    | 'activeAiDrawer'
+    | 'onActiveAiDrawerChange'
+    | 'onNavigationToggle'
+    | 'navigationOpen'
+    | 'navigation'
+    | 'navigationFocusControl'
+    | 'placement'
+  > = widgetizedState
+    ? // safe: appLayoutInternals and widgetizedState are always populated together
+      appLayoutState.appLayoutInternals!
+    : {
+        ariaLabels,
+        breadcrumbs: appLayoutProps.breadcrumbs,
+        discoveredBreadcrumbs: null,
+        verticalOffsets: FALLBACK_VERTICAL_OFFSETS,
+        isMobile,
+        setToolbarHeight: noop,
+        aiDrawer,
+        activeAiDrawer,
+        onActiveAiDrawerChange,
+        onNavigationToggle: noop,
+        navigationOpen,
+        navigation,
+        navigationFocusControl: fallbackNavigationFocusControlRef.current,
+        placement: appLayoutProps.placement,
+      };
+
+  return (
+    <>
+      {!!effectiveToolbarProps && !embeddedViewMode && !aiDrawerExpandedMode && (
+        <AppLayoutToolbar
+          appLayoutInternals={fallbackAppLayoutInternals}
+          toolbarProps={effectiveToolbarProps}
+          featureNotificationsProps={featureNotificationsProps}
+        />
+      )}
+      {aiDrawer && (
+        <div
+          className={clsx(
+            styles['ai-drawer'],
+            (drawerExpandedMode || drawerExpandedModeInChildLayout) && !aiDrawerExpandedMode && styles.hidden
+          )}
+        >
+          <ActiveDrawersContext.Provider value={activeAiDrawer ? [activeAiDrawer.id] : []}>
+            {(!!activeAiDrawerId || (aiDrawer?.preserveInactiveContent && wasAiDrawerOpenRef.current)) && (
+              <>
+                {(wasAiDrawerOpenRef.current = true)}
+                <AppLayoutGlobalAiDrawerImplementation
+                  show={!!activeAiDrawerId}
+                  activeAiDrawer={aiDrawer ?? null}
+                  // safe: only rendered once aiDrawer (part of the ready widgetized state) is truthy
+                  appLayoutInternals={appLayoutState.appLayoutInternals!}
+                  aiDrawerProps={{
+                    activeAiDrawerSize: activeAiDrawerSize!,
+                    minAiDrawerSize: minAiDrawerSize!,
+                    maxAiDrawerSize: maxAiDrawerSize!,
+                    aiDrawer: aiDrawer!,
+                    ariaLabels,
+                    aiDrawerFocusControl,
+                    isMobile,
+                    drawersOpenQueue,
+                    onActiveAiDrawerChange,
+                    onActiveDrawerResize: ({ size }) => onActiveAiDrawerResize!(size),
+                    expandedDrawerId,
+                    setExpandedDrawerId: setExpandedDrawerId!,
+                  }}
+                />
+              </>
+            )}
+          </ActiveDrawersContext.Provider>
+        </div>
+      )}
+      {navigation && (
+        <div
+          className={clsx(
+            styles.navigation,
+            !navigationOpen && styles['panel-hidden'],
+            toolsOpen && styles['unfocusable-mobile'],
+            !navigationAnimationDisabled && sharedStyles['with-motion-horizontal'],
+            (drawerExpandedMode || drawerExpandedModeInChildLayout) && styles.hidden
+          )}
+        >
+          <AppLayoutBuiltInErrorBoundary>
+            <AppLayoutNavigation
+              appLayoutInternals={fallbackAppLayoutInternals}
+              bottomDrawerReportedSize={bottomDrawerReportedSize}
+            />
+          </AppLayoutBuiltInErrorBoundary>
+        </div>
+      )}
+    </>
+  );
+};
+
+export const BeforeMainSlotImplementation = (props: SkeletonPartProps) => (
+  <AppLayoutBuiltInErrorBoundary>
+    <BeforeMainSlotImplementationInternal {...props} />
+  </AppLayoutBuiltInErrorBoundary>
+);
+
+export const createWidgetizedAppLayoutBeforeMainSlot = createWidgetizedComponent(
+  BeforeMainSlotImplementation,
+  BeforeMainSlotSkeleton
+);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/is-create-ref-persisted-in-guarded-use-ref.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/is-create-ref-persisted-in-guarded-use-ref.ts
@@ -1,0 +1,239 @@
+import type { ControlFlowAnalysis } from "../../semantic/control-flow-graph.js";
+import type { ScopeAnalysis, SymbolDescriptor } from "../../semantic/scope-analysis.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { collectConstAliasSymbols } from "../../utils/collect-const-alias-symbols.js";
+import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
+import { findTransparentExpressionRoot } from "../../utils/find-transparent-expression-root.js";
+import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { resolveReactRefSymbol } from "../../utils/react-ref-origin.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+
+const getEmptyRefValueKind = (
+  expression: EsTreeNode,
+  scopes: ScopeAnalysis,
+): "false" | "null" | "undefined" | null => {
+  const candidate = stripParenExpression(expression);
+  if (isNodeOfType(candidate, "Literal")) {
+    if (candidate.value === null) return "null";
+    if (candidate.value === false) return "false";
+  }
+  if (
+    isNodeOfType(candidate, "Identifier") &&
+    candidate.name === "undefined" &&
+    !scopes.symbolFor(candidate)
+  ) {
+    return "undefined";
+  }
+  return null;
+};
+
+const isCurrentMemberForSymbol = (
+  expression: EsTreeNode,
+  symbol: SymbolDescriptor,
+  scopes: ScopeAnalysis,
+): boolean => {
+  const candidate = stripParenExpression(expression);
+  if (
+    !isNodeOfType(candidate, "MemberExpression") ||
+    getStaticPropertyName(candidate) !== "current"
+  ) {
+    return false;
+  }
+  const receiver = stripParenExpression(candidate.object);
+  return isNodeOfType(receiver, "Identifier") && scopes.symbolFor(receiver)?.id === symbol.id;
+};
+
+const findPersistenceAssignment = (
+  createRefCall: EsTreeNodeOfType<"CallExpression">,
+): EsTreeNodeOfType<"AssignmentExpression"> | null => {
+  let current = findTransparentExpressionRoot(createRefCall);
+  while (current.parent) {
+    if (
+      isNodeOfType(current.parent, "AssignmentExpression") &&
+      current.parent.operator === "=" &&
+      current.parent.right === current
+    ) {
+      return current.parent;
+    }
+    const property = current.parent;
+    if (!isNodeOfType(property, "Property") || property.value !== current) return null;
+    const objectExpression = property.parent;
+    if (!isNodeOfType(objectExpression, "ObjectExpression")) return null;
+    current = findTransparentExpressionRoot(objectExpression);
+  }
+  return null;
+};
+
+const findGuard = (
+  assignment: EsTreeNodeOfType<"AssignmentExpression">,
+): EsTreeNodeOfType<"IfStatement"> | null => {
+  const expressionStatement = assignment.parent;
+  if (!isNodeOfType(expressionStatement, "ExpressionStatement")) return null;
+  const container = expressionStatement.parent;
+  if (isNodeOfType(container, "IfStatement") && container.consequent === expressionStatement) {
+    return container;
+  }
+  if (
+    !isNodeOfType(container, "BlockStatement") ||
+    container.body.length !== 1 ||
+    container.body[0] !== expressionStatement ||
+    !isNodeOfType(container.parent, "IfStatement") ||
+    container.parent.consequent !== container
+  ) {
+    return null;
+  }
+  return container.parent;
+};
+
+const doesGuardProveEmptyRef = (
+  guard: EsTreeNodeOfType<"IfStatement">,
+  symbol: SymbolDescriptor,
+  initialValueKind: "false" | "null" | "undefined",
+  scopes: ScopeAnalysis,
+): boolean => {
+  const test = stripParenExpression(guard.test);
+  if (
+    isNodeOfType(test, "UnaryExpression") &&
+    test.operator === "!" &&
+    isCurrentMemberForSymbol(test.argument, symbol, scopes)
+  ) {
+    return true;
+  }
+  if (!isNodeOfType(test, "BinaryExpression") || !["==", "==="].includes(test.operator)) {
+    return false;
+  }
+  const comparedValueKind = isCurrentMemberForSymbol(test.left, symbol, scopes)
+    ? getEmptyRefValueKind(test.right, scopes)
+    : isCurrentMemberForSymbol(test.right, symbol, scopes)
+      ? getEmptyRefValueKind(test.left, scopes)
+      : null;
+  if (!comparedValueKind) return false;
+  if (test.operator === "===") return comparedValueKind === initialValueKind;
+  return (
+    (comparedValueKind === "null" || comparedValueKind === "undefined") &&
+    (initialValueKind === "null" || initialValueKind === "undefined")
+  );
+};
+
+const isDirectCurrentWrite = (
+  identifier: EsTreeNode,
+  symbol: SymbolDescriptor,
+  scopes: ScopeAnalysis,
+): EsTreeNode | null => {
+  const receiverRoot = findTransparentExpressionRoot(identifier);
+  const memberExpression = receiverRoot.parent;
+  if (
+    !isNodeOfType(memberExpression, "MemberExpression") ||
+    memberExpression.object !== receiverRoot ||
+    !isCurrentMemberForSymbol(memberExpression, symbol, scopes)
+  ) {
+    return null;
+  }
+  const memberRoot = findTransparentExpressionRoot(memberExpression);
+  const parent = memberRoot.parent;
+  if (isNodeOfType(parent, "AssignmentExpression") && parent.left === memberRoot) {
+    return parent;
+  }
+  if (isNodeOfType(parent, "UpdateExpression") && parent.argument === memberRoot) {
+    return parent;
+  }
+  if (
+    isNodeOfType(parent, "UnaryExpression") &&
+    parent.operator === "delete" &&
+    parent.argument === memberRoot
+  ) {
+    return parent;
+  }
+  return null;
+};
+
+const isKnownPersistentRefReference = (
+  identifier: EsTreeNode,
+  symbol: SymbolDescriptor,
+  aliasSymbolIds: Set<number>,
+  scopes: ScopeAnalysis,
+): boolean => {
+  const referenceRoot = findTransparentExpressionRoot(identifier);
+  const parent = referenceRoot.parent;
+  if (
+    isNodeOfType(parent, "MemberExpression") &&
+    parent.object === referenceRoot &&
+    isCurrentMemberForSymbol(parent, symbol, scopes)
+  ) {
+    return true;
+  }
+  if (
+    !isNodeOfType(parent, "VariableDeclarator") ||
+    parent.init !== referenceRoot ||
+    !isNodeOfType(parent.id, "Identifier")
+  ) {
+    return false;
+  }
+  const aliasSymbol = scopes.symbolFor(parent.id);
+  return Boolean(aliasSymbol && aliasSymbolIds.has(aliasSymbol.id));
+};
+
+export const isCreateRefPersistedInGuardedUseRef = (
+  createRefCall: EsTreeNodeOfType<"CallExpression">,
+  enclosingFunction: EsTreeNode,
+  scopes: ScopeAnalysis,
+  cfg: ControlFlowAnalysis,
+): boolean => {
+  const assignment = findPersistenceAssignment(createRefCall);
+  if (
+    !assignment ||
+    !isNodeOfType(assignment.left, "MemberExpression") ||
+    getStaticPropertyName(assignment.left) !== "current"
+  ) {
+    return false;
+  }
+  const receiver = stripParenExpression(assignment.left.object);
+  if (!isNodeOfType(receiver, "Identifier")) return false;
+  const receiverSymbol = scopes.symbolFor(receiver);
+  const refSymbol = resolveReactRefSymbol(assignment.left, scopes, {
+    resolveNamedAliases: true,
+  });
+  if (
+    !receiverSymbol ||
+    !refSymbol ||
+    receiverSymbol.id !== refSymbol.id ||
+    refSymbol.kind !== "const" ||
+    !refSymbol.initializer ||
+    findEnclosingFunction(refSymbol.bindingIdentifier) !== enclosingFunction ||
+    !refSymbol.references.every((reference) => reference.flag === "read")
+  ) {
+    return false;
+  }
+  const refInitializer = stripParenExpression(refSymbol.initializer);
+  if (
+    !isNodeOfType(refInitializer, "CallExpression") ||
+    !cfg.isUnconditionalFromEntry(refInitializer) ||
+    refInitializer.arguments.length > 1
+  ) {
+    return false;
+  }
+  const initialValueKind =
+    refInitializer.arguments.length === 0
+      ? "undefined"
+      : getEmptyRefValueKind(refInitializer.arguments[0], scopes);
+  if (!initialValueKind) return false;
+  const guard = findGuard(assignment);
+  if (!guard || !doesGuardProveEmptyRef(guard, refSymbol, initialValueKind, scopes)) return false;
+  const aliasSymbols = collectConstAliasSymbols(refSymbol, scopes);
+  const aliasSymbolIds = new Set(aliasSymbols.map((aliasSymbol) => aliasSymbol.id));
+  for (const aliasSymbol of aliasSymbols) {
+    for (const reference of aliasSymbol.references) {
+      if (
+        reference.flag !== "read" ||
+        !isKnownPersistentRefReference(reference.identifier, aliasSymbol, aliasSymbolIds, scopes)
+      ) {
+        return false;
+      }
+      const write = isDirectCurrentWrite(reference.identifier, aliasSymbol, scopes);
+      if (write && write !== assignment) return false;
+    }
+  }
+  return true;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-create-ref-in-function-component.guarded-ref.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-create-ref-in-function-component.guarded-ref.regressions.test.ts
@@ -1,0 +1,231 @@
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noCreateRefInFunctionComponent } from "./no-create-ref-in-function-component.js";
+
+const REACT_BENCH_EVIDENCE_SHA256 =
+  "dd5101abb13ff47b037aa4b715b700162664324e6c22b436fba2f033ff1c6c8e";
+const RECONSTRUCTED_SOURCE_SHA256 =
+  "b07ffb8d4de282140eb407725e51b093e7b29a2c40441d9885f1e41d4609d576";
+const REACT_BENCH_FIXTURE = fileURLToPath(
+  new URL("./__fixtures__/create-ref-guarded-reactbench.txt", import.meta.url),
+);
+
+const runGuardedRefRule = (source: string) => runRule(noCreateRefInFunctionComponent, source);
+
+describe("no-create-ref-in-function-component — guarded useRef persistence", () => {
+  it(`replays the exact React Bench source (${REACT_BENCH_EVIDENCE_SHA256})`, () => {
+    const reconstructedSource = readFileSync(REACT_BENCH_FIXTURE, "utf8").replaceAll("\r\n", "\n");
+    expect(createHash("sha256").update(reconstructedSource).digest("hex")).toBe(
+      RECONSTRUCTED_SOURCE_SHA256,
+    );
+    const result = runRule(noCreateRefInFunctionComponent, reconstructedSource, {
+      filename: `${REACT_BENCH_FIXTURE}.tsx`,
+    });
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent for exact nested values persisted behind null and false guards", () => {
+    const nullGuardResult = runGuardedRefRule(`import React, { createRef } from "react";
+export const Input = () => {
+  const controlRef = React.useRef(null);
+  if (controlRef.current === null) {
+    controlRef.current = { refs: { target: createRef() } };
+  }
+  return <Unknown control={controlRef.current} />;
+};`);
+    const falseGuardResult = runGuardedRefRule(`import * as ReactRuntime from "react";
+export const Input = () => {
+  const controlRef = ReactRuntime.useRef(false);
+  if (controlRef.current === false) {
+    controlRef.current = { refs: { target: ReactRuntime.createRef() } };
+  }
+  return <Unknown control={controlRef.current} />;
+};`);
+    const undefinedGuardResult = runGuardedRefRule(`import { createRef, useRef } from "react";
+export const Input = () => {
+  const controlRef = useRef();
+  if (controlRef.current === undefined) {
+    controlRef.current = { refs: { target: createRef() } };
+  }
+  return <Unknown control={controlRef.current} />;
+};`);
+    expect(nullGuardResult.parseErrors).toEqual([]);
+    expect(nullGuardResult.diagnostics).toEqual([]);
+    expect(falseGuardResult.parseErrors).toEqual([]);
+    expect(falseGuardResult.diagnostics).toEqual([]);
+    expect(undefinedGuardResult.parseErrors).toEqual([]);
+    expect(undefinedGuardResult.diagnostics).toEqual([]);
+  });
+
+  it("reports when the guard and assignment target different refs", () => {
+    const result = runGuardedRefRule(`import { createRef, useRef } from "react";
+export const Input = () => {
+  const guardRef = useRef(null);
+  const controlRef = useRef(null);
+  if (!guardRef.current) {
+    controlRef.current = { refs: { target: createRef() } };
+  }
+  return <Unknown control={controlRef.current} />;
+};`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports when the explicit guard cannot match the initial ref value", () => {
+    const result = runGuardedRefRule(`import { createRef, useRef } from "react";
+export const Input = () => {
+  const controlRef = useRef(null);
+  if (controlRef.current === false) {
+    controlRef.current = { refs: { target: createRef() } };
+  }
+  return <Unknown control={controlRef.current} />;
+};`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports without a stabilizing assignment", () => {
+    const result = runGuardedRefRule(`import { createRef, useRef } from "react";
+export const Input = ({ observe }) => {
+  const controlRef = useRef(null);
+  if (!controlRef.current) {
+    const control = { refs: { target: createRef() } };
+    observe(control);
+  }
+  return <Unknown control={controlRef.current} />;
+};`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports when createRef is observed before persistence", () => {
+    const result = runGuardedRefRule(`import { createRef, useRef } from "react";
+export const Input = ({ observe }) => {
+  const controlRef = useRef(null);
+  if (!controlRef.current) {
+    controlRef.current = { refs: { target: observe(createRef()) } };
+  }
+  return <Unknown control={controlRef.current} />;
+};`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports when persistence is conditional inside the empty-ref guard", () => {
+    const result = runGuardedRefRule(`import { createRef, useRef } from "react";
+export const Input = ({ enabled }) => {
+  const controlRef = useRef(null);
+  if (!controlRef.current) {
+    if (enabled) {
+      controlRef.current = { refs: { target: createRef() } };
+    }
+  }
+  return <Unknown control={controlRef.current} />;
+};`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports when the outer ref binding is mutable", () => {
+    const result = runGuardedRefRule(`import { createRef, useRef } from "react";
+export const Input = () => {
+  let controlRef = useRef(null);
+  if (!controlRef.current) {
+    controlRef.current = { refs: { target: createRef() } };
+  }
+  return <Unknown control={controlRef.current} />;
+};`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports when useRef is shadowed", () => {
+    const result = runGuardedRefRule(`import { createRef } from "react";
+const useRef = (current) => ({ current });
+export const Input = () => {
+  const controlRef = useRef(null);
+  if (!controlRef.current) {
+    controlRef.current = { refs: { target: createRef() } };
+  }
+  return <Unknown control={controlRef.current} />;
+};`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports when the useRef call is not unconditional from component entry", () => {
+    const result = runGuardedRefRule(`import { createRef, useRef } from "react";
+export const Input = ({ enabled }) => {
+  if (!enabled) return null;
+  const controlRef = useRef(null);
+  if (!controlRef.current) {
+    controlRef.current = { refs: { target: createRef() } };
+  }
+  return <Unknown control={controlRef.current} />;
+};`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports after a later clear or replacement of the persistent value", () => {
+    const clearResult = runGuardedRefRule(`import { createRef, useRef } from "react";
+export const Input = ({ reset }) => {
+  const controlRef = useRef(null);
+  if (!controlRef.current) {
+    controlRef.current = { refs: { target: createRef() } };
+  }
+  if (reset) controlRef.current = null;
+  return <Unknown control={controlRef.current} />;
+};`);
+    const replacementResult = runGuardedRefRule(`import { createRef, useRef } from "react";
+export const Input = ({ replace }) => {
+  const controlRef = useRef(null);
+  if (!controlRef.current) {
+    controlRef.current = { refs: { target: createRef() } };
+  }
+  const replaceControl = () => {
+    controlRef.current = { refs: { target: createRef() } };
+  };
+    return <Unknown control={controlRef.current} replace={replace ? replaceControl : undefined} />;
+};`);
+    expect(clearResult.diagnostics).toHaveLength(1);
+    expect(replacementResult.diagnostics).toHaveLength(1);
+  });
+
+  it("reports later writes through wrapped ref receivers", () => {
+    const result = runGuardedRefRule(`import { createRef, useRef } from "react";
+export const Input = ({ reset }) => {
+  const controlRef = useRef(null);
+  if (!controlRef.current) {
+    controlRef.current = { refs: { target: createRef() } };
+  }
+  if (reset === "parenthesized") (controlRef).current = null;
+  if (reset === "asserted") (controlRef as typeof controlRef).current = null;
+  if (reset === "non-null") controlRef!.current = null;
+  return <Unknown control={controlRef.current} />;
+};`);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports later writes and escapes through const ref aliases", () => {
+    const aliasWriteResult = runGuardedRefRule(`import { createRef, useRef } from "react";
+export const Input = ({ reset }) => {
+  const controlRef = useRef(null);
+  if (!controlRef.current) {
+    controlRef.current = { refs: { target: createRef() } };
+  }
+  const firstAlias = controlRef;
+  const secondAlias = firstAlias;
+  if (reset) secondAlias.current = null;
+  return <Unknown control={controlRef.current} />;
+};`);
+    const escapedAliasResult = runGuardedRefRule(`import { createRef, useRef } from "react";
+export const Input = ({ resetRef }) => {
+  const controlRef = useRef(null);
+  if (!controlRef.current) {
+    controlRef.current = { refs: { target: createRef() } };
+  }
+  const controlAlias = controlRef;
+  resetRef(controlAlias);
+  return <Unknown control={controlRef.current} />;
+};`);
+    expect(aliasWriteResult.diagnostics).toHaveLength(1);
+    expect(escapedAliasResult.diagnostics).toHaveLength(1);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-create-ref-in-function-component.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-create-ref-in-function-component.ts
@@ -8,6 +8,7 @@ import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isReactApiCall } from "../../utils/is-react-api-call.js";
 import { isReactHookName } from "../../utils/is-react-hook-name.js";
 import { isCreateRefResultWriteOnly } from "./is-create-ref-result-write-only.js";
+import { isCreateRefPersistedInGuardedUseRef } from "./is-create-ref-persisted-in-guarded-use-ref.js";
 import { isProvenOneShotTestingLibraryComponent } from "./is-proven-one-shot-testing-library-component.js";
 import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
@@ -137,6 +138,11 @@ export const noCreateRefInFunctionComponent = defineRule({
       }
       if (
         isProvenOneShotTestingLibraryComponent(enclosingFunction, context.filename, context.scopes)
+      ) {
+        return;
+      }
+      if (
+        isCreateRefPersistedInGuardedUseRef(node, enclosingFunction, context.scopes, context.cfg)
       ) {
         return;
       }


### PR DESCRIPTION
## Why

`no-create-ref-in-function-component` reported three `createRef()` calls that are initialized once into a persistent React `useRef().current` value. React preserves the outer ref object across renders, and the exact empty-value guard prevents later renders from replacing the nested refs.

React Bench evidence: `fix-react-cloudscape-design-comp__mun7kHG`, `src/app-layout/visual-refresh-toolbar/visual-refresh-toolbar.tsx/before-main-slot.tsx:35`.

- evidence SHA-256: `dd5101abb13ff47b037aa4b715b700162664324e6c22b436fba2f033ff1c6c8e`
- reconstructed source SHA-256: `b07ffb8d4de282140eb407725e51b093e7b29a2c40441d9885f1e41d4609d576`
- exact replay: current main `3` diagnostics → this branch `0`

## What changed

- Prove only direct or object-literal `createRef()` values persisted by the sole matching empty-ref guard.
- Require a resolved React `useRef`, immutable local binding, unconditional hook initialization, matching sentinel, and no later `.current` writes.
- Keep reporting mismatched guards, observed-before-persistence values, nested conditional writes, mutable or shadowed refs, conditional hooks, and later clears or replacements.
- Freeze the exact React Bench source and hashes in regression coverage.
- Add a strict-fuzz regression seed and a patch changeset.

## Validation

- `nr build`
- `nr test`
- `nr typecheck`
- `nr lint`
- `nr format:check`
- `nr smoke:json-report`
- `FUZZ_RULE=no-create-ref-in-function-component FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz`
- exact React Bench replay and adversarial positive/negative controls

Local RDE could not yield diagnostic evidence because its current parser accepts schema version 1 while current React Doctor emits schema version 3; every attempted repository was rejected before diagnostics. Daytona parity is intentionally pending behind the existing shared queue.

Tracking: RDFPFN792026

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-only heuristic change with broad negative tests; risk is under-reporting unsafe `createRef` in edge cases, not runtime behavior.
> 
> **Overview**
> **`no-create-ref-in-function-component`** no longer warns when `createRef()` is stored once on a stable **`useRef().current`** behind a matching empty-ref guard (e.g. `if (!ref.current) { ref.current = { … createRef() … } }`).
> 
> A new **`isCreateRefPersistedInGuardedUseRef`** helper proves that pattern with scope/CFG checks: real `useRef`, const binding, unconditional hook init, guard aligned with the initial sentinel (`null` / `false` / `undefined`), direct or object-literal persistence, and no later `.current` writes (including via const aliases). Unsafe variants still report.
> 
> Coverage adds a React Bench fixture replay, adversarial regression tests, a fuzz corpus seed, and a patch changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d62408a7e60c5201fa38e43edff043fb6d28953d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->