### PR TITLE
fix(ci): serialize Windows test tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,13 @@ jobs:
 
       - run: pnpm install --frozen-lockfile --prefer-offline
 
-      - run: pnpm test
+      - name: Run tests
+        if: ${{ matrix.os != 'blacksmith-8vcpu-windows-2025' }}
+        run: pnpm test
+
+      - name: Run Windows tests serially
+        if: ${{ matrix.os == 'blacksmith-8vcpu-windows-2025' }}
+        run: pnpm test --concurrency=1
 
       # deslop-js/-cli assert on POSIX-separator paths, so their suites are
       # build-only on Windows (mirrors the deslop upstream matrix).


### PR DESCRIPTION
## Summary

- keep every non-Windows matrix leg unchanged
- run Turbo test tasks one at a time on the Windows runner
- preserve all existing test assertions and timeout budgets

## Root cause

Windows test failures move between the language-server and core suites while package tests run concurrently. The affected tests spawn child scanners and have deliberate 5–30 second deadlines; cross-package process contention starves those children on the Windows runner. Four runs failed in language-server tests, and the first isolated-package attempt moved the same timeout pattern into core tests. Serializing the package tasks removes that contention without weakening coverage.

## Validation

- `nr test --concurrency=1`
- `nr lint`
- `nr typecheck`
- `nr format:check`
- `nr smoke:json-report`
- focused language-server suite: 13 files, 65 tests passed

This PR must not merge until the Windows matrix job and all other checks are green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that limits parallelism on one runner; no application or test logic changes.
> 
> **Overview**
> **CI test job** now runs package tests with **Turbo concurrency 1** only on the `blacksmith-8vcpu-windows-2025` matrix leg; all other OS legs still use the default `pnpm test`.
> 
> This splits the former single test step into two named steps with mutually exclusive `if` conditions so Windows avoids cross-package parallel test contention that was causing flaky timeouts in scanner-heavy suites, without changing assertions or timeouts on Linux/macOS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8a38a8037075ac1f617ebe295ac468d1f945610. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->