### PR TITLE
FPFNFIX82: RDFPFN82026: exclude media latches from all-state resets

### DIFF
--- a/.changeset/avoid-media-latch-all-state-reset.md
+++ b/.changeset/avoid-media-latch-all-state-reset.md
@@ -1,0 +1,6 @@
+---
+"oxlint-plugin-react-doctor": patch
+"eslint-plugin-react-doctor": patch
+---
+
+Avoid treating a resource failure latch as an all-state prop reset.

--- a/packages/fuzz/corpus/regressions/no-reset-all-state-on-prop-change--resource-failure-latch.tsx
+++ b/packages/fuzz/corpus/regressions/no-reset-all-state-on-prop-change--resource-failure-latch.tsx
@@ -1,0 +1,20 @@
+// rule: no-reset-all-state-on-prop-change
+// verdict: pass
+// weakness: library-idiom
+// source: verified ReactBench Jumper trial 2GBTh7Z
+
+import { useEffect, useState } from "react";
+
+interface VideoPreviewProps {
+  src: string;
+}
+
+export const VideoPreview = ({ src }: VideoPreviewProps) => {
+  const [hasFailed, setHasFailed] = useState(false);
+
+  useEffect(() => {
+    setHasFailed(false);
+  }, [src]);
+
+  return <video hidden={hasFailed} src={src} onError={() => setHasFailed(true)} />;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-reset-all-state-on-prop-change.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-reset-all-state-on-prop-change.regressions.test.ts
@@ -68,6 +68,27 @@ describe("no-reset-all-state-on-prop-change — regressions", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("still reports an editable value reset despite a resource error writer", () => {
+    const result = runRule(
+      noResetAllStateOnPropChange,
+      `function Editor({ documentId }) {
+        const [draft, setDraft] = useState("");
+        useEffect(() => {
+          setDraft("");
+        }, [documentId]);
+        return (
+          <>
+            <input value={draft} onChange={(event) => setDraft(event.target.value)} />
+            <img src={documentId} onError={() => setDraft("unavailable")} />
+          </>
+        );
+      }`,
+      { forceJsx: true },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("stays silent for an extracted async loading lifecycle helper", () => {
     const result = runRule(
       noResetAllStateOnPropChange,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-reset-all-state-on-prop-change.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-reset-all-state-on-prop-change.regressions.test.ts
@@ -3,6 +3,71 @@ import { runRule } from "../../../test-utils/run-rule.js";
 import { noResetAllStateOnPropChange } from "./no-reset-all-state-on-prop-change.js";
 
 describe("no-reset-all-state-on-prop-change — regressions", () => {
+  it("stays silent when the only state is a media failure latch reset for a new resource", () => {
+    const result = runRule(
+      noResetAllStateOnPropChange,
+      `function AnimatedBackground({ src, mime }) {
+        const [hasFailed, setHasFailed] = useState(false);
+        useEffect(() => {
+          setHasFailed(false);
+        }, [src, mime]);
+        const handleLoadedData = (event) => {
+          event.currentTarget.play()?.catch(() => setHasFailed(true));
+        };
+        return (
+          <video
+            src={src}
+            type={mime}
+            onLoadedData={handleLoadedData}
+            onError={() => setHasFailed(true)}
+          />
+        );
+      }`,
+      { forceJsx: true },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still reports when all state includes an ordinary prop-keyed draft reset", () => {
+    const result = runRule(
+      noResetAllStateOnPropChange,
+      `function Editor({ documentId, previewUrl }) {
+        const [draft, setDraft] = useState("");
+        const [previewFailed, setPreviewFailed] = useState(false);
+        useEffect(() => {
+          setDraft("");
+          setPreviewFailed(false);
+        }, [documentId, previewUrl]);
+        return (
+          <>
+            <input value={draft} onChange={(event) => setDraft(event.target.value)} />
+            <img src={previewUrl} onError={() => setPreviewFailed(true)} />
+          </>
+        );
+      }`,
+      { forceJsx: true },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still reports when the changed prop does not identify the resource", () => {
+    const result = runRule(
+      noResetAllStateOnPropChange,
+      `function Preview({ userId, previewUrl }) {
+        const [hasFailed, setHasFailed] = useState(false);
+        useEffect(() => {
+          setHasFailed(false);
+        }, [userId]);
+        return <img src={previewUrl} onError={() => setHasFailed(true)} />;
+      }`,
+      { forceJsx: true },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("stays silent for an extracted async loading lifecycle helper", () => {
     const result = runRule(
       noResetAllStateOnPropChange,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-reset-all-state-on-prop-change.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-reset-all-state-on-prop-change.ts
@@ -32,6 +32,7 @@ import {
   isState,
   isSyncStateSetterCall,
 } from "./utils/effect/react.js";
+import { hasResourceLifecycleSetterWriter } from "./utils/has-resource-lifecycle-setter-writer.js";
 import { getStaticMemberPropertyName } from "./utils/static-member-property-name.js";
 
 // 1:1 port of upstream `src/rules/no-reset-all-state-on-prop-change.js`.
@@ -1247,6 +1248,13 @@ const findPropUsedToResetAllState = (
     isSetStateToInitialValue(analysis, context, ref),
   );
   if (!allResetToInitial) return null;
+  if (
+    stateSetterRefs.every((setterReference) =>
+      hasResourceLifecycleSetterWriter(analysis, context, setterReference, useEffectNode, depsRefs),
+    )
+  ) {
+    return null;
+  }
 
   // The sync reset is the loading phase of a fetch lifecycle when the SAME
   // state is set again from an async continuation inside this effect (the


### PR DESCRIPTION
## Dependency

This PR is intentionally stacked on #1546. That PR adds the shared, resource-provenance helper. This PR contains the independent fix for `no-reset-all-state-on-prop-change` only.

## Problem

`no-reset-all-state-on-prop-change` counts `useState` cells mechanically. In a component with one state cell, resetting one external-resource failure latch satisfies the phrase “clears all state”:

```tsx
const [hasFailed, setHasFailed] = useState(false);

useEffect(() => {
  setHasFailed(false);
}, [src, mime]);

return (
  <video
    src={src}
    onError={() => setHasFailed(true)}
  />
);
```

The warning recommends key-remounting the component as if `hasFailed` were user-editable subtree state. It is instead runtime history for the current media resource. The latch must clear when `src` or `mime` identifies a replacement so playback can retry. Remounting the animated wrapper can also change `AnimatePresence` identity and animation timing.

The audited ReactBench trial `fix-react-jumperexchange-jumper__2GBTh7Z` proves the mismatch:

- Task: `fix-react-jumperexchange-jumper-exchange-2917`.
- File: `src/components/core/AnimatedBackgroundImage/AnimatedBackgroundImage.tsx`, lines 20-24.
- `verifier/model.patch` adds the single `hasFailed` state cell, media error/play-rejection writers, and the resource-keyed reset.
- `verifier/test.log` records 28/28 behavioral tests passing, including runtime error fallback, autoplay rejection, and same-source MIME retry.
- `verifier/rd-after.json` adds `no-reset-all-state-on-prop-change` at the effect.
- The oracle models the same concept as a keyed failure identity, confirming that this is resource history rather than redundant UI state.

React documents keying as the remedy when a profile or subtree represents a conceptually different entity. The benchmark component deliberately preserves its animated wrapper while replacing only the media resource:

- https://react.dev/learn/you-might-not-need-an-effect#resetting-all-state-when-a-prop-changes
- https://html.spec.whatwg.org/multipage/media.html#event-media-error

## Fix

After proving that every synchronous write restores its initializer, the rule now asks whether every reset state is tied to a proven intrinsic resource lifecycle and to the resource dependency changed by the effect. If all reset cells are resource lifecycle latches, the “all state reset” conclusion is not emitted.

The scope remains deliberately narrow:

- A one-cell media failure latch keyed by its own `src` is silent.
- A failure latch reset by an unrelated prop still reports.
- A mixed component that clears both a media latch and an ordinary editable draft still reports.
- The published one-cell profile comment reset still reports.

```tsx
const [comment, setComment] = useState("");

useEffect(() => {
  setComment("");
}, [userId]);

return <textarea value={comment} onChange={(event) => setComment(event.target.value)} />;
```

## Verification

- Exact one-cell Jumper media latch: silent.
- Wrong-resource dependency and mixed draft/media counterexamples: still report.
- Focused rule suite: 94/94 passing.
- Oxlint plugin suite: 25,536 passing, 201 skipped.
- Full repository test suite: 15/15 tasks passing.
- Strict fuzz run: 782/782 passing with seed 2082026 and the 500-iteration setting.
- Added a fuzz regression seeded from ReactBench trial `2GBTh7Z`.
- Fuzz smoke: 192 passing, 782 skipped.
- Lint, typecheck, format check, and JSON report smoke test pass.

Local RDE sampling is blocked because `AXIOM_DATASET` is not configured. Daytona PR parity is blocked because `DAYTONA_API_KEY` is not configured; CI remains the authoritative parity signal.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow lint-rule heuristic change with extensive regression tests; no runtime or security impact.
> 
> **Overview**
> **`no-reset-all-state-on-prop-change`** no longer treats a lone **media/resource failure latch** (e.g. `hasFailed` cleared when `src` changes) as “clears all state,” so it stops recommending a `key` remount for that pattern.
> 
> After the rule confirms every synchronous setter in the effect restores its initializer, it now bails out when **each** of those setters is tied to a proven intrinsic resource lifecycle (error/load handlers on `video`/`img`, identity attrs like `src`, and effect deps that match that resource). Mixed cases—editable draft plus latch, latch reset on the wrong prop, or draft reset with only incidental error writers—still report.
> 
> Adds regression tests, a fuzz corpus case from ReactBench, and a patch changeset for both eslint and oxlint plugins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cff304ff1aa0c8131f950fc2ade6a3053555ae63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Parity results

This supersedes the earlier environment note: Daytona parity completed after the PR was opened.

| Check | Result |
| --- | --- |
| Exact head | `bbcb2d4af93d2425161cdb0e0a3d47a634e6ea1a` |
| Projects compared | 5,766 |
| Skipped projects | 0 |
| Added / removed | 0 / 4 |
| Target rule | `no-reset-all-state-on-prop-change` |
| Artifact verification | passed |

All four removals match the intended resource-failure-latch boundary; parity added no diagnostics. Artifacts: `tmp/parity-batch-1544-1547-retry-5766/pr-1547/artifacts/`.
