### PR TITLE
FPFNFIX82: recognize self-reconnecting observer cleanup

### DIFF
--- a/.changeset/recognize-reconnecting-observer-cleanup.md
+++ b/.changeset/recognize-reconnecting-observer-cleanup.md
@@ -1,0 +1,6 @@
+---
+"oxlint-plugin-react-doctor": patch
+"eslint-plugin-react-doctor": patch
+---
+
+Recognize observer reconnect helpers that release each replacement and the latest observer on cleanup.

--- a/packages/fuzz/corpus/regressions/effect-needs-cleanup--reconnecting-observer.tsx
+++ b/packages/fuzz/corpus/regressions/effect-needs-cleanup--reconnecting-observer.tsx
@@ -1,0 +1,16 @@
+// effect-needs-cleanup | wrapper-transparency | ReactBench Cloudscape visual context
+import { useLayoutEffect } from "react";
+
+export const VisualContextWatcher = ({ element }: { element: HTMLElement }): null => {
+  useLayoutEffect(() => {
+    let observer: MutationObserver | undefined;
+    const refresh = () => {
+      observer?.disconnect();
+      observer = new MutationObserver(refresh);
+      observer.observe(element, { attributes: true, childList: true });
+    };
+    refresh();
+    return () => observer?.disconnect();
+  }, [element]);
+  return null;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.regressions.test.ts
@@ -3001,6 +3001,96 @@ export const useResizableColumns = () => {
 });
 
 describe("effect-needs-cleanup adversarial edge cases (observers / connections / retained functions)", () => {
+  it("accepts an observer replaced by a self-reconnecting helper with unmount cleanup", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useLayoutEffect } from "react";
+export const ContextWatcher = ({ element }) => {
+  useLayoutEffect(() => {
+    let observer;
+    const refresh = () => {
+      observer?.disconnect();
+      observer = new MutationObserver(refresh);
+      for (let node = element; node; node = node.parentElement) {
+        observer.observe(node, { attributes: true, childList: true });
+      }
+    };
+    refresh();
+    return () => observer?.disconnect();
+  }, [element]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("flags a reconnect helper that replaces the observer without releasing the previous one", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useLayoutEffect } from "react";
+export const ContextWatcher = ({ element }) => {
+  useLayoutEffect(() => {
+    let observer;
+    const refresh = () => {
+      observer = new MutationObserver(refresh);
+      observer.observe(element, { attributes: true });
+    };
+    refresh();
+    return () => observer?.disconnect();
+  }, [element]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags reconnect cleanup that is conditional on an unrelated value", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useLayoutEffect } from "react";
+export const ContextWatcher = ({ element, shouldDisconnect }) => {
+  useLayoutEffect(() => {
+    let observer;
+    const refresh = () => {
+      if (shouldDisconnect) observer?.disconnect();
+      observer = new MutationObserver(refresh);
+      observer.observe(element, { attributes: true });
+    };
+    refresh();
+    return () => observer?.disconnect();
+  }, [element, shouldDisconnect]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a reconnect helper also retained by an unrelated external owner", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useLayoutEffect } from "react";
+export const ContextWatcher = ({ element, scheduler }) => {
+  useLayoutEffect(() => {
+    let observer;
+    const refresh = () => {
+      observer?.disconnect();
+      observer = new MutationObserver(refresh);
+      observer.observe(element, { attributes: true });
+    };
+    refresh();
+    scheduler.register(refresh);
+    return () => observer?.disconnect();
+  }, [element, scheduler]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("flags an observer registered through a nested helper with no cleanup", () => {
     const result = runRule(
       effectNeedsCleanup,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -1,4 +1,5 @@
 import {
+  EXTERNAL_SYNC_OBSERVER_CONSTRUCTORS,
   SOCKET_CONSTRUCTOR_NAMES_REQUIRING_CLEANUP,
   TIMER_CALLEE_NAMES_REQUIRING_CLEANUP,
   TIMER_CLEANUP_CALLEE_NAMES,
@@ -1582,14 +1583,166 @@ const findSingleDirectInvocation = (
     : null;
 };
 
+const isGlobalObserverConstruction = (
+  node: EsTreeNode,
+  context: RuleContext,
+): node is EsTreeNodeOfType<"NewExpression"> => {
+  if (!isNodeOfType(node, "NewExpression")) return false;
+  const constructor = stripParenExpression(node.callee);
+  return (
+    isNodeOfType(constructor, "Identifier") &&
+    EXTERNAL_SYNC_OBSERVER_CONSTRUCTORS.has(constructor.name) &&
+    context.scopes.isGlobalReference(constructor)
+  );
+};
+
+const isNullishObserverInitializer = (
+  expression: EsTreeNode | null | undefined,
+  context: RuleContext,
+): boolean => {
+  if (!expression) return true;
+  const initializer = stripParenExpression(expression);
+  return (
+    (isNodeOfType(initializer, "Literal") && initializer.value === null) ||
+    (isNodeOfType(initializer, "Identifier") &&
+      initializer.name === "undefined" &&
+      context.scopes.isGlobalReference(initializer))
+  );
+};
+
+const findReconnectHelperInvocation = (
+  usageFunction: EsTreeNode,
+  effectCallback: EsTreeNode,
+  usage: SubscribeLikeUsage,
+  context: RuleContext,
+): EsTreeNode | null => {
+  if (
+    !isFunctionLike(usageFunction) ||
+    usageFunction.async ||
+    usageFunction.generator ||
+    usage.receiverKey === null ||
+    !isNodeOfType(usage.node, "CallExpression")
+  ) {
+    return null;
+  }
+  const usageCallee = stripParenExpression(usage.node.callee);
+  const usageReceiver = isNodeOfType(usageCallee, "MemberExpression")
+    ? stripParenExpression(usageCallee.object)
+    : null;
+  if (!usageReceiver || !isNodeOfType(usageReceiver, "Identifier")) return null;
+  const observerSymbol = context.scopes.symbolFor(usageReceiver);
+  const observerDeclaration = observerSymbol?.declarationNode;
+  if (
+    !observerSymbol ||
+    (observerSymbol.kind !== "let" && observerSymbol.kind !== "var") ||
+    !isNodeOfType(observerDeclaration, "VariableDeclarator") ||
+    observerDeclaration.id !== observerSymbol.bindingIdentifier ||
+    findEnclosingFunction(observerDeclaration) !== effectCallback ||
+    !isNullishObserverInitializer(observerDeclaration.init, context)
+  ) {
+    return null;
+  }
+
+  const observerAssignments: EsTreeNodeOfType<"AssignmentExpression">[] = [];
+  for (const reference of observerSymbol.references) {
+    const referenceRoot = findTransparentExpressionRoot(reference.identifier);
+    const referenceParent = referenceRoot.parent;
+    if (
+      isNodeOfType(referenceParent, "AssignmentExpression") &&
+      referenceParent.operator === "=" &&
+      referenceParent.left === referenceRoot
+    ) {
+      observerAssignments.push(referenceParent);
+      continue;
+    }
+    const member = referenceParent;
+    const methodCall = member?.parent;
+    if (
+      !isNodeOfType(member, "MemberExpression") ||
+      member.object !== referenceRoot ||
+      !isNodeOfType(methodCall, "CallExpression") ||
+      methodCall.callee !== member ||
+      !["disconnect", "observe", "unobserve"].includes(getStaticPropertyKeyName(member) ?? "")
+    ) {
+      return null;
+    }
+  }
+  if (observerAssignments.length !== 1) return null;
+  const observerAssignment = observerAssignments[0];
+  if (!observerAssignment) return null;
+  const observerConstruction = stripParenExpression(observerAssignment.right);
+  if (
+    !isGlobalObserverConstruction(observerConstruction, context) ||
+    findEnclosingFunction(observerAssignment) !== usageFunction ||
+    !canNodeReachLaterNodeWithinFunction(observerAssignment, usage.node, usageFunction, context)
+  ) {
+    return null;
+  }
+
+  const matchingReleaseAnchors: EsTreeNode[] = [];
+  const assignmentStart = getRangeStart(observerAssignment);
+  if (assignmentStart === null) return null;
+  walkAst(usageFunction.body, (child: EsTreeNode) => {
+    if (child !== usageFunction.body && isFunctionLike(child)) return false;
+    if (!isNodeOfType(child, "CallExpression")) return;
+    const childStart = getRangeStart(child);
+    if (
+      childStart === null ||
+      childStart >= assignmentStart ||
+      !doesReleaseCallMatchUsage(child, usage, context)
+    ) {
+      return;
+    }
+    matchingReleaseAnchors.push(
+      findLiveExpressionGuardForRelease(child, usageFunction, usage.receiverKey ?? "", context) ??
+        child,
+    );
+  });
+  if (!doNodesCoverEveryPathFromFunctionEntry(usageFunction, matchingReleaseAnchors, context)) {
+    return null;
+  }
+
+  const functionBindingIdentifier = getFunctionBindingIdentifier(usageFunction);
+  const functionSymbol = functionBindingIdentifier
+    ? context.scopes.symbolFor(functionBindingIdentifier)
+    : null;
+  if (!functionSymbol) return null;
+  const directInvocations: EsTreeNode[] = [];
+  for (const reference of functionSymbol.references) {
+    const directCall = findDirectCallForReference(reference.identifier);
+    if (directCall && findEnclosingFunction(directCall) === effectCallback) {
+      directInvocations.push(directCall);
+      continue;
+    }
+    const referenceRoot = findTransparentExpressionRoot(reference.identifier);
+    const construction = referenceRoot.parent;
+    if (
+      !construction ||
+      !isGlobalObserverConstruction(construction, context) ||
+      findEnclosingFunction(construction) !== usageFunction ||
+      !construction.arguments.some((argument) => argument === referenceRoot)
+    ) {
+      return null;
+    }
+  }
+  const directInvocation = directInvocations.length === 1 ? directInvocations[0] : null;
+  return directInvocation && isNodeReachableWithinFunction(directInvocation, context)
+    ? directInvocation
+    : null;
+};
+
 const resolveCleanupPathAnchor = (
-  usageNode: EsTreeNode,
+  usage: SubscribeLikeUsage,
   effectCallback: EsTreeNode,
   context: RuleContext,
 ): EsTreeNode => {
-  const usageFunction = findEnclosingFunction(usageNode);
-  if (!usageFunction || usageFunction === effectCallback) return usageNode;
-  return findSingleDirectInvocation(usageFunction, effectCallback, context) ?? usageNode;
+  const usageFunction = findEnclosingFunction(usage.node);
+  if (!usageFunction || usageFunction === effectCallback) return usage.node;
+  return (
+    findSingleDirectInvocation(usageFunction, effectCallback, context) ??
+    findReconnectHelperInvocation(usageFunction, effectCallback, usage, context) ??
+    usage.node
+  );
 };
 
 const resolveSingleAssignedCleanupFunction = (
@@ -2818,7 +2971,7 @@ const effectHasCleanupForUsage = (
     return true;
   }
   return doMatchingNodesCoverEveryPathAfterUsage(
-    resolveCleanupPathAnchor(usage.node, callback, context),
+    resolveCleanupPathAnchor(usage, callback, context),
     matchingCleanupReturns,
     context,
   );


### PR DESCRIPTION
## Why

ReactBench RDH exposed an `effect-needs-cleanup` false positive in Cloudscape's visual-context observer (`write-react-cloudscape-design-co__BkahTcP`).

The effect owns one `MutationObserver` variable. Every reconnect releases the previous observer before replacing it, and the returned cleanup releases the latest observer on unmount:

```tsx
let observer: MutationObserver | undefined

const reconnect = () => {
  observer?.disconnect()
  observer = new MutationObserver(reconnect)
  observer.observe(element, { attributes: true, childList: true })
}

reconnect()
return () => observer?.disconnect()
```

Before this change, the detector anchored the nested `observe()` call inside `reconnect` and could not prove that the outer direct invocation was followed by cleanup. Rewriting this working lifecycle solely to satisfy the diagnostic adds churn without improving resource ownership.

The platform contract says `disconnect()` stops the observer and permits later reuse. React requires Effect cleanup to undo setup on dependency change or unmount. This pattern satisfies both contracts.

- MDN: https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver/disconnect
- React: https://react.dev/reference/react/useEffect#reference

## What changed

- Recognize only a self-reconnecting helper whose observer binding is local and nullable.
- Require exactly one observer construction and a guaranteed matching release before every replacement.
- Require exactly one direct helper invocation and the normal returned Effect cleanup for the latest observer.
- Reject async/generator helpers, conditional replacement cleanup, extra retainers, unknown observer uses, and replacement without prior release.
- Add the exact ReactBench shape, adversarial negative cases, and a fuzz regression.

The existing true-positive behavior is preserved: replacement without `observer?.disconnect()` before construction still reports.

## Eval results

A bounded local RDE pass processed 25 project roots. The target rule produced only its existing real-world diagnostic population; this branch adds no new diagnostic surface. A wider pass reached 99 roots but was interrupted on a stalled monorepo root and is not counted as parity evidence. Daytona PR parity will be attached separately.

## Test plan

- `nr test --filter oxlint-plugin-react-doctor`
- `nr typecheck --filter oxlint-plugin-react-doctor`
- `nr build`
- `FUZZ_RULE=effect-needs-cleanup FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz`
- `nr --filter @react-doctor/fuzz test`
- `nr test && nr lint && nr typecheck && nr format:check && nr smoke:json-report`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes static analysis heuristics in a widely used effect rule; incorrect recognition could hide real leaks or reintroduce false positives, though scope is narrow and heavily regression-tested.
> 
> **Overview**
> Fixes a **false positive** in `effect-needs-cleanup` when an effect uses a **self-reconnecting observer helper** (disconnect → `new MutationObserver` → observe) with unmount cleanup on the latest instance—matching Cloudscape’s visual-context pattern.
> 
> The rule now treats that helper like a single setup path: **`findReconnectHelperInvocation`** proves a local nullable `let` observer, one reassignment to a global observer constructor, **mandatory `disconnect` before every replacement**, exactly one direct helper call from the effect, and the usual returned cleanup. **`resolveCleanupPathAnchor`** anchors cleanup coverage on that invocation instead of the nested `observe()` call.
> 
> **Still flagged:** replacement without prior release, conditional disconnect, extra retainers of the helper, and other adversarial shapes. Adds regression tests, a fuzz corpus case, and a patch changeset for both lint plugins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5144487f96706e5e52218b03b74b51a37ca9f6ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->