### PR TITLE
fix(rule): preserve lifecycle synchronization semantics

### DIFF
--- a/.changeset/quiet-react-bench-lifecycle-sync.md
+++ b/.changeset/quiet-react-bench-lifecycle-sync.md
@@ -1,0 +1,6 @@
+---
+"oxlint-plugin-react-doctor": patch
+"eslint-plugin-react-doctor": patch
+---
+
+Preserve resource-lifecycle resets, controlled state fallbacks, and prop-originated synchronization without hiding genuine child-owned state handoffs.

--- a/packages/fuzz/corpus/regressions/effect-needs-cleanup--issue-1558-owned-cleanups.tsx
+++ b/packages/fuzz/corpus/regressions/effect-needs-cleanup--issue-1558-owned-cleanups.tsx
@@ -3,7 +3,7 @@
 // weakness: cleanup-provenance
 // source: issue #1558
 
-import { useEffect } from "react";
+import { useCallback, useEffect, useRef } from "react";
 
 export const Watchdog = ({ AppState, done }) => {
   useEffect(() => {
@@ -35,5 +35,23 @@ export const Tabs = ({ onPress, tabs }) => {
       for (const unsubscribe of unsubscribers) unsubscribe();
     };
   }, [onPress, tabs]);
+  return null;
+};
+
+export const PermissionCard = ({ interactive, requestId, resolved, timeoutMs }) => {
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const stopTimer = useCallback(() => {
+    if (timerRef.current) {
+      clearInterval(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    if (resolved || !interactive) return;
+    timerRef.current = setInterval(() => tick(requestId, timeoutMs), 1000);
+    return () => stopTimer();
+  }, [interactive, requestId, resolved, stopTimer, timeoutMs]);
+
   return null;
 };

--- a/packages/fuzz/corpus/regressions/exhaustive-deps--controlled-state-fallback.tsx
+++ b/packages/fuzz/corpus/regressions/exhaustive-deps--controlled-state-fallback.tsx
@@ -1,0 +1,20 @@
+// verdict: pass
+// rule: exhaustive-deps
+// weakness: unreachable-fresh-fallback
+// source: React Bench RangeSelect
+
+import { useMemo, useState } from "react";
+
+interface RangeSelectProps {
+  defaultValue?: string[];
+  placeholder: string;
+  value?: string[];
+}
+
+export const RangeSelect = ({ defaultValue, placeholder, value }: RangeSelectProps) => {
+  const [internalSelectedOptions] = useState(defaultValue ?? []);
+  const isControlled = value !== undefined;
+  const selectedOptions = (isControlled ? value : internalSelectedOptions) ?? [];
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  return useMemo(() => selectedOptions.join(", ") || placeholder, [selectedOptions, placeholder]);
+};

--- a/packages/fuzz/corpus/regressions/exhaustive-deps--controlled-state-global-generics.tsx
+++ b/packages/fuzz/corpus/regressions/exhaustive-deps--controlled-state-global-generics.tsx
@@ -1,0 +1,30 @@
+// verdict: pass
+// rule: exhaustive-deps
+// weakness: controlled-state-global-generic
+// source: Bugbot PR #1579
+
+import { useCallback, useState } from "react";
+
+interface ArrayRangeSelectProps {
+  onChange: (value: Array<string>) => void;
+  value?: Array<string>;
+}
+
+export const ArrayRangeSelect = ({ onChange, value }: ArrayRangeSelectProps) => {
+  const [internalSelectedOptions] = useState<Array<string>>([]);
+  const isControlled = value !== undefined;
+  const selectedOptions = (isControlled ? value : internalSelectedOptions) ?? [];
+  return useCallback(() => onChange(selectedOptions), [onChange, selectedOptions]);
+};
+
+interface ReadonlyArrayRangeSelectProps {
+  onChange: (value: ReadonlyArray<string>) => void;
+  value?: ReadonlyArray<string>;
+}
+
+export const ReadonlyArrayRangeSelect = ({ onChange, value }: ReadonlyArrayRangeSelectProps) => {
+  const [internalSelectedOptions] = useState<ReadonlyArray<string>>([]);
+  const isControlled = value !== undefined;
+  const selectedOptions = (isControlled ? value : internalSelectedOptions) ?? [];
+  return useCallback(() => onChange(selectedOptions), [onChange, selectedOptions]);
+};

--- a/packages/fuzz/corpus/regressions/no-reset-all-state-on-prop-change--owned-resource-release.tsx
+++ b/packages/fuzz/corpus/regressions/no-reset-all-state-on-prop-change--owned-resource-release.tsx
@@ -1,0 +1,67 @@
+// verdict: pass
+// rule: no-reset-all-state-on-prop-change
+// weakness: resource-lifecycle
+// source: React Bench OpenFlipbook and Glific
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export const GeometryOverlay = ({ nodeId, status }) => {
+  const [phase, setPhase] = useState("idle");
+  const previousRef = useRef({ nodeId, status });
+  const controllerRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    const previous = previousRef.current;
+    const didResourceChange = previous.nodeId !== nodeId || previous.status !== status;
+    if (didResourceChange) {
+      controllerRef.current?.abort();
+      controllerRef.current = null;
+      setPhase("idle");
+    }
+    previousRef.current = { nodeId, status };
+  }, [nodeId, status]);
+
+  return phase;
+};
+
+export const EvaluationList = ({ searchQuery }) => {
+  const [pendingDownloads, setPendingDownloads] = useState<Record<string, boolean>>({});
+  const requestsRef = useRef(new Map<string, AbortController>());
+  const abortAllRequests = () => {
+    requestsRef.current.forEach((controller) => controller.abort());
+    requestsRef.current.clear();
+  };
+
+  useEffect(() => {
+    if (!requestsRef.current.size) return;
+    abortAllRequests();
+    setPendingDownloads({});
+  }, [searchQuery]);
+
+  return Object.keys(pendingDownloads).length;
+};
+
+export const VersionedResource = ({ resourceId }) => {
+  const [phase, setPhase] = useState("idle");
+  const generationRef = useRef(0);
+
+  useEffect(() => {
+    generationRef.current += 1;
+    setPhase("idle");
+  }, [resourceId]);
+
+  return phase;
+};
+
+export const MemoizedCleanupResource = ({ resourceId }) => {
+  const [phase, setPhase] = useState("idle");
+  const controllerRef = useRef<AbortController | null>(null);
+  const abortRequest = useCallback(() => controllerRef.current?.abort(), []);
+
+  useEffect(() => {
+    setPhase("idle");
+    return () => abortRequest();
+  }, [resourceId, abortRequest]);
+
+  return phase;
+};

--- a/packages/fuzz/corpus/regressions/parent-sync--prop-memoizer-echo.tsx
+++ b/packages/fuzz/corpus/regressions/parent-sync--prop-memoizer-echo.tsx
@@ -1,0 +1,29 @@
+// verdict: pass
+// rule: no-pass-data-to-parent, no-pass-live-state-to-parent, no-prop-callback-in-effect
+// weakness: prop-provenance
+// source: React Bench MultiSelectField
+
+import { useEffect, useRef, useState } from "react";
+
+const useDeepCompareMemoize = <Value,>(value: Value): Value => {
+  const valueRef = useRef(value);
+  if (JSON.stringify(valueRef.current) !== JSON.stringify(value)) valueRef.current = value;
+  return valueRef.current;
+};
+
+export const MultiSelectField = ({ values, onPendingChange }) => {
+  const [preValues, setPreValues] = useState([]);
+  const memoizedValues = useDeepCompareMemoize(values);
+  const onPendingChangeRef = useRef(onPendingChange);
+
+  useEffect(() => {
+    onPendingChangeRef.current = onPendingChange;
+  }, [onPendingChange]);
+
+  useEffect(() => {
+    setPreValues(memoizedValues);
+    onPendingChangeRef.current?.(memoizedValues);
+  }, [memoizedValues]);
+
+  return preValues.length;
+};

--- a/packages/fuzz/corpus/regressions/parent-sync--prop-transform-echo.tsx
+++ b/packages/fuzz/corpus/regressions/parent-sync--prop-transform-echo.tsx
@@ -1,0 +1,50 @@
+// verdict: pass
+// rule: no-pass-data-to-parent, no-prop-callback-in-effect
+// weakness: prop-provenance
+// source: React Bench MultiSelectField
+
+import { useEffect, useEffectEvent, useMemo, useState } from "react";
+
+export const SerializedValues = ({ values, onPendingChange }) => {
+  const valuesKey = JSON.stringify(values);
+
+  useEffect(() => {
+    const parsedValues = JSON.parse(valuesKey);
+    onPendingChange?.(parsedValues);
+  }, [valuesKey, onPendingChange]);
+
+  return null;
+};
+
+export const MemoizedValues = ({ values, onPendingChange }) => {
+  const resolvedValues = useMemo(() => values ?? [], [values]);
+  const reportPendingChange = useEffectEvent((nextValues) => {
+    onPendingChange?.(nextValues);
+  });
+
+  useEffect(() => {
+    reportPendingChange(resolvedValues);
+  }, [resolvedValues]);
+
+  return null;
+};
+
+export const OpenLifecycle = ({ values, onPendingChange, onSearch }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [pendingValues, setPendingValues] = useState(values);
+  const [searchValue, setSearchValue] = useState("stale");
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setPendingValues(values);
+    onPendingChange?.(values);
+    setSearchValue("");
+    onSearch?.("");
+  }, [isOpen, values, onPendingChange, onSearch]);
+
+  return (
+    <button onClick={() => setIsOpen(true)}>
+      Open {pendingValues.length + searchValue.length}
+    </button>
+  );
+};

--- a/packages/fuzz/corpus/true-positives/exhaustive-deps--imported-array-shadow.tsx
+++ b/packages/fuzz/corpus/true-positives/exhaustive-deps--imported-array-shadow.tsx
@@ -1,0 +1,19 @@
+// verdict: fail
+// rule: exhaustive-deps
+// weakness: imported-global-type-shadow
+// source: Bugbot PR #1579
+
+import { useCallback, useState } from "react";
+import type { Selection as Array } from "./selection";
+
+interface RangeSelectProps {
+  onChange: (value: Array<string>) => void;
+  value?: Array<string>;
+}
+
+export const RangeSelect = ({ onChange, value }: RangeSelectProps) => {
+  const [internalSelectedOptions] = useState<string[]>([]);
+  const isControlled = value !== undefined;
+  const selectedOptions = (isControlled ? value : internalSelectedOptions) ?? [];
+  return useCallback(() => onChange(selectedOptions), [onChange, selectedOptions]);
+};

--- a/packages/fuzz/tests/fuzz-harness-smoke.test.ts
+++ b/packages/fuzz/tests/fuzz-harness-smoke.test.ts
@@ -21,9 +21,13 @@ const VERDICT_DIRECTIVE_PATTERN = /^\/\/ verdict: (pass|fail)$/m;
 
 describe("fuzz harness oracles", () => {
   it("reads corpus directives from CRLF files", () => {
-    const code = "// rule: example-rule\r\n// verdict: fail\r\n";
+    const code = "// rule: example-rule, second-rule\r\n// verdict: fail\r\n";
 
-    expect(RULE_DIRECTIVE_PATTERN.exec(code)?.[1]).toBe("example-rule");
+    expect(
+      RULE_DIRECTIVE_PATTERN.exec(code)?.[1]
+        ?.split(",")
+        .map((ruleId) => ruleId.trim()),
+    ).toEqual(["example-rule", "second-rule"]);
     expect(VERDICT_DIRECTIVE_PATTERN.exec(code)?.[1]).toBe("fail");
   });
 
@@ -85,29 +89,33 @@ describe("fuzz harness oracles", () => {
     let declaredVerdictCount = 0;
 
     for (const entry of corpus) {
-      const ruleId = RULE_DIRECTIVE_PATTERN.exec(entry.code)?.[1];
+      const ruleIds = RULE_DIRECTIVE_PATTERN.exec(entry.code)?.[1]
+        ?.split(",")
+        .map((ruleId) => ruleId.trim());
       const verdict = VERDICT_DIRECTIVE_PATTERN.exec(entry.code)?.[1];
       if (!verdict) continue;
       declaredVerdictCount += 1;
-      if (!ruleId) {
+      if (!ruleIds?.length) {
         verdictFailures.push(`${entry.relativePath}: missing rule`);
         continue;
       }
-      const rule = rulesById.get(ruleId);
-      if (!rule) {
-        verdictFailures.push(`${entry.relativePath}: unknown rule ${ruleId}`);
-        continue;
-      }
-      const result = runRule(rule, entry.code, {
-        filename: entry.relativePath,
-        settings: livenessFixturesById.get(ruleId)?.settings,
-        forceJsx: true,
-      });
-      const didFire = result.diagnostics.length > 0;
-      if ((verdict === "fail") !== didFire) {
-        verdictFailures.push(
-          `${entry.relativePath}: expected ${verdict}, received ${result.diagnostics.length} diagnostics`,
-        );
+      for (const ruleId of ruleIds) {
+        const rule = rulesById.get(ruleId);
+        if (!rule) {
+          verdictFailures.push(`${entry.relativePath}: unknown rule ${ruleId}`);
+          continue;
+        }
+        const result = runRule(rule, entry.code, {
+          filename: entry.relativePath,
+          settings: livenessFixturesById.get(ruleId)?.settings,
+          forceJsx: true,
+        });
+        const didFire = result.diagnostics.length > 0;
+        if ((verdict === "fail") !== didFire) {
+          verdictFailures.push(
+            `${entry.relativePath} (${ruleId}): expected ${verdict}, received ${result.diagnostics.length} diagnostics`,
+          );
+        }
       }
     }
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.regressions.test.ts
@@ -1611,6 +1611,27 @@ describe("react-builtins/exhaustive-deps — regressions", () => {
       expect(result.diagnostics).toEqual([]);
     });
 
+    it.each(["Array<string>", "ReadonlyArray<string>"])(
+      "accepts a controlled value typed with the global %s generic",
+      (controlledValueType) => {
+        const code = `
+          interface RangeSelectProps {
+            value?: ${controlledValueType};
+            onChange: (value: ${controlledValueType}) => void;
+          }
+          function RangeSelect({ value, onChange }: RangeSelectProps) {
+            const [internalSelectedOptions] = useState<${controlledValueType}>([]);
+            const isControlled = value !== undefined;
+            const selectedOptions = (isControlled ? value : internalSelectedOptions) ?? [];
+            return useCallback(() => onChange(selectedOptions), [selectedOptions, onChange]);
+          }
+        `;
+        const result = runRule(exhaustiveDeps, code);
+        expect(result.parseErrors).toEqual([]);
+        expect(result.diagnostics).toEqual([]);
+      },
+    );
+
     it("still reports a fresh fallback that can be selected", () => {
       const code = `
         function RangeSelect({ value, onChange }) {
@@ -1682,6 +1703,27 @@ describe("react-builtins/exhaustive-deps — regressions", () => {
         expect(messages).toContain("rebuilt every render");
       },
     );
+
+    it("still reports when an imported type shadows the global Array generic", () => {
+      const code = `
+        import type { Selection as Array } from "./selection";
+        interface RangeSelectProps {
+          value?: Array<string>;
+          onChange: (value: Array<string>) => void;
+        }
+        function RangeSelect({ value, onChange }: RangeSelectProps) {
+          const [internalValue] = useState<string[]>([]);
+          const isControlled = value !== undefined;
+          const selectedValue = (isControlled ? value : internalValue) ?? [];
+          return useCallback(() => onChange(selectedValue), [selectedValue, onChange]);
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      const messages = result.diagnostics.map((diagnostic) => diagnostic.message).join("\n");
+      expect(messages).toContain("selectedValue");
+      expect(messages).toContain("rebuilt every render");
+    });
 
     it("still reports a controlled-state fallback when the discriminator is mutable", () => {
       const code = `

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.regressions.test.ts
@@ -1660,6 +1660,29 @@ describe("react-builtins/exhaustive-deps — regressions", () => {
       expect(messages).toContain("rebuilt every render");
     });
 
+    it.each(["React.ReactNode", "ImportedSelection"])(
+      "still reports a controlled-state fallback when %s nullability is unproven",
+      (controlledValueType) => {
+        const code = `
+          interface RangeSelectProps {
+            value?: ${controlledValueType};
+            onChange: (value: ${controlledValueType}) => void;
+          }
+          function RangeSelect({ value, onChange }: RangeSelectProps) {
+            const [internalValue] = useState("");
+            const isControlled = value !== undefined;
+            const selectedValue = (isControlled ? value : internalValue) ?? [];
+            return useCallback(() => onChange(selectedValue), [selectedValue, onChange]);
+          }
+        `;
+        const result = runRule(exhaustiveDeps, code);
+        expect(result.parseErrors).toEqual([]);
+        const messages = result.diagnostics.map((diagnostic) => diagnostic.message).join("\n");
+        expect(messages).toContain("selectedValue");
+        expect(messages).toContain("rebuilt every render");
+      },
+    );
+
     it("still reports a controlled-state fallback when the discriminator is mutable", () => {
       const code = `
         function RangeSelect({ value, forceUncontrolled, onChange }) {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.regressions.test.ts
@@ -1556,6 +1556,112 @@ describe("react-builtins/exhaustive-deps — regressions", () => {
       expect(messages).toContain("rebuilt every render");
     });
 
+    it("accepts an unreachable fresh fallback after controlled-state narrowing", () => {
+      const code = `
+        function RangeSelect({ defaultValue, value, onChange, placeholder }) {
+          const [internalSelectedOptions] = useState(defaultValue ?? []);
+          const isControlled = value !== undefined;
+          const selectedOptions = (isControlled ? value : internalSelectedOptions) ?? [];
+          const handleRangeChange = useCallback(() => {
+            onChange(isControlled ? selectedOptions : [...selectedOptions]);
+          }, [selectedOptions, isControlled, onChange]);
+          const displayText = useMemo(
+            () => selectedOptions.join(", ") || placeholder,
+            [selectedOptions, placeholder],
+          );
+          return [handleRangeChange, displayText];
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it("accepts the controlled value as the non-nullish state initializer", () => {
+      const code = `
+        function RangeSelect({ value, onChange, placeholder }) {
+          const [internalSelectedOptions] = useState(value ?? []);
+          const isControlled = value !== undefined;
+          const selectedOptions = (isControlled ? value : internalSelectedOptions) ?? [];
+          const handleRangeChange = useCallback(
+            () => onChange(selectedOptions),
+            [selectedOptions, onChange],
+          );
+          const displayText = useMemo(
+            () => selectedOptions.join(", ") || placeholder,
+            [selectedOptions, placeholder],
+          );
+          return [handleRangeChange, displayText];
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it("still reports a fresh fallback that can be selected", () => {
+      const code = `
+        function RangeSelect({ value, onChange }) {
+          const selectedOptions = value ?? [];
+          return useCallback(() => onChange(selectedOptions), [selectedOptions, onChange]);
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      const messages = result.diagnostics.map((diagnostic) => diagnostic.message).join("\n");
+      expect(messages).toContain("selectedOptions");
+      expect(messages).toContain("rebuilt every render");
+    });
+
+    it("still reports a controlled-state fallback when uncontrolled state may be nullish", () => {
+      const code = `
+        function RangeSelect({ value, onChange }) {
+          const [internalSelectedOptions] = useState();
+          const isControlled = value !== undefined;
+          const selectedOptions = (isControlled ? value : internalSelectedOptions) ?? [];
+          return useCallback(() => onChange(selectedOptions), [selectedOptions, onChange]);
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      const messages = result.diagnostics.map((diagnostic) => diagnostic.message).join("\n");
+      expect(messages).toContain("selectedOptions");
+      expect(messages).toContain("rebuilt every render");
+    });
+
+    it("still reports a controlled-state fallback when the discriminator is mutable", () => {
+      const code = `
+        function RangeSelect({ value, forceUncontrolled, onChange }) {
+          const [internalSelectedOptions] = useState([]);
+          let isControlled = value !== undefined;
+          isControlled = forceUncontrolled ? false : isControlled;
+          const selectedOptions = (isControlled ? value : internalSelectedOptions) ?? [];
+          return useCallback(() => onChange(selectedOptions), [selectedOptions, onChange]);
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      const messages = result.diagnostics.map((diagnostic) => diagnostic.message).join("\n");
+      expect(messages).toContain("selectedOptions");
+      expect(messages).toContain("rebuilt every render");
+    });
+
+    it("still reports a controlled-state fallback with a lazy nullish state initializer", () => {
+      const code = `
+        function RangeSelect({ value, onChange }) {
+          const [internalSelectedOptions] = useState(() => undefined);
+          const isControlled = value !== undefined;
+          const selectedOptions = (isControlled ? value : internalSelectedOptions) ?? [];
+          return useCallback(() => onChange(selectedOptions), [selectedOptions, onChange]);
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      const messages = result.diagnostics.map((diagnostic) => diagnostic.message).join("\n");
+      expect(messages).toContain("selectedOptions");
+      expect(messages).toContain("rebuilt every render");
+    });
+
     it("still reports an exact derived dependency with a fresh ternary branch as unstable", () => {
       const code = `
         function Cell({ direct, preferDirect }) {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.regressions.test.ts
@@ -1558,7 +1558,13 @@ describe("react-builtins/exhaustive-deps — regressions", () => {
 
     it("accepts an unreachable fresh fallback after controlled-state narrowing", () => {
       const code = `
-        function RangeSelect({ defaultValue, value, onChange, placeholder }) {
+        interface RangeSelectProps {
+          defaultValue?: string[];
+          value?: string[];
+          onChange: (value: string[]) => void;
+          placeholder: string;
+        }
+        function RangeSelect({ defaultValue, value, onChange, placeholder }: RangeSelectProps) {
           const [internalSelectedOptions] = useState(defaultValue ?? []);
           const isControlled = value !== undefined;
           const selectedOptions = (isControlled ? value : internalSelectedOptions) ?? [];
@@ -1579,7 +1585,13 @@ describe("react-builtins/exhaustive-deps — regressions", () => {
 
     it("accepts the controlled value as the non-nullish state initializer", () => {
       const code = `
-        function RangeSelect({ value, onChange, placeholder }) {
+        import React from "react";
+        interface RangeSelectProps {
+          value?: string[];
+          onChange: (value: string[]) => void;
+          placeholder: string;
+        }
+        const RangeSelect: React.FC<RangeSelectProps> = ({ value, onChange, placeholder }) => {
           const [internalSelectedOptions] = useState(value ?? []);
           const isControlled = value !== undefined;
           const selectedOptions = (isControlled ? value : internalSelectedOptions) ?? [];
@@ -1592,7 +1604,7 @@ describe("react-builtins/exhaustive-deps — regressions", () => {
             [selectedOptions, placeholder],
           );
           return [handleRangeChange, displayText];
-        }
+        };
       `;
       const result = runRule(exhaustiveDeps, code);
       expect(result.parseErrors).toEqual([]);
@@ -1617,6 +1629,25 @@ describe("react-builtins/exhaustive-deps — regressions", () => {
       const code = `
         function RangeSelect({ value, onChange }) {
           const [internalSelectedOptions] = useState();
+          const isControlled = value !== undefined;
+          const selectedOptions = (isControlled ? value : internalSelectedOptions) ?? [];
+          return useCallback(() => onChange(selectedOptions), [selectedOptions, onChange]);
+        }
+      `;
+      const result = runRule(exhaustiveDeps, code);
+      expect(result.parseErrors).toEqual([]);
+      const messages = result.diagnostics.map((diagnostic) => diagnostic.message).join("\n");
+      expect(messages).toContain("selectedOptions");
+      expect(messages).toContain("rebuilt every render");
+    });
+
+    it("still reports a controlled-state fallback when the controlled value may be null", () => {
+      const code = `
+        function RangeSelect({ value, onChange }: {
+          value?: string[] | null;
+          onChange: (value: string[]) => void;
+        }) {
+          const [internalSelectedOptions] = useState<string[]>([]);
           const isControlled = value !== undefined;
           const selectedOptions = (isControlled ? value : internalSelectedOptions) ?? [];
           return useCallback(() => onChange(selectedOptions), [selectedOptions, onChange]);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.ts
@@ -10,8 +10,11 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { findForwardedFreshHookDependencies } from "../../utils/find-forwarded-fresh-hook-dependencies.js";
 import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
+import { findSameFileTypeDeclarations } from "../../utils/find-same-file-type-declaration.js";
 import { findTransparentExpressionRoot } from "../../utils/find-transparent-expression-root.js";
+import { getStaticKeyName } from "../../utils/get-static-key-name.js";
 import { getStaticTemplateLiteralValue } from "../../utils/get-static-template-literal-value.js";
+import { getSymbolTypeAnnotation } from "../../utils/get-symbol-type-annotation.js";
 import { isAstNode } from "../../utils/is-ast-node.js";
 import { isReactComponentOrHookName } from "../../utils/is-react-component-or-hook-name.js";
 import { isReactApiCall } from "../../utils/is-react-api-call.js";
@@ -56,6 +59,7 @@ import {
   symbolHasStableValue,
 } from "./exhaustive-deps-symbol-stability.js";
 import { symbolHasReactUseEffectEventOrigin } from "../../utils/symbol-has-react-use-effect-event-origin.js";
+import { symbolHasReactComponentTypeAnnotation } from "../../utils/symbol-has-react-component-type-annotation.js";
 
 // Port of `oxc_linter::rules::react::exhaustive_deps`. Diffs the
 // closure-captured set of an effect / memo callback against its
@@ -955,6 +959,168 @@ const isUndefinedExpression = (node: EsTreeNode, scopes: ScopeAnalysis): boolean
   );
 };
 
+const getComponentPropsType = (
+  symbol: SymbolDescriptor,
+  scopes: ScopeAnalysis,
+): EsTreeNode | null => {
+  const bindingProperty = symbol.bindingIdentifier.parent;
+  const bindingPattern = bindingProperty?.parent;
+  if (isNodeOfType(bindingPattern, "ObjectPattern")) {
+    const annotation = bindingPattern.typeAnnotation;
+    if (annotation && isNodeOfType(annotation, "TSTypeAnnotation")) {
+      return annotation.typeAnnotation;
+    }
+  }
+  const componentFunction = findEnclosingFunction(symbol.bindingIdentifier);
+  if (!componentFunction) return null;
+  const functionRoot = findTransparentExpressionRoot(componentFunction);
+  const declarator = functionRoot.parent;
+  if (
+    !isNodeOfType(declarator, "VariableDeclarator") ||
+    declarator.init !== functionRoot ||
+    !isNodeOfType(declarator.id, "Identifier")
+  ) {
+    return null;
+  }
+  const componentSymbol = scopes.symbolFor(declarator.id);
+  if (!componentSymbol || !symbolHasReactComponentTypeAnnotation(componentSymbol, scopes)) {
+    return null;
+  }
+  const annotation = declarator.id.typeAnnotation;
+  if (!annotation || !isNodeOfType(annotation, "TSTypeAnnotation")) return null;
+  const componentType = annotation.typeAnnotation;
+  return isNodeOfType(componentType, "TSTypeReference")
+    ? (componentType.typeArguments?.params[0] ?? null)
+    : null;
+};
+
+const getNamedPropsPropertyType = (
+  typeNode: EsTreeNode,
+  propertyName: string,
+  referenceNode: EsTreeNode,
+  visitedTypeNames: ReadonlySet<string> = new Set(),
+): EsTreeNode | null => {
+  if (isNodeOfType(typeNode, "TSTypeAnnotation")) {
+    return getNamedPropsPropertyType(
+      typeNode.typeAnnotation,
+      propertyName,
+      referenceNode,
+      visitedTypeNames,
+    );
+  }
+  if (isNodeOfType(typeNode, "TSIntersectionType")) {
+    for (const memberType of typeNode.types) {
+      const propertyType = getNamedPropsPropertyType(
+        memberType,
+        propertyName,
+        referenceNode,
+        visitedTypeNames,
+      );
+      if (propertyType) return propertyType;
+    }
+    return null;
+  }
+  if (isNodeOfType(typeNode, "TSTypeAliasDeclaration")) {
+    return getNamedPropsPropertyType(
+      typeNode.typeAnnotation,
+      propertyName,
+      referenceNode,
+      visitedTypeNames,
+    );
+  }
+  const members = isNodeOfType(typeNode, "TSTypeLiteral")
+    ? typeNode.members
+    : isNodeOfType(typeNode, "TSInterfaceDeclaration")
+      ? typeNode.body.body
+      : null;
+  if (members) {
+    for (const member of members) {
+      if (
+        !isNodeOfType(member, "TSPropertySignature") ||
+        getStaticKeyName(member.key) !== propertyName
+      ) {
+        continue;
+      }
+      return member.typeAnnotation?.typeAnnotation ?? null;
+    }
+    return null;
+  }
+  if (
+    !isNodeOfType(typeNode, "TSTypeReference") ||
+    !isNodeOfType(typeNode.typeName, "Identifier") ||
+    visitedTypeNames.has(typeNode.typeName.name)
+  ) {
+    return null;
+  }
+  const nextVisitedTypeNames = new Set(visitedTypeNames).add(typeNode.typeName.name);
+  for (const declaration of findSameFileTypeDeclarations(referenceNode, typeNode.typeName.name)) {
+    const propertyType = getNamedPropsPropertyType(
+      declaration,
+      propertyName,
+      referenceNode,
+      nextVisitedTypeNames,
+    );
+    if (propertyType) return propertyType;
+  }
+  return null;
+};
+
+const typeExcludesNull = (
+  typeNode: EsTreeNode,
+  referenceNode: EsTreeNode,
+  visitedTypeNames: ReadonlySet<string> = new Set(),
+): boolean => {
+  if (isNodeOfType(typeNode, "TSTypeAnnotation")) {
+    return typeExcludesNull(typeNode.typeAnnotation, referenceNode, visitedTypeNames);
+  }
+  if (
+    isNodeOfType(typeNode, "TSNullKeyword") ||
+    isNodeOfType(typeNode, "TSAnyKeyword") ||
+    isNodeOfType(typeNode, "TSUnknownKeyword")
+  ) {
+    return false;
+  }
+  if (isNodeOfType(typeNode, "TSUnionType")) {
+    return typeNode.types.every((memberType) =>
+      typeExcludesNull(memberType, referenceNode, visitedTypeNames),
+    );
+  }
+  if (
+    !isNodeOfType(typeNode, "TSTypeReference") ||
+    !isNodeOfType(typeNode.typeName, "Identifier")
+  ) {
+    return true;
+  }
+  if (visitedTypeNames.has(typeNode.typeName.name)) return false;
+  const declarations = findSameFileTypeDeclarations(referenceNode, typeNode.typeName.name);
+  if (declarations.length === 0) return true;
+  const nextVisitedTypeNames = new Set(visitedTypeNames).add(typeNode.typeName.name);
+  return declarations.every((declaration) =>
+    isNodeOfType(declaration, "TSTypeAliasDeclaration")
+      ? typeExcludesNull(declaration.typeAnnotation, referenceNode, nextVisitedTypeNames)
+      : true,
+  );
+};
+
+const controlledValueTypeExcludesNull = (
+  controlledValue: EsTreeNode,
+  scopes: ScopeAnalysis,
+): boolean => {
+  const candidate = unwrapExpression(controlledValue);
+  if (!isNodeOfType(candidate, "Identifier")) return false;
+  const symbol = scopes.symbolFor(candidate);
+  if (!symbol) return false;
+  const directType = getSymbolTypeAnnotation(symbol);
+  if (directType) return typeExcludesNull(directType, candidate);
+  const bindingProperty = symbol.bindingIdentifier.parent;
+  if (!isNodeOfType(bindingProperty, "Property")) return false;
+  const propertyName = getStaticKeyName(bindingProperty.key);
+  const propsType = getComponentPropsType(symbol, scopes);
+  if (!propertyName || !propsType) return false;
+  const propertyType = getNamedPropsPropertyType(propsType, propertyName, candidate);
+  return Boolean(propertyType && typeExcludesNull(propertyType, candidate));
+};
+
 const isProvablyNonNullishStateInitializer = (
   node: EsTreeNode,
   scopes: ScopeAnalysis,
@@ -1046,7 +1212,9 @@ const isControlledStateSelection = (node: EsTreeNode, scopes: ScopeAnalysis): bo
   }
   const stateInitializer = getReactStateInitializer(candidate.alternate, scopes);
   return Boolean(
-    stateInitializer && isProvablyNonNullishStateInitializer(stateInitializer, scopes),
+    stateInitializer &&
+    isProvablyNonNullishStateInitializer(stateInitializer, scopes) &&
+    controlledValueTypeExcludesNull(controlledValue, scopes),
   );
 };
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.ts
@@ -10,7 +10,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { findForwardedFreshHookDependencies } from "../../utils/find-forwarded-fresh-hook-dependencies.js";
 import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
-import { hasImportedBinding } from "../../utils/find-import-source-for-name.js";
+import { getImportSourceForName } from "../../utils/find-import-source-for-name.js";
 import { findSameFileTypeDeclarations } from "../../utils/find-same-file-type-declaration.js";
 import { findTransparentExpressionRoot } from "../../utils/find-transparent-expression-root.js";
 import { getStaticKeyName } from "../../utils/get-static-key-name.js";
@@ -1094,7 +1094,7 @@ const typeExcludesNull = (
   const declarations = findSameFileTypeDeclarations(referenceNode, typeNode.typeName.name);
   if (declarations.length === 0) {
     return (
-      !hasImportedBinding(referenceNode, typeNode.typeName.name) &&
+      getImportSourceForName(referenceNode, typeNode.typeName.name) === null &&
       NON_NULLISH_GLOBAL_TYPE_REFERENCES.has(typeNode.typeName.name)
     );
   }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.ts
@@ -1085,20 +1085,16 @@ const typeExcludesNull = (
       typeExcludesNull(memberType, referenceNode, visitedTypeNames),
     );
   }
-  if (
-    !isNodeOfType(typeNode, "TSTypeReference") ||
-    !isNodeOfType(typeNode.typeName, "Identifier")
-  ) {
-    return true;
-  }
+  if (!isNodeOfType(typeNode, "TSTypeReference")) return true;
+  if (!isNodeOfType(typeNode.typeName, "Identifier")) return false;
   if (visitedTypeNames.has(typeNode.typeName.name)) return false;
   const declarations = findSameFileTypeDeclarations(referenceNode, typeNode.typeName.name);
-  if (declarations.length === 0) return true;
+  if (declarations.length === 0) return false;
   const nextVisitedTypeNames = new Set(visitedTypeNames).add(typeNode.typeName.name);
   return declarations.every((declaration) =>
     isNodeOfType(declaration, "TSTypeAliasDeclaration")
       ? typeExcludesNull(declaration.typeAnnotation, referenceNode, nextVisitedTypeNames)
-      : true,
+      : isNodeOfType(declaration, "TSInterfaceDeclaration"),
   );
 };
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.ts
@@ -934,19 +934,143 @@ const isRegExpLiteral = (node: EsTreeNode): boolean => {
   return Boolean((node as { regex?: unknown }).regex);
 };
 
-const isUnstableInitializer = (node: EsTreeNode | null, isNestedInitializer = false): boolean => {
+const isSameSymbol = (left: EsTreeNode, right: EsTreeNode, scopes: ScopeAnalysis): boolean => {
+  const leftCandidate = unwrapExpression(left);
+  const rightCandidate = unwrapExpression(right);
+  if (!isNodeOfType(leftCandidate, "Identifier") || !isNodeOfType(rightCandidate, "Identifier")) {
+    return false;
+  }
+  const leftSymbol = scopes.symbolFor(leftCandidate);
+  const rightSymbol = scopes.symbolFor(rightCandidate);
+  return Boolean(leftSymbol && rightSymbol && leftSymbol.id === rightSymbol.id);
+};
+
+const isUndefinedExpression = (node: EsTreeNode, scopes: ScopeAnalysis): boolean => {
+  const candidate = unwrapExpression(node);
+  return (
+    (isNodeOfType(candidate, "Identifier") &&
+      candidate.name === "undefined" &&
+      scopes.isGlobalReference(candidate)) ||
+    (isNodeOfType(candidate, "UnaryExpression") && candidate.operator === "void")
+  );
+};
+
+const isProvablyNonNullishStateInitializer = (
+  node: EsTreeNode,
+  scopes: ScopeAnalysis,
+  visitedSymbolIds: ReadonlySet<number> = new Set(),
+): boolean => {
+  const candidate = unwrapExpression(node);
+  if (
+    isNodeOfType(candidate, "ArrayExpression") ||
+    isNodeOfType(candidate, "ObjectExpression") ||
+    isNodeOfType(candidate, "ClassExpression") ||
+    isNodeOfType(candidate, "NewExpression") ||
+    isNodeOfType(candidate, "TemplateLiteral")
+  ) {
+    return true;
+  }
+  if (isNodeOfType(candidate, "Literal")) return candidate.value !== null;
+  if (isNodeOfType(candidate, "LogicalExpression") && candidate.operator === "??") {
+    return isProvablyNonNullishStateInitializer(candidate.right, scopes, visitedSymbolIds);
+  }
+  if (isNodeOfType(candidate, "ConditionalExpression")) {
+    return (
+      isProvablyNonNullishStateInitializer(candidate.consequent, scopes, visitedSymbolIds) &&
+      isProvablyNonNullishStateInitializer(candidate.alternate, scopes, visitedSymbolIds)
+    );
+  }
+  if (!isNodeOfType(candidate, "Identifier")) return false;
+  const symbol = scopes.symbolFor(candidate);
+  if (
+    !symbol ||
+    symbol.kind !== "const" ||
+    !symbol.initializer ||
+    visitedSymbolIds.has(symbol.id)
+  ) {
+    return false;
+  }
+  const nextVisitedSymbolIds = new Set(visitedSymbolIds).add(symbol.id);
+  return isProvablyNonNullishStateInitializer(symbol.initializer, scopes, nextVisitedSymbolIds);
+};
+
+const getReactStateInitializer = (node: EsTreeNode, scopes: ScopeAnalysis): EsTreeNode | null => {
+  const candidate = unwrapExpression(node);
+  if (!isNodeOfType(candidate, "Identifier")) return null;
+  const stateSymbol = scopes.symbolFor(candidate);
+  const declarator = stateSymbol?.declarationNode;
+  if (
+    !stateSymbol ||
+    !declarator ||
+    !isNodeOfType(declarator, "VariableDeclarator") ||
+    !isNodeOfType(declarator.id, "ArrayPattern") ||
+    declarator.id.elements[0] !== stateSymbol.bindingIdentifier ||
+    !isNodeOfType(declarator.init, "CallExpression") ||
+    !isReactApiCall(declarator.init, "useState", scopes, {
+      allowGlobalReactNamespace: true,
+      allowUnboundBareCalls: true,
+      resolveNamedAliases: true,
+    })
+  ) {
+    return null;
+  }
+  const stateInitializer = declarator.init.arguments[0];
+  return isAstNode(stateInitializer) && !isNodeOfType(stateInitializer, "SpreadElement")
+    ? stateInitializer
+    : null;
+};
+
+const isControlledStateSelection = (node: EsTreeNode, scopes: ScopeAnalysis): boolean => {
+  const candidate = unwrapExpression(node);
+  if (!isNodeOfType(candidate, "ConditionalExpression")) return false;
+  const test = unwrapExpression(candidate.test);
+  if (!isNodeOfType(test, "Identifier")) return false;
+  const testSymbol = scopes.symbolFor(test);
+  const comparison = testSymbol?.initializer ? unwrapExpression(testSymbol.initializer) : null;
+  if (
+    testSymbol?.kind !== "const" ||
+    !comparison ||
+    !isNodeOfType(comparison, "BinaryExpression") ||
+    (comparison.operator !== "!==" && comparison.operator !== "!=")
+  ) {
+    return false;
+  }
+  let controlledValue: EsTreeNode | null = null;
+  if (isUndefinedExpression(comparison.right, scopes)) {
+    controlledValue = comparison.left;
+  } else if (isUndefinedExpression(comparison.left, scopes)) {
+    controlledValue = comparison.right;
+  }
+  if (!controlledValue || !isSameSymbol(candidate.consequent, controlledValue, scopes)) {
+    return false;
+  }
+  const stateInitializer = getReactStateInitializer(candidate.alternate, scopes);
+  return Boolean(
+    stateInitializer && isProvablyNonNullishStateInitializer(stateInitializer, scopes),
+  );
+};
+
+const isUnstableInitializer = (
+  node: EsTreeNode | null,
+  scopes: ScopeAnalysis,
+  isNestedInitializer = false,
+): boolean => {
   if (!node) return false;
   const stripped = unwrapExpression(node);
   if (isRegExpLiteral(stripped)) return true;
   if (isNodeOfType(stripped, "ConditionalExpression")) {
     return (
-      isUnstableInitializer(stripped.consequent, true) ||
-      isUnstableInitializer(stripped.alternate, true)
+      isUnstableInitializer(stripped.consequent, scopes, true) ||
+      isUnstableInitializer(stripped.alternate, scopes, true)
     );
   }
   if (isNodeOfType(stripped, "LogicalExpression")) {
+    if (stripped.operator === "??" && isControlledStateSelection(stripped.left, scopes)) {
+      return isUnstableInitializer(stripped.left, scopes, true);
+    }
     return (
-      isUnstableInitializer(stripped.left, true) || isUnstableInitializer(stripped.right, true)
+      isUnstableInitializer(stripped.left, scopes, true) ||
+      isUnstableInitializer(stripped.right, scopes, true)
     );
   }
   return (
@@ -970,7 +1094,7 @@ const isPotentiallyFreshComparedValue = (
   visitedSymbolIds: Set<number> = new Set(),
 ): boolean => {
   const candidate = unwrapExpression(node);
-  if (isUnstableInitializer(candidate)) return true;
+  if (isUnstableInitializer(candidate, scopes)) return true;
   if (isNodeOfType(candidate, "ConditionalExpression")) {
     return (
       isPotentiallyFreshComparedValue(candidate.consequent, scopes, visitedSymbolIds) ||
@@ -1004,7 +1128,7 @@ const isExtraDepAllowedForHook = (
   return Boolean(
     rootSymbol &&
     !symbolHasStableValue(rootSymbol, scopes) &&
-    !isUnstableInitializer(rootSymbol.initializer),
+    !isUnstableInitializer(rootSymbol.initializer, scopes),
   );
 };
 
@@ -2122,7 +2246,7 @@ If the missing value is recreated every render, move it inside the hook or stabi
             !rootSymbol ||
             !hasDirectIdentifierDeclarator(rootSymbol) ||
             symbolHasStableValue(rootSymbol, context.scopes) ||
-            !isUnstableInitializer(rootSymbol.initializer)
+            !isUnstableInitializer(rootSymbol.initializer, context.scopes)
           ) {
             continue;
           }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/exhaustive-deps.ts
@@ -10,6 +10,7 @@ import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { findForwardedFreshHookDependencies } from "../../utils/find-forwarded-fresh-hook-dependencies.js";
 import { findEnclosingFunction } from "../../utils/find-enclosing-function.js";
+import { hasImportedBinding } from "../../utils/find-import-source-for-name.js";
 import { findSameFileTypeDeclarations } from "../../utils/find-same-file-type-declaration.js";
 import { findTransparentExpressionRoot } from "../../utils/find-transparent-expression-root.js";
 import { getStaticKeyName } from "../../utils/get-static-key-name.js";
@@ -90,6 +91,8 @@ const EFFECT_HOOKS_ALLOWING_EXTRA_REACTIVE_DEPS: ReadonlySet<string> = new Set([
 ]);
 
 const SOLE_WRITER_GUARD_HOOKS: ReadonlySet<string> = new Set(["useEffect", "useLayoutEffect"]);
+
+const NON_NULLISH_GLOBAL_TYPE_REFERENCES: ReadonlySet<string> = new Set(["Array", "ReadonlyArray"]);
 
 const buildAdditionalHooksRegex = (additional: string): RegExp | null => {
   if (!additional) return null;
@@ -1089,7 +1092,12 @@ const typeExcludesNull = (
   if (!isNodeOfType(typeNode.typeName, "Identifier")) return false;
   if (visitedTypeNames.has(typeNode.typeName.name)) return false;
   const declarations = findSameFileTypeDeclarations(referenceNode, typeNode.typeName.name);
-  if (declarations.length === 0) return false;
+  if (declarations.length === 0) {
+    return (
+      !hasImportedBinding(referenceNode, typeNode.typeName.name) &&
+      NON_NULLISH_GLOBAL_TYPE_REFERENCES.has(typeNode.typeName.name)
+    );
+  }
   const nextVisitedTypeNames = new Set(visitedTypeNames).add(typeNode.typeName.name);
   return declarations.every((declaration) =>
     isNodeOfType(declaration, "TSTypeAliasDeclaration")

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.regressions.test.ts
@@ -62,6 +62,37 @@ export const MultiSelectField = ({ onPendingChange }) => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("still flags child-produced call data mixed with a prop fallback", () => {
+    const result = runRule(
+      noPassDataToParent,
+      `import { useEffect } from "react";
+const Child = ({ categories, onChange }) => {
+  useEffect(() => {
+    const savedValue = readSavedValue();
+    onChange(savedValue || categories[0].id);
+  }, [categories, onChange]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags global mutable data indexed by a prop", () => {
+    const result = runRule(
+      noPassDataToParent,
+      `import { useEffect } from "react";
+const Child = ({ animationId, onFrame }) => {
+  useEffect(() => {
+    onFrame(window.ANIMATION_DATA[animationId]);
+  }, [animationId, onFrame]);
+  return null;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("stays silent when a callback parameter is passed through a parent callback", () => {
     const result = runRule(
       noPassDataToParent,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.ts
@@ -57,6 +57,8 @@ import {
   isProvenReactRefCurrentExpression,
   isProvenReactRefCurrentSnapshotExpression,
 } from "./utils/resolve-parent-callback-provenance.js";
+import { isCustomHookStateResultReference } from "./utils/is-custom-hook-state-result-reference.js";
+import { isComparisonMemoizerHookName } from "./utils/is-comparison-memoizer-hook-name.js";
 
 // 1:1 port of upstream `src/rules/no-pass-data-to-parent.js`, narrowed to
 // DIRECT parent-callback call sites. The verification run showed the
@@ -282,6 +284,118 @@ const hasMutableBindingWrite = (reference: Reference): boolean =>
       (candidateReference) => candidateReference.isWrite() && !candidateReference.init,
     ),
   );
+
+const TRANSPARENT_PROP_VALUE_HOOK_NAMES: ReadonlySet<string> = new Set(["useMemo", "useRef"]);
+
+const isOpaqueHookResultReference = (
+  analysis: ProgramAnalysis,
+  reference: Reference,
+  scopes: ScopeAnalysis,
+): boolean =>
+  Boolean(
+    reference.resolved?.defs.some((definition) => {
+      const declarator = definition.node as unknown as EsTreeNode;
+      if (!isNodeOfType(declarator, "VariableDeclarator") || !declarator.init) return false;
+      const initializer = stripParenExpression(declarator.init as EsTreeNode);
+      if (!isNodeOfType(initializer, "CallExpression")) return false;
+      const callee = stripParenExpression(initializer.callee);
+      const calleeName = isNodeOfType(callee, "Identifier")
+        ? callee.name
+        : getStaticMemberPropertyName(callee);
+      if (!calleeName || !/^use[A-Z0-9]/.test(calleeName)) return false;
+      if (isReactHookCall(initializer, TRANSPARENT_PROP_VALUE_HOOK_NAMES, scopes)) return false;
+      if (
+        isComparisonMemoizerHookName(calleeName) &&
+        !isCustomHookStateResultReference(analysis, reference, scopes)
+      ) {
+        return false;
+      }
+      return true;
+    }),
+  );
+
+const isComponentPropOriginatedReference = (
+  analysis: ProgramAnalysis,
+  reference: Reference,
+  scopes: ScopeAnalysis,
+): boolean => {
+  const provenanceReferences = [reference, ...getUpstreamRefs(analysis, reference)];
+  if (!provenanceReferences.some((provenanceReference) => isProp(analysis, provenanceReference))) {
+    return false;
+  }
+  return !provenanceReferences.some(
+    (provenanceReference) =>
+      hasMutableBindingWrite(provenanceReference) ||
+      isState(analysis, provenanceReference) ||
+      isOpaqueHookResultReference(analysis, provenanceReference, scopes) ||
+      isCustomHookStateResultReference(analysis, provenanceReference, scopes),
+  );
+};
+
+const hasComponentPropOriginWithoutChildState = (
+  analysis: ProgramAnalysis,
+  expression: EsTreeNode,
+  scopes: ScopeAnalysis,
+): boolean => {
+  const expressionReferences = getDownstreamRefs(analysis, expression);
+  if (expressionReferences.length === 0) return false;
+  const provenanceReferences = expressionReferences.flatMap((reference) => [
+    reference,
+    ...getUpstreamRefs(analysis, reference),
+  ]);
+  if (!provenanceReferences.some((reference) => isProp(analysis, reference))) return false;
+  return !provenanceReferences.some(
+    (reference) =>
+      hasMutableBindingWrite(reference) ||
+      isState(analysis, reference) ||
+      isOpaqueHookResultReference(analysis, reference, scopes) ||
+      isCustomHookStateResultReference(analysis, reference, scopes),
+  );
+};
+
+const isTransparentComponentPropEchoExpression = (
+  analysis: ProgramAnalysis,
+  expression: EsTreeNode,
+  scopes: ScopeAnalysis,
+): boolean => {
+  if (!hasComponentPropOriginWithoutChildState(analysis, expression, scopes)) return false;
+  const candidate = stripParenExpression(expression);
+  if (!isNodeOfType(candidate, "Identifier")) return true;
+  const reference = getRef(analysis, candidate);
+  if (!reference || isProp(analysis, reference)) return Boolean(reference);
+  if (hasMutableBindingWrite(reference)) return false;
+  const declarators = reference.resolved?.defs
+    .map((definition) => definition.node as unknown as EsTreeNode)
+    .filter((definitionNode) => isNodeOfType(definitionNode, "VariableDeclarator"));
+  if (declarators?.length !== 1) return false;
+  const declarator = declarators[0];
+  if (!declarator || !isNodeOfType(declarator, "VariableDeclarator") || !declarator.init) {
+    return false;
+  }
+  const initializer = stripParenExpression(declarator.init as EsTreeNode);
+  if (!isNodeOfType(initializer, "CallExpression")) return true;
+  if (isReactHookCall(initializer, TRANSPARENT_PROP_VALUE_HOOK_NAMES, scopes)) return true;
+  const callee = stripParenExpression(initializer.callee);
+  const calleeName = isNodeOfType(callee, "Identifier")
+    ? callee.name
+    : getStaticMemberPropertyName(callee);
+  const calleeReceiver = isNodeOfType(callee, "MemberExpression")
+    ? stripParenExpression(callee.object)
+    : null;
+  if (
+    calleeName === "parse" &&
+    isNodeOfType(calleeReceiver, "Identifier") &&
+    calleeReceiver.name === "JSON" &&
+    scopes.isGlobalReference(calleeReceiver)
+  ) {
+    return true;
+  }
+  return Boolean(
+    calleeName &&
+    isComparisonMemoizerHookName(calleeName) &&
+    !isOpaqueHookResultReference(analysis, reference, scopes),
+  );
+};
 
 const getParentCallbackPropName = (
   analysis: ProgramAnalysis,
@@ -1548,6 +1662,22 @@ export const noPassDataToParent = defineRule({
                   (isNodeOfType(identifier, "Identifier") ? identifier.name : methodName) ?? "",
                 ),
               );
+          const directDataArguments = (callExpr.arguments ?? []).filter(
+            (argument) =>
+              !isNodeOfType(argument, "SpreadElement") && !isFunctionLike(argument as EsTreeNode),
+          );
+          if (
+            directDataArguments.length > 0 &&
+            directDataArguments.every((argument) =>
+              isTransparentComponentPropEchoExpression(
+                analysis,
+                argument as EsTreeNode,
+                context.scopes,
+              ),
+            )
+          ) {
+            continue;
+          }
           const isLeafRef = (argRef: Reference): boolean =>
             getUpstreamRefs(analysis, argRef).length === 1;
           const argsUpstreamRefs = (callExpr.arguments ?? [])
@@ -1629,7 +1759,15 @@ export const noPassDataToParent = defineRule({
             const argIdentifier = argRef.identifier as unknown as EsTreeNode;
             if (isTypeScriptTypePosition(argIdentifier)) return false;
             if (isReducerState(analysis, argRef)) return true;
+            if (
+              isNodeOfType(argIdentifier, "Identifier") &&
+              argIdentifier.name === "JSON" &&
+              context.scopes.isGlobalReference(argIdentifier)
+            ) {
+              return false;
+            }
             if (isUseStateIdentifier(argIdentifier)) return false;
+            if (isComponentPropOriginatedReference(analysis, argRef, context.scopes)) return false;
             if (isProp(analysis, argRef)) return false;
             if (isUseRefIdentifier(argIdentifier)) return false;
             if (isRefCurrent(argRef)) return false;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-data-to-parent.ts
@@ -286,6 +286,16 @@ const hasMutableBindingWrite = (reference: Reference): boolean =>
   );
 
 const TRANSPARENT_PROP_VALUE_HOOK_NAMES: ReadonlySet<string> = new Set(["useMemo", "useRef"]);
+const TRANSPARENT_GLOBAL_VALUE_NAMES: ReadonlySet<string> = new Set([
+  "Array",
+  "Boolean",
+  "JSON",
+  "Math",
+  "Number",
+  "Object",
+  "String",
+  "undefined",
+]);
 
 const isOpaqueHookResultReference = (
   analysis: ProgramAnalysis,
@@ -314,6 +324,51 @@ const isOpaqueHookResultReference = (
     }),
   );
 
+const isOpaqueCallResultReference = (
+  analysis: ProgramAnalysis,
+  reference: Reference,
+  scopes: ScopeAnalysis,
+): boolean =>
+  Boolean(
+    reference.resolved?.defs.some((definition) => {
+      const declarator = definition.node as unknown as EsTreeNode;
+      if (!isNodeOfType(declarator, "VariableDeclarator") || !declarator.init) return false;
+      const initializer = stripParenExpression(declarator.init as EsTreeNode);
+      if (!isNodeOfType(initializer, "CallExpression")) return false;
+      if (isReactHookCall(initializer, TRANSPARENT_PROP_VALUE_HOOK_NAMES, scopes)) return false;
+      const callee = stripParenExpression(initializer.callee);
+      const calleeName = isNodeOfType(callee, "Identifier")
+        ? callee.name
+        : getStaticMemberPropertyName(callee);
+      if (calleeName && isComparisonMemoizerHookName(calleeName)) return false;
+      const calleeRoot = isNodeOfType(callee, "MemberExpression")
+        ? stripParenExpression(callee.object)
+        : callee;
+      if (
+        isNodeOfType(calleeRoot, "Identifier") &&
+        scopes.isGlobalReference(calleeRoot) &&
+        TRANSPARENT_GLOBAL_VALUE_NAMES.has(calleeRoot.name)
+      ) {
+        return false;
+      }
+      const calleeReference = isNodeOfType(calleeRoot, "Identifier")
+        ? getRef(analysis, calleeRoot)
+        : null;
+      return (
+        !calleeReference || !isComponentPropOriginatedReference(analysis, calleeReference, scopes)
+      );
+    }),
+  );
+
+const isOpaqueGlobalValueReference = (reference: Reference, scopes: ScopeAnalysis): boolean => {
+  const identifier = reference.identifier as unknown as EsTreeNode;
+  return (
+    isNodeOfType(identifier, "Identifier") &&
+    scopes.isGlobalReference(identifier) &&
+    !TRANSPARENT_GLOBAL_VALUE_NAMES.has(identifier.name)
+  );
+};
+
 const isComponentPropOriginatedReference = (
   analysis: ProgramAnalysis,
   reference: Reference,
@@ -328,6 +383,8 @@ const isComponentPropOriginatedReference = (
       hasMutableBindingWrite(provenanceReference) ||
       isState(analysis, provenanceReference) ||
       isOpaqueHookResultReference(analysis, provenanceReference, scopes) ||
+      isOpaqueCallResultReference(analysis, provenanceReference, scopes) ||
+      isOpaqueGlobalValueReference(provenanceReference, scopes) ||
       isCustomHookStateResultReference(analysis, provenanceReference, scopes),
   );
 };
@@ -349,6 +406,8 @@ const hasComponentPropOriginWithoutChildState = (
       hasMutableBindingWrite(reference) ||
       isState(analysis, reference) ||
       isOpaqueHookResultReference(analysis, reference, scopes) ||
+      isOpaqueCallResultReference(analysis, reference, scopes) ||
+      isOpaqueGlobalValueReference(reference, scopes) ||
       isCustomHookStateResultReference(analysis, reference, scopes),
   );
 };
@@ -364,10 +423,12 @@ const isTransparentComponentPropEchoExpression = (
   const reference = getRef(analysis, candidate);
   if (!reference || isProp(analysis, reference)) return Boolean(reference);
   if (hasMutableBindingWrite(reference)) return false;
-  const declarators = reference.resolved?.defs
-    .map((definition) => definition.node as unknown as EsTreeNode)
-    .filter((definitionNode) => isNodeOfType(definitionNode, "VariableDeclarator"));
-  if (declarators?.length !== 1) return false;
+  const declarators: EsTreeNode[] = [];
+  for (const definition of reference.resolved?.defs ?? []) {
+    const definitionNode = definition.node as unknown as EsTreeNode;
+    if (isNodeOfType(definitionNode, "VariableDeclarator")) declarators.push(definitionNode);
+  }
+  if (declarators.length !== 1) return false;
   const declarator = declarators[0];
   if (!declarator || !isNodeOfType(declarator, "VariableDeclarator") || !declarator.init) {
     return false;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-live-state-to-parent.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-pass-live-state-to-parent.ts
@@ -204,6 +204,7 @@ const collectUpstreamStateRefs = (
   ref: Reference,
   stateRefs: Reference[],
   visited: Set<Reference>,
+  scopes: RuleContext["scopes"],
 ): void => {
   if (visited.has(ref)) return;
   visited.add(ref);
@@ -211,7 +212,7 @@ const collectUpstreamStateRefs = (
     stateRefs.push(ref);
     return;
   }
-  if (isCustomHookStateResultReference(analysis, ref)) {
+  if (isCustomHookStateResultReference(analysis, ref, scopes)) {
     stateRefs.push(ref);
     return;
   }
@@ -235,7 +236,7 @@ const collectUpstreamStateRefs = (
       if (isInsideSpreadElement(innerRef.identifier as unknown as EsTreeNode, initializer)) {
         continue;
       }
-      collectUpstreamStateRefs(analysis, innerRef, stateRefs, visited);
+      collectUpstreamStateRefs(analysis, innerRef, stateRefs, visited, scopes);
     }
   }
 };
@@ -251,6 +252,7 @@ const collectPropCallbackBoundStateRefs = (
   analysis: ProgramAnalysis,
   ref: Reference,
   isPropCallbackRef: (innerRef: Reference) => boolean,
+  scopes: RuleContext["scopes"],
 ): Reference[] => {
   const stateRefs: Reference[] = [];
   for (const upRef of getUpstreamRefs(analysis, ref)) {
@@ -263,7 +265,7 @@ const collectPropCallbackBoundStateRefs = (
       if (isFunctionLike(argument as EsTreeNode)) continue;
       for (const argRef of getDownstreamRefs(analysis, argument as EsTreeNode)) {
         if (resolveToFunction(argRef)) continue;
-        collectUpstreamStateRefs(analysis, argRef, stateRefs, new Set());
+        collectUpstreamStateRefs(analysis, argRef, stateRefs, new Set(), scopes);
       }
     }
   }
@@ -273,13 +275,14 @@ const collectPropCallbackBoundStateRefs = (
 const collectDirectCallStateRefs = (
   analysis: ProgramAnalysis,
   callExpression: EsTreeNodeOfType<"CallExpression">,
+  scopes: RuleContext["scopes"],
 ): Reference[] => {
   const stateReferences: Reference[] = [];
   for (const argument of callExpression.arguments) {
     if (isFunctionLike(argument as EsTreeNode)) continue;
     for (const argumentReference of getDownstreamRefs(analysis, argument as EsTreeNode)) {
       if (resolveToFunction(argumentReference)) continue;
-      collectUpstreamStateRefs(analysis, argumentReference, stateReferences, new Set());
+      collectUpstreamStateRefs(analysis, argumentReference, stateReferences, new Set(), scopes);
     }
   }
   return stateReferences;
@@ -588,15 +591,19 @@ export const noPassLiveStateToParent = defineRule({
 
         const stateArgRefs =
           transparentPropReference || notificationCallbackPropNames
-            ? collectDirectCallStateRefs(analysis, callExpr)
+            ? collectDirectCallStateRefs(analysis, callExpr, context.scopes)
             : callGraphReferences.flatMap((callGraphReference) =>
-                collectPropCallbackBoundStateRefs(analysis, callGraphReference, (innerRef) =>
-                  isParentNotificationCallbackRef(
-                    analysis,
-                    innerRef,
-                    context,
-                    discardedDirectLocalEffectHelper,
-                  ),
+                collectPropCallbackBoundStateRefs(
+                  analysis,
+                  callGraphReference,
+                  (innerRef) =>
+                    isParentNotificationCallbackRef(
+                      analysis,
+                      innerRef,
+                      context,
+                      discardedDirectLocalEffectHelper,
+                    ),
+                  context.scopes,
                 ),
               );
         const handsSetterNamedCallbackData = propCallbackRefs.some(

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-prop-callback-in-effect.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-prop-callback-in-effect.ts
@@ -302,10 +302,18 @@ export const noPropCallbackInEffect = defineRule({
               context.scopes,
             ),
         );
-        const stateDependencyReferences = analysis
-          ? [...reactStateDeps, ...customHookStateDeps].flatMap((element) =>
+        const reactStateDependencyReferences = analysis
+          ? reactStateDeps.flatMap((element) =>
               getStateDependencyReferences(analysis, element, propStackTracker.isPropName),
             )
+          : [];
+        const stateDependencyReferences = analysis
+          ? [
+              ...reactStateDependencyReferences,
+              ...customHookStateDeps.flatMap((element) =>
+                getStateDependencyReferences(analysis, element, propStackTracker.isPropName),
+              ),
+            ]
           : [];
         const stateLikeDeps = [...reactStateDeps, ...customHookStateDeps];
         if (stateLikeDeps.length === 0) return;
@@ -384,12 +392,17 @@ export const noPropCallbackInEffect = defineRule({
           const calleeName = getPropCallbackName(child);
           if (!calleeName) return;
           if (analysis) {
-            if (cleanupPropCallbackNames.has(calleeName)) return;
             const doesUseStateDependency = doesCallUseStateDependency(
               analysis,
               child,
               stateDependencyReferences,
             );
+            const doesUseReactStateDependency = doesCallUseStateDependency(
+              analysis,
+              child,
+              reactStateDependencyReferences,
+            );
+            if (cleanupPropCallbackNames.has(calleeName) && !doesUseReactStateDependency) return;
             if (
               !doesUseStateDependency &&
               (reactStateDeps.length === 0 ||

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-prop-callback-in-effect.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-prop-callback-in-effect.ts
@@ -26,7 +26,7 @@ import {
 } from "./utils/effect/ast.js";
 import { isExternallyDrivenState } from "./utils/effect/external-state.js";
 import { getProgramAnalysis, type ProgramAnalysis } from "./utils/effect/get-program-analysis.js";
-import { isReducerState, isState } from "./utils/effect/react.js";
+import { isReducerState, isState, isStateSetterCall } from "./utils/effect/react.js";
 import { getParentCallbackPropNames } from "./utils/resolve-parent-callback-provenance.js";
 import { isCustomHookStateResultReference } from "./utils/is-custom-hook-state-result-reference.js";
 
@@ -121,11 +121,12 @@ const isCustomHookStateDependency = (
   analysis: ProgramAnalysis | null,
   element: EsTreeNode,
   isPropName: (name: string) => boolean,
+  scopes: RuleContext["scopes"],
 ): boolean =>
   Boolean(
     analysis &&
     getStateDependencyReferences(analysis, element, isPropName).some((reference) =>
-      isCustomHookStateResultReference(analysis, reference),
+      isCustomHookStateResultReference(analysis, reference, scopes),
     ),
   );
 
@@ -134,7 +135,7 @@ const isSameReference = (left: Reference, right: Reference): boolean =>
     ? left.resolved === right.resolved
     : left.identifier === right.identifier;
 
-const doesCallUseCustomHookStateDependency = (
+const doesCallUseStateDependency = (
   analysis: ProgramAnalysis,
   callExpression: EsTreeNodeOfType<"CallExpression">,
   dependencyReferences: readonly Reference[],
@@ -153,6 +154,51 @@ const doesCallUseCustomHookStateDependency = (
         ),
     );
   });
+
+const areEquivalentPayloadExpressions = (
+  analysis: ProgramAnalysis,
+  left: EsTreeNode,
+  right: EsTreeNode,
+): boolean => {
+  const leftCandidate = stripParenExpression(left);
+  const rightCandidate = stripParenExpression(right);
+  if (isNodeOfType(leftCandidate, "Literal") && isNodeOfType(rightCandidate, "Literal")) {
+    return Object.is(leftCandidate.value, rightCandidate.value);
+  }
+  if (!isNodeOfType(leftCandidate, "Identifier") || !isNodeOfType(rightCandidate, "Identifier")) {
+    return false;
+  }
+  const leftReference = getRef(analysis, leftCandidate);
+  const rightReference = getRef(analysis, rightCandidate);
+  return Boolean(
+    leftReference?.resolved &&
+    rightReference?.resolved &&
+    leftReference.resolved === rightReference.resolved,
+  );
+};
+
+const hasMatchingLocalStateWrite = (
+  analysis: ProgramAnalysis,
+  effectBody: EsTreeNode,
+  callbackCall: EsTreeNodeOfType<"CallExpression">,
+): boolean => {
+  const callbackPayload = callbackCall.arguments[0];
+  if (!callbackPayload || isNodeOfType(callbackPayload, "SpreadElement")) return false;
+  let didFindMatchingWrite = false;
+  walkInsideStatementBlocks(effectBody, (child: EsTreeNode) => {
+    if (didFindMatchingWrite || !isNodeOfType(child, "CallExpression")) return;
+    const callee = stripParenExpression(child.callee);
+    if (!isNodeOfType(callee, "Identifier")) return;
+    const setterReference = getRef(analysis, callee);
+    if (!setterReference || !isStateSetterCall(analysis, setterReference)) return;
+    const writtenValue = child.arguments[0];
+    if (!writtenValue || isNodeOfType(writtenValue, "SpreadElement")) return;
+    if (areEquivalentPayloadExpressions(analysis, callbackPayload, writtenValue)) {
+      didFindMatchingWrite = true;
+    }
+  });
+  return didFindMatchingWrite;
+};
 
 const getRefHeldPropCallbackName = (
   callExpression: EsTreeNodeOfType<"CallExpression">,
@@ -249,10 +295,15 @@ export const noPropCallbackInEffect = defineRule({
         const customHookStateDeps = dependencyElements.filter(
           (element) =>
             !reactStateDeps.includes(element) &&
-            isCustomHookStateDependency(analysis, element, propStackTracker.isPropName),
+            isCustomHookStateDependency(
+              analysis,
+              element,
+              propStackTracker.isPropName,
+              context.scopes,
+            ),
         );
-        const customHookStateDependencyReferences = analysis
-          ? customHookStateDeps.flatMap((element) =>
+        const stateDependencyReferences = analysis
+          ? [...reactStateDeps, ...customHookStateDeps].flatMap((element) =>
               getStateDependencyReferences(analysis, element, propStackTracker.isPropName),
             )
           : [];
@@ -332,17 +383,20 @@ export const noPropCallbackInEffect = defineRule({
           if (!isNodeOfType(child, "CallExpression")) return;
           const calleeName = getPropCallbackName(child);
           if (!calleeName) return;
-          if (
-            reactStateDeps.length === 0 &&
-            analysis &&
-            (!doesCallUseCustomHookStateDependency(
+          if (analysis) {
+            if (cleanupPropCallbackNames.has(calleeName)) return;
+            const doesUseStateDependency = doesCallUseStateDependency(
               analysis,
               child,
-              customHookStateDependencyReferences,
-            ) ||
-              cleanupPropCallbackNames.has(calleeName))
-          ) {
-            return;
+              stateDependencyReferences,
+            );
+            if (
+              !doesUseStateDependency &&
+              (reactStateDeps.length === 0 ||
+                hasMatchingLocalStateWrite(analysis, callback.body, child))
+            ) {
+              return;
+            }
           }
           // Only the "lift state up" hand-back fires: a discarded
           // `onChange(state)`. When the prop call's result flows somewhere

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-reset-all-state-on-prop-change.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-reset-all-state-on-prop-change.ts
@@ -33,6 +33,7 @@ import {
   isSyncStateSetterCall,
 } from "./utils/effect/react.js";
 import { hasResourceLifecycleSetterWriter } from "./utils/has-resource-lifecycle-setter-writer.js";
+import { hasSynchronousResourceLifecycleTransition } from "./utils/has-synchronous-resource-lifecycle-transition.js";
 import { getStaticMemberPropertyName } from "./utils/static-member-property-name.js";
 
 // 1:1 port of upstream `src/rules/no-reset-all-state-on-prop-change.js`.
@@ -1248,6 +1249,7 @@ const findPropUsedToResetAllState = (
     isSetStateToInitialValue(analysis, context, ref),
   );
   if (!allResetToInitial) return null;
+  if (hasSynchronousResourceLifecycleTransition(effectFn, context.scopes)) return null;
   if (
     stateSetterRefs.every((setterReference) =>
       hasResourceLifecycleSetterWriter(analysis, context, setterReference, useEffectNode, depsRefs),

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/react-bench-pr-488.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/react-bench-pr-488.regressions.test.ts
@@ -223,6 +223,69 @@ describe("React Bench PR 488 false-positive regressions", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it("still reports a reset paired with a plain superseded property write", () => {
+    const result = runRule(
+      noResetAllStateOnPropChange,
+      `import { useEffect, useState } from "react";
+      const Editor = ({ documentId }) => {
+        const [draft, setDraft] = useState("");
+        const status = { superseded: false };
+        useEffect(() => {
+          status.superseded = true;
+          setDraft("");
+        }, [documentId]);
+        return <input value={draft} onChange={(event) => setDraft(event.target.value)} />;
+      };`,
+      { forceJsx: true },
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still reports a reset paired with an unrelated listener cleanup", () => {
+    const result = runRule(
+      noResetAllStateOnPropChange,
+      `import { useEffect, useState } from "react";
+      const Editor = ({ documentId }) => {
+        const [draft, setDraft] = useState("");
+        useEffect(() => {
+          setDraft("");
+          const handleResize = () => {};
+          window.addEventListener("resize", handleResize);
+          return () => window.removeEventListener("resize", handleResize);
+        }, [documentId]);
+        return <input value={draft} onChange={(event) => setDraft(event.target.value)} />;
+      };`,
+      { forceJsx: true },
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("accepts state synchronized by a locally owned observer", () => {
+    const result = runRule(
+      noResetAllStateOnPropChange,
+      `import { useEffect, useState } from "react";
+      const Outline = ({ items }) => {
+        const [activeId, setActiveId] = useState("");
+        useEffect(() => {
+          const observer = new IntersectionObserver((entries) => {
+            const activeEntry = entries.find((entry) => entry.isIntersecting);
+            if (activeEntry) setActiveId(activeEntry.target.id);
+          });
+          items.forEach((item) => observer.observe(item));
+          return () => observer.disconnect();
+        }, [items]);
+        return activeId;
+      };`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("accepts component-scope timer cleanup delegated through a stable helper", () => {
     const result = runRule(
       effectNeedsCleanup,
@@ -378,6 +441,25 @@ describe("React Bench PR 488 false-positive regressions", () => {
 
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still reports state synchronization when the callback also clears on cleanup", () => {
+    const result = runRule(
+      noPropCallbackInEffect,
+      `import { useEffect, useState } from "react";
+      const Editor = ({ onChange }) => {
+        const [draft, setDraft] = useState("");
+        useEffect(() => {
+          onChange(draft);
+          return () => onChange(null);
+        }, [draft, onChange]);
+        return <input value={draft} onChange={(event) => setDraft(event.target.value)} />;
+      };`,
+      { forceJsx: true },
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
   });
 
   it.each([noPassLiveStateToParent, noPropCallbackInEffect])(

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/react-bench-pr-488.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/react-bench-pr-488.regressions.test.ts
@@ -1,0 +1,444 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { effectNeedsCleanup } from "./effect-needs-cleanup.js";
+import { noPassDataToParent } from "./no-pass-data-to-parent.js";
+import { noPassLiveStateToParent } from "./no-pass-live-state-to-parent.js";
+import { noPropCallbackInEffect } from "./no-prop-callback-in-effect.js";
+import { noResetAllStateOnPropChange } from "./no-reset-all-state-on-prop-change.js";
+
+describe("React Bench PR 488 false-positive regressions", () => {
+  it("accepts an epoch reset coupled to aborting an owned async run", () => {
+    const result = runRule(
+      noResetAllStateOnPropChange,
+      `import { useEffect, useRef, useState } from "react";
+      const GeometryOverlay = ({ nodeId, onLocalize, hasDrawable, localizeStatus }) => {
+        const [localPhase, setLocalPhase] = useState("idle");
+        const prevDepsRef = useRef({ nodeId, onLocalize, hasDrawable, localizeStatus });
+        const runAbortRef = useRef(null);
+        const generationRef = useRef(0);
+        const actionRunActiveRef = useRef(false);
+        useEffect(() => {
+          const previousDependencies = prevDepsRef.current;
+          let isFreshGeneration = false;
+          let shouldAbort = false;
+          if (previousDependencies.nodeId !== nodeId) {
+            isFreshGeneration = true;
+            shouldAbort = true;
+          }
+          if (previousDependencies.onLocalize !== onLocalize) {
+            isFreshGeneration = true;
+            shouldAbort = true;
+          }
+          if (previousDependencies.hasDrawable !== hasDrawable) {
+            isFreshGeneration = true;
+            if (hasDrawable) shouldAbort = true;
+          }
+          if (previousDependencies.localizeStatus !== localizeStatus) isFreshGeneration = true;
+          if (shouldAbort) {
+            runAbortRef.current?.abort();
+            runAbortRef.current = null;
+          }
+          if (isFreshGeneration) {
+            generationRef.current += 1;
+            actionRunActiveRef.current = false;
+            setLocalPhase("idle");
+          }
+          prevDepsRef.current = { nodeId, onLocalize, hasDrawable, localizeStatus };
+        }, [nodeId, onLocalize, hasDrawable, localizeStatus]);
+        return localPhase;
+      };`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("accepts request progress cleared only while aborting outstanding requests", () => {
+    const result = runRule(
+      noResetAllStateOnPropChange,
+      `import { useEffect, useRef, useState } from "react";
+      const EvaluationList = ({ searchQuery }) => {
+        const [pendingDownloads, setPendingDownloads] = useState({});
+        const requestsRef = useRef(new Map());
+        const abortAllRequests = () => {
+          requestsRef.current.forEach(({ controller }) => controller.abort());
+          requestsRef.current.clear();
+        };
+        useEffect(() => {
+          if (!requestsRef.current.size) return;
+          abortAllRequests();
+          setPendingDownloads({});
+        }, [searchQuery]);
+        return pendingDownloads;
+      };`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it.each([
+    [
+      "an epoch increment",
+      `const generationRef = useRef(0);
+      useEffect(() => {
+        generationRef.current += 1;
+        setPhase("idle");
+      }, [resourceId]);`,
+    ],
+    [
+      "an owned attempt invalidation",
+      `const attemptRef = useRef(null);
+      useEffect(() => {
+        attemptRef.current = null;
+        setPhase("idle");
+      }, [resourceId]);`,
+    ],
+    [
+      "a request-token reset",
+      `const requestTokensRef = useRef(new Map());
+      useEffect(() => {
+        requestTokensRef.current = new Map();
+        setPhase("idle");
+      }, [resourceId]);`,
+    ],
+    [
+      "a superseded-attempt marker",
+      `const attemptRef = useRef({ superseded: false });
+      useEffect(() => {
+        attemptRef.current.superseded = true;
+        setPhase("idle");
+      }, [resourceId]);`,
+    ],
+  ])("accepts an all-state reset coupled to %s", (_scenario, effectSource) => {
+    const result = runRule(
+      noResetAllStateOnPropChange,
+      `import { useEffect, useRef, useState } from "react";
+      const ResourceView = ({ resourceId }) => {
+        const [phase, setPhase] = useState("idle");
+        ${effectSource}
+        return phase;
+      };`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("accepts cleanup delegated through a memoized helper", () => {
+    const result = runRule(
+      noResetAllStateOnPropChange,
+      `import { useCallback, useEffect, useRef, useState } from "react";
+      const EvaluationList = ({ searchQuery }) => {
+        const [pendingDownloads, setPendingDownloads] = useState({});
+        const requestsRef = useRef(new Map());
+        const abortAllRequests = useCallback(() => {
+          requestsRef.current.forEach(({ controller }) => controller.abort());
+          requestsRef.current.clear();
+        }, []);
+        useEffect(() => {
+          abortAllRequests();
+          setPendingDownloads({});
+        }, [searchQuery, abortAllRequests]);
+        return pendingDownloads;
+      };`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("accepts a state reset paired with returned resource cleanup", () => {
+    const result = runRule(
+      noResetAllStateOnPropChange,
+      `import { useEffect, useRef, useState } from "react";
+      const ResourceView = ({ resourceId }) => {
+        const [phase, setPhase] = useState("idle");
+        const controllerRef = useRef(null);
+        useEffect(() => {
+          setPhase("idle");
+          return () => controllerRef.current?.abort();
+        }, [resourceId]);
+        return phase;
+      };`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still reports an ordinary all-state reset on a prop change", () => {
+    const result = runRule(
+      noResetAllStateOnPropChange,
+      `import { useEffect, useState } from "react";
+      const Editor = ({ documentId }) => {
+        const [draft, setDraft] = useState("");
+        useEffect(() => setDraft(""), [documentId]);
+        return <input value={draft} onChange={(event) => setDraft(event.target.value)} />;
+      };`,
+      { forceJsx: true },
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still reports a reset when a resource-release helper is not invoked", () => {
+    const result = runRule(
+      noResetAllStateOnPropChange,
+      `import { useEffect, useRef, useState } from "react";
+      const Editor = ({ documentId }) => {
+        const [draft, setDraft] = useState("");
+        const controllerRef = useRef(null);
+        const abortRequest = () => controllerRef.current?.abort();
+        useEffect(() => {
+          void abortRequest;
+          setDraft("");
+        }, [documentId]);
+        return <input value={draft} onChange={(event) => setDraft(event.target.value)} />;
+      };`,
+      { forceJsx: true },
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still reports UI state and a non-resource busy flag reset together", () => {
+    const result = runRule(
+      noResetAllStateOnPropChange,
+      `import { useEffect, useRef, useState } from "react";
+      const Editor = ({ documentId }) => {
+        const [phase, setPhase] = useState("idle");
+        const busyRef = useRef(false);
+        useEffect(() => {
+          busyRef.current = false;
+          setPhase("idle");
+        }, [documentId]);
+        return phase;
+      };`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("accepts component-scope timer cleanup delegated through a stable helper", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useCallback, useEffect, useRef } from "react";
+      const PermissionCard = ({ requestId, timeoutMs, resolved, interactive }) => {
+        const timerRef = useRef(null);
+        const stopTimer = useCallback(() => {
+          if (timerRef.current) {
+            clearInterval(timerRef.current);
+            timerRef.current = null;
+          }
+        }, []);
+        useEffect(() => {
+          if (resolved || !interactive) return;
+          timerRef.current = setInterval(() => tick(requestId, timeoutMs), 1000);
+          return () => {
+            stopTimer();
+          };
+        }, [requestId, timeoutMs, resolved, interactive, stopTimer]);
+        return null;
+      };`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  const parentSyncRules = [noPassDataToParent, noPassLiveStateToParent, noPropCallbackInEffect];
+
+  it.each(parentSyncRules)("accepts prop-originated data echoed through %s", (rule) => {
+    const result = runRule(
+      rule,
+      `import { useEffect, useRef, useState } from "react";
+      const useDeepCompareMemoize = (value) => value;
+      const MultiSelectField = ({ values, onPendingChange }) => {
+        const [preValues, setPreValues] = useState([]);
+        const memoizedValues = useDeepCompareMemoize(values);
+        const onPendingChangeRef = useRef(onPendingChange);
+        useEffect(() => {
+          onPendingChangeRef.current = onPendingChange;
+        }, [onPendingChange]);
+        useEffect(() => {
+          setPreValues(memoizedValues);
+          onPendingChangeRef.current?.(memoizedValues);
+        }, [memoizedValues]);
+        return preValues.length;
+      };`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it.each([noPassDataToParent, noPropCallbackInEffect])(
+    "accepts guarded prop-originated synchronization through %s",
+    (rule) => {
+      const result = runRule(
+        rule,
+        `import { useEffect, useRef, useState } from "react";
+        const MultiSelectField = ({ values, onPendingChange }) => {
+          const [preValues, setPreValues] = useState([]);
+          const syncedValuesKeyRef = useRef("");
+          useEffect(() => {
+            const valuesKey = JSON.stringify(values);
+            if (syncedValuesKeyRef.current === valuesKey) return;
+            syncedValuesKeyRef.current = valuesKey;
+            setPreValues(values);
+            onPendingChange?.(values);
+          }, [values, onPendingChange]);
+          return preValues.length;
+        };`,
+      );
+
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    },
+  );
+
+  it.each([
+    [
+      "a JSON round trip",
+      `const valuesKey = JSON.stringify(values);
+        useEffect(() => {
+          const parsedValues = JSON.parse(valuesKey);
+          setPreValues(parsedValues);
+          onPendingChange?.(parsedValues);
+        }, [valuesKey, onPendingChange]);`,
+    ],
+    [
+      "a useMemo fallback",
+      `const resolvedValues = useMemo(() => values ?? [], [values]);
+        useEffect(() => {
+          setPreValues(resolvedValues);
+          onPendingChange?.(resolvedValues);
+        }, [resolvedValues, onPendingChange]);`,
+    ],
+    [
+      "an effect-event wrapper",
+      `const reportPendingChange = useEffectEvent((nextValues) => {
+          onPendingChange?.(nextValues);
+        });
+        useEffect(() => {
+          setPreValues(values);
+          reportPendingChange(values);
+        }, [values]);`,
+    ],
+    [
+      "a render-time ref stabilizer",
+      `const previousValuesRef = useRef(values);
+        const areEqual = JSON.stringify(previousValuesRef.current) === JSON.stringify(values);
+        const stableValues = areEqual ? previousValuesRef.current : values;
+        previousValuesRef.current = stableValues;
+        useEffect(() => {
+          setPreValues(stableValues);
+          onPendingChange?.(stableValues);
+        }, [stableValues, onPendingChange]);`,
+    ],
+  ])("accepts prop-originated data preserved through %s", (_scenario, synchronizationSource) => {
+    const result = runRule(
+      noPassDataToParent,
+      `import { useEffect, useEffectEvent, useMemo, useRef, useState } from "react";
+      const MultiSelectField = ({ values, onPendingChange }) => {
+        const [preValues, setPreValues] = useState([]);
+        ${synchronizationSource}
+        return preValues.length;
+      };`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("accepts lifecycle notifications with prop and constant payloads", () => {
+    const result = runRule(
+      noPropCallbackInEffect,
+      `import { useEffect, useState } from "react";
+      const MultiSelectField = ({ values, onPendingChange, onSearch }) => {
+        const [isOpen, setIsOpen] = useState(false);
+        const [preValues, setPreValues] = useState([]);
+        const [searchValue, setSearchValue] = useState("stale");
+        useEffect(() => {
+          if (isOpen) {
+            setPreValues(values);
+            onPendingChange?.(values);
+            setSearchValue("");
+            onSearch?.("");
+          }
+        }, [isOpen]);
+        return <button onClick={() => setIsOpen(true)}>{preValues.length + searchValue.length}</button>;
+      };`,
+      { forceJsx: true },
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it.each([noPassLiveStateToParent, noPropCallbackInEffect])(
+    "still reports child-owned state through %s",
+    (rule) => {
+      const result = runRule(
+        rule,
+        `import { useEffect, useState } from "react";
+      const MultiSelectField = ({ onPendingChange }) => {
+        const [draft, setDraft] = useState([]);
+        useEffect(() => {
+          onPendingChange?.(draft);
+        }, [draft, onPendingChange]);
+        return <button onClick={() => setDraft(["local"])}>Change</button>;
+      };`,
+        { forceJsx: true },
+      );
+
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    },
+  );
+
+  it.each([noPassLiveStateToParent, noPropCallbackInEffect])(
+    "still reports state created inside a memoizer-named custom hook through %s",
+    (rule) => {
+      const result = runRule(
+        rule,
+        `import { useEffect, useState } from "react";
+        const useDeepCompareMemoize = (value) => {
+          const [localValue] = useState(value);
+          return localValue;
+        };
+        const MultiSelectField = ({ values, onPendingChange }) => {
+          const memoizedValues = useDeepCompareMemoize(values);
+          useEffect(() => {
+            onPendingChange?.(memoizedValues);
+          }, [memoizedValues, onPendingChange]);
+          return null;
+        };`,
+      );
+
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    },
+  );
+
+  it("still reports child-produced hook data passed to a parent", () => {
+    const result = runRule(
+      noPassDataToParent,
+      `import { useEffect } from "react";
+      const MultiSelectField = ({ values, onPendingChange }) => {
+        const selectedValues = useSelectedValues(values);
+        useEffect(() => {
+          onPendingChange?.(selectedValues);
+        }, [selectedValues, onPendingChange]);
+        return null;
+      };`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/react-bench-pr-488.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/react-bench-pr-488.regressions.test.ts
@@ -264,6 +264,29 @@ describe("React Bench PR 488 false-positive regressions", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
+  it.each(["networkRef", "frameworkRef"])(
+    "still reports an ordinary reset paired with %s clearing",
+    (refName) => {
+      const result = runRule(
+        noResetAllStateOnPropChange,
+        `import { useEffect, useRef, useState } from "react";
+        const Editor = ({ documentId }) => {
+          const [draft, setDraft] = useState("");
+          const ${refName} = useRef(null);
+          useEffect(() => {
+            ${refName}.current = null;
+            setDraft("");
+          }, [documentId]);
+          return <input value={draft} onChange={(event) => setDraft(event.target.value)} />;
+        };`,
+        { forceJsx: true },
+      );
+
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    },
+  );
+
   it("accepts state synchronized by a locally owned observer", () => {
     const result = runRule(
       noResetAllStateOnPropChange,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/has-synchronous-resource-lifecycle-transition.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/has-synchronous-resource-lifecycle-transition.ts
@@ -1,0 +1,116 @@
+import { GLOBAL_RELEASE_METHOD_NAMES } from "../../../constants/react.js";
+import type { ScopeAnalysis } from "../../../semantic/scope-analysis.js";
+import { collectReturnedCleanupFunctions } from "../../../utils/collect-returned-cleanup-functions.js";
+import type { EsTreeNode } from "../../../utils/es-tree-node.js";
+import { getStaticPropertyName } from "../../../utils/get-static-property-name.js";
+import { getTransparentReactCallbackWrapperArgument } from "../../../utils/get-transparent-react-callback-wrapper-argument.js";
+import { isFunctionLike } from "../../../utils/is-function-like.js";
+import { isNodeOfType } from "../../../utils/is-node-of-type.js";
+import { isReactApiCall } from "../../../utils/is-react-api-call.js";
+import { isSynchronousIteratorCallbackCall } from "../../../utils/is-synchronous-iterator-callback.js";
+import { resolveExactLocalFunction } from "../../../utils/resolve-exact-local-function.js";
+import { stripParenExpression } from "../../../utils/strip-paren-expression.js";
+import { walkAst } from "../../../utils/walk-ast.js";
+
+const RESOURCE_IDENTITY_REF_NAME_PATTERN =
+  /(?:abort|activation|attempt|controller|epoch|gen|generation|pending|request|session|token|version)s?(?:Ref)?$/i;
+const RESOURCE_INVALIDATION_MARKER_NAMES: ReadonlySet<string> = new Set(["superseded"]);
+
+const resolveSynchronousFunction = (
+  expression: EsTreeNode,
+  scopes: ScopeAnalysis,
+): EsTreeNode | null => {
+  const directFunction = resolveExactLocalFunction(expression, scopes);
+  if (directFunction) return directFunction;
+  const candidate = stripParenExpression(expression);
+  if (!isNodeOfType(candidate, "Identifier")) return null;
+  const symbol = scopes.referenceFor(candidate)?.resolvedSymbol ?? scopes.symbolFor(candidate);
+  if (!symbol?.initializer) return null;
+  const wrappedFunction = getTransparentReactCallbackWrapperArgument(
+    symbol.initializer,
+    symbol,
+    scopes,
+  );
+  return wrappedFunction && isFunctionLike(wrappedFunction) ? wrappedFunction : null;
+};
+
+const isResourceIdentityRefCurrent = (node: EsTreeNode, scopes: ScopeAnalysis): boolean => {
+  const candidate = stripParenExpression(node);
+  if (
+    !isNodeOfType(candidate, "MemberExpression") ||
+    getStaticPropertyName(candidate) !== "current"
+  ) {
+    return false;
+  }
+  const receiver = stripParenExpression(candidate.object);
+  if (!isNodeOfType(receiver, "Identifier")) return false;
+  const receiverSymbol =
+    scopes.referenceFor(receiver)?.resolvedSymbol ?? scopes.symbolFor(receiver);
+  return Boolean(
+    receiverSymbol?.initializer &&
+    RESOURCE_IDENTITY_REF_NAME_PATTERN.test(receiverSymbol.name) &&
+    isReactApiCall(receiverSymbol.initializer, "useRef", scopes, {
+      allowGlobalReactNamespace: true,
+      allowUnboundBareCalls: true,
+      resolveNamedAliases: true,
+    }),
+  );
+};
+
+const isSynchronousResourceInvalidation = (node: EsTreeNode, scopes: ScopeAnalysis): boolean => {
+  if (isNodeOfType(node, "UpdateExpression")) {
+    return isResourceIdentityRefCurrent(node.argument, scopes);
+  }
+  if (!isNodeOfType(node, "AssignmentExpression")) return false;
+  if (isResourceIdentityRefCurrent(node.left, scopes)) return true;
+  const target = stripParenExpression(node.left);
+  const assignedValue = stripParenExpression(node.right);
+  return Boolean(
+    node.operator === "=" &&
+    isNodeOfType(target, "MemberExpression") &&
+    RESOURCE_INVALIDATION_MARKER_NAMES.has(getStaticPropertyName(target) ?? "") &&
+    isNodeOfType(assignedValue, "Literal") &&
+    assignedValue.value === true,
+  );
+};
+
+export const hasSynchronousResourceLifecycleTransition = (
+  rootFunction: EsTreeNode,
+  scopes: ScopeAnalysis,
+): boolean => {
+  const pendingFunctions = [rootFunction, ...collectReturnedCleanupFunctions(rootFunction, scopes)];
+  const visitedFunctions = new Set<EsTreeNode>();
+  while (pendingFunctions.length > 0) {
+    const currentFunction = pendingFunctions.pop();
+    if (!currentFunction || visitedFunctions.has(currentFunction)) continue;
+    visitedFunctions.add(currentFunction);
+    let didFindLifecycleTransition = false;
+    walkAst(currentFunction, (child) => {
+      if (didFindLifecycleTransition) return false;
+      if (child !== currentFunction && isFunctionLike(child)) return false;
+      if (isSynchronousResourceInvalidation(child, scopes)) {
+        didFindLifecycleTransition = true;
+        return false;
+      }
+      if (!isNodeOfType(child, "CallExpression")) return;
+      const callee = stripParenExpression(child.callee);
+      const memberName = isNodeOfType(callee, "MemberExpression")
+        ? getStaticPropertyName(callee)
+        : null;
+      if (memberName && GLOBAL_RELEASE_METHOD_NAMES.has(memberName)) {
+        didFindLifecycleTransition = true;
+        return false;
+      }
+      const invokedFunction = resolveSynchronousFunction(child.callee, scopes);
+      if (invokedFunction) pendingFunctions.push(invokedFunction);
+      for (const argument of child.arguments) {
+        if (isNodeOfType(argument, "SpreadElement")) continue;
+        if (!isSynchronousIteratorCallbackCall(child, argument)) continue;
+        const iteratorFunction = resolveSynchronousFunction(argument, scopes);
+        if (iteratorFunction) pendingFunctions.push(iteratorFunction);
+      }
+    });
+    if (didFindLifecycleTransition) return true;
+  }
+  return false;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/has-synchronous-resource-lifecycle-transition.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/has-synchronous-resource-lifecycle-transition.ts
@@ -14,7 +14,7 @@ import { stripParenExpression } from "../../../utils/strip-paren-expression.js";
 import { walkAst } from "../../../utils/walk-ast.js";
 
 const RESOURCE_IDENTITY_REF_NAME_PATTERN =
-  /(?:abort|activation|attempt|controller|epoch|gen|generation|localization|pending|request|session|token|version|work)(?:[A-Za-z0-9]*Refs?|s)?$/i;
+  /(?:(?:^(?:abort|activation|attempt|controller|epoch|gen|generation|localization|pending|request|session|token|version)|(?:Abort|Activation|Attempt|Controller|Epoch|Gen|Generation|Localization|Pending|Request|Session|Token|Version))[A-Za-z0-9]*|(?:^work|Work)(?:Refs?)?)$/;
 const RESOURCE_INVALIDATION_MARKER_NAMES: ReadonlySet<string> = new Set(["superseded"]);
 const RESOURCE_COLLECTION_CLEAR_METHOD_NAMES: ReadonlySet<string> = new Set(["clear"]);
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/has-synchronous-resource-lifecycle-transition.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/has-synchronous-resource-lifecycle-transition.ts
@@ -2,6 +2,7 @@ import { GLOBAL_RELEASE_METHOD_NAMES } from "../../../constants/react.js";
 import type { ScopeAnalysis } from "../../../semantic/scope-analysis.js";
 import { collectReturnedCleanupFunctions } from "../../../utils/collect-returned-cleanup-functions.js";
 import type { EsTreeNode } from "../../../utils/es-tree-node.js";
+import { findEnclosingFunction } from "../../../utils/find-enclosing-function.js";
 import { getStaticPropertyName } from "../../../utils/get-static-property-name.js";
 import { getTransparentReactCallbackWrapperArgument } from "../../../utils/get-transparent-react-callback-wrapper-argument.js";
 import { isFunctionLike } from "../../../utils/is-function-like.js";
@@ -13,8 +14,9 @@ import { stripParenExpression } from "../../../utils/strip-paren-expression.js";
 import { walkAst } from "../../../utils/walk-ast.js";
 
 const RESOURCE_IDENTITY_REF_NAME_PATTERN =
-  /(?:abort|activation|attempt|controller|epoch|gen|generation|pending|request|session|token|version)s?(?:Ref)?$/i;
+  /(?:abort|activation|attempt|controller|epoch|gen|generation|localization|pending|request|session|token|version|work)(?:[A-Za-z0-9]*Refs?|s)?$/i;
 const RESOURCE_INVALIDATION_MARKER_NAMES: ReadonlySet<string> = new Set(["superseded"]);
+const RESOURCE_COLLECTION_CLEAR_METHOD_NAMES: ReadonlySet<string> = new Set(["clear"]);
 
 const resolveSynchronousFunction = (
   expression: EsTreeNode,
@@ -57,9 +59,108 @@ const isResourceIdentityRefCurrent = (node: EsTreeNode, scopes: ScopeAnalysis): 
   );
 };
 
-const isSynchronousResourceInvalidation = (node: EsTreeNode, scopes: ScopeAnalysis): boolean => {
+const isDescendantOf = (node: EsTreeNode, ancestor: EsTreeNode): boolean => {
+  let current: EsTreeNode | null | undefined = node;
+  while (current) {
+    if (current === ancestor) return true;
+    current = current.parent;
+  }
+  return false;
+};
+
+const expressionContainsResourceIdentityRef = (
+  expression: EsTreeNode,
+  scopes: ScopeAnalysis,
+): boolean => {
+  let didFindResourceIdentityRef = false;
+  walkAst(expression, (child) => {
+    if (didFindResourceIdentityRef) return false;
+    if (isResourceIdentityRefCurrent(child, scopes)) {
+      didFindResourceIdentityRef = true;
+      return false;
+    }
+  });
+  return didFindResourceIdentityRef;
+};
+
+const isOwnedResourceExpression = (
+  expression: EsTreeNode,
+  rootFunction: EsTreeNode,
+  scopes: ScopeAnalysis,
+  visitedSymbolIds: ReadonlySet<number> = new Set(),
+): boolean => {
+  const candidate = stripParenExpression(expression);
+  if (isResourceIdentityRefCurrent(candidate, scopes)) return true;
+  if (isNodeOfType(candidate, "CallExpression")) {
+    return expressionContainsResourceIdentityRef(candidate, scopes);
+  }
+  if (isNodeOfType(candidate, "MemberExpression")) {
+    return isOwnedResourceExpression(candidate.object, rootFunction, scopes, visitedSymbolIds);
+  }
+  if (!isNodeOfType(candidate, "Identifier")) return false;
+  const symbol = scopes.referenceFor(candidate)?.resolvedSymbol ?? scopes.symbolFor(candidate);
+  if (!symbol?.declarationNode || visitedSymbolIds.has(symbol.id)) {
+    return false;
+  }
+  const nextVisitedSymbolIds = new Set(visitedSymbolIds).add(symbol.id);
+  if (symbol.initializer) {
+    const initializer = stripParenExpression(symbol.initializer);
+    if (
+      isNodeOfType(initializer, "NewExpression") &&
+      isDescendantOf(symbol.declarationNode, rootFunction)
+    ) {
+      return true;
+    }
+    if (isOwnedResourceExpression(initializer, rootFunction, scopes, nextVisitedSymbolIds)) {
+      return true;
+    }
+  }
+  let declarationAncestor: EsTreeNode | null | undefined = symbol.bindingIdentifier.parent;
+  while (declarationAncestor && declarationAncestor !== rootFunction) {
+    if (
+      isNodeOfType(declarationAncestor, "ForOfStatement") &&
+      expressionContainsResourceIdentityRef(declarationAncestor.right, scopes)
+    ) {
+      return true;
+    }
+    if (isFunctionLike(declarationAncestor)) break;
+    declarationAncestor = declarationAncestor.parent;
+  }
+  const declaringFunction = findEnclosingFunction(symbol.bindingIdentifier);
+  const iteratorCall = declaringFunction?.parent;
+  if (
+    declaringFunction &&
+    isNodeOfType(iteratorCall, "CallExpression") &&
+    isSynchronousIteratorCallbackCall(iteratorCall, declaringFunction) &&
+    expressionContainsResourceIdentityRef(iteratorCall.callee, scopes)
+  ) {
+    return true;
+  }
+  let didFindResourceAcquisition = false;
+  walkAst(rootFunction, (child) => {
+    if (didFindResourceAcquisition) return false;
+    if (child !== rootFunction && isFunctionLike(child)) return false;
+    if (!isNodeOfType(child, "AssignmentExpression") || child.operator !== "=") return;
+    const assignmentTarget = stripParenExpression(child.left);
+    if (!isNodeOfType(assignmentTarget, "Identifier")) return;
+    const targetSymbol =
+      scopes.referenceFor(assignmentTarget)?.resolvedSymbol ?? scopes.symbolFor(assignmentTarget);
+    if (targetSymbol?.id !== symbol.id) return;
+    if (isNodeOfType(stripParenExpression(child.right), "NewExpression")) {
+      didFindResourceAcquisition = true;
+      return false;
+    }
+  });
+  return didFindResourceAcquisition;
+};
+
+const isSynchronousResourceInvalidation = (
+  node: EsTreeNode,
+  rootFunction: EsTreeNode,
+  scopes: ScopeAnalysis,
+): boolean => {
   if (isNodeOfType(node, "UpdateExpression")) {
-    return isResourceIdentityRefCurrent(node.argument, scopes);
+    return isOwnedResourceExpression(node.argument, rootFunction, scopes);
   }
   if (!isNodeOfType(node, "AssignmentExpression")) return false;
   if (isResourceIdentityRefCurrent(node.left, scopes)) return true;
@@ -69,6 +170,7 @@ const isSynchronousResourceInvalidation = (node: EsTreeNode, scopes: ScopeAnalys
     node.operator === "=" &&
     isNodeOfType(target, "MemberExpression") &&
     RESOURCE_INVALIDATION_MARKER_NAMES.has(getStaticPropertyName(target) ?? "") &&
+    isOwnedResourceExpression(target.object, rootFunction, scopes) &&
     isNodeOfType(assignedValue, "Literal") &&
     assignedValue.value === true,
   );
@@ -88,7 +190,7 @@ export const hasSynchronousResourceLifecycleTransition = (
     walkAst(currentFunction, (child) => {
       if (didFindLifecycleTransition) return false;
       if (child !== currentFunction && isFunctionLike(child)) return false;
-      if (isSynchronousResourceInvalidation(child, scopes)) {
+      if (isSynchronousResourceInvalidation(child, rootFunction, scopes)) {
         didFindLifecycleTransition = true;
         return false;
       }
@@ -97,7 +199,17 @@ export const hasSynchronousResourceLifecycleTransition = (
       const memberName = isNodeOfType(callee, "MemberExpression")
         ? getStaticPropertyName(callee)
         : null;
-      if (memberName && GLOBAL_RELEASE_METHOD_NAMES.has(memberName)) {
+      const releaseReceiver = isNodeOfType(callee, "MemberExpression")
+        ? stripParenExpression(callee.object)
+        : null;
+      if (
+        memberName &&
+        releaseReceiver &&
+        ((GLOBAL_RELEASE_METHOD_NAMES.has(memberName) &&
+          isOwnedResourceExpression(releaseReceiver, rootFunction, scopes)) ||
+          (RESOURCE_COLLECTION_CLEAR_METHOD_NAMES.has(memberName) &&
+            isResourceIdentityRefCurrent(releaseReceiver, scopes)))
+      ) {
         didFindLifecycleTransition = true;
         return false;
       }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/is-comparison-memoizer-hook-name.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/is-comparison-memoizer-hook-name.ts
@@ -1,0 +1,4 @@
+const COMPARISON_MEMOIZER_HOOK_NAME_PATTERN = /^use(?:Deep|Shallow)?CompareMemo(?:ize|izedValue)?$/;
+
+export const isComparisonMemoizerHookName = (hookName: string): boolean =>
+  COMPARISON_MEMOIZER_HOOK_NAME_PATTERN.test(hookName);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/is-custom-hook-state-result-reference.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/is-custom-hook-state-result-reference.ts
@@ -1,11 +1,16 @@
 import type { Reference } from "eslint-scope";
 import { BUILTIN_HOOK_NAMES, HOOK_NAME_PATTERN } from "../../../constants/react.js";
+import type { ScopeAnalysis } from "../../../semantic/scope-analysis.js";
 import type { EsTreeNode } from "../../../utils/es-tree-node.js";
 import { isNodeOfType } from "../../../utils/is-node-of-type.js";
+import { isReactApiCall } from "../../../utils/is-react-api-call.js";
+import { resolveExactLocalFunction } from "../../../utils/resolve-exact-local-function.js";
 import { stripParenExpression } from "../../../utils/strip-paren-expression.js";
+import { walkAst } from "../../../utils/walk-ast.js";
 import { getDownstreamRefs } from "./effect/ast.js";
 import type { ProgramAnalysis } from "./effect/get-program-analysis.js";
 import { isProp } from "./effect/react.js";
+import { isComparisonMemoizerHookName } from "./is-comparison-memoizer-hook-name.js";
 
 const NON_STATE_CUSTOM_HOOK_NAMES: ReadonlySet<string> = new Set([
   "useCallbackRef",
@@ -16,6 +21,30 @@ const NON_STATE_CUSTOM_HOOK_NAMES: ReadonlySet<string> = new Set([
   "useMemoizedFn",
   "useStableCallback",
 ]);
+
+const REACT_STATE_HOOK_NAMES: ReadonlySet<string> = new Set(["useReducer", "useState"]);
+
+const isLocalNonStateMemoizerHook = (
+  initializer: EsTreeNode,
+  hookName: string,
+  scopes: ScopeAnalysis,
+): boolean => {
+  if (!isComparisonMemoizerHookName(hookName)) return false;
+  const candidate = stripParenExpression(initializer);
+  if (!isNodeOfType(candidate, "CallExpression")) return false;
+  const hookFunction = resolveExactLocalFunction(candidate.callee, scopes);
+  if (!hookFunction) return false;
+  let doesCreateState = false;
+  walkAst(hookFunction, (child) => {
+    if (child !== hookFunction && isNodeOfType(child, "CallExpression")) {
+      if (isReactApiCall(child, REACT_STATE_HOOK_NAMES, scopes)) {
+        doesCreateState = true;
+        return false;
+      }
+    }
+  });
+  return !doesCreateState;
+};
 
 const EXTERNAL_SUBSCRIPTION_HOOK_NAMES: ReadonlySet<string> = new Set([
   "useIntersectionObserver",
@@ -41,6 +70,7 @@ const getHookCalleeName = (initializer: EsTreeNode): string | null => {
 export const isCustomHookStateResultReference = (
   analysis: ProgramAnalysis,
   reference: Reference,
+  scopes: ScopeAnalysis,
 ): boolean =>
   Boolean(
     reference.resolved?.defs.some((definition) => {
@@ -52,6 +82,7 @@ export const isCustomHookStateResultReference = (
         !HOOK_NAME_PATTERN.test(calleeName) ||
         BUILTIN_HOOK_NAMES.has(calleeName) ||
         NON_STATE_CUSTOM_HOOK_NAMES.has(calleeName) ||
+        isLocalNonStateMemoizerHook(declarator.init as EsTreeNode, calleeName, scopes) ||
         EXTERNAL_SUBSCRIPTION_HOOK_NAMES.has(calleeName)
       ) {
         return false;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/find-import-source-for-name.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/find-import-source-for-name.ts
@@ -57,9 +57,6 @@ const getImportLookup = (node: EsTreeNode): Map<string, ImportInfo> | null => {
   return cached;
 };
 
-export const hasImportedBinding = (contextNode: EsTreeNode, localIdentifierName: string): boolean =>
-  Boolean(getImportLookup(contextNode)?.has(localIdentifierName));
-
 // True if the enclosing module imports anything from any of `moduleSources`.
 // A cheap existence gate for detectors whose signal can only come from a
 // specific library — when the import is absent, callers skip their AST walk

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/find-import-source-for-name.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/find-import-source-for-name.ts
@@ -57,6 +57,9 @@ const getImportLookup = (node: EsTreeNode): Map<string, ImportInfo> | null => {
   return cached;
 };
 
+export const hasImportedBinding = (contextNode: EsTreeNode, localIdentifierName: string): boolean =>
+  Boolean(getImportLookup(contextNode)?.has(localIdentifierName));
+
 // True if the enclosing module imports anything from any of `moduleSources`.
 // A cheap existence gate for detectors whose signal can only come from a
 // specific library — when the import is absent, callers skip their AST walk


### PR DESCRIPTION
## Why

React Bench PR #488 excluded six React Doctor rules after 193 of 198 adjudicated occurrences proved to be false positives. The remaining detector gaps still reported valid controlled-state fallbacks, owned-resource transitions, and prop-originated lifecycle synchronization; five genuine reset-state findings must remain reportable.

Before, 54 confirmed false-positive occurrences still reported. After, all 193 confirmed false positives are silent and the five named true positives still report at their exact locations.

## What changed

- prove synchronous owned-resource release and identity invalidation before suppressing reset-state diagnostics
- recognize bounded controlled-state dependency selections whose fresh fallback is unreachable
- preserve prop provenance through immutable memoizers, transparent transforms, refs, and global JSON round trips without accepting child-owned state
- require equivalent local state writes for state-driven lifecycle callback synchronization
- retain state ownership for memoizer-named custom hooks that create React state
- add focused rule regressions, deterministic multi-rule fuzz verdicts, corpus fixtures, and a patch changeset

## Eval results

The self-contained React Bench PR #488 runner processed 166 full-source examples and 198 diagnostic occurrences with zero parse failures. It matched all intended outcomes: 193 confirmed false positives are silent and only the five required true-positive suffixes report.

Exact-SHA parity compared da0647e275c75494ec00b3657b34a17235a0f85b with 1b8c62ba6acf55a038916bbfe695dd54926cd12a across all 2,000 pinned projects: 2,000 compared, zero skipped, +0 additions, -24 removals, and 10,364 unchanged diagnostics. The removals are 19 no-pass-data-to-parent, four no-prop-callback-in-effect, and one no-reset-all-state-on-prop-change finding; all 24 identities match the source-audited false-positive set.

Paired sequential performance found zero project regressions. Candidate aggregate time was 539,632.191 ms versus 541,731.395 ms for base (0.996x); median project ratio was 0.994 and p95 was 1.113.

The exact-head full-rule shadow completed 2,000/2,000 with zero failures. Projecting its reports onto the five-rule impact scope matched the scoped candidate exactly: +0/-0 with all 10,364 diagnostics unchanged and zero skipped projects.

Local RDE could not start because the sibling eval environment is missing AXIOM_DATASET and AXIOM_TOKEN; the complete Daytona evidence above used the copied DAYTONA_API_KEY.

## Test plan

- bun tmp/audit-react-bench-pr-488.ts --summary — 198/198 intended outcomes, zero parse failures
- nr test — passed all 15 tasks
- nr lint — exit 0; only existing fuzz-corpus warnings
- nr typecheck — passed all 16 tasks
- nr format:check — passed all 6,180 files
- nr smoke:json-report — schema v3 report passed
- strict 500-mutation fuzz runs for all six affected rules plus the final exhaustive-deps review fixes — passed
- fuzz corpus verdict smoke — all declared pass/fail seeds preserved
- nlx react-doctor@latest --verbose --scope changed — no issues
- full GitHub CI matrix — passed, including Node 20 rerun
- git diff --check — passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad changes to static-analysis heuristics across six related rules could miss edge-case violations or over-suppress, though extensive regression and fuzz corpus coverage mitigates that.
> 
> **Overview**
> **React Doctor / ESLint plugin:** several state-and-effects rules get smarter provenance and lifecycle analysis so React Bench–style patterns stop false-alarming without weakening real findings.
> 
> **`exhaustive-deps`** now treats classic controlled/uncontrolled `?? []` selections as stable when the uncontrolled branch is provably non-nullish and the controlled prop type excludes null (including global `Array` / `ReadonlyArray`), while still reporting reachable fresh fallbacks and imported types that shadow `Array`.
> 
> **`no-reset-all-state-on-prop-change`** skips “reset all state on prop change” when the same effect synchronously invalidates or releases owned resources (abort, ref epoch bumps, collection clears, memoized cleanup helpers, etc.) via new `hasSynchronousResourceLifecycleTransition`.
> 
> **Parent-sync rules** (`no-pass-data-to-parent`, `no-pass-live-state-to-parent`, `no-prop-callback-in-effect`) allow arguments that only echo props through transparent paths (deep-compare memoizers, `useMemo`/`JSON` transforms, ref-stabilized values) and require equivalent local state writes before flagging lifecycle prop callbacks; memoizer-named custom hooks that actually call `useState`/`useReducer` still count as child-owned state.
> 
> **Fuzz harness** corpus directives can list multiple comma-separated rules; new regression/true-positive fixtures and a large `react-bench-pr-488` regression suite lock behavior. Patch **changeset** for both `oxlint-plugin-react-doctor` and `eslint-plugin-react-doctor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b8c62ba6acf55a038916bbfe695dd54926cd12a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
