### PR TITLE
fix(cli): print cancellation footer once

### DIFF
--- a/.changeset/avoid-duplicate-tui-cancel-footer.md
+++ b/.changeset/avoid-duplicate-tui-cancel-footer.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Prevent Ctrl-C from printing the completed-scan footer after the interactive cancellation footer.

--- a/packages/react-doctor/src/cli/ink/hooks/use-exit-on-ctrl-c.ts
+++ b/packages/react-doctor/src/cli/ink/hooks/use-exit-on-ctrl-c.ts
@@ -5,9 +5,10 @@ import { recordCount } from "../../utils/record-metric.js";
 
 const SHOW_CURSOR = "\u001B[?25h";
 
-export const useExitOnCtrlC = (): void => {
+export const useExitOnCtrlC = (onCancel?: () => void): void => {
   useInput((input, key) => {
     if (key.ctrl && input === "c") {
+      onCancel?.();
       recordCount(METRIC.tuiCancelled, 1, { resourceFooter: true });
       process.stdin.setRawMode?.(false);
       process.stdout.write(SHOW_CURSOR);

--- a/packages/react-doctor/src/cli/ink/scan-app.tsx
+++ b/packages/react-doctor/src/cli/ink/scan-app.tsx
@@ -29,7 +29,7 @@ export const ScanApp = ({
 }: ScanAppProps) => {
   const snapshot = useScanStore(store);
   const { exit } = useApp();
-  useExitOnCtrlC();
+  useExitOnCtrlC(onQuit);
   const handleQuit = (): void => {
     onQuit?.();
     exit();

--- a/packages/react-doctor/tests/ink/scan-app.test.tsx
+++ b/packages/react-doctor/tests/ink/scan-app.test.tsx
@@ -10,6 +10,7 @@ import {
   TUI_REPORT_STATUS_ROWS,
   TUI_REPORT_VIEWPORT_MARGIN_ROWS,
 } from "../../src/cli/utils/constants.js";
+import * as exitGracefullyModule from "../../src/cli/utils/exit-gracefully.js";
 import * as launchAgent from "../../src/cli/utils/launch-agent.js";
 import * as openUrlModule from "../../src/cli/utils/open-url.js";
 import { ScanApp } from "../../src/cli/ink/scan-app.js";
@@ -621,6 +622,38 @@ describe("ScanApp", () => {
     await flush();
 
     expect(onQuit).toHaveBeenCalledOnce();
+    unmount();
+  });
+
+  it("marks the report quit before cancelling after issue review", async () => {
+    const exitGracefullySpy = vi
+      .spyOn(exitGracefullyModule, "exitGracefully")
+      .mockImplementation(() => {});
+    const store = createScanStore();
+    const onQuit = vi.fn();
+    store.setReport({
+      diagnostics: [makeDiagnostic({ rule: "rules-of-hooks", severity: "error" })],
+      score: SCORE,
+      projectedScore: null,
+      projectName: "demo-app",
+      rootDirectory: "/tmp/demo-app",
+      scannedFileCount: 1,
+      elapsedMilliseconds: 10,
+      isOffline: true,
+      noScoreMessage: "Score unavailable.",
+    });
+
+    const { stdin, unmount } = render(<ScanApp store={store} onQuit={onQuit} />);
+    await flush();
+    stdin.write("\r");
+    await flush();
+    stdin.write("\u001B");
+    await flush();
+    stdin.write("\u0003");
+    await flush();
+
+    expect(onQuit).toHaveBeenCalledOnce();
+    expect(exitGracefullySpy).toHaveBeenCalledOnce();
     unmount();
   });
 


### PR DESCRIPTION
## Why

Before: pressing Ctrl-C after opening and closing the issue review cleared Ink and printed the cancellation footer, then the resolved report lifecycle printed the normal scan footer again.

After: Ctrl-C marks the existing TUI quit state before clearing Ink, so cancellation owns the only footer while normal completion remains unchanged.

Product brief:
- Job: let an interactive CLI user cancel after reviewing issues and get one clear exit message with a restored terminal.
- Reuse: use the existing `pendingActions.didQuit` footer suppression instead of adding another output mode or state owner.
- Metric: keep the existing `tui.cancelled` counter; no new telemetry surface is needed.
- Compatibility: patch changeset only; no flags, config, report schema, score, package API, or GitHub Action behavior changes.
- Kill signal: revert if cancellation telemetry starts reporting errors or the lifecycle regression can no longer prove one footer owner.

## What changed

- notify `ScanApp`'s existing quit owner before the Ctrl-C path clears the active Ink renderer
- preserve the dedicated cancellation footer and suppress the completed-scan footer
- cover the full report → issue review → back → Ctrl-C sequence

## Test plan

- `nr test`
- `nr lint`
- `nr typecheck`
- `nr format:check`
- `nr smoke:json-report`
- `npx -y react-doctor@latest --verbose --scope changed`
- real PTY on a Next.js project: `--scope full --verbose --yes`, enter issue review, escape back, then Ctrl-C; exits 130 with one cancellation footer

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CLI-only change to Ctrl-C handling with a focused regression test; no auth, data, or API impact.
> 
> **Overview**
> Fixes a TUI bug where **Ctrl-C** after visiting issue review and returning to the report could print **two footers**: the cancellation message and then the normal completed-scan footer.
> 
> `useExitOnCtrlC` now accepts an optional **`onCancel`** callback and **`ScanApp`** passes **`onQuit`** into it so Ctrl-C sets the same **`pendingActions.didQuit`** flag as **q** / **Esc** before Ink tears down. That reuses existing footer suppression instead of new state.
> 
> A new **`scan-app`** test covers report → issue review → back → Ctrl-C and asserts **`onQuit`** and **`exitGracefully`** run once.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 408aa3ce42d13aa200dcca78ea3287d1580b73fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->