### PR TITLE
fix: [server-auth-actions] skip credential-establishing endpoints

### DIFF
--- a/.changeset/fix-server-auth-actions-credential-establishing.md
+++ b/.changeset/fix-server-auth-actions-credential-establishing.md
@@ -1,0 +1,12 @@
+---
+"oxlint-plugin-react-doctor": patch
+"react-doctor": patch
+---
+
+fix(server-auth-actions): skip credential-establishing actions via SDK detection
+
+The `server-auth-actions` rule now correctly skips server actions that perform credential-establishing operations (signup, signin, OTP verification, password reset) by detecting calls to auth SDK methods like `supabase.auth.signUp()`, `auth.signInWithPassword()`, and `auth.verifyOtp()`. These actions legitimately run for anonymous callers, so requiring authentication would be incorrect.
+
+This resolves the documented false positive where credential-establishing endpoints were incorrectly flagged as unauthenticated privileged operations.
+
+Closes #1538

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-auth-actions.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-auth-actions.regressions.test.ts
@@ -131,6 +131,68 @@ describe("server/server-auth-actions — regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("uses the executed auth SDK call when the action name is neutral", () => {
+    const result = runRule(
+      serverAuthActions,
+      `"use server";
+      export async function createAccountAction(input) {
+        const supabase = await createClient();
+        const { data, error } = await supabase.auth.signUp(input);
+        if (error) return { error: error.message };
+        await supabase.from("profiles").update({ ready: true }).eq("id", data.user.id);
+        return { success: true };
+      }`,
+      { filename: "app/actions/auth.ts" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still flags unrelated auth methods", () => {
+    const result = runRule(
+      serverAuthActions,
+      `"use server";
+      export async function deleteAccountAction(input) {
+        const supabase = await createClient();
+        await supabase.auth.signOut();
+        await supabase.from("profiles").delete().eq("id", input.id);
+      }`,
+      { filename: "app/actions/auth.ts" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags credential calls hidden in uncalled helpers", () => {
+    const result = runRule(
+      serverAuthActions,
+      `"use server";
+      export async function updateAccountAction(input) {
+        const establishCredentials = async () => {
+          await supabase.auth.signUp(input);
+        };
+        await supabase.from("profiles").update(input.profile).eq("id", input.id);
+      }`,
+      { filename: "app/actions/auth.ts" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags similarly named methods outside an auth receiver", () => {
+    const result = runRule(
+      serverAuthActions,
+      `"use server";
+      export async function updateAccountAction(input) {
+        await marketing.signUp(input.email);
+        await database.users.update(input.profile);
+      }`,
+      { filename: "app/actions/auth.ts" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("still flags a privileged ungated action", () => {
     const result = runRule(
       serverAuthActions,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-auth-actions.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-auth-actions.regressions.test.ts
@@ -163,6 +163,21 @@ describe("server/server-auth-actions — regressions", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("still flags unrelated actions that happen to establish credentials", () => {
+    const result = runRule(
+      serverAuthActions,
+      `"use server";
+      export async function purgeDataAction(input) {
+        const supabase = await createClient();
+        await supabase.auth.signUp(input);
+        await database.users.delete(input.userId);
+      }`,
+      { filename: "app/actions/admin.ts" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("still flags credential calls hidden in uncalled helpers", () => {
     const result = runRule(
       serverAuthActions,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-auth-actions.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-auth-actions.regressions.test.ts
@@ -145,6 +145,36 @@ describe("server/server-auth-actions — regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("recognizes documented leading credential aliases", () => {
+    const sources = [
+      `"use server";
+       export async function verifyAuthCodePhoneAction(input) {
+         await auth.verifyOtp(input.code);
+         await database.sessions.update(input.session);
+       }`,
+      `"use server";
+       export async function emailVerificationAction(input) {
+         await auth.verifyEmail(input.token);
+         await database.sessions.update(input.session);
+       }`,
+      `"use server";
+       export async function passwordResetAction(input) {
+         await auth.resetPasswordForEmail(input.email);
+         await database.sessions.update(input.session);
+       }`,
+      `"use server";
+       export async function SIGN_UP_PHONE_ONLY_ACTION(input) {
+         await authClient.signUp(input);
+         await database.sessions.update(input.session);
+       }`,
+    ];
+    for (const source of sources) {
+      const result = runRule(serverAuthActions, source, { filename: "app/actions/auth.ts" });
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    }
+  });
+
   it("uses the executed auth SDK call when the action name is neutral", () => {
     const result = runRule(
       serverAuthActions,
@@ -215,6 +245,11 @@ describe("server/server-auth-actions — regressions", () => {
        export async function syncProfileForRegistrationAction(input) {
          const supabase = await createClient();
          await supabase.auth.signUp(input);
+         await database.users.delete(input.userId);
+       }`,
+      `"use server";
+       export async function DELETE_ACCOUNT_AFTER_SIGN_UP_ACTION(input) {
+         await authClient.signUp(input);
          await database.users.delete(input.userId);
        }`,
     ];

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-auth-actions.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-auth-actions.regressions.test.ts
@@ -179,18 +179,24 @@ describe("server/server-auth-actions — regressions", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
-  it("still flags similarly named methods outside an auth receiver", () => {
-    const result = runRule(
-      serverAuthActions,
+  it("still flags credential lookalikes outside a known auth provider", () => {
+    const sources = [
       `"use server";
-      export async function updateAccountAction(input) {
-        await marketing.signUp(input.email);
-        await database.users.update(input.profile);
-      }`,
-      { filename: "app/actions/auth.ts" },
-    );
-    expect(result.parseErrors).toEqual([]);
-    expect(result.diagnostics).toHaveLength(1);
+       export async function updateAccountAction(input) {
+         await marketing.signUp(input.email);
+         await database.users.update(input.profile);
+       }`,
+      `"use server";
+       export async function updateAccountAction(input) {
+         await analytics.auth.signUp({ event: "campaign" });
+         await database.users.update(input.profile);
+       }`,
+    ];
+    for (const source of sources) {
+      const result = runRule(serverAuthActions, source, { filename: "app/actions/auth.ts" });
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    }
   });
 
   it("still flags a privileged ungated action", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-auth-actions.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-auth-actions.regressions.test.ts
@@ -110,12 +110,12 @@ describe("server/server-auth-actions — regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
-  it("does not flag Supabase verifyOtp actions (credential-establishing SDK call)", () => {
+  it("does not flag extended Supabase verifyOtp actions (credential-establishing SDK call)", () => {
     const result = runRule(
       serverAuthActions,
       `"use server";
       import { createClient } from "@/lib/supabase/server";
-      export async function verifyOtpAction(input) {
+      export async function verifyOtpPhoneAction(input) {
         const supabase = await createClient();
         const { data, error } = await supabase.auth.verifyOtp({
           phone: input.phone,
@@ -124,6 +124,20 @@ describe("server/server-auth-actions — regressions", () => {
         });
         if (error) return { error: error.message };
         return { success: true, session: data.session };
+      }`,
+      { filename: "app/actions/auth.ts" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not flag extended OAuth callback actions", () => {
+    const result = runRule(
+      serverAuthActions,
+      `"use server";
+      export async function handleOAuthCallbackAction(input) {
+        await auth.handleOAuthCallback(input.code);
+        await database.sessions.update(input.session);
       }`,
       { filename: "app/actions/auth.ts" },
     );
@@ -184,18 +198,31 @@ describe("server/server-auth-actions — regressions", () => {
   });
 
   it("still flags unrelated actions that happen to establish credentials", () => {
-    const result = runRule(
-      serverAuthActions,
+    const sources = [
       `"use server";
-      export async function purgeDataAction(input) {
-        const supabase = await createClient();
-        await supabase.auth.signUp(input);
-        await database.users.delete(input.userId);
-      }`,
-      { filename: "app/actions/admin.ts" },
-    );
-    expect(result.parseErrors).toEqual([]);
-    expect(result.diagnostics).toHaveLength(1);
+       export async function purgeDataAction(input) {
+         const supabase = await createClient();
+         await supabase.auth.signUp(input);
+         await database.users.delete(input.userId);
+       }`,
+      `"use server";
+       export async function deleteAccountAfterSignupAction(input) {
+         const supabase = await createClient();
+         await supabase.auth.signUp(input);
+         await database.users.delete(input.userId);
+       }`,
+      `"use server";
+       export async function syncProfileForRegistrationAction(input) {
+         const supabase = await createClient();
+         await supabase.auth.signUp(input);
+         await database.users.delete(input.userId);
+       }`,
+    ];
+    for (const source of sources) {
+      const result = runRule(serverAuthActions, source, { filename: "app/actions/admin.ts" });
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    }
   });
 
   it("still flags credential calls hidden in uncalled helpers", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-auth-actions.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-auth-actions.regressions.test.ts
@@ -69,6 +69,68 @@ describe("server/server-auth-actions — regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("does not flag Supabase signUp actions (credential-establishing SDK call)", () => {
+    const result = runRule(
+      serverAuthActions,
+      `"use server";
+      import { createClient } from "@/lib/supabase/server";
+      export async function signUpPhoneOnlyAction(input) {
+        const supabase = await createClient();
+        const { data, error } = await supabase.auth.signUp({
+          phone: input.phone,
+          password: input.password,
+        });
+        if (error) return { error: error.message };
+        await supabase.from("profiles").update({ phone: input.phone }).eq("id", data.user.id);
+        return { success: true };
+      }`,
+      { filename: "app/actions/auth.ts" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not flag Supabase signIn actions (credential-establishing SDK call)", () => {
+    const result = runRule(
+      serverAuthActions,
+      `"use server";
+      import { createClient } from "@/lib/supabase/server";
+      export async function loginWithEmailAction(input) {
+        const supabase = await createClient();
+        const { data, error } = await supabase.auth.signInWithPassword({
+          email: input.email,
+          password: input.password,
+        });
+        if (error) return { error: error.message };
+        return { success: true, user: data.user };
+      }`,
+      { filename: "app/actions/auth.ts" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not flag Supabase verifyOtp actions (credential-establishing SDK call)", () => {
+    const result = runRule(
+      serverAuthActions,
+      `"use server";
+      import { createClient } from "@/lib/supabase/server";
+      export async function verifyOtpAction(input) {
+        const supabase = await createClient();
+        const { data, error } = await supabase.auth.verifyOtp({
+          phone: input.phone,
+          token: input.token,
+          type: "sms",
+        });
+        if (error) return { error: error.message };
+        return { success: true, session: data.session };
+      }`,
+      { filename: "app/actions/auth.ts" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("still flags a privileged ungated action", () => {
     const result = runRule(
       serverAuthActions,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-auth-actions.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-auth-actions.regressions.test.ts
@@ -148,6 +148,26 @@ describe("server/server-auth-actions — regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("recognizes credential calls on direct auth namespaces", () => {
+    const sources = [
+      `"use server";
+       export async function createAccountAction(input) {
+         await auth.signUp(input);
+         await database.users.update(input.profile);
+       }`,
+      `"use server";
+       export async function createAccountAction(input) {
+         await authClient.resetPasswordForEmail(input.email);
+         await database.users.update(input.profile);
+       }`,
+    ];
+    for (const source of sources) {
+      const result = runRule(serverAuthActions, source, { filename: "app/actions/auth.ts" });
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    }
+  });
+
   it("still flags unrelated auth methods", () => {
     const result = runRule(
       serverAuthActions,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-auth-actions.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-auth-actions.ts
@@ -1547,6 +1547,8 @@ const containsCredentialEstablishingAuthCall = (
       if (!isNodeOfType(receiverObject, "MemberExpression") || receiverObject.computed) return;
       const receiverProperty = getStaticPropertyName(receiverObject);
       if (receiverProperty !== "auth") return;
+      const providerSource = buildDottedReceiverSource(receiverObject.object);
+      if (!AUTH_OBJECT_PATTERN.test(providerSource)) return;
       foundCredentialCall = true;
       return false;
     });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-auth-actions.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-auth-actions.ts
@@ -1503,8 +1503,13 @@ const CREDENTIAL_OPERATION_NAMES: ReadonlySet<string> = new Set([
 const CREDENTIAL_OPERATION_PREFIX_NAMES: ReadonlySet<string> = new Set([
   ...CREDENTIAL_OPERATION_NAMES,
   "createaccount",
+  "emailverification",
   "handleoauthcallback",
+  "passwordreset",
+  "verifyauthcode",
 ]);
+
+const CREDENTIAL_ACTION_NAME_SEPARATOR_PATTERN = /[_$]+/g;
 
 const CREDENTIAL_ESTABLISHING_AUTH_SDK_METHODS: ReadonlySet<string> = new Set([
   "signUp",
@@ -1531,13 +1536,17 @@ const CREDENTIAL_ESTABLISHING_AUTH_SDK_METHODS: ReadonlySet<string> = new Set([
 // email verify, password reset) legitimately runs for anonymous callers —
 // no prior session can exist, so demanding an auth() gate on it is wrong.
 const isCredentialEstablishingActionName = (actionName: string): boolean => {
-  const tokens = mergeCredentialPhraseTokens(tokenizeIdentifierWords(actionName));
+  const tokens = mergeCredentialPhraseTokens(
+    tokenizeIdentifierWords(actionName.replace(CREDENTIAL_ACTION_NAME_SEPARATOR_PATTERN, " ")),
+  );
   const operationTokens = tokens.at(-1) === "action" ? tokens.slice(0, -1) : tokens;
   return CREDENTIAL_OPERATION_NAMES.has(operationTokens.join(""));
 };
 
 const hasCredentialEstablishingActionNameSignal = (actionName: string): boolean => {
-  const tokens = mergeCredentialPhraseTokens(tokenizeIdentifierWords(actionName));
+  const tokens = mergeCredentialPhraseTokens(
+    tokenizeIdentifierWords(actionName.replace(CREDENTIAL_ACTION_NAME_SEPARATOR_PATTERN, " ")),
+  );
   const operationTokens = tokens.at(-1) === "action" ? tokens.slice(0, -1) : tokens;
   for (let prefixLength = operationTokens.length; prefixLength > 0; prefixLength -= 1) {
     const prefix = operationTokens.slice(0, prefixLength).join("");

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-auth-actions.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-auth-actions.ts
@@ -1576,7 +1576,7 @@ const inspectServerAction = (
   if (hasPublicNameToken(candidate.displayName)) return;
 
   const executionGraph = collectExecutedFunctionBodies(candidate.functionNode, context);
-  
+
   if (containsCredentialEstablishingAuthCall(executionGraph, context)) return;
 
   const rootNodes = collectAuthScanRoots(candidate.functionNode, context);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-auth-actions.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-auth-actions.ts
@@ -1530,6 +1530,15 @@ const isCredentialEstablishingActionName = (actionName: string): boolean => {
   return CREDENTIAL_OPERATION_NAMES.has(operationTokens.join(""));
 };
 
+const hasCredentialEstablishingActionNameSignal = (actionName: string): boolean => {
+  const tokens = mergeCredentialPhraseTokens(tokenizeIdentifierWords(actionName));
+  const operationTokens = tokens.at(-1) === "action" ? tokens.slice(0, -1) : tokens;
+  return (
+    operationTokens.join("") === "createaccount" ||
+    operationTokens.some((token) => CREDENTIAL_OPERATION_NAMES.has(token))
+  );
+};
+
 const containsCredentialEstablishingAuthCall = (
   executionGraph: ExecutedFunctionGraph,
   context: RuleContext,
@@ -1579,7 +1588,12 @@ const inspectServerAction = (
 
   const executionGraph = collectExecutedFunctionBodies(candidate.functionNode, context);
 
-  if (containsCredentialEstablishingAuthCall(executionGraph, context)) return;
+  if (
+    hasCredentialEstablishingActionNameSignal(candidate.displayName) &&
+    containsCredentialEstablishingAuthCall(executionGraph, context)
+  ) {
+    return;
+  }
 
   const rootNodes = collectAuthScanRoots(candidate.functionNode, context);
   if (

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-auth-actions.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-auth-actions.ts
@@ -1500,6 +1500,12 @@ const CREDENTIAL_OPERATION_NAMES: ReadonlySet<string> = new Set([
   "magiclink",
 ]);
 
+const CREDENTIAL_OPERATION_PREFIX_NAMES: ReadonlySet<string> = new Set([
+  ...CREDENTIAL_OPERATION_NAMES,
+  "createaccount",
+  "handleoauthcallback",
+]);
+
 const CREDENTIAL_ESTABLISHING_AUTH_SDK_METHODS: ReadonlySet<string> = new Set([
   "signUp",
   "signup",
@@ -1533,10 +1539,11 @@ const isCredentialEstablishingActionName = (actionName: string): boolean => {
 const hasCredentialEstablishingActionNameSignal = (actionName: string): boolean => {
   const tokens = mergeCredentialPhraseTokens(tokenizeIdentifierWords(actionName));
   const operationTokens = tokens.at(-1) === "action" ? tokens.slice(0, -1) : tokens;
-  return (
-    operationTokens.join("") === "createaccount" ||
-    operationTokens.some((token) => CREDENTIAL_OPERATION_NAMES.has(token))
-  );
+  for (let prefixLength = operationTokens.length; prefixLength > 0; prefixLength -= 1) {
+    const prefix = operationTokens.slice(0, prefixLength).join("");
+    if (CREDENTIAL_OPERATION_PREFIX_NAMES.has(prefix)) return true;
+  }
+  return false;
 };
 
 const containsCredentialEstablishingAuthCall = (

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-auth-actions.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-auth-actions.ts
@@ -1552,11 +1552,17 @@ const containsCredentialEstablishingAuthCall = (
       if (!isNodeOfType(callee, "MemberExpression") || callee.computed) return;
       const methodName = getStaticPropertyName(callee);
       if (!methodName || !CREDENTIAL_ESTABLISHING_AUTH_SDK_METHODS.has(methodName)) return;
-      const receiverObject = unwrapTypeWrappedCallee(callee.object);
-      if (!isNodeOfType(receiverObject, "MemberExpression") || receiverObject.computed) return;
-      const receiverProperty = getStaticPropertyName(receiverObject);
-      if (receiverProperty !== "auth") return;
-      const providerSource = buildDottedReceiverSource(receiverObject.object);
+      const authReceiver = unwrapTypeWrappedCallee(callee.object);
+      let providerSource: string;
+      if (isNodeOfType(authReceiver, "Identifier")) {
+        providerSource = authReceiver.name;
+      } else if (isNodeOfType(authReceiver, "MemberExpression") && !authReceiver.computed) {
+        const receiverProperty = getStaticPropertyName(authReceiver);
+        if (receiverProperty !== "auth") return;
+        providerSource = buildDottedReceiverSource(authReceiver.object);
+      } else {
+        return;
+      }
       if (!AUTH_OBJECT_PATTERN.test(providerSource)) return;
       foundCredentialCall = true;
       return false;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-auth-actions.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/server/server-auth-actions.ts
@@ -1500,6 +1500,27 @@ const CREDENTIAL_OPERATION_NAMES: ReadonlySet<string> = new Set([
   "magiclink",
 ]);
 
+const CREDENTIAL_ESTABLISHING_AUTH_SDK_METHODS: ReadonlySet<string> = new Set([
+  "signUp",
+  "signup",
+  "signIn",
+  "signin",
+  "signInWithPassword",
+  "signInWithOtp",
+  "signInWithOAuth",
+  "signInWithEmail",
+  "signInWithPhone",
+  "signInAnonymously",
+  "verifyOtp",
+  "verifyEmail",
+  "confirmOtp",
+  "resetPasswordForEmail",
+  "sendPasswordResetEmail",
+  "handleOAuthCallback",
+  "handleCallback",
+  "exchangeCodeForSession",
+]);
+
 // A credential-establishing action (login, signup, OAuth callback, OTP /
 // email verify, password reset) legitimately runs for anonymous callers —
 // no prior session can exist, so demanding an auth() gate on it is wrong.
@@ -1507,6 +1528,31 @@ const isCredentialEstablishingActionName = (actionName: string): boolean => {
   const tokens = mergeCredentialPhraseTokens(tokenizeIdentifierWords(actionName));
   const operationTokens = tokens.at(-1) === "action" ? tokens.slice(0, -1) : tokens;
   return CREDENTIAL_OPERATION_NAMES.has(operationTokens.join(""));
+};
+
+const containsCredentialEstablishingAuthCall = (
+  executionGraph: ExecutedFunctionGraph,
+  context: RuleContext,
+): boolean => {
+  for (const executedBody of executionGraph.bodies) {
+    let foundCredentialCall = false;
+    walkExecutedServerActionNodes(executedBody, context, (node) => {
+      if (foundCredentialCall) return false;
+      if (!isNodeOfType(node, "CallExpression")) return;
+      const callee = unwrapTypeWrappedCallee(node.callee);
+      if (!isNodeOfType(callee, "MemberExpression") || callee.computed) return;
+      const methodName = getStaticPropertyName(callee);
+      if (!methodName || !CREDENTIAL_ESTABLISHING_AUTH_SDK_METHODS.has(methodName)) return;
+      const receiverObject = unwrapTypeWrappedCallee(callee.object);
+      if (!isNodeOfType(receiverObject, "MemberExpression") || receiverObject.computed) return;
+      const receiverProperty = getStaticPropertyName(receiverObject);
+      if (receiverProperty !== "auth") return;
+      foundCredentialCall = true;
+      return false;
+    });
+    if (foundCredentialCall) return true;
+  }
+  return false;
 };
 
 // Naming an exported action "public" (`getPostPublicAction`) declares the
@@ -1530,6 +1576,9 @@ const inspectServerAction = (
   if (hasPublicNameToken(candidate.displayName)) return;
 
   const executionGraph = collectExecutedFunctionBodies(candidate.functionNode, context);
+  
+  if (containsCredentialEstablishingAuthCall(executionGraph, context)) return;
+
   const rootNodes = collectAuthScanRoots(candidate.functionNode, context);
   if (
     containsAuthCheck(


### PR DESCRIPTION
## Why

`server-auth-actions` reported credential-establishing endpoints such as signup, OTP verification, email verification, OAuth callbacks, and password reset. These endpoints legitimately run for anonymous callers, so requiring a prior session creates an unfixable false positive.

## What changed

- Exempt credential-establishing actions only when a leading credential-intent name is corroborated by an executed known auth SDK call.
- Support direct auth namespaces (`auth.signUp`, `authClient.resetPasswordForEmail`) and provider namespaces such as `supabase.auth.signUp` without accepting unrelated lookalikes such as `analytics.auth.signUp`.
- Normalize camelCase and screaming-snake action names and cover documented aliases including `verifyAuthCode`, `emailVerification`, `passwordReset`, and `handleOAuthCallback`.
- Preserve diagnostics for unrelated privileged actions, non-leading credential words, uncalled helpers, unrelated auth methods, and unknown providers.
- Add a patch changeset for `oxlint-plugin-react-doctor` and `react-doctor`.

## Eval results

| Check             | Result                              |
| ----------------- | ----------------------------------- |
| Projects compared | `2,000`                                            |
| Skipped projects  | `0`                                                |
| Added / removed   | `0 / 1`                                            |
| Target rule delta | `0 / 1`                                            |
| False positives   | `1` confirmed baseline FP removed                  |
| Artifacts         | Daytona `bd4a14ae-b2c9-4979-a164-29e784ad6ed3`; parity SHA-256 `6afd44a9d7ab481994220b074a9ef7121fb9226b3c6cec2577c7d8b101193a1f` |

The sole removal is `antoineross/Hikari@c1f16f54:utils/auth-helpers/server.ts:33`. `signInWithEmail` validates the email, calls `supabase.auth.signInWithOtp`, and writes only a preferred-sign-in-view cookie after the credential call succeeds. This is the intended credential-establishing-endpoint false-positive fix. There were no added diagnostics.

## Test plan

- `nr test src/plugin/rules/server/server-auth-actions.regressions.test.ts` — 84/84 passed
- `nr test` in `packages/oxlint-plugin-react-doctor` — 25,519 passed, 201 skipped
- `FUZZ_RULE=server-auth-actions FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz` — passed
- Bounded RDE — 5/5 roots processed, zero `server-auth-actions` hits; JSONL SHA-256 `4f45015866557fbf59ab4e92de0f28bc900f9510df848e90f1b97dd29581b70c`
- `nr typecheck` — 16/16 tasks passed
- `nr format:check` — passed
- `nr test` — 15/15 tasks passed
- `nr lint` — passed (existing warnings only)
- `nr build` — 9/9 tasks passed
- `nr smoke:json-report` — passed (`schemaVersion=3`, full mode)
- Exact one-rule current-main Daytona parity — 2,000/2,000 projects, 0 skipped, 0 added / 1 confirmed-FP removed
- GitHub build, lint, typecheck, CodeQL, React Doctor, package preview, and platform test matrix — passed

Closes #1538
