### PR TITLE
FPFNFIX82 Detect passive request-owner windows

### DIFF
--- a/.changeset/detect-passive-request-owner.md
+++ b/.changeset/detect-passive-request-owner.md
@@ -1,0 +1,7 @@
+---
+"oxlint-plugin-react-doctor": patch
+"eslint-plugin-react-doctor": patch
+"react-doctor": patch
+---
+
+Add an opt-in diagnostic for stale-request guards backed by passively synchronized owner refs.

--- a/packages/fuzz/corpus/regressions/no-passive-request-owner-ref--contradictory-guards.tsx
+++ b/packages/fuzz/corpus/regressions/no-passive-request-owner-ref--contradictory-guards.tsx
@@ -1,0 +1,21 @@
+// rule: no-passive-request-owner-ref
+// verdict: pass
+// weakness: control-flow
+// source: pull request review regression
+export const History = ({ viewId, shouldLoad }) => {
+  const ownerRef = useRef(viewId);
+  const [, setVersions] = useState([]);
+  useEffect(() => {
+    ownerRef.current = viewId;
+  }, [viewId]);
+  const refresh = async () => {
+    if (shouldLoad) {
+      await load(viewId);
+      if (ownerRef.current !== viewId) return;
+    }
+    if (!shouldLoad) {
+      setVersions([]);
+    }
+  };
+  return <button onClick={refresh}>Refresh</button>;
+};

--- a/packages/fuzz/corpus/regressions/no-passive-request-owner-ref--mismatch-branch-commit.tsx
+++ b/packages/fuzz/corpus/regressions/no-passive-request-owner-ref--mismatch-branch-commit.tsx
@@ -1,0 +1,19 @@
+// rule: no-passive-request-owner-ref
+// verdict: pass
+// weakness: control-flow
+// source: pull request review regression
+export const History = ({ viewId }) => {
+  const ownerRef = useRef(viewId);
+  const [, setWasSuperseded] = useState(false);
+  useEffect(() => {
+    ownerRef.current = viewId;
+  }, [viewId]);
+  const refresh = async () => {
+    await load(viewId);
+    if (ownerRef.current !== viewId) {
+      setWasSuperseded(true);
+      return;
+    }
+  };
+  return <button onClick={refresh}>Refresh</button>;
+};

--- a/packages/fuzz/corpus/true-positives/no-passive-request-owner-ref--else-branch-commit.tsx
+++ b/packages/fuzz/corpus/true-positives/no-passive-request-owner-ref--else-branch-commit.tsx
@@ -1,0 +1,20 @@
+// rule: no-passive-request-owner-ref
+// verdict: fail
+// weakness: control-flow
+// source: pull request review regression
+export const History = ({ viewId }) => {
+  const ownerRef = useRef(viewId);
+  const [, setItems] = useState([]);
+  useEffect(() => {
+    ownerRef.current = viewId;
+  }, [viewId]);
+  const refresh = async () => {
+    const items = await load(viewId);
+    if (ownerRef.current !== viewId) {
+      return;
+    } else {
+      setItems(items);
+    }
+  };
+  return <button onClick={refresh}>Refresh</button>;
+};

--- a/packages/fuzz/corpus/true-positives/no-passive-request-owner-ref--multiple-owner-syncs.tsx
+++ b/packages/fuzz/corpus/true-positives/no-passive-request-owner-ref--multiple-owner-syncs.tsx
@@ -1,0 +1,19 @@
+// rule: no-passive-request-owner-ref
+// verdict: fail
+// weakness: traversal-completeness
+// source: pull request review regression
+export const History = ({ documentId, viewId }) => {
+  const documentRef = useRef(documentId);
+  const viewRef = useRef(viewId);
+  const [, setItems] = useState([]);
+  useEffect(() => {
+    documentRef.current = documentId;
+    viewRef.current = viewId;
+  }, [documentId, viewId]);
+  const refresh = async () => {
+    const items = await load(viewId);
+    if (viewRef.current !== viewId) return;
+    setItems(items);
+  };
+  return <button onClick={refresh}>Refresh</button>;
+};

--- a/packages/fuzz/corpus/true-positives/no-passive-request-owner-ref--stale-owner.tsx
+++ b/packages/fuzz/corpus/true-positives/no-passive-request-owner-ref--stale-owner.tsx
@@ -1,0 +1,16 @@
+// rule: no-passive-request-owner-ref
+// verdict: fail
+// source: stale request owner regression
+export const History = ({ viewId }) => {
+  const ownerRef = useRef(viewId);
+  const [, setVersions] = useState([]);
+  useEffect(() => {
+    ownerRef.current = viewId;
+  }, [viewId]);
+  const refresh = async () => {
+    const versions = await load(viewId);
+    if (ownerRef.current !== viewId) return;
+    setVersions(versions);
+  };
+  return <button onClick={refresh}>Refresh</button>;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/core-rule-registry-data.json
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/core-rule-registry-data.json
@@ -6214,6 +6214,24 @@
     }
   },
   {
+    "key": "react-doctor/no-passive-request-owner-ref",
+    "id": "no-passive-request-owner-ref",
+    "source": "react-doctor",
+    "originallyExternal": false,
+    "rule": {
+      "id": "no-passive-request-owner-ref",
+      "title": "Passive owner ref leaves a stale-request window",
+      "severity": "warn",
+      "recommendation": "Invalidate requests when the owner changes before an old promise can settle, or bind the request to lifecycle cleanup instead of trusting a ref synchronized by `useEffect`.",
+      "category": "Bugs",
+      "framework": "global",
+      "requires": ["react"],
+      "tags": ["react-jsx-only"],
+      "defaultEnabled": false,
+      "isScanRule": false
+    }
+  },
+  {
     "key": "react-doctor/no-path-prefix-containment",
     "id": "no-path-prefix-containment",
     "source": "react-doctor",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness-fixtures.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness-fixtures.ts
@@ -2567,6 +2567,9 @@ export const useListNavigation = ({ selectedIndex, focusItem }) => {
   }, [focusItem, selectedIndex]);
 };`,
   },
+  "no-passive-request-owner-ref": {
+    code: "export const History = ({ viewId }) => { const ownerRef = useRef(viewId); const [, setItems] = useState([]); useEffect(() => { ownerRef.current = viewId; }, [viewId]); const refresh = async () => { const items = await load(viewId); if (ownerRef.current !== viewId) return; setItems(items); }; return <button onClick={refresh}>Refresh</button>; };",
+  },
   "no-focus-in-animation-completion-handler": {
     code: 'import { useRef } from "react";\nexport const Dialog = () => { const inputRef = useRef(null); return <><input ref={inputRef} /><div onAnimationEnd={() => inputRef.current.focus()} /></>; };',
   },

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
@@ -385,6 +385,7 @@ import { noOversizedLongHeading } from "./rules/design/no-oversized-long-heading
 import { noOverwideTextMeasure } from "./rules/design/no-overwide-text-measure.js";
 import { noPassDataToParent } from "./rules/state-and-effects/no-pass-data-to-parent.js";
 import { noPassLiveStateToParent } from "./rules/state-and-effects/no-pass-live-state-to-parent.js";
+import { noPassiveRequestOwnerRef } from "./rules/state-and-effects/no-passive-request-owner-ref.js";
 import { noPathPrefixContainment } from "./rules/security/no-path-prefix-containment.js";
 import { noPermanentWillChange } from "./rules/performance/no-permanent-will-change.js";
 import { noPillNavigationCount } from "./rules/design/no-pill-navigation-count.js";
@@ -5330,6 +5331,18 @@ export const reactDoctorRules = [
       framework: "global",
       category: "Bugs",
       requires: [...new Set<Capability>(["react", ...(noPassLiveStateToParent.requires ?? [])])],
+    },
+  },
+  {
+    key: "react-doctor/no-passive-request-owner-ref",
+    id: "no-passive-request-owner-ref",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...noPassiveRequestOwnerRef,
+      framework: "global",
+      category: "Bugs",
+      requires: [...new Set<Capability>(["react", ...(noPassiveRequestOwnerRef.requires ?? [])])],
     },
   },
   {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-passive-request-owner-ref.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-passive-request-owner-ref.test.ts
@@ -195,4 +195,29 @@ const History = ({ documentId }) => {
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toEqual([]);
   });
+
+  it("ignores an owner guard and setter under contradictory sequential guards", () => {
+    const result = runRule(
+      noPassiveRequestOwnerRef,
+      `const History = ({ viewId, shouldLoad }) => {
+  const activeViewIdRef = useRef(viewId);
+  const [, setVersions] = useState([]);
+  useEffect(() => {
+    activeViewIdRef.current = viewId;
+  }, [viewId]);
+  const refresh = async () => {
+    if (shouldLoad) {
+      await load(viewId);
+      if (activeViewIdRef.current !== viewId) return;
+    }
+    if (!shouldLoad) {
+      setVersions([]);
+    }
+  };
+  return <button onClick={refresh}>Refresh</button>;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-passive-request-owner-ref.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-passive-request-owner-ref.test.ts
@@ -220,4 +220,27 @@ const History = ({ documentId }) => {
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toEqual([]);
   });
+
+  it("ignores a state update inside the owner-mismatch bailout", () => {
+    const result = runRule(
+      noPassiveRequestOwnerRef,
+      `const History = ({ viewId }) => {
+  const activeViewIdRef = useRef(viewId);
+  const [, setWasSuperseded] = useState(false);
+  useEffect(() => {
+    activeViewIdRef.current = viewId;
+  }, [viewId]);
+  const refresh = async () => {
+    await load(viewId);
+    if (activeViewIdRef.current !== viewId) {
+      setWasSuperseded(true);
+      return;
+    }
+  };
+  return <button onClick={refresh}>Refresh</button>;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-passive-request-owner-ref.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-passive-request-owner-ref.test.ts
@@ -243,4 +243,51 @@ const History = ({ documentId }) => {
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toEqual([]);
   });
+
+  it("reports a state commit in the owner-match else branch", () => {
+    const result = runRule(
+      noPassiveRequestOwnerRef,
+      `const History = ({ viewId }) => {
+  const activeViewIdRef = useRef(viewId);
+  const [, setVersions] = useState([]);
+  useEffect(() => {
+    activeViewIdRef.current = viewId;
+  }, [viewId]);
+  const refresh = async () => {
+    const versions = await load(viewId);
+    if (activeViewIdRef.current !== viewId) {
+      return;
+    } else {
+      setVersions(versions);
+    }
+  };
+  return <button onClick={refresh}>Refresh</button>;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports a later passive owner synchronization in the same effect", () => {
+    const result = runRule(
+      noPassiveRequestOwnerRef,
+      `const History = ({ documentId, viewId }) => {
+  const documentIdRef = useRef(documentId);
+  const viewIdRef = useRef(viewId);
+  const [, setVersions] = useState([]);
+  useEffect(() => {
+    documentIdRef.current = documentId;
+    viewIdRef.current = viewId;
+  }, [documentId, viewId]);
+  const refresh = async () => {
+    const versions = await load(viewId);
+    if (viewIdRef.current !== viewId) return;
+    setVersions(versions);
+  };
+  return <button onClick={refresh}>Refresh</button>;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-passive-request-owner-ref.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-passive-request-owner-ref.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noPassiveRequestOwnerRef } from "./no-passive-request-owner-ref.js";
+
+describe("no-passive-request-owner-ref", () => {
+  it("reports a post-await commit guarded by an owner ref synchronized in useEffect", () => {
+    const result = runRule(
+      noPassiveRequestOwnerRef,
+      `import { useCallback, useEffect, useRef, useState } from "react";
+const History = ({ viewId, open }) => {
+  const activeViewIdRef = useRef(viewId);
+  const [, setVersions] = useState([]);
+  useEffect(() => {
+    activeViewIdRef.current = viewId;
+  }, [viewId]);
+  const refreshHistory = useCallback(async () => {
+    const versions = await loadVersions(viewId);
+    if (activeViewIdRef.current !== viewId || !open) return;
+    setVersions(versions);
+  }, [open, viewId]);
+  return <button onClick={refreshHistory}>Refresh</button>;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports aliased passive effects and reversed owner comparisons", () => {
+    const result = runRule(
+      noPassiveRequestOwnerRef,
+      `import { useEffect as useAfterPaint, useRef, useReducer } from "react";
+const History = ({ documentId }) => {
+  const documentIdRef = useRef(documentId);
+  const [, dispatch] = useReducer(reducer, null);
+  useAfterPaint(() => {
+    documentIdRef.current = documentId;
+  }, [documentId]);
+  const refresh = async () => {
+    const result = await load(documentId);
+    if (documentId != documentIdRef.current) return;
+    dispatch({ type: "loaded", result });
+  };
+  return <button onClick={refresh}>Refresh</button>;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("keeps render-time owner synchronization outside this rule", () => {
+    const result = runRule(
+      noPassiveRequestOwnerRef,
+      `const History = ({ viewId }) => {
+  const activeViewIdRef = useRef(viewId);
+  activeViewIdRef.current = viewId;
+  const [, setVersions] = useState([]);
+  const refresh = async () => {
+    const versions = await load(viewId);
+    if (activeViewIdRef.current !== viewId) return;
+    setVersions(versions);
+  };
+  return <button onClick={refresh}>Refresh</button>;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("ignores a layout-effect owner synchronization", () => {
+    const result = runRule(
+      noPassiveRequestOwnerRef,
+      `const History = ({ viewId }) => {
+  const activeViewIdRef = useRef(viewId);
+  const [, setVersions] = useState([]);
+  useLayoutEffect(() => {
+    activeViewIdRef.current = viewId;
+  }, [viewId]);
+  const refresh = async () => {
+    const versions = await load(viewId);
+    if (activeViewIdRef.current !== viewId) return;
+    setVersions(versions);
+  };
+  return <button onClick={refresh}>Refresh</button>;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("ignores an effect that does not depend on the owner", () => {
+    const result = runRule(
+      noPassiveRequestOwnerRef,
+      `const History = ({ viewId }) => {
+  const activeViewIdRef = useRef(viewId);
+  const [, setVersions] = useState([]);
+  useEffect(() => {
+    activeViewIdRef.current = viewId;
+  }, []);
+  const refresh = async () => {
+    const versions = await load(viewId);
+    if (activeViewIdRef.current !== viewId) return;
+    setVersions(versions);
+  };
+  return <button onClick={refresh}>Refresh</button>;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("ignores a guard checked only before suspension", () => {
+    const result = runRule(
+      noPassiveRequestOwnerRef,
+      `const History = ({ viewId }) => {
+  const activeViewIdRef = useRef(viewId);
+  const [, setVersions] = useState([]);
+  useEffect(() => {
+    activeViewIdRef.current = viewId;
+  }, [viewId]);
+  const refresh = async () => {
+    if (activeViewIdRef.current !== viewId) return;
+    const versions = await load(viewId);
+    setVersions(versions);
+  };
+  return <button onClick={refresh}>Refresh</button>;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("ignores passive synchronization without a post-await state commit", () => {
+    const result = runRule(
+      noPassiveRequestOwnerRef,
+      `const History = ({ viewId }) => {
+  const activeViewIdRef = useRef(viewId);
+  useEffect(() => {
+    activeViewIdRef.current = viewId;
+  }, [viewId]);
+  const refresh = async () => {
+    const versions = await load(viewId);
+    if (activeViewIdRef.current !== viewId) return;
+    cache.set(viewId, versions);
+  };
+  return <button onClick={refresh}>Refresh</button>;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("ignores a request generation ref unrelated to the passively synchronized owner", () => {
+    const result = runRule(
+      noPassiveRequestOwnerRef,
+      `const History = ({ viewId }) => {
+  const activeViewIdRef = useRef(viewId);
+  const requestIdRef = useRef(0);
+  const [, setVersions] = useState([]);
+  useEffect(() => {
+    activeViewIdRef.current = viewId;
+  }, [viewId]);
+  const refresh = async () => {
+    const requestId = ++requestIdRef.current;
+    const versions = await load(viewId);
+    if (requestId !== requestIdRef.current) return;
+    setVersions(versions);
+  };
+  return <button onClick={refresh}>Refresh</button>;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("ignores an owner guard and setter on exclusive branches", () => {
+    const result = runRule(
+      noPassiveRequestOwnerRef,
+      `const History = ({ viewId, shouldLoad }) => {
+  const activeViewIdRef = useRef(viewId);
+  const [, setVersions] = useState([]);
+  useEffect(() => {
+    activeViewIdRef.current = viewId;
+  }, [viewId]);
+  const refresh = async () => {
+    if (shouldLoad) {
+      await load(viewId);
+      if (activeViewIdRef.current !== viewId) return;
+    } else {
+      setVersions([]);
+    }
+  };
+  return <button onClick={refresh}>Refresh</button>;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-passive-request-owner-ref.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-passive-request-owner-ref.ts
@@ -1,0 +1,234 @@
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { canNodeReachLaterNodeWithinFunction } from "../../utils/can-node-reach-later-node-within-function.js";
+import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
+import { getEffectCallback } from "../../utils/get-effect-callback.js";
+import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
+import { isEarlyExitStatement } from "../../utils/is-early-exit-statement.js";
+import { isFunctionLike } from "../../utils/is-function-like.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { isReactApiCall } from "../../utils/is-react-api-call.js";
+import { isReactHookResultReference } from "../../utils/is-react-hook-result-reference.js";
+import type { RuleContext } from "../../utils/rule-context.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import { walkAst } from "../../utils/walk-ast.js";
+import { walkOwnFunctionScope } from "../../utils/walk-own-function-scope.js";
+
+const MESSAGE =
+  "This request guard relies on an owner ref updated by a passive effect, leaving a render-to-effect window where an old request can commit into the new owner. Invalidate the request before that window or tie it to a cleanup that runs before stale commits.";
+
+const EFFECT_HOOKS = new Set(["useEffect"]);
+const REF_HOOKS = new Set(["useRef"]);
+const STATE_DISPATCHER_HOOKS = new Set(["useReducer", "useState"]);
+
+interface PassiveOwnerSync {
+  ownerFunction: EsTreeNode;
+  ownerRefSymbolId: number;
+  ownerSymbolId: number;
+}
+
+const isCurrentMemberForSymbol = (
+  node: EsTreeNode,
+  symbolId: number,
+  context: RuleContext,
+): boolean => {
+  const candidate = stripParenExpression(node);
+  if (!isNodeOfType(candidate, "MemberExpression")) return false;
+  if (getStaticPropertyName(candidate) !== "current") return false;
+  const receiver = stripParenExpression(candidate.object);
+  return (
+    isNodeOfType(receiver, "Identifier") && context.scopes.symbolFor(receiver)?.id === symbolId
+  );
+};
+
+const doesDependencyArrayContainSymbol = (
+  effectCall: EsTreeNodeOfType<"CallExpression">,
+  symbolId: number,
+  context: RuleContext,
+): boolean => {
+  const dependencyArgument = effectCall.arguments[1];
+  if (!dependencyArgument) return false;
+  const dependencyArray = stripParenExpression(dependencyArgument);
+  if (!isNodeOfType(dependencyArray, "ArrayExpression")) return false;
+  return dependencyArray.elements.some((element) => {
+    if (!element) return false;
+    const dependency = stripParenExpression(element);
+    return (
+      isNodeOfType(dependency, "Identifier") &&
+      context.scopes.symbolFor(dependency)?.id === symbolId
+    );
+  });
+};
+
+const findPassiveOwnerSync = (
+  effectCall: EsTreeNodeOfType<"CallExpression">,
+  context: RuleContext,
+): PassiveOwnerSync | null => {
+  const ownerFunction = findEnclosingFunction(effectCall);
+  const callback = getEffectCallback(effectCall, context.scopes);
+  if (!ownerFunction || !isFunctionLike(callback)) return null;
+  let passiveOwnerSync: PassiveOwnerSync | null = null;
+  walkOwnFunctionScope(callback, (node: EsTreeNode) => {
+    if (passiveOwnerSync || !isNodeOfType(node, "AssignmentExpression") || node.operator !== "=") {
+      return;
+    }
+    const target = stripParenExpression(node.left);
+    const owner = stripParenExpression(node.right);
+    if (
+      !isNodeOfType(target, "MemberExpression") ||
+      getStaticPropertyName(target) !== "current" ||
+      !isNodeOfType(owner, "Identifier")
+    ) {
+      return;
+    }
+    const ownerRef = stripParenExpression(target.object);
+    if (
+      !isNodeOfType(ownerRef, "Identifier") ||
+      !isReactHookResultReference(ownerRef, REF_HOOKS, null, context.scopes)
+    ) {
+      return;
+    }
+    const ownerSymbol = context.scopes.symbolFor(owner);
+    const ownerRefSymbol = context.scopes.symbolFor(ownerRef);
+    if (
+      !ownerSymbol ||
+      !ownerRefSymbol ||
+      ownerSymbol.kind !== "parameter" ||
+      ownerSymbol.scope.node !== ownerFunction ||
+      !doesDependencyArrayContainSymbol(effectCall, ownerSymbol.id, context)
+    ) {
+      return;
+    }
+    passiveOwnerSync = {
+      ownerFunction,
+      ownerRefSymbolId: ownerRefSymbol.id,
+      ownerSymbolId: ownerSymbol.id,
+    };
+  });
+  return passiveOwnerSync;
+};
+
+const doesTestContainOwnerMismatch = (
+  test: EsTreeNode,
+  passiveOwnerSync: PassiveOwnerSync,
+  context: RuleContext,
+): boolean => {
+  let hasOwnerMismatch = false;
+  walkAst(test, (node: EsTreeNode) => {
+    if (
+      hasOwnerMismatch ||
+      !isNodeOfType(node, "BinaryExpression") ||
+      (node.operator !== "!=" && node.operator !== "!==")
+    ) {
+      return;
+    }
+    const left = stripParenExpression(node.left);
+    const right = stripParenExpression(node.right);
+    const isOwnerIdentifier = (candidate: EsTreeNode): boolean =>
+      isNodeOfType(candidate, "Identifier") &&
+      context.scopes.symbolFor(candidate)?.id === passiveOwnerSync.ownerSymbolId;
+    hasOwnerMismatch =
+      (isCurrentMemberForSymbol(left, passiveOwnerSync.ownerRefSymbolId, context) &&
+        isOwnerIdentifier(right)) ||
+      (isOwnerIdentifier(left) &&
+        isCurrentMemberForSymbol(right, passiveOwnerSync.ownerRefSymbolId, context));
+  });
+  return hasOwnerMismatch;
+};
+
+const isStateDispatcherCall = (node: EsTreeNode, context: RuleContext): boolean => {
+  if (!isNodeOfType(node, "CallExpression")) return false;
+  const callee = stripParenExpression(node.callee);
+  return (
+    isNodeOfType(callee, "Identifier") &&
+    isReactHookResultReference(callee, STATE_DISPATCHER_HOOKS, 1, context.scopes)
+  );
+};
+
+const doesAsyncFunctionTrustPassiveOwner = (
+  asyncFunction: EsTreeNode,
+  passiveOwnerSync: PassiveOwnerSync,
+  context: RuleContext,
+): boolean => {
+  if (!isFunctionLike(asyncFunction) || !asyncFunction.async) return false;
+  const awaitNodes: EsTreeNode[] = [];
+  const ownerGuards: EsTreeNode[] = [];
+  const stateDispatcherCalls: EsTreeNode[] = [];
+  walkOwnFunctionScope(asyncFunction, (node: EsTreeNode) => {
+    if (isNodeOfType(node, "AwaitExpression")) {
+      awaitNodes.push(node);
+      return;
+    }
+    if (
+      isNodeOfType(node, "IfStatement") &&
+      isEarlyExitStatement(node.consequent) &&
+      doesTestContainOwnerMismatch(node.test, passiveOwnerSync, context)
+    ) {
+      ownerGuards.push(node);
+      return;
+    }
+    if (isStateDispatcherCall(node, context)) stateDispatcherCalls.push(node);
+  });
+  return ownerGuards.some(
+    (ownerGuard) =>
+      awaitNodes.some((awaitNode) =>
+        canNodeReachLaterNodeWithinFunction(awaitNode, ownerGuard, asyncFunction, context),
+      ) &&
+      stateDispatcherCalls.some((stateDispatcherCall) =>
+        canNodeReachLaterNodeWithinFunction(
+          ownerGuard,
+          stateDispatcherCall,
+          asyncFunction,
+          context,
+        ),
+      ),
+  );
+};
+
+const hasAsyncCommitTrustingPassiveOwner = (
+  passiveOwnerSync: PassiveOwnerSync,
+  context: RuleContext,
+): boolean => {
+  let hasUnsafeCommit = false;
+  walkAst(passiveOwnerSync.ownerFunction, (node: EsTreeNode) => {
+    if (
+      node !== passiveOwnerSync.ownerFunction &&
+      isFunctionLike(node) &&
+      doesAsyncFunctionTrustPassiveOwner(node, passiveOwnerSync, context)
+    ) {
+      hasUnsafeCommit = true;
+      return false;
+    }
+  });
+  return hasUnsafeCommit;
+};
+
+export const noPassiveRequestOwnerRef = defineRule({
+  id: "no-passive-request-owner-ref",
+  title: "Passive owner ref leaves a stale-request window",
+  severity: "warn",
+  category: "Bugs",
+  tags: ["react-jsx-only"],
+  defaultEnabled: false,
+  recommendation:
+    "Invalidate requests when the owner changes before an old promise can settle, or bind the request to lifecycle cleanup instead of trusting a ref synchronized by `useEffect`.",
+  create: (context: RuleContext) => ({
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+      if (
+        !isReactApiCall(node, EFFECT_HOOKS, context.scopes, {
+          allowGlobalReactNamespace: true,
+          allowUnboundBareCalls: true,
+          resolveNamedAliases: true,
+        })
+      ) {
+        return;
+      }
+      const passiveOwnerSync = findPassiveOwnerSync(node, context);
+      if (!passiveOwnerSync) return;
+      if (hasAsyncCommitTrustingPassiveOwner(passiveOwnerSync, context)) {
+        context.report({ node, message: MESSAGE });
+      }
+    },
+  }),
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-passive-request-owner-ref.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-passive-request-owner-ref.ts
@@ -63,16 +63,16 @@ const doesDependencyArrayContainSymbol = (
   });
 };
 
-const findPassiveOwnerSync = (
+const findPassiveOwnerSyncs = (
   effectCall: EsTreeNodeOfType<"CallExpression">,
   context: RuleContext,
-): PassiveOwnerSync | null => {
+): PassiveOwnerSync[] => {
   const ownerFunction = findEnclosingFunction(effectCall);
   const callback = getEffectCallback(effectCall, context.scopes);
-  if (!ownerFunction || !isFunctionLike(callback)) return null;
-  let passiveOwnerSync: PassiveOwnerSync | null = null;
+  if (!ownerFunction || !isFunctionLike(callback)) return [];
+  const passiveOwnerSyncs: PassiveOwnerSync[] = [];
   walkOwnFunctionScope(callback, (node: EsTreeNode) => {
-    if (passiveOwnerSync || !isNodeOfType(node, "AssignmentExpression") || node.operator !== "=") {
+    if (!isNodeOfType(node, "AssignmentExpression") || node.operator !== "=") {
       return;
     }
     const target = stripParenExpression(node.left);
@@ -102,13 +102,22 @@ const findPassiveOwnerSync = (
     ) {
       return;
     }
-    passiveOwnerSync = {
+    if (
+      passiveOwnerSyncs.some(
+        (passiveOwnerSync) =>
+          passiveOwnerSync.ownerRefSymbolId === ownerRefSymbol.id &&
+          passiveOwnerSync.ownerSymbolId === ownerSymbol.id,
+      )
+    ) {
+      return;
+    }
+    passiveOwnerSyncs.push({
       ownerFunction,
       ownerRefSymbolId: ownerRefSymbol.id,
       ownerSymbolId: ownerSymbol.id,
-    };
+    });
   });
-  return passiveOwnerSync;
+  return passiveOwnerSyncs;
 };
 
 const doesTestContainOwnerMismatch = (
@@ -155,7 +164,7 @@ const doesAsyncFunctionTrustPassiveOwner = (
 ): boolean => {
   if (!isFunctionLike(asyncFunction) || !asyncFunction.async) return false;
   const awaitNodes: EsTreeNode[] = [];
-  const ownerGuards: EsTreeNode[] = [];
+  const ownerGuards: EsTreeNodeOfType<"IfStatement">[] = [];
   const stateDispatcherCalls: EsTreeNode[] = [];
   walkOwnFunctionScope(asyncFunction, (node: EsTreeNode) => {
     if (isNodeOfType(node, "AwaitExpression")) {
@@ -179,7 +188,7 @@ const doesAsyncFunctionTrustPassiveOwner = (
       ) &&
       stateDispatcherCalls.some(
         (stateDispatcherCall) =>
-          !isDescendantWithoutFunctionBoundary(stateDispatcherCall, ownerGuard) &&
+          !isDescendantWithoutFunctionBoundary(stateDispatcherCall, ownerGuard.consequent) &&
           nodesCanCoExecute(ownerGuard, stateDispatcherCall, context) &&
           canNodeReachLaterNodeWithinFunction(
             ownerGuard,
@@ -229,9 +238,12 @@ export const noPassiveRequestOwnerRef = defineRule({
       ) {
         return;
       }
-      const passiveOwnerSync = findPassiveOwnerSync(node, context);
-      if (!passiveOwnerSync) return;
-      if (hasAsyncCommitTrustingPassiveOwner(passiveOwnerSync, context)) {
+      const passiveOwnerSyncs = findPassiveOwnerSyncs(node, context);
+      if (
+        passiveOwnerSyncs.some((passiveOwnerSync) =>
+          hasAsyncCommitTrustingPassiveOwner(passiveOwnerSync, context),
+        )
+      ) {
         context.report({ node, message: MESSAGE });
       }
     },

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-passive-request-owner-ref.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-passive-request-owner-ref.ts
@@ -6,6 +6,7 @@ import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
 import { getEffectCallback } from "../../utils/get-effect-callback.js";
 import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
 import { isEarlyExitStatement } from "../../utils/is-early-exit-statement.js";
+import { isDescendantWithoutFunctionBoundary } from "../../utils/is-descendant-without-function-boundary.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isReactApiCall } from "../../utils/is-react-api-call.js";
@@ -178,6 +179,7 @@ const doesAsyncFunctionTrustPassiveOwner = (
       ) &&
       stateDispatcherCalls.some(
         (stateDispatcherCall) =>
+          !isDescendantWithoutFunctionBoundary(stateDispatcherCall, ownerGuard) &&
           nodesCanCoExecute(ownerGuard, stateDispatcherCall, context) &&
           canNodeReachLaterNodeWithinFunction(
             ownerGuard,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-passive-request-owner-ref.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-passive-request-owner-ref.ts
@@ -10,6 +10,7 @@ import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isReactApiCall } from "../../utils/is-react-api-call.js";
 import { isReactHookResultReference } from "../../utils/is-react-hook-result-reference.js";
+import { nodesCanCoExecute } from "../../utils/nodes-can-co-execute.js";
 import type { RuleContext } from "../../utils/rule-context.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import { walkAst } from "../../utils/walk-ast.js";
@@ -175,13 +176,15 @@ const doesAsyncFunctionTrustPassiveOwner = (
       awaitNodes.some((awaitNode) =>
         canNodeReachLaterNodeWithinFunction(awaitNode, ownerGuard, asyncFunction, context),
       ) &&
-      stateDispatcherCalls.some((stateDispatcherCall) =>
-        canNodeReachLaterNodeWithinFunction(
-          ownerGuard,
-          stateDispatcherCall,
-          asyncFunction,
-          context,
-        ),
+      stateDispatcherCalls.some(
+        (stateDispatcherCall) =>
+          nodesCanCoExecute(ownerGuard, stateDispatcherCall, context) &&
+          canNodeReachLaterNodeWithinFunction(
+            ownerGuard,
+            stateDispatcherCall,
+            asyncFunction,
+            context,
+          ),
       ),
   );
 };


### PR DESCRIPTION
## Why

A request guard can still allow an old request to commit into a newly rendered owner when the owner ref is synchronized in a passive effect. React renders the new prop before that effect runs, leaving a window where the ref still identifies the old owner.

## Bad

```tsx
useEffect(() => {
  ownerRef.current = viewId
}, [viewId])

const refresh = async () => {
  const versions = await load(viewId)
  if (ownerRef.current !== viewId) return
  setVersions(versions)
}
```

## Good

Invalidate the request during owner change before stale work can settle, or tie ownership to lifecycle cleanup that runs before stale commits.

## What changed

- Adds the opt-in `no-passive-request-owner-ref` Bugs rule.
- Requires a real passive effect syncing a prop into a real `useRef`.
- Requires an async path with `await`, a post-await owner-mismatch early return, and a reachable state commit.
- Excludes layout effects, pre-await-only guards, missing owner dependencies, unrelated generation refs, and mutually exclusive paths.
- Adds focused regression tests, a strict fuzz true-positive seed, registry/liveness updates, and a patch changeset.

## Validation

- `nr build`
- `nr test` — 15/15 workspace tasks passed
- `nr lint`
- `nr typecheck`
- `nr format:check`
- `nr smoke:json-report`
- strict rule fuzz, 500 cases
- RDE: 100 project roots across 12 repositories, 0 target diagnostics and 0 false positives

The rule is deliberately disabled by default while the taxonomy matures.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New lint rule is disabled by default with broad test and fuzz coverage; no runtime or auth/data-path changes.
> 
> **Overview**
> Adds an **opt-in** `no-passive-request-owner-ref` Bugs diagnostic (off by default) for async flows that trust an owner `useRef` updated in **`useEffect`** to block stale commits after `await`.
> 
> The rule fires when a passive effect syncs a prop into `ref.current` with that prop in the dependency array, an async handler awaits, then uses an owner-mismatch early return before a reachable `useState`/`useReducer` update. It skips render-time ref sync, `useLayoutEffect`, missing owner deps, pre-await-only guards, unrelated request-id refs, and several control-flow shapes (exclusive branches, mismatch-branch-only updates).
> 
> Wiring includes oxlint rule implementation, registry/liveness metadata, unit tests, fuzz corpus seeds, and a patch changeset across the react-doctor packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68e24fa1bd77b62cae5acb0a17307481cd040203. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->