### PR TITLE
FPFNFIX82 Fix form and fragment diagnostics

### DIFF
--- a/.changeset/check-form-fragment-owners.md
+++ b/.changeset/check-form-fragment-owners.md
@@ -1,0 +1,6 @@
+---
+"oxlint-plugin-react-doctor": patch
+"eslint-plugin-react-doctor": patch
+---
+
+Limit missing button type diagnostics to form-owned buttons and report broken literal fragment links.

--- a/packages/core/tests/cross-file-rule-ids.test.ts
+++ b/packages/core/tests/cross-file-rule-ids.test.ts
@@ -142,6 +142,7 @@ describe("CROSS_FILE_RULE_IDS", () => {
 
   it("contains the verified set and nothing the analysis can't justify", () => {
     expect([...CROSS_FILE_RULE_IDS].sort()).toEqual([
+      "anchor-target-exists",
       "client-passive-event-listeners",
       "exhaustive-deps",
       "ink-ctrl-c-handler-requires-exit-option",

--- a/packages/fuzz/corpus/regressions/anchor-target-exists--spread-over-static-id.tsx
+++ b/packages/fuzz/corpus/regressions/anchor-target-exists--spread-over-static-id.tsx
@@ -1,0 +1,11 @@
+// rule: anchor-target-exists
+// weakness: cross-file
+// source: Cursor Bugbot PR #1561
+// verdict: pass
+
+export const SpreadOverStaticId = ({ elementProps }) => (
+  <>
+    <a href="#about">About</a>
+    <main id="about" {...elementProps} />
+  </>
+);

--- a/packages/fuzz/corpus/regressions/anchor-target-exists--text-fragment-directive.tsx
+++ b/packages/fuzz/corpus/regressions/anchor-target-exists--text-fragment-directive.tsx
@@ -1,0 +1,13 @@
+// rule: anchor-target-exists
+// weakness: special-syntax
+// source: Cursor Bugbot PR #1561
+// verdict: pass
+
+export const TextFragmentLink = () => <a href="#:~:text=React%20Doctor">React Doctor</a>;
+
+export const CombinedTextFragmentLink = () => (
+  <>
+    <a href="#about:~:text=React%20Doctor">React Doctor</a>
+    <main id="about" />
+  </>
+);

--- a/packages/fuzz/corpus/regressions/button-has-type--outside-form.tsx
+++ b/packages/fuzz/corpus/regressions/button-has-type--outside-form.tsx
@@ -1,0 +1,10 @@
+// rule: button-has-type
+// verdict: pass
+// weakness: form-ownership
+// source: React Bench Figma-to-code audit
+
+export const MenuButton = () => (
+  <main>
+    <button>Open menu</button>
+  </main>
+);

--- a/packages/fuzz/corpus/true-positives/anchor-target-exists--jsx-template-content.tsx
+++ b/packages/fuzz/corpus/true-positives/anchor-target-exists--jsx-template-content.tsx
@@ -1,0 +1,13 @@
+// rule: anchor-target-exists
+// weakness: hidden-subtree
+// source: Cursor Bugbot PR #1561
+// verdict: fail
+
+export const TemplateContentTarget = () => (
+  <>
+    <a href="#about">About</a>
+    <template>
+      <main id="about" />
+    </template>
+  </>
+);

--- a/packages/fuzz/corpus/true-positives/anchor-target-exists--markup-in-script-text.tsx
+++ b/packages/fuzz/corpus/true-positives/anchor-target-exists--markup-in-script-text.tsx
@@ -1,0 +1,11 @@
+// rule: anchor-target-exists
+// weakness: cross-file
+// source: Cursor Bugbot PR #1561
+// verdict: fail
+
+export const MissingTargetWithMarkupText = () => (
+  <>
+    <a href="#about">About</a>
+    <script>{`const markup = '<main id="about"></main>';`}</script>
+  </>
+);

--- a/packages/fuzz/corpus/true-positives/anchor-target-exists--missing-fragment.tsx
+++ b/packages/fuzz/corpus/true-positives/anchor-target-exists--missing-fragment.tsx
@@ -1,0 +1,6 @@
+// rule: anchor-target-exists
+// verdict: fail
+// weakness: cross-file
+// source: React Bench Figma-to-code audit
+
+export const AboutLink = () => <a href="#about">About</a>;

--- a/packages/oxlint-plugin-react-doctor/scripts/generate-rule-registry.mjs
+++ b/packages/oxlint-plugin-react-doctor/scripts/generate-rule-registry.mjs
@@ -141,6 +141,7 @@ const EFFECT_RULES_PORTED_FROM_EXTERNAL = new Set([
 // `customRulesOnly`. Without this list every new in-house rule we drop
 // into `a11y/` would silently disappear for users who narrow scope.
 const RULES_NOT_PORTED_FROM_EXTERNAL = new Set([
+  "anchor-target-exists",
   "data-table-requires-accessible-name",
   "details-requires-summary",
   "fieldset-requires-legend",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/cross-file-rule-ids.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/cross-file-rule-ids.ts
@@ -42,6 +42,7 @@ import { REACT_ROUTER_RULE_IDS } from "./react-router.js";
 export const CROSS_FILE_RULE_IDS: ReadonlySet<string> = new Set([
   ...INK_RULE_IDS,
   "client-passive-event-listeners",
+  "anchor-target-exists",
   "exhaustive-deps",
   "no-barrel-import",
   "nextjs-async-dynamic-api-not-awaited",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/core-rule-registry-data.json
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/core-rule-registry-data.json
@@ -136,7 +136,7 @@
     "key": "react-doctor/anchor-target-exists",
     "id": "anchor-target-exists",
     "source": "react-doctor",
-    "originallyExternal": true,
+    "originallyExternal": false,
     "rule": {
       "id": "anchor-target-exists",
       "title": "Fragment link target is missing",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/core-rule-registry-data.json
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/core-rule-registry-data.json
@@ -133,6 +133,22 @@
     }
   },
   {
+    "key": "react-doctor/anchor-target-exists",
+    "id": "anchor-target-exists",
+    "source": "react-doctor",
+    "originallyExternal": true,
+    "rule": {
+      "id": "anchor-target-exists",
+      "title": "Fragment link target is missing",
+      "severity": "warn",
+      "recommendation": "Add an element with the referenced id, or update the fragment link to point to an existing target.",
+      "category": "Accessibility",
+      "framework": "global",
+      "requires": ["react"],
+      "isScanRule": false
+    }
+  },
+  {
     "key": "react-doctor/aria-activedescendant-has-tabindex",
     "id": "aria-activedescendant-has-tabindex",
     "source": "react-doctor",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/cross-file-dependencies.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/cross-file-dependencies.ts
@@ -574,6 +574,7 @@ export const CROSS_FILE_DEPENDENCY_COLLECTORS: ReadonlyMap<string, CrossFileDepe
  * partition), forcing a conscious classification.
  */
 export const UNBOUNDED_CROSS_FILE_RULE_IDS: ReadonlySet<string> = new Set([
+  "anchor-target-exists",
   "nextjs-no-img-element",
   "no-img-without-dimensions",
   "no-loading-flag-reset-outside-finally",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness-fixtures.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness-fixtures.ts
@@ -66,6 +66,9 @@ export const livenessFixtures: Readonly<Record<string, LivenessFixture>> = {
   "anchor-is-valid": {
     code: 'const B = () => <a href="#" onClick={go}>Go</a>;',
   },
+  "anchor-target-exists": {
+    code: 'const B = () => <a href="#missing">Missing</a>;',
+  },
   "aria-activedescendant-has-tabindex": {
     code: '<div contentEditable="false" aria-activedescendant={activeId} />',
   },
@@ -118,7 +121,7 @@ export const livenessFixtures: Readonly<Record<string, LivenessFixture>> = {
     filePath: ".github/workflows/release.yml",
   },
   "button-has-type": {
-    code: "<button type />",
+    code: "<form><button type /></form>",
   },
   "checked-requires-onchange-or-readonly": {
     code: 'const C = ({ checked, locked }) => <input type="checkbox" checked={checked} disabled={locked} />;',

--- a/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness.test.ts
@@ -12,6 +12,7 @@ const INTRINSIC_STRING_ALIAS_RULE_IDS: ReadonlyArray<string> = [
   "anchor-ambiguous-text",
   "anchor-has-content",
   "anchor-is-valid",
+  "anchor-target-exists",
   "aria-activedescendant-has-tabindex",
   "aria-role",
   "aria-unsupported-elements",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.test.ts
@@ -8,6 +8,7 @@ const REANIMATED_LAYOUT_RULE_ID = "rn-animate-layout-property";
 const CASCADING_SET_STATE_RULE_ID = "no-cascading-set-state";
 const HOOK_IMPORT_RENAME_RULE_ID = "hook-import-rename-loses-use-prefix";
 const IN_HOUSE_A11Y_RULE_IDS = [
+  "anchor-target-exists",
   "data-table-requires-accessible-name",
   "details-requires-summary",
   "fieldset-requires-legend",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
@@ -898,7 +898,7 @@ export const reactDoctorRules = [
     key: "react-doctor/anchor-target-exists",
     id: "anchor-target-exists",
     source: "react-doctor",
-    originallyExternal: true,
+    originallyExternal: false,
     rule: {
       ...anchorTargetExists,
       framework: "global",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
@@ -17,6 +17,7 @@ import { altText } from "./rules/a11y/alt-text.js";
 import { anchorAmbiguousText } from "./rules/a11y/anchor-ambiguous-text.js";
 import { anchorHasContent } from "./rules/a11y/anchor-has-content.js";
 import { anchorIsValid } from "./rules/a11y/anchor-is-valid.js";
+import { anchorTargetExists } from "./rules/a11y/anchor-target-exists.js";
 import { ariaActivedescendantHasTabindex } from "./rules/a11y/aria-activedescendant-has-tabindex.js";
 import { ariaBrailleEquivalent } from "./rules/a11y/aria-braille-equivalent.js";
 import { ariaProps } from "./rules/a11y/aria-props.js";
@@ -891,6 +892,18 @@ export const reactDoctorRules = [
       framework: "global",
       category: "Accessibility",
       requires: [...new Set<Capability>(["react", ...(anchorIsValid.requires ?? [])])],
+    },
+  },
+  {
+    key: "react-doctor/anchor-target-exists",
+    id: "anchor-target-exists",
+    source: "react-doctor",
+    originallyExternal: true,
+    rule: {
+      ...anchorTargetExists,
+      framework: "global",
+      category: "Accessibility",
+      requires: [...new Set<Capability>(["react", ...(anchorTargetExists.requires ?? [])])],
     },
   },
   {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/anchor-is-valid.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/anchor-is-valid.ts
@@ -3,6 +3,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { flattenJsxName } from "../../utils/flatten-jsx-name.js";
 import { getElementType } from "../../utils/get-element-type.js";
+import { getJsxA11yHrefAttributeNames } from "../../utils/get-jsx-a11y-href-attribute-names.js";
 import { getJsxPropStaticStringValues } from "../../utils/get-jsx-prop-static-string-values.js";
 import { hasJsxA11ySettings } from "../../utils/has-jsx-a11y-settings.js";
 import { hasJsxPropIgnoreCase } from "../../utils/has-jsx-prop-ignore-case.js";
@@ -21,10 +22,6 @@ interface AnchorIsValidSettings {
   validHrefs?: ReadonlyArray<string>;
 }
 
-interface JsxA11ySettings {
-  attributes?: { href?: ReadonlyArray<string> };
-}
-
 const resolveSettings = (
   settings: Readonly<Record<string, unknown>> | undefined,
 ): { validHrefs: ReadonlySet<string>; hrefAttributeNames: ReadonlyArray<string> } => {
@@ -33,12 +30,9 @@ const resolveSettings = (
     typeof reactDoctor === "object" && reactDoctor !== null
       ? ((reactDoctor as { anchorIsValid?: AnchorIsValidSettings }).anchorIsValid ?? {})
       : {};
-  const jsxA11y = settings?.["jsx-a11y"];
-  const a11ySettings =
-    typeof jsxA11y === "object" && jsxA11y !== null ? (jsxA11y as JsxA11ySettings) : {};
   return {
     validHrefs: new Set(ruleSettings.validHrefs ?? []),
-    hrefAttributeNames: a11ySettings.attributes?.href ?? ["href"],
+    hrefAttributeNames: getJsxA11yHrefAttributeNames(settings),
   };
 };
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/anchor-target-exists.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/anchor-target-exists.test.ts
@@ -275,6 +275,28 @@ describe("a11y/anchor-target-exists", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("does not treat id text inside another HTML attribute as an id", () => {
+    fs.writeFileSync(
+      path.join(temporaryDirectory, "other.html"),
+      `<main title='Copy id="about"' data-copy="id=about"></main>`,
+      "utf8",
+    );
+    const result = runProjectRule(`const Link = () => <a href="#about">About</a>;`);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("accepts an HTML id after another attribute mentions id text", () => {
+    fs.writeFileSync(
+      path.join(temporaryDirectory, "other.html"),
+      `<main title='Copy id="wrong"' id="about"></main>`,
+      "utf8",
+    );
+    const result = runProjectRule(`const Link = () => <a href="#about">About</a>;`);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("does not treat comments, raw text, or visible text as HTML ids", () => {
     fs.writeFileSync(
       path.join(temporaryDirectory, "other.html"),

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/anchor-target-exists.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/anchor-target-exists.test.ts
@@ -45,6 +45,14 @@ describe("a11y/anchor-target-exists", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("keeps known target ids from partially dynamic expressions", () => {
+    const result = runProjectRule(
+      `const Valid = ({ condition, name }) => <><a href="#about">About</a><section id={condition ? "about" : name} /></>;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("reports a literal fragment without a project target", () => {
     const result = runProjectRule(`const Broken = () => <a href="#about">About</a>;`);
     expect(result.parseErrors).toEqual([]);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/anchor-target-exists.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/anchor-target-exists.test.ts
@@ -17,8 +17,8 @@ afterEach(() => {
   fs.rmSync(temporaryDirectory, { recursive: true, force: true });
 });
 
-const runProjectRule = (code: string) => {
-  const filename = path.join(temporaryDirectory, "src", "app.tsx");
+const runProjectRule = (code: string, relativeFilePath = "src/app.tsx") => {
+  const filename = path.join(temporaryDirectory, relativeFilePath);
   fs.mkdirSync(path.dirname(filename), { recursive: true });
   fs.writeFileSync(filename, code, "utf8");
   fs.writeFileSync(path.join(temporaryDirectory, "package.json"), "{}\n", "utf8");
@@ -59,6 +59,32 @@ describe("a11y/anchor-target-exists", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("ignores hash-router paths", () => {
+    const result = runProjectRule(
+      `const Links = () => <><a href="#/about">About</a><a href="#!/settings">Settings</a></>;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("skips testlike files", () => {
+    const result = runProjectRule(
+      `const Broken = () => <a href="#about">About</a>;`,
+      "src/app.test.tsx",
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("accepts a same-file target outside the production project index", () => {
+    const result = runProjectRule(
+      `const Valid = () => <><a href="#about">About</a><section id="about" /></>;`,
+      ".generated/app.tsx",
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("accepts a target in another JSX file", () => {
     fs.mkdirSync(path.join(temporaryDirectory, "src"), { recursive: true });
     fs.writeFileSync(
@@ -86,6 +112,17 @@ describe("a11y/anchor-target-exists", () => {
     fs.writeFileSync(
       path.join(temporaryDirectory, "other.html"),
       `<main id="contact"></main>`,
+      "utf8",
+    );
+    const result = runProjectRule(`const Link = () => <a href="#about">About</a>;`);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not treat data-id as an HTML id", () => {
+    fs.writeFileSync(
+      path.join(temporaryDirectory, "other.html"),
+      `<main data-id="about"></main>`,
       "utf8",
     );
     const result = runProjectRule(`const Link = () => <a href="#about">About</a>;`);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/anchor-target-exists.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/anchor-target-exists.test.ts
@@ -67,6 +67,50 @@ describe("a11y/anchor-target-exists", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("ignores text fragment directives", () => {
+    const result = runProjectRule(
+      `const Link = () => <a href="#:~:text=React%20Doctor">React Doctor</a>;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("validates the element id before a text fragment directive", () => {
+    const validResult = runProjectRule(
+      `const Link = () => <><a href="#about:~:text=React%20Doctor">React Doctor</a><main id="about" /></>;`,
+    );
+    expect(validResult.parseErrors).toEqual([]);
+    expect(validResult.diagnostics).toEqual([]);
+
+    resetStaticProjectDomIdCache();
+    const brokenResult = runProjectRule(
+      `const Link = () => <a href="#missing:~:text=React%20Doctor">React Doctor</a>;`,
+    );
+    expect(brokenResult.parseErrors).toEqual([]);
+    expect(brokenResult.diagnostics).toHaveLength(1);
+    expect(brokenResult.diagnostics[0]?.message).toContain('"#missing"');
+  });
+
+  it("reports a missing target on a configured anchor component", () => {
+    const result = runRule(
+      anchorTargetExists,
+      `const Link = () => <NavigationLink href="#about">About</NavigationLink>;`,
+      { settings: { "jsx-a11y": { components: { NavigationLink: "a" } } } },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("accepts a target used by a configured anchor component", () => {
+    const result = runRule(
+      anchorTargetExists,
+      `const Link = () => <><NavigationLink href="#about">About</NavigationLink><main id="about" /></>;`,
+      { settings: { "jsx-a11y": { components: { NavigationLink: "a" } } } },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("skips testlike files", () => {
     const result = runProjectRule(
       `const Broken = () => <a href="#about">About</a>;`,
@@ -93,6 +137,47 @@ describe("a11y/anchor-target-exists", () => {
       "utf8",
     );
     const result = runProjectRule(`const Link = () => <a href="#about">About</a>;`);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("skips a missing-target claim when a JSX spread can provide or replace an id", () => {
+    const result = runProjectRule(
+      `const Link = (props) => <><a href="#about">About</a><main id="about" {...props} /></>;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("resolves ids from static JSX spread objects", () => {
+    const result = runProjectRule(
+      `const Links = () => <><a href="#about">About</a><a href="#missing">Missing</a><main {...{ id: "about" }} /></>;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0]?.message).toContain('"#missing"');
+  });
+
+  it("uses the last explicit JSX id", () => {
+    const result = runProjectRule(
+      `const Link = () => <><a href="#about">About</a><main id="about" id="contact" /></>;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not treat ids inside JSX template content as document targets", () => {
+    const result = runProjectRule(
+      `const Link = () => <><a href="#about">About</a><template><main id="about" /></template></>;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("accepts an id on the JSX template element itself", () => {
+    const result = runProjectRule(
+      `const Link = () => <><a href="#about">About</a><template id="about"><main id="inside" /></template></>;`,
+    );
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toEqual([]);
   });
@@ -128,5 +213,69 @@ describe("a11y/anchor-target-exists", () => {
     const result = runProjectRule(`const Link = () => <a href="#about">About</a>;`);
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not treat comments, raw text, or visible text as HTML ids", () => {
+    fs.writeFileSync(
+      path.join(temporaryDirectory, "other.html"),
+      `
+        <!-- <main id="about"></main> -->
+        <script>const markup = '<main id="about"></main>';</script>
+        <style>.example::after { content: '<main id="about"></main>'; }</style>
+        <p> id="about" </p>
+      `,
+      "utf8",
+    );
+    const result = runProjectRule(`const Link = () => <a href="#about">About</a>;`);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("accepts an HTML id when other text resembles markup", () => {
+    fs.writeFileSync(
+      path.join(temporaryDirectory, "other.html"),
+      `
+        <!-- <main id="wrong"></main> -->
+        <script>const markup = '<main id="wrong"></main>';</script>
+        <main class="shell" id="about" data-label=">"></main>
+      `,
+      "utf8",
+    );
+    const result = runProjectRule(`const Link = () => <a href="#about">About</a>;`);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("accepts an id on a raw-text element while ignoring its body", () => {
+    fs.writeFileSync(
+      path.join(temporaryDirectory, "other.html"),
+      `<script id="about">const markup = '<main id="wrong"></main>';</script>`,
+      "utf8",
+    );
+    const result = runProjectRule(`const Link = () => <a href="#about">About</a>;`);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not treat ids inside an HTML template as document targets", () => {
+    fs.writeFileSync(
+      path.join(temporaryDirectory, "other.html"),
+      `<template><main id="about"></main></template>`,
+      "utf8",
+    );
+    const result = runProjectRule(`const Link = () => <a href="#about">About</a>;`);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("accepts an id on the HTML template element itself", () => {
+    fs.writeFileSync(
+      path.join(temporaryDirectory, "other.html"),
+      `<template id="about"><main id="inside"></main></template>`,
+      "utf8",
+    );
+    const result = runProjectRule(`const Link = () => <a href="#about">About</a>;`);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
   });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/anchor-target-exists.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/anchor-target-exists.test.ts
@@ -218,6 +218,14 @@ describe("a11y/anchor-target-exists", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("keeps known ids from static spreads containing a later dynamic spread", () => {
+    const result = runProjectRule(
+      `const Link = (props) => <><a href="#about">About</a><main {...{ ...{ id: "about", ...props } }} /></>;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("uses the last explicit JSX id", () => {
     const result = runProjectRule(
       `const Link = () => <><a href="#about">About</a><main id="about" id="contact" /></>;`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/anchor-target-exists.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/anchor-target-exists.test.ts
@@ -37,6 +37,14 @@ describe("a11y/anchor-target-exists", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("accepts a target id resolved through a const alias", () => {
+    const result = runProjectRule(
+      `const SECTION_ID = "about"; const Valid = () => <><a href="#about">About</a><section id={SECTION_ID} /></>;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("reports a literal fragment without a project target", () => {
     const result = runProjectRule(`const Broken = () => <a href="#about">About</a>;`);
     expect(result.parseErrors).toEqual([]);
@@ -111,6 +119,30 @@ describe("a11y/anchor-target-exists", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("reads configured href attribute names", () => {
+    const settings = {
+      "jsx-a11y": {
+        attributes: { href: ["to"] },
+        components: { NavigationLink: "a" },
+      },
+    };
+    const validResult = runRule(
+      anchorTargetExists,
+      `const Link = () => <><NavigationLink to="#about">About</NavigationLink><main id="about" /></>;`,
+      { settings },
+    );
+    expect(validResult.parseErrors).toEqual([]);
+    expect(validResult.diagnostics).toEqual([]);
+
+    const brokenResult = runRule(
+      anchorTargetExists,
+      `const Link = () => <NavigationLink to="#about">About</NavigationLink>;`,
+      { settings },
+    );
+    expect(brokenResult.parseErrors).toEqual([]);
+    expect(brokenResult.diagnostics).toHaveLength(1);
+  });
+
   it("skips testlike files", () => {
     const result = runProjectRule(
       `const Broken = () => <a href="#about">About</a>;`,
@@ -141,6 +173,18 @@ describe("a11y/anchor-target-exists", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("accepts a const-aliased target in another JSX file", () => {
+    fs.mkdirSync(path.join(temporaryDirectory, "src"), { recursive: true });
+    fs.writeFileSync(
+      path.join(temporaryDirectory, "src", "about.tsx"),
+      `const SECTION_ID = "about"; export const About = () => <section id={SECTION_ID} />;`,
+      "utf8",
+    );
+    const result = runProjectRule(`const Link = () => <a href="#about">About</a>;`);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("skips a missing-target claim when a JSX spread can provide or replace an id", () => {
     const result = runProjectRule(
       `const Link = (props) => <><a href="#about">About</a><main id="about" {...props} /></>;`,
@@ -156,6 +200,14 @@ describe("a11y/anchor-target-exists", () => {
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0]?.message).toContain('"#missing"');
+  });
+
+  it("resolves const-aliased ids from static JSX spread objects", () => {
+    const result = runProjectRule(
+      `const SECTION_ID = "about"; const Link = () => <><a href="#about">About</a><main {...{ id: SECTION_ID }} /></>;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
   });
 
   it("uses the last explicit JSX id", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/anchor-target-exists.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/anchor-target-exists.test.ts
@@ -53,6 +53,14 @@ describe("a11y/anchor-target-exists", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("keeps known target ids from dynamic nullish and falsy defaults", () => {
+    const result = runProjectRule(
+      `const Valid = (props) => <><a href="#about">About</a><a href="#contact">Contact</a><section id={props.id ?? "about"} /><section id={props.otherId || "contact"} /></>;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("reports a literal fragment without a project target", () => {
     const result = runProjectRule(`const Broken = () => <a href="#about">About</a>;`);
     expect(result.parseErrors).toEqual([]);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/anchor-target-exists.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/anchor-target-exists.test.ts
@@ -51,9 +51,9 @@ describe("a11y/anchor-target-exists", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
-  it("allows the empty document-top fragment and non-fragment links", () => {
+  it("allows document-top fragments and non-fragment links", () => {
     const result = runProjectRule(
-      `const Links = () => <><a href="#">Top</a><a href="https://example.com/#about">External</a><a href="mailto:user@example.com">Mail</a><a href="tel:+15551212">Call</a></>;`,
+      `const Links = () => <><a href="#">Top</a><a href="#top">Top</a><a href="#TOP">Top</a><a href="https://example.com/#about">External</a><a href="mailto:user@example.com">Mail</a><a href="tel:+15551212">Call</a></>;`,
     );
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toEqual([]);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/anchor-target-exists.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/anchor-target-exists.test.ts
@@ -1,0 +1,95 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { resetStaticProjectDomIdCache } from "../../utils/get-static-project-dom-ids.js";
+import { anchorTargetExists } from "./anchor-target-exists.js";
+
+let temporaryDirectory: string;
+
+beforeEach(() => {
+  temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "rd-anchor-target-"));
+});
+
+afterEach(() => {
+  resetStaticProjectDomIdCache();
+  fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+});
+
+const runProjectRule = (code: string) => {
+  const filename = path.join(temporaryDirectory, "src", "app.tsx");
+  fs.mkdirSync(path.dirname(filename), { recursive: true });
+  fs.writeFileSync(filename, code, "utf8");
+  fs.writeFileSync(path.join(temporaryDirectory, "package.json"), "{}\n", "utf8");
+  return runRule(anchorTargetExists, code, {
+    filename,
+    settings: { "react-doctor": { rootDirectory: temporaryDirectory } },
+  });
+};
+
+describe("a11y/anchor-target-exists", () => {
+  it("accepts a literal fragment with a same-file target", () => {
+    const result = runProjectRule(
+      `const Valid = () => <><a href="#about">About</a><section id="about" /></>;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("reports a literal fragment without a project target", () => {
+    const result = runProjectRule(`const Broken = () => <a href="#about">About</a>;`);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("ignores dynamic fragment hrefs", () => {
+    const result = runProjectRule(
+      "const Dynamic = ({ target }) => <a href={`#${target}`}>Section</a>;",
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("allows the empty document-top fragment and non-fragment links", () => {
+    const result = runProjectRule(
+      `const Links = () => <><a href="#">Top</a><a href="https://example.com/#about">External</a><a href="mailto:user@example.com">Mail</a><a href="tel:+15551212">Call</a></>;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("accepts a target in another JSX file", () => {
+    fs.mkdirSync(path.join(temporaryDirectory, "src"), { recursive: true });
+    fs.writeFileSync(
+      path.join(temporaryDirectory, "src", "about.tsx"),
+      `export const About = () => <section id="about" />;`,
+      "utf8",
+    );
+    const result = runProjectRule(`const Link = () => <a href="#about">About</a>;`);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("accepts a target in an HTML file", () => {
+    fs.writeFileSync(
+      path.join(temporaryDirectory, "index.html"),
+      `<main id="about"></main>`,
+      "utf8",
+    );
+    const result = runProjectRule(`const Link = () => <a href="#about">About</a>;`);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not accept a different literal id", () => {
+    fs.writeFileSync(
+      path.join(temporaryDirectory, "other.html"),
+      `<main id="contact"></main>`,
+      "utf8",
+    );
+    const result = runProjectRule(`const Link = () => <a href="#about">About</a>;`);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/anchor-target-exists.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/anchor-target-exists.ts
@@ -1,12 +1,12 @@
 import { EMPTY_RULE_VISITORS } from "../../utils/empty-rule-visitors.js";
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { getElementType } from "../../utils/get-element-type.js";
 import { getAuthoritativeJsxAttribute } from "../../utils/get-authoritative-jsx-attribute.js";
 import { getReactDoctorStringSetting } from "../../utils/get-react-doctor-setting.js";
 import { getStaticProjectDomIds } from "../../utils/get-static-project-dom-ids.js";
 import { getStringLiteralAttributeValue } from "../../utils/get-string-literal-attribute-value.js";
 import { isTestlikeFilename } from "../../utils/is-testlike-filename.js";
-import { resolveJsxElementType } from "../../utils/resolve-jsx-element-type.js";
 
 interface PendingFragmentLink {
   readonly hrefAttribute: EsTreeNodeOfType<"JSXAttribute">;
@@ -29,21 +29,25 @@ export const anchorTargetExists = defineRule({
         programNode = node;
       },
       JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
-        if (resolveJsxElementType(node) !== "a") return;
+        if (getElementType(node, context.settings) !== "a") return;
         const hrefAttribute = getAuthoritativeJsxAttribute(node.attributes, "href", false);
         if (!hrefAttribute) return;
         const href = getStringLiteralAttributeValue(hrefAttribute);
-        const normalizedHref = href?.toLowerCase();
         if (
           !href?.startsWith("#") ||
           href.length === 1 ||
           href.startsWith("#/") ||
-          href.startsWith("#!") ||
-          normalizedHref === "#top"
+          href.startsWith("#!")
         ) {
           return;
         }
-        pendingFragmentLinks.push({ hrefAttribute, targetId: href.slice(1) });
+        const textFragmentDirectiveIndex = href.indexOf(":~:");
+        const targetId = href.slice(
+          1,
+          textFragmentDirectiveIndex === -1 ? undefined : textFragmentDirectiveIndex,
+        );
+        if (!targetId || targetId.toLowerCase() === "top") return;
+        pendingFragmentLinks.push({ hrefAttribute, targetId });
       },
       "Program:exit"() {
         if (!programNode || pendingFragmentLinks.length === 0) return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/anchor-target-exists.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/anchor-target-exists.ts
@@ -3,6 +3,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { getElementType } from "../../utils/get-element-type.js";
 import { getAuthoritativeJsxAttribute } from "../../utils/get-authoritative-jsx-attribute.js";
+import { getJsxA11yHrefAttributeNames } from "../../utils/get-jsx-a11y-href-attribute-names.js";
 import { getReactDoctorStringSetting } from "../../utils/get-react-doctor-setting.js";
 import { getStaticProjectDomIds } from "../../utils/get-static-project-dom-ids.js";
 import { getStringLiteralAttributeValue } from "../../utils/get-string-literal-attribute-value.js";
@@ -30,7 +31,11 @@ export const anchorTargetExists = defineRule({
       },
       JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
         if (getElementType(node, context.settings) !== "a") return;
-        const hrefAttribute = getAuthoritativeJsxAttribute(node.attributes, "href", false);
+        let hrefAttribute: EsTreeNodeOfType<"JSXAttribute"> | null = null;
+        for (const hrefAttributeName of getJsxA11yHrefAttributeNames(context.settings)) {
+          hrefAttribute = getAuthoritativeJsxAttribute(node.attributes, hrefAttributeName, false);
+          if (hrefAttribute) break;
+        }
         if (!hrefAttribute) return;
         const href = getStringLiteralAttributeValue(hrefAttribute);
         if (

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/anchor-target-exists.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/anchor-target-exists.ts
@@ -33,11 +33,13 @@ export const anchorTargetExists = defineRule({
         const hrefAttribute = getAuthoritativeJsxAttribute(node.attributes, "href", false);
         if (!hrefAttribute) return;
         const href = getStringLiteralAttributeValue(hrefAttribute);
+        const normalizedHref = href?.toLowerCase();
         if (
           !href?.startsWith("#") ||
           href.length === 1 ||
           href.startsWith("#/") ||
-          href.startsWith("#!")
+          href.startsWith("#!") ||
+          normalizedHref === "#top"
         ) {
           return;
         }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/anchor-target-exists.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/anchor-target-exists.ts
@@ -1,9 +1,11 @@
+import { EMPTY_RULE_VISITORS } from "../../utils/empty-rule-visitors.js";
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { getAuthoritativeJsxAttribute } from "../../utils/get-authoritative-jsx-attribute.js";
 import { getReactDoctorStringSetting } from "../../utils/get-react-doctor-setting.js";
 import { getStaticProjectDomIds } from "../../utils/get-static-project-dom-ids.js";
 import { getStringLiteralAttributeValue } from "../../utils/get-string-literal-attribute-value.js";
+import { isTestlikeFilename } from "../../utils/is-testlike-filename.js";
 import { resolveJsxElementType } from "../../utils/resolve-jsx-element-type.js";
 
 interface PendingFragmentLink {
@@ -18,6 +20,7 @@ export const anchorTargetExists = defineRule({
   recommendation:
     "Add an element with the referenced id, or update the fragment link to point to an existing target.",
   create: (context) => {
+    if (isTestlikeFilename(context.filename)) return EMPTY_RULE_VISITORS;
     const pendingFragmentLinks: PendingFragmentLink[] = [];
     let programNode: EsTreeNodeOfType<"Program"> | null = null;
 
@@ -30,7 +33,14 @@ export const anchorTargetExists = defineRule({
         const hrefAttribute = getAuthoritativeJsxAttribute(node.attributes, "href", false);
         if (!hrefAttribute) return;
         const href = getStringLiteralAttributeValue(hrefAttribute);
-        if (!href?.startsWith("#") || href.length === 1) return;
+        if (
+          !href?.startsWith("#") ||
+          href.length === 1 ||
+          href.startsWith("#/") ||
+          href.startsWith("#!")
+        ) {
+          return;
+        }
         pendingFragmentLinks.push({ hrefAttribute, targetId: href.slice(1) });
       },
       "Program:exit"() {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/anchor-target-exists.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/anchor-target-exists.ts
@@ -1,0 +1,55 @@
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { getAuthoritativeJsxAttribute } from "../../utils/get-authoritative-jsx-attribute.js";
+import { getReactDoctorStringSetting } from "../../utils/get-react-doctor-setting.js";
+import { getStaticProjectDomIds } from "../../utils/get-static-project-dom-ids.js";
+import { getStringLiteralAttributeValue } from "../../utils/get-string-literal-attribute-value.js";
+import { resolveJsxElementType } from "../../utils/resolve-jsx-element-type.js";
+
+interface PendingFragmentLink {
+  readonly hrefAttribute: EsTreeNodeOfType<"JSXAttribute">;
+  readonly targetId: string;
+}
+
+export const anchorTargetExists = defineRule({
+  id: "anchor-target-exists",
+  title: "Fragment link target is missing",
+  severity: "warn",
+  recommendation:
+    "Add an element with the referenced id, or update the fragment link to point to an existing target.",
+  create: (context) => {
+    const pendingFragmentLinks: PendingFragmentLink[] = [];
+    let programNode: EsTreeNodeOfType<"Program"> | null = null;
+
+    return {
+      Program(node: EsTreeNodeOfType<"Program">) {
+        programNode = node;
+      },
+      JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
+        if (resolveJsxElementType(node) !== "a") return;
+        const hrefAttribute = getAuthoritativeJsxAttribute(node.attributes, "href", false);
+        if (!hrefAttribute) return;
+        const href = getStringLiteralAttributeValue(hrefAttribute);
+        if (!href?.startsWith("#") || href.length === 1) return;
+        pendingFragmentLinks.push({ hrefAttribute, targetId: href.slice(1) });
+      },
+      "Program:exit"() {
+        if (!programNode || pendingFragmentLinks.length === 0) return;
+        const staticProjectDomIds = getStaticProjectDomIds({
+          configuredRootDirectory: getReactDoctorStringSetting(context.settings, "rootDirectory"),
+          currentFilePath: context.filename ?? "",
+          currentProgramNode: programNode,
+          currentScopes: context.scopes,
+        });
+        if (!staticProjectDomIds) return;
+        for (const pendingFragmentLink of pendingFragmentLinks) {
+          if (staticProjectDomIds.has(pendingFragmentLink.targetId)) continue;
+          context.report({
+            node: pendingFragmentLink.hrefAttribute,
+            message: `This fragment link points to "#${pendingFragmentLink.targetId}", but no matching static id was found in the project.`,
+          });
+        }
+      },
+    };
+  },
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/control-has-associated-label.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/control-has-associated-label.regressions.test.ts
@@ -968,6 +968,32 @@ describe("a11y/control-has-associated-label regressions", () => {
     expect(result.diagnostics).toHaveLength(6);
   });
 
+  it("reports nested decorative glyph and repeated-bar labels", () => {
+    const result = runRule(
+      controlHasAssociatedLabel,
+      `
+        const Player = () => (
+          <nav>
+            <button className="sound">⌁<span>×</span></button>
+            <button className="sound"><i /><span>╎╎╎╎╎╎</span></button>
+            <button className="mute">⌁ <span>|||||||</span></button>
+          </nav>
+        );
+      `,
+    );
+
+    expect(result.diagnostics).toHaveLength(3);
+  });
+
+  it("accepts a button named by an SVG title", () => {
+    const result = runRule(
+      controlHasAssociatedLabel,
+      `<button><svg><title>Close</title></svg></button>`,
+    );
+
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("accepts concise text, numeric, and explicitly named symbol controls", () => {
     const result = runRule(
       controlHasAssociatedLabel,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-array-index-as-key.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-array-index-as-key.regressions.test.ts
@@ -3,6 +3,21 @@ import { runRule } from "../../../test-utils/run-rule.js";
 import { noArrayIndexAsKey } from "./no-array-index-as-key.js";
 
 describe("correctness/no-array-index-as-key regressions", () => {
+  it("stays silent on immutable decorative Array.from elements", () => {
+    const result = runRule(
+      noArrayIndexAsKey,
+      `Array.from({ length: 16 }, (_, i) => <i key={i} />);`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent on data-mapped decorative elements without component state", () => {
+    const result = runRule(noArrayIndexAsKey, `items.map((item, i) => <i key={i} />);`);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   describe("reachable index fallbacks", () => {
     it("flags the authentic Lobe nullish fallback after it is inlined", () => {
       const result = runRule(

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/__fixtures__/oxc-divergences.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/__fixtures__/oxc-divergences.ts
@@ -16,6 +16,11 @@ export interface OxcDivergence {
 }
 
 export const DIVERGENCES: Record<string, OxcDivergence> = {
+  "button-has-type": {
+    failSkips: [0, 15, 16, 27],
+    reason:
+      "Intentional: a missing button type only matters when the button has a static form owner.",
+  },
   "jsx-no-target-blank": {
     failSkips: [31],
     reason:

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/button-has-type.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/button-has-type.regressions.test.ts
@@ -3,10 +3,73 @@ import { runRule } from "../../../test-utils/run-rule.js";
 import { buttonHasType } from "./button-has-type.js";
 
 describe("react-builtins/button-has-type — regressions", () => {
+  it("stays silent for a button without a form owner", () => {
+    const result = runRule(
+      buttonHasType,
+      `const Outside = () => <main><button>Open menu</button></main>;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("flags a button without a type inside an intrinsic form", () => {
+    const result = runRule(
+      buttonHasType,
+      `const Inside = () => <form><button>Save</button></form>;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("flags a button with a literal associated form", () => {
+    const result = runRule(
+      buttonHasType,
+      `const Associated = () => <><form id="settings" /><button form="settings">Save</button></>;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not invent a form owner from a custom component", () => {
+    const result = runRule(
+      buttonHasType,
+      `const InsideCustom = () => <Form><button>Save</button></Form>;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("requires a statically nonempty associated form id", () => {
+    const result = runRule(
+      buttonHasType,
+      `const Buttons = ({ formId }) => <><button form="">Empty</button><button form={formId}>Dynamic</button></>;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("applies form ownership to createElement buttons", () => {
+    const outsideResult = runRule(buttonHasType, `React.createElement("button", null, "Open");`);
+    const nestedResult = runRule(
+      buttonHasType,
+      `React.createElement("form", null, React.createElement("button", null, "Save"));`,
+    );
+    const associatedResult = runRule(
+      buttonHasType,
+      `React.createElement("button", { form: "settings" }, "Save");`,
+    );
+    expect(outsideResult.parseErrors).toEqual([]);
+    expect(outsideResult.diagnostics).toEqual([]);
+    expect(nestedResult.parseErrors).toEqual([]);
+    expect(nestedResult.diagnostics).toHaveLength(1);
+    expect(associatedResult.parseErrors).toEqual([]);
+    expect(associatedResult.diagnostics).toHaveLength(1);
+  });
+
   it("treats an exact const string JSX alias as a button", () => {
     const invalidResult = runRule(
       buttonHasType,
-      'const ButtonTag = "button" as const; const Save = () => <ButtonTag>Save</ButtonTag>;',
+      'const ButtonTag = "button" as const; const Save = () => <form><ButtonTag>Save</ButtonTag></form>;',
     );
     const validResult = runRule(
       buttonHasType,
@@ -221,7 +284,7 @@ describe("react-builtins/button-has-type — regressions", () => {
   });
 
   it("still flags createElement('button', {}) with no type and no spread", () => {
-    const result = runRule(buttonHasType, `React.createElement("button", {});`);
+    const result = runRule(buttonHasType, `React.createElement("button", { form: "settings" });`);
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics.length).toBeGreaterThan(0);
   });
@@ -229,13 +292,19 @@ describe("react-builtins/button-has-type — regressions", () => {
   // Bugbot: nullish props (undefined / void 0) carry no type, like an explicit
   // null — they must still report missing, not be treated as an opaque bag.
   it("still flags createElement('button', undefined)", () => {
-    const result = runRule(buttonHasType, `React.createElement("button", undefined);`);
+    const result = runRule(
+      buttonHasType,
+      `React.createElement("form", null, React.createElement("button", undefined));`,
+    );
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics.length).toBeGreaterThan(0);
   });
 
   it("still flags createElement('button', void 0)", () => {
-    const result = runRule(buttonHasType, `React.createElement("button", void 0);`);
+    const result = runRule(
+      buttonHasType,
+      `React.createElement("form", null, React.createElement("button", void 0));`,
+    );
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics.length).toBeGreaterThan(0);
   });
@@ -343,7 +412,7 @@ describe("react-builtins/button-has-type — regressions", () => {
        import { usePress } from "react-aria";
        export const UnstyledPressButton = forwardRef((props, ref) => {
          const { pressProps } = usePress(props);
-         return <button {...pressProps} ref={ref} className={pressProps.className} />;
+         return <form><button {...pressProps} ref={ref} className={pressProps.className} /></form>;
        });`,
     );
     expect(result.parseErrors).toEqual([]);
@@ -360,7 +429,7 @@ describe("react-builtins/button-has-type — regressions", () => {
        import { mergeProps, useFocus, useHover } from "react-aria";
        export function CopyButton({ text }) {
          const { tooltipState, triggerProps } = useCopyButtonTooltipState();
-         return <button className="x" onClick={() => {}} {...triggerProps}>copy</button>;
+         return <form><button className="x" onClick={() => {}} {...triggerProps}>copy</button></form>;
        }
        function useCopyButtonTooltipState() {
          const tooltipState = { open() {}, close() {} };
@@ -378,7 +447,7 @@ describe("react-builtins/button-has-type — regressions", () => {
       buttonHasType,
       `const Button = ({ onClick }) => {
         const handlers = { onClick };
-        return <button {...handlers}>x</button>;
+        return <form><button {...handlers}>x</button></form>;
       };`,
     );
     expect(result.parseErrors).toEqual([]);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/button-has-type.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/button-has-type.ts
@@ -4,7 +4,11 @@ import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import type { BindingInfo } from "../../utils/find-variable-initializer.js";
 import { findVariableInitializer } from "../../utils/find-variable-initializer.js";
 import { getImportedNameFromModule } from "../../utils/find-import-source-for-name.js";
+import { getAuthoritativeJsxAttribute } from "../../utils/get-authoritative-jsx-attribute.js";
+import { getStaticObjectPropertyValue } from "../../utils/get-static-object-property-value.js";
+import { getStaticStringExpression } from "../../utils/get-static-string-expression.js";
 import { getStaticTemplateLiteralValue } from "../../utils/get-static-template-literal-value.js";
+import { getStringLiteralAttributeValue } from "../../utils/get-string-literal-attribute-value.js";
 import { hasJsxPropIgnoreCase } from "../../utils/has-jsx-prop-ignore-case.js";
 import { hasJsxSpreadAttribute } from "../../utils/has-jsx-spread-attribute.js";
 import { isCreateElementCall } from "../../utils/is-create-element-call.js";
@@ -458,6 +462,45 @@ const reportInvalid = (context: Parameters<Rule["create"]>[0], reportNode: EsTre
   context.report({ node: reportNode, message: INVALID_MESSAGE });
 };
 
+const jsxButtonHasAssociatedForm = (
+  openingElement: EsTreeNodeOfType<"JSXOpeningElement">,
+): boolean => {
+  const formAttribute = getAuthoritativeJsxAttribute(openingElement.attributes, "form", false);
+  return Boolean(formAttribute && getStringLiteralAttributeValue(formAttribute)?.trim());
+};
+
+const createElementButtonHasAssociatedForm = (
+  propsArgument: EsTreeNode | null | undefined,
+): boolean => {
+  const formPropertyValue = propsArgument
+    ? getStaticObjectPropertyValue(propsArgument, "form")
+    : undefined;
+  return Boolean(getStaticStringExpression(formPropertyValue)?.trim());
+};
+
+const isFormCreateElementCall = (node: EsTreeNode): boolean => {
+  if (!isNodeOfType(node, "CallExpression") || !isCreateElementCall(node)) return false;
+  const elementType = node.arguments[0];
+  return Boolean(
+    elementType && isNodeOfType(elementType, "Literal") && elementType.value === "form",
+  );
+};
+
+const hasStaticFormAncestor = (node: EsTreeNode): boolean => {
+  let ancestor = node.parent;
+  while (ancestor) {
+    if (
+      isNodeOfType(ancestor, "JSXElement") &&
+      resolveJsxElementType(ancestor.openingElement) === "form"
+    ) {
+      return true;
+    }
+    if (isFormCreateElementCall(ancestor)) return true;
+    ancestor = ancestor.parent;
+  }
+  return false;
+};
+
 // Port of `oxc_linter::rules::react::button_has_type`. Flags
 //   - `<button>` without a `type` attribute,
 //   - `<button type="foo">` outside the allowed set,
@@ -483,6 +526,7 @@ export const buttonHasType = defineRule({
         if (resolveJsxElementType(node) !== "button") return;
         const typeAttr = hasJsxPropIgnoreCase(node.attributes, "type");
         if (!typeAttr) {
+          if (!jsxButtonHasAssociatedForm(node) && !hasStaticFormAncestor(node)) return;
           // A spread (`<button {...props} />`) can forward `type` at
           // runtime, so the absence of an explicit attribute isn't proof —
           // unless every spread provably cannot carry a `type` key (e.g.
@@ -530,10 +574,13 @@ export const buttonHasType = defineRule({
           return;
         }
         const propsArgument = node.arguments[1];
+        const hasFormOwner =
+          createElementButtonHasAssociatedForm(propsArgument) || hasStaticFormAncestor(node);
         // No props (`createElement("button")`) or explicitly nullish props
         // (`…, null)`, `…, undefined)`, `…, void 0)`) carry no `type` — unlike
         // an opaque bag, which may forward one at runtime → missing.
         if (!propsArgument || isNullishExpression(propsArgument)) {
+          if (!hasFormOwner) return;
           context.report({ node, message: MISSING_MESSAGE });
           return;
         }
@@ -559,6 +606,7 @@ export const buttonHasType = defineRule({
           }
         }
         if (!typeProp) {
+          if (!hasFormOwner) return;
           // `{ ...props }` may supply `type` at runtime, just like a JSX
           // spread — unless every spread provably cannot carry `type`.
           if (hasSpread) {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/build-source-project-index.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/build-source-project-index.ts
@@ -20,6 +20,7 @@ export interface SourceProjectModule {
 
 export interface SourceProjectIndex {
   readonly modulesByFilePath: ReadonlyMap<string, SourceProjectModule>;
+  readonly htmlFilePaths: ReadonlyArray<string>;
   readonly consumerModulesByFilePath: ReadonlyMap<string, ReadonlySet<SourceProjectModule>>;
   readonly resolvedSourcePathByNode: WeakMap<EsTreeNode, string>;
   readonly unresolvedRuntimeSources: ReadonlySet<string>;
@@ -29,6 +30,7 @@ export interface SourceProjectIndex {
 const SOURCE_PROJECT_FILE_PATTERN = /\.[cm]?[jt]sx?$/i;
 const SOURCE_PROJECT_DECLARATION_FILE_PATTERN = /\.d\.[cm]?[jt]s$/i;
 const SOURCE_PROJECT_MDX_FILE_PATTERN = /\.mdx$/i;
+const SOURCE_PROJECT_HTML_FILE_PATTERN = /\.html?$/i;
 const SOURCE_PROJECT_IGNORED_DIRECTORY_NAMES: ReadonlySet<string> = new Set([
   ".angular",
   ".astro",
@@ -62,8 +64,13 @@ const getSourceProjectModuleScopes = (programNode: EsTreeNodeOfType<"Program">):
 
 const listProductionSourceFiles = (
   rootDirectory: string,
-): { sourceFilePaths: ReadonlyArray<string>; hasOpaqueMdxConsumerSurface: boolean } | null => {
+): {
+  sourceFilePaths: ReadonlyArray<string>;
+  htmlFilePaths: ReadonlyArray<string>;
+  hasOpaqueMdxConsumerSurface: boolean;
+} | null => {
   const sourceFilePaths: string[] = [];
+  const htmlFilePaths: string[] = [];
   const pendingDirectories = [rootDirectory];
   let hasOpaqueMdxConsumerSurface = false;
 
@@ -93,13 +100,17 @@ const listProductionSourceFiles = (
         hasOpaqueMdxConsumerSurface = true;
         continue;
       }
+      if (SOURCE_PROJECT_HTML_FILE_PATTERN.test(entry.name)) {
+        htmlFilePaths.push(normalizeFilename(absolutePath));
+        continue;
+      }
       if (!SOURCE_PROJECT_FILE_PATTERN.test(entry.name)) continue;
       if (SOURCE_PROJECT_DECLARATION_FILE_PATTERN.test(entry.name)) continue;
       sourceFilePaths.push(normalizeFilename(absolutePath));
     }
   }
 
-  return { sourceFilePaths, hasOpaqueMdxConsumerSurface };
+  return { sourceFilePaths, htmlFilePaths, hasOpaqueMdxConsumerSurface };
 };
 
 const getRuntimeModuleSource = (node: EsTreeNode): string | null => {
@@ -202,6 +213,7 @@ export const buildSourceProjectIndex = (
 
   return {
     modulesByFilePath,
+    htmlFilePaths: productionSourceFiles.htmlFilePaths,
     consumerModulesByFilePath,
     resolvedSourcePathByNode,
     unresolvedRuntimeSources,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-jsx-a11y-href-attribute-names.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-jsx-a11y-href-attribute-names.ts
@@ -1,0 +1,18 @@
+const DEFAULT_HREF_ATTRIBUTE_NAMES: ReadonlyArray<string> = ["href"];
+
+export const getJsxA11yHrefAttributeNames = (
+  settings: Readonly<Record<string, unknown>> | undefined,
+): ReadonlyArray<string> => {
+  const jsxA11y = settings?.["jsx-a11y"];
+  if (typeof jsxA11y !== "object" || jsxA11y === null) return DEFAULT_HREF_ATTRIBUTE_NAMES;
+  const attributes = Reflect.get(jsxA11y, "attributes");
+  if (typeof attributes !== "object" || attributes === null) return DEFAULT_HREF_ATTRIBUTE_NAMES;
+  const hrefAttributeNames = Reflect.get(attributes, "href");
+  if (
+    !Array.isArray(hrefAttributeNames) ||
+    !hrefAttributeNames.every((attributeName: unknown) => typeof attributeName === "string")
+  ) {
+    return DEFAULT_HREF_ATTRIBUTE_NAMES;
+  }
+  return hrefAttributeNames;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-jsx-prop-static-string-values.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-jsx-prop-static-string-values.ts
@@ -85,6 +85,23 @@ const resolveStaticStringExpressionValues = (
       });
       continue;
     }
+    if (
+      shouldKeepKnownValues &&
+      isNodeOfType(expression, "LogicalExpression") &&
+      (expression.operator === "??" || expression.operator === "||")
+    ) {
+      workItems.push({
+        expression: expression.right,
+        remainingConstAliases: workItem.remainingConstAliases,
+        resolvingSymbols: new Set(workItem.resolvingSymbols),
+      });
+      workItems.push({
+        expression: expression.left,
+        remainingConstAliases: workItem.remainingConstAliases,
+        resolvingSymbols: new Set(workItem.resolvingSymbols),
+      });
+      continue;
+    }
     if (isNodeOfType(expression, "Identifier")) {
       const symbol = scopes.referenceFor(expression)?.resolvedSymbol;
       if (

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-jsx-prop-static-string-values.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-jsx-prop-static-string-values.ts
@@ -17,9 +17,10 @@ interface StaticStringWorkItem {
 interface StaticStringResolutionOptions {
   readonly maximumConstAliases?: number | null;
   readonly shouldFoldStaticConditions?: boolean;
+  readonly shouldKeepKnownValues?: boolean;
 }
 
-export const getStaticStringExpressionValues = (
+const resolveStaticStringExpressionValues = (
   rawExpression: EsTreeNode,
   scopes: ScopeAnalysis,
   options: StaticStringResolutionOptions = {},
@@ -29,6 +30,7 @@ export const getStaticStringExpressionValues = (
       ? MAX_CONST_RESOLUTION_HOPS
       : options.maximumConstAliases;
   const shouldFoldStaticConditions = options.shouldFoldStaticConditions ?? false;
+  const shouldKeepKnownValues = options.shouldKeepKnownValues ?? false;
   const staticStringValues: string[] = [];
   const workItems: StaticStringWorkItem[] = [
     {
@@ -43,13 +45,19 @@ export const getStaticStringExpressionValues = (
     if (!workItem) continue;
     const expression = stripParenExpression(workItem.expression);
     if (isNodeOfType(expression, "Literal")) {
-      if (typeof expression.value !== "string") return null;
+      if (typeof expression.value !== "string") {
+        if (shouldKeepKnownValues) continue;
+        return null;
+      }
       staticStringValues.push(expression.value);
       continue;
     }
     if (isNodeOfType(expression, "TemplateLiteral")) {
       const staticValue = getStaticTemplateLiteralValue(expression);
-      if (staticValue === null) return null;
+      if (staticValue === null) {
+        if (shouldKeepKnownValues) continue;
+        return null;
+      }
       staticStringValues.push(staticValue);
       continue;
     }
@@ -88,6 +96,7 @@ export const getStaticStringExpressionValues = (
         workItem.remainingConstAliases === 0 ||
         workItem.resolvingSymbols.has(symbol)
       ) {
+        if (shouldKeepKnownValues) continue;
         return null;
       }
       workItem.resolvingSymbols.add(symbol);
@@ -99,11 +108,24 @@ export const getStaticStringExpressionValues = (
       });
       continue;
     }
-    return null;
+    if (!shouldKeepKnownValues) return null;
   }
 
-  return staticStringValues;
+  return staticStringValues.length > 0 ? staticStringValues : null;
 };
+
+export const getStaticStringExpressionValues = (
+  rawExpression: EsTreeNode,
+  scopes: ScopeAnalysis,
+  options: StaticStringResolutionOptions = {},
+): ReadonlyArray<string> | null =>
+  resolveStaticStringExpressionValues(rawExpression, scopes, options);
+
+export const getKnownStaticStringExpressionValues = (
+  rawExpression: EsTreeNode,
+  scopes: ScopeAnalysis,
+): ReadonlyArray<string> | null =>
+  resolveStaticStringExpressionValues(rawExpression, scopes, { shouldKeepKnownValues: true });
 
 // Static-resolution big brother of `getJsxPropStringValue`: returns EVERY
 // string the attribute can statically evaluate to, or null when any
@@ -122,6 +144,7 @@ const getJsxPropStaticStringValuesWithMode = (
   scopes: ScopeAnalysis,
   maximumConstAliases: number | null,
   shouldFoldStaticConditions: boolean,
+  shouldKeepKnownValues = false,
 ): ReadonlyArray<string> | null => {
   const value = attribute.value;
   if (!value) return null;
@@ -132,6 +155,7 @@ const getJsxPropStaticStringValuesWithMode = (
     return getStaticStringExpressionValues(value.expression as EsTreeNode, scopes, {
       maximumConstAliases,
       shouldFoldStaticConditions,
+      shouldKeepKnownValues,
     });
   }
   return null;
@@ -148,3 +172,9 @@ export const getJsxPropExhaustiveStaticStringValues = (
   scopes: ScopeAnalysis,
 ): ReadonlyArray<string> | null =>
   getJsxPropStaticStringValuesWithMode(attribute, scopes, null, true);
+
+export const getJsxPropKnownStaticStringValues = (
+  attribute: EsTreeNodeOfType<"JSXAttribute">,
+  scopes: ScopeAnalysis,
+): ReadonlyArray<string> | null =>
+  getJsxPropStaticStringValuesWithMode(attribute, scopes, MAX_CONST_RESOLUTION_HOPS, false, true);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-jsx-prop-static-string-values.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-jsx-prop-static-string-values.ts
@@ -14,12 +14,21 @@ interface StaticStringWorkItem {
   resolvingSymbols: Set<SymbolDescriptor>;
 }
 
-const resolveStaticStringValues = (
+interface StaticStringResolutionOptions {
+  readonly maximumConstAliases?: number | null;
+  readonly shouldFoldStaticConditions?: boolean;
+}
+
+export const getStaticStringExpressionValues = (
   rawExpression: EsTreeNode,
   scopes: ScopeAnalysis,
-  maximumConstAliases: number | null,
-  shouldFoldStaticConditions: boolean,
+  options: StaticStringResolutionOptions = {},
 ): ReadonlyArray<string> | null => {
+  const maximumConstAliases =
+    options.maximumConstAliases === undefined
+      ? MAX_CONST_RESOLUTION_HOPS
+      : options.maximumConstAliases;
+  const shouldFoldStaticConditions = options.shouldFoldStaticConditions ?? false;
   const staticStringValues: string[] = [];
   const workItems: StaticStringWorkItem[] = [
     {
@@ -120,12 +129,10 @@ const getJsxPropStaticStringValuesWithMode = (
     return typeof value.value === "string" ? [value.value] : null;
   }
   if (isNodeOfType(value, "JSXExpressionContainer")) {
-    return resolveStaticStringValues(
-      value.expression as EsTreeNode,
-      scopes,
+    return getStaticStringExpressionValues(value.expression as EsTreeNode, scopes, {
       maximumConstAliases,
       shouldFoldStaticConditions,
-    );
+    });
   }
   return null;
 };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-static-project-dom-ids.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-static-project-dom-ids.ts
@@ -21,8 +21,8 @@ interface StaticProjectDomIdInput {
   readonly currentScopes: ScopeAnalysis;
 }
 
-const HTML_ID_ATTRIBUTE_PATTERN =
-  /(?:^|\s)id\s*=\s*(?:"(?<doubleQuoted>[^"]*)"|'(?<singleQuoted>[^']*)'|(?<unquoted>[^\s"'=<>`]+))/gim;
+const HTML_ATTRIBUTE_PATTERN =
+  /(?<attributeName>[^\s"'<>/=]+)(?:\s*=\s*(?:"(?<doubleQuoted>[^"]*)"|'(?<singleQuoted>[^']*)'|(?<unquoted>[^\s"'=<>`]+)))?/g;
 const HTML_TOKEN_PATTERN =
   /<!--[\s\S]*?-->|(?<skippedContentOpeningTag><(?<skippedContentTag>script|style|textarea|title|xmp|iframe|noembed|noframes|plaintext|template)\b(?:"[^"]*"|'[^']*'|[^'"<>])*?>)[\s\S]*?(?:<\/\k<skippedContentTag>\s*>|$)|(?<openingTag><[A-Za-z][\w:-]*(?:"[^"]*"|'[^']*'|[^'"<>])*>)/gi;
 const cachedStaticDomIdsByRootDirectory = new Map<string, ReadonlySet<string> | null>();
@@ -88,7 +88,8 @@ const collectStaticHtmlIds = (content: string, ids: Set<string>): void => {
   for (const tokenMatch of content.matchAll(HTML_TOKEN_PATTERN)) {
     const openingTag = tokenMatch.groups?.skippedContentOpeningTag ?? tokenMatch.groups?.openingTag;
     if (!openingTag) continue;
-    for (const idAttributeMatch of openingTag.matchAll(HTML_ID_ATTRIBUTE_PATTERN)) {
+    for (const idAttributeMatch of openingTag.matchAll(HTML_ATTRIBUTE_PATTERN)) {
+      if (idAttributeMatch.groups?.attributeName?.toLowerCase() !== "id") continue;
       const id =
         idAttributeMatch.groups?.doubleQuoted ??
         idAttributeMatch.groups?.singleQuoted ??

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-static-project-dom-ids.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-static-project-dom-ids.ts
@@ -18,7 +18,7 @@ interface StaticProjectDomIdInput {
 }
 
 const HTML_ID_ATTRIBUTE_PATTERN =
-  /\bid\s*=\s*(?:"(?<doubleQuoted>[^"]*)"|'(?<singleQuoted>[^']*)'|(?<unquoted>[^\s"'=<>`]+))/gi;
+  /(?:^|[\s<])id\s*=\s*(?:"(?<doubleQuoted>[^"]*)"|'(?<singleQuoted>[^']*)'|(?<unquoted>[^\s"'=<>`]+))/gim;
 const cachedStaticDomIdsByRootDirectory = new Map<string, ReadonlySet<string> | null>();
 
 const collectStaticJsxIds = (programNode: EsTreeNodeOfType<"Program">, ids: Set<string>): void => {
@@ -89,5 +89,5 @@ export const getStaticProjectDomIds = (
     return null;
   }
   cachedStaticDomIdsByRootDirectory.set(rootDirectory, projectIds);
-  return projectIds;
+  return new Set([...projectIds, ...currentIds]);
 };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-static-project-dom-ids.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-static-project-dom-ids.ts
@@ -3,11 +3,13 @@ import * as path from "node:path";
 import type { ScopeAnalysis } from "../semantic/scope-analysis.js";
 import { buildSourceProjectIndex } from "./build-source-project-index.js";
 import type { EsTreeNodeOfType } from "./es-tree-node-of-type.js";
-import { getAuthoritativeJsxAttribute } from "./get-authoritative-jsx-attribute.js";
+import { getStaticStringExpression } from "./get-static-string-expression.js";
 import { getStringLiteralAttributeValue } from "./get-string-literal-attribute-value.js";
 import { isNodeOfType } from "./is-node-of-type.js";
 import { isPathInside } from "./is-path-inside.js";
 import { normalizeFilename } from "./normalize-filename.js";
+import { resolveJsxElementType } from "./resolve-jsx-element-type.js";
+import { resolveStaticJsxAttribute } from "./resolve-static-jsx-attribute.js";
 import { walkAst } from "./walk-ast.js";
 
 interface StaticProjectDomIdInput {
@@ -18,23 +20,68 @@ interface StaticProjectDomIdInput {
 }
 
 const HTML_ID_ATTRIBUTE_PATTERN =
-  /(?:^|[\s<])id\s*=\s*(?:"(?<doubleQuoted>[^"]*)"|'(?<singleQuoted>[^']*)'|(?<unquoted>[^\s"'=<>`]+))/gim;
+  /(?:^|\s)id\s*=\s*(?:"(?<doubleQuoted>[^"]*)"|'(?<singleQuoted>[^']*)'|(?<unquoted>[^\s"'=<>`]+))/gim;
+const HTML_TOKEN_PATTERN =
+  /<!--[\s\S]*?-->|(?<skippedContentOpeningTag><(?<skippedContentTag>script|style|textarea|title|xmp|iframe|noembed|noframes|plaintext|template)\b(?:"[^"]*"|'[^']*'|[^'"<>])*?>)[\s\S]*?(?:<\/\k<skippedContentTag>\s*>|$)|(?<openingTag><[A-Za-z][\w:-]*(?:"[^"]*"|'[^']*'|[^'"<>])*>)/gi;
 const cachedStaticDomIdsByRootDirectory = new Map<string, ReadonlySet<string> | null>();
+
+const collectResolvedStaticJsxId = (
+  idResolution: ReturnType<typeof resolveStaticJsxAttribute>,
+  ids: Set<string>,
+): void => {
+  if (!idResolution.isPresent) return;
+  const id = (
+    idResolution.attribute
+      ? getStringLiteralAttributeValue(idResolution.attribute)
+      : getStaticStringExpression(idResolution.expression)
+  )?.trim();
+  if (id) ids.add(id);
+};
+
+const isInsideJsxTemplateContent = (openingElement: EsTreeNodeOfType<"JSXOpeningElement">) => {
+  let ancestor = openingElement.parent;
+  if (isNodeOfType(ancestor, "JSXElement") && ancestor.openingElement === openingElement) {
+    ancestor = ancestor.parent;
+  }
+  while (ancestor) {
+    if (
+      isNodeOfType(ancestor, "JSXElement") &&
+      resolveJsxElementType(ancestor.openingElement) === "template"
+    ) {
+      return true;
+    }
+    ancestor = ancestor.parent;
+  }
+  return false;
+};
 
 const collectStaticJsxIds = (programNode: EsTreeNodeOfType<"Program">, ids: Set<string>): void => {
   walkAst(programNode, (node) => {
     if (!isNodeOfType(node, "JSXOpeningElement")) return;
-    const idAttribute = getAuthoritativeJsxAttribute(node.attributes, "id", false);
-    const id = idAttribute ? getStringLiteralAttributeValue(idAttribute)?.trim() : null;
-    if (id) ids.add(id);
+    if (isInsideJsxTemplateContent(node)) return;
+    const idResolution = resolveStaticJsxAttribute(node.attributes, "id", false);
+    if (idResolution.isUnknown) {
+      for (const attribute of node.attributes) {
+        collectResolvedStaticJsxId(resolveStaticJsxAttribute([attribute], "id", false), ids);
+      }
+      return;
+    }
+    collectResolvedStaticJsxId(idResolution, ids);
   });
 };
 
 const collectStaticHtmlIds = (content: string, ids: Set<string>): void => {
-  for (const match of content.matchAll(HTML_ID_ATTRIBUTE_PATTERN)) {
-    const id =
-      match.groups?.doubleQuoted ?? match.groups?.singleQuoted ?? match.groups?.unquoted ?? "";
-    if (id.trim()) ids.add(id.trim());
+  for (const tokenMatch of content.matchAll(HTML_TOKEN_PATTERN)) {
+    const openingTag = tokenMatch.groups?.skippedContentOpeningTag ?? tokenMatch.groups?.openingTag;
+    if (!openingTag) continue;
+    for (const idAttributeMatch of openingTag.matchAll(HTML_ID_ATTRIBUTE_PATTERN)) {
+      const id =
+        idAttributeMatch.groups?.doubleQuoted ??
+        idAttributeMatch.groups?.singleQuoted ??
+        idAttributeMatch.groups?.unquoted ??
+        "";
+      if (id.trim()) ids.add(id.trim());
+    }
   }
 };
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-static-project-dom-ids.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-static-project-dom-ids.ts
@@ -7,6 +7,7 @@ import {
   getJsxPropKnownStaticStringValues,
   getKnownStaticStringExpressionValues,
 } from "./get-jsx-prop-static-string-values.js";
+import { getStaticPropertyKeyName } from "./get-static-property-key-name.js";
 import { isNodeOfType } from "./is-node-of-type.js";
 import { isPathInside } from "./is-path-inside.js";
 import { normalizeFilename } from "./normalize-filename.js";
@@ -44,6 +45,29 @@ const collectResolvedStaticJsxId = (
   }
 };
 
+const collectKnownStaticObjectIds = (
+  objectExpression: EsTreeNodeOfType<"ObjectExpression">,
+  scopes: ScopeAnalysis,
+  ids: Set<string>,
+): void => {
+  for (const property of objectExpression.properties) {
+    if (isNodeOfType(property, "SpreadElement")) {
+      if (isNodeOfType(property.argument, "ObjectExpression")) {
+        collectKnownStaticObjectIds(property.argument, scopes, ids);
+      }
+      continue;
+    }
+    if (!isNodeOfType(property, "Property")) continue;
+    if (getStaticPropertyKeyName(property, { allowComputedString: true })?.toLowerCase() !== "id") {
+      continue;
+    }
+    for (const candidateId of getKnownStaticStringExpressionValues(property.value, scopes) ?? []) {
+      const id = candidateId.trim();
+      if (id) ids.add(id);
+    }
+  }
+};
+
 const isInsideJsxTemplateContent = (openingElement: EsTreeNodeOfType<"JSXOpeningElement">) => {
   let ancestor = openingElement.parent;
   if (isNodeOfType(ancestor, "JSXElement") && ancestor.openingElement === openingElement) {
@@ -77,6 +101,12 @@ const collectStaticJsxIds = (
           scopes,
           ids,
         );
+        if (
+          isNodeOfType(attribute, "JSXSpreadAttribute") &&
+          isNodeOfType(attribute.argument, "ObjectExpression")
+        ) {
+          collectKnownStaticObjectIds(attribute.argument, scopes, ids);
+        }
       }
       return;
     }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-static-project-dom-ids.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-static-project-dom-ids.ts
@@ -3,8 +3,10 @@ import * as path from "node:path";
 import type { ScopeAnalysis } from "../semantic/scope-analysis.js";
 import { buildSourceProjectIndex } from "./build-source-project-index.js";
 import type { EsTreeNodeOfType } from "./es-tree-node-of-type.js";
-import { getStaticStringExpression } from "./get-static-string-expression.js";
-import { getStringLiteralAttributeValue } from "./get-string-literal-attribute-value.js";
+import {
+  getJsxPropStaticStringValues,
+  getStaticStringExpressionValues,
+} from "./get-jsx-prop-static-string-values.js";
 import { isNodeOfType } from "./is-node-of-type.js";
 import { isPathInside } from "./is-path-inside.js";
 import { normalizeFilename } from "./normalize-filename.js";
@@ -27,15 +29,19 @@ const cachedStaticDomIdsByRootDirectory = new Map<string, ReadonlySet<string> | 
 
 const collectResolvedStaticJsxId = (
   idResolution: ReturnType<typeof resolveStaticJsxAttribute>,
+  scopes: ScopeAnalysis,
   ids: Set<string>,
 ): void => {
   if (!idResolution.isPresent) return;
-  const id = (
-    idResolution.attribute
-      ? getStringLiteralAttributeValue(idResolution.attribute)
-      : getStaticStringExpression(idResolution.expression)
-  )?.trim();
-  if (id) ids.add(id);
+  const candidateIds = idResolution.attribute
+    ? getJsxPropStaticStringValues(idResolution.attribute, scopes)
+    : idResolution.expression
+      ? getStaticStringExpressionValues(idResolution.expression, scopes)
+      : null;
+  for (const candidateId of candidateIds ?? []) {
+    const id = candidateId?.trim();
+    if (id) ids.add(id);
+  }
 };
 
 const isInsideJsxTemplateContent = (openingElement: EsTreeNodeOfType<"JSXOpeningElement">) => {
@@ -55,18 +61,26 @@ const isInsideJsxTemplateContent = (openingElement: EsTreeNodeOfType<"JSXOpening
   return false;
 };
 
-const collectStaticJsxIds = (programNode: EsTreeNodeOfType<"Program">, ids: Set<string>): void => {
+const collectStaticJsxIds = (
+  programNode: EsTreeNodeOfType<"Program">,
+  scopes: ScopeAnalysis,
+  ids: Set<string>,
+): void => {
   walkAst(programNode, (node) => {
     if (!isNodeOfType(node, "JSXOpeningElement")) return;
     if (isInsideJsxTemplateContent(node)) return;
     const idResolution = resolveStaticJsxAttribute(node.attributes, "id", false);
     if (idResolution.isUnknown) {
       for (const attribute of node.attributes) {
-        collectResolvedStaticJsxId(resolveStaticJsxAttribute([attribute], "id", false), ids);
+        collectResolvedStaticJsxId(
+          resolveStaticJsxAttribute([attribute], "id", false),
+          scopes,
+          ids,
+        );
       }
       return;
     }
-    collectResolvedStaticJsxId(idResolution, ids);
+    collectResolvedStaticJsxId(idResolution, scopes, ids);
   });
 };
 
@@ -102,7 +116,7 @@ export const getStaticProjectDomIds = (
   input: StaticProjectDomIdInput,
 ): ReadonlySet<string> | null => {
   const currentIds = new Set<string>();
-  collectStaticJsxIds(input.currentProgramNode, currentIds);
+  collectStaticJsxIds(input.currentProgramNode, input.currentScopes, currentIds);
   const rootDirectory = resolveProjectRootDirectory(input);
   if (!rootDirectory) return currentIds;
 
@@ -125,7 +139,7 @@ export const getStaticProjectDomIds = (
 
   const projectIds = new Set<string>();
   for (const projectModule of projectIndex.modulesByFilePath.values()) {
-    collectStaticJsxIds(projectModule.programNode, projectIds);
+    collectStaticJsxIds(projectModule.programNode, projectModule.scopes, projectIds);
   }
   try {
     for (const htmlFilePath of projectIndex.htmlFilePaths) {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-static-project-dom-ids.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-static-project-dom-ids.ts
@@ -1,0 +1,93 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { ScopeAnalysis } from "../semantic/scope-analysis.js";
+import { buildSourceProjectIndex } from "./build-source-project-index.js";
+import type { EsTreeNodeOfType } from "./es-tree-node-of-type.js";
+import { getAuthoritativeJsxAttribute } from "./get-authoritative-jsx-attribute.js";
+import { getStringLiteralAttributeValue } from "./get-string-literal-attribute-value.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+import { isPathInside } from "./is-path-inside.js";
+import { normalizeFilename } from "./normalize-filename.js";
+import { walkAst } from "./walk-ast.js";
+
+interface StaticProjectDomIdInput {
+  readonly configuredRootDirectory?: string;
+  readonly currentFilePath: string;
+  readonly currentProgramNode: EsTreeNodeOfType<"Program">;
+  readonly currentScopes: ScopeAnalysis;
+}
+
+const HTML_ID_ATTRIBUTE_PATTERN =
+  /\bid\s*=\s*(?:"(?<doubleQuoted>[^"]*)"|'(?<singleQuoted>[^']*)'|(?<unquoted>[^\s"'=<>`]+))/gi;
+const cachedStaticDomIdsByRootDirectory = new Map<string, ReadonlySet<string> | null>();
+
+const collectStaticJsxIds = (programNode: EsTreeNodeOfType<"Program">, ids: Set<string>): void => {
+  walkAst(programNode, (node) => {
+    if (!isNodeOfType(node, "JSXOpeningElement")) return;
+    const idAttribute = getAuthoritativeJsxAttribute(node.attributes, "id", false);
+    const id = idAttribute ? getStringLiteralAttributeValue(idAttribute)?.trim() : null;
+    if (id) ids.add(id);
+  });
+};
+
+const collectStaticHtmlIds = (content: string, ids: Set<string>): void => {
+  for (const match of content.matchAll(HTML_ID_ATTRIBUTE_PATTERN)) {
+    const id =
+      match.groups?.doubleQuoted ?? match.groups?.singleQuoted ?? match.groups?.unquoted ?? "";
+    if (id.trim()) ids.add(id.trim());
+  }
+};
+
+const resolveProjectRootDirectory = (input: StaticProjectDomIdInput): string | null => {
+  if (!path.isAbsolute(input.currentFilePath)) return null;
+  const rootDirectory = input.configuredRootDirectory
+    ? normalizeFilename(input.configuredRootDirectory)
+    : null;
+  if (!rootDirectory || !isPathInside(input.currentFilePath, rootDirectory)) return null;
+  return rootDirectory;
+};
+
+export const resetStaticProjectDomIdCache = (): void => {
+  cachedStaticDomIdsByRootDirectory.clear();
+};
+
+export const getStaticProjectDomIds = (
+  input: StaticProjectDomIdInput,
+): ReadonlySet<string> | null => {
+  const currentIds = new Set<string>();
+  collectStaticJsxIds(input.currentProgramNode, currentIds);
+  const rootDirectory = resolveProjectRootDirectory(input);
+  if (!rootDirectory) return currentIds;
+
+  if (cachedStaticDomIdsByRootDirectory.has(rootDirectory)) {
+    const cachedIds = cachedStaticDomIdsByRootDirectory.get(rootDirectory);
+    return cachedIds ? new Set([...cachedIds, ...currentIds]) : null;
+  }
+
+  const currentFilePath = normalizeFilename(input.currentFilePath);
+  const projectIndex = buildSourceProjectIndex(
+    rootDirectory,
+    currentFilePath,
+    input.currentProgramNode,
+    input.currentScopes,
+  );
+  if (!projectIndex) {
+    cachedStaticDomIdsByRootDirectory.set(rootDirectory, null);
+    return null;
+  }
+
+  const projectIds = new Set<string>();
+  for (const projectModule of projectIndex.modulesByFilePath.values()) {
+    collectStaticJsxIds(projectModule.programNode, projectIds);
+  }
+  try {
+    for (const htmlFilePath of projectIndex.htmlFilePaths) {
+      collectStaticHtmlIds(fs.readFileSync(htmlFilePath, "utf8"), projectIds);
+    }
+  } catch {
+    cachedStaticDomIdsByRootDirectory.set(rootDirectory, null);
+    return null;
+  }
+  cachedStaticDomIdsByRootDirectory.set(rootDirectory, projectIds);
+  return projectIds;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-static-project-dom-ids.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-static-project-dom-ids.ts
@@ -4,8 +4,8 @@ import type { ScopeAnalysis } from "../semantic/scope-analysis.js";
 import { buildSourceProjectIndex } from "./build-source-project-index.js";
 import type { EsTreeNodeOfType } from "./es-tree-node-of-type.js";
 import {
-  getJsxPropStaticStringValues,
-  getStaticStringExpressionValues,
+  getJsxPropKnownStaticStringValues,
+  getKnownStaticStringExpressionValues,
 } from "./get-jsx-prop-static-string-values.js";
 import { isNodeOfType } from "./is-node-of-type.js";
 import { isPathInside } from "./is-path-inside.js";
@@ -34,9 +34,9 @@ const collectResolvedStaticJsxId = (
 ): void => {
   if (!idResolution.isPresent) return;
   const candidateIds = idResolution.attribute
-    ? getJsxPropStaticStringValues(idResolution.attribute, scopes)
+    ? getJsxPropKnownStaticStringValues(idResolution.attribute, scopes)
     : idResolution.expression
-      ? getStaticStringExpressionValues(idResolution.expression, scopes)
+      ? getKnownStaticStringExpressionValues(idResolution.expression, scopes)
       : null;
   for (const candidateId of candidateIds ?? []) {
     const id = candidateId?.trim();

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/reset-filesystem-caches.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/reset-filesystem-caches.ts
@@ -1,9 +1,11 @@
 import { resetManifestCaches } from "./read-nearest-package-manifest.js";
 import { resetCrossFileExportCaches } from "./resolve-cross-file-function-export.js";
+import { resetStaticProjectDomIdCache } from "./get-static-project-dom-ids.js";
 import { resetTsconfigAliasCaches } from "./resolve-tsconfig-alias.js";
 
 export const resetFilesystemCaches = (): void => {
   resetCrossFileExportCaches();
   resetManifestCaches();
+  resetStaticProjectDomIdCache();
   resetTsconfigAliasCaches();
 };

--- a/packages/react-doctor/tests/regressions/line-scope-multiline-span.test.ts
+++ b/packages/react-doctor/tests/regressions/line-scope-multiline-span.test.ts
@@ -21,12 +21,14 @@ describe("line-scoped multiline diagnostics", () => {
       files: {
         "src/App.tsx": [
           "export const App = () => (",
-          "  <button",
-          '    className="primary"',
-          "    disabled",
-          "  >",
-          "    Save",
-          "  </button>",
+          "  <form>",
+          "    <button",
+          '      className="primary"',
+          "      disabled",
+          "    >",
+          "      Save",
+          "    </button>",
+          "  </form>",
           ");",
         ].join("\n"),
       },
@@ -38,8 +40,8 @@ describe("line-scoped multiline diagnostics", () => {
     });
 
     expect(diagnostics.find((diagnostic) => diagnostic.rule === "button-has-type")).toMatchObject({
-      line: 2,
-      endLine: 5,
+      line: 3,
+      endLine: 6,
     });
   });
 });


### PR DESCRIPTION
## Why

`button-has-type` reports buttons that cannot submit a form, while literal same-page fragment links can point to targets that do not exist anywhere in the project.

Before, an out-of-form `<button>` without `type` emitted a diagnostic and `<a href="#missing">` did not. After, missing button types are scoped to statically form-owned buttons and missing literal fragment targets are reported conservatively across JSX, TSX, and HTML files.

## What changed

- require a static intrinsic form ancestor or literal `form` association before reporting a missing button type
- add `anchor-target-exists` with project-wide static ID resolution and dynamic-value bailouts
- preserve `href="#"`, external URLs, dynamic fragments, custom form components, and cross-file targets
- add exact symbol-only-control and immutable decorative-index regression coverage for the fixes already merged on `main`
- add a patch changeset for both published lint plugins

## Eval results

Daytona parity is pending and will be added before this PR is declared merge-ready.

## Test plan

- `nr test`
- `nr lint`
- `nr typecheck`
- `nr format:check`
- `nr build`
- `nr smoke:json-report`
- `nr -C packages/fuzz test`
- strict 500-iteration fuzz runs for `button-has-type` and `anchor-target-exists`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default lint behavior for all `button-has-type` users and introduces a new project-wide cross-file rule that scans HTML and JS/TSX; mis-scoping could miss real submit-button bugs or over-report fragment links, but coverage is heavily tested.
> 
> **Overview**
> Narrows **`button-has-type`** so missing/invalid `type` is only reported when a button is statically tied to a form—nested in an intrinsic `<form>`, `createElement("form", …)`, or a literal non-empty `form` attribute—and updates OXC parity skips and tests accordingly. Standalone UI buttons (e.g. menus) no longer get false positives.
> 
> Adds in-house a11y rule **`anchor-target-exists`**, which flags literal in-page fragment links (`#id`, including text-fragment directives) when no matching static `id` exists anywhere in the project. Resolution walks JSX/TSX across the source index, parses `.html` ids conservatively, ignores ids inside `<template>` content and string/script noise, and bails on dynamic hrefs and hash-router paths. The rule is registered as **cross-file / unbounded** for lint-cache correctness.
> 
> Supporting work: shared **`getJsxA11yHrefAttribute-names`**, **`get-static-project-dom-ids`** with HTML indexing in **`build-source-project-index`**, and richer “known partial” static string resolution for id attributes. Also adds fuzz corpus cases and small regressions for **`control-has-associated-label`**, **`no-array-index-as-key`**, and related fixtures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fa21a4493254eef4e4d116f1bfd29ef0a8cffa3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->