### PR TITLE
FPFNFIX82: RDFPFN82026: recognize media failure latches

### DIFF
--- a/.changeset/recognize-media-failure-latches.md
+++ b/.changeset/recognize-media-failure-latches.md
@@ -1,0 +1,6 @@
+---
+"oxlint-plugin-react-doctor": patch
+"eslint-plugin-react-doctor": patch
+---
+
+Ignore resource-keyed media failure latch resets in no-adjust-state-on-prop-change.

--- a/packages/fuzz/corpus/regressions/no-adjust-state-on-prop-change--resource-failure-latch.tsx
+++ b/packages/fuzz/corpus/regressions/no-adjust-state-on-prop-change--resource-failure-latch.tsx
@@ -1,0 +1,33 @@
+// rule: no-adjust-state-on-prop-change
+// verdict: pass
+// weakness: library-idiom
+// source: verified ReactBench Jumper trial 2GBTh7Z
+
+import { useEffect, useState } from "react";
+import type { SyntheticEvent } from "react";
+
+interface AnimatedBackgroundProps {
+  mime: string;
+  src: string;
+}
+
+export const AnimatedBackground = ({ mime, src }: AnimatedBackgroundProps) => {
+  const [hasFailed, setHasFailed] = useState(false);
+
+  useEffect(() => {
+    setHasFailed(false);
+  }, [src, mime]);
+
+  const handleLoadedData = (event: SyntheticEvent<HTMLVideoElement>) => {
+    event.currentTarget.play()?.catch(() => setHasFailed(true));
+  };
+
+  return (
+    <video
+      hidden={hasFailed}
+      src={src}
+      onError={() => setHasFailed(true)}
+      onLoadedData={handleLoadedData}
+    />
+  );
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-adjust-state-on-prop-change.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-adjust-state-on-prop-change.regressions.test.ts
@@ -674,6 +674,49 @@ describe("no-adjust-state-on-prop-change — regressions", () => {
       expect(result.diagnostics).toHaveLength(1);
     });
 
+    it("still reports when a dependency is only read by a non-resource attribute", () => {
+      const result = runRule(
+        noAdjustStateOnPropChange,
+        `function Preview({ userId, previewUrl }) {
+          const [hasFailed, setHasFailed] = useState(false);
+          useEffect(() => {
+            setHasFailed(false);
+          }, [userId]);
+          return (
+            <img
+              src={previewUrl}
+              aria-label={userId}
+              onError={() => setHasFailed(true)}
+            />
+          );
+        }`,
+        { forceJsx: true },
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    });
+
+    it("still reports an editable value reset despite a resource error writer", () => {
+      const result = runRule(
+        noAdjustStateOnPropChange,
+        `function Editor({ documentId }) {
+          const [draft, setDraft] = useState("");
+          useEffect(() => {
+            setDraft("");
+          }, [documentId]);
+          return (
+            <>
+              <input value={draft} onChange={(event) => setDraft(event.target.value)} />
+              <img src={documentId} onError={() => setDraft("unavailable")} />
+            </>
+          );
+        }`,
+        { forceJsx: true },
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    });
+
     it("stays silent on an async probe whose on* handler assignments set the same state (psysonic artistHero)", () => {
       const result = runRule(
         noAdjustStateOnPropChange,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-adjust-state-on-prop-change.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-adjust-state-on-prop-change.regressions.test.ts
@@ -601,6 +601,79 @@ describe("no-adjust-state-on-prop-change — regressions", () => {
   });
 
   describe("docs-validation round 2", () => {
+    it("stays silent when a media failure latch resets for a new resource", () => {
+      const result = runRule(
+        noAdjustStateOnPropChange,
+        `function AnimatedBackground({ src, mime }) {
+          const [hasFailed, setHasFailed] = useState(false);
+          useEffect(() => {
+            setHasFailed(false);
+          }, [src, mime]);
+          const handleLoadedData = (event) => {
+            event.currentTarget.play()?.catch(() => setHasFailed(true));
+          };
+          const handlePlaybackError = () => setHasFailed(true);
+          return (
+            <video
+              src={src}
+              type={mime}
+              onLoadedData={handleLoadedData}
+              onError={handlePlaybackError}
+            />
+          );
+        }`,
+        { forceJsx: true },
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it("still reports a draft reset when unrelated media also has an error handler", () => {
+      const result = runRule(
+        noAdjustStateOnPropChange,
+        `function Editor({ documentId, previewUrl }) {
+          const [draft, setDraft] = useState("");
+          const [previewFailed, setPreviewFailed] = useState(false);
+          useEffect(() => {
+            setDraft("");
+          }, [documentId]);
+          return (
+            <>
+              <input value={draft} onChange={(event) => setDraft(event.target.value)} />
+              <img src={previewUrl} onError={() => setPreviewFailed(true)} />
+            </>
+          );
+        }`,
+        { forceJsx: true },
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    });
+
+    it("still reports a failure reset when the changed prop does not identify the resource", () => {
+      const result = runRule(
+        noAdjustStateOnPropChange,
+        `function Preview({ userId, previewUrl }) {
+          const [hasFailed, setHasFailed] = useState(false);
+          useEffect(() => {
+            setHasFailed(false);
+          }, [userId]);
+          return (
+            <img
+              src={previewUrl}
+              onError={() => {
+                logFailure(userId);
+                setHasFailed(true);
+              }}
+            />
+          );
+        }`,
+        { forceJsx: true },
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    });
+
     it("stays silent on an async probe whose on* handler assignments set the same state (psysonic artistHero)", () => {
       const result = runRule(
         noAdjustStateOnPropChange,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-adjust-state-on-prop-change.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-adjust-state-on-prop-change.ts
@@ -16,6 +16,7 @@ import { getProgramAnalysis } from "./utils/effect/get-program-analysis.js";
 import type { ProgramAnalysis } from "./utils/effect/get-program-analysis.js";
 import { getEffectDepsRefs, hasCleanup, isProp, isState } from "./utils/effect/react.js";
 import { hasDeferredOrExternalEffectWork } from "./utils/has-deferred-or-external-effect-work.js";
+import { hasResourceLifecycleSetterWriter } from "./utils/has-resource-lifecycle-setter-writer.js";
 
 const writesPropDerivedValue = (analysis: ProgramAnalysis, fact: EffectStateWriteFact): boolean => {
   if (fact.writesPropDerivedMemberValue) return true;
@@ -92,6 +93,18 @@ export const noAdjustStateOnPropChange = defineRule({
         if (
           fact.isDeferred ||
           hasDeferredOrExternalEffectWork(analysis, node, context.scopes, fact.callExpression)
+        ) {
+          continue;
+        }
+        if (
+          fact.matchesStateInitializer &&
+          hasResourceLifecycleSetterWriter(
+            analysis,
+            context,
+            fact.setterReference,
+            node,
+            dependencyReferences,
+          )
         ) {
           continue;
         }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/has-resource-lifecycle-setter-writer.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/has-resource-lifecycle-setter-writer.ts
@@ -10,7 +10,7 @@ import { isProvenIntrinsicJsxElement } from "../../../utils/is-proven-intrinsic-
 import { resolveJsxElementType } from "../../../utils/resolve-jsx-element-type.js";
 import type { RuleContext } from "../../../utils/rule-context.js";
 import { walkAst } from "../../../utils/walk-ast.js";
-import { getRef } from "./effect/ast.js";
+import { getCallExpr, getRef } from "./effect/ast.js";
 import type { ProgramAnalysis } from "./effect/get-program-analysis.js";
 import { isSetterWiredToJsxHandler } from "./is-controlled-prop-mirror.js";
 
@@ -31,6 +31,20 @@ const RESOURCE_LIFECYCLE_EVENT_NAMES: ReadonlySet<string> = new Set([
   "onSuspend",
   "onWaiting",
 ]);
+
+const RESOURCE_IDENTITY_ATTRIBUTE_NAMES: ReadonlySet<string> = new Set([
+  "data",
+  "href",
+  "src",
+  "srcSet",
+]);
+
+const writesFailureLatch = (setterReference: Reference): boolean => {
+  const callExpression = getCallExpr(setterReference);
+  if (!callExpression || !isNodeOfType(callExpression, "CallExpression")) return false;
+  const writtenValue = callExpression.arguments?.[0] as EsTreeNode | undefined;
+  return Boolean(isNodeOfType(writtenValue, "Literal") && writtenValue.value === true);
+};
 
 const isResourceLifecycleAttribute = (
   analysis: ProgramAnalysis,
@@ -54,6 +68,12 @@ const isResourceLifecycleAttribute = (
   let readsDependency = false;
   for (const siblingAttribute of openingElement.attributes ?? []) {
     if (siblingAttribute === attribute) continue;
+    if (
+      !isNodeOfType(siblingAttribute, "JSXAttribute") ||
+      !RESOURCE_IDENTITY_ATTRIBUTE_NAMES.has(getJsxAttributeName(siblingAttribute.name) ?? "")
+    ) {
+      continue;
+    }
     walkAst(siblingAttribute, (child): boolean | void => {
       if (readsDependency) return false;
       if (!isNodeOfType(child, "Identifier")) return;
@@ -87,6 +107,7 @@ export const hasResourceLifecycleSetterWriter = (
 
   for (const reference of setterReference.resolved.references) {
     if (reference.init) continue;
+    if (!writesFailureLatch(reference)) continue;
     const identifier = reference.identifier as unknown as EsTreeNode;
     let outermostFunctionBelowComponent: EsTreeNode | null = null;
     let cursor: EsTreeNode | null | undefined = identifier;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/has-resource-lifecycle-setter-writer.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/has-resource-lifecycle-setter-writer.ts
@@ -1,0 +1,108 @@
+import type { Reference } from "eslint-scope";
+import { DOM_PROPERTY_TO_ALLOWED_TAGS } from "../../../constants/dom-property-tags.js";
+import type { EsTreeNode } from "../../../utils/es-tree-node.js";
+import { findEnclosingFunction } from "../../../utils/find-enclosing-function.js";
+import { getFunctionBindingIdentifier } from "../../../utils/get-function-binding-name.js";
+import { getJsxAttributeName } from "../../../utils/get-jsx-attribute-name.js";
+import { isFunctionLike } from "../../../utils/is-function-like.js";
+import { isNodeOfType } from "../../../utils/is-node-of-type.js";
+import { isProvenIntrinsicJsxElement } from "../../../utils/is-proven-intrinsic-jsx-element.js";
+import { resolveJsxElementType } from "../../../utils/resolve-jsx-element-type.js";
+import type { RuleContext } from "../../../utils/rule-context.js";
+import { walkAst } from "../../../utils/walk-ast.js";
+import { getRef } from "./effect/ast.js";
+import type { ProgramAnalysis } from "./effect/get-program-analysis.js";
+import { isSetterWiredToJsxHandler } from "./is-controlled-prop-mirror.js";
+
+const RESOURCE_LIFECYCLE_EVENT_NAMES: ReadonlySet<string> = new Set([
+  "onAbort",
+  "onCanPlay",
+  "onCanPlayThrough",
+  "onEmptied",
+  "onEncrypted",
+  "onEnded",
+  "onError",
+  "onLoad",
+  "onLoadedData",
+  "onLoadedMetadata",
+  "onLoadStart",
+  "onProgress",
+  "onStalled",
+  "onSuspend",
+  "onWaiting",
+]);
+
+const isResourceLifecycleAttribute = (
+  analysis: ProgramAnalysis,
+  context: RuleContext,
+  dependencyVariables: ReadonlySet<unknown>,
+  attribute: EsTreeNode,
+): boolean => {
+  if (!isNodeOfType(attribute, "JSXAttribute")) return false;
+  const attributeName = getJsxAttributeName(attribute.name);
+  if (!attributeName || !RESOURCE_LIFECYCLE_EVENT_NAMES.has(attributeName)) return false;
+  const openingElement = attribute.parent;
+  if (
+    !isNodeOfType(openingElement, "JSXOpeningElement") ||
+    !isProvenIntrinsicJsxElement(openingElement, context.scopes)
+  ) {
+    return false;
+  }
+  const elementName = resolveJsxElementType(openingElement);
+  if (!DOM_PROPERTY_TO_ALLOWED_TAGS.get(attributeName)?.has(elementName)) return false;
+
+  let readsDependency = false;
+  for (const siblingAttribute of openingElement.attributes ?? []) {
+    if (siblingAttribute === attribute) continue;
+    walkAst(siblingAttribute, (child): boolean | void => {
+      if (readsDependency) return false;
+      if (!isNodeOfType(child, "Identifier")) return;
+      const reference = getRef(analysis, child);
+      if (reference?.resolved && dependencyVariables.has(reference.resolved)) {
+        readsDependency = true;
+        return false;
+      }
+    });
+    if (readsDependency) break;
+  }
+  return readsDependency;
+};
+
+export const hasResourceLifecycleSetterWriter = (
+  analysis: ProgramAnalysis,
+  context: RuleContext,
+  setterReference: Reference,
+  effectNode: EsTreeNode,
+  dependencyReferences: readonly Reference[],
+): boolean => {
+  if (!setterReference.resolved) return false;
+  const componentFunction = findEnclosingFunction(effectNode);
+  if (!componentFunction) return false;
+  const dependencyVariables = new Set(
+    dependencyReferences.flatMap((reference) => (reference.resolved ? [reference.resolved] : [])),
+  );
+  if (dependencyVariables.size === 0) return false;
+  const matchesAttribute = (attribute: EsTreeNode): boolean =>
+    isResourceLifecycleAttribute(analysis, context, dependencyVariables, attribute);
+
+  for (const reference of setterReference.resolved.references) {
+    if (reference.init) continue;
+    const identifier = reference.identifier as unknown as EsTreeNode;
+    let outermostFunctionBelowComponent: EsTreeNode | null = null;
+    let cursor: EsTreeNode | null | undefined = identifier;
+    while (cursor && cursor !== componentFunction) {
+      if (isNodeOfType(cursor, "JSXAttribute") && matchesAttribute(cursor)) return true;
+      if (isFunctionLike(cursor)) outermostFunctionBelowComponent = cursor;
+      cursor = cursor.parent ?? null;
+    }
+    if (!outermostFunctionBelowComponent) continue;
+    const bindingIdentifier = getFunctionBindingIdentifier(outermostFunctionBelowComponent);
+    if (
+      isNodeOfType(bindingIdentifier, "Identifier") &&
+      isSetterWiredToJsxHandler(componentFunction, bindingIdentifier.name, matchesAttribute)
+    ) {
+      return true;
+    }
+  }
+  return false;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/is-controlled-prop-mirror.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/is-controlled-prop-mirror.ts
@@ -98,6 +98,7 @@ const referencesIdentifierNamed = (root: EsTreeNode, identifierName: string): bo
 export const isSetterWiredToJsxHandler = (
   componentFunction: EsTreeNode,
   setterName: string,
+  matchesAttribute: (attribute: EsTreeNode) => boolean = () => true,
 ): boolean => {
   let isWired = false;
   walkAst(componentFunction, (child: EsTreeNode): boolean | void => {
@@ -109,7 +110,7 @@ export const isSetterWiredToJsxHandler = (
     ) {
       return false;
     }
-    if (!isNodeOfType(child, "JSXAttribute") || !child.value) return;
+    if (!isNodeOfType(child, "JSXAttribute") || !child.value || !matchesAttribute(child)) return;
     const attributeName = getJsxAttributeName(child.name);
     if (!attributeName || !isEventHandlerName(attributeName)) return;
     if (referencesIdentifierNamed(child.value, setterName)) {


### PR DESCRIPTION
## Problem

`no-adjust-state-on-prop-change` treated a media playback failure latch as render-derived state merely because it resets when `src` or `mime` changes:

```tsx
const [hasFailed, setHasFailed] = useState(false);

useEffect(() => {
  setHasFailed(false);
}, [src, mime]);

const handleLoadedData = (event) => {
  event.currentTarget.play()?.catch(() => setHasFailed(true));
};

return (
  <video
    src={src}
    onLoadedData={handleLoadedData}
    onError={() => setHasFailed(true)}
  />
);
```

That state is not calculable from props during render. It records whether the current external media resource failed at runtime. Resetting the latch for a new resource identity is the retry boundary; preserving the old failure would incorrectly keep the replacement video hidden.

This came from the audited ReactBench trial `fix-react-jumperexchange-jumper__2GBTh7Z` in task `fix-react-jumperexchange-jumper-exchange-2917`:

- `verifier/model.patch` adds the exact `src`/`mime` reset and video error/play rejection writers.
- `verifier/test.log` records 28/28 focused behavioral tests passing.
- Tests cover runtime media error, rejected autoplay, and retry when MIME changes for the same source.
- `verifier/rd-after.json` adds `no-adjust-state-on-prop-change` at the reset.
- Reward is zero only because the React Doctor gate rejects the new diagnostic.

React guidance distinguishes redundant prop-derived state from synchronization with external systems. The HTML media lifecycle separately defines `error` and `loadeddata` as resource events:

- https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
- https://html.spec.whatwg.org/multipage/media.html#event-media-error
- https://html.spec.whatwg.org/multipage/media.html#event-media-loadeddata

## Fix

The rule now suppresses this shape only when all of the following are proven:

1. The effect restores the state initializer.
2. The same setter is written from a high-signal lifecycle event on a proven intrinsic resource element.
3. An effect dependency is also read by a different attribute on that same resource element, tying the reset to resource identity.

This accepts the benchmark shape while preserving the published true positive:

```tsx
const [draft, setDraft] = useState("");

useEffect(() => {
  setDraft("");
}, [documentId]);

return <input value={draft} onChange={(event) => setDraft(event.target.value)} />;
```

The detector also continues to report when an unrelated image has an error handler, when the changed prop is not the resource input, when the dependency is mentioned only inside the error handler, and when the JSX target is an unproven custom component.

The JSX handler matcher gained a predicate so the resource proof reuses the existing shadow-aware binding traversal instead of adding a parallel name-resolution implementation.

## Verification

- Exact Jumper media-latch regression: silent.
- Unrelated media and wrong-resource dependency counterexamples: still report.
- Nearby document draft reset: still reports.
- Added a fuzz regression seeded from ReactBench trial `2GBTh7Z`.
- Focused rule suites: 58/58 passing.
- Oxlint plugin suite: 25,533 passing, 201 skipped.
- Full repository test suite: 15/15 tasks passing.
- Strict fuzz run: 782/782 passing with seed 2082026 and the 500-iteration setting.
- Fuzz smoke: 192 passing, 782 skipped.
- Lint, typecheck, format check, and JSON report smoke test pass.

Local RDE sampling is blocked because `AXIOM_DATASET` is not configured. Daytona PR parity is blocked because `DAYTONA_API_KEY` is not configured; CI remains the authoritative parity signal.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Targeted heuristic change to a widely used lint rule; false negatives are possible if the resource-latch pattern is approximated without meeting all proof conditions.
> 
> **Overview**
> **`no-adjust-state-on-prop-change`** no longer flags effects that reset state to its initializer when that pattern is a **media/resource failure latch** tied to resource identity.
> 
> The rule skips a write when the effect restores the initial value, the same setter is later set to `true` from a resource lifecycle handler (`onError`, `onLoadedData`, etc.) on a proven intrinsic element (`video`, `img`, …), and an effect dependency is read by a sibling identity attribute (`src`, `href`, `data`, `srcSet`) on that element. A new **`hasResourceLifecycleSetterWriter`** helper implements that proof; **`isSetterWiredToJsxHandler`** accepts an optional attribute predicate so handler wiring checks can require matching lifecycle handlers.
> 
> Regression tests and a fuzz corpus case cover the Jumper-style video latch (silent) while draft resets and mismatched dependency/resource shapes still report.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c12f06db23c18158f0f3e75c56d77f616160080. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Parity results

This supersedes the earlier environment note: Daytona parity completed after the PR was opened.

| Check | Result |
| --- | --- |
| Exact head | `7c12f06db23c18158f0f3e75c56d77f616160080` |
| Projects compared | 5,766 |
| Skipped projects | 0 |
| Added / removed | 1 / 7 |
| Target rule | `no-adjust-state-on-prop-change` |
| Artifact verification | passed |

The one nominal addition is not a new source hit: the same Onyx diagnostic at `ImagePreview.tsx:27` remains after its adjacent resource-latch diagnostic is removed, so its `fixGroupId` disappears. The semantic delta is six net removals at the intended resource-failure-latch boundary. Artifacts: `tmp/parity-batch-1544-1547-retry-5766/pr-1546/artifacts/`.
