### PR TITLE
FPFNFIX82 Fix symbol-only control names

### DIFF
--- a/.changeset/name-symbol-controls.md
+++ b/.changeset/name-symbol-controls.md
@@ -1,0 +1,6 @@
+---
+"oxlint-plugin-react-doctor": patch
+"eslint-plugin-react-doctor": patch
+---
+
+Report symbol-only controls that lack a meaningful accessible name.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/control-has-associated-label.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/control-has-associated-label.regressions.test.ts
@@ -986,6 +986,41 @@ describe("a11y/control-has-associated-label regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("accepts logical fallbacks when either possible child provides label text", () => {
+    const result = runRule(
+      controlHasAssociatedLabel,
+      `
+        const Pager = ({ label }) => (
+          <nav>
+            <button>{"Close" || "×"}</button>
+            <button>{label || "×"}</button>
+            <button>{"Close" ?? "×"}</button>
+            <button>{label ?? "×"}</button>
+          </nav>
+        );
+      `,
+    );
+
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("reports logical fallbacks when neither possible child provides label text", () => {
+    const result = runRule(
+      controlHasAssociatedLabel,
+      `
+        const Pager = () => (
+          <nav>
+            <button>{"" || "×"}</button>
+            <button>{null ?? "×"}</button>
+            <button>{true && "×"}</button>
+          </nav>
+        );
+      `,
+    );
+
+    expect(result.diagnostics).toHaveLength(3);
+  });
+
   it("accepts icon buttons carrying either an aria-label or a native title", () => {
     const result = runRule(
       controlHasAssociatedLabel,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/control-has-associated-label.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/control-has-associated-label.regressions.test.ts
@@ -948,6 +948,44 @@ describe("a11y/control-has-associated-label regressions", () => {
     expect(result.diagnostics).toHaveLength(3);
   });
 
+  it("reports controls whose only child text is a symbol or emoji", () => {
+    const result = runRule(
+      controlHasAssociatedLabel,
+      `
+        const Player = ({ playing, onToggle }) => (
+          <nav>
+            <button>×</button>
+            <button>{"＋"}</button>
+            <button>{\`➕\`}</button>
+            <button>{playing ? "Ⅱ" : "▶"}</button>
+            <button>⏮</button>
+            <button role="switch" onClick={onToggle}>🔊</button>
+          </nav>
+        );
+      `,
+    );
+
+    expect(result.diagnostics).toHaveLength(6);
+  });
+
+  it("accepts concise text, numeric, and explicitly named symbol controls", () => {
+    const result = runRule(
+      controlHasAssociatedLabel,
+      `
+        const Pager = () => (
+          <nav>
+            <button>Close</button>
+            <button>1</button>
+            <button aria-label="Add photo">＋</button>
+            <button title="Previous track">⏮</button>
+          </nav>
+        );
+      `,
+    );
+
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("accepts icon buttons carrying either an aria-label or a native title", () => {
     const result = runRule(
       controlHasAssociatedLabel,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/control-has-associated-label.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/control-has-associated-label.ts
@@ -598,8 +598,13 @@ const expressionProvidesLabel = (
     );
   }
   if (isNodeOfType(expression, "LogicalExpression")) {
-    // Only the right side of `guard && <content/>` renders as content.
-    return expressionProvidesLabel(expression.right as EsTreeNode, currentDepth, context);
+    if (expression.operator === "&&") {
+      return expressionProvidesLabel(expression.right, currentDepth, context);
+    }
+    return (
+      expressionProvidesLabel(expression.left, currentDepth, context) ||
+      expressionProvidesLabel(expression.right, currentDepth, context)
+    );
   }
   if (isNodeOfType(expression, "JSXElement") || isNodeOfType(expression, "JSXFragment")) {
     return checkChildForLabel(expression, currentDepth, context);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/control-has-associated-label.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/control-has-associated-label.ts
@@ -8,6 +8,7 @@ import { getStaticTemplateLiteralValue } from "../../utils/get-static-template-l
 import { getJsxAttributeName } from "../../utils/get-jsx-attribute-name.js";
 import { getJsxPropStringValue } from "../../utils/get-jsx-prop-string-value.js";
 import { hasJsxPropIgnoreCase } from "../../utils/has-jsx-prop-ignore-case.js";
+import { hasLetterOrDecimalDigit } from "../../utils/has-letter-or-decimal-digit.js";
 import { isHiddenFromScreenReader } from "../../utils/is-hidden-from-screen-reader.js";
 import { isInteractiveElement } from "../../utils/is-interactive-element.js";
 import { isInteractiveRole } from "../../utils/is-interactive-role.js";
@@ -20,7 +21,7 @@ import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
 import { getStringLiteralAttributeValue } from "../../utils/get-string-literal-attribute-value.js";
 
 const MESSAGE =
-  "Blind users can't tell what this control does because screen readers find no label, so add visible text, `aria-label`, or `aria-labelledby`.";
+  "Blind users can't tell what this control does because its name is missing or only a symbol, so add visible text, `aria-label`, or `aria-labelledby`.";
 
 interface ControlHasAssociatedLabelSettings {
   depth?: number;
@@ -582,9 +583,13 @@ const expressionProvidesLabel = (
   const expression = stripParenExpression(rawExpression);
   if (isNodeOfType(expression, "JSXEmptyExpression")) return false;
   if (isNodeOfType(expression, "Literal")) {
-    if (typeof expression.value === "string") return expression.value.trim().length > 0;
+    if (typeof expression.value === "string") return hasLetterOrDecimalDigit(expression.value);
     if (typeof expression.value === "number") return true;
     return false;
+  }
+  if (isNodeOfType(expression, "TemplateLiteral")) {
+    const staticValue = getStaticTemplateLiteralValue(expression);
+    return staticValue === null || hasLetterOrDecimalDigit(staticValue);
   }
   if (isNodeOfType(expression, "ConditionalExpression")) {
     return (
@@ -611,7 +616,7 @@ const checkChildForLabel = (
   if (isNodeOfType(child, "JSXExpressionContainer")) {
     return expressionProvidesLabel(child.expression as EsTreeNode, currentDepth, context);
   }
-  if (isNodeOfType(child, "JSXText")) return child.value.trim().length > 0;
+  if (isNodeOfType(child, "JSXText")) return hasLetterOrDecimalDigit(child.value);
   if (isNodeOfType(child, "JSXFragment")) {
     return child.children.some((nestedChild) =>
       checkChildForLabel(nestedChild as EsTreeNode, currentDepth + 1, context),

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/has-letter-or-decimal-digit.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/has-letter-or-decimal-digit.ts
@@ -1,0 +1,4 @@
+const LETTER_OR_DECIMAL_DIGIT_PATTERN = /[\p{L}\p{Nd}]/u;
+
+export const hasLetterOrDecimalDigit = (value: string): boolean =>
+  LETTER_OR_DECIMAL_DIGIT_PATTERN.test(value);


### PR DESCRIPTION
## Summary

- make `control-has-associated-label` reject static child text made only of symbols or emoji
- preserve conservative handling for dynamic text and existing support for visible words, decimal page numbers, `aria-label`, `aria-labelledby`, and native `title`
- cover direct JSX text, string expressions, static templates, conditional symbol controls, and valid named controls
- add patch changesets for the oxlint and ESLint plugins

## Why

The Figma-to-code audit found real false negatives in Spotify and Placify: controls such as `×`, `＋`, `Ⅱ`, and `▶` passed because any non-empty JSX text counted as a useful label. A glyph may be visible, but it does not name the control's action for assistive technology.

This follows WAI guidance that an icon control's accessible name should describe its function rather than repeat the icon.

## Evaluation

- cached Luna/Sol source audit: 21 → 480 diagnostics, exposing 459 previously missed symbol-only controls across 156 of 315 rollouts; no parse errors
- bounded React Doctor Evals sample: 78 → 83 diagnostics across 100 project roots
- inspected all five added open-source hits: two unnamed kebab-menu controls and three emoji-only heart/mail/share actions; all are true positives
- strict fuzz: 500 iterations, 468 executed programs, 225 firing programs, zero findings

## Validation

- focused rule regression tests: 62/62
- full repository tests: 15/15 tasks, including 25,542 oxlint-plugin tests
- `nr lint`
- `nr typecheck`
- `nr smoke:json-report`
- `nr format:check`
- `nr build`

RDE artifacts are preserved at `/tmp/react-doctor-rde-symbolic/` in the authoring environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Increases diagnostic volume on real codebases but only narrows one a11y rule with explicit safe harbors; misclassification of edge-case Unicode text is the main behavioral risk.
> 
> **Overview**
> **`control-has-associated-label`** no longer treats any non-empty JSX child text as an accessible name. Static text must include at least one Unicode letter or decimal digit via new **`hasLetterOrDecimalDigit`**, so controls labeled only with glyphs or emoji (e.g. `×`, `▶`, `🔊`) are reported.
> 
> The rule message now calls out symbol-only names. Label detection also applies that check to static template literals, and **`||` / `??`** fallbacks are analyzed on both sides so a wordy branch still satisfies the rule when the other branch is symbol-only. **`aria-label`**, **`title`**, visible words, page numbers, and existing icon/label paths are unchanged.
> 
> Patch changesets cover both **oxlint** and **eslint** react-doctor plugins; regression tests cover symbol-only controls, valid exceptions, and logical fallbacks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aec5ad169aa3a9b8dffb1975d11a0d596e42e16c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->