### PR TITLE
perf: reduce heavy rule scan overhead

### DIFF
--- a/.changeset/fast-heavy-rules.md
+++ b/.changeset/fast-heavy-rules.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Reduce default rule scan overhead by gating framework-specific visitors and skipping expensive analyses until their prerequisite syntax is present.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-unguarded-browser-global-at-module-scope.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-unguarded-browser-global-at-module-scope.ts
@@ -533,6 +533,8 @@ export const noUnguardedBrowserGlobalAtModuleScope = defineRule({
 
     let guardAliasNames: ReadonlySet<string> = NO_GUARD_ALIASES;
     let browserOnlyGuardEndOffsetsByGlobalName = new Map<string, number[]>();
+    let programNode: EsTreeNodeOfType<"Program"> | null = null;
+    let didAnalyzeGuards = false;
 
     const importedGuardResolutionByName = new Map<string, ImportedGuardResolution>();
     let importedGuardResolutionCount = 0;
@@ -585,6 +587,17 @@ export const noUnguardedBrowserGlobalAtModuleScope = defineRule({
     };
 
     const reportRead = (node: EsTreeNode, globalName: string): void => {
+      if (!isEvaluatedAtImportTime(node)) return;
+      if (!didAnalyzeGuards && programNode) {
+        guardAliasNames = collectGuardAliasNames(programNode);
+        browserOnlyGuardEndOffsetsByGlobalName = collectBrowserOnlyGuardEndOffsets(
+          programNode,
+          context,
+          guardAliasNames,
+          classifyImportedGuardIdentifier,
+        );
+        didAnalyzeGuards = true;
+      }
       if (
         browserOnlyGuardEndOffsetsByGlobalName
           .get(globalName)
@@ -592,7 +605,6 @@ export const noUnguardedBrowserGlobalAtModuleScope = defineRule({
       ) {
         return;
       }
-      if (!isEvaluatedAtImportTime(node)) return;
       if (
         isGuardedAgainstSsrCrash(
           node,
@@ -611,13 +623,7 @@ export const noUnguardedBrowserGlobalAtModuleScope = defineRule({
 
     return {
       Program(node: EsTreeNodeOfType<"Program">) {
-        guardAliasNames = collectGuardAliasNames(node);
-        browserOnlyGuardEndOffsetsByGlobalName = collectBrowserOnlyGuardEndOffsets(
-          node,
-          context,
-          guardAliasNames,
-          classifyImportedGuardIdentifier,
-        );
+        programNode = node;
       },
       Identifier(node: EsTreeNodeOfType<"Identifier">) {
         if (!BROWSER_GLOBAL_NAMES.has(node.name)) return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/heavy-rules.performance.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/heavy-rules.performance.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../test-utils/run-rule.js";
+import { noLoadingFlagResetOutsideFinally } from "./state-and-effects/no-loading-flag-reset-outside-finally.js";
+import { noEffectChain } from "./state-and-effects/no-effect-chain.js";
+import { noUnstableNestedComponents } from "./react-builtins/no-unstable-nested-components.js";
+import { rerenderStateOnlyInHandlers } from "./state-and-effects/rerender-state-only-in-handlers.js";
+import { rnNoRawText } from "./react-native/rn-no-raw-text.js";
+
+const COMPONENT_COUNT = 300;
+const TEXT_WRAPPER_COUNT = 150;
+
+const componentSource = Array.from(
+  { length: COMPONENT_COUNT },
+  (_, componentIndex) => `
+    export const Component${componentIndex} = ({ seed }) => {
+      const [value, setValue] = useState(seed);
+      useEffect(() => subscribe(seed), [seed]);
+      return <button onClick={() => setValue(seed + 1)}>{value}</button>;
+    };
+  `,
+).join("\n");
+
+const textWrapperSource = Array.from({ length: TEXT_WRAPPER_COUNT }, (_, offset) => {
+  const wrapperIndex = TEXT_WRAPPER_COUNT - offset - 1;
+  const elementName = wrapperIndex === 0 ? "Text" : `Wrapper${wrapperIndex - 1}`;
+  return `const Wrapper${wrapperIndex} = ({ children }) => <${elementName}>{children}</${elementName}>;`;
+}).join("\n");
+
+describe("heavy rule performance", () => {
+  for (const performanceCase of [
+    { ruleName: "nested components", rule: noUnstableNestedComponents },
+    { ruleName: "effect chains", rule: noEffectChain },
+    { ruleName: "loading resets", rule: noLoadingFlagResetOutsideFinally },
+    { ruleName: "handler-only state", rule: rerenderStateOnlyInHandlers },
+  ]) {
+    it(`handles many ordinary components for ${performanceCase.ruleName}`, () => {
+      const result = runRule(
+        performanceCase.rule,
+        `import { useEffect, useState } from "react"; ${componentSource}`,
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(0);
+    });
+  }
+
+  it("classifies a long reverse-ordered text-wrapper chain", () => {
+    const result = runRule(
+      rnNoRawText,
+      `import { Text } from "react-native"; ${textWrapperSource} const Screen = () => <Wrapper${TEXT_WRAPPER_COUNT - 1}>Hello</Wrapper${TEXT_WRAPPER_COUNT - 1}>;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-async-dynamic-api-not-awaited.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-async-dynamic-api-not-awaited.ts
@@ -6,12 +6,14 @@ import {
 import { MUTATING_ARRAY_METHODS, PROMISE_SETTLE_METHODS } from "../../constants/js.js";
 import type { BasicBlock } from "../../semantic/control-flow-graph.js";
 import type { SymbolDescriptor } from "../../semantic/scope-analysis.js";
+import { createProgramGatedVisitors } from "../../utils/create-program-gated-visitors.js";
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { executesDuringRender } from "../../utils/executes-during-render.js";
 import {
   getImportedNameFromModule,
+  hasImportFromModules,
   isNamespaceImportFromModule,
 } from "../../utils/find-import-source-for-name.js";
 import { findTransparentExpressionRoot } from "../../utils/find-transparent-expression-root.js";
@@ -37,6 +39,7 @@ import { nodeDominatesNode } from "../../utils/node-dominates-node.js";
 import { normalizeFilename } from "../../utils/normalize-filename.js";
 import { resolveConstIdentifierAlias } from "../../utils/resolve-const-identifier-alias.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import type { RuleVisitors } from "../../utils/rule-visitors.js";
 import { statementAlwaysExits } from "../../utils/statement-always-exits.js";
 import {
   stripParenExpression,
@@ -83,6 +86,7 @@ const COERCIVE_GLOBAL_NAMES: ReadonlySet<string> = new Set([
 ]);
 const NON_CONSUMING_UNARY_OPERATORS: ReadonlySet<string> = new Set(["!", "typeof", "void"]);
 const SITEMAP_FILE_PATTERN = new RegExp(`^sitemap\\.${NEXTJS_SOURCE_FILE_EXTENSION_GROUP}$`);
+const NEXT_HEADERS_MODULES: ReadonlyArray<string> = ["next/headers"];
 const MESSAGE =
   "This Next.js request API returns a Promise. Synchronous property access warns in Next.js 15 and is removed in Next.js 16; await it or unwrap it with React `use()`.";
 
@@ -132,6 +136,15 @@ interface ProjectedClearingSitesInput {
   symbol: SymbolDescriptor;
   targetOwner: EsTreeNode | null;
 }
+
+const isNextSitemapFile = (context: RuleContext): boolean => {
+  const basename = path.basename(context.filename ?? "");
+  const normalizedFilename = normalizeFilename(context.filename ?? "");
+  return (
+    (isInProjectDirectory(context, "app") || normalizedFilename.startsWith("app/")) &&
+    SITEMAP_FILE_PATTERN.test(basename)
+  );
+};
 
 const resolvesToImportBinding = (context: RuleContext, identifier: EsTreeNode): boolean =>
   findVisibleSymbol(identifier, context.scopes)?.kind === "import";
@@ -357,10 +370,7 @@ const getOfficialAsyncPropContract = (
   functionNode: EsTreeNode,
 ): OfficialAsyncPropContract | null => {
   const basename = path.basename(context.filename ?? "");
-  const normalizedFilename = normalizeFilename(context.filename ?? "");
-  const isSitemapFile =
-    (isInProjectDirectory(context, "app") || normalizedFilename.startsWith("app/")) &&
-    SITEMAP_FILE_PATTERN.test(basename);
+  const isSitemapFile = isNextSitemapFile(context);
   if (!isSitemapFile && !isFrameworkRouteOrSpecialFilename(context, "next")) return null;
   const program = findProgramRoot(functionNode);
   if (!program) return null;
@@ -3063,6 +3073,179 @@ const memberExpressionIsDirectlyUnwrapped = (
   );
 };
 
+const createActiveVisitors = (context: RuleContext): RuleVisitors => ({
+  FunctionDeclaration(node: EsTreeNodeOfType<"FunctionDeclaration">) {
+    reportNestedOfficialParameterDestructure(context, node);
+  },
+  FunctionExpression(node: EsTreeNodeOfType<"FunctionExpression">) {
+    reportNestedOfficialParameterDestructure(context, node);
+  },
+  ArrowFunctionExpression(node: EsTreeNodeOfType<"ArrowFunctionExpression">) {
+    reportNestedOfficialParameterDestructure(context, node);
+  },
+  MemberExpression(node: EsTreeNodeOfType<"MemberExpression">) {
+    if (node.computed) reportOfficialDirectValueConsumption(context, node.property);
+    if (memberExpressionIsAssignmentTarget(node)) {
+      const assignment = findTransparentExpressionRoot(node).parent;
+      if (
+        assignment &&
+        isNodeOfType(assignment, "AssignmentExpression") &&
+        assignment.operator !== "="
+      ) {
+        reportDirectSynchronousConsumption(context, node);
+      }
+      return;
+    }
+    if (memberExpressionIsDirectlyUnwrapped(context, node)) {
+      return;
+    }
+    const source = findPendingDynamicApiSource(context, node.object);
+    if (!source) return;
+    if (isPromiseSettleAccess(context, node)) return;
+    context.report({ node: source, message: MESSAGE });
+  },
+  VariableDeclarator(node: EsTreeNodeOfType<"VariableDeclarator">) {
+    if (!node.init) return;
+    reportDirectDestructure(context, node.init, node.id);
+    if (isNodeOfType(node.id, "Identifier")) {
+      reportAssignedPendingExpression(context, node.init, node.id);
+    } else {
+      reportPatternAssignedPendingExpressions(context, node.id, node.init);
+      reportOfficialPropsPatternAliases(context, node.id, node.init);
+    }
+  },
+  AssignmentExpression(node: EsTreeNodeOfType<"AssignmentExpression">) {
+    if (node.operator === "=") {
+      reportDirectDestructure(context, node.right, node.left);
+      if (!isNodeOfType(stripParenExpression(node.left), "Identifier")) {
+        reportPatternAssignedPendingExpressions(context, node.left, node.right);
+        reportOfficialPropsPatternAliases(context, node.left, node.right);
+      }
+    } else if (node.operator !== "&&=" && node.operator !== "||=" && node.operator !== "??=") {
+      if (!isNodeOfType(stripParenExpression(node.left), "MemberExpression")) {
+        reportDirectSynchronousConsumption(context, node.left);
+      }
+      return;
+    }
+    const assignmentTarget = stripParenExpression(node.left);
+    if (!isNodeOfType(assignmentTarget, "Identifier")) return;
+    if (node.operator === "&&=" || node.operator === "||=" || node.operator === "??=") {
+      if (
+        expressionMayRetainOfficialPendingValue(context, assignmentTarget) ||
+        capturedSymbolMayBePendingAtInvocation(context, assignmentTarget)
+      ) {
+        context.report({ node: assignmentTarget, message: MESSAGE });
+      }
+    }
+    reportAssignedPendingExpression(context, node.right, assignmentTarget);
+  },
+  UpdateExpression(node: EsTreeNodeOfType<"UpdateExpression">) {
+    reportDirectSynchronousConsumption(context, node.argument);
+  },
+  Property(node: EsTreeNodeOfType<"Property">) {
+    if (node.computed) reportOfficialDirectValueConsumption(context, node.key);
+  },
+  ConditionalExpression(node: EsTreeNodeOfType<"ConditionalExpression">) {
+    reportOfficialDirectValueConsumption(context, node.test);
+  },
+  LogicalExpression(node: EsTreeNodeOfType<"LogicalExpression">) {
+    reportOfficialDirectValueConsumption(context, node.left);
+  },
+  IfStatement(node: EsTreeNodeOfType<"IfStatement">) {
+    reportOfficialDirectValueConsumption(context, node.test);
+  },
+  WhileStatement(node: EsTreeNodeOfType<"WhileStatement">) {
+    reportOfficialDirectValueConsumption(context, node.test);
+  },
+  DoWhileStatement(node: EsTreeNodeOfType<"DoWhileStatement">) {
+    reportOfficialDirectValueConsumption(context, node.test);
+  },
+  ForStatement(node: EsTreeNodeOfType<"ForStatement">) {
+    if (node.test) reportOfficialDirectValueConsumption(context, node.test);
+  },
+  SwitchStatement(node: EsTreeNodeOfType<"SwitchStatement">) {
+    reportOfficialDirectValueConsumption(context, node.discriminant);
+  },
+  SpreadElement(node: EsTreeNodeOfType<"SpreadElement">) {
+    reportDirectSynchronousConsumption(context, node.argument);
+  },
+  ForInStatement(node: EsTreeNodeOfType<"ForInStatement">) {
+    reportDirectSynchronousConsumption(context, node.right);
+  },
+  ForOfStatement(node: EsTreeNodeOfType<"ForOfStatement">) {
+    reportDirectSynchronousConsumption(context, node.right);
+  },
+  YieldExpression(node: EsTreeNodeOfType<"YieldExpression">) {
+    if (!node.delegate || !node.argument) return;
+    reportDirectSynchronousConsumption(context, node.argument);
+  },
+  BinaryExpression(node: EsTreeNodeOfType<"BinaryExpression">) {
+    if (node.operator === "in") {
+      reportDirectSynchronousConsumption(context, node.right);
+      reportOfficialDirectValueConsumption(context, node.left);
+      return;
+    }
+    reportOfficialDirectValueConsumption(context, node.left);
+    reportOfficialDirectValueConsumption(context, node.right);
+  },
+  UnaryExpression(node: EsTreeNodeOfType<"UnaryExpression">) {
+    if (node.operator !== "void") reportOfficialDirectValueConsumption(context, node.argument);
+  },
+  TemplateLiteral(node: EsTreeNodeOfType<"TemplateLiteral">) {
+    if (
+      node.parent &&
+      isNodeOfType(node.parent, "TaggedTemplateExpression") &&
+      node.parent.quasi === node
+    ) {
+      const directTag = stripParenExpression(node.parent.tag);
+      const aliasSymbol = isNodeOfType(directTag, "Identifier")
+        ? resolveConstIdentifierAlias(directTag, context.scopes)
+        : null;
+      const tag = stripParenExpression(
+        aliasSymbol?.kind === "const" && aliasSymbol.initializer
+          ? aliasSymbol.initializer
+          : directTag,
+      );
+      if (!isNodeOfType(tag, "MemberExpression")) return;
+      const receiver = stripParenExpression(tag.object);
+      if (
+        !isNodeOfType(receiver, "Identifier") ||
+        receiver.name !== "String" ||
+        !context.scopes.isGlobalReference(receiver) ||
+        getResolvedStaticPropertyName(tag, context.scopes) !== "raw"
+      ) {
+        return;
+      }
+    }
+    for (const expression of node.expressions) {
+      reportOfficialDirectValueConsumption(context, expression);
+    }
+  },
+  JSXExpressionContainer(node: EsTreeNodeOfType<"JSXExpressionContainer">) {
+    if (isAstNode(node.expression)) {
+      reportOfficialDirectValueConsumption(context, node.expression);
+    }
+  },
+  CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+    for (const argument of node.arguments) {
+      if (isNodeOfType(argument, "SpreadElement")) continue;
+      if (isGlobalEnumerationCallForArgument(context, node, argument)) {
+        reportDirectSynchronousConsumption(context, argument);
+      }
+      if (isGlobalCoercionCallForArgument(context, node, argument)) {
+        reportOfficialDirectValueConsumption(context, argument);
+      }
+    }
+  },
+  NewExpression(node: EsTreeNodeOfType<"NewExpression">) {
+    for (const argument of node.arguments) {
+      if (isNodeOfType(argument, "SpreadElement")) continue;
+      if (!isGlobalIterableConstructorForArgument(context, node, argument)) continue;
+      reportDirectSynchronousConsumption(context, argument);
+    }
+  },
+});
+
 export const nextjsAsyncDynamicApiNotAwaited = defineRule({
   id: "nextjs-async-dynamic-api-not-awaited",
   title: "Synchronous Next.js request API access",
@@ -3071,176 +3254,12 @@ export const nextjsAsyncDynamicApiNotAwaited = defineRule({
   severity: "error",
   recommendation:
     "Await `cookies()`, `headers()`, `draftMode()`, and async route `params` or `searchParams`, or unwrap their promises with React `use()`, before reading properties.",
-  create: (context: RuleContext) => ({
-    FunctionDeclaration(node: EsTreeNodeOfType<"FunctionDeclaration">) {
-      reportNestedOfficialParameterDestructure(context, node);
-    },
-    FunctionExpression(node: EsTreeNodeOfType<"FunctionExpression">) {
-      reportNestedOfficialParameterDestructure(context, node);
-    },
-    ArrowFunctionExpression(node: EsTreeNodeOfType<"ArrowFunctionExpression">) {
-      reportNestedOfficialParameterDestructure(context, node);
-    },
-    MemberExpression(node: EsTreeNodeOfType<"MemberExpression">) {
-      if (node.computed) reportOfficialDirectValueConsumption(context, node.property);
-      if (memberExpressionIsAssignmentTarget(node)) {
-        const assignment = findTransparentExpressionRoot(node).parent;
-        if (
-          assignment &&
-          isNodeOfType(assignment, "AssignmentExpression") &&
-          assignment.operator !== "="
-        ) {
-          reportDirectSynchronousConsumption(context, node);
-        }
-        return;
-      }
-      if (memberExpressionIsDirectlyUnwrapped(context, node)) {
-        return;
-      }
-      const source = findPendingDynamicApiSource(context, node.object);
-      if (!source) return;
-      if (isPromiseSettleAccess(context, node)) return;
-      context.report({ node: source, message: MESSAGE });
-    },
-    VariableDeclarator(node: EsTreeNodeOfType<"VariableDeclarator">) {
-      if (!node.init) return;
-      reportDirectDestructure(context, node.init, node.id);
-      if (isNodeOfType(node.id, "Identifier")) {
-        reportAssignedPendingExpression(context, node.init, node.id);
-      } else {
-        reportPatternAssignedPendingExpressions(context, node.id, node.init);
-        reportOfficialPropsPatternAliases(context, node.id, node.init);
-      }
-    },
-    AssignmentExpression(node: EsTreeNodeOfType<"AssignmentExpression">) {
-      if (node.operator === "=") {
-        reportDirectDestructure(context, node.right, node.left);
-        if (!isNodeOfType(stripParenExpression(node.left), "Identifier")) {
-          reportPatternAssignedPendingExpressions(context, node.left, node.right);
-          reportOfficialPropsPatternAliases(context, node.left, node.right);
-        }
-      } else if (node.operator !== "&&=" && node.operator !== "||=" && node.operator !== "??=") {
-        if (!isNodeOfType(stripParenExpression(node.left), "MemberExpression")) {
-          reportDirectSynchronousConsumption(context, node.left);
-        }
-        return;
-      }
-      const assignmentTarget = stripParenExpression(node.left);
-      if (!isNodeOfType(assignmentTarget, "Identifier")) return;
-      if (node.operator === "&&=" || node.operator === "||=" || node.operator === "??=") {
-        if (
-          expressionMayRetainOfficialPendingValue(context, assignmentTarget) ||
-          capturedSymbolMayBePendingAtInvocation(context, assignmentTarget)
-        ) {
-          context.report({ node: assignmentTarget, message: MESSAGE });
-        }
-      }
-      reportAssignedPendingExpression(context, node.right, assignmentTarget);
-    },
-    UpdateExpression(node: EsTreeNodeOfType<"UpdateExpression">) {
-      reportDirectSynchronousConsumption(context, node.argument);
-    },
-    Property(node: EsTreeNodeOfType<"Property">) {
-      if (node.computed) reportOfficialDirectValueConsumption(context, node.key);
-    },
-    ConditionalExpression(node: EsTreeNodeOfType<"ConditionalExpression">) {
-      reportOfficialDirectValueConsumption(context, node.test);
-    },
-    LogicalExpression(node: EsTreeNodeOfType<"LogicalExpression">) {
-      reportOfficialDirectValueConsumption(context, node.left);
-    },
-    IfStatement(node: EsTreeNodeOfType<"IfStatement">) {
-      reportOfficialDirectValueConsumption(context, node.test);
-    },
-    WhileStatement(node: EsTreeNodeOfType<"WhileStatement">) {
-      reportOfficialDirectValueConsumption(context, node.test);
-    },
-    DoWhileStatement(node: EsTreeNodeOfType<"DoWhileStatement">) {
-      reportOfficialDirectValueConsumption(context, node.test);
-    },
-    ForStatement(node: EsTreeNodeOfType<"ForStatement">) {
-      if (node.test) reportOfficialDirectValueConsumption(context, node.test);
-    },
-    SwitchStatement(node: EsTreeNodeOfType<"SwitchStatement">) {
-      reportOfficialDirectValueConsumption(context, node.discriminant);
-    },
-    SpreadElement(node: EsTreeNodeOfType<"SpreadElement">) {
-      reportDirectSynchronousConsumption(context, node.argument);
-    },
-    ForInStatement(node: EsTreeNodeOfType<"ForInStatement">) {
-      reportDirectSynchronousConsumption(context, node.right);
-    },
-    ForOfStatement(node: EsTreeNodeOfType<"ForOfStatement">) {
-      reportDirectSynchronousConsumption(context, node.right);
-    },
-    YieldExpression(node: EsTreeNodeOfType<"YieldExpression">) {
-      if (!node.delegate || !node.argument) return;
-      reportDirectSynchronousConsumption(context, node.argument);
-    },
-    BinaryExpression(node: EsTreeNodeOfType<"BinaryExpression">) {
-      if (node.operator === "in") {
-        reportDirectSynchronousConsumption(context, node.right);
-        reportOfficialDirectValueConsumption(context, node.left);
-        return;
-      }
-      reportOfficialDirectValueConsumption(context, node.left);
-      reportOfficialDirectValueConsumption(context, node.right);
-    },
-    UnaryExpression(node: EsTreeNodeOfType<"UnaryExpression">) {
-      if (node.operator !== "void") reportOfficialDirectValueConsumption(context, node.argument);
-    },
-    TemplateLiteral(node: EsTreeNodeOfType<"TemplateLiteral">) {
-      if (
-        node.parent &&
-        isNodeOfType(node.parent, "TaggedTemplateExpression") &&
-        node.parent.quasi === node
-      ) {
-        const directTag = stripParenExpression(node.parent.tag);
-        const aliasSymbol = isNodeOfType(directTag, "Identifier")
-          ? resolveConstIdentifierAlias(directTag, context.scopes)
-          : null;
-        const tag = stripParenExpression(
-          aliasSymbol?.kind === "const" && aliasSymbol.initializer
-            ? aliasSymbol.initializer
-            : directTag,
-        );
-        if (!isNodeOfType(tag, "MemberExpression")) return;
-        const receiver = stripParenExpression(tag.object);
-        if (
-          !isNodeOfType(receiver, "Identifier") ||
-          receiver.name !== "String" ||
-          !context.scopes.isGlobalReference(receiver) ||
-          getResolvedStaticPropertyName(tag, context.scopes) !== "raw"
-        ) {
-          return;
-        }
-      }
-      for (const expression of node.expressions) {
-        reportOfficialDirectValueConsumption(context, expression);
-      }
-    },
-    JSXExpressionContainer(node: EsTreeNodeOfType<"JSXExpressionContainer">) {
-      if (isAstNode(node.expression)) {
-        reportOfficialDirectValueConsumption(context, node.expression);
-      }
-    },
-    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
-      for (const argument of node.arguments) {
-        if (isNodeOfType(argument, "SpreadElement")) continue;
-        if (isGlobalEnumerationCallForArgument(context, node, argument)) {
-          reportDirectSynchronousConsumption(context, argument);
-        }
-        if (isGlobalCoercionCallForArgument(context, node, argument)) {
-          reportOfficialDirectValueConsumption(context, argument);
-        }
-      }
-    },
-    NewExpression(node: EsTreeNodeOfType<"NewExpression">) {
-      for (const argument of node.arguments) {
-        if (isNodeOfType(argument, "SpreadElement")) continue;
-        if (!isGlobalIterableConstructorForArgument(context, node, argument)) continue;
-        reportDirectSynchronousConsumption(context, argument);
-      }
-    },
-  }),
+  create: (context: RuleContext) =>
+    createProgramGatedVisitors({
+      createVisitors: () => createActiveVisitors(context),
+      shouldAnalyzeProgram: (programNode) =>
+        hasImportFromModules(programNode, NEXT_HEADERS_MODULES) ||
+        isNextSitemapFile(context) ||
+        isFrameworkRouteOrSpecialFilename(context, "next"),
+    }),
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/r3f/r3f-no-recursive-raf-with-use-frame.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/r3f/r3f-no-recursive-raf-with-use-frame.test.ts
@@ -180,6 +180,27 @@ describe("r3f-no-recursive-raf-with-use-frame", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("supports CommonJS and TypeScript import-equals module references", () => {
+    for (const moduleBinding of [
+      `const Fiber = require("@react-three/fiber");`,
+      `import Fiber = require("@react-three/fiber");`,
+    ]) {
+      const result = runRule(
+        r3fNoRecursiveRafWithUseFrame,
+        `
+          const Scene = () => {
+            Fiber.useFrame(() => updateScene());
+            const animate = () => requestAnimationFrame(animate);
+            requestAnimationFrame(animate);
+            return null;
+          };
+          ${moduleBinding}
+        `,
+      );
+      expect(result.diagnostics).toHaveLength(1);
+    }
+  });
+
   it("allows one-shot animation frames including demand invalidation", () => {
     const result = runRule(
       r3fNoRecursiveRafWithUseFrame,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/r3f/r3f-no-recursive-raf-with-use-frame.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/r3f/r3f-no-recursive-raf-with-use-frame.ts
@@ -1,4 +1,5 @@
 import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
+import { createProgramGatedVisitors } from "../../utils/create-program-gated-visitors.js";
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
@@ -10,11 +11,13 @@ import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { resolveConstIdentifierAlias } from "../../utils/resolve-const-identifier-alias.js";
 import { resolveRecursiveAnimationFrameCallback } from "../../utils/resolve-recursive-animation-frame-callback.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import type { RuleVisitors } from "../../utils/rule-visitors.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import { getApiReferenceProvenance } from "./utils/get-api-reference-provenance.js";
 import { isR3fApiCall } from "./utils/is-r3f-api-call.js";
 import { isR3fReactApiCall } from "./utils/is-r3f-react-api-call.js";
 import { isR3fUseThreeStateProperty } from "./utils/is-r3f-use-three-state-property.js";
+import { programReferencesR3f } from "./utils/program-references-r3f.js";
 import { resolveLocalReactCallback } from "./utils/resolve-local-react-callback.js";
 import { walkFunctionExecution } from "./utils/walk-function-execution.js";
 
@@ -67,6 +70,59 @@ const collectR3fRendererAnimationLoopStarts = (
   return starts;
 };
 
+const createActiveVisitors = (context: RuleContext): RuleVisitors => {
+  const hasUseFrameByOwner = new Map<EsTreeNode, boolean>();
+  const analyzedRenderOwners = new Set<EsTreeNode>();
+  const reportedStarts = new Set<EsTreeNode>();
+  const ownerUsesFrameSubscription = (owner: EsTreeNode): boolean => {
+    const cachedResult = hasUseFrameByOwner.get(owner);
+    if (cachedResult !== undefined) return cachedResult;
+    let hasUseFrame = false;
+    walkFunctionExecution(owner, context.scopes, (candidate) => {
+      if (!hasUseFrame && isR3fApiCall(candidate, "useFrame", context.scopes)) {
+        hasUseFrame = true;
+      }
+    });
+    hasUseFrameByOwner.set(owner, hasUseFrame);
+    return hasUseFrame;
+  };
+  const reportStarts = (executedFunction: EsTreeNode, owner: EsTreeNode): void => {
+    if (!ownerUsesFrameSubscription(owner)) return;
+    for (const start of collectRecursiveAnimationFrameStarts(executedFunction, context.scopes)) {
+      if (reportedStarts.has(start)) continue;
+      reportedStarts.add(start);
+      context.report({
+        node: start,
+        message:
+          "This component starts a recursive requestAnimationFrame loop while also subscribing to R3F useFrame. Move the repeated work into useFrame so R3F owns frame scheduling",
+      });
+    }
+    for (const start of collectR3fRendererAnimationLoopStarts(executedFunction, context)) {
+      if (reportedStarts.has(start)) continue;
+      reportedStarts.add(start);
+      context.report({
+        node: start,
+        message:
+          "This component starts setAnimationLoop on R3F's renderer while also subscribing to useFrame. Move the repeated work into useFrame so R3F remains the only frame scheduler",
+      });
+    }
+  };
+
+  return {
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+      const owner = findRenderPhaseComponentOrHook(node, context.scopes);
+      if (!owner) return;
+      if (!analyzedRenderOwners.has(owner)) {
+        analyzedRenderOwners.add(owner);
+        reportStarts(owner, owner);
+      }
+      if (!isR3fReactApiCall(node, EFFECT_HOOK_NAMES, context.scopes)) return;
+      const effectCallback = getEffectCallback(node, context.scopes);
+      if (effectCallback) reportStarts(effectCallback, owner);
+    },
+  };
+};
+
 export const r3fNoRecursiveRafWithUseFrame = defineRule({
   id: "r3f-no-recursive-raf-with-use-frame",
   title: "Competing animation loop alongside useFrame",
@@ -74,56 +130,9 @@ export const r3fNoRecursiveRafWithUseFrame = defineRule({
   severity: "warn",
   recommendation:
     "Use R3F's useFrame subscription as the component's single animation loop instead of starting a second browser or renderer loop",
-  create: (context: RuleContext) => {
-    const hasUseFrameByOwner = new Map<EsTreeNode, boolean>();
-    const analyzedRenderOwners = new Set<EsTreeNode>();
-    const reportedStarts = new Set<EsTreeNode>();
-    const ownerUsesFrameSubscription = (owner: EsTreeNode): boolean => {
-      const cachedResult = hasUseFrameByOwner.get(owner);
-      if (cachedResult !== undefined) return cachedResult;
-      let hasUseFrame = false;
-      walkFunctionExecution(owner, context.scopes, (candidate) => {
-        if (!hasUseFrame && isR3fApiCall(candidate, "useFrame", context.scopes)) {
-          hasUseFrame = true;
-        }
-      });
-      hasUseFrameByOwner.set(owner, hasUseFrame);
-      return hasUseFrame;
-    };
-    const reportStarts = (executedFunction: EsTreeNode, owner: EsTreeNode): void => {
-      if (!ownerUsesFrameSubscription(owner)) return;
-      for (const start of collectRecursiveAnimationFrameStarts(executedFunction, context.scopes)) {
-        if (reportedStarts.has(start)) continue;
-        reportedStarts.add(start);
-        context.report({
-          node: start,
-          message:
-            "This component starts a recursive requestAnimationFrame loop while also subscribing to R3F useFrame. Move the repeated work into useFrame so R3F owns frame scheduling",
-        });
-      }
-      for (const start of collectR3fRendererAnimationLoopStarts(executedFunction, context)) {
-        if (reportedStarts.has(start)) continue;
-        reportedStarts.add(start);
-        context.report({
-          node: start,
-          message:
-            "This component starts setAnimationLoop on R3F's renderer while also subscribing to useFrame. Move the repeated work into useFrame so R3F remains the only frame scheduler",
-        });
-      }
-    };
-
-    return {
-      CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
-        const owner = findRenderPhaseComponentOrHook(node, context.scopes);
-        if (!owner) return;
-        if (!analyzedRenderOwners.has(owner)) {
-          analyzedRenderOwners.add(owner);
-          reportStarts(owner, owner);
-        }
-        if (!isR3fReactApiCall(node, EFFECT_HOOK_NAMES, context.scopes)) return;
-        const effectCallback = getEffectCallback(node, context.scopes);
-        if (effectCallback) reportStarts(effectCallback, owner);
-      },
-    };
-  },
+  create: (context: RuleContext) =>
+    createProgramGatedVisitors({
+      createVisitors: () => createActiveVisitors(context),
+      shouldAnalyzeProgram: programReferencesR3f,
+    }),
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/r3f/r3f-require-global-effect-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/r3f/r3f-require-global-effect-cleanup.ts
@@ -19,6 +19,7 @@ import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import { walkAst } from "../../utils/walk-ast.js";
 import { isR3fApiCall } from "./utils/is-r3f-api-call.js";
 import { isR3fReactApiCall } from "./utils/is-r3f-react-api-call.js";
+import { programReferencesR3f } from "./utils/program-references-r3f.js";
 import { resolveR3fCallback } from "./utils/resolve-r3f-callback.js";
 import { walkFunctionExecution } from "./utils/walk-function-execution.js";
 
@@ -263,6 +264,7 @@ export const r3fRequireGlobalEffectCleanup = defineRule({
     "Register addEffect, addAfterEffect, and addTail from an effect and return the exact disposer so remounts do not retain global render-loop callbacks",
   create: (context: RuleContext) => {
     const reportedRegistrations = new Set<EsTreeNode>();
+    let shouldAnalyzeFile = false;
     const reportRegistration = (registration: EsTreeNode): void => {
       if (reportedRegistrations.has(registration)) return;
       reportedRegistrations.add(registration);
@@ -274,7 +276,12 @@ export const r3fRequireGlobalEffectCleanup = defineRule({
     };
 
     return {
+      Program(programNode: EsTreeNodeOfType<"Program">) {
+        shouldAnalyzeFile = programReferencesR3f(programNode);
+      },
       CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+        if (!shouldAnalyzeFile) return;
+
         if (isR3fReactApiCall(node, EFFECT_HOOK_NAMES, context.scopes)) {
           const effectCallback = getEffectCallback(node, context.scopes);
           if (!effectCallback) return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/r3f/utils/program-references-r3f.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/r3f/utils/program-references-r3f.ts
@@ -1,0 +1,28 @@
+import type { EsTreeNodeOfType } from "../../../utils/es-tree-node-of-type.js";
+import { hasImportFromModules } from "../../../utils/find-import-source-for-name.js";
+import { getRequireCallSource } from "../../../utils/get-require-call-source.js";
+import { isNodeOfType } from "../../../utils/is-node-of-type.js";
+import { someAst } from "../../../utils/some-ast.js";
+import { R3F_PUBLIC_MODULES } from "./r3f-public-modules.js";
+
+const R3F_PUBLIC_MODULE_LIST = [...R3F_PUBLIC_MODULES];
+
+export const programReferencesR3f = (programNode: EsTreeNodeOfType<"Program">): boolean => {
+  if (hasImportFromModules(programNode, R3F_PUBLIC_MODULE_LIST)) return true;
+  if (
+    programNode.body.some(
+      (statement) =>
+        isNodeOfType(statement, "TSImportEqualsDeclaration") &&
+        isNodeOfType(statement.moduleReference, "TSExternalModuleReference") &&
+        isNodeOfType(statement.moduleReference.expression, "Literal") &&
+        typeof statement.moduleReference.expression.value === "string" &&
+        R3F_PUBLIC_MODULES.has(statement.moduleReference.expression.value),
+    )
+  ) {
+    return true;
+  }
+
+  return someAst(programNode, (candidate) =>
+    R3F_PUBLIC_MODULES.has(getRequireCallSource(candidate) ?? ""),
+  );
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-unstable-nested-components.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-unstable-nested-components.ts
@@ -109,8 +109,8 @@ const isReactClassComponent = (classNode: EsTreeNode, scopes: ScopeAnalysis): bo
 // Walk up to find the FIRST enclosing function/class component.
 const findEnclosingComponent = (
   node: EsTreeNode,
-  scopes: ScopeAnalysis,
-  controlFlow: ControlFlowAnalysis,
+  functionContainsComponentOutput: (functionNode: EsTreeNode) => boolean,
+  classIsReactComponent: (classNode: EsTreeNode) => boolean,
 ): { component: EsTreeNode; name: string | null } | null => {
   let walker: EsTreeNode | null | undefined = node.parent;
   while (walker) {
@@ -119,14 +119,14 @@ const findEnclosingComponent = (
       if (
         componentName &&
         isReactComponentName(componentName) &&
-        functionContainsJsxOrCreateElement(walker, scopes, controlFlow)
+        functionContainsComponentOutput(walker)
       ) {
         return { component: walker, name: componentName };
       }
       // Anonymous default-exported function returning JSX counts too.
       if (
         !componentName &&
-        functionContainsJsxOrCreateElement(walker, scopes, controlFlow) &&
+        functionContainsComponentOutput(walker) &&
         walker.parent &&
         isNodeOfType(walker.parent, "ExportDefaultDeclaration")
       ) {
@@ -134,11 +134,7 @@ const findEnclosingComponent = (
       }
     }
     if (isNodeOfType(walker, "ClassDeclaration") || isNodeOfType(walker, "ClassExpression")) {
-      if (
-        walker.id &&
-        isReactComponentName(walker.id.name) &&
-        isReactClassComponent(walker, scopes)
-      ) {
+      if (walker.id && isReactComponentName(walker.id.name) && classIsReactComponent(walker)) {
         return { component: walker, name: walker.id.name };
       }
     }
@@ -491,6 +487,24 @@ export const noUnstableNestedComponents = defineRule({
     // instantiated by their consumer and keep firing as before.
     const instantiatedComponentNames = new Set<string>();
     const instantiatedBindingIdentifiers = new Set<EsTreeNode>();
+    const componentOutputByFunction = new WeakMap<EsTreeNode, boolean>();
+    const reactComponentByClass = new WeakMap<EsTreeNode, boolean>();
+
+    const functionContainsComponentOutput = (functionNode: EsTreeNode): boolean => {
+      const cachedResult = componentOutputByFunction.get(functionNode);
+      if (cachedResult !== undefined) return cachedResult;
+      const result = functionContainsJsxOrCreateElement(functionNode, context.scopes, context.cfg);
+      componentOutputByFunction.set(functionNode, result);
+      return result;
+    };
+
+    const classIsReactComponent = (classNode: EsTreeNode): boolean => {
+      const cachedResult = reactComponentByClass.get(classNode);
+      if (cachedResult !== undefined) return cachedResult;
+      const result = isReactClassComponent(classNode, context.scopes);
+      reactComponentByClass.set(classNode, result);
+      return result;
+    };
 
     const recordInstantiation = (identifier: EsTreeNode, name: string): void => {
       instantiatedComponentNames.add(name);
@@ -556,7 +570,11 @@ export const noUnstableNestedComponents = defineRule({
         if (renderPropRegex.test(propInfo.propName)) return;
         if (settings.allowAsProps) return;
       }
-      const enclosing = findEnclosingComponent(candidateNode, context.scopes, context.cfg);
+      const enclosing = findEnclosingComponent(
+        candidateNode,
+        functionContainsComponentOutput,
+        classIsReactComponent,
+      );
       if (!enclosing) return;
       // A prop / object-callback candidate is instantiated by its
       // consumer, so don't gate it on local instantiation.
@@ -575,15 +593,13 @@ export const noUnstableNestedComponents = defineRule({
         "FunctionDeclaration" | "FunctionExpression" | "ArrowFunctionExpression"
       >,
     ): void => {
-      if (!functionContainsJsxOrCreateElement(node as EsTreeNode, context.scopes, context.cfg)) {
-        return;
-      }
       const inferredName = inferFunctionLikeName(node as EsTreeNode);
       const propInfo = isComponentDeclaredInProp(node as EsTreeNode);
       const isObjectCallback = isObjectCallbackCandidate(node as EsTreeNode);
       const isNameCandidate = inferredName !== null && isReactComponentName(inferredName);
       const isCandidate = isNameCandidate || propInfo !== null || isObjectCallback;
       if (!isCandidate) return;
+      if (!functionContainsComponentOutput(node as EsTreeNode)) return;
       const requiredInstantiationName =
         isNameCandidate && propInfo === null && !isObjectCallback ? inferredName : null;
       enqueueCandidate(node as EsTreeNode, requiredInstantiationName);
@@ -615,13 +631,13 @@ export const noUnstableNestedComponents = defineRule({
         // PascalCase-named class (`class NewRoot extends RootState` in
         // tldraw, `class Tool extends BaseTool`, etc.) as a nested React
         // component candidate.
-        if (!isReactClassComponent(node as EsTreeNode, context.scopes)) return;
+        if (!classIsReactComponent(node as EsTreeNode)) return;
         enqueueCandidate(node as EsTreeNode, null);
       },
       ClassExpression(node: EsTreeNodeOfType<"ClassExpression">) {
         const inferredName = node.id?.name ?? inferFunctionLikeName(node as EsTreeNode);
         if (!inferredName || !isReactComponentName(inferredName)) return;
-        if (!isReactClassComponent(node as EsTreeNode, context.scopes)) return;
+        if (!classIsReactComponent(node as EsTreeNode)) return;
         enqueueCandidate(node as EsTreeNode, null);
       },
       CallExpression(node: EsTreeNodeOfType<"CallExpression">) {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-raw-text.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-raw-text.ts
@@ -7,7 +7,6 @@ import {
 } from "../../constants/react-native.js";
 import { HTML_TAGS } from "../../constants/html-tags.js";
 import { SVG_TAGS } from "../../constants/svg-tags.js";
-import { containsJsxElement } from "../../utils/contains-jsx-element.js";
 import { defineRule } from "../../utils/define-rule.js";
 import { hasDirective } from "../../utils/has-directive.js";
 import { isInsidePlatformOsWebBranch } from "../../utils/is-inside-platform-os-web-branch.js";
@@ -173,9 +172,6 @@ export const rnNoRawText = defineRule({
     return {
       Program(programNode: EsTreeNodeOfType<"Program">) {
         isDomComponentFile = hasDirective(programNode, "use dom");
-        // A file with no JSX never fires the JSXElement visitor, so the
-        // wrapper classification would go unread — skip the fixpoint walk.
-        if (!containsJsxElement(programNode)) return;
         const childrenForwarding = collectTextWrapperComponents(
           programNode,
           isTextHandlingComponent,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-effect-chain.ts
@@ -2455,6 +2455,9 @@ export const noEffectChain = defineRule({
 
       const useStateBindings = collectUseStateBindings(componentBody, context.scopes);
       if (useStateBindings.length === 0) return;
+      const effectCalls = findTopLevelEffectCalls(componentBody, context.scopes);
+      if (effectCalls.length < 2) return;
+
       const setterToStateName = new Map<string, string>();
       const stateSymbolIds = new Map<string, number>();
       const setterSymbolIdToStateName = new Map<number, string>();
@@ -2477,7 +2480,7 @@ export const noEffectChain = defineRule({
       const stateSymbolIdSet = new Set(stateSymbolIds.values());
 
       const effectInfos: EffectInfo[] = [];
-      for (const effectCall of findTopLevelEffectCalls(componentBody, context.scopes)) {
+      for (const effectCall of effectCalls) {
         const callback = getEffectCallback(effectCall, context.scopes);
         if (!callback || !isFunctionLike(callback) || callback.async) continue;
         const analysisFunctions = collectSynchronouslyInvokedFunctions(callback, context.scopes);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-loading-flag-reset-outside-finally.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-loading-flag-reset-outside-finally.ts
@@ -2501,6 +2501,7 @@ const findFirstAwaitAfter = (awaitSites: ReadonlyArray<AwaitSite>, start: number
 };
 
 const analyzeFunction = (functionNode: EsTreeNode, context: RuleContext): void => {
+  if (!isFunctionLike(functionNode) || !functionNode.async) return;
   const awaitSites: AwaitSite[] = [];
   const settersByKey = new Map<string, SetterCall[]>();
   const registerHelperResets = (callNode: EsTreeNodeOfType<"CallExpression">): void => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-mutable-in-deps.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-mutable-in-deps.ts
@@ -112,34 +112,39 @@ export const noMutableInDeps = defineRule({
       componentParams: ReadonlyArray<EsTreeNode> = [],
     ): void => {
       if (!componentBody || !isNodeOfType(componentBody, "BlockStatement")) return;
+      const mutableDependencyCandidates: EsTreeNode[] = [];
+      walkAst(componentBody, (child: EsTreeNode) => {
+        if (!isNodeOfType(child, "CallExpression")) return;
+        if (!isReactHookCall(child, HOOKS_WITH_DEPS, context.scopes)) return;
+        const depsNode = child.arguments[1];
+        if (!isNodeOfType(depsNode, "ArrayExpression")) return;
+        for (const element of depsNode.elements) {
+          if (isNodeOfType(element, "MemberExpression")) {
+            mutableDependencyCandidates.push(element);
+          }
+        }
+      });
+      if (mutableDependencyCandidates.length === 0) return;
+
       const useRefBindingNames = collectUseRefBindingNames(componentBody, context.scopes);
       const localBindingNames = collectLocalBindingNames(componentBody);
       for (const param of componentParams) collectPatternNames(param, localBindingNames);
 
-      walkAst(componentBody, (child: EsTreeNode) => {
-        if (!isNodeOfType(child, "CallExpression")) return;
-        if (!isReactHookCall(child, HOOKS_WITH_DEPS, context.scopes)) return;
-        if ((child.arguments?.length ?? 0) < 2) return;
-        const depsNode = child.arguments[1];
-        if (!isNodeOfType(depsNode, "ArrayExpression")) return;
-
-        for (const element of depsNode.elements ?? []) {
-          if (!element) continue;
-          const issue = findMutableDepIssue(element, useRefBindingNames, localBindingNames);
-          if (!issue) continue;
-          if (issue.kind === "ref-current") {
-            context.report({
-              node: element,
-              message: `Changing "${issue.rootName}.current" does not re-render the component, so this dependency will not make the effect run again.`,
-            });
-          } else {
-            context.report({
-              node: element,
-              message: `Values like "${issue.rootName}.*" can change without re-rendering the component, so this dependency will not make the effect run again.`,
-            });
-          }
+      for (const element of mutableDependencyCandidates) {
+        const issue = findMutableDepIssue(element, useRefBindingNames, localBindingNames);
+        if (!issue) continue;
+        if (issue.kind === "ref-current") {
+          context.report({
+            node: element,
+            message: `Changing "${issue.rootName}.current" does not re-render the component, so this dependency will not make the effect run again.`,
+          });
+        } else {
+          context.report({
+            node: element,
+            message: `Values like "${issue.rootName}.*" can change without re-rendering the component, so this dependency will not make the effect run again.`,
+          });
         }
-      });
+      }
     };
 
     return {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/rerender-state-only-in-handlers.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/rerender-state-only-in-handlers.ts
@@ -210,15 +210,16 @@ export const rerenderStateOnlyInHandlers = defineRule({
       if (!componentBody || !isNodeOfType(componentBody, "BlockStatement")) return;
       const bindings = collectUseStateBindings(componentBody, context.scopes);
       if (bindings.length === 0) return;
-
-      const renderReachableExpressions = collectRenderReachableExpressions(componentBody);
-      if (renderReachableExpressions.length === 0) return;
-
       const {
         dependencyGraph,
         directRenderNames: cachedDirectRenderNames,
         renderReachableNames: cachedRenderReachableNames,
       } = getComponentRenderDependencyAnalysis(componentBody, context.scopes);
+      if (bindings.every((binding) => cachedRenderReachableNames.has(binding.valueName))) return;
+
+      const renderReachableExpressions = collectRenderReachableExpressions(componentBody);
+      if (renderReachableExpressions.length === 0) return;
+
       const directRenderNames = new Set(cachedDirectRenderNames);
       const renderReachableNames = new Set(cachedRenderReachableNames);
       // A top-level `void someState;` is the deliberate "re-render to

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/collect-use-state-bindings.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/collect-use-state-bindings.ts
@@ -5,19 +5,30 @@ import { isReactHookCall } from "../../../utils/is-react-hook-call.js";
 import { isSetterIdentifier } from "../../../utils/is-setter-identifier.js";
 import { isNodeOfType } from "../../../utils/is-node-of-type.js";
 
+export interface UseStateBinding {
+  readonly valueName: string;
+  readonly setterName: string;
+  readonly declarator: EsTreeNodeOfType<"VariableDeclarator">;
+}
+
+const useStateBindingsByScopes = new WeakMap<
+  ScopeAnalysis,
+  WeakMap<EsTreeNode, ReadonlyArray<UseStateBinding>>
+>();
+
 export const collectUseStateBindings = (
   componentBody: EsTreeNode,
   scopes: ScopeAnalysis,
-): Array<{
-  valueName: string;
-  setterName: string;
-  declarator: EsTreeNodeOfType<"VariableDeclarator">;
-}> => {
-  const bindings: Array<{
-    valueName: string;
-    setterName: string;
-    declarator: EsTreeNodeOfType<"VariableDeclarator">;
-  }> = [];
+): ReadonlyArray<UseStateBinding> => {
+  let bindingsByComponent = useStateBindingsByScopes.get(scopes);
+  if (!bindingsByComponent) {
+    bindingsByComponent = new WeakMap();
+    useStateBindingsByScopes.set(scopes, bindingsByComponent);
+  }
+  const cachedBindings = bindingsByComponent.get(componentBody);
+  if (cachedBindings) return cachedBindings;
+
+  const bindings: UseStateBinding[] = [];
   if (!isNodeOfType(componentBody, "BlockStatement")) return bindings;
 
   for (const statement of componentBody.body ?? []) {
@@ -44,5 +55,6 @@ export const collectUseStateBindings = (
       });
     }
   }
+  bindingsByComponent.set(componentBody, bindings);
   return bindings;
 };

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/valtio/valtio-no-proxy-read-in-render.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/valtio/valtio-no-proxy-read-in-render.ts
@@ -3,11 +3,13 @@ import type {
   ScopeDescriptor,
   SymbolDescriptor,
 } from "../../semantic/scope-analysis.js";
+import { createProgramGatedVisitors } from "../../utils/create-program-gated-visitors.js";
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { findRenderPhaseComponentOrHook } from "../../utils/find-render-phase-component-or-hook.js";
 import { findTransparentExpressionRoot } from "../../utils/find-transparent-expression-root.js";
+import { hasImportFromModules } from "../../utils/find-import-source-for-name.js";
 import { getImportedName } from "../../utils/get-imported-name.js";
 import { getStaticPropertyKeyName } from "../../utils/get-static-property-key-name.js";
 import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
@@ -17,6 +19,7 @@ import { isWithinAssignmentTarget } from "../../utils/is-within-assignment-targe
 import { resolveConstIdentifierAlias } from "../../utils/resolve-const-identifier-alias.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import type { RuleContext } from "../../utils/rule-context.js";
+import type { RuleVisitors } from "../../utils/rule-visitors.js";
 
 interface ProxyPath {
   readonly rootKey: string;
@@ -36,6 +39,7 @@ interface SnapshotTarget {
 }
 
 const VALTIO_REACT_MODULE_SOURCES = new Set(["valtio", "valtio/react"]);
+const VALTIO_REACT_MODULE_SOURCE_LIST = [...VALTIO_REACT_MODULE_SOURCES];
 const REACT_DEPENDENCY_ARRAY_HOOK_NAMES = new Set([
   "useCallback",
   "useEffect",
@@ -404,6 +408,84 @@ const wasTargetReplacedBeforeRead = (
     );
   });
 
+const createActiveVisitors = (context: RuleContext): RuleVisitors => {
+  const snapshotTargets: SnapshotTarget[] = [];
+  const identifierCandidates: EsTreeNode[] = [];
+  const writeTargets: EsTreeNode[] = [];
+  return {
+    CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+      const snapshotTarget = getSnapshotTarget(node, context);
+      if (snapshotTarget) snapshotTargets.push(snapshotTarget);
+    },
+    Identifier(node: EsTreeNodeOfType<"Identifier">) {
+      if (context.scopes.referenceFor(node)) identifierCandidates.push(node);
+    },
+    AssignmentExpression(node: EsTreeNodeOfType<"AssignmentExpression">) {
+      writeTargets.push(...collectAssignmentWriteTargets(node.left));
+    },
+    UpdateExpression(node: EsTreeNodeOfType<"UpdateExpression">) {
+      writeTargets.push(node.argument);
+    },
+    "Program:exit"() {
+      const reportedExpressions = new Set<EsTreeNode>();
+      for (const identifier of identifierCandidates) {
+        const readExpression = findOutermostMemberRead(identifier);
+        if (
+          reportedExpressions.has(readExpression) ||
+          (isWithinAssignmentTarget(readExpression) &&
+            !isReadPositionWithinAssignmentTarget(readExpression)) ||
+          isSnapshotArgument(readExpression, context.scopes)
+        ) {
+          continue;
+        }
+        const readAliasCaptures = new Map<number, ProxyAliasCapture>();
+        const readPath = resolveProxyPath(
+          readExpression,
+          context.scopes,
+          new Set(),
+          null,
+          readAliasCaptures,
+        );
+        const readPosition = readExpression.range?.[0];
+        const ownerFunction = findRenderPhaseComponentOrHook(readExpression, context.scopes);
+        if (!readPath || typeof readPosition !== "number" || !ownerFunction) continue;
+        const readScope = context.scopes.scopeFor(readExpression);
+        const matchingTarget = snapshotTargets.find(
+          (target) =>
+            target.ownerFunction === ownerFunction &&
+            target.declarationEnd < readPosition &&
+            target.snapshotBindingScopes.some((bindingScope) =>
+              isScopeWithin(readScope, bindingScope),
+            ) &&
+            isPathPrefix(target.path, readPath) &&
+            (readAliasCaptures.size === 0 ||
+              [...readAliasCaptures.values()].some(
+                (aliasCapture) =>
+                  isPathPrefix(aliasCapture.path, target.path) ||
+                  (isPathPrefix(target.path, aliasCapture.path) &&
+                    readPath.properties.length > aliasCapture.path.properties.length),
+              )) &&
+            !wasTargetReplacedBeforeRead(
+              target,
+              readPosition,
+              writeTargets,
+              readAliasCaptures,
+              context,
+            ),
+        );
+        if (
+          !matchingTarget ||
+          isStableProxyDependency(readExpression, readPath, matchingTarget, context.scopes)
+        ) {
+          continue;
+        }
+        reportedExpressions.add(readExpression);
+        context.report({ node: readExpression, message: MESSAGE });
+      }
+    },
+  };
+};
+
 export const valtioNoProxyReadInRender = defineRule({
   id: "valtio-no-proxy-read-in-render",
   title: "Valtio proxy read during render",
@@ -411,81 +493,10 @@ export const valtioNoProxyReadInRender = defineRule({
   recommendation:
     "Read reactive render values from useSnapshot. Reserve the mutable proxy for event handlers, effects, and other callbacks that need the latest value.",
   requires: ["valtio:1"],
-  create: (context: RuleContext) => {
-    const snapshotTargets: SnapshotTarget[] = [];
-    const identifierCandidates: EsTreeNode[] = [];
-    const writeTargets: EsTreeNode[] = [];
-    return {
-      CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
-        const snapshotTarget = getSnapshotTarget(node, context);
-        if (snapshotTarget) snapshotTargets.push(snapshotTarget);
-      },
-      Identifier(node: EsTreeNodeOfType<"Identifier">) {
-        if (context.scopes.referenceFor(node)) identifierCandidates.push(node);
-      },
-      AssignmentExpression(node: EsTreeNodeOfType<"AssignmentExpression">) {
-        writeTargets.push(...collectAssignmentWriteTargets(node.left));
-      },
-      UpdateExpression(node: EsTreeNodeOfType<"UpdateExpression">) {
-        writeTargets.push(node.argument);
-      },
-      "Program:exit"() {
-        const reportedExpressions = new Set<EsTreeNode>();
-        for (const identifier of identifierCandidates) {
-          const readExpression = findOutermostMemberRead(identifier);
-          if (
-            reportedExpressions.has(readExpression) ||
-            (isWithinAssignmentTarget(readExpression) &&
-              !isReadPositionWithinAssignmentTarget(readExpression)) ||
-            isSnapshotArgument(readExpression, context.scopes)
-          ) {
-            continue;
-          }
-          const readAliasCaptures = new Map<number, ProxyAliasCapture>();
-          const readPath = resolveProxyPath(
-            readExpression,
-            context.scopes,
-            new Set(),
-            null,
-            readAliasCaptures,
-          );
-          const readPosition = readExpression.range?.[0];
-          const ownerFunction = findRenderPhaseComponentOrHook(readExpression, context.scopes);
-          if (!readPath || typeof readPosition !== "number" || !ownerFunction) continue;
-          const readScope = context.scopes.scopeFor(readExpression);
-          const matchingTarget = snapshotTargets.find(
-            (target) =>
-              target.ownerFunction === ownerFunction &&
-              target.declarationEnd < readPosition &&
-              target.snapshotBindingScopes.some((bindingScope) =>
-                isScopeWithin(readScope, bindingScope),
-              ) &&
-              isPathPrefix(target.path, readPath) &&
-              (readAliasCaptures.size === 0 ||
-                [...readAliasCaptures.values()].some(
-                  (aliasCapture) =>
-                    isPathPrefix(aliasCapture.path, target.path) ||
-                    (isPathPrefix(target.path, aliasCapture.path) &&
-                      readPath.properties.length > aliasCapture.path.properties.length),
-                )) &&
-              !wasTargetReplacedBeforeRead(
-                target,
-                readPosition,
-                writeTargets,
-                readAliasCaptures,
-                context,
-              ),
-          );
-          if (
-            !matchingTarget ||
-            isStableProxyDependency(readExpression, readPath, matchingTarget, context.scopes)
-          ) {
-            continue;
-          }
-          reportedExpressions.add(readExpression);
-          context.report({ node: readExpression, message: MESSAGE });
-        }
-      },
-    };
-  },
+  create: (context: RuleContext) =>
+    createProgramGatedVisitors({
+      createVisitors: () => createActiveVisitors(context),
+      shouldAnalyzeProgram: (programNode) =>
+        hasImportFromModules(programNode, VALTIO_REACT_MODULE_SOURCE_LIST),
+    }),
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/collect-text-wrapper-components.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/collect-text-wrapper-components.ts
@@ -414,6 +414,11 @@ export interface ChildrenForwardingComponents {
   nonTextWrappers: ReadonlySet<string>;
 }
 
+interface ComponentDeclaration {
+  readonly componentName: string;
+  readonly definitionNode: EsTreeNode;
+}
+
 export type ChildrenForwardingKind = "text" | "nonText" | "unknown";
 
 // Classifies a component definition by where it forwards its `children`:
@@ -515,7 +520,12 @@ export const collectTextWrapperComponents = (
   const wrappers = new Set<string>();
   const nonTextWrappers = new Set<string>();
   const componentBindingCounts = new Map<string, number>();
+  const componentDeclarations: ComponentDeclaration[] = [];
+  let didContainJsxElement = false;
   walkAst(programNode, (node) => {
+    if (isNodeOfType(node, "JSXElement") || isNodeOfType(node, "JSXFragment")) {
+      didContainJsxElement = true;
+    }
     let componentName: string | null = null;
     if (
       (isNodeOfType(node, "ImportSpecifier") ||
@@ -534,14 +544,23 @@ export const collectTextWrapperComponents = (
     }
     if (!componentName || !isReactComponentName(componentName)) return;
     componentBindingCounts.set(componentName, (componentBindingCounts.get(componentName) ?? 0) + 1);
+    if (isNodeOfType(node, "VariableDeclarator") && node.init) {
+      componentDeclarations.push({ componentName, definitionNode: node.init });
+    } else if (
+      isNodeOfType(node, "FunctionDeclaration") ||
+      isNodeOfType(node, "ClassDeclaration")
+    ) {
+      componentDeclarations.push({ componentName, definitionNode: node });
+    }
   });
+  if (!didContainJsxElement) return { textWrappers: wrappers, nonTextWrappers };
   const isTextHandlingElement = (elementName: string, contextNode: EsTreeNode): boolean =>
     isTextHandlingRoot(elementName, contextNode) || wrappers.has(elementName);
   const isNonTextHostElement = (elementName: string, contextNode: EsTreeNode): boolean =>
     isNonTextHostRoot(elementName, contextNode) || nonTextWrappers.has(elementName);
 
-  const recordDeclaration = (componentName: string | null, definitionNode: EsTreeNode | null) => {
-    if (componentName && componentBindingCounts.get(componentName) !== 1) return;
+  const recordDeclaration = (componentName: string, definitionNode: EsTreeNode): void => {
+    if (componentBindingCounts.get(componentName) !== 1) return;
     recordWrapperFromDeclaration(
       componentName,
       definitionNode,
@@ -555,18 +574,9 @@ export const collectTextWrapperComponents = (
   while (true) {
     const wrappersSizeBeforePass = wrappers.size;
     const nonTextSizeBeforePass = nonTextWrappers.size;
-    walkAst(programNode, (node) => {
-      if (isNodeOfType(node, "VariableDeclarator")) {
-        const componentName = node.id && isNodeOfType(node.id, "Identifier") ? node.id.name : null;
-        recordDeclaration(componentName, node.init ?? null);
-      } else if (
-        isNodeOfType(node, "FunctionDeclaration") ||
-        isNodeOfType(node, "ClassDeclaration")
-      ) {
-        const componentName = node.id && isNodeOfType(node.id, "Identifier") ? node.id.name : null;
-        recordDeclaration(componentName, node);
-      }
-    });
+    for (const declaration of componentDeclarations) {
+      recordDeclaration(declaration.componentName, declaration.definitionNode);
+    }
     if (
       wrappers.size === wrappersSizeBeforePass &&
       nonTextWrappers.size === nonTextSizeBeforePass

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/create-program-gated-visitors.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/create-program-gated-visitors.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+import { parseFixture } from "../../test-utils/parse-fixture.js";
+import { createProgramGatedVisitors } from "./create-program-gated-visitors.js";
+
+const programNode = parseFixture("").program;
+
+describe("createProgramGatedVisitors", () => {
+  it("registers active selectors before traversal while suppressing an ineligible file", () => {
+    const identifierVisitor = vi.fn();
+    const visitors = createProgramGatedVisitors({
+      createVisitors: () => ({ Identifier: identifierVisitor }),
+      shouldAnalyzeProgram: () => false,
+    });
+
+    expect(Object.keys(visitors)).toEqual(["Identifier", "Program"]);
+    visitors.Program?.(programNode);
+    visitors.Identifier?.({ type: "Identifier", name: "value" });
+    expect(identifierVisitor).not.toHaveBeenCalled();
+  });
+
+  it("forwards active visitors after the program gate passes", () => {
+    const programVisitor = vi.fn();
+    const identifierVisitor = vi.fn();
+    const visitors = createProgramGatedVisitors({
+      createVisitors: () => ({ Program: programVisitor, Identifier: identifierVisitor }),
+      shouldAnalyzeProgram: () => true,
+    });
+
+    visitors.Program?.(programNode);
+    visitors.Identifier?.({ type: "Identifier", name: "value" });
+    expect(programVisitor).toHaveBeenCalledOnce();
+    expect(identifierVisitor).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/create-program-gated-visitors.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/create-program-gated-visitors.ts
@@ -1,0 +1,30 @@
+import type { EsTreeNodeOfType } from "./es-tree-node-of-type.js";
+import type { RuleVisitors } from "./rule-visitors.js";
+
+interface CreateProgramGatedVisitorsInput {
+  readonly createVisitors: () => RuleVisitors;
+  readonly shouldAnalyzeProgram: (programNode: EsTreeNodeOfType<"Program">) => boolean;
+}
+
+export const createProgramGatedVisitors = ({
+  createVisitors,
+  shouldAnalyzeProgram,
+}: CreateProgramGatedVisitorsInput): RuleVisitors => {
+  const activeVisitors = createVisitors();
+  const gatedVisitors: RuleVisitors = {};
+  let shouldAnalyzeFile = false;
+
+  for (const [selector, visitor] of Object.entries(activeVisitors)) {
+    gatedVisitors[selector] = (node) => {
+      if (shouldAnalyzeFile) visitor(node);
+    };
+  }
+
+  const programVisitor = activeVisitors.Program;
+  gatedVisitors.Program = (programNode: EsTreeNodeOfType<"Program">) => {
+    shouldAnalyzeFile = shouldAnalyzeProgram(programNode);
+    if (shouldAnalyzeFile && programVisitor) programVisitor(programNode);
+  };
+
+  return gatedVisitors;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/create-remotion-render-evidence-checker.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/create-remotion-render-evidence-checker.ts
@@ -1,4 +1,5 @@
 import { createRemotionCompositionOwnershipAnalyzer } from "./create-remotion-composition-ownership-analyzer.js";
+import type { ScopeAnalysis } from "../semantic/scope-analysis.js";
 import type { EsTreeNode } from "./es-tree-node.js";
 import { findJsxAttribute } from "./find-jsx-attribute.js";
 import { findProgramRoot } from "./find-program-root.js";
@@ -35,14 +36,50 @@ export interface RemotionRenderEvidenceChecker {
   functionHasEvidence: (functionNode: EsTreeNode) => boolean;
 }
 
+interface RemotionRenderEvidenceState {
+  readonly evidenceByFunction: WeakMap<object, boolean>;
+  readonly inspectedPrograms: WeakSet<object>;
+  readonly isOwnedByRegisteredComposition: (functionNode: EsTreeNode) => boolean;
+  readonly registeredCompositionFunctions: WeakSet<object>;
+}
+
+const REMOTION_RENDER_EVIDENCE_STATES = new WeakMap<
+  ScopeAnalysis,
+  WeakMap<object, Map<string, RemotionRenderEvidenceState>>
+>();
+
 export const createRemotionRenderEvidenceChecker = (
   context: RuleContext,
 ): RemotionRenderEvidenceChecker => {
   const scopes = context.scopes;
-  const evidenceByFunction = new WeakMap<object, boolean>();
-  const registeredCompositionFunctions = new WeakSet<object>();
-  const inspectedPrograms = new WeakSet<object>();
-  const isOwnedByRegisteredComposition = createRemotionCompositionOwnershipAnalyzer(context);
+  let statesBySettings = REMOTION_RENDER_EVIDENCE_STATES.get(scopes);
+  if (!statesBySettings) {
+    statesBySettings = new WeakMap();
+    REMOTION_RENDER_EVIDENCE_STATES.set(scopes, statesBySettings);
+  }
+  const settingsKey = context.settings ?? scopes;
+  let statesByFilename = statesBySettings.get(settingsKey);
+  if (!statesByFilename) {
+    statesByFilename = new Map();
+    statesBySettings.set(settingsKey, statesByFilename);
+  }
+  const filename = context.filename ?? "";
+  let state = statesByFilename.get(filename);
+  if (!state) {
+    state = {
+      evidenceByFunction: new WeakMap(),
+      registeredCompositionFunctions: new WeakSet(),
+      inspectedPrograms: new WeakSet(),
+      isOwnedByRegisteredComposition: createRemotionCompositionOwnershipAnalyzer(context),
+    };
+    statesByFilename.set(filename, state);
+  }
+  const {
+    evidenceByFunction,
+    inspectedPrograms,
+    isOwnedByRegisteredComposition,
+    registeredCompositionFunctions,
+  } = state;
 
   const collectRegisteredCompositionFunctions = (functionNode: EsTreeNode): void => {
     const program = findProgramRoot(functionNode);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/find-render-phase-component-or-hook.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/find-render-phase-component-or-hook.ts
@@ -4,15 +4,35 @@ import { executesDuringRender } from "./executes-during-render.js";
 import { findEnclosingFunction } from "./find-enclosing-function.js";
 import type { EsTreeNode } from "./es-tree-node.js";
 
+const RENDER_PHASE_OWNER_CACHE = new WeakMap<
+  ScopeAnalysis,
+  WeakMap<EsTreeNode, EsTreeNode | null>
+>();
+
 export const findRenderPhaseComponentOrHook = (
   node: EsTreeNode,
   scopes: ScopeAnalysis,
 ): EsTreeNode | null => {
   let functionNode = findEnclosingFunction(node);
+  const cacheKey = functionNode ?? node;
+  let ownersByNode = RENDER_PHASE_OWNER_CACHE.get(scopes);
+  if (!ownersByNode) {
+    ownersByNode = new WeakMap();
+    RENDER_PHASE_OWNER_CACHE.set(scopes, ownersByNode);
+  }
+  const cachedOwner = ownersByNode.get(cacheKey);
+  if (cachedOwner !== undefined) return cachedOwner;
   while (functionNode) {
-    if (componentOrHookDisplayNameForFunction(functionNode)) return functionNode;
-    if (!executesDuringRender(functionNode, scopes)) return null;
+    if (componentOrHookDisplayNameForFunction(functionNode)) {
+      ownersByNode.set(cacheKey, functionNode);
+      return functionNode;
+    }
+    if (!executesDuringRender(functionNode, scopes)) {
+      ownersByNode.set(cacheKey, null);
+      return null;
+    }
     functionNode = findEnclosingFunction(functionNode);
   }
+  ownersByNode.set(cacheKey, null);
   return null;
 };


### PR DESCRIPTION
## Why

Default scans paid the full AST and semantic-analysis cost for framework-specific and multi-pass rules even when their prerequisite imports or syntax were absent. A paired local stress run measured a 3,504 ms base median and a 3,094 ms candidate median, with identical diagnostics.

## What changed

- gate Next.js, React Three Fiber, and Valtio visitors behind program-level evidence
- share scope-owned caches and add cheap exits before expensive analyses
- collapse repeated React Native text-wrapper scans into one program pass
- preserve ESM, CommonJS, and TypeScript import-equals compatibility
- add scale, host, and regression coverage plus a patch changeset

## Eval results

| Check | Result |
| --- | --- |
| Paired local stress run | 11.7% lower median wall time; 1,200 diagnostics on both revisions |
| Local open-source eval | 100 projects; 99 affected diagnostics on both revisions; no diagnostic delta |
| Strict fuzz | 15 affected targets × 500 iterations passed |
| Remote full parity | 2,000 projects; 1,190,954 diagnostics on both revisions; +0/−0; no skipped projects |
| Remote impacted-rule parity | 2,000 projects; 16,827 diagnostics on both revisions; +0/−0; no skipped projects |
| Full-shadow validation | Scoped and full-shadow-filtered semantic indexes match exactly |

## Test plan

- `nr test`
- `nr lint`
- `nr typecheck`
- `nr format:check`
- `nr smoke:json-report`
- `nr gen:check`
- focused heavy-rule tests and strict fuzz runs
