### PR TITLE
FPFNFIX82 Allow cheap empty collection refs

### DIFF
--- a/.changeset/cheap-collection-refs.md
+++ b/.changeset/cheap-collection-refs.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Allow cheap zero-argument built-in collection constructors in ref initialization.

--- a/packages/fuzz/corpus/regressions/rerender-lazy-ref-init--empty-built-in-collections.tsx
+++ b/packages/fuzz/corpus/regressions/rerender-lazy-ref-init--empty-built-in-collections.tsx
@@ -1,0 +1,14 @@
+// rule: rerender-lazy-ref-init
+// verdict: pass
+// weakness: library-idiom
+// source: React Bench RD 0.9.3 second-pass FP-001
+
+import { useRef } from "react";
+
+export const EmptyCollectionRefs = () => {
+  const map = useRef(new Map());
+  const set = useRef(new Set());
+  const weakMap = useRef(new WeakMap());
+  const weakSet = useRef(new WeakSet());
+  return null;
+};

--- a/packages/fuzz/corpus/true-positives/rerender-lazy-ref-init--zero-argument-constructors.tsx
+++ b/packages/fuzz/corpus/true-positives/rerender-lazy-ref-init--zero-argument-constructors.tsx
@@ -5,8 +5,6 @@
 import { useRef } from "react";
 
 export const Cache = () => {
-  const entries = useRef(new Map());
-  const selected = useRef(new Set());
   const controller = useRef(new AbortController());
   return null;
 };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/rerender-lazy-ref-init.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/rerender-lazy-ref-init.regressions.test.ts
@@ -58,7 +58,7 @@ describe("rerender-lazy-ref-init — regressions", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
-  it("flags a construction with only type arguments", () => {
+  it("allows a global empty collection construction with only type arguments", () => {
     const result = runRule(
       rerenderLazyRefInit,
       `function C() {
@@ -67,10 +67,10 @@ describe("rerender-lazy-ref-init — regressions", () => {
       }`,
     );
     expect(result.parseErrors).toEqual([]);
-    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics).toEqual([]);
   });
 
-  it("flags a TS-wrapped zero-argument construction", () => {
+  it("allows a TS-wrapped global empty collection construction", () => {
     const result = runRule(
       rerenderLazyRefInit,
       `function C() {
@@ -79,7 +79,7 @@ describe("rerender-lazy-ref-init — regressions", () => {
       }`,
     );
     expect(result.parseErrors).toEqual([]);
-    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics).toEqual([]);
   });
 
   it("flags a TS-wrapped expensive construction (wrapper transparency)", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/rerender-lazy-ref-init.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/rerender-lazy-ref-init.test.ts
@@ -88,7 +88,7 @@ describe("rerender-lazy-ref-init", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
-  it("flags zero-argument constructors", () => {
+  it("allows cheap empty collection constructors but flags other zero-argument constructors", () => {
     const result = runRule(
       rerenderLazyRefInit,
       `
@@ -105,7 +105,8 @@ describe("rerender-lazy-ref-init", () => {
     );
 
     expect(result.parseErrors).toEqual([]);
-    expect(result.diagnostics).toHaveLength(5);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("new AbortController()");
   });
 
   it("flags `new Set(props.items)` — a runtime argument iterates its input on every render", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/rerender-lazy-ref-init.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/rerender-lazy-ref-init.ts
@@ -7,6 +7,13 @@ import { isReactHookName } from "../../utils/is-react-hook-name.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 
+const CHEAP_EMPTY_COLLECTION_CONSTRUCTOR_NAMES: ReadonlySet<string> = new Set([
+  "Map",
+  "Set",
+  "WeakMap",
+  "WeakSet",
+]);
+
 export const rerenderLazyRefInit = defineRule({
   id: "rerender-lazy-ref-init",
   title: "Ref initializer runs on every render",
@@ -34,6 +41,16 @@ export const rerenderLazyRefInit = defineRule({
       const calleeName = isNodeOfType(callee, "Identifier")
         ? callee.name
         : (memberPropertyName ?? "fn");
+
+      if (
+        isNewCall &&
+        initializer.arguments.length === 0 &&
+        isNodeOfType(callee, "Identifier") &&
+        CHEAP_EMPTY_COLLECTION_CONSTRUCTOR_NAMES.has(callee.name) &&
+        context.scopes.isGlobalReference(callee)
+      ) {
+        return;
+      }
 
       if (TRIVIAL_INITIALIZER_NAMES.has(calleeName)) return;
 


### PR DESCRIPTION
## Why\n\nrerender-lazy-ref-init treated cheap, pure zero-argument collection constructors as expensive eager ref initialization. The benchmark found 128 false-positive occurrences across 86 trials.\n\n## What changed\n\n- permit zero-argument global Map, Set, WeakMap, and WeakSet constructors\n- preserve diagnostics for argument-bearing constructors, shadowed bindings, and unknown factories\n- add focused rule regressions and fuzz corpus coverage\n\n## Eval results\n\nCached replay changed the confirmed empty-collection cluster from 128 findings across 86 trials to zero. A nearby useRef(emptyBatch()) diagnostic remains.\n\nPull request parity is blocked because DAYTONA_API_KEY is unavailable in the publishing environment.\n\n## Test plan\n\n- nr -C packages/oxlint-plugin-react-doctor test\n- nr -C packages/fuzz test\n- FUZZ_RULE=rerender-lazy-ref-init FUZZ_ITERATIONS=500 FUZZ_STRICT=1 nr -C packages/fuzz fuzz\n- nr test\n- nr typecheck\n- nr lint\n- nr format:check