### PR TITLE
fix(rules): preserve state effect provenance

### DIFF
--- a/.changeset/fix-state-effect-provenance.md
+++ b/.changeset/fix-state-effect-provenance.md
@@ -1,0 +1,6 @@
+---
+"oxlint-plugin-react-doctor": patch
+"eslint-plugin-react-doctor": patch
+---
+
+Fix derived-state detection through render-updated refs and avoid flagging finite timer lifecycle shutdowns as prop-driven state adjustments.

--- a/packages/fuzz/corpus/regressions/no-adjust-state-on-prop-change--slideshow-terminal-transition.tsx
+++ b/packages/fuzz/corpus/regressions/no-adjust-state-on-prop-change--slideshow-terminal-transition.tsx
@@ -1,7 +1,7 @@
 // rule: no-adjust-state-on-prop-change
 // verdict: pass
 // weakness: library-idiom
-// source: verified React Bench SlideshowContext trial 5sz2qXB
+// source: React Bench SlideshowContext trial 26Vu5Fo
 
 import * as React from "react";
 import { useTimeouts } from "./timeouts";
@@ -21,11 +21,15 @@ export const Slideshow = ({ disabled }: SlideshowProps) => {
   }, [clearTimeout]);
 
   React.useEffect(() => {
-    if (playing && disabled) {
+    if (disabled) {
       cancelScheduler();
-      setPlaying(false);
+      if (playing) {
+        setPlaying(false);
+      }
+    } else if (playing) {
+      scheduler.current = setTimeout(() => {}, 1_000);
     }
-  }, [playing, disabled, cancelScheduler]);
+  }, [playing, disabled, cancelScheduler, setTimeout]);
 
   return playing;
 };

--- a/packages/fuzz/corpus/regressions/no-derived-state--ref-guarded-selection-repair.tsx
+++ b/packages/fuzz/corpus/regressions/no-derived-state--ref-guarded-selection-repair.tsx
@@ -1,0 +1,46 @@
+// rule: no-derived-state
+// verdict: fail
+// weakness: ref-provenance
+// source: React Bench AppFlowy DocumentHistoryModal trial 2oin5YH
+
+import { useEffect, useMemo, useRef, useState } from "react";
+
+interface Version {
+  versionId: string;
+}
+
+interface DocumentHistoryModalProps {
+  initialVersions: Version[];
+}
+
+export const DocumentHistoryModal = ({ initialVersions }: DocumentHistoryModalProps) => {
+  const [versions] = useState(initialVersions);
+  const [selectedVersionId, setSelectedVersionId] = useState("");
+  const selectedVersionIdRef = useRef(selectedVersionId);
+  selectedVersionIdRef.current = selectedVersionId;
+  const visibleVersions = useMemo(() => [...versions], [versions]);
+
+  useEffect(() => {
+    if (visibleVersions.length === 0) {
+      if (selectedVersionIdRef.current) {
+        setSelectedVersionId("");
+      }
+      return;
+    }
+
+    if (!visibleVersions.some((version) => version.versionId === selectedVersionIdRef.current)) {
+      setSelectedVersionId(visibleVersions[0].versionId);
+    }
+  }, [visibleVersions]);
+
+  return (
+    <select
+      value={selectedVersionId}
+      onChange={(event) => setSelectedVersionId(event.target.value)}
+    >
+      {visibleVersions.map((version) => (
+        <option key={version.versionId}>{version.versionId}</option>
+      ))}
+    </select>
+  );
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-adjust-state-on-prop-change-slideshow.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-adjust-state-on-prop-change-slideshow.regressions.test.ts
@@ -3,6 +3,80 @@ import { runRule } from "../../../test-utils/run-rule.js";
 import { noAdjustStateOnPropChange } from "./no-adjust-state-on-prop-change.js";
 
 describe("no-adjust-state-on-prop-change — Slideshow terminal transitions", () => {
+  it("stays silent when a disabled finite slideshow cancels its timer before stopping", () => {
+    const result = runRule(
+      noAdjustStateOnPropChange,
+      `import * as React from "react";
+      import { useTimeouts } from "../../index.js";
+      function Slideshow({ disabled }) {
+        const [playing, setPlaying] = React.useState(true);
+        const { setTimeout, clearTimeout } = useTimeouts();
+        const scheduler = React.useRef();
+        const cancelScheduler = React.useCallback(() => {
+          clearTimeout(scheduler.current);
+          scheduler.current = undefined;
+        }, [clearTimeout]);
+        React.useEffect(() => {
+          if (disabled) {
+            cancelScheduler();
+            if (playing) {
+              setPlaying(false);
+            }
+          } else if (playing) {
+            scheduler.current = setTimeout(advance, 1000);
+          }
+        }, [playing, disabled, cancelScheduler, setTimeout]);
+        return playing;
+      }`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("reports a nested state adjustment when timer scheduling precedes it", () => {
+    const result = runRule(
+      noAdjustStateOnPropChange,
+      `function Slideshow({ disabled }) {
+        const [playing, setPlaying] = useState(true);
+        useEffect(() => {
+          if (disabled) {
+            setTimeout(advance, 1000);
+            if (playing) {
+              setPlaying(false);
+            }
+          }
+        }, [playing, disabled]);
+        return playing;
+      }`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("reports a nested state adjustment when timer cancellation follows it", () => {
+    const result = runRule(
+      noAdjustStateOnPropChange,
+      `function Slideshow({ disabled }) {
+        const [playing, setPlaying] = useState(true);
+        const scheduler = useRef();
+        useEffect(() => {
+          if (disabled) {
+            if (playing) {
+              setPlaying(false);
+            }
+            clearTimeout(scheduler.current);
+          }
+        }, [playing, disabled]);
+        return playing;
+      }`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it.each([
     ["direct transition", "cancelScheduler(); setPlaying(false);"],
     ["stable callback transition", "pause();"],

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-adjust-state-on-prop-change.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-adjust-state-on-prop-change.ts
@@ -92,7 +92,7 @@ export const noAdjustStateOnPropChange = defineRule({
       for (const fact of facts) {
         if (
           fact.isDeferred ||
-          hasDeferredOrExternalEffectWork(analysis, node, context.scopes, fact.callExpression)
+          hasDeferredOrExternalEffectWork(analysis, node, context, fact.callExpression)
         ) {
           continue;
         }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-derived-state.ref-provenance.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-derived-state.ref-provenance.test.ts
@@ -3,6 +3,72 @@ import { runRule } from "../../../test-utils/run-rule.js";
 import { noDerivedState } from "./no-derived-state.js";
 
 describe("no-derived-state — ref value provenance", () => {
+  it("detects selection repair guarded by state copied through a ref", () => {
+    const result = runRule(
+      noDerivedState,
+      `function DocumentHistoryModal({ initialVersions }) {
+        const [versions] = useState(initialVersions);
+        const [selectedVersionId, setSelectedVersionId] = useState("");
+        const selectedVersionIdRef = useRef(selectedVersionId);
+        selectedVersionIdRef.current = selectedVersionId;
+        const visibleVersions = useMemo(() => [...versions], [versions]);
+        useEffect(() => {
+          if (visibleVersions.length === 0) {
+            if (selectedVersionIdRef.current) {
+              setSelectedVersionId("");
+            }
+            return;
+          }
+          if (!visibleVersions.some(
+            (version) => version.versionId === selectedVersionIdRef.current
+          )) {
+            setSelectedVersionId(visibleVersions[0].versionId);
+          }
+        }, [visibleVersions]);
+        return (
+          <VersionList
+            versions={visibleVersions}
+            selected={selectedVersionId}
+            onSelect={setSelectedVersionId}
+          />
+        );
+      }`,
+      { forceJsx: true },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("keeps selection repair quiet when the guard ref can hold an external value", () => {
+    const result = runRule(
+      noDerivedState,
+      `function DocumentHistoryModal({ initialVersions }) {
+        const [versions] = useState(initialVersions);
+        const [selectedVersionId, setSelectedVersionId] = useState("");
+        const selectedVersionIdRef = useRef(selectedVersionId);
+        selectedVersionIdRef.current = readExternalSelection();
+        const visibleVersions = useMemo(() => [...versions], [versions]);
+        useEffect(() => {
+          if (!visibleVersions.some(
+            (version) => version.versionId === selectedVersionIdRef.current
+          )) {
+            setSelectedVersionId(visibleVersions[0].versionId);
+          }
+        }, [visibleVersions]);
+        return (
+          <VersionList
+            versions={visibleVersions}
+            selected={selectedVersionId}
+            onSelect={setSelectedVersionId}
+          />
+        );
+      }`,
+      { forceJsx: true },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("detects prop-derived state copied through a ref", () => {
     const result = runRule(
       noDerivedState,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/collect-effect-state-write-facts.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/collect-effect-state-write-facts.ts
@@ -1793,6 +1793,7 @@ const collectFrameSetterCalls = (
 const expressionReadsStateDeclarator = (
   analysis: ProgramAnalysis,
   context: RuleContext,
+  frame: EffectExecutionFrame,
   expression: EsTreeNode,
   stateDeclarator: EsTreeNode,
 ): boolean => {
@@ -1937,6 +1938,22 @@ const expressionReadsStateDeclarator = (
     expression,
     (child: EsTreeNode): void => {
       if (readsState) return;
+      if (isNodeOfType(child, "MemberExpression") && getStaticMemberName(child) === "current") {
+        const valueEvidence = collectValueEvidence(analysis, child, frame, 1);
+        const sourceStateDeclarators = [...valueEvidence.sourceReferences]
+          .filter((reference) => isState(analysis, reference))
+          .map((reference) => getUseStateDecl(analysis, reference));
+        if (
+          sourceStateDeclarators.length > 0 &&
+          sourceStateDeclarators.every((declarator) => declarator === stateDeclarator) &&
+          !valueEvidence.hasUnknownSource &&
+          !valueEvidence.hasDeferredIntroducedValue &&
+          !valueEvidence.readsExternalValue
+        ) {
+          readsState = true;
+        }
+        return;
+      }
       if (!isNodeOfType(child, "Identifier")) return;
       const reference = getRef(analysis, child);
       if (
@@ -2003,7 +2020,13 @@ const isNodeControlledByStateInFrame = (
       isNodeOfType(cursor, "IfStatement") &&
       (isAstDescendant(child, cursor.consequent as EsTreeNode) ||
         Boolean(cursor.alternate && isAstDescendant(child, cursor.alternate as EsTreeNode))) &&
-      expressionReadsStateDeclarator(analysis, context, cursor.test as EsTreeNode, stateDeclarator)
+      expressionReadsStateDeclarator(
+        analysis,
+        context,
+        frame,
+        cursor.test as EsTreeNode,
+        stateDeclarator,
+      )
     ) {
       return true;
     }
@@ -2011,14 +2034,26 @@ const isNodeControlledByStateInFrame = (
       isNodeOfType(cursor, "ConditionalExpression") &&
       (isAstDescendant(child, cursor.consequent as EsTreeNode) ||
         isAstDescendant(child, cursor.alternate as EsTreeNode)) &&
-      expressionReadsStateDeclarator(analysis, context, cursor.test as EsTreeNode, stateDeclarator)
+      expressionReadsStateDeclarator(
+        analysis,
+        context,
+        frame,
+        cursor.test as EsTreeNode,
+        stateDeclarator,
+      )
     ) {
       return true;
     }
     if (
       isNodeOfType(cursor, "LogicalExpression") &&
       isAstDescendant(child, cursor.right as EsTreeNode) &&
-      expressionReadsStateDeclarator(analysis, context, cursor.left as EsTreeNode, stateDeclarator)
+      expressionReadsStateDeclarator(
+        analysis,
+        context,
+        frame,
+        cursor.left as EsTreeNode,
+        stateDeclarator,
+      )
     ) {
       return true;
     }
@@ -2038,6 +2073,7 @@ const isNodeControlledByStateInFrame = (
           expressionReadsStateDeclarator(
             analysis,
             context,
+            frame,
             precedingStatement.test as EsTreeNode,
             stateDeclarator,
           )

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/has-deferred-or-external-effect-work.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/has-deferred-or-external-effect-work.ts
@@ -15,10 +15,12 @@ import { getStaticPropertyName } from "../../../utils/get-static-property-name.j
 import { isAstDescendant } from "../../../utils/is-ast-descendant.js";
 import { isFunctionLike } from "../../../utils/is-function-like.js";
 import { isNodeOfType } from "../../../utils/is-node-of-type.js";
+import { nodeDominatesNode } from "../../../utils/node-dominates-node.js";
 import { isReactHookCall } from "../../../utils/is-react-hook-call.js";
 import { readStaticBoolean } from "../../../utils/read-static-boolean.js";
 import { resolveReactUseStatePair } from "../../../utils/resolve-react-use-state-pair.js";
 import { resolveExactLocalFunction } from "../../../utils/resolve-exact-local-function.js";
+import type { RuleContext } from "../../../utils/rule-context.js";
 import { stripParenExpression } from "../../../utils/strip-paren-expression.js";
 import { walkAst } from "../../../utils/walk-ast.js";
 import { getRef, getUpstreamRefs, resolveToFunction } from "./effect/ast.js";
@@ -249,8 +251,10 @@ const isWorkRelatedToWrite = (
   writeNode: EsTreeNode,
   writeFunction: EsTreeNode,
   writeStateSymbolId: number | null,
-  scopes: ScopeAnalysis,
+  context: RuleContext,
+  isResourceCancellation = false,
 ): boolean => {
+  const { scopes } = context;
   if (isNodeOfType(writeNode, "CallExpression") && isNodeOfType(writeNode.callee, "Identifier")) {
     const setterBinding = getRef(analysis, writeNode.callee)?.resolved;
     if (setterBinding) {
@@ -303,6 +307,14 @@ const isWorkRelatedToWrite = (
   const workRegion = getControlRegion(workAnchor, writeFunction);
   const writeRegion = getControlRegion(writeNode, writeFunction);
   if (
+    isResourceCancellation &&
+    writeRegion &&
+    doesControlRegionReadState(writeRegion, writeStateSymbolId, scopes) &&
+    nodeDominatesNode(workAnchor, writeNode, context)
+  ) {
+    return true;
+  }
+  if (
     workRegion !== null &&
     workRegion === writeRegion &&
     doesControlRegionReadState(workRegion, writeStateSymbolId, scopes)
@@ -326,9 +338,10 @@ const isWorkRelatedToWrite = (
 export const hasDeferredOrExternalEffectWork = (
   analysis: ProgramAnalysis,
   effectNode: EsTreeNode,
-  scopes: ScopeAnalysis,
+  context: RuleContext,
   writeNode: EsTreeNode,
 ): boolean => {
+  const { scopes } = context;
   const effectFunction = getEffectFn(analysis, effectNode);
   const writeFunction = findEnclosingFunction(writeNode);
   if (!effectFunction || !writeFunction) return false;
@@ -380,7 +393,7 @@ export const hasDeferredOrExternalEffectWork = (
             writeNode,
             writeFunction,
             writeStateSymbolId,
-            scopes,
+            context,
           )
         ) {
           didFindRelatedWork = true;
@@ -402,7 +415,7 @@ export const hasDeferredOrExternalEffectWork = (
             writeNode,
             writeFunction,
             writeStateSymbolId,
-            scopes,
+            context,
           )
         ) {
           didFindRelatedWork = true;
@@ -415,10 +428,11 @@ export const hasDeferredOrExternalEffectWork = (
         ? getStaticPropertyName(callee)
         : null;
       const localFunction = resolveInvokedFunction(analysis, callee, scopes);
+      const timerOperationName = resolveTimerOperationName(callee, scopes);
       const isExternalWork =
         isFetchCall(child) ||
         isSubscribeOrObserveCallExpression(child) ||
-        resolveTimerOperationName(callee, scopes) !== null ||
+        timerOperationName !== null ||
         Boolean(memberName && DEFERRED_MEMBER_NAMES.has(memberName)) ||
         Boolean(localFunction && isFunctionLike(localFunction) && localFunction.async);
       if (
@@ -432,7 +446,8 @@ export const hasDeferredOrExternalEffectWork = (
           writeNode,
           writeFunction,
           writeStateSymbolId,
-          scopes,
+          context,
+          Boolean(timerOperationName && TIMER_CLEANUP_CALLEE_NAMES.has(timerOperationName)),
         )
       ) {
         didFindRelatedWork = true;


### PR DESCRIPTION
## Why

A React Bench audit found two detector attribution errors in real agent trials:

- `no-derived-state` missed selection repair when the selected state was read through a render-updated ref, then appeared falsely NEW after an agent removed the ref indirection.
- `no-adjust-state-on-prop-change` treated a finite slideshow shutdown as a prop-driven draft reset even though the effect canceled its owned timer before stopping playback.

## What changed

- Trace conservative state provenance through `.current` reads in synchronous effect guards.
- Treat a recognized timer cancellation that dominates a state-controlled write as related lifecycle work.
- Preserve reporting when scheduling precedes the write, cancellation follows it, or ref provenance includes external values.
- Add exact focused regressions and permanent fuzz corpus cases from React Bench trials `2oin5YH` and `26Vu5Fo`.
- Add a patch changeset for both published lint plugins.

## Local eval results

Compared the candidate checkout with npm `0.9.5` over the same 100 pinned React Doctor Evals project roots. Sorted diagnostic identities matched exactly:

- `no-derived-state`: 25 baseline / 25 candidate
- `no-adjust-state-on-prop-change`: 133 baseline / 133 candidate
- Added / removed: 0 / 0
- Artifacts: `/home/aidenybai/Developer/react-doctor-evals/tmp/audit-fix-eval/`

PR Daytona parity is pending on this pushed head.

## Test plan

- `nr build`
- `nr test` (15/15 tasks successful)
- `nr lint`
- `nr typecheck` (16/16 tasks successful)
- `nr format:check`
- `nr -C packages/fuzz test`
- `FUZZ_RULE=no-derived-state FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr -C packages/fuzz fuzz`
- `FUZZ_RULE=no-adjust-state-on-prop-change FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr -C packages/fuzz fuzz`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes heuristic analysis in shared effect state-write utilities used by multiple rules; evals report identical diagnostic counts vs baseline, but edge-case behavior around refs and timers could shift.
> 
> **Overview**
> Fixes **false negatives and false positives** in state/effect lint rules by tightening how synchronous guards and timer work are attributed.
> 
> **`no-derived-state`** now treats **`.current` reads** as reading the same state when value evidence shows they only mirror that state (e.g. `ref.current = selectedId` each render), so **selection-repair effects** guarded by the ref are reported again. Guards stay quiet when the ref can hold **external** values.
> 
> **`no-adjust-state-on-prop-change`** passes full **`RuleContext`** into deferred/external-work analysis. **`clearTimeout`** (and similar cleanup) that **dominates** a state-guarded `setState` is treated as **related lifecycle work**, so patterns like cancel-then-stop on `disabled` are not flagged. **Scheduling before** the write or **cancellation after** it still reports.
> 
> Adds **regression tests** and **fuzz corpus** cases from React Bench trials, plus a **patch changeset** for both published lint plugins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22487e7ef1ce21d886015230a91e29bf7899b27a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->