### PR TITLE
fix: recognize browser media lifecycles

### DIFF
--- a/.changeset/easy-jeans-tap.md
+++ b/.changeset/easy-jeans-tap.md
@@ -1,0 +1,6 @@
+---
+"eslint-plugin-react-doctor": patch
+"oxlint-plugin-react-doctor": patch
+---
+
+Recognize browser media capability and playback lifecycles without masking unrelated prop-driven state adjustments, and resolve cross-file helpers with dotted basenames.

--- a/packages/core/tests/cross-file-rule-ids.test.ts
+++ b/packages/core/tests/cross-file-rule-ids.test.ts
@@ -187,6 +187,7 @@ describe("CROSS_FILE_RULE_IDS", () => {
       "no-locale-format-in-render",
       "no-match-media-in-state-initializer",
       "no-mutating-reducer-state",
+      "no-reset-all-state-on-prop-change",
       "no-side-effect-in-state-updater-function",
       "no-unguarded-browser-global-at-module-scope",
       "no-unguarded-browser-global-in-render-or-hook-init",

--- a/packages/fuzz/corpus/regressions/no-adjust-state-on-prop-change--media-capability-sync.tsx
+++ b/packages/fuzz/corpus/regressions/no-adjust-state-on-prop-change--media-capability-sync.tsx
@@ -1,0 +1,30 @@
+// rule: no-adjust-state-on-prop-change
+// verdict: pass
+// weakness: library-idiom
+// source: verified ReactBench Jumper trial Zjiziuh
+
+import { useEffect, useState } from "react";
+
+interface AnimatedBackgroundProps {
+  mime: string;
+  src: string;
+}
+
+export const AnimatedBackground = ({ mime, src }: AnimatedBackgroundProps) => {
+  const mediaKey = `${src}:${mime}`;
+  const [videoSupport, setVideoSupport] = useState<{
+    isPlayable: boolean;
+    mediaKey: string;
+  } | null>(null);
+
+  useEffect(() => {
+    if (!src || !mime.startsWith("video/")) {
+      setVideoSupport(null);
+      return;
+    }
+    const video = document.createElement("video");
+    setVideoSupport({ isPlayable: video.canPlayType(mime) !== "", mediaKey });
+  }, [mediaKey, mime, src]);
+
+  return videoSupport?.isPlayable ? <video src={src} /> : null;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/cross-file-rule-ids.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/cross-file-rule-ids.ts
@@ -58,6 +58,7 @@ export const CROSS_FILE_RULE_IDS: ReadonlySet<string> = new Set([
   "no-locale-format-in-render",
   "no-match-media-in-state-initializer",
   "no-create-ref-in-function-component",
+  "no-reset-all-state-on-prop-change",
   "no-side-effect-in-state-updater-function",
   "no-adjust-state-on-prop-change",
   "no-derived-state",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/constants/dom.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/constants/dom.ts
@@ -74,6 +74,7 @@ export const EXTERNAL_SYNC_OBSERVER_CONSTRUCTORS = new Set([
 
 export const EXTERNAL_SYNC_DOM_MEMBER_METHOD_NAMES = new Set([
   "blur",
+  "canPlayType",
   "focus",
   "getBoundingClientRect",
   "getClientRects",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/cross-file-dependencies.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/cross-file-dependencies.ts
@@ -549,6 +549,7 @@ export const CROSS_FILE_DEPENDENCY_COLLECTORS: ReadonlyMap<string, CrossFileDepe
     ["no-derived-state-effect", collectEffectValueHelperDependencies],
     ["no-event-handler", collectEffectValueHelperDependencies],
     ["no-initialize-state", collectEffectValueHelperDependencies],
+    ["no-reset-all-state-on-prop-change", collectEffectValueHelperDependencies],
     ["no-mutating-reducer-state", collectMutatingReducerDependencies],
     ["no-side-effect-in-state-updater-function", collectStateUpdaterDependencies],
     ["no-unguarded-browser-global-at-module-scope", collectBrowserGuardDependencies],

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-adjust-state-on-prop-change-media-capability.cross-file.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-adjust-state-on-prop-change-media-capability.cross-file.test.ts
@@ -1,0 +1,159 @@
+import * as fs from "node:fs";
+import os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { __clearParseSourceFileCacheForTests } from "../../utils/parse-source-file.js";
+import { __clearTsconfigAliasCacheForTests } from "../../utils/resolve-tsconfig-alias.js";
+import { noAdjustStateOnPropChange } from "./no-adjust-state-on-prop-change.js";
+
+let temporaryDirectory: string;
+
+beforeEach(() => {
+  temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "media-capability-helper-"));
+  __clearParseSourceFileCacheForTests();
+  __clearTsconfigAliasCacheForTests();
+});
+
+afterEach(() => {
+  fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+});
+
+const writeFile = (relativePath: string, contents: string): string => {
+  const absolutePath = path.join(temporaryDirectory, relativePath);
+  fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+  fs.writeFileSync(absolutePath, contents, "utf8");
+  return absolutePath;
+};
+
+const runConsumer = (source: string): ReturnType<typeof runRule> => {
+  const consumerPath = writeFile("src/AnimatedBackground.tsx", source);
+  return runRule(noAdjustStateOnPropChange, source, { filename: consumerPath });
+};
+
+describe("no-adjust-state-on-prop-change — imported media capability helpers", () => {
+  it("stays silent for a browser capability helper", () => {
+    writeFile(
+      "src/media.ts",
+      `export const isPlayableVideoType = (mime) =>
+        document.createElement("video").canPlayType(mime) !== "";`,
+    );
+    const result = runConsumer(`
+import { isPlayableVideoType } from "./media";
+function AnimatedBackground({ src, mime }) {
+  const [videoSupport, setVideoSupport] = useState(null);
+  useEffect(() => {
+    if (!src || !mime) {
+      setVideoSupport(null);
+      return;
+    }
+    const isPlayable = isPlayableVideoType(mime);
+    setVideoSupport({ src, isPlayable });
+  }, [src, mime]);
+  return videoSupport;
+}
+`);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still reports an unrelated reset beside an imported capability query", () => {
+    writeFile(
+      "src/media.ts",
+      `export const isPlayableVideoType = (mime) =>
+        document.createElement("video").canPlayType(mime) !== "";`,
+    );
+    const result = runConsumer(`
+import { isPlayableVideoType } from "./media";
+function Editor({ documentId, mime }) {
+  const [draft, setDraft] = useState(null);
+  const [isPlayable, setIsPlayable] = useState(false);
+  useEffect(() => {
+    setDraft(null);
+    setIsPlayable(isPlayableVideoType(mime));
+  }, [documentId, mime]);
+  return draft ?? isPlayable;
+}
+`);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not trust an imported helper with a shadowed document binding", () => {
+    writeFile(
+      "src/media.ts",
+      `const document = { createElement: () => ({ canPlayType: () => "probably" }) };
+       export const isPlayableVideoType = (mime) =>
+         document.createElement("video").canPlayType(mime) !== "";`,
+    );
+    const result = runConsumer(`
+import { isPlayableVideoType } from "./media";
+function Capability({ mime }) {
+  const [isPlayable, setIsPlayable] = useState(false);
+  useEffect(() => {
+    setIsPlayable(false);
+    isPlayableVideoType(mime);
+  }, [mime]);
+  return isPlayable;
+}
+`);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not count browser work inside an uncalled nested function", () => {
+    writeFile(
+      "src/media.ts",
+      `export const formatMime = (mime) => {
+        const probe = () => document.createElement("video").canPlayType(mime);
+        return mime.trim();
+      };`,
+    );
+    const result = runConsumer(`
+import { formatMime } from "./media";
+function Capability({ mime }) {
+  const [normalizedMime, setNormalizedMime] = useState("");
+  useEffect(() => {
+    setNormalizedMime("");
+    formatMime(mime);
+  }, [mime]);
+  return normalizedMime;
+}
+`);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays silent for a function-declaration capability helper", () => {
+    writeFile(
+      "src/AnimatedBackground.utils.ts",
+      `export function canPlayVideoMime(normalizedMime) {
+        if (typeof document === "undefined") return false;
+        const video = document.createElement("video");
+        const result = video.canPlayType(normalizedMime);
+        return result === "maybe" || result === "probably";
+      }`,
+    );
+    const result = runConsumer(`
+import { canPlayVideoMime } from "./AnimatedBackground.utils";
+function AnimatedBackground({ src, normalizedMime }) {
+  const [isVideoPlayable, setIsVideoPlayable] = useState(false);
+  useEffect(() => {
+    if (!src || !normalizedMime) {
+      setIsVideoPlayable(false);
+      return;
+    }
+    setIsVideoPlayable(canPlayVideoMime(normalizedMime));
+  }, [src, normalizedMime]);
+  return isVideoPlayable;
+}
+`);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-adjust-state-on-prop-change-media-capability.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-adjust-state-on-prop-change-media-capability.regressions.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noAdjustStateOnPropChange } from "./no-adjust-state-on-prop-change.js";
+
+describe("no-adjust-state-on-prop-change — media capability synchronization", () => {
+  it("stays silent when an effect stores browser media capability", () => {
+    const result = runRule(
+      noAdjustStateOnPropChange,
+      `function AnimatedBackground({ src, mime }) {
+        const normalizedMime = mime?.trim().toLowerCase();
+        const isVideoCandidate = normalizedMime?.startsWith("video/");
+        const mediaKey = src + normalizedMime;
+        const [videoSupport, setVideoSupport] = useState(null);
+        useEffect(() => {
+          if (!src || !normalizedMime || !isVideoCandidate) {
+            setVideoSupport(null);
+            return;
+          }
+          const video = document.createElement("video");
+          const isPlayable = video.canPlayType(normalizedMime) !== "";
+          setVideoSupport({ mediaKey, isPlayable });
+        }, [src, normalizedMime, isVideoCandidate, mediaKey]);
+        return videoSupport;
+      }`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent when a typed media ref supplies the capability", () => {
+    const result = runRule(
+      noAdjustStateOnPropChange,
+      `import { useEffect, useRef, useState } from "react";
+      function AnimatedBackground({ mime }) {
+        const videoRef = useRef<HTMLVideoElement>(null);
+        const [isPlayable, setIsPlayable] = useState(false);
+        useEffect(() => {
+          const video = videoRef.current;
+          if (!video) return;
+          setIsPlayable(video.canPlayType(mime) !== "");
+        }, [mime]);
+        return <video ref={videoRef} hidden={!isPlayable} />;
+      }`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("reports an unrelated prop-keyed reset beside a media capability query", () => {
+    const result = runRule(
+      noAdjustStateOnPropChange,
+      `function Editor({ documentId, mime }) {
+        const [draft, setDraft] = useState(null);
+        useEffect(() => {
+          setDraft(null);
+          document.createElement("video").canPlayType(mime);
+        }, [documentId, mime]);
+        return draft;
+      }`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not trust a shadowed document binding", () => {
+    const result = runRule(
+      noAdjustStateOnPropChange,
+      `function Capability({ document, mime }) {
+        const [isPlayable, setIsPlayable] = useState(false);
+        useEffect(() => {
+          setIsPlayable(false);
+          document.createElement("video").canPlayType(mime);
+        }, [mime]);
+        return isPlayable;
+      }`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not trust a user object with a matching method name", () => {
+    const result = runRule(
+      noAdjustStateOnPropChange,
+      `function Capability({ codec, mime }) {
+        const [isPlayable, setIsPlayable] = useState(false);
+        useEffect(() => {
+          setIsPlayable(false);
+          codec.canPlayType(mime);
+        }, [mime]);
+        return isPlayable;
+      }`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays silent for a nullable browser-created media element", () => {
+    const result = runRule(
+      noAdjustStateOnPropChange,
+      `function Capability({ mime }) {
+        const [isPlayable, setIsPlayable] = useState(false);
+        useEffect(() => {
+          const video = typeof document === "undefined"
+            ? null
+            : document.createElement("video");
+          if (!video) {
+            setIsPlayable(false);
+            return;
+          }
+          setIsPlayable(video.canPlayType(mime) !== "");
+        }, [mime]);
+        return isPlayable;
+      }`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-adjust-state-on-prop-change.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-adjust-state-on-prop-change.regressions.test.ts
@@ -312,6 +312,49 @@ describe("no-adjust-state-on-prop-change — regressions", () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it("stays silent when prop-driven state accompanies scrolling a highlighted row into view", () => {
+    const result = runRule(
+      noAdjustStateOnPropChange,
+      `import { useEffect, useRef, useState } from "react";
+      function ActivityRow({ highlighted }) {
+        const [isExpanded, setIsExpanded] = useState(false);
+        const rowRef = useRef<HTMLDivElement>(null);
+        useEffect(() => {
+          if (highlighted && rowRef.current) {
+            rowRef.current.scrollIntoView({ behavior: "smooth", block: "center" });
+            setIsExpanded(true);
+          }
+        }, [highlighted]);
+        return null;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent when a prop change synchronizes state with measured element height", () => {
+    const result = runRule(
+      noAdjustStateOnPropChange,
+      `import { useEffect, useRef, useState } from "react";
+      function AnimatedCollapsible({ children, collapsed }) {
+        const sectionRef = useRef<HTMLHeadingElement>(null);
+        const [height, setHeight] = useState(collapsed ? 0 : undefined);
+        useEffect(() => {
+          if (!collapsed) {
+            if (sectionRef.current) {
+              setHeight(sectionRef.current.getBoundingClientRect().height);
+            }
+          } else {
+            setHeight(0);
+          }
+        }, [collapsed, children]);
+        return null;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("stays silent on the initial-sync call of a subscription effect (appflowy awareness selector)", () => {
     const result = runRule(
       noAdjustStateOnPropChange,
@@ -628,6 +671,31 @@ describe("no-adjust-state-on-prop-change — regressions", () => {
       expect(result.diagnostics).toEqual([]);
     });
 
+    it("stays silent when a media failure latch stores the failed resource key", () => {
+      const result = runRule(
+        noAdjustStateOnPropChange,
+        `function AnimatedBackground({ src, mime }) {
+          const [failedKey, setFailedKey] = useState(null);
+          const sourceKey = useMemo(() => src + "|" + mime, [src, mime]);
+          useEffect(() => {
+            setFailedKey(null);
+          }, [sourceKey]);
+          const handlePlaybackError = () => setFailedKey(sourceKey);
+          return (
+            <video
+              src={src}
+              type={mime}
+              onError={handlePlaybackError}
+              hidden={failedKey === sourceKey}
+            />
+          );
+        }`,
+        { forceJsx: true },
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
     it("still reports a draft reset when unrelated media also has an error handler", () => {
       const result = runRule(
         noAdjustStateOnPropChange,
@@ -715,6 +783,71 @@ describe("no-adjust-state-on-prop-change — regressions", () => {
       );
       expect(result.parseErrors).toEqual([]);
       expect(result.diagnostics).toHaveLength(1);
+    });
+
+    it("stays silent when a resource failure latch is written by a playback effect", () => {
+      const result = runRule(
+        noAdjustStateOnPropChange,
+        `import { useEffect, useRef, useState } from "react";
+        function Preview({ src, mime }) {
+          const videoRef = useRef<HTMLVideoElement>(null);
+          const [playbackFailed, setPlaybackFailed] = useState(false);
+          useEffect(() => {
+            setPlaybackFailed(false);
+          }, [src, mime]);
+          useEffect(() => {
+            const video = videoRef.current;
+            if (!video) return;
+            video.play().catch(() => setPlaybackFailed(true));
+          }, [src, mime]);
+          return <video ref={videoRef} src={src} />;
+        }`,
+        { forceJsx: true },
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it("still reports an editable reset written during a playback effect", () => {
+      const result = runRule(
+        noAdjustStateOnPropChange,
+        `import { useEffect, useRef, useState } from "react";
+        function Editor({ documentId }) {
+          const videoRef = useRef<HTMLVideoElement>(null);
+          const [draft, setDraft] = useState("");
+          useEffect(() => {
+            setDraft("");
+          }, [documentId]);
+          useEffect(() => {
+            videoRef.current?.play().catch(() => setDraft("unavailable"));
+          }, [documentId]);
+          return <video ref={videoRef} src={documentId} />;
+        }`,
+        { forceJsx: true },
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+    });
+
+    it("stays silent for a resource-key reconciliation through handler wrappers", () => {
+      const result = runRule(
+        noAdjustStateOnPropChange,
+        `function Preview({ src, mime }) {
+          const mediaKey = src + "|" + mime;
+          const [failedKey, setFailedKey] = useState(null);
+          useEffect(() => {
+            setFailedKey((previousFailedKey) =>
+              previousFailedKey === mediaKey ? previousFailedKey : null,
+            );
+          }, [mediaKey]);
+          const markFailed = (key) => setFailedKey(key);
+          const handleError = () => markFailed(mediaKey);
+          return <video src={src} onError={handleError} />;
+        }`,
+        { forceJsx: true },
+      );
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toEqual([]);
     });
 
     it("stays silent on an async probe whose on* handler assignments set the same state (psysonic artistHero)", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-adjust-state-on-prop-change.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-adjust-state-on-prop-change.ts
@@ -97,13 +97,13 @@ export const noAdjustStateOnPropChange = defineRule({
           continue;
         }
         if (
-          fact.matchesStateInitializer &&
           hasResourceLifecycleSetterWriter(
             analysis,
             context,
             fact.setterReference,
             node,
             dependencyReferences,
+            fact.matchesStateInitializer,
           )
         ) {
           continue;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-reset-all-state-on-prop-change.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-reset-all-state-on-prop-change.ts
@@ -1252,7 +1252,14 @@ const findPropUsedToResetAllState = (
   if (hasSynchronousResourceLifecycleTransition(effectFn, context.scopes)) return null;
   if (
     stateSetterRefs.every((setterReference) =>
-      hasResourceLifecycleSetterWriter(analysis, context, setterReference, useEffectNode, depsRefs),
+      hasResourceLifecycleSetterWriter(
+        analysis,
+        context,
+        setterReference,
+        useEffectNode,
+        depsRefs,
+        true,
+      ),
     )
   ) {
     return null;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/collect-effect-state-write-facts.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/collect-effect-state-write-facts.ts
@@ -1627,7 +1627,15 @@ const matchesStateInitializer = (
   if (!isNodeOfType(stateDeclarator.init, "CallExpression")) return false;
   const writtenValue = callExpression.arguments?.[0];
   const initializerValue = stateDeclarator.init.arguments?.[0];
-  if (!writtenValue || !initializerValue) return false;
+  if (!writtenValue) return false;
+  if (!initializerValue) {
+    const unwrappedWrittenValue = stripParenExpression(writtenValue as EsTreeNode);
+    return (
+      isNodeOfType(unwrappedWrittenValue, "Identifier") &&
+      unwrappedWrittenValue.name === "undefined" &&
+      !getRef(analysis, unwrappedWrittenValue)?.resolved
+    );
+  }
   const unwrappedInitializer = stripParenExpression(initializerValue as EsTreeNode);
   if (
     isNodeOfType(unwrappedInitializer, "LogicalExpression") &&

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/has-deferred-or-external-effect-work.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/has-deferred-or-external-effect-work.ts
@@ -1,11 +1,14 @@
 import {
+  EXTERNAL_SYNC_DOM_MEMBER_METHOD_NAMES,
   EXTERNAL_SYNC_OBSERVER_CONSTRUCTORS,
   TIMER_AND_SCHEDULER_DIRECT_CALLEE_NAMES,
   TIMER_CLEANUP_CALLEE_NAMES,
 } from "../../../constants/dom.js";
 import { FETCH_CALLEE_NAMES, FETCH_MEMBER_OBJECTS } from "../../../constants/library.js";
+import { analyzeScopes } from "../../../semantic/scope-analysis.js";
 import type { ScopeAnalysis } from "../../../semantic/scope-analysis.js";
 import type { EsTreeNode } from "../../../utils/es-tree-node.js";
+import { resolveImportedExportName } from "../../../utils/find-exported-function-body.js";
 import { findEnclosingFunction } from "../../../utils/find-enclosing-function.js";
 import { getFinalSequenceExpressionValue } from "../../../utils/get-final-sequence-expression-value.js";
 import { getDestructuredBindingPropertyName } from "../../../utils/get-destructured-binding-property-name.js";
@@ -15,10 +18,12 @@ import { getStaticPropertyName } from "../../../utils/get-static-property-name.j
 import { isAstDescendant } from "../../../utils/is-ast-descendant.js";
 import { isFunctionLike } from "../../../utils/is-function-like.js";
 import { isNodeOfType } from "../../../utils/is-node-of-type.js";
+import { isProvenBrowserApiReceiver } from "../../../utils/is-proven-browser-api-receiver.js";
 import { nodeDominatesNode } from "../../../utils/node-dominates-node.js";
 import { isReactHookCall } from "../../../utils/is-react-hook-call.js";
 import { readStaticBoolean } from "../../../utils/read-static-boolean.js";
 import { resolveReactUseStatePair } from "../../../utils/resolve-react-use-state-pair.js";
+import { resolveCrossFileFunctionExportWithFilePath } from "../../../utils/resolve-cross-file-function-export.js";
 import { resolveExactLocalFunction } from "../../../utils/resolve-exact-local-function.js";
 import type { RuleContext } from "../../../utils/rule-context.js";
 import { stripParenExpression } from "../../../utils/strip-paren-expression.js";
@@ -54,6 +59,66 @@ const SYNCHRONOUS_ITERATOR_MEMBER_NAMES: ReadonlySet<string> = new Set([
   "reduceRight",
   "some",
 ]);
+
+const crossFileScopeAnalysisByProgram = new WeakMap<EsTreeNode, ScopeAnalysis>();
+
+const isExternalDomSyncMemberCall = (
+  callExpression: EsTreeNode,
+  scopes: ScopeAnalysis,
+): boolean => {
+  if (!isNodeOfType(callExpression, "CallExpression")) return false;
+  const callee = stripParenExpression(callExpression.callee);
+  if (!isNodeOfType(callee, "MemberExpression")) return false;
+  const memberName = getStaticPropertyName(callee);
+  return Boolean(
+    memberName &&
+    EXTERNAL_SYNC_DOM_MEMBER_METHOD_NAMES.has(memberName) &&
+    isProvenBrowserApiReceiver(callee.object, "dom-event-target", scopes),
+  );
+};
+
+const isImportedExternalDomSyncCall = (
+  callExpression: EsTreeNode,
+  context: RuleContext,
+): boolean => {
+  if (!isNodeOfType(callExpression, "CallExpression") || !context.filename) return false;
+  const callee = stripParenExpression(callExpression.callee);
+  if (!isNodeOfType(callee, "Identifier")) return false;
+  const symbol = context.scopes.symbolFor(callee);
+  if (!symbol || symbol.kind !== "import") return false;
+  const importSpecifier = symbol.declarationNode;
+  const importDeclaration = importSpecifier.parent;
+  const exportedName = resolveImportedExportName(importSpecifier);
+  if (
+    !exportedName ||
+    !isNodeOfType(importDeclaration, "ImportDeclaration") ||
+    typeof importDeclaration.source.value !== "string"
+  ) {
+    return false;
+  }
+  const importedFunction = resolveCrossFileFunctionExportWithFilePath(
+    context.filename,
+    importDeclaration.source.value,
+    exportedName,
+  );
+  if (!importedFunction || !isFunctionLike(importedFunction.functionNode)) return false;
+  let importedScopes = crossFileScopeAnalysisByProgram.get(importedFunction.programNode);
+  if (!importedScopes) {
+    importedScopes = analyzeScopes(importedFunction.programNode);
+    crossFileScopeAnalysisByProgram.set(importedFunction.programNode, importedScopes);
+  }
+  let didFindExternalDomSync = false;
+  const importedFunctionBody = importedFunction.functionNode.body;
+  walkAst(importedFunctionBody, (child) => {
+    if (didFindExternalDomSync) return false;
+    if (child !== importedFunctionBody && isFunctionLike(child)) return false;
+    if (isExternalDomSyncMemberCall(child, importedScopes)) {
+      didFindExternalDomSync = true;
+      return false;
+    }
+  });
+  return didFindExternalDomSync;
+};
 
 const resolveInvokedFunction = (
   analysis: ProgramAnalysis,
@@ -253,8 +318,17 @@ const isWorkRelatedToWrite = (
   writeStateSymbolId: number | null,
   context: RuleContext,
   isResourceCancellation = false,
+  isExternalDomStateSync = false,
 ): boolean => {
   const { scopes } = context;
+  let workAnchor = workNode;
+  if (workFunction !== writeFunction) {
+    const invocationEdge = invocationPath.findLast(
+      (candidateEdge) => candidateEdge.parentFunction === writeFunction,
+    );
+    if (!invocationEdge) return false;
+    workAnchor = invocationEdge.callExpression;
+  }
   if (isNodeOfType(writeNode, "CallExpression") && isNodeOfType(writeNode.callee, "Identifier")) {
     const setterBinding = getRef(analysis, writeNode.callee)?.resolved;
     if (setterBinding) {
@@ -272,6 +346,25 @@ const isWorkRelatedToWrite = (
         }
       });
       if (writesSameState) return true;
+      if (isExternalDomStateSync) {
+        let hasRelatedStateWrite = false;
+        walkAst(writeFunction, (child) => {
+          if (hasRelatedStateWrite) return false;
+          if (child !== writeFunction && isFunctionLike(child)) return false;
+          if (
+            !isNodeOfType(child, "CallExpression") ||
+            !isNodeOfType(child.callee, "Identifier") ||
+            getRef(analysis, child.callee)?.resolved !== setterBinding
+          ) {
+            return;
+          }
+          if (isAstDescendant(workAnchor, child) || nodeDominatesNode(workAnchor, child, context)) {
+            hasRelatedStateWrite = true;
+            return false;
+          }
+        });
+        if (hasRelatedStateWrite) return true;
+      }
     }
   }
   if (propDependencyBindings.size > 0) {
@@ -295,14 +388,6 @@ const isWorkRelatedToWrite = (
     if ([...propDependencyBindings].every((propBinding) => workPropBindings.has(propBinding))) {
       return true;
     }
-  }
-  let workAnchor = workNode;
-  if (workFunction !== writeFunction) {
-    const invocationEdge = invocationPath.findLast(
-      (candidateEdge) => candidateEdge.parentFunction === writeFunction,
-    );
-    if (!invocationEdge) return false;
-    workAnchor = invocationEdge.callExpression;
   }
   const workRegion = getControlRegion(workAnchor, writeFunction);
   const writeRegion = getControlRegion(writeNode, writeFunction);
@@ -429,8 +514,11 @@ export const hasDeferredOrExternalEffectWork = (
         : null;
       const localFunction = resolveInvokedFunction(analysis, callee, scopes);
       const timerOperationName = resolveTimerOperationName(callee, scopes);
+      const isExternalDomSyncCall =
+        isExternalDomSyncMemberCall(child, scopes) || isImportedExternalDomSyncCall(child, context);
       const isExternalWork =
         isFetchCall(child) ||
+        isExternalDomSyncCall ||
         isSubscribeOrObserveCallExpression(child) ||
         timerOperationName !== null ||
         Boolean(memberName && DEFERRED_MEMBER_NAMES.has(memberName)) ||
@@ -448,6 +536,7 @@ export const hasDeferredOrExternalEffectWork = (
           writeStateSymbolId,
           context,
           Boolean(timerOperationName && TIMER_CLEANUP_CALLEE_NAMES.has(timerOperationName)),
+          isExternalDomSyncCall,
         )
       ) {
         didFindRelatedWork = true;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/has-resource-lifecycle-setter-writer.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/has-resource-lifecycle-setter-writer.ts
@@ -4,15 +4,23 @@ import type { EsTreeNode } from "../../../utils/es-tree-node.js";
 import { findEnclosingFunction } from "../../../utils/find-enclosing-function.js";
 import { getFunctionBindingIdentifier } from "../../../utils/get-function-binding-name.js";
 import { getJsxAttributeName } from "../../../utils/get-jsx-attribute-name.js";
+import { getStaticPropertyName } from "../../../utils/get-static-property-name.js";
 import { isFunctionLike } from "../../../utils/is-function-like.js";
 import { isNodeOfType } from "../../../utils/is-node-of-type.js";
+import { isProvenBrowserApiReceiver } from "../../../utils/is-proven-browser-api-receiver.js";
 import { isProvenIntrinsicJsxElement } from "../../../utils/is-proven-intrinsic-jsx-element.js";
+import { isReactHookCall } from "../../../utils/is-react-hook-call.js";
 import { resolveJsxElementType } from "../../../utils/resolve-jsx-element-type.js";
+import { stripParenExpression } from "../../../utils/strip-paren-expression.js";
 import type { RuleContext } from "../../../utils/rule-context.js";
 import { walkAst } from "../../../utils/walk-ast.js";
-import { getCallExpr, getRef } from "./effect/ast.js";
+import { getCallExpr, getRef, getUpstreamRefs } from "./effect/ast.js";
 import type { ProgramAnalysis } from "./effect/get-program-analysis.js";
-import { isSetterWiredToJsxHandler } from "./is-controlled-prop-mirror.js";
+import { hasDeferredOrExternalEffectWork } from "./has-deferred-or-external-effect-work.js";
+import {
+  isSetterWiredToJsxHandler,
+  referencesIdentifierNamed,
+} from "./is-controlled-prop-mirror.js";
 
 const RESOURCE_LIFECYCLE_EVENT_NAMES: ReadonlySet<string> = new Set([
   "onAbort",
@@ -39,11 +47,41 @@ const RESOURCE_IDENTITY_ATTRIBUTE_NAMES: ReadonlySet<string> = new Set([
   "srcSet",
 ]);
 
-const writesFailureLatch = (setterReference: Reference): boolean => {
+const RESOURCE_SYNC_METHOD_NAMES: ReadonlySet<string> = new Set(["load", "pause", "play"]);
+
+const writesFailureLatch = (
+  analysis: ProgramAnalysis,
+  setterReference: Reference,
+  dependencyVariables: ReadonlySet<unknown>,
+): boolean => {
   const callExpression = getCallExpr(setterReference);
   if (!callExpression || !isNodeOfType(callExpression, "CallExpression")) return false;
   const writtenValue = callExpression.arguments?.[0] as EsTreeNode | undefined;
-  return Boolean(isNodeOfType(writtenValue, "Literal") && writtenValue.value === true);
+  if (isNodeOfType(writtenValue, "Literal") && writtenValue.value === true) return true;
+  if (!writtenValue) return false;
+  if (isNodeOfType(writtenValue, "Identifier")) {
+    const writtenReference = getRef(analysis, writtenValue);
+    if (writtenReference?.resolved?.defs.some((definition) => definition.type === "Parameter")) {
+      return true;
+    }
+  }
+  let writesResourceIdentity = false;
+  walkAst(writtenValue, (child) => {
+    if (writesResourceIdentity) return false;
+    if (!isNodeOfType(child, "Identifier")) return;
+    const reference = getRef(analysis, child);
+    if (
+      reference &&
+      getUpstreamRefs(analysis, reference).some(
+        (upstreamReference) =>
+          upstreamReference.resolved && dependencyVariables.has(upstreamReference.resolved),
+      )
+    ) {
+      writesResourceIdentity = true;
+      return false;
+    }
+  });
+  return writesResourceIdentity;
 };
 
 const isResourceLifecycleAttribute = (
@@ -88,26 +126,186 @@ const isResourceLifecycleAttribute = (
   return readsDependency;
 };
 
+const hasResourceIdentityElement = (
+  analysis: ProgramAnalysis,
+  context: RuleContext,
+  dependencyVariables: ReadonlySet<unknown>,
+  componentFunction: EsTreeNode,
+): boolean => {
+  if (!isFunctionLike(componentFunction)) return false;
+  let didFindResourceIdentity = false;
+  walkAst(componentFunction.body, (child) => {
+    if (didFindResourceIdentity) return false;
+    if (!isNodeOfType(child, "JSXOpeningElement")) return;
+    if (!isProvenIntrinsicJsxElement(child, context.scopes)) return;
+    for (const attribute of child.attributes ?? []) {
+      if (
+        !isNodeOfType(attribute, "JSXAttribute") ||
+        !RESOURCE_IDENTITY_ATTRIBUTE_NAMES.has(getJsxAttributeName(attribute.name) ?? "")
+      ) {
+        continue;
+      }
+      walkAst(attribute, (attributeChild) => {
+        if (didFindResourceIdentity) return false;
+        if (!isNodeOfType(attributeChild, "Identifier")) return;
+        const reference = getRef(analysis, attributeChild);
+        if (
+          reference &&
+          getUpstreamRefs(analysis, reference).some(
+            (upstreamReference) =>
+              upstreamReference.resolved && dependencyVariables.has(upstreamReference.resolved),
+          )
+        ) {
+          didFindResourceIdentity = true;
+          return false;
+        }
+      });
+      if (didFindResourceIdentity) return false;
+    }
+  });
+  return didFindResourceIdentity;
+};
+
+const isWrittenByResourceSyncEffect = (
+  analysis: ProgramAnalysis,
+  context: RuleContext,
+  setterReference: Reference,
+  componentFunction: EsTreeNode,
+): boolean => {
+  const identifier = setterReference.identifier as unknown as EsTreeNode;
+  let cursor: EsTreeNode | null | undefined = identifier;
+  let effectCall: EsTreeNode | null = null;
+  while (cursor && cursor !== componentFunction) {
+    if (
+      isFunctionLike(cursor) &&
+      isNodeOfType(cursor.parent, "CallExpression") &&
+      cursor.parent.arguments?.[0] === cursor &&
+      isReactHookCall(cursor.parent, "useEffect", context.scopes)
+    ) {
+      effectCall = cursor.parent;
+      break;
+    }
+    cursor = cursor.parent ?? null;
+  }
+  if (!effectCall || !isNodeOfType(effectCall, "CallExpression")) return false;
+  const writerCall = getCallExpr(setterReference);
+  if (writerCall && hasDeferredOrExternalEffectWork(analysis, effectCall, context, writerCall)) {
+    return true;
+  }
+  const effectFunction = effectCall.arguments?.[0];
+  if (!effectFunction || !isFunctionLike(effectFunction)) return false;
+  let didFindResourceSync = false;
+  walkAst(effectFunction.body, (child) => {
+    if (didFindResourceSync) return false;
+    if (!isNodeOfType(child, "CallExpression")) return;
+    const callee = stripParenExpression(child.callee);
+    if (!isNodeOfType(callee, "MemberExpression")) return;
+    const methodName = getStaticPropertyName(callee);
+    if (
+      methodName &&
+      RESOURCE_SYNC_METHOD_NAMES.has(methodName) &&
+      isProvenBrowserApiReceiver(callee.object, "dom-event-target", context.scopes)
+    ) {
+      didFindResourceSync = true;
+      return false;
+    }
+  });
+  return didFindResourceSync;
+};
+
+const isFunctionTransitivelyWiredToResourceHandler = (
+  componentFunction: EsTreeNode,
+  functionName: string,
+  matchesAttribute: (attribute: EsTreeNode) => boolean,
+): boolean => {
+  if (!isFunctionLike(componentFunction)) return false;
+  const pendingFunctionNames = [functionName];
+  const visitedFunctionNames = new Set<string>();
+  while (pendingFunctionNames.length > 0) {
+    const pendingFunctionName = pendingFunctionNames.pop();
+    if (!pendingFunctionName || visitedFunctionNames.has(pendingFunctionName)) continue;
+    visitedFunctionNames.add(pendingFunctionName);
+    if (isSetterWiredToJsxHandler(componentFunction, pendingFunctionName, matchesAttribute)) {
+      return true;
+    }
+    walkAst(componentFunction.body, (child) => {
+      if (!isFunctionLike(child)) return;
+      const bindingIdentifier = getFunctionBindingIdentifier(child);
+      if (
+        isNodeOfType(bindingIdentifier, "Identifier") &&
+        !visitedFunctionNames.has(bindingIdentifier.name) &&
+        referencesIdentifierNamed(child.body, pendingFunctionName)
+      ) {
+        pendingFunctionNames.push(bindingIdentifier.name);
+      }
+    });
+  }
+  return false;
+};
+
 export const hasResourceLifecycleSetterWriter = (
   analysis: ProgramAnalysis,
   context: RuleContext,
   setterReference: Reference,
   effectNode: EsTreeNode,
   dependencyReferences: readonly Reference[],
+  matchesStateInitializer: boolean,
 ): boolean => {
   if (!setterReference.resolved) return false;
   const componentFunction = findEnclosingFunction(effectNode);
-  if (!componentFunction) return false;
+  if (!componentFunction || !isFunctionLike(componentFunction)) return false;
   const dependencyVariables = new Set(
-    dependencyReferences.flatMap((reference) => (reference.resolved ? [reference.resolved] : [])),
+    dependencyReferences.flatMap((reference) =>
+      getUpstreamRefs(analysis, reference).flatMap((upstreamReference) =>
+        upstreamReference.resolved ? [upstreamReference.resolved] : [],
+      ),
+    ),
   );
   if (dependencyVariables.size === 0) return false;
+  const resetCall = getCallExpr(setterReference);
+  const resetValue = isNodeOfType(resetCall, "CallExpression")
+    ? (resetCall.arguments?.[0] as EsTreeNode | undefined)
+    : undefined;
+  let isResourceKeyReconciliation = false;
+  if (!matchesStateInitializer && resetValue && isFunctionLike(resetValue)) {
+    const parameterNames = new Set(
+      (resetValue.params ?? []).flatMap((parameter) =>
+        isNodeOfType(parameter, "Identifier") ? [parameter.name] : [],
+      ),
+    );
+    let readsPreviousValue = false;
+    let readsDependency = false;
+    let returnsNull = false;
+    walkAst(resetValue.body, (child) => {
+      if (isNodeOfType(child, "Literal") && child.value === null) returnsNull = true;
+      if (!isNodeOfType(child, "Identifier")) return;
+      if (parameterNames.has(child.name)) readsPreviousValue = true;
+      const reference = getRef(analysis, child);
+      if (
+        reference &&
+        getUpstreamRefs(analysis, reference).some(
+          (upstreamReference) =>
+            upstreamReference.resolved && dependencyVariables.has(upstreamReference.resolved),
+        )
+      ) {
+        readsDependency = true;
+      }
+    });
+    isResourceKeyReconciliation = readsPreviousValue && readsDependency && returnsNull;
+  }
+  if (!matchesStateInitializer && !isResourceKeyReconciliation) return false;
   const matchesAttribute = (attribute: EsTreeNode): boolean =>
     isResourceLifecycleAttribute(analysis, context, dependencyVariables, attribute);
+  const hasMatchingResourceIdentity = hasResourceIdentityElement(
+    analysis,
+    context,
+    dependencyVariables,
+    componentFunction,
+  );
 
   for (const reference of setterReference.resolved.references) {
     if (reference.init) continue;
-    if (!writesFailureLatch(reference)) continue;
+    if (!writesFailureLatch(analysis, reference, dependencyVariables)) continue;
     const identifier = reference.identifier as unknown as EsTreeNode;
     let outermostFunctionBelowComponent: EsTreeNode | null = null;
     let cursor: EsTreeNode | null | undefined = identifier;
@@ -120,7 +318,22 @@ export const hasResourceLifecycleSetterWriter = (
     const bindingIdentifier = getFunctionBindingIdentifier(outermostFunctionBelowComponent);
     if (
       isNodeOfType(bindingIdentifier, "Identifier") &&
-      isSetterWiredToJsxHandler(componentFunction, bindingIdentifier.name, matchesAttribute)
+      (isSetterWiredToJsxHandler(
+        componentFunction,
+        setterReference.identifier.name,
+        matchesAttribute,
+      ) ||
+        isFunctionTransitivelyWiredToResourceHandler(
+          componentFunction,
+          bindingIdentifier.name,
+          matchesAttribute,
+        ))
+    ) {
+      return true;
+    }
+    if (
+      hasMatchingResourceIdentity &&
+      isWrittenByResourceSyncEffect(analysis, context, reference, componentFunction)
     ) {
       return true;
     }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/is-controlled-prop-mirror.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/utils/is-controlled-prop-mirror.ts
@@ -76,7 +76,7 @@ const isPropertyNamePosition = (identifier: EsTreeNode): boolean => {
   return false;
 };
 
-const referencesIdentifierNamed = (root: EsTreeNode, identifierName: string): boolean => {
+export const referencesIdentifierNamed = (root: EsTreeNode, identifierName: string): boolean => {
   let isReferenced = false;
   walkAst(root, (child: EsTreeNode): boolean | void => {
     if (isReferenced) return false;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-proven-browser-api-receiver.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-proven-browser-api-receiver.ts
@@ -445,6 +445,24 @@ export const isProvenBrowserApiReceiver = (
       ),
     );
   }
+  if (isNodeOfType(expression, "ConditionalExpression")) {
+    const branches = [expression.consequent, expression.alternate];
+    const nonNullishBranches = branches.filter(
+      (branch) =>
+        !(isNodeOfType(branch, "Literal") && branch.value === null) &&
+        !(
+          isNodeOfType(branch, "Identifier") &&
+          branch.name === "undefined" &&
+          scopes.isGlobalReference(branch)
+        ),
+    );
+    return (
+      nonNullishBranches.length > 0 &&
+      nonNullishBranches.every((branch) =>
+        isProvenBrowserApiReceiver(branch, receiverKind, scopes, new Set(visitedSymbolIds)),
+      )
+    );
+  }
   if (!isNodeOfType(expression, "MemberExpression")) return false;
   const classMember = getClassMemberDefinition(expression);
   if (classMember && isNodeOfType(classMember, "PropertyDefinition")) {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-relative-import-path.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-relative-import-path.test.ts
@@ -29,6 +29,15 @@ describe("resolveRelativeImportPath", () => {
     expect(resolveRelativeImportPath(sourceFilePath, "./component")).toBe(importedFilePath);
   });
 
+  it("resolves a dotted basename without a source extension", () => {
+    const sourceFilePath = path.join(temporaryDirectory, "src/page.tsx");
+    const importedFilePath = path.join(temporaryDirectory, "src/component.utils.ts");
+    fs.mkdirSync(path.dirname(importedFilePath), { recursive: true });
+    fs.writeFileSync(importedFilePath, "export const value = true;", "utf8");
+
+    expect(resolveRelativeImportPath(sourceFilePath, "./component.utils")).toBe(importedFilePath);
+  });
+
   it("reuses filesystem classifications until scan caches reset", () => {
     const sourceFilePath = path.join(temporaryDirectory, "src/page.tsx");
     const importedFilePath = path.join(temporaryDirectory, "src/component.tsx");

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-relative-import-path.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/resolve-relative-import-path.ts
@@ -46,7 +46,7 @@ const getExistingDirectoryPath = (directoryPath: string): string | null => {
 
 const getModuleFilePathCandidates = (modulePath: string): string[] => {
   const extension = path.extname(modulePath);
-  if (!extension) {
+  if (!MODULE_FILE_EXTENSIONS.includes(extension)) {
     return MODULE_FILE_EXTENSIONS.map((moduleExtension) => `${modulePath}${moduleExtension}`);
   }
 


### PR DESCRIPTION
## Summary

- recognize media capability, playback, and failure state as browser resource synchronization without masking unrelated prop-state adjustments
- follow local and imported lifecycle helpers, including dotted-basename imports, while keeping setter and control-flow ownership bounded
- cover omitted useState initializers, cross-file dependency collection, adversarial near-misses, and fuzz regressions

## Audit evidence

- exact React Bench replay: 131/131 diagnostics removed across 99 affected trials
- 100-repository RDE comparison against parent: zero added diagnostics; two additional genuine DOM-sync false positives removed
- removed RDE cases: ActivityLog scrollIntoView synchronization and AnimatedCollapsible getBoundingClientRect measurement

## Validation

- full test suite: 2,427 React Doctor tests passed (27 skipped); plugin suite after final regressions: 26,218 passed (205 skipped)
- full typecheck, lint, format check, plugin build, and JSON-report smoke test passed
- strict fuzz: 500 iterations passed; full fuzz suite: 196 passed (788 skipped)
- duplicate search: four truffler queries returned no matches

Daytona parity was unavailable locally because DAYTONA_API_KEY is not set; the local RDE comparison completed successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Heuristic changes in widely used state/effect rules can shift diagnostic counts; behavior is heavily regression-tested but subtle false positive/negative risk remains.
> 
> **Overview**
> **`no-adjust-state-on-prop-change`** and **`no-reset-all-state-on-prop-change`** now treat browser media capability checks, playback/failure latches, and other DOM sync work as legitimate resource lifecycles instead of “adjust state when props change,” while still flagging unrelated prop-keyed resets (e.g. clearing draft state beside a `canPlayType` probe).
> 
> The exemption logic is broadened: **`canPlayType`** joins the external DOM-sync method set; **`has-deferred-or-external-effect-work`** follows **imported** helpers that perform proven DOM sync and links related state writes to that work; **`has-resource-lifecycle-setter-writer`** takes a **`matchesStateInitializer`** flag, recognizes resource-key reconciliation updaters, **`play`/`pause`/`load`** on media refs, and failure writes tied to `src`/handler wiring. **`matchesStateInitializer`** also treats **`setState(undefined)`** when `useState` has no initial argument.
> 
> **`resolve-relative-import-path`** fixes imports whose basename contains a dot (e.g. `./AnimatedBackground.utils`) by only treating known module extensions as extensions, so cross-file capability helpers resolve. **`no-reset-all-state-on-prop-change`** is registered for cross-file lint caching like the related effect rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d545841015139ea84649c8cfd9f1c3c2d206d160. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->