### PR TITLE
fix(cli): preserve scrollback during project selection

### DIFF
--- a/.changeset/friendly-terminals-remember.md
+++ b/.changeset/friendly-terminals-remember.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Keep terminal history visible while selecting workspace projects in the interactive CLI.

--- a/packages/react-doctor/src/cli/ink/run-scan-app.tsx
+++ b/packages/react-doctor/src/cli/ink/run-scan-app.tsx
@@ -180,6 +180,7 @@ const promptProjectSelection = (
 ): Promise<string[]> =>
   new Promise((resolve) => {
     let disposeRenderer = (): void => {};
+    recordCount(METRIC.tuiProjectSelectInlineShown);
     const instance = render(
       <ProjectSelect
         packages={packages}
@@ -189,7 +190,7 @@ const promptProjectSelection = (
           resolve(directories);
         }}
       />,
-      { alternateScreen: true, exitOnCtrlC: false },
+      { alternateScreen: false, exitOnCtrlC: false },
     );
     let didClearRenderer = false;
     const clearRenderer = (): void => {

--- a/packages/react-doctor/src/cli/utils/constants.ts
+++ b/packages/react-doctor/src/cli/utils/constants.ts
@@ -336,6 +336,7 @@ export const METRIC = {
   tuiFindingNavigated: "tui.finding_navigated",
   tuiIssueStreamShown: "tui.issue_stream_shown",
   tuiProjectPathContextShown: "tui.project_path_context_shown",
+  tuiProjectSelectInlineShown: "tui.project_select_inline_shown",
   tuiReportActionSelected: "tui.report_action_selected",
   tuiCancelled: "tui.cancelled",
   tuiScanInlineShown: "tui.scan_inline_shown",

--- a/packages/react-doctor/tests/ink/run-scan-app.test.ts
+++ b/packages/react-doctor/tests/ink/run-scan-app.test.ts
@@ -202,7 +202,7 @@ describe("runScanApp", () => {
     vi.clearAllMocks();
   });
 
-  it("uses a disposable screen for project selection", async () => {
+  it("keeps terminal scrollback visible during project selection", async () => {
     vi.spyOn(process.stdout, "write").mockImplementation(() => true);
     const rootDirectory = "/repo";
     const originalIsTtyDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
@@ -227,7 +227,7 @@ describe("runScanApp", () => {
     }
 
     expect(vi.mocked(render).mock.calls[0]?.[1]).toEqual({
-      alternateScreen: true,
+      alternateScreen: false,
       exitOnCtrlC: false,
     });
   });


### PR DESCRIPTION
## Why

The interactive workspace picker entered the terminal's alternate screen, replacing the user's visible shell history while they selected projects.

Before: opening the picker cleared the viewport and hid prior terminal context.

After: the picker renders inline, preserves scrollback, and still clears only its own rows when submitted or cancelled.

## What changed

- render project selection on the main screen instead of the alternate screen
- record the anonymous `tui.project_select_inline_shown` adoption metric
- cover the scrollback-preserving renderer mode with a regression test
- add a patch changeset for the CLI behavior fix

Parity was not run because this changes terminal rendering only; detector behavior is unchanged.

## Test plan

- `nr build`
- `nr test`
- `nr typecheck`
- `nr lint`
- `nr format:check`
- `nlx react-doctor@latest --verbose --scope changed --no-score`
- manually verified in a PTY against `/Users/aidenybai/Developer/same` that a pre-existing scrollback sentinel remains visible and no alternate-screen sequence is emitted

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Terminal rendering-only change with no scan, auth, or data-path impact; existing clear/unmount lifecycle is unchanged.
> 
> **Overview**
> The interactive workspace **project picker** no longer switches the terminal to Ink’s alternate screen, so prior shell output stays visible while you choose packages.
> 
> `promptProjectSelection` now renders `ProjectSelect` with **`alternateScreen: false`** (aligned with scan/report TUI), still registers the active renderer, and clears only the picker’s rows on submit or cancel. A **`tui.project_select_inline_shown`** adoption metric is recorded when the inline picker opens.
> 
> Regression coverage expects the new render options; a patch **changeset** documents the CLI behavior fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61abcc50d9c07a2b33e75e043e27b02ed9c68cce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->