### PR TITLE
fix: exclude setState updater callbacks from zustand-no-fresh-selector-result

### DIFF
--- a/.changeset/fix-zustand-setstate-false-positive.md
+++ b/.changeset/fix-zustand-setstate-false-positive.md
@@ -1,0 +1,9 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Fix false positive in zustand-no-fresh-selector-result for setState updater callbacks
+
+The rule no longer flags callbacks passed to Zustand's imperative store API methods (setState, getState, subscribe, getInitialState). These methods accept updater callbacks or listeners, not selectors, so they should not be subject to the fresh-reference check.
+
+Fixes #1575

--- a/.changeset/fix-zustand-setstate-false-positive.md
+++ b/.changeset/fix-zustand-setstate-false-positive.md
@@ -2,8 +2,4 @@
 "oxlint-plugin-react-doctor": patch
 ---
 
-Fix false positive in zustand-no-fresh-selector-result for setState updater callbacks
-
-The rule no longer flags callbacks passed to Zustand's imperative store API methods (setState, getState, subscribe, getInitialState). These methods accept updater callbacks or listeners, not selectors, so they should not be subject to the fresh-reference check.
-
-Fixes #1575
+Avoid reporting callbacks passed to destructured Zustand imperative store methods as fresh-reference selectors.

--- a/packages/fuzz/corpus/regressions/zustand-no-fresh-selector-result--setstate-updater.tsx
+++ b/packages/fuzz/corpus/regressions/zustand-no-fresh-selector-result--setstate-updater.tsx
@@ -1,17 +1,23 @@
+// rule: zustand-no-fresh-selector-result
+// verdict: pass
+// weakness: alias-guard
+// source: millionco/react-doctor#1575
+
 import { create } from "zustand";
 
 interface GuidedTourStore {
-  guidedTours: Record<string, any>;
+  guidedTours: Record<string, boolean>;
 }
 
-const useGuidedTourStore = create<GuidedTourStore>((set) => ({
+const useGuidedTourStore = create<GuidedTourStore>(() => ({
   guidedTours: {},
 }));
 
-const { setState } = useGuidedTourStore;
+const { setState: updateGuidedTourStore } = useGuidedTourStore;
+const updateGuidedTourStoreAlias = updateGuidedTourStore;
 
-setState((state) => ({
-  guidedTours: { ...state.guidedTours, foo: "bar" },
+updateGuidedTourStoreAlias((state) => ({
+  guidedTours: { ...state.guidedTours, foo: true },
 }));
 
 const setMenuState = useGuidedTourStore.setState;
@@ -19,11 +25,9 @@ setMenuState((state) => ({
   guidedTours: state.guidedTours,
 }));
 
-setState(
+updateGuidedTourStore(
   (state) =>
-    state.guidedTours["test"]
-      ? {}
-      : { guidedTours: { ...state.guidedTours, test: true } },
+    state.guidedTours["test"] ? {} : { guidedTours: { ...state.guidedTours, test: true } },
   false,
   "addGuidedTour",
 );

--- a/packages/fuzz/corpus/regressions/zustand-no-fresh-selector-result--setstate-updater.tsx
+++ b/packages/fuzz/corpus/regressions/zustand-no-fresh-selector-result--setstate-updater.tsx
@@ -1,0 +1,29 @@
+import { create } from "zustand";
+
+interface GuidedTourStore {
+  guidedTours: Record<string, any>;
+}
+
+const useGuidedTourStore = create<GuidedTourStore>((set) => ({
+  guidedTours: {},
+}));
+
+const { setState } = useGuidedTourStore;
+
+setState((state) => ({
+  guidedTours: { ...state.guidedTours, foo: "bar" },
+}));
+
+const setMenuState = useGuidedTourStore.setState;
+setMenuState((state) => ({
+  guidedTours: state.guidedTours,
+}));
+
+setState(
+  (state) =>
+    state.guidedTours["test"]
+      ? {}
+      : { guidedTours: { ...state.guidedTours, test: true } },
+  false,
+  "addGuidedTour",
+);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-fresh-selector-result.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-fresh-selector-result.test.ts
@@ -474,15 +474,17 @@ describe("zustand-no-fresh-selector-result", () => {
     );
   });
 
-  it("does not flag setState updater callbacks from destructuring", () => {
+  it("does not flag imperative API callbacks from destructuring or alias chains", () => {
     expectDiagnosticCount(
       `
         import { create } from "zustand";
-        const useGuidedTourStore = create((set) => ({ guidedTours: {}, setState: set }));
-        const { setState } = useGuidedTourStore;
-        setState((state) => ({
+        const useGuidedTourStore = create(() => ({ guidedTours: {} }));
+        const { setState: updateStore, subscribe: listenToStore } = useGuidedTourStore;
+        const updateStoreAlias = updateStore;
+        updateStoreAlias((state) => ({
           guidedTours: { ...state.guidedTours, foo: "bar" },
         }));
+        listenToStore((state) => ({ guidedTours: state.guidedTours }));
       `,
       0,
     );
@@ -492,7 +494,7 @@ describe("zustand-no-fresh-selector-result", () => {
     expectDiagnosticCount(
       `
         import { create } from "zustand";
-        const useGuidedTourStore = create((set) => ({ guidedTours: {}, setState: set }));
+        const useGuidedTourStore = create(() => ({ guidedTours: {} }));
         const setMenuState = useGuidedTourStore.setState;
         setMenuState((state) => ({ guidedTours: state.guidedTours }));
       `,
@@ -500,28 +502,16 @@ describe("zustand-no-fresh-selector-result", () => {
     );
   });
 
-  it("does not flag getState, subscribe, or getInitialState calls", () => {
+  it("still flags bound stores named like imperative API methods", () => {
     expectDiagnosticCount(
       `
         import { create } from "zustand";
-        const useStore = create(() => ({ count: 0, items: [] }));
-        const { getState, subscribe, getInitialState } = useStore;
-        const currentState = getState();
-        const unsub = subscribe((state) => ({ derived: state.items.map(x => x.id) }));
-        const initial = getInitialState();
+        const setState = create(() => ({ count: 0 }));
+        const subscribe = create(() => ({ items: [] }));
+        const summary = setState((state) => ({ count: state.count }));
+        const items = subscribe((state) => [...state.items]);
       `,
-      0,
-    );
-  });
-
-  it("still flags legitimate selectors that return fresh objects", () => {
-    expectDiagnosticCount(
-      `
-        import { create } from "zustand";
-        const useStore = create(() => ({ count: 0, items: [] }));
-        const summary = useStore((state) => ({ count: state.count, items: state.items }));
-      `,
-      1,
+      2,
     );
   });
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-fresh-selector-result.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-fresh-selector-result.test.ts
@@ -473,4 +473,74 @@ describe("zustand-no-fresh-selector-result", () => {
       2,
     );
   });
+
+  it("does not flag setState updater callbacks from destructuring", () => {
+    expectDiagnosticCount(
+      `
+        import { create } from "zustand";
+        const useGuidedTourStore = create((set) => ({ guidedTours: {}, setState: set }));
+        const { setState } = useGuidedTourStore;
+        setState((state) => ({
+          guidedTours: { ...state.guidedTours, foo: "bar" },
+        }));
+      `,
+      0,
+    );
+  });
+
+  it("does not flag setState updater callbacks from property access", () => {
+    expectDiagnosticCount(
+      `
+        import { create } from "zustand";
+        const useGuidedTourStore = create((set) => ({ guidedTours: {}, setState: set }));
+        const setMenuState = useGuidedTourStore.setState;
+        setMenuState((state) => ({ guidedTours: state.guidedTours }));
+      `,
+      0,
+    );
+  });
+
+  it("does not flag getState, subscribe, or getInitialState calls", () => {
+    expectDiagnosticCount(
+      `
+        import { create } from "zustand";
+        const useStore = create(() => ({ count: 0, items: [] }));
+        const { getState, subscribe, getInitialState } = useStore;
+        const currentState = getState();
+        const unsub = subscribe((state) => ({ derived: state.items.map(x => x.id) }));
+        const initial = getInitialState();
+      `,
+      0,
+    );
+  });
+
+  it("still flags legitimate selectors that return fresh objects", () => {
+    expectDiagnosticCount(
+      `
+        import { create } from "zustand";
+        const useStore = create(() => ({ count: 0, items: [] }));
+        const summary = useStore((state) => ({ count: state.count, items: state.items }));
+      `,
+      1,
+    );
+  });
+
+  it("does not flag setState with devtools arguments", () => {
+    expectDiagnosticCount(
+      `
+        import { create } from "zustand";
+        const useStore = create(() => ({ filters: [] }));
+        const { setState } = useStore;
+        setState(
+          (state) =>
+            state.filters.includes(value)
+              ? {}
+              : { filters: [...state.filters, value] },
+          false,
+          "addFilter",
+        );
+      `,
+      0,
+    );
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-fresh-selector-result.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-fresh-selector-result.ts
@@ -3,6 +3,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { functionReturnsCollectionAtPath } from "../../utils/function-returns-collection-at-path.js";
+import { getDestructuredBindingPropertyName } from "../../utils/get-destructured-binding-property-name.js";
 import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
@@ -122,6 +123,8 @@ const resolveZustandStoreCreation = (
   };
 };
 
+const ZUSTAND_STORE_API_METHODS = new Set(["setState", "getState", "subscribe", "getInitialState"]);
+
 const resolveZustandBoundStore = (
   expression: EsTreeNode,
   scopes: ScopeAnalysis,
@@ -134,7 +137,10 @@ const resolveZustandBoundStore = (
     symbol?.kind !== "const" ||
     !symbol.initializer ||
     visitedSymbolIds.has(symbol.id) ||
-    symbol.references.some((reference) => reference.flag !== "read")
+    symbol.references.some((reference) => reference.flag !== "read") ||
+    ZUSTAND_STORE_API_METHODS.has(
+      getDestructuredBindingPropertyName(symbol.bindingIdentifier) ?? "",
+    )
   ) {
     return null;
   }
@@ -144,8 +150,6 @@ const resolveZustandBoundStore = (
     resolveZustandBoundStore(symbol.initializer, scopes, visitedSymbolIds)
   );
 };
-
-const ZUSTAND_STORE_API_METHODS = new Set(["setState", "getState", "subscribe", "getInitialState"]);
 
 const getZustandSelectorCall = (
   callExpression: EsTreeNodeOfType<"CallExpression">,
@@ -162,11 +166,6 @@ const getZustandSelectorCall = (
       return null;
     }
     return { selector, storeCreatorFunction: null };
-  }
-
-  const callee = stripParenExpression(callExpression.callee);
-  if (isNodeOfType(callee, "Identifier") && ZUSTAND_STORE_API_METHODS.has(callee.name)) {
-    return null;
   }
 
   const boundStore = resolveZustandBoundStore(callExpression.callee, scopes);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-fresh-selector-result.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/zustand-no-fresh-selector-result.ts
@@ -145,6 +145,8 @@ const resolveZustandBoundStore = (
   );
 };
 
+const ZUSTAND_STORE_API_METHODS = new Set(["setState", "getState", "subscribe", "getInitialState"]);
+
 const getZustandSelectorCall = (
   callExpression: EsTreeNodeOfType<"CallExpression">,
   scopes: ScopeAnalysis,
@@ -160,6 +162,11 @@ const getZustandSelectorCall = (
       return null;
     }
     return { selector, storeCreatorFunction: null };
+  }
+
+  const callee = stripParenExpression(callExpression.callee);
+  if (isNodeOfType(callee, "Identifier") && ZUSTAND_STORE_API_METHODS.has(callee.name)) {
+    return null;
   }
 
   const boundStore = resolveZustandBoundStore(callExpression.callee, scopes);


### PR DESCRIPTION
## Why

Zustand bound stores expose imperative APIs such as `setState` and `subscribe`. When those methods were destructured, the rule followed the source store binding and treated their callbacks as selectors, producing false positives.

Before:

```tsx
const { setState } = useStore;
setState((state) => ({ count: state.count + 1 }));
```

After: callbacks reached through verified imperative API bindings stay quiet, while a real bound store still reports fresh selector results even if its local name happens to be `setState` or `subscribe`.

Fixes #1575.

## What changed

- Resolve destructured imperative methods by binding and property identity instead of callee text.
- Preserve diagnostics for legitimate bound store hooks with API-like local names.
- Cover renamed destructuring, alias chains, property access, and devtools arguments.
- Add a verdict-preserving fuzz regression and a patch changeset.

## Eval results

| Check | Result |
| --- | --- |
| Project roots scanned | `100` |
| Repositories scanned | `12` |
| Target-rule diagnostics | `0` |
| Scan errors | `0` |
| False positives | `0` |
| Artifact | `react-doctor-evals/.evals/-home-aidenybai--codex-worktrees-ef9c-react-doctor.jsonl` |

## Test plan

- `nr test`
- `nr typecheck`
- `nr lint`
- `nr format:check`
- `nr smoke:json-report`
- `FUZZ_RULE=zustand-no-fresh-selector-result FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz`
