### PR TITLE
test(fuzz): pin exhaustive React Bench audit corpus

### DIFF
--- a/packages/fuzz/corpus/README.md
+++ b/packages/fuzz/corpus/README.md
@@ -34,4 +34,4 @@ Header format:
 // react-major: <major, only when the false positive depends on React version>
 ```
 
-Files must parse cleanly as TSX (`pnpm test` enforces it).
+Files may use `.ts`, `.tsx`, `.js`, or `.jsx` and must parse cleanly (`pnpm test` enforces it).

--- a/packages/fuzz/corpus/react-bench-0.9.6-audit.json
+++ b/packages/fuzz/corpus/react-bench-0.9.6-audit.json
@@ -1,0 +1,299 @@
+{
+  "sourcePayloadSha256": "401b1bb234c1ed791557e2580b762fb10a8395a39fd950f5c8a51bb00104d5c0",
+  "expected": {
+    "falsePositiveCohorts": 25,
+    "falseNegativeCohorts": 3,
+    "falsePositiveMemberships": 130,
+    "falseNegativeMemberships": 13,
+    "uniqueTrials": 139
+  },
+  "callsites": [
+    {
+      "cohortId": "async-defer-await-cancellation-guard",
+      "verdict": "pass",
+      "rule": "async-defer-await",
+      "fixture": "regressions/async-defer-await--react-bench-ignore-guard.ts",
+      "trialSuffixes": ["w5MHgUd"]
+    },
+    {
+      "cohortId": "fetch-status-checked-after-body-parse",
+      "verdict": "pass",
+      "rule": "no-fetch-response-used-without-status-check",
+      "fixture": "regressions/no-fetch-response-used-without-status-check--react-bench-status-ordering.ts",
+      "trialSuffixes": [
+        "bQCehQS",
+        "6e8jKRD",
+        "emYgfjP",
+        "G4riGPB",
+        "2LpaCGW",
+        "XnFGKmn",
+        "AaUNfFt",
+        "TNKdaXb"
+      ]
+    },
+    {
+      "cohortId": "detached-docs-deferred-destruction",
+      "verdict": "pass",
+      "rule": "effect-needs-cleanup",
+      "fixture": "regressions/effect-needs-cleanup--react-bench-audit-callsites.tsx",
+      "trialSuffixes": [
+        "QStaygg",
+        "uMqtGN8",
+        "7SbKFr8",
+        "C6HhHNL",
+        "ws6ZVf9",
+        "wu54WQz",
+        "kL9Vzxk",
+        "qh6ZkSY"
+      ]
+    },
+    {
+      "cohortId": "media-query-subscription-has-cleanup",
+      "verdict": "pass",
+      "rule": "effect-needs-cleanup",
+      "fixture": "regressions/effect-needs-cleanup--react-bench-audit-callsites.tsx",
+      "trialSuffixes": ["MCdNwJQ", "3isMm2U", "z4xqWR5"]
+    },
+    {
+      "cohortId": "indirect-listener-cleanup-registry",
+      "verdict": "pass",
+      "rule": "effect-needs-cleanup",
+      "fixture": "regressions/effect-needs-cleanup--react-bench-audit-callsites.tsx",
+      "trialSuffixes": ["ejqqBec", "avxG9N9"]
+    },
+    {
+      "cohortId": "loading-reset-is-finally-or-owned",
+      "verdict": "pass",
+      "rule": "no-loading-flag-reset-outside-finally",
+      "fixture": "regressions/no-loading-flag-reset-outside-finally--react-bench-completion-ownership.tsx",
+      "trialSuffixes": [
+        "CTVq8o9",
+        "gu2qyRm",
+        "uspGZY4",
+        "GLjaWsR",
+        "kNmWwRd",
+        "M3HhN3f",
+        "ZaSGMv8",
+        "8QP7FAL",
+        "6N8fft4",
+        "qqtwGcZ"
+      ]
+    },
+    {
+      "cohortId": "async-error-clear-has-ownership-token",
+      "verdict": "pass",
+      "rule": "no-unowned-async-error-clear",
+      "fixture": "regressions/no-unowned-async-error-clear--react-bench-request-owner.tsx",
+      "trialSuffixes": ["bhiF9eP", "qqtwGcZ"]
+    },
+    {
+      "cohortId": "stale-timer-ref-is-not-pending-signal",
+      "verdict": "pass",
+      "rule": "no-stale-timer-ref",
+      "fixture": "regressions/no-stale-timer-ref--react-bench-cleanup-only-guards.tsx",
+      "trialSuffixes": ["Ws7nM9R", "nS8EuPj", "M3HhN3f", "o8pcxMD"]
+    },
+    {
+      "cohortId": "trusted-katex-html-producer",
+      "verdict": "pass",
+      "rule": "dangerous-html-sink",
+      "fixture": "regressions/dangerous-html-sink--react-bench-katex-producers.tsx",
+      "trialSuffixes": ["7cZ5Gvj", "2zXeke3", "F3MuFLG", "JvtCxYU"]
+    },
+    {
+      "cohortId": "effect-cleanup-victory-indirect-cancel-run",
+      "verdict": "pass",
+      "rule": "effect-needs-cleanup",
+      "fixture": "regressions/effect-needs-cleanup--react-bench-audit-callsites.tsx",
+      "trialSuffixes": ["88jQzRD", "aeMK9eD"]
+    },
+    {
+      "cohortId": "effect-cleanup-trycomp-indirect-listener-removal-expansion",
+      "verdict": "pass",
+      "rule": "effect-needs-cleanup",
+      "fixture": "regressions/effect-needs-cleanup--react-bench-audit-callsites.tsx",
+      "trialSuffixes": ["nAh2Mxq", "zrbr6AH"]
+    },
+    {
+      "cohortId": "effect-cleanup-reacttooltip-iterated-pairs",
+      "verdict": "pass",
+      "rule": "effect-needs-cleanup",
+      "fixture": "regressions/effect-needs-cleanup--react-bench-audit-callsites.tsx",
+      "trialSuffixes": [
+        "2xcugfq",
+        "4NEr2t2",
+        "5AxVzn6",
+        "DQFTEGA",
+        "QneQp7M",
+        "TR7edkq",
+        "YHaQ88r",
+        "aecBVdS",
+        "dYVmBZS",
+        "ebMMb98",
+        "g9B3XUC",
+        "gEhshoM",
+        "htuANUE",
+        "oHHysJL",
+        "pExmysK",
+        "tBaGBd3",
+        "wUW8Wgi"
+      ]
+    },
+    {
+      "cohortId": "effect-cleanup-bnb-direct-pairs",
+      "verdict": "pass",
+      "rule": "effect-needs-cleanup",
+      "fixture": "regressions/effect-needs-cleanup--react-bench-audit-callsites.tsx",
+      "trialSuffixes": ["5odW8Ek", "A7XPDBt", "US9nhiT", "WUdXCny", "YZ5KC7c"]
+    },
+    {
+      "cohortId": "effect-cleanup-bnb-callback-ref-detach",
+      "verdict": "pass",
+      "rule": "effect-needs-cleanup",
+      "fixture": "regressions/effect-needs-cleanup--react-bench-audit-callsites.tsx",
+      "trialSuffixes": [
+        "EKusD36",
+        "FpzyALL",
+        "GtCTXMf",
+        "JdFwJxH",
+        "kEoi8Bt",
+        "ryJktE5",
+        "vYaWp9W",
+        "xXDKawb"
+      ]
+    },
+    {
+      "cohortId": "effect-cleanup-bnb-indirect-drag-stop",
+      "verdict": "pass",
+      "rule": "effect-needs-cleanup",
+      "fixture": "regressions/effect-needs-cleanup--react-bench-audit-callsites.tsx",
+      "trialSuffixes": ["HrxF9LS", "rDyahxk"]
+    },
+    {
+      "cohortId": "effect-cleanup-bnb-inert-ref-timers",
+      "verdict": "pass",
+      "rule": "effect-needs-cleanup",
+      "fixture": "regressions/effect-needs-cleanup--react-bench-audit-callsites.tsx",
+      "trialSuffixes": [
+        "NqzXCLi",
+        "gJ5Yf7c",
+        "mXv9WSm",
+        "H8nceDx",
+        "KPggtNZ",
+        "Q7zWgtA",
+        "SVQMhde",
+        "bh6DdEW",
+        "7x7vgBS",
+        "aGrvFG9"
+      ]
+    },
+    {
+      "cohortId": "effect-cleanup-reacttooltip-indirect-timer-cancel",
+      "verdict": "pass",
+      "rule": "effect-needs-cleanup",
+      "fixture": "regressions/effect-needs-cleanup--react-bench-audit-callsites.tsx",
+      "trialSuffixes": [
+        "Mab63Up",
+        "PF8wGPB",
+        "itC5ei4",
+        "jTMVxrq",
+        "reYV8TW",
+        "z9DJCF5",
+        "Vj5tx86",
+        "e27wYm5"
+      ]
+    },
+    {
+      "cohortId": "effect-cleanup-reacttooltip-mounted-guard",
+      "verdict": "pass",
+      "rule": "effect-needs-cleanup",
+      "fixture": "regressions/effect-needs-cleanup--react-bench-audit-callsites.tsx",
+      "trialSuffixes": ["CeZVVAm", "JWQ63fX", "Vj5tx86", "e27wYm5", "qxsHyf3", "yMnaf68"]
+    },
+    {
+      "cohortId": "fetch-status-post-read-guard-expansion",
+      "verdict": "pass",
+      "rule": "no-fetch-response-used-without-status-check",
+      "fixture": "regressions/no-fetch-response-used-without-status-check--react-bench-status-ordering.ts",
+      "trialSuffixes": [
+        "8nfzx2J",
+        "Dk4Z3iL",
+        "FRK8YDs",
+        "FrjMPfq",
+        "KZNREKa",
+        "Rzdydrc",
+        "VSJwo2N",
+        "aqVWUuD",
+        "c9yrZid",
+        "dXQNN3T",
+        "iwaZFRj",
+        "jwWH9dK",
+        "mpSp8So",
+        "wwwZ3aR"
+      ]
+    },
+    {
+      "cohortId": "fetch-status-helper-before-read-expansion",
+      "verdict": "pass",
+      "rule": "no-fetch-response-used-without-status-check",
+      "fixture": "regressions/no-fetch-response-used-without-status-check--react-bench-status-ordering.ts",
+      "trialSuffixes": ["UMVQe3h"]
+    },
+    {
+      "cohortId": "loading-reset-settings-finally-expansion",
+      "verdict": "pass",
+      "rule": "no-loading-flag-reset-outside-finally",
+      "fixture": "regressions/no-loading-flag-reset-outside-finally--react-bench-completion-ownership.tsx",
+      "trialSuffixes": ["4AKNJyx", "AYhZqV4"]
+    },
+    {
+      "cohortId": "loading-reset-tracecat-mirrored-branches",
+      "verdict": "pass",
+      "rule": "no-loading-flag-reset-outside-finally",
+      "fixture": "regressions/no-loading-flag-reset-outside-finally--react-bench-completion-ownership.tsx",
+      "trialSuffixes": ["CsU5j5F", "cyft985", "hzELC8Y", "mggmJ9p", "xTAvqSC"]
+    },
+    {
+      "cohortId": "loading-reset-claude-owned-finally",
+      "verdict": "pass",
+      "rule": "no-loading-flag-reset-outside-finally",
+      "fixture": "regressions/no-loading-flag-reset-outside-finally--react-bench-completion-ownership.tsx",
+      "trialSuffixes": ["SzANNdf", "U46675r", "WAV94zz"]
+    },
+    {
+      "cohortId": "async-error-clear-request-owner-expansion",
+      "verdict": "pass",
+      "rule": "no-unowned-async-error-clear",
+      "fixture": "regressions/no-unowned-async-error-clear--react-bench-request-owner.tsx",
+      "trialSuffixes": ["NbCpsk4", "QoPHAna"]
+    },
+    {
+      "cohortId": "dangerous-html-katex-escaped-fallback-expansion",
+      "verdict": "pass",
+      "rule": "dangerous-html-sink",
+      "fixture": "regressions/dangerous-html-sink--react-bench-katex-producers.tsx",
+      "trialSuffixes": ["B9d5ZSS"]
+    },
+    {
+      "cohortId": "history-mutation-inside-state-updater",
+      "verdict": "fail",
+      "rule": "no-side-effect-in-state-updater-function",
+      "fixture": "true-positives/no-side-effect-in-state-updater-function--react-bench-history-and-prop-callbacks.tsx",
+      "trialSuffixes": ["4cArjqi", "WL7WieW", "eXGcE2R", "g8rYdBJ", "kc2SYFf"]
+    },
+    {
+      "cohortId": "arbitrary-prop-callback-inside-state-updater",
+      "verdict": "fail",
+      "rule": "no-side-effect-in-state-updater-function",
+      "fixture": "true-positives/no-side-effect-in-state-updater-function--react-bench-history-and-prop-callbacks.tsx",
+      "trialSuffixes": ["zTe5J63", "qfnSJ92", "bAyzc4U", "5PUQo8r", "LfNQ9g7", "HFg6Dum"]
+    },
+    {
+      "cohortId": "history-mutation-inside-state-updater-masked",
+      "verdict": "fail",
+      "rule": "no-side-effect-in-state-updater-function",
+      "fixture": "true-positives/no-side-effect-in-state-updater-function--react-bench-history-and-prop-callbacks.tsx",
+      "trialSuffixes": ["VxZhgvA", "R4CRYqC"]
+    }
+  ]
+}

--- a/packages/fuzz/corpus/regressions/async-defer-await--react-bench-ignore-guard.ts
+++ b/packages/fuzz/corpus/regressions/async-defer-await--react-bench-ignore-guard.ts
@@ -1,0 +1,14 @@
+// rule: async-defer-await
+// verdict: pass
+// weakness: name-heuristic
+// source: React Bench 0.9.6 exhaustive audit
+
+declare const getOrganizationConfig: () => Promise<string>;
+declare const render: (value: string) => void;
+declare let ignore: boolean;
+
+export const refreshHostedCart = async () => {
+  const config = await getOrganizationConfig();
+  if (ignore) return;
+  render(config);
+};

--- a/packages/fuzz/corpus/regressions/dangerous-html-sink--react-bench-katex-producers.tsx
+++ b/packages/fuzz/corpus/regressions/dangerous-html-sink--react-bench-katex-producers.tsx
@@ -1,0 +1,22 @@
+// rule: dangerous-html-sink
+// verdict: pass
+// weakness: cross-file
+// source: React Bench 0.9.6 exhaustive audit
+
+import katex from "katex";
+
+const escapeHtml = (value: string): string =>
+  value.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
+
+const renderKatexToHtml = (value: string): string => {
+  try {
+    return katex.renderToString(value, { throwOnError: false, trust: false });
+  } catch {
+    return `<code>${escapeHtml(value)}</code>`;
+  }
+};
+
+export const MathMessage = ({ value }: { value: string }) => {
+  const html = renderKatexToHtml(value);
+  return <span dangerouslySetInnerHTML={{ __html: html }} />;
+};

--- a/packages/fuzz/corpus/regressions/effect-needs-cleanup--react-bench-audit-callsites.tsx
+++ b/packages/fuzz/corpus/regressions/effect-needs-cleanup--react-bench-audit-callsites.tsx
@@ -1,0 +1,162 @@
+// rule: effect-needs-cleanup
+// verdict: pass
+// weakness: cleanup-provenance
+// source: React Bench 0.9.6 exhaustive audit
+
+import { useCallback, useEffect, useRef, useSyncExternalStore } from "react";
+
+export const DetachedDocuments = ({ documents }) => {
+  const documentMapRef = useRef(new Map(documents));
+  const clearDocuments = useCallback(() => {
+    const detachedDocuments = Array.from(documentMapRef.current.values());
+    documentMapRef.current.clear();
+    if (detachedDocuments.length === 0) return;
+    setTimeout(() => detachedDocuments.forEach((document) => document.destroy()), 0);
+  }, []);
+  return <button onClick={clearDocuments}>Clear</button>;
+};
+
+export const MediaSubscription = ({ breakpoint, notify }) => {
+  const subscribe = useCallback(() => {
+    const media = window.matchMedia(breakpoint);
+    const handleMatch = () => notify();
+    if (media.addEventListener) {
+      media.addEventListener("change", handleMatch);
+      return () => media.removeEventListener("change", handleMatch);
+    }
+    media.addListener(handleMatch);
+    return () => media.removeListener(handleMatch);
+  }, [breakpoint, notify]);
+  useSyncExternalStore(
+    subscribe,
+    () => false,
+    () => false,
+  );
+  return null;
+};
+
+export const CleanupRegistry = ({ targets }) => {
+  useEffect(() => {
+    const cleanups = [];
+    for (const target of targets) {
+      const handler = () => undefined;
+      target.addEventListener("change", handler);
+      cleanups.push(() => target.removeEventListener("change", handler));
+    }
+    return () => cleanups.forEach((cleanup) => cleanup());
+  }, [targets]);
+  return null;
+};
+
+export const IndirectDragStop = ({ startResizing }) => {
+  const handleMouseMove = () => startResizing();
+  const stopResizing = () => window.removeEventListener("mousemove", handleMouseMove);
+  useEffect(() => {
+    window.addEventListener("mousemove", handleMouseMove);
+    return () => stopResizing();
+  }, [startResizing]);
+  return null;
+};
+
+export const VictoryRun = ({ timer }) => {
+  const mountedRef = useRef(true);
+  const runRef = useRef({ loopID: null });
+  const cancelCurrentRun = useCallback(
+    (force) => {
+      if (runRef.current.loopID) timer.unsubscribe(runRef.current.loopID);
+      if (force) runRef.current.loopID = null;
+    },
+    [timer],
+  );
+  useEffect(() => {
+    runRef.current.loopID = timer.subscribe(() => undefined);
+    return () => {
+      mountedRef.current = false;
+      cancelCurrentRun(true);
+    };
+  }, [cancelCurrentRun, timer]);
+  return null;
+};
+
+export const IteratedListenerPairs = ({ elementRefs, enabledEvents, isCaptureEvent }) => {
+  useEffect(() => {
+    enabledEvents.forEach(({ event, listener }) =>
+      elementRefs.forEach((element) =>
+        element.addEventListener(event, listener, isCaptureEvent(event)),
+      ),
+    );
+    return () =>
+      enabledEvents.forEach(({ event, listener }) =>
+        elementRefs.forEach((element) =>
+          element.removeEventListener(event, listener, isCaptureEvent(event)),
+        ),
+      );
+  }, [elementRefs, enabledEvents, isCaptureEvent]);
+  return null;
+};
+
+export const DirectListenerPair = ({ element, onWheel }) => {
+  useEffect(() => {
+    const options = { passive: false };
+    element.addEventListener("wheel", onWheel, options);
+    return () => element.removeEventListener("wheel", onWheel);
+  }, [element, onWheel]);
+  return null;
+};
+
+export const CallbackRefReplacement = ({ handleWheel }) => {
+  const viewportRef = useRef(null);
+  const setViewport = useCallback(
+    (node) => {
+      const previous = viewportRef.current;
+      if (previous && previous !== node) previous.removeEventListener("wheel", handleWheel);
+      viewportRef.current = node;
+      if (node) node.addEventListener("wheel", handleWheel, { passive: false });
+    },
+    [handleWheel],
+  );
+  return <div ref={setViewport} />;
+};
+
+export const InertEventTimer = () => {
+  const suppressClickRef = useRef(false);
+  const handlePointerUp = () => {
+    suppressClickRef.current = true;
+    setTimeout(() => {
+      suppressClickRef.current = false;
+    }, 100);
+  };
+  return <button onPointerUp={handlePointerUp}>Release</button>;
+};
+
+export const RefOwnedTimer = ({ delay, open }) => {
+  const pendingShowRef = useRef(null);
+  const cancelPendingShow = useCallback(() => {
+    if (!pendingShowRef.current) return;
+    clearTimeout(pendingShowRef.current.timer);
+    pendingShowRef.current = null;
+  }, []);
+  useEffect(() => () => cancelPendingShow(), [cancelPendingShow]);
+  useEffect(() => {
+    cancelPendingShow();
+    pendingShowRef.current = { timer: setTimeout(open, delay) };
+  }, [cancelPendingShow, delay, open]);
+  return null;
+};
+
+export const MountedGuardTimer = ({ setIsOpen }) => {
+  const mounted = useRef(true);
+  useEffect(
+    () => () => {
+      mounted.current = false;
+    },
+    [],
+  );
+  useEffect(() => {
+    setTimeout(() => {
+      if (!mounted.current) return;
+      setIsOpen(true);
+    }, 10);
+  }, [setIsOpen]);
+  return null;
+};

--- a/packages/fuzz/corpus/regressions/no-fetch-response-used-without-status-check--react-bench-status-ordering.ts
+++ b/packages/fuzz/corpus/regressions/no-fetch-response-used-without-status-check--react-bench-status-ordering.ts
@@ -1,0 +1,26 @@
+// rule: no-fetch-response-used-without-status-check
+// verdict: pass
+// weakness: control-flow
+// source: React Bench 0.9.6 exhaustive audit
+
+interface ApiKeys {
+  keys: string[];
+}
+
+const isApiKeyListResponse = (value: unknown): value is ApiKeys =>
+  typeof value === "object" && value !== null && "keys" in value;
+
+const isSuccessfulResponse = (response: Response): boolean => response.ok;
+
+export const loadAfterParsing = async (): Promise<ApiKeys> => {
+  const response = await fetch("/api/keys");
+  const data: unknown = await response.json();
+  if (!response.ok || !isApiKeyListResponse(data)) throw new Error("Unable to load keys");
+  return data;
+};
+
+export const loadAfterHelperGuard = async (): Promise<unknown> => {
+  const response = await fetch("/api/settings");
+  if (!isSuccessfulResponse(response)) throw new Error("Unable to load settings");
+  return response.json();
+};

--- a/packages/fuzz/corpus/regressions/no-loading-flag-reset-outside-finally--react-bench-completion-ownership.tsx
+++ b/packages/fuzz/corpus/regressions/no-loading-flag-reset-outside-finally--react-bench-completion-ownership.tsx
@@ -1,0 +1,37 @@
+// rule: no-loading-flag-reset-outside-finally
+// verdict: pass
+// weakness: control-flow
+// source: React Bench 0.9.6 exhaustive audit
+
+import { useRef, useState } from "react";
+
+export const OwnedCompletion = ({ save }) => {
+  const [, setPending] = useState(false);
+  const activeRequestRef = useRef(0);
+  const requestSequenceRef = useRef(0);
+  const run = async () => {
+    const requestId = ++requestSequenceRef.current;
+    activeRequestRef.current = requestId;
+    setPending(true);
+    try {
+      await save();
+    } finally {
+      if (activeRequestRef.current === requestId) setPending(false);
+    }
+  };
+  return <button onClick={() => void run()}>Save</button>;
+};
+
+export const MirroredCompletion = ({ upload }) => {
+  const [, setUploading] = useState(false);
+  const run = async () => {
+    setUploading(true);
+    try {
+      await upload();
+      setUploading(false);
+    } catch {
+      setUploading(false);
+    }
+  };
+  return <button onClick={() => void run()}>Upload</button>;
+};

--- a/packages/fuzz/corpus/regressions/no-stale-timer-ref--react-bench-cleanup-only-guards.tsx
+++ b/packages/fuzz/corpus/regressions/no-stale-timer-ref--react-bench-cleanup-only-guards.tsx
@@ -1,0 +1,22 @@
+// rule: no-stale-timer-ref
+// verdict: pass
+// weakness: control-flow
+// source: React Bench 0.9.6 exhaustive audit
+
+import { useEffect, useRef } from "react";
+
+export const PermissionTimer = ({ countdown, tick }) => {
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  useEffect(() => {
+    timerRef.current = setInterval(tick, 1000);
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current);
+    };
+  }, [tick]);
+  useEffect(() => {
+    if (countdown !== 0 || !timerRef.current) return;
+    clearInterval(timerRef.current);
+    timerRef.current = null;
+  }, [countdown]);
+  return null;
+};

--- a/packages/fuzz/corpus/regressions/no-unowned-async-error-clear--react-bench-request-owner.tsx
+++ b/packages/fuzz/corpus/regressions/no-unowned-async-error-clear--react-bench-request-owner.tsx
@@ -1,0 +1,31 @@
+// rule: no-unowned-async-error-clear
+// verdict: pass
+// weakness: alias-guard
+// source: React Bench 0.9.6 exhaustive audit
+
+import { useRef, useState } from "react";
+
+export const RequestDelivery = ({ request, respond }) => {
+  const activeRequestIdRef = useRef(request.requestId);
+  const [deliveryError, setDeliveryError] = useState(null);
+  const deliver = async () => {
+    const targetId = request.requestId;
+    const result = await respond(request);
+    if (activeRequestIdRef.current !== targetId) return;
+    setDeliveryError(result.ok ? null : { requestId: targetId, reason: result.reason });
+  };
+  return <button onClick={() => void deliver()}>{deliveryError ? "Retry" : "Send"}</button>;
+};
+
+export const SnapshotDelivery = ({ request, respond }) => {
+  const requestIdRef = useRef(request.requestId);
+  requestIdRef.current = request.requestId;
+  const [, setDeliveryError] = useState(null);
+  const deliver = async () => {
+    const sentFor = requestIdRef.current;
+    const result = await respond(request);
+    if (requestIdRef.current !== sentFor) return;
+    setDeliveryError(result.ok ? null : result.reason);
+  };
+  return <button onClick={() => void deliver()}>Send</button>;
+};

--- a/packages/fuzz/corpus/true-positives/no-side-effect-in-state-updater-function--react-bench-history-and-prop-callbacks.tsx
+++ b/packages/fuzz/corpus/true-positives/no-side-effect-in-state-updater-function--react-bench-history-and-prop-callbacks.tsx
@@ -1,0 +1,27 @@
+// rule: no-side-effect-in-state-updater-function
+// verdict: fail
+// weakness: receiver-provenance
+// source: React Bench 0.9.6 exhaustive audit
+
+import { useState } from "react";
+
+export const HistoryMutation = ({ href }) => {
+  const [, setParams] = useState(new URLSearchParams());
+  setParams((previous) => {
+    const next = new URLSearchParams(previous);
+    window.history.pushState(null, "", href);
+    return next;
+  });
+  return null;
+};
+
+export const BodyDestructuredCallback = (props) => {
+  const { activeIds, onSelectedRowsChange } = props;
+  const [, setSelectedRowIds] = useState([]);
+  setSelectedRowIds((previous) => {
+    const next = previous.filter((id) => activeIds.includes(id));
+    if (next.length !== previous.length) onSelectedRowsChange(next);
+    return next;
+  });
+  return null;
+};

--- a/packages/fuzz/src/load-fuzz-corpus.ts
+++ b/packages/fuzz/src/load-fuzz-corpus.ts
@@ -118,7 +118,7 @@ export const loadFuzzCorpus = (
     try {
       const code = fs.readFileSync(fullPath, "utf8");
       entries.push({
-        relativePath: path.relative(corpusDirectory, fullPath),
+        relativePath: path.relative(corpusDirectory, fullPath).split(path.sep).join("/"),
         code,
         ...readCorpusDirectives(code),
       });

--- a/packages/fuzz/src/load-fuzz-corpus.ts
+++ b/packages/fuzz/src/load-fuzz-corpus.ts
@@ -13,7 +13,7 @@ export interface FuzzCorpusLoadOptions {
   maximumFiles?: number;
 }
 
-const CORPUS_FILE_PATTERN = /\.(tsx|jsx)$/;
+const CORPUS_FILE_PATTERN = /\.(tsx|ts|jsx|js)$/;
 const RULE_DIRECTIVE_PATTERN = /^\/\/ rule: (.+)$/m;
 const VERDICT_DIRECTIVE_PATTERN = /^\/\/ verdict: (pass|fail)$/m;
 const SKIPPED_DIRECTORY_NAMES = new Set(["node_modules", ".git", "dist", "build", "coverage"]);

--- a/packages/fuzz/src/load-fuzz-corpus.ts
+++ b/packages/fuzz/src/load-fuzz-corpus.ts
@@ -18,6 +18,9 @@ const RULE_DIRECTIVE_PATTERN = /^\/\/ rule: (.+)$/m;
 const VERDICT_DIRECTIVE_PATTERN = /^\/\/ verdict: (pass|fail)$/m;
 const SKIPPED_DIRECTORY_NAMES = new Set(["node_modules", ".git", "dist", "build", "coverage"]);
 
+const isCorpusFileName = (fileName: string): boolean =>
+  CORPUS_FILE_PATTERN.test(fileName) && !fileName.endsWith(".d.ts");
+
 const readCorpusDirectives = (code: string): Pick<FuzzCorpusEntry, "ruleIds" | "verdict"> => {
   const ruleIds = RULE_DIRECTIVE_PATTERN.exec(code)?.[1]
     ?.split(",")
@@ -53,7 +56,7 @@ const collectCorpusFilePaths = (rootDirectory: string, budget: number): string[]
         if (!SKIPPED_DIRECTORY_NAMES.has(name)) walk(fullPath);
         continue;
       }
-      if (!CORPUS_FILE_PATTERN.test(name)) continue;
+      if (!isCorpusFileName(name)) continue;
       if (stats.size > MAX_CORPUS_FILE_BYTES || stats.size === 0) continue;
       filePaths.push(fullPath);
     }
@@ -94,7 +97,7 @@ export const loadFuzzCorpus = (
       buckets.push(collectCorpusFilePaths(fullPath, maximumFiles));
       continue;
     }
-    if (CORPUS_FILE_PATTERN.test(name) && stats.size <= MAX_CORPUS_FILE_BYTES && stats.size > 0) {
+    if (isCorpusFileName(name) && stats.size <= MAX_CORPUS_FILE_BYTES && stats.size > 0) {
       looseFiles.push(fullPath);
     }
   }

--- a/packages/fuzz/tests/fuzz-harness-smoke.test.ts
+++ b/packages/fuzz/tests/fuzz-harness-smoke.test.ts
@@ -52,7 +52,7 @@ describe("fuzz harness oracles", () => {
     });
     const seedRelativePaths = fs
       .readdirSync(corpusDirectory, { encoding: "utf8", recursive: true })
-      .filter((relativePath) => /\.(tsx|jsx)$/.test(relativePath))
+      .filter((relativePath) => /\.(tsx|ts|jsx|js)$/.test(relativePath))
       .sort();
     expect(corpus.length).toBeGreaterThan(MAX_CORPUS_FILES);
     expect(corpus.map((entry) => entry.relativePath).sort()).toEqual(seedRelativePaths);

--- a/packages/fuzz/tests/fuzz-harness-smoke.test.ts
+++ b/packages/fuzz/tests/fuzz-harness-smoke.test.ts
@@ -53,6 +53,7 @@ describe("fuzz harness oracles", () => {
     const seedRelativePaths = fs
       .readdirSync(corpusDirectory, { encoding: "utf8", recursive: true })
       .filter((relativePath) => /\.(tsx|ts|jsx|js)$/.test(relativePath))
+      .map((relativePath) => relativePath.split(path.sep).join("/"))
       .sort();
     expect(corpus.length).toBeGreaterThan(MAX_CORPUS_FILES);
     expect(corpus.map((entry) => entry.relativePath).sort()).toEqual(seedRelativePaths);

--- a/packages/fuzz/tests/fuzz-harness-smoke.test.ts
+++ b/packages/fuzz/tests/fuzz-harness-smoke.test.ts
@@ -52,7 +52,10 @@ describe("fuzz harness oracles", () => {
     });
     const seedRelativePaths = fs
       .readdirSync(corpusDirectory, { encoding: "utf8", recursive: true })
-      .filter((relativePath) => /\.(tsx|ts|jsx|js)$/.test(relativePath))
+      .filter(
+        (relativePath) =>
+          /\.(tsx|ts|jsx|js)$/.test(relativePath) && !relativePath.endsWith(".d.ts"),
+      )
       .map((relativePath) => relativePath.split(path.sep).join("/"))
       .sort();
     expect(corpus.length).toBeGreaterThan(MAX_CORPUS_FILES);

--- a/packages/fuzz/tests/load-fuzz-corpus.test.ts
+++ b/packages/fuzz/tests/load-fuzz-corpus.test.ts
@@ -62,4 +62,20 @@ describe("loadFuzzCorpus", () => {
       },
     ]);
   });
+
+  it.each(["tsx", "ts", "jsx", "js"])("loads .%s source files", (extension) => {
+    const directory = makeCorpusDirectory();
+    fs.writeFileSync(path.join(directory, `declared.${extension}`), "export const value = 1;");
+
+    expect(loadFuzzCorpus(directory).map((entry) => entry.relativePath)).toEqual([
+      `declared.${extension}`,
+    ]);
+  });
+
+  it("ignores non-source files", () => {
+    const directory = makeCorpusDirectory();
+    fs.writeFileSync(path.join(directory, "manifest.json"), "{}");
+
+    expect(loadFuzzCorpus(directory)).toEqual([]);
+  });
 });

--- a/packages/fuzz/tests/load-fuzz-corpus.test.ts
+++ b/packages/fuzz/tests/load-fuzz-corpus.test.ts
@@ -78,4 +78,15 @@ describe("loadFuzzCorpus", () => {
 
     expect(loadFuzzCorpus(directory)).toEqual([]);
   });
+
+  it("returns portable relative paths for nested seeds", () => {
+    const directory = makeCorpusDirectory();
+    const nestedDirectory = path.join(directory, "nested", "deeper");
+    fs.mkdirSync(nestedDirectory, { recursive: true });
+    fs.writeFileSync(path.join(nestedDirectory, "declared.tsx"), "export const value = 1;");
+
+    expect(loadFuzzCorpus(directory).map((entry) => entry.relativePath)).toEqual([
+      "nested/deeper/declared.tsx",
+    ]);
+  });
 });

--- a/packages/fuzz/tests/load-fuzz-corpus.test.ts
+++ b/packages/fuzz/tests/load-fuzz-corpus.test.ts
@@ -79,6 +79,19 @@ describe("loadFuzzCorpus", () => {
     expect(loadFuzzCorpus(directory)).toEqual([]);
   });
 
+  it("ignores TypeScript declaration files", () => {
+    const directory = makeCorpusDirectory();
+    const nestedDirectory = path.join(directory, "nested");
+    fs.mkdirSync(nestedDirectory);
+    fs.writeFileSync(path.join(directory, "root.d.ts"), "declare const rootValue: string;");
+    fs.writeFileSync(
+      path.join(nestedDirectory, "nested.d.ts"),
+      "declare const nestedValue: string;",
+    );
+
+    expect(loadFuzzCorpus(directory)).toEqual([]);
+  });
+
   it("returns portable relative paths for nested seeds", () => {
     const directory = makeCorpusDirectory();
     const nestedDirectory = path.join(directory, "nested", "deeper");

--- a/packages/fuzz/tests/react-bench-audit-corpus.test.ts
+++ b/packages/fuzz/tests/react-bench-audit-corpus.test.ts
@@ -1,0 +1,97 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vite-plus/test";
+import { loadFuzzCorpus } from "../src/load-fuzz-corpus.js";
+
+interface ReactBenchAuditExpectedCounts {
+  falsePositiveCohorts: number;
+  falseNegativeCohorts: number;
+  falsePositiveMemberships: number;
+  falseNegativeMemberships: number;
+  uniqueTrials: number;
+}
+
+interface ReactBenchAuditCallsite {
+  cohortId: string;
+  verdict: "pass" | "fail";
+  rule: string;
+  fixture: string;
+  trialSuffixes: string[];
+}
+
+interface ReactBenchAuditManifest {
+  sourcePayloadSha256: string;
+  expected: ReactBenchAuditExpectedCounts;
+  callsites: ReactBenchAuditCallsite[];
+}
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const corpusDirectory = path.join(packageRoot, "corpus");
+const manifestPath = path.join(corpusDirectory, "react-bench-0.9.6-audit.json");
+const manifest: ReactBenchAuditManifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+
+describe("React Bench 0.9.6 audit corpus", () => {
+  it("accounts for every confirmed FP and FN callsite membership", () => {
+    const falsePositiveCallsites = manifest.callsites.filter(
+      (callsite) => callsite.verdict === "pass",
+    );
+    const falseNegativeCallsites = manifest.callsites.filter(
+      (callsite) => callsite.verdict === "fail",
+    );
+    const falsePositiveMembershipCount = falsePositiveCallsites.reduce(
+      (count, callsite) => count + callsite.trialSuffixes.length,
+      0,
+    );
+    const falseNegativeMembershipCount = falseNegativeCallsites.reduce(
+      (count, callsite) => count + callsite.trialSuffixes.length,
+      0,
+    );
+    const uniqueTrialSuffixes = new Set(
+      manifest.callsites.flatMap((callsite) => callsite.trialSuffixes),
+    );
+
+    expect(falsePositiveCallsites).toHaveLength(manifest.expected.falsePositiveCohorts);
+    expect(falseNegativeCallsites).toHaveLength(manifest.expected.falseNegativeCohorts);
+    expect(falsePositiveMembershipCount).toBe(manifest.expected.falsePositiveMemberships);
+    expect(falseNegativeMembershipCount).toBe(manifest.expected.falseNegativeMemberships);
+    expect(uniqueTrialSuffixes.size).toBe(manifest.expected.uniqueTrials);
+  });
+
+  it("contains no duplicate cohort or cohort-trial callsite", () => {
+    const cohortIds = manifest.callsites.map((callsite) => callsite.cohortId);
+    const callsiteKeys = manifest.callsites.flatMap((callsite) =>
+      callsite.trialSuffixes.map((trialSuffix) => `${callsite.cohortId}:${trialSuffix}`),
+    );
+
+    expect(new Set(cohortIds).size).toBe(cohortIds.length);
+    expect(new Set(callsiteKeys).size).toBe(callsiteKeys.length);
+    for (const callsite of manifest.callsites) {
+      expect(new Set(callsite.trialSuffixes).size).toBe(callsite.trialSuffixes.length);
+    }
+  });
+
+  it("maps every cohort to a loaded deterministic fuzz verdict", () => {
+    const loadedCorpus = loadFuzzCorpus(corpusDirectory, {
+      maximumFiles: Number.POSITIVE_INFINITY,
+    });
+    const entriesByPath = new Map(loadedCorpus.map((entry) => [entry.relativePath, entry]));
+
+    for (const callsite of manifest.callsites) {
+      const entry = entriesByPath.get(callsite.fixture);
+      expect(entry, callsite.fixture).toBeDefined();
+      expect(entry?.ruleIds, callsite.fixture).toContain(callsite.rule);
+      expect(entry?.verdict, callsite.fixture).toBe(callsite.verdict);
+    }
+  });
+
+  it("deduplicates semantically shared callsites into unique fixture sources", () => {
+    const fixturePaths = [...new Set(manifest.callsites.map((callsite) => callsite.fixture))];
+    const fixtureSources = fixturePaths.map((fixturePath) =>
+      fs.readFileSync(path.join(corpusDirectory, fixturePath), "utf8"),
+    );
+
+    expect(new Set(fixtureSources).size).toBe(fixtureSources.length);
+    expect(fixturePaths.length).toBeLessThan(manifest.callsites.length);
+  });
+});


### PR DESCRIPTION
## What changed

- add a machine-checked manifest for every confirmed React Bench 0.9.6 FP/FN cohort fixed by #1601
- preserve all 143 cohort/trial callsite memberships (139 unique trials) in eight deduplicated deterministic fuzz fixtures
- load `.ts` and `.js` corpus seeds in addition to `.tsx` and `.jsx`
- verify cohort counts, membership uniqueness, fixture existence, rule mapping, verdicts, and semantic fixture deduplication

## Why

The detector fixes in #1601 had focused rule tests, but the fuzz corpus only retained a small representative subset. The corpus loader also silently skipped 96 existing `.ts`/`.js` seeds, including a fetch-status regression. This makes the complete audited surface durable and mutation-testable.

The manifest is pinned to audit payload SHA-256 `401b1bb234c1ed791557e2580b762fb10a8395a39fd950f5c8a51bb00104d5c0` and was mechanically compared with the source payload: 28/28 cohorts, 143/143 memberships, no missing or extra rows.

## Validation

- `pnpm --filter @react-doctor/fuzz test`
- `pnpm --filter @react-doctor/fuzz fuzz` (788/788 rules)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `pnpm test` (full repository suite)
- `pnpm smoke:json-report`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to fuzz corpus data, loader behavior, and tests; no production detector or runtime paths are modified in this PR.
> 
> **Overview**
> Pins the full **React Bench 0.9.6** false-positive / false-negative audit as durable fuzz coverage, with a SHA-256–pinned manifest and machine-checked cohort metadata.
> 
> Adds `react-bench-0.9.6-audit.json` (expected cohort/membership/trial counts plus 28 cohort → fixture mappings) and **eight deduplicated** regression/true-positive seeds that encode the audited callsite patterns (effect cleanup, fetch status ordering, loading/error ownership, KaTeX HTML, state-updater side effects, etc.). A new test suite asserts manifest arithmetic, uniqueness, fixture loadability, rule/verdict directives, and semantic deduplication.
> 
> **Corpus loader** now ingests `.ts`/`.js` seeds (not only `.tsx`/`.jsx`), skips `.d.ts`, and emits **portable** `relativePath` values with forward slashes; README and harness tests align with those rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69014b28b0eceaf9b6ab6276fb5bac4afe9c5923. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->