### PR TITLE
feat(evals): add incremental parity caching

### DIFF
--- a/.agents/skills/run-parity/SKILL.md
+++ b/.agents/skills/run-parity/SKILL.md
@@ -39,6 +39,65 @@ nr --silent eval \
   > <absolute-run-directory>/candidate.ndjson
 ```
 
+Cache a successful baseline only under its exact React Doctor commit, corpus
+manifest hash, evaluator schema, and ruleset/config hash. A cached baseline must
+still pass the streaming validator before reuse. PRs may share that immutable
+baseline, but never combine their candidate heads or deltas.
+
+The evaluator stamps every record with the exact detector commit, revision-local
+rule/config hash, and evaluator source hash. Never cache an older unstamped run.
+After the normal input validator passes, create the adjacent provenance file:
+
+```sh
+node .agents/skills/run-parity/scripts/baseline-cache-provenance.mjs create \
+  --baseline <baseline.ndjson> \
+  --corpus-manifest <corpus-manifest.json> \
+  --base-commit <full-base-commit> \
+  --repository <react-doctor-repository-url> \
+  --evaluator-source-hash <packages-evals-source-hash> \
+  --config-contract revision-local-rule-config-v1 \
+  --rule-set-hash <stamped-full-ruleset-hash>
+```
+
+Get the expected evaluator hash with `nr --silent source-hash` from
+`packages/evals`. Before every reuse, run the same command with `verify`.
+Verification streams the raw NDJSON bytes, requires full-baseline `ruleKeys: []`,
+checks every record's producer, and independently requires the exact pinned
+corpus project set to match its manifest. Any mismatch is a cache miss.
+
+For rule-only pull requests, build the conservative impact manifest before the
+candidate run:
+
+```sh
+node .agents/skills/run-parity/scripts/find-impacted-rules.mjs \
+  <repository-root> <base-ref> <head-ref> <impact.json>
+```
+
+Use incremental mode only when the manifest reports `"mode": "incremental"`.
+Its `candidateRuleKeys` already includes known diagnostic-interaction closure.
+Write those keys unchanged to the rules JSON and pass each as a repeatable
+candidate argument:
+
+```sh
+nr --silent eval \
+  --repositories <validated-baseline-or-corpus-manifest> \
+  --react-doctor-repository <head-repository-url> \
+  --react-doctor-ref <headRefOid> \
+  --rule <plugin/rule> \
+  > <absolute-run-directory>/candidate-scoped.ndjson
+```
+
+The evaluator stamps every unselected revision-local rule `off`. When the
+scope contains no security-scan rule it also skips that whole-tree pass.
+Security-scan rule changes, global runner/config/report/registry changes,
+removed or renamed rule IDs, unresolved runtime edges, parse failures, and
+other uncertain dependency surfaces fall back to full parity.
+
+Every run keeps its hard outer timeout. Short evaluator budgets cap aggregate
+retry reserve at 25% of the time remaining when an attempt starts, leaving at
+least 75% for active work instead of letting snapshot build consume the whole
+first-attempt deadline.
+
 The baseline records resolved repository hashes. Reusing the baseline as the candidate corpus prevents default branches from moving between runs.
 
 Before the candidate run, stream-validate every baseline record. This rejects unpinned repositories, evaluation errors, malformed reports, and incomplete projects without loading the NDJSON corpus into memory:
@@ -76,10 +135,54 @@ The comparator streams both NDJSON inputs, stages baseline records in the system
 
 For exit code `1`, inspect affected source locations before classifying changes.
 
+For a scoped comparison, filter the full baseline to the same rule and
+always-on invariant scope:
+
+```sh
+node .agents/skills/run-parity/scripts/compare-parity.mjs \
+  --rules <rules.json> \
+  <baseline.ndjson> \
+  <candidate-scoped.ndjson> \
+  > <run-directory>/parity-scoped.json
+```
+
+The scoped comparator rejects arbitrary out-of-scope candidate diagnostics,
+requires exact project/framework/analyzed-file coverage, preserves duplicate
+multiplicity, and compares every semantic diagnostic field including canonical
+primary and related paths.
+
+Build compact Merkle indexes when the same baseline or candidate will be
+compared more than once:
+
+```sh
+node .agents/skills/run-parity/scripts/build-parity-index.mjs \
+  --rules <rules.json> <baseline.ndjson> \
+  > <baseline.index.json>
+
+node .agents/skills/run-parity/scripts/build-parity-index.mjs \
+  --candidate --rules <rules.json> <candidate-scoped.ndjson> \
+  > <candidate.index.json>
+
+node .agents/skills/run-parity/scripts/compare-parity-indexes.mjs \
+  <baseline.index.json> <candidate.index.json> \
+  > <index-diff.json>
+```
+
+Equal whole-run roots stop immediately. Differing roots descend through rule
+hashes and then project buckets. Empty project/rule buckets are explicit, and
+scope or coverage metadata drift fails closed.
+
+Until incremental parity has enough shadow history to become a required gate,
+run one full candidate at the exact same head/corpus/concurrency policy and
+require its rule-filtered output to match the scoped candidate exactly. Report
+measured wall time and project latency; do not project a speedup from samples.
+
 Validate comparator changes from the repository root:
 
 ```sh
 node --test .agents/skills/run-parity/scripts/compare-parity.test.mjs
+node --test .agents/skills/run-parity/scripts/find-impacted-rules.test.mjs
+node --test .agents/skills/run-parity/scripts/parity-index.test.mjs
 node --test .agents/skills/run-parity/scripts/validate-parity-input.test.mjs
 ```
 

--- a/.agents/skills/run-parity/SKILL.md
+++ b/.agents/skills/run-parity/SKILL.md
@@ -91,7 +91,10 @@ The evaluator stamps every unselected revision-local rule `off`. When the
 scope contains no security-scan rule it also skips that whole-tree pass.
 Security-scan rule changes, global runner/config/report/registry changes,
 removed or renamed rule IDs, unresolved runtime edges, parse failures, and
-other uncertain dependency surfaces fall back to full parity.
+other uncertain dependency surfaces fall back to full parity. Plugin utilities
+that reach a host module without first crossing a mapped rule boundary also
+fall back to full parity. A manifest with no runtime rule impact uses full mode;
+never construct an empty incremental rule scope.
 
 Every run keeps its hard outer timeout. Short evaluator budgets cap aggregate
 retry reserve at 25% of the time remaining when an attempt starts, leaving at

--- a/.agents/skills/run-parity/scripts/baseline-cache-provenance.mjs
+++ b/.agents/skills/run-parity/scripts/baseline-cache-provenance.mjs
@@ -1,0 +1,412 @@
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { readFile, rename, writeFile } from "node:fs/promises";
+import { basename, dirname, extname, join, resolve } from "node:path";
+import { StringDecoder } from "node:string_decoder";
+import { fileURLToPath } from "node:url";
+import { compareStrings } from "./compare-parity.mjs";
+
+const PROVENANCE_SCHEMA_VERSION = 1;
+const PROCESS_ARGUMENT_START_INDEX = 2;
+const OPTION_ARGUMENT_STRIDE = 2;
+const OPTION_PREFIX_LENGTH = 2;
+const GIT_COMMIT_PATTERN = /^[0-9a-f]{40}$/i;
+const SHA256_PATTERN = /^[0-9a-f]{64}$/;
+const REQUIRED_OPTIONS = [
+  "baseline",
+  "corpus-manifest",
+  "base-commit",
+  "repository",
+  "evaluator-source-hash",
+  "config-contract",
+  "rule-set-hash",
+];
+const ALLOWED_OPTIONS = new Set([...REQUIRED_OPTIONS, "provenance"]);
+const PRODUCER_KEYS = [
+  "configContract",
+  "evaluatorSourceHash",
+  "reactDoctorCommit",
+  "reactDoctorRepository",
+  "ruleKeys",
+  "ruleSetHash",
+];
+const PROJECT_KEYS = ["name", "org", "ref", "rootDir"];
+
+const hashBytes = (contents) => createHash("sha256").update(contents).digest("hex");
+
+const canonicalizeJsonValue = (value) => {
+  if (Array.isArray(value)) return value.map(canonicalizeJsonValue);
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([leftKey], [rightKey]) => compareStrings(leftKey, rightKey))
+        .map(([key, innerValue]) => [key, canonicalizeJsonValue(innerValue)]),
+    );
+  }
+  return value;
+};
+
+const serializeCanonicalValue = (value) => JSON.stringify(canonicalizeJsonValue(value));
+
+const hashCanonicalValue = (value) => hashBytes(serializeCanonicalValue(value));
+
+const getDefaultProvenancePath = (baselinePath) => {
+  const extension = extname(baselinePath);
+  const stem = extension.length === 0 ? basename(baselinePath) : basename(baselinePath, extension);
+  return join(dirname(baselinePath), `${stem}.provenance.json`);
+};
+
+const assertExactKeys = (value, expectedKeys, description) => {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${description} must be an object`);
+  }
+  const actualKeys = Object.keys(value).sort(compareStrings);
+  const sortedExpectedKeys = [...expectedKeys].sort(compareStrings);
+  if (serializeCanonicalValue(actualKeys) !== serializeCanonicalValue(sortedExpectedKeys)) {
+    throw new Error(`${description} has unexpected fields`);
+  }
+};
+
+const assertNonemptyString = (value, description) => {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`${description} must be a nonempty string`);
+  }
+};
+
+const assertSha256 = (value, description) => {
+  if (typeof value !== "string" || !SHA256_PATTERN.test(value)) {
+    throw new Error(`${description} must be a lowercase SHA-256 digest`);
+  }
+};
+
+const assertPositiveSafeInteger = (value, description) => {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`${description} must be a positive safe integer`);
+  }
+};
+
+const validateProducer = (producer, description) => {
+  assertExactKeys(producer, PRODUCER_KEYS, description);
+  assertNonemptyString(producer.reactDoctorRepository, `${description}.reactDoctorRepository`);
+  assertNonemptyString(producer.reactDoctorCommit, `${description}.reactDoctorCommit`);
+  if (!GIT_COMMIT_PATTERN.test(producer.reactDoctorCommit)) {
+    throw new Error(`${description}.reactDoctorCommit must be a 40-character commit`);
+  }
+  assertSha256(producer.evaluatorSourceHash, `${description}.evaluatorSourceHash`);
+  assertNonemptyString(producer.configContract, `${description}.configContract`);
+  assertSha256(producer.ruleSetHash, `${description}.ruleSetHash`);
+  if (
+    !Array.isArray(producer.ruleKeys) ||
+    producer.ruleKeys.some((ruleKey) => typeof ruleKey !== "string")
+  ) {
+    throw new Error(`${description}.ruleKeys must be a string array`);
+  }
+};
+
+const buildExpectedProducer = ({
+  reactDoctorRepository,
+  reactDoctorCommit,
+  evaluatorSourceHash,
+  configContract,
+  ruleSetHash,
+}) => {
+  const producer = {
+    reactDoctorRepository,
+    reactDoctorCommit,
+    evaluatorSourceHash,
+    configContract,
+    ruleSetHash,
+    ruleKeys: [],
+  };
+  validateProducer(producer, "expected producer");
+  return producer;
+};
+
+const canonicalizeProjectTuple = (repository, description) => {
+  assertExactKeys(repository, PROJECT_KEYS, description);
+  for (const key of PROJECT_KEYS) {
+    assertNonemptyString(repository[key], `${description}.${key}`);
+  }
+  if (!GIT_COMMIT_PATTERN.test(repository.ref)) {
+    throw new Error(`${description}.ref must be a 40-character commit`);
+  }
+  return [repository.org, repository.name, repository.ref, repository.rootDir];
+};
+
+const buildProjectSet = (repositories, description) => {
+  if (!Array.isArray(repositories) || repositories.length === 0) {
+    throw new Error(`${description} must be a nonempty array`);
+  }
+  const tupleKeys = repositories.map((repository, index) =>
+    JSON.stringify(canonicalizeProjectTuple(repository, `${description}[${index}]`)),
+  );
+  const uniqueTupleKeys = new Set(tupleKeys);
+  if (uniqueTupleKeys.size !== tupleKeys.length) {
+    throw new Error(`${description} contains duplicate project tuples`);
+  }
+  return [...uniqueTupleKeys].sort(compareStrings).map((tupleKey) => JSON.parse(tupleKey));
+};
+
+const loadCorpusManifest = async (manifestPath) => {
+  const contents = await readFile(manifestPath);
+  let repositories;
+  try {
+    repositories = JSON.parse(contents.toString("utf8"));
+  } catch (error) {
+    throw new Error(`Corpus manifest is not valid JSON: ${error.message}`);
+  }
+  const projectSet = buildProjectSet(repositories, "corpus manifest");
+  return {
+    manifestSha256: hashBytes(contents),
+    projectCount: projectSet.length,
+    projectSet,
+    projectSetSha256: hashCanonicalValue(projectSet),
+  };
+};
+
+const scanBaseline = async ({ baselinePath, expectedProducer }) => {
+  const artifactHash = createHash("sha256");
+  const decoder = new StringDecoder("utf8");
+  const repositories = [];
+  let byteLength = 0;
+  let bufferedText = "";
+  let recordCount = 0;
+
+  const consumeLine = (line) => {
+    if (line.trim().length === 0) return;
+    let record;
+    try {
+      record = JSON.parse(line);
+    } catch (error) {
+      throw new Error(`Baseline record ${recordCount + 1} is not valid JSON: ${error.message}`);
+    }
+    if (record === null || typeof record !== "object" || Array.isArray(record)) {
+      throw new Error(`Baseline record ${recordCount + 1} must be an object`);
+    }
+    const recordNumber = recordCount + 1;
+    validateProducer(record.evaluation, `baseline record ${recordNumber}.evaluation`);
+    if (serializeCanonicalValue(record.evaluation) !== serializeCanonicalValue(expectedProducer)) {
+      throw new Error(
+        `Baseline record ${recordNumber} producer provenance does not match expected`,
+      );
+    }
+    if (record.evaluation.ruleKeys.length !== 0) {
+      throw new Error(`Baseline record ${recordNumber} is not a full baseline`);
+    }
+    repositories.push(record.repository);
+    recordCount = recordNumber;
+  };
+
+  for await (const chunk of createReadStream(baselinePath)) {
+    artifactHash.update(chunk);
+    byteLength += chunk.byteLength;
+    bufferedText += decoder.write(chunk);
+    let newlineIndex = bufferedText.indexOf("\n");
+    while (newlineIndex !== -1) {
+      consumeLine(bufferedText.slice(0, newlineIndex));
+      bufferedText = bufferedText.slice(newlineIndex + 1);
+      newlineIndex = bufferedText.indexOf("\n");
+    }
+  }
+  bufferedText += decoder.end();
+  if (bufferedText.length !== 0) consumeLine(bufferedText);
+  if (recordCount === 0) throw new Error("Baseline must contain at least one record");
+
+  const projectSet = buildProjectSet(repositories, "baseline");
+  return {
+    artifact: {
+      sha256: artifactHash.digest("hex"),
+      byteLength,
+      recordCount,
+    },
+    projectSet,
+    projectSetSha256: hashCanonicalValue(projectSet),
+  };
+};
+
+const assertProjectSetsMatch = (baseline, corpus) => {
+  if (
+    baseline.projectSetSha256 !== corpus.projectSetSha256 ||
+    serializeCanonicalValue(baseline.projectSet) !== serializeCanonicalValue(corpus.projectSet)
+  ) {
+    throw new Error("Baseline project tuple set does not exactly match the corpus manifest");
+  }
+};
+
+const buildProvenance = ({ baseline, corpus, producer }) => ({
+  schemaVersion: PROVENANCE_SCHEMA_VERSION,
+  artifact: baseline.artifact,
+  corpus: {
+    manifestSha256: corpus.manifestSha256,
+    projectSetSha256: corpus.projectSetSha256,
+    projectCount: corpus.projectCount,
+  },
+  producer,
+});
+
+const writeProvenance = async (provenancePath, provenance) => {
+  const temporaryPath = `${provenancePath}.tmp`;
+  await writeFile(temporaryPath, `${JSON.stringify(provenance, null, 2)}\n`, {
+    flag: "wx",
+  });
+  await rename(temporaryPath, provenancePath);
+};
+
+export const createBaselineCacheProvenance = async ({
+  baselinePath,
+  corpusManifestPath,
+  provenancePath = getDefaultProvenancePath(baselinePath),
+  reactDoctorRepository,
+  reactDoctorCommit,
+  evaluatorSourceHash,
+  configContract,
+  ruleSetHash,
+}) => {
+  const producer = buildExpectedProducer({
+    reactDoctorRepository,
+    reactDoctorCommit,
+    evaluatorSourceHash,
+    configContract,
+    ruleSetHash,
+  });
+  const [baseline, corpus] = await Promise.all([
+    scanBaseline({ baselinePath, expectedProducer: producer }),
+    loadCorpusManifest(corpusManifestPath),
+  ]);
+  assertProjectSetsMatch(baseline, corpus);
+  const provenance = buildProvenance({ baseline, corpus, producer });
+  await writeProvenance(provenancePath, provenance);
+  return provenance;
+};
+
+const validateProvenance = (provenance) => {
+  assertExactKeys(provenance, ["artifact", "corpus", "producer", "schemaVersion"], "provenance");
+  if (provenance.schemaVersion !== PROVENANCE_SCHEMA_VERSION) {
+    throw new Error(`Unsupported provenance schema version: ${provenance.schemaVersion}`);
+  }
+  assertExactKeys(
+    provenance.artifact,
+    ["byteLength", "recordCount", "sha256"],
+    "provenance.artifact",
+  );
+  assertExactKeys(
+    provenance.corpus,
+    ["manifestSha256", "projectCount", "projectSetSha256"],
+    "provenance.corpus",
+  );
+  assertSha256(provenance.artifact.sha256, "provenance.artifact.sha256");
+  assertPositiveSafeInteger(provenance.artifact.byteLength, "provenance.artifact.byteLength");
+  assertPositiveSafeInteger(provenance.artifact.recordCount, "provenance.artifact.recordCount");
+  assertSha256(provenance.corpus.manifestSha256, "provenance.corpus.manifestSha256");
+  assertSha256(provenance.corpus.projectSetSha256, "provenance.corpus.projectSetSha256");
+  assertPositiveSafeInteger(provenance.corpus.projectCount, "provenance.corpus.projectCount");
+  validateProducer(provenance.producer, "provenance.producer");
+};
+
+const assertExactValue = (actual, expected, description) => {
+  if (serializeCanonicalValue(actual) !== serializeCanonicalValue(expected)) {
+    throw new Error(`${description} does not match`);
+  }
+};
+
+export const verifyBaselineCacheProvenance = async ({
+  baselinePath,
+  corpusManifestPath,
+  provenancePath = getDefaultProvenancePath(baselinePath),
+  reactDoctorRepository,
+  reactDoctorCommit,
+  evaluatorSourceHash,
+  configContract,
+  ruleSetHash,
+}) => {
+  const expectedProducer = buildExpectedProducer({
+    reactDoctorRepository,
+    reactDoctorCommit,
+    evaluatorSourceHash,
+    configContract,
+    ruleSetHash,
+  });
+  const provenanceContents = await readFile(provenancePath, "utf8");
+  let provenance;
+  try {
+    provenance = JSON.parse(provenanceContents);
+  } catch (error) {
+    throw new Error(`Provenance is not valid JSON: ${error.message}`);
+  }
+  validateProvenance(provenance);
+  assertExactValue(provenance.producer, expectedProducer, "Provenance producer");
+
+  const [baseline, corpus] = await Promise.all([
+    scanBaseline({ baselinePath, expectedProducer }),
+    loadCorpusManifest(corpusManifestPath),
+  ]);
+  assertProjectSetsMatch(baseline, corpus);
+  assertExactValue(provenance.artifact, baseline.artifact, "Raw baseline artifact");
+  assertExactValue(
+    provenance.corpus,
+    {
+      manifestSha256: corpus.manifestSha256,
+      projectSetSha256: corpus.projectSetSha256,
+      projectCount: corpus.projectCount,
+    },
+    "Corpus provenance",
+  );
+  return provenance;
+};
+
+const parseCliArguments = (argumentsList) => {
+  const [mode, ...optionArguments] = argumentsList;
+  if (mode !== "create" && mode !== "verify") {
+    throw new Error("Usage: baseline-cache-provenance.mjs <create|verify> [options]");
+  }
+  const options = {};
+  for (let index = 0; index < optionArguments.length; index += OPTION_ARGUMENT_STRIDE) {
+    const option = optionArguments[index];
+    const value = optionArguments[index + 1];
+    if (!option?.startsWith("--") || value === undefined || value.startsWith("--")) {
+      throw new Error(`Invalid option near ${option ?? "<end>"}`);
+    }
+    const optionName = option.slice(OPTION_PREFIX_LENGTH);
+    if (!ALLOWED_OPTIONS.has(optionName)) throw new Error(`Unknown option: ${option}`);
+    if (options[optionName] !== undefined) throw new Error(`Duplicate option: ${option}`);
+    options[optionName] = value;
+  }
+  for (const requiredOption of REQUIRED_OPTIONS) {
+    if (options[requiredOption] === undefined) {
+      throw new Error(`Missing required option: --${requiredOption}`);
+    }
+  }
+  const baselinePath = resolve(options.baseline);
+  return {
+    mode,
+    input: {
+      baselinePath,
+      corpusManifestPath: resolve(options["corpus-manifest"]),
+      provenancePath:
+        options.provenance === undefined
+          ? getDefaultProvenancePath(baselinePath)
+          : resolve(options.provenance),
+      reactDoctorCommit: options["base-commit"],
+      reactDoctorRepository: options.repository,
+      evaluatorSourceHash: options["evaluator-source-hash"],
+      configContract: options["config-contract"],
+      ruleSetHash: options["rule-set-hash"],
+    },
+  };
+};
+
+const main = async () => {
+  const { mode, input } = parseCliArguments(process.argv.slice(PROCESS_ARGUMENT_START_INDEX));
+  const provenance =
+    mode === "create"
+      ? await createBaselineCacheProvenance(input)
+      : await verifyBaselineCacheProvenance(input);
+  process.stdout.write(`${JSON.stringify(provenance)}\n`);
+};
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
+  main().catch((error) => {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/.agents/skills/run-parity/scripts/baseline-cache-provenance.test.mjs
+++ b/.agents/skills/run-parity/scripts/baseline-cache-provenance.test.mjs
@@ -1,0 +1,187 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  createBaselineCacheProvenance,
+  verifyBaselineCacheProvenance,
+} from "./baseline-cache-provenance.mjs";
+
+const BASE_COMMIT = "0123456789abcdef0123456789abcdef01234567";
+const TARGET_COMMIT = "89abcdef0123456789abcdef0123456789abcdef";
+const REACT_DOCTOR_REPOSITORY = "https://github.com/millionco/react-doctor.git";
+const EVALUATOR_SOURCE_HASH = "a".repeat(64);
+const CONFIG_CONTRACT = "all-rules-error-v1";
+const RULE_SET_HASH = "b".repeat(64);
+
+const buildRepository = (overrides = {}) => ({
+  org: "example",
+  name: "project",
+  ref: TARGET_COMMIT,
+  rootDir: ".",
+  ...overrides,
+});
+
+const buildEvaluation = (overrides = {}) => ({
+  reactDoctorRepository: REACT_DOCTOR_REPOSITORY,
+  reactDoctorCommit: BASE_COMMIT,
+  evaluatorSourceHash: EVALUATOR_SOURCE_HASH,
+  configContract: CONFIG_CONTRACT,
+  ruleSetHash: RULE_SET_HASH,
+  ruleKeys: [],
+  ...overrides,
+});
+
+const buildRecord = (overrides = {}) => ({
+  schemaVersion: 1,
+  repository: buildRepository(),
+  evaluation: buildEvaluation(),
+  report: { ok: true },
+  ...overrides,
+});
+
+const withFixture = async (callback, records = [buildRecord()]) => {
+  const directory = await mkdtemp(join(tmpdir(), "baseline-cache-provenance-"));
+  const baselinePath = join(directory, "baseline.ndjson");
+  const corpusManifestPath = join(directory, "corpus-manifest.json");
+  const provenancePath = join(directory, "baseline.provenance.json");
+  await writeFile(baselinePath, `${records.map((record) => JSON.stringify(record)).join("\n")}\n`);
+  await writeFile(
+    corpusManifestPath,
+    `${JSON.stringify(
+      records.map((record) => record.repository),
+      null,
+      2,
+    )}\n`,
+  );
+  const input = {
+    baselinePath,
+    corpusManifestPath,
+    provenancePath,
+    reactDoctorRepository: REACT_DOCTOR_REPOSITORY,
+    reactDoctorCommit: BASE_COMMIT,
+    evaluatorSourceHash: EVALUATOR_SOURCE_HASH,
+    configContract: CONFIG_CONTRACT,
+    ruleSetHash: RULE_SET_HASH,
+  };
+  try {
+    await callback({ directory, input });
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+};
+
+test("creates adjacent schema v1 provenance and verifies it", async () => {
+  await withFixture(async ({ input }) => {
+    const created = await createBaselineCacheProvenance(input);
+    const persisted = JSON.parse(await readFile(input.provenancePath, "utf8"));
+    const verified = await verifyBaselineCacheProvenance(input);
+
+    assert.equal(created.schemaVersion, 1);
+    assert.equal(created.artifact.recordCount, 1);
+    assert.equal(created.artifact.byteLength > 0, true);
+    assert.match(created.artifact.sha256, /^[0-9a-f]{64}$/);
+    assert.match(created.corpus.manifestSha256, /^[0-9a-f]{64}$/);
+    assert.match(created.corpus.projectSetSha256, /^[0-9a-f]{64}$/);
+    assert.deepEqual(persisted, created);
+    assert.deepEqual(verified, created);
+  });
+});
+
+test("rejects a corpus manifest with a different project tuple", async () => {
+  await withFixture(async ({ input }) => {
+    await writeFile(
+      input.corpusManifestPath,
+      `${JSON.stringify([buildRepository({ rootDir: "packages/app" })])}\n`,
+    );
+
+    await assert.rejects(
+      createBaselineCacheProvenance(input),
+      /project tuple set does not exactly match/,
+    );
+  });
+});
+
+test("rejects wrong expected commit, config contract, and evaluator source hash", async () => {
+  await withFixture(async ({ input }) => {
+    await createBaselineCacheProvenance(input);
+
+    await assert.rejects(
+      verifyBaselineCacheProvenance({
+        ...input,
+        reactDoctorCommit: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      }),
+      /producer provenance does not match expected|Provenance producer does not match/,
+    );
+    await assert.rejects(
+      verifyBaselineCacheProvenance({
+        ...input,
+        configContract: "different-config",
+      }),
+      /producer provenance does not match expected|Provenance producer does not match/,
+    );
+    await assert.rejects(
+      verifyBaselineCacheProvenance({
+        ...input,
+        evaluatorSourceHash: "c".repeat(64),
+      }),
+      /producer provenance does not match expected|Provenance producer does not match/,
+    );
+  });
+});
+
+test("rejects raw-byte tampering after provenance creation", async () => {
+  await withFixture(async ({ input }) => {
+    await createBaselineCacheProvenance(input);
+    const original = await readFile(input.baselinePath, "utf8");
+    await writeFile(input.baselinePath, original.replace("\n", " \n"));
+
+    await assert.rejects(
+      verifyBaselineCacheProvenance(input),
+      /Raw baseline artifact does not match/,
+    );
+  });
+});
+
+test("rejects mixed record producer provenance", async () => {
+  const records = [
+    buildRecord(),
+    buildRecord({
+      repository: buildRepository({ name: "second" }),
+      evaluation: buildEvaluation({ ruleSetHash: "d".repeat(64) }),
+    }),
+  ];
+  await withFixture(async ({ input }) => {
+    await assert.rejects(
+      createBaselineCacheProvenance(input),
+      /record 2 producer provenance does not match expected/,
+    );
+  }, records);
+});
+
+test("rejects scoped records as a full baseline cache", async () => {
+  const records = [
+    buildRecord({
+      evaluation: buildEvaluation({ ruleKeys: ["react-doctor/example"] }),
+    }),
+  ];
+  await withFixture(async ({ input }) => {
+    await assert.rejects(
+      createBaselineCacheProvenance(input),
+      /producer provenance does not match expected|not a full baseline/,
+    );
+  }, records);
+});
+
+test("rejects provenance and corpus tampering independently", async () => {
+  await withFixture(async ({ input }) => {
+    await createBaselineCacheProvenance(input);
+    const provenance = JSON.parse(await readFile(input.provenancePath, "utf8"));
+    provenance.corpus.projectSetSha256 = "f".repeat(64);
+    await writeFile(input.provenancePath, `${JSON.stringify(provenance)}\n`);
+
+    await assert.rejects(verifyBaselineCacheProvenance(input), /Corpus provenance does not match/);
+  });
+});

--- a/.agents/skills/run-parity/scripts/build-parity-index.mjs
+++ b/.agents/skills/run-parity/scripts/build-parity-index.mjs
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { fileURLToPath } from "node:url";
+import {
+  INVARIANT_DIAGNOSTIC_PLUGIN,
+  INVARIANT_DIAGNOSTIC_RULE_KEYS,
+  TYPESCRIPT_INVARIANT_RULE_SCOPE,
+  compareStrings,
+  coverageFingerprint,
+  diagnosticCount,
+  diagnosticRuleKey,
+  diagnosticsByIdentity,
+  loadSelectedRuleKeys,
+  readRun,
+} from "./compare-parity.mjs";
+
+export const PARITY_INDEX_SCHEMA_VERSION = 1;
+export const PARITY_INDEX_SEMANTIC_CONTRACT = "compare-parity@1";
+export const PARITY_INDEX_HASH_ALGORITHM = "sha256";
+const INVALID_INPUT_EXIT_CODE = 2;
+const EXPECTED_ARGUMENT_COUNT = 3;
+const CANDIDATE_ARGUMENT_COUNT = 4;
+const JSON_INDENT_SPACES = 2;
+
+export const semanticHash = (value) =>
+  createHash(PARITY_INDEX_HASH_ALGORITHM).update(JSON.stringify(value)).digest("hex");
+
+const indexRuleBucketKey = (ruleKey) =>
+  ruleKey.startsWith(`${INVARIANT_DIAGNOSTIC_PLUGIN}/`) ? TYPESCRIPT_INVARIANT_RULE_SCOPE : ruleKey;
+
+export const buildRuleBucketKeys = (selectedRuleKeys) =>
+  [
+    ...new Set([
+      TYPESCRIPT_INVARIANT_RULE_SCOPE,
+      ...INVARIANT_DIAGNOSTIC_RULE_KEYS,
+      ...[...selectedRuleKeys].map(indexRuleBucketKey),
+    ]),
+  ].sort(compareStrings);
+
+const buildProjectRuleBuckets = (diagnostics, ruleBucketKeys) => {
+  const entriesByRule = new Map(ruleBucketKeys.map((ruleKey) => [ruleKey, []]));
+  for (const [identity, occurrences] of diagnostics) {
+    const canonicalDiagnostic = JSON.parse(identity);
+    const ruleKey = indexRuleBucketKey(diagnosticRuleKey(canonicalDiagnostic));
+    const entries = entriesByRule.get(ruleKey);
+    if (!entries) {
+      throw new Error(`Diagnostic cannot be assigned to the parity index scope: ${ruleKey}`);
+    }
+    entries.push([identity, occurrences.length]);
+  }
+
+  return ruleBucketKeys.map((ruleKey) => {
+    const entries = entriesByRule
+      .get(ruleKey)
+      .sort((left, right) => compareStrings(left[0], right[0]));
+    const bucketDiagnosticCount = entries.reduce(
+      (total, [, occurrenceCount]) => total + occurrenceCount,
+      0,
+    );
+    return {
+      rule: ruleKey,
+      diagnosticCount: bucketDiagnosticCount,
+      semanticHash: semanticHash(entries),
+    };
+  });
+};
+
+export const buildParityIndex = async ({ inputPath, selectedRuleKeys, rejectOutsideRuleScope }) => {
+  const ruleScope = [...selectedRuleKeys].sort(compareStrings);
+  const ruleBucketKeys = buildRuleBucketKeys(selectedRuleKeys);
+  const sourceHasher = createHash(PARITY_INDEX_HASH_ALGORITHM);
+  const projects = [];
+  const seenProjectKeys = new Set();
+
+  const projectCount = await readRun(inputPath, (record, key, line) => {
+    if (seenProjectKeys.has(key)) {
+      throw new Error(`${inputPath} contains duplicate project ${key}`);
+    }
+    seenProjectKeys.add(key);
+    sourceHasher.update(line);
+    sourceHasher.update("\n");
+
+    const indexedDiagnostics = diagnosticsByIdentity(
+      record,
+      rejectOutsideRuleScope,
+      selectedRuleKeys,
+    );
+    if (indexedDiagnostics.error) {
+      throw new Error(`${inputPath} project ${key}: ${indexedDiagnostics.error}`);
+    }
+    const projectCoverageFingerprint = coverageFingerprint(record);
+    if (projectCoverageFingerprint === null) {
+      throw new Error(`${inputPath} project ${key}: scoped parity index requires v3 coverage`);
+    }
+    projects.push({
+      key,
+      repository: record.repository,
+      coverageHash: semanticHash(projectCoverageFingerprint),
+      diagnosticCount: diagnosticCount(indexedDiagnostics.diagnostics),
+      rules: buildProjectRuleBuckets(indexedDiagnostics.diagnostics, ruleBucketKeys),
+    });
+  });
+
+  if (projectCount === 0) {
+    throw new Error("Parity input must contain at least one eval record");
+  }
+
+  projects.sort((left, right) => compareStrings(left.key, right.key));
+  const rules = ruleBucketKeys.map((ruleKey, ruleIndex) => {
+    const projectBuckets = projects.map((project) => project.rules[ruleIndex]);
+    return {
+      rule: ruleKey,
+      diagnosticCount: projectBuckets.reduce((total, bucket) => total + bucket.diagnosticCount, 0),
+      semanticHash: semanticHash(
+        projects.map((project, projectIndex) => [
+          project.key,
+          projectBuckets[projectIndex].diagnosticCount,
+          projectBuckets[projectIndex].semanticHash,
+        ]),
+      ),
+    };
+  });
+  const coverage = {
+    projectCount,
+    projectSetHash: semanticHash(projects.map((project) => project.key)),
+    projectCoverageHash: semanticHash(
+      projects.map((project) => [project.key, project.coverageHash]),
+    ),
+  };
+  const invariantRuleScope = [
+    TYPESCRIPT_INVARIANT_RULE_SCOPE,
+    ...[...INVARIANT_DIAGNOSTIC_RULE_KEYS].sort(compareStrings),
+  ];
+  const runSemantics = {
+    semanticContract: PARITY_INDEX_SEMANTIC_CONTRACT,
+    ruleScope,
+    invariantRuleScope,
+    ruleBucketKeys,
+    coverage,
+    rules,
+  };
+
+  return {
+    schemaVersion: PARITY_INDEX_SCHEMA_VERSION,
+    hashAlgorithm: PARITY_INDEX_HASH_ALGORITHM,
+    semanticContract: PARITY_INDEX_SEMANTIC_CONTRACT,
+    sourceHash: sourceHasher.digest("hex"),
+    ruleScope,
+    invariantRuleScope,
+    ruleBucketKeys,
+    coverage,
+    projects,
+    rules,
+    wholeRunHash: semanticHash(runSemantics),
+  };
+};
+
+const runCli = async () => {
+  const indexArguments = process.argv.slice(2);
+  const rejectOutsideRuleScope =
+    indexArguments.length === CANDIDATE_ARGUMENT_COUNT && indexArguments[0] === "--candidate";
+  const scopedArguments = rejectOutsideRuleScope ? indexArguments.slice(1) : indexArguments;
+  if (scopedArguments.length !== EXPECTED_ARGUMENT_COUNT || scopedArguments[0] !== "--rules") {
+    process.stderr.write(
+      "Usage: build-parity-index.mjs [--candidate] --rules <rules.json> <input.ndjson>\n",
+    );
+    process.exitCode = INVALID_INPUT_EXIT_CODE;
+    return;
+  }
+
+  try {
+    const selectedRuleKeys = loadSelectedRuleKeys(scopedArguments[1]);
+    const index = await buildParityIndex({
+      inputPath: scopedArguments[2],
+      selectedRuleKeys,
+      rejectOutsideRuleScope,
+    });
+    process.stdout.write(`${JSON.stringify(index, undefined, JSON_INDENT_SPACES)}\n`);
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = INVALID_INPUT_EXIT_CODE;
+  }
+};
+
+if (fileURLToPath(import.meta.url) === process.argv[1]) {
+  await runCli();
+}

--- a/.agents/skills/run-parity/scripts/build-parity-index.mjs
+++ b/.agents/skills/run-parity/scripts/build-parity-index.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { createHash } from "node:crypto";
+import { resolve as resolveFileSystemPath } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   INVARIANT_DIAGNOSTIC_PLUGIN,
@@ -183,6 +184,6 @@ const runCli = async () => {
   }
 };
 
-if (fileURLToPath(import.meta.url) === process.argv[1]) {
+if (process.argv[1] && fileURLToPath(import.meta.url) === resolveFileSystemPath(process.argv[1])) {
   await runCli();
 }

--- a/.agents/skills/run-parity/scripts/compare-parity-indexes.mjs
+++ b/.agents/skills/run-parity/scripts/compare-parity-indexes.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { readFileSync } from "node:fs";
+import { resolve as resolveFileSystemPath } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   PARITY_INDEX_HASH_ALGORITHM,
@@ -326,6 +327,6 @@ const runCli = () => {
   }
 };
 
-if (fileURLToPath(import.meta.url) === process.argv[1]) {
+if (process.argv[1] && fileURLToPath(import.meta.url) === resolveFileSystemPath(process.argv[1])) {
   runCli();
 }

--- a/.agents/skills/run-parity/scripts/compare-parity-indexes.mjs
+++ b/.agents/skills/run-parity/scripts/compare-parity-indexes.mjs
@@ -1,0 +1,331 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import {
+  PARITY_INDEX_HASH_ALGORITHM,
+  PARITY_INDEX_SCHEMA_VERSION,
+  PARITY_INDEX_SEMANTIC_CONTRACT,
+  buildRuleBucketKeys,
+  semanticHash,
+} from "./build-parity-index.mjs";
+import {
+  INVARIANT_DIAGNOSTIC_RULE_KEYS,
+  TYPESCRIPT_INVARIANT_RULE_SCOPE,
+  compareStrings,
+  projectKey,
+  validateEvalRecord,
+} from "./compare-parity.mjs";
+
+const PARITY_DIFFERENCE_EXIT_CODE = 1;
+const INVALID_INPUT_EXIT_CODE = 2;
+const EXPECTED_ARGUMENT_COUNT = 2;
+const JSON_INDENT_SPACES = 2;
+const HASH_PATTERN = /^[0-9a-f]{64}$/;
+const RULE_SCOPE_KEY_PATTERN = /^[a-z0-9][a-z0-9-]*\/[A-Za-z0-9][A-Za-z0-9-]*$/;
+const RULE_BUCKET_KEY_PATTERN = /^(?:TS\/\*|[a-z0-9][a-z0-9-]*\/[A-Za-z0-9][A-Za-z0-9-]*)$/;
+
+const isRecord = (value) => typeof value === "object" && value !== null && !Array.isArray(value);
+const isHash = (value) => typeof value === "string" && HASH_PATTERN.test(value);
+const isNonnegativeInteger = (value) => Number.isInteger(value) && value >= 0;
+const hasCanonicalOrder = (values) =>
+  values.every((value, valueIndex) => valueIndex === 0 || values[valueIndex - 1] < value);
+
+const validateRuleSummary = (ruleSummary, expectedRuleKey) =>
+  isRecord(ruleSummary) &&
+  ruleSummary.rule === expectedRuleKey &&
+  isNonnegativeInteger(ruleSummary.diagnosticCount) &&
+  isHash(ruleSummary.semanticHash);
+
+export const validateParityIndex = (index) => {
+  if (
+    !isRecord(index) ||
+    index.schemaVersion !== PARITY_INDEX_SCHEMA_VERSION ||
+    index.hashAlgorithm !== PARITY_INDEX_HASH_ALGORITHM ||
+    index.semanticContract !== PARITY_INDEX_SEMANTIC_CONTRACT ||
+    !isHash(index.sourceHash) ||
+    !Array.isArray(index.ruleScope) ||
+    index.ruleScope.length === 0 ||
+    !index.ruleScope.every(
+      (ruleKey) => typeof ruleKey === "string" && RULE_SCOPE_KEY_PATTERN.test(ruleKey),
+    ) ||
+    !hasCanonicalOrder(index.ruleScope) ||
+    !Array.isArray(index.invariantRuleScope) ||
+    !Array.isArray(index.ruleBucketKeys) ||
+    !index.ruleBucketKeys.every(
+      (ruleKey) => typeof ruleKey === "string" && RULE_BUCKET_KEY_PATTERN.test(ruleKey),
+    ) ||
+    !hasCanonicalOrder(index.ruleBucketKeys) ||
+    !isRecord(index.coverage) ||
+    !Array.isArray(index.projects) ||
+    !Array.isArray(index.rules) ||
+    !isHash(index.wholeRunHash)
+  ) {
+    return "Invalid parity index schema";
+  }
+
+  const expectedInvariantRuleScope = [
+    TYPESCRIPT_INVARIANT_RULE_SCOPE,
+    ...[...INVARIANT_DIAGNOSTIC_RULE_KEYS].sort(compareStrings),
+  ];
+  const expectedRuleBucketKeys = buildRuleBucketKeys(new Set(index.ruleScope));
+  if (
+    JSON.stringify(index.invariantRuleScope) !== JSON.stringify(expectedInvariantRuleScope) ||
+    JSON.stringify(index.ruleBucketKeys) !== JSON.stringify(expectedRuleBucketKeys)
+  ) {
+    return "Parity index rule scope metadata is inconsistent";
+  }
+  if (
+    index.coverage.projectCount !== index.projects.length ||
+    index.projects.length === 0 ||
+    !isHash(index.coverage.projectSetHash) ||
+    !isHash(index.coverage.projectCoverageHash) ||
+    index.rules.length !== index.ruleBucketKeys.length
+  ) {
+    return "Parity index coverage or rule count is inconsistent";
+  }
+
+  const projectKeys = [];
+  const seenProjectKeys = new Set();
+  for (const project of index.projects) {
+    if (
+      !isRecord(project) ||
+      typeof project.key !== "string" ||
+      !isRecord(project.repository) ||
+      !validateEvalRecord({ schemaVersion: 1, repository: project.repository }) ||
+      project.key !== projectKey(project.repository) ||
+      seenProjectKeys.has(project.key) ||
+      (project.coverageHash !== null && !isHash(project.coverageHash)) ||
+      !isNonnegativeInteger(project.diagnosticCount) ||
+      !Array.isArray(project.rules) ||
+      project.rules.length !== index.ruleBucketKeys.length
+    ) {
+      return "Invalid parity index project";
+    }
+    seenProjectKeys.add(project.key);
+    projectKeys.push(project.key);
+    let projectDiagnosticCount = 0;
+    for (const [ruleIndex, ruleBucket] of project.rules.entries()) {
+      if (!validateRuleSummary(ruleBucket, index.ruleBucketKeys[ruleIndex])) {
+        return "Invalid parity index project rule bucket";
+      }
+      projectDiagnosticCount += ruleBucket.diagnosticCount;
+    }
+    if (projectDiagnosticCount !== project.diagnosticCount) {
+      return "Parity index project diagnostic count is inconsistent";
+    }
+  }
+  if (!hasCanonicalOrder(projectKeys)) {
+    return "Parity index projects are not in canonical order";
+  }
+  if (
+    index.coverage.projectSetHash !== semanticHash(projectKeys) ||
+    index.coverage.projectCoverageHash !==
+      semanticHash(index.projects.map((project) => [project.key, project.coverageHash]))
+  ) {
+    return "Parity index coverage hashes are inconsistent";
+  }
+
+  for (const [ruleIndex, ruleSummary] of index.rules.entries()) {
+    const ruleKey = index.ruleBucketKeys[ruleIndex];
+    if (!validateRuleSummary(ruleSummary, ruleKey)) {
+      return "Invalid parity index rule summary";
+    }
+    const projectBuckets = index.projects.map((project) => project.rules[ruleIndex]);
+    const diagnosticCount = projectBuckets.reduce(
+      (total, bucket) => total + bucket.diagnosticCount,
+      0,
+    );
+    const aggregateHash = semanticHash(
+      index.projects.map((project, projectIndex) => [
+        project.key,
+        projectBuckets[projectIndex].diagnosticCount,
+        projectBuckets[projectIndex].semanticHash,
+      ]),
+    );
+    if (
+      ruleSummary.diagnosticCount !== diagnosticCount ||
+      ruleSummary.semanticHash !== aggregateHash
+    ) {
+      return "Parity index rule aggregate is inconsistent";
+    }
+  }
+
+  const runSemantics = {
+    semanticContract: index.semanticContract,
+    ruleScope: index.ruleScope,
+    invariantRuleScope: index.invariantRuleScope,
+    ruleBucketKeys: index.ruleBucketKeys,
+    coverage: index.coverage,
+    rules: index.rules,
+  };
+  if (index.wholeRunHash !== semanticHash(runSemantics)) {
+    return "Parity index whole-run hash is inconsistent";
+  }
+  return null;
+};
+
+const compareMetadata = (baselineIndex, candidateIndex) => {
+  const mismatches = [];
+  if (baselineIndex.semanticContract !== candidateIndex.semanticContract) {
+    mismatches.push("Semantic contracts differ");
+  }
+  if (JSON.stringify(baselineIndex.ruleScope) !== JSON.stringify(candidateIndex.ruleScope)) {
+    mismatches.push("Requested rule scopes differ");
+  }
+  if (
+    JSON.stringify(baselineIndex.invariantRuleScope) !==
+    JSON.stringify(candidateIndex.invariantRuleScope)
+  ) {
+    mismatches.push("Invariant rule scopes differ");
+  }
+  if (
+    JSON.stringify(baselineIndex.ruleBucketKeys) !== JSON.stringify(candidateIndex.ruleBucketKeys)
+  ) {
+    mismatches.push("Rule bucket scopes differ");
+  }
+  if (baselineIndex.coverage.projectSetHash !== candidateIndex.coverage.projectSetHash) {
+    mismatches.push("Project sets differ");
+    return mismatches;
+  }
+  for (const [projectIndex, baselineProject] of baselineIndex.projects.entries()) {
+    const candidateProject = candidateIndex.projects[projectIndex];
+    if (baselineProject.key !== candidateProject.key) {
+      mismatches.push("Project ordering differs");
+      break;
+    }
+    if (baselineProject.coverageHash !== candidateProject.coverageHash) {
+      mismatches.push(`Project coverage differs: ${baselineProject.key}`);
+    }
+  }
+  return mismatches;
+};
+
+export const compareParityIndexes = (baselineIndex, candidateIndex) => {
+  const baselineError = validateParityIndex(baselineIndex);
+  const candidateError = validateParityIndex(candidateIndex);
+  if (baselineError || candidateError) {
+    return {
+      valid: false,
+      baselineError,
+      candidateError,
+      metadataMismatches: [],
+    };
+  }
+
+  const metadataMismatches = compareMetadata(baselineIndex, candidateIndex);
+  if (metadataMismatches.length > 0) {
+    return {
+      valid: false,
+      baselineError: null,
+      candidateError: null,
+      metadataMismatches,
+    };
+  }
+
+  if (baselineIndex.wholeRunHash === candidateIndex.wholeRunHash) {
+    return {
+      valid: true,
+      match: true,
+      baselineWholeRunHash: baselineIndex.wholeRunHash,
+      candidateWholeRunHash: candidateIndex.wholeRunHash,
+      summary: {
+        comparedProjects: baselineIndex.projects.length,
+        comparedRules: baselineIndex.rules.length,
+        ruleHashesChecked: 0,
+        projectRuleHashesChecked: 0,
+        changedRules: 0,
+        changedProjectRuleBuckets: 0,
+      },
+      changedRules: [],
+    };
+  }
+
+  const changedRules = [];
+  let changedProjectRuleBucketCount = 0;
+  let projectRuleHashCheckCount = 0;
+  for (const [ruleIndex, baselineRule] of baselineIndex.rules.entries()) {
+    const candidateRule = candidateIndex.rules[ruleIndex];
+    if (baselineRule.semanticHash === candidateRule.semanticHash) continue;
+
+    const changedProjects = [];
+    for (const [projectIndex, baselineProject] of baselineIndex.projects.entries()) {
+      projectRuleHashCheckCount += 1;
+      const baselineBucket = baselineProject.rules[ruleIndex];
+      const candidateProject = candidateIndex.projects[projectIndex];
+      const candidateBucket = candidateProject.rules[ruleIndex];
+      if (baselineBucket.semanticHash === candidateBucket.semanticHash) continue;
+      changedProjects.push({
+        repository: baselineProject.repository,
+        baselineDiagnostics: baselineBucket.diagnosticCount,
+        candidateDiagnostics: candidateBucket.diagnosticCount,
+        baselineHash: baselineBucket.semanticHash,
+        candidateHash: candidateBucket.semanticHash,
+      });
+    }
+    changedProjectRuleBucketCount += changedProjects.length;
+    changedRules.push({
+      rule: baselineRule.rule,
+      baselineDiagnostics: baselineRule.diagnosticCount,
+      candidateDiagnostics: candidateRule.diagnosticCount,
+      baselineHash: baselineRule.semanticHash,
+      candidateHash: candidateRule.semanticHash,
+      changedProjects,
+    });
+  }
+
+  return {
+    valid: true,
+    match: changedRules.length === 0,
+    baselineWholeRunHash: baselineIndex.wholeRunHash,
+    candidateWholeRunHash: candidateIndex.wholeRunHash,
+    summary: {
+      comparedProjects: baselineIndex.projects.length,
+      comparedRules: baselineIndex.rules.length,
+      ruleHashesChecked: baselineIndex.rules.length,
+      projectRuleHashesChecked: projectRuleHashCheckCount,
+      changedRules: changedRules.length,
+      changedProjectRuleBuckets: changedProjectRuleBucketCount,
+    },
+    changedRules,
+  };
+};
+
+const readIndex = (indexPath) => {
+  try {
+    return JSON.parse(readFileSync(indexPath, "utf8"));
+  } catch {
+    throw new Error(`${indexPath} is not valid JSON`);
+  }
+};
+
+const runCli = () => {
+  const comparisonArguments = process.argv.slice(2);
+  if (comparisonArguments.length !== EXPECTED_ARGUMENT_COUNT) {
+    process.stderr.write(
+      "Usage: compare-parity-indexes.mjs <baseline.index.json> <candidate.index.json>\n",
+    );
+    process.exitCode = INVALID_INPUT_EXIT_CODE;
+    return;
+  }
+
+  try {
+    const comparison = compareParityIndexes(
+      readIndex(comparisonArguments[0]),
+      readIndex(comparisonArguments[1]),
+    );
+    process.stdout.write(`${JSON.stringify(comparison, undefined, JSON_INDENT_SPACES)}\n`);
+    if (!comparison.valid) {
+      process.exitCode = INVALID_INPUT_EXIT_CODE;
+    } else if (!comparison.match) {
+      process.exitCode = PARITY_DIFFERENCE_EXIT_CODE;
+    }
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = INVALID_INPUT_EXIT_CODE;
+  }
+};
+
+if (fileURLToPath(import.meta.url) === process.argv[1]) {
+  runCli();
+}

--- a/.agents/skills/run-parity/scripts/compare-parity.mjs
+++ b/.agents/skills/run-parity/scripts/compare-parity.mjs
@@ -16,14 +16,17 @@ import { tmpdir } from "node:os";
 import { join, posix } from "node:path";
 import { createInterface } from "node:readline";
 import { isDeepStrictEqual } from "node:util";
+import { fileURLToPath } from "node:url";
 
 const PARITY_SCHEMA_VERSION = 1;
 const PARITY_DIFFERENCE_EXIT_CODE = 1;
 const INVALID_INPUT_EXIT_CODE = 2;
 const JSON_INDENT_SPACES = 2;
 const EXPECTED_ARGUMENT_COUNT = 2;
+const SCOPED_ARGUMENT_COUNT = 4;
 const BASELINE_RECORD_FILE_SUFFIX = ".json";
 const PINNED_REF_PATTERN = /^[0-9a-f]{40}$/i;
+const RULE_KEY_PATTERN = /^[a-z0-9][a-z0-9-]*\/[A-Za-z0-9][A-Za-z0-9-]*$/;
 const REPORT_SCHEMA_VERSIONS = new Set([1, 2, 3]);
 const REPORT_MODES = new Set(["full", "diff", "staged", "baseline"]);
 const REPORT_FRAMEWORKS = new Set([
@@ -42,23 +45,62 @@ const REPORT_FRAMEWORKS = new Set([
 const GITHUB_OWNER_PATTERN = /^[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?$/;
 const GITHUB_REPOSITORY_PATTERN = /^[A-Za-z0-9._-]+$/;
 const UNSAFE_ROOT_DIRECTORY_PATTERN = /["'`$;&|<>\\\r\n]/;
-
-const [baselinePath, candidatePath] = process.argv.slice(2);
-
-if (process.argv.slice(2).length !== EXPECTED_ARGUMENT_COUNT) {
-  process.stderr.write("Usage: compare-parity.mjs <baseline.ndjson> <candidate.ndjson>\n");
-  process.exit(INVALID_INPUT_EXIT_CODE);
-}
+export const INVARIANT_DIAGNOSTIC_PLUGIN = "TS";
+export const TYPESCRIPT_INVARIANT_RULE_SCOPE = `${INVARIANT_DIAGNOSTIC_PLUGIN}/*`;
+export const INVARIANT_DIAGNOSTIC_RULE_KEYS = new Set([
+  "react-doctor/expo-env-local-not-gitignored",
+  "react-doctor/expo-gitignore",
+  "react-doctor/expo-lockfile",
+  "react-doctor/expo-metro-config",
+  "react-doctor/expo-no-cli-dependencies",
+  "react-doctor/expo-no-conflicting-dependency-override",
+  "react-doctor/expo-no-redundant-dependency",
+  "react-doctor/expo-no-unimodules-packages",
+  "react-doctor/expo-package-json-conflict",
+  "react-doctor/expo-reanimated-v4-requires-new-arch",
+  "react-doctor/expo-router-no-react-navigation",
+  "react-doctor/expo-updates-no-unsafe-production-config",
+  "react-doctor/expo-vector-icons-conflict",
+  "react-doctor/no-vulnerable-react-server-components",
+  "react-doctor/require-pnpm-hardening",
+  "react-doctor/require-reduced-motion",
+  "react-doctor/rn-android-release-shrinking-disabled",
+  "react-doctor/rn-library-react-in-dependencies",
+  "react-doctor/rn-no-metro-babel-preset",
+  "react-doctor/rn-no-metro-babel-runtime-version",
+  "react-doctor/rn-react-compiler-plugin-first",
+  "react-doctor/rn-reanimated-worklets-plugin-last",
+]);
 
 const isRecord = (value) => typeof value === "object" && value !== null && !Array.isArray(value);
 
-const compareStrings = (left, right) => {
+export const loadSelectedRuleKeys = (ruleKeysPath) => {
+  if (!ruleKeysPath) return null;
+  let parsedRuleKeys;
+  try {
+    parsedRuleKeys = JSON.parse(readFileSync(ruleKeysPath, "utf8"));
+  } catch {
+    throw new Error(`${ruleKeysPath} is not valid JSON`);
+  }
+  if (
+    !Array.isArray(parsedRuleKeys) ||
+    parsedRuleKeys.length === 0 ||
+    !parsedRuleKeys.every(
+      (ruleKey) => typeof ruleKey === "string" && RULE_KEY_PATTERN.test(ruleKey),
+    )
+  ) {
+    throw new Error(`${ruleKeysPath} must be a non-empty array of canonical plugin/rule keys`);
+  }
+  return new Set(parsedRuleKeys);
+};
+
+export const compareStrings = (left, right) => {
   if (left < right) return -1;
   if (left > right) return 1;
   return 0;
 };
 
-const projectKey = (repository) =>
+export const projectKey = (repository) =>
   JSON.stringify([repository.org, repository.name, repository.ref, repository.rootDir]);
 
 const validateRepository = (repository) =>
@@ -77,7 +119,7 @@ const validateRepository = (repository) =>
   repository.rootDir !== ".." &&
   !repository.rootDir.startsWith("../");
 
-const validateEvalRecord = (record) =>
+export const validateEvalRecord = (record) =>
   isRecord(record) &&
   record.schemaVersion === PARITY_SCHEMA_VERSION &&
   validateRepository(record.repository);
@@ -121,16 +163,75 @@ const getCanonicalDiagnosticPath = (report, project, diagnostic) => {
   return relativePath(report.directory, diagnosticPath);
 };
 
+const optionalProperty = (name, value) => (value === undefined ? {} : { [name]: value });
+
+const canonicalRelatedLocation = (report, project, location) => {
+  const projectRoot = getProjectRoot(report, project);
+  return {
+    filePath: relativePath(report.directory, resolvePath(projectRoot, location.filePath)),
+    line: location.line,
+    column: location.column,
+    ...optionalProperty("offset", location.offset),
+    ...optionalProperty("length", location.length),
+    ...optionalProperty("endLine", location.endLine),
+    ...optionalProperty("endColumn", location.endColumn),
+    message: location.message,
+  };
+};
+
+const canonicalDiagnostic = (report, project, diagnostic) => ({
+  filePath: getCanonicalDiagnosticPath(report, project, diagnostic),
+  plugin: diagnostic.plugin,
+  rule: diagnostic.rule,
+  severity: diagnostic.severity,
+  ...optionalProperty("title", diagnostic.title),
+  message: diagnostic.message,
+  help: diagnostic.help,
+  ...optionalProperty("url", diagnostic.url),
+  line: diagnostic.line,
+  column: diagnostic.column,
+  ...optionalProperty("offset", diagnostic.offset),
+  ...optionalProperty("length", diagnostic.length),
+  ...optionalProperty("endLine", diagnostic.endLine),
+  ...optionalProperty("endColumn", diagnostic.endColumn),
+  category: diagnostic.category,
+  tags: [...(diagnostic.tags ?? [])].sort(compareStrings),
+  ...optionalProperty("matchByOccurrence", diagnostic.matchByOccurrence),
+  ...optionalProperty("fileContext", diagnostic.fileContext),
+  ...optionalProperty("suppressionHint", diagnostic.suppressionHint),
+  ...optionalProperty(
+    "relatedLocations",
+    diagnostic.relatedLocations?.map((location) =>
+      canonicalRelatedLocation(report, project, location),
+    ),
+  ),
+  ...optionalProperty("fixGroupId", diagnostic.fixGroupId),
+});
+
 const diagnosticKey = (report, project, diagnostic) =>
-  JSON.stringify([
-    getCanonicalDiagnosticPath(report, project, diagnostic),
-    diagnostic.line,
-    diagnostic.column,
-    diagnostic.plugin,
-    diagnostic.rule,
-    diagnostic.severity,
-    diagnostic.message,
-  ]);
+  JSON.stringify(canonicalDiagnostic(report, project, diagnostic));
+
+export const diagnosticRuleKey = (diagnostic) => `${diagnostic.plugin}/${diagnostic.rule}`;
+
+const isOptionalFiniteNumber = (value) =>
+  value === undefined || (typeof value === "number" && Number.isFinite(value) && value >= 0);
+
+const isOptionalString = (value) => value === undefined || typeof value === "string";
+
+const validateRelatedLocation = (location) =>
+  isRecord(location) &&
+  typeof location.filePath === "string" &&
+  typeof location.line === "number" &&
+  Number.isFinite(location.line) &&
+  location.line >= 0 &&
+  typeof location.column === "number" &&
+  Number.isFinite(location.column) &&
+  location.column >= 0 &&
+  isOptionalFiniteNumber(location.offset) &&
+  isOptionalFiniteNumber(location.length) &&
+  isOptionalFiniteNumber(location.endLine) &&
+  isOptionalFiniteNumber(location.endColumn) &&
+  typeof location.message === "string";
 
 const validateDiagnostic = (diagnostic, reportSchemaVersion) =>
   isRecord(diagnostic) &&
@@ -147,6 +248,22 @@ const validateDiagnostic = (diagnostic, reportSchemaVersion) =>
   typeof diagnostic.message === "string" &&
   typeof diagnostic.help === "string" &&
   typeof diagnostic.category === "string" &&
+  isOptionalString(diagnostic.title) &&
+  isOptionalString(diagnostic.url) &&
+  isOptionalFiniteNumber(diagnostic.offset) &&
+  isOptionalFiniteNumber(diagnostic.length) &&
+  isOptionalFiniteNumber(diagnostic.endLine) &&
+  isOptionalFiniteNumber(diagnostic.endColumn) &&
+  (diagnostic.matchByOccurrence === undefined ||
+    typeof diagnostic.matchByOccurrence === "boolean") &&
+  (diagnostic.fileContext === undefined ||
+    diagnostic.fileContext === "test" ||
+    diagnostic.fileContext === "story") &&
+  isOptionalString(diagnostic.suppressionHint) &&
+  (diagnostic.relatedLocations === undefined ||
+    (Array.isArray(diagnostic.relatedLocations) &&
+      diagnostic.relatedLocations.every(validateRelatedLocation))) &&
+  isOptionalString(diagnostic.fixGroupId) &&
   (reportSchemaVersion !== 3 ||
     (typeof diagnostic.id === "string" &&
       typeof diagnostic.normalizedFilePath === "string" &&
@@ -293,7 +410,34 @@ const validateReport = (report) => {
   return null;
 };
 
-const readRun = async (filePath, onRecord) => {
+const canonicalCoverageFilePath = (report, project, filePath) =>
+  relativePath(report.directory, resolvePath(getProjectRoot(report, project), filePath));
+
+export const coverageFingerprint = (record) => {
+  if (!record.report || record.report.schemaVersion !== 3) return null;
+  const report = record.report;
+  const projects = report.projects
+    .map((project) => ({
+      directory: relativePath(report.directory, resolvePath(report.directory, project.directory)),
+      packageRoot: relativePath(
+        report.directory,
+        resolvePath(report.directory, project.packageRoot),
+      ),
+      framework: project.framework,
+      analyzedFiles: project.analyzedFiles
+        .map((filePath) => canonicalCoverageFilePath(report, project, filePath))
+        .sort(compareStrings),
+      analyzedFileCount: project.analyzedFileCount,
+      ...optionalProperty("scannedFileCount", project.scannedFileCount),
+    }))
+    .sort((left, right) => compareStrings(JSON.stringify(left), JSON.stringify(right)));
+  return JSON.stringify({
+    reactDetected: report.reactDetected ?? null,
+    projects,
+  });
+};
+
+export const readRun = async (filePath, onRecord) => {
   const lines = createInterface({ input: createReadStream(filePath) });
   let lineNumber = 0;
   let recordCount = 0;
@@ -321,17 +465,11 @@ const baselineRecordPath = (temporaryDirectory, key) =>
     `${createHash("sha256").update(key).digest("hex")}${BASELINE_RECORD_FILE_SUFFIX}`,
   );
 
-const addCanonicalDiagnostic = (diagnostics, identity, diagnostic) => {
-  const existingDiagnostic = diagnostics.get(identity);
-  if (
-    !existingDiagnostic ||
-    compareStrings(JSON.stringify(diagnostic), JSON.stringify(existingDiagnostic)) < 0
-  ) {
-    diagnostics.set(identity, diagnostic);
-  }
-};
+const isInvariantDiagnostic = (diagnostic) =>
+  diagnostic.plugin === INVARIANT_DIAGNOSTIC_PLUGIN ||
+  INVARIANT_DIAGNOSTIC_RULE_KEYS.has(diagnosticRuleKey(diagnostic));
 
-const diagnosticsByIdentity = (record) => {
+export const diagnosticsByIdentity = (record, rejectOutsideRuleScope, selectedRuleKeys = null) => {
   if (Object.hasOwn(record, "error")) {
     if (
       typeof record.error !== "string" ||
@@ -348,14 +486,33 @@ const diagnosticsByIdentity = (record) => {
   const diagnostics = new Map();
   for (const project of record.report.projects) {
     for (const diagnostic of project.diagnostics) {
-      addCanonicalDiagnostic(
-        diagnostics,
-        diagnosticKey(record.report, project, diagnostic),
-        diagnostic,
-      );
+      const ruleKey = diagnosticRuleKey(diagnostic);
+      if (
+        selectedRuleKeys &&
+        !selectedRuleKeys.has(ruleKey) &&
+        !isInvariantDiagnostic(diagnostic)
+      ) {
+        if (rejectOutsideRuleScope) {
+          return { error: `Candidate emitted diagnostic outside rule scope: ${ruleKey}` };
+        }
+        continue;
+      }
+      const identity = diagnosticKey(record.report, project, diagnostic);
+      const occurrences = diagnostics.get(identity) ?? [];
+      occurrences.push(diagnostic);
+      diagnostics.set(identity, occurrences);
     }
   }
+  for (const occurrences of diagnostics.values()) {
+    occurrences.sort((left, right) => compareStrings(JSON.stringify(left), JSON.stringify(right)));
+  }
   return { diagnostics };
+};
+
+export const diagnosticCount = (diagnostics) => {
+  let count = 0;
+  for (const occurrences of diagnostics.values()) count += occurrences.length;
+  return count;
 };
 
 const summarizeRules = (entries) => {
@@ -409,129 +566,229 @@ const writeOutputArray = async (name, entries, hasFollowingProperty) => {
   await writeOutputChunk(`${closingPrefix}  ]${hasFollowingProperty ? "," : ""}\n`);
 };
 
-try {
-  const temporaryDirectory = mkdtempSync(join(tmpdir(), "react-doctor-parity-"));
-  const added = [];
-  const removed = [];
-  const skippedProjects = [];
-  let unchangedCount = 0;
-  let baselineDiagnosticCount = 0;
-  let candidateDiagnosticCount = 0;
-  let comparedProjectCount = 0;
-
-  const compareRecords = (baselineRecord, candidateRecord) => {
-    const repository = candidateRecord?.repository ?? baselineRecord?.repository;
-    const baseline = baselineRecord
-      ? diagnosticsByIdentity(baselineRecord)
-      : { error: "Missing baseline record" };
-    const candidate = candidateRecord
-      ? diagnosticsByIdentity(candidateRecord)
-      : { error: "Missing candidate record" };
-
-    if (baseline.error || candidate.error) {
-      skippedProjects.push({
-        repository,
-        baselineError: baseline.error,
-        candidateError: candidate.error,
-      });
-      return;
-    }
-
-    comparedProjectCount += 1;
-    baselineDiagnosticCount += baseline.diagnostics.size;
-    candidateDiagnosticCount += candidate.diagnostics.size;
-
-    const identities = new Set([...baseline.diagnostics.keys(), ...candidate.diagnostics.keys()]);
-    for (const identity of identities) {
-      const baselineDiagnostic = baseline.diagnostics.get(identity);
-      const candidateDiagnostic = candidate.diagnostics.get(identity);
-      if (baselineDiagnostic && candidateDiagnostic) {
-        unchangedCount += 1;
-      } else if (baselineDiagnostic) {
-        removed.push(buildDiagnosticEntry(repository, identity, baselineDiagnostic));
-      } else if (candidateDiagnostic) {
-        added.push(buildDiagnosticEntry(repository, identity, candidateDiagnostic));
-      }
-    }
-  };
-
-  let baselineProjectCount;
-  let candidateProjectCount;
+const compareParity = async ({ baselinePath, candidatePath, selectedRuleKeys = null }) => {
   try {
-    baselineProjectCount = await readRun(baselinePath, (record, key, line) => {
-      const recordPath = baselineRecordPath(temporaryDirectory, key);
-      if (existsSync(recordPath)) {
-        throw new Error(`${baselinePath} contains duplicate project ${key}`);
-      }
-      writeFileSync(recordPath, line);
-    });
+    const temporaryDirectory = mkdtempSync(join(tmpdir(), "react-doctor-parity-"));
+    const added = [];
+    const removed = [];
+    const skippedProjects = [];
+    let unchangedCount = 0;
+    let baselineDiagnosticCount = 0;
+    let candidateDiagnosticCount = 0;
+    let comparedProjectCount = 0;
 
-    const candidateKeys = new Set();
-    candidateProjectCount = await readRun(candidatePath, (candidateRecord, key) => {
-      if (candidateKeys.has(key)) {
-        throw new Error(`${candidatePath} contains duplicate project ${key}`);
-      }
-      candidateKeys.add(key);
-      const recordPath = baselineRecordPath(temporaryDirectory, key);
-      if (!existsSync(recordPath)) {
-        compareRecords(undefined, candidateRecord);
+    const compareRecords = (baselineRecord, candidateRecord) => {
+      const repository = candidateRecord?.repository ?? baselineRecord?.repository;
+      const baseline = baselineRecord
+        ? diagnosticsByIdentity(baselineRecord, false, selectedRuleKeys)
+        : { error: "Missing baseline record" };
+      const candidate = candidateRecord
+        ? diagnosticsByIdentity(candidateRecord, true, selectedRuleKeys)
+        : { error: "Missing candidate record" };
+
+      if (baseline.error || candidate.error) {
+        skippedProjects.push({
+          repository,
+          baselineError: baseline.error,
+          candidateError: candidate.error,
+        });
         return;
       }
-      const baselineRecord = JSON.parse(readFileSync(recordPath, "utf8"));
-      unlinkSync(recordPath);
-      compareRecords(baselineRecord, candidateRecord);
-    });
 
-    if (baselineProjectCount === 0 || candidateProjectCount === 0) {
-      throw new Error("Parity inputs must each contain at least one eval record");
+      const baselineCoverageFingerprint = baselineRecord
+        ? coverageFingerprint(baselineRecord)
+        : null;
+      const candidateCoverageFingerprint = candidateRecord
+        ? coverageFingerprint(candidateRecord)
+        : null;
+      if (
+        selectedRuleKeys !== null &&
+        (baselineCoverageFingerprint === null || candidateCoverageFingerprint === null)
+      ) {
+        skippedProjects.push({
+          repository,
+          baselineError:
+            baselineCoverageFingerprint === null
+              ? "Scoped parity requires v3 project coverage"
+              : null,
+          candidateError:
+            candidateCoverageFingerprint === null
+              ? "Scoped parity requires v3 project coverage"
+              : null,
+        });
+        return;
+      }
+      if (
+        baselineCoverageFingerprint !== null &&
+        candidateCoverageFingerprint !== null &&
+        baselineCoverageFingerprint !== candidateCoverageFingerprint
+      ) {
+        skippedProjects.push({
+          repository,
+          baselineError: "Project coverage differs from candidate",
+          candidateError: "Project coverage differs from baseline",
+        });
+        return;
+      }
+
+      comparedProjectCount += 1;
+      baselineDiagnosticCount += diagnosticCount(baseline.diagnostics);
+      candidateDiagnosticCount += diagnosticCount(candidate.diagnostics);
+
+      const identities = new Set([...baseline.diagnostics.keys(), ...candidate.diagnostics.keys()]);
+      for (const identity of identities) {
+        const baselineDiagnostics = baseline.diagnostics.get(identity) ?? [];
+        const candidateDiagnostics = candidate.diagnostics.get(identity) ?? [];
+        const matchingCount = Math.min(baselineDiagnostics.length, candidateDiagnostics.length);
+        unchangedCount += matchingCount;
+        for (
+          let occurrenceIndex = matchingCount;
+          occurrenceIndex < baselineDiagnostics.length;
+          occurrenceIndex += 1
+        ) {
+          removed.push(
+            buildDiagnosticEntry(
+              repository,
+              JSON.stringify([identity, occurrenceIndex]),
+              baselineDiagnostics[occurrenceIndex],
+            ),
+          );
+        }
+        for (
+          let occurrenceIndex = matchingCount;
+          occurrenceIndex < candidateDiagnostics.length;
+          occurrenceIndex += 1
+        ) {
+          added.push(
+            buildDiagnosticEntry(
+              repository,
+              JSON.stringify([identity, occurrenceIndex]),
+              candidateDiagnostics[occurrenceIndex],
+            ),
+          );
+        }
+      }
+    };
+
+    let baselineProjectCount;
+    let candidateProjectCount;
+    try {
+      baselineProjectCount = await readRun(baselinePath, (record, key, line) => {
+        const recordPath = baselineRecordPath(temporaryDirectory, key);
+        if (existsSync(recordPath)) {
+          throw new Error(`${baselinePath} contains duplicate project ${key}`);
+        }
+        writeFileSync(recordPath, line);
+      });
+
+      const candidateKeys = new Set();
+      candidateProjectCount = await readRun(candidatePath, (candidateRecord, key) => {
+        if (candidateKeys.has(key)) {
+          throw new Error(`${candidatePath} contains duplicate project ${key}`);
+        }
+        candidateKeys.add(key);
+        const recordPath = baselineRecordPath(temporaryDirectory, key);
+        if (!existsSync(recordPath)) {
+          compareRecords(undefined, candidateRecord);
+          return;
+        }
+        const baselineRecord = JSON.parse(readFileSync(recordPath, "utf8"));
+        unlinkSync(recordPath);
+        compareRecords(baselineRecord, candidateRecord);
+      });
+
+      if (baselineProjectCount === 0 || candidateProjectCount === 0) {
+        throw new Error("Parity inputs must each contain at least one eval record");
+      }
+
+      for (const fileName of readdirSync(temporaryDirectory).sort(compareStrings)) {
+        if (!fileName.endsWith(BASELINE_RECORD_FILE_SUFFIX)) continue;
+        const recordPath = join(temporaryDirectory, fileName);
+        compareRecords(JSON.parse(readFileSync(recordPath, "utf8")), undefined);
+      }
+    } finally {
+      rmSync(temporaryDirectory, { recursive: true, force: true });
     }
 
-    for (const fileName of readdirSync(temporaryDirectory).sort(compareStrings)) {
-      if (!fileName.endsWith(BASELINE_RECORD_FILE_SUFFIX)) continue;
-      const recordPath = join(temporaryDirectory, fileName);
-      compareRecords(JSON.parse(readFileSync(recordPath, "utf8")), undefined);
+    added.sort(compareDiagnosticEntries);
+    removed.sort(compareDiagnosticEntries);
+    skippedProjects.sort(compareSkippedProjects);
+    const summary = {
+      baselineProjects: baselineProjectCount,
+      candidateProjects: candidateProjectCount,
+      comparedProjects: comparedProjectCount,
+      skippedProjects: skippedProjects.length,
+      baselineDiagnostics: baselineDiagnosticCount,
+      candidateDiagnostics: candidateDiagnosticCount,
+      added: added.length,
+      removed: removed.length,
+      unchanged: unchangedCount,
+    };
+    const rules = {
+      added: summarizeRules(added),
+      removed: summarizeRules(removed),
+    };
+
+    await writeOutputChunk("{\n");
+    await writeOutputProperty("schemaVersion", PARITY_SCHEMA_VERSION);
+    if (selectedRuleKeys) {
+      await writeOutputProperty("ruleScope", [...selectedRuleKeys].sort(compareStrings));
+      await writeOutputProperty("invariantRuleScope", [
+        TYPESCRIPT_INVARIANT_RULE_SCOPE,
+        ...[...INVARIANT_DIAGNOSTIC_RULE_KEYS].sort(compareStrings),
+      ]);
     }
-  } finally {
-    rmSync(temporaryDirectory, { recursive: true, force: true });
-  }
+    await writeOutputProperty("summary", summary);
+    await writeOutputProperty("rules", rules);
+    await writeOutputArray("added", added, true);
+    await writeOutputArray("removed", removed, true);
+    await writeOutputArray("skippedProjects", skippedProjects, false);
+    await writeOutputChunk("}\n");
+    process.stderr.write(
+      `Parity: +${added.length} -${removed.length}, unchanged ${unchangedCount}, skipped projects ${skippedProjects.length}\n`,
+    );
 
-  added.sort(compareDiagnosticEntries);
-  removed.sort(compareDiagnosticEntries);
-  skippedProjects.sort(compareSkippedProjects);
-  const summary = {
-    baselineProjects: baselineProjectCount,
-    candidateProjects: candidateProjectCount,
-    comparedProjects: comparedProjectCount,
-    skippedProjects: skippedProjects.length,
-    baselineDiagnostics: baselineDiagnosticCount,
-    candidateDiagnostics: candidateDiagnosticCount,
-    added: added.length,
-    removed: removed.length,
-    unchanged: unchangedCount,
-  };
-  const rules = {
-    added: summarizeRules(added),
-    removed: summarizeRules(removed),
-  };
-
-  await writeOutputChunk("{\n");
-  await writeOutputProperty("schemaVersion", PARITY_SCHEMA_VERSION);
-  await writeOutputProperty("summary", summary);
-  await writeOutputProperty("rules", rules);
-  await writeOutputArray("added", added, true);
-  await writeOutputArray("removed", removed, true);
-  await writeOutputArray("skippedProjects", skippedProjects, false);
-  await writeOutputChunk("}\n");
-  process.stderr.write(
-    `Parity: +${added.length} -${removed.length}, unchanged ${unchangedCount}, skipped projects ${skippedProjects.length}\n`,
-  );
-
-  if (skippedProjects.length > 0) {
+    if (skippedProjects.length > 0) {
+      process.exitCode = INVALID_INPUT_EXIT_CODE;
+    } else if (added.length > 0 || removed.length > 0) {
+      process.exitCode = PARITY_DIFFERENCE_EXIT_CODE;
+    }
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
     process.exitCode = INVALID_INPUT_EXIT_CODE;
-  } else if (added.length > 0 || removed.length > 0) {
-    process.exitCode = PARITY_DIFFERENCE_EXIT_CODE;
   }
-} catch (error) {
-  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
-  process.exitCode = INVALID_INPUT_EXIT_CODE;
+};
+
+const runCli = async () => {
+  const comparisonArguments = process.argv.slice(2);
+  const hasRuleScope =
+    comparisonArguments.length === SCOPED_ARGUMENT_COUNT && comparisonArguments[0] === "--rules";
+  const [baselinePath, candidatePath] = hasRuleScope
+    ? comparisonArguments.slice(2)
+    : comparisonArguments;
+
+  if (
+    (!hasRuleScope && comparisonArguments.length !== EXPECTED_ARGUMENT_COUNT) ||
+    (hasRuleScope && (!baselinePath || !candidatePath))
+  ) {
+    process.stderr.write(
+      "Usage: compare-parity.mjs [--rules <rules.json>] <baseline.ndjson> <candidate.ndjson>\n",
+    );
+    process.exitCode = INVALID_INPUT_EXIT_CODE;
+    return;
+  }
+
+  try {
+    const selectedRuleKeys = loadSelectedRuleKeys(
+      hasRuleScope ? comparisonArguments[1] : undefined,
+    );
+    await compareParity({ baselinePath, candidatePath, selectedRuleKeys });
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = INVALID_INPUT_EXIT_CODE;
+  }
+};
+
+if (fileURLToPath(import.meta.url) === process.argv[1]) {
+  await runCli();
 }

--- a/.agents/skills/run-parity/scripts/compare-parity.mjs
+++ b/.agents/skills/run-parity/scripts/compare-parity.mjs
@@ -13,7 +13,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join, posix } from "node:path";
+import { join, posix, resolve as resolveFileSystemPath } from "node:path";
 import { createInterface } from "node:readline";
 import { isDeepStrictEqual } from "node:util";
 import { fileURLToPath } from "node:url";
@@ -789,6 +789,6 @@ const runCli = async () => {
   }
 };
 
-if (fileURLToPath(import.meta.url) === process.argv[1]) {
+if (process.argv[1] && fileURLToPath(import.meta.url) === resolveFileSystemPath(process.argv[1])) {
   await runCli();
 }

--- a/.agents/skills/run-parity/scripts/compare-parity.test.mjs
+++ b/.agents/skills/run-parity/scripts/compare-parity.test.mjs
@@ -100,7 +100,7 @@ const buildRecord = (repository = buildRepository(), report = buildReport()) => 
   report,
 });
 
-const runComparison = (baselineRecords, candidateRecords) => {
+const runComparison = (baselineRecords, candidateRecords, ruleKeys = null) => {
   const temporaryDirectory = mkdtempSync(join(tmpdir(), "react-doctor-parity-"));
   try {
     const baselinePath = join(temporaryDirectory, "baseline.ndjson");
@@ -113,7 +113,14 @@ const runComparison = (baselineRecords, candidateRecords) => {
       candidatePath,
       candidateRecords.map((record) => JSON.stringify(record)).join("\n") + "\n",
     );
-    return spawnSync(process.execPath, [scriptPath, baselinePath, candidatePath], {
+    const comparisonArguments = [scriptPath];
+    if (ruleKeys !== null) {
+      const ruleKeysPath = join(temporaryDirectory, "rules.json");
+      writeFileSync(ruleKeysPath, JSON.stringify(ruleKeys));
+      comparisonArguments.push("--rules", ruleKeysPath);
+    }
+    comparisonArguments.push(baselinePath, candidatePath);
+    return spawnSync(process.execPath, comparisonArguments, {
       encoding: "utf8",
     });
   } finally {
@@ -171,6 +178,37 @@ test("canonicalizes matching legacy and v3 diagnostics to report-relative identi
   assert.equal(comparison.summary.unchanged, 1);
 });
 
+test("accepts canonical rule keys with camelCase rule segments", () => {
+  const diagnostic = buildV3Diagnostic({
+    id: "src/app.tsx::1:1::react-doctor/no-derived-useState::digest",
+    rule: "no-derived-useState",
+  });
+  const record = buildRecord(
+    buildRepository(),
+    buildReport({
+      diagnostics: [diagnostic],
+      projects: [
+        {
+          directory: "/workspace/target",
+          packageRoot: "/workspace/target",
+          framework: "nextjs",
+          project: {},
+          diagnostics: [diagnostic],
+          score: null,
+          skippedChecks: [],
+          analyzedFiles: ["src/app.tsx"],
+          analyzedFileCount: 1,
+          complete: true,
+          elapsedMilliseconds: 1,
+        },
+      ],
+    }),
+  );
+  const result = runComparison([record], [record], ["react-doctor/no-derived-useState"]);
+
+  assert.equal(result.status, SUCCESS_EXIT_CODE, result.stderr);
+});
+
 test("keeps same-named files in nested projects as distinct identities", () => {
   const firstDiagnostic = buildV3Diagnostic({
     id: "packages/first/package.json::0:0::react-doctor/example::first",
@@ -215,7 +253,7 @@ test("accepts complete Astro project reports", () => {
   assert.equal(JSON.parse(result.stdout).summary.unchanged, 1);
 });
 
-test("does not count duplicate diagnostic identities more than once", () => {
+test("preserves duplicate diagnostic multiplicity", () => {
   const diagnostic = buildV3Diagnostic();
   const addedDiagnostic = buildV3Diagnostic({
     id: "src/app.tsx::2:1::react-doctor/added::digest",
@@ -252,12 +290,310 @@ test("does not count duplicate diagnostic identities more than once", () => {
     candidateProjects: 1,
     comparedProjects: 1,
     skippedProjects: 0,
-    baselineDiagnostics: 1,
-    candidateDiagnostics: 2,
-    added: 1,
+    baselineDiagnostics: 2,
+    candidateDiagnostics: 4,
+    added: 2,
     removed: 0,
-    unchanged: 1,
+    unchanged: 2,
   });
+});
+
+test("compares only selected rule diagnostics against a full baseline", () => {
+  const selectedDiagnostic = buildV3Diagnostic();
+  const unselectedDiagnostic = buildV3Diagnostic({
+    id: "src/app.tsx::2:1::react-doctor/unselected::digest",
+    line: 2,
+    rule: "unselected",
+  });
+  const baselineReport = buildReport({
+    projects: [
+      {
+        ...buildReport().projects[0],
+        diagnostics: [selectedDiagnostic, unselectedDiagnostic],
+      },
+    ],
+    diagnostics: [selectedDiagnostic, unselectedDiagnostic],
+  });
+  const candidateReport = buildReport({
+    projects: [{ ...buildReport().projects[0], diagnostics: [selectedDiagnostic] }],
+    diagnostics: [selectedDiagnostic],
+  });
+
+  const result = runComparison(
+    [buildRecord(buildRepository(), baselineReport)],
+    [buildRecord(buildRepository(), candidateReport)],
+    ["react-doctor/example"],
+  );
+
+  assert.equal(result.status, SUCCESS_EXIT_CODE, result.stderr);
+  const comparison = JSON.parse(result.stdout);
+  assert.deepEqual(comparison.ruleScope, ["react-doctor/example"]);
+  assert.equal(comparison.summary.baselineDiagnostics, 1);
+  assert.equal(comparison.summary.candidateDiagnostics, 1);
+  assert.equal(comparison.summary.unchanged, 1);
+});
+
+test("compares always-on TypeScript and environment diagnostics within a rule scope", () => {
+  const selectedDiagnostic = buildV3Diagnostic();
+  const typescriptDiagnostic = buildV3Diagnostic({
+    id: "src/types.ts::1:1::TS/8011::digest",
+    normalizedFilePath: "src/types.ts",
+    filePath: "src/types.ts",
+    plugin: "TS",
+    rule: "8011",
+    message: "Type annotations can only be used in TypeScript files.",
+  });
+  const environmentDiagnostic = buildV3Diagnostic({
+    id: "package.json::0:0::react-doctor/require-pnpm-hardening::digest",
+    normalizedFilePath: "package.json",
+    filePath: "package.json",
+    line: 0,
+    column: 0,
+    rule: "require-pnpm-hardening",
+  });
+  const unselectedDiagnostic = buildV3Diagnostic({
+    id: "src/app.tsx::2:1::react-doctor/unselected::digest",
+    line: 2,
+    rule: "unselected",
+  });
+  const buildScopedReport = (diagnostics) =>
+    buildReport({
+      projects: [{ ...buildReport().projects[0], diagnostics }],
+      diagnostics,
+    });
+
+  const result = runComparison(
+    [
+      buildRecord(
+        buildRepository(),
+        buildScopedReport([
+          selectedDiagnostic,
+          typescriptDiagnostic,
+          environmentDiagnostic,
+          unselectedDiagnostic,
+        ]),
+      ),
+    ],
+    [
+      buildRecord(
+        buildRepository(),
+        buildScopedReport([selectedDiagnostic, typescriptDiagnostic, environmentDiagnostic]),
+      ),
+    ],
+    ["react-doctor/example"],
+  );
+
+  assert.equal(result.status, SUCCESS_EXIT_CODE, result.stderr);
+  const comparison = JSON.parse(result.stdout);
+  assert.equal(comparison.summary.baselineDiagnostics, 3);
+  assert.equal(comparison.summary.candidateDiagnostics, 3);
+  assert.equal(comparison.summary.unchanged, 3);
+  assert.ok(comparison.invariantRuleScope.includes("TS/*"));
+  assert.ok(comparison.invariantRuleScope.includes("react-doctor/require-pnpm-hardening"));
+});
+
+test("detects changed always-on diagnostics within a rule scope", () => {
+  const baselineInvariantDiagnostic = buildV3Diagnostic({
+    id: "src/types.ts::1:1::TS/8011::digest",
+    plugin: "TS",
+    rule: "8011",
+    message: "Baseline parser diagnostic",
+  });
+  const candidateInvariantDiagnostic = {
+    ...baselineInvariantDiagnostic,
+    message: "Candidate parser diagnostic",
+  };
+  const buildScopedReport = (diagnostic) =>
+    buildReport({
+      projects: [{ ...buildReport().projects[0], diagnostics: [diagnostic] }],
+      diagnostics: [diagnostic],
+    });
+
+  const result = runComparison(
+    [buildRecord(buildRepository(), buildScopedReport(baselineInvariantDiagnostic))],
+    [buildRecord(buildRepository(), buildScopedReport(candidateInvariantDiagnostic))],
+    ["react-doctor/example"],
+  );
+
+  assert.equal(result.status, 1, result.stderr);
+  assert.equal(JSON.parse(result.stdout).summary.added, 1);
+  assert.equal(JSON.parse(result.stdout).summary.removed, 1);
+});
+
+test("rejects candidate diagnostics outside the selected rule scope", () => {
+  const selectedDiagnostic = buildV3Diagnostic();
+  const unselectedDiagnostic = buildV3Diagnostic({
+    id: "src/app.tsx::2:1::react-doctor/unselected::digest",
+    line: 2,
+    rule: "unselected",
+  });
+  const baselineRecord = buildRecord();
+  const candidateReport = buildReport({
+    projects: [
+      {
+        ...buildReport().projects[0],
+        diagnostics: [selectedDiagnostic, unselectedDiagnostic],
+      },
+    ],
+    diagnostics: [selectedDiagnostic, unselectedDiagnostic],
+  });
+
+  const result = runComparison(
+    [baselineRecord],
+    [buildRecord(buildRepository(), candidateReport)],
+    ["react-doctor/example"],
+  );
+
+  assert.equal(result.status, 2, result.stderr);
+  assert.match(JSON.parse(result.stdout).skippedProjects[0].candidateError, /outside rule scope/);
+});
+
+test("rejects candidate reports that omit a zero-hit analyzed file", () => {
+  const baselineReport = buildReport();
+  baselineReport.projects[0].analyzedFiles = ["src/app.tsx", "src/zero-hit.tsx"];
+  baselineReport.projects[0].analyzedFileCount = 2;
+  baselineReport.projects[0].scannedFileCount = 2;
+  const candidateReport = buildReport();
+  candidateReport.projects[0].scannedFileCount = 1;
+
+  const result = runComparison(
+    [buildRecord(buildRepository(), baselineReport)],
+    [buildRecord(buildRepository(), candidateReport)],
+    ["react-doctor/example"],
+  );
+
+  assert.equal(result.status, 2, result.stderr);
+  assert.match(JSON.parse(result.stdout).skippedProjects[0].candidateError, /coverage differs/);
+});
+
+test("rejects candidate reports that omit a zero-hit project", () => {
+  const diagnosticProject = buildReport().projects[0];
+  const zeroHitProject = {
+    ...diagnosticProject,
+    directory: "/workspace/target/packages/zero-hit",
+    packageRoot: "/workspace/target/packages/zero-hit",
+    diagnostics: [],
+    analyzedFiles: ["src/index.ts"],
+  };
+  const baselineReport = buildReport({
+    projects: [diagnosticProject, zeroHitProject],
+    diagnostics: diagnosticProject.diagnostics,
+  });
+  const candidateReport = buildReport();
+
+  const result = runComparison(
+    [buildRecord(buildRepository(), baselineReport)],
+    [buildRecord(buildRepository(), candidateReport)],
+    ["react-doctor/example"],
+  );
+
+  assert.equal(result.status, 2, result.stderr);
+  assert.match(JSON.parse(result.stdout).skippedProjects[0].candidateError, /coverage differs/);
+});
+
+for (const [name, mutateProject] of [
+  ["framework", (project) => (project.framework = "vite")],
+  [
+    "package root",
+    (project) => {
+      project.directory = "/workspace/target/packages/app";
+      project.packageRoot = "/workspace/target/packages/app";
+    },
+  ],
+]) {
+  test(`rejects candidate project ${name} drift`, () => {
+    const candidateReport = buildReport();
+    mutateProject(candidateReport.projects[0]);
+    const result = runComparison(
+      [buildRecord()],
+      [buildRecord(buildRepository(), candidateReport)],
+      ["react-doctor/example"],
+    );
+
+    assert.equal(result.status, 2, result.stderr);
+    assert.match(JSON.parse(result.stdout).skippedProjects[0].candidateError, /coverage differs/);
+  });
+}
+
+test("accepts semantically identical coverage in a different file order", () => {
+  const baselineReport = buildReport();
+  baselineReport.projects[0].analyzedFiles = ["src/app.tsx", "src/other.tsx"];
+  baselineReport.projects[0].analyzedFileCount = 2;
+  baselineReport.projects[0].scannedFileCount = 2;
+  const candidateReport = structuredClone(baselineReport);
+  candidateReport.projects[0].analyzedFiles.reverse();
+
+  const result = runComparison(
+    [buildRecord(buildRepository(), baselineReport)],
+    [buildRecord(buildRepository(), candidateReport)],
+  );
+
+  assert.equal(result.status, SUCCESS_EXIT_CODE, result.stderr);
+});
+
+for (const [name, mutateDiagnostic] of [
+  ["help text", (diagnostic) => (diagnostic.help = "Different help.")],
+  ["category", (diagnostic) => (diagnostic.category = "Performance")],
+  ["tags", (diagnostic) => (diagnostic.tags = ["performance"])],
+  ["title", (diagnostic) => (diagnostic.title = "Different title")],
+  ["URL", (diagnostic) => (diagnostic.url = "https://example.com/rule")],
+  ["span", (diagnostic) => (diagnostic.length = 4)],
+  [
+    "related locations",
+    (diagnostic) =>
+      (diagnostic.relatedLocations = [
+        {
+          filePath: "src/helper.ts",
+          line: 2,
+          column: 3,
+          message: "Related",
+        },
+      ]),
+  ],
+  ["fix group", (diagnostic) => (diagnostic.fixGroupId = "group")],
+]) {
+  test(`detects a diagnostic ${name} change`, () => {
+    const baselineReport = buildReport();
+    const candidateReport = structuredClone(baselineReport);
+    mutateDiagnostic(candidateReport.projects[0].diagnostics[0]);
+    mutateDiagnostic(candidateReport.diagnostics[0]);
+    const result = runComparison(
+      [buildRecord(buildRepository(), baselineReport)],
+      [buildRecord(buildRepository(), candidateReport)],
+    );
+
+    assert.equal(result.status, 1, result.stderr);
+    const summary = JSON.parse(result.stdout).summary;
+    assert.equal(summary.added, 1);
+    assert.equal(summary.removed, 1);
+    assert.equal(summary.unchanged, 0);
+  });
+}
+
+test("canonicalizes related-location paths across report roots", () => {
+  const repository = buildRepository("workspace", "packages/ui");
+  const baselineReport = buildReport();
+  baselineReport.projects[0].diagnostics[0].relatedLocations = [
+    {
+      filePath: "src/helper.ts",
+      line: 2,
+      column: 3,
+      message: "Related",
+    },
+  ];
+  baselineReport.diagnostics[0].relatedLocations =
+    baselineReport.projects[0].diagnostics[0].relatedLocations;
+  const candidateReport = structuredClone(baselineReport);
+  candidateReport.projects[0].diagnostics[0].relatedLocations[0].filePath =
+    "/workspace/target/src/helper.ts";
+  candidateReport.diagnostics[0].relatedLocations[0].filePath = "/workspace/target/src/helper.ts";
+
+  const result = runComparison(
+    [buildRecord(repository, baselineReport)],
+    [buildRecord(repository, candidateReport)],
+  );
+
+  assert.equal(result.status, SUCCESS_EXIT_CODE, result.stderr);
 });
 
 test("classifies explicitly incomplete project reports as skipped", () => {
@@ -337,6 +673,26 @@ test("rejects malformed diagnostics and inconsistent flattened diagnostics", () 
   assert.equal(mismatchedResult.status, 2, mismatchedResult.stderr);
 });
 
+test("rejects malformed optional diagnostic fields", () => {
+  const report = buildReport();
+  report.projects[0].diagnostics[0].relatedLocations = [
+    {
+      filePath: "src/helper.ts",
+      line: "2",
+      column: 3,
+      message: "Related",
+    },
+  ];
+  report.diagnostics[0].relatedLocations = report.projects[0].diagnostics[0].relatedLocations;
+
+  const result = runComparison(
+    [buildRecord(buildRepository(), report)],
+    [buildRecord(buildRepository(), report)],
+  );
+
+  assert.equal(result.status, 2, result.stderr);
+});
+
 test("accepts semantically equal flattened diagnostics with reordered object keys", () => {
   const report = buildReport();
   const reorderedDiagnostic = Object.fromEntries(Object.entries(report.diagnostics[0]).reverse());
@@ -396,6 +752,18 @@ test("accepts complete v2 reports and requires baseline data", () => {
 
   assert.equal(completeResult.status, 0, completeResult.stderr);
   assert.equal(missingResult.status, 2, missingResult.stderr);
+});
+
+test("rejects legacy reports in scoped parity because coverage is unavailable", () => {
+  const legacyReport = buildReport({ schemaVersion: 1 });
+  const result = runComparison(
+    [buildRecord(buildRepository(), legacyReport)],
+    [buildRecord(buildRepository(), legacyReport)],
+    ["react-doctor/example"],
+  );
+
+  assert.equal(result.status, 2);
+  assert.match(result.stdout, /Scoped parity requires v3 project coverage/);
 });
 
 test("rejects malformed repository refs before comparison", () => {

--- a/.agents/skills/run-parity/scripts/compare-parity.test.mjs
+++ b/.agents/skills/run-parity/scripts/compare-parity.test.mjs
@@ -8,6 +8,7 @@ import { fileURLToPath } from "node:url";
 
 const SUCCESS_EXIT_CODE = 0;
 const scriptPath = fileURLToPath(new URL("./compare-parity.mjs", import.meta.url));
+const scriptDirectory = fileURLToPath(new URL(".", import.meta.url));
 
 const buildRepository = (name = "project", rootDir = ".") => ({
   org: "example",
@@ -100,7 +101,12 @@ const buildRecord = (repository = buildRepository(), report = buildReport()) => 
   report,
 });
 
-const runComparison = (baselineRecords, candidateRecords, ruleKeys = null) => {
+const runComparison = (
+  baselineRecords,
+  candidateRecords,
+  ruleKeys = null,
+  useRelativeScriptPath = false,
+) => {
   const temporaryDirectory = mkdtempSync(join(tmpdir(), "react-doctor-parity-"));
   try {
     const baselinePath = join(temporaryDirectory, "baseline.ndjson");
@@ -113,7 +119,7 @@ const runComparison = (baselineRecords, candidateRecords, ruleKeys = null) => {
       candidatePath,
       candidateRecords.map((record) => JSON.stringify(record)).join("\n") + "\n",
     );
-    const comparisonArguments = [scriptPath];
+    const comparisonArguments = [useRelativeScriptPath ? "./compare-parity.mjs" : scriptPath];
     if (ruleKeys !== null) {
       const ruleKeysPath = join(temporaryDirectory, "rules.json");
       writeFileSync(ruleKeysPath, JSON.stringify(ruleKeys));
@@ -122,11 +128,20 @@ const runComparison = (baselineRecords, candidateRecords, ruleKeys = null) => {
     comparisonArguments.push(baselinePath, candidatePath);
     return spawnSync(process.execPath, comparisonArguments, {
       encoding: "utf8",
+      cwd: useRelativeScriptPath ? scriptDirectory : undefined,
     });
   } finally {
     rmSync(temporaryDirectory, { recursive: true, force: true });
   }
 };
+
+test("runs the comparator through a relative CLI script path", () => {
+  const record = buildRecord();
+  const result = runComparison([record], [record], null, true);
+
+  assert.equal(result.status, SUCCESS_EXIT_CODE, result.stderr);
+  assert.equal(JSON.parse(result.stdout).summary.unchanged, 1);
+});
 
 test("canonicalizes matching legacy and v3 diagnostics to report-relative identities", () => {
   const repository = buildRepository("workspace", "packages/ui");

--- a/.agents/skills/run-parity/scripts/find-impacted-rules.mjs
+++ b/.agents/skills/run-parity/scripts/find-impacted-rules.mjs
@@ -298,21 +298,26 @@ const buildReverseDependencies = (dependencies) => {
   return reverseDependencies;
 };
 
-const collectImpactedRules = (graph, changedPaths) => {
+const collectRuleImpact = (graph, changedPaths) => {
   const pendingPaths = changedPaths.filter((sourcePath) => graph.sourceTree.has(sourcePath));
   const visitedPaths = new Set();
   const impactedRules = new Set();
+  const unscopedRuntimePaths = new Set();
   while (pendingPaths.length > 0) {
     const sourcePath = pendingPaths.pop();
     if (!sourcePath || visitedPaths.has(sourcePath)) continue;
     visitedPaths.add(sourcePath);
     const ruleKey = graph.ruleKeyBySourcePath.get(sourcePath);
-    if (ruleKey) impactedRules.add(ruleKey);
+    if (ruleKey) {
+      impactedRules.add(ruleKey);
+      continue;
+    }
+    if (!isIncrementalRuntimePath(sourcePath)) unscopedRuntimePaths.add(sourcePath);
     for (const importerPath of graph.reverseDependencies.get(sourcePath) ?? []) {
       pendingPaths.push(importerPath);
     }
   }
-  return impactedRules;
+  return { impactedRules, unscopedRuntimePaths };
 };
 
 const buildRuleFingerprint = (graph, ruleSourcePath) => {
@@ -373,18 +378,31 @@ const buildManifest = (repositoryDirectory, baseRef, headRef) => {
       fallbackReasons.push(`Global runtime change requires full parity: ${sourcePath}`);
     }
   }
+  const baseImpact = collectRuleImpact(baseGraph, runtimeChangedPaths);
+  const headImpact = collectRuleImpact(headGraph, runtimeChangedPaths);
   const directlyImpactedRuleKeys = new Set([
-    ...collectImpactedRules(baseGraph, runtimeChangedPaths),
-    ...collectImpactedRules(headGraph, runtimeChangedPaths),
+    ...baseImpact.impactedRules,
+    ...headImpact.impactedRules,
   ]);
+  for (const sourcePath of new Set([
+    ...baseImpact.unscopedRuntimePaths,
+    ...headImpact.unscopedRuntimePaths,
+  ])) {
+    fallbackReasons.push(`Plugin host dependency requires full parity: ${sourcePath}`);
+  }
+  if (runtimeChangedPaths.length === 0) {
+    fallbackReasons.push("No runtime rule impact requires full parity");
+  }
   const impactedRuleKeys = addDiagnosticInteractionClosure(directlyImpactedRuleKeys);
-  for (const sourcePath of runtimeChangedPaths.filter((path) => path.startsWith(RULES_ROOT))) {
+  for (const sourcePath of runtimeChangedPaths.filter(
+    (path) => path.startsWith(PLUGIN_SOURCE_ROOT) && isIncrementalRuntimePath(path),
+  )) {
     const mappedRuleKeys = new Set([
-      ...collectImpactedRules(baseGraph, [sourcePath]),
-      ...collectImpactedRules(headGraph, [sourcePath]),
+      ...collectRuleImpact(baseGraph, [sourcePath]).impactedRules,
+      ...collectRuleImpact(headGraph, [sourcePath]).impactedRules,
     ]);
     if (mappedRuleKeys.size === 0) {
-      fallbackReasons.push(`Changed rule runtime cannot be mapped to a rule: ${sourcePath}`);
+      fallbackReasons.push(`Changed plugin runtime cannot be mapped to a rule: ${sourcePath}`);
     }
   }
   for (const ruleKey of directlyImpactedRuleKeys) {

--- a/.agents/skills/run-parity/scripts/find-impacted-rules.mjs
+++ b/.agents/skills/run-parity/scripts/find-impacted-rules.mjs
@@ -1,0 +1,475 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { writeFileSync } from "node:fs";
+import { posix, resolve as resolveFileSystemPath } from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+
+const IMPACT_SCHEMA_VERSION = 1;
+const EXPECTED_ARGUMENT_COUNT = 4;
+const PLUGIN_SOURCE_ROOT = "packages/oxlint-plugin-react-doctor/src";
+const RULES_ROOT = `${PLUGIN_SOURCE_ROOT}/plugin/rules/`;
+const INCREMENTAL_RUNTIME_ROOTS = [
+  RULES_ROOT,
+  `${PLUGIN_SOURCE_ROOT}/plugin/constants/`,
+  `${PLUGIN_SOURCE_ROOT}/plugin/utils/`,
+];
+const RUNTIME_SOURCE_PATTERN = /\.(?:[cm]?[jt]sx?|json)$/;
+const TEST_SOURCE_PATTERN =
+  /(?:^|\/)(?:__fixtures__|fixtures|tests?)\/|(?:\.|^)(?:test|spec)\.[cm]?[jt]sx?$|\.regressions\.test\.[cm]?[jt]sx?$|\/liveness\/liveness-fixtures\.ts$/;
+const IGNORED_CHANGE_PATTERN = /^(?:\.changeset\/|docs?\/|packages\/fuzz\/)|\.(?:md|mdx|snap)$/;
+const RULE_KEY_PREFIX = "react-doctor/";
+const FINGERPRINT_VERSION = "react-doctor-parity-rule-fingerprint-v1";
+const FULL_PARITY_RULE_KEYS = new Set(["react-doctor/react-compiler-no-manual-memoization"]);
+const DIAGNOSTIC_INTERACTION_GROUPS = [
+  [
+    "react-doctor/no-initialize-state",
+    "react-doctor/no-adjust-state-on-prop-change",
+    "react-doctor/no-derived-state",
+    "react-doctor/no-derived-state-effect",
+  ],
+  ["react-doctor/rules-of-hooks", "react-hooks-js/hooks"],
+];
+
+const usage = () =>
+  "Usage: find-impacted-rules.mjs <repository-directory> <base-ref> <head-ref> <output-path>";
+
+const runGit = (repositoryDirectory, argumentsToPass) =>
+  execFileSync("git", ["-C", repositoryDirectory, ...argumentsToPass], {
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024 * 128,
+  });
+
+const resolveCommit = (repositoryDirectory, ref) =>
+  runGit(repositoryDirectory, ["rev-parse", "--verify", `${ref}^{commit}`]).trim();
+
+const listSourcePaths = (repositoryDirectory, ref) =>
+  runGit(repositoryDirectory, ["ls-tree", "-r", "-z", "--name-only", ref, "--", PLUGIN_SOURCE_ROOT])
+    .split("\0")
+    .filter(
+      (sourcePath) =>
+        sourcePath.length > 0 &&
+        RUNTIME_SOURCE_PATTERN.test(sourcePath) &&
+        !sourcePath.endsWith(".d.ts") &&
+        !TEST_SOURCE_PATTERN.test(sourcePath),
+    );
+
+const readGitFile = (repositoryDirectory, ref, sourcePath) =>
+  runGit(repositoryDirectory, ["show", `${ref}:${sourcePath}`]);
+
+const loadSourceTree = (repositoryDirectory, ref) =>
+  new Map(
+    listSourcePaths(repositoryDirectory, ref).map((sourcePath) => [
+      sourcePath,
+      readGitFile(repositoryDirectory, ref, sourcePath),
+    ]),
+  );
+
+const isRuntimeImport = (node) => {
+  const importClause = node.importClause;
+  if (!importClause) return true;
+  if (importClause.isTypeOnly || importClause.name) return !importClause.isTypeOnly;
+  const namedBindings = importClause.namedBindings;
+  if (!namedBindings || ts.isNamespaceImport(namedBindings)) return true;
+  return namedBindings.elements.some((specifier) => !specifier.isTypeOnly);
+};
+
+const isRuntimeExport = (node) => {
+  if (node.isTypeOnly) return false;
+  const exportClause = node.exportClause;
+  if (!exportClause || !ts.isNamedExports(exportClause)) return true;
+  return exportClause.elements.some((specifier) => !specifier.isTypeOnly);
+};
+
+const resolveRelativeModule = (sourcePath, moduleSpecifier, sourcePaths) => {
+  const unresolvedPath = posix.normalize(posix.join(posix.dirname(sourcePath), moduleSpecifier));
+  let extensionCandidates;
+  if (unresolvedPath.endsWith(".js")) {
+    extensionCandidates = [
+      `${unresolvedPath.slice(0, -3)}.ts`,
+      `${unresolvedPath.slice(0, -3)}.tsx`,
+      unresolvedPath,
+    ];
+  } else if (unresolvedPath.endsWith(".jsx")) {
+    extensionCandidates = [`${unresolvedPath.slice(0, -4)}.tsx`, unresolvedPath];
+  } else if (unresolvedPath.endsWith(".mjs")) {
+    extensionCandidates = [`${unresolvedPath.slice(0, -4)}.mts`, unresolvedPath];
+  } else if (unresolvedPath.endsWith(".cjs")) {
+    extensionCandidates = [`${unresolvedPath.slice(0, -4)}.cts`, unresolvedPath];
+  } else if (RUNTIME_SOURCE_PATTERN.test(unresolvedPath)) {
+    extensionCandidates = [unresolvedPath];
+  } else {
+    extensionCandidates = [
+      `${unresolvedPath}.ts`,
+      `${unresolvedPath}.tsx`,
+      `${unresolvedPath}.mts`,
+      `${unresolvedPath}.cts`,
+      `${unresolvedPath}.js`,
+      `${unresolvedPath}.jsx`,
+      `${unresolvedPath}.mjs`,
+      `${unresolvedPath}.cjs`,
+      `${unresolvedPath}.json`,
+      `${unresolvedPath}/index.ts`,
+      `${unresolvedPath}/index.tsx`,
+      `${unresolvedPath}/index.mts`,
+      `${unresolvedPath}/index.cts`,
+      `${unresolvedPath}/index.js`,
+      `${unresolvedPath}/index.jsx`,
+      `${unresolvedPath}/index.mjs`,
+      `${unresolvedPath}/index.cjs`,
+      `${unresolvedPath}/index.json`,
+    ];
+  }
+  return extensionCandidates.find((candidatePath) => sourcePaths.has(candidatePath)) ?? null;
+};
+
+const collectModuleSpecifiers = (sourcePath, sourceContents) => {
+  if (sourcePath.endsWith(".json")) return { moduleSpecifiers: [], uncertainty: null };
+  const scriptKind = sourcePath.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS;
+  const sourceFile = ts.createSourceFile(
+    sourcePath,
+    sourceContents,
+    ts.ScriptTarget.Latest,
+    true,
+    scriptKind,
+  );
+  if (sourceFile.parseDiagnostics.length > 0) {
+    return {
+      moduleSpecifiers: [],
+      uncertainty: `TypeScript could not parse ${sourcePath}`,
+    };
+  }
+  const moduleSpecifiers = [];
+  let uncertainty = null;
+  for (const statement of sourceFile.statements) {
+    if (
+      ts.isImportDeclaration(statement) &&
+      isRuntimeImport(statement) &&
+      ts.isStringLiteral(statement.moduleSpecifier)
+    ) {
+      moduleSpecifiers.push(statement.moduleSpecifier.text);
+    }
+    if (
+      ts.isImportEqualsDeclaration(statement) &&
+      !statement.isTypeOnly &&
+      ts.isExternalModuleReference(statement.moduleReference)
+    ) {
+      const moduleExpression = statement.moduleReference.expression;
+      if (moduleExpression && ts.isStringLiteralLike(moduleExpression)) {
+        moduleSpecifiers.push(moduleExpression.text);
+      } else {
+        uncertainty = `Non-literal runtime module edge in ${sourcePath}`;
+      }
+    }
+    if (
+      ts.isExportDeclaration(statement) &&
+      isRuntimeExport(statement) &&
+      statement.moduleSpecifier &&
+      ts.isStringLiteral(statement.moduleSpecifier)
+    ) {
+      moduleSpecifiers.push(statement.moduleSpecifier.text);
+    }
+  }
+  const visit = (node) => {
+    if (ts.isCallExpression(node)) {
+      const isDynamicImport = node.expression.kind === ts.SyntaxKind.ImportKeyword;
+      const isRequire = ts.isIdentifier(node.expression) && node.expression.text === "require";
+      if (isDynamicImport || isRequire) {
+        const [argument] = node.arguments;
+        if (argument && ts.isStringLiteralLike(argument)) {
+          moduleSpecifiers.push(argument.text);
+        } else {
+          uncertainty = `Non-literal runtime module edge in ${sourcePath}`;
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(sourceFile, visit);
+  return { moduleSpecifiers, uncertainty };
+};
+
+const extractRuleKey = (sourcePath, sourceContents) => {
+  if (!sourcePath.startsWith(RULES_ROOT) || !sourcePath.endsWith(".ts")) return null;
+  const sourceFile = ts.createSourceFile(
+    sourcePath,
+    sourceContents,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  let ruleKey = null;
+  const visit = (node) => {
+    if (
+      ruleKey === null &&
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      (node.expression.text === "defineRule" || node.expression.text === "defineRetiredRule")
+    ) {
+      const [definition] = node.arguments;
+      if (definition && ts.isObjectLiteralExpression(definition)) {
+        for (const property of definition.properties) {
+          if (
+            ts.isPropertyAssignment(property) &&
+            ((ts.isIdentifier(property.name) && property.name.text === "id") ||
+              (ts.isStringLiteral(property.name) && property.name.text === "id")) &&
+            ts.isStringLiteralLike(property.initializer)
+          ) {
+            ruleKey = `${RULE_KEY_PREFIX}${property.initializer.text}`;
+            return;
+          }
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(sourceFile, visit);
+  return ruleKey;
+};
+
+const buildModuleGraph = (sourceTree) => {
+  const sourcePaths = new Set(sourceTree.keys());
+  const dependencies = new Map();
+  const ruleKeyBySourcePath = new Map();
+  const sourcePathByRuleKey = new Map();
+  const uncertainties = [];
+  for (const [sourcePath, sourceContents] of sourceTree) {
+    const { moduleSpecifiers, uncertainty } = collectModuleSpecifiers(sourcePath, sourceContents);
+    if (uncertainty) uncertainties.push(uncertainty);
+    const resolvedDependencies = new Set();
+    for (const moduleSpecifier of moduleSpecifiers) {
+      if (!moduleSpecifier.startsWith(".")) continue;
+      const resolvedPath = resolveRelativeModule(sourcePath, moduleSpecifier, sourcePaths);
+      if (resolvedPath === null) {
+        uncertainties.push(`Unresolved runtime module ${moduleSpecifier} from ${sourcePath}`);
+      } else {
+        resolvedDependencies.add(resolvedPath);
+      }
+    }
+    dependencies.set(sourcePath, resolvedDependencies);
+    const ruleKey = extractRuleKey(sourcePath, sourceContents);
+    if (ruleKey !== null) {
+      const existingSourcePath = sourcePathByRuleKey.get(ruleKey);
+      if (existingSourcePath) {
+        uncertainties.push(`Duplicate rule key ${ruleKey}`);
+      }
+      ruleKeyBySourcePath.set(sourcePath, ruleKey);
+      sourcePathByRuleKey.set(ruleKey, sourcePath);
+    }
+  }
+  return {
+    dependencies,
+    reverseDependencies: buildReverseDependencies(dependencies),
+    ruleKeyBySourcePath,
+    sourceTree,
+    uncertainties,
+  };
+};
+
+const listChangedPaths = (repositoryDirectory, baseRef, headRef) => {
+  const forwardPaths = runGit(repositoryDirectory, [
+    "diff",
+    "--name-only",
+    "-z",
+    baseRef,
+    headRef,
+  ]).split("\0");
+  const reversePaths = runGit(repositoryDirectory, [
+    "diff",
+    "--name-only",
+    "-z",
+    headRef,
+    baseRef,
+  ]).split("\0");
+  return [...new Set([...forwardPaths, ...reversePaths].filter(Boolean))].sort();
+};
+
+const buildReverseDependencies = (dependencies) => {
+  const reverseDependencies = new Map();
+  for (const [sourcePath, dependencyPaths] of dependencies) {
+    for (const dependencyPath of dependencyPaths) {
+      const importers = reverseDependencies.get(dependencyPath) ?? new Set();
+      importers.add(sourcePath);
+      reverseDependencies.set(dependencyPath, importers);
+    }
+  }
+  return reverseDependencies;
+};
+
+const collectImpactedRules = (graph, changedPaths) => {
+  const pendingPaths = changedPaths.filter((sourcePath) => graph.sourceTree.has(sourcePath));
+  const visitedPaths = new Set();
+  const impactedRules = new Set();
+  while (pendingPaths.length > 0) {
+    const sourcePath = pendingPaths.pop();
+    if (!sourcePath || visitedPaths.has(sourcePath)) continue;
+    visitedPaths.add(sourcePath);
+    const ruleKey = graph.ruleKeyBySourcePath.get(sourcePath);
+    if (ruleKey) impactedRules.add(ruleKey);
+    for (const importerPath of graph.reverseDependencies.get(sourcePath) ?? []) {
+      pendingPaths.push(importerPath);
+    }
+  }
+  return impactedRules;
+};
+
+const buildRuleFingerprint = (graph, ruleSourcePath) => {
+  const pendingPaths = [ruleSourcePath];
+  const visitedPaths = new Set();
+  while (pendingPaths.length > 0) {
+    const sourcePath = pendingPaths.pop();
+    if (!sourcePath || visitedPaths.has(sourcePath)) continue;
+    visitedPaths.add(sourcePath);
+    for (const dependencyPath of graph.dependencies.get(sourcePath) ?? []) {
+      pendingPaths.push(dependencyPath);
+    }
+  }
+  const hash = createHash("sha256").update(FINGERPRINT_VERSION).update("\0");
+  for (const sourcePath of [...visitedPaths].sort()) {
+    hash
+      .update(sourcePath)
+      .update("\0")
+      .update(graph.sourceTree.get(sourcePath) ?? "")
+      .update("\0");
+  }
+  return hash.digest("hex");
+};
+
+const isIgnoredChange = (sourcePath) =>
+  IGNORED_CHANGE_PATTERN.test(sourcePath) || TEST_SOURCE_PATTERN.test(sourcePath);
+
+const isIncrementalRuntimePath = (sourcePath) =>
+  INCREMENTAL_RUNTIME_ROOTS.some((runtimeRoot) => sourcePath.startsWith(runtimeRoot));
+
+const addDiagnosticInteractionClosure = (ruleKeys) => {
+  const closedRuleKeys = new Set(ruleKeys);
+  for (const interactionGroup of DIAGNOSTIC_INTERACTION_GROUPS) {
+    if (interactionGroup.some((ruleKey) => closedRuleKeys.has(ruleKey))) {
+      for (const ruleKey of interactionGroup) closedRuleKeys.add(ruleKey);
+    }
+  }
+  return closedRuleKeys;
+};
+
+const isSecurityScanRule = (graph, ruleKey) => {
+  for (const [sourcePath, sourceRuleKey] of graph.ruleKeyBySourcePath) {
+    if (sourceRuleKey === ruleKey) return sourcePath.startsWith(`${RULES_ROOT}security-scan/`);
+  }
+  return false;
+};
+
+const buildManifest = (repositoryDirectory, baseRef, headRef) => {
+  const baseCommit = resolveCommit(repositoryDirectory, baseRef);
+  const headCommit = resolveCommit(repositoryDirectory, headRef);
+  const changedPaths = listChangedPaths(repositoryDirectory, baseCommit, headCommit);
+  const baseGraph = buildModuleGraph(loadSourceTree(repositoryDirectory, baseCommit));
+  const headGraph = buildModuleGraph(loadSourceTree(repositoryDirectory, headCommit));
+  const fallbackReasons = [...baseGraph.uncertainties, ...headGraph.uncertainties];
+  const runtimeChangedPaths = changedPaths.filter((sourcePath) => !isIgnoredChange(sourcePath));
+  for (const sourcePath of runtimeChangedPaths) {
+    if (!sourcePath.startsWith(PLUGIN_SOURCE_ROOT) || !isIncrementalRuntimePath(sourcePath)) {
+      fallbackReasons.push(`Global runtime change requires full parity: ${sourcePath}`);
+    }
+  }
+  const directlyImpactedRuleKeys = new Set([
+    ...collectImpactedRules(baseGraph, runtimeChangedPaths),
+    ...collectImpactedRules(headGraph, runtimeChangedPaths),
+  ]);
+  const impactedRuleKeys = addDiagnosticInteractionClosure(directlyImpactedRuleKeys);
+  for (const sourcePath of runtimeChangedPaths.filter((path) => path.startsWith(RULES_ROOT))) {
+    const mappedRuleKeys = new Set([
+      ...collectImpactedRules(baseGraph, [sourcePath]),
+      ...collectImpactedRules(headGraph, [sourcePath]),
+    ]);
+    if (mappedRuleKeys.size === 0) {
+      fallbackReasons.push(`Changed rule runtime cannot be mapped to a rule: ${sourcePath}`);
+    }
+  }
+  for (const ruleKey of directlyImpactedRuleKeys) {
+    if (isSecurityScanRule(baseGraph, ruleKey) || isSecurityScanRule(headGraph, ruleKey)) {
+      fallbackReasons.push(`Security scan rule requires full parity: ${ruleKey}`);
+    }
+  }
+  for (const ruleKey of impactedRuleKeys) {
+    if (FULL_PARITY_RULE_KEYS.has(ruleKey)) {
+      fallbackReasons.push(`Cross-rule suppression requires full parity: ${ruleKey}`);
+    }
+  }
+  for (const sourcePath of runtimeChangedPaths.filter((path) =>
+    path.startsWith(PLUGIN_SOURCE_ROOT),
+  )) {
+    if (!baseGraph.sourceTree.has(sourcePath) && !headGraph.sourceTree.has(sourcePath)) {
+      fallbackReasons.push(`Changed runtime source is outside the graph: ${sourcePath}`);
+    }
+  }
+  const allRuleKeys = new Set([
+    ...baseGraph.ruleKeyBySourcePath.values(),
+    ...headGraph.ruleKeyBySourcePath.values(),
+  ]);
+  const headRuleKeys = new Set(headGraph.ruleKeyBySourcePath.values());
+  for (const ruleKey of directlyImpactedRuleKeys) {
+    if (!headRuleKeys.has(ruleKey)) {
+      fallbackReasons.push(`Removed or renamed rule requires full parity: ${ruleKey}`);
+    }
+  }
+  const mode = fallbackReasons.length === 0 ? "incremental" : "full";
+  const selectedRuleKeys = mode === "incremental" ? impactedRuleKeys : allRuleKeys;
+  const ruleSourcePathByKey = new Map();
+  for (const [sourcePath, ruleKey] of baseGraph.ruleKeyBySourcePath) {
+    ruleSourcePathByKey.set(ruleKey, { base: sourcePath });
+  }
+  for (const [sourcePath, ruleKey] of headGraph.ruleKeyBySourcePath) {
+    const existing = ruleSourcePathByKey.get(ruleKey) ?? {};
+    ruleSourcePathByKey.set(ruleKey, { ...existing, head: sourcePath });
+  }
+  const rules = [...selectedRuleKeys].sort().map((ruleKey) => {
+    const sourcePaths = ruleSourcePathByKey.get(ruleKey) ?? {};
+    return {
+      ruleKey,
+      baseFingerprint: sourcePaths.base ? buildRuleFingerprint(baseGraph, sourcePaths.base) : null,
+      headFingerprint: sourcePaths.head ? buildRuleFingerprint(headGraph, sourcePaths.head) : null,
+    };
+  });
+  return {
+    schemaVersion: IMPACT_SCHEMA_VERSION,
+    mode,
+    baseCommit,
+    headCommit,
+    changedPaths,
+    runtimeChangedPaths,
+    impactedRuleKeys: rules.map((rule) => rule.ruleKey),
+    candidateRuleKeys:
+      mode === "incremental"
+        ? rules
+            .map((rule) => rule.ruleKey)
+            .filter((ruleKey) => !ruleKey.startsWith("react-doctor/") || headRuleKeys.has(ruleKey))
+        : [],
+    fallbackReasons: [...new Set(fallbackReasons)].sort(),
+    rules,
+  };
+};
+
+const isMain =
+  process.argv[1] && fileURLToPath(import.meta.url) === resolveFileSystemPath(process.argv[1]);
+
+if (isMain) {
+  const argumentsToParse = process.argv.slice(2);
+  if (argumentsToParse.length !== EXPECTED_ARGUMENT_COUNT) {
+    process.stderr.write(`${usage()}\n`);
+    process.exitCode = 2;
+  } else {
+    const [repositoryDirectory, baseRef, headRef, outputPath] = argumentsToParse;
+    try {
+      const manifest = buildManifest(repositoryDirectory, baseRef, headRef);
+      writeFileSync(outputPath, `${JSON.stringify(manifest, undefined, 2)}\n`, { mode: 0o600 });
+      process.stderr.write(
+        `Rule impact: ${manifest.mode}, ${manifest.impactedRuleKeys.length} rule(s)\n`,
+      );
+    } catch (error) {
+      process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+      process.exitCode = 2;
+    }
+  }
+}

--- a/.agents/skills/run-parity/scripts/find-impacted-rules.test.mjs
+++ b/.agents/skills/run-parity/scripts/find-impacted-rules.test.mjs
@@ -1,0 +1,713 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+
+const scriptPath = fileURLToPath(new URL("./find-impacted-rules.mjs", import.meta.url));
+const RULES_ROOT = "packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects";
+const UTILS_ROOT = "packages/oxlint-plugin-react-doctor/src/plugin/utils";
+
+const writeRepositoryFile = (repositoryDirectory, filePath, contents) => {
+  const absolutePath = join(repositoryDirectory, filePath);
+  mkdirSync(dirname(absolutePath), { recursive: true });
+  writeFileSync(absolutePath, contents);
+};
+
+const commit = (repositoryDirectory, message) => {
+  execFileSync("git", ["-C", repositoryDirectory, "add", "."]);
+  execFileSync("git", ["-C", repositoryDirectory, "commit", "-m", message]);
+  return execFileSync("git", ["-C", repositoryDirectory, "rev-parse", "HEAD"], {
+    encoding: "utf8",
+  }).trim();
+};
+
+const makeRule = (identifier, id, dependencyPath) => `import { shared } from "${dependencyPath}";
+import type { Rule } from "../../utils/rule.js";
+import { defineRule } from "../../utils/define-rule.js";
+export const ${identifier}: Rule = defineRule({ id: "${id}", create: () => shared });
+`;
+
+const initializeRepository = () => {
+  const repositoryDirectory = mkdtempSync(join(tmpdir(), "react-doctor-rule-impact-"));
+  execFileSync("git", ["-C", repositoryDirectory, "init", "-q"]);
+  execFileSync("git", ["-C", repositoryDirectory, "config", "user.email", "test@example.com"]);
+  execFileSync("git", ["-C", repositoryDirectory, "config", "user.name", "Test"]);
+  writeRepositoryFile(
+    repositoryDirectory,
+    `${UTILS_ROOT}/shared.ts`,
+    "export const shared = {};\n",
+  );
+  writeRepositoryFile(
+    repositoryDirectory,
+    `${UTILS_ROOT}/define-rule.ts`,
+    "export const defineRule = (rule) => rule;\n",
+  );
+  writeRepositoryFile(
+    repositoryDirectory,
+    `${UTILS_ROOT}/rule.ts`,
+    "export interface Rule { id: string; create: () => unknown }\n",
+  );
+  writeRepositoryFile(
+    repositoryDirectory,
+    `${RULES_ROOT}/first.ts`,
+    makeRule("first", "first", "../../utils/shared.js"),
+  );
+  writeRepositoryFile(
+    repositoryDirectory,
+    `${RULES_ROOT}/second.ts`,
+    makeRule("second", "second", "../../utils/shared.js"),
+  );
+  return repositoryDirectory;
+};
+
+const runImpact = (repositoryDirectory, baseRef, headRef) => {
+  const outputPath = join(repositoryDirectory, "impact.json");
+  const result = spawnSync(
+    process.execPath,
+    [scriptPath, repositoryDirectory, baseRef, headRef, outputPath],
+    { encoding: "utf8" },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  return JSON.parse(readFileSync(outputPath, "utf8"));
+};
+
+test("selects every rule that transitively imports a changed utility", () => {
+  const repositoryDirectory = initializeRepository();
+  try {
+    const baseRef = commit(repositoryDirectory, "base");
+    writeRepositoryFile(
+      repositoryDirectory,
+      `${UTILS_ROOT}/shared.ts`,
+      "export const shared = { changed: true };\n",
+    );
+    const headRef = commit(repositoryDirectory, "head");
+
+    const manifest = runImpact(repositoryDirectory, baseRef, headRef);
+
+    assert.equal(manifest.mode, "incremental");
+    assert.deepEqual(manifest.impactedRuleKeys, ["react-doctor/first", "react-doctor/second"]);
+    assert.equal(
+      manifest.rules.every((rule) => rule.baseFingerprint !== rule.headFingerprint),
+      true,
+    );
+  } finally {
+    rmSync(repositoryDirectory, { recursive: true, force: true });
+  }
+});
+
+test("selects one directly changed rule", () => {
+  const repositoryDirectory = initializeRepository();
+  try {
+    const baseRef = commit(repositoryDirectory, "base");
+    writeRepositoryFile(
+      repositoryDirectory,
+      `${RULES_ROOT}/first.ts`,
+      makeRule("first", "first", "../../utils/define-rule.js"),
+    );
+    const headRef = commit(repositoryDirectory, "head");
+
+    const manifest = runImpact(repositoryDirectory, baseRef, headRef);
+
+    assert.equal(manifest.mode, "incremental");
+    assert.deepEqual(manifest.impactedRuleKeys, ["react-doctor/first"]);
+  } finally {
+    rmSync(repositoryDirectory, { recursive: true, force: true });
+  }
+});
+
+test("tracks TypeScript import-equals require edges", () => {
+  const repositoryDirectory = initializeRepository();
+  try {
+    writeRepositoryFile(
+      repositoryDirectory,
+      `${RULES_ROOT}/first.ts`,
+      `import shared = require("../../utils/shared.js");
+import type Missing = require("../../utils/missing.js");
+import { defineRule } from "../../utils/define-rule.js";
+export const first = defineRule({ id: "first", create: () => shared });
+`,
+    );
+    const baseRef = commit(repositoryDirectory, "base");
+    writeRepositoryFile(
+      repositoryDirectory,
+      `${UTILS_ROOT}/shared.ts`,
+      "export const shared = { changed: true };\n",
+    );
+    const headRef = commit(repositoryDirectory, "head");
+
+    const manifest = runImpact(repositoryDirectory, baseRef, headRef);
+
+    assert.equal(manifest.mode, "incremental");
+    assert.deepEqual(manifest.impactedRuleKeys, ["react-doctor/first", "react-doctor/second"]);
+  } finally {
+    rmSync(repositoryDirectory, { recursive: true, force: true });
+  }
+});
+
+test("tracks side-effect imports", () => {
+  const repositoryDirectory = initializeRepository();
+  try {
+    writeRepositoryFile(
+      repositoryDirectory,
+      `${UTILS_ROOT}/side-effect.ts`,
+      "export const marker = 1;\n",
+    );
+    writeRepositoryFile(
+      repositoryDirectory,
+      `${RULES_ROOT}/first.ts`,
+      `import "../../utils/side-effect.js";
+import { defineRule } from "../../utils/define-rule.js";
+export const first = defineRule({ id: "first", create: () => ({}) });
+`,
+    );
+    const baseRef = commit(repositoryDirectory, "base");
+    writeRepositoryFile(
+      repositoryDirectory,
+      `${UTILS_ROOT}/side-effect.ts`,
+      "export const marker = 2;\n",
+    );
+    const headRef = commit(repositoryDirectory, "head");
+
+    const manifest = runImpact(repositoryDirectory, baseRef, headRef);
+
+    assert.equal(manifest.mode, "incremental");
+    assert.deepEqual(manifest.impactedRuleKeys, ["react-doctor/first"]);
+  } finally {
+    rmSync(repositoryDirectory, { recursive: true, force: true });
+  }
+});
+
+test("tracks named re-exports and export-star chains", () => {
+  const repositoryDirectory = initializeRepository();
+  try {
+    writeRepositoryFile(
+      repositoryDirectory,
+      `${UTILS_ROOT}/re-export-leaf.ts`,
+      "export const reExported = {};\n",
+    );
+    writeRepositoryFile(
+      repositoryDirectory,
+      `${UTILS_ROOT}/named-barrel.ts`,
+      'export { reExported } from "./re-export-leaf.js";\n',
+    );
+    writeRepositoryFile(
+      repositoryDirectory,
+      `${UTILS_ROOT}/star-barrel.ts`,
+      'export * from "./named-barrel.js";\n',
+    );
+    writeRepositoryFile(
+      repositoryDirectory,
+      `${RULES_ROOT}/first.ts`,
+      `import { reExported } from "../../utils/star-barrel.js";
+import { defineRule } from "../../utils/define-rule.js";
+export const first = defineRule({ id: "first", create: () => reExported });
+`,
+    );
+    const baseRef = commit(repositoryDirectory, "base");
+    writeRepositoryFile(
+      repositoryDirectory,
+      `${UTILS_ROOT}/re-export-leaf.ts`,
+      "export const reExported = { changed: true };\n",
+    );
+    const headRef = commit(repositoryDirectory, "head");
+
+    const manifest = runImpact(repositoryDirectory, baseRef, headRef);
+
+    assert.equal(manifest.mode, "incremental");
+    assert.deepEqual(manifest.impactedRuleKeys, ["react-doctor/first"]);
+  } finally {
+    rmSync(repositoryDirectory, { recursive: true, force: true });
+  }
+});
+
+test("resolves JavaScript specifiers to TypeScript and TSX sources", () => {
+  const repositoryDirectory = initializeRepository();
+  try {
+    writeRepositoryFile(
+      repositoryDirectory,
+      `${UTILS_ROOT}/typescript-helper.ts`,
+      "export const typescriptHelper = {};\n",
+    );
+    writeRepositoryFile(
+      repositoryDirectory,
+      `${UTILS_ROOT}/tsx-helper.tsx`,
+      `import { typescriptHelper } from "./typescript-helper.js";
+export const tsxHelper = typescriptHelper;
+`,
+    );
+    writeRepositoryFile(
+      repositoryDirectory,
+      `${RULES_ROOT}/first.ts`,
+      `import { tsxHelper } from "../../utils/tsx-helper.js";
+import { defineRule } from "../../utils/define-rule.js";
+export const first = defineRule({ id: "first", create: () => tsxHelper });
+`,
+    );
+    const baseRef = commit(repositoryDirectory, "base");
+    writeRepositoryFile(
+      repositoryDirectory,
+      `${UTILS_ROOT}/typescript-helper.ts`,
+      "export const typescriptHelper = { changed: true };\n",
+    );
+    const headRef = commit(repositoryDirectory, "head");
+
+    const manifest = runImpact(repositoryDirectory, baseRef, headRef);
+
+    assert.equal(manifest.mode, "incremental");
+    assert.deepEqual(manifest.impactedRuleKeys, ["react-doctor/first"]);
+  } finally {
+    rmSync(repositoryDirectory, { recursive: true, force: true });
+  }
+});
+
+test("resolves extensionless files, directory indexes, and JSON modules", () => {
+  const repositoryDirectory = initializeRepository();
+  try {
+    writeRepositoryFile(repositoryDirectory, `${UTILS_ROOT}/data.json`, '{"marker":1}\n');
+    writeRepositoryFile(
+      repositoryDirectory,
+      `${UTILS_ROOT}/directory/index.ts`,
+      `import data from "../data.json";
+export const indexed = data;
+`,
+    );
+    writeRepositoryFile(
+      repositoryDirectory,
+      `${UTILS_ROOT}/resolver.ts`,
+      `import { indexed } from "./directory";
+export const resolved = indexed;
+`,
+    );
+    writeRepositoryFile(
+      repositoryDirectory,
+      `${RULES_ROOT}/first.ts`,
+      `import { resolved } from "../../utils/resolver";
+import { defineRule } from "../../utils/define-rule.js";
+export const first = defineRule({ id: "first", create: () => resolved });
+`,
+    );
+    const baseRef = commit(repositoryDirectory, "base");
+    writeRepositoryFile(repositoryDirectory, `${UTILS_ROOT}/data.json`, '{"marker":2}\n');
+    const headRef = commit(repositoryDirectory, "head");
+
+    const manifest = runImpact(repositoryDirectory, baseRef, headRef);
+
+    assert.equal(manifest.mode, "incremental");
+    assert.deepEqual(manifest.impactedRuleKeys, ["react-doctor/first"]);
+  } finally {
+    rmSync(repositoryDirectory, { recursive: true, force: true });
+  }
+});
+
+test("terminates and preserves impact through dependency cycles", () => {
+  const repositoryDirectory = initializeRepository();
+  try {
+    writeRepositoryFile(
+      repositoryDirectory,
+      `${UTILS_ROOT}/cycle-a.ts`,
+      `import { cycleB } from "./cycle-b.js";
+export const cycleA = cycleB;
+`,
+    );
+    writeRepositoryFile(
+      repositoryDirectory,
+      `${UTILS_ROOT}/cycle-b.ts`,
+      `import { cycleA } from "./cycle-a.js";
+export const cycleB = cycleA;
+`,
+    );
+    writeRepositoryFile(
+      repositoryDirectory,
+      `${RULES_ROOT}/first.ts`,
+      `import { cycleA } from "../../utils/cycle-a.js";
+import { defineRule } from "../../utils/define-rule.js";
+export const first = defineRule({ id: "first", create: () => cycleA });
+`,
+    );
+    const baseRef = commit(repositoryDirectory, "base");
+    writeRepositoryFile(
+      repositoryDirectory,
+      `${UTILS_ROOT}/cycle-b.ts`,
+      `import { cycleA } from "./cycle-a.js";
+export const cycleB = { cycleA };
+`,
+    );
+    const headRef = commit(repositoryDirectory, "head");
+
+    const manifest = runImpact(repositoryDirectory, baseRef, headRef);
+
+    assert.equal(manifest.mode, "incremental");
+    assert.deepEqual(manifest.impactedRuleKeys, ["react-doctor/first"]);
+    assert.equal(manifest.rules[0].baseFingerprint === manifest.rules[0].headFingerprint, false);
+  } finally {
+    rmSync(repositoryDirectory, { recursive: true, force: true });
+  }
+});
+
+test("falls back to all rules for global runtime changes", () => {
+  const repositoryDirectory = initializeRepository();
+  try {
+    const baseRef = commit(repositoryDirectory, "base");
+    writeRepositoryFile(
+      repositoryDirectory,
+      "packages/core/src/run-oxlint.ts",
+      "export const changed = true;\n",
+    );
+    const headRef = commit(repositoryDirectory, "head");
+
+    const manifest = runImpact(repositoryDirectory, baseRef, headRef);
+
+    assert.equal(manifest.mode, "full");
+    assert.deepEqual(manifest.impactedRuleKeys, ["react-doctor/first", "react-doctor/second"]);
+    assert.match(manifest.fallbackReasons[0], /Global runtime change/);
+  } finally {
+    rmSync(repositoryDirectory, { recursive: true, force: true });
+  }
+});
+
+test("falls back to all rules for non-literal runtime imports", () => {
+  const repositoryDirectory = initializeRepository();
+  try {
+    writeRepositoryFile(
+      repositoryDirectory,
+      `${RULES_ROOT}/first.ts`,
+      `import { defineRule } from "../../utils/define-rule.js";
+const moduleName = "./dynamic.js";
+export const first = defineRule({ id: "first", create: () => import(moduleName) });
+`,
+    );
+    const baseRef = commit(repositoryDirectory, "base");
+    writeRepositoryFile(
+      repositoryDirectory,
+      `${RULES_ROOT}/second.ts`,
+      `${makeRule("second", "second", "../../utils/shared.js")}\n`,
+    );
+    const headRef = commit(repositoryDirectory, "head");
+
+    const manifest = runImpact(repositoryDirectory, baseRef, headRef);
+
+    assert.equal(manifest.mode, "full");
+    assert.match(manifest.fallbackReasons.join("\n"), /Non-literal runtime module edge/);
+  } finally {
+    rmSync(repositoryDirectory, { recursive: true, force: true });
+  }
+});
+
+test("falls back to full parity when a rule is deleted", () => {
+  const repositoryDirectory = initializeRepository();
+  try {
+    const baseRef = commit(repositoryDirectory, "base");
+    rmSync(join(repositoryDirectory, `${RULES_ROOT}/first.ts`));
+    const headRef = commit(repositoryDirectory, "head");
+
+    const manifest = runImpact(repositoryDirectory, baseRef, headRef);
+
+    assert.equal(manifest.mode, "full");
+    assert.match(manifest.fallbackReasons.join("\n"), /Removed or renamed rule.*first/);
+  } finally {
+    rmSync(repositoryDirectory, { recursive: true, force: true });
+  }
+});
+
+test("falls back to full parity when a rule identifier is renamed", () => {
+  const repositoryDirectory = initializeRepository();
+  try {
+    const baseRef = commit(repositoryDirectory, "base");
+    writeRepositoryFile(
+      repositoryDirectory,
+      `${RULES_ROOT}/first.ts`,
+      makeRule("renamed", "renamed", "../../utils/shared.js"),
+    );
+    const headRef = commit(repositoryDirectory, "head");
+
+    const manifest = runImpact(repositoryDirectory, baseRef, headRef);
+
+    assert.equal(manifest.mode, "full");
+    assert.match(manifest.fallbackReasons.join("\n"), /Removed or renamed rule.*first/);
+    assert.deepEqual(manifest.impactedRuleKeys, [
+      "react-doctor/first",
+      "react-doctor/renamed",
+      "react-doctor/second",
+    ]);
+  } finally {
+    rmSync(repositoryDirectory, { recursive: true, force: true });
+  }
+});
+
+test("keeps a source-only rule file rename incremental", () => {
+  const repositoryDirectory = initializeRepository();
+  try {
+    const baseRef = commit(repositoryDirectory, "base");
+    execFileSync("git", [
+      "-C",
+      repositoryDirectory,
+      "mv",
+      `${RULES_ROOT}/first.ts`,
+      `${RULES_ROOT}/first-renamed.ts`,
+    ]);
+    const headRef = commit(repositoryDirectory, "head");
+
+    const manifest = runImpact(repositoryDirectory, baseRef, headRef);
+
+    assert.equal(manifest.mode, "incremental");
+    assert.deepEqual(manifest.impactedRuleKeys, ["react-doctor/first"]);
+    assert.equal(manifest.rules[0].baseFingerprint === manifest.rules[0].headFingerprint, false);
+  } finally {
+    rmSync(repositoryDirectory, { recursive: true, force: true });
+  }
+});
+
+test("falls back to full parity for parse failures", () => {
+  const repositoryDirectory = initializeRepository();
+  try {
+    const baseRef = commit(repositoryDirectory, "base");
+    writeRepositoryFile(
+      repositoryDirectory,
+      `${UTILS_ROOT}/shared.ts`,
+      "export const shared = ;\n",
+    );
+    const headRef = commit(repositoryDirectory, "head");
+
+    const manifest = runImpact(repositoryDirectory, baseRef, headRef);
+
+    assert.equal(manifest.mode, "full");
+    assert.match(manifest.fallbackReasons.join("\n"), /TypeScript could not parse.*shared\.ts/);
+  } finally {
+    rmSync(repositoryDirectory, { recursive: true, force: true });
+  }
+});
+
+test("falls back to full parity for unresolved relative runtime modules", () => {
+  const repositoryDirectory = initializeRepository();
+  try {
+    writeRepositoryFile(
+      repositoryDirectory,
+      `${RULES_ROOT}/first.ts`,
+      `import { missing } from "../../utils/missing.js";
+import { defineRule } from "../../utils/define-rule.js";
+export const first = defineRule({ id: "first", create: () => missing });
+`,
+    );
+    const baseRef = commit(repositoryDirectory, "base");
+    writeRepositoryFile(
+      repositoryDirectory,
+      `${RULES_ROOT}/second.ts`,
+      `${makeRule("second", "second", "../../utils/shared.js")}
+export const marker = 1;
+`,
+    );
+    const headRef = commit(repositoryDirectory, "head");
+
+    const manifest = runImpact(repositoryDirectory, baseRef, headRef);
+
+    assert.equal(manifest.mode, "full");
+    assert.match(manifest.fallbackReasons.join("\n"), /Unresolved runtime module.*missing\.js/);
+  } finally {
+    rmSync(repositoryDirectory, { recursive: true, force: true });
+  }
+});
+
+test("falls back to full parity for duplicate rule keys", () => {
+  const repositoryDirectory = initializeRepository();
+  try {
+    writeRepositoryFile(
+      repositoryDirectory,
+      `${RULES_ROOT}/second.ts`,
+      makeRule("second", "first", "../../utils/shared.js"),
+    );
+    const baseRef = commit(repositoryDirectory, "base");
+    writeRepositoryFile(
+      repositoryDirectory,
+      `${RULES_ROOT}/first.ts`,
+      `${makeRule("first", "first", "../../utils/shared.js")}
+export const marker = 1;
+`,
+    );
+    const headRef = commit(repositoryDirectory, "head");
+
+    const manifest = runImpact(repositoryDirectory, baseRef, headRef);
+
+    assert.equal(manifest.mode, "full");
+    assert.match(manifest.fallbackReasons.join("\n"), /Duplicate rule key react-doctor\/first/);
+  } finally {
+    rmSync(repositoryDirectory, { recursive: true, force: true });
+  }
+});
+
+test("falls back to full parity when a changed rule implementation cannot be mapped", () => {
+  const repositoryDirectory = initializeRepository();
+  try {
+    const wrappedRulePath = `${RULES_ROOT}/wrapped.ts`;
+    writeRepositoryFile(
+      repositoryDirectory,
+      wrappedRulePath,
+      `import { defineRule as buildRule } from "../../utils/define-rule.js";
+const ruleId = "wrapped";
+export const wrapped = buildRule({ id: ruleId, create: () => ({}) });
+`,
+    );
+    const baseRef = commit(repositoryDirectory, "base");
+    writeRepositoryFile(
+      repositoryDirectory,
+      wrappedRulePath,
+      `import { defineRule as buildRule } from "../../utils/define-rule.js";
+const ruleId = "wrapped";
+export const wrapped = buildRule({ id: ruleId, create: () => ({ changed: true }) });
+`,
+    );
+    const headRef = commit(repositoryDirectory, "head");
+
+    const manifest = runImpact(repositoryDirectory, baseRef, headRef);
+
+    assert.equal(manifest.mode, "full");
+    assert.match(
+      manifest.fallbackReasons.join("\n"),
+      /Changed rule runtime cannot be mapped to a rule/,
+    );
+  } finally {
+    rmSync(repositoryDirectory, { recursive: true, force: true });
+  }
+});
+
+test("ignores test and documentation-only changes", () => {
+  const repositoryDirectory = initializeRepository();
+  try {
+    const baseRef = commit(repositoryDirectory, "base");
+    writeRepositoryFile(
+      repositoryDirectory,
+      `${RULES_ROOT}/first.test.ts`,
+      "export const testMarker = true;\n",
+    );
+    writeRepositoryFile(repositoryDirectory, "docs/parity.md", "# Parity\n");
+    const headRef = commit(repositoryDirectory, "head");
+
+    const manifest = runImpact(repositoryDirectory, baseRef, headRef);
+
+    assert.equal(manifest.mode, "incremental");
+    assert.deepEqual(manifest.runtimeChangedPaths, []);
+    assert.deepEqual(manifest.impactedRuleKeys, []);
+    assert.deepEqual(manifest.candidateRuleKeys, []);
+  } finally {
+    rmSync(repositoryDirectory, { recursive: true, force: true });
+  }
+});
+
+test("closes derived-state and hooks diagnostic interactions", () => {
+  const repositoryDirectory = initializeRepository();
+  try {
+    for (const ruleName of [
+      "no-adjust-state-on-prop-change",
+      "no-derived-state",
+      "no-derived-state-effect",
+      "no-initialize-state",
+      "rules-of-hooks",
+    ]) {
+      writeRepositoryFile(
+        repositoryDirectory,
+        `${RULES_ROOT}/${ruleName}.ts`,
+        makeRule(ruleName.replaceAll("-", "_"), ruleName, "../../utils/shared.js"),
+      );
+    }
+    const baseCommit = commit(repositoryDirectory, "base");
+    writeRepositoryFile(
+      repositoryDirectory,
+      `${RULES_ROOT}/no-derived-state.ts`,
+      `${makeRule("no_derived_state", "no-derived-state", "../../utils/shared.js")}
+export const marker = 1;
+`,
+    );
+    const derivedStateHeadCommit = commit(repositoryDirectory, "derived state");
+    const derivedStateManifest = runImpact(repositoryDirectory, baseCommit, derivedStateHeadCommit);
+    assert.deepEqual(derivedStateManifest.candidateRuleKeys, [
+      "react-doctor/no-adjust-state-on-prop-change",
+      "react-doctor/no-derived-state",
+      "react-doctor/no-derived-state-effect",
+      "react-doctor/no-initialize-state",
+    ]);
+
+    rmSync(join(repositoryDirectory, "impact.json"), { force: true });
+    writeRepositoryFile(
+      repositoryDirectory,
+      `${RULES_ROOT}/rules-of-hooks.ts`,
+      `${makeRule("rules_of_hooks", "rules-of-hooks", "../../utils/shared.js")}
+export const marker = 2;
+`,
+    );
+    const hooksHeadCommit = commit(repositoryDirectory, "hooks");
+    const hooksManifest = runImpact(repositoryDirectory, derivedStateHeadCommit, hooksHeadCommit);
+    assert.deepEqual(hooksManifest.candidateRuleKeys, [
+      "react-doctor/rules-of-hooks",
+      "react-hooks-js/hooks",
+    ]);
+  } finally {
+    rmSync(repositoryDirectory, { recursive: true, force: true });
+  }
+});
+
+test("falls back to full parity for security scan rules", () => {
+  const repositoryDirectory = initializeRepository();
+  try {
+    const securityRulePath =
+      "packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/no-risk.ts";
+    writeRepositoryFile(
+      repositoryDirectory,
+      securityRulePath,
+      makeRule("no_risk", "no-risk", "../../utils/shared.js"),
+    );
+    const baseCommit = commit(repositoryDirectory, "base");
+    writeRepositoryFile(
+      repositoryDirectory,
+      securityRulePath,
+      `${makeRule("no_risk", "no-risk", "../../utils/shared.js")}
+export const marker = 1;
+`,
+    );
+    const headCommit = commit(repositoryDirectory, "head");
+    const manifest = runImpact(repositoryDirectory, baseCommit, headCommit);
+    assert.equal(manifest.mode, "full");
+    assert.match(manifest.fallbackReasons.join("\n"), /Security scan rule requires full parity/);
+  } finally {
+    rmSync(repositoryDirectory, { recursive: true, force: true });
+  }
+});
+
+test("falls back to full parity for cross-rule suppression", () => {
+  const repositoryDirectory = initializeRepository();
+  try {
+    const manualMemoizationRulePath = `${RULES_ROOT}/react-compiler-no-manual-memoization.ts`;
+    writeRepositoryFile(
+      repositoryDirectory,
+      manualMemoizationRulePath,
+      makeRule(
+        "react_compiler_no_manual_memoization",
+        "react-compiler-no-manual-memoization",
+        "../../utils/shared.js",
+      ),
+    );
+    const baseCommit = commit(repositoryDirectory, "base");
+    writeRepositoryFile(
+      repositoryDirectory,
+      manualMemoizationRulePath,
+      `${makeRule(
+        "react_compiler_no_manual_memoization",
+        "react-compiler-no-manual-memoization",
+        "../../utils/shared.js",
+      )}
+export const marker = 1;
+`,
+    );
+    const headCommit = commit(repositoryDirectory, "head");
+    const manifest = runImpact(repositoryDirectory, baseCommit, headCommit);
+
+    assert.equal(manifest.mode, "full");
+    assert.match(
+      manifest.fallbackReasons.join("\n"),
+      /Cross-rule suppression requires full parity/,
+    );
+  } finally {
+    rmSync(repositoryDirectory, { recursive: true, force: true });
+  }
+});

--- a/.agents/skills/run-parity/scripts/find-impacted-rules.test.mjs
+++ b/.agents/skills/run-parity/scripts/find-impacted-rules.test.mjs
@@ -7,6 +7,7 @@ import assert from "node:assert/strict";
 import { fileURLToPath } from "node:url";
 
 const scriptPath = fileURLToPath(new URL("./find-impacted-rules.mjs", import.meta.url));
+const PLUGIN_ROOT = "packages/oxlint-plugin-react-doctor/src/plugin";
 const RULES_ROOT = "packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects";
 const UTILS_ROOT = "packages/oxlint-plugin-react-doctor/src/plugin/utils";
 
@@ -368,6 +369,73 @@ test("falls back to all rules for global runtime changes", () => {
   }
 });
 
+test("falls back to full parity when a changed utility is imported only by the plugin host", () => {
+  const repositoryDirectory = initializeRepository();
+  try {
+    writeRepositoryFile(
+      repositoryDirectory,
+      `${UTILS_ROOT}/host-only.ts`,
+      "export const hostOnly = 1;\n",
+    );
+    writeRepositoryFile(
+      repositoryDirectory,
+      `${PLUGIN_ROOT}/react-doctor-plugin.ts`,
+      `import { hostOnly } from "./utils/host-only.js";
+export const plugin = { hostOnly };
+`,
+    );
+    const baseRef = commit(repositoryDirectory, "base");
+    writeRepositoryFile(
+      repositoryDirectory,
+      `${UTILS_ROOT}/host-only.ts`,
+      "export const hostOnly = 2;\n",
+    );
+    const headRef = commit(repositoryDirectory, "head");
+
+    const manifest = runImpact(repositoryDirectory, baseRef, headRef);
+
+    assert.equal(manifest.mode, "full");
+    assert.deepEqual(manifest.impactedRuleKeys, ["react-doctor/first", "react-doctor/second"]);
+    assert.match(
+      manifest.fallbackReasons.join("\n"),
+      /Plugin host dependency requires full parity.*react-doctor-plugin\.ts/,
+    );
+  } finally {
+    rmSync(repositoryDirectory, { recursive: true, force: true });
+  }
+});
+
+test("falls back to full parity when a changed utility reaches both a rule and a global host", () => {
+  const repositoryDirectory = initializeRepository();
+  try {
+    writeRepositoryFile(
+      repositoryDirectory,
+      `${PLUGIN_ROOT}/cross-file-dependencies.ts`,
+      `import { shared } from "./utils/shared.js";
+export const crossFileDependencies = shared;
+`,
+    );
+    const baseRef = commit(repositoryDirectory, "base");
+    writeRepositoryFile(
+      repositoryDirectory,
+      `${UTILS_ROOT}/shared.ts`,
+      "export const shared = { changed: true };\n",
+    );
+    const headRef = commit(repositoryDirectory, "head");
+
+    const manifest = runImpact(repositoryDirectory, baseRef, headRef);
+
+    assert.equal(manifest.mode, "full");
+    assert.deepEqual(manifest.impactedRuleKeys, ["react-doctor/first", "react-doctor/second"]);
+    assert.match(
+      manifest.fallbackReasons.join("\n"),
+      /Plugin host dependency requires full parity.*cross-file-dependencies\.ts/,
+    );
+  } finally {
+    rmSync(repositoryDirectory, { recursive: true, force: true });
+  }
+});
+
 test("falls back to all rules for non-literal runtime imports", () => {
   const repositoryDirectory = initializeRepository();
   try {
@@ -565,14 +633,14 @@ export const wrapped = buildRule({ id: ruleId, create: () => ({ changed: true })
     assert.equal(manifest.mode, "full");
     assert.match(
       manifest.fallbackReasons.join("\n"),
-      /Changed rule runtime cannot be mapped to a rule/,
+      /Changed plugin runtime cannot be mapped to a rule/,
     );
   } finally {
     rmSync(repositoryDirectory, { recursive: true, force: true });
   }
 });
 
-test("ignores test and documentation-only changes", () => {
+test("falls back to full parity for test and documentation-only changes", () => {
   const repositoryDirectory = initializeRepository();
   try {
     const baseRef = commit(repositoryDirectory, "base");
@@ -586,10 +654,14 @@ test("ignores test and documentation-only changes", () => {
 
     const manifest = runImpact(repositoryDirectory, baseRef, headRef);
 
-    assert.equal(manifest.mode, "incremental");
+    assert.equal(manifest.mode, "full");
     assert.deepEqual(manifest.runtimeChangedPaths, []);
-    assert.deepEqual(manifest.impactedRuleKeys, []);
+    assert.deepEqual(manifest.impactedRuleKeys, ["react-doctor/first", "react-doctor/second"]);
     assert.deepEqual(manifest.candidateRuleKeys, []);
+    assert.match(
+      manifest.fallbackReasons.join("\n"),
+      /No runtime rule impact requires full parity/,
+    );
   } finally {
     rmSync(repositoryDirectory, { recursive: true, force: true });
   }

--- a/.agents/skills/run-parity/scripts/parity-index.test.mjs
+++ b/.agents/skills/run-parity/scripts/parity-index.test.mjs
@@ -1,12 +1,15 @@
+import { spawnSync } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
 import { buildParityIndex, semanticHash } from "./build-parity-index.mjs";
 import { compareParityIndexes, validateParityIndex } from "./compare-parity-indexes.mjs";
 
 const selectedRuleKeys = new Set(["react-doctor/example", "react-doctor/other"]);
+const scriptDirectory = fileURLToPath(new URL(".", import.meta.url));
 
 const buildRepository = (name) => ({
   org: "example",
@@ -92,6 +95,37 @@ const buildIndex = async (records, rejectOutsideRuleScope = false, ruleKeys = se
     rmSync(temporaryDirectory, { recursive: true, force: true });
   }
 };
+
+test("runs parity index CLIs through relative script paths", () => {
+  const temporaryDirectory = mkdtempSync(join(tmpdir(), "react-doctor-parity-index-cli-"));
+  try {
+    const inputPath = join(temporaryDirectory, "run.ndjson");
+    const ruleKeysPath = join(temporaryDirectory, "rules.json");
+    const baselineIndexPath = join(temporaryDirectory, "baseline.index.json");
+    const candidateIndexPath = join(temporaryDirectory, "candidate.index.json");
+    writeFileSync(inputPath, `${JSON.stringify(buildRecord({ name: "first" }))}\n`);
+    writeFileSync(ruleKeysPath, JSON.stringify([...selectedRuleKeys]));
+
+    const buildResult = spawnSync(
+      process.execPath,
+      ["./build-parity-index.mjs", "--rules", ruleKeysPath, inputPath],
+      { cwd: scriptDirectory, encoding: "utf8" },
+    );
+    assert.equal(buildResult.status, 0, buildResult.stderr);
+    writeFileSync(baselineIndexPath, buildResult.stdout);
+    writeFileSync(candidateIndexPath, buildResult.stdout);
+
+    const compareResult = spawnSync(
+      process.execPath,
+      ["./compare-parity-indexes.mjs", baselineIndexPath, candidateIndexPath],
+      { cwd: scriptDirectory, encoding: "utf8" },
+    );
+    assert.equal(compareResult.status, 0, compareResult.stderr);
+    assert.equal(JSON.parse(compareResult.stdout).match, true);
+  } finally {
+    rmSync(temporaryDirectory, { recursive: true, force: true });
+  }
+});
 
 test("accepts canonical rule keys with camelCase rule segments", async () => {
   const diagnostic = buildDiagnostic({

--- a/.agents/skills/run-parity/scripts/parity-index.test.mjs
+++ b/.agents/skills/run-parity/scripts/parity-index.test.mjs
@@ -1,0 +1,286 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+import { buildParityIndex, semanticHash } from "./build-parity-index.mjs";
+import { compareParityIndexes, validateParityIndex } from "./compare-parity-indexes.mjs";
+
+const selectedRuleKeys = new Set(["react-doctor/example", "react-doctor/other"]);
+
+const buildRepository = (name) => ({
+  org: "example",
+  name,
+  ref: "0123456789abcdef0123456789abcdef01234567",
+  rootDir: ".",
+});
+
+const buildDiagnostic = (overrides = {}) => ({
+  filePath: "src/app.tsx",
+  normalizedFilePath: "src/app.tsx",
+  id: "src/app.tsx::1:1::react-doctor/example::digest",
+  line: 1,
+  column: 1,
+  plugin: "react-doctor",
+  rule: "example",
+  severity: "warning",
+  title: "Example",
+  message: "Example diagnostic",
+  help: "Fix the example.",
+  category: "Correctness",
+  tags: [],
+  ...overrides,
+});
+
+const buildRecord = ({
+  name,
+  diagnostics = [buildDiagnostic()],
+  analyzedFiles = ["src/app.tsx"],
+}) => {
+  const directory = `/workspace/${name}`;
+  const project = {
+    directory,
+    packageRoot: directory,
+    framework: "nextjs",
+    project: {},
+    diagnostics,
+    score: null,
+    skippedChecks: [],
+    analyzedFiles,
+    analyzedFileCount: analyzedFiles.length,
+    complete: true,
+    elapsedMilliseconds: 1,
+  };
+  return {
+    schemaVersion: 1,
+    repository: buildRepository(name),
+    report: {
+      schemaVersion: 3,
+      version: "0.9.2",
+      ok: true,
+      directory,
+      mode: "full",
+      diff: null,
+      reactDetected: true,
+      projects: [project],
+      diagnostics,
+      summary: {
+        errorCount: diagnostics.filter((diagnostic) => diagnostic.severity === "error").length,
+        warningCount: diagnostics.filter((diagnostic) => diagnostic.severity === "warning").length,
+        affectedFileCount: new Set(diagnostics.map((diagnostic) => diagnostic.filePath)).size,
+        totalDiagnosticCount: diagnostics.length,
+        score: null,
+        scoreLabel: null,
+      },
+      elapsedMilliseconds: 1,
+      error: null,
+    },
+  };
+};
+
+const buildIndex = async (records, rejectOutsideRuleScope = false, ruleKeys = selectedRuleKeys) => {
+  const temporaryDirectory = mkdtempSync(join(tmpdir(), "react-doctor-parity-index-"));
+  try {
+    const inputPath = join(temporaryDirectory, "run.ndjson");
+    writeFileSync(inputPath, `${records.map((record) => JSON.stringify(record)).join("\n")}\n`);
+    return await buildParityIndex({
+      inputPath,
+      selectedRuleKeys: ruleKeys,
+      rejectOutsideRuleScope,
+    });
+  } finally {
+    rmSync(temporaryDirectory, { recursive: true, force: true });
+  }
+};
+
+test("accepts canonical rule keys with camelCase rule segments", async () => {
+  const diagnostic = buildDiagnostic({
+    id: "src/app.tsx::1:1::react-doctor/prefer-useReducer::digest",
+    rule: "prefer-useReducer",
+  });
+  const index = await buildIndex(
+    [buildRecord({ name: "first", diagnostics: [diagnostic] })],
+    false,
+    new Set(["react-doctor/prefer-useReducer"]),
+  );
+
+  assert.equal(validateParityIndex(index), null);
+});
+
+test("writes explicit empty project-rule buckets", async () => {
+  const index = await buildIndex([buildRecord({ name: "first" })]);
+  const emptyBucket = index.projects[0].rules.find(
+    (ruleBucket) => ruleBucket.rule === "react-doctor/other",
+  );
+
+  assert.deepEqual(emptyBucket, {
+    rule: "react-doctor/other",
+    diagnosticCount: 0,
+    semanticHash: semanticHash([]),
+  });
+  assert.equal(validateParityIndex(index), null);
+});
+
+test("preserves duplicate diagnostic multiplicity", async () => {
+  const diagnostic = buildDiagnostic();
+  const baselineIndex = await buildIndex([
+    buildRecord({ name: "first", diagnostics: [diagnostic] }),
+  ]);
+  const candidateIndex = await buildIndex([
+    buildRecord({ name: "first", diagnostics: [diagnostic, diagnostic] }),
+  ]);
+  const comparison = compareParityIndexes(baselineIndex, candidateIndex);
+
+  assert.equal(comparison.valid, true);
+  assert.equal(comparison.match, false);
+  assert.equal(comparison.summary.changedRules, 1);
+  assert.equal(comparison.summary.changedProjectRuleBuckets, 1);
+  assert.equal(comparison.changedRules[0].baselineDiagnostics, 1);
+  assert.equal(comparison.changedRules[0].candidateDiagnostics, 2);
+});
+
+test("canonicalizes record and diagnostic order", async () => {
+  const firstRecord = buildRecord({
+    name: "first",
+    diagnostics: [
+      buildDiagnostic(),
+      buildDiagnostic({
+        id: "src/other.tsx::2:2::react-doctor/other::digest",
+        filePath: "src/other.tsx",
+        normalizedFilePath: "src/other.tsx",
+        line: 2,
+        column: 2,
+        rule: "other",
+      }),
+    ],
+    analyzedFiles: ["src/app.tsx", "src/other.tsx"],
+  });
+  const secondRecord = buildRecord({ name: "second" });
+  const baselineIndex = await buildIndex([firstRecord, secondRecord]);
+  const candidateIndex = await buildIndex([
+    secondRecord,
+    {
+      ...firstRecord,
+      report: {
+        ...firstRecord.report,
+        diagnostics: [...firstRecord.report.diagnostics].reverse(),
+        projects: [
+          {
+            ...firstRecord.report.projects[0],
+            diagnostics: [...firstRecord.report.projects[0].diagnostics].reverse(),
+            analyzedFiles: [...firstRecord.report.projects[0].analyzedFiles].reverse(),
+          },
+        ],
+      },
+    },
+  ]);
+  const comparison = compareParityIndexes(baselineIndex, candidateIndex);
+
+  assert.equal(comparison.valid, true);
+  assert.equal(comparison.match, true);
+  assert.equal(comparison.summary.ruleHashesChecked, 0);
+  assert.equal(comparison.summary.projectRuleHashesChecked, 0);
+  assert.equal(baselineIndex.wholeRunHash, candidateIndex.wholeRunHash);
+  assert.notEqual(baselineIndex.sourceHash, candidateIndex.sourceHash);
+});
+
+test("descends only into changed rule and project hashes", async () => {
+  const baselineIndex = await buildIndex([
+    buildRecord({ name: "first" }),
+    buildRecord({ name: "second" }),
+  ]);
+  const candidateIndex = await buildIndex([
+    buildRecord({
+      name: "first",
+      diagnostics: [buildDiagnostic({ help: "Use the safe form." })],
+    }),
+    buildRecord({ name: "second" }),
+  ]);
+  const comparison = compareParityIndexes(baselineIndex, candidateIndex);
+
+  assert.equal(comparison.valid, true);
+  assert.equal(comparison.summary.comparedRules, baselineIndex.ruleBucketKeys.length);
+  assert.equal(comparison.summary.ruleHashesChecked, baselineIndex.ruleBucketKeys.length);
+  assert.equal(comparison.summary.projectRuleHashesChecked, 2);
+  assert.equal(comparison.summary.changedRules, 1);
+  assert.equal(comparison.summary.changedProjectRuleBuckets, 1);
+  assert.equal(comparison.changedRules[0].rule, "react-doctor/example");
+  assert.equal(comparison.changedRules[0].changedProjects[0].repository.name, "first");
+});
+
+test("fails closed when zero-hit coverage metadata differs", async () => {
+  const baselineIndex = await buildIndex([buildRecord({ name: "first" })]);
+  const candidateIndex = await buildIndex([
+    buildRecord({
+      name: "first",
+      analyzedFiles: ["src/app.tsx", "src/zero-hit.tsx"],
+    }),
+  ]);
+  const comparison = compareParityIndexes(baselineIndex, candidateIndex);
+
+  assert.equal(comparison.valid, false);
+  assert.match(comparison.metadataMismatches[0], /coverage differs/);
+});
+
+test("fails closed when project sets differ", async () => {
+  const baselineIndex = await buildIndex([buildRecord({ name: "first" })]);
+  const candidateIndex = await buildIndex([buildRecord({ name: "second" })]);
+  const comparison = compareParityIndexes(baselineIndex, candidateIndex);
+
+  assert.equal(comparison.valid, false);
+  assert.deepEqual(comparison.metadataMismatches, ["Project sets differ"]);
+});
+
+test("candidate indexing rejects diagnostics outside the requested scope", async () => {
+  await assert.rejects(
+    buildIndex(
+      [
+        buildRecord({
+          name: "first",
+          diagnostics: [buildDiagnostic({ rule: "outside" })],
+        }),
+      ],
+      true,
+    ),
+    /outside rule scope/,
+  );
+});
+
+test("rejects legacy records because scoped coverage is unavailable", async () => {
+  const record = buildRecord({ name: "first" });
+  record.report.schemaVersion = 1;
+  for (const project of record.report.projects) {
+    delete project.packageRoot;
+    delete project.framework;
+    delete project.complete;
+    delete project.analyzedFiles;
+    delete project.analyzedFileCount;
+  }
+
+  await assert.rejects(buildIndex([record]), /scoped parity index requires v3 coverage/);
+});
+
+test("rejects tampered aggregate and whole-run hashes", async () => {
+  const index = await buildIndex([buildRecord({ name: "first" })]);
+  const tamperedAggregate = structuredClone(index);
+  tamperedAggregate.rules[0].semanticHash = semanticHash("tampered");
+  assert.match(validateParityIndex(tamperedAggregate), /aggregate is inconsistent/);
+
+  const tamperedWholeRun = structuredClone(index);
+  tamperedWholeRun.wholeRunHash = semanticHash("tampered");
+  assert.match(validateParityIndex(tamperedWholeRun), /whole-run hash is inconsistent/);
+});
+
+test("rejects tampered repository metadata even when its key is recomputed", async () => {
+  const index = await buildIndex([buildRecord({ name: "first" })]);
+  const tamperedIndex = structuredClone(index);
+  tamperedIndex.projects[0].repository.rootDir = "../outside";
+  tamperedIndex.projects[0].key = JSON.stringify([
+    tamperedIndex.projects[0].repository.org,
+    tamperedIndex.projects[0].repository.name,
+    tamperedIndex.projects[0].repository.ref,
+    tamperedIndex.projects[0].repository.rootDir,
+  ]);
+
+  assert.match(validateParityIndex(tamperedIndex), /Invalid parity index project/);
+});

--- a/packages/evals/package.json
+++ b/packages/evals/package.json
@@ -8,6 +8,7 @@
   "sideEffects": false,
   "scripts": {
     "eval": "tsx src/cli.ts",
+    "source-hash": "tsx src/print-evaluator-source-hash.ts",
     "test": "vp test run",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/evals/src/constants.ts
+++ b/packages/evals/src/constants.ts
@@ -5,6 +5,7 @@ export const DEFAULT_TARGET_REPOSITORY_REF = "HEAD";
 export const DEFAULT_TARGET_ROOT_DIRECTORY = ".";
 export const REPOSITORY_SOURCE_EXTENSIONS: ReadonlyArray<string> = [".json", ".ndjson", ".txt"];
 export const PINNED_REPOSITORY_REF_PATTERN = /^[0-9a-f]{40}$/i;
+export const EVALUATION_RULE_KEY_PATTERN = /^[a-z0-9][a-z0-9-]*\/[A-Za-z0-9][A-Za-z0-9-]*$/;
 export const DEFAULT_CORPUS_REPOSITORY_COUNT = 2_000;
 export const DEFAULT_CORPUS_CONCURRENCY = 200;
 export const DEFAULT_REPOSITORIES_PER_SANDBOX = 10;
@@ -13,7 +14,9 @@ export const DEFAULT_EVALUATION_MAX_DURATION_MINUTES = 45;
 export const EVALUATION_CLEANUP_RESERVE_MINUTES = 2;
 export const EVALUATION_RETRY_CONCURRENCIES: ReadonlyArray<number> = [50, 10, 2];
 export const EVALUATION_RETRY_ATTEMPT_RESERVE_MINUTES = 5;
+export const EVALUATION_MAXIMUM_RETRY_RESERVE_RATIO = 0.25;
 export const EVALUATION_RETRY_REPOSITORIES_PER_SANDBOX = 1;
+export const EVALUATION_CONFIG_CONTRACT = "revision-local-rule-config-v1";
 
 export const DAYTONA_RUN_NAME = "react-doctor";
 export const SANDBOX_IMAGE = "node:22-bookworm";
@@ -29,6 +32,8 @@ export const SANDBOX_DELETE_TIMEOUT_SECONDS = 120;
 export const SANDBOX_CLEANUP_CONCURRENCY = 50;
 export const SANDBOX_CREATE_CONCURRENCY = 20;
 export const SANDBOX_REPORT_PATH = "/tmp/react-doctor-report.json";
+export const REACT_DOCTOR_EVALUATION_PROVENANCE_PATH =
+  "/workspace/react-doctor-evaluation-provenance.json";
 
 export const EVALUATION_SCHEMA_VERSION = 1;
 export const REACT_DOCTOR_REPORT_SCHEMA_VERSIONS: ReadonlySet<number> = new Set([1, 2, 3]);
@@ -69,10 +74,80 @@ export const PREPARE_REACT_DOCTOR_COMMANDS: ReadonlyArray<string> = [
   `git -C ${REACT_DOCTOR_WORK_DIRECTORY} fetch -q --depth 1 origin "$REACT_DOCTOR_REF"`,
   `git -C ${REACT_DOCTOR_WORK_DIRECTORY} checkout -q --detach FETCH_HEAD`,
 ];
+const EVALUATION_RULE_CONFIGURATION_SOURCE = `const availableRuleKeys = [
+  ...REACT_DOCTOR_RULES.map((registryEntry) => registryEntry.key),
+  ...Object.keys(REACT_COMPILER_RULES),
+].sort();
+const requestedRuleKeys = JSON.parse(process.env.REACT_DOCTOR_RULE_KEYS ?? "[]");
+if (!Array.isArray(requestedRuleKeys) || !requestedRuleKeys.every((ruleKey) => typeof ruleKey === "string")) {
+  throw new Error("REACT_DOCTOR_RULE_KEYS must be a JSON array of rule keys");
+}
+const availableRuleKeySet = new Set(availableRuleKeys);
+const requestedRuleKeySet = new Set(requestedRuleKeys);
+const unknownRuleKeys = requestedRuleKeys.filter((ruleKey) => !availableRuleKeySet.has(ruleKey));
+if (unknownRuleKeys.length > 0) {
+  throw new Error("Unknown React Doctor eval rules: " + unknownRuleKeys.join(", "));
+}
+const isScopedEvaluation = requestedRuleKeys.length > 0;
+const hasSelectedSecurityScanRule = REACT_DOCTOR_RULES.some(
+  (registryEntry) =>
+    registryEntry.rule.isScanRule === true && requestedRuleKeySet.has(registryEntry.key),
+);
+const rules = Object.fromEntries(
+  availableRuleKeys.map((ruleKey) => [
+    ruleKey,
+    !isScopedEvaluation || requestedRuleKeySet.has(ruleKey) ? "error" : "off",
+  ]),
+);
+const config = {
+  adoptExistingLintConfig: false,
+  respectInlineDisables: false,
+  ...(isScopedEvaluation && !hasSelectedSecurityScanRule
+    ? { ignore: { tags: ["security-scan"] } }
+    : {}),
+  rules,
+  warnings: true,
+};`;
+export const MATERIALIZE_REACT_DOCTOR_EVALUATION_PROVENANCE_COMMAND = `node --input-type=module <<'REACT_DOCTOR_EVAL_PROVENANCE'
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import * as fs from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const { REACT_COMPILER_RULES, REACT_DOCTOR_RULES } = await import(
+  pathToFileURL(
+    "${REACT_DOCTOR_WORK_DIRECTORY}/packages/oxlint-plugin-react-doctor/dist/index.js",
+  ).href
+);
+${EVALUATION_RULE_CONFIGURATION_SOURCE}
+const ruleSetHash = createHash("sha256")
+  .update(JSON.stringify({
+    configContract: "${EVALUATION_CONFIG_CONTRACT}",
+    config,
+  }))
+  .digest("hex");
+const provenance = {
+  reactDoctorRepository: process.env.REACT_DOCTOR_REPOSITORY,
+  reactDoctorCommit: execFileSync(
+    "git",
+    ["-C", "${REACT_DOCTOR_WORK_DIRECTORY}", "rev-parse", "HEAD"],
+    { encoding: "utf8" },
+  ).trim(),
+  configContract: "${EVALUATION_CONFIG_CONTRACT}",
+  ruleSetHash,
+  ruleKeys: [...requestedRuleKeySet].sort(),
+};
+fs.writeFileSync(
+  "${REACT_DOCTOR_EVALUATION_PROVENANCE_PATH}",
+  JSON.stringify(provenance) + "\\n",
+  { mode: 0o600 },
+);
+REACT_DOCTOR_EVAL_PROVENANCE`;
 export const BUILD_REACT_DOCTOR_COMMANDS: ReadonlyArray<string> = [
   "corepack enable",
   "npx --yes --package @antfu/ni ni --frozen",
   "./node_modules/.bin/turbo run build --filter=react-doctor",
+  MATERIALIZE_REACT_DOCTOR_EVALUATION_PROVENANCE_COMMAND,
 ];
 
 export const SETUP_TARGET_REPOSITORY_COMMAND = `set -eu
@@ -97,17 +172,7 @@ const { REACT_COMPILER_RULES, REACT_DOCTOR_RULES } = await import(
   ).href
 );
 
-const ruleKeys = [
-  ...REACT_DOCTOR_RULES.map((registryEntry) => registryEntry.key),
-  ...Object.keys(REACT_COMPILER_RULES),
-];
-const rules = Object.fromEntries(ruleKeys.map((ruleKey) => [ruleKey, "error"]));
-const config = {
-  adoptExistingLintConfig: false,
-  respectInlineDisables: false,
-  rules,
-  warnings: true,
-};
+${EVALUATION_RULE_CONFIGURATION_SOURCE}
 const configContents = "export default " + JSON.stringify(config) + ";\\n";
 const CONFIG_FILE_MODE = 0o600;
 const targetCheckoutDirectory = fs.realpathSync("/workspace/target");

--- a/packages/evals/src/corpus.ts
+++ b/packages/evals/src/corpus.ts
@@ -12,9 +12,22 @@ export interface CorpusRepositoryGroup {
   rootDirectories: ReadonlyArray<string>;
 }
 
+export interface ReactDoctorEvaluationProvenance {
+  reactDoctorRepository: string;
+  reactDoctorCommit: string;
+  configContract: string;
+  ruleSetHash: string;
+  ruleKeys: ReadonlyArray<string>;
+}
+
+export interface EvaluationProvenance extends ReactDoctorEvaluationProvenance {
+  evaluatorSourceHash: string;
+}
+
 export interface CorpusEvaluationRecord {
   schemaVersion: number;
   repository: CorpusRepository;
+  evaluation?: EvaluationProvenance;
   report?: unknown;
   error?: string;
 }

--- a/packages/evals/src/evaluate-repository-batch.ts
+++ b/packages/evals/src/evaluate-repository-batch.ts
@@ -6,6 +6,7 @@ import type { Daytona, Sandbox } from "@daytona/sdk";
 import {
   DAYTONA_RUN_NAME,
   EVALUATION_SCHEMA_VERSION,
+  REACT_DOCTOR_EVALUATION_PROVENANCE_PATH,
   RESOLVE_TARGET_REPOSITORY_REF_COMMAND,
   SANDBOX_DELETE_TIMEOUT_SECONDS,
   SANDBOX_REPORT_DOWNLOAD_TIMEOUT_SECONDS,
@@ -15,13 +16,19 @@ import {
   SCAN_COMMAND,
   SETUP_TARGET_REPOSITORY_COMMAND,
 } from "./constants.js";
-import type { CorpusEvaluationRecord, CorpusRepository, CorpusRepositoryGroup } from "./corpus.js";
+import type {
+  CorpusEvaluationRecord,
+  CorpusRepository,
+  CorpusRepositoryGroup,
+  EvaluationProvenance,
+} from "./corpus.js";
 import { executeSandboxCommand } from "./execute-sandbox-command.js";
 import {
   EvaluationDeadlineExceededError,
   getEvaluationTimeoutSeconds,
 } from "./utils/get-evaluation-timeout-seconds.js";
 import { parseReactDoctorReport } from "./utils/parse-react-doctor-report.js";
+import { parseReactDoctorEvaluationProvenance } from "./utils/parse-react-doctor-evaluation-provenance.js";
 import { toErrorMessage } from "./utils/to-error-message.js";
 
 export interface EvaluateRepositoryBatchInput {
@@ -29,12 +36,14 @@ export interface EvaluateRepositoryBatchInput {
   createSandbox: (sandboxName: string, deadlineMilliseconds: number) => Promise<Sandbox>;
   repositoryGroups: ReadonlyArray<CorpusRepositoryGroup>;
   evaluationDeadlineMilliseconds: number;
+  evaluatorSourceHash: string;
   onRecord: (record: CorpusEvaluationRecord) => Promise<void>;
 }
 
 interface EvaluateRepositoryGroupInput {
   sandbox: Sandbox;
   repositoryGroup: CorpusRepositoryGroup;
+  evaluationProvenance: EvaluationProvenance;
   evaluationDeadlineMilliseconds: number;
   onRecord: (record: CorpusEvaluationRecord) => Promise<void>;
 }
@@ -64,6 +73,7 @@ const buildFailureRecords = (
 const evaluateRepositoryGroup = async ({
   sandbox,
   repositoryGroup,
+  evaluationProvenance,
   evaluationDeadlineMilliseconds,
   onRecord,
 }: EvaluateRepositoryGroupInput): Promise<ReadonlyArray<CorpusEvaluationRecord>> => {
@@ -132,6 +142,7 @@ const evaluateRepositoryGroup = async ({
       await onRecord({
         schemaVersion: EVALUATION_SCHEMA_VERSION,
         repository,
+        evaluation: evaluationProvenance,
         report,
       });
     } catch (error) {
@@ -146,6 +157,7 @@ export const evaluateRepositoryBatch = async ({
   createSandbox,
   repositoryGroups,
   evaluationDeadlineMilliseconds,
+  evaluatorSourceHash,
   onRecord,
 }: EvaluateRepositoryBatchInput): Promise<ReadonlyArray<CorpusEvaluationRecord>> => {
   const sandboxName = `${DAYTONA_RUN_NAME}-${randomUUID()}`;
@@ -161,12 +173,32 @@ export const evaluateRepositoryBatch = async ({
       );
     }
 
+    let evaluationProvenance: EvaluationProvenance;
+    try {
+      const provenanceContents = await sandbox.fs.downloadFile(
+        REACT_DOCTOR_EVALUATION_PROVENANCE_PATH,
+        getEvaluationTimeoutSeconds({
+          deadlineMilliseconds: evaluationDeadlineMilliseconds,
+          maximumTimeoutSeconds: SANDBOX_REPORT_DOWNLOAD_TIMEOUT_SECONDS,
+        }),
+      );
+      evaluationProvenance = {
+        ...parseReactDoctorEvaluationProvenance(provenanceContents.toString("utf8")),
+        evaluatorSourceHash,
+      };
+    } catch (error) {
+      return repositoryGroups.flatMap((repositoryGroup) =>
+        buildFailureRecords(buildRepositories(repositoryGroup), error),
+      );
+    }
+
     const failedRecords: CorpusEvaluationRecord[] = [];
     for (const repositoryGroup of repositoryGroups) {
       failedRecords.push(
         ...(await evaluateRepositoryGroup({
           sandbox,
           repositoryGroup,
+          evaluationProvenance,
           evaluationDeadlineMilliseconds,
           onRecord,
         })),

--- a/packages/evals/src/parse-evaluation-arguments.ts
+++ b/packages/evals/src/parse-evaluation-arguments.ts
@@ -10,6 +10,7 @@ import {
   DEFAULT_REPOSITORIES_PER_SANDBOX,
   DEFAULT_REPOSITORIES_SOURCES,
   EVALUATION_CLEANUP_RESERVE_MINUTES,
+  EVALUATION_RULE_KEY_PATTERN,
   EVALUATION_RETRY_ATTEMPT_RESERVE_MINUTES,
   EVALUATION_RETRY_CONCURRENCIES,
 } from "./constants.js";
@@ -23,6 +24,7 @@ export interface EvaluationOptions {
   maxDurationMinutes: number;
   reactDoctorRepository: string;
   reactDoctorRef: string;
+  ruleKeys: ReadonlyArray<string>;
 }
 
 export const parseEvaluationArguments = (
@@ -64,12 +66,16 @@ export const parseEvaluationArguments = (
         type: "string",
         default: DEFAULT_REACT_DOCTOR_REF,
       },
+      rule: {
+        type: "string",
+        multiple: true,
+      },
     },
   });
 
   if (positionals.length !== 0) {
     throw new Error(
-      "Usage: nr eval -- [--repositories <path-url-or-directory>]... [--repository-limit <count>] [--project-roots-per-repository <count>] [--concurrency <count>] [--repositories-per-sandbox <count>] [--max-duration-minutes <count>] [--react-doctor-ref <git-ref>]",
+      "Usage: nr eval -- [--repositories <path-url-or-directory>]... [--repository-limit <count>] [--project-roots-per-repository <count>] [--concurrency <count>] [--repositories-per-sandbox <count>] [--max-duration-minutes <count>] [--react-doctor-ref <git-ref>] [--rule <plugin/rule>]...",
     );
   }
 
@@ -103,6 +109,12 @@ export const parseEvaluationArguments = (
     );
   }
 
+  const ruleKeys = [...new Set(values.rule ?? [])];
+  const invalidRuleKey = ruleKeys.find((ruleKey) => !EVALUATION_RULE_KEY_PATTERN.test(ruleKey));
+  if (invalidRuleKey !== undefined) {
+    throw new Error(`--rule must be a canonical plugin/rule key: ${invalidRuleKey}`);
+  }
+
   return {
     repositoriesSources: values.repositories ?? DEFAULT_REPOSITORIES_SOURCES,
     repositoryLimit,
@@ -112,5 +124,6 @@ export const parseEvaluationArguments = (
     maxDurationMinutes,
     reactDoctorRepository: values["react-doctor-repository"],
     reactDoctorRef: values["react-doctor-ref"],
+    ruleKeys,
   };
 };

--- a/packages/evals/src/print-evaluator-source-hash.ts
+++ b/packages/evals/src/print-evaluator-source-hash.ts
@@ -1,0 +1,3 @@
+import { getEvaluatorSourceHash } from "./utils/get-evaluator-source-hash.js";
+
+process.stdout.write(`${getEvaluatorSourceHash()}\n`);

--- a/packages/evals/src/run-corpus-evaluation.ts
+++ b/packages/evals/src/run-corpus-evaluation.ts
@@ -33,6 +33,7 @@ import { loadCorpusRepositories } from "./load-corpus-repositories.js";
 import type { EvaluationOptions } from "./parse-evaluation-arguments.js";
 import { runEvaluationAttempts } from "./run-evaluation-attempts.js";
 import { getEvaluationAttemptDeadlineMilliseconds } from "./utils/get-evaluation-attempt-deadline-milliseconds.js";
+import { getEvaluatorSourceHash } from "./utils/get-evaluator-source-hash.js";
 import { getEvaluationTimeoutSeconds } from "./utils/get-evaluation-timeout-seconds.js";
 import { toErrorMessage } from "./utils/to-error-message.js";
 
@@ -50,6 +51,7 @@ export const runCorpusEvaluation = async (options: EvaluationOptions): Promise<v
     0,
   );
   const startedAt = globalThis.performance.now();
+  const evaluatorSourceHash = getEvaluatorSourceHash();
   const evaluationDeadlineMilliseconds =
     startedAt +
     (options.maxDurationMinutes - EVALUATION_CLEANUP_RESERVE_MINUTES) * MILLISECONDS_PER_MINUTE;
@@ -72,6 +74,7 @@ export const runCorpusEvaluation = async (options: EvaluationOptions): Promise<v
           .env({
             REACT_DOCTOR_REPOSITORY: options.reactDoctorRepository,
             REACT_DOCTOR_REF: options.reactDoctorRef,
+            REACT_DOCTOR_RULE_KEYS: JSON.stringify(options.ruleKeys),
           })
           .runCommands(...PREPARE_REACT_DOCTOR_COMMANDS)
           .workdir(REACT_DOCTOR_WORK_DIRECTORY)
@@ -140,6 +143,7 @@ export const runCorpusEvaluation = async (options: EvaluationOptions): Promise<v
           daytona,
           createSandbox,
           repositoryGroups: repositoryBatch,
+          evaluatorSourceHash,
           evaluationDeadlineMilliseconds: getEvaluationAttemptDeadlineMilliseconds({
             evaluationDeadlineMilliseconds,
             attemptIndex,

--- a/packages/evals/src/utils/get-evaluation-attempt-deadline-milliseconds.ts
+++ b/packages/evals/src/utils/get-evaluation-attempt-deadline-milliseconds.ts
@@ -1,19 +1,33 @@
-import { EVALUATION_RETRY_ATTEMPT_RESERVE_MINUTES, MILLISECONDS_PER_MINUTE } from "../constants.js";
+import {
+  EVALUATION_MAXIMUM_RETRY_RESERVE_RATIO,
+  EVALUATION_RETRY_ATTEMPT_RESERVE_MINUTES,
+  MILLISECONDS_PER_MINUTE,
+} from "../constants.js";
 
 export interface GetEvaluationAttemptDeadlineMillisecondsInput {
   evaluationDeadlineMilliseconds: number;
   attemptIndex: number;
   totalAttempts: number;
+  nowMilliseconds?: number;
 }
 
 export const getEvaluationAttemptDeadlineMilliseconds = ({
   evaluationDeadlineMilliseconds,
   attemptIndex,
   totalAttempts,
+  nowMilliseconds = globalThis.performance.now(),
 }: GetEvaluationAttemptDeadlineMillisecondsInput): number => {
   const remainingAttemptCount = Math.max(totalAttempts - attemptIndex - 1, 0);
+  const requestedRetryReserveMilliseconds =
+    remainingAttemptCount * EVALUATION_RETRY_ATTEMPT_RESERVE_MINUTES * MILLISECONDS_PER_MINUTE;
+  const remainingEvaluationBudgetMilliseconds = Math.max(
+    evaluationDeadlineMilliseconds - nowMilliseconds,
+    0,
+  );
+  const maximumRetryReserveMilliseconds =
+    remainingEvaluationBudgetMilliseconds * EVALUATION_MAXIMUM_RETRY_RESERVE_RATIO;
   return (
     evaluationDeadlineMilliseconds -
-    remainingAttemptCount * EVALUATION_RETRY_ATTEMPT_RESERVE_MINUTES * MILLISECONDS_PER_MINUTE
+    Math.min(requestedRetryReserveMilliseconds, maximumRetryReserveMilliseconds)
   );
 };

--- a/packages/evals/src/utils/get-evaluator-source-hash.ts
+++ b/packages/evals/src/utils/get-evaluator-source-hash.ts
@@ -1,0 +1,49 @@
+import { createHash } from "node:crypto";
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export interface GetEvaluatorSourceHashInput {
+  sourceDirectory: string;
+  packageManifestPath: string;
+  lockfilePath: string;
+}
+
+const collectSourceFilePaths = (directory: string): ReadonlyArray<string> =>
+  readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = join(directory, entry.name);
+    if (entry.isDirectory()) return collectSourceFilePaths(entryPath);
+    return entry.isFile() && entry.name.endsWith(".ts") ? [entryPath] : [];
+  });
+
+const defaultInput = (): GetEvaluatorSourceHashInput => {
+  const sourceDirectory = dirname(fileURLToPath(new URL("../cli.ts", import.meta.url)));
+  const packageDirectory = dirname(sourceDirectory);
+  return {
+    sourceDirectory,
+    packageManifestPath: join(packageDirectory, "package.json"),
+    lockfilePath: join(packageDirectory, "..", "..", "pnpm-lock.yaml"),
+  };
+};
+
+export const getEvaluatorSourceHash = (
+  input: GetEvaluatorSourceHashInput = defaultInput(),
+): string => {
+  const sourceFilePaths = collectSourceFilePaths(input.sourceDirectory);
+  const fileEntries = [
+    ...sourceFilePaths.map((filePath) => ({
+      label: `src/${relative(input.sourceDirectory, filePath).replaceAll("\\", "/")}`,
+      filePath,
+    })),
+    { label: "package.json", filePath: input.packageManifestPath },
+    { label: "pnpm-lock.yaml", filePath: input.lockfilePath },
+  ].sort((left, right) => left.label.localeCompare(right.label));
+  const sourceHasher = createHash("sha256");
+  for (const fileEntry of fileEntries) {
+    sourceHasher.update(fileEntry.label);
+    sourceHasher.update("\0");
+    sourceHasher.update(readFileSync(fileEntry.filePath));
+    sourceHasher.update("\0");
+  }
+  return sourceHasher.digest("hex");
+};

--- a/packages/evals/src/utils/parse-react-doctor-evaluation-provenance.ts
+++ b/packages/evals/src/utils/parse-react-doctor-evaluation-provenance.ts
@@ -1,0 +1,39 @@
+import {
+  EVALUATION_CONFIG_CONTRACT,
+  EVALUATION_RULE_KEY_PATTERN,
+  PINNED_REPOSITORY_REF_PATTERN,
+} from "../constants.js";
+import type { ReactDoctorEvaluationProvenance } from "../corpus.js";
+
+const SHA256_PATTERN = /^[0-9a-f]{64}$/;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+export const parseReactDoctorEvaluationProvenance = (
+  provenanceContents: string,
+): ReactDoctorEvaluationProvenance => {
+  const provenance: unknown = JSON.parse(provenanceContents);
+  if (
+    !isRecord(provenance) ||
+    typeof provenance.reactDoctorRepository !== "string" ||
+    typeof provenance.reactDoctorCommit !== "string" ||
+    !PINNED_REPOSITORY_REF_PATTERN.test(provenance.reactDoctorCommit) ||
+    provenance.configContract !== EVALUATION_CONFIG_CONTRACT ||
+    typeof provenance.ruleSetHash !== "string" ||
+    !SHA256_PATTERN.test(provenance.ruleSetHash) ||
+    !Array.isArray(provenance.ruleKeys) ||
+    !provenance.ruleKeys.every(
+      (ruleKey) => typeof ruleKey === "string" && EVALUATION_RULE_KEY_PATTERN.test(ruleKey),
+    )
+  ) {
+    throw new Error("Invalid React Doctor evaluation provenance");
+  }
+  return {
+    reactDoctorRepository: provenance.reactDoctorRepository,
+    reactDoctorCommit: provenance.reactDoctorCommit,
+    configContract: provenance.configContract,
+    ruleSetHash: provenance.ruleSetHash,
+    ruleKeys: provenance.ruleKeys,
+  };
+};

--- a/packages/evals/tests/evaluate-repository-batch.test.ts
+++ b/packages/evals/tests/evaluate-repository-batch.test.ts
@@ -1,7 +1,11 @@
 import { Daytona, Sandbox } from "@daytona/sdk";
 import { describe, expect, it, vi } from "vite-plus/test";
 
-import { SANDBOX_REPORT_PATH } from "../src/constants.js";
+import {
+  EVALUATION_CONFIG_CONTRACT,
+  REACT_DOCTOR_EVALUATION_PROVENANCE_PATH,
+  SANDBOX_REPORT_PATH,
+} from "../src/constants.js";
 import { evaluateRepositoryBatch } from "../src/evaluate-repository-batch.js";
 
 const buildReport = () => ({
@@ -42,12 +46,25 @@ const buildReport = () => ({
 describe("evaluateRepositoryBatch", () => {
   it("downloads the report file instead of parsing truncated command output", async () => {
     const report = buildReport();
+    const evaluationProvenance = {
+      reactDoctorRepository: "https://github.com/millionco/react-doctor.git",
+      reactDoctorCommit: "c".repeat(40),
+      configContract: EVALUATION_CONFIG_CONTRACT,
+      ruleSetHash: "d".repeat(64),
+      ruleKeys: [],
+    };
     const executeCommand = vi
       .fn()
       .mockResolvedValueOnce({ exitCode: 0, result: "" })
       .mockResolvedValueOnce({ exitCode: 0, result: "a".repeat(40) })
       .mockResolvedValueOnce({ exitCode: 0, result: '{"ok":true' });
-    const downloadFile = vi.fn(async () => Buffer.from(JSON.stringify(report)));
+    const downloadFile = vi.fn(async (filePath: string) =>
+      Buffer.from(
+        JSON.stringify(
+          filePath === REACT_DOCTOR_EVALUATION_PROVENANCE_PATH ? evaluationProvenance : report,
+        ),
+      ),
+    );
     const sandbox = Object.create(Sandbox.prototype);
     Object.defineProperties(sandbox, {
       id: { value: "sandbox-id" },
@@ -70,6 +87,7 @@ describe("evaluateRepositoryBatch", () => {
         },
       ],
       evaluationDeadlineMilliseconds: globalThis.performance.now() + 60_000,
+      evaluatorSourceHash: "e".repeat(64),
       onRecord: async (record) => {
         records.push(record);
       },
@@ -86,8 +104,17 @@ describe("evaluateRepositoryBatch", () => {
           ref: "a".repeat(40),
           rootDir: ".",
         },
+        evaluation: {
+          ...evaluationProvenance,
+          evaluatorSourceHash: "e".repeat(64),
+        },
         report,
       },
     ]);
+    expect(downloadFile).toHaveBeenCalledWith(
+      REACT_DOCTOR_EVALUATION_PROVENANCE_PATH,
+      expect.any(Number),
+    );
+    expect(downloadFile).toHaveBeenCalledWith(SANDBOX_REPORT_PATH, expect.any(Number));
   });
 });

--- a/packages/evals/tests/get-evaluation-attempt-deadline-milliseconds.test.ts
+++ b/packages/evals/tests/get-evaluation-attempt-deadline-milliseconds.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vite-plus/test";
 import { getEvaluationAttemptDeadlineMilliseconds } from "../src/utils/get-evaluation-attempt-deadline-milliseconds.js";
 
 describe("getEvaluationAttemptDeadlineMilliseconds", () => {
-  it("reserves time for every remaining retry attempt", () => {
+  it("caps retry reserves so the active attempt keeps most of a short budget", () => {
     const evaluationDeadlineMilliseconds = 28 * 60_000;
 
     expect(
@@ -11,22 +11,36 @@ describe("getEvaluationAttemptDeadlineMilliseconds", () => {
         evaluationDeadlineMilliseconds,
         attemptIndex: 0,
         totalAttempts: 3,
+        nowMilliseconds: 0,
       }),
-    ).toBe(18 * 60_000);
+    ).toBe(21 * 60_000);
     expect(
       getEvaluationAttemptDeadlineMilliseconds({
         evaluationDeadlineMilliseconds,
         attemptIndex: 1,
         totalAttempts: 3,
+        nowMilliseconds: 21 * 60_000,
       }),
-    ).toBe(23 * 60_000);
+    ).toBe(26.25 * 60_000);
     expect(
       getEvaluationAttemptDeadlineMilliseconds({
         evaluationDeadlineMilliseconds,
         attemptIndex: 2,
         totalAttempts: 3,
+        nowMilliseconds: 26.25 * 60_000,
       }),
     ).toBe(evaluationDeadlineMilliseconds);
+  });
+
+  it("preserves the fixed retry reserve when the remaining budget is large", () => {
+    expect(
+      getEvaluationAttemptDeadlineMilliseconds({
+        evaluationDeadlineMilliseconds: 60 * 60_000,
+        attemptIndex: 0,
+        totalAttempts: 3,
+        nowMilliseconds: 0,
+      }),
+    ).toBe(50 * 60_000);
   });
 
   it("uses the evaluation deadline when no retries remain", () => {
@@ -35,6 +49,7 @@ describe("getEvaluationAttemptDeadlineMilliseconds", () => {
         evaluationDeadlineMilliseconds: 28 * 60_000,
         attemptIndex: 0,
         totalAttempts: 1,
+        nowMilliseconds: 0,
       }),
     ).toBe(28 * 60_000);
   });

--- a/packages/evals/tests/get-evaluator-source-hash.test.ts
+++ b/packages/evals/tests/get-evaluator-source-hash.test.ts
@@ -1,0 +1,41 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { describe, expect, it } from "vite-plus/test";
+
+import { getEvaluatorSourceHash } from "../src/utils/get-evaluator-source-hash.js";
+
+const buildHashFixture = (temporaryDirectory: string) => {
+  const sourceDirectory = path.join(temporaryDirectory, "src");
+  const packageManifestPath = path.join(temporaryDirectory, "package.json");
+  const lockfilePath = path.join(temporaryDirectory, "pnpm-lock.yaml");
+  fs.mkdirSync(path.join(sourceDirectory, "utils"), { recursive: true });
+  fs.writeFileSync(path.join(sourceDirectory, "cli.ts"), "export const cli = true;\n");
+  fs.writeFileSync(path.join(sourceDirectory, "utils", "helper.ts"), "export const helper = 1;\n");
+  fs.writeFileSync(packageManifestPath, '{"name":"fixture"}\n');
+  fs.writeFileSync(lockfilePath, "lockfileVersion: '9.0'\n");
+  return { sourceDirectory, packageManifestPath, lockfilePath };
+};
+
+describe("getEvaluatorSourceHash", () => {
+  it("is stable across roots and changes when an implementation input changes", () => {
+    const firstDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-source-hash-"));
+    const secondDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-source-hash-"));
+    try {
+      const firstInput = buildHashFixture(firstDirectory);
+      const secondInput = buildHashFixture(secondDirectory);
+      const initialHash = getEvaluatorSourceHash(firstInput);
+
+      expect(getEvaluatorSourceHash(secondInput)).toBe(initialHash);
+      fs.writeFileSync(
+        path.join(secondInput.sourceDirectory, "utils", "helper.ts"),
+        "export const helper = 2;\n",
+      );
+      expect(getEvaluatorSourceHash(secondInput)).not.toBe(initialHash);
+    } finally {
+      fs.rmSync(firstDirectory, { force: true, recursive: true });
+      fs.rmSync(secondDirectory, { force: true, recursive: true });
+    }
+  });
+});

--- a/packages/evals/tests/materialize-all-rules-config.test.ts
+++ b/packages/evals/tests/materialize-all-rules-config.test.ts
@@ -5,7 +5,14 @@ import { execFileSync, spawnSync } from "node:child_process";
 
 import { afterEach, describe, expect, it } from "vite-plus/test";
 
-import { MATERIALIZE_ALL_RULES_CONFIG_COMMAND, SCAN_COMMAND } from "../src/constants.js";
+import {
+  EVALUATION_CONFIG_CONTRACT,
+  MATERIALIZE_ALL_RULES_CONFIG_COMMAND,
+  MATERIALIZE_REACT_DOCTOR_EVALUATION_PROVENANCE_COMMAND,
+  REACT_DOCTOR_EVALUATION_PROVENANCE_PATH,
+  REACT_DOCTOR_WORK_DIRECTORY,
+  SCAN_COMMAND,
+} from "../src/constants.js";
 
 const temporaryDirectories: string[] = [];
 const INTEGRATION_TEST_TIMEOUT_MS = 30_000;
@@ -48,8 +55,8 @@ describe("MATERIALIZE_ALL_RULES_CONFIG_COMMAND", () => {
         path.join(pluginDirectory, "index.js"),
         `export const REACT_COMPILER_RULES = { "react-hooks-js/compiler-rule": "warn" };
 export const REACT_DOCTOR_RULES = [
-  { key: "react-doctor/default-rule" },
-  { key: "react-doctor/opt-in-rule" },
+  { key: "react-doctor/default-rule", rule: { isScanRule: false } },
+  { key: "react-doctor/opt-in-rule", rule: { isScanRule: false } },
 ];
 `,
       );
@@ -82,6 +89,201 @@ export const REACT_DOCTOR_RULES = [
         fs.readFileSync(path.join(targetRootDirectory, "doctor.config.ts"), "utf8"),
       );
       expect(fs.existsSync(path.join(ignoredProjectDirectory, "doctor.config.ts"))).toBe(false);
+    },
+  );
+
+  it(
+    "enables only explicitly selected revision-local rules",
+    { timeout: INTEGRATION_TEST_TIMEOUT_MS },
+    () => {
+      const temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-eval-"));
+      temporaryDirectories.push(temporaryDirectory);
+      const reactDoctorDirectory = path.join(temporaryDirectory, "react-doctor");
+      const pluginDirectory = path.join(
+        reactDoctorDirectory,
+        "packages/oxlint-plugin-react-doctor/dist",
+      );
+      const targetDirectory = path.join(temporaryDirectory, "target");
+      fs.mkdirSync(pluginDirectory, { recursive: true });
+      fs.mkdirSync(targetDirectory, { recursive: true });
+      fs.writeFileSync(
+        path.join(pluginDirectory, "index.js"),
+        `export const REACT_COMPILER_RULES = { "react-hooks-js/compiler-rule": "warn" };
+export const REACT_DOCTOR_RULES = [
+  { key: "react-doctor/selected-rule", rule: { isScanRule: false } },
+  { key: "react-doctor/unselected-rule", rule: { isScanRule: false } },
+];
+`,
+      );
+
+      const command = MATERIALIZE_ALL_RULES_CONFIG_COMMAND.replaceAll(
+        "/workspace/react-doctor",
+        normalizeEmbeddedPath(reactDoctorDirectory),
+      ).replaceAll("/workspace/target", normalizeEmbeddedPath(targetDirectory));
+      execFileSync("sh", ["-c", command], {
+        env: {
+          ...process.env,
+          REACT_DOCTOR_RULE_KEYS: JSON.stringify(["react-doctor/selected-rule"]),
+          TARGET_ROOT_DIRECTORY: ".",
+        },
+      });
+
+      expect(fs.readFileSync(path.join(targetDirectory, "doctor.config.ts"), "utf8")).toBe(
+        `export default ${JSON.stringify({
+          adoptExistingLintConfig: false,
+          respectInlineDisables: false,
+          ignore: { tags: ["security-scan"] },
+          rules: {
+            "react-doctor/selected-rule": "error",
+            "react-doctor/unselected-rule": "off",
+            "react-hooks-js/compiler-rule": "off",
+          },
+          warnings: true,
+        })};\n`,
+      );
+    },
+  );
+
+  it(
+    "freezes the exact detector revision and revision-local rule configuration",
+    { timeout: INTEGRATION_TEST_TIMEOUT_MS },
+    () => {
+      const temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-eval-"));
+      temporaryDirectories.push(temporaryDirectory);
+      const reactDoctorDirectory = path.join(temporaryDirectory, "react-doctor");
+      const pluginDirectory = path.join(
+        reactDoctorDirectory,
+        "packages/oxlint-plugin-react-doctor/dist",
+      );
+      const provenancePath = path.join(temporaryDirectory, "evaluation-provenance.json");
+      fs.mkdirSync(pluginDirectory, { recursive: true });
+      fs.writeFileSync(
+        path.join(pluginDirectory, "index.js"),
+        `export const REACT_COMPILER_RULES = { "react-hooks-js/compiler-rule": "warn" };
+export const REACT_DOCTOR_RULES = [
+  { key: "react-doctor/no-derived-useState", rule: { isScanRule: false } },
+  { key: "react-doctor/security-rule", rule: { isScanRule: true } },
+];
+`,
+      );
+      execFileSync("git", ["-C", reactDoctorDirectory, "init", "-q"]);
+      execFileSync("git", ["-C", reactDoctorDirectory, "config", "user.email", "test@example.com"]);
+      execFileSync("git", ["-C", reactDoctorDirectory, "config", "user.name", "Test"]);
+      execFileSync("git", ["-C", reactDoctorDirectory, "add", "."]);
+      execFileSync("git", ["-C", reactDoctorDirectory, "commit", "-q", "-m", "fixture"]);
+      const expectedCommit = execFileSync(
+        "git",
+        ["-C", reactDoctorDirectory, "rev-parse", "HEAD"],
+        { encoding: "utf8" },
+      ).trim();
+      const command = MATERIALIZE_REACT_DOCTOR_EVALUATION_PROVENANCE_COMMAND.replaceAll(
+        REACT_DOCTOR_EVALUATION_PROVENANCE_PATH,
+        normalizeEmbeddedPath(provenancePath),
+      ).replaceAll(REACT_DOCTOR_WORK_DIRECTORY, normalizeEmbeddedPath(reactDoctorDirectory));
+
+      execFileSync("sh", ["-c", command], {
+        env: {
+          ...process.env,
+          REACT_DOCTOR_REPOSITORY: "https://github.com/millionco/react-doctor.git",
+          REACT_DOCTOR_RULE_KEYS: JSON.stringify(["react-doctor/no-derived-useState"]),
+        },
+      });
+
+      expect(JSON.parse(fs.readFileSync(provenancePath, "utf8"))).toEqual({
+        reactDoctorRepository: "https://github.com/millionco/react-doctor.git",
+        reactDoctorCommit: expectedCommit,
+        configContract: EVALUATION_CONFIG_CONTRACT,
+        ruleSetHash: expect.stringMatching(/^[0-9a-f]{64}$/),
+        ruleKeys: ["react-doctor/no-derived-useState"],
+      });
+    },
+  );
+
+  it(
+    "keeps the security scan enabled when a scan rule is selected",
+    { timeout: INTEGRATION_TEST_TIMEOUT_MS },
+    () => {
+      const temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-eval-"));
+      temporaryDirectories.push(temporaryDirectory);
+      const reactDoctorDirectory = path.join(temporaryDirectory, "react-doctor");
+      const pluginDirectory = path.join(
+        reactDoctorDirectory,
+        "packages/oxlint-plugin-react-doctor/dist",
+      );
+      const targetDirectory = path.join(temporaryDirectory, "target");
+      fs.mkdirSync(pluginDirectory, { recursive: true });
+      fs.mkdirSync(targetDirectory, { recursive: true });
+      fs.writeFileSync(
+        path.join(pluginDirectory, "index.js"),
+        `export const REACT_COMPILER_RULES = {};
+export const REACT_DOCTOR_RULES = [
+  { key: "react-doctor/scan-rule", rule: { isScanRule: true } },
+  { key: "react-doctor/lint-rule", rule: { isScanRule: false } },
+];
+`,
+      );
+
+      const command = MATERIALIZE_ALL_RULES_CONFIG_COMMAND.replaceAll(
+        "/workspace/react-doctor",
+        normalizeEmbeddedPath(reactDoctorDirectory),
+      ).replaceAll("/workspace/target", normalizeEmbeddedPath(targetDirectory));
+      execFileSync("sh", ["-c", command], {
+        env: {
+          ...process.env,
+          REACT_DOCTOR_RULE_KEYS: JSON.stringify(["react-doctor/scan-rule"]),
+          TARGET_ROOT_DIRECTORY: ".",
+        },
+      });
+
+      expect(fs.readFileSync(path.join(targetDirectory, "doctor.config.ts"), "utf8")).toBe(
+        `export default ${JSON.stringify({
+          adoptExistingLintConfig: false,
+          respectInlineDisables: false,
+          rules: {
+            "react-doctor/lint-rule": "off",
+            "react-doctor/scan-rule": "error",
+          },
+          warnings: true,
+        })};\n`,
+      );
+    },
+  );
+
+  it(
+    "rejects selected rules missing from the evaluated revision",
+    { timeout: INTEGRATION_TEST_TIMEOUT_MS },
+    () => {
+      const temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-eval-"));
+      temporaryDirectories.push(temporaryDirectory);
+      const reactDoctorDirectory = path.join(temporaryDirectory, "react-doctor");
+      const pluginDirectory = path.join(
+        reactDoctorDirectory,
+        "packages/oxlint-plugin-react-doctor/dist",
+      );
+      const targetDirectory = path.join(temporaryDirectory, "target");
+      fs.mkdirSync(pluginDirectory, { recursive: true });
+      fs.mkdirSync(targetDirectory, { recursive: true });
+      fs.writeFileSync(
+        path.join(pluginDirectory, "index.js"),
+        "export const REACT_COMPILER_RULES = {}; export const REACT_DOCTOR_RULES = [];",
+      );
+
+      const command = MATERIALIZE_ALL_RULES_CONFIG_COMMAND.replaceAll(
+        "/workspace/react-doctor",
+        normalizeEmbeddedPath(reactDoctorDirectory),
+      ).replaceAll("/workspace/target", normalizeEmbeddedPath(targetDirectory));
+      const result = spawnSync("sh", ["-c", command], {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          REACT_DOCTOR_RULE_KEYS: JSON.stringify(["react-doctor/missing-rule"]),
+          TARGET_ROOT_DIRECTORY: ".",
+        },
+      });
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("Unknown React Doctor eval rules");
+      expect(fs.existsSync(path.join(targetDirectory, "doctor.config.ts"))).toBe(false);
     },
   );
 

--- a/packages/evals/tests/parse-evaluation-arguments.test.ts
+++ b/packages/evals/tests/parse-evaluation-arguments.test.ts
@@ -13,6 +13,7 @@ describe("parseEvaluationArguments", () => {
       maxDurationMinutes: 45,
       reactDoctorRepository: "https://github.com/millionco/react-doctor.git",
       reactDoctorRef: "main",
+      ruleKeys: [],
     });
   });
 
@@ -35,6 +36,12 @@ describe("parseEvaluationArguments", () => {
         "20",
         "--react-doctor-ref",
         "feature/eval",
+        "--rule",
+        "react-doctor/no-derived-useState",
+        "--rule",
+        "react-doctor/no-derived-useState",
+        "--rule",
+        "react-doctor/prefer-useReducer",
       ]),
     ).toMatchObject({
       repositoriesSources: ["repositories.json", "repositories.txt"],
@@ -44,11 +51,18 @@ describe("parseEvaluationArguments", () => {
       projectRootsPerRepository: 3,
       maxDurationMinutes: 20,
       reactDoctorRef: "feature/eval",
+      ruleKeys: ["react-doctor/no-derived-useState", "react-doctor/prefer-useReducer"],
     });
   });
 
   it("rejects invalid concurrency", () => {
     expect(() => parseEvaluationArguments(["--concurrency", "0"])).toThrow("positive integer");
+  });
+
+  it("rejects malformed rule keys", () => {
+    expect(() => parseEvaluationArguments(["--rule", "react-doctor/no-example;false"])).toThrow(
+      "canonical plugin/rule key",
+    );
   });
 
   it("rejects invalid scale and duration controls", () => {

--- a/packages/evals/tests/parse-react-doctor-evaluation-provenance.test.ts
+++ b/packages/evals/tests/parse-react-doctor-evaluation-provenance.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { EVALUATION_CONFIG_CONTRACT } from "../src/constants.js";
+import { parseReactDoctorEvaluationProvenance } from "../src/utils/parse-react-doctor-evaluation-provenance.js";
+
+const buildProvenance = () => ({
+  reactDoctorRepository: "https://github.com/millionco/react-doctor.git",
+  reactDoctorCommit: "a".repeat(40),
+  configContract: EVALUATION_CONFIG_CONTRACT,
+  ruleSetHash: "b".repeat(64),
+  ruleKeys: ["react-doctor/no-derived-useState"],
+});
+
+describe("parseReactDoctorEvaluationProvenance", () => {
+  it("accepts an exact pinned producer record", () => {
+    const provenance = buildProvenance();
+
+    expect(parseReactDoctorEvaluationProvenance(JSON.stringify(provenance))).toEqual(provenance);
+  });
+
+  it("rejects unpinned commits and unknown config contracts", () => {
+    expect(() =>
+      parseReactDoctorEvaluationProvenance(
+        JSON.stringify({ ...buildProvenance(), reactDoctorCommit: "main" }),
+      ),
+    ).toThrow("Invalid React Doctor evaluation provenance");
+    expect(() =>
+      parseReactDoctorEvaluationProvenance(
+        JSON.stringify({ ...buildProvenance(), configContract: "unknown" }),
+      ),
+    ).toThrow("Invalid React Doctor evaluation provenance");
+  });
+});


### PR DESCRIPTION
## Summary

- fail closed when plugin host dependencies or empty impacts cannot produce a safe incremental scope, and resolve relative script entrypoints
- compute a conservative base/head rule-impact closure and run only affected rules, with fail-closed full-parity fallbacks
- add exact semantic comparison plus compact rule/project Merkle indexes for cheap unchanged-output detection
- add provenance-verified full-baseline caching bound to corpus, evaluator, detector commit, config contract, and rule set
- preserve hard timeouts while reserving at least 75% of remaining time for active evaluation work

## Validation

- script tests: 97/97
- eval tests: 70/70
- full repository tests: 15/15 tasks
- typecheck: 16/16 tasks
- lint and format check
- React Doctor changed-scope scan: 100/100, no issues
- diff check and pre/post truffler dedup review

## Benchmark

On the controlled PR #1521 pair, full current-main parity completed 2,000 projects in 807.464s wall time. The one-rule candidate core pass completed 1,999 projects in 641.615s, 20.5% faster; one exact transport retry took another 224.255s, so the retry-inclusive pair was not faster. No broad speedup is projected from this single pair.

The scoped diff found a real #1521 false negative and blocked that detector PR, demonstrating that the reduced run retained the relevant signal. The pre-provenance baseline remains benchmark evidence only and is intentionally ineligible for cache reuse.

## Release impact

Private eval and parity tooling only; no changeset.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches eval runner timeouts, sandbox rule configuration, and parity correctness gates; mistakes could miss regressions or reject valid caches, but scope is private tooling with heavy test coverage and fail-closed full-parity fallbacks.
> 
> **Overview**
> Extends the **run-parity** workflow and **packages/evals** so PR parity can reuse immutable full baselines, run only impacted rules when safe, and compare outputs with stricter semantics.
> 
> **Baseline cache:** New `baseline-cache-provenance.mjs` creates/verifies sidecar JSON tied to raw NDJSON bytes, corpus project set, detector commit, evaluator source hash, config contract, and full-baseline `ruleKeys: []`. Documented create/verify flow and `nr source-hash` in evals.
> 
> **Incremental scope:** `find-impacted-rules.mjs` diffs base/head plugin sources via a TypeScript module graph, closes diagnostic-interaction groups, and emits `incremental` vs `full` with explicit fallback reasons (security-scan rules, host-only deps, renames, etc.). Eval accepts repeatable `--rule` keys; sandbox config turns unselected rules `off` and can skip security-scan when no scan rule is in scope. Records carry `evaluation` provenance (commit, `ruleSetHash`, `ruleKeys`, `evaluatorSourceHash`).
> 
> **Comparison:** `compare-parity.mjs` gains `--rules` scoped mode with v3 coverage fingerprints, invariant TS/env diagnostics, duplicate multiplicity, and richer canonical diagnostic fields. `build-parity-index.mjs` / `compare-parity-indexes.mjs` add Merkle-style indexes for cheap re-compares. Retry deadline math caps aggregate retry reserve at 25% of remaining budget.
> 
> Until incremental parity is a required gate, docs still call for a shadow full candidate at the same head and exact match against the scoped run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07761a319887542d9fc5340e8db62eaef738f73b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->