### PR TITLE
fix(core): honor standard Knip config files

### DIFF
--- a/.changeset/friendly-knips-listen.md
+++ b/.changeset/friendly-knips-listen.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Load standard JavaScript and TypeScript Knip configuration files when collecting dead-code entry and ignore patterns.

--- a/packages/core/src/check-dead-code.ts
+++ b/packages/core/src/check-dead-code.ts
@@ -2,10 +2,7 @@ import { spawn } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { Diagnostic } from "./types/index.js";
-import {
-  collectDeadCodeEntryPatterns,
-  collectDeadCodeIgnorePatterns,
-} from "./dead-code/collect-dead-code-patterns.js";
+import { collectDeadCodePatterns } from "./dead-code/collect-dead-code-patterns.js";
 import {
   collectAnalyzedFileStats,
   computeDeadCodeCacheKey,
@@ -569,8 +566,7 @@ export const checkDeadCode = async (options: CheckDeadCodeOptions): Promise<Diag
   const rootDirectory = toCanonicalPath(options.rootDirectory);
   if (!fs.existsSync(path.join(rootDirectory, "package.json"))) return [];
 
-  const entryPatterns = collectDeadCodeEntryPatterns(rootDirectory);
-  const ignorePatterns = collectDeadCodeIgnorePatterns(rootDirectory);
+  const { entryPatterns, ignorePatterns } = await collectDeadCodePatterns(rootDirectory);
   const tsConfigPath = resolveTsConfigPath(rootDirectory);
   const deslopJsModuleSpecifier =
     options.deslopJsModuleSpecifier ?? import.meta.resolve("deslop-js");

--- a/packages/core/src/dead-code/collect-dead-code-patterns.ts
+++ b/packages/core/src/dead-code/collect-dead-code-patterns.ts
@@ -1,8 +1,12 @@
+import { createJiti } from "jiti";
 import path from "node:path";
 import { collectIgnorePatterns } from "../collect-ignore-patterns.js";
+import { isFile } from "../project-info/index.js";
 import { readIgnoreFile } from "../read-ignore-file.js";
-import { failOpenReadJson } from "../utils/fail-open-read-json.js";
+import { importDefaultExport } from "../utils/import-default-export.js";
 import { isRecord } from "../utils/is-record.js";
+import { readJson5File } from "../utils/read-json5-file.js";
+import { KNIP_CONFIG_FILENAMES, KNIP_DATA_CONFIG_FILENAMES } from "./knip-config-filenames.js";
 
 interface KnipWorkspaceConfig {
   readonly entry?: unknown;
@@ -15,21 +19,47 @@ interface KnipConfig {
   readonly workspaces?: unknown;
 }
 
-const KNIP_JSON_FILENAME = "knip.json";
+interface DeadCodePatterns {
+  readonly entryPatterns: ReadonlyArray<string>;
+  readonly ignorePatterns: ReadonlyArray<string>;
+}
 
-const readKnipConfig = (rootDirectory: string): KnipConfig | null => {
-  const knipJson = failOpenReadJson<unknown | null>(
-    path.join(rootDirectory, KNIP_JSON_FILENAME),
-    null,
-  );
-  if (isRecord(knipJson)) return knipJson;
+const jiti = createJiti(import.meta.url, { moduleCache: false });
 
-  const packageJson = failOpenReadJson<unknown | null>(
-    path.join(rootDirectory, "package.json"),
-    null,
-  );
-  const packageKnipConfig = isRecord(packageJson) ? packageJson.knip : null;
-  return isRecord(packageKnipConfig) ? packageKnipConfig : null;
+const resolveKnipConfigExport = async (configExport: unknown): Promise<KnipConfig | null> => {
+  const config = typeof configExport === "function" ? await configExport() : await configExport;
+  return isRecord(config) ? config : null;
+};
+
+const loadKnipConfigFile = async (
+  configFilename: string,
+  filePath: string,
+): Promise<KnipConfig | null> => {
+  try {
+    const configExport = KNIP_DATA_CONFIG_FILENAMES.has(configFilename)
+      ? readJson5File(filePath)
+      : await importDefaultExport(jiti, filePath);
+    return await resolveKnipConfigExport(configExport);
+  } catch {
+    return null;
+  }
+};
+
+const loadKnipConfig = async (rootDirectory: string): Promise<KnipConfig | null> => {
+  for (const configFilename of KNIP_CONFIG_FILENAMES) {
+    const filePath = path.join(rootDirectory, configFilename);
+    if (!isFile(filePath)) continue;
+    const config = await loadKnipConfigFile(configFilename, filePath);
+    if (config) return config;
+  }
+
+  try {
+    const packageJson = readJson5File(path.join(rootDirectory, "package.json"));
+    const packageKnipConfig = isRecord(packageJson) ? packageJson.knip : null;
+    return isRecord(packageKnipConfig) ? packageKnipConfig : null;
+  } catch {
+    return null;
+  }
 };
 
 const normalizePatternList = (value: unknown): string[] => {
@@ -69,10 +99,9 @@ const collectKnipWorkspacePatterns = (
 };
 
 const collectKnipPatterns = (
-  rootDirectory: string,
+  config: KnipConfig | null,
   settingName: keyof Pick<KnipConfig, "entry" | "ignore">,
 ): string[] => {
-  const config = readKnipConfig(rootDirectory);
   if (!config) return [];
   return [
     ...normalizePatternList(config[settingName]),
@@ -80,15 +109,18 @@ const collectKnipPatterns = (
   ];
 };
 
-// `ignore.files` is intentionally excluded: it suppresses *reporting* (via the
-// diagnostic pipeline), so those files must stay in deslop's graph or a file
-// imported only by an ignored file is falsely flagged unused (react-doctor#830).
-export const collectDeadCodeIgnorePatterns = (rootDirectory: string): string[] => {
+// `ignore.files` is intentionally excluded: it suppresses reporting through
+// the diagnostic pipeline, so ignored importers must stay in the graph and
+// keep their imported files reachable (react-doctor#830).
+const collectDeadCodeIgnorePatterns = (
+  rootDirectory: string,
+  config: KnipConfig | null,
+): string[] => {
   const seen = new Set<string>();
   const sources = [
     readIgnoreFile(path.join(rootDirectory, ".gitignore")),
     collectIgnorePatterns(rootDirectory),
-    collectKnipPatterns(rootDirectory, "ignore"),
+    collectKnipPatterns(config, "ignore"),
   ];
   for (const source of sources) {
     for (const pattern of source) seen.add(pattern);
@@ -96,5 +128,13 @@ export const collectDeadCodeIgnorePatterns = (rootDirectory: string): string[] =
   return [...seen].filter((pattern) => pattern.length > 0);
 };
 
-export const collectDeadCodeEntryPatterns = (rootDirectory: string): string[] =>
-  [...new Set(collectKnipPatterns(rootDirectory, "entry"))].filter((pattern) => pattern.length > 0);
+const collectDeadCodeEntryPatterns = (config: KnipConfig | null): string[] =>
+  [...new Set(collectKnipPatterns(config, "entry"))].filter((pattern) => pattern.length > 0);
+
+export const collectDeadCodePatterns = async (rootDirectory: string): Promise<DeadCodePatterns> => {
+  const config = await loadKnipConfig(rootDirectory);
+  return {
+    entryPatterns: collectDeadCodeEntryPatterns(config),
+    ignorePatterns: collectDeadCodeIgnorePatterns(rootDirectory, config),
+  };
+};

--- a/packages/core/src/dead-code/dead-code-result-cache.ts
+++ b/packages/core/src/dead-code/dead-code-result-cache.ts
@@ -7,6 +7,7 @@ import { ANALYZED_MANIFEST_FILENAMES, DEFAULT_EXTENSIONS } from "deslop-js/analy
 import type { Diagnostic } from "../types/index.js";
 import { DEAD_CODE_CACHE_FILENAME, DEAD_CODE_CACHE_SCHEMA_VERSION } from "../constants.js";
 import { Diagnostic as DiagnosticSchema } from "../schemas.js";
+import { KNIP_CONFIG_FILENAMES } from "./knip-config-filenames.js";
 import { atomicWriteJson } from "../utils/atomic-write-json.js";
 import { failOpenReadJson } from "../utils/fail-open-read-json.js";
 import { hashFileContents } from "../utils/hash-file-contents.js";
@@ -75,11 +76,11 @@ interface PersistedDeadCodeResultCache {
 const ANALYZED_FILE_EXTENSIONS = new Set(DEFAULT_EXTENSIONS);
 
 // Beyond what deslop itself reads, the dead-code PASS also depends on:
-// `knip.json` (read core-side by `collect-dead-code-patterns.ts` to derive
-// the entry/ignore patterns) and `deno.lock` (an extra proxy for installed
+// Knip configuration (read core-side by `collect-dead-code-patterns.ts` to
+// derive the entry/ignore patterns) and `deno.lock` (an extra proxy for installed
 // `node_modules` metadata — deslop reads installed packages' bin/peer fields,
 // which only change through an install that rewrites a lockfile).
-const CORE_SIDE_MANIFEST_NAMES = ["knip.json", "deno.lock"];
+const CORE_SIDE_MANIFEST_NAMES = [...KNIP_CONFIG_FILENAMES, "deno.lock"];
 
 const ANALYZED_MANIFEST_NAMES = new Set([
   ...ANALYZED_MANIFEST_FILENAMES,

--- a/packages/core/src/dead-code/knip-config-filenames.ts
+++ b/packages/core/src/dead-code/knip-config-filenames.ts
@@ -1,0 +1,18 @@
+export const KNIP_DATA_CONFIG_FILENAMES: ReadonlySet<string> = new Set([
+  "knip.json",
+  "knip.jsonc",
+  ".knip.json",
+  ".knip.jsonc",
+]);
+
+export const KNIP_CONFIG_FILENAMES: ReadonlyArray<string> = [
+  ...KNIP_DATA_CONFIG_FILENAMES,
+  "knip.ts",
+  "knip.js",
+  "knip.mjs",
+  "knip.cjs",
+  "knip.config.ts",
+  "knip.config.js",
+  "knip.config.mjs",
+  "knip.config.cjs",
+];

--- a/packages/core/src/dead-code/knip-config-filenames.ts
+++ b/packages/core/src/dead-code/knip-config-filenames.ts
@@ -9,10 +9,6 @@ export const KNIP_CONFIG_FILENAMES: ReadonlyArray<string> = [
   ...KNIP_DATA_CONFIG_FILENAMES,
   "knip.ts",
   "knip.js",
-  "knip.mjs",
-  "knip.cjs",
   "knip.config.ts",
   "knip.config.js",
-  "knip.config.mjs",
-  "knip.config.cjs",
 ];

--- a/packages/core/src/load-config.ts
+++ b/packages/core/src/load-config.ts
@@ -1,15 +1,15 @@
 import * as Console from "effect/Console";
 import * as Effect from "effect/Effect";
-import * as fs from "node:fs";
 import * as path from "node:path";
-import { parseJSON5 } from "confbox";
 import { fileURLToPath } from "node:url";
 import { createJiti } from "jiti";
 import type { Jiti } from "jiti";
 import type { ReactDoctorConfig } from "./types/index.js";
 import { isFile, isPlainObject } from "./project-info/index.js";
+import { importDefaultExport } from "./utils/import-default-export.js";
 import { isProjectBoundary } from "./utils/is-project-boundary.js";
 import { messageFromUnknown } from "./utils/message-from-unknown.js";
+import { readJson5File } from "./utils/read-json5-file.js";
 import { validateConfigTypes } from "./validate-config-types.js";
 
 const warn = (message: string): void => {
@@ -55,11 +55,6 @@ interface DirectoryConfigResult {
 
 // One jiti instance, reused across loads so its transform cache is warm.
 const jiti = createJiti(import.meta.url);
-
-const importDefaultExport = async (jitiInstance: Jiti, filePath: string): Promise<unknown> => {
-  const imported = await jitiInstance.import<{ default?: unknown }>(filePath);
-  return imported?.default ?? imported;
-};
 
 // Config files authored against the published package import `defineConfig`
 // from `react-doctor/api` at runtime. When the scanned repo has no
@@ -133,12 +128,6 @@ const loadModuleConfig = async (filePath: string): Promise<unknown> => {
   }
 };
 
-// JSON5 is a strict superset of JSON: it allows comments and trailing
-// commas (the "JSONC" features), but still throws on genuinely malformed
-// input so a broken config is detected rather than silently recovered.
-const readDataConfig = (filePath: string): unknown =>
-  parseJSON5(fs.readFileSync(filePath, "utf-8"));
-
 // Reads the `reactDoctor` config object embedded in a directory's
 // package.json, or null when it's absent or malformed. A malformed
 // package.json is not ours to police, so it reads as "no embedded config".
@@ -146,7 +135,7 @@ const readEmbeddedPackageJsonConfig = (directory: string): Record<string, unknow
   const packageJsonPath = path.join(directory, PACKAGE_JSON_FILENAME);
   if (!isFile(packageJsonPath)) return null;
   try {
-    const packageJson = parseJSON5(fs.readFileSync(packageJsonPath, "utf-8"));
+    const packageJson = readJson5File(packageJsonPath);
     if (isPlainObject(packageJson)) {
       const embeddedConfig = packageJson[PACKAGE_JSON_CONFIG_KEY];
       if (isPlainObject(embeddedConfig)) return embeddedConfig;
@@ -180,7 +169,7 @@ const loadLegacyConfig = (directory: string): DirectoryConfigResult => {
   const legacyFilePath = path.join(directory, LEGACY_CONFIG_FILENAME);
   if (!isFile(legacyFilePath)) return { status: "absent", loaded: null };
   try {
-    const parsed = readDataConfig(legacyFilePath);
+    const parsed = readJson5File(legacyFilePath);
     if (isPlainObject(parsed)) {
       warn(
         `${LEGACY_CONFIG_FILENAME} is deprecated — rename it to ${CONFIG_BASENAME}.json (or author a ${CONFIG_BASENAME}.ts). It is still read for now.`,
@@ -209,7 +198,7 @@ const loadConfigFromDirectory = async (directory: string): Promise<DirectoryConf
     if (!isFile(filePath)) continue;
     const isDataFile = DATA_CONFIG_EXTENSIONS.has(extension);
     try {
-      const parsed = isDataFile ? readDataConfig(filePath) : await loadModuleConfig(filePath);
+      const parsed = isDataFile ? readJson5File(filePath) : await loadModuleConfig(filePath);
       if (isPlainObject(parsed)) {
         return {
           status: "found",

--- a/packages/core/src/utils/import-default-export.ts
+++ b/packages/core/src/utils/import-default-export.ts
@@ -1,0 +1,9 @@
+import type { Jiti } from "jiti";
+
+export const importDefaultExport = async (
+  jitiInstance: Jiti,
+  filePath: string,
+): Promise<unknown> => {
+  const imported = await jitiInstance.import<{ default?: unknown }>(filePath);
+  return imported?.default ?? imported;
+};

--- a/packages/core/src/utils/read-json5-file.ts
+++ b/packages/core/src/utils/read-json5-file.ts
@@ -1,0 +1,5 @@
+import { parseJSON5 } from "confbox";
+import * as fs from "node:fs";
+
+export const readJson5File = (filePath: string): unknown =>
+  parseJSON5(fs.readFileSync(filePath, "utf-8"));

--- a/packages/core/tests/check-dead-code.test.ts
+++ b/packages/core/tests/check-dead-code.test.ts
@@ -18,14 +18,6 @@ const KNIP_MODULE_CONFIG_CASES: ReadonlyArray<KnipModuleConfigCase> = [
     filename: "knip.config.js",
     source: 'export default { ignore: ["src/generated.ts"] };\n',
   },
-  {
-    filename: "knip.config.mjs",
-    source: 'export default { ignore: ["src/generated.ts"] };\n',
-  },
-  {
-    filename: "knip.config.cjs",
-    source: 'module.exports = { ignore: ["src/generated.ts"] };\n',
-  },
 ];
 
 afterAll(() => {
@@ -256,6 +248,19 @@ describe("checkDeadCode", () => {
       expect(patterns.ignorePatterns).toContain("src/generated.ts");
     });
   }
+
+  it("ignores module filenames outside Knip's default discovery list", async () => {
+    const directory = setupProject("knip-default-config-locations", {
+      "src/index.ts": "export const used = 1;\n",
+      "knip.mjs": 'export default { ignore: ["src/nonstandard.ts"] };\n',
+      "knip.config.cjs": 'module.exports = { ignore: ["src/nonstandard.ts"] };\n',
+      "knip.config.ts": 'export default { ignore: ["src/canonical.ts"] };\n',
+    });
+
+    const patterns = await collectDeadCodePatterns(directory);
+    expect(patterns.ignorePatterns).toContain("src/canonical.ts");
+    expect(patterns.ignorePatterns).not.toContain("src/nonstandard.ts");
+  });
 
   it("reloads a Knip module configuration after it changes", async () => {
     const directory = setupProject("knip-config-reload", {

--- a/packages/core/tests/check-dead-code.test.ts
+++ b/packages/core/tests/check-dead-code.test.ts
@@ -3,9 +3,30 @@ import os from "node:os";
 import * as path from "node:path";
 import { afterAll, describe, expect, it } from "vite-plus/test";
 import { checkDeadCode } from "../src/check-dead-code.js";
+import { collectDeadCodePatterns } from "../src/dead-code/collect-dead-code-patterns.js";
 import { resolveReactDoctorCacheDir } from "../src/utils/resolve-react-doctor-cache-dir.js";
 
 const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "rd-check-dead-code-"));
+
+interface KnipModuleConfigCase {
+  readonly filename: string;
+  readonly source: string;
+}
+
+const KNIP_MODULE_CONFIG_CASES: ReadonlyArray<KnipModuleConfigCase> = [
+  {
+    filename: "knip.config.js",
+    source: 'export default { ignore: ["src/generated.ts"] };\n',
+  },
+  {
+    filename: "knip.config.mjs",
+    source: 'export default { ignore: ["src/generated.ts"] };\n',
+  },
+  {
+    filename: "knip.config.cjs",
+    source: 'module.exports = { ignore: ["src/generated.ts"] };\n',
+  },
+];
 
 afterAll(() => {
   fs.rmSync(tempRoot, { recursive: true, force: true });
@@ -185,6 +206,70 @@ describe("checkDeadCode", () => {
     expect(capturedInput?.entryPatterns).toContain("packages/*/src/main.ts");
     expect(capturedInput?.ignorePatterns).toContain("src/generated.ts");
     expect(capturedInput?.ignorePatterns).toContain("packages/*/src/fixtures.ts");
+  });
+
+  it("loads entry and ignore patterns from knip.config.ts", async () => {
+    const directory = setupProject("knip-typescript-worker-input", {
+      "src/index.ts": "export const used = 1;\n",
+      "knip.config.ts":
+        'const sourceDirectory: string = "src";\n' +
+        "export default async () => ({\n" +
+        "  entry: [`${sourceDirectory}/custom-entry.ts`],\n" +
+        "  ignore: [`${sourceDirectory}/generated.ts`],\n" +
+        '  workspaces: { "packages/*": { entry: ["src/main.ts"], ignore: ["src/fixtures.ts"] } },\n' +
+        "});\n",
+    });
+    let capturedInput: {
+      entryPatterns: ReadonlyArray<string>;
+      ignorePatterns: ReadonlyArray<string>;
+    } | null = null;
+
+    await checkDeadCode({
+      rootDirectory: directory,
+      createWorker: (input) => {
+        capturedInput = input;
+        return {
+          result: Promise.resolve({
+            unusedFiles: [],
+            unusedExports: [],
+            unusedDependencies: [],
+            circularDependencies: [],
+          }),
+        };
+      },
+    });
+
+    expect(capturedInput?.entryPatterns).toContain("src/custom-entry.ts");
+    expect(capturedInput?.entryPatterns).toContain("packages/*/src/main.ts");
+    expect(capturedInput?.ignorePatterns).toContain("src/generated.ts");
+    expect(capturedInput?.ignorePatterns).toContain("packages/*/src/fixtures.ts");
+  });
+
+  for (const configCase of KNIP_MODULE_CONFIG_CASES) {
+    it(`loads ignore patterns from ${configCase.filename}`, async () => {
+      const directory = setupProject(`knip-${configCase.filename}`, {
+        "src/index.ts": "export const used = 1;\n",
+        [configCase.filename]: configCase.source,
+      });
+
+      const patterns = await collectDeadCodePatterns(directory);
+      expect(patterns.ignorePatterns).toContain("src/generated.ts");
+    });
+  }
+
+  it("reloads a Knip module configuration after it changes", async () => {
+    const directory = setupProject("knip-config-reload", {
+      "src/index.ts": "export const used = 1;\n",
+      "knip.config.ts": 'export default { ignore: ["src/first.ts"] };\n',
+    });
+    const configFilePath = path.join(directory, "knip.config.ts");
+
+    expect((await collectDeadCodePatterns(directory)).ignorePatterns).toContain("src/first.ts");
+    fs.writeFileSync(configFilePath, 'export default { ignore: ["src/second.ts"] };\n');
+
+    const reloadedPatterns = await collectDeadCodePatterns(directory);
+    expect(reloadedPatterns.ignorePatterns).toContain("src/second.ts");
+    expect(reloadedPatterns.ignorePatterns).not.toContain("src/first.ts");
   });
 
   it("maps unused exports, dependencies, and cycles from worker results", async () => {

--- a/packages/core/tests/dead-code-result-cache.test.ts
+++ b/packages/core/tests/dead-code-result-cache.test.ts
@@ -6,6 +6,7 @@ import { ANALYZED_MANIFEST_FILENAMES, DEFAULT_EXTENSIONS } from "deslop-js/analy
 import { afterAll, beforeAll, describe, expect, it } from "vite-plus/test";
 import type { Diagnostic } from "../src/types/index.js";
 import { checkDeadCode } from "../src/check-dead-code.js";
+import { KNIP_CONFIG_FILENAMES } from "../src/dead-code/knip-config-filenames.js";
 import {
   collectAnalyzedFileStats,
   computeDeadCodeCacheKey,
@@ -159,6 +160,18 @@ describe("fingerprinted file sets (imported from deslop-js/analyzed-inputs)", ()
         true,
       );
       fs.rmSync(probePath);
+    }
+  });
+
+  it("stats every Knip configuration file React Doctor reads", () => {
+    const directory = setupProject("stat-knip-config-coverage", {
+      "src/index.ts": "export const used = 1;\n",
+    });
+    for (const filename of KNIP_CONFIG_FILENAMES) {
+      const filePath = path.join(directory, filename);
+      fs.writeFileSync(filePath, "export default {};\n");
+      expect(collectAnalyzedFileStats(directory).has(filename), filename).toBe(true);
+      fs.rmSync(filePath);
     }
   });
 

--- a/packages/react-doctor/README.md
+++ b/packages/react-doctor/README.md
@@ -13,7 +13,6 @@ React Doctor deterministically scans your codebase and finds issues across state
 
 Works across React frameworks and React-enabled sites - Next.js, Vite, Astro, TanStack, React Native, Expo, you name it.
 
-
 [Website →](https://react.doctor/docs)
 
 ## Install


### PR DESCRIPTION
## Why

React Doctor previously read dead-code `entry` and `ignore` patterns only from `knip.json` and `package.json#knip`. Projects using standard JavaScript or TypeScript Knip config files therefore received false-positive unused-file diagnostics and had to duplicate their ignores.

This fixes #1583 by making existing Knip configuration the single source of truth. No new React Doctor option is introduced: the loader reuses the existing Jiti and JSON5 machinery, preserves fail-open behavior, and relies on the existing `deadCode.failed` and diagnostic-count telemetry to monitor rollout health. Revert the dynamic loader if dead-code failure rates materially regress after release.

## What changed

- Load Knip JSON/JSONC, JS/TS, MJS/CJS, and `package.json#knip` configuration locations in Knip precedence order.
- Support object, promise, synchronous-function, and asynchronous-function config exports without caching stale module values.
- Fingerprint every supported Knip config filename for dead-code result-cache invalidation.
- Add regression coverage for TypeScript workspace patterns, JS/MJS/CJS configs, config reloads, and cache inputs.
- Add a patch changeset for `react-doctor`.

Rule parity was not run because this changes the core dead-code configuration adapter, not a lint-rule detector.

## Test plan

- `nr test`
- `nr lint`
- `nr typecheck`
- `nr format:check`
- `nr smoke:json-report`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which files feed dead-code entry/ignore patterns and adds dynamic Jiti loads; failures are fail-open but wrong patterns could still shift unused-file diagnostics until cache invalidation.
> 
> **Overview**
> **Dead-code analysis** now derives `entry` and `ignore` patterns from the same Knip config locations users already use, instead of only `knip.json` and embedded `package.json#knip`. That should cut false unused-file reports for projects on `knip.config.ts` and similar setups (#1583).
> 
> **Knip loading** walks a fixed filename list (`knip.json` / JSONC variants, then `knip.ts` / `knip.js` / `knip.config.*`), uses JSON5 for data files and **Jiti** (`moduleCache: false`) for modules, and accepts object, promise, or function exports. Non-standard names like `knip.mjs` are ignored so behavior stays aligned with Knip’s discovery rules.
> 
> **Integration:** `checkDeadCode` awaits a single `collectDeadCodePatterns` call; the dead-code **result cache** fingerprints every supported Knip config filename so edits invalidate cached diagnostics. `readJson5File` and `importDefaultExport` are shared with config loading.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5592fb658fb8c2758b9a5800048417d7b888ec38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->