### PR TITLE
fix(cli): isolate interactive React runtime

### DIFF
--- a/.changeset/fix-isolated-ink-runtime.md
+++ b/.changeset/fix-isolated-ink-runtime.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Bundle the interactive Ink renderer with its own React runtime so scans cannot load a missing or incompatible React version from the inspected project.

--- a/packages/react-doctor/package.json
+++ b/packages/react-doctor/package.json
@@ -65,21 +65,18 @@
     "deslop-js": "workspace:*",
     "eslint-plugin-react-hooks": "^7.1.1",
     "figures": "^6.1.0",
-    "ink": "^7.1.0",
-    "ink-spinner": "^5.0.0",
     "jiti": "^2.7.0",
     "magicast": "^0.5.3",
     "oxc-resolver": "^11.24.2",
     "oxlint": ">=1.76.0 <1.77.0",
     "oxlint-plugin-react-doctor": "workspace:*",
     "prompts": "^2.4.2",
-    "react": "19.2.5",
-    "terminal-link": "^5.0.0",
     "typescript": ">=5.0.4 <6",
     "vscode-languageserver": "^9.0.1",
     "vscode-languageserver-textdocument": "^1.0.12",
     "vscode-uri": "^3.1.0",
-    "yaml": "^2.9.0"
+    "yaml": "^2.9.0",
+    "yoga-layout": "~3.2.1"
   },
   "devDependencies": {
     "@react-doctor/api": "workspace:*",
@@ -90,8 +87,12 @@
     "@types/react": "^19.2.14",
     "@xterm/headless": "^6.0.0",
     "commander": "^14.0.3",
+    "ink": "^7.1.0",
+    "ink-spinner": "^5.0.0",
     "ink-testing-library": "^4.0.0",
-    "ora": "^9.4.0"
+    "ora": "^9.4.0",
+    "react": "19.2.5",
+    "react-devtools-core": "^7.0.1"
   },
   "engines": {
     "node": "^20.19.0 || >=22.13.0"

--- a/packages/react-doctor/src/cli/ink/components/tui-link.tsx
+++ b/packages/react-doctor/src/cli/ink/components/tui-link.tsx
@@ -1,14 +1,18 @@
 import { Text, Transform } from "ink";
 import type { ReactNode } from "react";
-import terminalLink from "terminal-link";
+import { formatHyperlink } from "../../utils/format-hyperlink.js";
+import { supportsHyperlinks } from "../../utils/supports-hyperlinks.js";
 
 export interface TuiLinkProps {
   readonly children: ReactNode;
   readonly url: string;
 }
 
-export const TuiLink = ({ children, url }: TuiLinkProps) => (
-  <Transform transform={(text) => terminalLink(text, url, { fallback: false })}>
-    <Text>{children}</Text>
-  </Transform>
-);
+export const TuiLink = ({ children, url }: TuiLinkProps) => {
+  const shouldFormatHyperlink = supportsHyperlinks();
+  return (
+    <Transform transform={(text) => (shouldFormatHyperlink ? formatHyperlink(text, url) : text)}>
+      <Text>{children}</Text>
+    </Transform>
+  );
+};

--- a/packages/react-doctor/src/cli/ink/react-runtime.ts
+++ b/packages/react-doctor/src/cli/ink/react-runtime.ts
@@ -1,7 +1,1 @@
-import { createRequire } from "node:module";
-import type * as React from "react";
-
-const requireFromInk = createRequire(createRequire(import.meta.url).resolve("ink"));
-const inkReact: typeof React = requireFromInk("react");
-
-export const { useEffect, useMemo, useRef, useState, useSyncExternalStore } = inkReact;
+export { useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";

--- a/packages/react-doctor/tests/ink/tui-link.test.tsx
+++ b/packages/react-doctor/tests/ink/tui-link.test.tsx
@@ -1,13 +1,27 @@
 import { render } from "ink-testing-library";
-import { describe, expect, it } from "vite-plus/test";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import { TuiLink } from "../../src/cli/ink/components/tui-link.js";
 
 describe("TuiLink", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it("preserves readable link text when hyperlinks are unavailable", () => {
     const url = "https://react.doctor/docs/rules/example";
     const { lastFrame, unmount } = render(<TuiLink url={url}>Rule guide: {url}</TuiLink>);
 
     expect(lastFrame()).toBe(`Rule guide: ${url}`);
+    unmount();
+  });
+
+  it("renders a terminal hyperlink when hyperlinks are available", () => {
+    vi.stubEnv("FORCE_HYPERLINK", "1");
+    const url = "https://react.doctor";
+    const { lastFrame, unmount } = render(<TuiLink url={url}>React Doctor</TuiLink>);
+
+    expect(lastFrame()).toContain(`]8;;${url}`);
+    expect(lastFrame()).toContain("React Doctor");
     unmount();
   });
 });

--- a/packages/react-doctor/vite.config.ts
+++ b/packages/react-doctor/vite.config.ts
@@ -63,17 +63,26 @@ export default defineConfig({
     {
       entry: { cli: "./src/cli/index.ts" },
       deps: {
-        // Inline pure-JS CLI deps so `npm i react-doctor` skips
-        // ~15 transitive installs (commander, ora, and ora's spinner
-        // / cursor / log-symbols / string-width chain). Native
-        // (oxlint), the lint plugin, prompts (we monkey-patch it via
-        // require so the runtime copy must be on disk), agent-install
-        // (its jsonc-parser/yaml/toml transitives ship as UMD that
-        // doesn't bundle cleanly), and the typescript compiler all
-        // stay external.
+        // Inline pure-JS CLI deps and the Ink/React renderer so the inspected
+        // project cannot supply a missing or incompatible React peer. Native
+        // dependencies, Yoga's WASM module, prompts (we monkey-patch it via
+        // require), agent-install (its config parsers ship as UMD), and the
+        // TypeScript compiler stay external.
         // `yaml` (pure JS, no native deps) backs the `ci config` in-place
         // workflow editor; inline it so end users get no extra install.
-        alwaysBundle: ["commander", "ora", "yaml"],
+        alwaysBundle: [
+          "commander",
+          "ink",
+          "ink-spinner",
+          "ora",
+          "react",
+          "react-devtools-core",
+          "react/jsx-runtime",
+          "react/jsx-dev-runtime",
+          "react-reconciler",
+          "scheduler",
+          "yaml",
+        ],
         neverBundle: [
           "@astrojs/compiler",
           // Sentry bundles its own OpenTelemetry instrumentation chain
@@ -117,16 +126,7 @@ export default defineConfig({
           "oxlint-plugin-react-doctor",
           "prompts",
           "typescript",
-          // The interactive Ink report (lazy-loaded for `experimental-tui`).
-          // Ink pulls `yoga-layout` (a wasm module) and React resolves
-          // `react/jsx-runtime` via the automatic JSX transform — both break
-          // when inlined, so keep them external and let Node resolve them from
-          // node_modules on install.
-          "ink",
-          "ink-spinner",
-          "react",
-          "react/jsx-runtime",
-          "react/jsx-dev-runtime",
+          "yoga-layout",
         ],
       },
       dts: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -285,12 +285,6 @@ importers:
       figures:
         specifier: ^6.1.0
         version: 6.1.0
-      ink:
-        specifier: ^7.1.0
-        version: 7.1.0(@types/react@19.2.14)(react@19.2.5)
-      ink-spinner:
-        specifier: ^5.0.0
-        version: 5.0.0(ink@7.1.0(@types/react@19.2.14)(react@19.2.5))(react@19.2.5)
       jiti:
         specifier: ^2.7.0
         version: 2.7.0
@@ -309,12 +303,6 @@ importers:
       prompts:
         specifier: ^2.4.2
         version: 2.4.2
-      react:
-        specifier: 19.2.5
-        version: 19.2.5
-      terminal-link:
-        specifier: ^5.0.0
-        version: 5.0.0
       typescript:
         specifier: '>=5.0.4 <6'
         version: 5.9.3
@@ -330,6 +318,9 @@ importers:
       yaml:
         specifier: ^2.9.0
         version: 2.9.0
+      yoga-layout:
+        specifier: ~3.2.1
+        version: 3.2.1
     devDependencies:
       '@react-doctor/api':
         specifier: workspace:*
@@ -355,12 +346,24 @@ importers:
       commander:
         specifier: ^14.0.3
         version: 14.0.3
+      ink:
+        specifier: ^7.1.0
+        version: 7.1.0(@types/react@19.2.14)(react-devtools-core@7.0.1)(react@19.2.5)
+      ink-spinner:
+        specifier: ^5.0.0
+        version: 5.0.0(ink@7.1.0(@types/react@19.2.14)(react-devtools-core@7.0.1)(react@19.2.5))(react@19.2.5)
       ink-testing-library:
         specifier: ^4.0.0
         version: 4.0.0(@types/react@19.2.14)
       ora:
         specifier: ^9.4.0
         version: 9.4.0
+      react:
+        specifier: 19.2.5
+        version: 19.2.5
+      react-devtools-core:
+        specifier: ^7.0.1
+        version: 7.0.1
 
   packages/vscode-react-doctor:
     dependencies:
@@ -3319,10 +3322,6 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
-  has-flag@5.0.1:
-    resolution: {integrity: sha512-CsNUt5x9LUdx6hnk/E2SZLsDyvfqANZSUq4+D3D8RzDJ2M+HDTIkF60ibS1vHaK55vzgiZw1bEPFG9yH7l33wA==}
-    engines: {node: '>=12'}
-
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
@@ -3982,6 +3981,9 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
+  react-devtools-core@7.0.1:
+    resolution: {integrity: sha512-C3yNvRHaizlpiASzy7b9vbnBGLrhvdhl1CbdU6EnZgxPNbai60szdLtl+VL76UNOt5bOoVTOz5rNWZxgGt+Gsw==}
+
   react-reconciler@0.33.0:
     resolution: {integrity: sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA==}
     engines: {node: '>=0.10.0'}
@@ -4177,17 +4179,9 @@ packages:
   stubborn-utils@1.0.2:
     resolution: {integrity: sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==}
 
-  supports-color@10.2.2:
-    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
-    engines: {node: '>=18'}
-
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
-
-  supports-hyperlinks@4.5.0:
-    resolution: {integrity: sha512-ZW2OvfeCXrNTbLakPUzjQG922EeGCOteFSVoek5DKStTh898wf7zgtuFlzQN8HfZCxC3Eh02yJVrRW51hADf+w==}
-    engines: {node: '>=20'}
 
   tagged-tag@1.0.0:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
@@ -4200,10 +4194,6 @@ packages:
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
-
-  terminal-link@5.0.0:
-    resolution: {integrity: sha512-qFAy10MTMwjzjU8U16YS4YoZD+NQLHzLssFMNqgravjbvIPNiqkGFR4yjhJfmY9R5OFU7+yHxc6y+uGHkKwLRA==}
-    engines: {node: '>=20'}
 
   terminal-size@4.0.1:
     resolution: {integrity: sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ==}
@@ -4457,6 +4447,18 @@ packages:
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
+
+  ws@7.5.13:
+    resolution: {integrity: sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==}
+    engines: {node: '>=8.3.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   ws@8.20.0:
     resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
@@ -7244,8 +7246,6 @@ snapshots:
 
   has-flag@4.0.0: {}
 
-  has-flag@5.0.1: {}
-
   has-symbols@1.1.0: {}
 
   has-tostringtag@1.0.2:
@@ -7303,17 +7303,17 @@ snapshots:
 
   ini@7.0.0: {}
 
-  ink-spinner@5.0.0(ink@7.1.0(@types/react@19.2.14)(react@19.2.5))(react@19.2.5):
+  ink-spinner@5.0.0(ink@7.1.0(@types/react@19.2.14)(react-devtools-core@7.0.1)(react@19.2.5))(react@19.2.5):
     dependencies:
       cli-spinners: 2.9.2
-      ink: 7.1.0(@types/react@19.2.14)(react@19.2.5)
+      ink: 7.1.0(@types/react@19.2.14)(react-devtools-core@7.0.1)(react@19.2.5)
       react: 19.2.5
 
   ink-testing-library@4.0.0(@types/react@19.2.14):
     optionalDependencies:
       '@types/react': 19.2.14
 
-  ink@7.1.0(@types/react@19.2.14)(react@19.2.5):
+  ink@7.1.0(@types/react@19.2.14)(react-devtools-core@7.0.1)(react@19.2.5):
     dependencies:
       '@alcalzone/ansi-tokenize': 0.3.0
       ansi-escapes: 7.3.0
@@ -7343,6 +7343,7 @@ snapshots:
       yoga-layout: 3.2.1
     optionalDependencies:
       '@types/react': 19.2.14
+      react-devtools-core: 7.0.1
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -7922,6 +7923,14 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
+  react-devtools-core@7.0.1:
+    dependencies:
+      shell-quote: 1.10.0
+      ws: 7.5.13
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   react-reconciler@0.33.0(react@19.2.5):
     dependencies:
       react: 19.2.5
@@ -8122,16 +8131,9 @@ snapshots:
 
   stubborn-utils@1.0.2: {}
 
-  supports-color@10.2.2: {}
-
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
-
-  supports-hyperlinks@4.5.0:
-    dependencies:
-      has-flag: 5.0.1
-      supports-color: 10.2.2
 
   tagged-tag@1.0.0: {}
 
@@ -8144,11 +8146,6 @@ snapshots:
       yallist: 5.0.0
 
   term-size@2.2.1: {}
-
-  terminal-link@5.0.0:
-    dependencies:
-      ansi-escapes: 7.3.0
-      supports-hyperlinks: 4.5.0
 
   terminal-size@4.0.1: {}
 
@@ -8437,6 +8434,8 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+
+  ws@7.5.13: {}
 
   ws@8.20.0: {}
 

--- a/scripts/smoke-packed-cli-install.ts
+++ b/scripts/smoke-packed-cli-install.ts
@@ -25,6 +25,11 @@ const FORBIDDEN_INSTALLED_PACKAGES: readonly string[] = [
   "ini",
   "effect",
   "@effect/platform-node-shared",
+  "ink",
+  "ink-link",
+  "ink-spinner",
+  "react-devtools-core",
+  "react-reconciler",
 ];
 const COMMAND_OUTPUT_MAX_BYTES = 50 * 1024 * 1024;
 
@@ -109,7 +114,15 @@ const main = (): void => {
     fs.mkdirSync(installDirectory);
     fs.writeFileSync(
       path.join(installDirectory, "package.json"),
-      `${JSON.stringify({ name: "react-doctor-packed-cli-smoke", private: true }, null, 2)}\n`,
+      `${JSON.stringify(
+        {
+          name: "react-doctor-packed-cli-smoke",
+          private: true,
+          dependencies: { react: "18.3.1" },
+        },
+        null,
+        2,
+      )}\n`,
     );
 
     // Pack the CLI together with its unbundled workspace dependencies:
@@ -206,6 +219,17 @@ const main = (): void => {
       console.error("Installed CLI did not produce a schema-valid JsonReport.");
       console.error("stdout:", scanResult.stdout.slice(0, 2_000));
       console.error("cause:", cause);
+      process.exit(1);
+    }
+
+    const defaultScanResult = runCommand({
+      command: process.execPath,
+      args: [binaryPath, FIXTURE_DIRECTORY, "--no-score", "--no-dead-code", "--blocking", "none"],
+      cwd: installDirectory,
+    });
+    if (!defaultScanResult.stdout.includes("React Doctor")) {
+      console.error("Installed CLI did not render the default report.");
+      console.error("stdout:", defaultScanResult.stdout.slice(0, 2_000));
       process.exit(1);
     }
 

--- a/scripts/smoke-packed-cli-install.ts
+++ b/scripts/smoke-packed-cli-install.ts
@@ -222,15 +222,16 @@ const main = (): void => {
       process.exit(1);
     }
 
-    const defaultScanResult = runCommand({
-      command: process.execPath,
-      args: [binaryPath, FIXTURE_DIRECTORY, "--no-score", "--no-dead-code", "--blocking", "none"],
-      cwd: installDirectory,
-    });
-    if (!defaultScanResult.stdout.includes("React Doctor")) {
-      console.error("Installed CLI did not render the default report.");
-      console.error("stdout:", defaultScanResult.stdout.slice(0, 2_000));
-      process.exit(1);
+    if (process.platform !== "win32") {
+      runCommand({
+        command: "python3",
+        args: [
+          path.join(REPOSITORY_ROOT, "scripts/smoke-tty-prompt.py"),
+          "--cli-binary",
+          binaryPath,
+        ],
+        cwd: installDirectory,
+      });
     }
 
     console.log(

--- a/scripts/smoke-tty-prompt.py
+++ b/scripts/smoke-tty-prompt.py
@@ -39,7 +39,7 @@ import termios
 import time
 
 REPOSITORY_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-CLI_BINARY_PATH = os.path.join(REPOSITORY_ROOT, "packages", "react-doctor", "dist", "cli.js")
+DEFAULT_CLI_BINARY_PATH = os.path.join(REPOSITORY_ROOT, "packages", "react-doctor", "dist", "cli.js")
 
 # If the prompt is still open this long after the CLI started, the event loop
 # is being held open correctly. The regression self-exits within ~100ms of the
@@ -218,7 +218,7 @@ def read_pty_until(master_fd, process, captured_output, deadline, marker=None):
     return captured_output
 
 
-def run_prompt_in_pty(fixture_directory, delayed_git_directory):
+def run_prompt_in_pty(cli_binary_path, fixture_directory, delayed_git_directory):
     child_environment = {
         key: value
         for key, value in os.environ.items()
@@ -235,7 +235,7 @@ def run_prompt_in_pty(fixture_directory, delayed_git_directory):
         struct.pack("HHHH", TERMINAL_ROWS, TERMINAL_COLUMNS, 0, 0),
     )
     process = subprocess.Popen(
-        [NODE_BINARY_PATH, CLI_BINARY_PATH, fixture_directory, "--no-lint", "--no-dead-code", "--no-score"],
+        [NODE_BINARY_PATH, cli_binary_path, fixture_directory, "--no-lint", "--no-dead-code", "--no-score"],
         stdin=slave_fd,
         stdout=slave_fd,
         stderr=slave_fd,
@@ -285,6 +285,7 @@ def main():
     preparation_mode = parser.add_mutually_exclusive_group()
     preparation_mode.add_argument("--prepare-fixture")
     preparation_mode.add_argument("--prepare-git-wrapper")
+    parser.add_argument("--cli-binary", default=DEFAULT_CLI_BINARY_PATH)
     arguments = parser.parse_args()
     if arguments.prepare_fixture:
         fixture_directory = os.path.abspath(arguments.prepare_fixture)
@@ -297,8 +298,9 @@ def main():
         create_delayed_git_wrapper(fixture_directory, resolve_git_binary())
         return
 
-    if not os.path.isfile(CLI_BINARY_PATH):
-        fail(f"Built CLI missing at {CLI_BINARY_PATH}. Run `pnpm build` first.")
+    cli_binary_path = os.path.abspath(arguments.cli_binary)
+    if not os.path.isfile(cli_binary_path):
+        fail(f"Built CLI missing at {cli_binary_path}. Run `pnpm build` first.")
 
     fixture_directory = tempfile.mkdtemp(prefix="react-doctor-tty-smoke-")
     try:
@@ -306,6 +308,7 @@ def main():
         git_binary_path = initialize_git_repository(fixture_directory)
         delayed_git_directory = create_delayed_git_wrapper(fixture_directory, git_binary_path)
         exited_by_itself, scan_feedback_rendered, output = run_prompt_in_pty(
+            cli_binary_path,
             fixture_directory,
             delayed_git_directory,
         )


### PR DESCRIPTION
## Why

React Doctor 0.9.4 could resolve the Ink renderer through the inspected project package graph. Global pnpm installs and projects with older React versions could therefore fail with missing React packages, invalid hook calls, or missing React 19 exports.

Before: Ink, React, and ink-link remained external and could mix with the target project React runtime.

After: the CLI ships one bundled Ink/React renderer and leaves only the Yoga WASM package external.

## What changed

- bundle the Ink, React, reconciler, scheduler, and renderer support dependencies into the CLI
- replace ink-link with the existing terminal hyperlink utilities
- move bundled renderer packages to development dependencies and retain yoga-layout as the runtime dependency
- exercise the packed default renderer inside a host project pinned to React 18
- assert renderer implementation packages are absent from the installed production dependency tree
- add fallback and supported-terminal hyperlink coverage
- add a patch changeset for react-doctor

## Test plan

- `nr test`
- `nr lint`
- `nr typecheck`
- `nr format:check`
- `nr check:published-deps`
- `nr smoke:packed-cli-install`

RDE is not applicable because this is a CLI packaging/runtime isolation fix and does not change diagnostic rules.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CLI packaging and the interactive renderer dependency graph, which can affect installs and TUI behavior across environments, though risk is mitigated by expanded smoke tests and keeping only yoga-layout external.
> 
> **Overview**
> Fixes failures when the scanned project’s package graph supplied a missing or incompatible React for the experimental Ink TUI (e.g. global pnpm installs or React 18 hosts).
> 
> **Bundling:** The Vite pack step now inlines `ink`, `ink-spinner`, `react`, JSX runtimes, `react-reconciler`, `scheduler`, and `react-devtools-core`, while **`yoga-layout` stays external** (WASM). Those renderer packages move to **devDependencies**; runtime deps drop `terminal-link` and add `yoga-layout`. `react-runtime.ts` no longer loads React via Ink’s `node_modules`—it re-exports hooks from the bundled `react`.
> 
> **TUI links:** `TuiLink` drops `terminal-link` in favor of existing `formatHyperlink` / `supportsHyperlinks`, with a test for OSC 8 output when `FORCE_HYPERLINK=1`.
> 
> **Smoke coverage:** Packed-install smoke installs into a host pinned to **React 18.3.1**, asserts Ink/React implementation packages are absent from production `node_modules`, and on non-Windows runs the PTY prompt smoke against the **packed** CLI via `--cli-binary`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad13a3c149c9dd8de9aff15e2d281848262c6ee1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->