### PR TITLE
FPFNFIX82: RDFPFN82026: ignore empty ref registries

### DIFF
--- a/.changeset/quiet-empty-ref-registries.md
+++ b/.changeset/quiet-empty-ref-registries.md
@@ -1,0 +1,6 @@
+---
+"oxlint-plugin-react-doctor": patch
+"eslint-plugin-react-doctor": patch
+---
+
+Avoid reporting `rerender-lazy-ref-init` for empty built-in registry constructors.

--- a/packages/fuzz/corpus/regressions/rerender-lazy-ref-init--empty-built-in-registry.tsx
+++ b/packages/fuzz/corpus/regressions/rerender-lazy-ref-init--empty-built-in-registry.tsx
@@ -1,0 +1,13 @@
+// rule: rerender-lazy-ref-init
+// verdict: pass
+// weakness: library-idiom
+// source: ReactBench RD093-FP-001
+
+import { useRef } from "react";
+
+export const Registry = () => {
+  const entriesById = useRef(new Map<string, string>());
+  const visitedIds = useRef(new Set<string>());
+
+  return <output>{entriesById.current.size + visitedIds.current.size}</output>;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/rerender-lazy-ref-init.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/rerender-lazy-ref-init.regressions.test.ts
@@ -58,7 +58,7 @@ describe("rerender-lazy-ref-init — regressions", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
-  it("flags a construction with only type arguments", () => {
+  it("stays quiet for an empty built-in registry with only type arguments", () => {
     const result = runRule(
       rerenderLazyRefInit,
       `function C() {
@@ -67,10 +67,10 @@ describe("rerender-lazy-ref-init — regressions", () => {
       }`,
     );
     expect(result.parseErrors).toEqual([]);
-    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics).toEqual([]);
   });
 
-  it("flags a TS-wrapped zero-argument construction", () => {
+  it("stays quiet for a TS-wrapped empty built-in registry", () => {
     const result = runRule(
       rerenderLazyRefInit,
       `function C() {
@@ -79,7 +79,7 @@ describe("rerender-lazy-ref-init — regressions", () => {
       }`,
     );
     expect(result.parseErrors).toEqual([]);
-    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics).toEqual([]);
   });
 
   it("flags a TS-wrapped expensive construction (wrapper transparency)", () => {
@@ -94,7 +94,7 @@ describe("rerender-lazy-ref-init — regressions", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
-  it("still flags an aliased constructor binding", () => {
+  it("stays quiet for a proven alias of an empty built-in registry", () => {
     const result = runRule(
       rerenderLazyRefInit,
       `function C() {
@@ -104,7 +104,19 @@ describe("rerender-lazy-ref-init — regressions", () => {
       }`,
     );
     expect(result.parseErrors).toEqual([]);
-    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays quiet for an empty registry from the global object", () => {
+    const result = runRule(
+      rerenderLazyRefInit,
+      `function C() {
+        const byKey = useRef(new globalThis.Map());
+        return null;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
   });
 
   it("flags a shadowing binding of a built-in constructor name", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/rerender-lazy-ref-init.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/rerender-lazy-ref-init.test.ts
@@ -88,7 +88,7 @@ describe("rerender-lazy-ref-init", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
-  it("flags zero-argument constructors", () => {
+  it("stays quiet for empty built-in registries but flags other constructors", () => {
     const result = runRule(
       rerenderLazyRefInit,
       `
@@ -100,12 +100,17 @@ describe("rerender-lazy-ref-init", () => {
         const weakSeen = useRef(new WeakSet());
         const weakById = useRef(new WeakMap());
         const controller = useRef(new AbortController());
+        const startedAt = useRef(new Date());
       }
     `,
     );
 
     expect(result.parseErrors).toEqual([]);
-    expect(result.diagnostics).toHaveLength(5);
+    expect(result.diagnostics).toHaveLength(2);
+    expect(result.diagnostics.map(({ message }) => message)).toEqual([
+      expect.stringContaining("new AbortController()"),
+      expect.stringContaining("new Date()"),
+    ]);
   });
 
   it("flags `new Set(props.items)` — a runtime argument iterates its input on every render", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/rerender-lazy-ref-init.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/rerender-lazy-ref-init.ts
@@ -2,10 +2,13 @@ import { TRIVIAL_INITIALIZER_NAMES } from "../../constants/react.js";
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { isReactHookCall } from "../../utils/is-react-hook-call.js";
+import { isProvenGlobalNamespaceReference } from "../../utils/is-proven-global-namespace-reference.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isReactHookName } from "../../utils/is-react-hook-name.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+
+const EMPTY_REGISTRY_CONSTRUCTOR_NAMES = ["Map", "Set", "WeakMap", "WeakSet"];
 
 export const rerenderLazyRefInit = defineRule({
   id: "rerender-lazy-ref-init",
@@ -36,6 +39,16 @@ export const rerenderLazyRefInit = defineRule({
         : (memberPropertyName ?? "fn");
 
       if (TRIVIAL_INITIALIZER_NAMES.has(calleeName)) return;
+
+      if (
+        isNewCall &&
+        initializer.arguments.length === 0 &&
+        EMPTY_REGISTRY_CONSTRUCTOR_NAMES.some((constructorName) =>
+          isProvenGlobalNamespaceReference(callee, constructorName, context.scopes),
+        )
+      ) {
+        return;
+      }
 
       if (isPlainCall && isReactHookName(calleeName)) return;
 


### PR DESCRIPTION
## Why

ReactBench RDH finding `RD093-FP-001` confirmed that `rerender-lazy-ref-init` treats cheap, empty registry allocation as if it were expensive initialization.

The audited pattern is ordinary persistent registry setup:

```tsx
const tree = useRef(new Map());
const visited = useRef(new Set());
```

React does evaluate a `useRef` initializer on every render, but the rule contract recommends the nullable lazy-initialization pattern specifically to avoid **expensive** discarded work. For an empty built-in registry, rewriting the code to this:

```tsx
const tree = useRef<Map<Key, Node> | null>(null);
if (tree.current === null) tree.current = new Map();
```

preserves behavior while adding a branch, a nullable type, and render-time assignment. There is no semantic defect to repair and no meaningful performance win to justify that ceremony.

The consolidated ReactBench v0.9.3 audit found:

- 86 affected RDH trials
- 128 raw `rerender-lazy-ref-init` occurrences
- 29 affected trials whose behavioral tests passed
- 0 rewarded affected trials, showing that this lint-only rewrite was acting as a benchmark gate

Representative evidence: `fix-react-rdh-nteract-semiotic-a__svGNKJS`, `src/components/AccessibleNavTree.tsx:64-65`. The nearby true positive remains `useRef(buildExpensiveCache())`, covered by the rule's focused tests.

This narrows the regression introduced by #1492. It does not restore the old broad exemption for `Date` or `AbortController`.

Grounding:

- React documents that the initial ref value is ignored after the initial render and presents lazy initialization for creation that is expensive: https://react.dev/reference/react/useRef#avoiding-recreating-the-ref-contents
- Audit record: `RD093-FP-001` in `rd-0.9.3-second-pass.jsonl`

## What changed

- exempt only zero-argument built-in `Map`, `Set`, `WeakMap`, and `WeakSet` construction
- resolve the constructor through the existing scope-aware global namespace analysis, so proven aliases and `globalThis.Map` are handled without trusting the spelling alone
- continue reporting:
  - registries with runtime data, such as `new Set(items)`
  - imported or shadowed constructors named `Map` or `Set`
  - unknown/user-defined constructors
  - `new Date()` and `new AbortController()`
- add focused boundary tests and a permanent fuzz regression fixture
- add patch changesets for both published lint-plugin packages

The detector boundary is now:

```tsx
useRef(new Map());          // quiet: cheap empty built-in registry
useRef(new Set(items));     // report: iterates runtime data every render
useRef(new HeavyModel());   // report: unknown construction cost
useRef(new Date());         // report: time-dependent value changes every render
```

Local RDE could not start because the evaluator requires `AXIOM_DATASET`, which is not configured in this environment. No RDE or Daytona parity result is claimed.

## Test plan

- `nr -C packages/oxlint-plugin-react-doctor test src/plugin/rules/state-and-effects/rerender-lazy-ref-init.test.ts src/plugin/rules/state-and-effects/rerender-lazy-ref-init.regressions.test.ts` — 19 passed
- `FUZZ_RULE=rerender-lazy-ref-init FUZZ_STRICT=1 FUZZ_ITERATIONS=500 FUZZ_SEED=2082026 nr fuzz` — passed
- `nr -C packages/fuzz test` — 192 passed, 782 skipped
- `nr test` — passed
- `nr lint` — passed with existing corpus warnings
- `nr typecheck` — passed
- `nr format:check` — passed
- `nr smoke:json-report` — passed (`schemaVersion=3`, 0 diagnostics)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-only heuristic change with targeted tests and fuzz regression; no runtime app behavior changes.
> 
> **Overview**
> Narrows **`rerender-lazy-ref-init`** so it no longer warns on **`useRef(new Map())`**, **`Set`**, **`WeakMap`**, or **`WeakSet`** when the call has **no runtime arguments** and scope analysis proves the constructor is the real global builtin (including **`globalThis.Map`** and aliases like **`const M = Map`**).
> 
> **Still reported:** registries with runtime data (**`new Set(items)`**), shadowed/imported **`Map`/`Set`**, member callees (**`ns.Map()`**), and other non-trivial **`new`** such as **`Date`** and **`AbortController`**. Adds regression/fuzz coverage and patch changesets for both lint plugin packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed36a407e340c7c62256c7f4a37bd67ae8283fe2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Parity results

This supersedes the earlier environment note: Daytona parity completed after the PR was opened.

| Check | Result |
| --- | --- |
| Exact head | `ed36a407e340c7c62256c7f4a37bd67ae8283fe2` |
| Projects compared | 5,766 |
| Skipped projects | 0 |
| Added / removed | 0 / 514 |
| Target rule | `rerender-lazy-ref-init` |
| Artifact verification | passed |

All 514 removals are the intended zero-argument built-in registry boundary; parity added no diagnostics. Artifacts: `tmp/parity-batch-1544-1547-retry-5766/pr-1544/artifacts/`.
