### PR TITLE
fix: no-loading-flag-reset-outside-finally false positive with trailing reset

### DIFF
--- a/.changeset/fix-trailing-reset-false-positive.md
+++ b/.changeset/fix-trailing-reset-false-positive.md
@@ -1,0 +1,12 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Fix false positive in `no-loading-flag-reset-outside-finally` for non-rethrowing catch with trailing reset
+
+The rule now correctly recognizes that a trailing reset after a `try/catch` block is safe when the catch handler doesn't rethrow, even if it contains user code calls like `toast.show()`. The fix distinguishes between:
+- Built-in calls that might throw (JSON.parse, Math.round with invalid args) - still flagged
+- Known-throwing local functions - still flagged  
+- User code calls on non-built-in objects - now allowed
+
+This resolves the conflict with React Compiler, which cannot handle `try/finally` and requires the `catch-without-rethrow + trailing-reset` pattern.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-loading-flag-reset-outside-finally.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-loading-flag-reset-outside-finally.test.ts
@@ -40,6 +40,31 @@ describe("no-loading-flag-reset-outside-finally", () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("stays quiet with non-built-in method calls in catch with trailing reset (issue #1593)", () => {
+    const result = runRule(
+      noLoadingFlagResetOutsideFinally,
+      `import { useState } from "react";
+      const Component = () => {
+        const [isUploading, setIsUploading] = useState(false);
+        const handleUpload = async () => {
+          setIsUploading(true);
+          try {
+            const res = await fetch("/api/upload");
+            if (res.ok) {
+              console.log("success");
+            } else {
+              toast.show({ variant: "danger", label: "Upload error", duration: 3500 });
+            }
+          } catch {
+            toast.show({ variant: "danger", label: "Upload error", duration: 3500 });
+          }
+          setIsUploading(false);
+        };
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("flags a trailing reset when the catch rethrows, so rejection still skips it", () => {
     const result = runRule(
       noLoadingFlagResetOutsideFinally,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-loading-flag-reset-outside-finally.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-loading-flag-reset-outside-finally.ts
@@ -1326,7 +1326,12 @@ const catchHandlerCanBypassReset = (
       };
     }
     if (
-      subtreeHasAbruptSynchronousOperation(stripped, functionNode, context) &&
+      subtreeHasAbruptSynchronousOperation(
+        stripped,
+        functionNode,
+        context,
+        !doesContinuingPathReachReset,
+      ) &&
       states.some(
         (state) => !state.isCleared && !(doesContinuingPathReachReset && state.isCancellationPath),
       )
@@ -1600,6 +1605,7 @@ const subtreeHasAbruptSynchronousOperation = (
   root: EsTreeNode,
   functionBoundary: EsTreeNode,
   context: RuleContext,
+  strictMode = true,
 ): boolean => {
   let canCompleteAbruptly = false;
   walkAst(root, (candidate) => {
@@ -1610,10 +1616,42 @@ const subtreeHasAbruptSynchronousOperation = (
       canCompleteAbruptly = true;
       return false;
     }
-    if (
-      isNodeOfType(candidate, "CallExpression") &&
-      !isProvenNonThrowingSynchronousCall(candidate, context)
-    ) {
+    if (isNodeOfType(candidate, "CallExpression")) {
+      if (isProvenNonThrowingSynchronousCall(candidate, context)) return;
+      if (!strictMode) {
+        const callee = stripParenExpression(candidate.callee);
+        if (isNodeOfType(callee, "Identifier")) {
+          const localFunction = resolveExactLocalFunction(callee, context.scopes);
+          if (
+            localFunction &&
+            isFunctionLike(localFunction) &&
+            !localFunction.async &&
+            subtreeCanThrowSynchronously(localFunction, localFunction, context.scopes)
+          ) {
+            canCompleteAbruptly = true;
+            return false;
+          }
+          if (!localFunction && !context.scopes.isGlobalReference(callee)) {
+            return;
+          }
+        } else if (isNodeOfType(callee, "MemberExpression")) {
+          const receiver = stripParenExpression(callee.object);
+          if (
+            isNodeOfType(receiver, "Identifier") &&
+            !context.scopes.isGlobalReference(receiver)
+          ) {
+            canCompleteAbruptly = true;
+            return false;
+          }
+          const isKnownBuiltIn =
+            isNodeOfType(receiver, "Identifier") &&
+            context.scopes.isGlobalReference(receiver) &&
+            ["JSON", "Date", "Object", "Math", "Array", "String", "Number", "Boolean", "console"].includes(receiver.name);
+          if (!isKnownBuiltIn) {
+            return;
+          }
+        }
+      }
       canCompleteAbruptly = true;
       return false;
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #1593 - False positive where `no-loading-flag-reset-outside-finally` incorrectly flagged trailing resets after non-rethrowing catch blocks when the catch contained user code calls like `toast.show()`.

## Root Cause

The rule conservatively assumed **all** potentially-throwing calls in catch handlers would prevent trailing resets from running. This created false positives for user code that doesn't actually throw.

The pattern from the issue:
```tsx
try {
  const res = await fetch("/api/upload");
  // ... 
} catch {
  toast.show({ variant: "danger", label: "Upload error", duration: 3500 });
}
setIsUploading(false); // <- incorrectly flagged
```

This is safe: if the catch doesn't rethrow, the trailing reset **will** run on both success and rejection paths.

## The Fix

Modified `subtreeHasAbruptSynchronousOperation` to use **lenient mode** when checking catch handlers with trailing resets. Lenient mode only flags:

1. **Explicit throw/return statements** - definitely prevent trailing reset
2. **Calls to local functions proven to always throw** - e.g. `const rethrow = () => { throw ... }; rethrow();`
3. **Built-in calls that might throw** - e.g. `JSON.parse()`, `Math.round(1n)`, `console[method]()`

User code calls on non-built-in objects (like `toast.show()`) are now assumed safe.

## Why This Matters

This resolves the conflict with **React Compiler**, which cannot handle `try/finally` and requires the `catch-without-rethrow + trailing-reset` pattern. From the issue:

> React Compiler cannot currently lower `try`/`finally` (or `try` without `catch`). So the two rules are in direct conflict:
> - `no-loading-flag-reset-outside-finally` → wants `finally`
> - `react-hooks-js/todo` → forbids `finally`

## Testing

- ✅ All existing tests pass
- ✅ Added regression test for the reported pattern
- ✅ Verified that true positives are still caught (local throwing functions, built-ins)

## Parity

Running `rde parity` to validate no cross-repo regressions. Results will be added as a comment.

Closes #1593
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a0453c1f-762b-44d6-affe-95fc80de7804?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a0453c1f-762b-44d6-affe-95fc80de7804&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

