### PR TITLE
fix(rule): harden effect cleanup regressions

### DIFF
--- a/.changeset/quiet-swallowed-catches.md
+++ b/.changeset/quiet-swallowed-catches.md
@@ -1,0 +1,6 @@
+---
+"oxlint-plugin-react-doctor": patch
+"react-doctor": patch
+---
+
+Accept trailing loading resets after non-rethrowing catch handlers, and preserve effect-local cleanup helpers with deterministic false-positive and false-negative fuzz replay.

--- a/packages/fuzz/README.md
+++ b/packages/fuzz/README.md
@@ -45,10 +45,10 @@ that never fires is only having its early bails fuzzed.
 
 Each compatible canonical liveness fixture runs first, so the harness reaches
 a known reporting path before exploring generated and corpus-derived programs.
-Corpus seeds with a `// verdict: pass` or `// verdict: fail` header are also
-run deterministically by the smoke suite against the rule named in their
-`// rule:` header. Use `pass` for false-positive regressions and `fail` for
-confirmed true positives.
+Corpus seeds with a `// verdict: pass` or `// verdict: fail` header run
+deterministically in both the smoke suite and the targeted fuzz run against the
+rule named in their `// rule:` header. Use `pass` for false-positive regressions
+and `fail` for confirmed true positives.
 
 Every case is reproducible from its seed; reproducers for findings are written
 to `tmp/fuzz-findings/`.

--- a/packages/fuzz/corpus/README.md
+++ b/packages/fuzz/corpus/README.md
@@ -12,11 +12,10 @@ Two seed families, split by expected rule verdict:
   genuine bug a rule must flag, kept as a mutation seed so its shape keeps
   applying pressure.
 
-The harness enforces **no firing expectations** for either family — its
-oracles are crash, slowness, verdict-preserving invariance, and verdict
-drops, and `firedProgramCount` is a coverage stat only. Whether a seed must
-or must not fire is pinned by the owning rule's unit test file, never by
-fuzzing.
+Seeds with `// verdict: pass` or `// verdict: fail` are replayed
+deterministically by both the smoke suite and targeted fuzzing. Seeds without a
+verdict remain mutation-only inputs. `firedProgramCount` is still a coverage
+stat rather than a correctness oracle for generated programs.
 
 **The evolving loop (see the `fuzz` skill):** whenever a new false positive
 is confirmed — from a user report, an RDE eval, a react-bench run, review,

--- a/packages/fuzz/corpus/regressions/effect-needs-cleanup--issue-1594-local-cleanup-helper.tsx
+++ b/packages/fuzz/corpus/regressions/effect-needs-cleanup--issue-1594-local-cleanup-helper.tsx
@@ -1,0 +1,30 @@
+// verdict: pass
+// rule: effect-needs-cleanup
+// weakness: cleanup-provenance
+// source: issue #1594
+
+import { useEffect } from "react";
+
+export const ConnectionStatus = ({ online }) => {
+  useEffect(() => {
+    const timerRef = { current: null as ReturnType<typeof setTimeout> | null };
+    const clearOfflineTimer = () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+    const applyState = (nextOnline: boolean) => {
+      if (!nextOnline && !timerRef.current) {
+        timerRef.current = setTimeout(() => updateStatus(), 1_000);
+      }
+    };
+
+    applyState(online);
+    return () => {
+      clearOfflineTimer();
+    };
+  }, [online]);
+
+  return null;
+};

--- a/packages/fuzz/corpus/regressions/no-loading-flag-reset-outside-finally--issue-1593-swallowed-catch.tsx
+++ b/packages/fuzz/corpus/regressions/no-loading-flag-reset-outside-finally--issue-1593-swallowed-catch.tsx
@@ -1,0 +1,16 @@
+// verdict: pass
+// rule: no-loading-flag-reset-outside-finally
+// weakness: control-flow
+// source: issue #1593
+
+export const handleUpload = async () => {
+  setIsUploading(true);
+  try {
+    const response = await upload();
+    if (response.ok) onSuccess();
+    else toast.show({ variant: "danger", label: "Upload failed" });
+  } catch {
+    toast.show({ variant: "danger", label: "Upload failed" });
+  }
+  setIsUploading(false);
+};

--- a/packages/fuzz/corpus/true-positives/effect-needs-cleanup--deferred-helper-after-teardown.tsx
+++ b/packages/fuzz/corpus/true-positives/effect-needs-cleanup--deferred-helper-after-teardown.tsx
@@ -1,0 +1,21 @@
+// verdict: fail
+// rule: effect-needs-cleanup
+// weakness: cleanup-provenance
+// source: issue #1594 adversarial boundary
+
+import { useEffect } from "react";
+
+export const ConnectionStatus = ({ source }) => {
+  useEffect(() => {
+    const timerRef = { current: null as ReturnType<typeof setTimeout> | null };
+    const clearOfflineTimer = () => clearTimeout(timerRef.current);
+    const applyState = (online: boolean) => {
+      if (!online) timerRef.current = setTimeout(() => updateStatus(), 1_000);
+    };
+
+    source.read().then((online) => applyState(online));
+    return () => clearOfflineTimer();
+  }, [source]);
+
+  return null;
+};

--- a/packages/fuzz/src/ast-equivalent-fuzz-variants.ts
+++ b/packages/fuzz/src/ast-equivalent-fuzz-variants.ts
@@ -26,6 +26,7 @@ const hasSpan = (node: EsTreeNode | null | undefined): node is EsTreeNode & Requ
 
 const EFFECT_HOOK_NAMES = new Set(["useEffect", "useInsertionEffect", "useLayoutEffect"]);
 const EFFECT_CALLBACK_ALIAS_PREFIX = "__reactDoctorFuzzEffectCallback";
+const CLEANUP_CALL_ALIAS_PREFIX = "__reactDoctorFuzzCleanupCall";
 
 const buildEffectCallbackAliasVariant = (
   code: string,
@@ -66,6 +67,78 @@ const buildEffectCallbackAliasVariant = (
   }
   return {
     label: "inline effect callbacks extracted to const bindings",
+    code: variantCode,
+  };
+};
+
+const buildCleanupCallAliasVariant = (
+  code: string,
+  program: EsTreeNode,
+): EquivalentVariant | null => {
+  if (code.includes(CLEANUP_CALL_ALIAS_PREFIX)) return null;
+  const replacements: SpanReplacement[] = [];
+  let cleanupCallIndex = 0;
+  walkAst(program, (node) => {
+    if (!isNodeOfType(node, "CallExpression") || !isHookCall(node, EFFECT_HOOK_NAMES)) return;
+    const callbackArgument = node.arguments[0];
+    if (!callbackArgument || isNodeOfType(callbackArgument, "SpreadElement")) return;
+    const callback = stripParenExpression(callbackArgument);
+    if (!isFunctionLike(callback) || !isNodeOfType(callback.body, "BlockStatement")) return;
+    walkAst(callback.body, (returnNode) => {
+      if (returnNode !== callback.body && isFunctionLike(returnNode)) return false;
+      if (
+        !isNodeOfType(returnNode, "ReturnStatement") ||
+        !returnNode.argument ||
+        !hasSpan(returnNode)
+      ) {
+        return;
+      }
+      const cleanupFunction = stripParenExpression(returnNode.argument);
+      if (
+        !isNodeOfType(cleanupFunction, "ArrowFunctionExpression") ||
+        cleanupFunction.async ||
+        cleanupFunction.generator ||
+        cleanupFunction.params.length > 0
+      ) {
+        return false;
+      }
+      const cleanupCalls: EsTreeNode[] = [];
+      walkAst(cleanupFunction.body, (cleanupChild) => {
+        if (cleanupCalls.length > 0) return false;
+        if (cleanupChild !== cleanupFunction.body && isFunctionLike(cleanupChild)) return false;
+        if (!isNodeOfType(cleanupChild, "CallExpression") || !hasSpan(cleanupChild)) return;
+        cleanupCalls.push(cleanupChild);
+        return false;
+      });
+      const cleanupCall = cleanupCalls[0];
+      if (!hasSpan(cleanupCall)) return false;
+      const lineStart = code.lastIndexOf("\n", returnNode.start - 1) + 1;
+      const indentation = code.slice(lineStart, returnNode.start);
+      if (!/^[\t ]*$/.test(indentation)) return false;
+      const cleanupCallName = `${CLEANUP_CALL_ALIAS_PREFIX}${cleanupCallIndex}`;
+      cleanupCallIndex += 1;
+      replacements.push(
+        {
+          start: lineStart,
+          end: lineStart,
+          text: `${indentation}const ${cleanupCallName} = () => ${code.slice(cleanupCall.start, cleanupCall.end)};\n`,
+        },
+        { start: cleanupCall.start, end: cleanupCall.end, text: `${cleanupCallName}()` },
+      );
+      return false;
+    });
+  });
+  if (replacements.length === 0) return null;
+  replacements.sort((left, right) => right.start - left.start);
+  let variantCode = code;
+  for (const replacement of replacements) {
+    variantCode =
+      variantCode.slice(0, replacement.start) +
+      replacement.text +
+      variantCode.slice(replacement.end);
+  }
+  return {
+    label: "effect cleanup calls extracted to local helpers",
     code: variantCode,
   };
 };
@@ -119,6 +192,7 @@ export const buildAstEquivalentFuzzVariants = (
   code: string,
   filename: string,
   shouldExtractEffectCallbacks = false,
+  shouldExtractCleanupCalls = false,
 ): EquivalentVariant[] => {
   const variants: EquivalentVariant[] = [];
   const program = parseProgram(code, filename);
@@ -155,6 +229,10 @@ export const buildAstEquivalentFuzzVariants = (
   if (shouldExtractEffectCallbacks) {
     const effectCallbackAliasVariant = buildEffectCallbackAliasVariant(code, program);
     if (effectCallbackAliasVariant) variants.push(effectCallbackAliasVariant);
+  }
+  if (shouldExtractCleanupCalls) {
+    const cleanupCallAliasVariant = buildCleanupCallAliasVariant(code, program);
+    if (cleanupCallAliasVariant) variants.push(cleanupCallAliasVariant);
   }
   return variants;
 };

--- a/packages/fuzz/src/ast-equivalent-fuzz-variants.ts
+++ b/packages/fuzz/src/ast-equivalent-fuzz-variants.ts
@@ -102,15 +102,18 @@ const buildCleanupCallAliasVariant = (
       ) {
         return false;
       }
-      const cleanupCalls: EsTreeNode[] = [];
-      walkAst(cleanupFunction.body, (cleanupChild) => {
-        if (cleanupCalls.length > 0) return false;
-        if (cleanupChild !== cleanupFunction.body && isFunctionLike(cleanupChild)) return false;
-        if (!isNodeOfType(cleanupChild, "CallExpression") || !hasSpan(cleanupChild)) return;
-        cleanupCalls.push(cleanupChild);
-        return false;
-      });
-      const cleanupCall = cleanupCalls[0];
+      const cleanupBody = stripParenExpression(cleanupFunction.body);
+      let cleanupCall: EsTreeNode | null = null;
+      if (isNodeOfType(cleanupBody, "CallExpression")) {
+        cleanupCall = cleanupBody;
+      } else if (
+        isNodeOfType(cleanupBody, "BlockStatement") &&
+        cleanupBody.body.length === 1 &&
+        isNodeOfType(cleanupBody.body[0], "ExpressionStatement")
+      ) {
+        const cleanupExpression = stripParenExpression(cleanupBody.body[0].expression);
+        if (isNodeOfType(cleanupExpression, "CallExpression")) cleanupCall = cleanupExpression;
+      }
       if (!hasSpan(cleanupCall)) return false;
       const lineStart = code.lastIndexOf("\n", returnNode.start - 1) + 1;
       const indentation = code.slice(lineStart, returnNode.start);

--- a/packages/fuzz/src/fuzz-rule.ts
+++ b/packages/fuzz/src/fuzz-rule.ts
@@ -26,8 +26,14 @@ const EFFECT_CALLBACK_ALIAS_RULE_IDS = new Set([
   "no-effect-chain",
   "no-fetch-in-effect",
 ]);
+const CLEANUP_CALL_ALIAS_RULE_IDS = new Set(["effect-needs-cleanup"]);
 
-export type FuzzFindingKind = "crash" | "slow" | "invariant-violation" | "verdict-drop";
+export type FuzzFindingKind =
+  | "crash"
+  | "slow"
+  | "invariant-violation"
+  | "verdict-drop"
+  | "verdict-mismatch";
 
 export interface FuzzFinding {
   ruleId: string;
@@ -223,6 +229,30 @@ export const fuzzRuleWithStats = (
     }
   }
 
+  for (const corpusEntry of corpus) {
+    if (!corpusEntry.verdict || !corpusEntry.ruleIds?.includes(ruleId)) continue;
+    const corpusOutcome = checkProgram(
+      corpusEntry.code,
+      corpusEntry.relativePath,
+      baseSeed,
+      0,
+      "declared corpus verdict",
+    );
+    if (!corpusOutcome || corpusOutcome.crashDetail !== undefined) continue;
+    const didFire = (corpusOutcome.diagnosticSignature?.length ?? 0) > 0;
+    const shouldFire = corpusEntry.verdict === "fail";
+    if (didFire === shouldFire) continue;
+    findings.push({
+      ruleId,
+      kind: "verdict-mismatch",
+      seed: baseSeed,
+      iteration: 0,
+      detail: `${corpusEntry.relativePath} declared ${corpusEntry.verdict} but produced ${corpusOutcome.diagnosticSignature?.length ?? 0} diagnostics`,
+      code: corpusEntry.code,
+      variantLabel: "declared corpus verdict",
+    });
+  }
+
   for (let iteration = 0; iteration < iterations; iteration += 1) {
     const iterationSeed = (baseSeed * 1_000_003 + iteration) >>> 0;
     const random = createSeededRandom(iterationSeed);
@@ -314,7 +344,12 @@ export const fuzzRuleWithStats = (
 
     for (const variant of [
       ...buildEquivalentFuzzVariants(code, sections),
-      ...buildAstEquivalentFuzzVariants(code, filename, EFFECT_CALLBACK_ALIAS_RULE_IDS.has(ruleId)),
+      ...buildAstEquivalentFuzzVariants(
+        code,
+        filename,
+        EFFECT_CALLBACK_ALIAS_RULE_IDS.has(ruleId),
+        CLEANUP_CALL_ALIAS_RULE_IDS.has(ruleId),
+      ),
     ]) {
       const variantOutcome = runRuleOnCode(rule, variant.code, filename);
       if (variantOutcome.hasParseErrors === true) continue;

--- a/packages/fuzz/src/load-fuzz-corpus.ts
+++ b/packages/fuzz/src/load-fuzz-corpus.ts
@@ -5,6 +5,8 @@ import { MAX_CORPUS_FILES, MAX_CORPUS_FILE_BYTES } from "./constants.js";
 export interface FuzzCorpusEntry {
   relativePath: string;
   code: string;
+  ruleIds?: string[];
+  verdict?: "pass" | "fail";
 }
 
 export interface FuzzCorpusLoadOptions {
@@ -12,7 +14,21 @@ export interface FuzzCorpusLoadOptions {
 }
 
 const CORPUS_FILE_PATTERN = /\.(tsx|jsx)$/;
+const RULE_DIRECTIVE_PATTERN = /^\/\/ rule: (.+)$/m;
+const VERDICT_DIRECTIVE_PATTERN = /^\/\/ verdict: (pass|fail)$/m;
 const SKIPPED_DIRECTORY_NAMES = new Set(["node_modules", ".git", "dist", "build", "coverage"]);
+
+const readCorpusDirectives = (code: string): Pick<FuzzCorpusEntry, "ruleIds" | "verdict"> => {
+  const ruleIds = RULE_DIRECTIVE_PATTERN.exec(code)?.[1]
+    ?.split(",")
+    .map((ruleId) => ruleId.trim())
+    .filter(Boolean);
+  const verdict = VERDICT_DIRECTIVE_PATTERN.exec(code)?.[1];
+  const directives: Pick<FuzzCorpusEntry, "ruleIds" | "verdict"> = {};
+  if (ruleIds && ruleIds.length > 0) directives.ruleIds = ruleIds;
+  if (verdict === "pass" || verdict === "fail") directives.verdict = verdict;
+  return directives;
+};
 
 const collectCorpusFilePaths = (rootDirectory: string, budget: number): string[] => {
   const filePaths: string[] = [];
@@ -100,9 +116,11 @@ export const loadFuzzCorpus = (
   const entries: FuzzCorpusEntry[] = [];
   for (const fullPath of selectedPaths) {
     try {
+      const code = fs.readFileSync(fullPath, "utf8");
       entries.push({
         relativePath: path.relative(corpusDirectory, fullPath),
-        code: fs.readFileSync(fullPath, "utf8"),
+        code,
+        ...readCorpusDirectives(code),
       });
     } catch {
       continue;

--- a/packages/fuzz/tests/fuzz-harness-smoke.test.ts
+++ b/packages/fuzz/tests/fuzz-harness-smoke.test.ts
@@ -16,21 +16,8 @@ import { isNodeOfType } from "../../oxlint-plugin-react-doctor/src/plugin/utils/
 import type { Rule } from "../../oxlint-plugin-react-doctor/src/plugin/utils/rule.js";
 
 const NOOP_RULE: Rule = { id: "fuzz-smoke-noop", severity: "warn", create: () => ({}) };
-const RULE_DIRECTIVE_PATTERN = /^\/\/ rule: ([^\r\n]+)$/m;
-const VERDICT_DIRECTIVE_PATTERN = /^\/\/ verdict: (pass|fail)$/m;
 
 describe("fuzz harness oracles", () => {
-  it("reads corpus directives from CRLF files", () => {
-    const code = "// rule: example-rule, second-rule\r\n// verdict: fail\r\n";
-
-    expect(
-      RULE_DIRECTIVE_PATTERN.exec(code)?.[1]
-        ?.split(",")
-        .map((ruleId) => ruleId.trim()),
-    ).toEqual(["example-rule", "second-rule"]);
-    expect(VERDICT_DIRECTIVE_PATTERN.exec(code)?.[1]).toBe("fail");
-  });
-
   // Generator health: every unmutated program must parse — a snippet-pool
   // typo would otherwise silently turn iterations into parse-error skips.
   it("generates programs that all parse cleanly", () => {
@@ -89,10 +76,8 @@ describe("fuzz harness oracles", () => {
     let declaredVerdictCount = 0;
 
     for (const entry of corpus) {
-      const ruleIds = RULE_DIRECTIVE_PATTERN.exec(entry.code)?.[1]
-        ?.split(",")
-        .map((ruleId) => ruleId.trim());
-      const verdict = VERDICT_DIRECTIVE_PATTERN.exec(entry.code)?.[1];
+      const ruleIds = entry.ruleIds;
+      const verdict = entry.verdict;
       if (!verdict) continue;
       declaredVerdictCount += 1;
       if (!ruleIds?.length) {
@@ -258,5 +243,28 @@ React.useEffect(() => {
       "useInsertionEffect(__reactDoctorFuzzEffectCallback2, []);",
     );
     expect(runRule(NOOP_RULE, aliasVariant?.code ?? "").parseErrors).toEqual([]);
+  });
+
+  it("extracts effect cleanup calls to local helpers", () => {
+    const variants = buildAstEquivalentFuzzVariants(
+      `const Widget = ({ delay }) => {
+  useEffect(() => {
+    const timerId = setTimeout(refresh, delay);
+    return () => clearTimeout(timerId);
+  }, [delay]);
+  return null;
+};`,
+      "fixture.tsx",
+      false,
+      true,
+    );
+    const helperVariant = variants.find(
+      (variant) => variant.label === "effect cleanup calls extracted to local helpers",
+    );
+    expect(helperVariant?.code).toContain(
+      "const __reactDoctorFuzzCleanupCall0 = () => clearTimeout(timerId);",
+    );
+    expect(helperVariant?.code).toContain("return () => __reactDoctorFuzzCleanupCall0();");
+    expect(runRule(NOOP_RULE, helperVariant?.code ?? "").parseErrors).toEqual([]);
   });
 });

--- a/packages/fuzz/tests/fuzz-harness-smoke.test.ts
+++ b/packages/fuzz/tests/fuzz-harness-smoke.test.ts
@@ -250,7 +250,9 @@ React.useEffect(() => {
       `const Widget = ({ delay }) => {
   useEffect(() => {
     const timerId = setTimeout(refresh, delay);
-    return () => clearTimeout(timerId);
+    return () => {
+      clearTimeout(timerId);
+    };
   }, [delay]);
   return null;
 };`,
@@ -264,7 +266,31 @@ React.useEffect(() => {
     expect(helperVariant?.code).toContain(
       "const __reactDoctorFuzzCleanupCall0 = () => clearTimeout(timerId);",
     );
-    expect(helperVariant?.code).toContain("return () => __reactDoctorFuzzCleanupCall0();");
+    expect(helperVariant?.code).toContain("__reactDoctorFuzzCleanupCall0();");
     expect(runRule(NOOP_RULE, helperVariant?.code ?? "").parseErrors).toEqual([]);
+  });
+
+  it("does not hoist calls that depend on cleanup-local bindings", () => {
+    const variants = buildAstEquivalentFuzzVariants(
+      `const Widget = ({ delay }) => {
+  useEffect(() => {
+    const timerRef = { current: setTimeout(refresh, delay) };
+    return () => {
+      const timerId = timerRef.current;
+      clearTimeout(timerId);
+    };
+  }, [delay]);
+  return null;
+};`,
+      "fixture.tsx",
+      false,
+      true,
+    );
+
+    expect(
+      variants.some(
+        (variant) => variant.label === "effect cleanup calls extracted to local helpers",
+      ),
+    ).toBe(false);
   });
 });

--- a/packages/fuzz/tests/fuzz-rule.test.ts
+++ b/packages/fuzz/tests/fuzz-rule.test.ts
@@ -36,4 +36,30 @@ describe("fuzzRuleWithStats", () => {
     expect(result.stats.executedProgramCount).toBeGreaterThan(0);
     expect(result.stats.firedProgramCount).toBeGreaterThan(0);
   });
+
+  it("replays declared corpus verdicts deterministically", () => {
+    const result = fuzzRuleWithStats(livenessRule.id, livenessRule, {
+      iterations: 0,
+      corpus: [
+        {
+          relativePath: "regressions/liveness-rule--unexpected-fire.tsx",
+          code: "const positiveLivenessMarker = true;",
+          ruleIds: [livenessRule.id],
+          verdict: "pass",
+        },
+        {
+          relativePath: "true-positives/liveness-rule--unexpected-silence.tsx",
+          code: "const negativeMarker = true;",
+          ruleIds: [livenessRule.id],
+          verdict: "fail",
+        },
+      ],
+    });
+
+    expect(result.stats.executedProgramCount).toBe(2);
+    expect(result.findings.map((finding) => finding.kind)).toEqual([
+      "verdict-mismatch",
+      "verdict-mismatch",
+    ]);
+  });
 });

--- a/packages/fuzz/tests/load-fuzz-corpus.test.ts
+++ b/packages/fuzz/tests/load-fuzz-corpus.test.ts
@@ -45,4 +45,21 @@ describe("loadFuzzCorpus", () => {
       MAX_CORPUS_FILES + 1,
     );
   });
+
+  it("loads declared rule IDs and verdicts", () => {
+    const directory = makeCorpusDirectory();
+    fs.writeFileSync(
+      path.join(directory, "declared.tsx"),
+      "// rule: first-rule, second-rule\r\n// verdict: pass\r\nexport const Seed = <div />;",
+    );
+
+    expect(loadFuzzCorpus(directory)).toEqual([
+      {
+        relativePath: "declared.tsx",
+        code: "// rule: first-rule, second-rule\r\n// verdict: pass\r\nexport const Seed = <div />;",
+        ruleIds: ["first-rule", "second-rule"],
+        verdict: "pass",
+      },
+    ]);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup-issue-1594.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup-issue-1594.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { effectNeedsCleanup } from "./effect-needs-cleanup.js";
+
+const runEffectNeedsCleanup = (code: string) => runRule(effectNeedsCleanup, code);
+
+describe("effect-needs-cleanup issue #1594", () => {
+  it("accepts a ref timer allocated and released through effect-local helpers", () => {
+    const result = runEffectNeedsCleanup(`
+      import { useEffect } from "react";
+
+      const Status = ({ online }) => {
+        useEffect(() => {
+          const timerRef = { current: null as ReturnType<typeof setTimeout> | null };
+
+          const clearOfflineTimer = () => {
+            if (timerRef.current) {
+              clearTimeout(timerRef.current);
+              timerRef.current = null;
+            }
+          };
+
+          const applyState = (nextOnline: boolean) => {
+            if (!nextOnline && !timerRef.current) {
+              timerRef.current = setTimeout(() => updateStatus(), 1_000);
+            }
+          };
+
+          applyState(online);
+          return () => {
+            clearOfflineTimer();
+          };
+        }, [online]);
+
+        return null;
+      };
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("accepts the same ownership through nested cleanup helpers", () => {
+    const result = runEffectNeedsCleanup(`
+      import { useEffect } from "react";
+
+      const Status = ({ online }) => {
+        useEffect(() => {
+          const timerRef = { current: null as ReturnType<typeof setTimeout> | null };
+          const releaseTimer = () => clearTimeout(timerRef.current);
+          const clearOfflineTimer = () => releaseTimer();
+          const applyState = () => {
+            timerRef.current = setTimeout(() => updateStatus(), 1_000);
+          };
+
+          applyState();
+          return () => clearOfflineTimer();
+        }, [online]);
+
+        return null;
+      };
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("accepts a ref timer allocated by an effect-owned subscription callback", () => {
+    const result = runEffectNeedsCleanup(`
+      import { useEffect } from "react";
+
+      const Status = ({ source }) => {
+        useEffect(() => {
+          const timerRef = { current: null as ReturnType<typeof setTimeout> | null };
+          const clearOfflineTimer = () => {
+            if (timerRef.current) {
+              clearTimeout(timerRef.current);
+              timerRef.current = null;
+            }
+          };
+          const applyState = (online: boolean) => {
+            if (!online && !timerRef.current) {
+              timerRef.current = setTimeout(() => updateStatus(), 1_000);
+            }
+          };
+
+          const unsubscribe = source.subscribe((online) => applyState(online));
+          return () => {
+            clearOfflineTimer();
+            unsubscribe();
+          };
+        }, [source]);
+
+        return null;
+      };
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("rejects a ref timer that a promise callback can allocate after teardown", () => {
+    const result = runEffectNeedsCleanup(`
+      import { useEffect } from "react";
+
+      const Status = ({ source }) => {
+        useEffect(() => {
+          const timerRef = { current: null as ReturnType<typeof setTimeout> | null };
+          const clearOfflineTimer = () => clearTimeout(timerRef.current);
+          const applyState = (online: boolean) => {
+            if (!online) timerRef.current = setTimeout(() => updateStatus(), 1_000);
+          };
+
+          source.read().then((online) => applyState(online));
+          return () => clearOfflineTimer();
+        }, [source]);
+
+        return null;
+      };
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("rejects a cleanup helper that releases a different timer", () => {
+    const result = runEffectNeedsCleanup(`
+      import { useEffect } from "react";
+
+      const Status = ({ online }) => {
+        useEffect(() => {
+          const timerRef = { current: null as ReturnType<typeof setTimeout> | null };
+          const otherTimerRef = { current: null as ReturnType<typeof setTimeout> | null };
+          const clearOfflineTimer = () => clearTimeout(otherTimerRef.current);
+          const applyState = () => {
+            timerRef.current = setTimeout(() => updateStatus(), 1_000);
+          };
+
+          applyState();
+          return () => clearOfflineTimer();
+        }, [online]);
+
+        return null;
+      };
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("rejects a cleanup helper skipped on one teardown path", () => {
+    const result = runEffectNeedsCleanup(`
+      import { useEffect } from "react";
+
+      const Status = ({ online, shouldRelease }) => {
+        useEffect(() => {
+          const timerRef = { current: null as ReturnType<typeof setTimeout> | null };
+          const clearOfflineTimer = () => clearTimeout(timerRef.current);
+          const applyState = () => {
+            timerRef.current = setTimeout(() => updateStatus(), 1_000);
+          };
+
+          applyState();
+          return () => {
+            if (shouldRelease) clearOfflineTimer();
+          };
+        }, [online, shouldRelease]);
+
+        return null;
+      };
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-loading-flag-reset-outside-finally.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-loading-flag-reset-outside-finally.test.ts
@@ -40,6 +40,25 @@ describe("no-loading-flag-reset-outside-finally", () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("stays quiet when a non-rethrowing catch performs opaque error reporting before a trailing reset", () => {
+    const result = runRule(
+      noLoadingFlagResetOutsideFinally,
+      `const handleUpload = async () => {
+        setIsUploading(true);
+        try {
+          const response = await upload();
+          if (response.ok) onSuccess();
+          else toast.show({ variant: "danger", label: "Upload failed" });
+        } catch {
+          toast.show({ variant: "danger", label: "Upload failed" });
+        }
+        setIsUploading(false);
+      };`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("flags a trailing reset when the catch rethrows, so rejection still skips it", () => {
     const result = runRule(
       noLoadingFlagResetOutsideFinally,
@@ -2993,6 +3012,29 @@ describe("no-loading-flag-reset-outside-finally audit regressions", () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("reuses throw coverage across repeated local catch helper calls", () => {
+    const helperCalls = Array.from(
+      { length: STRESS_SITE_COUNT },
+      (_, callIndex) => `observe(${callIndex});`,
+    ).join("\n");
+    const result = runRule(
+      noLoadingFlagResetOutsideFinally,
+      `import { useState } from "react";
+      const C = () => {
+        const [, setLoading] = useState(false);
+        const observe = (value) => console.info(value);
+        const run = async () => {
+          setLoading(true);
+          try { await fetch("/value"); }
+          catch { ${helperCalls} }
+          setLoading(false);
+        };
+      };`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("groups stable setter aliases by binding identity", () => {
     const aliasedReset = runRule(
       noLoadingFlagResetOutsideFinally,
@@ -3359,23 +3401,23 @@ describe("no-loading-flag-reset-outside-finally audit regressions", () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
-  it("keeps potentially throwing and dynamic global calls conservative", () => {
-    const catchBodies = [
-      'JSON.parse("invalid")',
-      "Date.parse(Symbol())",
-      'Object.defineProperty(null, "value", {})',
-      "Math.round(1n)",
-      "Math.round(formatDuration())",
-      "Math.round(performance.now() - start); const start = performance.now()",
-      'String({ toString() { throw new Error("failed") } })',
-      'const method = "round"; Math[method](1)',
-      'const method = "log"; console[method](error)',
-      "console.missing(error)",
-      'const console = { log() { throw new Error("failed") } }; console.log(error)',
-      'const performance = { now() { throw new Error("failed") } }; performance.now()',
-      'const String = () => { throw new Error("failed") }; String(error)',
+  it("distinguishes opaque catch calls from provably throwing local implementations", () => {
+    const catchCases: ReadonlyArray<[string, number]> = [
+      ['JSON.parse("invalid")', 0],
+      ["Date.parse(Symbol())", 0],
+      ['Object.defineProperty(null, "value", {})', 0],
+      ["Math.round(1n)", 0],
+      ["Math.round(formatDuration())", 0],
+      ["Math.round(performance.now() - start); const start = performance.now()", 0],
+      ['String({ toString() { throw new Error("failed") } })', 0],
+      ['const method = "round"; Math[method](1)', 0],
+      ['const method = "log"; console[method](error)', 0],
+      ["console.missing(error)", 0],
+      ['const console = { log() { throw new Error("failed") } }; console.log(error)', 1],
+      ['const performance = { now() { throw new Error("failed") } }; performance.now()', 1],
+      ['const String = () => { throw new Error("failed") }; String(error)', 1],
     ];
-    for (const catchBody of catchBodies) {
+    for (const [catchBody, expectedDiagnosticCount] of catchCases) {
       const result = runRule(
         noLoadingFlagResetOutsideFinally,
         `async function run() {
@@ -3388,7 +3430,7 @@ describe("no-loading-flag-reset-outside-finally audit regressions", () => {
           setLoading(false);
         }`,
       );
-      expect(result.diagnostics).toHaveLength(1);
+      expect(result.diagnostics, catchBody).toHaveLength(expectedDiagnosticCount);
     }
   });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-loading-flag-reset-outside-finally.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-loading-flag-reset-outside-finally.ts
@@ -4,6 +4,7 @@ import { analyzeScopes, type ScopeAnalysis } from "../../semantic/scope-analysis
 import { collectReturnedCleanupFunctions } from "../../utils/collect-returned-cleanup-functions.js";
 import { collectConstAliasSymbols } from "../../utils/collect-const-alias-symbols.js";
 import { defineRule } from "../../utils/define-rule.js";
+import { doNodesCoverEveryPathFromFunctionEntry } from "../../utils/do-nodes-cover-every-path-from-function-entry.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
 import { findTransparentExpressionRoot } from "../../utils/find-transparent-expression-root.js";
@@ -1325,8 +1326,11 @@ const catchHandlerCanBypassReset = (
         hasUnsafeExit: right.hasUnsafeExit,
       };
     }
+    const hasAbruptCompletion = doesContinuingPathReachReset
+      ? subtreeCallsDefinitelyThrowingLocalFunction(stripped, context)
+      : subtreeHasAbruptSynchronousOperation(stripped, functionNode, context);
     if (
-      subtreeHasAbruptSynchronousOperation(stripped, functionNode, context) &&
+      hasAbruptCompletion &&
       states.some(
         (state) => !state.isCleared && !(doesContinuingPathReachReset && state.isCancellationPath),
       )
@@ -1619,6 +1623,44 @@ const subtreeHasAbruptSynchronousOperation = (
     }
   });
   return canCompleteAbruptly;
+};
+
+const subtreeCallsDefinitelyThrowingLocalFunction = (
+  root: EsTreeNode,
+  context: RuleContext,
+): boolean => {
+  let doesDefinitelyThrow = false;
+  const localFunctionThrowCoverage = new Map<EsTreeNode, boolean>();
+  walkAst(root, (candidate) => {
+    if (doesDefinitelyThrow) return false;
+    if (candidate !== root && isFunctionLike(candidate)) return false;
+    if (!isNodeOfType(candidate, "CallExpression")) return;
+    const localFunction = resolveExactLocalFunction(candidate.callee, context.scopes);
+    if (!localFunction || !isFunctionLike(localFunction) || localFunction.async) return;
+    let doesLocalFunctionDefinitelyThrow = localFunctionThrowCoverage.get(localFunction);
+    if (doesLocalFunctionDefinitelyThrow === undefined) {
+      const escapingThrows: EsTreeNode[] = [];
+      walkOwnFunctionScope(localFunction, (helperChild) => {
+        if (
+          isNodeOfType(helperChild, "ThrowStatement") &&
+          !isInsideNonRethrowingTry(helperChild, localFunction)
+        ) {
+          escapingThrows.push(helperChild);
+        }
+      });
+      doesLocalFunctionDefinitelyThrow = doNodesCoverEveryPathFromFunctionEntry(
+        localFunction,
+        escapingThrows,
+        context,
+      );
+      localFunctionThrowCoverage.set(localFunction, doesLocalFunctionDefinitelyThrow);
+    }
+    if (doesLocalFunctionDefinitelyThrow) {
+      doesDefinitelyThrow = true;
+      return false;
+    }
+  });
+  return doesDefinitelyThrow;
 };
 
 const hasAbruptCompletionBefore = (


### PR DESCRIPTION
## Why

`no-loading-flag-reset-outside-finally` treated every opaque call in a swallowing `catch` as a possible synchronous throw, so handled upload failures could incorrectly make a trailing loading reset look unreachable. The `effect-needs-cleanup` local-helper shape from #1594 was already quiet on current source, but its ownership boundary was not protected by deterministic semantic fuzzing.

After this change, ordinary error-reporting calls can fall through to the reset, while explicit exits and exact local helpers proven to throw on every CFG path remain reportable. Cleanup helper indirection is covered by both pass and fail seeds instead of relying on random mutation to rediscover it.

## What changed

- Narrow catch bypass detection to CFG-proven always-throwing local helpers and cache repeated helper coverage.
- Replay labeled fuzz corpus verdicts deterministically and report mismatches as blocking findings.
- Add an AST-equivalent cleanup-helper mutation for `effect-needs-cleanup`.
- Add focused FP/FN regressions for #1593 and #1594 plus a patch changeset.

## Eval results

| Check | Result |
| --- | --- |
| Project roots compared | 100 |
| Skipped projects | Not reported by the local runner |
| Added / removed | 0 / 0 |
| Target rule delta | 0 / 0 |
| False positives | 0 in inspected target-rule hits |
| Artifacts | Local RDE comparison against `react-doctor@0.9.5` |

## Test plan

- `nr test` — 15/15 tasks passed
- `nr lint` — passed
- `nr typecheck` — 16/16 tasks passed
- `nr format:check` — passed
- `nr smoke:json-report` — schema v3 smoke passed
- `FUZZ_RULE=effect-needs-cleanup FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz` — passed
- `FUZZ_RULE=no-loading-flag-reset-outside-finally FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz` — passed
- `nlx react-doctor@latest --verbose --scope changed` — 100/100, no diagnostics

Closes #1593.
Closes #1594.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes control-flow analysis in a state/effects lint rule and tightens fuzz oracles; behavior shifts are intentional but could affect edge-case diagnostics beyond the fixed issues.
> 
> **Overview**
> **`no-loading-flag-reset-outside-finally`** no longer treats every opaque call in a swallowing `catch` as blocking a trailing loading reset. On paths that continue to the reset, only **CFG-proven always-throwing** exact local helpers still count as abrupt completion; ordinary reporting calls (e.g. `toast.show`) allow the reset. Tests and corpus cover #1593.
> 
> **Fuzz harness** parses `// rule:` / `// verdict:` from corpus files, **replays declared pass/fail verdicts** at fuzz start (new **`verdict-mismatch`** finding), and documents that labeled seeds run in smoke and targeted fuzz. For **`effect-needs-cleanup`**, an AST variant hoists effect cleanup calls into local helpers (with guards so cleanup-local bindings are not hoisted); pass/fail seeds lock #1594 behavior.
> 
> **`effect-needs-cleanup`** gains focused unit tests for effect-local cleanup helpers (subscription vs deferred promise allocation).
> 
> Patch changeset for `react-doctor` and `oxlint-plugin-react-doctor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a231dc0537197844ca2c4762392e15e405689f8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->