### PR TITLE
test: stabilize cross-platform CI timing

### DIFF
--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.performance.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.performance.test.ts
@@ -23,21 +23,18 @@ const buildRetainedHandlersSource = (
   return `const Component = () => {\n${handlers}\nreturn <>${buttons}</>;\n};`;
 };
 
-const measureCpuDuration = (
+const measureDuration = (
   handlerCount: number,
   buildRegistration: (handlerIndex: number) => string,
 ): number => {
   const source = buildRetainedHandlersSource(handlerCount, buildRegistration);
-  let totalDuration = 0;
+  const startedAt = process.hrtime.bigint();
   for (let repetition = 0; repetition < MEASUREMENT_REPETITION_COUNT; repetition += 1) {
-    const startedCpuUsage = process.cpuUsage();
     const result = runRule(effectNeedsCleanup, source);
-    const elapsedCpuUsage = process.cpuUsage(startedCpuUsage);
-    totalDuration += elapsedCpuUsage.user + elapsedCpuUsage.system;
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toHaveLength(handlerCount);
   }
-  return totalDuration;
+  return Number(process.hrtime.bigint() - startedAt);
 };
 
 describe("effect-needs-cleanup performance", () => {
@@ -53,15 +50,9 @@ describe("effect-needs-cleanup performance", () => {
     },
   ]) {
     it(`scales near-linearly across retained ${performanceCase.name}`, () => {
-      measureCpuDuration(SMALL_HANDLER_COUNT, performanceCase.buildRegistration);
-      const smallDuration = measureCpuDuration(
-        SMALL_HANDLER_COUNT,
-        performanceCase.buildRegistration,
-      );
-      const largeDuration = measureCpuDuration(
-        LARGE_HANDLER_COUNT,
-        performanceCase.buildRegistration,
-      );
+      measureDuration(SMALL_HANDLER_COUNT, performanceCase.buildRegistration);
+      const smallDuration = measureDuration(SMALL_HANDLER_COUNT, performanceCase.buildRegistration);
+      const largeDuration = measureDuration(LARGE_HANDLER_COUNT, performanceCase.buildRegistration);
       expect(largeDuration).toBeLessThan(smallDuration * MAXIMUM_SCALING_MULTIPLIER);
     });
   }

--- a/packages/react-doctor/tests/regressions/rn-package-scoping.test.ts
+++ b/packages/react-doctor/tests/regressions/rn-package-scoping.test.ts
@@ -53,6 +53,7 @@ const FIXTURES_DIRECTORY = path.resolve(
   "fixtures",
 );
 const MIXED_MONOREPO_FIXTURE = path.join(FIXTURES_DIRECTORY, "mixed-rn-web-monorepo");
+const MIXED_MONOREPO_SCAN_TIMEOUT_MS = 60_000;
 
 const findRnDiagnostics = (diagnostics: Diagnostic[]): Diagnostic[] =>
   diagnostics.filter((diagnostic) => diagnostic.rule.startsWith("rn-"));
@@ -79,7 +80,7 @@ describe("mixed RN + web monorepo: rn-* rules respect package boundaries", () =>
         hasReactNativeWorkspace: true,
       },
     });
-  });
+  }, MIXED_MONOREPO_SCAN_TIMEOUT_MS);
 
   it("fires rn-no-raw-text inside the React Native (Expo) workspace", () => {
     const mobileRnRawText = findDiagnosticsByFile(


### PR DESCRIPTION
## Why

Main CI has two timing flakes:

- `rn-package-scoping.test.ts` performs a real Oxlint scan in `beforeAll`; it exceeded Vitest's default 10-second hook timeout on Ubuntu 22 and Ubuntu 24. The same setup took 11.03 seconds alone and 34.7 seconds under the full local suite.
- `effect-needs-cleanup.performance.test.ts` used `process.cpuUsage()`, which can report zero for a short sample on Windows and make the scaling assertion impossible to satisfy.

## What changed

- Give the real mixed-monorepo scan a bounded 60-second setup timeout.
- Measure the performance ratio with monotonic, high-resolution `process.hrtime.bigint()`.

## Validation

- `nr test`
- `nr lint`
- `nr typecheck`
- `nr format:check`
- `nr smoke:json-report`
- RN regression file: 86 tests passed
- Performance regression: 20 consecutive focused runs passed

No changeset: test-only CI stabilization.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only timeout and timing-measurement changes; no runtime, lint rules, or production behavior affected.
> 
> **Overview**
> Addresses CI flakes in two test files without changing product code.
> 
> In **`rn-package-scoping.test.ts`**, the mixed-monorepo `beforeAll` that runs a full `runOxlint` scan now passes a **60s** hook timeout (`MIXED_MONOREPO_SCAN_TIMEOUT_MS`) so slow Ubuntu CI runners no longer hit Vitest’s default 10s limit.
> 
> In **`effect-needs-cleanup.performance.test.ts`**, the scaling benchmark renames `measureCpuDuration` → **`measureDuration`** and switches from **`process.cpuUsage()`** to **`process.hrtime.bigint()`** so elapsed time is always non-zero on Windows (where CPU usage could read 0 for short samples) while keeping the same near-linear scaling assertion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c06b6673a44ea0a0a21348b908dd123849bf5a2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->