### PR TITLE
perf: index effect cleanup analysis

### DIFF
--- a/.changeset/icy-bars-run.md
+++ b/.changeset/icy-bars-run.md
@@ -1,0 +1,6 @@
+---
+"oxlint-plugin-react-doctor": patch
+"eslint-plugin-react-doctor": patch
+---
+
+Make effect cleanup analysis scale linearly across files with many retained timer and listener callbacks.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.performance.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.performance.test.ts
@@ -23,16 +23,17 @@ const buildRetainedHandlersSource = (
   return `const Component = () => {\n${handlers}\nreturn <>${buttons}</>;\n};`;
 };
 
-const measureFastestDuration = (
+const measureFastestCpuDuration = (
   handlerCount: number,
   buildRegistration: (handlerIndex: number) => string,
 ): number => {
   const source = buildRetainedHandlersSource(handlerCount, buildRegistration);
   let fastestDuration = Number.POSITIVE_INFINITY;
   for (let repetition = 0; repetition < MEASUREMENT_REPETITION_COUNT; repetition += 1) {
-    const startedAt = performance.now();
+    const startedCpuUsage = process.cpuUsage();
     const result = runRule(effectNeedsCleanup, source);
-    fastestDuration = Math.min(fastestDuration, performance.now() - startedAt);
+    const elapsedCpuUsage = process.cpuUsage(startedCpuUsage);
+    fastestDuration = Math.min(fastestDuration, elapsedCpuUsage.user + elapsedCpuUsage.system);
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toHaveLength(handlerCount);
   }
@@ -52,12 +53,12 @@ describe("effect-needs-cleanup performance", () => {
     },
   ]) {
     it(`scales near-linearly across retained ${performanceCase.name}`, () => {
-      measureFastestDuration(SMALL_HANDLER_COUNT, performanceCase.buildRegistration);
-      const smallDuration = measureFastestDuration(
+      measureFastestCpuDuration(SMALL_HANDLER_COUNT, performanceCase.buildRegistration);
+      const smallDuration = measureFastestCpuDuration(
         SMALL_HANDLER_COUNT,
         performanceCase.buildRegistration,
       );
-      const largeDuration = measureFastestDuration(
+      const largeDuration = measureFastestCpuDuration(
         LARGE_HANDLER_COUNT,
         performanceCase.buildRegistration,
       );

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.performance.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.performance.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { effectNeedsCleanup } from "./effect-needs-cleanup.js";
+
+const SMALL_HANDLER_COUNT = 100;
+const LARGE_HANDLER_COUNT = 500;
+const MEASUREMENT_REPETITION_COUNT = 3;
+const MAXIMUM_SCALING_MULTIPLIER = 15;
+
+const buildRetainedHandlersSource = (
+  handlerCount: number,
+  buildRegistration: (handlerIndex: number) => string,
+): string => {
+  const handlers = Array.from(
+    { length: handlerCount },
+    (_, handlerIndex) =>
+      `const handler${handlerIndex} = () => { ${buildRegistration(handlerIndex)} };`,
+  ).join("\n");
+  const buttons = Array.from(
+    { length: handlerCount },
+    (_, handlerIndex) => `<button onClick={handler${handlerIndex}} />`,
+  ).join("\n");
+  return `const Component = () => {\n${handlers}\nreturn <>${buttons}</>;\n};`;
+};
+
+const measureFastestDuration = (
+  handlerCount: number,
+  buildRegistration: (handlerIndex: number) => string,
+): number => {
+  const source = buildRetainedHandlersSource(handlerCount, buildRegistration);
+  let fastestDuration = Number.POSITIVE_INFINITY;
+  for (let repetition = 0; repetition < MEASUREMENT_REPETITION_COUNT; repetition += 1) {
+    const startedAt = performance.now();
+    const result = runRule(effectNeedsCleanup, source);
+    fastestDuration = Math.min(fastestDuration, performance.now() - startedAt);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(handlerCount);
+  }
+  return fastestDuration;
+};
+
+describe("effect-needs-cleanup performance", () => {
+  for (const performanceCase of [
+    {
+      name: "timers",
+      buildRegistration: (handlerIndex: number) => `setInterval(task${handlerIndex}, 1000);`,
+    },
+    {
+      name: "listeners",
+      buildRegistration: (handlerIndex: number) =>
+        `window.addEventListener("resize", listener${handlerIndex});`,
+    },
+  ]) {
+    it(`scales near-linearly across retained ${performanceCase.name}`, () => {
+      measureFastestDuration(SMALL_HANDLER_COUNT, performanceCase.buildRegistration);
+      const smallDuration = measureFastestDuration(
+        SMALL_HANDLER_COUNT,
+        performanceCase.buildRegistration,
+      );
+      const largeDuration = measureFastestDuration(
+        LARGE_HANDLER_COUNT,
+        performanceCase.buildRegistration,
+      );
+      expect(largeDuration).toBeLessThan(smallDuration * MAXIMUM_SCALING_MULTIPLIER);
+    });
+  }
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.performance.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.performance.test.ts
@@ -23,21 +23,21 @@ const buildRetainedHandlersSource = (
   return `const Component = () => {\n${handlers}\nreturn <>${buttons}</>;\n};`;
 };
 
-const measureFastestCpuDuration = (
+const measureCpuDuration = (
   handlerCount: number,
   buildRegistration: (handlerIndex: number) => string,
 ): number => {
   const source = buildRetainedHandlersSource(handlerCount, buildRegistration);
-  let fastestDuration = Number.POSITIVE_INFINITY;
+  let totalDuration = 0;
   for (let repetition = 0; repetition < MEASUREMENT_REPETITION_COUNT; repetition += 1) {
     const startedCpuUsage = process.cpuUsage();
     const result = runRule(effectNeedsCleanup, source);
     const elapsedCpuUsage = process.cpuUsage(startedCpuUsage);
-    fastestDuration = Math.min(fastestDuration, elapsedCpuUsage.user + elapsedCpuUsage.system);
+    totalDuration += elapsedCpuUsage.user + elapsedCpuUsage.system;
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toHaveLength(handlerCount);
   }
-  return fastestDuration;
+  return totalDuration;
 };
 
 describe("effect-needs-cleanup performance", () => {
@@ -53,12 +53,12 @@ describe("effect-needs-cleanup performance", () => {
     },
   ]) {
     it(`scales near-linearly across retained ${performanceCase.name}`, () => {
-      measureFastestCpuDuration(SMALL_HANDLER_COUNT, performanceCase.buildRegistration);
-      const smallDuration = measureFastestCpuDuration(
+      measureCpuDuration(SMALL_HANDLER_COUNT, performanceCase.buildRegistration);
+      const smallDuration = measureCpuDuration(
         SMALL_HANDLER_COUNT,
         performanceCase.buildRegistration,
       );
-      const largeDuration = measureFastestCpuDuration(
+      const largeDuration = measureCpuDuration(
         LARGE_HANDLER_COUNT,
         performanceCase.buildRegistration,
       );

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -173,9 +173,31 @@ interface ReactRefEffectAnalysis {
   usageByRefSymbolId: Map<number, ReactRefEffectUsage>;
 }
 
+interface EffectRetainedInvocation {
+  call: EsTreeNodeOfType<"CallExpression">;
+  isDirect: boolean;
+}
+
+interface FileReleaseCallIndex {
+  identifierCallsByName: Map<string, EsTreeNode[]>;
+  potentialNonTimerCalls: EsTreeNode[];
+}
+
 const REACT_REF_EFFECT_ANALYSIS_CACHE = new WeakMap<
   RuleContext,
   WeakMap<EsTreeNode, ReactRefEffectAnalysis>
+>();
+const EFFECT_RETAINED_INVOCATIONS_CACHE = new WeakMap<
+  RuleContext,
+  WeakMap<EsTreeNode, Map<EsTreeNode, EffectRetainedInvocation[]>>
+>();
+const FILE_RELEASE_CALL_INDEX_CACHE = new WeakMap<
+  RuleContext,
+  WeakMap<EsTreeNode, FileReleaseCallIndex>
+>();
+const COMPONENT_EFFECT_CALLS_CACHE = new WeakMap<
+  RuleContext,
+  WeakMap<EsTreeNode, EsTreeNodeOfType<"CallExpression">[]>
 >();
 
 const RESOURCE_NOUN_BY_KIND = {
@@ -5417,8 +5439,43 @@ const fileContainsReleaseForUsage = (usage: SubscribeLikeUsage, context: RuleCon
   const anyNode = usage.node;
   let programNode: EsTreeNode = anyNode;
   while (programNode.parent) programNode = programNode.parent;
+  let indexesByProgram = FILE_RELEASE_CALL_INDEX_CACHE.get(context);
+  if (!indexesByProgram) {
+    indexesByProgram = new WeakMap();
+    FILE_RELEASE_CALL_INDEX_CACHE.set(context, indexesByProgram);
+  }
+  let releaseCallIndex = indexesByProgram.get(programNode);
+  if (!releaseCallIndex) {
+    const identifierCallsByName = new Map<string, EsTreeNode[]>();
+    const potentialNonTimerCalls: EsTreeNode[] = [];
+    walkAst(programNode, (child: EsTreeNode) => {
+      const callNode = isNodeOfType(child, "ChainExpression") ? child.expression : child;
+      if (!isNodeOfType(callNode, "CallExpression")) return;
+      const callee = isNodeOfType(callNode.callee, "ChainExpression")
+        ? callNode.callee.expression
+        : callNode.callee;
+      if (isNodeOfType(callee, "Identifier")) {
+        const namedCalls = identifierCallsByName.get(callee.name) ?? [];
+        namedCalls.push(child);
+        identifierCallsByName.set(callee.name, namedCalls);
+        potentialNonTimerCalls.push(child);
+      } else if (getReleaseVerbName(child)) {
+        potentialNonTimerCalls.push(child);
+      }
+    });
+    releaseCallIndex = { identifierCallsByName, potentialNonTimerCalls };
+    indexesByProgram.set(programNode, releaseCallIndex);
+  }
+  let candidates: ReadonlyArray<EsTreeNode>;
+  if (usage.kind === "timer") {
+    const expectedCleanupName =
+      usage.registrationVerbName === "setInterval" ? "clearInterval" : "clearTimeout";
+    candidates = releaseCallIndex.identifierCallsByName.get(expectedCleanupName) ?? [];
+  } else {
+    candidates = releaseCallIndex.potentialNonTimerCalls;
+  }
   let didFindRelease = false;
-  walkAst(programNode, (child: EsTreeNode) => {
+  const inspectCandidate = (child: EsTreeNode): void | false => {
     if (didFindRelease) return false;
     if (
       doesReleaseCallMatchUsage(child, usage, context) &&
@@ -5427,7 +5484,10 @@ const fileContainsReleaseForUsage = (usage: SubscribeLikeUsage, context: RuleCon
       didFindRelease = true;
       return false;
     }
-  });
+  };
+  for (const candidate of candidates) {
+    if (inspectCandidate(candidate) === false) break;
+  }
   return didFindRelease;
 };
 
@@ -5843,24 +5903,35 @@ const hasGuaranteedRefOwnedUnmountCleanup = (
 ): boolean => {
   const componentFunction = findEnclosingFunction(retainedFunction);
   if (!componentFunction || !isFunctionLike(componentFunction)) return false;
-  let didFindCleanupEffect = false;
-  walkAst(componentFunction.body, (child: EsTreeNode) => {
-    if (didFindCleanupEffect) return false;
-    if (
-      !isNodeOfType(child, "CallExpression") ||
-      findEnclosingFunction(child) !== componentFunction ||
-      !isReactApiCall(child, "useEffect", context.scopes)
-    ) {
-      return;
-    }
-    const effectStatement = findTransparentExpressionRoot(child).parent;
+  let effectCallsByComponent = COMPONENT_EFFECT_CALLS_CACHE.get(context);
+  if (!effectCallsByComponent) {
+    effectCallsByComponent = new WeakMap();
+    COMPONENT_EFFECT_CALLS_CACHE.set(context, effectCallsByComponent);
+  }
+  let effectCalls = effectCallsByComponent.get(componentFunction);
+  if (!effectCalls) {
+    const collectedEffectCalls: EsTreeNodeOfType<"CallExpression">[] = [];
+    walkAst(componentFunction.body, (child: EsTreeNode) => {
+      if (
+        isNodeOfType(child, "CallExpression") &&
+        findEnclosingFunction(child) === componentFunction &&
+        isReactApiCall(child, "useEffect", context.scopes)
+      ) {
+        collectedEffectCalls.push(child);
+      }
+    });
+    effectCalls = collectedEffectCalls;
+    effectCallsByComponent.set(componentFunction, effectCalls);
+  }
+  for (const effectCall of effectCalls) {
+    const effectStatement = findTransparentExpressionRoot(effectCall).parent;
     if (
       !isNodeOfType(effectStatement, "ExpressionStatement") ||
       effectStatement.parent !== componentFunction.body
     ) {
-      return;
+      continue;
     }
-    const effectCallback = getEffectCallback(child);
+    const effectCallback = getEffectCallback(effectCall);
     if (
       effectCallback &&
       effectReturnsRefOwnedCleanup(
@@ -5871,11 +5942,10 @@ const hasGuaranteedRefOwnedUnmountCleanup = (
         context,
       )
     ) {
-      didFindCleanupEffect = true;
-      return false;
+      return true;
     }
-  });
-  return didFindCleanupEffect;
+  }
+  return false;
 };
 
 const isUseSyncExternalStoreSubscribeFunction = (
@@ -6524,11 +6594,6 @@ const isInlineRetainedHandlerFunction = (
   return isPassedInline && findRenderPhaseComponentOrHook(parentNode, context.scopes) !== null;
 };
 
-interface EffectRetainedInvocation {
-  call: EsTreeNodeOfType<"CallExpression">;
-  isDirect: boolean;
-}
-
 interface InvocationArgumentValue {
   isDefinitelyUndefined: boolean;
   truthiness: "falsy" | "truthy" | "unknown";
@@ -6791,7 +6856,25 @@ const getEffectRetainedInvocations = (
   if (!isFunctionLike(retainedFunction)) return [];
   const componentFunction = findEnclosingFunction(retainedFunction);
   if (!componentFunction || !isFunctionLike(componentFunction)) return [];
-  const invocations: EffectRetainedInvocation[] = [];
+  let invocationsByComponent = EFFECT_RETAINED_INVOCATIONS_CACHE.get(context);
+  if (!invocationsByComponent) {
+    invocationsByComponent = new WeakMap();
+    EFFECT_RETAINED_INVOCATIONS_CACHE.set(context, invocationsByComponent);
+  }
+  const cachedInvocations = invocationsByComponent.get(componentFunction);
+  if (cachedInvocations) return cachedInvocations.get(retainedFunction) ?? [];
+
+  const invocationsByRetainedFunction = new Map<EsTreeNode, EffectRetainedInvocation[]>();
+  const recordInvocation = (
+    targetFunction: EsTreeNode | null,
+    call: EsTreeNodeOfType<"CallExpression">,
+    isDirect: boolean,
+  ): void => {
+    if (!targetFunction) return;
+    const invocations = invocationsByRetainedFunction.get(targetFunction) ?? [];
+    invocations.push({ call, isDirect });
+    invocationsByRetainedFunction.set(targetFunction, invocations);
+  };
   walkAst(componentFunction.body, (child: EsTreeNode) => {
     if (
       !isNodeOfType(child, "CallExpression") ||
@@ -6810,19 +6893,21 @@ const getEffectRetainedInvocations = (
       ) {
         return;
       }
-      const isDirectInvocation =
-        resolveRefOwnedCleanupFunction(effectChild.callee, context) === retainedFunction;
-      const isSynchronousIteratorInvocation = effectChild.arguments.some(
-        (argument) =>
-          isAstNode(argument) &&
-          resolveRefOwnedCleanupFunction(argument, context) === retainedFunction &&
-          isSynchronousIteratorCallbackCall(effectChild, argument),
+      recordInvocation(
+        resolveRefOwnedCleanupFunction(effectChild.callee, context),
+        effectChild,
+        true,
       );
-      if (isDirectInvocation) invocations.push({ call: effectChild, isDirect: true });
-      if (isSynchronousIteratorInvocation) invocations.push({ call: effectChild, isDirect: false });
+      for (const argument of effectChild.arguments) {
+        if (!isAstNode(argument) || !isSynchronousIteratorCallbackCall(effectChild, argument)) {
+          continue;
+        }
+        recordInvocation(resolveRefOwnedCleanupFunction(argument, context), effectChild, false);
+      }
     });
   });
-  return invocations;
+  invocationsByComponent.set(componentFunction, invocationsByRetainedFunction);
+  return invocationsByRetainedFunction.get(retainedFunction) ?? [];
 };
 
 export const effectNeedsCleanup = defineRule({


### PR DESCRIPTION
## Why

PR #1559 made `effect-needs-cleanup` substantially more precise, but retained callbacks could trigger repeated whole-file and whole-component walks. Files with many retained timer or listener callbacks therefore scaled quadratically.

## What changed

- index release candidates once per file
- index component effect calls and effect-retained invocations once per component
- preserve cleanup matching, reachability, optional-chain traversal order, and diagnostic ordering
- add scaling regression coverage for retained timers and listeners
- add a patch changeset for the Oxlint and ESLint plugins

## Performance

| 1,000 retained callbacks | `origin/main` | This PR | Speedup |
| --- | ---: | ---: | ---: |
| Timers | 1,963.7 ms | 25.4 ms | 77× |
| Listeners | 2,629.1 ms | 23.6 ms | 111× |

## Eval results

| Check | Result |
| --- | --- |
| Project roots compared | 100 |
| Target diagnostics | 51 across 8 repositories |
| Added / removed | 0 / 0 |
| Strict fuzz | 500 iterations, no findings |

Local RDE parity was exact. Daytona PR parity was not run before push because there was no PR head yet.

## Test plan

- `nr test`
- `nr typecheck`
- `nr lint`
- `nr format:check`
- `nr build`
- `nr smoke:json-report`
- `FUZZ_RULE=effect-needs-cleanup FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz`
- React Doctor changed-scope scan for `packages/oxlint-plugin-react-doctor`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only performance work on lint rule internals with parity/fuzz coverage; no intended diagnostic changes, though caching logic is complex enough to warrant regression tests.
> 
> **Overview**
> Fixes **quadratic slowdown** in `effect-needs-cleanup` when a file has many retained timer or listener callbacks by **indexing work once** instead of re-walking the AST for every callback.
> 
> **Per-file release lookup** builds a cached map of call sites (e.g. `clearInterval` / `clearTimeout` by name, plus non-timer release candidates) and only scans those candidates when checking whether a usage has a matching cleanup.
> 
> **Per-component caches** collect `useEffect` calls once and compute effect-retained invocations in a single pass, keyed by retained function, instead of repeating those walks per handler.
> 
> Adds **CPU scaling regression tests** for retained timers and listeners (100 vs 500 handlers), and a **patch changeset** for `oxlint-plugin-react-doctor` and `eslint-plugin-react-doctor`. Intended behavior and diagnostic ordering stay the same; this is an analysis-path optimization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85271e432b0337e0ea77e8bec4827d80c5a761c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->