### PR TITLE
fix(core): detect React Compiler through Rolldown Babel

### DIFF
--- a/.changeset/detect-rolldown-compiler-options.md
+++ b/.changeset/detect-rolldown-compiler-options.md
@@ -1,0 +1,6 @@
+---
+"@react-doctor/core": patch
+"react-doctor": patch
+---
+
+Detect React Compiler transforms passed through an installed `@rolldown/plugin-babel` wrapper.

--- a/packages/core/src/project-info/detectors.ts
+++ b/packages/core/src/project-info/detectors.ts
@@ -2072,6 +2072,14 @@ const analyzeConfigNode = (
           ) {
             return true;
           }
+          if (
+            allowCompilerTransform &&
+            importBinding.moduleSpecifier === "@rolldown/plugin-babel" &&
+            importBinding.exportName === "default" &&
+            node.arguments.some((argument) => analyzeConfigNode(argument, analysis, false))
+          ) {
+            return true;
+          }
           const hasCompilerTransform = analyzeImportedConfig({
             analysis,
             moduleSpecifier: importBinding.moduleSpecifier,

--- a/packages/core/tests/discover-project.test.ts
+++ b/packages/core/tests/discover-project.test.ts
@@ -2573,47 +2573,83 @@ describe("discoverProject", () => {
     expect(projectInfo.hasReactCompilerLintPlugin).toBe(true);
   });
 
-  it("detects the official Vite 8 React Compiler preset through defineConfig re-exports", () => {
-    const projectDirectory = path.join(tempDirectory, "vite-react-compiler-preset");
-    const viteDirectory = path.join(projectDirectory, "node_modules", "vite");
-    const viteChunksDirectory = path.join(viteDirectory, "chunks");
-    fs.mkdirSync(viteChunksDirectory, { recursive: true });
-    fs.writeFileSync(
-      path.join(projectDirectory, "package.json"),
-      JSON.stringify({
-        name: "vite-react-compiler-preset",
-        dependencies: { react: "^19.0.0" },
-        devDependencies: {
-          "@rolldown/plugin-babel": "^0.2.0",
-          "@vitejs/plugin-react": "^6.0.0",
-          vite: "^8.1.0",
-        },
-      }),
-    );
-    fs.writeFileSync(
-      path.join(viteDirectory, "package.json"),
-      JSON.stringify({
-        name: "vite",
-        type: "module",
-        exports: "./index.js",
-      }),
-    );
-    fs.writeFileSync(
-      path.join(viteDirectory, "index.js"),
-      "import { d as defineConfig } from './chunks/config.js';\nexport { defineConfig };\n",
-    );
-    fs.writeFileSync(
-      path.join(viteChunksDirectory, "config.js"),
-      "const defineConfig = (config) => config;\nexport { defineConfig as d };\n",
-    );
-    fs.writeFileSync(
-      path.join(projectDirectory, "vite.config.ts"),
-      "import { defineConfig } from 'vite';\nimport react, { reactCompilerPreset } from '@vitejs/plugin-react';\nimport babel from '@rolldown/plugin-babel';\nexport default defineConfig({ plugins: [react(), babel({ presets: [reactCompilerPreset()] })] });\n",
-    );
+  it.each([
+    {
+      configurationName: "preset",
+      compilerImports: "import react, { reactCompilerPreset } from '@vitejs/plugin-react';",
+      babelOptions: "presets: [reactCompilerPreset()]",
+    },
+    {
+      configurationName: "direct-plugin",
+      compilerImports:
+        "import jsxSyntax from '@babel/plugin-syntax-jsx';\nimport react from '@vitejs/plugin-react';\nimport reactCompiler from 'babel-plugin-react-compiler';",
+      babelOptions: "plugins: [jsxSyntax, reactCompiler]",
+    },
+  ])(
+    "detects the official Vite 8 React Compiler $configurationName through installed config wrappers",
+    ({ configurationName, compilerImports, babelOptions }) => {
+      const projectDirectory = path.join(tempDirectory, `vite-react-compiler-${configurationName}`);
+      const viteDirectory = path.join(projectDirectory, "node_modules", "vite");
+      const viteChunksDirectory = path.join(viteDirectory, "chunks");
+      const rolldownBabelDirectory = path.join(
+        projectDirectory,
+        "node_modules",
+        "@rolldown",
+        "plugin-babel",
+      );
+      fs.mkdirSync(viteChunksDirectory, { recursive: true });
+      fs.mkdirSync(rolldownBabelDirectory, { recursive: true });
+      fs.writeFileSync(
+        path.join(projectDirectory, "package.json"),
+        JSON.stringify({
+          name: `vite-react-compiler-${configurationName}`,
+          dependencies: { react: "^19.0.0" },
+          devDependencies: {
+            "@babel/plugin-syntax-jsx": "^7.0.0",
+            "@rolldown/plugin-babel": "^0.2.0",
+            "@vitejs/plugin-react": "^6.0.0",
+            "babel-plugin-react-compiler": "^1.0.0",
+            vite: "^8.1.0",
+          },
+        }),
+      );
+      fs.writeFileSync(
+        path.join(viteDirectory, "package.json"),
+        JSON.stringify({
+          name: "vite",
+          type: "module",
+          exports: "./index.js",
+        }),
+      );
+      fs.writeFileSync(
+        path.join(viteDirectory, "index.js"),
+        "import { d as defineConfig } from './chunks/config.js';\nexport { defineConfig };\n",
+      );
+      fs.writeFileSync(
+        path.join(viteChunksDirectory, "config.js"),
+        "const defineConfig = (config) => config;\nexport { defineConfig as d };\n",
+      );
+      fs.writeFileSync(
+        path.join(rolldownBabelDirectory, "package.json"),
+        JSON.stringify({
+          name: "@rolldown/plugin-babel",
+          type: "module",
+          exports: "./index.js",
+        }),
+      );
+      fs.writeFileSync(
+        path.join(rolldownBabelDirectory, "index.js"),
+        "const babelPlugin = async (rawOptions) => ({ name: '@rolldown/plugin-babel', transform() { return rawOptions; } });\nexport { babelPlugin as default };\n",
+      );
+      fs.writeFileSync(
+        path.join(projectDirectory, "vite.config.ts"),
+        `import { defineConfig } from 'vite';\n${compilerImports}\nimport babel from '@rolldown/plugin-babel';\nexport default defineConfig({ plugins: [react(), babel({ ${babelOptions} })] });\n`,
+      );
 
-    const projectInfo = discoverProject(projectDirectory);
-    expect(projectInfo.hasReactCompiler).toBe(true);
-  });
+      const projectInfo = discoverProject(projectDirectory);
+      expect(projectInfo.hasReactCompiler).toBe(true);
+    },
+  );
 
   it.each([
     { wrapperName: "withNextConfig", argument: "nextConfig", expected: true },


### PR DESCRIPTION
## Why

React Doctor can suppress compiler-redundant diagnostics only when project discovery recognizes that React Compiler is enabled. In the Vite configuration from #1591, discovery followed the installed `@rolldown/plugin-babel` implementation before inspecting the call-site Babel options, so the compiler plugin was missed.

Before this change, direct `babel-plugin-react-compiler` and official preset configurations routed through the installed Rolldown Babel wrapper could produce `hasReactCompiler: false`. After this change, the wrapper's Babel options are analyzed first, allowing existing compiler-aware suppression to remove `no-effect-with-fresh-deps` findings while preserving correctness diagnostics such as `exhaustive-deps`.

## What changed

- detect React Compiler configuration passed to the default `@rolldown/plugin-babel` export
- cover both the official Vite React Compiler preset and the direct Babel plugin configuration from the issue
- add a patch changeset for `@react-doctor/core` and `react-doctor`

## Eval results

RDE was not run because this changes project compiler discovery rather than lint-rule matching behavior. The regression fixture exercises the installed Vite and Rolldown wrapper path that previously lost the compiler configuration.

## Test plan

- `nr --filter @react-doctor/core test tests/discover-project.test.ts`
- `nr test`
- `nr lint`
- `nr typecheck`
- `nr format:check`
- `nr smoke:json-report`

All passed locally.

Closes #1591.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to static config parsing for one import path; behavior only broadens compiler detection for Rolldown-wrapped Babel options.
> 
> **Overview**
> **React Compiler detection** no longer stops at the installed `@rolldown/plugin-babel` package. When Vite config calls the plugin’s default export, discovery now inspects those **call-site arguments** (presets/plugins) for compiler transforms before following the wrapper module, so `hasReactCompiler` can be true for official `reactCompilerPreset()` and direct `babel-plugin-react-compiler` setups.
> 
> Regression coverage is expanded to **both** configuration styles with a minimal installed Rolldown Babel stub, plus a patch changeset for `@react-doctor/core` and `react-doctor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14422f37b21eb0a958d8bd66166ffcbcebbe1706. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->