### PR TITLE
FPFNFIX82: ignore type-only parent-data references

### DIFF
--- a/.changeset/ignore-type-only-parent-data.md
+++ b/.changeset/ignore-type-only-parent-data.md
@@ -1,0 +1,6 @@
+---
+"oxlint-plugin-react-doctor": patch
+"eslint-plugin-react-doctor": patch
+---
+
+Ignore TypeScript type-only identifiers when tracing data passed to parent callbacks.

--- a/packages/fuzz/corpus/regressions/no-pass-data-to-parent--typescript-prop-fallback.tsx
+++ b/packages/fuzz/corpus/regressions/no-pass-data-to-parent--typescript-prop-fallback.tsx
@@ -1,0 +1,29 @@
+// rule: no-pass-data-to-parent
+// weakness: typescript-type-position
+// source: ReactBench Remarkable UI MultiSelectField
+
+import { useEffect } from "react";
+
+interface SelectOptionValue {
+  value: string;
+}
+
+interface MultiSelectFieldProperties<Value extends SelectOptionValue> {
+  onPendingChange?: (values: Value[]) => void;
+  values?: Value[];
+}
+
+const EMPTY_VALUES: SelectOptionValue[] = [];
+
+export const MultiSelectField = <Value extends SelectOptionValue>({
+  onPendingChange,
+  values: valuesProperty,
+}: MultiSelectFieldProperties<Value>) => {
+  const values = (valuesProperty ?? (EMPTY_VALUES as Value[])) as Value[];
+
+  useEffect(() => {
+    onPendingChange?.(values);
+  }, [onPendingChange, values]);
+
+  return null;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.regressions.test.ts
@@ -5,6 +5,46 @@ import { noPassDataToParent } from "./no-pass-data-to-parent.js";
 const DEEP_REGISTER_ALIAS_CHAIN_LENGTH = 2_000;
 
 describe("no-pass-data-to-parent — regressions", () => {
+  it("stays silent when a required pending-change callback receives the parent-supplied value", () => {
+    const result = runRule(
+      noPassDataToParent,
+      `import { useEffect } from "react";
+interface SelectOptionValue {
+  id: string;
+}
+interface MultiSelectFieldProperties<Value extends SelectOptionValue> {
+  onPendingChange?: (values: Value[]) => void;
+  values?: Value[];
+}
+const EMPTY_VALUES: SelectOptionValue[] = [];
+export const MultiSelectField = <Value extends SelectOptionValue>({ onPendingChange, values: valuesProp }: MultiSelectFieldProperties<Value>) => {
+  const values = (valuesProp ?? (EMPTY_VALUES as Value[])) as Value[];
+  useEffect(() => {
+    onPendingChange?.(values);
+  }, [onPendingChange, values]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still flags child-produced hook data wrapped in a TypeScript cast", () => {
+    const result = runRule(
+      noPassDataToParent,
+      `import { useEffect } from "react";
+export const MultiSelectField = <Value,>({ onPendingChange }) => {
+  const values = useSelectedValues() as Value[];
+  useEffect(() => {
+    onPendingChange(values);
+  }, [onPendingChange, values]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("stays silent when a callback parameter is passed through a parent callback", () => {
     const result = runRule(
       noPassDataToParent,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.regressions.test.ts
@@ -45,6 +45,23 @@ export const MultiSelectField = <Value,>({ onPendingChange }) => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("still flags child-produced hook data wrapped in an angle-bracket assertion", () => {
+    const result = runRule(
+      noPassDataToParent,
+      `import { useEffect } from "react";
+export const MultiSelectField = ({ onPendingChange }) => {
+  const values = <string[]>useSelectedValues();
+  useEffect(() => {
+    onPendingChange(values);
+  }, [onPendingChange, values]);
+  return null;
+};`,
+      { filename: "fixture.ts" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("stays silent when a callback parameter is passed through a parent callback", () => {
     const result = runRule(
       noPassDataToParent,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.ts
@@ -9,6 +9,7 @@ import { findTransparentExpressionRoot } from "../../utils/find-transparent-expr
 import { collectFunctionReturnStatements } from "../../utils/collect-function-return-statements.js";
 import { isNamespacedApiCallee } from "../../utils/is-namespaced-api-call.js";
 import { isReactHookCall } from "../../utils/is-react-hook-call.js";
+import { isTypeScriptTypePosition } from "../../utils/is-typescript-type-position.js";
 import {
   DATA_SINK_METHOD_NAMES,
   STRING_READ_METHOD_NAMES,
@@ -1624,6 +1625,7 @@ export const noPassDataToParent = defineRule({
 
           const isSomeArgsData = argsUpstreamRefs.some((argRef) => {
             const argIdentifier = argRef.identifier as unknown as EsTreeNode;
+            if (isTypeScriptTypePosition(argIdentifier)) return false;
             if (isUseStateIdentifier(argIdentifier)) return false;
             if (isProp(analysis, argRef)) return false;
             if (isUseRefIdentifier(argIdentifier)) return false;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-typescript-type-position.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-typescript-type-position.ts
@@ -1,0 +1,15 @@
+import type { EsTreeNode } from "./es-tree-node.js";
+
+const TYPESCRIPT_EXPRESSION_WRAPPER_TYPES = new Set([
+  "TSAsExpression",
+  "TSInstantiationExpression",
+  "TSNonNullExpression",
+  "TSSatisfiesExpression",
+]);
+
+export const isTypeScriptTypePosition = (node: EsTreeNode): boolean => {
+  const parent = node.parent;
+  if (!parent?.type.startsWith("TS")) return false;
+  if (!TYPESCRIPT_EXPRESSION_WRAPPER_TYPES.has(parent.type)) return true;
+  return !("expression" in parent && parent.expression === node);
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-typescript-type-position.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-typescript-type-position.ts
@@ -5,6 +5,7 @@ const TYPESCRIPT_EXPRESSION_WRAPPER_TYPES = new Set([
   "TSInstantiationExpression",
   "TSNonNullExpression",
   "TSSatisfiesExpression",
+  "TSTypeAssertion",
 ]);
 
 export const isTypeScriptTypePosition = (node: EsTreeNode): boolean => {


### PR DESCRIPTION
## Why

ReactBench RDH exposed a `no-pass-data-to-parent` false positive in Remarkable UI's `MultiSelectField` (`fix-react-rdh-embeddable-hq-rema__Q2u3qLp`). The current corpus contains 21 affected trials, 20 of which pass behavior tests.

```tsx
const values =
  (valuesProp ?? (EMPTY_VALUES_FALLBACK as Value[])) as Value[]

useEffect(() => {
  onPendingChange?.(values)
}, [onPendingChange, values])
```

The runtime value is parent-supplied and is sent to the required parent callback. The false positive came from generic type parameter `Value` inside `as Value[]`: dataflow counted that type-erased identifier as child-produced runtime data.

Type assertions do not add runtime behavior and are removed by TypeScript. Changing component architecture therefore cannot fix the alleged flow; the detector must ignore type-only identifiers.

- TypeScript: https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#type-assertions

## What changed

- Add a focused AST utility that distinguishes TypeScript type positions from runtime expressions inside `as`, `satisfies`, non-null, and instantiation wrappers.
- Ignore only type-position references while classifying callback-argument provenance.
- Preserve diagnostics for child-produced runtime values, including `useSelectedValues() as Value[]`.
- Add the exact generic prop-fallback regression, the child-hook counterexample, a fuzz regression, and a patch changeset.

## Eval results

A bounded local RDE pass processed 25 project roots. Both existing target-rule hits remained: tldraw's SVG export callback and chat message persistence. The change introduced no incidental diagnostics. Daytona PR parity will be attached separately.

## Test plan

- `nr test --filter oxlint-plugin-react-doctor`
- `nr typecheck --filter oxlint-plugin-react-doctor`
- `nr build`
- `FUZZ_RULE=no-pass-data-to-parent FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz`
- `nr --filter @react-doctor/fuzz test`
- `nr test && nr lint && nr typecheck && nr format:check && nr smoke:json-report`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow guard in one rule’s argument provenance check with targeted tests; low chance of missing real violations unless type-position detection is wrong.
> 
> **Overview**
> Fixes a **false positive** in `no-pass-data-to-parent` when generic components coerce parent props with TypeScript assertions (e.g. `(valuesProp ?? (EMPTY_VALUES as Value[])) as Value[]` then `onPendingChange?.(values)`). Provenance tracing was treating identifiers like `Value` inside `as Value[]` as runtime child data.
> 
> Adds **`isTypeScriptTypePosition`** to tell type-only AST slots from the wrapped runtime expression in `as`, `satisfies`, non-null, and instantiation nodes, and skips those references when classifying callback arguments. **Child-produced values** passed through casts (e.g. `useSelectedValues() as Value[]`) still report.
> 
> Includes regression tests, a fuzz corpus case, and a patch changeset for both lint plugins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04cc00838d27d92314eec19d6a8cd4b1ec53ba4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->