### PR TITLE
chore: use preinstalled Chrome for Playwright in CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "devDependencies": {
     "@changesets/changelog-github": "^0.7.0",
     "@changesets/cli": "^2.31.0",
+    "@playwright/test": "1.62.0",
     "@rayhanadev/truffler": "^0.4.2",
     "@sentry/cli": "^3.4.3",
     "@types/node": "^25.6.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "@playwright/test";
+
+const isCI = Boolean(process.env.CI);
+
+export default defineConfig({
+  use: {
+    channel: isCI ? "chrome" : undefined,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
       '@changesets/cli':
         specifier: ^2.31.0
         version: 2.31.0(@types/node@25.6.0)
+      '@playwright/test':
+        specifier: 1.62.0
+        version: 1.62.0
       '@rayhanadev/truffler':
         specifier: ^0.4.2
         version: 0.4.2
@@ -2149,6 +2152,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@playwright/test@1.62.0':
+    resolution: {integrity: sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA==}
+    engines: {node: '>=20'}
+    hasBin: true
+
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
@@ -3251,6 +3259,11 @@ packages:
     resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
     engines: {node: '>=6 <7 || >=8'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -3844,6 +3857,16 @@ packages:
 
   pixelmatch@7.2.0:
     resolution: {integrity: sha512-xhcb4yHu9sM/G7foGzoLtXYcC0zHEaOXXjRKhGup0fw78Nf2Tkiapv4EQyMzrbcmQPsllAI7DbFY2UT7PlI9Pg==}
+    hasBin: true
+
+  playwright-core@1.62.0:
+    resolution: {integrity: sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.0:
+    resolution: {integrity: sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==}
+    engines: {node: '>=20'}
     hasBin: true
 
   pngjs@7.0.0:
@@ -6007,6 +6030,10 @@ snapshots:
   '@oxlint/binding-win32-x64-msvc@1.76.0':
     optional: true
 
+  '@playwright/test@1.62.0':
+    dependencies:
+      playwright: 1.62.0
+
   '@polka/url@1.0.0-next.29': {}
 
   '@protobufjs/aspromise@1.1.2': {}
@@ -7089,6 +7116,9 @@ snapshots:
       jsonfile: 4.0.0
       universalify: 0.1.2
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -7726,6 +7756,14 @@ snapshots:
   pixelmatch@7.2.0:
     dependencies:
       pngjs: 7.0.0
+
+  playwright-core@1.62.0: {}
+
+  playwright@1.62.0:
+    dependencies:
+      playwright-core: 1.62.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   pngjs@7.0.0: {}
 


### PR DESCRIPTION
## Summary

- add a root Playwright configuration
- select the preinstalled `chrome` channel when `CI` is set
- keep Playwright's default browser channel for local runs
- add `@playwright/test` as a root development dependency

## Why

GitHub Actions runners already provide Chrome. Selecting that channel in CI lets Playwright use the runner-provided browser while preserving the default local development behavior.

## Validation

- `nr format:check -- playwright.config.ts`
- `nr lint -- playwright.config.ts`
- asserted the resolved channel is unset locally and `chrome` under `CI=1`
- `nr typecheck` (16/16 tasks passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test tooling and CI browser selection only; no application or production runtime behavior changes.
> 
> **Overview**
> Adds **root Playwright setup** so browser tests can run in CI without downloading Playwright’s bundled Chromium.
> 
> A new `playwright.config.ts` sets `use.channel` to **`chrome` when `CI` is set**, so runs on GitHub Actions use the runner’s preinstalled Chrome; locally `channel` stays unset so Playwright keeps its default browser behavior. **`@playwright/test` 1.62.0** is added as a root dev dependency with lockfile updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8105a5c83ae3a7c70c22d500f2a4132ef109a7d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->