### PR TITLE
fix(cli): keep interactive scans in Ink

### DIFF
--- a/.changeset/keep-interactive-scans-in-ink.md
+++ b/.changeset/keep-interactive-scans-in-ink.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Keep interactive scans in the Ink dashboard when using scoped scans, verbose output, diagnostic dumps, debug mode, and deprecated compatibility flags.

--- a/packages/react-doctor/src/cli/commands/scan.ts
+++ b/packages/react-doctor/src/cli/commands/scan.ts
@@ -7,7 +7,10 @@ import type { InspectFlags } from "../utils/inspect-flags.js";
 import { isNonInteractiveEnvironment } from "../utils/is-non-interactive-environment.js";
 import { recordCount } from "../utils/record-metric.js";
 import { resolveCliInspectOptions } from "../utils/resolve-cli-inspect-options.js";
+import { warnDeprecatedDiff } from "../utils/resolve-scope.js";
 import { shouldUseTui } from "../utils/should-use-tui.js";
+import { validateModeFlags } from "../utils/validate-mode-flags.js";
+import { warnDeprecatedFailOn } from "../utils/warn-deprecated-fail-on.js";
 
 export interface RunScanCommandInput {
   readonly directory: string;
@@ -35,10 +38,9 @@ export const runScanCommand = async (input: RunScanCommandInput): Promise<void> 
 
   await runProjectMigrations(path.resolve(input.directory));
   const scanTarget = await resolveScanTarget(input.directory, { allowAmbiguous: true });
-  if (!shouldUseTui({ ...tuiEnvironment, userConfig: scanTarget.userConfig })) {
-    await inspectAction(input.directory, input.flags, input.invocationCommand);
-    return;
-  }
+  validateModeFlags(input.flags);
+  warnDeprecatedFailOn(input.flags, scanTarget.userConfig);
+  warnDeprecatedDiff(input.flags, scanTarget.userConfig);
   recordCount(METRIC.cliInvoked, 1, { command: input.invocationCommand });
   const { runScanApp } = await import("../ink/run-scan-app.js");
   const { shouldFail } = await runScanApp({
@@ -47,7 +49,8 @@ export const runScanCommand = async (input: RunScanCommandInput): Promise<void> 
     options: resolveCliInspectOptions(input.flags, null),
     projectFlag: input.flags.project,
     skipPrompts: input.flags.yes ?? false,
-    blocking: input.flags.blocking,
+    blocking: input.flags.blocking ?? input.flags.failOn,
+    flags: input.flags,
   });
   if (shouldFail) process.exitCode = 1;
 };

--- a/packages/react-doctor/src/cli/ink/run-scan-app.tsx
+++ b/packages/react-doctor/src/cli/ink/run-scan-app.tsx
@@ -433,6 +433,7 @@ interface ScanExecutionContext {
 interface CompletedTuiScan {
   readonly scans: ReadonlyArray<SurfaceFilterableScan>;
   readonly diagnostics: ReadonlyArray<Diagnostic>;
+  readonly diagnosticsAreGateExempt?: boolean;
   readonly scoreResult: ScoreResult | null;
   readonly projectName: string;
   readonly scannedFileCount: number;
@@ -491,7 +492,11 @@ const runMountedScan = async (
     }
     await executePendingActions();
     return {
-      shouldFail: shouldFailScanGate({ scans: completedScan.scans, blockingLevel }),
+      shouldFail: shouldFailScanGate({
+        scans: completedScan.scans,
+        blockingLevel,
+        diagnosticsAreGateExempt: completedScan.diagnosticsAreGateExempt,
+      }),
     };
   } catch (error) {
     mountedRenderer.dispose();
@@ -567,6 +572,7 @@ const runSingleProjectScan = async (
     return {
       scans: [{ result, config: projectScan.config }],
       diagnostics: reportSelection.diagnostics,
+      diagnosticsAreGateExempt: scopePlan.baselineIntended && result.baselineDelta === undefined,
       scoreResult: result.score,
       projectName: result.project.projectName,
       scannedFileCount: result.scannedFileCount ?? 0,
@@ -608,16 +614,18 @@ const runMultiProjectScan = async (
     return { shouldFail: false };
   }
   const projectCount = projectScans.length;
-  const rootProjectScan = projectScans.find(
-    ({ projectScan }) => path.resolve(projectScan.directory) === path.resolve(rootDirectory),
-  )?.projectScan;
+  const rootProjectScan = discoveredProjectScans.find(
+    (projectScan) => path.resolve(projectScan.directory) === path.resolve(rootDirectory),
+  );
   const workspaceDeadCodeOwner = resolveWorkspaceDeadCodeOwner({
     rootDirectory,
-    projectDirectories: projectScans.map(({ projectScan }) => projectScan.directory),
+    projectDirectories: discoveredProjectScans.map((projectScan) => projectScan.directory),
     isRootDeadCodeEnabled: input.options?.deadCode ?? rootProjectScan?.config?.deadCode ?? true,
   });
   if (workspaceDeadCodeOwner !== null) {
-    recordCount(METRIC.scanWorkspaceDeadCodeShared, 1, { projectCount });
+    recordCount(METRIC.scanWorkspaceDeadCodeShared, 1, {
+      projectCount: discoveredProjectScans.length,
+    });
   }
   const presentation = resolveScanPresentation(
     input,
@@ -680,8 +688,7 @@ const runMultiProjectScan = async (
             }),
           },
           concurrentScan: true,
-          excludedProjectDirectories: projectScans
-            .map(({ projectScan: candidateProjectScan }) => candidateProjectScan)
+          excludedProjectDirectories: discoveredProjectScans
             .filter((candidateProjectScan) =>
               isPathInsideDirectory(candidateProjectScan.directory, projectScan.directory),
             )
@@ -800,6 +807,11 @@ const runMultiProjectScan = async (
     return {
       scans: results,
       diagnostics: combinedDiagnostics,
+      diagnosticsAreGateExempt:
+        scopePlan.baselineIntended &&
+        (skippedProjects.length > 0 ||
+          results.length === 0 ||
+          results.some(({ result }) => result.baselineDelta === undefined)),
       scoreResult: summary.aggregateScore,
       projectName: summary.projectName,
       scannedFileCount,

--- a/packages/react-doctor/src/cli/ink/run-scan-app.tsx
+++ b/packages/react-doctor/src/cli/ink/run-scan-app.tsx
@@ -26,6 +26,7 @@ import { createInvocationInspect } from "../../inspect.js";
 import type { ReactDoctorInspectOptions } from "../../inspect.js";
 import { buildNoScoreMessage } from "../utils/build-no-score-message.js";
 import { hasIncompleteScoreAnalysis } from "../utils/has-incomplete-score-analysis.js";
+import type { InspectFlags } from "../utils/inspect-flags.js";
 import { registerActiveTuiRenderer } from "../utils/active-tui-renderer.js";
 import { buildEmptyReportMessage } from "../utils/build-empty-report-message.js";
 import { computeProjectedScore } from "../utils/compute-score-projection.js";
@@ -36,7 +37,7 @@ import { discoverWorkspacePackages, selectProjects } from "../utils/select-proje
 import { isCiEnvironment } from "../utils/is-ci-environment.js";
 import { formatElapsedTime } from "../utils/render-diagnostics.js";
 import { pluralize } from "../utils/pluralize.js";
-import { printFooter } from "../utils/render-summary.js";
+import { printDiagnosticsDump, printFooter } from "../utils/render-summary.js";
 import { toForwardSlashes } from "../utils/path-format.js";
 import { detectLaunchableAgents } from "../utils/detect-launchable-agents.js";
 import { CLI_AGENT_BINARIES, launchCliAgent } from "../utils/launch-agent.js";
@@ -55,7 +56,9 @@ import {
 import { isShareOptedOut } from "../utils/is-share-opted-out.js";
 import { resolveCliInspectOptions } from "../utils/resolve-cli-inspect-options.js";
 import { resolveBlockingLevel } from "../utils/resolve-blocking-level.js";
+import { resolveProjectTuiScanScope } from "../utils/resolve-project-tui-scan-scope.js";
 import { resolveProjectScan, type ResolvedProjectScan } from "../utils/resolve-project-scan.js";
+import { resolveTuiScanScope, type TuiScanScopePlan } from "../utils/resolve-tui-scan-scope.js";
 import { selectReportDiagnostics } from "../utils/select-report-diagnostics.js";
 import { shouldFailScanGate } from "../utils/should-fail-scan-gate.js";
 import { ProjectSelect } from "./components/project-select.js";
@@ -71,6 +74,7 @@ import type {
 
 export interface RunScanAppInput {
   readonly directory: string;
+  readonly flags?: InspectFlags;
   readonly scanTarget?: ResolvedScanTarget;
   readonly options?: ReactDoctorInspectOptions;
   readonly projectFlag?: string;
@@ -88,7 +92,9 @@ interface ScanPresentation {
   readonly isOffline: boolean;
   readonly initialProgress: string;
   readonly noScoreMessage: string;
+  readonly outputDirectory?: string;
   readonly shouldRecommendCi: boolean;
+  readonly verbose: boolean;
 }
 
 interface CompletedProjectScanOutcome {
@@ -133,9 +139,11 @@ const resolveScanPresentation = (
       isShareOptedOut(projectScans, input.options?.noScore),
     initialProgress: projectScans.length > 1 ? "Indexing workspace files…" : "Scanning project…",
     noScoreMessage: buildNoScoreMessage({ isScoreDisabled }),
+    outputDirectory: input.options?.outputDirectory,
     shouldRecommendCi:
       projectScans.length > 1 ||
       projectScans.some((projectScan) => isCiUnconfigured(projectScan.directory)),
+    verbose: input.options?.verbose === true,
   };
 };
 
@@ -459,6 +467,15 @@ const runMountedScan = async (
     mountedRenderer = mountRenderer("report");
     await mountedRenderer.instance.waitUntilExit();
     mountedRenderer.dispose();
+    if (presentation.outputDirectory !== undefined || presentation.verbose) {
+      await Effect.runPromise(
+        printDiagnosticsDump(
+          [...completedScan.diagnostics],
+          presentation.outputDirectory,
+          presentation.verbose,
+        ),
+      );
+    }
     if (!pendingActions.didQuit) {
       await printExitFooter({
         diagnostics: completedScan.diagnostics,
@@ -486,14 +503,28 @@ const runSingleProjectScan = async (
   rootScanTarget: ResolvedScanTarget,
   projectDirectory: string,
   input: RunScanAppInput,
+  scopePlan: TuiScanScopePlan,
   blockingLevel: BlockingLevel,
   inspectProject: ReturnType<typeof createInvocationInspect>,
 ): Promise<RunScanAppResult> => {
   const projectScan = await resolveProjectScan(rootScanTarget, projectDirectory);
+  const isSupplyChainEnabled =
+    input.options?.supplyChain ?? projectScan.config?.supplyChain?.enabled ?? true;
+  const scopeOptions = resolveProjectTuiScanScope({
+    plan: scopePlan,
+    projectDirectory: projectScan.directory,
+    rootDirectory: rootScanTarget.resolvedDirectory,
+    supplyChainEnabled: isSupplyChainEnabled,
+  });
+  if (scopeOptions === null) {
+    process.stdout.write("No changed source files in the selected project.\n");
+    return { shouldFail: false };
+  }
   const presentation = resolveScanPresentation(input, [projectScan]);
   return runMountedScan(projectScan.directory, presentation, blockingLevel, async (context) => {
     const result = await inspectProject(projectScan.directory, {
       ...resolveTuiInspectOptions(input, projectScan.config),
+      ...scopeOptions,
       isCi: isCiEnvironment(),
       configOverride: projectScan.config,
       configSourceDirectory: projectScan.configSourceDirectory ?? undefined,
@@ -548,31 +579,50 @@ const runMultiProjectScan = async (
   rootScanTarget: ResolvedScanTarget,
   directories: ReadonlyArray<string>,
   input: RunScanAppInput,
+  scopePlan: TuiScanScopePlan,
   blockingLevel: BlockingLevel,
   inspectProject: ReturnType<typeof createInvocationInspect>,
 ): Promise<RunScanAppResult> => {
   const feedbackStartTime = performance.now();
   const rootDirectory = rootScanTarget.resolvedDirectory;
-  const projectScans = deduplicateProjectScans(
+  const discoveredProjectScans = deduplicateProjectScans(
     await mapWithConcurrency(
       [...directories],
       DEFAULT_PROJECT_SCAN_CONCURRENCY,
       (projectDirectory) => resolveProjectScan(rootScanTarget, projectDirectory),
     ),
   );
+  const projectScans = discoveredProjectScans.flatMap((projectScan) => {
+    const isSupplyChainEnabled =
+      input.options?.supplyChain ?? projectScan.config?.supplyChain?.enabled ?? true;
+    const scopeOptions = resolveProjectTuiScanScope({
+      plan: scopePlan,
+      projectDirectory: projectScan.directory,
+      rootDirectory,
+      supplyChainEnabled: isSupplyChainEnabled,
+    });
+    return scopeOptions === null ? [] : [{ projectScan, scopeOptions }];
+  });
+  if (projectScans.length === 0) {
+    process.stdout.write("No changed source files in the selected projects.\n");
+    return { shouldFail: false };
+  }
   const projectCount = projectScans.length;
   const rootProjectScan = projectScans.find(
-    (projectScan) => path.resolve(projectScan.directory) === path.resolve(rootDirectory),
-  );
+    ({ projectScan }) => path.resolve(projectScan.directory) === path.resolve(rootDirectory),
+  )?.projectScan;
   const workspaceDeadCodeOwner = resolveWorkspaceDeadCodeOwner({
     rootDirectory,
-    projectDirectories: projectScans.map((projectScan) => projectScan.directory),
+    projectDirectories: projectScans.map(({ projectScan }) => projectScan.directory),
     isRootDeadCodeEnabled: input.options?.deadCode ?? rootProjectScan?.config?.deadCode ?? true,
   });
   if (workspaceDeadCodeOwner !== null) {
     recordCount(METRIC.scanWorkspaceDeadCodeShared, 1, { projectCount });
   }
-  const presentation = resolveScanPresentation(input, projectScans);
+  const presentation = resolveScanPresentation(
+    input,
+    projectScans.map(({ projectScan }) => projectScan),
+  );
   return runMountedScan(rootDirectory, presentation, blockingLevel, async (context) => {
     const startTime = performance.now();
     let finishedCount = 0;
@@ -582,14 +632,17 @@ const runMultiProjectScan = async (
     });
     context.store.setProgress(`Scanning ${projectCount} projects…`);
     await yieldToEventLoop();
-    const precomputedSourceFileCounts = await collectProjectSourceFileCounts(
-      rootDirectory,
-      projectScans.map((projectScan) => projectScan.directory),
-    );
+    const precomputedSourceFileCounts =
+      scopePlan.scope === "full"
+        ? await collectProjectSourceFileCounts(
+            rootDirectory,
+            projectScans.map(({ projectScan }) => projectScan.directory),
+          )
+        : null;
     const scanOutcomes = await mapWithConcurrency(
       projectScans,
       DEFAULT_PROJECT_SCAN_CONCURRENCY,
-      async (projectScan) => {
+      async ({ projectScan, scopeOptions }) => {
         if (
           input.options?.deadlineEpochMs !== undefined &&
           remainingDeadlineBudgetMs(input.options.deadlineEpochMs) === 0
@@ -612,12 +665,13 @@ const runMultiProjectScan = async (
         const ownsWorkspaceDeadCode = projectScan.directory === workspaceDeadCodeOwner;
         const result = await inspectProject(projectScan.directory, {
           ...inspectOptions,
+          ...scopeOptions,
           deadCode:
             workspaceDeadCodeOwner === null ? inspectOptions.deadCode : ownsWorkspaceDeadCode,
           isCi: isCiEnvironment(),
           configOverride: projectScan.config,
           configSourceDirectory: projectScan.configSourceDirectory ?? undefined,
-          precomputedSourceFileCount: precomputedSourceFileCounts.get(projectScan.directory),
+          precomputedSourceFileCount: precomputedSourceFileCounts?.get(projectScan.directory),
           uiLayers: {
             reporter: Reporter.layerNoop,
             progress: progressLayerForStore(context.store, {
@@ -627,6 +681,7 @@ const runMultiProjectScan = async (
           },
           concurrentScan: true,
           excludedProjectDirectories: projectScans
+            .map(({ projectScan: candidateProjectScan }) => candidateProjectScan)
             .filter((candidateProjectScan) =>
               isPathInsideDirectory(candidateProjectScan.directory, projectScan.directory),
             )
@@ -757,6 +812,11 @@ export const runScanApp = async (input: RunScanAppInput): Promise<RunScanAppResu
   const scanTarget =
     input.scanTarget ?? (await resolveScanTarget(input.directory, { allowAmbiguous: true }));
   const rootDirectory = scanTarget.resolvedDirectory;
+  const scopePlan = await resolveTuiScanScope({
+    directory: rootDirectory,
+    flags: input.flags ?? {},
+    userConfig: scanTarget.userConfig,
+  });
   const deadlineEpochMs =
     input.options?.deadlineEpochMs ??
     (input.options?.maxDurationMs != null ? Date.now() + input.options.maxDurationMs : undefined);
@@ -784,6 +844,7 @@ export const runScanApp = async (input: RunScanAppInput): Promise<RunScanAppResu
       scanTarget,
       selectedDirectories[0],
       resolvedInput,
+      scopePlan,
       blockingLevel,
       inspectProject,
     );
@@ -792,6 +853,7 @@ export const runScanApp = async (input: RunScanAppInput): Promise<RunScanAppResu
     scanTarget,
     selectedDirectories,
     resolvedInput,
+    scopePlan,
     blockingLevel,
     inspectProject,
   );

--- a/packages/react-doctor/src/cli/utils/resolve-project-tui-scan-scope.ts
+++ b/packages/react-doctor/src/cli/utils/resolve-project-tui-scan-scope.ts
@@ -1,0 +1,87 @@
+import type { ChangedFileLineRanges } from "@react-doctor/core";
+import type { ReactDoctorInspectOptions } from "../../inspect.js";
+import { projectManifestChanged } from "./project-manifest-changed.js";
+import {
+  resolveProjectChangedLineRanges,
+  resolveProjectDiffIncludePaths,
+} from "./resolve-project-diff-include-paths.js";
+import { resolveProjectSourceFilePaths } from "./resolve-project-source-file-paths.js";
+import type { TuiScanScopePlan } from "./resolve-tui-scan-scope.js";
+
+export interface ProjectTuiScanScopeOptions {
+  readonly baseline?: ReactDoctorInspectOptions["baseline"];
+  readonly changedLineRanges?: ReadonlyArray<ChangedFileLineRanges>;
+  readonly includePaths?: string[];
+  readonly supplyChainManifestChanged?: boolean;
+}
+
+export interface ResolveProjectTuiScanScopeInput {
+  readonly plan: TuiScanScopePlan;
+  readonly projectDirectory: string;
+  readonly rootDirectory: string;
+  readonly supplyChainEnabled: boolean;
+}
+
+export const resolveProjectTuiScanScope = (
+  input: ResolveProjectTuiScanScopeInput,
+): ProjectTuiScanScopeOptions | null => {
+  if (input.plan.scope === "full") return {};
+  if (input.plan.diffInfo === null) return null;
+
+  const changedSourceFiles = resolveProjectDiffIncludePaths(
+    input.rootDirectory,
+    input.projectDirectory,
+    input.plan.diffInfo,
+  );
+  const baselineBaseFiles =
+    input.plan.baselineDiffPlan === null
+      ? null
+      : resolveProjectSourceFilePaths(
+          input.rootDirectory,
+          input.projectDirectory,
+          input.plan.baselineDiffPlan.baseFiles,
+        );
+  const baselineHeadFiles =
+    input.plan.baselineDiffPlan === null
+      ? null
+      : resolveProjectSourceFilePaths(
+          input.rootDirectory,
+          input.projectDirectory,
+          input.plan.baselineDiffPlan.headFiles,
+        );
+  const supplyChainManifestChanged =
+    input.supplyChainEnabled &&
+    projectManifestChanged(input.rootDirectory, input.projectDirectory, input.plan.diffInfo);
+  const hasBaselineOnlyFiles = (baselineBaseFiles?.length ?? 0) > 0;
+
+  if (!supplyChainManifestChanged && changedSourceFiles.length === 0 && !hasBaselineOnlyFiles) {
+    return null;
+  }
+
+  const includePaths = [...changedSourceFiles];
+  if (includePaths.length === 0 && hasBaselineOnlyFiles) {
+    includePaths.push(...(baselineBaseFiles ?? []));
+  }
+  if (supplyChainManifestChanged) includePaths.push("package.json");
+
+  return {
+    includePaths,
+    baseline:
+      input.plan.baselineRef !== null && baselineBaseFiles !== null && baselineHeadFiles !== null
+        ? {
+            ref: input.plan.baselineRef,
+            baseFiles: baselineBaseFiles,
+            headFiles: baselineHeadFiles,
+          }
+        : undefined,
+    changedLineRanges:
+      input.plan.scope === "lines" && input.plan.changedLineRanges !== null
+        ? resolveProjectChangedLineRanges(
+            input.rootDirectory,
+            input.projectDirectory,
+            input.plan.changedLineRanges,
+          )
+        : undefined,
+    supplyChainManifestChanged,
+  };
+};

--- a/packages/react-doctor/src/cli/utils/resolve-tui-scan-scope.ts
+++ b/packages/react-doctor/src/cli/utils/resolve-tui-scan-scope.ts
@@ -14,6 +14,7 @@ import { validateIncludeUntrackedScope } from "./validate-mode-flags.js";
 
 export interface TuiScanScopePlan {
   readonly baselineDiffPlan: GitBaselineDiffPlan | null;
+  readonly baselineIntended: boolean;
   readonly baselineRef: string | null;
   readonly changedLineRanges: ReadonlyArray<ChangedFileLineRanges> | null;
   readonly diffInfo: DiffInfo | null;
@@ -75,6 +76,7 @@ export const resolveTuiScanScope = async (
 
   return {
     baselineDiffPlan,
+    baselineIntended: scope === "changed" && diffInfo !== null && !diffInfo.isCurrentChanges,
     baselineRef,
     changedLineRanges,
     diffInfo,

--- a/packages/react-doctor/src/cli/utils/resolve-tui-scan-scope.ts
+++ b/packages/react-doctor/src/cli/utils/resolve-tui-scan-scope.ts
@@ -1,0 +1,83 @@
+import { getBaselineDiffPlan, getChangedLineRanges, getDiffInfo } from "@react-doctor/core";
+import type {
+  ChangedFileLineRanges,
+  DiffInfo,
+  GitBaselineDiffPlan,
+  ReactDoctorConfig,
+  ScopeValue,
+} from "@react-doctor/core";
+import type { InspectFlags } from "./inspect-flags.js";
+import { cliLogger } from "./cli-logger.js";
+import { resolveMergeBaseRef } from "./materialize-baseline-files.js";
+import { finalizeScope, resolveScope } from "./resolve-scope.js";
+import { validateIncludeUntrackedScope } from "./validate-mode-flags.js";
+
+export interface TuiScanScopePlan {
+  readonly baselineDiffPlan: GitBaselineDiffPlan | null;
+  readonly baselineRef: string | null;
+  readonly changedLineRanges: ReadonlyArray<ChangedFileLineRanges> | null;
+  readonly diffInfo: DiffInfo | null;
+  readonly scope: ScopeValue;
+}
+
+export interface ResolveTuiScanScopeInput {
+  readonly directory: string;
+  readonly flags: InspectFlags;
+  readonly userConfig: ReactDoctorConfig | null;
+}
+
+export const resolveTuiScanScope = async (
+  input: ResolveTuiScanScopeInput,
+): Promise<TuiScanScopePlan> => {
+  const requestedScope = resolveScope(input.flags, input.userConfig);
+  const includeUntracked = input.flags.includeUntracked ?? false;
+  validateIncludeUntrackedScope(includeUntracked, requestedScope.scope);
+  const wantsDiff = requestedScope.scope !== undefined && requestedScope.scope !== "full";
+  const diffInfo = wantsDiff
+    ? await getDiffInfo(input.directory, requestedScope.base, includeUntracked)
+    : null;
+  const scope = await finalizeScope({
+    requested: requestedScope,
+    diffInfo,
+    skipPrompts: true,
+    isQuiet: false,
+  });
+  let comparisonBaseRef: string | null = null;
+  if (scope !== "full" && diffInfo !== null && !diffInfo.isCurrentChanges) {
+    if (diffInfo.baseSha !== undefined) {
+      comparisonBaseRef = await resolveMergeBaseRef(input.directory, diffInfo.baseSha);
+    } else if (diffInfo.diffBaseRef !== undefined) {
+      comparisonBaseRef = diffInfo.diffBaseRef;
+    } else {
+      comparisonBaseRef = await resolveMergeBaseRef(input.directory, diffInfo.baseBranch);
+    }
+  }
+  const baselineRef = scope === "changed" ? comparisonBaseRef : null;
+  const baselineDiffPlan =
+    baselineRef === null ? null : await getBaselineDiffPlan(input.directory, baselineRef);
+  const linesBaseRef = diffInfo?.isCurrentChanges ? "HEAD" : comparisonBaseRef;
+  const canComputeChangedLines =
+    scope === "lines" && diffInfo !== null && (diffInfo.isCurrentChanges || linesBaseRef !== null);
+  const changedLineRanges = canComputeChangedLines
+    ? await getChangedLineRanges({
+        directory: input.directory,
+        baseRef: linesBaseRef ?? undefined,
+        files: [...diffInfo.changedFiles],
+        includeUntracked,
+      })
+    : null;
+  if (scope === "lines" && changedLineRanges === null) {
+    cliLogger.warn(
+      "Could not determine changed lines (no base ref or git diff failed); reporting all issues in changed files.",
+    );
+    cliLogger.break();
+  }
+
+  return {
+    baselineDiffPlan,
+    baselineRef,
+    changedLineRanges,
+    diffInfo,
+    scope,
+  };
+};

--- a/packages/react-doctor/src/cli/utils/should-use-tui.ts
+++ b/packages/react-doctor/src/cli/utils/should-use-tui.ts
@@ -1,10 +1,8 @@
-import type { ReactDoctorConfig } from "@react-doctor/core";
 import type { InspectFlags } from "./inspect-flags.js";
 import { TUI_MIN_NODE_MAJOR_VERSION } from "./constants.js";
 
 export interface ShouldUseTuiInput {
   readonly flags: InspectFlags;
-  readonly userConfig?: ReactDoctorConfig | null;
   readonly isNonInteractiveEnvironment: boolean;
   readonly nodeMajorVersion: number;
   readonly stdinIsTty: boolean;
@@ -26,30 +24,12 @@ export const shouldUseTui = (input: ShouldUseTuiInput): boolean => {
   }
 
   const flags = input.flags;
-  let requiresStableConfiguredScope = false;
-  if (input.userConfig?.scope !== undefined) {
-    requiresStableConfiguredScope = input.userConfig.scope !== "full";
-  } else if (input.userConfig?.diff !== undefined) {
-    requiresStableConfiguredScope =
-      input.userConfig.diff !== false && input.userConfig.diff !== "false";
-  } else if (input.userConfig?.base !== undefined) {
-    requiresStableConfiguredScope = true;
-  }
-  const requiresStableRenderer =
-    flags.verbose === true ||
-    flags.outputDir !== undefined ||
+  const requiresHeadlessRenderer =
     flags.score === true ||
     flags.json === true ||
     flags.jsonCompact === true ||
     flags.jsonOut !== undefined ||
     flags.staged === true ||
-    flags.scope !== undefined ||
-    flags.base !== undefined ||
-    flags.includeUntracked === true ||
-    flags.diff !== undefined ||
-    flags.changedFilesFrom !== undefined ||
-    flags.debug === true ||
-    flags.failOn !== undefined ||
-    requiresStableConfiguredScope;
-  return !requiresStableRenderer;
+    flags.changedFilesFrom !== undefined;
+  return !requiresHeadlessRenderer;
 };

--- a/packages/react-doctor/tests/ink/run-scan-app.test.ts
+++ b/packages/react-doctor/tests/ink/run-scan-app.test.ts
@@ -2,8 +2,13 @@ import * as path from "node:path";
 import * as Effect from "effect/Effect";
 import { render } from "ink";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
-import type { InspectResult, ResolvedScanTarget, WorkspacePackage } from "@react-doctor/core";
-import { Reporter, resolveScanTarget } from "@react-doctor/core";
+import type {
+  DiffInfo,
+  InspectResult,
+  ResolvedScanTarget,
+  WorkspacePackage,
+} from "@react-doctor/core";
+import { getBaselineDiffPlan, getDiffInfo, Reporter, resolveScanTarget } from "@react-doctor/core";
 import { runScanApp } from "../../src/cli/ink/run-scan-app.js";
 import type { ScanStore, TuiHandoffRequest } from "../../src/cli/ink/scan-store.js";
 import { clearActiveTuiRenderer } from "../../src/cli/utils/active-tui-renderer.js";
@@ -92,6 +97,8 @@ vi.mock("@react-doctor/core", async (importOriginal) => {
         mapInput: (input: Input) => Promise<Output>,
       ): Promise<Output[]> => Promise.all(inputs.map(mapInput)),
     ),
+    getBaselineDiffPlan: vi.fn(),
+    getDiffInfo: vi.fn(),
   };
 });
 
@@ -380,6 +387,76 @@ describe("runScanApp", () => {
     );
   });
 
+  it("preserves workspace dead-code ownership when a scoped scan skips the root", async () => {
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const rootDirectory = "/repo";
+    const webDirectory = "/repo/apps/web";
+    const diffInfo: DiffInfo = {
+      currentBranch: "feature",
+      baseBranch: "main",
+      changedFiles: ["apps/web/package.json"],
+      isCurrentChanges: true,
+    };
+    vi.mocked(getDiffInfo).mockResolvedValue(diffInfo);
+    mockState.projectDirectories.push(rootDirectory, webDirectory);
+    mockState.scanTargets.set(
+      rootDirectory,
+      buildScanTarget(rootDirectory, rootDirectory, null, rootDirectory),
+    );
+    mockState.scanTargets.set(
+      webDirectory,
+      buildScanTarget(webDirectory, webDirectory, null, webDirectory),
+    );
+    mockState.inspectResults.set(webDirectory, buildInspectResult(webDirectory));
+
+    await runScanApp({
+      directory: rootDirectory,
+      flags: { scope: "files" },
+      skipPrompts: true,
+    });
+
+    expect(inspect).toHaveBeenCalledTimes(1);
+    expect(inspect).toHaveBeenCalledWith(
+      webDirectory,
+      expect.objectContaining({ deadCode: false }),
+    );
+  });
+
+  it("excludes unchanged nested projects from a scoped ancestor scan", async () => {
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const rootDirectory = "/repo";
+    const webDirectory = "/repo/apps/web";
+    const diffInfo: DiffInfo = {
+      currentBranch: "feature",
+      baseBranch: "main",
+      changedFiles: ["src/app.tsx"],
+      isCurrentChanges: true,
+    };
+    vi.mocked(getDiffInfo).mockResolvedValue(diffInfo);
+    mockState.projectDirectories.push(rootDirectory, webDirectory);
+    mockState.scanTargets.set(
+      rootDirectory,
+      buildScanTarget(rootDirectory, rootDirectory, null, rootDirectory),
+    );
+    mockState.scanTargets.set(
+      webDirectory,
+      buildScanTarget(webDirectory, webDirectory, null, webDirectory),
+    );
+    mockState.inspectResults.set(rootDirectory, buildInspectResult(rootDirectory));
+
+    await runScanApp({
+      directory: rootDirectory,
+      flags: { scope: "files" },
+      skipPrompts: true,
+    });
+
+    expect(inspect).toHaveBeenCalledTimes(1);
+    expect(inspect).toHaveBeenCalledWith(
+      rootDirectory,
+      expect.objectContaining({ excludedProjectDirectories: [webDirectory] }),
+    );
+  });
+
   it("scans aliased selections that resolve to one project root once", async () => {
     vi.spyOn(process.stdout, "write").mockImplementation(() => true);
     const rootDirectory = "/repo";
@@ -585,6 +662,37 @@ describe("runScanApp", () => {
       skipPrompts: true,
     });
     expect(surfaceExcludedResult.shouldFail).toBe(false);
+  });
+
+  it("keeps diagnostics advisory when an intended baseline cannot be computed", async () => {
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const rootDirectory = "/repo";
+    const diffInfo: DiffInfo = {
+      currentBranch: "feature",
+      baseBranch: "main",
+      diffBaseRef: "base-commit",
+      changedFiles: ["src/app.tsx"],
+      isCurrentChanges: false,
+    };
+    vi.mocked(getDiffInfo).mockResolvedValue(diffInfo);
+    vi.mocked(getBaselineDiffPlan).mockResolvedValue(null);
+    mockState.projectDirectories.push(rootDirectory);
+    mockState.scanTargets.set(
+      rootDirectory,
+      buildScanTarget(rootDirectory, rootDirectory, null, rootDirectory),
+    );
+    mockState.inspectResults.set(rootDirectory, {
+      ...buildInspectResult(rootDirectory),
+      diagnostics: [buildDiagnostic({ severity: "error" })],
+    });
+
+    const result = await runScanApp({
+      directory: rootDirectory,
+      flags: { scope: "changed" },
+      skipPrompts: true,
+    });
+
+    expect(result.shouldFail).toBe(false);
   });
 
   it("applies the CLI surface and category filter to the TUI report", async () => {

--- a/packages/react-doctor/tests/ink/run-scan-app.test.ts
+++ b/packages/react-doctor/tests/ink/run-scan-app.test.ts
@@ -248,7 +248,7 @@ describe("runScanApp", () => {
 
     try {
       const scanPromise = runScanApp({ directory: rootDirectory });
-      await Promise.resolve();
+      await vi.waitFor(() => expect(render).toHaveBeenCalled());
       const selectionRenderer = vi.mocked(render).mock.results[0]?.value;
 
       clearActiveTuiRenderer();

--- a/packages/react-doctor/tests/resolve-project-tui-scan-scope.test.ts
+++ b/packages/react-doctor/tests/resolve-project-tui-scan-scope.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vite-plus/test";
+import type { DiffInfo, ScopeValue } from "@react-doctor/core";
+import type { TuiScanScopePlan } from "../src/cli/utils/resolve-tui-scan-scope.js";
+import { resolveProjectTuiScanScope } from "../src/cli/utils/resolve-project-tui-scan-scope.js";
+
+const buildDiffInfo = (changedFiles: string[]): DiffInfo => ({
+  currentBranch: "feature",
+  baseBranch: "main",
+  changedFiles,
+  isCurrentChanges: true,
+});
+
+const buildPlan = (
+  scope: ScopeValue,
+  changedFiles: string[] = ["apps/web/src/app.tsx"],
+): TuiScanScopePlan => ({
+  baselineDiffPlan: null,
+  baselineRef: null,
+  changedLineRanges: null,
+  diffInfo: scope === "full" ? null : buildDiffInfo(changedFiles),
+  scope,
+});
+
+describe("resolveProjectTuiScanScope", () => {
+  it("returns no restrictions for full scans", () => {
+    expect(
+      resolveProjectTuiScanScope({
+        plan: buildPlan("full"),
+        projectDirectory: "/repo/apps/web",
+        rootDirectory: "/repo",
+        supplyChainEnabled: true,
+      }),
+    ).toEqual({});
+  });
+
+  it("maps changed files and line ranges into a workspace project", () => {
+    const plan = buildPlan("lines");
+    const scopedPlan: TuiScanScopePlan = {
+      ...plan,
+      changedLineRanges: [{ file: "apps/web/src/app.tsx", ranges: [[3, 5]] }],
+    };
+
+    expect(
+      resolveProjectTuiScanScope({
+        plan: scopedPlan,
+        projectDirectory: "/repo/apps/web",
+        rootDirectory: "/repo",
+        supplyChainEnabled: true,
+      }),
+    ).toEqual({
+      baseline: undefined,
+      changedLineRanges: [{ file: "src/app.tsx", ranges: [[3, 5]] }],
+      includePaths: ["src/app.tsx"],
+      supplyChainManifestChanged: false,
+    });
+  });
+
+  it("keeps a manifest-only project when supply-chain checks are enabled", () => {
+    expect(
+      resolveProjectTuiScanScope({
+        plan: buildPlan("files", ["apps/web/package.json"]),
+        projectDirectory: "/repo/apps/web",
+        rootDirectory: "/repo",
+        supplyChainEnabled: true,
+      }),
+    ).toEqual({
+      baseline: undefined,
+      changedLineRanges: undefined,
+      includePaths: ["package.json"],
+      supplyChainManifestChanged: true,
+    });
+  });
+
+  it("keeps deleted baseline files in changed scope", () => {
+    const plan: TuiScanScopePlan = {
+      ...buildPlan("changed", []),
+      baselineDiffPlan: {
+        baseFiles: ["apps/web/src/deleted.tsx"],
+        headFiles: [],
+        untrackedFiles: [],
+      },
+      baselineRef: "base-commit",
+    };
+
+    expect(
+      resolveProjectTuiScanScope({
+        plan,
+        projectDirectory: "/repo/apps/web",
+        rootDirectory: "/repo",
+        supplyChainEnabled: false,
+      }),
+    ).toEqual({
+      baseline: {
+        ref: "base-commit",
+        baseFiles: ["src/deleted.tsx"],
+        headFiles: [],
+      },
+      changedLineRanges: undefined,
+      includePaths: ["src/deleted.tsx"],
+      supplyChainManifestChanged: false,
+    });
+  });
+
+  it("skips projects without relevant changes", () => {
+    expect(
+      resolveProjectTuiScanScope({
+        plan: buildPlan("files", ["apps/admin/src/app.tsx"]),
+        projectDirectory: "/repo/apps/web",
+        rootDirectory: "/repo",
+        supplyChainEnabled: true,
+      }),
+    ).toBeNull();
+  });
+});

--- a/packages/react-doctor/tests/resolve-tui-scan-scope.test.ts
+++ b/packages/react-doctor/tests/resolve-tui-scan-scope.test.ts
@@ -35,6 +35,7 @@ describe("resolveTuiScanScope", () => {
       resolveTuiScanScope({ directory: "/repo", flags: {}, userConfig: null }),
     ).resolves.toEqual({
       baselineDiffPlan: null,
+      baselineIntended: false,
       baselineRef: null,
       changedLineRanges: null,
       diffInfo: null,
@@ -75,6 +76,7 @@ describe("resolveTuiScanScope", () => {
     expect(getDiffInfo).toHaveBeenCalledWith("/repo", undefined, false);
     expect(resolveMergeBaseRef).not.toHaveBeenCalled();
     expect(getBaselineDiffPlan).toHaveBeenCalledWith("/repo", "base-commit");
+    expect(plan.baselineIntended).toBe(true);
     expect(plan.baselineRef).toBe("base-commit");
     expect(plan.scope).toBe("changed");
   });

--- a/packages/react-doctor/tests/resolve-tui-scan-scope.test.ts
+++ b/packages/react-doctor/tests/resolve-tui-scan-scope.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { getBaselineDiffPlan, getChangedLineRanges, getDiffInfo } from "@react-doctor/core";
+import type { ChangedFileLineRanges, DiffInfo } from "@react-doctor/core";
+import { resolveMergeBaseRef } from "../src/cli/utils/materialize-baseline-files.js";
+import { resolveTuiScanScope } from "../src/cli/utils/resolve-tui-scan-scope.js";
+
+vi.mock("@react-doctor/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@react-doctor/core")>();
+  return {
+    ...actual,
+    getBaselineDiffPlan: vi.fn(),
+    getChangedLineRanges: vi.fn(),
+    getDiffInfo: vi.fn(),
+  };
+});
+
+vi.mock("../src/cli/utils/materialize-baseline-files.js", () => ({
+  resolveMergeBaseRef: vi.fn(),
+}));
+
+const buildDiffInfo = (overrides: Partial<DiffInfo> = {}): DiffInfo => ({
+  currentBranch: "feature",
+  baseBranch: "main",
+  changedFiles: ["src/app.tsx"],
+  ...overrides,
+});
+
+describe("resolveTuiScanScope", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("keeps an unscoped interactive scan full without reading git", async () => {
+    await expect(
+      resolveTuiScanScope({ directory: "/repo", flags: {}, userConfig: null }),
+    ).resolves.toEqual({
+      baselineDiffPlan: null,
+      baselineRef: null,
+      changedLineRanges: null,
+      diffInfo: null,
+      scope: "full",
+    });
+    expect(getDiffInfo).not.toHaveBeenCalled();
+  });
+
+  it("honors a scoped scan from project config", async () => {
+    const diffInfo = buildDiffInfo({ isCurrentChanges: true });
+    vi.mocked(getDiffInfo).mockResolvedValue(diffInfo);
+
+    const plan = await resolveTuiScanScope({
+      directory: "/repo",
+      flags: {},
+      userConfig: { scope: "files" },
+    });
+
+    expect(getDiffInfo).toHaveBeenCalledWith("/repo", undefined, false);
+    expect(plan.scope).toBe("files");
+  });
+
+  it("builds a baseline plan for changed scope", async () => {
+    const diffInfo = buildDiffInfo({ diffBaseRef: "base-commit" });
+    vi.mocked(getDiffInfo).mockResolvedValue(diffInfo);
+    vi.mocked(getBaselineDiffPlan).mockResolvedValue({
+      baseFiles: ["src/app.tsx"],
+      headFiles: ["src/app.tsx"],
+      untrackedFiles: [],
+    });
+
+    const plan = await resolveTuiScanScope({
+      directory: "/repo",
+      flags: { scope: "changed" },
+      userConfig: null,
+    });
+
+    expect(getDiffInfo).toHaveBeenCalledWith("/repo", undefined, false);
+    expect(resolveMergeBaseRef).not.toHaveBeenCalled();
+    expect(getBaselineDiffPlan).toHaveBeenCalledWith("/repo", "base-commit");
+    expect(plan.baselineRef).toBe("base-commit");
+    expect(plan.scope).toBe("changed");
+  });
+
+  it("computes line ranges against HEAD for working tree changes", async () => {
+    const diffInfo = buildDiffInfo({ isCurrentChanges: true });
+    const changedLineRanges: ChangedFileLineRanges[] = [{ file: "src/app.tsx", ranges: [[4, 8]] }];
+    vi.mocked(getDiffInfo).mockResolvedValue(diffInfo);
+    vi.mocked(getChangedLineRanges).mockResolvedValue(changedLineRanges);
+
+    const plan = await resolveTuiScanScope({
+      directory: "/repo",
+      flags: { scope: "lines", includeUntracked: true },
+      userConfig: null,
+    });
+
+    expect(getChangedLineRanges).toHaveBeenCalledWith({
+      directory: "/repo",
+      baseRef: "HEAD",
+      files: ["src/app.tsx"],
+      includeUntracked: true,
+    });
+    expect(plan.changedLineRanges).toEqual(changedLineRanges);
+  });
+});

--- a/packages/react-doctor/tests/run-scan-command.test.ts
+++ b/packages/react-doctor/tests/run-scan-command.test.ts
@@ -29,6 +29,18 @@ vi.mock("../src/cli/utils/should-use-tui.js", () => ({
   shouldUseTui: vi.fn(() => true),
 }));
 
+vi.mock("../src/cli/utils/resolve-scope.js", () => ({
+  warnDeprecatedDiff: vi.fn(),
+}));
+
+vi.mock("../src/cli/utils/validate-mode-flags.js", () => ({
+  validateModeFlags: vi.fn(),
+}));
+
+vi.mock("../src/cli/utils/warn-deprecated-fail-on.js", () => ({
+  warnDeprecatedFailOn: vi.fn(),
+}));
+
 vi.mock("@react-doctor/core", () => ({
   resolveScanTarget: vi.fn(async (directory: string) => ({
     resolvedDirectory: directory,
@@ -47,7 +59,10 @@ import { runProjectMigrations } from "../src/cli/utils/cli-migrations.js";
 import { METRIC } from "../src/cli/utils/constants.js";
 import { recordCount } from "../src/cli/utils/record-metric.js";
 import { resolveCliInspectOptions } from "../src/cli/utils/resolve-cli-inspect-options.js";
+import { warnDeprecatedDiff } from "../src/cli/utils/resolve-scope.js";
 import { shouldUseTui } from "../src/cli/utils/should-use-tui.js";
+import { validateModeFlags } from "../src/cli/utils/validate-mode-flags.js";
+import { warnDeprecatedFailOn } from "../src/cli/utils/warn-deprecated-fail-on.js";
 
 describe("runScanCommand", () => {
   const previousExitCode = process.exitCode;
@@ -67,7 +82,15 @@ describe("runScanCommand", () => {
   });
 
   it("runs the interactive report with the root scan flags", async () => {
-    const flags = { blocking: "warning", project: "app", score: false, yes: true };
+    const flags = {
+      blocking: undefined,
+      diff: false,
+      failOn: "warning",
+      project: "app",
+      score: false,
+      scope: "full",
+      yes: true,
+    };
 
     await runScanCommand({ directory: "/tmp/project", flags, invocationCommand: "inspect" });
 
@@ -85,26 +108,18 @@ describe("runScanCommand", () => {
       projectFlag: "app",
       skipPrompts: true,
       blocking: "warning",
+      flags,
     });
     expect(recordCount).toHaveBeenCalledWith(METRIC.cliInvoked, 1, { command: "inspect" });
     expect(resolveScanTarget).toHaveBeenCalledWith("/tmp/project", { allowAmbiguous: true });
     expect(runProjectMigrations).toHaveBeenCalledWith(path.resolve("/tmp/project"));
+    expect(validateModeFlags).toHaveBeenCalledWith(flags);
+    expect(warnDeprecatedFailOn).toHaveBeenCalledWith(flags, null);
+    expect(warnDeprecatedDiff).toHaveBeenCalledWith(flags, null);
     expect(inspectAction).not.toHaveBeenCalled();
   });
 
-  it("uses the stable renderer when project config requires diff semantics", async () => {
-    vi.mocked(shouldUseTui).mockReturnValueOnce(true).mockReturnValueOnce(false);
-    const flags = {};
-
-    await runScanCommand({ directory: "/tmp/project", flags, invocationCommand: "inspect" });
-
-    expect(runProjectMigrations).toHaveBeenCalledWith(path.resolve("/tmp/project"));
-    expect(inspectAction).toHaveBeenCalledWith("/tmp/project", flags, "inspect");
-    expect(runScanApp).not.toHaveBeenCalled();
-    expect(recordCount).not.toHaveBeenCalled();
-  });
-
-  it("uses the stable renderer when the TUI gate rejects the environment or flags", async () => {
+  it("uses headless output when the TUI gate rejects the environment or flags", async () => {
     vi.mocked(shouldUseTui).mockReturnValue(false);
     const flags = { json: true };
 

--- a/packages/react-doctor/tests/should-use-tui.test.ts
+++ b/packages/react-doctor/tests/should-use-tui.test.ts
@@ -25,41 +25,38 @@ describe("shouldUseTui", () => {
     ["stdin without raw mode", { supportsRawMode: false }],
     ["Node 21", { nodeMajorVersion: 21 }],
     ["dumb terminal", { terminalName: "dumb" }],
-  ])("uses the stable renderer in a %s", (_name, overrides) => {
+  ])("uses headless output in a %s", (_name, overrides) => {
     expect(shouldUseTui(makeInput(overrides))).toBe(false);
   });
 
   it.each([
-    ["verbose output", { verbose: true }],
-    ["diagnostic output directory", { outputDir: "diagnostics" }],
     ["score-only output", { score: true }],
     ["JSON output", { json: true }],
     ["compact JSON output", { jsonCompact: true }],
     ["JSON output file", { jsonOut: "report.json" }],
     ["staged scope", { staged: true }],
-    ["explicit scope", { scope: "changed" }],
-    ["base branch", { base: "main" }],
-    ["untracked files", { includeUntracked: true }],
-    ["deprecated diff scope", { diff: true }],
-    ["deprecated full diff scope", { diff: false }],
     ["changed-file input", { changedFilesFrom: "files.txt" }],
-    ["debug output", { debug: true }],
-    ["deprecated failure gate", { failOn: "warning" }],
-  ])("uses the stable renderer for %s", (_name, flags: InspectFlags) => {
+  ])("uses headless output for %s", (_name, flags: InspectFlags) => {
     expect(shouldUseTui(makeInput({ flags }))).toBe(false);
   });
 
   it("keeps supported scan controls in the TUI", () => {
     const flags: InspectFlags = {
       blocking: "warning",
+      base: "main",
       category: "Security",
       deadCode: false,
+      debug: true,
+      diff: false,
+      failOn: "warning",
       lint: false,
       maxDuration: "30",
+      outputDir: "diagnostics",
       parallel: false,
       project: "app",
       respectInlineDisables: false,
       score: false,
+      scope: "full",
       supplyChain: false,
       telemetry: false,
       warnings: false,
@@ -69,18 +66,19 @@ describe("shouldUseTui", () => {
     expect(shouldUseTui(makeInput({ flags }))).toBe(true);
   });
 
-  it.each([
-    ["changed scope", { scope: "changed" }],
-    ["legacy diff scope", { diff: true }],
-    ["base-driven scope selection", { base: "main" }],
-  ])("uses the stable renderer for config-defined %s", (_name, userConfig) => {
-    expect(shouldUseTui(makeInput({ userConfig }))).toBe(false);
+  it("keeps verbose output in the TUI", () => {
+    expect(shouldUseTui(makeInput({ flags: { verbose: true } }))).toBe(true);
   });
 
-  it.each([[{ scope: "full" }], [{ diff: false }], [{ diff: "false" }]])(
-    "keeps a config-defined full scan in the TUI",
-    (userConfig) => {
-      expect(shouldUseTui(makeInput({ userConfig }))).toBe(true);
-    },
-  );
+  it.each([
+    ["changed scope", { scope: "changed" }],
+    ["untracked files", { scope: "files", includeUntracked: true }],
+    ["deprecated diff scope", { diff: true }],
+  ])("keeps %s in the TUI", (_name, flags: InspectFlags) => {
+    expect(shouldUseTui(makeInput({ flags }))).toBe(true);
+  });
+
+  it("does not let project config change an interactive renderer", () => {
+    expect(shouldUseTui(makeInput())).toBe(true);
+  });
 });


### PR DESCRIPTION
## Why

Interactive scans silently fell back to the removed static renderer whenever users supplied scope, verbose, output-dir, debug, fail-on, or config scope options. Before this change, even `--scope full` could show the old UI. After this change, every supported human-terminal scan stays in the Ink dashboard while machine-readable, CI, staged, and hook-based contracts remain headless.

## What changed

- route supported interactive flags and configured scopes through the Ink dashboard
- preserve files, changed, and lines scope behavior, including baselines, workspace project filtering, changed-line ranges, and manifest supply-chain checks
- preserve verbose output, diagnostic dumps, deprecation warnings, and fail-on compatibility
- add focused routing and scan-plan regression coverage
- add a patch changeset for the CLI behavior fix
- retain the existing `tuiScanInlineShown` telemetry signal; watch interactive adoption and error rate for two releases and revert the widened route if crash rate regresses

## Test plan

- `nr test`
- `nr lint`
- `nr typecheck`
- `nr format:check`
- `nr smoke:json-report`
- `nr test tests/should-use-tui.test.ts tests/run-scan-command.test.ts tests/resolve-tui-scan-scope.test.ts tests/resolve-project-tui-scan-scope.test.ts tests/ink/run-scan-app.test.ts`
- ran the built CLI in a real interactive PTY against a disposable Next.js project with `--scope full --blocking none`; confirmed the Ink dashboard, animated score, issue review, action prompts, and keyboard exit
- ran `npx -y react-doctor@latest --verbose --scope changed` to verify the current published compatibility path

Rule parity was not run because this changes CLI routing and scan planning, not detector behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Reworks interactive CLI routing and git-scoped scan planning in the Ink path; mis-scoping or gate logic could change which projects run and whether scans fail, though headless/CI entry points stay isolated.
> 
> **Overview**
> Interactive terminal scans **no longer bail out to headless `inspect`** when users pass scope, verbose, `--output-dir`, debug, `fail-on`, or config-driven diff/scope options. `shouldUseTui` now only forces headless for machine-readable/CI contracts (JSON, score-only, staged, `changedFilesFrom`); project config no longer overrides the Ink choice.
> 
> The Ink path **plans and applies the same scoped scan semantics** as headless: `resolveTuiScanScope` builds git diff, baseline, and line-range plans; `resolveProjectTuiScanScope` maps them per workspace package (skip unchanged apps, manifest-only supply-chain, deleted baseline files). After the dashboard exits, **verbose and diagnostic dumps** still run via `printDiagnosticsDump`. **Exit gating** treats missing baseline deltas in `changed` scope as advisory (`diagnosticsAreGateExempt`), matching degraded-baseline behavior elsewhere.
> 
> `runScanCommand` runs mode validation and deprecation warnings before Ink, passes full `flags` into `runScanApp`, and maps deprecated `failOn` onto `blocking`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e83b8d5a0beb23d0ed8f7cc8ade35119aaa3f7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->