### PR TITLE
RDFPFN792026: recognize external effect synchronization

### DIFF
--- a/.changeset/fuzzy-effects-focus.md
+++ b/.changeset/fuzzy-effects-focus.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Avoid no-event-handler false positives for deferred ref focus and state-backed collection ref synchronization.

--- a/packages/fuzz/corpus/regressions/no-event-handler--decision-error-focus.tsx
+++ b/packages/fuzz/corpus/regressions/no-event-handler--decision-error-focus.tsx
@@ -1,0 +1,29 @@
+// rule: no-event-handler
+// verdict: pass
+// weakness: external-synchronization
+// source: React Bench write-react-theduffman85-crowdse__rbzUMnz Decisions
+import { useEffect, useRef, useState } from "react";
+
+export const DecisionDialog = () => {
+  const [errorInfo, setErrorInfo] = useState<Error | null>(null);
+  const focusPendingRef = useRef(false);
+  const dismissRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (errorInfo && focusPendingRef.current) {
+      focusPendingRef.current = false;
+      requestAnimationFrame(() => dismissRef.current?.focus());
+    }
+  }, [errorInfo]);
+
+  return (
+    <button
+      onClick={() => {
+        focusPendingRef.current = true;
+        setErrorInfo(new Error("failed"));
+      }}
+    >
+      Delete
+    </button>
+  );
+};

--- a/packages/fuzz/corpus/regressions/no-event-handler--deferred-error-focus.tsx
+++ b/packages/fuzz/corpus/regressions/no-event-handler--deferred-error-focus.tsx
@@ -1,0 +1,22 @@
+// rule: no-event-handler
+// verdict: pass
+// weakness: external-synchronization
+// source: React Bench write-react-theduffman85-crowdse__Dmxf8wU
+import { useEffect, useRef, useState } from "react";
+
+export const DeleteDialog = () => {
+  const [deleteError, setDeleteError] = useState<Error | null>(null);
+  const dismissRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (deleteError) {
+      setTimeout(() => dismissRef.current?.focus(), 0);
+    }
+  }, [deleteError]);
+
+  return (
+    <form onSubmit={() => setDeleteError(new Error("failed"))}>
+      {deleteError && <button ref={dismissRef}>Dismiss</button>}
+    </form>
+  );
+};

--- a/packages/fuzz/corpus/regressions/no-event-handler--nested-error-focus.tsx
+++ b/packages/fuzz/corpus/regressions/no-event-handler--nested-error-focus.tsx
@@ -1,0 +1,30 @@
+// rule: no-event-handler
+// verdict: pass
+// weakness: external-synchronization
+// source: React Bench write-react-theduffman85-crowdse__yzTKQqw
+import { useEffect, useRef, useState } from "react";
+
+export const AddDialog = () => {
+  const [errorInfo, setErrorInfo] = useState<Error | null>(null);
+  const [isPending, setIsPending] = useState(false);
+  const dismissRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (errorInfo) {
+      if (!isPending) {
+        requestAnimationFrame(() => dismissRef.current?.focus());
+      }
+    }
+  }, [errorInfo, isPending]);
+
+  return (
+    <button
+      onClick={() => {
+        setIsPending(false);
+        setErrorInfo(new Error("failed"));
+      }}
+    >
+      Add
+    </button>
+  );
+};

--- a/packages/fuzz/corpus/regressions/no-event-handler--pending-error-focus.tsx
+++ b/packages/fuzz/corpus/regressions/no-event-handler--pending-error-focus.tsx
@@ -1,0 +1,29 @@
+// rule: no-event-handler
+// verdict: pass
+// weakness: external-synchronization
+// source: React Bench write-react-theduffman85-crowdse__rbzUMnz Alerts
+import { useEffect, useRef, useState } from "react";
+
+export const AlertDialog = () => {
+  const [errorInfo, setErrorInfo] = useState<Error | null>(null);
+  const focusPendingRef = useRef(false);
+  const dismissRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (errorInfo && focusPendingRef.current) {
+      focusPendingRef.current = false;
+      requestAnimationFrame(() => dismissRef.current?.focus());
+    }
+  }, [errorInfo]);
+
+  return (
+    <button
+      onClick={() => {
+        focusPendingRef.current = true;
+        setErrorInfo(new Error("failed"));
+      }}
+    >
+      Delete
+    </button>
+  );
+};

--- a/packages/fuzz/corpus/regressions/no-event-handler--state-backed-map-ref.tsx
+++ b/packages/fuzz/corpus/regressions/no-event-handler--state-backed-map-ref.tsx
@@ -1,0 +1,28 @@
+// rule: no-event-handler
+// verdict: pass
+// weakness: external-synchronization
+// source: React Bench write-react-xr843-fojin-775__w6mMqoi
+import { useEffect, useRef, useState } from "react";
+
+interface Message {
+  id: number;
+}
+
+export const FeedbackList = () => {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const feedbackStateRef = useRef(new Map<number, { pending: Map<number, string> }>());
+
+  useEffect(() => {
+    for (const message of messages) {
+      if (feedbackStateRef.current.has(message.id)) continue;
+      feedbackStateRef.current.set(message.id, { pending: new Map() });
+    }
+    for (const id of feedbackStateRef.current.keys()) {
+      if (!messages.some((message) => message.id === id)) {
+        feedbackStateRef.current.delete(id);
+      }
+    }
+  }, [messages]);
+
+  return <button onClick={() => setMessages([{ id: 1 }])}>Load</button>;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-event-handler.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-event-handler.regressions.test.ts
@@ -792,6 +792,206 @@ describe("no-event-handler — regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("stays silent when error state schedules focus after the dismiss control mounts", () => {
+    const result = runRule(
+      noEventHandler,
+      `function DeleteDialog() {
+        const [deleteError, setDeleteError] = useState(null);
+        const dismissRef = useRef(null);
+        useEffect(() => {
+          if (deleteError) {
+            setTimeout(() => dismissRef.current?.focus(), 0);
+          }
+        }, [deleteError]);
+        return (
+          <form onSubmit={() => setDeleteError(new Error("failed"))}>
+            {deleteError && <button ref={dismissRef}>Dismiss</button>}
+          </form>
+        );
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent when a pending ref gates requestAnimationFrame focus synchronization", () => {
+    const result = runRule(
+      noEventHandler,
+      `function DeleteDialog() {
+        const [errorInfo, setErrorInfo] = useState(null);
+        const focusPendingRef = useRef(false);
+        const dismissRef = useRef(null);
+        useEffect(() => {
+          if (errorInfo && focusPendingRef.current) {
+            focusPendingRef.current = false;
+            requestAnimationFrame(() => dismissRef.current?.focus());
+          }
+        }, [errorInfo]);
+        return (
+          <button onClick={() => {
+            focusPendingRef.current = true;
+            setErrorInfo({ message: "failed" });
+          }}>
+            Delete
+          </button>
+        );
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent when focus waits for both an error and pending work to settle", () => {
+    const result = runRule(
+      noEventHandler,
+      `function AddDialog() {
+        const [errorInfo, setErrorInfo] = useState(null);
+        const [isPending, setIsPending] = useState(false);
+        const dismissRef = useRef(null);
+        useEffect(() => {
+          if (errorInfo) {
+            if (!isPending) {
+              requestAnimationFrame(() => dismissRef.current?.focus());
+            }
+          }
+        }, [errorInfo, isPending]);
+        return (
+          <button onClick={() => {
+            setIsPending(false);
+            setErrorInfo({ message: "failed" });
+          }}>
+            Add
+          </button>
+        );
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent when separate modal error state schedules focus after commit", () => {
+    const result = runRule(
+      noEventHandler,
+      `function DecisionDialogs() {
+        const [deleteErrorInfo, setDeleteErrorInfo] = useState(null);
+        const [addErrorInfo, setAddErrorInfo] = useState(null);
+        const deleteDismissRef = useRef(null);
+        const addDismissRef = useRef(null);
+        useEffect(() => {
+          if (deleteErrorInfo) {
+            requestAnimationFrame(() => deleteDismissRef.current?.focus());
+          }
+        }, [deleteErrorInfo]);
+        useEffect(() => {
+          if (addErrorInfo) {
+            requestAnimationFrame(() => addDismissRef.current?.focus());
+          }
+        }, [addErrorInfo]);
+        return (
+          <>
+            <button onClick={() => setDeleteErrorInfo({ message: "delete failed" })}>Delete</button>
+            <button onClick={() => setAddErrorInfo({ message: "add failed" })}>Add</button>
+          </>
+        );
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent when handler-written state synchronizes a Map held by a ref", () => {
+    const result = runRule(
+      noEventHandler,
+      `function FeedbackList() {
+        const [messages, setMessages] = useState([]);
+        const feedbackStateRef = useRef(new Map());
+        useEffect(() => {
+          for (const message of messages) {
+            if (feedbackStateRef.current.has(message.id)) continue;
+            feedbackStateRef.current.set(message.id, { pending: new Map() });
+          }
+          for (const id of feedbackStateRef.current.keys()) {
+            if (!messages.some((message) => message.id === id)) {
+              feedbackStateRef.current.delete(id);
+            }
+          }
+        }, [messages]);
+        return <button onClick={() => setMessages([{ id: 1 }])}>Load</button>;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still reports a deferred prop callback instead of treating every timer as focus sync", () => {
+    const result = runRule(
+      noEventHandler,
+      `function Toast({ onShow }) {
+        const [visible, setVisible] = useState(false);
+        useEffect(() => {
+          if (visible) setTimeout(() => onShow(), 0);
+        }, [visible, onShow]);
+        return <button onClick={() => setVisible(true)} />;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still reports mixed scheduled focus and event work", () => {
+    const result = runRule(
+      noEventHandler,
+      `function Form() {
+        const [submitted, setSubmitted] = useState(false);
+        const statusRef = useRef(null);
+        useEffect(() => {
+          if (submitted) {
+            setTimeout(() => {
+              statusRef.current?.focus();
+              post("/submit");
+            }, 0);
+          }
+        }, [submitted]);
+        return <button onClick={() => setSubmitted(true)}>Submit</button>;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still reports delete calls on opaque clients stored in refs", () => {
+    const result = runRule(
+      noEventHandler,
+      `function Resource({ apiClient }) {
+        const [shouldDelete, setShouldDelete] = useState(false);
+        const apiClientRef = useRef(apiClient);
+        useEffect(() => {
+          if (shouldDelete) apiClientRef.current.delete("/resource");
+        }, [shouldDelete]);
+        return <button onClick={() => setShouldDelete(true)}>Delete</button>;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still reports collection mutations when useRef is shadowed", () => {
+    const result = runRule(
+      noEventHandler,
+      `const useRef = (value) => ({ current: value });
+      function Selection() {
+        const [shouldClear, setShouldClear] = useState(false);
+        const selected = useRef(new Set());
+        useEffect(() => {
+          if (shouldClear) selected.current.delete("active");
+        }, [shouldClear]);
+        return <button onClick={() => setShouldClear(true)}>Clear</button>;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("stays silent on a window.scrollTo consequent", () => {
     const result = runRule(
       noEventHandler,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-event-handler.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-event-handler.regressions.test.ts
@@ -959,6 +959,27 @@ describe("no-event-handler — regressions", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("still reports mixed scheduled focus and non-call work", () => {
+    const result = runRule(
+      noEventHandler,
+      `function Form() {
+        const [submitted, setSubmitted] = useState(false);
+        const statusRef = useRef(null);
+        useEffect(() => {
+          if (submitted) {
+            setTimeout(() => {
+              statusRef.current?.focus();
+              document.title = "Submitted";
+            }, 0);
+          }
+        }, [submitted]);
+        return <button onClick={() => setSubmitted(true)}>Submit</button>;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("still reports delete calls on opaque clients stored in refs", () => {
     const result = runRule(
       noEventHandler,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-event-handler.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-event-handler.ts
@@ -1,11 +1,17 @@
 import type { Reference } from "eslint-scope";
+import { TIMER_AND_SCHEDULER_DIRECT_CALLEE_NAMES } from "../../constants/dom.js";
+import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { getRootIdentifier } from "../../utils/get-root-identifier.js";
+import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isReactHookCall } from "../../utils/is-react-hook-call.js";
+import { resolveReactRefSymbol } from "../../utils/react-ref-origin.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import { walkAst } from "../../utils/walk-ast.js";
 import { collectBoundedEffectExecutionFrames } from "./utils/collect-effect-state-write-facts.js";
 import { getDownstreamRefs, getRef, getUpstreamRefs } from "./utils/effect/ast.js";
@@ -39,11 +45,121 @@ const collectGuardStateReferences = (
   return stateReferences;
 };
 
+const findReactRefSymbolInMemberChain = (
+  expression: EsTreeNode,
+  scopes: ScopeAnalysis,
+): ReturnType<typeof resolveReactRefSymbol> => {
+  let currentExpression = stripParenExpression(expression);
+  while (isNodeOfType(currentExpression, "MemberExpression")) {
+    const refSymbol = resolveReactRefSymbol(currentExpression, scopes, {
+      allowUnboundBareCalls: true,
+      resolveNamedAliases: true,
+    });
+    if (refSymbol) return refSymbol;
+    currentExpression = stripParenExpression(currentExpression.object as EsTreeNode);
+  }
+  return null;
+};
+
+const isReactRefMemberCall = (
+  callExpression: EsTreeNodeOfType<"CallExpression">,
+  memberName: string,
+  scopes: ScopeAnalysis,
+): boolean => {
+  const callee = stripParenExpression(callExpression.callee);
+  if (!isNodeOfType(callee, "MemberExpression") || getStaticPropertyName(callee) !== memberName) {
+    return false;
+  }
+  return findReactRefSymbolInMemberChain(callee, scopes) !== null;
+};
+
+const isCollectionRefMutation = (
+  callExpression: EsTreeNodeOfType<"CallExpression">,
+  scopes: ScopeAnalysis,
+): boolean => {
+  const callee = stripParenExpression(callExpression.callee);
+  if (!isNodeOfType(callee, "MemberExpression")) return false;
+  const memberName = getStaticPropertyName(callee);
+  if (!memberName) return false;
+  const refSymbol = findReactRefSymbolInMemberChain(callee, scopes);
+  const refCall = refSymbol?.initializer ? stripParenExpression(refSymbol.initializer) : null;
+  const initialValue =
+    refCall && isNodeOfType(refCall, "CallExpression") && refCall.arguments?.[0]
+      ? stripParenExpression(refCall.arguments[0] as EsTreeNode)
+      : null;
+  if (
+    !initialValue ||
+    !isNodeOfType(initialValue, "NewExpression") ||
+    !isNodeOfType(initialValue.callee, "Identifier") ||
+    !scopes.isGlobalReference(initialValue.callee)
+  ) {
+    return false;
+  }
+  if (initialValue.callee.name === "Map") {
+    return memberName === "set" || memberName === "delete" || memberName === "clear";
+  }
+  if (initialValue.callee.name === "Set") {
+    return memberName === "add" || memberName === "delete" || memberName === "clear";
+  }
+  return false;
+};
+
+const getSchedulerName = (
+  callExpression: EsTreeNodeOfType<"CallExpression">,
+  scopes: ScopeAnalysis,
+): string | null => {
+  const callee = stripParenExpression(callExpression.callee);
+  if (
+    isNodeOfType(callee, "Identifier") &&
+    scopes.isGlobalReference(callee) &&
+    TIMER_AND_SCHEDULER_DIRECT_CALLEE_NAMES.has(callee.name)
+  ) {
+    return callee.name;
+  }
+  if (!isNodeOfType(callee, "MemberExpression")) return null;
+  const memberName = getStaticPropertyName(callee);
+  if (!memberName || !TIMER_AND_SCHEDULER_DIRECT_CALLEE_NAMES.has(memberName)) return null;
+  const rootIdentifier = getRootIdentifier(callee);
+  return rootIdentifier &&
+    (rootIdentifier.name === "globalThis" ||
+      rootIdentifier.name === "self" ||
+      rootIdentifier.name === "window") &&
+    scopes.isGlobalReference(rootIdentifier)
+    ? memberName
+    : null;
+};
+
+const isDeferredRefFocusSynchronization = (
+  callExpression: EsTreeNodeOfType<"CallExpression">,
+  scopes: ScopeAnalysis,
+): boolean => {
+  if (!getSchedulerName(callExpression, scopes)) return false;
+  const callback = callExpression.arguments?.[0] as EsTreeNode | undefined;
+  if (!isFunctionLike(callback)) return false;
+  let hasRefFocusCall = false;
+  let hasOtherCall = false;
+  walkAst(callback.body as EsTreeNode, (child: EsTreeNode): boolean | void => {
+    if (hasOtherCall) return false;
+    if (child !== callback && isFunctionLike(child)) {
+      hasOtherCall = true;
+      return false;
+    }
+    if (!isNodeOfType(child, "CallExpression")) return;
+    if (isReactRefMemberCall(child, "focus", scopes)) {
+      hasRefFocusCall = true;
+      return;
+    }
+    hasOtherCall = true;
+    return false;
+  });
+  return hasRefFocusCall && !hasOtherCall;
+};
+
 const consequentHasTransferableWork = (
   analysis: ProgramAnalysis,
   consequent: EsTreeNode,
+  scopes: ScopeAnalysis,
 ): boolean => {
-  if (findTriggeredSideEffectCalleeName(consequent)) return true;
   if (
     getDownstreamRefs(analysis, consequent).some((reference) =>
       isPropCallbackInvocationRef(analysis, reference),
@@ -56,6 +172,16 @@ const consequentHasTransferableWork = (
     if (hasTransferableWork) return false;
     if (child !== consequent && isFunctionLike(child)) return false;
     if (!isNodeOfType(child, "CallExpression")) return;
+    if (
+      isDeferredRefFocusSynchronization(child, scopes) ||
+      isCollectionRefMutation(child, scopes)
+    ) {
+      return;
+    }
+    if (findTriggeredSideEffectCalleeName(child)) {
+      hasTransferableWork = true;
+      return false;
+    }
     if (isNodeOfType(child.callee, "Identifier")) {
       const calleeReference = getRef(analysis, child.callee);
       if (calleeReference && isStateSetterCall(analysis, calleeReference)) return;
@@ -136,7 +262,11 @@ export const noEventHandler = defineRule({
           if (reported) return false;
           if (child !== frame.functionNode && isFunctionLike(child)) return false;
           if (!isNodeOfType(child, "IfStatement") || child.alternate) return;
-          if (!consequentHasTransferableWork(analysis, child.consequent as EsTreeNode)) return;
+          if (
+            !consequentHasTransferableWork(analysis, child.consequent as EsTreeNode, context.scopes)
+          ) {
+            return;
+          }
           const stateReferences = collectGuardStateReferences(analysis, child.test as EsTreeNode);
           const handlerStateDeclarators = new Set(
             stateReferences

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-event-handler.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-event-handler.ts
@@ -136,23 +136,17 @@ const isDeferredRefFocusSynchronization = (
   if (!getSchedulerName(callExpression, scopes)) return false;
   const callback = callExpression.arguments?.[0] as EsTreeNode | undefined;
   if (!isFunctionLike(callback)) return false;
-  let hasRefFocusCall = false;
-  let hasOtherCall = false;
-  walkAst(callback.body as EsTreeNode, (child: EsTreeNode): boolean | void => {
-    if (hasOtherCall) return false;
-    if (child !== callback && isFunctionLike(child)) {
-      hasOtherCall = true;
-      return false;
-    }
-    if (!isNodeOfType(child, "CallExpression")) return;
-    if (isReactRefMemberCall(child, "focus", scopes)) {
-      hasRefFocusCall = true;
-      return;
-    }
-    hasOtherCall = true;
-    return false;
-  });
-  return hasRefFocusCall && !hasOtherCall;
+  const callbackBody = stripParenExpression(callback.body as EsTreeNode);
+  if (isNodeOfType(callbackBody, "CallExpression")) {
+    return isReactRefMemberCall(callbackBody, "focus", scopes);
+  }
+  if (!isNodeOfType(callbackBody, "BlockStatement") || callbackBody.body.length !== 1) return false;
+  const statement = callbackBody.body[0] as EsTreeNode;
+  return (
+    isNodeOfType(statement, "ExpressionStatement") &&
+    isNodeOfType(statement.expression, "CallExpression") &&
+    isReactRefMemberCall(statement.expression, "focus", scopes)
+  );
 };
 
 const consequentHasTransferableWork = (


### PR DESCRIPTION
## Why

React Bench source reconstruction confirmed five `no-event-handler` false positives on immutable main `86add142688fa951a456d86c006f3f8c7c36c070`:

- four error-state effects defer focus until the conditional dismiss control exists after commit
- one effect synchronizes handler-written message state into a `Map` held by a React ref

These effects synchronize React state with external DOM or mutable-ref state; they are not state-mediated event handlers.

## What

- recognize scheduler callbacks that exclusively focus a proven React ref
- recognize `Map` and `Set` mutations through a proven React ref with a matching collection initializer
- retain diagnostics for deferred prop callbacks, mixed focus/event work, opaque ref clients, and shadowed `useRef`
- add five React Bench regressions, four adversarial negative controls, five strict-fuzz corpus cases, and a patch changeset

## Exact replay

| Revision | Files | Parse errors | Diagnostics |
| --- | ---: | ---: | ---: |
| immutable main `86add1426` | 5 | 0 | 5 |
| this PR `b21dc5087` | 5 | 0 | 0 |

Removed diagnostics: 5. Added diagnostics: 0.

## Validation

- focused rule contracts and regressions: pass
- full plugin suite: 25,100 pass / 201 skip
- full repository tests: 15/15 tasks pass
- strict fuzz: `FUZZ_RULE=no-event-handler FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz`
- fuzz corpus: 192 pass / 782 skip
- full build: 9/9 tasks pass
- lint: pass (existing corpus warnings only)
- typecheck: 16/16 tasks pass
- format: pass
- JSON report smoke: pass
- post-change truffler duplicate-symbol search: no duplicate helper surface found

The bounded RDE run could not start because the eval environment lacks required `AXIOM_DATASET`; no scans were run. Daytona parity is intentionally deferred because the shared parity queue is paused and must not be interrupted.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes heuristic classification in a widely used lint rule; regressions and adversarial tests limit false negatives, but edge cases may still slip through.
> 
> **Overview**
> Reduces **`no-event-handler`** false positives by treating some effect consequents as **external synchronization** instead of “faked event handlers.”
> 
> **`consequentHasTransferableWork`** now skips scheduler callbacks (`setTimeout`, `requestAnimationFrame`, etc.) whose body only calls **`.focus()`** on a proven React ref, and skips **`Map`/`Set`** mutations on refs initialized with **`new Map()`** / **`new Set()`**. Prop-callback timers, mixed focus plus other work, opaque ref API calls, and shadowed **`useRef`** still report.
> 
> Adds five fuzz corpus regressions (React Bench shapes), matching unit tests, adversarial “still reports” cases, and a patch changeset for **`oxlint-plugin-react-doctor`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff11123156a322d3131b4fa8140ff4d17c79c1d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Final current-main parity

The immutable 2,000-project matrix replay is complete against current main `6b64dfaf9e973139d1df2d09f405c9d916e158a3` and prospective merge commit `14973352b99a0e772c538746fc70f77b17fe436d`. Both candidate and scoped shared-base artifacts contain 2,000/2,000 records with zero failed or skipped projects. The exact `react-doctor/no-event-handler` comparison is `+0/-0`, with 1,322 unchanged diagnostic identities.

- candidate NDJSON SHA-256: `2916e4568f71f3f56b2e5d6689b5be238bb0bd20ff705e8d518249d120bed14a`
- scoped base NDJSON SHA-256: `7e22605a84ef17853e0f2a748fc6fe2a11e3a1a0180ef190f25671f26140f4ee`
- parity JSON SHA-256: `23efbff491d524f36183967b9777f03d065e1ff06d75c71f1ffd0824faec0d61`
- descriptor SHA-256: `59e18f816a01b3c8367690c5173ef2e934d59c0015309de5a7efdb04b729f268`
- evaluator source SHA-256: `7dcb7c25d0608f37151cd4354d708f14980876a5463fcea95d4ad4d3f9f21c40`
- corpus manifest SHA-256: `ff8f5bfca41e411d4ad16b57d69c90c5a7b723ea6190f5ef94052af64af02b01`

The Group B evaluator was cleaned and its exact Daytona sandbox/snapshot set was verified absent.
