### PR TITLE
FPFNFIX82 Detect controlled selection focus theft

### DIFF
--- a/.changeset/detect-controlled-selection-focus.md
+++ b/.changeset/detect-controlled-selection-focus.md
@@ -1,0 +1,7 @@
+---
+"oxlint-plugin-react-doctor": patch
+"eslint-plugin-react-doctor": patch
+"react-doctor": patch
+---
+
+Add an opt-in diagnostic for effects that let externally controlled selection changes move focus.

--- a/packages/fuzz/corpus/true-positives/no-controlled-selection-focus-effect--external-selection.tsx
+++ b/packages/fuzz/corpus/true-positives/no-controlled-selection-focus-effect--external-selection.tsx
@@ -1,0 +1,12 @@
+// rule: no-controlled-selection-focus-effect
+// verdict: fail
+// source: Floating UI controlled selectedIndex focus regression
+import { useModernLayoutEffect } from "./use-modern-layout-effect";
+
+export const useListNavigation = ({ selectedIndex, focusItem, listRef }) => {
+  const indexRef = useRef(null);
+  useModernLayoutEffect(() => {
+    indexRef.current = selectedIndex;
+    focusItem(listRef, indexRef);
+  }, [focusItem, listRef, selectedIndex]);
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/core-rule-registry-data.json
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/core-rule-registry-data.json
@@ -3756,6 +3756,24 @@
     }
   },
   {
+    "key": "react-doctor/no-controlled-selection-focus-effect",
+    "id": "no-controlled-selection-focus-effect",
+    "source": "react-doctor",
+    "originallyExternal": false,
+    "rule": {
+      "id": "no-controlled-selection-focus-effect",
+      "title": "Controlled selection change steals focus",
+      "severity": "warn",
+      "recommendation": "Move selection-driven focus into the keyboard or pointer navigation path, or prove that the list just opened before focusing the selected item.",
+      "category": "Accessibility",
+      "framework": "global",
+      "requires": ["react"],
+      "tags": ["react-jsx-only"],
+      "defaultEnabled": false,
+      "isScanRule": false
+    }
+  },
+  {
     "key": "react-doctor/no-cramped-container-padding",
     "id": "no-cramped-container-padding",
     "source": "react-doctor",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness-fixtures.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness-fixtures.ts
@@ -2554,6 +2554,16 @@ export const livenessFixtures: Readonly<Record<string, LivenessFixture>> = {
   "no-unowned-async-error-clear": {
     code: 'import { useEffect, useState } from "react";\nexport const Request = ({ currentId, send }) => { const [ownerId, setOwnerId] = useState(null); useEffect(() => { if (ownerId !== currentId) setOwnerId(null); }, [currentId, ownerId]); const respond = async (request) => { await send(request); if (request.failed) setOwnerId(request.requestId); else setOwnerId(null); }; return <button onClick={() => respond({ requestId: currentId })}>Send</button>; };',
   },
+  "no-controlled-selection-focus-effect": {
+    code: `import { useModernLayoutEffect } from "./use-modern-layout-effect";
+export const useListNavigation = ({ selectedIndex, focusItem }) => {
+  const indexRef = useRef(null);
+  useModernLayoutEffect(() => {
+    indexRef.current = selectedIndex;
+    focusItem(indexRef);
+  }, [focusItem, selectedIndex]);
+};`,
+  },
   "no-focus-in-animation-completion-handler": {
     code: 'import { useRef } from "react";\nexport const Dialog = () => { const inputRef = useRef(null); return <><input ref={inputRef} /><div onAnimationEnd={() => inputRef.current.focus()} /></>; };',
   },

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
@@ -237,6 +237,7 @@ import { noCollapsedLiteralOrChainAsValue } from "./rules/correctness/no-collaps
 import { noCommonRootFont } from "./rules/design/no-common-root-font.js";
 import { noConflictingSpringOptions } from "./rules/performance/no-conflicting-spring-options.js";
 import { noControlledInputValueWithoutStateUpdate } from "./rules/correctness/no-controlled-input-value-without-state-update.js";
+import { noControlledSelectionFocusEffect } from "./rules/state-and-effects/no-controlled-selection-focus-effect.js";
 import { noCrampedContainerPadding } from "./rules/design/no-cramped-container-padding.js";
 import { noCreateContextInRender } from "./rules/state-and-effects/no-create-context-in-render.js";
 import { noCreateObjectUrlInRender } from "./rules/state-and-effects/no-create-object-url-in-render.js";
@@ -3521,6 +3522,20 @@ export const reactDoctorRules = [
       ...noControlledInputValueWithoutStateUpdate,
       framework: "global",
       category: "Bugs",
+    },
+  },
+  {
+    key: "react-doctor/no-controlled-selection-focus-effect",
+    id: "no-controlled-selection-focus-effect",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noControlledSelectionFocusEffect,
+      framework: "global",
+      category: "Accessibility",
+      requires: [
+        ...new Set<Capability>(["react", ...(noControlledSelectionFocusEffect.requires ?? [])]),
+      ],
     },
   },
   {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-controlled-selection-focus-effect.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-controlled-selection-focus-effect.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noControlledSelectionFocusEffect } from "./no-controlled-selection-focus-effect.js";
+
+describe("no-controlled-selection-focus-effect", () => {
+  it("reports a controlled selection copied into a focus index by a layout effect", () => {
+    const result = runRule(
+      noControlledSelectionFocusEffect,
+      `import { useModernLayoutEffect } from "./use-modern-layout-effect";
+export const useListNavigation = ({ enabled, open, floating, selectedIndex, listRef, focusItem }) => {
+  const indexRef = useRef(null);
+  useModernLayoutEffect(() => {
+    if (!enabled || !open || !floating || selectedIndex == null) return;
+    indexRef.current = selectedIndex;
+    focusItem(listRef, indexRef);
+  }, [enabled, open, floating, selectedIndex, listRef, focusItem]);
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports React effects through aliases and TypeScript wrappers", () => {
+    const result = runRule(
+      noControlledSelectionFocusEffect,
+      `import { useLayoutEffect as useCommittedEffect } from "react";
+const Picker = ({ selectedKey }: { selectedKey: string }) => {
+  const keyRef = useRef<string | null>(null);
+  useCommittedEffect(() => {
+    keyRef.current = selectedKey as string;
+    focusOption((keyRef satisfies typeof keyRef));
+  }, [selectedKey]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("ignores navigation focus performed by an event handler", () => {
+    const result = runRule(
+      noControlledSelectionFocusEffect,
+      `const Picker = ({ selectedIndex, focusItem }) => {
+  const indexRef = useRef(null);
+  const navigate = () => {
+    indexRef.current = selectedIndex;
+    focusItem(indexRef);
+  };
+  return <button onKeyDown={navigate}>Next</button>;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("ignores local selection state", () => {
+    const result = runRule(
+      noControlledSelectionFocusEffect,
+      `const Picker = () => {
+  const [selectedIndex] = useState(0);
+  const indexRef = useRef(null);
+  useLayoutEffect(() => {
+    indexRef.current = selectedIndex;
+    focusItem(indexRef);
+  }, [selectedIndex]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("ignores opening focus that does not rerun for selection changes", () => {
+    const result = runRule(
+      noControlledSelectionFocusEffect,
+      `const Picker = ({ open, selectedIndex }) => {
+  const indexRef = useRef(null);
+  useLayoutEffect(() => {
+    if (!open) return;
+    indexRef.current = selectedIndex;
+    focusItem(indexRef);
+  }, [open]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("ignores selection synchronization without a focus action", () => {
+    const result = runRule(
+      noControlledSelectionFocusEffect,
+      `const Picker = ({ selectedIndex }) => {
+  const indexRef = useRef(null);
+  useLayoutEffect(() => {
+    indexRef.current = selectedIndex;
+    scrollItemIntoView(indexRef);
+  }, [selectedIndex]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("ignores a focus helper that does not consume the synchronized ref", () => {
+    const result = runRule(
+      noControlledSelectionFocusEffect,
+      `const Picker = ({ selectedIndex, triggerRef }) => {
+  const indexRef = useRef(null);
+  useLayoutEffect(() => {
+    indexRef.current = selectedIndex;
+    focusTrigger(triggerRef);
+  }, [selectedIndex, triggerRef]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("ignores a locally declared effect-wrapper lookalike", () => {
+    const result = runRule(
+      noControlledSelectionFocusEffect,
+      `const useModernLayoutEffect = (callback) => callback;
+const Picker = ({ selectedIndex }) => {
+  const indexRef = useRef(null);
+  useModernLayoutEffect(() => {
+    indexRef.current = selectedIndex;
+    focusItem(indexRef);
+  }, [selectedIndex]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("keeps direct selection lookups outside the first detector contract", () => {
+    const result = runRule(
+      noControlledSelectionFocusEffect,
+      `const Picker = ({ selectedIndex, itemRefs }) => {
+  useLayoutEffect(() => {
+    itemRefs.current[selectedIndex]?.focus();
+  }, [selectedIndex, itemRefs]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-controlled-selection-focus-effect.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-controlled-selection-focus-effect.ts
@@ -1,0 +1,150 @@
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
+import { getCalleeName } from "../../utils/get-callee-name.js";
+import { getEffectCallback } from "../../utils/get-effect-callback.js";
+import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
+import { isFunctionLike } from "../../utils/is-function-like.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { isReactEffectHookCall } from "../../utils/is-react-effect-hook-call.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+
+const MESSAGE =
+  "This effect focuses an item whenever a controlled selection changes, so an external selection update can steal focus. Gate focus on user navigation or on the list opening.";
+
+const IMPORTED_EFFECT_WRAPPER_NAMES = new Set([
+  "useIsomorphicLayoutEffect",
+  "useModernLayoutEffect",
+]);
+
+const CONTROLLED_SELECTION_NAME_PATTERN = /^(?:selected|selection)(?:index|id|key|item|value)?$/i;
+
+const isRecognizedEffectCall = (
+  call: EsTreeNodeOfType<"CallExpression">,
+  context: RuleContext,
+): boolean => {
+  if (isReactEffectHookCall(call, context.scopes)) return true;
+  const callee = stripParenExpression(call.callee);
+  if (!isNodeOfType(callee, "Identifier") || !IMPORTED_EFFECT_WRAPPER_NAMES.has(callee.name)) {
+    return false;
+  }
+  return context.scopes.symbolFor(callee)?.kind === "import";
+};
+
+const getControlledSelectionDependencies = (
+  call: EsTreeNodeOfType<"CallExpression">,
+  ownerFunction: EsTreeNode,
+  context: RuleContext,
+): ReadonlySet<number> => {
+  const dependencyArgument = call.arguments[1];
+  if (!dependencyArgument) return new Set();
+  const dependencyArray = stripParenExpression(dependencyArgument);
+  if (!isNodeOfType(dependencyArray, "ArrayExpression")) return new Set();
+  const selectionSymbolIds = new Set<number>();
+  for (const element of dependencyArray.elements) {
+    if (!element) continue;
+    const dependency = stripParenExpression(element);
+    if (
+      !isNodeOfType(dependency, "Identifier") ||
+      !CONTROLLED_SELECTION_NAME_PATTERN.test(dependency.name)
+    ) {
+      continue;
+    }
+    const symbol = context.scopes.symbolFor(dependency);
+    if (symbol?.kind === "parameter" && symbol.scope.node === ownerFunction) {
+      selectionSymbolIds.add(symbol.id);
+    }
+  }
+  return selectionSymbolIds;
+};
+
+const getSelectionRefSymbolId = (
+  statement: EsTreeNode,
+  selectionSymbolIds: ReadonlySet<number>,
+  context: RuleContext,
+): number | null => {
+  if (!isNodeOfType(statement, "ExpressionStatement")) return null;
+  const expression = stripParenExpression(statement.expression);
+  if (!isNodeOfType(expression, "AssignmentExpression") || expression.operator !== "=") {
+    return null;
+  }
+  const target = stripParenExpression(expression.left);
+  const selection = stripParenExpression(expression.right);
+  if (
+    !isNodeOfType(target, "MemberExpression") ||
+    getStaticPropertyName(target) !== "current" ||
+    !isNodeOfType(selection, "Identifier")
+  ) {
+    return null;
+  }
+  const selectionSymbol = context.scopes.symbolFor(selection);
+  if (!selectionSymbol || !selectionSymbolIds.has(selectionSymbol.id)) return null;
+  const reference = stripParenExpression(target.object);
+  if (!isNodeOfType(reference, "Identifier")) return null;
+  const referenceSymbol = context.scopes.symbolFor(reference);
+  if (!referenceSymbol) return null;
+  return referenceSymbol.id;
+};
+
+const isFocusCallUsingReference = (
+  statement: EsTreeNode,
+  referenceSymbolId: number,
+  context: RuleContext,
+): boolean => {
+  if (!isNodeOfType(statement, "ExpressionStatement")) return false;
+  const expression = stripParenExpression(statement.expression);
+  if (!isNodeOfType(expression, "CallExpression")) return false;
+  const calleeName = getCalleeName(expression);
+  if (!calleeName?.startsWith("focus")) return false;
+  return expression.arguments.some((argument) => {
+    const value = stripParenExpression(argument);
+    return (
+      isNodeOfType(value, "Identifier") && context.scopes.symbolFor(value)?.id === referenceSymbolId
+    );
+  });
+};
+
+const findControlledSelectionFocus = (
+  call: EsTreeNodeOfType<"CallExpression">,
+  context: RuleContext,
+): boolean => {
+  const ownerFunction = findEnclosingFunction(call);
+  const callback = getEffectCallback(call, context.scopes);
+  if (
+    !ownerFunction ||
+    !isFunctionLike(callback) ||
+    !isNodeOfType(callback.body, "BlockStatement")
+  ) {
+    return false;
+  }
+  const selectionSymbolIds = getControlledSelectionDependencies(call, ownerFunction, context);
+  if (selectionSymbolIds.size === 0) return false;
+  const selectionRefSymbolIds = new Set<number>();
+  for (const statement of callback.body.body) {
+    const selectionRefSymbolId = getSelectionRefSymbolId(statement, selectionSymbolIds, context);
+    if (selectionRefSymbolId !== null) selectionRefSymbolIds.add(selectionRefSymbolId);
+    for (const referenceSymbolId of selectionRefSymbolIds) {
+      if (isFocusCallUsingReference(statement, referenceSymbolId, context)) return true;
+    }
+  }
+  return false;
+};
+
+export const noControlledSelectionFocusEffect = defineRule({
+  id: "no-controlled-selection-focus-effect",
+  title: "Controlled selection change steals focus",
+  severity: "warn",
+  category: "Accessibility",
+  tags: ["react-jsx-only"],
+  defaultEnabled: false,
+  recommendation:
+    "Move selection-driven focus into the keyboard or pointer navigation path, or prove that the list just opened before focusing the selected item.",
+  create: (context: RuleContext) => ({
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+      if (!isRecognizedEffectCall(node, context)) return;
+      if (findControlledSelectionFocus(node, context)) context.report({ node, message: MESSAGE });
+    },
+  }),
+});


### PR DESCRIPTION
## Why

A controlled selection update can rerun a layout effect that focuses the selected item. External state changes can then move focus away from the user current control or list navigation target.

Bad:

```tsx
useLayoutEffect(() => {
  indexRef.current = selectedIndex
  focusItem(indexRef)
}, [selectedIndex])
```

Good:

```tsx
const handleNavigation = () => {
  indexRef.current = selectedIndex
  focusItem(indexRef)
}
```

## What changed

- adds the opt-in Accessibility rule `react-doctor/no-controlled-selection-focus-effect`
- requires a controlled selection parameter in the effect dependencies, synchronization into a ref, and a following focus helper that consumes the same ref
- recognizes React effect aliases and imported isomorphic/modern layout-effect wrappers
- keeps local state, event-handler focus, opening-only effects, unrelated refs, and direct lookup patterns outside this initial contract
- adds focused regression, liveness, fuzz, and patch changeset coverage

## RDE results

The rule was temporarily enabled only for validation and run over 100 project roots representing 12 unique repositories.

| Projects | Diagnostics | Confirmed false positives |
| ---: | ---: | ---: |
| 100 | 0 | 0 |

The shipped registry setting remains opt-in (`defaultEnabled: false`).

## Test plan

- `nr build`
- `nr test`
- `nr lint`
- `nr typecheck`
- `nr format:check`
- `nr smoke:json-report`
- `FUZZ_RULE=no-controlled-selection-focus-effect FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz`
- targeted RDE scan with the rule temporarily enabled

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New opt-in diagnostic only; no runtime or default-enabled behavior changes in consumer apps.
> 
> **Overview**
> Adds an **opt-in** Accessibility diagnostic `react-doctor/no-controlled-selection-focus-effect` (warn, `defaultEnabled: false`) across react-doctor, eslint-plugin-react-doctor, and oxlint-plugin-react-doctor.
> 
> The rule flags layout/effect callbacks that depend on a **controlled selection prop** (e.g. `selectedIndex`), copy it into a ref, then call a `focus*` helper with that ref—patterns where external selection updates can **steal focus**. It recognizes React effect hooks plus imported `useModernLayoutEffect` / `useIsomorphicLayoutEffect` wrappers, and deliberately skips event-handler navigation, local `useState` selection, open-only deps, scroll-without-focus, unrelated refs, local effect-wrapper shims, and direct `itemRefs[selectedIndex]?.focus()` lookups.
> 
> Wiring includes oxlint rule implementation, registry JSON, liveness fixture, fuzz true-positive corpus, unit tests, and a patch changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fea5ad0435e615114e3694a8938d00be4340812. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->