### PR TITLE
feat(evals): pair parity scans in one sandbox

### DIFF
--- a/.agents/skills/run-parity/SKILL.md
+++ b/.agents/skills/run-parity/SKILL.md
@@ -89,7 +89,10 @@ existing artifact. Paired sandboxes fetch each target repository once into one
 object store, then scan isolated base/treatment target worktrees with isolated
 detector installs, config files, and report paths. A project pair is emitted
 only after both sides succeed, so retries cannot leave a partial successful
-pair in either output.
+pair in either output. Paired writes use one single-writer queue and roll the
+baseline back if either sink fails. Any nonzero paired evaluator run still
+makes both output artifacts invalid and non-reusable; discard them instead of
+feeding them to the comparator or cache.
 
 Paired sandboxes request four CPU cores, eight GiB of memory, and twenty GiB of
 disk. `--paired-execution auto` is the default and runs the scans in parallel

--- a/.agents/skills/run-parity/SKILL.md
+++ b/.agents/skills/run-parity/SKILL.md
@@ -65,6 +65,44 @@ Verification streams the raw NDJSON bytes, requires full-baseline `ruleKeys: []`
 checks every record's producer, and independently requires the exact pinned
 corpus project set to match its manifest. Any mismatch is a cache miss.
 
+On a cache hit, keep the base out of Daytona: run the normal candidate-only
+command above against the validated cached baseline and do not pass any
+`--paired-*` option.
+
+On a cache miss, or for a required full-versus-scoped shadow run, evaluate both
+detectors in the same Daytona sandbox:
+
+```sh
+nr --silent eval \
+  --repositories <corpus-manifest-or-validated-input> \
+  --paired-baseline-output <absolute-new-baseline-path> \
+  --paired-base-react-doctor-repository <base-repository-url> \
+  --paired-base-react-doctor-ref <base-or-full-shadow-commit> \
+  --react-doctor-repository <treatment-repository-url> \
+  --react-doctor-ref <treatment-commit> \
+  --rule <treatment-plugin/rule> \
+  > <absolute-run-directory>/candidate.ndjson
+```
+
+The baseline output path is created exclusively and never overwrites an
+existing artifact. Paired sandboxes fetch each target repository once into one
+object store, then scan isolated base/treatment target worktrees with isolated
+detector installs, config files, and report paths. A project pair is emitted
+only after both sides succeed, so retries cannot leave a partial successful
+pair in either output.
+
+Paired sandboxes request four CPU cores, eight GiB of memory, and twenty GiB of
+disk. `--paired-execution auto` is the default and runs the scans in parallel
+only when the sandbox has at least four CPU cores. Use
+`--paired-execution sequential` for the controlled sequential benchmark or
+when parallel execution is undesirable. Paired evaluations default to 50
+sandboxes, below the observed capacity ceiling for four-core sandboxes; pass
+`--concurrency` only when the Daytona allocation supports a different envelope.
+Both modes share the same hard attempt deadline and exact evaluation-label
+cleanup. Each paired scan has a five-minute command cap so a small number of
+stuck sandboxes cannot consume the whole attempt budget; the ordinary evaluator
+retains its existing timeout.
+
 For rule-only pull requests, build the conservative impact manifest before the
 candidate run:
 

--- a/packages/evals/src/constants.ts
+++ b/packages/evals/src/constants.ts
@@ -23,10 +23,16 @@ export const SANDBOX_IMAGE = "node:22-bookworm";
 export const SANDBOX_CPU_CORES = 2;
 export const SANDBOX_MEMORY_GIB = 4;
 export const SANDBOX_DISK_GIB = 10;
+export const PAIRED_SANDBOX_CPU_CORES = 4;
+export const PAIRED_SANDBOX_MEMORY_GIB = 8;
+export const PAIRED_SANDBOX_DISK_GIB = 20;
+export const PAIRED_SCAN_MINIMUM_PARALLEL_CPU_CORES = 4;
+export const DEFAULT_PAIRED_CORPUS_CONCURRENCY = 50;
 export const SANDBOX_AUTO_STOP_INTERVAL_MINUTES = 60;
 export const SANDBOX_CREATE_TIMEOUT_SECONDS = 600;
 export const SANDBOX_SETUP_TIMEOUT_SECONDS = 1_800;
 export const SANDBOX_SCAN_TIMEOUT_SECONDS = 1_800;
+export const PAIRED_SANDBOX_SCAN_TIMEOUT_SECONDS = 300;
 export const SANDBOX_REPORT_DOWNLOAD_TIMEOUT_SECONDS = 1_800;
 export const SANDBOX_DELETE_TIMEOUT_SECONDS = 120;
 export const SANDBOX_CLEANUP_CONCURRENCY = 50;
@@ -34,6 +40,17 @@ export const SANDBOX_CREATE_CONCURRENCY = 20;
 export const SANDBOX_REPORT_PATH = "/tmp/react-doctor-report.json";
 export const REACT_DOCTOR_EVALUATION_PROVENANCE_PATH =
   "/workspace/react-doctor-evaluation-provenance.json";
+export const BASE_REACT_DOCTOR_WORK_DIRECTORY = "/workspace/react-doctor-base";
+export const TREATMENT_REACT_DOCTOR_WORK_DIRECTORY = "/workspace/react-doctor-treatment";
+export const BASE_REACT_DOCTOR_EVALUATION_PROVENANCE_PATH =
+  "/workspace/react-doctor-base-evaluation-provenance.json";
+export const TREATMENT_REACT_DOCTOR_EVALUATION_PROVENANCE_PATH =
+  "/workspace/react-doctor-treatment-evaluation-provenance.json";
+export const TARGET_REPOSITORY_DIRECTORY = "/workspace/target-repository.git";
+export const BASE_TARGET_WORK_DIRECTORY = "/workspace/target-base";
+export const TREATMENT_TARGET_WORK_DIRECTORY = "/workspace/target-treatment";
+export const BASE_SANDBOX_REPORT_PATH = "/tmp/react-doctor-base-report.json";
+export const TREATMENT_SANDBOX_REPORT_PATH = "/tmp/react-doctor-treatment-report.json";
 
 export const EVALUATION_SCHEMA_VERSION = 1;
 export const REACT_DOCTOR_REPORT_SCHEMA_VERSIONS: ReadonlySet<number> = new Set([1, 2, 3]);
@@ -65,8 +82,10 @@ export const MILLISECONDS_PER_SECOND = 1_000;
 export const MILLISECONDS_PER_MINUTE = 60_000;
 export const PERCENT_MULTIPLIER = 100;
 export const SUMMARY_DECIMAL_PLACES = 1;
+export const EVALUATION_ARTIFACT_FILE_MODE = 0o600;
 
 export const REACT_DOCTOR_WORK_DIRECTORY = "/workspace/react-doctor";
+export const TARGET_WORK_DIRECTORY = "/workspace/target";
 export const PREPARE_REACT_DOCTOR_COMMANDS: ReadonlyArray<string> = [
   `mkdir -p ${REACT_DOCTOR_WORK_DIRECTORY}`,
   `git -C ${REACT_DOCTOR_WORK_DIRECTORY} init -q`,
@@ -74,39 +93,46 @@ export const PREPARE_REACT_DOCTOR_COMMANDS: ReadonlyArray<string> = [
   `git -C ${REACT_DOCTOR_WORK_DIRECTORY} fetch -q --depth 1 origin "$REACT_DOCTOR_REF"`,
   `git -C ${REACT_DOCTOR_WORK_DIRECTORY} checkout -q --detach FETCH_HEAD`,
 ];
-const EVALUATION_RULE_CONFIGURATION_SOURCE = `const availableRuleKeys = [
-  ...REACT_DOCTOR_RULES.map((registryEntry) => registryEntry.key),
-  ...Object.keys(REACT_COMPILER_RULES),
-].sort();
-const requestedRuleKeys = JSON.parse(process.env.REACT_DOCTOR_RULE_KEYS ?? "[]");
-if (!Array.isArray(requestedRuleKeys) || !requestedRuleKeys.every((ruleKey) => typeof ruleKey === "string")) {
-  throw new Error("REACT_DOCTOR_RULE_KEYS must be a JSON array of rule keys");
-}
-const availableRuleKeySet = new Set(availableRuleKeys);
-const requestedRuleKeySet = new Set(requestedRuleKeys);
-const unknownRuleKeys = requestedRuleKeys.filter((ruleKey) => !availableRuleKeySet.has(ruleKey));
-if (unknownRuleKeys.length > 0) {
-  throw new Error("Unknown React Doctor eval rules: " + unknownRuleKeys.join(", "));
-}
-const isScopedEvaluation = requestedRuleKeys.length > 0;
-const hasSelectedSecurityScanRule = REACT_DOCTOR_RULES.some(
-  (registryEntry) =>
-    registryEntry.rule.isScanRule === true && requestedRuleKeySet.has(registryEntry.key),
-);
-const rules = Object.fromEntries(
-  availableRuleKeys.map((ruleKey) => [
-    ruleKey,
-    !isScopedEvaluation || requestedRuleKeySet.has(ruleKey) ? "error" : "off",
-  ]),
-);
-const config = {
-  adoptExistingLintConfig: false,
-  respectInlineDisables: false,
-  ...(isScopedEvaluation && !hasSelectedSecurityScanRule
-    ? { ignore: { tags: ["security-scan"] } }
-    : {}),
-  rules,
-  warnings: true,
+const EVALUATION_RULE_CONFIGURATION_SOURCE = `const buildEvaluationRuleConfiguration = ({
+  reactCompilerRules,
+  reactDoctorRules,
+  requestedRuleKeysJson,
+}) => {
+  const availableRuleKeys = [
+    ...reactDoctorRules.map((registryEntry) => registryEntry.key),
+    ...Object.keys(reactCompilerRules),
+  ].sort();
+  const requestedRuleKeys = JSON.parse(requestedRuleKeysJson ?? "[]");
+  if (!Array.isArray(requestedRuleKeys) || !requestedRuleKeys.every((ruleKey) => typeof ruleKey === "string")) {
+    throw new Error("REACT_DOCTOR_RULE_KEYS must be a JSON array of rule keys");
+  }
+  const availableRuleKeySet = new Set(availableRuleKeys);
+  const requestedRuleKeySet = new Set(requestedRuleKeys);
+  const unknownRuleKeys = requestedRuleKeys.filter((ruleKey) => !availableRuleKeySet.has(ruleKey));
+  if (unknownRuleKeys.length > 0) {
+    throw new Error("Unknown React Doctor eval rules: " + unknownRuleKeys.join(", "));
+  }
+  const isScopedEvaluation = requestedRuleKeys.length > 0;
+  const hasSelectedSecurityScanRule = reactDoctorRules.some(
+    (registryEntry) =>
+      registryEntry.rule.isScanRule === true && requestedRuleKeySet.has(registryEntry.key),
+  );
+  const rules = Object.fromEntries(
+    availableRuleKeys.map((ruleKey) => [
+      ruleKey,
+      !isScopedEvaluation || requestedRuleKeySet.has(ruleKey) ? "error" : "off",
+    ]),
+  );
+  const config = {
+    adoptExistingLintConfig: false,
+    respectInlineDisables: false,
+    ...(isScopedEvaluation && !hasSelectedSecurityScanRule
+      ? { ignore: { tags: ["security-scan"] } }
+      : {}),
+    rules,
+    warnings: true,
+  };
+  return { config, requestedRuleKeySet };
 };`;
 export const MATERIALIZE_REACT_DOCTOR_EVALUATION_PROVENANCE_COMMAND = `node --input-type=module <<'REACT_DOCTOR_EVAL_PROVENANCE'
 import { execFileSync } from "node:child_process";
@@ -116,10 +142,15 @@ import { pathToFileURL } from "node:url";
 
 const { REACT_COMPILER_RULES, REACT_DOCTOR_RULES } = await import(
   pathToFileURL(
-    "${REACT_DOCTOR_WORK_DIRECTORY}/packages/oxlint-plugin-react-doctor/dist/index.js",
+    process.env.REACT_DOCTOR_WORK_DIRECTORY + "/packages/oxlint-plugin-react-doctor/dist/index.js",
   ).href
 );
 ${EVALUATION_RULE_CONFIGURATION_SOURCE}
+const { config, requestedRuleKeySet } = buildEvaluationRuleConfiguration({
+  reactCompilerRules: REACT_COMPILER_RULES,
+  reactDoctorRules: REACT_DOCTOR_RULES,
+  requestedRuleKeysJson: process.env.REACT_DOCTOR_RULE_KEYS,
+});
 const ruleSetHash = createHash("sha256")
   .update(JSON.stringify({
     configContract: "${EVALUATION_CONFIG_CONTRACT}",
@@ -130,7 +161,7 @@ const provenance = {
   reactDoctorRepository: process.env.REACT_DOCTOR_REPOSITORY,
   reactDoctorCommit: execFileSync(
     "git",
-    ["-C", "${REACT_DOCTOR_WORK_DIRECTORY}", "rev-parse", "HEAD"],
+    ["-C", process.env.REACT_DOCTOR_WORK_DIRECTORY, "rev-parse", "HEAD"],
     { encoding: "utf8" },
   ).trim(),
   configContract: "${EVALUATION_CONFIG_CONTRACT}",
@@ -138,7 +169,7 @@ const provenance = {
   ruleKeys: [...requestedRuleKeySet].sort(),
 };
 fs.writeFileSync(
-  "${REACT_DOCTOR_EVALUATION_PROVENANCE_PATH}",
+  process.env.REACT_DOCTOR_EVALUATION_PROVENANCE_PATH,
   JSON.stringify(provenance) + "\\n",
   { mode: 0o600 },
 );
@@ -150,15 +181,49 @@ export const BUILD_REACT_DOCTOR_COMMANDS: ReadonlyArray<string> = [
   MATERIALIZE_REACT_DOCTOR_EVALUATION_PROVENANCE_COMMAND,
 ];
 
-export const SETUP_TARGET_REPOSITORY_COMMAND = `set -eu
-rm -rf /workspace/target
-mkdir -p /workspace/target
-git -C /workspace/target init -q
-git -C /workspace/target remote add origin "$TARGET_REPOSITORY"
-git -C /workspace/target fetch -q --depth 1 origin "$TARGET_REF"
-git -C /workspace/target checkout -q --detach FETCH_HEAD`;
+export const PREPARE_PAIRED_REACT_DOCTOR_COMMANDS: ReadonlyArray<string> = [
+  `mkdir -p "${BASE_REACT_DOCTOR_WORK_DIRECTORY}"`,
+  `git -C "${BASE_REACT_DOCTOR_WORK_DIRECTORY}" init -q`,
+  `git -C "${BASE_REACT_DOCTOR_WORK_DIRECTORY}" remote add origin "$BASE_REACT_DOCTOR_REPOSITORY"`,
+  `git -C "${BASE_REACT_DOCTOR_WORK_DIRECTORY}" fetch -q --depth 1 origin "$BASE_REACT_DOCTOR_REF"`,
+  `git -C "${BASE_REACT_DOCTOR_WORK_DIRECTORY}" checkout -q --detach FETCH_HEAD`,
+  `mkdir -p "${TREATMENT_REACT_DOCTOR_WORK_DIRECTORY}"`,
+  `git -C "${TREATMENT_REACT_DOCTOR_WORK_DIRECTORY}" init -q`,
+  `git -C "${TREATMENT_REACT_DOCTOR_WORK_DIRECTORY}" remote add origin "$TREATMENT_REACT_DOCTOR_REPOSITORY"`,
+  `git -C "${TREATMENT_REACT_DOCTOR_WORK_DIRECTORY}" fetch -q --depth 1 origin "$TREATMENT_REACT_DOCTOR_REF"`,
+  `git -C "${TREATMENT_REACT_DOCTOR_WORK_DIRECTORY}" checkout -q --detach FETCH_HEAD`,
+];
 
-export const RESOLVE_TARGET_REPOSITORY_REF_COMMAND = "git -C /workspace/target rev-parse HEAD";
+export const BUILD_PAIRED_REACT_DOCTOR_COMMANDS: ReadonlyArray<string> = [
+  "corepack enable",
+  `cd "${BASE_REACT_DOCTOR_WORK_DIRECTORY}" && npx --yes --package @antfu/ni ni --frozen`,
+  `cd "${BASE_REACT_DOCTOR_WORK_DIRECTORY}" && ./node_modules/.bin/turbo run build --filter=react-doctor`,
+  `cd "${TREATMENT_REACT_DOCTOR_WORK_DIRECTORY}" && npx --yes --package @antfu/ni ni --frozen`,
+  `cd "${TREATMENT_REACT_DOCTOR_WORK_DIRECTORY}" && ./node_modules/.bin/turbo run build --filter=react-doctor`,
+  `REACT_DOCTOR_WORK_DIRECTORY="${BASE_REACT_DOCTOR_WORK_DIRECTORY}" REACT_DOCTOR_REPOSITORY="$BASE_REACT_DOCTOR_REPOSITORY" REACT_DOCTOR_RULE_KEYS="$BASE_REACT_DOCTOR_RULE_KEYS" REACT_DOCTOR_EVALUATION_PROVENANCE_PATH="${BASE_REACT_DOCTOR_EVALUATION_PROVENANCE_PATH}" ${MATERIALIZE_REACT_DOCTOR_EVALUATION_PROVENANCE_COMMAND}`,
+  `REACT_DOCTOR_WORK_DIRECTORY="${TREATMENT_REACT_DOCTOR_WORK_DIRECTORY}" REACT_DOCTOR_REPOSITORY="$TREATMENT_REACT_DOCTOR_REPOSITORY" REACT_DOCTOR_RULE_KEYS="$TREATMENT_REACT_DOCTOR_RULE_KEYS" REACT_DOCTOR_EVALUATION_PROVENANCE_PATH="${TREATMENT_REACT_DOCTOR_EVALUATION_PROVENANCE_PATH}" ${MATERIALIZE_REACT_DOCTOR_EVALUATION_PROVENANCE_COMMAND}`,
+];
+
+export const SETUP_TARGET_REPOSITORY_COMMAND = `set -eu
+rm -rf "${TARGET_WORK_DIRECTORY}"
+mkdir -p "${TARGET_WORK_DIRECTORY}"
+git -C "${TARGET_WORK_DIRECTORY}" init -q
+git -C "${TARGET_WORK_DIRECTORY}" remote add origin "$TARGET_REPOSITORY"
+git -C "${TARGET_WORK_DIRECTORY}" fetch -q --depth 1 origin "$TARGET_REF"
+git -C "${TARGET_WORK_DIRECTORY}" checkout -q --detach FETCH_HEAD`;
+
+export const RESOLVE_TARGET_REPOSITORY_REF_COMMAND = `git -C "${TARGET_WORK_DIRECTORY}" rev-parse HEAD`;
+
+export const SETUP_PAIRED_TARGET_REPOSITORY_COMMAND = `set -eu
+rm -rf "${TARGET_REPOSITORY_DIRECTORY}" "${BASE_TARGET_WORK_DIRECTORY}" "${TREATMENT_TARGET_WORK_DIRECTORY}"
+git init -q --bare "${TARGET_REPOSITORY_DIRECTORY}"
+git -C "${TARGET_REPOSITORY_DIRECTORY}" remote add origin "$TARGET_REPOSITORY"
+git -C "${TARGET_REPOSITORY_DIRECTORY}" fetch -q --depth 1 origin "$TARGET_REF"
+resolved_ref=$(git -C "${TARGET_REPOSITORY_DIRECTORY}" rev-parse FETCH_HEAD)
+git -C "${TARGET_REPOSITORY_DIRECTORY}" worktree add -q --detach "${BASE_TARGET_WORK_DIRECTORY}" "$resolved_ref"
+git -C "${TARGET_REPOSITORY_DIRECTORY}" worktree add -q --detach "${TREATMENT_TARGET_WORK_DIRECTORY}" "$resolved_ref"`;
+
+export const RESOLVE_PAIRED_TARGET_REPOSITORY_REF_COMMAND = `git -C "${TARGET_REPOSITORY_DIRECTORY}" rev-parse FETCH_HEAD`;
 
 export const MATERIALIZE_ALL_RULES_CONFIG_COMMAND = `node --input-type=module <<'REACT_DOCTOR_EVAL_CONFIG'
 import { randomUUID } from "node:crypto";
@@ -168,14 +233,19 @@ import { pathToFileURL } from "node:url";
 
 const { REACT_COMPILER_RULES, REACT_DOCTOR_RULES } = await import(
   pathToFileURL(
-    "/workspace/react-doctor/packages/oxlint-plugin-react-doctor/dist/index.js",
+    process.env.REACT_DOCTOR_WORK_DIRECTORY + "/packages/oxlint-plugin-react-doctor/dist/index.js",
   ).href
 );
 
 ${EVALUATION_RULE_CONFIGURATION_SOURCE}
+const { config } = buildEvaluationRuleConfiguration({
+  reactCompilerRules: REACT_COMPILER_RULES,
+  reactDoctorRules: REACT_DOCTOR_RULES,
+  requestedRuleKeysJson: process.env.REACT_DOCTOR_RULE_KEYS,
+});
 const configContents = "export default " + JSON.stringify(config) + ";\\n";
 const CONFIG_FILE_MODE = 0o600;
-const targetCheckoutDirectory = fs.realpathSync("/workspace/target");
+const targetCheckoutDirectory = fs.realpathSync(process.env.TARGET_CHECKOUT_DIRECTORY);
 const targetRootDirectory = path.join(
   targetCheckoutDirectory,
   process.env.TARGET_ROOT_DIRECTORY ?? ".",
@@ -237,8 +307,13 @@ for (const configuredDirectory of configuredDirectories) {
 REACT_DOCTOR_EVAL_CONFIG`;
 
 export const SCAN_COMMAND = `set -eu
+: "\${REACT_DOCTOR_WORK_DIRECTORY:?}"
+: "\${REACT_DOCTOR_RULE_KEYS:?}"
+: "\${TARGET_CHECKOUT_DIRECTORY:?}"
+: "\${TARGET_ROOT_DIRECTORY:?}"
+: "\${SANDBOX_REPORT_PATH:?}"
 ${MATERIALIZE_ALL_RULES_CONFIG_COMMAND}
-node /workspace/react-doctor/packages/react-doctor/bin/react-doctor.js \
+node "$REACT_DOCTOR_WORK_DIRECTORY/packages/react-doctor/bin/react-doctor.js" \
   --json \
   --blocking none \
   --diff false \
@@ -246,5 +321,5 @@ node /workspace/react-doctor/packages/react-doctor/bin/react-doctor.js \
   --no-supply-chain \
   --no-telemetry \
   --no-score \
-  "/workspace/target/$TARGET_ROOT_DIRECTORY" \
-  > ${SANDBOX_REPORT_PATH}`;
+  "$TARGET_CHECKOUT_DIRECTORY/$TARGET_ROOT_DIRECTORY" \
+  > "$SANDBOX_REPORT_PATH"`;

--- a/packages/evals/src/evaluate-repository-batch.ts
+++ b/packages/evals/src/evaluate-repository-batch.ts
@@ -56,7 +56,12 @@ export interface EvaluateRepositoryBatchInput {
 
 export interface PairedRepositoryBatchEvaluation {
   runScansInParallel: boolean;
-  onBaselineRecord: (record: CorpusEvaluationRecord) => Promise<void>;
+  onPairedRecords: (records: PairedEvaluationRecords) => Promise<void>;
+}
+
+export interface PairedEvaluationRecords {
+  baseline: CorpusEvaluationRecord;
+  treatment: CorpusEvaluationRecord;
 }
 
 interface EvaluateRepositoryGroupInput {
@@ -71,7 +76,7 @@ interface EvaluateRepositoryGroupInput {
 interface PairedRepositoryGroupEvaluation {
   baselineEvaluationProvenance: EvaluationProvenance;
   runScansInParallel: boolean;
-  onBaselineRecord: (record: CorpusEvaluationRecord) => Promise<void>;
+  onPairedRecords: (records: PairedEvaluationRecords) => Promise<void>;
 }
 
 interface ScanRepositoryInput {
@@ -193,8 +198,10 @@ const evaluateRepositoryGroup = async ({
 
   const failedRecords: CorpusEvaluationRecord[] = [];
   for (const repository of repositories) {
-    try {
-      if (paired) {
+    if (paired) {
+      let baselineReport: unknown;
+      let treatmentReport: unknown;
+      try {
         const scanBaseline = () =>
           scanRepository({
             sandbox,
@@ -219,8 +226,6 @@ const evaluateRepositoryGroup = async ({
             descriptionPrefix: "Scan treatment",
             scanTimeoutSeconds: PAIRED_SANDBOX_SCAN_TIMEOUT_SECONDS,
           });
-        let baselineReport: unknown;
-        let treatmentReport: unknown;
         if (paired.runScansInParallel) {
           const [baselineResult, treatmentResult] = await Promise.allSettled([
             scanBaseline(),
@@ -234,21 +239,28 @@ const evaluateRepositoryGroup = async ({
           baselineReport = await scanBaseline();
           treatmentReport = await scanTreatment();
         }
-        await paired.onBaselineRecord({
+      } catch (error) {
+        failedRecords.push(...buildFailureRecords([repository], error));
+        continue;
+      }
+      await paired.onPairedRecords({
+        baseline: {
           schemaVersion: EVALUATION_SCHEMA_VERSION,
           repository,
           evaluation: paired.baselineEvaluationProvenance,
           report: baselineReport,
-        });
-        await onRecord({
+        },
+        treatment: {
           schemaVersion: EVALUATION_SCHEMA_VERSION,
           repository,
           evaluation: evaluationProvenance,
           report: treatmentReport,
-        });
-        continue;
-      }
+        },
+      });
+      continue;
+    }
 
+    try {
       const report = await scanRepository({
         sandbox,
         repository,
@@ -349,7 +361,7 @@ export const evaluateRepositoryBatch = async ({
               ? {
                   baselineEvaluationProvenance,
                   runScansInParallel: paired.runScansInParallel,
-                  onBaselineRecord: paired.onBaselineRecord,
+                  onPairedRecords: paired.onPairedRecords,
                 }
               : undefined,
         })),

--- a/packages/evals/src/evaluate-repository-batch.ts
+++ b/packages/evals/src/evaluate-repository-batch.ts
@@ -4,9 +4,16 @@ import { DaytonaNotFoundError } from "@daytona/sdk";
 import type { Daytona, Sandbox } from "@daytona/sdk";
 
 import {
+  BASE_REACT_DOCTOR_EVALUATION_PROVENANCE_PATH,
+  BASE_REACT_DOCTOR_WORK_DIRECTORY,
+  BASE_SANDBOX_REPORT_PATH,
+  BASE_TARGET_WORK_DIRECTORY,
   DAYTONA_RUN_NAME,
   EVALUATION_SCHEMA_VERSION,
   REACT_DOCTOR_EVALUATION_PROVENANCE_PATH,
+  REACT_DOCTOR_WORK_DIRECTORY,
+  PAIRED_SANDBOX_SCAN_TIMEOUT_SECONDS,
+  RESOLVE_PAIRED_TARGET_REPOSITORY_REF_COMMAND,
   RESOLVE_TARGET_REPOSITORY_REF_COMMAND,
   SANDBOX_DELETE_TIMEOUT_SECONDS,
   SANDBOX_REPORT_DOWNLOAD_TIMEOUT_SECONDS,
@@ -14,7 +21,13 @@ import {
   SANDBOX_SCAN_TIMEOUT_SECONDS,
   SANDBOX_SETUP_TIMEOUT_SECONDS,
   SCAN_COMMAND,
+  SETUP_PAIRED_TARGET_REPOSITORY_COMMAND,
   SETUP_TARGET_REPOSITORY_COMMAND,
+  TARGET_WORK_DIRECTORY,
+  TREATMENT_REACT_DOCTOR_EVALUATION_PROVENANCE_PATH,
+  TREATMENT_REACT_DOCTOR_WORK_DIRECTORY,
+  TREATMENT_SANDBOX_REPORT_PATH,
+  TREATMENT_TARGET_WORK_DIRECTORY,
 } from "./constants.js";
 import type {
   CorpusEvaluationRecord,
@@ -38,6 +51,12 @@ export interface EvaluateRepositoryBatchInput {
   evaluationDeadlineMilliseconds: number;
   evaluatorSourceHash: string;
   onRecord: (record: CorpusEvaluationRecord) => Promise<void>;
+  paired?: PairedRepositoryBatchEvaluation;
+}
+
+export interface PairedRepositoryBatchEvaluation {
+  runScansInParallel: boolean;
+  onBaselineRecord: (record: CorpusEvaluationRecord) => Promise<void>;
 }
 
 interface EvaluateRepositoryGroupInput {
@@ -46,6 +65,25 @@ interface EvaluateRepositoryGroupInput {
   evaluationProvenance: EvaluationProvenance;
   evaluationDeadlineMilliseconds: number;
   onRecord: (record: CorpusEvaluationRecord) => Promise<void>;
+  paired?: PairedRepositoryGroupEvaluation;
+}
+
+interface PairedRepositoryGroupEvaluation {
+  baselineEvaluationProvenance: EvaluationProvenance;
+  runScansInParallel: boolean;
+  onBaselineRecord: (record: CorpusEvaluationRecord) => Promise<void>;
+}
+
+interface ScanRepositoryInput {
+  sandbox: Sandbox;
+  repository: CorpusRepository;
+  reactDoctorWorkDirectory: string;
+  reactDoctorRuleKeys: ReadonlyArray<string>;
+  targetWorkDirectory: string;
+  reportPath: string;
+  evaluationDeadlineMilliseconds: number;
+  descriptionPrefix: string;
+  scanTimeoutSeconds: number;
 }
 
 const buildRepositories = (
@@ -70,19 +108,60 @@ const buildFailureRecords = (
   }));
 };
 
+const scanRepository = async ({
+  sandbox,
+  repository,
+  reactDoctorWorkDirectory,
+  reactDoctorRuleKeys,
+  targetWorkDirectory,
+  reportPath,
+  evaluationDeadlineMilliseconds,
+  descriptionPrefix,
+  scanTimeoutSeconds,
+}: ScanRepositoryInput): Promise<unknown> => {
+  const commandResult = await executeSandboxCommand({
+    sandbox,
+    command: SCAN_COMMAND,
+    environment: {
+      REACT_DOCTOR_WORK_DIRECTORY: reactDoctorWorkDirectory,
+      REACT_DOCTOR_RULE_KEYS: JSON.stringify(reactDoctorRuleKeys),
+      TARGET_CHECKOUT_DIRECTORY: targetWorkDirectory,
+      TARGET_ROOT_DIRECTORY: repository.rootDir,
+      SANDBOX_REPORT_PATH: reportPath,
+      SENTRY_DSN: "",
+      SENTRY_TRACES_SAMPLE_RATE: "0",
+    },
+    timeoutSeconds: getEvaluationTimeoutSeconds({
+      deadlineMilliseconds: evaluationDeadlineMilliseconds,
+      maximumTimeoutSeconds: scanTimeoutSeconds,
+    }),
+    description: `${descriptionPrefix} ${repository.org}/${repository.name}:${repository.rootDir}`,
+    acceptNonZeroExitCode: true,
+  });
+  const reportContents = await sandbox.fs.downloadFile(
+    reportPath,
+    getEvaluationTimeoutSeconds({
+      deadlineMilliseconds: evaluationDeadlineMilliseconds,
+      maximumTimeoutSeconds: SANDBOX_REPORT_DOWNLOAD_TIMEOUT_SECONDS,
+    }),
+  );
+  return parseReactDoctorReport(reportContents.toString("utf8"), commandResult.exitCode);
+};
+
 const evaluateRepositoryGroup = async ({
   sandbox,
   repositoryGroup,
   evaluationProvenance,
   evaluationDeadlineMilliseconds,
   onRecord,
+  paired,
 }: EvaluateRepositoryGroupInput): Promise<ReadonlyArray<CorpusEvaluationRecord>> => {
   let repositories = buildRepositories(repositoryGroup);
   try {
     const repositoryUrl = `https://github.com/${repositoryGroup.org}/${repositoryGroup.name}.git`;
     await executeSandboxCommand({
       sandbox,
-      command: SETUP_TARGET_REPOSITORY_COMMAND,
+      command: paired ? SETUP_PAIRED_TARGET_REPOSITORY_COMMAND : SETUP_TARGET_REPOSITORY_COMMAND,
       environment: {
         TARGET_REPOSITORY: repositoryUrl,
         TARGET_REF: repositoryGroup.ref,
@@ -96,7 +175,9 @@ const evaluateRepositoryGroup = async ({
     const resolvedRef = (
       await executeSandboxCommand({
         sandbox,
-        command: RESOLVE_TARGET_REPOSITORY_REF_COMMAND,
+        command: paired
+          ? RESOLVE_PAIRED_TARGET_REPOSITORY_REF_COMMAND
+          : RESOLVE_TARGET_REPOSITORY_REF_COMMAND,
         environment: {},
         timeoutSeconds: getEvaluationTimeoutSeconds({
           deadlineMilliseconds: evaluationDeadlineMilliseconds,
@@ -113,32 +194,72 @@ const evaluateRepositoryGroup = async ({
   const failedRecords: CorpusEvaluationRecord[] = [];
   for (const repository of repositories) {
     try {
-      const commandResult = await executeSandboxCommand({
+      if (paired) {
+        const scanBaseline = () =>
+          scanRepository({
+            sandbox,
+            repository,
+            reactDoctorWorkDirectory: BASE_REACT_DOCTOR_WORK_DIRECTORY,
+            reactDoctorRuleKeys: paired.baselineEvaluationProvenance.ruleKeys,
+            targetWorkDirectory: BASE_TARGET_WORK_DIRECTORY,
+            reportPath: BASE_SANDBOX_REPORT_PATH,
+            evaluationDeadlineMilliseconds,
+            descriptionPrefix: "Scan base",
+            scanTimeoutSeconds: PAIRED_SANDBOX_SCAN_TIMEOUT_SECONDS,
+          });
+        const scanTreatment = () =>
+          scanRepository({
+            sandbox,
+            repository,
+            reactDoctorWorkDirectory: TREATMENT_REACT_DOCTOR_WORK_DIRECTORY,
+            reactDoctorRuleKeys: evaluationProvenance.ruleKeys,
+            targetWorkDirectory: TREATMENT_TARGET_WORK_DIRECTORY,
+            reportPath: TREATMENT_SANDBOX_REPORT_PATH,
+            evaluationDeadlineMilliseconds,
+            descriptionPrefix: "Scan treatment",
+            scanTimeoutSeconds: PAIRED_SANDBOX_SCAN_TIMEOUT_SECONDS,
+          });
+        let baselineReport: unknown;
+        let treatmentReport: unknown;
+        if (paired.runScansInParallel) {
+          const [baselineResult, treatmentResult] = await Promise.allSettled([
+            scanBaseline(),
+            scanTreatment(),
+          ]);
+          if (baselineResult.status === "rejected") throw baselineResult.reason;
+          if (treatmentResult.status === "rejected") throw treatmentResult.reason;
+          baselineReport = baselineResult.value;
+          treatmentReport = treatmentResult.value;
+        } else {
+          baselineReport = await scanBaseline();
+          treatmentReport = await scanTreatment();
+        }
+        await paired.onBaselineRecord({
+          schemaVersion: EVALUATION_SCHEMA_VERSION,
+          repository,
+          evaluation: paired.baselineEvaluationProvenance,
+          report: baselineReport,
+        });
+        await onRecord({
+          schemaVersion: EVALUATION_SCHEMA_VERSION,
+          repository,
+          evaluation: evaluationProvenance,
+          report: treatmentReport,
+        });
+        continue;
+      }
+
+      const report = await scanRepository({
         sandbox,
-        command: SCAN_COMMAND,
-        environment: {
-          TARGET_ROOT_DIRECTORY: repository.rootDir,
-          SENTRY_DSN: "",
-          SENTRY_TRACES_SAMPLE_RATE: "0",
-        },
-        timeoutSeconds: getEvaluationTimeoutSeconds({
-          deadlineMilliseconds: evaluationDeadlineMilliseconds,
-          maximumTimeoutSeconds: SANDBOX_SCAN_TIMEOUT_SECONDS,
-        }),
-        description: `Scan ${repository.org}/${repository.name}:${repository.rootDir}`,
-        acceptNonZeroExitCode: true,
+        repository,
+        reactDoctorWorkDirectory: REACT_DOCTOR_WORK_DIRECTORY,
+        reactDoctorRuleKeys: evaluationProvenance.ruleKeys,
+        targetWorkDirectory: TARGET_WORK_DIRECTORY,
+        reportPath: SANDBOX_REPORT_PATH,
+        evaluationDeadlineMilliseconds,
+        descriptionPrefix: "Scan",
+        scanTimeoutSeconds: SANDBOX_SCAN_TIMEOUT_SECONDS,
       });
-      const reportContents = await sandbox.fs.downloadFile(
-        SANDBOX_REPORT_PATH,
-        getEvaluationTimeoutSeconds({
-          deadlineMilliseconds: evaluationDeadlineMilliseconds,
-          maximumTimeoutSeconds: SANDBOX_REPORT_DOWNLOAD_TIMEOUT_SECONDS,
-        }),
-      );
-      const report = parseReactDoctorReport(
-        reportContents.toString("utf8"),
-        commandResult.exitCode,
-      );
       await onRecord({
         schemaVersion: EVALUATION_SCHEMA_VERSION,
         repository,
@@ -159,6 +280,7 @@ export const evaluateRepositoryBatch = async ({
   evaluationDeadlineMilliseconds,
   evaluatorSourceHash,
   onRecord,
+  paired,
 }: EvaluateRepositoryBatchInput): Promise<ReadonlyArray<CorpusEvaluationRecord>> => {
   const sandboxName = `${DAYTONA_RUN_NAME}-${randomUUID()}`;
   let sandbox: Sandbox | undefined;
@@ -172,20 +294,41 @@ export const evaluateRepositoryBatch = async ({
         buildFailureRecords(buildRepositories(repositoryGroup), error),
       );
     }
+    const activeSandbox = sandbox;
 
     let evaluationProvenance: EvaluationProvenance;
+    let baselineEvaluationProvenance: EvaluationProvenance | undefined;
     try {
-      const provenanceContents = await sandbox.fs.downloadFile(
-        REACT_DOCTOR_EVALUATION_PROVENANCE_PATH,
-        getEvaluationTimeoutSeconds({
-          deadlineMilliseconds: evaluationDeadlineMilliseconds,
-          maximumTimeoutSeconds: SANDBOX_REPORT_DOWNLOAD_TIMEOUT_SECONDS,
-        }),
+      const provenanceTimeoutSeconds = getEvaluationTimeoutSeconds({
+        deadlineMilliseconds: evaluationDeadlineMilliseconds,
+        maximumTimeoutSeconds: SANDBOX_REPORT_DOWNLOAD_TIMEOUT_SECONDS,
+      });
+      const provenancePaths = paired
+        ? [
+            BASE_REACT_DOCTOR_EVALUATION_PROVENANCE_PATH,
+            TREATMENT_REACT_DOCTOR_EVALUATION_PROVENANCE_PATH,
+          ]
+        : [REACT_DOCTOR_EVALUATION_PROVENANCE_PATH];
+      const provenanceContents = await Promise.all(
+        provenancePaths.map((provenancePath) =>
+          activeSandbox.fs.downloadFile(provenancePath, provenanceTimeoutSeconds),
+        ),
       );
+      const treatmentProvenanceContents = provenanceContents.at(-1);
+      if (!treatmentProvenanceContents) {
+        throw new Error("React Doctor evaluation provenance is missing");
+      }
       evaluationProvenance = {
-        ...parseReactDoctorEvaluationProvenance(provenanceContents.toString("utf8")),
+        ...parseReactDoctorEvaluationProvenance(treatmentProvenanceContents.toString("utf8")),
         evaluatorSourceHash,
       };
+      const baselineProvenanceContents = paired ? provenanceContents[0] : undefined;
+      if (baselineProvenanceContents) {
+        baselineEvaluationProvenance = {
+          ...parseReactDoctorEvaluationProvenance(baselineProvenanceContents.toString("utf8")),
+          evaluatorSourceHash,
+        };
+      }
     } catch (error) {
       return repositoryGroups.flatMap((repositoryGroup) =>
         buildFailureRecords(buildRepositories(repositoryGroup), error),
@@ -196,11 +339,19 @@ export const evaluateRepositoryBatch = async ({
     for (const repositoryGroup of repositoryGroups) {
       failedRecords.push(
         ...(await evaluateRepositoryGroup({
-          sandbox,
+          sandbox: activeSandbox,
           repositoryGroup,
           evaluationProvenance,
           evaluationDeadlineMilliseconds,
           onRecord,
+          paired:
+            paired && baselineEvaluationProvenance
+              ? {
+                  baselineEvaluationProvenance,
+                  runScansInParallel: paired.runScansInParallel,
+                  onBaselineRecord: paired.onBaselineRecord,
+                }
+              : undefined,
         })),
       );
     }

--- a/packages/evals/src/parse-evaluation-arguments.ts
+++ b/packages/evals/src/parse-evaluation-arguments.ts
@@ -1,9 +1,11 @@
 import { parseArgs } from "node:util";
+import { isAbsolute } from "node:path";
 
 import {
   DEFAULT_CORPUS_CONCURRENCY,
   DEFAULT_CORPUS_REPOSITORY_COUNT,
   DEFAULT_EVALUATION_MAX_DURATION_MINUTES,
+  DEFAULT_PAIRED_CORPUS_CONCURRENCY,
   DEFAULT_PROJECT_ROOTS_PER_REPOSITORY,
   DEFAULT_REACT_DOCTOR_REF,
   DEFAULT_REACT_DOCTOR_REPOSITORY,
@@ -15,6 +17,14 @@ import {
   EVALUATION_RETRY_CONCURRENCIES,
 } from "./constants.js";
 
+export interface PairedEvaluationOptions {
+  baselineOutputPath: string;
+  baseReactDoctorRepository: string;
+  baseReactDoctorRef: string;
+  baseRuleKeys: ReadonlyArray<string>;
+  execution: "auto" | "parallel" | "sequential";
+}
+
 export interface EvaluationOptions {
   repositoriesSources: ReadonlyArray<string>;
   repositoryLimit: number;
@@ -25,6 +35,7 @@ export interface EvaluationOptions {
   reactDoctorRepository: string;
   reactDoctorRef: string;
   ruleKeys: ReadonlyArray<string>;
+  paired?: PairedEvaluationOptions;
 }
 
 export const parseEvaluationArguments = (
@@ -40,7 +51,6 @@ export const parseEvaluationArguments = (
       },
       concurrency: {
         type: "string",
-        default: String(DEFAULT_CORPUS_CONCURRENCY),
       },
       "repository-limit": {
         type: "string",
@@ -70,16 +80,43 @@ export const parseEvaluationArguments = (
         type: "string",
         multiple: true,
       },
+      "paired-baseline-output": {
+        type: "string",
+      },
+      "paired-base-react-doctor-repository": {
+        type: "string",
+      },
+      "paired-base-react-doctor-ref": {
+        type: "string",
+      },
+      "paired-base-rule": {
+        type: "string",
+        multiple: true,
+      },
+      "paired-execution": {
+        type: "string",
+      },
     },
   });
 
   if (positionals.length !== 0) {
     throw new Error(
-      "Usage: nr eval -- [--repositories <path-url-or-directory>]... [--repository-limit <count>] [--project-roots-per-repository <count>] [--concurrency <count>] [--repositories-per-sandbox <count>] [--max-duration-minutes <count>] [--react-doctor-ref <git-ref>] [--rule <plugin/rule>]...",
+      "Usage: nr eval -- [--repositories <path-url-or-directory>]... [--repository-limit <count>] [--project-roots-per-repository <count>] [--concurrency <count>] [--repositories-per-sandbox <count>] [--max-duration-minutes <count>] [--react-doctor-ref <git-ref>] [--rule <plugin/rule>]... [--paired-baseline-output <absolute-path> --paired-base-react-doctor-ref <git-ref>]",
     );
   }
 
-  const concurrency = Number(values.concurrency);
+  const pairedOptionValues = [
+    values["paired-baseline-output"],
+    values["paired-base-react-doctor-repository"],
+    values["paired-base-react-doctor-ref"],
+    values["paired-base-rule"],
+    values["paired-execution"],
+  ];
+  const hasPairedOption = pairedOptionValues.some((value) => value !== undefined);
+  const defaultConcurrency = hasPairedOption
+    ? DEFAULT_PAIRED_CORPUS_CONCURRENCY
+    : DEFAULT_CORPUS_CONCURRENCY;
+  const concurrency = Number(values.concurrency ?? defaultConcurrency);
   if (!Number.isInteger(concurrency) || concurrency < 1) {
     throw new Error("--concurrency must be a positive integer");
   }
@@ -115,6 +152,41 @@ export const parseEvaluationArguments = (
     throw new Error(`--rule must be a canonical plugin/rule key: ${invalidRuleKey}`);
   }
 
+  let paired: PairedEvaluationOptions | undefined;
+  if (hasPairedOption) {
+    const baselineOutputPath = values["paired-baseline-output"];
+    const baseReactDoctorRef = values["paired-base-react-doctor-ref"];
+    if (baselineOutputPath === undefined || baseReactDoctorRef === undefined) {
+      throw new Error(
+        "Paired evaluation requires --paired-baseline-output and --paired-base-react-doctor-ref",
+      );
+    }
+    if (!isAbsolute(baselineOutputPath)) {
+      throw new Error("--paired-baseline-output must be an absolute path");
+    }
+    const execution = values["paired-execution"] ?? "auto";
+    if (execution !== "auto" && execution !== "parallel" && execution !== "sequential") {
+      throw new Error("--paired-execution must be auto, parallel, or sequential");
+    }
+    const baseRuleKeys = [...new Set(values["paired-base-rule"] ?? [])];
+    const invalidBaseRuleKey = baseRuleKeys.find(
+      (ruleKey) => !EVALUATION_RULE_KEY_PATTERN.test(ruleKey),
+    );
+    if (invalidBaseRuleKey !== undefined) {
+      throw new Error(
+        `--paired-base-rule must be a canonical plugin/rule key: ${invalidBaseRuleKey}`,
+      );
+    }
+    paired = {
+      baselineOutputPath,
+      baseReactDoctorRepository:
+        values["paired-base-react-doctor-repository"] ?? values["react-doctor-repository"],
+      baseReactDoctorRef,
+      baseRuleKeys,
+      execution,
+    };
+  }
+
   return {
     repositoriesSources: values.repositories ?? DEFAULT_REPOSITORIES_SOURCES,
     repositoryLimit,
@@ -125,5 +197,6 @@ export const parseEvaluationArguments = (
     reactDoctorRepository: values["react-doctor-repository"],
     reactDoctorRef: values["react-doctor-ref"],
     ruleKeys,
+    paired,
   };
 };

--- a/packages/evals/src/run-corpus-evaluation.ts
+++ b/packages/evals/src/run-corpus-evaluation.ts
@@ -1,21 +1,31 @@
 import { randomUUID } from "node:crypto";
 import { once } from "node:events";
+import { createWriteStream } from "node:fs";
+import { finished } from "node:stream/promises";
 
 import { Daytona, DaytonaNotFoundError, Image } from "@daytona/sdk";
 import pLimit from "p-limit";
 
 import { cleanupEvaluationSandboxes } from "./cleanup-evaluation-sandboxes.js";
 import {
+  BUILD_PAIRED_REACT_DOCTOR_COMMANDS,
   BUILD_REACT_DOCTOR_COMMANDS,
   DAYTONA_RUN_NAME,
   EVALUATION_CLEANUP_RESERVE_MINUTES,
+  EVALUATION_ARTIFACT_FILE_MODE,
   EVALUATION_RETRY_CONCURRENCIES,
   MILLISECONDS_PER_MINUTE,
   MILLISECONDS_PER_SECOND,
+  PAIRED_SANDBOX_CPU_CORES,
+  PAIRED_SANDBOX_DISK_GIB,
+  PAIRED_SANDBOX_MEMORY_GIB,
+  PAIRED_SCAN_MINIMUM_PARALLEL_CPU_CORES,
   PERCENT_MULTIPLIER,
+  PREPARE_PAIRED_REACT_DOCTOR_COMMANDS,
   PREPARE_REACT_DOCTOR_COMMANDS,
   PROGRESS_INTERVAL_PROJECTS,
   REACT_DOCTOR_WORK_DIRECTORY,
+  REACT_DOCTOR_EVALUATION_PROVENANCE_PATH,
   SANDBOX_AUTO_STOP_INTERVAL_MINUTES,
   SANDBOX_CPU_CORES,
   SANDBOX_CREATE_CONCURRENCY,
@@ -36,158 +46,234 @@ import { getEvaluationAttemptDeadlineMilliseconds } from "./utils/get-evaluation
 import { getEvaluatorSourceHash } from "./utils/get-evaluator-source-hash.js";
 import { getEvaluationTimeoutSeconds } from "./utils/get-evaluation-timeout-seconds.js";
 import { toErrorMessage } from "./utils/to-error-message.js";
+import { writeNdjsonRecord } from "./utils/write-ndjson-record.js";
+
+const buildEvaluationSnapshotImage = (options: EvaluationOptions): Image => {
+  if (options.paired) {
+    return Image.base(SANDBOX_IMAGE)
+      .env({
+        BASE_REACT_DOCTOR_REPOSITORY: options.paired.baseReactDoctorRepository,
+        BASE_REACT_DOCTOR_REF: options.paired.baseReactDoctorRef,
+        BASE_REACT_DOCTOR_RULE_KEYS: JSON.stringify(options.paired.baseRuleKeys),
+        TREATMENT_REACT_DOCTOR_REPOSITORY: options.reactDoctorRepository,
+        TREATMENT_REACT_DOCTOR_REF: options.reactDoctorRef,
+        TREATMENT_REACT_DOCTOR_RULE_KEYS: JSON.stringify(options.ruleKeys),
+      })
+      .runCommands(...PREPARE_PAIRED_REACT_DOCTOR_COMMANDS)
+      .runCommands(...BUILD_PAIRED_REACT_DOCTOR_COMMANDS);
+  }
+  return Image.base(SANDBOX_IMAGE)
+    .env({
+      REACT_DOCTOR_REPOSITORY: options.reactDoctorRepository,
+      REACT_DOCTOR_REF: options.reactDoctorRef,
+      REACT_DOCTOR_RULE_KEYS: JSON.stringify(options.ruleKeys),
+      REACT_DOCTOR_WORK_DIRECTORY,
+      REACT_DOCTOR_EVALUATION_PROVENANCE_PATH,
+    })
+    .runCommands(...PREPARE_REACT_DOCTOR_COMMANDS)
+    .workdir(REACT_DOCTOR_WORK_DIRECTORY)
+    .runCommands(...BUILD_REACT_DOCTOR_COMMANDS);
+};
+
+const shouldRunPairedScansInParallel = (options: EvaluationOptions): boolean => {
+  if (!options.paired || options.paired.execution === "sequential") return false;
+  const hasAdequateCpu = PAIRED_SANDBOX_CPU_CORES >= PAIRED_SCAN_MINIMUM_PARALLEL_CPU_CORES;
+  if (options.paired.execution === "parallel" && !hasAdequateCpu) {
+    throw new Error(
+      `Parallel paired evaluation requires at least ${PAIRED_SCAN_MINIMUM_PARALLEL_CPU_CORES} sandbox CPU cores`,
+    );
+  }
+  return hasAdequateCpu;
+};
 
 export const runCorpusEvaluation = async (options: EvaluationOptions): Promise<void> => {
-  const loadedRepositories = await loadCorpusRepositories(options.repositoriesSources);
-  const repositoryGroups = groupCorpusRepositories(loadedRepositories)
-    .slice(0, options.repositoryLimit)
-    .map((repositoryGroup) => ({
-      ...repositoryGroup,
-      rootDirectories: repositoryGroup.rootDirectories.slice(0, options.projectRootsPerRepository),
-    }));
-  const projectCount = repositoryGroups.reduce(
-    (totalProjectCount, repositoryGroup) =>
-      totalProjectCount + repositoryGroup.rootDirectories.length,
-    0,
-  );
-  const startedAt = globalThis.performance.now();
-  const evaluatorSourceHash = getEvaluatorSourceHash();
-  const evaluationDeadlineMilliseconds =
-    startedAt +
-    (options.maxDurationMinutes - EVALUATION_CLEANUP_RESERVE_MINUTES) * MILLISECONDS_PER_MINUTE;
-  let completedProjects = 0;
-  let failedProjects = 0;
-
-  process.stderr.write(
-    `Evaluating ${projectCount} projects from ${repositoryGroups.length} repositories in batches of ${options.repositoriesPerSandbox} at concurrency ${options.concurrency}\n`,
-  );
-
-  const daytona = new Daytona();
-  const evaluationId = randomUUID();
-  const snapshotName = `${DAYTONA_RUN_NAME}-snapshot-${evaluationId}`;
+  const baselineOutputStream = options.paired
+    ? createWriteStream(options.paired.baselineOutputPath, {
+        flags: "wx",
+        mode: EVALUATION_ARTIFACT_FILE_MODE,
+      })
+    : undefined;
+  if (baselineOutputStream) await once(baselineOutputStream, "open");
   try {
-    process.stderr.write(`Building React Doctor snapshot ${snapshotName}\n`);
-    await daytona.snapshot.create(
-      {
-        name: snapshotName,
-        image: Image.base(SANDBOX_IMAGE)
-          .env({
-            REACT_DOCTOR_REPOSITORY: options.reactDoctorRepository,
-            REACT_DOCTOR_REF: options.reactDoctorRef,
-            REACT_DOCTOR_RULE_KEYS: JSON.stringify(options.ruleKeys),
-          })
-          .runCommands(...PREPARE_REACT_DOCTOR_COMMANDS)
-          .workdir(REACT_DOCTOR_WORK_DIRECTORY)
-          .runCommands(...BUILD_REACT_DOCTOR_COMMANDS),
-        resources: {
-          cpu: SANDBOX_CPU_CORES,
-          memory: SANDBOX_MEMORY_GIB,
-          disk: SANDBOX_DISK_GIB,
-        },
-      },
-      {
-        timeout: getEvaluationTimeoutSeconds({
-          deadlineMilliseconds: evaluationDeadlineMilliseconds,
-          maximumTimeoutSeconds: SANDBOX_SETUP_TIMEOUT_SECONDS,
-        }),
-      },
+    const loadedRepositories = await loadCorpusRepositories(options.repositoriesSources);
+    const repositoryGroups = groupCorpusRepositories(loadedRepositories)
+      .slice(0, options.repositoryLimit)
+      .map((repositoryGroup) => ({
+        ...repositoryGroup,
+        rootDirectories: repositoryGroup.rootDirectories.slice(
+          0,
+          options.projectRootsPerRepository,
+        ),
+      }));
+    const projectCount = repositoryGroups.reduce(
+      (totalProjectCount, repositoryGroup) =>
+        totalProjectCount + repositoryGroup.rootDirectories.length,
+      0,
+    );
+    const startedAt = globalThis.performance.now();
+    const evaluatorSourceHash = getEvaluatorSourceHash();
+    const evaluationDeadlineMilliseconds =
+      startedAt +
+      (options.maxDurationMinutes - EVALUATION_CLEANUP_RESERVE_MINUTES) * MILLISECONDS_PER_MINUTE;
+    let completedProjects = 0;
+    let failedProjects = 0;
+    const runPairedScansInParallel = shouldRunPairedScansInParallel(options);
+
+    process.stderr.write(
+      `Evaluating ${projectCount} projects from ${repositoryGroups.length} repositories in batches of ${options.repositoriesPerSandbox} at concurrency ${options.concurrency}\n`,
     );
 
-    const recordEvaluation = async (record: CorpusEvaluationRecord): Promise<void> => {
-      if (!process.stdout.write(`${JSON.stringify(record)}\n`)) {
-        await once(process.stdout, "drain");
-      }
-      completedProjects += 1;
-      if (record.error) failedProjects += 1;
-      if (completedProjects % PROGRESS_INTERVAL_PROJECTS === 0) {
-        process.stderr.write(`Processed ${completedProjects}/${projectCount} projects\n`);
-      }
-    };
-
-    const attemptConcurrencies = [
-      options.concurrency,
-      ...EVALUATION_RETRY_CONCURRENCIES.map((concurrency) =>
-        Math.min(options.concurrency, concurrency),
-      ),
-    ];
-    const limitSandboxCreation = pLimit(Math.min(options.concurrency, SANDBOX_CREATE_CONCURRENCY));
-    const createSandbox = (sandboxName: string, deadlineMilliseconds: number) =>
-      limitSandboxCreation(() =>
-        daytona.create(
-          {
-            name: sandboxName,
-            snapshot: snapshotName,
-            ephemeral: true,
-            autoStopInterval: SANDBOX_AUTO_STOP_INTERVAL_MINUTES,
-            labels: {
-              evaluation: evaluationId,
-              project: DAYTONA_RUN_NAME,
-              purpose: "eval-repository",
-              run: DAYTONA_RUN_NAME,
-            },
-          },
-          {
-            timeout: getEvaluationTimeoutSeconds({
-              deadlineMilliseconds,
-              maximumTimeoutSeconds: SANDBOX_CREATE_TIMEOUT_SECONDS,
-            }),
-          },
-        ),
-      );
-    await runEvaluationAttempts({
-      repositoryGroups,
-      repositoriesPerSandbox: options.repositoriesPerSandbox,
-      attemptConcurrencies,
-      evaluateRepositoryBatch: (repositoryBatch, attemptIndex) =>
-        evaluateRepositoryBatch({
-          daytona,
-          createSandbox,
-          repositoryGroups: repositoryBatch,
-          evaluatorSourceHash,
-          evaluationDeadlineMilliseconds: getEvaluationAttemptDeadlineMilliseconds({
-            evaluationDeadlineMilliseconds,
-            attemptIndex,
-            totalAttempts: attemptConcurrencies.length,
-          }),
-          onRecord: recordEvaluation,
-        }),
-      beforeRetry: () => cleanupEvaluationSandboxes({ daytona, evaluationId }),
-      onBeforeRetryFailure: (error) => {
-        process.stderr.write(
-          `Failed to clean up Daytona sandboxes before retry: ${toErrorMessage(error)}\n`,
-        );
-      },
-      onRetry: (retry) => {
-        process.stderr.write(
-          `Retrying ${retry.failedProjectCount} projects at concurrency ${retry.concurrency} (attempt ${retry.attemptNumber}/${retry.totalAttempts})\n`,
-        );
-      },
-      onFinalFailure: recordEvaluation,
-    });
-  } finally {
+    const daytona = new Daytona();
+    const evaluationId = randomUUID();
+    const snapshotName = `${DAYTONA_RUN_NAME}-snapshot-${evaluationId}`;
     try {
-      await cleanupEvaluationSandboxes({ daytona, evaluationId });
+      process.stderr.write(`Building React Doctor snapshot ${snapshotName}\n`);
+      const snapshotStartedAt = globalThis.performance.now();
+      await daytona.snapshot.create(
+        {
+          name: snapshotName,
+          image: buildEvaluationSnapshotImage(options),
+          resources: options.paired
+            ? {
+                cpu: PAIRED_SANDBOX_CPU_CORES,
+                memory: PAIRED_SANDBOX_MEMORY_GIB,
+                disk: PAIRED_SANDBOX_DISK_GIB,
+              }
+            : {
+                cpu: SANDBOX_CPU_CORES,
+                memory: SANDBOX_MEMORY_GIB,
+                disk: SANDBOX_DISK_GIB,
+              },
+        },
+        {
+          timeout: getEvaluationTimeoutSeconds({
+            deadlineMilliseconds: evaluationDeadlineMilliseconds,
+            maximumTimeoutSeconds: SANDBOX_SETUP_TIMEOUT_SECONDS,
+          }),
+        },
+      );
+      const snapshotSetupSeconds =
+        (globalThis.performance.now() - snapshotStartedAt) / MILLISECONDS_PER_SECOND;
+      process.stderr.write(
+        `Snapshot ready in ${snapshotSetupSeconds.toFixed(SUMMARY_DECIMAL_PLACES)}s\n`,
+      );
+
+      const recordEvaluation = async (record: CorpusEvaluationRecord): Promise<void> => {
+        await writeNdjsonRecord(process.stdout, record);
+        completedProjects += 1;
+        if (record.error) failedProjects += 1;
+        if (completedProjects % PROGRESS_INTERVAL_PROJECTS === 0) {
+          process.stderr.write(`Processed ${completedProjects}/${projectCount} projects\n`);
+        }
+      };
+      const recordBaselineEvaluation = async (record: CorpusEvaluationRecord): Promise<void> => {
+        if (!baselineOutputStream) {
+          throw new Error("Paired baseline output stream is missing");
+        }
+        await writeNdjsonRecord(baselineOutputStream, record);
+      };
+
+      const attemptConcurrencies = [
+        options.concurrency,
+        ...EVALUATION_RETRY_CONCURRENCIES.map((concurrency) =>
+          Math.min(options.concurrency, concurrency),
+        ),
+      ];
+      const limitSandboxCreation = pLimit(
+        Math.min(options.concurrency, SANDBOX_CREATE_CONCURRENCY),
+      );
+      const createSandbox = (sandboxName: string, deadlineMilliseconds: number) =>
+        limitSandboxCreation(() =>
+          daytona.create(
+            {
+              name: sandboxName,
+              snapshot: snapshotName,
+              ephemeral: true,
+              autoStopInterval: SANDBOX_AUTO_STOP_INTERVAL_MINUTES,
+              labels: {
+                evaluation: evaluationId,
+                project: DAYTONA_RUN_NAME,
+                purpose: "eval-repository",
+                run: DAYTONA_RUN_NAME,
+              },
+            },
+            {
+              timeout: getEvaluationTimeoutSeconds({
+                deadlineMilliseconds,
+                maximumTimeoutSeconds: SANDBOX_CREATE_TIMEOUT_SECONDS,
+              }),
+            },
+          ),
+        );
+      await runEvaluationAttempts({
+        repositoryGroups,
+        repositoriesPerSandbox: options.repositoriesPerSandbox,
+        attemptConcurrencies,
+        evaluateRepositoryBatch: (repositoryBatch, attemptIndex) =>
+          evaluateRepositoryBatch({
+            daytona,
+            createSandbox,
+            repositoryGroups: repositoryBatch,
+            evaluatorSourceHash,
+            evaluationDeadlineMilliseconds: getEvaluationAttemptDeadlineMilliseconds({
+              evaluationDeadlineMilliseconds,
+              attemptIndex,
+              totalAttempts: attemptConcurrencies.length,
+            }),
+            onRecord: recordEvaluation,
+            paired: options.paired
+              ? {
+                  runScansInParallel: runPairedScansInParallel,
+                  onBaselineRecord: recordBaselineEvaluation,
+                }
+              : undefined,
+          }),
+        beforeRetry: () => cleanupEvaluationSandboxes({ daytona, evaluationId }),
+        onBeforeRetryFailure: (error) => {
+          process.stderr.write(
+            `Failed to clean up Daytona sandboxes before retry: ${toErrorMessage(error)}\n`,
+          );
+        },
+        onRetry: (retry) => {
+          process.stderr.write(
+            `Retrying ${retry.failedProjectCount} projects at concurrency ${retry.concurrency} (attempt ${retry.attemptNumber}/${retry.totalAttempts})\n`,
+          );
+        },
+        onFinalFailure: async (record) => {
+          if (options.paired) await recordBaselineEvaluation(record);
+          await recordEvaluation(record);
+        },
+      });
     } finally {
       try {
-        const snapshot = await daytona.snapshot.get(snapshotName);
-        await daytona.snapshot.delete(snapshot);
-      } catch (error) {
-        if (!(error instanceof DaytonaNotFoundError)) {
-          process.stderr.write(
-            `Failed to delete Daytona snapshot ${snapshotName}: ${toErrorMessage(error)}\n`,
-          );
+        await cleanupEvaluationSandboxes({ daytona, evaluationId });
+      } finally {
+        try {
+          const snapshot = await daytona.snapshot.get(snapshotName);
+          await daytona.snapshot.delete(snapshot);
+        } catch (error) {
+          if (!(error instanceof DaytonaNotFoundError)) {
+            process.stderr.write(
+              `Failed to delete Daytona snapshot ${snapshotName}: ${toErrorMessage(error)}\n`,
+            );
+          }
         }
       }
     }
-  }
 
-  const successfulProjects = completedProjects - failedProjects;
-  const completionRate = (successfulProjects / projectCount) * PERCENT_MULTIPLIER;
-  const elapsedSeconds = (globalThis.performance.now() - startedAt) / MILLISECONDS_PER_SECOND;
-  process.stderr.write(
-    `Completion: ${completionRate.toFixed(SUMMARY_DECIMAL_PLACES)}% (${successfulProjects}/${projectCount}), failures: ${failedProjects}, elapsed: ${elapsedSeconds.toFixed(SUMMARY_DECIMAL_PLACES)}s\n`,
-  );
-  if (failedProjects !== 0) {
-    throw new Error(`Evaluation failed for ${failedProjects} projects`);
+    const successfulProjects = completedProjects - failedProjects;
+    const completionRate = (successfulProjects / projectCount) * PERCENT_MULTIPLIER;
+    const elapsedSeconds = (globalThis.performance.now() - startedAt) / MILLISECONDS_PER_SECOND;
+    process.stderr.write(
+      `Completion: ${completionRate.toFixed(SUMMARY_DECIMAL_PLACES)}% (${successfulProjects}/${projectCount}), failures: ${failedProjects}, elapsed: ${elapsedSeconds.toFixed(SUMMARY_DECIMAL_PLACES)}s\n`,
+    );
+    if (failedProjects !== 0) {
+      throw new Error(`Evaluation failed for ${failedProjects} projects`);
+    }
+  } finally {
+    if (baselineOutputStream) {
+      baselineOutputStream.end();
+      await finished(baselineOutputStream);
+    }
   }
 };

--- a/packages/evals/src/run-corpus-evaluation.ts
+++ b/packages/evals/src/run-corpus-evaluation.ts
@@ -1,7 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { once } from "node:events";
-import { createWriteStream } from "node:fs";
-import { finished } from "node:stream/promises";
+import { open } from "node:fs/promises";
 
 import { Daytona, DaytonaNotFoundError, Image } from "@daytona/sdk";
 import pLimit from "p-limit";
@@ -38,10 +36,12 @@ import {
 } from "./constants.js";
 import type { CorpusEvaluationRecord } from "./corpus.js";
 import { evaluateRepositoryBatch } from "./evaluate-repository-batch.js";
+import type { PairedEvaluationRecords } from "./evaluate-repository-batch.js";
 import { groupCorpusRepositories } from "./group-corpus-repositories.js";
 import { loadCorpusRepositories } from "./load-corpus-repositories.js";
 import type { EvaluationOptions } from "./parse-evaluation-arguments.js";
 import { runEvaluationAttempts } from "./run-evaluation-attempts.js";
+import { createPairedNdjsonWriter } from "./utils/create-paired-ndjson-writer.js";
 import { getEvaluationAttemptDeadlineMilliseconds } from "./utils/get-evaluation-attempt-deadline-milliseconds.js";
 import { getEvaluatorSourceHash } from "./utils/get-evaluator-source-hash.js";
 import { getEvaluationTimeoutSeconds } from "./utils/get-evaluation-timeout-seconds.js";
@@ -87,13 +87,15 @@ const shouldRunPairedScansInParallel = (options: EvaluationOptions): boolean => 
 };
 
 export const runCorpusEvaluation = async (options: EvaluationOptions): Promise<void> => {
-  const baselineOutputStream = options.paired
-    ? createWriteStream(options.paired.baselineOutputPath, {
-        flags: "wx",
-        mode: EVALUATION_ARTIFACT_FILE_MODE,
+  const baselineFileHandle = options.paired
+    ? await open(options.paired.baselineOutputPath, "wx", EVALUATION_ARTIFACT_FILE_MODE)
+    : undefined;
+  const writePairedRecords = baselineFileHandle
+    ? createPairedNdjsonWriter({
+        baselineFileHandle,
+        treatmentOutput: process.stdout,
       })
     : undefined;
-  if (baselineOutputStream) await once(baselineOutputStream, "open");
   try {
     const loadedRepositories = await loadCorpusRepositories(options.repositoriesSources);
     const repositoryGroups = groupCorpusRepositories(loadedRepositories)
@@ -166,11 +168,22 @@ export const runCorpusEvaluation = async (options: EvaluationOptions): Promise<v
           process.stderr.write(`Processed ${completedProjects}/${projectCount} projects\n`);
         }
       };
-      const recordBaselineEvaluation = async (record: CorpusEvaluationRecord): Promise<void> => {
-        if (!baselineOutputStream) {
-          throw new Error("Paired baseline output stream is missing");
+      const recordPairedEvaluation = async ({
+        baseline,
+        treatment,
+      }: PairedEvaluationRecords): Promise<void> => {
+        if (!writePairedRecords) {
+          throw new Error("Paired record writer is missing");
         }
-        await writeNdjsonRecord(baselineOutputStream, record);
+        await writePairedRecords({
+          baselineRecord: baseline,
+          treatmentRecord: treatment,
+        });
+        completedProjects += 1;
+        if (treatment.error) failedProjects += 1;
+        if (completedProjects % PROGRESS_INTERVAL_PROJECTS === 0) {
+          process.stderr.write(`Processed ${completedProjects}/${projectCount} projects\n`);
+        }
       };
 
       const attemptConcurrencies = [
@@ -224,7 +237,7 @@ export const runCorpusEvaluation = async (options: EvaluationOptions): Promise<v
             paired: options.paired
               ? {
                   runScansInParallel: runPairedScansInParallel,
-                  onBaselineRecord: recordBaselineEvaluation,
+                  onPairedRecords: recordPairedEvaluation,
                 }
               : undefined,
           }),
@@ -240,8 +253,11 @@ export const runCorpusEvaluation = async (options: EvaluationOptions): Promise<v
           );
         },
         onFinalFailure: async (record) => {
-          if (options.paired) await recordBaselineEvaluation(record);
-          await recordEvaluation(record);
+          if (options.paired) {
+            await recordPairedEvaluation({ baseline: record, treatment: record });
+          } else {
+            await recordEvaluation(record);
+          }
         },
       });
     } finally {
@@ -271,9 +287,6 @@ export const runCorpusEvaluation = async (options: EvaluationOptions): Promise<v
       throw new Error(`Evaluation failed for ${failedProjects} projects`);
     }
   } finally {
-    if (baselineOutputStream) {
-      baselineOutputStream.end();
-      await finished(baselineOutputStream);
-    }
+    await baselineFileHandle?.close();
   }
 };

--- a/packages/evals/src/utils/create-paired-ndjson-writer.ts
+++ b/packages/evals/src/utils/create-paired-ndjson-writer.ts
@@ -1,0 +1,84 @@
+import type { Writable } from "node:stream";
+
+import pLimit from "p-limit";
+
+import { serializeNdjsonRecord } from "./serialize-ndjson-record.js";
+import { writeWritableContents } from "./write-writable-contents.js";
+
+export interface PairedNdjsonRecords {
+  baselineRecord: unknown;
+  treatmentRecord: unknown;
+}
+
+export interface CreatePairedNdjsonWriterInput {
+  baselineFileHandle: PairedBaselineFile;
+  treatmentOutput: Writable;
+}
+
+export interface PairedBaselineFile {
+  write: (
+    contents: Buffer,
+    offset: number,
+    length: number,
+    position: number,
+  ) => Promise<{ bytesWritten: number }>;
+  truncate: (length?: number) => Promise<void>;
+}
+
+export interface PairedNdjsonWriter {
+  (records: PairedNdjsonRecords): Promise<void>;
+}
+
+const writeFileContentsAtOffset = async (
+  fileHandle: PairedBaselineFile,
+  contents: Buffer,
+  initialOffset: number,
+): Promise<void> => {
+  let writtenByteCount = 0;
+  while (writtenByteCount < contents.byteLength) {
+    const { bytesWritten } = await fileHandle.write(
+      contents,
+      writtenByteCount,
+      contents.byteLength - writtenByteCount,
+      initialOffset + writtenByteCount,
+    );
+    if (bytesWritten === 0) throw new Error("Failed to append paired baseline record");
+    writtenByteCount += bytesWritten;
+  }
+};
+
+export const createPairedNdjsonWriter = ({
+  baselineFileHandle,
+  treatmentOutput,
+}: CreatePairedNdjsonWriterInput): PairedNdjsonWriter => {
+  const limitWrite = pLimit(1);
+  let baselineOffset = 0;
+  let hasWriteFailed = false;
+  let writeFailure: unknown;
+
+  return (records) =>
+    limitWrite(async () => {
+      if (hasWriteFailed) throw writeFailure;
+      const baselineContents = Buffer.from(serializeNdjsonRecord(records.baselineRecord));
+      const treatmentContents = serializeNdjsonRecord(records.treatmentRecord);
+      try {
+        await writeFileContentsAtOffset(baselineFileHandle, baselineContents, baselineOffset);
+        await writeWritableContents(treatmentOutput, treatmentContents);
+      } catch (error) {
+        try {
+          await baselineFileHandle.truncate(baselineOffset);
+        } catch (rollbackError) {
+          writeFailure = new AggregateError(
+            [error, rollbackError],
+            "Failed to write a paired record and roll back its baseline",
+          );
+          hasWriteFailed = true;
+          throw writeFailure;
+        }
+        writeFailure = error;
+        hasWriteFailed = true;
+        throw error;
+      }
+      baselineOffset += baselineContents.byteLength;
+    });
+};

--- a/packages/evals/src/utils/serialize-ndjson-record.ts
+++ b/packages/evals/src/utils/serialize-ndjson-record.ts
@@ -1,0 +1,1 @@
+export const serializeNdjsonRecord = (record: unknown): string => `${JSON.stringify(record)}\n`;

--- a/packages/evals/src/utils/write-ndjson-record.ts
+++ b/packages/evals/src/utils/write-ndjson-record.ts
@@ -1,8 +1,8 @@
-import { once } from "node:events";
 import type { Writable } from "node:stream";
 
+import { serializeNdjsonRecord } from "./serialize-ndjson-record.js";
+import { writeWritableContents } from "./write-writable-contents.js";
+
 export const writeNdjsonRecord = async (output: Writable, record: unknown): Promise<void> => {
-  if (!output.write(`${JSON.stringify(record)}\n`)) {
-    await once(output, "drain");
-  }
+  await writeWritableContents(output, serializeNdjsonRecord(record));
 };

--- a/packages/evals/src/utils/write-ndjson-record.ts
+++ b/packages/evals/src/utils/write-ndjson-record.ts
@@ -1,0 +1,8 @@
+import { once } from "node:events";
+import type { Writable } from "node:stream";
+
+export const writeNdjsonRecord = async (output: Writable, record: unknown): Promise<void> => {
+  if (!output.write(`${JSON.stringify(record)}\n`)) {
+    await once(output, "drain");
+  }
+};

--- a/packages/evals/src/utils/write-writable-contents.ts
+++ b/packages/evals/src/utils/write-writable-contents.ts
@@ -1,0 +1,27 @@
+import type { Writable } from "node:stream";
+
+export const writeWritableContents = async (output: Writable, contents: string): Promise<void> =>
+  new Promise((resolve, reject) => {
+    let isSettled = false;
+    const handleError = (error: Error) => {
+      if (isSettled) return;
+      isSettled = true;
+      reject(error);
+    };
+    output.once("error", handleError);
+    try {
+      output.write(contents, (error) => {
+        if (error) {
+          handleError(error);
+          return;
+        }
+        if (isSettled) return;
+        isSettled = true;
+        output.off("error", handleError);
+        resolve();
+      });
+    } catch (error) {
+      output.off("error", handleError);
+      handleError(error instanceof Error ? error : new Error(String(error)));
+    }
+  });

--- a/packages/evals/tests/create-paired-ndjson-writer.test.ts
+++ b/packages/evals/tests/create-paired-ndjson-writer.test.ts
@@ -1,0 +1,156 @@
+import * as fs from "node:fs";
+import { open } from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Writable } from "node:stream";
+
+import { afterEach, describe, expect, it } from "vite-plus/test";
+
+import { EVALUATION_ARTIFACT_FILE_MODE } from "../src/constants.js";
+import type { PairedBaselineFile } from "../src/utils/create-paired-ndjson-writer.js";
+import { createPairedNdjsonWriter } from "../src/utils/create-paired-ndjson-writer.js";
+
+const CONCURRENT_PAIR_COUNT = 100;
+const PARTIAL_BASELINE_WRITE_BYTE_COUNT = 3;
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const temporaryDirectory of temporaryDirectories.splice(0)) {
+    fs.rmSync(temporaryDirectory, { force: true, recursive: true });
+  }
+});
+
+const makeBaselineFile = async () => {
+  const temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-pair-writer-"));
+  temporaryDirectories.push(temporaryDirectory);
+  const baselinePath = path.join(temporaryDirectory, "baseline.ndjson");
+  return {
+    baselineFileHandle: await open(baselinePath, "wx+", EVALUATION_ARTIFACT_FILE_MODE),
+    baselinePath,
+  };
+};
+
+describe("createPairedNdjsonWriter", () => {
+  it("rolls back the baseline and rejects later pairs when the treatment write fails", async () => {
+    const { baselineFileHandle, baselinePath } = await makeBaselineFile();
+    const treatmentOutput = new Writable({
+      write: (_chunk, _encoding, callback) => callback(new Error("treatment write failed")),
+    });
+    const writePairedRecords = createPairedNdjsonWriter({
+      baselineFileHandle,
+      treatmentOutput,
+    });
+
+    await expect(
+      writePairedRecords({
+        baselineRecord: { identity: "baseline-success" },
+        treatmentRecord: { identity: "treatment-failure" },
+      }),
+    ).rejects.toThrow("treatment write failed");
+    await expect(
+      writePairedRecords({
+        baselineRecord: { identity: "later-baseline" },
+        treatmentRecord: { identity: "later-treatment" },
+      }),
+    ).rejects.toThrow("treatment write failed");
+
+    expect(fs.readFileSync(baselinePath, "utf8")).toBe("");
+    await baselineFileHandle.close();
+  });
+
+  it("serializes concurrent pairs with every identity exactly once", async () => {
+    const { baselineFileHandle, baselinePath } = await makeBaselineFile();
+    const treatmentChunks: string[] = [];
+    const treatmentOutput = new Writable({
+      write: (chunk, _encoding, callback) => {
+        treatmentChunks.push(chunk.toString());
+        callback();
+      },
+    });
+    const writePairedRecords = createPairedNdjsonWriter({
+      baselineFileHandle,
+      treatmentOutput,
+    });
+
+    await Promise.all(
+      Array.from({ length: CONCURRENT_PAIR_COUNT }, (_, identity) =>
+        writePairedRecords({
+          baselineRecord: { identity },
+          treatmentRecord: { identity },
+        }),
+      ),
+    );
+
+    const baselineIdentities = fs
+      .readFileSync(baselinePath, "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line).identity);
+    const treatmentIdentities = treatmentChunks
+      .join("")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line).identity);
+    const expectedIdentities = Array.from(
+      { length: CONCURRENT_PAIR_COUNT },
+      (_, identity) => identity,
+    );
+    expect(baselineIdentities).toEqual(expectedIdentities);
+    expect(treatmentIdentities).toEqual(expectedIdentities);
+    expect(new Set(baselineIdentities).size).toBe(CONCURRENT_PAIR_COUNT);
+    expect(new Set(treatmentIdentities).size).toBe(CONCURRENT_PAIR_COUNT);
+    await baselineFileHandle.close();
+  });
+
+  it("rolls a partial baseline write back to the prior committed offset", async () => {
+    let baselineContents = Buffer.alloc(0);
+    let shouldFailBaselineWrite = false;
+    const baselineFileHandle: PairedBaselineFile = {
+      write: async (contents, offset, length, position) => {
+        const requestedContents = contents.subarray(offset, offset + length);
+        const writtenContents = shouldFailBaselineWrite
+          ? requestedContents.subarray(0, PARTIAL_BASELINE_WRITE_BYTE_COUNT)
+          : requestedContents;
+        const nextBaselineContents = Buffer.alloc(
+          Math.max(baselineContents.byteLength, position + writtenContents.byteLength),
+        );
+        baselineContents.copy(nextBaselineContents);
+        writtenContents.copy(nextBaselineContents, position);
+        baselineContents = nextBaselineContents;
+        if (shouldFailBaselineWrite) throw new Error("partial baseline write failed");
+        return { bytesWritten: writtenContents.byteLength };
+      },
+      truncate: async (length = 0) => {
+        baselineContents = baselineContents.subarray(0, length);
+      },
+    };
+    const treatmentChunks: string[] = [];
+    const treatmentOutput = new Writable({
+      write: (chunk, _encoding, callback) => {
+        treatmentChunks.push(chunk.toString());
+        callback();
+      },
+    });
+    const writePairedRecords = createPairedNdjsonWriter({
+      baselineFileHandle,
+      treatmentOutput,
+    });
+    const committedBaselineRecord = { identity: "committed-baseline" };
+    const committedTreatmentRecord = { identity: "committed-treatment" };
+    await writePairedRecords({
+      baselineRecord: committedBaselineRecord,
+      treatmentRecord: committedTreatmentRecord,
+    });
+    shouldFailBaselineWrite = true;
+
+    await expect(
+      writePairedRecords({
+        baselineRecord: { identity: "partial-baseline" },
+        treatmentRecord: { identity: "unwritten-treatment" },
+      }),
+    ).rejects.toThrow("partial baseline write failed");
+
+    expect(baselineContents.toString()).toBe(`${JSON.stringify(committedBaselineRecord)}\n`);
+    expect(treatmentChunks.join("")).toBe(`${JSON.stringify(committedTreatmentRecord)}\n`);
+  });
+});

--- a/packages/evals/tests/evaluate-repository-batch.test.ts
+++ b/packages/evals/tests/evaluate-repository-batch.test.ts
@@ -222,8 +222,9 @@ describe("evaluateRepositoryBatch", () => {
         },
         paired: {
           runScansInParallel,
-          onBaselineRecord: async (record) => {
-            baselineRecords.push(record);
+          onPairedRecords: async ({ baseline, treatment }) => {
+            baselineRecords.push(baseline);
+            treatmentRecords.push(treatment);
           },
         },
       });
@@ -322,7 +323,7 @@ describe("evaluateRepositoryBatch", () => {
       }),
     });
     const onRecord = vi.fn(async () => undefined);
-    const onBaselineRecord = vi.fn(async () => undefined);
+    const onPairedRecords = vi.fn(async () => undefined);
 
     const failedRecords = await evaluateRepositoryBatch({
       daytona,
@@ -338,14 +339,14 @@ describe("evaluateRepositoryBatch", () => {
       evaluationDeadlineMilliseconds: globalThis.performance.now() + 60_000,
       evaluatorSourceHash: "f".repeat(64),
       onRecord,
-      paired: { runScansInParallel: true, onBaselineRecord },
+      paired: { runScansInParallel: true, onPairedRecords },
     });
 
     expect(executeCommand.mock.calls.filter(([command]) => command === SCAN_COMMAND)).toHaveLength(
       2,
     );
     expect(didBaselineScanSettle).toBe(true);
-    expect(onBaselineRecord).not.toHaveBeenCalled();
+    expect(onPairedRecords).not.toHaveBeenCalled();
     expect(onRecord).not.toHaveBeenCalled();
     expect(failedRecords).toEqual([
       {
@@ -359,5 +360,70 @@ describe("evaluateRepositoryBatch", () => {
         error: "treatment failed",
       },
     ]);
+  });
+
+  it("propagates paired sink failures instead of returning a retryable record", async () => {
+    const baselineProvenance = {
+      reactDoctorRepository: "https://github.com/millionco/react-doctor.git",
+      reactDoctorCommit: "a".repeat(40),
+      configContract: EVALUATION_CONFIG_CONTRACT,
+      ruleSetHash: "b".repeat(64),
+      ruleKeys: [],
+    };
+    const treatmentProvenance = {
+      ...baselineProvenance,
+      reactDoctorCommit: "c".repeat(40),
+      ruleSetHash: "d".repeat(64),
+    };
+    const executeCommand = vi.fn(async (command: string) => ({
+      exitCode: 0,
+      result: command.includes("rev-parse") ? "e".repeat(40) : "",
+    }));
+    const downloadFile = vi.fn(async (filePath: string) => {
+      if (filePath === BASE_REACT_DOCTOR_EVALUATION_PROVENANCE_PATH) {
+        return Buffer.from(JSON.stringify(baselineProvenance));
+      }
+      if (filePath === TREATMENT_REACT_DOCTOR_EVALUATION_PROVENANCE_PATH) {
+        return Buffer.from(JSON.stringify(treatmentProvenance));
+      }
+      const reportDirectory =
+        filePath === BASE_SANDBOX_REPORT_PATH
+          ? BASE_TARGET_WORK_DIRECTORY
+          : TREATMENT_TARGET_WORK_DIRECTORY;
+      return Buffer.from(JSON.stringify(buildReport(reportDirectory)));
+    });
+    const sandbox = Object.create(Sandbox.prototype);
+    Object.defineProperties(sandbox, {
+      id: { value: "sandbox-id" },
+      process: { value: { executeCommand } },
+      fs: { value: { downloadFile } },
+    });
+    const daytona = new Daytona({ apiKey: "test" });
+    const deleteSandbox = vi.fn(async () => undefined);
+    Object.defineProperty(daytona, "delete", { value: deleteSandbox });
+    const onPairedRecords = vi.fn(async () => {
+      throw new Error("artifact sink failed");
+    });
+
+    await expect(
+      evaluateRepositoryBatch({
+        daytona,
+        createSandbox: async () => sandbox,
+        repositoryGroups: [
+          {
+            org: "example",
+            name: "repository",
+            ref: "f".repeat(40),
+            rootDirectories: ["."],
+          },
+        ],
+        evaluationDeadlineMilliseconds: globalThis.performance.now() + 60_000,
+        evaluatorSourceHash: "f".repeat(64),
+        onRecord: vi.fn(async () => undefined),
+        paired: { runScansInParallel: true, onPairedRecords },
+      }),
+    ).rejects.toThrow("artifact sink failed");
+    expect(onPairedRecords).toHaveBeenCalledOnce();
+    expect(deleteSandbox).toHaveBeenCalledOnce();
   });
 });

--- a/packages/evals/tests/evaluate-repository-batch.test.ts
+++ b/packages/evals/tests/evaluate-repository-batch.test.ts
@@ -2,23 +2,36 @@ import { Daytona, Sandbox } from "@daytona/sdk";
 import { describe, expect, it, vi } from "vite-plus/test";
 
 import {
+  BASE_REACT_DOCTOR_EVALUATION_PROVENANCE_PATH,
+  BASE_REACT_DOCTOR_WORK_DIRECTORY,
+  BASE_SANDBOX_REPORT_PATH,
+  BASE_TARGET_WORK_DIRECTORY,
   EVALUATION_CONFIG_CONTRACT,
+  MILLISECONDS_PER_SECOND,
+  PAIRED_SANDBOX_SCAN_TIMEOUT_SECONDS,
   REACT_DOCTOR_EVALUATION_PROVENANCE_PATH,
   SANDBOX_REPORT_PATH,
+  SCAN_COMMAND,
+  TREATMENT_REACT_DOCTOR_EVALUATION_PROVENANCE_PATH,
+  TREATMENT_REACT_DOCTOR_WORK_DIRECTORY,
+  TREATMENT_SANDBOX_REPORT_PATH,
+  TREATMENT_TARGET_WORK_DIRECTORY,
 } from "../src/constants.js";
 import { evaluateRepositoryBatch } from "../src/evaluate-repository-batch.js";
 
-const buildReport = () => ({
+const PAIRED_SCAN_DELAY_MS = 5;
+
+const buildReport = (directory = "/workspace/target") => ({
   schemaVersion: 3,
   version: "0.8.1",
   ok: true,
-  directory: "/workspace/target",
+  directory,
   mode: "full",
   diff: null,
   projects: [
     {
-      directory: "/workspace/target",
-      packageRoot: "/workspace/target",
+      directory,
+      packageRoot: directory,
       framework: "nextjs",
       project: {},
       diagnostics: [],
@@ -95,6 +108,10 @@ describe("evaluateRepositoryBatch", () => {
 
     expect(failedRecords).toEqual([]);
     expect(downloadFile).toHaveBeenCalledWith(SANDBOX_REPORT_PATH, expect.any(Number));
+    expect(downloadFile).not.toHaveBeenCalledWith(
+      BASE_REACT_DOCTOR_EVALUATION_PROVENANCE_PATH,
+      expect.any(Number),
+    );
     expect(records).toEqual([
       {
         schemaVersion: 1,
@@ -116,5 +133,231 @@ describe("evaluateRepositoryBatch", () => {
       expect.any(Number),
     );
     expect(downloadFile).toHaveBeenCalledWith(SANDBOX_REPORT_PATH, expect.any(Number));
+  });
+
+  it.each([
+    ["parallel", true, 2],
+    ["sequential", false, 1],
+  ])(
+    "runs paired scans %s with isolated detector, target, and report paths",
+    async (_executionName, runScansInParallel, expectedMaximumActiveScans) => {
+      const baselineProvenance = {
+        reactDoctorRepository: "https://github.com/millionco/react-doctor.git",
+        reactDoctorCommit: "a".repeat(40),
+        configContract: EVALUATION_CONFIG_CONTRACT,
+        ruleSetHash: "b".repeat(64),
+        ruleKeys: [],
+      };
+      const treatmentProvenance = {
+        reactDoctorRepository: "https://github.com/millionco/react-doctor.git",
+        reactDoctorCommit: "c".repeat(40),
+        configContract: EVALUATION_CONFIG_CONTRACT,
+        ruleSetHash: "d".repeat(64),
+        ruleKeys: ["react-doctor/selected-rule"],
+      };
+      let activeScanCount = 0;
+      let maximumActiveScanCount = 0;
+      const scanEnvironments: Array<Record<string, string>> = [];
+      const executeCommand = vi.fn(
+        async (
+          command: string,
+          _cwd: string | undefined,
+          environment: Record<string, string>,
+          _timeoutSeconds: number,
+        ) => {
+          if (command !== SCAN_COMMAND) {
+            return {
+              exitCode: 0,
+              result: command.includes("rev-parse") ? "e".repeat(40) : "",
+            };
+          }
+          scanEnvironments.push(environment);
+          activeScanCount += 1;
+          maximumActiveScanCount = Math.max(maximumActiveScanCount, activeScanCount);
+          await new Promise((resolve) => setTimeout(resolve, PAIRED_SCAN_DELAY_MS));
+          activeScanCount -= 1;
+          return { exitCode: 0, result: "" };
+        },
+      );
+      const downloadFile = vi.fn(async (filePath: string) => {
+        if (filePath === BASE_REACT_DOCTOR_EVALUATION_PROVENANCE_PATH) {
+          return Buffer.from(JSON.stringify(baselineProvenance));
+        }
+        if (filePath === TREATMENT_REACT_DOCTOR_EVALUATION_PROVENANCE_PATH) {
+          return Buffer.from(JSON.stringify(treatmentProvenance));
+        }
+        if (filePath === BASE_SANDBOX_REPORT_PATH) {
+          return Buffer.from(JSON.stringify(buildReport(BASE_TARGET_WORK_DIRECTORY)));
+        }
+        return Buffer.from(JSON.stringify(buildReport(TREATMENT_TARGET_WORK_DIRECTORY)));
+      });
+      const sandbox = Object.create(Sandbox.prototype);
+      Object.defineProperties(sandbox, {
+        id: { value: "sandbox-id" },
+        process: { value: { executeCommand } },
+        fs: { value: { downloadFile } },
+      });
+      const daytona = new Daytona({ apiKey: "test" });
+      Object.defineProperty(daytona, "delete", { value: vi.fn(async () => undefined) });
+      const baselineRecords: unknown[] = [];
+      const treatmentRecords: unknown[] = [];
+
+      const failedRecords = await evaluateRepositoryBatch({
+        daytona,
+        createSandbox: async () => sandbox,
+        repositoryGroups: [
+          {
+            org: "example",
+            name: "repository",
+            ref: "f".repeat(40),
+            rootDirectories: ["."],
+          },
+        ],
+        evaluationDeadlineMilliseconds:
+          globalThis.performance.now() +
+          (PAIRED_SANDBOX_SCAN_TIMEOUT_SECONDS + 1) * MILLISECONDS_PER_SECOND,
+        evaluatorSourceHash: "f".repeat(64),
+        onRecord: async (record) => {
+          treatmentRecords.push(record);
+        },
+        paired: {
+          runScansInParallel,
+          onBaselineRecord: async (record) => {
+            baselineRecords.push(record);
+          },
+        },
+      });
+
+      expect(failedRecords).toEqual([]);
+      expect(maximumActiveScanCount).toBe(expectedMaximumActiveScans);
+      expect(scanEnvironments).toHaveLength(2);
+      expect(
+        scanEnvironments.map((environment) => environment.REACT_DOCTOR_WORK_DIRECTORY),
+      ).toEqual([BASE_REACT_DOCTOR_WORK_DIRECTORY, TREATMENT_REACT_DOCTOR_WORK_DIRECTORY]);
+      expect(
+        executeCommand.mock.calls
+          .filter(([command]) => command === SCAN_COMMAND)
+          .map(([, , , timeoutSeconds]) => timeoutSeconds),
+      ).toEqual([PAIRED_SANDBOX_SCAN_TIMEOUT_SECONDS, PAIRED_SANDBOX_SCAN_TIMEOUT_SECONDS]);
+      expect(scanEnvironments).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            REACT_DOCTOR_WORK_DIRECTORY: BASE_REACT_DOCTOR_WORK_DIRECTORY,
+            REACT_DOCTOR_RULE_KEYS: "[]",
+            TARGET_CHECKOUT_DIRECTORY: BASE_TARGET_WORK_DIRECTORY,
+            SANDBOX_REPORT_PATH: BASE_SANDBOX_REPORT_PATH,
+          }),
+          expect.objectContaining({
+            REACT_DOCTOR_WORK_DIRECTORY: TREATMENT_REACT_DOCTOR_WORK_DIRECTORY,
+            REACT_DOCTOR_RULE_KEYS: JSON.stringify(["react-doctor/selected-rule"]),
+            TARGET_CHECKOUT_DIRECTORY: TREATMENT_TARGET_WORK_DIRECTORY,
+            SANDBOX_REPORT_PATH: TREATMENT_SANDBOX_REPORT_PATH,
+          }),
+        ]),
+      );
+      expect(baselineRecords).toHaveLength(1);
+      expect(treatmentRecords).toHaveLength(1);
+      expect(baselineRecords[0]).toEqual(
+        expect.objectContaining({
+          evaluation: expect.objectContaining({ reactDoctorCommit: "a".repeat(40) }),
+          report: expect.objectContaining({ directory: BASE_TARGET_WORK_DIRECTORY }),
+        }),
+      );
+      expect(treatmentRecords[0]).toEqual(
+        expect.objectContaining({
+          evaluation: expect.objectContaining({ reactDoctorCommit: "c".repeat(40) }),
+          report: expect.objectContaining({ directory: TREATMENT_TARGET_WORK_DIRECTORY }),
+        }),
+      );
+    },
+  );
+
+  it("waits for both parallel scans before retrying without a partial baseline", async () => {
+    const baselineProvenance = {
+      reactDoctorRepository: "https://github.com/millionco/react-doctor.git",
+      reactDoctorCommit: "a".repeat(40),
+      configContract: EVALUATION_CONFIG_CONTRACT,
+      ruleSetHash: "b".repeat(64),
+      ruleKeys: [],
+    };
+    const treatmentProvenance = {
+      ...baselineProvenance,
+      reactDoctorCommit: "c".repeat(40),
+      ruleSetHash: "d".repeat(64),
+    };
+    let didBaselineScanSettle = false;
+    const executeCommand = vi.fn(
+      async (command: string, _cwd: string | undefined, environment: Record<string, string>) => {
+        if (command.includes("rev-parse")) return { exitCode: 0, result: "e".repeat(40) };
+        if (command === SCAN_COMMAND) {
+          if (environment.REACT_DOCTOR_WORK_DIRECTORY === BASE_REACT_DOCTOR_WORK_DIRECTORY) {
+            await new Promise((resolve) => setTimeout(resolve, PAIRED_SCAN_DELAY_MS));
+            didBaselineScanSettle = true;
+          } else {
+            throw new Error("treatment failed");
+          }
+        }
+        return { exitCode: 0, result: "" };
+      },
+    );
+    const downloadFile = vi.fn(async (filePath: string) => {
+      if (filePath === BASE_REACT_DOCTOR_EVALUATION_PROVENANCE_PATH) {
+        return Buffer.from(JSON.stringify(baselineProvenance));
+      }
+      if (filePath === TREATMENT_REACT_DOCTOR_EVALUATION_PROVENANCE_PATH) {
+        return Buffer.from(JSON.stringify(treatmentProvenance));
+      }
+      return Buffer.from(JSON.stringify(buildReport(BASE_TARGET_WORK_DIRECTORY)));
+    });
+    const sandbox = Object.create(Sandbox.prototype);
+    Object.defineProperties(sandbox, {
+      id: { value: "sandbox-id" },
+      process: { value: { executeCommand } },
+      fs: { value: { downloadFile } },
+    });
+    const daytona = new Daytona({ apiKey: "test" });
+    Object.defineProperty(daytona, "delete", {
+      value: vi.fn(async () => {
+        expect(didBaselineScanSettle).toBe(true);
+      }),
+    });
+    const onRecord = vi.fn(async () => undefined);
+    const onBaselineRecord = vi.fn(async () => undefined);
+
+    const failedRecords = await evaluateRepositoryBatch({
+      daytona,
+      createSandbox: async () => sandbox,
+      repositoryGroups: [
+        {
+          org: "example",
+          name: "repository",
+          ref: "f".repeat(40),
+          rootDirectories: ["."],
+        },
+      ],
+      evaluationDeadlineMilliseconds: globalThis.performance.now() + 60_000,
+      evaluatorSourceHash: "f".repeat(64),
+      onRecord,
+      paired: { runScansInParallel: true, onBaselineRecord },
+    });
+
+    expect(executeCommand.mock.calls.filter(([command]) => command === SCAN_COMMAND)).toHaveLength(
+      2,
+    );
+    expect(didBaselineScanSettle).toBe(true);
+    expect(onBaselineRecord).not.toHaveBeenCalled();
+    expect(onRecord).not.toHaveBeenCalled();
+    expect(failedRecords).toEqual([
+      {
+        schemaVersion: 1,
+        repository: {
+          org: "example",
+          name: "repository",
+          ref: "e".repeat(40),
+          rootDir: ".",
+        },
+        error: "treatment failed",
+      },
+    ]);
   });
 });

--- a/packages/evals/tests/materialize-all-rules-config.test.ts
+++ b/packages/evals/tests/materialize-all-rules-config.test.ts
@@ -9,14 +9,33 @@ import {
   EVALUATION_CONFIG_CONTRACT,
   MATERIALIZE_ALL_RULES_CONFIG_COMMAND,
   MATERIALIZE_REACT_DOCTOR_EVALUATION_PROVENANCE_COMMAND,
-  REACT_DOCTOR_EVALUATION_PROVENANCE_PATH,
-  REACT_DOCTOR_WORK_DIRECTORY,
+  PREPARE_PAIRED_REACT_DOCTOR_COMMANDS,
   SCAN_COMMAND,
 } from "../src/constants.js";
 
 const temporaryDirectories: string[] = [];
 const INTEGRATION_TEST_TIMEOUT_MS = 30_000;
 const normalizeEmbeddedPath = (filePath: string): string => filePath.replaceAll("\\", "/");
+
+interface BuildCommandEnvironmentInput {
+  reactDoctorDirectory: string;
+  targetDirectory: string;
+  targetRootDirectory?: string;
+  ruleKeys?: ReadonlyArray<string>;
+}
+
+const buildCommandEnvironment = ({
+  reactDoctorDirectory,
+  targetDirectory,
+  targetRootDirectory = ".",
+  ruleKeys = [],
+}: BuildCommandEnvironmentInput): NodeJS.ProcessEnv => ({
+  ...process.env,
+  REACT_DOCTOR_WORK_DIRECTORY: normalizeEmbeddedPath(reactDoctorDirectory),
+  REACT_DOCTOR_RULE_KEYS: JSON.stringify(ruleKeys),
+  TARGET_CHECKOUT_DIRECTORY: normalizeEmbeddedPath(targetDirectory),
+  TARGET_ROOT_DIRECTORY: targetRootDirectory,
+});
 
 afterEach(() => {
   for (const temporaryDirectory of temporaryDirectories.splice(0)) {
@@ -25,6 +44,12 @@ afterEach(() => {
 });
 
 describe("MATERIALIZE_ALL_RULES_CONFIG_COMMAND", () => {
+  it("keeps paired snapshot build steps valid as Dockerfile RUN instructions", () => {
+    expect(PREPARE_PAIRED_REACT_DOCTOR_COMMANDS).not.toEqual(
+      expect.arrayContaining([expect.stringContaining("\n")]),
+    );
+  });
+
   it("normalizes Windows paths before embedding them in JavaScript", () => {
     expect(normalizeEmbeddedPath("C:\\Users\\runner\\repo")).toBe("C:/Users/runner/repo");
   });
@@ -65,12 +90,12 @@ export const REACT_DOCTOR_RULES = [
       fs.writeFileSync(path.join(targetRootDirectory, "doctor.config.ts"), "export default {};");
       fs.writeFileSync(path.join(nestedProjectDirectory, "doctor.config.ts"), "export default {};");
 
-      const command = MATERIALIZE_ALL_RULES_CONFIG_COMMAND.replaceAll(
-        "/workspace/react-doctor",
-        normalizeEmbeddedPath(reactDoctorDirectory),
-      ).replaceAll("/workspace/target", normalizeEmbeddedPath(targetDirectory));
-      execFileSync("sh", ["-c", command], {
-        env: { ...process.env, TARGET_ROOT_DIRECTORY: "app" },
+      execFileSync("sh", ["-c", MATERIALIZE_ALL_RULES_CONFIG_COMMAND], {
+        env: buildCommandEnvironment({
+          reactDoctorDirectory,
+          targetDirectory,
+          targetRootDirectory: "app",
+        }),
       });
 
       expect(fs.readFileSync(path.join(targetRootDirectory, "doctor.config.ts"), "utf8")).toBe(
@@ -116,16 +141,12 @@ export const REACT_DOCTOR_RULES = [
 `,
       );
 
-      const command = MATERIALIZE_ALL_RULES_CONFIG_COMMAND.replaceAll(
-        "/workspace/react-doctor",
-        normalizeEmbeddedPath(reactDoctorDirectory),
-      ).replaceAll("/workspace/target", normalizeEmbeddedPath(targetDirectory));
-      execFileSync("sh", ["-c", command], {
-        env: {
-          ...process.env,
-          REACT_DOCTOR_RULE_KEYS: JSON.stringify(["react-doctor/selected-rule"]),
-          TARGET_ROOT_DIRECTORY: ".",
-        },
+      execFileSync("sh", ["-c", MATERIALIZE_ALL_RULES_CONFIG_COMMAND], {
+        env: buildCommandEnvironment({
+          reactDoctorDirectory,
+          targetDirectory,
+          ruleKeys: ["react-doctor/selected-rule"],
+        }),
       });
 
       expect(fs.readFileSync(path.join(targetDirectory, "doctor.config.ts"), "utf8")).toBe(
@@ -176,16 +197,13 @@ export const REACT_DOCTOR_RULES = [
         ["-C", reactDoctorDirectory, "rev-parse", "HEAD"],
         { encoding: "utf8" },
       ).trim();
-      const command = MATERIALIZE_REACT_DOCTOR_EVALUATION_PROVENANCE_COMMAND.replaceAll(
-        REACT_DOCTOR_EVALUATION_PROVENANCE_PATH,
-        normalizeEmbeddedPath(provenancePath),
-      ).replaceAll(REACT_DOCTOR_WORK_DIRECTORY, normalizeEmbeddedPath(reactDoctorDirectory));
-
-      execFileSync("sh", ["-c", command], {
+      execFileSync("sh", ["-c", MATERIALIZE_REACT_DOCTOR_EVALUATION_PROVENANCE_COMMAND], {
         env: {
           ...process.env,
           REACT_DOCTOR_REPOSITORY: "https://github.com/millionco/react-doctor.git",
           REACT_DOCTOR_RULE_KEYS: JSON.stringify(["react-doctor/no-derived-useState"]),
+          REACT_DOCTOR_WORK_DIRECTORY: normalizeEmbeddedPath(reactDoctorDirectory),
+          REACT_DOCTOR_EVALUATION_PROVENANCE_PATH: normalizeEmbeddedPath(provenancePath),
         },
       });
 
@@ -223,16 +241,12 @@ export const REACT_DOCTOR_RULES = [
 `,
       );
 
-      const command = MATERIALIZE_ALL_RULES_CONFIG_COMMAND.replaceAll(
-        "/workspace/react-doctor",
-        normalizeEmbeddedPath(reactDoctorDirectory),
-      ).replaceAll("/workspace/target", normalizeEmbeddedPath(targetDirectory));
-      execFileSync("sh", ["-c", command], {
-        env: {
-          ...process.env,
-          REACT_DOCTOR_RULE_KEYS: JSON.stringify(["react-doctor/scan-rule"]),
-          TARGET_ROOT_DIRECTORY: ".",
-        },
+      execFileSync("sh", ["-c", MATERIALIZE_ALL_RULES_CONFIG_COMMAND], {
+        env: buildCommandEnvironment({
+          reactDoctorDirectory,
+          targetDirectory,
+          ruleKeys: ["react-doctor/scan-rule"],
+        }),
       });
 
       expect(fs.readFileSync(path.join(targetDirectory, "doctor.config.ts"), "utf8")).toBe(
@@ -268,17 +282,13 @@ export const REACT_DOCTOR_RULES = [
         "export const REACT_COMPILER_RULES = {}; export const REACT_DOCTOR_RULES = [];",
       );
 
-      const command = MATERIALIZE_ALL_RULES_CONFIG_COMMAND.replaceAll(
-        "/workspace/react-doctor",
-        normalizeEmbeddedPath(reactDoctorDirectory),
-      ).replaceAll("/workspace/target", normalizeEmbeddedPath(targetDirectory));
-      const result = spawnSync("sh", ["-c", command], {
+      const result = spawnSync("sh", ["-c", MATERIALIZE_ALL_RULES_CONFIG_COMMAND], {
         encoding: "utf8",
-        env: {
-          ...process.env,
-          REACT_DOCTOR_RULE_KEYS: JSON.stringify(["react-doctor/missing-rule"]),
-          TARGET_ROOT_DIRECTORY: ".",
-        },
+        env: buildCommandEnvironment({
+          reactDoctorDirectory,
+          targetDirectory,
+          ruleKeys: ["react-doctor/missing-rule"],
+        }),
       });
 
       expect(result.status).not.toBe(0);
@@ -310,12 +320,12 @@ export const REACT_DOCTOR_RULES = [
       fs.writeFileSync(symlinkTargetPath, "sentinel");
       fs.symlinkSync(symlinkTargetPath, path.join(targetRootDirectory, "doctor.config.ts"));
 
-      const command = MATERIALIZE_ALL_RULES_CONFIG_COMMAND.replaceAll(
-        "/workspace/react-doctor",
-        normalizeEmbeddedPath(reactDoctorDirectory),
-      ).replaceAll("/workspace/target", normalizeEmbeddedPath(targetDirectory));
-      execFileSync("sh", ["-c", command], {
-        env: { ...process.env, TARGET_ROOT_DIRECTORY: "app" },
+      execFileSync("sh", ["-c", MATERIALIZE_ALL_RULES_CONFIG_COMMAND], {
+        env: buildCommandEnvironment({
+          reactDoctorDirectory,
+          targetDirectory,
+          targetRootDirectory: "app",
+        }),
       });
 
       expect(fs.readFileSync(symlinkTargetPath, "utf8")).toBe("sentinel");
@@ -350,13 +360,13 @@ export const REACT_DOCTOR_RULES = [
       );
       fs.symlinkSync(outsideDirectory, path.join(targetDirectory, "app"));
 
-      const command = MATERIALIZE_ALL_RULES_CONFIG_COMMAND.replaceAll(
-        "/workspace/react-doctor",
-        normalizeEmbeddedPath(reactDoctorDirectory),
-      ).replaceAll("/workspace/target", normalizeEmbeddedPath(targetDirectory));
-      const result = spawnSync("sh", ["-c", command], {
+      const result = spawnSync("sh", ["-c", MATERIALIZE_ALL_RULES_CONFIG_COMMAND], {
         encoding: "utf8",
-        env: { ...process.env, TARGET_ROOT_DIRECTORY: "app" },
+        env: buildCommandEnvironment({
+          reactDoctorDirectory,
+          targetDirectory,
+          targetRootDirectory: "app",
+        }),
       });
 
       expect(result.status).not.toBe(0);
@@ -384,13 +394,13 @@ export const REACT_DOCTOR_RULES = [
         "export const REACT_COMPILER_RULES = {}; export const REACT_DOCTOR_RULES = [];",
       );
 
-      const command = MATERIALIZE_ALL_RULES_CONFIG_COMMAND.replaceAll(
-        "/workspace/react-doctor",
-        normalizeEmbeddedPath(reactDoctorDirectory),
-      ).replaceAll("/workspace/target", normalizeEmbeddedPath(targetDirectory));
-      const result = spawnSync("sh", ["-c", command], {
+      const result = spawnSync("sh", ["-c", MATERIALIZE_ALL_RULES_CONFIG_COMMAND], {
         encoding: "utf8",
-        env: { ...process.env, TARGET_ROOT_DIRECTORY: "app" },
+        env: buildCommandEnvironment({
+          reactDoctorDirectory,
+          targetDirectory,
+          targetRootDirectory: "app",
+        }),
       });
 
       expect(result.status).not.toBe(0);
@@ -429,12 +439,12 @@ export const REACT_DOCTOR_RULES = [
       fs.writeFileSync(path.join(outsideDirectory, "package.json"), "{}");
       fs.symlinkSync(outsideDirectory, path.join(targetRootDirectory, "linked-package"));
 
-      const command = MATERIALIZE_ALL_RULES_CONFIG_COMMAND.replaceAll(
-        "/workspace/react-doctor",
-        normalizeEmbeddedPath(reactDoctorDirectory),
-      ).replaceAll("/workspace/target", normalizeEmbeddedPath(targetDirectory));
-      execFileSync("sh", ["-c", command], {
-        env: { ...process.env, TARGET_ROOT_DIRECTORY: "app" },
+      execFileSync("sh", ["-c", MATERIALIZE_ALL_RULES_CONFIG_COMMAND], {
+        env: buildCommandEnvironment({
+          reactDoctorDirectory,
+          targetDirectory,
+          targetRootDirectory: "app",
+        }),
       });
 
       expect(fs.existsSync(path.join(outsideDirectory, "doctor.config.ts"))).toBe(false);
@@ -449,10 +459,20 @@ export const REACT_DOCTOR_RULES = [
       temporaryDirectories.push(temporaryDirectory);
       const sentinelPath = path.join(temporaryDirectory, "scan-ran");
       const command = SCAN_COMMAND.replace(MATERIALIZE_ALL_RULES_CONFIG_COMMAND, "false").replace(
-        /node \/workspace\/react-doctor[\s\S]*$/,
+        /node "\$REACT_DOCTOR_WORK_DIRECTORY[\s\S]*$/,
         `touch "${sentinelPath}"`,
       );
-      const result = spawnSync("sh", ["-c", command], { encoding: "utf8" });
+      const result = spawnSync("sh", ["-c", command], {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          REACT_DOCTOR_WORK_DIRECTORY: "/workspace/react-doctor",
+          REACT_DOCTOR_RULE_KEYS: "[]",
+          TARGET_CHECKOUT_DIRECTORY: "/workspace/target",
+          TARGET_ROOT_DIRECTORY: ".",
+          SANDBOX_REPORT_PATH: "/tmp/report.json",
+        },
+      });
 
       expect(result.status).not.toBe(0);
       expect(fs.existsSync(sentinelPath)).toBe(false);
@@ -464,10 +484,16 @@ export const REACT_DOCTOR_RULES = [
     { timeout: INTEGRATION_TEST_TIMEOUT_MS },
     () => {
       const command = SCAN_COMMAND.replace(MATERIALIZE_ALL_RULES_CONFIG_COMMAND, "true").replace(
-        "node /workspace/react-doctor/packages/react-doctor/bin/react-doctor.js",
+        'node "$REACT_DOCTOR_WORK_DIRECTORY/packages/react-doctor/bin/react-doctor.js"',
         "true",
       );
-      const environment = { ...process.env };
+      const environment = {
+        ...process.env,
+        REACT_DOCTOR_WORK_DIRECTORY: "/workspace/react-doctor",
+        REACT_DOCTOR_RULE_KEYS: "[]",
+        TARGET_CHECKOUT_DIRECTORY: "/workspace/target",
+        SANDBOX_REPORT_PATH: "/tmp/report.json",
+      };
       Reflect.deleteProperty(environment, "TARGET_ROOT_DIRECTORY");
 
       const result = spawnSync("sh", ["-c", command], { encoding: "utf8", env: environment });

--- a/packages/evals/tests/paired-target-worktrees.test.ts
+++ b/packages/evals/tests/paired-target-worktrees.test.ts
@@ -63,19 +63,43 @@ describe("SETUP_PAIRED_TARGET_REPOSITORY_COMMAND", () => {
         encoding: "utf8",
       }).trim(),
     ).toBe(targetRef);
-    const resolvedTargetRepositoryDirectory = fs.realpathSync(targetRepositoryDirectory);
-    const resolvedBaseCommonDirectory = fs.realpathSync(
-      execFileSync("git", ["-C", baseWorkDirectory, "rev-parse", "--git-common-dir"], {
-        encoding: "utf8",
-      }).trim(),
+    const baseCommonDirectory = execFileSync(
+      "git",
+      ["-C", baseWorkDirectory, "rev-parse", "--git-common-dir"],
+      { encoding: "utf8" },
+    ).trim();
+    const treatmentCommonDirectory = execFileSync(
+      "git",
+      ["-C", treatmentWorkDirectory, "rev-parse", "--git-common-dir"],
+      { encoding: "utf8" },
+    ).trim();
+    const resolvedBaseCommonDirectory = path.resolve(baseWorkDirectory, baseCommonDirectory);
+    const resolvedTreatmentCommonDirectory = path.resolve(
+      treatmentWorkDirectory,
+      treatmentCommonDirectory,
     );
-    const resolvedTreatmentCommonDirectory = fs.realpathSync(
-      execFileSync("git", ["-C", treatmentWorkDirectory, "rev-parse", "--git-common-dir"], {
-        encoding: "utf8",
-      }).trim(),
+    const commonDirectorySentinelName = "shared-common-directory-sentinel";
+    const commonDirectorySentinelContents = "shared\n";
+    fs.writeFileSync(
+      path.join(targetRepositoryDirectory, commonDirectorySentinelName),
+      commonDirectorySentinelContents,
     );
-    expect(resolvedBaseCommonDirectory).toBe(resolvedTargetRepositoryDirectory);
-    expect(resolvedTreatmentCommonDirectory).toBe(resolvedTargetRepositoryDirectory);
+    expect(
+      fs.readFileSync(path.join(resolvedBaseCommonDirectory, commonDirectorySentinelName), "utf8"),
+    ).toBe(commonDirectorySentinelContents);
+    expect(
+      fs.readFileSync(
+        path.join(resolvedTreatmentCommonDirectory, commonDirectorySentinelName),
+        "utf8",
+      ),
+    ).toBe(commonDirectorySentinelContents);
+    expect(
+      execFileSync(
+        "git",
+        ["--git-dir", resolvedBaseCommonDirectory, "rev-parse", "--is-bare-repository"],
+        { encoding: "utf8" },
+      ).trim(),
+    ).toBe("true");
 
     fs.writeFileSync(path.join(baseWorkDirectory, "doctor.config.ts"), "base\n");
     fs.writeFileSync(path.join(treatmentWorkDirectory, "doctor.config.ts"), "treatment\n");

--- a/packages/evals/tests/paired-target-worktrees.test.ts
+++ b/packages/evals/tests/paired-target-worktrees.test.ts
@@ -63,12 +63,19 @@ describe("SETUP_PAIRED_TARGET_REPOSITORY_COMMAND", () => {
         encoding: "utf8",
       }).trim(),
     ).toBe(targetRef);
-    expect(fs.readFileSync(path.join(baseWorkDirectory, ".git"), "utf8")).toContain(
-      targetRepositoryDirectory,
+    const resolvedTargetRepositoryDirectory = fs.realpathSync(targetRepositoryDirectory);
+    const resolvedBaseCommonDirectory = fs.realpathSync(
+      execFileSync("git", ["-C", baseWorkDirectory, "rev-parse", "--git-common-dir"], {
+        encoding: "utf8",
+      }).trim(),
     );
-    expect(fs.readFileSync(path.join(treatmentWorkDirectory, ".git"), "utf8")).toContain(
-      targetRepositoryDirectory,
+    const resolvedTreatmentCommonDirectory = fs.realpathSync(
+      execFileSync("git", ["-C", treatmentWorkDirectory, "rev-parse", "--git-common-dir"], {
+        encoding: "utf8",
+      }).trim(),
     );
+    expect(resolvedBaseCommonDirectory).toBe(resolvedTargetRepositoryDirectory);
+    expect(resolvedTreatmentCommonDirectory).toBe(resolvedTargetRepositoryDirectory);
 
     fs.writeFileSync(path.join(baseWorkDirectory, "doctor.config.ts"), "base\n");
     fs.writeFileSync(path.join(treatmentWorkDirectory, "doctor.config.ts"), "treatment\n");

--- a/packages/evals/tests/paired-target-worktrees.test.ts
+++ b/packages/evals/tests/paired-target-worktrees.test.ts
@@ -1,0 +1,82 @@
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { afterEach, describe, expect, it } from "vite-plus/test";
+
+import {
+  BASE_TARGET_WORK_DIRECTORY,
+  SETUP_PAIRED_TARGET_REPOSITORY_COMMAND,
+  TARGET_REPOSITORY_DIRECTORY,
+  TREATMENT_TARGET_WORK_DIRECTORY,
+} from "../src/constants.js";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const temporaryDirectory of temporaryDirectories.splice(0)) {
+    fs.rmSync(temporaryDirectory, { force: true, recursive: true });
+  }
+});
+
+describe("SETUP_PAIRED_TARGET_REPOSITORY_COMMAND", () => {
+  it("shares fetched objects while isolating base and treatment worktrees", () => {
+    const temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-pair-"));
+    temporaryDirectories.push(temporaryDirectory);
+    const sourceDirectory = path.join(temporaryDirectory, "source");
+    const targetRepositoryDirectory = path.join(temporaryDirectory, "target-repository.git");
+    const baseWorkDirectory = path.join(temporaryDirectory, "target-base");
+    const treatmentWorkDirectory = path.join(temporaryDirectory, "target-treatment");
+    fs.mkdirSync(sourceDirectory, { recursive: true });
+    fs.writeFileSync(path.join(sourceDirectory, "package.json"), "{}\n");
+    execFileSync("git", ["-C", sourceDirectory, "init", "-q"]);
+    execFileSync("git", ["-C", sourceDirectory, "config", "user.email", "test@example.com"]);
+    execFileSync("git", ["-C", sourceDirectory, "config", "user.name", "Test"]);
+    execFileSync("git", ["-C", sourceDirectory, "add", "."]);
+    execFileSync("git", ["-C", sourceDirectory, "commit", "-q", "-m", "fixture"]);
+    const targetRef = execFileSync("git", ["-C", sourceDirectory, "rev-parse", "HEAD"], {
+      encoding: "utf8",
+    }).trim();
+    const command = SETUP_PAIRED_TARGET_REPOSITORY_COMMAND.replaceAll(
+      TARGET_REPOSITORY_DIRECTORY,
+      targetRepositoryDirectory,
+    )
+      .replaceAll(BASE_TARGET_WORK_DIRECTORY, baseWorkDirectory)
+      .replaceAll(TREATMENT_TARGET_WORK_DIRECTORY, treatmentWorkDirectory);
+
+    execFileSync("sh", ["-c", command], {
+      env: {
+        ...process.env,
+        TARGET_REPOSITORY: sourceDirectory,
+        TARGET_REF: targetRef,
+      },
+    });
+
+    expect(
+      execFileSync("git", ["-C", baseWorkDirectory, "rev-parse", "HEAD"], {
+        encoding: "utf8",
+      }).trim(),
+    ).toBe(targetRef);
+    expect(
+      execFileSync("git", ["-C", treatmentWorkDirectory, "rev-parse", "HEAD"], {
+        encoding: "utf8",
+      }).trim(),
+    ).toBe(targetRef);
+    expect(fs.readFileSync(path.join(baseWorkDirectory, ".git"), "utf8")).toContain(
+      targetRepositoryDirectory,
+    );
+    expect(fs.readFileSync(path.join(treatmentWorkDirectory, ".git"), "utf8")).toContain(
+      targetRepositoryDirectory,
+    );
+
+    fs.writeFileSync(path.join(baseWorkDirectory, "doctor.config.ts"), "base\n");
+    fs.writeFileSync(path.join(treatmentWorkDirectory, "doctor.config.ts"), "treatment\n");
+    expect(fs.readFileSync(path.join(baseWorkDirectory, "doctor.config.ts"), "utf8")).toBe(
+      "base\n",
+    );
+    expect(fs.readFileSync(path.join(treatmentWorkDirectory, "doctor.config.ts"), "utf8")).toBe(
+      "treatment\n",
+    );
+  });
+});

--- a/packages/evals/tests/parse-evaluation-arguments.test.ts
+++ b/packages/evals/tests/parse-evaluation-arguments.test.ts
@@ -65,6 +65,83 @@ describe("parseEvaluationArguments", () => {
     );
   });
 
+  it("accepts an isolated paired baseline with independent rules and execution policy", () => {
+    expect(
+      parseEvaluationArguments([
+        "--react-doctor-repository",
+        "https://github.com/example/treatment.git",
+        "--react-doctor-ref",
+        "c".repeat(40),
+        "--rule",
+        "react-doctor/treatment-rule",
+        "--paired-baseline-output",
+        "/tmp/baseline.ndjson",
+        "--paired-base-react-doctor-repository",
+        "https://github.com/example/base.git",
+        "--paired-base-react-doctor-ref",
+        "b".repeat(40),
+        "--paired-base-rule",
+        "react-doctor/base-rule",
+        "--paired-base-rule",
+        "react-doctor/base-rule",
+        "--paired-execution",
+        "sequential",
+      ]),
+    ).toMatchObject({
+      concurrency: 50,
+      reactDoctorRepository: "https://github.com/example/treatment.git",
+      reactDoctorRef: "c".repeat(40),
+      ruleKeys: ["react-doctor/treatment-rule"],
+      paired: {
+        baselineOutputPath: "/tmp/baseline.ndjson",
+        baseReactDoctorRepository: "https://github.com/example/base.git",
+        baseReactDoctorRef: "b".repeat(40),
+        baseRuleKeys: ["react-doctor/base-rule"],
+        execution: "sequential",
+      },
+    });
+  });
+
+  it("requires paired output and base ref together", () => {
+    expect(() =>
+      parseEvaluationArguments(["--paired-base-react-doctor-ref", "b".repeat(40)]),
+    ).toThrow("requires --paired-baseline-output and --paired-base-react-doctor-ref");
+    expect(() =>
+      parseEvaluationArguments(["--paired-baseline-output", "/tmp/baseline.ndjson"]),
+    ).toThrow("requires --paired-baseline-output and --paired-base-react-doctor-ref");
+  });
+
+  it("rejects unsafe paired output, execution, and rule arguments", () => {
+    expect(() =>
+      parseEvaluationArguments([
+        "--paired-baseline-output",
+        "baseline.ndjson",
+        "--paired-base-react-doctor-ref",
+        "b".repeat(40),
+      ]),
+    ).toThrow("absolute path");
+    expect(() =>
+      parseEvaluationArguments([
+        "--paired-baseline-output",
+        "/tmp/baseline.ndjson",
+        "--paired-base-react-doctor-ref",
+        "b".repeat(40),
+        "--paired-execution",
+        "sometimes",
+      ]),
+    ).toThrow("auto, parallel, or sequential");
+    expect(() =>
+      parseEvaluationArguments([
+        "--paired-baseline-output",
+        "/tmp/baseline.ndjson",
+        "--paired-base-react-doctor-ref",
+        "b".repeat(40),
+        "--paired-base-rule",
+        "react-doctor/rule;false",
+      ]),
+    ).toThrow("canonical plugin/rule key");
+  });
+
   it("rejects invalid scale and duration controls", () => {
     expect(() => parseEvaluationArguments(["--repository-limit", "0"])).toThrow("positive integer");
     expect(() => parseEvaluationArguments(["--repositories-per-sandbox", "0"])).toThrow(

--- a/packages/evals/tests/run-corpus-evaluation.test.ts
+++ b/packages/evals/tests/run-corpus-evaluation.test.ts
@@ -1,0 +1,46 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { afterEach, describe, expect, it } from "vite-plus/test";
+
+import { runCorpusEvaluation } from "../src/run-corpus-evaluation.js";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const temporaryDirectory of temporaryDirectories.splice(0)) {
+    fs.rmSync(temporaryDirectory, { force: true, recursive: true });
+  }
+});
+
+describe("runCorpusEvaluation", () => {
+  it("refuses to overwrite an existing paired baseline before creating Daytona resources", async () => {
+    const temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-pair-"));
+    temporaryDirectories.push(temporaryDirectory);
+    const baselineOutputPath = path.join(temporaryDirectory, "baseline.ndjson");
+    fs.writeFileSync(baselineOutputPath, "immutable\n");
+
+    await expect(
+      runCorpusEvaluation({
+        repositoriesSources: [path.join(temporaryDirectory, "missing-corpus.json")],
+        repositoryLimit: 1,
+        concurrency: 1,
+        repositoriesPerSandbox: 1,
+        projectRootsPerRepository: 1,
+        maxDurationMinutes: 20,
+        reactDoctorRepository: "https://github.com/millionco/react-doctor.git",
+        reactDoctorRef: "c".repeat(40),
+        ruleKeys: [],
+        paired: {
+          baselineOutputPath,
+          baseReactDoctorRepository: "https://github.com/millionco/react-doctor.git",
+          baseReactDoctorRef: "b".repeat(40),
+          baseRuleKeys: [],
+          execution: "auto",
+        },
+      }),
+    ).rejects.toMatchObject({ code: "EEXIST" });
+    expect(fs.readFileSync(baselineOutputPath, "utf8")).toBe("immutable\n");
+  });
+});


### PR DESCRIPTION
## Why

A parity cache miss previously evaluated base and treatment in separate Daytona runs. That duplicated target fetches, sandbox startup, and corpus traversal, making the full 2,000-project gate too slow for ordinary rule PRs.

## What

- adds an opt-in paired evaluator that builds base and treatment detectors into one snapshot
- fetches each target repository once into one bare object store and creates isolated base/treatment worktrees
- isolates detector installs, rule configs, report paths, and provenance
- runs both scans in parallel on four-core sandboxes by default, with an explicit sequential mode
- caps each paired scan at five minutes and defaults paired runs to concurrency 50
- writes the baseline to a new exclusive 0600 NDJSON artifact and preserves the candidate stream on stdout
- documents cache-hit candidate-only and cache-miss paired parity workflows

## Evaluation

Exact 2,000-project replay:

| Metric | Previous path | Paired path |
| --- | ---: | ---: |
| Wall time | 1,449.079s | 811s |
| Speedup | — | 1.787x |
| Reduction | — | 44.03% |
| Completed | 2,000 | 2,000 |
| Final failures | 0 | 0 |

Parity compared all 2,000 projects: 2,496 diagnostics unchanged, with one removed and one added diagnostic. Exact source reconstruction showed the same async-await-in-loop rule relocating from an outer await to the awaited embedding call in Qeagle/reporter-engine; classified as a true-positive relocation, not an FP or FN.

All task-created Daytona sandboxes and the exact snapshot were deleted and verified absent after the run.

## Validation

- focused eval tests: 79 passed
- full test suite: passed
- lint: passed, pre-existing fuzz-corpus warnings only
- typecheck: passed
- format check: passed
- build: passed
- JSON report smoke: passed
- parity helper suites: 90 passed
- React Doctor changed-scope scan: 100/100, no issues
- post-change truffler duplicate search: no duplicate helpers

No changeset: this changes private eval tooling and the internal parity skill, not a published package surface.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large change to private eval/Daytona orchestration and artifact semantics; failures invalidate both outputs, but scope is internal tooling with strong test coverage rather than published product APIs.
> 
> **Overview**
> Adds an **opt-in paired evaluator** so parity cache misses can run base and treatment React Doctor in a **single Daytona sandbox** instead of two full corpus passes.
> 
> New `--paired-*` flags build **both detector revisions** into one snapshot (larger 4-core sandboxes, default concurrency **50**, **5-minute** per-scan cap). Each target repo is **fetched once** into a bare store with **isolated base/treatment worktrees**; scans use separate installs, rule keys, configs, reports, and provenance. Pairs are emitted only when **both sides succeed**; a **single-writer** NDJSON path writes baseline to an **exclusive `0600` file** and candidate to stdout, with **baseline rollback** if the treatment sink fails.
> 
> Sandbox commands are **parameterized via env** (`REACT_DOCTOR_WORK_DIRECTORY`, `TARGET_CHECKOUT_DIRECTORY`, etc.) so the same `SCAN_COMMAND` serves single and paired modes. The **run-parity** skill documents cache-hit candidate-only runs versus cache-miss paired runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7c7881e6a578c872c39d0b55f5557929d7e05e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->