### PR TITLE
FPFNFIX82: prove effect cleanup ownership

### DIFF
--- a/.changeset/own-effect-cleanup-paths.md
+++ b/.changeset/own-effect-cleanup-paths.md
@@ -1,0 +1,6 @@
+---
+"oxlint-plugin-react-doctor": patch
+"eslint-plugin-react-doctor": patch
+---
+
+Recognize callable subscription disposers, exhaustive disposer collections, and guarded effect-local timer cleanup paths.

--- a/packages/fuzz/corpus/regressions/effect-needs-cleanup--issue-1558-owned-cleanups.tsx
+++ b/packages/fuzz/corpus/regressions/effect-needs-cleanup--issue-1558-owned-cleanups.tsx
@@ -1,0 +1,39 @@
+// verdict: pass
+// rule: effect-needs-cleanup
+// weakness: cleanup-provenance
+// source: issue #1558
+
+import { useEffect } from "react";
+
+export const Watchdog = ({ AppState, done }) => {
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const disarm = () => {
+      if (timer != null) {
+        clearTimeout(timer);
+        timer = null;
+      }
+    };
+    const arm = () => {
+      if (timer != null) return;
+      timer = setTimeout(done, 30_000);
+    };
+    const subscription = AppState.addEventListener("change", () => arm());
+    arm();
+    return () => {
+      disarm();
+      subscription.remove();
+    };
+  }, [AppState, done]);
+  return null;
+};
+
+export const Tabs = ({ onPress, tabs }) => {
+  useEffect(() => {
+    const unsubscribers = tabs.map((tab) => tab.addListener("tabPress", onPress));
+    return () => {
+      for (const unsubscribe of unsubscribers) unsubscribe();
+    };
+  }, [onPress, tabs]);
+  return null;
+};

--- a/packages/fuzz/corpus/true-positives/effect-needs-cleanup--conditional-owned-timer-return.tsx
+++ b/packages/fuzz/corpus/true-positives/effect-needs-cleanup--conditional-owned-timer-return.tsx
@@ -1,0 +1,26 @@
+// rule: effect-needs-cleanup
+// verdict: fail
+// weakness: control-flow
+// source: pull request review regression
+
+import { useEffect } from "react";
+
+export const Watchdog = ({ done, enabled }) => {
+  useEffect(() => {
+    let timer = null;
+    const disarm = () => {
+      if (timer != null) {
+        clearTimeout(timer);
+        timer = null;
+      }
+    };
+    const arm = () => {
+      if (timer != null) return;
+      timer = setTimeout(done, 1000);
+    };
+    arm();
+    if (!enabled) return;
+    return () => disarm();
+  }, [done, enabled]);
+  return null;
+};

--- a/packages/fuzz/corpus/true-positives/effect-needs-cleanup--mixed-sync-unreleased-handler.tsx
+++ b/packages/fuzz/corpus/true-positives/effect-needs-cleanup--mixed-sync-unreleased-handler.tsx
@@ -1,0 +1,27 @@
+// rule: effect-needs-cleanup
+// verdict: fail
+// weakness: ownership
+// source: pull request review regression
+
+import { useEffect } from "react";
+
+export const Watchdog = ({ AppState, done }) => {
+  useEffect(() => {
+    let timer = null;
+    const disarm = () => {
+      if (timer != null) {
+        clearTimeout(timer);
+        timer = null;
+      }
+    };
+    const arm = () => {
+      if (timer != null) return;
+      timer = setTimeout(done, 1000);
+    };
+    const refresh = () => arm();
+    refresh();
+    AppState.addEventListener("change", refresh);
+    return () => disarm();
+  }, [AppState, done]);
+  return null;
+};

--- a/packages/fuzz/corpus/true-positives/effect-needs-cleanup--unrelated-conditional-timer-release.tsx
+++ b/packages/fuzz/corpus/true-positives/effect-needs-cleanup--unrelated-conditional-timer-release.tsx
@@ -1,0 +1,21 @@
+// rule: effect-needs-cleanup
+// verdict: fail
+// weakness: control-flow
+// source: pull request review regression
+
+import { useEffect } from "react";
+
+export const Watchdog = ({ done, enabled }) => {
+  useEffect(() => {
+    let timer = null;
+    const arm = () => {
+      if (timer != null) return;
+      timer = setTimeout(done, 1000);
+    };
+    arm();
+    return () => {
+      if (enabled) clearTimeout(timer);
+    };
+  }, [done, enabled]);
+  return null;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup-issue-1558.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup-issue-1558.test.ts
@@ -299,6 +299,96 @@ describe("effect-needs-cleanup issue 1558 cleanup ownership", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("reports conditional direct timer cleanup", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+      function Watchdog({ done, enabled }) {
+        useEffect(() => {
+          let timer = null;
+          const arm = () => {
+            if (timer != null) return;
+            timer = setTimeout(done, 1000);
+          };
+          arm();
+          return () => {
+            if (enabled) clearTimeout(timer);
+          };
+        }, [done, enabled]);
+        return null;
+      }`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("setTimeout");
+  });
+
+  it("reports a synchronously invoked timer helper retained by an unreleased listener", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+      function Watchdog({ AppState, done }) {
+        useEffect(() => {
+          let timer = null;
+          const disarm = () => {
+            if (timer != null) {
+              clearTimeout(timer);
+              timer = null;
+            }
+          };
+          const arm = () => {
+            if (timer != null) return;
+            timer = setTimeout(done, 1000);
+          };
+          const onChange = () => arm();
+          onChange();
+          AppState.addEventListener("change", onChange);
+          return () => disarm();
+        }, [AppState, done]);
+        return null;
+      }`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics.some((diagnostic) => diagnostic.message.includes("setTimeout"))).toBe(
+      true,
+    );
+  });
+
+  it("accepts a synchronously invoked timer helper retained by a released listener", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+      function Watchdog({ AppState, done }) {
+        useEffect(() => {
+          let timer = null;
+          const disarm = () => {
+            if (timer != null) {
+              clearTimeout(timer);
+              timer = null;
+            }
+          };
+          const arm = () => {
+            if (timer != null) return;
+            timer = setTimeout(done, 1000);
+          };
+          const onChange = () => arm();
+          onChange();
+          const subscription = AppState.addEventListener("change", onChange);
+          return () => {
+            disarm();
+            subscription.remove();
+          };
+        }, [AppState, done]);
+        return null;
+      }`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it.each([
     ["an unowned callback", "scheduleAgain(arm);", "subscription.remove();"],
     ["an async listener", "", "subscription.remove();", "async () => arm()"],

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup-issue-1558.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup-issue-1558.test.ts
@@ -240,6 +240,65 @@ describe("effect-needs-cleanup issue 1558 cleanup ownership", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("reports an armed timer when an effect exit omits cleanup", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+      function Watchdog({ done, enabled }) {
+        useEffect(() => {
+          let timer = null;
+          const disarm = () => {
+            if (timer != null) {
+              clearTimeout(timer);
+              timer = null;
+            }
+          };
+          const arm = () => {
+            if (timer != null) return;
+            timer = setTimeout(done, 1000);
+          };
+          arm();
+          if (!enabled) return;
+          return () => disarm();
+        }, [done, enabled]);
+        return null;
+      }`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("setTimeout");
+  });
+
+  it("accepts a timer armed only on a path that returns cleanup", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+      function Watchdog({ done, enabled }) {
+        useEffect(() => {
+          let timer = null;
+          const disarm = () => {
+            if (timer != null) {
+              clearTimeout(timer);
+              timer = null;
+            }
+          };
+          const arm = () => {
+            if (timer != null) return;
+            timer = setTimeout(done, 1000);
+          };
+          if (!enabled) return;
+          arm();
+          return () => disarm();
+        }, [done, enabled]);
+        return null;
+      }`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it.each([
     ["an unowned callback", "scheduleAgain(arm);", "subscription.remove();"],
     ["an async listener", "", "subscription.remove();", "async () => arm()"],

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup-issue-1558.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup-issue-1558.test.ts
@@ -1,0 +1,357 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { effectNeedsCleanup } from "./effect-needs-cleanup.js";
+
+describe("effect-needs-cleanup issue 1558 cleanup ownership", () => {
+  it.each([
+    ["returned disposer", "return unsubscribe;"],
+    ["invoked disposer", "return () => unsubscribe();"],
+  ])("accepts a plain-function subscription %s", (_, cleanup) => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+      function NetworkStatus({ NetInfo }) {
+        useEffect(() => {
+          const unsubscribe = NetInfo.addEventListener((state) => update(state));
+          ${cleanup}
+        }, [NetInfo]);
+        return null;
+      }`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("accepts timer cleanup delegated to an effect-local helper", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+      function AppStateWatchdog({ AppState, done }) {
+        useEffect(() => {
+          let timer: ReturnType<typeof setTimeout> | null = null;
+          const disarm = () => {
+            if (timer != null) {
+              clearTimeout(timer);
+              timer = null;
+            }
+          };
+          const arm = () => {
+            if (timer != null) return;
+            timer = setTimeout(done, 30_000);
+          };
+          const subscription = AppState.addEventListener("change", (state) =>
+            state === "active" ? arm() : disarm(),
+          );
+          arm();
+          return () => {
+            disarm();
+            subscription.remove();
+          };
+        }, [AppState, done]);
+        return null;
+      }`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it.each([
+    "unsubscribers.forEach((unsubscribe) => unsubscribe());",
+    "for (const unsubscribe of unsubscribers) unsubscribe();",
+  ])("accepts array-collected disposer cleanup through %s", (cleanup) => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+      function Tabs({ tabs, onPress }) {
+        useEffect(() => {
+          const unsubscribers = tabs.map((tab) => tab.addListener("tabPress", onPress));
+          return () => {
+            ${cleanup}
+          };
+        }, [tabs, onPress]);
+        return null;
+      }`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("accepts cleanup split across an owned object and subscription", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+      function PauseResume({ AppState, onPause, onResume }) {
+        useEffect(() => {
+          const coalescer = createPauseResumeCoalescer({ onPause, onResume });
+          const subscription = AppState.addEventListener("change", coalescer.handle);
+          return () => {
+            subscription.remove();
+            coalescer.dispose();
+          };
+        }, [AppState, onPause, onResume]);
+        return null;
+      }`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("reports a timer released only by a sibling unmount effect", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect, useLayoutEffect, useRef } from "react";
+      function Poster({ videoId, onPosterTimeout }) {
+        const watchdogRef = useRef(null);
+        useLayoutEffect(() => {
+          watchdogRef.current = setTimeout(onPosterTimeout, 4000);
+        }, [videoId, onPosterTimeout]);
+        useEffect(() => {
+          return () => {
+            if (watchdogRef.current) clearTimeout(watchdogRef.current);
+          };
+        }, []);
+        return null;
+      }`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("setTimeout");
+  });
+
+  it.each([
+    ["a legacy listener", "mediaQueryList.addListener(onChange)"],
+    ["a subscription object", 'AppState.addEventListener("change", onChange)'],
+    ["an event emitter", 'server.addListener("request", onChange)'],
+  ])("does not assume %s returns a callable cleanup", (_, registration) => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+      function Listener({ AppState, mediaQueryList, onChange, server }) {
+        useEffect(() => {
+          const cleanup = ${registration};
+          return cleanup;
+        }, [AppState, mediaQueryList, onChange, server]);
+        return null;
+      }`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it.each([
+    ["prop", "", "navigation"],
+    ["hook alias", 'import { useNavigation } from "@react-navigation/native";', "useNavigation()"],
+    ["parent navigator", "", "navigation.getParent()"],
+  ])("accepts a React Navigation disposer from a %s", (_, extraImport, receiver) => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+      ${extraImport}
+      function NavigationListener({ navigation, onFocus }) {
+        const appNavigation = ${receiver};
+        useEffect(() => {
+          const unsubscribe = appNavigation.addListener("focus", onFocus);
+          return unsubscribe;
+        }, [appNavigation, onFocus]);
+        return null;
+      }`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("accepts an aliased NetInfo default import", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+      import NetworkInformation from "@react-native-community/netinfo";
+      function NetworkStatus({ onChange }) {
+        useEffect(() => {
+          const unsubscribe = NetworkInformation.addEventListener(onChange);
+          return unsubscribe;
+        }, [onChange]);
+        return null;
+      }`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it.each(["unsubscribe();", "unsubscribe?.();"])(
+    "accepts an explicitly invoked plain-function disposer through %s",
+    (cleanup) => {
+      const result = runRule(
+        effectNeedsCleanup,
+        `import { useEffect } from "react";
+        function EmitterValue({ emitter, onValue }) {
+          useEffect(() => {
+            const unsubscribe = emitter.on(onValue);
+            return () => {
+              ${cleanup}
+            };
+          }, [emitter, onValue]);
+          return null;
+        }`,
+      );
+
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    },
+  );
+
+  it("accepts a guarded timer helper used by a named owned listener", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+      function Watchdog({ AppState, done }) {
+        useEffect(() => {
+          let timer = null;
+          const disarm = () => {
+            if (timer != null) {
+              clearTimeout(timer);
+              timer = null;
+            }
+          };
+          const arm = () => {
+            if (timer != null) return;
+            timer = setTimeout(done, 1000);
+          };
+          const onChange = () => arm();
+          const subscription = AppState.addEventListener("change", onChange);
+          arm();
+          return () => {
+            disarm();
+            subscription.remove();
+          };
+        }, [AppState, done]);
+        return null;
+      }`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it.each([
+    ["an unowned callback", "scheduleAgain(arm);", "subscription.remove();"],
+    ["an async listener", "", "subscription.remove();", "async () => arm()"],
+    ["an unreleased listener", "", "", "() => arm()"],
+  ])(
+    "reports a timer helper reachable from %s",
+    (_, extraSetup, subscriptionCleanup, listener = "() => arm()") => {
+      const result = runRule(
+        effectNeedsCleanup,
+        `import { useEffect } from "react";
+        function Watchdog({ AppState, done, scheduleAgain }) {
+          useEffect(() => {
+            let timer = null;
+            const disarm = () => {
+              if (timer != null) {
+                clearTimeout(timer);
+                timer = null;
+              }
+            };
+            const arm = () => {
+              if (timer != null) return;
+              timer = setTimeout(done, 1000);
+            };
+            const subscription = AppState.addEventListener("change", ${listener});
+            arm();
+            ${extraSetup}
+            return () => {
+              disarm();
+              ${subscriptionCleanup}
+            };
+          }, [AppState, done, scheduleAgain]);
+          return null;
+        }`,
+      );
+
+      expect(result.parseErrors).toEqual([]);
+      expect(
+        result.diagnostics.some((diagnostic) => diagnostic.message.includes("setTimeout")),
+      ).toBe(true);
+    },
+  );
+
+  it.each([
+    ["without a live-handle guard", "", "disarm();"],
+    ["with conditional cleanup", "if (timer != null) return;", "if (enabled) disarm();"],
+  ])("reports a timer helper %s", (_, guard, timerCleanup) => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+      function Watchdog({ AppState, done, enabled }) {
+        useEffect(() => {
+          let timer = null;
+          const disarm = () => {
+            if (timer != null) {
+              clearTimeout(timer);
+              timer = null;
+            }
+          };
+          const arm = () => {
+            ${guard}
+            timer = setTimeout(done, 1000);
+          };
+          const subscription = AppState.addEventListener("change", () => arm());
+          arm();
+          return () => {
+            ${timerCleanup}
+            subscription.remove();
+          };
+        }, [AppState, done, enabled]);
+        return null;
+      }`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("setTimeout");
+  });
+
+  it.each([
+    [
+      "an early exit",
+      `for (const unsubscribe of unsubscribers) {
+        unsubscribe();
+        break;
+      }`,
+    ],
+    [
+      "collection mutation",
+      `unsubscribers.pop();
+      for (const unsubscribe of unsubscribers) unsubscribe();`,
+    ],
+    [
+      "conditional forEach cleanup",
+      "unsubscribers.forEach((unsubscribe) => { if (enabled) unsubscribe(); });",
+    ],
+  ])("reports array-collected disposers with %s", (_, cleanup) => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect } from "react";
+      function Tabs({ enabled, onPress, tabs }) {
+        useEffect(() => {
+          const unsubscribers = tabs.map((tab) => tab.addListener("tabPress", onPress));
+          return () => {
+            ${cleanup}
+          };
+        }, [enabled, onPress, tabs]);
+        return null;
+      }`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("addListener");
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup-issue-1558.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup-issue-1558.test.ts
@@ -335,6 +335,16 @@ describe("effect-needs-cleanup issue 1558 cleanup ownership", () => {
       "conditional forEach cleanup",
       "unsubscribers.forEach((unsubscribe) => { if (enabled) unsubscribe(); });",
     ],
+    [
+      "outer conditional forEach cleanup",
+      "if (enabled) unsubscribers.forEach((unsubscribe) => unsubscribe());",
+    ],
+    [
+      "outer conditional for-of cleanup",
+      `if (enabled) {
+        for (const unsubscribe of unsubscribers) unsubscribe();
+      }`,
+    ],
   ])("reports array-collected disposers with %s", (_, cleanup) => {
     const result = runRule(
       effectNeedsCleanup,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -64,6 +64,7 @@ import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isNodeReachableWithinFunction } from "../../utils/is-node-reachable-within-function.js";
 import { isProvenNonThrowingBuiltInCall } from "../../utils/is-proven-non-throwing-built-in-call.js";
+import { resolveImportedApiReference } from "../../utils/resolve-imported-api-reference.js";
 import {
   isSynchronousIteratorCallback,
   isSynchronousIteratorCallbackCall,
@@ -745,6 +746,80 @@ const getCallRegistrationDetails = (
     eventKey: resolveResourceIdentityKey(callNode.arguments?.[0], context),
     handlerKey: resolveResourceIdentityKey(callNode.arguments?.[1], context),
   };
+};
+
+const isKnownNetInfoReceiver = (expression: EsTreeNode, context: RuleContext): boolean => {
+  const receiver = stripParenExpression(expression);
+  const importedReceiver = resolveImportedApiReference(receiver, context.scopes);
+  return (
+    (isNodeOfType(receiver, "Identifier") &&
+      receiver.name === "NetInfo" &&
+      context.scopes.symbolFor(receiver) !== null) ||
+    importedReceiver?.source === "@react-native-community/netinfo"
+  );
+};
+
+const isKnownReactNavigationReceiver = (
+  expression: EsTreeNode,
+  context: RuleContext,
+  visitedSymbolIds: Set<number> = new Set(),
+): boolean => {
+  const receiver = stripParenExpression(expression);
+  if (isNodeOfType(receiver, "Identifier")) {
+    const receiverSymbol = context.scopes.symbolFor(receiver);
+    if (!receiverSymbol || visitedSymbolIds.has(receiverSymbol.id)) return false;
+    if (receiver.name === "navigation") return true;
+    visitedSymbolIds.add(receiverSymbol.id);
+    const receiverInitializer = receiverSymbol.initializer
+      ? stripParenExpression(receiverSymbol.initializer)
+      : null;
+    const navigationHook = isNodeOfType(receiverInitializer, "CallExpression")
+      ? resolveImportedApiReference(receiverInitializer.callee, context.scopes)
+      : null;
+    if (
+      navigationHook?.importedName === "useNavigation" &&
+      navigationHook.source.startsWith("@react-navigation/")
+    ) {
+      return true;
+    }
+    return Boolean(
+      receiverInitializer &&
+      isKnownReactNavigationReceiver(receiverInitializer, context, visitedSymbolIds),
+    );
+  }
+  if (!isNodeOfType(receiver, "CallExpression")) return false;
+  const receiverCallee = stripParenExpression(receiver.callee);
+  return Boolean(
+    isNodeOfType(receiverCallee, "MemberExpression") &&
+    !receiverCallee.computed &&
+    isNodeOfType(receiverCallee.property, "Identifier") &&
+    receiverCallee.property.name === "getParent" &&
+    isKnownReactNavigationReceiver(receiverCallee.object, context, visitedSymbolIds),
+  );
+};
+
+const isKnownCallableSubscriptionResult = (
+  usage: SubscribeLikeUsage,
+  context: RuleContext,
+): boolean => {
+  if (!isNodeOfType(usage.node, "CallExpression")) return false;
+  if (isCleanupReturningSubscribeLikeCallExpression(usage.node)) return true;
+  const callee = stripParenExpression(usage.node.callee);
+  if (
+    !isNodeOfType(callee, "MemberExpression") ||
+    callee.computed ||
+    !isNodeOfType(callee.property, "Identifier")
+  ) {
+    return false;
+  }
+  if (callee.property.name === "addEventListener") {
+    return usage.node.arguments.length === 1 && isKnownNetInfoReceiver(callee.object, context);
+  }
+  return (
+    callee.property.name === "addListener" &&
+    usage.node.arguments.length >= 2 &&
+    isKnownReactNavigationReceiver(callee.object, context)
+  );
 };
 
 const resolveChannelClientKey = (
@@ -2050,6 +2125,31 @@ const doesTestRequireLiveExpressionKey = (
   );
 };
 
+const findBlockingLiveHandleGuard = (
+  callback: EsTreeNode,
+  usageNode: EsTreeNode,
+  handleKey: string,
+  context: RuleContext,
+): EsTreeNodeOfType<"IfStatement"> | null => {
+  if (!isFunctionLike(callback)) return null;
+  let matchingGuard: EsTreeNodeOfType<"IfStatement"> | null = null;
+  walkAst(callback.body, (child: EsTreeNode) => {
+    if (matchingGuard) return false;
+    if (child !== callback.body && isFunctionLike(child)) return false;
+    if (
+      isNodeOfType(child, "IfStatement") &&
+      !child.alternate &&
+      doesTestRequireLiveExpressionKey(child.test, handleKey, context) &&
+      !canNodeReachLaterNodeWithinFunction(child.consequent, usageNode, callback, context) &&
+      doMatchingNodesCoverEveryPathBeforeUsage(usageNode, [child], callback, context)
+    ) {
+      matchingGuard = child;
+      return false;
+    }
+  });
+  return matchingGuard;
+};
+
 const findLiveExpressionGuardForRelease = (
   releaseCall: EsTreeNode,
   owner: EsTreeNode,
@@ -2606,6 +2706,107 @@ const cleanupReturnsReleaseUsage = (
     );
   });
 
+const findSubscriptionRegistrationsForHandler = (
+  handlerFunction: EsTreeNode,
+  context: RuleContext,
+): EsTreeNodeOfType<"CallExpression">[] | null => {
+  if (!isFunctionLike(handlerFunction) || handlerFunction.async || handlerFunction.generator) {
+    return null;
+  }
+  const handlerRoot = findTransparentExpressionRoot(handlerFunction);
+  const inlineRegistration = handlerRoot.parent;
+  if (
+    isNodeOfType(inlineRegistration, "CallExpression") &&
+    inlineRegistration.arguments.some((argument) => argument === handlerRoot) &&
+    isSubscribeOrObserveCallExpression(inlineRegistration)
+  ) {
+    return [inlineRegistration];
+  }
+  const bindingIdentifier = getFunctionBindingIdentifier(handlerFunction);
+  const handlerSymbol = bindingIdentifier ? context.scopes.symbolFor(bindingIdentifier) : null;
+  if (!handlerSymbol || handlerSymbol.references.length === 0) return null;
+  const registrations: EsTreeNodeOfType<"CallExpression">[] = [];
+  for (const reference of handlerSymbol.references) {
+    const referenceRoot = findTransparentExpressionRoot(reference.identifier);
+    const registration = referenceRoot.parent;
+    if (
+      !isNodeOfType(registration, "CallExpression") ||
+      !registration.arguments.some((argument) => argument === referenceRoot) ||
+      !isSubscribeOrObserveCallExpression(registration)
+    ) {
+      return null;
+    }
+    registrations.push(registration);
+  }
+  return [...new Set(registrations)];
+};
+
+const isEffectOwnedSubscriptionHandler = (
+  handlerFunction: EsTreeNode,
+  callback: EsTreeNode,
+  cleanupReturns: ReadonlyArray<EsTreeNode>,
+  synchronouslyInvokedFunctions: ReadonlySet<EsTreeNode>,
+  context: RuleContext,
+): boolean => {
+  const registrations = findSubscriptionRegistrationsForHandler(handlerFunction, context);
+  if (
+    !registrations ||
+    registrations.length === 0 ||
+    !doNodesCoverEveryPathFromFunctionEntry(callback, cleanupReturns, context)
+  ) {
+    return false;
+  }
+  return registrations.every((registration) => {
+    const registrationOwner = findEnclosingFunction(registration);
+    if (
+      registrationOwner !== callback &&
+      (!registrationOwner || !synchronouslyInvokedFunctions.has(registrationOwner))
+    ) {
+      return false;
+    }
+    const registrationDetails = getCallRegistrationDetails(registration, context);
+    const registrationUsage: SubscribeLikeUsage = {
+      kind: "subscribe",
+      node: registration,
+      resourceName: registrationDetails.registrationVerbName ?? "subscribe",
+      handleKey: findAssignedResourceKey(registration, context, true),
+      ...registrationDetails,
+    };
+    return cleanupReturnsReleaseUsage(cleanupReturns, registrationUsage, context);
+  });
+};
+
+const hasOnlyEffectOwnedFunctionInvocations = (
+  usageFunction: EsTreeNode,
+  callback: EsTreeNode,
+  cleanupReturns: ReadonlyArray<EsTreeNode>,
+  context: RuleContext,
+): boolean => {
+  const bindingIdentifier = getFunctionBindingIdentifier(usageFunction);
+  const functionSymbol = bindingIdentifier ? context.scopes.symbolFor(bindingIdentifier) : null;
+  if (!functionSymbol || functionSymbol.references.length === 0) return false;
+  const synchronouslyInvokedFunctions = collectSynchronouslyEffectInvokedFunctions(
+    callback,
+    context.scopes,
+  );
+  return functionSymbol.references.every((reference) => {
+    const directCall = findDirectCallForReference(reference.identifier);
+    if (!directCall) return false;
+    const invocationOwner = findEnclosingFunction(directCall);
+    return Boolean(
+      invocationOwner &&
+      (synchronouslyInvokedFunctions.has(invocationOwner) ||
+        isEffectOwnedSubscriptionHandler(
+          invocationOwner,
+          callback,
+          cleanupReturns,
+          synchronouslyInvokedFunctions,
+          context,
+        )),
+    );
+  });
+};
+
 const getOwnedFunctionReference = (
   reference: EsTreeNode,
   usageFunction: EsTreeNode,
@@ -2718,6 +2919,32 @@ const hasGuardedRefOwnedNestedCleanup = (
   );
 };
 
+const collectGlobalReleaseProofs = (
+  cleanupFunction: EsTreeNode,
+  usage: SubscribeLikeUsage,
+  context: RuleContext,
+): GlobalReleaseProof[] => {
+  if (!isFunctionLike(cleanupFunction)) return [];
+  const globalReleaseProofs: GlobalReleaseProof[] = [];
+  walkAst(cleanupFunction.body, (child: EsTreeNode) => {
+    if (child !== cleanupFunction.body && isFunctionLike(child)) return false;
+    if (
+      isNodeOfType(child, "CallExpression") &&
+      isNodeOfType(child.callee, "Identifier") &&
+      context.scopes.isGlobalReference(child.callee) &&
+      doesReleaseCallMatchUsage(child, usage, context)
+    ) {
+      const handleGuard = findDirectHandleGuardForRelease(child, cleanupFunction, usage, context);
+      globalReleaseProofs.push({
+        anchor: handleGuard ?? child,
+        call: child,
+        handleGuard,
+      });
+    }
+  });
+  return globalReleaseProofs;
+};
+
 const hasGuardedDeferredCleanup = (
   callback: EsTreeNode,
   usage: SubscribeLikeUsage,
@@ -2729,6 +2956,11 @@ const hasGuardedDeferredCleanup = (
   }
   const usageFunction = findEnclosingFunction(usage.node);
   const promiseChainCall = usageFunction ? getPromiseChainCallForCallback(usageFunction) : null;
+  const hasEffectOwnedInvocations = Boolean(
+    usageFunction &&
+    isFunctionLike(usageFunction) &&
+    hasOnlyEffectOwnedFunctionInvocations(usageFunction, callback, cleanupReturns, context),
+  );
   if (
     usage.kind !== "timer" ||
     usage.handleKey === null ||
@@ -2740,9 +2972,10 @@ const hasGuardedDeferredCleanup = (
     !isNodeOfType(usage.node, "CallExpression") ||
     !isNodeOfType(usage.node.callee, "Identifier") ||
     !context.scopes.isGlobalReference(usage.node.callee) ||
-    !promiseChainCall ||
-    !collectEffectInvokedFunctions(callback).has(usageFunction) ||
-    !doMatchingNodesCoverEveryPathAfterUsage(promiseChainCall, cleanupReturns, context)
+    !collectEffectInvokedFunctions(callback, context.scopes).has(usageFunction) ||
+    (!promiseChainCall && !hasEffectOwnedInvocations) ||
+    (promiseChainCall &&
+      !doMatchingNodesCoverEveryPathAfterUsage(promiseChainCall, cleanupReturns, context))
   ) {
     return false;
   }
@@ -2774,30 +3007,15 @@ const hasGuardedDeferredCleanup = (
   const globalReleaseProofsByCleanup = new Map<EsTreeNode, GlobalReleaseProof[]>();
   for (const cleanupFunction of cleanupFunctions) {
     if (!isFunctionLike(cleanupFunction)) return false;
-    const globalReleaseProofs: GlobalReleaseProof[] = [];
-    walkAst(cleanupFunction.body, (child: EsTreeNode) => {
-      if (child !== cleanupFunction.body && isFunctionLike(child)) return false;
-      if (
-        isNodeOfType(child, "CallExpression") &&
-        isNodeOfType(child.callee, "Identifier") &&
-        context.scopes.isGlobalReference(child.callee) &&
-        doesReleaseCallMatchUsage(child, usage, context)
-      ) {
-        const handleGuard = findDirectHandleGuardForRelease(child, cleanupFunction, usage, context);
-        globalReleaseProofs.push({
-          anchor: handleGuard ?? child,
-          call: child,
-          handleGuard,
-        });
-      }
-    });
-    if (
-      !doNodesCoverEveryPathFromFunctionEntry(
-        cleanupFunction,
-        globalReleaseProofs.map((releaseProof) => releaseProof.anchor),
-        context,
-      )
-    ) {
+    const globalReleaseProofs = collectGlobalReleaseProofs(cleanupFunction, usage, context);
+    const hasRequiredRelease = promiseChainCall
+      ? doNodesCoverEveryPathFromFunctionEntry(
+          cleanupFunction,
+          globalReleaseProofs.map((releaseProof) => releaseProof.anchor),
+          context,
+        )
+      : doesCleanupFunctionReleaseUsage(cleanupFunction, usage, context);
+    if (!hasRequiredRelease) {
       return false;
     }
     globalReleaseProofsByCleanup.set(cleanupFunction, globalReleaseProofs);
@@ -2829,9 +3047,12 @@ const hasGuardedDeferredCleanup = (
     if (!isNullishReset) return true;
     const cleanupFunction = findEnclosingFunction(assignment);
     const globalReleaseProofs = cleanupFunction
-      ? globalReleaseProofsByCleanup.get(cleanupFunction)
+      ? (globalReleaseProofsByCleanup.get(cleanupFunction) ??
+        (hasEffectOwnedInvocations
+          ? collectGlobalReleaseProofs(cleanupFunction, usage, context)
+          : undefined))
       : undefined;
-    return !(
+    const isSafeReset = Boolean(
       cleanupFunction &&
       globalReleaseProofs &&
       doMatchingNodesCoverEveryPathBeforeUsage(
@@ -2844,8 +3065,9 @@ const hasGuardedDeferredCleanup = (
         ),
         cleanupFunction,
         context,
-      )
+      ),
     );
+    return !isSafeReset;
   });
   if (!hasUsageAssignment || hasUnsafeHandleAssignment) {
     return false;
@@ -2880,15 +3102,36 @@ const hasGuardedDeferredCleanup = (
     });
   }
   if (hasPotentialInterruption) return false;
-  return collectDeferredUsageGuardStates(usageFunction, usage.node, context).some(
-    (guardState) =>
+  const guardStates = collectDeferredUsageGuardStates(usageFunction, usage.node, context);
+  const blockingLiveHandleGuard = findBlockingLiveHandleGuard(
+    usageFunction,
+    usage.node,
+    usage.handleKey,
+    context,
+  );
+  if (blockingLiveHandleGuard) {
+    guardStates.push({
+      bindingIdentifier: handleSymbol.bindingIdentifier,
+      guardNode: blockingLiveHandleGuard,
+      key: usage.handleKey,
+      value: false,
+    });
+  }
+  return guardStates.some((guardState) => {
+    if (hasPotentialInterruptionAfterGuard(usageFunction, guardState, usage.node, context)) {
+      return false;
+    }
+    if (hasEffectOwnedInvocations && guardState.key === usage.handleKey) return true;
+    if (deferredUsageWritesGuardBeforeUsage(usageFunction, usage.node, guardState, context)) {
+      return false;
+    }
+    return (
       isEffectLocalLifecycleGuard(callback, guardState, cleanupFunctions, context) &&
-      !hasPotentialInterruptionAfterGuard(usageFunction, guardState, usage.node, context) &&
-      !deferredUsageWritesGuardBeforeUsage(usageFunction, usage.node, guardState, context) &&
       cleanupReturns.every((cleanupReturn) =>
         cleanupReturnInvalidatesGuard(cleanupReturn, guardState, context),
-      ),
-  );
+      )
+    );
+  });
 };
 
 const effectHasCleanupForUsage = (
@@ -2907,14 +3150,12 @@ const effectHasCleanupForUsage = (
     usage.kind === "subscribe" &&
     findEnclosingFunction(usage.node) === callback &&
     doesResourceResultEscape(usage.node, true, true, context) &&
-    isCleanupReturningSubscribeLikeCallExpression(usage.node)
+    isKnownCallableSubscriptionResult(usage, context)
   ) {
     return true;
   }
   if (!isNodeOfType(callback.body, "BlockStatement")) {
-    return (
-      callback.body === usage.node && isCleanupReturningSubscribeLikeCallExpression(callback.body)
-    );
+    return callback.body === usage.node && isKnownCallableSubscriptionResult(usage, context);
   }
   const matchingCleanupReturns: EsTreeNode[] = [];
   walkInsideStatementBlocks(callback.body, (child: EsTreeNode) => {
@@ -2943,7 +3184,7 @@ const effectHasCleanupForUsage = (
       isNodeOfType(returnedValue, "Identifier") &&
       usage.handleKey !== null &&
       resolveExpressionKey(returnedValue, context) === usage.handleKey &&
-      isCleanupReturningSubscribeLikeCallExpression(usage.node)
+      isKnownCallableSubscriptionResult(usage, context)
     ) {
       matchingCleanupReturns.push(child);
       return;
@@ -3660,13 +3901,28 @@ const doesReleaseCallMatchUsage = (
     );
   }
 
-  if (
-    isNodeOfType(callee, "Identifier") &&
-    usage.kind === "subscribe" &&
-    doesResourceKeyMatchUsageHandle(resolveExpressionKey(callee, context), usage, context) &&
-    isCleanupReturningSubscribeLikeCallExpression(usage.node)
-  ) {
-    return true;
+  if (isNodeOfType(callee, "Identifier") && usage.kind === "subscribe") {
+    if (doesResourceKeyMatchUsageHandle(resolveExpressionKey(callee, context), usage, context)) {
+      return true;
+    }
+    const mappedCollectionKey = findMappedResourceCollectionKey(usage.node, context);
+    if (mappedCollectionKey !== null) {
+      const collectionKeys = new Set([mappedCollectionKey]);
+      const releaseForOfStatement = findForOfStatementForIteratorExpression(callee, context);
+      const releaseCollectionKey = releaseForOfStatement
+        ? resolveExpressionKey(releaseForOfStatement.right, context)
+        : resolveIteratorCollectionKey(callee, context);
+      const hasExhaustiveRelease = releaseForOfStatement
+        ? isDirectExhaustiveForOfRelease(callNode, releaseForOfStatement)
+        : findDirectExhaustiveForEachCleanupFunction(callNode, collectionKeys, context) !== null;
+      if (
+        mappedCollectionKey === releaseCollectionKey &&
+        hasExhaustiveRelease &&
+        !hasCollectionMutationBeforeRelease(usage.node, callNode, collectionKeys, context)
+      ) {
+        return true;
+      }
+    }
   }
 
   const releaseVerbName = getReleaseVerbName(callNode);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -1899,6 +1899,7 @@ const doesCleanupFunctionReleaseUsage = (
   cleanupFunction: EsTreeNode,
   usage: SubscribeLikeUsage,
   context: RuleContext,
+  requiresDirectReleasePathCoverage = false,
   visitedFunctions: Set<EsTreeNode> = new Set(),
   parameterSubstitutions: ReadonlyMap<number, EsTreeNode> = new Map(),
 ): boolean => {
@@ -1958,6 +1959,13 @@ const doesCleanupFunctionReleaseUsage = (
         findForOfStatementForIteratorExpression(cleanupEventArgument, context) ??
         cleanupReceiverForOfStatement;
       if (!cleanupForOfStatement) {
+        if (requiresDirectReleasePathCoverage) {
+          matchingLoopOrHelperAnchors.push(
+            findDirectHandleGuardForRelease(cleanupChild, cleanupFunction, usage, context) ??
+              cleanupChild,
+          );
+          return;
+        }
         didCleanupFunctionMatch = true;
         return false;
       }
@@ -1996,6 +2004,7 @@ const doesCleanupFunctionReleaseUsage = (
         helperFunction,
         usage,
         context,
+        requiresDirectReleasePathCoverage,
         new Set(visitedFunctions),
         helperParameterSubstitutions,
       )
@@ -2277,6 +2286,7 @@ const hasRerunReleaseBeforeUsage = (
         helperFunction,
         usage,
         context,
+        false,
         new Set(),
         helperParameterSubstitutions,
       )
@@ -2716,6 +2726,7 @@ const cleanupReturnsReleaseUsage = (
 
 const findSubscriptionRegistrationsForHandler = (
   handlerFunction: EsTreeNode,
+  synchronouslyInvokedFunctions: ReadonlySet<EsTreeNode>,
   context: RuleContext,
 ): EsTreeNodeOfType<"CallExpression">[] | null => {
   if (!isFunctionLike(handlerFunction) || handlerFunction.async || handlerFunction.generator) {
@@ -2735,6 +2746,18 @@ const findSubscriptionRegistrationsForHandler = (
   if (!handlerSymbol || handlerSymbol.references.length === 0) return null;
   const registrations: EsTreeNodeOfType<"CallExpression">[] = [];
   for (const reference of handlerSymbol.references) {
+    const directCall = findDirectCallForReference(reference.identifier);
+    if (directCall) {
+      const invocationOwner = findEnclosingFunction(directCall);
+      if (
+        !invocationOwner ||
+        invocationOwner === handlerFunction ||
+        !synchronouslyInvokedFunctions.has(invocationOwner)
+      ) {
+        return null;
+      }
+      continue;
+    }
     const referenceRoot = findTransparentExpressionRoot(reference.identifier);
     const registration = referenceRoot.parent;
     if (
@@ -2756,7 +2779,11 @@ const isEffectOwnedSubscriptionHandler = (
   synchronouslyInvokedFunctions: ReadonlySet<EsTreeNode>,
   context: RuleContext,
 ): boolean => {
-  const registrations = findSubscriptionRegistrationsForHandler(handlerFunction, context);
+  const registrations = findSubscriptionRegistrationsForHandler(
+    handlerFunction,
+    synchronouslyInvokedFunctions,
+    context,
+  );
   if (
     !registrations ||
     registrations.length === 0 ||
@@ -2801,16 +2828,24 @@ const hasOnlyEffectOwnedFunctionInvocations = (
     const directCall = findDirectCallForReference(reference.identifier);
     if (!directCall) return false;
     const invocationOwner = findEnclosingFunction(directCall);
-    return Boolean(
-      invocationOwner &&
-      (synchronouslyInvokedFunctions.has(invocationOwner) ||
+    if (!invocationOwner) return false;
+    if (invocationOwner === callback) return true;
+    const registrations = findSubscriptionRegistrationsForHandler(
+      invocationOwner,
+      synchronouslyInvokedFunctions,
+      context,
+    );
+    if (registrations === null) return false;
+    return (
+      (registrations.length === 0 && synchronouslyInvokedFunctions.has(invocationOwner)) ||
+      (registrations.length > 0 &&
         isEffectOwnedSubscriptionHandler(
           invocationOwner,
           callback,
           cleanupReturns,
           synchronouslyInvokedFunctions,
           context,
-        )),
+        ))
     );
   });
 };
@@ -3025,7 +3060,7 @@ const hasGuardedDeferredCleanup = (
           globalReleaseProofs.map((releaseProof) => releaseProof.anchor),
           context,
         )
-      : doesCleanupFunctionReleaseUsage(cleanupFunction, usage, context);
+      : doesCleanupFunctionReleaseUsage(cleanupFunction, usage, context, true);
     if (!hasRequiredRelease) {
       return false;
     }
@@ -3168,6 +3203,24 @@ const effectHasCleanupForUsage = (
   if (!isNodeOfType(callback.body, "BlockStatement")) {
     return callback.body === usage.node && isKnownCallableSubscriptionResult(usage, context);
   }
+  const usageExpression = findTransparentExpressionRoot(usage.node);
+  const usageAssignment = usageExpression.parent;
+  const assignedHandleSymbol =
+    isNodeOfType(usageAssignment, "AssignmentExpression") &&
+    usageAssignment.operator === "=" &&
+    usageAssignment.right === usageExpression &&
+    isNodeOfType(usageAssignment.left, "Identifier")
+      ? context.scopes.symbolFor(usageAssignment.left)
+      : null;
+  const requiresDirectReleasePathCoverage =
+    usage.kind === "timer" &&
+    findEnclosingFunction(usage.node) !== callback &&
+    Boolean(
+      assignedHandleSymbol &&
+      (assignedHandleSymbol.kind === "let" || assignedHandleSymbol.kind === "var") &&
+      isNodeOfType(assignedHandleSymbol.declarationNode, "VariableDeclarator") &&
+      findEnclosingFunction(assignedHandleSymbol.declarationNode) === callback,
+    );
   const matchingCleanupReturns: EsTreeNode[] = [];
   walkInsideStatementBlocks(callback.body, (child: EsTreeNode) => {
     if (!isNodeOfType(child, "ReturnStatement")) return;
@@ -3215,7 +3268,14 @@ const effectHasCleanupForUsage = (
       return;
     }
     if (!cleanupFunction || !isFunctionLike(cleanupFunction)) return;
-    if (doesCleanupFunctionReleaseUsage(cleanupFunction, usage, context)) {
+    if (
+      doesCleanupFunctionReleaseUsage(
+        cleanupFunction,
+        usage,
+        context,
+        requiresDirectReleasePathCoverage,
+      )
+    ) {
       matchingCleanupReturns.push(child);
     }
   });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -2964,11 +2964,14 @@ const hasGuardedDeferredCleanup = (
   }
   const usageFunction = findEnclosingFunction(usage.node);
   const promiseChainCall = usageFunction ? getPromiseChainCallForCallback(usageFunction) : null;
-  const hasEffectOwnedInvocations = Boolean(
+  const hasEffectOwnedUsageInvocations = Boolean(
     usageFunction &&
     isFunctionLike(usageFunction) &&
     hasOnlyEffectOwnedFunctionInvocations(usageFunction, callback, cleanupReturns, context),
   );
+  const hasEffectOwnedCleanupPath =
+    hasEffectOwnedUsageInvocations &&
+    doNodesCoverEveryPathFromFunctionEntry(callback, cleanupReturns, context);
   if (
     usage.kind !== "timer" ||
     usage.handleKey === null ||
@@ -2981,7 +2984,7 @@ const hasGuardedDeferredCleanup = (
     !isNodeOfType(usage.node.callee, "Identifier") ||
     !context.scopes.isGlobalReference(usage.node.callee) ||
     !collectEffectInvokedFunctions(callback, context.scopes).has(usageFunction) ||
-    (!promiseChainCall && !hasEffectOwnedInvocations) ||
+    (!promiseChainCall && !hasEffectOwnedCleanupPath) ||
     (promiseChainCall &&
       !doMatchingNodesCoverEveryPathAfterUsage(promiseChainCall, cleanupReturns, context))
   ) {
@@ -3056,7 +3059,7 @@ const hasGuardedDeferredCleanup = (
     const cleanupFunction = findEnclosingFunction(assignment);
     const globalReleaseProofs = cleanupFunction
       ? (globalReleaseProofsByCleanup.get(cleanupFunction) ??
-        (hasEffectOwnedInvocations
+        (hasEffectOwnedCleanupPath
           ? collectGlobalReleaseProofs(cleanupFunction, usage, context)
           : undefined))
       : undefined;
@@ -3129,7 +3132,7 @@ const hasGuardedDeferredCleanup = (
     if (hasPotentialInterruptionAfterGuard(usageFunction, guardState, usage.node, context)) {
       return false;
     }
-    if (hasEffectOwnedInvocations && guardState.key === usage.handleKey) return true;
+    if (hasEffectOwnedCleanupPath && guardState.key === usage.handleKey) return true;
     if (deferredUsageWritesGuardBeforeUsage(usageFunction, usage.node, guardState, context)) {
       return false;
     }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -1923,6 +1923,14 @@ const doesCleanupFunctionReleaseUsage = (
       const cleanupCallee = isNodeOfType(cleanupCall, "CallExpression")
         ? stripParenExpression(cleanupCall.callee)
         : null;
+      const mappedResourceCollectionKey = findMappedResourceCollectionKey(usage.node, context);
+      const cleanupIdentifierLoop = isNodeOfType(cleanupCallee, "Identifier")
+        ? (findForOfStatementForIteratorExpression(cleanupCallee, context) ?? cleanupForEachCall)
+        : null;
+      if (mappedResourceCollectionKey !== null && cleanupIdentifierLoop) {
+        matchingLoopOrHelperAnchors.push(cleanupIdentifierLoop);
+        return;
+      }
       const cleanupReceiverForOfStatement = isNodeOfType(cleanupCallee, "MemberExpression")
         ? findForOfStatementForIteratorExpression(cleanupCallee.object, context)
         : null;


### PR DESCRIPTION
Closes #1558.

## Why

`effect-needs-cleanup` could see resource acquisition but lost cleanup ownership when the release crossed a local alias, helper, or collection boundary. That produced false positives for effects that already clean every resource they allocate.

For example, React Navigation and NetInfo return a callable disposer:

```tsx
useEffect(() => {
  const unsubscribe = navigation.addListener("focus", onFocus);
  return unsubscribe;
}, [navigation, onFocus]);
```

The rule reported `addListener` even though React invokes the returned disposer. It also reported guarded timers when both the timer and the subscription that can re-arm it are owned by the same effect:

```tsx
useEffect(() => {
  let timer: ReturnType<typeof setTimeout> | null = null;
  const disarm = () => {
    if (timer != null) {
      clearTimeout(timer);
      timer = null;
    }
  };
  const arm = () => {
    if (timer != null) return;
    timer = setTimeout(done, 30_000);
  };
  const subscription = AppState.addEventListener("change", arm);
  arm();
  return () => {
    disarm();
    subscription.remove();
  };
}, [AppState, done]);
```

The diagnostic was therefore based on syntactic proximity rather than lifecycle ownership.

## What changed

- Recognize documented callable disposers from NetInfo and React Navigation, including import aliases, `useNavigation()` aliases, and parent navigators.
- Recognize explicitly invoked disposer handles without assuming that ambiguous `addListener`/`addEventListener` return values are callable when they are returned directly.
- Prove guarded timer cleanup through effect-local `arm`/`disarm` helpers only when every invocation is synchronous and effect-owned, every subscription that can invoke the helper is released, and cleanup dominates every effect exit.
- Prove disposer-array cleanup through exhaustive `forEach` and `for...of` traversal while rejecting early exits, conditional release, or collection mutation.
- Keep the sibling-effect timer diagnostic. An unmount-only sibling cleanup cannot release an overwritten handle before the dependency effect reruns, so that shape can still leak.
- Add a patch changeset and a strict fuzz regression seed.

The conservative cases remain diagnostic: unknown direct-return listener APIs, async or externally escaping timer helpers, unreleased listener callbacks, timers without a live-handle guard, conditional cleanup, mutated disposer arrays, and loops with early exits.

## Eval results

| Run | Projects | `effect-needs-cleanup` diagnostics | Delta |
| --- | ---: | ---: | ---: |
| Base `b02bc694f` | 100 | 43 | — |
| Candidate | 100 | 40 | 3 removed, 0 added |

All three removals are grounded false positives in Excalidraw where `.on(...)` returns a disposer that the effect explicitly invokes:

- `components/ToolPopover.tsx:63`
- `data/library.ts:939`
- `hooks/useEmitter.ts:11`

Representative real leaks—uncleared timers and missing listener teardown—remain reported.

## Test plan

- `nr test` — 15/15 monorepo tasks passed; oxlint plugin 25,577 tests passed; CLI 2,438 tests passed.
- `nr lint` — passed with existing warnings only.
- `nr typecheck` — 16/16 tasks passed.
- `nr format:check` — passed.
- `nr smoke:json-report` — passed.
- `nr test effect-needs-cleanup` after rebasing onto current main — 591 tests passed.
- `FUZZ_RULE=effect-needs-cleanup FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz` — passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large static-analysis changes to a widely used lint rule could miss real leaks or clear some false positives; extensive tests and fuzz seeds mitigate but behavioral shifts affect all consumers.
> 
> **Overview**
> Tightens **`effect-needs-cleanup`** so it judges **lifecycle ownership** instead of only syntactic proximity, cutting false positives when effects already tear down what they allocate (closes #1558).
> 
> **Callable disposers:** NetInfo (`addEventListener` with one arg) and React Navigation (`addListener`, including `useNavigation()`, `navigation`, and `getParent()`) are treated as returning disposers safe to `return` from the effect. Generic `addListener` / `addEventListener` direct returns stay flagged. Explicit `unsubscribe()` / optional-call cleanup on plain-function disposers (e.g. `emitter.on`) is accepted.
> 
> **Disposer collections:** Cleanup that exhaustively invokes every entry from a `map`-built array via `forEach` or `for...of` counts as releasing those subscriptions; partial loops, mutation, conditionals, and early `break` do not.
> 
> **Effect-local timers:** `arm`/`disarm` helpers can satisfy timer cleanup when invocations stay synchronous and effect-owned, every listener that can re-arm is released, and cleanup covers all exits—while still reporting early returns after arming, unreleased listeners, conditional `clearTimeout`, missing live-handle guards, and sibling-effect timer patterns.
> 
> Shared logic lives in **oxlint** and **eslint** plugins (patch changeset); coverage adds issue #1558 tests, fuzz regression/pass seeds, and true-positive guardrails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e42fe36218f465e5125c5ac4cf837ad62e148791. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->