### PR TITLE
fix(rule): detect default clobbers reaching JSX

### DIFF
--- a/.changeset/bright-defaults-reach-jsx.md
+++ b/.changeset/bright-defaults-reach-jsx.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Detect props that overwrite defaults with undefined before reaching JSX attributes.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-spread-props-over-defaults-clobbers-with-undefined.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-spread-props-over-defaults-clobbers-with-undefined.test.ts
@@ -256,4 +256,129 @@ describe("no-spread-props-over-defaults-clobbers-with-undefined", () => {
     expect(memberCall.diagnostics).toHaveLength(1);
     expect(updateExpression.diagnostics).toHaveLength(1);
   });
+
+  it("flags destructured parameter merges passed through JSX", () => {
+    const directObject = runRule(
+      noSpreadPropsOverDefaultsClobbersWithUndefined,
+      `interface ButtonLabels { next: string; cancel: string }
+       interface Props { buttonLabels?: any }
+       const defaultLabels = { next: "Next", cancel: "Cancel" };
+       const Wizard = (_props: { buttonLabels: ButtonLabels }) => null;
+       const WizardFunction = ({ buttonLabels = {} }: Props) => <Wizard buttonLabels={{ ...defaultLabels, ...buttonLabels }} />;`,
+    );
+    const nestedAttribute = runRule(
+      noSpreadPropsOverDefaultsClobbersWithUndefined,
+      `interface SlotAttributes { wrapper?: { style?: object } }
+       interface Props { slots: Partial<SlotAttributes> }
+       const defaultSlots = { wrapper: { style: { width: 100 } } };
+       const Skeleton = ({ slots }: Props) => {
+         const resolved = { ...defaultSlots, ...slots };
+         return <div style={resolved.wrapper?.style} />;
+       };`,
+    );
+    const destructuredSpread = runRule(
+      noSpreadPropsOverDefaultsClobbersWithUndefined,
+      `interface SlotAttributes { wrapper?: { className: string } }
+       interface Props { slots: Partial<SlotAttributes> }
+       const defaultSlots = { wrapper: { className: "root" } };
+       const Skeleton = ({ slots }: Props) => {
+         const { wrapper } = { ...defaultSlots, ...slots };
+         return <div {...wrapper} />;
+       };`,
+    );
+    const unresolvedTypeWithOptionalAccess = runRule(
+      noSpreadPropsOverDefaultsClobbersWithUndefined,
+      `import type { SlotAttributes } from "./types";
+       declare const getDefaultSlots: () => SlotAttributes;
+       const Skeleton = ({ slots }: { slots: SlotAttributes }) => {
+         const defaultSlots = getDefaultSlots();
+         const resolved = { ...defaultSlots, ...slots };
+         return <div style={resolved.wrapper?.style} />;
+       };`,
+    );
+    const reactBenchAnyLabels = runRule(
+      noSpreadPropsOverDefaultsClobbersWithUndefined,
+      `import React from "react";
+       interface WizardProps {}
+       interface WizardFunctionProps extends WizardProps {
+         buttonLabels?: any;
+         fields: unknown[];
+       }
+       const defaultLabels = { cancel: "Cancel", next: "Next" };
+       const Wizard = (_props: unknown) => null;
+       const WizardFunction: React.FC<WizardFunctionProps> = ({ buttonLabels = {}, fields, ...props }) => (
+         <Wizard {...props} fields={fields} buttonLabels={{ ...defaultLabels, ...buttonLabels }} />
+       );`,
+    );
+    expect(directObject.diagnostics).toHaveLength(1);
+    expect(nestedAttribute.diagnostics).toHaveLength(1);
+    expect(destructuredSpread.diagnostics).toHaveLength(1);
+    expect(unresolvedTypeWithOptionalAccess.diagnostics).toHaveLength(1);
+    expect(reactBenchAnyLabels.diagnostics).toHaveLength(1);
+  });
+
+  it("keeps repaired and non-optional JSX sinks quiet", () => {
+    const requiredKeys = runRule(
+      noSpreadPropsOverDefaultsClobbersWithUndefined,
+      `interface ButtonLabels { next: string }
+       interface Props { buttonLabels: ButtonLabels }
+       const defaultLabels = { next: "Next" };
+       const Wizard = (_props: { buttonLabels: ButtonLabels }) => null;
+       const WizardFunction = ({ buttonLabels }: Props) => <Wizard buttonLabels={{ ...defaultLabels, ...buttonLabels }} />;`,
+    );
+    const finalDefaults = runRule(
+      noSpreadPropsOverDefaultsClobbersWithUndefined,
+      `interface ButtonLabels { next?: string }
+       interface Props { buttonLabels: ButtonLabels }
+       const defaultLabels = { next: "Next" };
+       const Wizard = (_props: { buttonLabels: Required<ButtonLabels> }) => null;
+       const WizardFunction = ({ buttonLabels }: Props) => <Wizard buttonLabels={{ ...defaultLabels, ...buttonLabels, ...defaultLabels }} />;`,
+    );
+    const attributeFallback = runRule(
+      noSpreadPropsOverDefaultsClobbersWithUndefined,
+      `interface SlotAttributes { wrapper?: { style?: object } }
+       interface Props { slots: Partial<SlotAttributes> }
+       const defaultSlots = { wrapper: { style: { width: 100 } } };
+       const Skeleton = ({ slots }: Props) => {
+         const resolved = { ...defaultSlots, ...slots };
+         return <div style={resolved.wrapper?.style ?? {}} />;
+       };`,
+    );
+    const spreadFallback = runRule(
+      noSpreadPropsOverDefaultsClobbersWithUndefined,
+      `interface SlotAttributes { wrapper?: { className: string } }
+       interface Props { slots: Partial<SlotAttributes> }
+       const defaultSlots = { wrapper: { className: "root" } };
+       const Skeleton = ({ slots }: Props) => {
+         const { wrapper } = { ...defaultSlots, ...slots };
+         return <div {...(wrapper ?? {})} />;
+       };`,
+    );
+    const unresolvedTypeWithoutOptionalAccess = runRule(
+      noSpreadPropsOverDefaultsClobbersWithUndefined,
+      `import type { SlotAttributes } from "./types";
+       declare const getDefaultSlots: () => SlotAttributes;
+       const Skeleton = ({ slots }: { slots: SlotAttributes }) => {
+         const defaultSlots = getDefaultSlots();
+         const resolved = { ...defaultSlots, ...slots };
+         return <div style={resolved.wrapper.style} />;
+       };`,
+    );
+    const opaqueDefaultsWithLaterRepair = runRule(
+      noSpreadPropsOverDefaultsClobbersWithUndefined,
+      `interface Props { width?: number }
+       declare const getDefaults: () => { width: number };
+       const Panel = (props: Props) => {
+         const defaults = getDefaults();
+         const merged = { ...defaults, ...props, width: 100 };
+         return <div data-width={merged.width} />;
+       };`,
+    );
+    expect(requiredKeys.diagnostics).toHaveLength(0);
+    expect(finalDefaults.diagnostics).toHaveLength(0);
+    expect(attributeFallback.diagnostics).toHaveLength(0);
+    expect(spreadFallback.diagnostics).toHaveLength(0);
+    expect(unresolvedTypeWithoutOptionalAccess.diagnostics).toHaveLength(0);
+    expect(opaqueDefaultsWithLaterRepair.diagnostics).toHaveLength(0);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-spread-props-over-defaults-clobbers-with-undefined.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-spread-props-over-defaults-clobbers-with-undefined.ts
@@ -15,6 +15,7 @@ import { resolveConstIdentifierRootSymbol } from "../../utils/resolve-const-iden
 import type { RuleContext } from "../../utils/rule-context.js";
 import { statementTerminates } from "../../utils/statement-terminates.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import { symbolHasReactComponentTypeAnnotation } from "../../utils/symbol-has-react-component-type-annotation.js";
 
 const MESSAGE =
   "Spreading props after defaults can replace a declared default with explicit undefined before that value reaches a computation. Reapply the default with ?? or strip undefined keys before merging.";
@@ -215,6 +216,7 @@ const typeAllowsUndefinedForKey = (
   if (!typeNode) return false;
   const inner = unwrapTypeAnnotation(typeNode);
   if (!inner) return true;
+  if (isNodeOfType(inner, "TSAnyKeyword")) return true;
   if (isNodeOfType(inner, "TSTypeAliasDeclaration")) {
     return typeAllowsUndefinedForKey(inner.typeAnnotation, keyName, context, visitedTypeSymbolIds);
   }
@@ -266,17 +268,40 @@ const typeAllowsUndefinedForKey = (
   );
 };
 
+const getContextualFunctionParameterType = (
+  functionNode: EsTreeNode,
+  context: RuleContext,
+): EsTreeNode | null => {
+  const functionRoot = findTransparentExpressionRoot(functionNode);
+  const declarator = functionRoot.parent;
+  if (
+    !isNodeOfType(declarator, "VariableDeclarator") ||
+    declarator.init !== functionRoot ||
+    !isNodeOfType(declarator.id, "Identifier")
+  ) {
+    return null;
+  }
+  const functionSymbol = context.scopes.symbolFor(declarator.id);
+  if (!functionSymbol || !symbolHasReactComponentTypeAnnotation(functionSymbol, context.scopes)) {
+    return null;
+  }
+  const annotation = unwrapTypeAnnotation(declarator.id.typeAnnotation);
+  if (!annotation || !isNodeOfType(annotation, "TSTypeReference")) return null;
+  return annotation.typeArguments?.params[0] ?? null;
+};
+
 const getFunctionParameterType = (
   functionNode: EsTreeNode,
   parameterSymbolId: number,
   context: RuleContext,
 ): EsTreeNode | null => {
   if (!isFunctionLike(functionNode)) return null;
-  for (const parameter of functionNode.params) {
+  const contextualParameterType = getContextualFunctionParameterType(functionNode, context);
+  for (const [parameterIndex, parameter] of functionNode.params.entries()) {
     const pattern = isNodeOfType(parameter, "AssignmentPattern") ? parameter.left : parameter;
-    const patternType = unwrapTypeAnnotation(
-      "typeAnnotation" in pattern ? pattern.typeAnnotation : null,
-    );
+    const patternType =
+      unwrapTypeAnnotation("typeAnnotation" in pattern ? pattern.typeAnnotation : null) ??
+      (parameterIndex === 0 ? contextualParameterType : null);
     if (isNodeOfType(pattern, "Identifier")) {
       if (context.scopes.symbolFor(pattern)?.id === parameterSymbolId) return patternType;
       continue;
@@ -290,6 +315,22 @@ const getFunctionParameterType = (
       ) {
         return patternType;
       }
+      if (!isNodeOfType(property, "Property")) continue;
+      const bindingPattern = isNodeOfType(property.value, "AssignmentPattern")
+        ? property.value.left
+        : property.value;
+      if (
+        !isNodeOfType(bindingPattern, "Identifier") ||
+        context.scopes.symbolFor(bindingPattern)?.id !== parameterSymbolId
+      ) {
+        continue;
+      }
+      const propertyName = getStaticPropertyKeyName(property, { allowComputedString: true });
+      if (!propertyName || !patternType) return null;
+      const parameterProperty = getTypeProperty(patternType, propertyName, context, new Set());
+      return parameterProperty && isNodeOfType(parameterProperty, "TSPropertySignature")
+        ? unwrapTypeAnnotation(parameterProperty.typeAnnotation)
+        : null;
     }
   }
   return null;
@@ -326,6 +367,38 @@ const unwrapSafeFallback = (node: EsTreeNode): EsTreeNode => {
   return current;
 };
 
+const expressionFeedsJsxAttribute = (expression: EsTreeNode): boolean => {
+  const expressionRoot = findTransparentExpressionRoot(expression);
+  const parent = expressionRoot.parent;
+  if (isNodeOfType(parent, "JSXSpreadAttribute")) {
+    return parent.argument === expressionRoot;
+  }
+  return Boolean(
+    isNodeOfType(parent, "JSXExpressionContainer") &&
+    parent.expression === expressionRoot &&
+    isNodeOfType(parent.parent, "JSXAttribute") &&
+    parent.parent.value === parent,
+  );
+};
+
+const expressionUsesOptionalMemberAccess = (expression: EsTreeNode): boolean => {
+  let current = expression;
+  while (current.parent) {
+    const parent = current.parent;
+    if (isNodeOfType(parent, "MemberExpression") && parent.object === current) {
+      if (parent.optional) return true;
+      current = parent;
+      continue;
+    }
+    if (isNodeOfType(parent, "ChainExpression") || isNodeOfType(parent, "TSNonNullExpression")) {
+      current = parent;
+      continue;
+    }
+    return false;
+  }
+  return false;
+};
+
 const referenceFeedsComputation = (reference: EsTreeNode, context: RuleContext): boolean => {
   let current = unwrapSafeFallback(reference);
   let parent = current.parent;
@@ -348,6 +421,7 @@ const referenceFeedsComputation = (reference: EsTreeNode, context: RuleContext):
     current = parent;
     parent = current.parent;
   }
+  if (expressionFeedsJsxAttribute(current)) return true;
   if (!parent) return false;
   if (isNodeOfType(parent, "BinaryExpression")) {
     if (["===", "!==", "==", "!="].includes(parent.operator)) {
@@ -624,6 +698,7 @@ const scalarSymbolFeedsComputation = (
   visitedSymbolIds: Set<number>,
   lowerBoundStart = Number.NEGATIVE_INFINITY,
   upperBoundStart = Number.POSITIVE_INFINITY,
+  requiresOptionalMemberAccess = false,
 ): boolean => {
   if (visitedSymbolIds.has(symbolId)) return false;
   visitedSymbolIds.add(symbolId);
@@ -645,7 +720,12 @@ const scalarSymbolFeedsComputation = (
     const identifier = reference.identifier;
     const referenceStart = getNodeStart(identifier);
     if (referenceStart <= lowerBoundStart || referenceStart >= nextWriteStart) continue;
-    if (referenceFeedsComputation(identifier, context)) return true;
+    if (
+      (!requiresOptionalMemberAccess || expressionUsesOptionalMemberAccess(identifier)) &&
+      referenceFeedsComputation(identifier, context)
+    ) {
+      return true;
+    }
     const expressionRoot = findTransparentExpressionRoot(identifier);
     const parent = expressionRoot.parent;
     if (
@@ -662,6 +742,8 @@ const scalarSymbolFeedsComputation = (
           symbolById,
           new Set(visitedSymbolIds),
           getNodeStart(parent),
+          Number.POSITIVE_INFINITY,
+          requiresOptionalMemberAccess,
         )
       ) {
         return true;
@@ -683,6 +765,8 @@ const scalarSymbolFeedsComputation = (
           symbolById,
           new Set(visitedSymbolIds),
           getNodeStart(parent),
+          Number.POSITIVE_INFINITY,
+          requiresOptionalMemberAccess,
         )
       ) {
         return true;
@@ -711,10 +795,14 @@ const objectSymbolFeedsComputation = (
     if (isNodeOfType(parent, "MemberExpression") && parent.object === identifier) {
       const keyName = getStaticPropertyName(parent);
       const priorWrite = getMemberPriorWrite(parent, symbol, context, repairStartsBySymbolAndBlock);
+      const typeAllowsUndefined = Boolean(
+        keyName && typeAllowsUndefinedForKey(parameterType, keyName, context),
+      );
       if (
         keyName &&
         (candidateKeys === null || candidateKeys.has(keyName)) &&
-        typeAllowsUndefinedForKey(parameterType, keyName, context) &&
+        ((candidateKeys !== null && typeAllowsUndefined) ||
+          expressionUsesOptionalMemberAccess(parent)) &&
         !priorWrite?.isSafe &&
         !memberUseIsGuarded(parent, symbol, keyName, context, priorWrite) &&
         referenceFeedsComputation(parent, context)
@@ -724,7 +812,8 @@ const objectSymbolFeedsComputation = (
       if (
         keyName &&
         (candidateKeys === null || candidateKeys.has(keyName)) &&
-        typeAllowsUndefinedForKey(parameterType, keyName, context) &&
+        ((candidateKeys !== null && typeAllowsUndefined) ||
+          expressionUsesOptionalMemberAccess(parent)) &&
         !priorWrite?.isSafe &&
         !memberUseIsGuarded(parent, symbol, keyName, context, priorWrite)
       ) {
@@ -774,10 +863,12 @@ const objectSymbolFeedsComputation = (
     for (const property of parent.id.properties) {
       if (!isNodeOfType(property, "Property")) continue;
       const keyName = getStaticPropertyKeyName(property, { allowComputedString: true });
+      const typeAllowsUndefined = Boolean(
+        keyName && typeAllowsUndefinedForKey(parameterType, keyName, context),
+      );
       if (
         !keyName ||
         (candidateKeys !== null && !candidateKeys.has(keyName)) ||
-        !typeAllowsUndefinedForKey(parameterType, keyName, context) ||
         isNodeOfType(property.value, "AssignmentPattern")
       ) {
         continue;
@@ -791,6 +882,9 @@ const objectSymbolFeedsComputation = (
             context,
             symbolById,
             new Set(visitedSymbolIds),
+            Number.NEGATIVE_INFINITY,
+            Number.POSITIVE_INFINITY,
+            candidateKeys === null || !typeAllowsUndefined,
           )
         ) {
           return true;
@@ -811,12 +905,20 @@ const objectExpressionFeedsComputation = (
 ): boolean => {
   const parent = objectExpression.parent;
   if (!parent) return false;
+  if (
+    expressionFeedsJsxAttribute(objectExpression) &&
+    candidateKeys !== null &&
+    [...candidateKeys].some((keyName) => typeAllowsUndefinedForKey(parameterType, keyName, context))
+  ) {
+    return true;
+  }
   if (isNodeOfType(parent, "MemberExpression") && parent.object === objectExpression) {
     const keyName = getStaticPropertyName(parent);
     return Boolean(
       keyName &&
       (candidateKeys === null || candidateKeys.has(keyName)) &&
-      typeAllowsUndefinedForKey(parameterType, keyName, context) &&
+      ((candidateKeys !== null && typeAllowsUndefinedForKey(parameterType, keyName, context)) ||
+        expressionUsesOptionalMemberAccess(parent)) &&
       referenceFeedsComputation(parent, context),
     );
   }
@@ -840,17 +942,30 @@ const objectExpressionFeedsComputation = (
   for (const property of parent.id.properties) {
     if (!isNodeOfType(property, "Property")) continue;
     const keyName = getStaticPropertyKeyName(property, { allowComputedString: true });
+    const typeAllowsUndefined = Boolean(
+      keyName && typeAllowsUndefinedForKey(parameterType, keyName, context),
+    );
     if (
       !keyName ||
       (candidateKeys !== null && !candidateKeys.has(keyName)) ||
-      !typeAllowsUndefinedForKey(parameterType, keyName, context) ||
       isNodeOfType(property.value, "AssignmentPattern") ||
       !isNodeOfType(property.value, "Identifier")
     ) {
       continue;
     }
     const symbol = context.scopes.symbolFor(property.value);
-    if (symbol && scalarSymbolFeedsComputation(symbol.id, context, symbolById, new Set())) {
+    if (
+      symbol &&
+      scalarSymbolFeedsComputation(
+        symbol.id,
+        context,
+        symbolById,
+        new Set(),
+        Number.NEGATIVE_INFINITY,
+        Number.POSITIVE_INFINITY,
+        candidateKeys === null || !typeAllowsUndefined,
+      )
+    ) {
       return true;
     }
   }
@@ -894,6 +1009,7 @@ export const noSpreadPropsOverDefaultsClobbersWithUndefined = defineRule({
           const parameterSymbolId = resolveParameterSourceSymbol(propsSource, context);
           if (parameterSymbolId === null) continue;
           const defaultedKeys = new Set<string>();
+          let hasUnknownDefaultedKeys = false;
           for (const possibleDefaultsSpread of spreadProperties.slice(0, propsIndex)) {
             const defaultsSource = stripParenExpression(possibleDefaultsSpread.argument);
             if (!isDefaultsSource(defaultsSource)) continue;
@@ -902,14 +1018,21 @@ export const noSpreadPropsOverDefaultsClobbersWithUndefined = defineRule({
               context,
               propertyWriteCache,
             );
-            if (!visiblePropertyWrites) continue;
+            if (!visiblePropertyWrites) {
+              hasUnknownDefaultedKeys = true;
+              continue;
+            }
             for (const [keyName, isSafe] of visiblePropertyWrites) {
               if (isSafe) defaultedKeys.add(keyName);
             }
           }
-          if (defaultedKeys.size === 0) continue;
+          if (defaultedKeys.size === 0 && !hasUnknownDefaultedKeys) continue;
           const lastExplicitWriteByKey = new Map<string, boolean>();
           const propsSpreadStart = getNodeStart(propsSpread);
+          const hasWriteAfterProps = node.properties.some(
+            (property) => getNodeStart(property) > propsSpreadStart,
+          );
+          if (hasUnknownDefaultedKeys && hasWriteAfterProps) continue;
           for (const property of node.properties) {
             if (getNodeStart(property) <= propsSpreadStart) continue;
             if (isNodeOfType(property, "Property")) {
@@ -937,10 +1060,14 @@ export const noSpreadPropsOverDefaultsClobbersWithUndefined = defineRule({
               if (defaultedKeys.has(keyName)) lastExplicitWriteByKey.set(keyName, isSafe);
             }
           }
-          const candidateKeys = new Set(
-            [...defaultedKeys].filter((keyName) => lastExplicitWriteByKey.get(keyName) !== true),
-          );
-          if (candidateKeys.size === 0) continue;
+          const candidateKeys = hasUnknownDefaultedKeys
+            ? null
+            : new Set(
+                [...defaultedKeys].filter(
+                  (keyName) => lastExplicitWriteByKey.get(keyName) !== true,
+                ),
+              );
+          if (candidateKeys?.size === 0) continue;
           const parameterType = getFunctionParameterType(
             enclosingFunction,
             parameterSymbolId,


### PR DESCRIPTION
## Why

React Bench exposed 16 confirmed gap rows representing 15 unique findings for `no-spread-props-over-defaults-clobbers-with-undefined`. The missed shapes destructure props, rely on a verified React component contextual type, or pass the merged object or a member directly into JSX.

## What changed

- resolve destructured parameter property types, including verified `React.FC<Props>` contextual props and `any` property maps
- recognize direct JSX attribute and JSX spread consumers
- permit opaque default-named providers only when no later write exists and optional access at the JSX sink independently proves undefined is possible
- preserve fallbacks, required keys, later repairs, unresolved non-optional types, and non-component abstentions
- add a patch changeset

## Evaluation

- exact React Bench replay: 16/16 frozen rows recovered, 15/15 reconstructed surfaces, 15 unique diagnostics, 0 reconstruction failures
- strict fuzz: 500 iterations with invariants, no findings; stats probe fired 2 programs out of 38 executed
- RDE local sample was invalid because the current RDE decoder expects JSON schema version 1 while React Doctor emits version 3; its zero-hit digest is not treated as clean evidence

## Test plan

- focused plugin suite: 962 files passed, 25,093 tests passed, 201 skipped
- full test: 15/15 Turbo tasks passed
- full typecheck: 16/16 Turbo tasks passed
- lint passed with existing corpus warnings
- format and format check passed
- full build: 9/9 Turbo tasks passed
- JSON report smoke passed at schema version 3
- exact React Bench replay passed after commit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes static-analysis behavior for a warn-level lint rule; broader JSX and typing heuristics may shift diagnostics in real codebases despite added tests.
> 
> **Overview**
> Extends **`no-spread-props-over-defaults-clobbers-with-undefined`** so merges like `{ ...defaults, ...props }` are flagged when the clobbered value flows into **JSX attributes or spreads**, not only into numeric or other non-JSX computations.
> 
> Parameter typing is richer: destructured props get per-key types, **`React.FC<Props>`** supplies contextual props when the parameter lacks an annotation, and **`any`** props are treated as allowing undefined. **Optional chaining** on members can satisfy “undefined is possible” when default keys are opaque or unknown.
> 
> Opaque default sources no longer block the rule entirely—unknown defaulted keys widen the candidate set unless a later spread/write repairs the merge. Existing quiet cases (required keys, `??` fallbacks, later repairs, non-component functions) stay covered by new tests. Patch **changeset** for `oxlint-plugin-react-doctor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10a4e268c9c4b1ac7a28a211071747f9da4735a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


## Current-main parity

| Check | Result |
| --- | --- |
| Current main / base | `6b64dfaf9e973139d1df2d09f405c9d916e158a3` |
| PR head | `10a4e268c9c4b1ac7a28a211071747f9da4735a1` |
| Prospective merge | `15ef3b1b9ad74d7e7281a2490f7101bff543bfb3` |
| Projects compared | `2,000 / 2,000` |
| Skipped projects | `0` |
| Added / removed | `+7 / -0` |
| Target-rule delta | `+7 / -0` |
| Exact adjudication | `7 TP, 0 FP, 0 reconstruction failures` |

All seven additions were reconstructed at their pinned repository commits and independently matched the refreshed rule contract. No current-main parity correctness blocker was found. Evaluation: `de00d4ee-f196-45f3-9012-c1c45e7e1dfb`; parity artifact SHA-256: `7534ffb9b49bc3eb9e3412498d5eba10b6b10d52755b2aad05fae0e6718e0bb8`.
