### PR TITLE
FPFNFIX82: RDFPFN82026: preserve mixed effect chains

### DIFF
--- a/.changeset/detect-mixed-effect-chains.md
+++ b/.changeset/detect-mixed-effect-chains.md
@@ -1,0 +1,6 @@
+---
+"oxlint-plugin-react-doctor": patch
+"eslint-plugin-react-doctor": patch
+---
+
+Detect local state chains isolated from an effect's external resource cleanup path.

--- a/packages/fuzz/corpus/regressions/no-effect-chain--committed-dom-followups.tsx
+++ b/packages/fuzz/corpus/regressions/no-effect-chain--committed-dom-followups.tsx
@@ -1,0 +1,49 @@
+// rule: no-effect-chain
+// verdict: pass
+// weakness: provenance
+// source: parity ReactNative Run, gluestack UI, and miu2d
+
+import { useEffect, useRef, useState } from "react";
+
+export const CommittedDomFollowups = ({ activeSection, frames, messages }) => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const consoleRef = useRef<HTMLDivElement | null>(null);
+  const itemRefs = useRef<Record<string, HTMLAnchorElement | null>>({});
+  const [activeId, setActiveId] = useState("");
+  const [canvasFrames, setCanvasFrames] = useState(frames);
+  const [consoleMessages, setConsoleMessages] = useState(messages);
+
+  useEffect(() => setActiveId(activeSection), [activeSection]);
+  useEffect(() => setCanvasFrames(frames), [frames]);
+  useEffect(() => setConsoleMessages(messages), [messages]);
+
+  useEffect(() => {
+    itemRefs.current[activeId]?.scrollIntoView({ block: "nearest" });
+  }, [activeId]);
+
+  useEffect(() => {
+    if (!canvasFrames) return;
+    const canvas = canvasRef.current;
+    const context = canvas?.getContext("2d");
+    context?.fillRect(0, 0, canvas.width, canvas.height);
+  }, [canvasFrames]);
+
+  useEffect(() => {
+    if (!consoleRef.current) return;
+    consoleRef.current.scrollTop = consoleRef.current.scrollHeight;
+  }, [consoleMessages]);
+
+  return (
+    <>
+      <a
+        ref={(element) => {
+          itemRefs.current.section = element;
+        }}
+      >
+        Section
+      </a>
+      <canvas ref={canvasRef} />
+      <div ref={consoleRef}>{consoleMessages.length}</div>
+    </>
+  );
+};

--- a/packages/fuzz/corpus/regressions/no-effect-chain--stored-channel-lifecycle.tsx
+++ b/packages/fuzz/corpus/regressions/no-effect-chain--stored-channel-lifecycle.tsx
@@ -1,0 +1,44 @@
+// rule: no-effect-chain
+// verdict: pass
+// weakness: control-flow
+// source: parity sanity-io/sanity LiveQueries.tsx
+
+import { useEffect, useState } from "react";
+
+interface Channel {
+  on: (eventName: string, callback: () => void) => void;
+  post: (eventName: string, value: string) => void;
+  start: () => () => void;
+}
+
+interface ChannelController {
+  createChannel: () => Channel;
+}
+
+interface StoredChannelLifecycleProps {
+  controller: ChannelController | null;
+  perspective: string;
+}
+
+export const StoredChannelLifecycle = ({
+  controller,
+  perspective,
+}: StoredChannelLifecycleProps) => {
+  const [channel, setChannel] = useState<Channel>();
+
+  useEffect((): (() => void) => {
+    if (controller) {
+      const nextChannel = controller.createChannel();
+      setChannel(nextChannel);
+      nextChannel.on("message", () => undefined);
+      return nextChannel.start();
+    }
+    return () => undefined;
+  }, [controller]);
+
+  useEffect(() => {
+    if (channel) channel.post("perspective", perspective);
+  }, [channel, perspective]);
+
+  return null;
+};

--- a/packages/fuzz/corpus/true-positives/no-effect-chain--mixed-object-url-cleanup.tsx
+++ b/packages/fuzz/corpus/true-positives/no-effect-chain--mixed-object-url-cleanup.tsx
@@ -1,0 +1,34 @@
+// rule: no-effect-chain
+// verdict: fail
+// weakness: control-flow
+// source: ReactBench RD093-FN-001
+
+import { useEffect, useState } from "react";
+
+interface ImageProps {
+  data?: Blob;
+  imageError?: Error;
+  onError: (error: Error) => void;
+}
+
+export const Image = ({ data, imageError, onError }: ImageProps) => {
+  const [error, setError] = useState<Error>();
+  const [imageObjectUrl, setImageObjectUrl] = useState<string>();
+
+  useEffect(() => {
+    if (error) onError(error);
+  }, [error, onError]);
+
+  useEffect(() => {
+    if (imageError) {
+      setError(imageError);
+      return undefined;
+    }
+    if (!data) return undefined;
+    const objectUrl = URL.createObjectURL(data);
+    setImageObjectUrl(objectUrl);
+    return () => URL.revokeObjectURL(objectUrl);
+  }, [data, imageError]);
+
+  return imageObjectUrl;
+};

--- a/packages/fuzz/corpus/true-positives/no-effect-chain--state-only-nested-cleanup.tsx
+++ b/packages/fuzz/corpus/true-positives/no-effect-chain--state-only-nested-cleanup.tsx
@@ -1,0 +1,22 @@
+// rule: no-effect-chain
+// verdict: fail
+// weakness: control-flow
+// source: parity netzwerg/react-svg-timeline
+
+import { useCallback, useEffect, useState } from "react";
+
+export const StateOnlyNestedCleanup = ({ active, source }) => {
+  const [mode, setMode] = useState("idle");
+  const [cursor, setCursor] = useState("default");
+  const setModeIfEnabled = useCallback((nextMode: string) => setMode(nextMode), []);
+
+  useEffect(() => {
+    if (active) {
+      setModeIfEnabled(source);
+      return () => setModeIfEnabled("idle");
+    }
+  }, [active, source, setModeIfEnabled]);
+
+  useEffect(() => setCursor(mode === "idle" ? "default" : "pointer"), [mode]);
+  return cursor;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/dom.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/dom.ts
@@ -74,6 +74,9 @@ export const EXTERNAL_SYNC_OBSERVER_CONSTRUCTORS = new Set([
 
 export const EXTERNAL_SYNC_DOM_MEMBER_METHOD_NAMES = new Set([
   "blur",
+  "clearRect",
+  "drawImage",
+  "fillRect",
   "focus",
   "getBoundingClientRect",
   "getClientRects",
@@ -87,6 +90,9 @@ export const EXTERNAL_SYNC_DOM_MEMBER_METHOD_NAMES = new Set([
   "select",
   "setRangeText",
   "setSelectionRange",
+  "strokeRect",
 ]);
+
+export const EXTERNAL_SYNC_DOM_MEMBER_PROPERTY_NAMES = new Set(["scrollLeft", "scrollTop"]);
 
 export const STORAGE_OBJECTS = new Set(["localStorage", "sessionStorage"]);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/dom.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/dom.ts
@@ -74,9 +74,6 @@ export const EXTERNAL_SYNC_OBSERVER_CONSTRUCTORS = new Set([
 
 export const EXTERNAL_SYNC_DOM_MEMBER_METHOD_NAMES = new Set([
   "blur",
-  "clearRect",
-  "drawImage",
-  "fillRect",
   "focus",
   "getBoundingClientRect",
   "getClientRects",
@@ -90,9 +87,6 @@ export const EXTERNAL_SYNC_DOM_MEMBER_METHOD_NAMES = new Set([
   "select",
   "setRangeText",
   "setSelectionRange",
-  "strokeRect",
 ]);
-
-export const EXTERNAL_SYNC_DOM_MEMBER_PROPERTY_NAMES = new Set(["scrollLeft", "scrollTop"]);
 
 export const STORAGE_OBJECTS = new Set(["localStorage", "sessionStorage"]);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.regressions.test.ts
@@ -609,6 +609,53 @@ describe("no-effect-chain — regressions", () => {
     expect(result.diagnostics.length).toBeGreaterThan(0);
   });
 
+  it("reports a local state chain isolated from an object URL cleanup branch", () => {
+    const result = runRule(
+      noEffectChain,
+      `function Image({ data, imageError, onError }) {
+        const [error, setError] = useState();
+        const [imageObjectUrl, setImageObjectUrl] = useState();
+        useEffect(() => {
+          if (error) onError(error);
+        }, [error, onError]);
+        useEffect(() => {
+          if (imageError) {
+            setError(imageError);
+            return undefined;
+          }
+          if (!data) return undefined;
+          const objectUrl = URL.createObjectURL(data);
+          setImageObjectUrl(objectUrl);
+          return () => URL.revokeObjectURL(objectUrl);
+        }, [data, imageError]);
+        return imageObjectUrl;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain('changes "error"');
+  });
+
+  it("keeps a state write on the object URL lifecycle path quiet", () => {
+    const result = runRule(
+      noEffectChain,
+      `function Image({ data }) {
+        const [imageObjectUrl, setImageObjectUrl] = useState();
+        const [status, setStatus] = useState("idle");
+        useEffect(() => {
+          if (!data) return undefined;
+          const objectUrl = URL.createObjectURL(data);
+          setImageObjectUrl(objectUrl);
+          return () => URL.revokeObjectURL(objectUrl);
+        }, [data]);
+        useEffect(() => setStatus(imageObjectUrl ? "ready" : "idle"), [imageObjectUrl]);
+        return status;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   // Docs-validation r2 docMismatch (Security.jsx): the downstream effect
   // only persists state to localStorage — synchronizing with an external
   // system, which the doc excludes; no re-render chain exists.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.regressions.test.ts
@@ -702,6 +702,71 @@ describe("no-effect-chain — regressions", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("reports through cleanup state values computed by ordinary helpers", () => {
+    const result = runRule(
+      noEffectChain,
+      `import { useEffect, useState } from "react";
+      const getIdleMode = () => "idle";
+      function Interaction({ active, source }) {
+        const [mode, setMode] = useState("idle");
+        const [cursor, setCursor] = useState("default");
+        useEffect(() => {
+          if (active) {
+            setMode(source);
+            return () => setMode(getIdleMode());
+          }
+        }, [active, source]);
+        useEffect(() => setCursor(mode === "idle" ? "default" : "pointer"), [mode]);
+        return cursor;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("keeps explicit resource work beside cleanup state restoration quiet", () => {
+    const result = runRule(
+      noEffectChain,
+      `import { useEffect, useState } from "react";
+      const getIdleMode = () => "idle";
+      function Interaction({ source }) {
+        const [mode, setMode] = useState("idle");
+        const [cursor, setCursor] = useState("default");
+        useEffect(() => {
+          const subscription = source.subscribe();
+          setMode("active");
+          return () => {
+            setMode(getIdleMode());
+            subscription.unsubscribe();
+          };
+        }, [source]);
+        useEffect(() => setCursor(mode === "idle" ? "default" : "pointer"), [mode]);
+        return cursor;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("keeps deferred cleanup work on its lifecycle path quiet", () => {
+    const result = runRule(
+      noEffectChain,
+      `import { useEffect, useState } from "react";
+      function Interaction({ source }) {
+        const [mode, setMode] = useState("idle");
+        const [cursor, setCursor] = useState("default");
+        useEffect(() => {
+          setMode(source);
+          return () => setTimeout(() => release(source), 0);
+        }, [source]);
+        useEffect(() => setCursor(mode === "idle" ? "default" : "pointer"), [mode]);
+        return cursor;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("does not treat an empty nested cleanup as external synchronization", () => {
     const result = runRule(
       noEffectChain,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.regressions.test.ts
@@ -680,6 +680,125 @@ describe("no-effect-chain — regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("reports through a nested cleanup that only restores React state", () => {
+    const result = runRule(
+      noEffectChain,
+      `import { useCallback, useEffect, useState } from "react";
+      function Interaction({ active, source }) {
+        const [mode, setMode] = useState("idle");
+        const [cursor, setCursor] = useState("default");
+        const setModeIfEnabled = useCallback((nextMode) => setMode(nextMode), []);
+        useEffect(() => {
+          if (active) {
+            setModeIfEnabled(source);
+            return () => setModeIfEnabled("idle");
+          }
+        }, [active, source, setModeIfEnabled]);
+        useEffect(() => setCursor(mode === "idle" ? "default" : "pointer"), [mode]);
+        return cursor;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not treat an empty nested cleanup as external synchronization", () => {
+    const result = runRule(
+      noEffectChain,
+      `function Select({ value }) {
+        const [selected, setSelected] = useState(value);
+        const [overflow, setOverflow] = useState(false);
+        useEffect(() => setSelected(value), [value]);
+        useEffect(() => {
+          if (selected) {
+            setOverflow(measure(selected));
+            return () => {};
+          }
+        }, [selected]);
+        return overflow;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("keeps a nested resource cleanup on its lifecycle path quiet", () => {
+    const result = runRule(
+      noEffectChain,
+      `function Map({ container }) {
+        const [map, setMap] = useState(null);
+        const [status, setStatus] = useState("idle");
+        useEffect(() => {
+          if (container) {
+            const nextMap = createMap(container);
+            setMap(nextMap);
+            return () => nextMap.destroy();
+          }
+        }, [container]);
+        useEffect(() => setStatus(map ? "ready" : "idle"), [map]);
+        return status;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("keeps scroll position synchronization through a host ref quiet", () => {
+    const result = runRule(
+      noEffectChain,
+      `function Console({ source }) {
+        const consoleRef = useRef(null);
+        const [entries, setEntries] = useState([]);
+        useEffect(() => setEntries(source), [source]);
+        useEffect(() => {
+          if (consoleRef.current) {
+            consoleRef.current.scrollTop = consoleRef.current.scrollHeight;
+          }
+        }, [entries]);
+        return <div ref={consoleRef}>{entries.length}</div>;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("keeps scrolling an intrinsic ref registry quiet", () => {
+    const result = runRule(
+      noEffectChain,
+      `function TableOfContents({ source }) {
+        const itemRefs = useRef({});
+        const [activeId, setActiveId] = useState("");
+        useEffect(() => setActiveId(source), [source]);
+        useEffect(() => {
+          itemRefs.current[activeId]?.scrollIntoView({ block: "nearest" });
+        }, [activeId]);
+        return <a ref={(element) => { itemRefs.current.section = element; }}>Section</a>;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("keeps canvas drawing through a host ref quiet", () => {
+    const result = runRule(
+      noEffectChain,
+      `function Preview({ source }) {
+        const canvasRef = useRef(null);
+        const [data, setData] = useState(null);
+        useEffect(() => setData(source), [source]);
+        useEffect(() => {
+          if (data) return;
+          const canvas = canvasRef.current;
+          const context = canvas?.getContext("2d");
+          context?.fillRect(0, 0, canvas.width, canvas.height);
+        }, [data]);
+        return <canvas ref={canvasRef} />;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   // Docs-validation r2 docMismatch (Security.jsx): the downstream effect
   // only persists state to localStorage — synchronizing with an external
   // system, which the doc excludes; no re-render chain exists.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.regressions.test.ts
@@ -656,6 +656,30 @@ describe("no-effect-chain — regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("keeps a stored channel handle on its lifecycle path quiet", () => {
+    const result = runRule(
+      noEffectChain,
+      `function LiveQueries({ controller, perspective }) {
+        const [channel, setChannel] = useState();
+        useEffect((): (() => void) => {
+          if (controller) {
+            const nextChannel = controller.createChannel();
+            setChannel(nextChannel);
+            nextChannel.on("message", receiveMessage);
+            return nextChannel.start();
+          }
+          return () => undefined;
+        }, [controller]);
+        useEffect(() => {
+          if (channel) channel.post("perspective", perspective);
+        }, [channel, perspective]);
+        return null;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   // Docs-validation r2 docMismatch (Security.jsx): the downstream effect
   // only persists state to localStorage — synchronizing with an external
   // system, which the doc excludes; no re-render chain exists.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.ts
@@ -12,6 +12,7 @@ import {
   HOOKS_WITH_DEPS,
 } from "../../constants/react.js";
 import { defineRule } from "../../utils/define-rule.js";
+import { canNodeReachNode } from "../../utils/can-node-reach-node.js";
 import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
 import { findTransparentExpressionRoot } from "../../utils/find-transparent-expression-root.js";
 import { getCalleeName } from "../../utils/get-callee-name.js";
@@ -29,6 +30,7 @@ import { isComponentAssignment } from "../../utils/is-component-assignment.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isInlineIntrinsicRefCallback } from "../../utils/is-inline-intrinsic-ref-callback.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { nodesCanCoExecute } from "../../utils/nodes-can-co-execute.js";
 import { isProvenBrowserApiReceiver } from "../../utils/is-proven-browser-api-receiver.js";
 import { isProvenIntrinsicJsxElement } from "../../utils/is-proven-intrinsic-jsx-element.js";
 import { isReactApiCall } from "../../utils/is-react-api-call.js";
@@ -265,6 +267,7 @@ interface StaticEffectStateValue {
 interface EffectStateWriteInfo {
   values: Set<boolean | number | string | null | undefined>;
   hasUnknownValue: boolean;
+  nodes: EsTreeNodeOfType<"CallExpression">[];
 }
 
 const readStaticEffectValue = (
@@ -503,10 +506,12 @@ const collectStateWritesInEffect = (
     const writeInfo = stateWrites.get(stateName) ?? {
       values: new Set<boolean | number | string | null | undefined>(),
       hasUnknownValue: false,
+      nodes: [],
     };
     const staticValue = readStaticSetterValue(child, scopes);
     if (staticValue) writeInfo.values.add(staticValue.value);
     else writeInfo.hasUnknownValue = true;
+    writeInfo.nodes.push(child);
     stateWrites.set(stateName, writeInfo);
   });
   return stateWrites;
@@ -2226,18 +2231,16 @@ const isExternalSyncNode = (node: EsTreeNode, scopes: ScopeAnalysis): boolean =>
   );
 };
 
-const isExternalSyncEffect = (
+const collectExternalSyncAnchors = (
   effectCallback: EsTreeNode,
   analysisFunctions: ReadonlySet<EsTreeNode>,
   setterToStateName: ReadonlyMap<string, string>,
   setterSymbolIdToStateName: ReadonlyMap<number, string>,
   scopes: ScopeAnalysis,
   allowCommittedDomSync: boolean,
-): boolean => {
-  if (!isFunctionLike(effectCallback)) return false;
-  // A cleanup return is the strongest signal that the effect owns
-  // an external resource — once we see one, we don't need to inspect
-  // the body for an external-sync call shape.
+): EsTreeNode[] => {
+  if (!isFunctionLike(effectCallback)) return [];
+  const externalSyncAnchors: EsTreeNode[] = [];
   if (!isNodeOfType(effectCallback.body, "BlockStatement")) {
     if (
       isFunctionShapedReturn(
@@ -2248,7 +2251,7 @@ const isExternalSyncEffect = (
         false,
       )
     ) {
-      return true;
+      externalSyncAnchors.push(effectCallback.body);
     }
   } else {
     for (const statement of effectCallback.body.body ?? []) {
@@ -2263,22 +2266,49 @@ const isExternalSyncEffect = (
           true,
         )
       ) {
-        return true;
+        externalSyncAnchors.push(statement);
       }
     }
   }
 
-  let didFindExternalCall = false;
   visitSynchronousFunctionBodies(analysisFunctions, (child) => {
     if (
       isExternalSyncNode(child, scopes) ||
       (allowCommittedDomSync && isCommittedDomSyncNode(child, scopes))
     ) {
-      didFindExternalCall = true;
+      externalSyncAnchors.push(child);
     }
   });
 
-  return didFindExternalCall;
+  return externalSyncAnchors;
+};
+
+const collectExternallySynchronizedStateNames = (
+  stateWrites: ReadonlyMap<string, EffectStateWriteInfo>,
+  externalSyncAnchors: readonly EsTreeNode[],
+  context: RuleContext,
+): Set<string> => {
+  const externallySynchronizedStateNames = new Set<string>();
+  if (externalSyncAnchors.length === 0) return externallySynchronizedStateNames;
+  for (const [stateName, writeInfo] of stateWrites) {
+    const areAllWritesPartOfExternalSync = writeInfo.nodes.every((writeNode) => {
+      const writeOwner = context.cfg.enclosingFunction(writeNode);
+      const functionCfg = writeOwner ? context.cfg.cfgFor(writeOwner) : null;
+      if (!writeOwner || !functionCfg) return true;
+      const sameOwnerAnchors = externalSyncAnchors.filter(
+        (anchor) => context.cfg.enclosingFunction(anchor) === writeOwner,
+      );
+      if (sameOwnerAnchors.length === 0) return true;
+      return sameOwnerAnchors.some(
+        (anchor) =>
+          nodesCanCoExecute(writeNode, anchor, context) &&
+          (canNodeReachNode(writeNode, anchor, functionCfg) ||
+            canNodeReachNode(anchor, writeNode, functionCfg)),
+      );
+    });
+    if (areAllWritesPartOfExternalSync) externallySynchronizedStateNames.add(stateName);
+  }
+  return externallySynchronizedStateNames;
 };
 
 interface EffectInfo {
@@ -2288,6 +2318,7 @@ interface EffectInfo {
   stateWrites: Map<string, EffectStateWriteInfo>;
   analysisFunctions: ReadonlySet<EsTreeNode>;
   isExternalSync: boolean;
+  externallySynchronizedStateNames: ReadonlySet<string>;
 }
 
 export const noEffectChain = defineRule({
@@ -2340,6 +2371,15 @@ export const noEffectChain = defineRule({
           context.scopes,
         );
         const writtenStateNames = new Set(stateWrites.keys());
+        const externalSyncAnchors = collectExternalSyncAnchors(
+          callback,
+          analysisFunctions,
+          setterToStateName,
+          setterSymbolIdToStateName,
+          context.scopes,
+          writtenStateNames.size === 0,
+        );
+        const doesCallStorageSetter = callsStorageHookSetter(analysisFunctions, storageSetterNames);
         effectInfos.push({
           node: effectCall,
           callback,
@@ -2351,24 +2391,19 @@ export const noEffectChain = defineRule({
           stateWrites,
           analysisFunctions,
           isExternalSync:
-            isExternalSyncEffect(
-              callback,
-              analysisFunctions,
-              setterToStateName,
-              setterSymbolIdToStateName,
-              context.scopes,
-              writtenStateNames.size === 0,
-            ) ||
-            callsStorageHookSetter(analysisFunctions, storageSetterNames) ||
+            externalSyncAnchors.length > 0 ||
+            doesCallStorageSetter ||
             (writtenStateNames.size === 0 &&
               callsOpaqueExternalSetter(analysisFunctions, setterToStateName)),
+          externallySynchronizedStateNames: doesCallStorageSetter
+            ? writtenStateNames
+            : collectExternallySynchronizedStateNames(stateWrites, externalSyncAnchors, context),
         });
       }
       if (effectInfos.length < 2) return;
 
       const reportedNodes = new Set<EsTreeNode>();
       for (const writerEffect of effectInfos) {
-        if (writerEffect.isExternalSync) continue;
         if (writerEffect.stateWrites.size === 0) continue;
         for (const readerEffect of effectInfos) {
           if (readerEffect === writerEffect) continue;
@@ -2377,6 +2412,7 @@ export const noEffectChain = defineRule({
 
           let chainedStateName: string | null = null;
           for (const writtenName of writerEffect.stateWrites.keys()) {
+            if (writerEffect.externallySynchronizedStateNames.has(writtenName)) continue;
             const writtenStateSymbolId = stateSymbolIds.get(writtenName);
             if (
               writtenStateSymbolId === undefined ||

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.ts
@@ -1,6 +1,5 @@
 import {
   EXTERNAL_SYNC_DOM_MEMBER_METHOD_NAMES,
-  EXTERNAL_SYNC_DOM_MEMBER_PROPERTY_NAMES,
   EXTERNAL_SYNC_OBSERVER_CONSTRUCTORS,
   SOCKET_CONSTRUCTOR_NAMES_REQUIRING_CLEANUP,
 } from "../../constants/dom.js";
@@ -52,6 +51,15 @@ import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { collectUseStateBindings } from "./utils/collect-use-state-bindings.js";
 import { isCleanupReturn } from "./utils/is-cleanup-return.js";
+
+const COMMITTED_DOM_MEMBER_METHOD_NAMES = new Set([
+  ...EXTERNAL_SYNC_DOM_MEMBER_METHOD_NAMES,
+  "clearRect",
+  "drawImage",
+  "fillRect",
+  "strokeRect",
+]);
+const COMMITTED_DOM_MEMBER_PROPERTY_NAMES = new Set(["scrollLeft", "scrollTop"]);
 
 // HACK: §7 of "You Might Not Need an Effect" — chains of computations:
 //
@@ -2094,7 +2102,7 @@ const isCommittedDomSyncNode = (node: EsTreeNode, scopes: ScopeAnalysis): boolea
     const target = stripParenExpression(node.left);
     return Boolean(
       isNodeOfType(target, "MemberExpression") &&
-      EXTERNAL_SYNC_DOM_MEMBER_PROPERTY_NAMES.has(getStaticPropertyName(target) ?? "") &&
+      COMMITTED_DOM_MEMBER_PROPERTY_NAMES.has(getStaticPropertyName(target) ?? "") &&
       isDerivedFromProvenDomRefCurrent(target.object, scopes),
     );
   }
@@ -2102,7 +2110,7 @@ const isCommittedDomSyncNode = (node: EsTreeNode, scopes: ScopeAnalysis): boolea
     const target = stripParenExpression(node.argument);
     return Boolean(
       isNodeOfType(target, "MemberExpression") &&
-      EXTERNAL_SYNC_DOM_MEMBER_PROPERTY_NAMES.has(getStaticPropertyName(target) ?? "") &&
+      COMMITTED_DOM_MEMBER_PROPERTY_NAMES.has(getStaticPropertyName(target) ?? "") &&
       isDerivedFromProvenDomRefCurrent(target.object, scopes),
     );
   }
@@ -2110,7 +2118,7 @@ const isCommittedDomSyncNode = (node: EsTreeNode, scopes: ScopeAnalysis): boolea
   const callee = stripParenExpression(node.callee);
   if (!isNodeOfType(callee, "MemberExpression")) return false;
   const propertyName = getStaticPropertyName(callee);
-  if (propertyName === null || !EXTERNAL_SYNC_DOM_MEMBER_METHOD_NAMES.has(propertyName)) {
+  if (propertyName === null || !COMMITTED_DOM_MEMBER_METHOD_NAMES.has(propertyName)) {
     return false;
   }
   return (
@@ -2302,12 +2310,17 @@ const cleanupFunctionHasExternalWork = (
   }
   const nextVisitedFunctions = new Set(visitedFunctions).add(cleanupFunction);
   let hasExternalWork = false;
-  walkInsideStatementBlocks(cleanupFunction.body, (child) => {
+  walkAst(cleanupFunction.body, (child) => {
     if (hasExternalWork) return false;
+    if (isFunctionLike(child)) return false;
     if (isNodeOfType(child, "CallExpression")) {
-      if (getStateNameForSetterCall(child, setterSymbolIdToStateName, scopes)) return;
-      if (isNodeOfType(child.callee, "Identifier") && isSetterIdentifier(child.callee.name)) {
-        return;
+      if (getStateNameForSetterCall(child, setterSymbolIdToStateName, scopes)) return false;
+      if (
+        isNodeOfType(child.callee, "Identifier") &&
+        isSetterIdentifier(child.callee.name) &&
+        !EXTERNAL_SYNC_DIRECT_CALLEE_NAMES.has(child.callee.name)
+      ) {
+        return false;
       }
       const invokedFunction = resolveSynchronouslyInvokedFunction(child.callee, scopes);
       if (
@@ -2319,7 +2332,7 @@ const cleanupFunctionHasExternalWork = (
           nextVisitedFunctions,
         )
       ) {
-        return;
+        return false;
       }
       hasExternalWork = true;
       return false;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.ts
@@ -13,6 +13,7 @@ import {
 } from "../../constants/react.js";
 import { defineRule } from "../../utils/define-rule.js";
 import { canNodeReachNode } from "../../utils/can-node-reach-node.js";
+import { collectFunctionReturnStatements } from "../../utils/collect-function-return-statements.js";
 import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
 import { findTransparentExpressionRoot } from "../../utils/find-transparent-expression-root.js";
 import { getCalleeName } from "../../utils/get-callee-name.js";
@@ -1653,7 +1654,9 @@ const isFunctionShapedReturn = (
   // `const unsub = subscribe(...)` line. We can't statically prove
   // it's function-typed without scope analysis, but in idiomatic React
   // this is the dominant cleanup pattern. Accept.
-  if (isNodeOfType(unwrappedReturnedValue, "Identifier")) return true;
+  if (isNodeOfType(unwrappedReturnedValue, "Identifier")) {
+    return !isProvenGlobalNamespaceReference(unwrappedReturnedValue, "undefined", scopes);
+  }
   return false;
 };
 
@@ -2254,9 +2257,8 @@ const collectExternalSyncAnchors = (
       externalSyncAnchors.push(effectCallback.body);
     }
   } else {
-    for (const statement of effectCallback.body.body ?? []) {
+    for (const statement of collectFunctionReturnStatements(effectCallback)) {
       if (
-        isNodeOfType(statement, "ReturnStatement") &&
         statement.argument &&
         isFunctionShapedReturn(
           statement.argument,
@@ -2294,11 +2296,11 @@ const collectExternallySynchronizedStateNames = (
     const areAllWritesPartOfExternalSync = writeInfo.nodes.every((writeNode) => {
       const writeOwner = context.cfg.enclosingFunction(writeNode);
       const functionCfg = writeOwner ? context.cfg.cfgFor(writeOwner) : null;
-      if (!writeOwner || !functionCfg) return true;
+      if (!writeOwner || !functionCfg) return false;
       const sameOwnerAnchors = externalSyncAnchors.filter(
         (anchor) => context.cfg.enclosingFunction(anchor) === writeOwner,
       );
-      if (sameOwnerAnchors.length === 0) return true;
+      if (sameOwnerAnchors.length === 0) return false;
       return sameOwnerAnchors.some(
         (anchor) =>
           nodesCanCoExecute(writeNode, anchor, context) &&
@@ -2405,6 +2407,12 @@ export const noEffectChain = defineRule({
       const reportedNodes = new Set<EsTreeNode>();
       for (const writerEffect of effectInfos) {
         if (writerEffect.stateWrites.size === 0) continue;
+        if (
+          writerEffect.isExternalSync &&
+          writerEffect.externallySynchronizedStateNames.size === 0
+        ) {
+          continue;
+        }
         for (const readerEffect of effectInfos) {
           if (readerEffect === writerEffect) continue;
           if (readerEffect.isExternalSync) continue;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.ts
@@ -1,5 +1,6 @@
 import {
   EXTERNAL_SYNC_DOM_MEMBER_METHOD_NAMES,
+  EXTERNAL_SYNC_DOM_MEMBER_PROPERTY_NAMES,
   EXTERNAL_SYNC_OBSERVER_CONSTRUCTORS,
   SOCKET_CONSTRUCTOR_NAMES_REQUIRING_CLEANUP,
 } from "../../constants/dom.js";
@@ -1943,6 +1944,46 @@ const storesOnlyIntrinsicRefCallbackValues = (
 ): boolean => {
   const refCall = getDirectReactRefCall(symbol, scopes);
   const initialValue = refCall?.arguments[0];
+  if (isNodeOfType(initialValue, "ObjectExpression") && initialValue.properties.length === 0) {
+    let intrinsicValueWriteCount = 0;
+    for (const reference of symbol.references) {
+      const identifier = findTransparentExpressionRoot(reference.identifier);
+      const currentMember = identifier.parent;
+      if (
+        !isNodeOfType(currentMember, "MemberExpression") ||
+        currentMember.object !== identifier ||
+        getStaticPropertyName(currentMember) !== "current"
+      ) {
+        return false;
+      }
+      const currentExpression = findTransparentExpressionRoot(currentMember);
+      const propertyMember = currentExpression.parent;
+      if (
+        !isNodeOfType(propertyMember, "MemberExpression") ||
+        propertyMember.object !== currentExpression
+      ) {
+        return false;
+      }
+      const propertyExpression = findTransparentExpressionRoot(propertyMember);
+      const parent = propertyExpression.parent;
+      if (isNodeOfType(parent, "AssignmentExpression") && parent.left === propertyExpression) {
+        if (parent.operator !== "=" || !isIntrinsicRefCallbackParameter(parent.right, scopes)) {
+          return false;
+        }
+        intrinsicValueWriteCount += 1;
+        continue;
+      }
+      if (
+        (isNodeOfType(parent, "UpdateExpression") && parent.argument === propertyExpression) ||
+        (isNodeOfType(parent, "UnaryExpression") &&
+          parent.operator === "delete" &&
+          parent.argument === propertyExpression)
+      ) {
+        return false;
+      }
+    }
+    return intrinsicValueWriteCount > 0;
+  }
   const hasDirectEmptyMapInitializer = Boolean(
     initialValue && isEmptyGlobalMapConstruction(initialValue, scopes),
   );
@@ -2035,12 +2076,7 @@ const isDerivedFromProvenDomRefCurrent = (
           (didReadCollectionValue && storesOnlyIntrinsicRefCallbackValues(symbol, scopes))),
       );
     }
-    return isDerivedFromProvenDomRefCurrent(
-      expression.object,
-      scopes,
-      didReadCollectionValue,
-      visitedSymbolIds,
-    );
+    return isDerivedFromProvenDomRefCurrent(expression.object, scopes, true, visitedSymbolIds);
   }
   if (!isNodeOfType(expression, "CallExpression")) return false;
   const callee = stripParenExpression(expression.callee);
@@ -2054,6 +2090,22 @@ const isDerivedFromProvenDomRefCurrent = (
 };
 
 const isCommittedDomSyncNode = (node: EsTreeNode, scopes: ScopeAnalysis): boolean => {
+  if (isNodeOfType(node, "AssignmentExpression")) {
+    const target = stripParenExpression(node.left);
+    return Boolean(
+      isNodeOfType(target, "MemberExpression") &&
+      EXTERNAL_SYNC_DOM_MEMBER_PROPERTY_NAMES.has(getStaticPropertyName(target) ?? "") &&
+      isDerivedFromProvenDomRefCurrent(target.object, scopes),
+    );
+  }
+  if (isNodeOfType(node, "UpdateExpression")) {
+    const target = stripParenExpression(node.argument);
+    return Boolean(
+      isNodeOfType(target, "MemberExpression") &&
+      EXTERNAL_SYNC_DOM_MEMBER_PROPERTY_NAMES.has(getStaticPropertyName(target) ?? "") &&
+      isDerivedFromProvenDomRefCurrent(target.object, scopes),
+    );
+  }
   if (!isNodeOfType(node, "CallExpression")) return false;
   const callee = stripParenExpression(node.callee);
   if (!isNodeOfType(callee, "MemberExpression")) return false;
@@ -2234,6 +2286,52 @@ const isExternalSyncNode = (node: EsTreeNode, scopes: ScopeAnalysis): boolean =>
   );
 };
 
+const cleanupFunctionHasExternalWork = (
+  cleanupFunction: EsTreeNode,
+  setterSymbolIdToStateName: ReadonlyMap<number, string>,
+  scopes: ScopeAnalysis,
+  visitedFunctions: ReadonlySet<EsTreeNode> = new Set(),
+): boolean => {
+  if (
+    !isFunctionLike(cleanupFunction) ||
+    cleanupFunction.async ||
+    cleanupFunction.generator ||
+    visitedFunctions.has(cleanupFunction)
+  ) {
+    return false;
+  }
+  const nextVisitedFunctions = new Set(visitedFunctions).add(cleanupFunction);
+  let hasExternalWork = false;
+  walkInsideStatementBlocks(cleanupFunction.body, (child) => {
+    if (hasExternalWork) return false;
+    if (isNodeOfType(child, "CallExpression")) {
+      if (getStateNameForSetterCall(child, setterSymbolIdToStateName, scopes)) return;
+      if (isNodeOfType(child.callee, "Identifier") && isSetterIdentifier(child.callee.name)) {
+        return;
+      }
+      const invokedFunction = resolveSynchronouslyInvokedFunction(child.callee, scopes);
+      if (
+        invokedFunction &&
+        !cleanupFunctionHasExternalWork(
+          invokedFunction,
+          setterSymbolIdToStateName,
+          scopes,
+          nextVisitedFunctions,
+        )
+      ) {
+        return;
+      }
+      hasExternalWork = true;
+      return false;
+    }
+    if (isExternalSyncNode(child, scopes) || isCommittedDomSyncNode(child, scopes)) {
+      hasExternalWork = true;
+      return false;
+    }
+  });
+  return hasExternalWork;
+};
+
 const collectExternalSyncAnchors = (
   effectCallback: EsTreeNode,
   analysisFunctions: ReadonlySet<EsTreeNode>,
@@ -2258,15 +2356,23 @@ const collectExternalSyncAnchors = (
     }
   } else {
     for (const statement of collectFunctionReturnStatements(effectCallback)) {
+      const returnedValue = statement.argument;
       if (
-        statement.argument &&
+        returnedValue &&
         isFunctionShapedReturn(
-          statement.argument,
+          returnedValue,
           setterToStateName,
           setterSymbolIdToStateName,
           scopes,
           true,
-        )
+        ) &&
+        (statement.parent === effectCallback.body ||
+          !isFunctionLike(stripParenExpression(returnedValue)) ||
+          cleanupFunctionHasExternalWork(
+            stripParenExpression(returnedValue),
+            setterSymbolIdToStateName,
+            scopes,
+          ))
       ) {
         externalSyncAnchors.push(statement);
       }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-mutate-then-set-or-return-same-reference.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-mutate-then-set-or-return-same-reference.ts
@@ -1,6 +1,7 @@
 import type { FunctionCfg } from "../../semantic/control-flow-graph.js";
 import type { SymbolDescriptor } from "../../semantic/scope-analysis.js";
 import { MUTATING_ARRAY_METHODS, MUTATING_COLLECTION_METHODS } from "../../constants/js.js";
+import { canNodeReachNode } from "../../utils/can-node-reach-node.js";
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
@@ -43,8 +44,6 @@ const FRESH_ARRAY_METHOD_NAMES = new Set([
   "toSpliced",
   "with",
 ]);
-
-const reachableBlockIdsByCfg = new WeakMap<FunctionCfg, Map<number, ReadonlySet<number>>>();
 
 interface MutationFact {
   readonly node: EsTreeNode;
@@ -89,30 +88,11 @@ const nodePrecedesOnReachablePath = (
   functionCfg: FunctionCfg,
   context: RuleContext,
 ): boolean => {
-  if (!nodesCanCoExecute(sourceNode, targetNode, context)) return false;
-  const sourceBlock = functionCfg.blockOf(sourceNode);
-  const targetBlock = functionCfg.blockOf(targetNode);
-  if (!sourceBlock || !targetBlock) return false;
-  if (sourceBlock === targetBlock) {
-    return (sourceNode.range?.[0] ?? 0) < (targetNode.range?.[0] ?? 0);
-  }
-  const reachableBlockIdsBySource = reachableBlockIdsByCfg.get(functionCfg) ?? new Map();
-  reachableBlockIdsByCfg.set(functionCfg, reachableBlockIdsBySource);
-  const cachedReachableBlockIds = reachableBlockIdsBySource.get(sourceBlock.id);
-  if (cachedReachableBlockIds) return cachedReachableBlockIds.has(targetBlock.id);
-  const pendingBlocks = [sourceBlock];
-  const visitedBlockIds = new Set([sourceBlock.id]);
-  while (pendingBlocks.length > 0) {
-    const block = pendingBlocks.pop();
-    if (!block) break;
-    for (const edge of block.successors) {
-      if (visitedBlockIds.has(edge.to.id)) continue;
-      visitedBlockIds.add(edge.to.id);
-      pendingBlocks.push(edge.to);
-    }
-  }
-  reachableBlockIdsBySource.set(sourceBlock.id, visitedBlockIds);
-  return visitedBlockIds.has(targetBlock.id);
+  return (
+    sourceNode !== targetNode &&
+    nodesCanCoExecute(sourceNode, targetNode, context) &&
+    canNodeReachNode(sourceNode, targetNode, functionCfg)
+  );
 };
 
 const expressionIsDefinitelyFreshReference = (

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/can-node-reach-node.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/can-node-reach-node.ts
@@ -1,0 +1,36 @@
+import type { FunctionCfg } from "../semantic/control-flow-graph.js";
+import type { EsTreeNode } from "./es-tree-node.js";
+
+const reachableBlockIdsByCfg = new WeakMap<FunctionCfg, Map<number, ReadonlySet<number>>>();
+
+export const canNodeReachNode = (
+  sourceNode: EsTreeNode,
+  targetNode: EsTreeNode,
+  functionCfg: FunctionCfg,
+): boolean => {
+  const sourceBlock = functionCfg.blockOf(sourceNode);
+  const targetBlock = functionCfg.blockOf(targetNode);
+  if (!sourceBlock || !targetBlock) return false;
+  if (sourceBlock === targetBlock) {
+    return (sourceNode.range?.[0] ?? 0) <= (targetNode.range?.[0] ?? 0);
+  }
+
+  const reachableBlockIdsBySource = reachableBlockIdsByCfg.get(functionCfg) ?? new Map();
+  reachableBlockIdsByCfg.set(functionCfg, reachableBlockIdsBySource);
+  const cachedReachableBlockIds = reachableBlockIdsBySource.get(sourceBlock.id);
+  if (cachedReachableBlockIds) return cachedReachableBlockIds.has(targetBlock.id);
+
+  const pendingBlocks = [sourceBlock];
+  const reachableBlockIds = new Set([sourceBlock.id]);
+  while (pendingBlocks.length > 0) {
+    const block = pendingBlocks.pop();
+    if (!block) break;
+    for (const edge of block.successors) {
+      if (reachableBlockIds.has(edge.to.id)) continue;
+      reachableBlockIds.add(edge.to.id);
+      pendingBlocks.push(edge.to);
+    }
+  }
+  reachableBlockIdsBySource.set(sourceBlock.id, reachableBlockIds);
+  return reachableBlockIds.has(targetBlock.id);
+};


### PR DESCRIPTION
## Problem

`no-effect-chain` treated any cleanup or external synchronization in an effect as proof that every state write in that effect belonged to the same external lifecycle. A mixed-purpose effect could therefore hide a real state chain.

The RDH Inrupt trial `fix-react-rdh-inrupt-archived-so__JzLSAV7` demonstrates the false negative:

```tsx
useEffect(() => {
  if (imageError) {
    setError(imageError)
    return undefined
  }

  const imageObjectUrl = URL.createObjectURL(data)
  setImageObjectUrl(imageObjectUrl)
  return () => URL.revokeObjectURL(imageObjectUrl)
}, [data, imageError])

useEffect(() => {
  if (error) onError(error)
}, [error, onError])
```

The object URL branch is a legitimate resource lifecycle. The `imageError → error → onError` branch is a separate state chain. Adding the URL cleanup made the original diagnostic disappear even though the callback chain remained.

Grounding:

- Trial artifacts: `verifier/model.patch`, `verifier/rd-before.json`, and `verifier/rd-after.json` in `fix-react-rdh-inrupt-archived-so__JzLSAV7`
- React chain guidance: https://react.dev/learn/you-might-not-need-an-effect#chains-of-computations
- React external-system boundary: https://react.dev/reference/react/useEffect#connecting-to-an-external-system

## Fix

The rule now records external-sync anchors and relates each state write to those anchors through control-flow reachability. It no longer assigns one blanket lifecycle label to the entire effect.

The detector now distinguishes three important shapes.

An isolated state-only branch remains reportable:

```tsx
if (imageError) {
  setError(imageError)
  return undefined
}
```

A state write that shares a real resource path stays quiet:

```tsx
const subscription = source.subscribe()
setMode("active")
return () => {
  setMode(getIdleMode())
  subscription.unsubscribe()
}
```

A nested cleanup containing only React state work does not suppress the chain:

```tsx
if (active) {
  setModeIfEnabled(source)
  return () => setModeIfEnabled("idle")
}
```

Committed DOM work remains external synchronization, including scrolling a proven host ref or intrinsic-ref registry and drawing through a canvas context:

```tsx
consoleRef.current.scrollTop = consoleRef.current.scrollHeight
context?.fillRect(0, 0, canvas.width, canvas.height)
```

Other boundary corrections:

- `return undefined` is not cleanup evidence.
- Empty or state-only nested cleanups are not external work.
- Real deferred APIs such as `setTimeout` are not mistaken for React setters.
- Stored channel, subscription, map, editor, DOM, and canvas lifecycles remain excluded.
- `no-mutate-then-set-or-return-same-reference` reuses the shared CFG reachability helper instead of maintaining duplicate traversal logic.

## Verification

Local:

- `no-effect-chain.regressions.test.ts`: 465/465 passing
- Full plugin suite after the detector correction: 25,551 passing, 201 skipped
- Strict fuzz: 500 iterations
- Fuzz corpus: 192 active fixtures passing, 782 skipped
- Repository test, lint, typecheck, format, build, and JSON-report smoke gates pass
- Exact-head GitHub CI, CodeQL, React Doctor, build, and platform test matrices pass

Exact-head paired parity:

| Check | Result |
| --- | --- |
| Base | `f7dbdfa399bddb16c5d0e4ba180fb3a1d297448d` |
| Head | `359c1ccb23836426b4e92fa2291f00d054a4043a` |
| Scope | `no-effect-chain`, `no-mutate-then-set-or-return-same-reference` |
| Projects | 2,000/2,000 |
| Failures / skipped | 0 / 0 |
| Added / removed / unchanged | 6 / 11 / 1,703 |
| Artifact validation | base and head passed the streaming validator |

All 17 deltas were inspected at their pinned repository commits.

- The 11 removals are intended external synchronization: form subscriptions, CometChat subscriptions, Redash map lifecycles, EditorJS lifecycle, DOM scrolling, and canvas redraw.
- Four additions are clear state-chain findings: derived Pi-hole configuration state, draft/block state, async image-selection pruning, and event/state routing.
- Two additions use opaque editor/logger bindings. They remain manual-adjudication candidates, not confirmed false positives; the syntax does not establish the external provenance needed to exempt them.
- No confirmed false-positive regression was found.

The expanded 5,766-project audit corpus was also attempted. It exhausted its bounded retry tail with 21 failed candidate records and no complete base artifact, so that run is explicitly invalid and is not used as passing evidence. The valid paired artifacts are preserved at:

`tmp/parity-pr-1545-359c1ccb2-paired-PU6THT/`

## Regression coverage

- Mixed object-URL cleanup true positive
- Same-path object-URL lifecycle true negative
- Stored channel lifecycle
- State-only and empty nested cleanups
- Helper-computed cleanup state
- Deferred cleanup work
- Subscription/resource cleanup
- Host-ref scroll synchronization
- Intrinsic-ref registries
- Canvas drawing
- Fuzz true-positive and regression fixtures
