### PR TITLE
fix(deslop): expose skipped dependency exemptions

### DIFF
--- a/.changeset/clear-dependency-abstentions.md
+++ b/.changeset/clear-dependency-abstentions.md
@@ -1,0 +1,6 @@
+---
+"deslop-js": patch
+"deslop-cli": patch
+---
+
+Expose declared dependencies conservatively excluded from unused-dependency analysis and explain the exclusions in human-readable CLI output.

--- a/packages/deslop-cli/src/format-result.ts
+++ b/packages/deslop-cli/src/format-result.ts
@@ -38,6 +38,16 @@ export const formatHumanReadableResult = (result: ScanResult): string => {
     lines.push("");
   }
 
+  const skippedDependencies = result.skippedDependencies ?? [];
+  if (skippedDependencies.length > 0) {
+    const dependencyLabel =
+      skippedDependencies.length === 1 ? "dependency was" : "dependencies were";
+    lines.push(
+      `Note: ${skippedDependencies.length} declared ${dependencyLabel} conservatively excluded from unused-dependency analysis (allowlisted names or binary providers).`,
+    );
+    lines.push("");
+  }
+
   if (result.circularDependencies.length > 0) {
     const cycleLabel = result.circularDependencies.length === 1 ? "cycle" : "cycles";
     lines.push(`${result.circularDependencies.length} circular ${cycleLabel}`);

--- a/packages/deslop-cli/tests/cli.test.ts
+++ b/packages/deslop-cli/tests/cli.test.ts
@@ -12,7 +12,11 @@ import {
   EXIT_CODE_RUNTIME_ERROR,
   EXIT_CODE_SUCCESS,
 } from "../src/constants.js";
-import { hasCircularIssues, hasUnusedIssues } from "../src/format-result.js";
+import {
+  formatHumanReadableResult,
+  hasCircularIssues,
+  hasUnusedIssues,
+} from "../src/format-result.js";
 import { resolveAnalyzeExitCode, runAnalyze } from "../src/run-analyze.js";
 import { validateRootDirectory } from "../src/utils/validate-root-directory.js";
 import { FIXTURES_DIR } from "./helpers/fixtures-dir.js";
@@ -21,12 +25,14 @@ const testDirectory = resolve(fileURLToPath(import.meta.url), "..");
 const packageDirectory = resolve(testDirectory, "..");
 const simpleAppFixture = resolve(FIXTURES_DIR, "simple-app");
 const cycleSimpleFixture = resolve(FIXTURES_DIR, "cycle-simple");
+const workspaceLocalBinFixture = resolve(FIXTURES_DIR, "workspace-local-bin");
 const cliEntryPath = resolve(packageDirectory, "src/cli.ts");
 
 const emptyScanResult: ScanResult = {
   unusedFiles: [],
   unusedExports: [],
   unusedDependencies: [],
+  skippedDependencies: [],
   circularDependencies: [],
   unusedTypes: [],
   misclassifiedDependencies: [],
@@ -164,6 +170,14 @@ describe("hasUnusedIssues / hasCircularIssues", () => {
 });
 
 describe("runAnalyze", () => {
+  it("should explain conservatively skipped dependencies in human output", async () => {
+    const scanResult = await analyze(defineConfig({ rootDir: workspaceLocalBinFixture }));
+    const output = formatHumanReadableResult(scanResult);
+
+    assert.match(output, /2 declared dependencies were conservatively excluded/);
+    assert.match(output, /allowlisted names or binary providers/);
+  });
+
   it("should return invalid root exit code for missing directories", async () => {
     const capture = createCaptureOutput();
     const exitCode = await runAnalyze(

--- a/packages/deslop-js/README.md
+++ b/packages/deslop-js/README.md
@@ -89,6 +89,7 @@ const result = await analyze(config);
 result.unusedFiles; // files unreachable from any entry point
 result.unusedExports; // exported symbols never imported
 result.unusedDependencies; // package.json deps not imported anywhere
+result.skippedDependencies; // declared deps conservatively excluded from unused-dependency analysis
 result.circularDependencies; // import cycles
 
 // redundancy / DRY findings (syntactic, on by default)
@@ -135,6 +136,11 @@ result.totalFiles;
 result.totalExports;
 result.analysisTimeMs;
 ```
+
+`skippedDependencies` makes conservative unused-dependency exemptions explicit. It includes
+packages matched by the framework/tooling name allowlist and installed packages that provide a
+binary, because those uses can occur outside source imports and package scripts. A clean
+`unusedDependencies` result is not a verdict for those packages.
 
 ## Programmatic Options
 

--- a/packages/deslop-js/src/index.ts
+++ b/packages/deslop-js/src/index.ts
@@ -144,6 +144,8 @@ export type {
   UnusedFile,
   UnusedExport,
   UnusedDependency,
+  SkippedDependency,
+  SkippedDependencyReason,
   CircularDependency,
   UnusedType,
   UnusedTypeKind,

--- a/packages/deslop-js/src/report/generate.ts
+++ b/packages/deslop-js/src/report/generate.ts
@@ -74,12 +74,13 @@ export const generateReport = (
     [],
     errorSink,
   );
-  const unusedDependencies = safeReportDetector(
+  const stalePackageReport = safeReportDetector(
     "detectStalePackages",
     () => detectStalePackages(graph, config, summaryCache),
-    [],
+    { unusedDependencies: [], skippedDependencies: [] },
     errorSink,
   );
+  const unusedDependencies = stalePackageReport.unusedDependencies;
   const circularDependencies = safeReportDetector(
     "detectCycles",
     () => detectCycles(graph),
@@ -287,6 +288,7 @@ export const generateReport = (
     unusedFiles,
     unusedExports,
     unusedDependencies,
+    skippedDependencies: stalePackageReport.skippedDependencies,
     circularDependencies,
     unusedTypes: semanticResult.unusedTypes,
     misclassifiedDependencies: semanticResult.misclassifiedDependencies,

--- a/packages/deslop-js/src/report/packages.ts
+++ b/packages/deslop-js/src/report/packages.ts
@@ -1,7 +1,13 @@
 import { resolve, join } from "node:path";
 import { readFileSync, existsSync } from "node:fs";
 import fg from "fast-glob";
-import type { DependencyGraph, UnusedDependency, DeslopConfig } from "../types.js";
+import type {
+  DependencyGraph,
+  DeslopConfig,
+  SkippedDependency,
+  SkippedDependencyReason,
+  UnusedDependency,
+} from "../types.js";
 import { IMPLICIT_DEPENDENCIES } from "../constants.js";
 import { extractPackageName } from "../utils/package-name.js";
 import { collectOverrideMappingsFromRecord } from "../utils/collect-override-mappings-from-record.js";
@@ -94,11 +100,16 @@ const discoverAllPackageJsonPaths = (
   return paths;
 };
 
+interface StalePackageReport {
+  unusedDependencies: UnusedDependency[];
+  skippedDependencies: SkippedDependency[];
+}
+
 export const detectStalePackages = (
   graph: DependencyGraph,
   config: DeslopConfig,
   summaryCache?: SummaryCache,
-): UnusedDependency[] => {
+): StalePackageReport => {
   const packageJsonPath = resolve(config.rootDir, "package.json");
   let packageJson: PackageJsonDependencies;
 
@@ -106,7 +117,7 @@ export const detectStalePackages = (
     const content = readFileSync(packageJsonPath, "utf-8");
     packageJson = JSON.parse(content);
   } catch {
-    return [];
+    return { unusedDependencies: [], skippedDependencies: [] };
   }
 
   const dependencies = packageJson.dependencies ?? {};
@@ -121,7 +132,12 @@ export const detectStalePackages = (
   }
 
   const declaredNames = new Set(declaredDependencies.keys());
-  const usedPackageNames = collectUsedPackages(graph);
+  const observedPackageNames = collectUsedPackages(graph);
+  const usedPackageNames = new Set(observedPackageNames);
+  const markPackageUsed = (packageName: string): void => {
+    observedPackageNames.add(packageName);
+    usedPackageNames.add(packageName);
+  };
 
   const monorepoRoot = findMonorepoRoot(config.rootDir);
   const nodeModulesSearchRoots =
@@ -152,13 +168,13 @@ export const detectStalePackages = (
       declaredNames,
       binToPackage,
     );
-    for (const packageName of scriptReferenced) usedPackageNames.add(packageName);
+    for (const packageName of scriptReferenced) markPackageUsed(packageName);
 
     const packageJsonConfigReferenced = collectPackageJsonConfigReferences(
       workspacePackageJsonPath,
       declaredNames,
     );
-    for (const packageName of packageJsonConfigReferenced) usedPackageNames.add(packageName);
+    for (const packageName of packageJsonConfigReferenced) markPackageUsed(packageName);
   }
 
   const nxProjectReferenced = collectNxProjectJsonReferences(
@@ -167,7 +183,7 @@ export const detectStalePackages = (
     binToPackage,
     summaryCache,
   );
-  for (const packageName of nxProjectReferenced) usedPackageNames.add(packageName);
+  for (const packageName of nxProjectReferenced) markPackageUsed(packageName);
 
   const configSearchRoots =
     monorepoRoot && monorepoRoot !== config.rootDir
@@ -180,10 +196,10 @@ export const detectStalePackages = (
       declaredNames,
       summaryCache,
     );
-    for (const packageName of configReferenced) usedPackageNames.add(packageName);
+    for (const packageName of configReferenced) markPackageUsed(packageName);
 
     const tsconfigReferenced = collectTsconfigReferencedPackages(configSearchRoot, summaryCache);
-    for (const packageName of tsconfigReferenced) usedPackageNames.add(packageName);
+    for (const packageName of tsconfigReferenced) markPackageUsed(packageName);
 
     const { packageNames: expoPluginPackageNames } = extractExpoConfigPluginEntries(
       configSearchRoot,
@@ -191,16 +207,16 @@ export const detectStalePackages = (
     );
     for (const packageName of expoPluginPackageNames) {
       if (declaredNames.has(packageName)) {
-        usedPackageNames.add(packageName);
+        markPackageUsed(packageName);
       }
     }
   }
 
   if (hasJsxFiles(graph)) {
-    if (declaredNames.has("react")) usedPackageNames.add("react");
-    if (declaredNames.has("react-dom")) usedPackageNames.add("react-dom");
-    if (declaredNames.has("react-native")) usedPackageNames.add("react-native");
-    if (declaredNames.has("react-native-web")) usedPackageNames.add("react-native-web");
+    if (declaredNames.has("react")) markPackageUsed("react");
+    if (declaredNames.has("react-dom")) markPackageUsed("react-dom");
+    if (declaredNames.has("react-native")) markPackageUsed("react-native");
+    if (declaredNames.has("react-native-web")) markPackageUsed("react-native-web");
   }
 
   if (declaredNames.has("react-dom")) {
@@ -220,11 +236,11 @@ export const detectStalePackages = (
     const hasWebFramework = webFrameworks.some(
       (framework) => declaredNames.has(framework) || usedPackageNames.has(framework),
     );
-    if (hasWebFramework) usedPackageNames.add("react-dom");
+    if (hasWebFramework) markPackageUsed("react-dom");
   }
 
   if (declaredNames.has("astro") && declaredNames.has("sharp")) {
-    usedPackageNames.add("sharp");
+    markPackageUsed("sharp");
   }
 
   if (declaredNames.has("react") && declaredNames.has("react-dom")) {
@@ -234,10 +250,10 @@ export const detectStalePackages = (
       const packageJson = JSON.parse(content);
       const peerDeps = packageJson.peerDependencies ?? {};
       if ("react" in peerDeps && declaredDependencies.get("react") === true) {
-        usedPackageNames.add("react");
+        markPackageUsed("react");
       }
       if ("react-dom" in peerDeps && declaredDependencies.get("react-dom") === true) {
-        usedPackageNames.add("react-dom");
+        markPackageUsed("react-dom");
       }
     } catch {
       // fall through
@@ -257,13 +273,33 @@ export const detectStalePackages = (
     monorepoRoot,
   );
   for (const { fromPackage, toPackage } of overrideMappings) {
-    if (declaredNames.has(toPackage)) usedPackageNames.add(toPackage);
+    if (declaredNames.has(toPackage)) markPackageUsed(toPackage);
     if (usedPackageNames.has(fromPackage) && declaredNames.has(toPackage)) {
-      usedPackageNames.add(toPackage);
+      markPackageUsed(toPackage);
     }
   }
 
   const candidateUnused = new Set<string>();
+  const skippedDependenciesByName = new Map<string, Set<SkippedDependencyReason>>();
+  const recordSkippedDependency = (
+    dependencyName: string,
+    reason: SkippedDependencyReason,
+  ): void => {
+    const reasons = skippedDependenciesByName.get(dependencyName) ?? new Set();
+    reasons.add(reason);
+    skippedDependenciesByName.set(dependencyName, reasons);
+  };
+
+  for (const [dependencyName] of declaredDependencies) {
+    if (observedPackageNames.has(dependencyName) || peerSatisfied.has(dependencyName)) continue;
+    if (isAlwaysConsideredUsed(dependencyName)) {
+      recordSkippedDependency(dependencyName, "allowlisted-name");
+    }
+    if (packagesProvidingBinary.has(dependencyName)) {
+      recordSkippedDependency(dependencyName, "provides-binary");
+    }
+  }
+
   for (const [dependencyName] of declaredDependencies) {
     if (isAlwaysConsideredUsed(dependencyName)) continue;
     if (usedPackageNames.has(dependencyName)) continue;
@@ -277,7 +313,7 @@ export const detectStalePackages = (
       summaryCache,
     );
     for (const packageName of sourceFileRescued) {
-      usedPackageNames.add(packageName);
+      markPackageUsed(packageName);
       candidateUnused.delete(packageName);
     }
   }
@@ -294,7 +330,15 @@ export const detectStalePackages = (
     });
   }
 
-  return unusedDependencies;
+  const skippedDependencies = [...skippedDependenciesByName.entries()]
+    .sort(([leftName], [rightName]) => leftName.localeCompare(rightName))
+    .map(([name, reasons]) => ({
+      name,
+      isDevDependency: declaredDependencies.get(name) ?? false,
+      reasons: [...reasons].sort(),
+    }));
+
+  return { unusedDependencies, skippedDependencies };
 };
 
 const collectUsedPackages = (graph: DependencyGraph): Set<string> => {

--- a/packages/deslop-js/src/types.ts
+++ b/packages/deslop-js/src/types.ts
@@ -184,6 +184,14 @@ export interface UnusedDependency {
   reason: string;
 }
 
+export type SkippedDependencyReason = "allowlisted-name" | "provides-binary";
+
+export interface SkippedDependency {
+  name: string;
+  isDevDependency: boolean;
+  reasons: SkippedDependencyReason[];
+}
+
 export interface CircularDependency {
   files: string[];
 }
@@ -597,6 +605,8 @@ export interface ScanResult {
   unusedFiles: UnusedFile[];
   unusedExports: UnusedExport[];
   unusedDependencies: UnusedDependency[];
+  /** Declared dependencies conservatively excluded from unused-dependency analysis. */
+  skippedDependencies?: SkippedDependency[];
   circularDependencies: CircularDependency[];
   unusedTypes: UnusedType[];
   misclassifiedDependencies: MisclassifiedDependency[];

--- a/packages/deslop-js/tests/analyze.test.ts
+++ b/packages/deslop-js/tests/analyze.test.ts
@@ -144,6 +144,7 @@ describe("dependency-tooling", () => {
       "@tauri-apps/cli",
       "@tinacms/cli",
       "@typescript/native-preview",
+      "chokidar-peer",
       // static bin fallback (no node_modules entry): `copy-styles` runs the
       // `cpy` bin that cpy-cli ships.
       "cpy-cli",
@@ -292,6 +293,20 @@ describe("workspace-local-bin", () => {
     assert.ok(
       !deps.includes("bin-only-tool"),
       `bin-only-tool declares a bin and is invokable outside the static scan (npx, hooks, CI) — it must not be flagged, got: ${deps}`,
+    );
+  });
+
+  it("should expose conservative dependency exemptions without reporting them as unused", async () => {
+    const result = await scanFixture("workspace-local-bin");
+    const skippedDependencies = result.skippedDependencies ?? [];
+
+    assert.deepEqual(skippedDependencies, [
+      { name: "bin-only-tool", isDevDependency: true, reasons: ["provides-binary"] },
+      { name: "expo-unused", isDevDependency: true, reasons: ["allowlisted-name"] },
+    ]);
+    assert.ok(
+      !staleDependencyNames(result).includes("expo-unused"),
+      "allowlisted dependencies must remain exempt from unused findings",
     );
   });
 });

--- a/packages/deslop-js/tests/fixtures/dependency-tooling/node_modules/chokidar-cli/package.json
+++ b/packages/deslop-js/tests/fixtures/dependency-tooling/node_modules/chokidar-cli/package.json
@@ -1,6 +1,9 @@
 {
   "name": "chokidar-cli",
   "version": "1.0.0",
+  "peerDependencies": {
+    "chokidar-peer": "*"
+  },
   "bin": {
     "chokidar": "./bin.js"
   }

--- a/packages/deslop-js/tests/fixtures/dependency-tooling/package.json
+++ b/packages/deslop-js/tests/fixtures/dependency-tooling/package.json
@@ -31,6 +31,7 @@
     "@tauri-apps/cli": "^2.0.0",
     "@tinacms/cli": "^1.0.0",
     "@typescript/native-preview": "^7.0.0-dev",
+    "chokidar-peer": "^1.0.0",
     "axe-core": "^4.11.0",
     "babel-eslint": "^10.0.0",
     "chokidar-cli": "^3.0.0",

--- a/packages/deslop-js/tests/fixtures/workspace-local-bin/package.json
+++ b/packages/deslop-js/tests/fixtures/workspace-local-bin/package.json
@@ -8,6 +8,7 @@
   "devDependencies": {
     "react-email": "^3.0.0",
     "bin-only-tool": "^1.0.0",
+    "expo-unused": "^1.0.0",
     "unused-dev-tool": "^1.0.0"
   }
 }


### PR DESCRIPTION
## Why

`deslop-js` conservatively exempts framework/tooling allowlisted packages and installed binary providers from unused-dependency findings, but a clean result gave no signal that those packages were excluded. That made the analysis coverage ambiguous.

Before: allowlisted and binary-providing dependencies were silently treated as used.

After: `ScanResult.skippedDependencies` exposes the exact package names and exemption reasons, and `deslop-cli` prints a concise human-readable note. Existing exemption behavior is unchanged.

## What changed

- Added additive `skippedDependencies` metadata with `allowlisted-name` and `provides-binary` reasons.
- Preserved the existing unused-dependency heuristics and only report unobserved exemptions.
- Added CLI output, README documentation, and regression coverage.
- Added a patch changeset for `deslop-js` and `deslop-cli`.

## Test plan

- `nr test` — 15 Turbo tasks; 2,473 React Doctor tests passed, 27 skipped.
- `nr test:deslop` — 521 `deslop-js` tests and 16 `deslop-cli` tests passed.
- `nr typecheck` — passed.
- `nr lint` — passed with existing warnings in fuzz corpus fixtures.
- `nr format` — passed.
- `git diff --check` — passed.
- `truffler` duplicate-symbol searches — no relevant duplicates found.

Eval results: not run; this is a deslop metadata and CLI-output change rather than a React Doctor rule change.

Fixes #1587

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API and CLI messaging only; unused-dependency detection rules are unchanged aside from reporting metadata.
> 
> **Overview**
> Unused-dependency analysis already skips some declared packages (tooling allowlists and binary-shipping installs), but that was invisible when the unused list was empty. This PR surfaces those exemptions without changing who gets flagged.
> 
> **`deslop-js`** adds optional `ScanResult.skippedDependencies` with per-package `allowlisted-name` and/or `provides-binary` reasons. `detectStalePackages` now returns both unused and skipped lists; exemptions are recorded only for declared deps that were not observed in imports and were not satisfied via peer heuristics.
> 
> **`deslop-cli`** prints a short **Note** after unused-dependency output when any skipped entries exist. README and exports document the field; tests cover the fixture shape and human-readable formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac95a012ca75e1bd0d80a6ce892331975534f1da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->