### PR TITLE
RDFPFN792026: prove ref-owned timer cleanup

### DIFF
--- a/.changeset/steady-timers-rest.md
+++ b/.changeset/steady-timers-rest.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Recognize ref-owned one-shot timer reschedules with helper-based replacement and unmount cleanup.

--- a/packages/fuzz/corpus/regressions/effect-needs-cleanup--eventsource-owned-listeners.tsx
+++ b/packages/fuzz/corpus/regressions/effect-needs-cleanup--eventsource-owned-listeners.tsx
@@ -1,0 +1,25 @@
+// verdict: pass
+// rule: effect-needs-cleanup
+// weakness: copy-tracking
+// source: GACWR/OpenUBA app/jobs/[id]/page.tsx:146 at 57e8a7fcadc5f851fd8e9a8647f5fbf34e9975f6
+import { useEffect, useRef } from "react";
+
+interface JobEventsProps {
+  jobId: string;
+}
+
+export const JobEvents = ({ jobId }: JobEventsProps) => {
+  const eventSourceRef = useRef<EventSource | null>(null);
+
+  useEffect(() => {
+    const source = new EventSource(`/api/jobs/${jobId}/events`);
+    eventSourceRef.current = source;
+    source.addEventListener("progress", () => {});
+    source.addEventListener("complete", () => {});
+    source.addEventListener("error", () => {});
+
+    return () => source.close();
+  }, [jobId]);
+
+  return null;
+};

--- a/packages/fuzz/corpus/regressions/effect-needs-cleanup--reactbench-ref-owned-reschedule.tsx
+++ b/packages/fuzz/corpus/regressions/effect-needs-cleanup--reactbench-ref-owned-reschedule.tsx
@@ -1,0 +1,44 @@
+// verdict: pass
+// rule: effect-needs-cleanup
+// weakness: copy-tracking
+// source: React Bench exact audit fix-react-reacttooltip-react-too__8qEHJro
+import { useCallback, useEffect, useRef } from "react";
+
+interface PendingOpen {
+  startedAt: number;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+interface RefOwnedRescheduleProps {
+  delay: number;
+  open: () => void;
+}
+
+export const RefOwnedReschedule = ({ delay, open }: RefOwnedRescheduleProps) => {
+  const pendingOpenRef = useRef<PendingOpen | null>(null);
+
+  const clearTimerRef = (ownedRef: React.MutableRefObject<PendingOpen | null>) => {
+    if (!ownedRef.current) return;
+    clearTimeout(ownedRef.current.timer);
+    ownedRef.current = null;
+  };
+
+  const cancelPendingOpen = useCallback(() => {
+    clearTimerRef(pendingOpenRef);
+  }, []);
+
+  useEffect(() => {
+    return () => cancelPendingOpen();
+  }, [cancelPendingOpen]);
+
+  useEffect(() => {
+    cancelPendingOpen();
+    const timer = setTimeout(open, delay);
+    pendingOpenRef.current = {
+      startedAt: Date.now(),
+      timer,
+    };
+  }, [cancelPendingOpen, delay, open]);
+
+  return null;
+};

--- a/packages/fuzz/corpus/regressions/effect-needs-cleanup--retained-resource-local-alias.tsx
+++ b/packages/fuzz/corpus/regressions/effect-needs-cleanup--retained-resource-local-alias.tsx
@@ -1,0 +1,22 @@
+// verdict: pass
+// rule: effect-needs-cleanup
+// weakness: copy-tracking
+// source: PR 1522 replacement Group B parity audit
+import { useEffect, useRef } from "react";
+
+interface RetainedConnectionProps {
+  url: string;
+}
+
+export const RetainedConnection = ({ url }: RetainedConnectionProps) => {
+  const socketRef = useRef<WebSocket | null>(null);
+
+  useEffect(() => {
+    const socket = new WebSocket(url);
+    socketRef.current = socket;
+
+    return () => socket.close();
+  }, [url]);
+
+  return null;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup-reactbench-regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup-reactbench-regressions.test.ts
@@ -889,6 +889,43 @@ const Connections = ({ primaryUrl, secondaryUrl }) => {
     expect(result.diagnostics[0].message).toContain("WebSocket");
   });
 
+  it("accepts EventSource listeners released by closing their exact local owner", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect, useRef } from "react";
+const JobEvents = ({ jobId }) => {
+  const eventSourceRef = useRef(null);
+  useEffect(() => {
+    const source = new EventSource(\`/api/jobs/\${jobId}/events\`);
+    eventSourceRef.current = source;
+    source.addEventListener("progress", () => {});
+    source.addEventListener("complete", () => {});
+    source.addEventListener("error", () => {});
+    return () => source.close();
+  }, [jobId]);
+  return null;
+};`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not treat close as owned listener cleanup for an opaque EventTarget", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+const Listener = ({ createTarget }) => {
+  useEffect(() => {
+    const target = createTarget();
+    target.addEventListener("change", () => {});
+    return () => target.close();
+  }, [createTarget]);
+  return null;
+};`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("addEventListener");
+  });
+
   it("keeps conditional and mismatched timer retention conservative", () => {
     const conditionalStorageResult = runRule(
       effectNeedsCleanup,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup-reactbench-regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup-reactbench-regressions.test.ts
@@ -825,6 +825,70 @@ const Delayed = ({ delay, task }) => {
     expect(objectStorageResult.diagnostics).toHaveLength(0);
   });
 
+  it("accepts retained resources released through their exact local aliases", () => {
+    const socketResult = runRule(
+      effectNeedsCleanup,
+      `import { useEffect, useRef } from "react";
+const Connection = ({ url }) => {
+  const socketRef = useRef(null);
+  useEffect(() => {
+    const socket = new WebSocket(url);
+    socketRef.current = socket;
+    return () => socket.close();
+  }, [url]);
+  return null;
+};`,
+    );
+    const timerResult = runRule(
+      effectNeedsCleanup,
+      `import { useEffect, useRef } from "react";
+const Poller = ({ pollInterval, refresh }) => {
+  const intervalRef = useRef(null);
+  useEffect(() => {
+    const intervalId = setInterval(refresh, pollInterval);
+    intervalRef.current = intervalId;
+    return () => clearInterval(intervalId);
+  }, [pollInterval, refresh]);
+  return null;
+};`,
+    );
+    const subscriptionResult = runRule(
+      effectNeedsCleanup,
+      `import { useEffect, useRef } from "react";
+const Subscriber = ({ source }) => {
+  const subscriptionRef = useRef(null);
+  useEffect(() => {
+    const subscription = source.subscribe(() => {});
+    subscriptionRef.current = subscription;
+    return () => subscription.unsubscribe();
+  }, [source]);
+  return null;
+};`,
+    );
+    expect(socketResult.diagnostics).toHaveLength(0);
+    expect(timerResult.diagnostics).toHaveLength(0);
+    expect(subscriptionResult.diagnostics).toHaveLength(0);
+  });
+
+  it("does not confuse a retained resource with a different local cleanup alias", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect, useRef } from "react";
+const Connections = ({ primaryUrl, secondaryUrl }) => {
+  const primarySocketRef = useRef(null);
+  useEffect(() => {
+    const primarySocket = new WebSocket(primaryUrl);
+    const secondarySocket = new WebSocket(secondaryUrl);
+    primarySocketRef.current = primarySocket;
+    return () => secondarySocket.close();
+  }, [primaryUrl, secondaryUrl]);
+  return null;
+};`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("WebSocket");
+  });
+
   it("keeps conditional and mismatched timer retention conservative", () => {
     const conditionalStorageResult = runRule(
       effectNeedsCleanup,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup-reactbench-regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup-reactbench-regressions.test.ts
@@ -733,4 +733,214 @@ const Delayed = ({ task }) => {
     );
     expect(result.diagnostics).toHaveLength(0);
   });
+
+  it("accepts a ref-owned timer released through a parameterized helper", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect, useRef } from "react";
+const Delayed = ({ delay, task }) => {
+  const timerRef = useRef(null);
+  const clearTimerRef = (ownedTimerRef) => {
+    if (ownedTimerRef.current) {
+      clearTimeout(ownedTimerRef.current);
+      ownedTimerRef.current = null;
+    }
+  };
+  useEffect(() => {
+    return () => clearTimerRef(timerRef);
+  }, []);
+  useEffect(() => {
+    clearTimerRef(timerRef);
+    timerRef.current = setTimeout(task, delay);
+  }, [delay, task]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("accepts ref-owned timers released through useCallback helpers", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useCallback, useEffect, useRef } from "react";
+const Delayed = ({ delay, task }) => {
+  const timerRef = useRef(null);
+  const clearTimer = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+  useEffect(() => {
+    return () => clearTimer();
+  }, [clearTimer]);
+  useEffect(() => {
+    clearTimer();
+    if (delay <= 0) return;
+    timerRef.current = setTimeout(task, delay);
+  }, [clearTimer, delay, task]);
+  return null;
+};`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("accepts timer handles retained in stable ref fields", () => {
+    const directStorageResult = runRule(
+      effectNeedsCleanup,
+      `import { useEffect, useRef } from "react";
+const Delayed = ({ delay, task }) => {
+  const timerRef = useRef(null);
+  useEffect(() => {
+    return () => clearTimeout(timerRef.current);
+  }, []);
+  useEffect(() => {
+    clearTimeout(timerRef.current);
+    const timer = setTimeout(task, delay);
+    timerRef.current = timer;
+  }, [delay, task]);
+  return null;
+};`,
+    );
+    const objectStorageResult = runRule(
+      effectNeedsCleanup,
+      `import { useEffect, useRef } from "react";
+const Delayed = ({ delay, task }) => {
+  const pendingRef = useRef(null);
+  useEffect(() => {
+    return () => clearTimeout(pendingRef.current.timeout);
+  }, []);
+  useEffect(() => {
+    clearTimeout(pendingRef.current.timeout);
+    pendingRef.current = {
+      timeout: setTimeout(task, delay),
+      startedAt: Date.now(),
+    };
+  }, [delay, task]);
+  return null;
+};`,
+    );
+    expect(directStorageResult.diagnostics).toHaveLength(0);
+    expect(objectStorageResult.diagnostics).toHaveLength(0);
+  });
+
+  it("keeps conditional and mismatched timer retention conservative", () => {
+    const conditionalStorageResult = runRule(
+      effectNeedsCleanup,
+      `import { useEffect, useRef } from "react";
+const Delayed = ({ delay, enabled, task }) => {
+  const timerRef = useRef(null);
+  useEffect(() => {
+    return () => clearTimeout(timerRef.current);
+  }, []);
+  useEffect(() => {
+    clearTimeout(timerRef.current);
+    const timer = setTimeout(task, delay);
+    if (enabled) timerRef.current = timer;
+  }, [delay, enabled, task]);
+  return null;
+};`,
+    );
+    const mismatchedStorageResult = runRule(
+      effectNeedsCleanup,
+      `import { useEffect, useRef } from "react";
+const Delayed = ({ delay, task }) => {
+  const pendingRef = useRef(null);
+  useEffect(() => {
+    return () => clearTimeout(pendingRef.current.otherTimeout);
+  }, []);
+  useEffect(() => {
+    clearTimeout(pendingRef.current.timeout);
+    const timer = setTimeout(task, delay);
+    pendingRef.current = { timeout: timer };
+  }, [delay, task]);
+  return null;
+};`,
+    );
+    expect(conditionalStorageResult.diagnostics).toHaveLength(1);
+    expect(mismatchedStorageResult.diagnostics).toHaveLength(1);
+  });
+
+  it("requires every cleanup-effect path to release the retained timer", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect, useRef } from "react";
+const Delayed = ({ delay, enabled, task }) => {
+  const timerRef = useRef(null);
+  useEffect(() => {
+    if (enabled) return () => clearTimeout(timerRef.current);
+  }, [enabled]);
+  useEffect(() => {
+    clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(task, delay);
+  }, [delay, task]);
+  return null;
+};`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("keeps parameterized helpers tied to the exact timer owner", () => {
+    const replacementMismatchResult = runRule(
+      effectNeedsCleanup,
+      `import { useEffect, useRef } from "react";
+const Delayed = ({ delay, task }) => {
+  const timerRef = useRef(null);
+  const otherTimerRef = useRef(null);
+  const clearTimerRef = (ownedTimerRef) => clearTimeout(ownedTimerRef.current);
+  useEffect(() => {
+    return () => clearTimerRef(timerRef);
+  }, []);
+  useEffect(() => {
+    clearTimerRef(otherTimerRef);
+    timerRef.current = setTimeout(task, delay);
+  }, [delay, task]);
+  return null;
+};`,
+    );
+    const unmountMismatchResult = runRule(
+      effectNeedsCleanup,
+      `import { useEffect, useRef } from "react";
+const Delayed = ({ delay, task }) => {
+  const timerRef = useRef(null);
+  const otherTimerRef = useRef(null);
+  const clearTimerRef = (ownedTimerRef) => clearTimeout(ownedTimerRef.current);
+  useEffect(() => {
+    return () => clearTimerRef(otherTimerRef);
+  }, []);
+  useEffect(() => {
+    clearTimerRef(timerRef);
+    timerRef.current = setTimeout(task, delay);
+  }, [delay, task]);
+  return null;
+};`,
+    );
+    expect(replacementMismatchResult.diagnostics).toHaveLength(1);
+    expect(unmountMismatchResult.diagnostics).toHaveLength(1);
+  });
+
+  it("keeps reassigned cleanup-helper parameters conservative", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect, useRef } from "react";
+const Delayed = ({ delay, task }) => {
+  const timerRef = useRef(null);
+  const otherTimerRef = useRef(null);
+  const clearTimerRef = (ownedTimerRef) => {
+    ownedTimerRef = otherTimerRef;
+    clearTimeout(ownedTimerRef.current);
+  };
+  useEffect(() => {
+    return () => clearTimerRef(timerRef);
+  }, []);
+  useEffect(() => {
+    clearTimerRef(timerRef);
+    timerRef.current = setTimeout(task, delay);
+  }, [delay, task]);
+  return null;
+};`,
+    );
+    expect(result.diagnostics).toHaveLength(1);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -180,6 +180,7 @@ const resolveExpressionKey = (
   expression: EsTreeNode | null | undefined,
   context: RuleContext,
   visitedSymbolIds: Set<number> = new Set(),
+  parameterSubstitutions: ReadonlyMap<number, EsTreeNode> = new Map(),
 ): string | null => {
   if (!expression) return null;
   const unwrappedExpression = stripParenExpression(expression);
@@ -192,6 +193,15 @@ const resolveExpressionKey = (
     }
     if (visitedSymbolIds.has(symbol.id)) return `symbol:${symbol.id}`;
     visitedSymbolIds.add(symbol.id);
+    const substitutedExpression = parameterSubstitutions.get(symbol.id);
+    if (substitutedExpression) {
+      return resolveExpressionKey(
+        substitutedExpression,
+        context,
+        visitedSymbolIds,
+        parameterSubstitutions,
+      );
+    }
     const bindingProperty = symbol.bindingIdentifier.parent;
     const bindingPattern = bindingProperty?.parent;
     const variableDeclarator = bindingPattern?.parent;
@@ -204,7 +214,12 @@ const resolveExpressionKey = (
       isNodeOfType(variableDeclarator, "VariableDeclarator") &&
       variableDeclarator.id === bindingPattern
     ) {
-      const objectKey = resolveExpressionKey(variableDeclarator.init, context, visitedSymbolIds);
+      const objectKey = resolveExpressionKey(
+        variableDeclarator.init,
+        context,
+        visitedSymbolIds,
+        parameterSubstitutions,
+      );
       return objectKey ? `${objectKey}.${bindingPropertyName}` : `symbol:${symbol.id}`;
     }
     const initializer = symbol.initializer ? stripParenExpression(symbol.initializer) : null;
@@ -213,13 +228,21 @@ const resolveExpressionKey = (
       initializer &&
       (isNodeOfType(initializer, "Identifier") || isNodeOfType(initializer, "MemberExpression"))
     ) {
-      return resolveExpressionKey(initializer, context, visitedSymbolIds) ?? `symbol:${symbol.id}`;
+      return (
+        resolveExpressionKey(initializer, context, visitedSymbolIds, parameterSubstitutions) ??
+        `symbol:${symbol.id}`
+      );
     }
     return `symbol:${symbol.id}`;
   }
   if (isNodeOfType(unwrappedExpression, "MemberExpression") && !unwrappedExpression.computed) {
     if (!isNodeOfType(unwrappedExpression.property, "Identifier")) return null;
-    const objectKey = resolveExpressionKey(unwrappedExpression.object, context, visitedSymbolIds);
+    const objectKey = resolveExpressionKey(
+      unwrappedExpression.object,
+      context,
+      visitedSymbolIds,
+      parameterSubstitutions,
+    );
     return objectKey ? `${objectKey}.${unwrappedExpression.property.name}` : null;
   }
   if (isNodeOfType(unwrappedExpression, "ThisExpression")) return "this";
@@ -454,16 +477,98 @@ const doEventListenerCapturesMatch = (
   );
 };
 
-const findAssignedResourceKey = (resourceNode: EsTreeNode, context: RuleContext): string | null => {
+interface RetainedResourceStorage {
+  anchor: EsTreeNode;
+  key: string;
+}
+
+const hasReactRefCurrentReceiver = (expression: EsTreeNode, context: RuleContext): boolean => {
+  let currentExpression = stripParenExpression(expression);
+  while (isNodeOfType(currentExpression, "MemberExpression")) {
+    if (
+      resolveReactRefSymbol(currentExpression, context.scopes, {
+        resolveNamedAliases: true,
+      })
+    ) {
+      return true;
+    }
+    currentExpression = stripParenExpression(currentExpression.object);
+  }
+  return false;
+};
+
+const resolveRetainedResourceStorage = (
+  expression: EsTreeNode,
+  context: RuleContext,
+): RetainedResourceStorage | null => {
+  const expressionRoot = findTransparentExpressionRoot(expression);
+  const expressionParent = expressionRoot.parent;
+  if (
+    isNodeOfType(expressionParent, "AssignmentExpression") &&
+    expressionParent.operator === "=" &&
+    expressionParent.right === expressionRoot &&
+    hasReactRefCurrentReceiver(expressionParent.left, context)
+  ) {
+    const key = resolveExpressionKey(expressionParent.left, context);
+    return key ? { anchor: expressionParent, key } : null;
+  }
+  if (
+    !isNodeOfType(expressionParent, "Property") ||
+    expressionParent.value !== expressionRoot ||
+    expressionParent.kind !== "init"
+  ) {
+    return null;
+  }
+  const propertyName = getStaticPropertyKeyName(expressionParent);
+  const objectExpression = expressionParent.parent;
+  if (!propertyName || !isNodeOfType(objectExpression, "ObjectExpression")) return null;
+  const objectRoot = findTransparentExpressionRoot(objectExpression);
+  const objectAssignment = objectRoot.parent;
+  if (
+    !isNodeOfType(objectAssignment, "AssignmentExpression") ||
+    objectAssignment.operator !== "=" ||
+    objectAssignment.right !== objectRoot ||
+    !hasReactRefCurrentReceiver(objectAssignment.left, context)
+  ) {
+    return null;
+  }
+  const objectKey = resolveExpressionKey(objectAssignment.left, context);
+  return objectKey
+    ? {
+        anchor: objectAssignment,
+        key: `${objectKey}.${propertyName}`,
+      }
+    : null;
+};
+
+const findAssignedResourceKey = (
+  resourceNode: EsTreeNode,
+  context: RuleContext,
+  includeRetainedStorage = false,
+): string | null => {
   const currentNode = findTransparentExpressionRoot(resourceNode);
   const parentNode = currentNode.parent;
   if (isNodeOfType(parentNode, "VariableDeclarator") && parentNode.init === currentNode) {
-    return resolveExpressionKey(parentNode.id, context);
+    const localKey = resolveExpressionKey(parentNode.id, context);
+    if (!includeRetainedStorage) return localKey;
+    if (!isNodeOfType(parentNode.id, "Identifier")) return localKey;
+    const localSymbol = context.scopes.symbolFor(parentNode.id);
+    if (!localSymbol || localSymbol.kind !== "const") return localKey;
+    const retainedStorages = localSymbol.references.flatMap((reference) => {
+      const storage = resolveRetainedResourceStorage(reference.identifier, context);
+      return storage ? [storage] : [];
+    });
+    const retainedStorage = retainedStorages.find((storage) =>
+      doMatchingNodesCoverEveryPathAfterUsage(resourceNode, [storage.anchor], context),
+    );
+    return retainedStorage?.key ?? localKey;
   }
   if (isNodeOfType(parentNode, "AssignmentExpression") && parentNode.right === currentNode) {
     return resolveExpressionKey(parentNode.left, context);
   }
-  return null;
+  return includeRetainedStorage
+    ? (resolveRetainedResourceStorage(currentNode, context)?.key ?? null)
+    : null;
 };
 
 const resolveStableMediaQueryListenerIdentityKey = (
@@ -643,7 +748,7 @@ const findSubscribeLikeUsages = (
         kind: "socket",
         node: child,
         resourceName: isNodeOfType(child.callee, "Identifier") ? child.callee.name : "WebSocket",
-        handleKey: findAssignedResourceKey(child, context),
+        handleKey: findAssignedResourceKey(child, context, true),
         receiverKey: null,
         registrationVerbName: null,
         eventKey: null,
@@ -662,7 +767,7 @@ const findSubscribeLikeUsages = (
         kind: "timer",
         node: child,
         resourceName: child.callee.name,
-        handleKey: findAssignedResourceKey(child, context),
+        handleKey: findAssignedResourceKey(child, context, true),
         receiverKey: null,
         registrationVerbName: child.callee.name,
         eventKey: null,
@@ -678,7 +783,7 @@ const findSubscribeLikeUsages = (
         kind: "subscribe",
         node: child,
         resourceName: subscribeOrObserveMethodName,
-        handleKey: findAssignedResourceKey(child, context),
+        handleKey: findAssignedResourceKey(child, context, true),
         ...registrationDetails,
       });
     }
@@ -1444,11 +1549,47 @@ const resolveSingleAssignedCleanupFunction = (
   return isFunctionLike(assignedValue) ? assignedValue : null;
 };
 
+const resolveCleanupHelperParameterSubstitutions = (
+  helperFunction: EsTreeNode,
+  helperCall: EsTreeNode,
+  context: RuleContext,
+  inheritedSubstitutions: ReadonlyMap<number, EsTreeNode>,
+): ReadonlyMap<number, EsTreeNode> | null => {
+  if (!isFunctionLike(helperFunction) || !isNodeOfType(helperCall, "CallExpression")) return null;
+  const substitutions = new Map(inheritedSubstitutions);
+  for (let parameterIndex = 0; parameterIndex < helperFunction.params.length; parameterIndex += 1) {
+    const parameter = helperFunction.params[parameterIndex];
+    const argument = helperCall.arguments?.[parameterIndex];
+    if (!isNodeOfType(parameter, "Identifier")) continue;
+    if (!argument || isNodeOfType(argument, "SpreadElement")) continue;
+    const parameterSymbol = context.scopes.symbolFor(parameter);
+    const hasDirectParameterWrite = parameterSymbol?.references.some((reference) => {
+      const referenceRoot = findTransparentExpressionRoot(reference.identifier);
+      const referenceParent = referenceRoot.parent;
+      return (
+        (isNodeOfType(referenceParent, "AssignmentExpression") &&
+          referenceParent.left === referenceRoot) ||
+        (isNodeOfType(referenceParent, "UpdateExpression") &&
+          referenceParent.argument === referenceRoot) ||
+        (isNodeOfType(referenceParent, "UnaryExpression") &&
+          referenceParent.operator === "delete" &&
+          referenceParent.argument === referenceRoot)
+      );
+    });
+    if (!parameterSymbol || hasDirectParameterWrite) {
+      return null;
+    }
+    substitutions.set(parameterSymbol.id, argument);
+  }
+  return substitutions;
+};
+
 const doesCleanupFunctionReleaseUsage = (
   cleanupFunction: EsTreeNode,
   usage: SubscribeLikeUsage,
   context: RuleContext,
   visitedFunctions: Set<EsTreeNode> = new Set(),
+  parameterSubstitutions: ReadonlyMap<number, EsTreeNode> = new Map(),
 ): boolean => {
   if (!isFunctionLike(cleanupFunction) || visitedFunctions.has(cleanupFunction)) return false;
   visitedFunctions.add(cleanupFunction);
@@ -1466,7 +1607,7 @@ const doesCleanupFunctionReleaseUsage = (
     const cleanupCall = isNodeOfType(cleanupChild, "ChainExpression")
       ? cleanupChild.expression
       : cleanupChild;
-    if (doesReleaseCallMatchUsage(cleanupChild, usage, context)) {
+    if (doesReleaseCallMatchUsage(cleanupChild, usage, context, parameterSubstitutions)) {
       const cleanupForEachCall = findEnclosingForEachCall(cleanupChild);
       const cleanupCallee = isNodeOfType(cleanupCall, "CallExpression")
         ? stripParenExpression(cleanupCall.callee)
@@ -1511,16 +1652,34 @@ const doesCleanupFunctionReleaseUsage = (
       return;
     }
     if (!isNodeOfType(cleanupCall, "CallExpression")) return;
-    const stableHelperFunction = resolveStableValue(cleanupCall.callee, context);
-    const helperFunction = isNodeOfType(stableHelperFunction, "Identifier")
-      ? resolveSingleAssignedCleanupFunction(stableHelperFunction, usage, context)
-      : stableHelperFunction;
+    const stableHelperValue = resolveStableValue(cleanupCall.callee, context);
+    const helperFunction = isNodeOfType(stableHelperValue, "Identifier")
+      ? resolveSingleAssignedCleanupFunction(stableHelperValue, usage, context)
+      : stableHelperValue
+        ? resolveRefOwnedCleanupFunction(stableHelperValue, context)
+        : null;
+    const helperParameterSubstitutions =
+      helperFunction && isFunctionLike(helperFunction)
+        ? resolveCleanupHelperParameterSubstitutions(
+            helperFunction,
+            cleanupCall,
+            context,
+            parameterSubstitutions,
+          )
+        : null;
     if (
       helperFunction &&
       isFunctionLike(helperFunction) &&
+      helperParameterSubstitutions &&
       !helperFunction.async &&
       !helperFunction.generator &&
-      doesCleanupFunctionReleaseUsage(helperFunction, usage, context, new Set(visitedFunctions))
+      doesCleanupFunctionReleaseUsage(
+        helperFunction,
+        usage,
+        context,
+        new Set(visitedFunctions),
+        helperParameterSubstitutions,
+      )
     ) {
       matchingLoopOrHelperAnchors.push(cleanupCall);
     }
@@ -1749,7 +1908,7 @@ const hasRerunReleaseBeforeUsage = (
     if (
       releaseStart === null ||
       releaseStart >= usageStart ||
-      (releaseBlock !== usageBlock && !handleGuard) ||
+      (releaseBlock !== usageBlock && !handleGuard && !allowUnreleasedPathsWithoutUsage) ||
       (!handleGuard && hasExecutionBoundaryNotSharedWithUsage(child, usage.node, callback))
     ) {
       return;
@@ -1758,11 +1917,22 @@ const hasRerunReleaseBeforeUsage = (
       matchingReleaseAnchors.push(handleGuard ?? child);
       return;
     }
-    const helperFunction = resolveStableValue(child.callee, context);
+    const helperFunction = resolveRefOwnedCleanupFunction(child.callee, context);
+    const helperParameterSubstitutions =
+      helperFunction && isFunctionLike(helperFunction)
+        ? resolveCleanupHelperParameterSubstitutions(helperFunction, child, context, new Map())
+        : null;
     if (
       helperFunction &&
       isFunctionLike(helperFunction) &&
-      doesCleanupFunctionReleaseUsage(helperFunction, usage, context)
+      helperParameterSubstitutions &&
+      doesCleanupFunctionReleaseUsage(
+        helperFunction,
+        usage,
+        context,
+        new Set(),
+        helperParameterSubstitutions,
+      )
     ) {
       matchingReleaseAnchors.push(handleGuard ?? child);
     }
@@ -1801,10 +1971,6 @@ const hasStableUnmountCleanupForUsage = (
       return;
     }
     if (!isReactHookCall(child, CLEANUP_EFFECT_HOOK_NAMES, context.scopes)) return;
-    const dependencyList = child.arguments?.[1];
-    if (!isNodeOfType(dependencyList, "ArrayExpression") || dependencyList.elements.length > 0) {
-      return;
-    }
     const cleanupCallback = getEffectCallback(child);
     if (
       cleanupCallback &&
@@ -3216,6 +3382,7 @@ const doesReleaseCallMatchUsage = (
   node: EsTreeNode,
   usage: SubscribeLikeUsage,
   context: RuleContext,
+  parameterSubstitutions: ReadonlyMap<number, EsTreeNode> = new Map(),
 ): boolean => {
   const callNode = isNodeOfType(node, "ChainExpression") ? node.expression : node;
   if (!isNodeOfType(callNode, "CallExpression")) return false;
@@ -3235,7 +3402,8 @@ const doesReleaseCallMatchUsage = (
     }
     if (
       usage.handleKey !== null &&
-      resolveExpressionKey(callNode.arguments?.[0], context) === usage.handleKey
+      resolveExpressionKey(callNode.arguments?.[0], context, new Set(), parameterSubstitutions) ===
+        usage.handleKey
     ) {
       return true;
     }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -579,6 +579,28 @@ const doesResourceKeyMatchUsageHandle = (
   resourceKey !== null &&
   (resourceKey === usage.handleKey || resourceKey === findAssignedResourceKey(usage.node, context));
 
+const doesSocketOwnerReleaseListenerUsage = (
+  releaseReceiverKey: string | null,
+  releaseVerbName: string,
+  usage: SubscribeLikeUsage,
+  context: RuleContext,
+): boolean => {
+  if (
+    usage.kind !== "subscribe" ||
+    usage.registrationVerbName !== "addEventListener" ||
+    !SOCKET_RELEASE_VERB_NAMES.has(releaseVerbName) ||
+    usage.receiverKey === null ||
+    releaseReceiverKey !== usage.receiverKey ||
+    !isNodeOfType(usage.node, "CallExpression")
+  ) {
+    return false;
+  }
+  const registrationCallee = stripParenExpression(usage.node.callee);
+  if (!isNodeOfType(registrationCallee, "MemberExpression")) return false;
+  const registrationOwner = resolveStableValue(registrationCallee.object, context);
+  return registrationOwner !== null && isSocketConstruction(registrationOwner);
+};
+
 const resolveStableMediaQueryListenerIdentityKey = (
   expression: EsTreeNode | null | undefined,
   context: RuleContext,
@@ -1730,6 +1752,9 @@ const doesBoundCleanupReleaseUsage = (
     return false;
   }
   const releaseVerbName = releaseMember.property.name;
+  if (doesSocketOwnerReleaseListenerUsage(releaseReceiverKey, releaseVerbName, usage, context)) {
+    return true;
+  }
   if (usage.kind === "socket") {
     return (
       doesResourceKeyMatchUsageHandle(releaseReceiverKey, usage, context) &&
@@ -3468,6 +3493,10 @@ const doesReleaseCallMatchUsage = (
   }
 
   if (isReactRefListenerReplacementRelease(callNode, usage, context)) return true;
+
+  if (doesSocketOwnerReleaseListenerUsage(releaseReceiverKey, releaseVerbName, usage, context)) {
+    return true;
+  }
 
   if (usage.kind === "socket") {
     return (

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -571,6 +571,14 @@ const findAssignedResourceKey = (
     : null;
 };
 
+const doesResourceKeyMatchUsageHandle = (
+  resourceKey: string | null,
+  usage: SubscribeLikeUsage,
+  context: RuleContext,
+): boolean =>
+  resourceKey !== null &&
+  (resourceKey === usage.handleKey || resourceKey === findAssignedResourceKey(usage.node, context));
+
 const resolveStableMediaQueryListenerIdentityKey = (
   expression: EsTreeNode | null | undefined,
   context: RuleContext,
@@ -1724,14 +1732,14 @@ const doesBoundCleanupReleaseUsage = (
   const releaseVerbName = releaseMember.property.name;
   if (usage.kind === "socket") {
     return (
-      usage.handleKey === releaseReceiverKey &&
+      doesResourceKeyMatchUsageHandle(releaseReceiverKey, usage, context) &&
       (SOCKET_RELEASE_VERB_NAMES.has(releaseVerbName) ||
         UNIVERSAL_RELEASE_VERB_NAMES.has(releaseVerbName))
     );
   }
   return (
     usage.kind === "subscribe" &&
-    usage.handleKey === releaseReceiverKey &&
+    doesResourceKeyMatchUsageHandle(releaseReceiverKey, usage, context) &&
     (releaseVerbName === "unsubscribe" ||
       releaseVerbName === "unsub" ||
       releaseVerbName === "close" ||
@@ -3401,9 +3409,11 @@ const doesReleaseCallMatchUsage = (
       return false;
     }
     if (
-      usage.handleKey !== null &&
-      resolveExpressionKey(callNode.arguments?.[0], context, new Set(), parameterSubstitutions) ===
-        usage.handleKey
+      doesResourceKeyMatchUsageHandle(
+        resolveExpressionKey(callNode.arguments?.[0], context, new Set(), parameterSubstitutions),
+        usage,
+        context,
+      )
     ) {
       return true;
     }
@@ -3417,8 +3427,7 @@ const doesReleaseCallMatchUsage = (
   if (
     isNodeOfType(callee, "Identifier") &&
     usage.kind === "subscribe" &&
-    usage.handleKey !== null &&
-    resolveExpressionKey(callee, context) === usage.handleKey &&
+    doesResourceKeyMatchUsageHandle(resolveExpressionKey(callee, context), usage, context) &&
     isCleanupReturningSubscribeLikeCallExpression(usage.node)
   ) {
     return true;
@@ -3462,16 +3471,14 @@ const doesReleaseCallMatchUsage = (
 
   if (usage.kind === "socket") {
     return (
-      usage.handleKey !== null &&
-      releaseReceiverKey === usage.handleKey &&
+      doesResourceKeyMatchUsageHandle(releaseReceiverKey, usage, context) &&
       (SOCKET_RELEASE_VERB_NAMES.has(releaseVerbName) ||
         UNIVERSAL_RELEASE_VERB_NAMES.has(releaseVerbName))
     );
   }
 
   if (
-    usage.handleKey !== null &&
-    releaseReceiverKey === usage.handleKey &&
+    doesResourceKeyMatchUsageHandle(releaseReceiverKey, usage, context) &&
     (releaseVerbName === "unsubscribe" ||
       releaseVerbName === "unsub" ||
       releaseVerbName === "close" ||


### PR DESCRIPTION
## Why

The exact React Bench source audit confirmed 23 current-main false positives for `effect-needs-cleanup`. These components retain a one-shot timer in stable ref-owned state, clear the previous handle before replacement, and release the live handle through a separate cleanup effect.

The detector could not prove that lifecycle when cleanup crossed a parameterized helper, the helper was wrapped in `useCallback`, or the timer result was copied into a ref field after creation.

## What changed

- substitute stable cleanup-helper parameters with their call-site arguments
- resolve `useCallback` cleanup helpers and dependency-bearing cleanup effects
- track timer handles retained directly or through an object field in a React ref
- require path-complete retention and owner-exact replacement/unmount cleanup
- add positive and adversarial negative regression coverage
- add a strict fuzz corpus regression and patch changeset

## Exact React Bench replay

Immutable base: `5dc936e111fda0d77bc7a8a36ece3b1ec6b9bf27`

- 23 supplied units
- 23 exact reconstructed sources
- 23 exact base reports
- 23 fixed on this head
- 0 residual gaps
- full diagnostic delta on exact sources: 0 added / 23 removed / 42 unchanged
- 0 reconstruction or source-location failures

Detail artifact SHA-256: `502d4ddad8deda694d7ba0e581f5734f6e91907bae73a651baf2c7578438e7e6`

## Validation

- `nr test`
- `nr typecheck`
- `nr lint`
- `nr format:check`
- `nr build`
- `nr smoke:json-report`
- full oxlint plugin suite: 962 files, 25,091 passed, 201 skipped
- fuzz package suite: 192 passed, 782 skipped
- strict target fuzz: 500 iterations
- deterministic target fuzz: seed 42, 100 iterations
- post-change truffler dedup search

RDE was attempted against 100 bounded roots but the current eval checkout rejects report schema 3 because it still expects schema 1, so it produced no valid detector evidence. Daytona parity is intentionally pending the shared audit parity queue and was not interrupted.

<!-- FINAL_PARITY_1522 -->
## Final Daytona parity

- immutable base: `6b64dfaf9e973139d1df2d09f405c9d916e158a3`
- candidate prospective merge: `2e0ff348c621a57062b94ab79f3b2a20495a8ddd` (PR head `7a5c28af6236fb55c49e033b16a9cc90a2753055`)
- exact rule scope: `react-doctor/effect-needs-cleanup`
- 2,000 baseline / 2,000 candidate / 2,000 compared / 0 skipped / 0 failed
- 2,685 baseline diagnostics / 2,674 candidate diagnostics
- exact delta: 0 added / 11 removed / 2,674 unchanged
- 11/11 removals reconstructed and classified as confirmed baseline false positives
- 0 confirmed false negatives, persistence gaps, reconstruction failures, or parity blockers
- all 9 previously classified removals preserved; the 2 new EventSource listener removals both close their exact local owner
- parity resource cleanup verified twice

Parity SHA-256: `60234e2b40671c7aa352f6539bee35949c49dcbb3be95f2bdf4209fd240310be`  
Baseline SHA-256: `c2bfc0c5d6bc4e7bc3520157271c84577ce6e5178b39ceab9f62512684a9bc51`  
Candidate SHA-256: `aa0f870f1925d1f3984229144d23126944c6f227812815d8395b4f3c7fa2698f`  
Descriptor SHA-256: `293741fb450029d9a59a1a9e2372adeb5f150ffea8678e3ecb30728b7cbfc467`  
Provenance SHA-256: `d71fc0d1ff6618120d05b58f261bbff97dea19aba99965e4336ad463b35086de`  
Impact manifest SHA-256: `ca52244e1c452f799c79f29f56e09ac5bbc09b87ea42e197a356dd0acaf4d36c`  
Evidence manifest SHA-256: `5d64a0f2270a6e732236ac344e8e43de4b3b4da8390d254526d3ad3aea9e33d6`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes static analysis in a large, path-sensitive rule; incorrect proofs could hide real leaks or reintroduce false positives, though coverage is heavily regression-tested.
> 
> **Overview**
> Tightens **`effect-needs-cleanup`** so ref-owned one-shot timers and similar retained handles stop false-positiveing when cleanup is split across effects and helpers.
> 
> The rule now tracks handles stored on **`ref.current`** (including nested object fields), maps cleanup-helper parameters to call-site arguments (including **`useCallback`** wrappers), and treats **`clearTimeout`/`clearInterval`** and local-alias releases (e.g. **`socket.close()`** on the same local as the socket) as matching the retained usage. Separate unmount cleanup effects are recognized even when they have a non-empty dependency array. **`EventSource`**-style **`addEventListener`** cleanup is accepted when **`close`** is on the socket constructor receiver; generic opaque targets still require real listener removal.
> 
> Adversarial cases stay strict: wrong ref passed to helpers, conditional ref assignment, mismatched object fields, partial cleanup-effect paths, and reassigned helper parameters still report. Adds React Bench regressions, fuzz corpus entries, and a patch changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a5c28af6236fb55c49e033b16a9cc90a2753055. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->