### PR TITLE
FPFNFIX82: detect stale async request error clears

### DIFF
--- a/.changeset/detect-unowned-async-error-clears.md
+++ b/.changeset/detect-unowned-async-error-clears.md
@@ -1,0 +1,6 @@
+---
+"oxlint-plugin-react-doctor": patch
+"eslint-plugin-react-doctor": patch
+---
+
+Detect stale async responses that clear error state owned by a newer request.

--- a/packages/fuzz/corpus/true-positives/no-unowned-async-error-clear--request-ownership.tsx
+++ b/packages/fuzz/corpus/true-positives/no-unowned-async-error-clear--request-ownership.tsx
@@ -1,0 +1,39 @@
+// rule: no-unowned-async-error-clear
+// weakness: async-request-ownership
+// source: ReactBench Tombelieber SessionInteractionCard
+
+import { useEffect, useState } from "react";
+
+interface RequestRecord {
+  failed: boolean;
+  requestId: string;
+}
+
+interface RequestCardProperties {
+  currentRequestId: string;
+  respond: (request: RequestRecord) => Promise<void>;
+}
+
+export const RequestCard = ({ currentRequestId, respond }: RequestCardProperties) => {
+  const [errorRequestId, setErrorRequestId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (errorRequestId !== null && errorRequestId !== currentRequestId) {
+      setErrorRequestId(null);
+    }
+  }, [currentRequestId, errorRequestId]);
+
+  const handleRespond = async (request: RequestRecord) => {
+    await respond(request);
+    setErrorRequestId(request.failed ? request.requestId : null);
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={() => handleRespond({ failed: false, requestId: currentRequestId })}
+    >
+      Retry
+    </button>
+  );
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/core-rule-registry-data.json
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/core-rule-registry-data.json
@@ -7679,6 +7679,24 @@
     }
   },
   {
+    "key": "react-doctor/no-unowned-async-error-clear",
+    "id": "no-unowned-async-error-clear",
+    "source": "react-doctor",
+    "originallyExternal": false,
+    "rule": {
+      "id": "no-unowned-async-error-clear",
+      "title": "Stale async response clears newer request state",
+      "severity": "warn",
+      "recommendation": "Guard async completion by request identity, perform an ownership-aware functional state update, or key the state-owning component by request ID.",
+      "category": "Bugs",
+      "framework": "global",
+      "requires": ["react"],
+      "tags": ["react-jsx-only"],
+      "defaultEnabled": false,
+      "isScanRule": false
+    }
+  },
+  {
     "key": "react-doctor/no-unsafe",
     "id": "no-unsafe",
     "source": "react-doctor",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness-fixtures.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness-fixtures.ts
@@ -2545,6 +2545,9 @@ export const livenessFixtures: Readonly<Record<string, LivenessFixture>> = {
   "no-collapse-request-error-to-empty-state": {
     code: 'import { useState } from "react";\nexport const Search = () => { const [items, setItems] = useState([]); const load = async () => { try { setItems(await (await fetch("/api/items")).json()); } catch { setItems([]); } }; if (!items.length) return <p>No results found</p>; return <ResultList items={items} />; };',
   },
+  "no-unowned-async-error-clear": {
+    code: 'import { useEffect, useState } from "react";\nexport const Request = ({ currentId, send }) => { const [ownerId, setOwnerId] = useState(null); useEffect(() => { if (ownerId !== currentId) setOwnerId(null); }, [currentId, ownerId]); const respond = async (request) => { await send(request); if (request.failed) setOwnerId(request.requestId); else setOwnerId(null); }; return <button onClick={() => respond({ requestId: currentId })}>Send</button>; };',
+  },
   "no-focus-in-animation-completion-handler": {
     code: 'import { useRef } from "react";\nexport const Dialog = () => { const inputRef = useRef(null); return <><input ref={inputRef} /><div onAnimationEnd={() => inputRef.current.focus()} /></>; };',
   },

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
@@ -473,6 +473,7 @@ import { noUnguardedThrowingParseCall } from "./rules/correctness/no-unguarded-t
 import { noUniformFeatureCardGrid } from "./rules/design/no-uniform-feature-card-grid.js";
 import { noUninformativeAriaLabel } from "./rules/a11y/no-uninformative-aria-label.js";
 import { noUnknownProperty } from "./rules/react-builtins/no-unknown-property.js";
+import { noUnownedAsyncErrorClear } from "./rules/state-and-effects/no-unowned-async-error-clear.js";
 import { noUnsafe } from "./rules/react-builtins/no-unsafe.js";
 import { noUnsafeJsonParse } from "./rules/correctness/no-unsafe-json-parse.js";
 import { noUnstableNestedComponents } from "./rules/react-builtins/no-unstable-nested-components.js";
@@ -6398,6 +6399,18 @@ export const reactDoctorRules = [
       framework: "global",
       category: "Bugs",
       requires: [...new Set<Capability>(["react", ...(noUnknownProperty.requires ?? [])])],
+    },
+  },
+  {
+    key: "react-doctor/no-unowned-async-error-clear",
+    id: "no-unowned-async-error-clear",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noUnownedAsyncErrorClear,
+      framework: "global",
+      category: "Bugs",
+      requires: [...new Set<Capability>(["react", ...(noUnownedAsyncErrorClear.requires ?? [])])],
     },
   },
   {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-unowned-async-error-clear.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-unowned-async-error-clear.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noUnownedAsyncErrorClear } from "./no-unowned-async-error-clear.js";
+
+describe("no-unowned-async-error-clear", () => {
+  it("flags a stale completion that clears error ownership for a newer request", () => {
+    const result = runRule(
+      noUnownedAsyncErrorClear,
+      `import { useCallback, useEffect, useState } from "react";
+function RequestCard({ currentRequest, respond }) {
+  const currentRequestId = currentRequest.requestId;
+  const [error, setError] = useState(null);
+  const [errorRequestId, setErrorRequestId] = useState(null);
+  useEffect(() => {
+    if (errorRequestId !== null && errorRequestId !== currentRequestId) {
+      setError(null);
+      setErrorRequestId(null);
+    }
+  }, [currentRequestId, errorRequestId]);
+  const handleRespond = useCallback(async (request) => {
+    const result = await respond(request);
+    if (result.ok) {
+      setError(null);
+      setErrorRequestId(null);
+    } else {
+      setError(result.error);
+      setErrorRequestId(request.requestId);
+    }
+  }, [respond]);
+  return <button onClick={() => handleRespond(currentRequest)}>Retry</button>;
+}
+function Screen(props) {
+  return <RequestCard currentRequest={props.request} respond={props.respond} />;
+}`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("accepts a functional ownership check before clearing the request error", () => {
+    const result = runRule(
+      noUnownedAsyncErrorClear,
+      `import { useCallback, useEffect, useState } from "react";
+function RequestCard({ currentRequest, respond }) {
+  const currentRequestId = currentRequest.requestId;
+  const [errorRequestId, setErrorRequestId] = useState(null);
+  useEffect(() => {
+    if (errorRequestId !== null && errorRequestId !== currentRequestId) {
+      setErrorRequestId(null);
+    }
+  }, [currentRequestId, errorRequestId]);
+  const handleRespond = useCallback(async (request) => {
+    const result = await respond(request);
+    if (result.ok) {
+      setErrorRequestId((ownerId) => ownerId === request.requestId ? null : ownerId);
+    } else {
+      setErrorRequestId(request.requestId);
+    }
+  }, [respond]);
+  return <button onClick={() => handleRespond(currentRequest)}>Retry</button>;
+}`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("accepts a current-request guard around the clear", () => {
+    const result = runRule(
+      noUnownedAsyncErrorClear,
+      `import { useCallback, useEffect, useState } from "react";
+function RequestCard({ currentRequest, respond }) {
+  const currentRequestId = currentRequest.requestId;
+  const [errorRequestId, setErrorRequestId] = useState(null);
+  useEffect(() => {
+    if (errorRequestId !== null && errorRequestId !== currentRequestId) {
+      setErrorRequestId(null);
+    }
+  }, [currentRequestId, errorRequestId]);
+  const handleRespond = useCallback(async (request) => {
+    const result = await respond(request);
+    if (result.ok && request.requestId === currentRequestId) {
+      setErrorRequestId(null);
+    } else if (!result.ok) {
+      setErrorRequestId(request.requestId);
+    }
+  }, [currentRequestId, respond]);
+  return <button onClick={() => handleRespond(currentRequest)}>Retry</button>;
+}`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("accepts request state isolated by a key at every local component use", () => {
+    const result = runRule(
+      noUnownedAsyncErrorClear,
+      `import { useCallback, useEffect, useState } from "react";
+function RequestCard({ currentRequest, respond }) {
+  const currentRequestId = currentRequest.requestId;
+  const [errorRequestId, setErrorRequestId] = useState(null);
+  useEffect(() => {
+    if (errorRequestId !== null && errorRequestId !== currentRequestId) {
+      setErrorRequestId(null);
+    }
+  }, [currentRequestId, errorRequestId]);
+  const handleRespond = useCallback(async (request) => {
+    const result = await respond(request);
+    if (result.ok) {
+      setErrorRequestId(null);
+    } else {
+      setErrorRequestId(request.requestId);
+    }
+  }, [respond]);
+  return <button onClick={() => handleRespond(currentRequest)}>Retry</button>;
+}
+function Screen(props) {
+  return <RequestCard key={props.request.requestId} currentRequest={props.request} respond={props.respond} />;
+}`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("ignores nullable state without proven request ownership", () => {
+    const result = runRule(
+      noUnownedAsyncErrorClear,
+      `import { useCallback, useState } from "react";
+function Form({ save }) {
+  const [errorRequestId, setErrorRequestId] = useState(null);
+  const submit = useCallback(async (request) => {
+    const result = await save(request);
+    setErrorRequestId(result.ok ? null : request.requestId);
+  }, [save]);
+  return <button onClick={() => submit({ requestId: "profile" })}>Save</button>;
+}`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("ignores ownership assignments that do not cross an await", () => {
+    const result = runRule(
+      noUnownedAsyncErrorClear,
+      `import { useEffect, useState } from "react";
+function RequestCard({ currentRequest }) {
+  const currentRequestId = currentRequest.requestId;
+  const [errorRequestId, setErrorRequestId] = useState(null);
+  useEffect(() => {
+    if (errorRequestId !== currentRequestId) setErrorRequestId(null);
+  }, [currentRequestId, errorRequestId]);
+  const update = (request) => setErrorRequestId(request.failed ? request.requestId : null);
+  return <button onClick={() => update(currentRequest)}>Update</button>;
+}`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("ignores a shadowed useState helper", () => {
+    const result = runRule(
+      noUnownedAsyncErrorClear,
+      `const useState = (value) => [value, () => undefined];
+function RequestCard({ currentRequest, respond }) {
+  const currentRequestId = currentRequest.requestId;
+  const [errorRequestId, setErrorRequestId] = useState(null);
+  if (errorRequestId !== currentRequestId) setErrorRequestId(null);
+  const handleRespond = async (request) => {
+    const result = await respond(request);
+    setErrorRequestId(result.ok ? null : request.requestId);
+  };
+  return <button onClick={() => handleRespond(currentRequest)}>Retry</button>;
+}`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-unowned-async-error-clear.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-unowned-async-error-clear.test.ts
@@ -170,11 +170,39 @@ function RequestCard({ currentRequest, respond }) {
   return <button onClick={() => handleRespond(currentRequest)}>Retry</button>;
 }
 function Screen(props) {
-  return <RequestCard key={props.request.requestId} currentRequest={props.request} respond={props.respond} />;
-}`,
+  return <RequestCard key={props.request.requestId} currentRequest={props.request} respond={props.respond}>Retry</RequestCard>;
+}
+RequestCard.displayName = "RequestCard";`,
     );
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not assume exported components are keyed at every render site", () => {
+    const result = runRule(
+      noUnownedAsyncErrorClear,
+      `import { useCallback, useEffect, useState } from "react";
+function RequestCard({ currentRequest, respond }) {
+  const currentRequestId = currentRequest.requestId;
+  const [errorRequestId, setErrorRequestId] = useState(null);
+  useEffect(() => {
+    if (errorRequestId !== null && errorRequestId !== currentRequestId) {
+      setErrorRequestId(null);
+    }
+  }, [currentRequestId, errorRequestId]);
+  const handleRespond = useCallback(async (request) => {
+    const result = await respond(request);
+    setErrorRequestId(result.ok ? null : request.requestId);
+  }, [respond]);
+  return <button onClick={() => handleRespond(currentRequest)}>Retry</button>;
+}
+function Screen(props) {
+  return <RequestCard key={props.request.requestId} currentRequest={props.request} respond={props.respond} />;
+}
+export { RequestCard, Screen };`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
   });
 
   it("ignores nullable state without proven request ownership", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-unowned-async-error-clear.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-unowned-async-error-clear.test.ts
@@ -91,6 +91,62 @@ function RequestCard({ currentRequest, respond }) {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("does not accept an unrelated request identity comparison", () => {
+    const result = runRule(
+      noUnownedAsyncErrorClear,
+      `import { useCallback, useEffect, useState } from "react";
+function RequestCard({ currentRequest, respond }) {
+  const currentRequestId = currentRequest.requestId;
+  const [errorRequestId, setErrorRequestId] = useState(null);
+  useEffect(() => {
+    if (errorRequestId !== null && errorRequestId !== currentRequestId) {
+      setErrorRequestId(null);
+    }
+  }, [currentRequestId, errorRequestId]);
+  const handleRespond = useCallback(async (request) => {
+    const result = await respond(request);
+    const isOriginalRequest = request.requestId === currentRequestId;
+    if (result.ok) {
+      setErrorRequestId(null);
+    } else {
+      setErrorRequestId(request.requestId);
+    }
+    return isOriginalRequest;
+  }, [currentRequestId, respond]);
+  return <button onClick={() => handleRespond(currentRequest)}>Retry</button>;
+}`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not accept a guard against an unrelated identity", () => {
+    const result = runRule(
+      noUnownedAsyncErrorClear,
+      `import { useCallback, useEffect, useState } from "react";
+function RequestCard({ currentRequest, respond }) {
+  const currentRequestId = currentRequest.requestId;
+  const [errorRequestId, setErrorRequestId] = useState(null);
+  useEffect(() => {
+    if (errorRequestId !== null && errorRequestId !== currentRequestId) {
+      setErrorRequestId(null);
+    }
+  }, [currentRequestId, errorRequestId]);
+  const handleRespond = useCallback(async (request) => {
+    const result = await respond(request);
+    if (result.ok && request.requestId === "archived") {
+      setErrorRequestId(null);
+    } else if (!result.ok) {
+      setErrorRequestId(request.requestId);
+    }
+  }, [respond]);
+  return <button onClick={() => handleRespond(currentRequest)}>Retry</button>;
+}`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("accepts request state isolated by a key at every local component use", () => {
     const result = runRule(
       noUnownedAsyncErrorClear,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-unowned-async-error-clear.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-unowned-async-error-clear.ts
@@ -20,14 +20,19 @@ const MESSAGE =
 
 interface RequestOwnerState {
   componentFunction: EsTreeNode;
+  ownerIdentityReferences: OwnerIdentityReference[];
   setterSymbol: SymbolDescriptor;
-  stateSymbol: SymbolDescriptor;
 }
 
 interface AsyncOwnerWrite {
   call: EsTreeNodeOfType<"CallExpression">;
   hasClear: boolean;
   hasRequestIdentity: boolean;
+}
+
+interface OwnerIdentityReference {
+  propertyName: string | null;
+  symbolId: number;
 }
 
 const isNullLiteral = (node: EsTreeNode | null | undefined): boolean => {
@@ -89,12 +94,29 @@ const expressionContainsRequestIdentity = (
   return hasRequestIdentity;
 };
 
-const stateHasIdentityComparison = (
+const getOwnerIdentityReference = (
+  node: EsTreeNode,
+  context: RuleContext,
+): OwnerIdentityReference | null => {
+  const expression = stripParenExpression(node);
+  if (isNodeOfType(expression, "Identifier")) {
+    const symbol = context.scopes.symbolFor(expression);
+    return symbol ? { propertyName: null, symbolId: symbol.id } : null;
+  }
+  if (!isNodeOfType(expression, "MemberExpression")) return null;
+  const receiver = stripParenExpression(expression.object);
+  if (!isNodeOfType(receiver, "Identifier")) return null;
+  const receiverSymbol = context.scopes.symbolFor(receiver);
+  const propertyName = getStaticPropertyName(expression);
+  return receiverSymbol && propertyName ? { propertyName, symbolId: receiverSymbol.id } : null;
+};
+
+const collectOwnerIdentityReferences = (
   stateSymbol: SymbolDescriptor,
   componentFunction: EsTreeNode,
   context: RuleContext,
-): boolean =>
-  stateSymbol.references.some((reference) => {
+): OwnerIdentityReference[] =>
+  stateSymbol.references.flatMap((reference) => {
     const referenceRoot = findTransparentExpressionRoot(reference.identifier);
     const comparison = referenceRoot.parent;
     if (
@@ -102,10 +124,11 @@ const stateHasIdentityComparison = (
       !["==", "===", "!=", "!=="].includes(comparison.operator) ||
       !isAstDescendant(comparison, componentFunction)
     ) {
-      return false;
+      return [];
     }
     const counterpart = comparison.left === referenceRoot ? comparison.right : comparison.left;
-    return counterpart !== referenceRoot && !isNullLiteral(counterpart);
+    const identityReference = getOwnerIdentityReference(counterpart, context);
+    return identityReference ? [identityReference] : [];
   });
 
 const getRequestOwnerState = (
@@ -135,15 +158,17 @@ const getRequestOwnerState = (
   const stateSymbol = context.scopes.symbolFor(stateIdentifier);
   const setterSymbol = context.scopes.symbolFor(setterIdentifier);
   const componentFunction = findEnclosingFunction(declarator);
-  if (
-    !stateSymbol ||
-    !setterSymbol ||
-    !componentFunction ||
-    !stateHasIdentityComparison(stateSymbol, componentFunction, context)
-  ) {
+  if (!stateSymbol || !setterSymbol || !componentFunction) {
     return null;
   }
-  return { componentFunction, setterSymbol, stateSymbol };
+  const ownerIdentityReferences = collectOwnerIdentityReferences(
+    stateSymbol,
+    componentFunction,
+    context,
+  );
+  return ownerIdentityReferences.length > 0
+    ? { componentFunction, ownerIdentityReferences, setterSymbol }
+    : null;
 };
 
 const openingElementHasKey = (openingElement: EsTreeNodeOfType<"JSXOpeningElement">): boolean =>
@@ -178,28 +203,66 @@ const componentIsKeyedAtEveryLocalUse = (
   });
 };
 
-const functionHasRequestOwnershipGuard = (
+const conditionHasRequestIdentityEquality = (
+  condition: EsTreeNode,
   asyncFunction: EsTreeNode,
+  ownerIdentityReferences: OwnerIdentityReference[],
   context: RuleContext,
 ): boolean => {
-  let hasOwnershipGuard = false;
-  walkOwnFunctionScope(asyncFunction, (child) => {
+  let hasRequestIdentityEquality = false;
+  walkAst(condition, (child) => {
     if (
-      hasOwnershipGuard ||
+      hasRequestIdentityEquality ||
       !isNodeOfType(child, "BinaryExpression") ||
-      !["==", "===", "!=", "!=="].includes(child.operator)
+      !["==", "==="].includes(child.operator)
     ) {
       return;
     }
+    const requestIdentity = getRequestIdentityMember(child.left, asyncFunction, context);
+    const counterpart = requestIdentity
+      ? child.right
+      : getRequestIdentityMember(child.right, asyncFunction, context)
+        ? child.left
+        : null;
+    const ownerIdentity = counterpart ? getOwnerIdentityReference(counterpart, context) : null;
     if (
-      getRequestIdentityMember(child.left, asyncFunction, context) ||
-      getRequestIdentityMember(child.right, asyncFunction, context)
+      ownerIdentity &&
+      ownerIdentityReferences.some(
+        (candidate) =>
+          candidate.symbolId === ownerIdentity.symbolId &&
+          candidate.propertyName === ownerIdentity.propertyName,
+      )
     ) {
-      hasOwnershipGuard = true;
+      hasRequestIdentityEquality = true;
       return false;
     }
   });
-  return hasOwnershipGuard;
+  return hasRequestIdentityEquality;
+};
+
+const callHasRequestOwnershipGuard = (
+  call: EsTreeNodeOfType<"CallExpression">,
+  asyncFunction: EsTreeNode,
+  ownerIdentityReferences: OwnerIdentityReference[],
+  context: RuleContext,
+): boolean => {
+  let ancestor = call.parent;
+  while (ancestor && ancestor !== asyncFunction) {
+    if (
+      isNodeOfType(ancestor, "IfStatement") &&
+      isAstDescendant(call, ancestor.consequent) &&
+      conditionHasRequestIdentityEquality(
+        ancestor.test,
+        asyncFunction,
+        ownerIdentityReferences,
+        context,
+      )
+    ) {
+      return true;
+    }
+    ancestor = ancestor.parent;
+  }
+  return false;
 };
 
 const collectAsyncOwnerWrites = (
@@ -246,12 +309,18 @@ const findUnsafeOwnerClear = (
     if (unsafeClear) return false;
     if (child === state.componentFunction || !isFunctionLike(child)) return;
     const writes = collectAsyncOwnerWrites(child, state.setterSymbol, context);
-    if (
-      writes.some((write) => write.hasClear) &&
-      writes.some((write) => write.hasRequestIdentity) &&
-      !functionHasRequestOwnershipGuard(child, context)
-    ) {
-      unsafeClear = writes.find((write) => write.hasClear)?.call ?? null;
+    if (writes.some((write) => write.hasRequestIdentity)) {
+      unsafeClear =
+        writes.find(
+          (write) =>
+            write.hasClear &&
+            !callHasRequestOwnershipGuard(
+              write.call,
+              child,
+              state.ownerIdentityReferences,
+              context,
+            ),
+        )?.call ?? null;
     }
     return false;
   });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-unowned-async-error-clear.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-unowned-async-error-clear.ts
@@ -18,6 +18,8 @@ import { walkOwnFunctionScope } from "../../utils/walk-own-function-scope.js";
 const MESSAGE =
   "An older async response can clear error state owned by a newer request. Check that this request still owns the error before clearing it, keep ownership in the state update, or key the state owner by request ID.";
 
+const COMPONENT_METADATA_PROPERTY_NAMES = new Set(["displayName", "propTypes"]);
+
 interface RequestOwnerState {
   componentFunction: EsTreeNode;
   ownerIdentityReferences: OwnerIdentityReference[];
@@ -179,6 +181,30 @@ const openingElementHasKey = (openingElement: EsTreeNodeOfType<"JSXOpeningElemen
       attribute.name.name === "key",
   );
 
+const getComponentOpeningElement = (
+  identifier: EsTreeNode,
+): EsTreeNodeOfType<"JSXOpeningElement"> | null => {
+  const openingElement = identifier.parent;
+  return isNodeOfType(openingElement, "JSXOpeningElement") && openingElement.name === identifier
+    ? openingElement
+    : null;
+};
+
+const isComponentClosingElementReference = (identifier: EsTreeNode): boolean => {
+  const closingElement = identifier.parent;
+  return isNodeOfType(closingElement, "JSXClosingElement") && closingElement.name === identifier;
+};
+
+const isComponentMetadataReference = (identifier: EsTreeNode): boolean => {
+  const referenceRoot = findTransparentExpressionRoot(identifier);
+  const member = referenceRoot.parent;
+  return (
+    isNodeOfType(member, "MemberExpression") &&
+    member.object === referenceRoot &&
+    COMPONENT_METADATA_PROPERTY_NAMES.has(getStaticPropertyName(member) ?? "")
+  );
+};
+
 const componentIsKeyedAtEveryLocalUse = (
   componentFunction: EsTreeNode,
   context: RuleContext,
@@ -193,14 +219,21 @@ const componentIsKeyedAtEveryLocalUse = (
     bindingScope = bindingScope.parent;
   }
   if (!componentSymbol || componentSymbol.references.length === 0) return false;
-  return componentSymbol.references.every((reference) => {
-    const openingElement = reference.identifier.parent;
-    return (
-      isNodeOfType(openingElement, "JSXOpeningElement") &&
-      openingElement.name === reference.identifier &&
-      openingElementHasKey(openingElement)
-    );
-  });
+  const openingElements: EsTreeNodeOfType<"JSXOpeningElement">[] = [];
+  for (const reference of componentSymbol.references) {
+    const openingElement = getComponentOpeningElement(reference.identifier);
+    if (openingElement) {
+      openingElements.push(openingElement);
+      continue;
+    }
+    if (
+      !isComponentClosingElementReference(reference.identifier) &&
+      !isComponentMetadataReference(reference.identifier)
+    ) {
+      return false;
+    }
+  }
+  return openingElements.length > 0 && openingElements.every(openingElementHasKey);
 };
 
 const conditionHasRequestIdentityEquality = (

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-unowned-async-error-clear.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-unowned-async-error-clear.ts
@@ -1,0 +1,277 @@
+import type { ScopeDescriptor, SymbolDescriptor } from "../../semantic/scope-analysis.js";
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
+import { findTransparentExpressionRoot } from "../../utils/find-transparent-expression-root.js";
+import { getFunctionBindingIdentifier } from "../../utils/get-function-binding-name.js";
+import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
+import { isAstDescendant } from "../../utils/is-ast-descendant.js";
+import { isFunctionLike } from "../../utils/is-function-like.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { isReactApiCall } from "../../utils/is-react-api-call.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import { walkAst } from "../../utils/walk-ast.js";
+import { walkOwnFunctionScope } from "../../utils/walk-own-function-scope.js";
+
+const MESSAGE =
+  "An older async response can clear error state owned by a newer request. Check that this request still owns the error before clearing it, keep ownership in the state update, or key the state owner by request ID.";
+
+interface RequestOwnerState {
+  componentFunction: EsTreeNode;
+  setterSymbol: SymbolDescriptor;
+  stateSymbol: SymbolDescriptor;
+}
+
+interface AsyncOwnerWrite {
+  call: EsTreeNodeOfType<"CallExpression">;
+  hasClear: boolean;
+  hasRequestIdentity: boolean;
+}
+
+const isNullLiteral = (node: EsTreeNode | null | undefined): boolean => {
+  if (!node) return false;
+  const expression = stripParenExpression(node);
+  return isNodeOfType(expression, "Literal") && expression.value === null;
+};
+
+const expressionContainsNull = (node: EsTreeNode): boolean => {
+  let hasNull = false;
+  walkAst(node, (child) => {
+    if (hasNull) return false;
+    if (child !== node && isFunctionLike(child)) return false;
+    if (!isNullLiteral(child)) return;
+    hasNull = true;
+    return false;
+  });
+  return hasNull;
+};
+
+const getRequestIdentityMember = (
+  node: EsTreeNode,
+  asyncFunction: EsTreeNode,
+  context: RuleContext,
+): EsTreeNodeOfType<"MemberExpression"> | null => {
+  const expression = stripParenExpression(node);
+  if (!isFunctionLike(asyncFunction) || !isNodeOfType(expression, "MemberExpression")) {
+    return null;
+  }
+  const propertyName = getStaticPropertyName(expression);
+  const receiver = stripParenExpression(expression.object);
+  if (!propertyName?.endsWith("Id") || !isNodeOfType(receiver, "Identifier")) return null;
+  const receiverSymbol = context.scopes.symbolFor(receiver);
+  if (!receiverSymbol) return null;
+  return asyncFunction.params.some((parameter) => {
+    const unwrappedParameter = stripParenExpression(parameter);
+    return (
+      isNodeOfType(unwrappedParameter, "Identifier") &&
+      context.scopes.symbolFor(unwrappedParameter)?.id === receiverSymbol.id
+    );
+  })
+    ? expression
+    : null;
+};
+
+const expressionContainsRequestIdentity = (
+  node: EsTreeNode,
+  asyncFunction: EsTreeNode,
+  context: RuleContext,
+): boolean => {
+  let hasRequestIdentity = false;
+  walkAst(node, (child) => {
+    if (hasRequestIdentity) return false;
+    if (child !== node && isFunctionLike(child)) return false;
+    if (!getRequestIdentityMember(child, asyncFunction, context)) return;
+    hasRequestIdentity = true;
+    return false;
+  });
+  return hasRequestIdentity;
+};
+
+const stateHasIdentityComparison = (
+  stateSymbol: SymbolDescriptor,
+  componentFunction: EsTreeNode,
+  context: RuleContext,
+): boolean =>
+  stateSymbol.references.some((reference) => {
+    const referenceRoot = findTransparentExpressionRoot(reference.identifier);
+    const comparison = referenceRoot.parent;
+    if (
+      !isNodeOfType(comparison, "BinaryExpression") ||
+      !["==", "===", "!=", "!=="].includes(comparison.operator) ||
+      !isAstDescendant(comparison, componentFunction)
+    ) {
+      return false;
+    }
+    const counterpart = comparison.left === referenceRoot ? comparison.right : comparison.left;
+    return counterpart !== referenceRoot && !isNullLiteral(counterpart);
+  });
+
+const getRequestOwnerState = (
+  declarator: EsTreeNodeOfType<"VariableDeclarator">,
+  context: RuleContext,
+): RequestOwnerState | null => {
+  if (
+    !isNodeOfType(declarator.id, "ArrayPattern") ||
+    !isNodeOfType(declarator.init, "CallExpression") ||
+    !isReactApiCall(declarator.init, "useState", context.scopes, {
+      allowGlobalReactNamespace: true,
+      resolveNamedAliases: true,
+    }) ||
+    declarator.init.arguments.length !== 1 ||
+    !isNullLiteral(declarator.init.arguments[0])
+  ) {
+    return null;
+  }
+  const stateIdentifier = declarator.id.elements[0];
+  const setterIdentifier = declarator.id.elements[1];
+  if (
+    !isNodeOfType(stateIdentifier, "Identifier") ||
+    !isNodeOfType(setterIdentifier, "Identifier")
+  ) {
+    return null;
+  }
+  const stateSymbol = context.scopes.symbolFor(stateIdentifier);
+  const setterSymbol = context.scopes.symbolFor(setterIdentifier);
+  const componentFunction = findEnclosingFunction(declarator);
+  if (
+    !stateSymbol ||
+    !setterSymbol ||
+    !componentFunction ||
+    !stateHasIdentityComparison(stateSymbol, componentFunction, context)
+  ) {
+    return null;
+  }
+  return { componentFunction, setterSymbol, stateSymbol };
+};
+
+const openingElementHasKey = (openingElement: EsTreeNodeOfType<"JSXOpeningElement">): boolean =>
+  openingElement.attributes.some(
+    (attribute) =>
+      isNodeOfType(attribute, "JSXAttribute") &&
+      isNodeOfType(attribute.name, "JSXIdentifier") &&
+      attribute.name.name === "key",
+  );
+
+const componentIsKeyedAtEveryLocalUse = (
+  componentFunction: EsTreeNode,
+  context: RuleContext,
+): boolean => {
+  const bindingIdentifier = getFunctionBindingIdentifier(componentFunction);
+  if (!bindingIdentifier) return false;
+  let bindingScope: ScopeDescriptor | null = context.scopes.scopeFor(componentFunction);
+  let componentSymbol: SymbolDescriptor | null = null;
+  while (bindingScope && !componentSymbol) {
+    componentSymbol =
+      bindingScope.symbols.find((symbol) => symbol.bindingIdentifier === bindingIdentifier) ?? null;
+    bindingScope = bindingScope.parent;
+  }
+  if (!componentSymbol || componentSymbol.references.length === 0) return false;
+  return componentSymbol.references.every((reference) => {
+    const openingElement = reference.identifier.parent;
+    return (
+      isNodeOfType(openingElement, "JSXOpeningElement") &&
+      openingElement.name === reference.identifier &&
+      openingElementHasKey(openingElement)
+    );
+  });
+};
+
+const functionHasRequestOwnershipGuard = (
+  asyncFunction: EsTreeNode,
+  context: RuleContext,
+): boolean => {
+  let hasOwnershipGuard = false;
+  walkOwnFunctionScope(asyncFunction, (child) => {
+    if (
+      hasOwnershipGuard ||
+      !isNodeOfType(child, "BinaryExpression") ||
+      !["==", "===", "!=", "!=="].includes(child.operator)
+    ) {
+      return;
+    }
+    if (
+      getRequestIdentityMember(child.left, asyncFunction, context) ||
+      getRequestIdentityMember(child.right, asyncFunction, context)
+    ) {
+      hasOwnershipGuard = true;
+      return false;
+    }
+  });
+  return hasOwnershipGuard;
+};
+
+const collectAsyncOwnerWrites = (
+  asyncFunction: EsTreeNode,
+  setterSymbol: SymbolDescriptor,
+  context: RuleContext,
+): AsyncOwnerWrite[] => {
+  if (!isFunctionLike(asyncFunction) || !asyncFunction.async) return [];
+  let firstAwaitEnd: number | null = null;
+  const writes: AsyncOwnerWrite[] = [];
+  walkOwnFunctionScope(asyncFunction, (child) => {
+    if (isNodeOfType(child, "AwaitExpression")) {
+      const awaitEnd = child.range[1];
+      firstAwaitEnd = firstAwaitEnd === null ? awaitEnd : Math.min(firstAwaitEnd, awaitEnd);
+      return;
+    }
+    if (
+      firstAwaitEnd === null ||
+      !isNodeOfType(child, "CallExpression") ||
+      child.range[0] < firstAwaitEnd ||
+      !isNodeOfType(child.callee, "Identifier") ||
+      context.scopes.symbolFor(child.callee)?.id !== setterSymbol.id
+    ) {
+      return;
+    }
+    const nextOwner = child.arguments[0];
+    if (!nextOwner || isFunctionLike(stripParenExpression(nextOwner))) return;
+    writes.push({
+      call: child,
+      hasClear: expressionContainsNull(nextOwner),
+      hasRequestIdentity: expressionContainsRequestIdentity(nextOwner, asyncFunction, context),
+    });
+  });
+  return writes;
+};
+
+const findUnsafeOwnerClear = (
+  state: RequestOwnerState,
+  context: RuleContext,
+): EsTreeNodeOfType<"CallExpression"> | null => {
+  if (componentIsKeyedAtEveryLocalUse(state.componentFunction, context)) return null;
+  let unsafeClear: EsTreeNodeOfType<"CallExpression"> | null = null;
+  walkAst(state.componentFunction, (child) => {
+    if (unsafeClear) return false;
+    if (child === state.componentFunction || !isFunctionLike(child)) return;
+    const writes = collectAsyncOwnerWrites(child, state.setterSymbol, context);
+    if (
+      writes.some((write) => write.hasClear) &&
+      writes.some((write) => write.hasRequestIdentity) &&
+      !functionHasRequestOwnershipGuard(child, context)
+    ) {
+      unsafeClear = writes.find((write) => write.hasClear)?.call ?? null;
+    }
+    return false;
+  });
+  return unsafeClear;
+};
+
+export const noUnownedAsyncErrorClear = defineRule({
+  id: "no-unowned-async-error-clear",
+  title: "Stale async response clears newer request state",
+  severity: "warn",
+  tags: ["react-jsx-only"],
+  defaultEnabled: false,
+  recommendation:
+    "Guard async completion by request identity, perform an ownership-aware functional state update, or key the state-owning component by request ID.",
+  create: (context: RuleContext) => ({
+    VariableDeclarator(node: EsTreeNodeOfType<"VariableDeclarator">) {
+      const state = getRequestOwnerState(node, context);
+      if (!state) return;
+      const unsafeClear = findUnsafeOwnerClear(state, context);
+      if (unsafeClear) context.report({ node: unsafeClear, message: MESSAGE });
+    },
+  }),
+});


### PR DESCRIPTION
## Why

ReactBench found a real async race in Tombelieber's `SessionInteractionCard` (`write-react-tombelieber-claude-v__2BtontA`) that no existing rule contract covered.

```tsx
const respond = async (request: RequestRecord) => {
  const result = await send(request)
  setErrorRequestId(result.ok ? null : request.requestId)
}
```

If request A starts, the component advances to request B, B fails, and then A succeeds, A's stale completion clears the error owned by B. The benchmark tests pass because they do not control this completion ordering.

The state already records an owner ID and compares it with the current request. The missing check is at the post-`await` clear. A safe clear keeps ownership inside the atomic state update:

```tsx
setErrorRequestId((ownerId) =>
  ownerId === request.requestId ? null : ownerId,
)
```

A current-request guard or keyed state isolation is also valid. React documents the same async-completion principle: older work must not update state after newer work owns the UI.

- React race-condition guidance: https://react.dev/reference/react/useEffect#fetching-data-with-effects

## What changed

- Add `no-unowned-async-error-clear`, a narrow correctness rule for post-`await` request-owner clears.
- Require nullable `useState` ownership, an identity comparison, an async handler crossing `await`, both owner assignment and clear, and no ownership guard.
- Accept ownership-aware functional updates, current-request guards, keyed local isolation, unproven nullable state, synchronous writes, and shadowed `useState`.
- Keep the rule disabled by default for an evidence-first initial rollout.
- Add rule tests, liveness coverage, a fuzz true-positive, and a patch changeset.

## Eval results

A bounded local RDE pass processed 25 project roots and produced 0 incidental target-rule diagnostics. Daytona PR parity will be attached separately.

## Test plan

- `nr test --filter oxlint-plugin-react-doctor`
- `nr typecheck --filter oxlint-plugin-react-doctor`
- `nr build`
- `FUZZ_RULE=no-unowned-async-error-clear FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz`
- `nr --filter @react-doctor/fuzz test`
- `nr test && nr lint && nr typecheck && nr format:check && nr smoke:json-report`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds an opt-in static analysis rule and test/corpus coverage only; no runtime or auth/data-path changes in application code.
> 
> **Overview**
> Adds **`no-unowned-async-error-clear`**, a new Bugs-category React Doctor rule (disabled by default) that warns when a post-`await` state update clears nullable request-owner error state without proving the async completion still owns it—covering races where an older success wipes error UI for a newer failed request.
> 
> The rule implementation traces nullable `useState` slots tied to request IDs via identity comparisons, then flags unguarded clears in async paths after `await`, while allowing ownership-aware functional updates, current-request guards, and components keyed by request ID at every local JSX use. Wiring includes registry/metadata updates, liveness fixtures, a fuzz true-positive corpus case, and a patch changeset for both oxlint and eslint plugin packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b9dcab41539264e9732fae0f99c670c1b7cbde7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->