### PR TITLE
test(fuzz): preserve React Bench diagnostic callsites

### DIFF
--- a/packages/fuzz/corpus/targets/r3f-no-extend-three-namespace--catalogue.tsx
+++ b/packages/fuzz/corpus/targets/r3f-no-extend-three-namespace--catalogue.tsx
@@ -1,5 +1,0 @@
-// rule: r3f-no-extend-three-namespace
-import { extend } from "@react-three/fiber";
-import * as THREE from "three";
-
-extend(THREE);

--- a/packages/fuzz/corpus/true-positives/no-adjust-state-on-prop-change--slideshow-pause.tsx
+++ b/packages/fuzz/corpus/true-positives/no-adjust-state-on-prop-change--slideshow-pause.tsx
@@ -1,0 +1,28 @@
+// rule: no-adjust-state-on-prop-change
+// verdict: fail
+// weakness: wrapper-transparency
+// source: React Bench SlideshowContext policy cohort, representative trial 26Vu5Fo
+
+import * as React from "react";
+
+interface SlideshowProps {
+  currentIndex: number;
+  disabled: boolean;
+}
+
+export const Slideshow = ({ currentIndex, disabled }: SlideshowProps) => {
+  const [playing, setPlaying] = React.useState(true);
+  const pause = React.useCallback(() => {
+    if (playing) {
+      setPlaying(false);
+    }
+  }, [playing]);
+
+  React.useEffect(() => {
+    if (playing && disabled) {
+      pause();
+    }
+  }, [currentIndex, playing, disabled, pause]);
+
+  return playing;
+};

--- a/packages/fuzz/corpus/true-positives/no-array-index-as-key--nullish-index-fallback.tsx
+++ b/packages/fuzz/corpus/true-positives/no-array-index-as-key--nullish-index-fallback.tsx
@@ -1,11 +1,12 @@
 // rule: no-array-index-as-key
+// verdict: fail
 // weakness: reachable-expression-branch
-// source: React Bench write-react-lobehub-lobe-ui-508__EAtLqrE
+// source: React Bench Accordion trial 2PCvs5j, deduplicated with EAtLqrE
 
-interface RowData {
-  id?: string;
-  label: string;
-}
+import { Children, Fragment, isValidElement } from "react";
+import type { ReactNode } from "react";
 
-export const StatefulRows = ({ rows }: { rows: RowData[] }) =>
-  rows.map((row, index) => <div key={row.id ?? index}>{row.label}</div>);
+export const Accordion = ({ children }: { children: ReactNode }) => {
+  const validChildren = Children.toArray(children).filter(isValidElement);
+  return validChildren.map((child, index) => <Fragment key={child.key ?? index}>{child}</Fragment>);
+};

--- a/packages/fuzz/corpus/true-positives/no-derived-state--direct-selection-repair.tsx
+++ b/packages/fuzz/corpus/true-positives/no-derived-state--direct-selection-repair.tsx
@@ -1,0 +1,55 @@
+// rule: no-derived-state
+// verdict: fail
+// weakness: alias-guard
+// source: React Bench DocumentHistoryModal false-NEW cohort (61 duplicate trials)
+
+import { useEffect, useMemo, useState } from "react";
+
+interface Version {
+  versionId: string;
+  visible: boolean;
+}
+
+export const DocumentHistoryModal = ({ initialVersions }: { initialVersions: Version[] }) => {
+  const [versions, setVersions] = useState(initialVersions);
+  const [onlyShowMine, setOnlyShowMine] = useState(false);
+  const visibleVersions = useMemo(() => {
+    let filtered = [...versions];
+    if (onlyShowMine) {
+      filtered = filtered.filter((version) => version.visible);
+    }
+    return filtered;
+  }, [versions, onlyShowMine]);
+  const [selectedVersionId, setSelectedVersionId] = useState("");
+
+  useEffect(() => {
+    if (visibleVersions.length === 0) {
+      if (selectedVersionId) {
+        setSelectedVersionId("");
+      }
+      return;
+    }
+
+    if (!visibleVersions.some((version) => version.versionId === selectedVersionId)) {
+      setSelectedVersionId(visibleVersions[0].versionId);
+    }
+  }, [visibleVersions, selectedVersionId]);
+
+  return (
+    <VersionList
+      versions={visibleVersions}
+      selectedVersionId={selectedVersionId}
+      onSelect={setSelectedVersionId}
+      onVersionsChange={setVersions}
+      onOnlyShowMineChange={setOnlyShowMine}
+    />
+  );
+};
+
+declare const VersionList: (props: {
+  versions: Version[];
+  selectedVersionId: string;
+  onSelect: (versionId: string) => void;
+  onVersionsChange: (versions: Version[]) => void;
+  onOnlyShowMineChange: (onlyShowMine: boolean) => void;
+}) => React.ReactNode;

--- a/packages/fuzz/corpus/true-positives/no-derived-state--ref-backed-selection-repair.tsx
+++ b/packages/fuzz/corpus/true-positives/no-derived-state--ref-backed-selection-repair.tsx
@@ -1,0 +1,67 @@
+// rule: no-derived-state
+// verdict: fail
+// weakness: alias-guard
+// source: React Bench DocumentHistoryModal ref-indirection cohort (310 duplicate trials)
+
+import { useEffect, useMemo, useRef, useState } from "react";
+
+interface Version {
+  versionId: string;
+  visible: boolean;
+}
+
+export const DocumentHistoryModal = ({
+  initialVersions,
+  viewId,
+}: {
+  initialVersions: Version[];
+  viewId: string;
+}) => {
+  const [versions, setVersions] = useState(initialVersions);
+  const [onlyShowMine, setOnlyShowMine] = useState(false);
+  const visibleVersions = useMemo(() => {
+    let filtered = [...versions];
+    if (onlyShowMine) {
+      filtered = filtered.filter((version) => version.visible);
+    }
+    return filtered;
+  }, [versions, onlyShowMine]);
+  const [selectedVersionId, setSelectedVersionId] = useState("");
+  const selectedVersionIdRef = useRef(selectedVersionId);
+  const activeViewIdRef = useRef(viewId);
+  const versionsRef = useRef(versions);
+  selectedVersionIdRef.current = selectedVersionId;
+  activeViewIdRef.current = viewId;
+  versionsRef.current = versions;
+
+  useEffect(() => {
+    if (visibleVersions.length === 0) {
+      if (selectedVersionIdRef.current) {
+        setSelectedVersionId("");
+      }
+      return;
+    }
+
+    if (!visibleVersions.some((version) => version.versionId === selectedVersionIdRef.current)) {
+      setSelectedVersionId(visibleVersions[0].versionId);
+    }
+  }, [visibleVersions]);
+
+  return (
+    <VersionList
+      versions={visibleVersions}
+      selectedVersionId={selectedVersionId}
+      onSelect={setSelectedVersionId}
+      onVersionsChange={setVersions}
+      onOnlyShowMineChange={setOnlyShowMine}
+    />
+  );
+};
+
+declare const VersionList: (props: {
+  versions: Version[];
+  selectedVersionId: string;
+  onSelect: (versionId: string) => void;
+  onVersionsChange: (versions: Version[]) => void;
+  onOnlyShowMineChange: (onlyShowMine: boolean) => void;
+}) => React.ReactNode;

--- a/packages/fuzz/corpus/true-positives/no-pass-live-state-to-parent--internxt-async-helper.tsx
+++ b/packages/fuzz/corpus/true-positives/no-pass-live-state-to-parent--internxt-async-helper.tsx
@@ -1,6 +1,7 @@
 // rule: no-pass-live-state-to-parent
+// verdict: fail
 // weakness: alias-guard
-// source: Internxt useTrashPagination launch-day trial
+// source: React Bench Internxt useTrashPagination representative trial 2UPR6Vm
 
 import { useCallback, useEffect, useState } from "react";
 

--- a/packages/fuzz/corpus/true-positives/no-ref-current-in-render--geometry-overlay-render-writes.tsx
+++ b/packages/fuzz/corpus/true-positives/no-ref-current-in-render--geometry-overlay-render-writes.tsx
@@ -1,0 +1,30 @@
+// rule: no-ref-current-in-render
+// verdict: fail
+// weakness: control-flow
+// source: React Bench GeometryOverlay representative trial 2PqCAFU
+
+import { useRef } from "react";
+
+interface Inputs {
+  hasGeometry: boolean;
+  nodeId: string;
+  status?: "running" | "failed";
+}
+
+export const GeometryOverlay = ({ nodeId, hasGeometry, status }: Inputs) => {
+  const inputs: Inputs = { nodeId, hasGeometry, status };
+  const inputsRef = useRef(inputs);
+  const versionRef = useRef(0);
+  const previous = inputsRef.current;
+
+  if (
+    previous.nodeId !== inputs.nodeId ||
+    previous.status !== inputs.status ||
+    previous.hasGeometry !== inputs.hasGeometry
+  ) {
+    inputsRef.current = inputs;
+    versionRef.current += 1;
+  }
+
+  return versionRef.current;
+};

--- a/packages/fuzz/corpus/true-positives/no-ref-current-in-render--phone-digits-render-writes.tsx
+++ b/packages/fuzz/corpus/true-positives/no-ref-current-in-render--phone-digits-render-writes.tsx
@@ -1,0 +1,45 @@
+// rule: no-ref-current-in-render
+// verdict: fail
+// weakness: control-flow
+// source: React Bench usePhoneDigits telemetry-only cohort (36 trials, three unique callsites)
+
+import { useRef } from "react";
+
+interface PhoneState {
+  inputValue: string;
+  isoCode: string | null;
+}
+
+class AsYouType {
+  constructor(_country?: string) {}
+
+  input(_value: string): void {}
+
+  reset(): void {}
+}
+
+export const usePhoneDigits = ({
+  value,
+  onChange,
+  defaultCountry,
+  nextState,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  defaultCountry?: string;
+  nextState: PhoneState;
+}) => {
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
+  const asYouTypeRef = useRef(new AsYouType(defaultCountry));
+  const previousCountryRef = useRef<string | null>(defaultCountry ?? null);
+
+  if (value !== nextState.inputValue) {
+    asYouTypeRef.current = new AsYouType(defaultCountry);
+    asYouTypeRef.current.reset();
+    asYouTypeRef.current.input(nextState.inputValue);
+    previousCountryRef.current = nextState.isoCode;
+  }
+
+  return previousCountryRef.current;
+};

--- a/packages/fuzz/corpus/true-positives/rules-of-hooks--hosted-cart-post-return-hooks.tsx
+++ b/packages/fuzz/corpus/true-positives/rules-of-hooks--hosted-cart-post-return-hooks.tsx
@@ -1,0 +1,24 @@
+// rule: rules-of-hooks
+// verdict: fail
+// weakness: control-flow
+// source: React Bench HostedCart representative trial 2qxm72N
+
+import { useEffect, useRef, useState } from "react";
+
+export const HostedCart = ({ persistKey }: { persistKey?: string }) => {
+  const [source, setSource] = useState<string>();
+
+  if (!persistKey) {
+    return null;
+  }
+
+  const previousPersistKey = useRef(persistKey);
+  useEffect(() => {
+    if (previousPersistKey.current !== persistKey) {
+      previousPersistKey.current = persistKey;
+      setSource(undefined);
+    }
+  }, [persistKey]);
+
+  return <iframe src={source} />;
+};


### PR DESCRIPTION
## What changed

- add deduplicated fuzz seeds for the audited DocumentHistory, SlideshowContext, usePhoneDigits, GeometryOverlay, HostedCart, Accordion, and useTrashPagination callsites
- pin each source shape with an explicit pass/fail verdict
- replace the generic Accordion fallback seed with the authentic React Bench callsite
- remove an exact duplicate R3F corpus target while retaining its sourced regression copy

## Why

The Harbor audit found repeated diagnostic shapes across hundreds of trials, but several authentic callsites were not represented in the fuzz corpus. That left detector behavior vulnerable to regression and made raw trial counts look like distinct cases.

## Validation

- `nr -C packages/fuzz test`
- `nr -C packages/fuzz typecheck`
- `nr format:check`
- strict 500-iteration fuzz runs for `no-derived-state`, `no-adjust-state-on-prop-change`, `no-ref-current-in-render`, `rules-of-hooks`, `no-array-index-as-key`, and `no-pass-live-state-to-parent`
- normalized rule-plus-source corpus duplicate scan: no duplicates

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only fuzz corpus changes with no production runtime impact.
> 
> **Overview**
> Adds **deduplicated React Bench fuzz seeds** for several lint rules so detector behavior stays pinned to real diagnostic shapes instead of generic stand-ins.
> 
> New `true-positives/` fixtures cover **`no-derived-state`** (DocumentHistoryModal direct vs ref-backed selection repair), **`no-adjust-state-on-prop-change`** (Slideshow pause-on-disabled), **`no-ref-current-in-render`** (GeometryOverlay and usePhoneDigits), and **`rules-of-hooks`** (HostedCart hooks after early return). Each seed includes **`// verdict: fail`**, weakness class, and trial/source metadata for deterministic replay.
> 
> **`no-array-index-as-key`** is replaced with the authentic Accordion `child.key ?? index` callsite; **`no-pass-live-state-to-parent`** gains explicit verdict/source headers. Removes a duplicate **`r3f-no-extend-three-namespace`** entry from `corpus/targets/` while keeping the sourced regression copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c2ea691ac76eac9d259f883d4f620b6e538f9cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->