### PR TITLE
fix(rules): accept compound unmount guards

### DIFF
--- a/.changeset/calm-timers-guard.md
+++ b/.changeset/calm-timers-guard.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Avoid reporting one-shot effect timers whose callbacks exit on a leading compound unmount guard.

--- a/packages/fuzz/corpus/react-bench-0.9.7-audit.json
+++ b/packages/fuzz/corpus/react-bench-0.9.7-audit.json
@@ -1,11 +1,11 @@
 {
-  "source": "React Bench 0.9.7 exhaustive all-diffs audit",
+  "source": "React Bench 0.9.7+0.9.8 exhaustive all-diffs audit",
   "expected": {
-    "totalCallsites": 108,
-    "passCallsites": 106,
+    "totalCallsites": 109,
+    "passCallsites": 107,
     "failCallsites": 2,
-    "uniqueTrials": 98,
-    "uniqueFixtures": 95
+    "uniqueTrials": 99,
+    "uniqueFixtures": 96
   },
   "fixtures": [
     {
@@ -111,6 +111,14 @@
         "dangerous-html-sink"
       ],
       "fixtureSourceSha256": "2156ba92f9f63b1e34de4287c2a8be0694172eb9b13e7d084ee1cb070c0c1c8c"
+    },
+    {
+      "fixture": "react-bench-0.9.7-audit/regressions/2aaefa9502f4--tooltip.tsx",
+      "verdict": "pass",
+      "rules": [
+        "effect-needs-cleanup"
+      ],
+      "fixtureSourceSha256": "2aaefa9502f425fb162e83305c71a54a70888fcd45860bd2ae1cd5f1eb7fe924"
     },
     {
       "fixture": "react-bench-0.9.7-audit/regressions/2cc99f329a93--message-markdown.tsx",
@@ -773,6 +781,7 @@
   "callsites": [
     {
       "suffix": "3hWu3XT",
+      "auditVersion": "0.9.7",
       "task": "write-react-pedropalau-react-bnb-gallery-185",
       "patchSha256": "9d440906643bbfd4ba84d692ae4bbb31b8c5024306fdbe7db0e4faf05e979dcd",
       "rule": "effect-needs-cleanup",
@@ -785,6 +794,7 @@
     },
     {
       "suffix": "3QykvFu",
+      "auditVersion": "0.9.7",
       "task": "write-react-pedropalau-react-bnb-gallery-185",
       "patchSha256": "50e34b461e7969525766ef246884b8168edaba8419508e5ccabd5a2eab826f21",
       "rule": "effect-needs-cleanup",
@@ -797,6 +807,7 @@
     },
     {
       "suffix": "4xT2CsQ",
+      "auditVersion": "0.9.7",
       "task": "fix-react-formidablelabs-victory-victory-animation",
       "patchSha256": "3ebdf36e959254bf59bf62587aad9aca397c813654dcd0ca5704ad365007e55d",
       "rule": "effect-needs-cleanup",
@@ -809,6 +820,7 @@
     },
     {
       "suffix": "59uRuXQ",
+      "auditVersion": "0.9.7",
       "task": "write-react-frankchen021-datastoria-199",
       "patchSha256": "48b68fba7e0c4f0d8dc117a726fda6b12810ff24ee17c0f7e8db5ddca0c3c4ba",
       "rule": "dangerous-html-sink",
@@ -821,6 +833,7 @@
     },
     {
       "suffix": "5g5yE7Y",
+      "auditVersion": "0.9.7",
       "task": "write-react-trycompai-comp-3248",
       "patchSha256": "2d2bf187f2d9fd29d059df9be27fce68b3b3bfec739a63ed66b78e7d03f6aa6b",
       "rule": "effect-needs-cleanup",
@@ -833,6 +846,7 @@
     },
     {
       "suffix": "69nChbz",
+      "auditVersion": "0.9.7",
       "task": "write-react-pedropalau-react-bnb-gallery-185",
       "patchSha256": "5ec95b92f091deb0643e89080ad6d27e3d780f1edb12d212da23cff61461d5fa",
       "rule": "effect-needs-cleanup",
@@ -845,6 +859,7 @@
     },
     {
       "suffix": "6qxjfR6",
+      "auditVersion": "0.9.7",
       "task": "write-react-pedropalau-react-bnb-gallery-185",
       "patchSha256": "b7ffe3c8c78b8df636ea9f806f1e37b9426ade38a79e6b2d4ea95f277e9d926e",
       "rule": "effect-needs-cleanup",
@@ -857,6 +872,7 @@
     },
     {
       "suffix": "7btopEX",
+      "auditVersion": "0.9.7",
       "task": "write-react-tombelieber-claude-view-70",
       "patchSha256": "9a9dfef8a63863155a74c5f18b7d095df09259cf357456a0fab2e6619f13938a",
       "rule": "no-loading-flag-reset-outside-finally",
@@ -869,6 +885,7 @@
     },
     {
       "suffix": "85J9Qms",
+      "auditVersion": "0.9.7",
       "task": "write-react-pedropalau-react-bnb-gallery-185",
       "patchSha256": "abcd8768305d0a56ad6e42b2b7011b9a9df36ca786e77fb09d3e8719af318b3e",
       "rule": "effect-needs-cleanup",
@@ -881,6 +898,7 @@
     },
     {
       "suffix": "8CUyZFi",
+      "auditVersion": "0.9.7",
       "task": "write-react-frankchen021-datastoria-199",
       "patchSha256": "35f0fa188e8bcefafcade62091bad1e2606417f7ce8c778b1c0e979de2cb9d23",
       "rule": "dangerous-html-sink",
@@ -893,6 +911,7 @@
     },
     {
       "suffix": "8hkokrf",
+      "auditVersion": "0.9.7",
       "task": "write-react-pedropalau-react-bnb-gallery-185",
       "patchSha256": "18fd232011f370c830b7a69ff736fd63bbad2ac30d4649d59cf2c5e2a21a8023",
       "rule": "effect-needs-cleanup",
@@ -905,6 +924,7 @@
     },
     {
       "suffix": "8zgcb8x",
+      "auditVersion": "0.9.7",
       "task": "fix-react-rdh-sofn-xyz-mailing-settings",
       "patchSha256": "fcabb9ddc5e045910ee9aa3389f901130f914705e747fe9207f40328d7c88692",
       "rule": "no-fetch-response-used-without-status-check",
@@ -917,6 +937,7 @@
     },
     {
       "suffix": "A2yzHp5",
+      "auditVersion": "0.9.7",
       "task": "fix-react-rdh-appflowy-io-appflowy-web-documenthistorymodal",
       "patchSha256": "3552f3a1625635e046f4969b7c3a8b6a50ea176d8a25b08cc5bb951c3cb83747",
       "rule": "effect-needs-cleanup",
@@ -929,6 +950,7 @@
     },
     {
       "suffix": "AeYgTmv",
+      "auditVersion": "0.9.7",
       "task": "write-react-tombelieber-claude-view-70",
       "patchSha256": "6a2f778f79bb5a4af543c7c19ad47d42935be2d8f25fe7dd8d227d3548d8d607",
       "rule": "no-loading-flag-reset-outside-finally",
@@ -941,6 +963,7 @@
     },
     {
       "suffix": "aUuXhdK",
+      "auditVersion": "0.9.7",
       "task": "write-react-pedropalau-react-bnb-gallery-185",
       "patchSha256": "5d31ac736a824855b6d85dd1bef7c2cc93f5b2eb6cde0f3cde11d233fc99744c",
       "rule": "effect-needs-cleanup",
@@ -953,6 +976,7 @@
     },
     {
       "suffix": "bDB9hMk",
+      "auditVersion": "0.9.7",
       "task": "write-react-pedropalau-react-bnb-gallery-185",
       "patchSha256": "27224e0257275637a7c0f2fdae575cfa1f11f2ee469f15dc839046ddad59d280",
       "rule": "effect-needs-cleanup",
@@ -965,6 +989,7 @@
     },
     {
       "suffix": "bwrYqBh",
+      "auditVersion": "0.9.7",
       "task": "write-react-pedropalau-react-bnb-gallery-185",
       "patchSha256": "30b31c93f72e2be620390146de2e59ef124644c28fb5207f17c628063d12e4a7",
       "rule": "effect-needs-cleanup",
@@ -977,6 +1002,7 @@
     },
     {
       "suffix": "c23ZTbu",
+      "auditVersion": "0.9.7",
       "task": "write-react-tombelieber-claude-view-70",
       "patchSha256": "f8217945b10c3d52843c2c55baf1aecc378e1cf78e7370c83ccc9980d1efcefc",
       "rule": "no-loading-flag-reset-outside-finally",
@@ -989,6 +1015,7 @@
     },
     {
       "suffix": "cgyxiZc",
+      "auditVersion": "0.9.7",
       "task": "write-react-tombelieber-claude-view-70",
       "patchSha256": "74bcb19cea2ba81cc970dd79049f0df8f03e4a2c473d202d5fbc3d40a135a9ea",
       "rule": "no-loading-flag-reset-outside-finally",
@@ -1001,6 +1028,7 @@
     },
     {
       "suffix": "ciNLW2X",
+      "auditVersion": "0.9.7",
       "task": "write-react-tombelieber-claude-view-70",
       "patchSha256": "6401c3e699561e75822686ef4bcdfd41c125fc1fa4e438b6c87b9b4e17cdeaaf",
       "rule": "no-loading-flag-reset-outside-finally",
@@ -1013,6 +1041,7 @@
     },
     {
       "suffix": "ciNLW2X",
+      "auditVersion": "0.9.7",
       "task": "write-react-tombelieber-claude-view-70",
       "patchSha256": "6401c3e699561e75822686ef4bcdfd41c125fc1fa4e438b6c87b9b4e17cdeaaf",
       "rule": "no-loading-flag-reset-outside-finally",
@@ -1025,6 +1054,7 @@
     },
     {
       "suffix": "ciNLW2X",
+      "auditVersion": "0.9.7",
       "task": "write-react-tombelieber-claude-view-70",
       "patchSha256": "6401c3e699561e75822686ef4bcdfd41c125fc1fa4e438b6c87b9b4e17cdeaaf",
       "rule": "no-loading-flag-reset-outside-finally",
@@ -1037,6 +1067,7 @@
     },
     {
       "suffix": "ciNLW2X",
+      "auditVersion": "0.9.7",
       "task": "write-react-tombelieber-claude-view-70",
       "patchSha256": "6401c3e699561e75822686ef4bcdfd41c125fc1fa4e438b6c87b9b4e17cdeaaf",
       "rule": "no-loading-flag-reset-outside-finally",
@@ -1049,6 +1080,7 @@
     },
     {
       "suffix": "ciNLW2X",
+      "auditVersion": "0.9.7",
       "task": "write-react-tombelieber-claude-view-70",
       "patchSha256": "6401c3e699561e75822686ef4bcdfd41c125fc1fa4e438b6c87b9b4e17cdeaaf",
       "rule": "no-loading-flag-reset-outside-finally",
@@ -1061,6 +1093,7 @@
     },
     {
       "suffix": "cSaK7t9",
+      "auditVersion": "0.9.7",
       "task": "write-react-tombelieber-claude-view-70",
       "patchSha256": "fc503f1acea7a0cc4f50f84f04d03778dfdf191907a630f0213288d3bae28fbf",
       "rule": "no-stale-timer-ref",
@@ -1073,6 +1106,7 @@
     },
     {
       "suffix": "dKQWsXr",
+      "auditVersion": "0.9.7",
       "task": "write-react-tracecathq-tracecat-2879",
       "patchSha256": "118ec0f98e2ece1c9a6499c747d8690648d9f3e7fdbb3a14ae740d9415e30a0c",
       "rule": "no-loading-flag-reset-outside-finally",
@@ -1085,6 +1119,7 @@
     },
     {
       "suffix": "e8STTuu",
+      "auditVersion": "0.9.7",
       "task": "write-react-pedropalau-react-bnb-gallery-185",
       "patchSha256": "d6ce51b596222c08b84f8f8f00fb895a68af7bf296500471cfedaeb151325ff0",
       "rule": "effect-needs-cleanup",
@@ -1097,6 +1132,7 @@
     },
     {
       "suffix": "eaU6h9M",
+      "auditVersion": "0.9.7",
       "task": "fix-react-rdh-sofn-xyz-mailing-settings",
       "patchSha256": "dc12b471232951f357648713700fc05b217686245e7e00eae055db53e46551e9",
       "rule": "no-loading-flag-reset-outside-finally",
@@ -1109,6 +1145,7 @@
     },
     {
       "suffix": "eaU6h9M",
+      "auditVersion": "0.9.7",
       "task": "fix-react-rdh-sofn-xyz-mailing-settings",
       "patchSha256": "dc12b471232951f357648713700fc05b217686245e7e00eae055db53e46551e9",
       "rule": "no-loading-flag-reset-outside-finally",
@@ -1121,6 +1158,7 @@
     },
     {
       "suffix": "eGYGezE",
+      "auditVersion": "0.9.7",
       "task": "write-react-pedropalau-react-bnb-gallery-185",
       "patchSha256": "bc194e8d5ba42cfc6e51efad86ab1dc9d4563db2ff76767e4d9d1ec93baf5c37",
       "rule": "effect-needs-cleanup",
@@ -1133,6 +1171,7 @@
     },
     {
       "suffix": "EjLmWwc",
+      "auditVersion": "0.9.7",
       "task": "write-react-pedropalau-react-bnb-gallery-185",
       "patchSha256": "673b5194061e65af17d909a227a40227f195792c1c910a1d19e8e46e588efac4",
       "rule": "effect-needs-cleanup",
@@ -1145,6 +1184,7 @@
     },
     {
       "suffix": "FQtYvfB",
+      "auditVersion": "0.9.7",
       "task": "fix-react-reacttooltip-react-tooltip-1205",
       "patchSha256": "a34e963ca9dd6fa3b6af083f41fbd26ca056e3e924ddb22fca166bd820a35eee",
       "rule": "effect-needs-cleanup",
@@ -1157,6 +1197,7 @@
     },
     {
       "suffix": "FSdzhai",
+      "auditVersion": "0.9.7",
       "task": "write-react-pedropalau-react-bnb-gallery-185",
       "patchSha256": "17787ce2137779f25839e7c41bd477e4d36b779022b9103cddaff72d862954bb",
       "rule": "effect-needs-cleanup",
@@ -1169,6 +1210,7 @@
     },
     {
       "suffix": "GDrqDDq",
+      "auditVersion": "0.9.7",
       "task": "write-react-tombelieber-claude-view-70",
       "patchSha256": "0a6d0da8e1d99cdc91d9a47eae7723625520e88a43a106002e9caec699878a9b",
       "rule": "no-loading-flag-reset-outside-finally",
@@ -1181,6 +1223,7 @@
     },
     {
       "suffix": "GZasht7",
+      "auditVersion": "0.9.7",
       "task": "fix-react-formidablelabs-victory-victory-animation",
       "patchSha256": "1fe8c698c99e6dd4b3423838d8d649c1fc8fc18e533752d8fb23ffcac359096b",
       "rule": "effect-needs-cleanup",
@@ -1193,6 +1236,7 @@
     },
     {
       "suffix": "H6SaVzY",
+      "auditVersion": "0.9.7",
       "task": "write-react-tombelieber-claude-view-70",
       "patchSha256": "77f7a1446d27b93ec6994b43f9dd0167db1ca0b24e34c2447cdac2414069b10f",
       "rule": "no-loading-flag-reset-outside-finally",
@@ -1205,6 +1249,7 @@
     },
     {
       "suffix": "iGvkBMR",
+      "auditVersion": "0.9.7",
       "task": "write-react-pedropalau-react-bnb-gallery-185",
       "patchSha256": "b6fa237f117ccd88000b3b5354f7c2eb913b7f6f2d5d373d0573477ee6314c3c",
       "rule": "effect-needs-cleanup",
@@ -1217,6 +1262,7 @@
     },
     {
       "suffix": "jmHkDF8",
+      "auditVersion": "0.9.7",
       "task": "write-react-frankchen021-datastoria-199",
       "patchSha256": "72c8ff7adc1fbbb8dda4633cfd9a7f2e9a53c5558a2899cba7b4c3f054c3bd41",
       "rule": "dangerous-html-sink",
@@ -1229,6 +1275,7 @@
     },
     {
       "suffix": "jmHkDF8",
+      "auditVersion": "0.9.7",
       "task": "write-react-frankchen021-datastoria-199",
       "patchSha256": "72c8ff7adc1fbbb8dda4633cfd9a7f2e9a53c5558a2899cba7b4c3f054c3bd41",
       "rule": "dangerous-html-sink",
@@ -1241,6 +1288,7 @@
     },
     {
       "suffix": "k6r9uYz",
+      "auditVersion": "0.9.7",
       "task": "fix-react-reacttooltip-react-tooltip-1205",
       "patchSha256": "59d14e1139809b3bd81dcb846e6a85a48707e4c993d1bcce23ca983e9610b4cc",
       "rule": "effect-needs-cleanup",
@@ -1253,6 +1301,7 @@
     },
     {
       "suffix": "kGRjWmt",
+      "auditVersion": "0.9.7",
       "task": "write-react-azouaoui-med-react-pro-sidebar-267",
       "patchSha256": "8553a9cd038ad240c3b3d5e45d6dc2b3adbce95ae6c13e2c5f4ad0dbe0cd7a4c",
       "rule": "effect-needs-cleanup",
@@ -1265,6 +1314,7 @@
     },
     {
       "suffix": "knV9S9X",
+      "auditVersion": "0.9.7",
       "task": "write-react-trycompai-comp-3248",
       "patchSha256": "3248591a9291cd3035527f60a9826fd3e8878d4c3b475f3478138359109eb0ec",
       "rule": "effect-needs-cleanup",
@@ -1277,6 +1327,7 @@
     },
     {
       "suffix": "KWSeZDE",
+      "auditVersion": "0.9.7",
       "task": "fix-react-rdh-sofn-xyz-mailing-settings",
       "patchSha256": "c482979f14c79b5a982ff5f27ec9f7c33c05ad3a6762e87653209e8f51e620b4",
       "rule": "no-fetch-response-used-without-status-check",
@@ -1289,6 +1340,7 @@
     },
     {
       "suffix": "KxgQFGt",
+      "auditVersion": "0.9.7",
       "task": "write-react-tracecathq-tracecat-2879",
       "patchSha256": "c070003cf2ef2a9d9d47da4e61c84e31d3d15742e198550bf9fc684463146edf",
       "rule": "no-loading-flag-reset-outside-finally",
@@ -1301,6 +1353,7 @@
     },
     {
       "suffix": "KYUPojL",
+      "auditVersion": "0.9.7",
       "task": "fix-react-rdh-sofn-xyz-mailing-settings",
       "patchSha256": "d42a2f4d9d37d9c60fc6f53c79de5f05952d5463f90d4be7bf650f003dbd53cb",
       "rule": "no-fetch-response-used-without-status-check",
@@ -1313,6 +1366,7 @@
     },
     {
       "suffix": "L4YTWaY",
+      "auditVersion": "0.9.7",
       "task": "write-react-tracecathq-tracecat-2879",
       "patchSha256": "ce3a8a757d87620d94ec95a13cd47dfdfa28ece4bb4853df1b58c5ec943f2ac5",
       "rule": "no-loading-flag-reset-outside-finally",
@@ -1325,6 +1379,7 @@
     },
     {
       "suffix": "Lg6RjoG",
+      "auditVersion": "0.9.7",
       "task": "fix-react-rdh-appflowy-io-appflowy-web-documenthistorymodal",
       "patchSha256": "31de08516e1e623fb16c826dd7b91adf676a815d9053864f4794ad65bea9d39b",
       "rule": "effect-needs-cleanup",
@@ -1337,6 +1392,7 @@
     },
     {
       "suffix": "LjT6Gsi",
+      "auditVersion": "0.9.7",
       "task": "fix-react-reacttooltip-react-tooltip-1205",
       "patchSha256": "5f384a06870ceff0d672ddf43b9e5f67cb8d4a7f74a738b68c4a99afc43e5910",
       "rule": "effect-needs-cleanup",
@@ -1349,6 +1405,7 @@
     },
     {
       "suffix": "LjT6Gsi",
+      "auditVersion": "0.9.7",
       "task": "fix-react-reacttooltip-react-tooltip-1205",
       "patchSha256": "5f384a06870ceff0d672ddf43b9e5f67cb8d4a7f74a738b68c4a99afc43e5910",
       "rule": "effect-needs-cleanup",
@@ -1361,6 +1418,7 @@
     },
     {
       "suffix": "LjT6Gsi",
+      "auditVersion": "0.9.7",
       "task": "fix-react-reacttooltip-react-tooltip-1205",
       "patchSha256": "5f384a06870ceff0d672ddf43b9e5f67cb8d4a7f74a738b68c4a99afc43e5910",
       "rule": "effect-needs-cleanup",
@@ -1373,6 +1431,7 @@
     },
     {
       "suffix": "Mc74ezG",
+      "auditVersion": "0.9.7",
       "task": "fix-react-reacttooltip-react-tooltip-1205",
       "patchSha256": "4043adbc7c65cd51f7e5d4efe999756cea83aaf36d75a3e43fdb7e16d7164e73",
       "rule": "effect-needs-cleanup",
@@ -1385,6 +1444,7 @@
     },
     {
       "suffix": "Mc74ezG",
+      "auditVersion": "0.9.7",
       "task": "fix-react-reacttooltip-react-tooltip-1205",
       "patchSha256": "4043adbc7c65cd51f7e5d4efe999756cea83aaf36d75a3e43fdb7e16d7164e73",
       "rule": "effect-needs-cleanup",
@@ -1397,6 +1457,7 @@
     },
     {
       "suffix": "mggYDtK",
+      "auditVersion": "0.9.7",
       "task": "write-react-tombelieber-claude-view-70",
       "patchSha256": "99267967e2dcfd885d6923075365d4f1133a0155fec441c03fd7b23b9db9d410",
       "rule": "no-loading-flag-reset-outside-finally",
@@ -1409,6 +1470,7 @@
     },
     {
       "suffix": "mwrqBJm",
+      "auditVersion": "0.9.7",
       "task": "fix-react-rdh-sofn-xyz-mailing-settings",
       "patchSha256": "96fd5248b3883593d8e401d4d3969e1e93930cbb58cb4aa23a73f9173260f06c",
       "rule": "no-fetch-response-used-without-status-check",
@@ -1421,6 +1483,7 @@
     },
     {
       "suffix": "NEqLJPs",
+      "auditVersion": "0.9.7",
       "task": "write-react-pedropalau-react-bnb-gallery-185",
       "patchSha256": "1fc841f0b5c8d4774191f6b1d31c026ae164b9d14227c923574abf952b70a021",
       "rule": "effect-needs-cleanup",
@@ -1433,6 +1496,7 @@
     },
     {
       "suffix": "nqCAUTG",
+      "auditVersion": "0.9.7",
       "task": "write-react-pedropalau-react-bnb-gallery-185",
       "patchSha256": "b9a70452c5e1293797061452118c5c47c0244dd5ddc781bba2518060ed58cacb",
       "rule": "effect-needs-cleanup",
@@ -1445,6 +1509,7 @@
     },
     {
       "suffix": "nWstAEn",
+      "auditVersion": "0.9.7",
       "task": "fix-react-reacttooltip-react-tooltip-1205",
       "patchSha256": "63ac7bf7e641bee8352e74832a6e5df92a179670da5c5f9861a21b080217d3b9",
       "rule": "effect-needs-cleanup",
@@ -1457,6 +1522,7 @@
     },
     {
       "suffix": "nZWy2VR",
+      "auditVersion": "0.9.7",
       "task": "write-react-pedropalau-react-bnb-gallery-185",
       "patchSha256": "479b770f69b88988d3d7be59227b90ca3695c1a570932126b498dc9b01129d7c",
       "rule": "effect-needs-cleanup",
@@ -1469,6 +1535,7 @@
     },
     {
       "suffix": "o7H9HZT",
+      "auditVersion": "0.9.7",
       "task": "write-react-azouaoui-med-react-pro-sidebar-267",
       "patchSha256": "fe0d20f5c9021fa2d64b55ae5fa66a77aab40bd01996b78cf925cbf74f00656b",
       "rule": "effect-needs-cleanup",
@@ -1481,6 +1548,7 @@
     },
     {
       "suffix": "p9xPe6V",
+      "auditVersion": "0.9.7",
       "task": "fix-react-reacttooltip-react-tooltip-1205",
       "patchSha256": "3b4335c6675fe7be4a1ff4a914b41bca5cf20db792f4cd724d7f016f9f896fcb",
       "rule": "effect-needs-cleanup",
@@ -1493,6 +1561,7 @@
     },
     {
       "suffix": "pdWLT3f",
+      "auditVersion": "0.9.7",
       "task": "write-react-pedropalau-react-bnb-gallery-185",
       "patchSha256": "96dae4bf4dddc287d12edcb8cd0c32aa3fecd7370b8d53862c8fb4b933017f25",
       "rule": "effect-needs-cleanup",
@@ -1505,6 +1574,7 @@
     },
     {
       "suffix": "pUceTHm",
+      "auditVersion": "0.9.7",
       "task": "write-react-tombelieber-claude-view-70",
       "patchSha256": "b189af65060eeb0ef11373e5f636d25036a1c915bae0a5f32617e9827b56e4b9",
       "rule": "no-loading-flag-reset-outside-finally",
@@ -1517,6 +1587,7 @@
     },
     {
       "suffix": "PyYKwCv",
+      "auditVersion": "0.9.7",
       "task": "fix-react-reacttooltip-react-tooltip-1205",
       "patchSha256": "aa1548cc38552741b7c49f282b134d3c2895a9521df8a6f6ba1ff21ec91a11d1",
       "rule": "effect-needs-cleanup",
@@ -1529,6 +1600,7 @@
     },
     {
       "suffix": "qeA8ADk",
+      "auditVersion": "0.9.7",
       "task": "fix-react-rdh-sofn-xyz-mailing-settings",
       "patchSha256": "f8fd8ca236ec655fdc0beca780f41d38aeda42b27151952fce494e03cd86694b",
       "rule": "no-fetch-response-used-without-status-check",
@@ -1541,6 +1613,7 @@
     },
     {
       "suffix": "qFbXfoU",
+      "auditVersion": "0.9.7",
       "task": "fix-react-rdh-sofn-xyz-mailing-settings",
       "patchSha256": "ec408d7d1e988c4174df7f6f88df45070aebb75b0feca068342f1a96ef18b2fa",
       "rule": "no-fetch-response-used-without-status-check",
@@ -1553,6 +1626,7 @@
     },
     {
       "suffix": "qFdtj8R",
+      "auditVersion": "0.9.7",
       "task": "write-react-tombelieber-claude-view-70",
       "patchSha256": "3d236d4b03478960a19deee9e29588e2b124f47fd888712ea1e37e628b0c5cbc",
       "rule": "no-loading-flag-reset-outside-finally",
@@ -1565,6 +1639,7 @@
     },
     {
       "suffix": "RcqthL9",
+      "auditVersion": "0.9.7",
       "task": "write-react-pedropalau-react-bnb-gallery-185",
       "patchSha256": "902ad30a6ce2aef9d2077b9b3d24d9e60cc43b7f9cefa4a2d39fd63650cea8ac",
       "rule": "effect-needs-cleanup",
@@ -1576,7 +1651,21 @@
       "verdict": "pass"
     },
     {
+      "suffix": "RD098RTT",
+      "auditVersion": "0.9.8",
+      "task": "fix-react-reacttooltip-react-tooltip-1205",
+      "patchSha256": "593ce722332373f1a794731286abd10d9d175f86688277ff7d20e085b93773eb",
+      "rule": "effect-needs-cleanup",
+      "filePath": "src/components/Tooltip/Tooltip.tsx",
+      "reportedLine": 243,
+      "sourceSha256": "2aaefa9502f425fb162e83305c71a54a70888fcd45860bd2ae1cd5f1eb7fe924",
+      "snippetSha256": "2aaefa9502f425fb162e83305c71a54a70888fcd45860bd2ae1cd5f1eb7fe924",
+      "fixture": "react-bench-0.9.7-audit/regressions/2aaefa9502f4--tooltip.tsx",
+      "verdict": "pass"
+    },
+    {
       "suffix": "Rit9CTf",
+      "auditVersion": "0.9.7",
       "task": "fix-react-rdh-appflowy-io-appflowy-web-documenthistorymodal",
       "patchSha256": "211a6bf23fe9dbccbd7d87659c701f69771a98c909a3113656508f8c84420146",
       "rule": "effect-needs-cleanup",
@@ -1589,6 +1678,7 @@
     },
     {
       "suffix": "Rkf6hKV",
+      "auditVersion": "0.9.7",
       "task": "fix-react-rdh-appflowy-io-appflowy-web-documenthistorymodal",
       "patchSha256": "3564bb6f197486b9718788ce7f4127a96f8649bffe421e2e66397fcb2fc4bbbb",
       "rule": "effect-needs-cleanup",
@@ -1601,6 +1691,7 @@
     },
     {
       "suffix": "RVBWvU2",
+      "auditVersion": "0.9.7",
       "task": "fix-react-rdh-sofn-xyz-mailing-settings",
       "patchSha256": "cbf9d3e1489a82c9e1a2c29c0a3c72f67278ead8c4068e306cb98d8521784ef2",
       "rule": "no-fetch-response-used-without-status-check",
@@ -1613,6 +1704,7 @@
     },
     {
       "suffix": "San7nfV",
+      "auditVersion": "0.9.7",
       "task": "write-react-pedropalau-react-bnb-gallery-185",
       "patchSha256": "fb7ed88b80deb87daa3939c022ae7c61fc1f2efd7dba3da0b292bc1087ca9a0f",
       "rule": "effect-needs-cleanup",
@@ -1625,6 +1717,7 @@
     },
     {
       "suffix": "SQSmbFe",
+      "auditVersion": "0.9.7",
       "task": "write-react-atomantic-portos-1698",
       "patchSha256": "ef0ebde8ac1f2ea52fcaf0d1e76b6ff189bbb98bfb5f9962e5ec5ac9aa7cfb0a",
       "rule": "no-side-effect-in-state-updater-function",
@@ -1637,6 +1730,7 @@
     },
     {
       "suffix": "t2MJVDe",
+      "auditVersion": "0.9.7",
       "task": "write-react-frankchen021-datastoria-199",
       "patchSha256": "553e95682a8a999533a15aeb75c73e42c3ff347536fba08b19fbe9b3f6802403",
       "rule": "dangerous-html-sink",
@@ -1649,6 +1743,7 @@
     },
     {
       "suffix": "TgaiL4H",
+      "auditVersion": "0.9.7",
       "task": "fix-react-reacttooltip-react-tooltip-1205",
       "patchSha256": "d432b9cae5105f61a6445752524fab1668b6acc6937faca07f0e7d052635d915",
       "rule": "effect-needs-cleanup",
@@ -1661,6 +1756,7 @@
     },
     {
       "suffix": "TLDAvPL",
+      "auditVersion": "0.9.7",
       "task": "write-react-pedropalau-react-bnb-gallery-185",
       "patchSha256": "26be183ac9e2b583f47f9a3d596c8a4864a7d883919e7f0fc39b136c95d036bc",
       "rule": "effect-needs-cleanup",
@@ -1673,6 +1769,7 @@
     },
     {
       "suffix": "tMA9S2M",
+      "auditVersion": "0.9.7",
       "task": "fix-react-rdh-sofn-xyz-mailing-settings",
       "patchSha256": "3f18834dc4fb448a55bdebdb307f0b1355c781466bc785b2a27811766f890d64",
       "rule": "no-fetch-response-used-without-status-check",
@@ -1685,6 +1782,7 @@
     },
     {
       "suffix": "tN7KTwG",
+      "auditVersion": "0.9.7",
       "task": "write-react-trycompai-comp-3248",
       "patchSha256": "1c8e1a5237b00a8ada41c1c220e02c54838c20f935e5a4ac8810d8804e737765",
       "rule": "effect-needs-cleanup",
@@ -1697,6 +1795,7 @@
     },
     {
       "suffix": "tnceAXq",
+      "auditVersion": "0.9.7",
       "task": "fix-react-reacttooltip-react-tooltip-1205",
       "patchSha256": "c28ed9475ca8b27d5121678fc50e7267cb8fb695389273388acbc916b61db1bb",
       "rule": "effect-needs-cleanup",
@@ -1709,6 +1808,7 @@
     },
     {
       "suffix": "TttYXSq",
+      "auditVersion": "0.9.7",
       "task": "write-react-tombelieber-claude-view-70",
       "patchSha256": "4a1affeb67bd7243e3f4bb6f2a75083c72584c78bbb85fc708fecd74df56cd45",
       "rule": "no-unowned-async-error-clear",
@@ -1721,6 +1821,7 @@
     },
     {
       "suffix": "UA2HwrB",
+      "auditVersion": "0.9.7",
       "task": "fix-react-rdh-appflowy-io-appflowy-web-documenthistorymodal",
       "patchSha256": "24bf6457baf98811595e26d27a3b08f3e19ead5c89955281287b090fd21279c0",
       "rule": "effect-needs-cleanup",
@@ -1733,6 +1834,7 @@
     },
     {
       "suffix": "uhPQe3N",
+      "auditVersion": "0.9.7",
       "task": "fix-react-reacttooltip-react-tooltip-1205",
       "patchSha256": "f6b7c79d6ff9f78ed02ec8670395b94493e3bf8191e5301def3d6563e3d24b33",
       "rule": "effect-needs-cleanup",
@@ -1745,6 +1847,7 @@
     },
     {
       "suffix": "UM9oWPj",
+      "auditVersion": "0.9.7",
       "task": "write-react-tracecathq-tracecat-2879",
       "patchSha256": "7527a41ee5ed681296a52012d9c6b03b2a9a1feca61d22fcb9b5c117aa0be8d5",
       "rule": "no-loading-flag-reset-outside-finally",
@@ -1757,6 +1860,7 @@
     },
     {
       "suffix": "ums2Ccx",
+      "auditVersion": "0.9.7",
       "task": "fix-react-reacttooltip-react-tooltip-1205",
       "patchSha256": "e74cbf1e459ea694ac2724a9c34a00a1e10bde099eabff21be06b7a5697520c5",
       "rule": "effect-needs-cleanup",
@@ -1769,6 +1873,7 @@
     },
     {
       "suffix": "uoccKA3",
+      "auditVersion": "0.9.7",
       "task": "write-react-pedropalau-react-bnb-gallery-185",
       "patchSha256": "65f727cedaf9e016e95755ec40e76a62f48a614c83411b841a1b29438eea565b",
       "rule": "effect-needs-cleanup",
@@ -1781,6 +1886,7 @@
     },
     {
       "suffix": "uRcmhcd",
+      "auditVersion": "0.9.7",
       "task": "fix-react-reacttooltip-react-tooltip-1205",
       "patchSha256": "cbc42e621c17fb9fbff067f96333c6cc47b14b379a2e336197d0d75add9bf417",
       "rule": "effect-needs-cleanup",
@@ -1793,6 +1899,7 @@
     },
     {
       "suffix": "UrywCLy",
+      "auditVersion": "0.9.7",
       "task": "write-react-pedropalau-react-bnb-gallery-185",
       "patchSha256": "015d99597a90703b3c590200dddd0e7bc4b7a0f6d8b37fd07cc17c59a8971df2",
       "rule": "effect-needs-cleanup",
@@ -1805,6 +1912,7 @@
     },
     {
       "suffix": "uWdHdPi",
+      "auditVersion": "0.9.7",
       "task": "write-react-azouaoui-med-react-pro-sidebar-267",
       "patchSha256": "bc41f2a4a44c9f98dccba033f0ebf2d555b8b802b88347850192a6b3deaff712",
       "rule": "effect-needs-cleanup",
@@ -1817,6 +1925,7 @@
     },
     {
       "suffix": "VGJPmx2",
+      "auditVersion": "0.9.7",
       "task": "write-react-frankchen021-datastoria-199",
       "patchSha256": "aca46e43abdf46ad8ce44ea5385c03ec22e69f5524b89bed5d6a9d887b5b84d6",
       "rule": "dangerous-html-sink",
@@ -1829,6 +1938,7 @@
     },
     {
       "suffix": "vGnjrGU",
+      "auditVersion": "0.9.7",
       "task": "write-react-pedropalau-react-bnb-gallery-185",
       "patchSha256": "6c1cf630eff15a3259ddff16a61b45010b5f3631a58646c32be329def5bfd01e",
       "rule": "effect-needs-cleanup",
@@ -1841,6 +1951,7 @@
     },
     {
       "suffix": "vvZxJVi",
+      "auditVersion": "0.9.7",
       "task": "fix-react-reacttooltip-react-tooltip-1205",
       "patchSha256": "3597f86327172ed067f5f6adbef55bed663a266f120fdca7ee5e09ef4cbeba21",
       "rule": "effect-needs-cleanup",
@@ -1853,6 +1964,7 @@
     },
     {
       "suffix": "vzVGFfV",
+      "auditVersion": "0.9.7",
       "task": "fix-react-rdh-appflowy-io-appflowy-web-documenthistorymodal",
       "patchSha256": "a8c3171df27f0062f628b91e322e418fed424f7809f31f208aa47ee7c10400f5",
       "rule": "effect-needs-cleanup",
@@ -1865,6 +1977,7 @@
     },
     {
       "suffix": "wArJTKh",
+      "auditVersion": "0.9.7",
       "task": "fix-react-reacttooltip-react-tooltip-1205",
       "patchSha256": "aab2db9fd5e0ee63bc5dcee4dd6f7c77411ed458db3037d20df4c3548ed9cf63",
       "rule": "effect-needs-cleanup",
@@ -1877,6 +1990,7 @@
     },
     {
       "suffix": "wbjdCnA",
+      "auditVersion": "0.9.7",
       "task": "fix-react-rdh-sofn-xyz-mailing-settings",
       "patchSha256": "7d3fb572a30cab4e64843dca534f8c60eb72902af1451fcb7daa30d707310915",
       "rule": "no-fetch-response-used-without-status-check",
@@ -1889,6 +2003,7 @@
     },
     {
       "suffix": "wDv3fd7",
+      "auditVersion": "0.9.7",
       "task": "write-react-tombelieber-claude-view-70",
       "patchSha256": "64986c53093cae322b521af4282cbc795e7dae9ff7602d5b4b9da2d29a2ba799",
       "rule": "no-loading-flag-reset-outside-finally",
@@ -1901,6 +2016,7 @@
     },
     {
       "suffix": "wDv3fd7",
+      "auditVersion": "0.9.7",
       "task": "write-react-tombelieber-claude-view-70",
       "patchSha256": "64986c53093cae322b521af4282cbc795e7dae9ff7602d5b4b9da2d29a2ba799",
       "rule": "no-unowned-async-error-clear",
@@ -1913,6 +2029,7 @@
     },
     {
       "suffix": "wNxChFj",
+      "auditVersion": "0.9.7",
       "task": "write-react-pedropalau-react-bnb-gallery-185",
       "patchSha256": "c57e5bad622d9e5e3c5d8d0da37f7bc926dfb6a693a4077e6e077915a01cd8cb",
       "rule": "effect-needs-cleanup",
@@ -1925,6 +2042,7 @@
     },
     {
       "suffix": "x7VUyKi",
+      "auditVersion": "0.9.7",
       "task": "write-react-tracecathq-tracecat-2879",
       "patchSha256": "1a78dd843384fd36d5339f6ffa1296fdb4ff44fb4f81fa50acfe17e634f52854",
       "rule": "no-loading-flag-reset-outside-finally",
@@ -1937,6 +2055,7 @@
     },
     {
       "suffix": "Xye9UXr",
+      "auditVersion": "0.9.7",
       "task": "fix-react-rdh-appflowy-io-appflowy-web-documenthistorymodal",
       "patchSha256": "d8f2330e71d383f3ff558152442e8f9102eb0a6a38441c73a97f160d0432829a",
       "rule": "effect-needs-cleanup",
@@ -1949,6 +2068,7 @@
     },
     {
       "suffix": "ydQnRk9",
+      "auditVersion": "0.9.7",
       "task": "fix-react-rdh-sofn-xyz-mailing-settings",
       "patchSha256": "eeb5e9ce0278b4f6e5ad15aae0badb1fb6bce3674188dfd13bbeb9b3c6dae63a",
       "rule": "no-fetch-response-used-without-status-check",
@@ -1961,6 +2081,7 @@
     },
     {
       "suffix": "YFKtagN",
+      "auditVersion": "0.9.7",
       "task": "fix-react-rdh-sofn-xyz-mailing-settings",
       "patchSha256": "dc085eb656bd57f7e798e4e2191e32af7e08373aead6b0b647493680334af511",
       "rule": "no-loading-flag-reset-outside-finally",
@@ -1973,6 +2094,7 @@
     },
     {
       "suffix": "yfTmUkt",
+      "auditVersion": "0.9.7",
       "task": "write-react-tombelieber-claude-view-70",
       "patchSha256": "6c60185fc5f0499dbb49243bb3cec0fec3f20c768298a5850d90100f520643a3",
       "rule": "no-loading-flag-reset-outside-finally",
@@ -1985,6 +2107,7 @@
     },
     {
       "suffix": "yGj7iPo",
+      "auditVersion": "0.9.7",
       "task": "write-react-tombelieber-claude-view-70",
       "patchSha256": "7d5aa3fae5442d4ba8dccde4e005667d4683fcfbc0fb27884a830c8abccdb823",
       "rule": "no-loading-flag-reset-outside-finally",
@@ -1997,6 +2120,7 @@
     },
     {
       "suffix": "yHA8h9X",
+      "auditVersion": "0.9.7",
       "task": "fix-react-rdh-sofn-xyz-mailing-settings",
       "patchSha256": "86c5f18ac8caad1a23a9057a796aefce3123e2652711be174bd481f6647d82ab",
       "rule": "no-fetch-response-used-without-status-check",
@@ -2009,6 +2133,7 @@
     },
     {
       "suffix": "z288GAh",
+      "auditVersion": "0.9.7",
       "task": "fix-react-rdh-sofn-xyz-mailing-settings",
       "patchSha256": "a89a6282bcd9e722c5b68cd1983888c40bf2d2f5196db66d87bc46386d2d4e8e",
       "rule": "no-fetch-response-used-without-status-check",
@@ -2021,6 +2146,7 @@
     },
     {
       "suffix": "zcWaWWS",
+      "auditVersion": "0.9.7",
       "task": "fix-react-rdh-sofn-xyz-mailing-settings",
       "patchSha256": "309e776b61d9d52520f03c4ccfe239cd58547e1e6615016853ff8f8b24cd051b",
       "rule": "no-fetch-response-used-without-status-check",
@@ -2033,6 +2159,7 @@
     },
     {
       "suffix": "ZFcupSH",
+      "auditVersion": "0.9.7",
       "task": "fix-react-rdh-sofn-xyz-mailing-settings",
       "patchSha256": "b49c1a1c2830e2b62b79dba2ad3e64e0e0f358c43eb898cef039b575f02eb1d4",
       "rule": "no-fetch-response-used-without-status-check",
@@ -2045,6 +2172,7 @@
     },
     {
       "suffix": "zozDEMR",
+      "auditVersion": "0.9.7",
       "task": "fix-react-rdh-appflowy-io-appflowy-web-documenthistorymodal",
       "patchSha256": "4fd2ae2fa864e6f9a463e485e0e7422c27a1bc0230f4970bfd3a2537b5f87888",
       "rule": "effect-needs-cleanup",
@@ -2057,6 +2185,7 @@
     },
     {
       "suffix": "zY62bGN",
+      "auditVersion": "0.9.7",
       "task": "write-react-pedropalau-react-bnb-gallery-185",
       "patchSha256": "9a03c994a034ebcb32ee460d8f6733b0cd48ebf9f7b7202f76140a0fa1dd6acc",
       "rule": "effect-needs-cleanup",

--- a/packages/fuzz/corpus/react-bench-0.9.7-audit/regressions/2aaefa9502f4--tooltip.tsx
+++ b/packages/fuzz/corpus/react-bench-0.9.7-audit/regressions/2aaefa9502f4--tooltip.tsx
@@ -1,0 +1,1054 @@
+// rule: effect-needs-cleanup
+// audit-verdict: pass
+// weakness: react-bench-exact-callsite
+// source: React Bench 0.9.8 exhaustive audit 2aaefa9502f425fb162e83305c71a54a70888fcd45860bd2ae1cd5f1eb7fe924
+import React, { useEffect, useState, useRef, useCallback, useImperativeHandle } from 'react'
+import { autoUpdate } from '@floating-ui/dom'
+import classNames from 'classnames'
+import {
+  debounce,
+  deepEqual,
+  useIsomorphicLayoutEffect,
+  getScrollParent,
+  computeTooltipPosition,
+  cssTimeToMs,
+} from 'utils'
+import type { IComputedPosition } from 'utils'
+import { useTooltip } from 'components/TooltipProvider'
+import coreStyles from './core-styles.module.css'
+import styles from './styles.module.css'
+import type {
+  AnchorCloseEvents,
+  AnchorOpenEvents,
+  GlobalCloseEvents,
+  IPosition,
+  ITooltip,
+  TooltipImperativeOpenOptions,
+} from './TooltipTypes'
+
+const Tooltip = ({
+  // props
+  forwardRef,
+  id,
+  className,
+  classNameArrow,
+  variant = 'dark',
+  anchorId,
+  anchorSelect,
+  place = 'top',
+  offset = 10,
+  events = ['hover'],
+  openOnClick = false,
+  positionStrategy = 'absolute',
+  middlewares,
+  wrapper: WrapperElement,
+  delayShow = 0,
+  delayHide = 0,
+  float = false,
+  hidden = false,
+  noArrow = false,
+  clickable = false,
+  closeOnEsc = false,
+  closeOnScroll = false,
+  closeOnResize = false,
+  openEvents,
+  closeEvents,
+  globalCloseEvents,
+  imperativeModeOnly,
+  style: externalStyles,
+  position,
+  afterShow,
+  afterHide,
+  // props handled by controller
+  content,
+  contentWrapperRef,
+  isOpen,
+  defaultIsOpen = false,
+  setIsOpen,
+  activeAnchor,
+  setActiveAnchor,
+  border,
+  opacity,
+  arrowColor,
+  role = 'tooltip',
+}: ITooltip) => {
+  const tooltipRef = useRef<HTMLElement>(null)
+  const tooltipArrowRef = useRef<HTMLElement>(null)
+  const tooltipShowDelayTimerRef = useRef<NodeJS.Timeout | null>(null)
+  const tooltipHideDelayTimerRef = useRef<NodeJS.Timeout | null>(null)
+  const missedTransitionTimerRef = useRef<NodeJS.Timeout | null>(null)
+  const tooltipShowDelayStartRef = useRef<number | null>(null)
+  const tooltipShowDelayAnchorRef = useRef<HTMLElement | null>(null)
+  const tooltipShowDelayTracksPropRef = useRef(false)
+  const tooltipInteractionAnchorRef = useRef<HTMLElement | null>(null)
+  const tooltipInteractionPointerRef = useRef(false)
+  const tooltipInteractionFocusRef = useRef(false)
+  const tooltipShowRequestRef = useRef(0)
+  const [computedPosition, setComputedPosition] = useState<IComputedPosition>({
+    tooltipStyles: {},
+    tooltipArrowStyles: {},
+    place,
+  })
+  const [show, setShow] = useState(false)
+  const [rendered, setRendered] = useState(false)
+  const [imperativeOptions, setImperativeOptions] = useState<TooltipImperativeOpenOptions | null>(
+    null,
+  )
+  const wasShowing = useRef(false)
+  const lastFloatPosition = useRef<IPosition | null>(null)
+  /**
+   * @todo Remove this in a future version (provider/wrapper method is deprecated)
+   */
+  const { anchorRefs, setActiveAnchor: setProviderActiveAnchor } = useTooltip(id)
+  const hoveringTooltip = useRef(false)
+  const [anchorsBySelect, setAnchorsBySelect] = useState<HTMLElement[]>([])
+  const mounted = useRef(false)
+
+  /**
+   * @todo Update when deprecated stuff gets removed.
+   */
+  const shouldOpenOnClick = openOnClick || events.includes('click')
+  const hasClickEvent =
+    shouldOpenOnClick || openEvents?.click || openEvents?.dblclick || openEvents?.mousedown
+  const actualOpenEvents: AnchorOpenEvents = openEvents
+    ? { ...openEvents }
+    : {
+        mouseover: true,
+        focus: true,
+        mouseenter: false,
+        click: false,
+        dblclick: false,
+        mousedown: false,
+      }
+  if (!openEvents && shouldOpenOnClick) {
+    Object.assign(actualOpenEvents, {
+      mouseenter: false,
+      focus: false,
+      mouseover: false,
+      click: true,
+    })
+  }
+  const actualCloseEvents: AnchorCloseEvents = closeEvents
+    ? { ...closeEvents }
+    : {
+        mouseout: true,
+        blur: true,
+        mouseleave: false,
+        click: false,
+        dblclick: false,
+        mouseup: false,
+      }
+  if (!closeEvents && shouldOpenOnClick) {
+    Object.assign(actualCloseEvents, {
+      mouseleave: false,
+      blur: false,
+      mouseout: false,
+    })
+  }
+  const actualGlobalCloseEvents: GlobalCloseEvents = globalCloseEvents
+    ? { ...globalCloseEvents }
+    : {
+        escape: closeOnEsc || false,
+        scroll: closeOnScroll || false,
+        resize: closeOnResize || false,
+        clickOutsideAnchor: hasClickEvent || false,
+      }
+
+  if (imperativeModeOnly) {
+    Object.assign(actualOpenEvents, {
+      mouseenter: false,
+      focus: false,
+      click: false,
+      dblclick: false,
+      mousedown: false,
+    })
+    Object.assign(actualCloseEvents, {
+      mouseleave: false,
+      blur: false,
+      click: false,
+      dblclick: false,
+      mouseup: false,
+    })
+    Object.assign(actualGlobalCloseEvents, {
+      escape: false,
+      scroll: false,
+      resize: false,
+      clickOutsideAnchor: false,
+    })
+  }
+
+  /**
+   * useLayoutEffect runs before useEffect,
+   * but should be used carefully because of caveats
+   * https://beta.reactjs.org/reference/react/useLayoutEffect#caveats
+   */
+  useIsomorphicLayoutEffect(() => {
+    mounted.current = true
+    return () => {
+      mounted.current = false
+    }
+  }, [])
+
+  const clearTooltipInteraction = () => {
+    tooltipInteractionAnchorRef.current = null
+    tooltipInteractionPointerRef.current = false
+    tooltipInteractionFocusRef.current = false
+  }
+
+  const clearTooltipShowDelay = (clearInteraction = true) => {
+    if (tooltipShowDelayTimerRef.current) {
+      clearTimeout(tooltipShowDelayTimerRef.current)
+    }
+    tooltipShowDelayTimerRef.current = null
+    tooltipShowDelayStartRef.current = null
+    tooltipShowDelayAnchorRef.current = null
+    tooltipShowDelayTracksPropRef.current = false
+    if (clearInteraction) {
+      clearTooltipInteraction()
+    }
+  }
+
+  const updateTooltipInteraction = (event: Event, isActive: boolean) => {
+    const target = (event.currentTarget ?? event.target) as HTMLElement | null
+    if (!target) {
+      return null
+    }
+    if (isActive && tooltipInteractionAnchorRef.current !== target) {
+      clearTooltipShowDelay()
+      tooltipInteractionAnchorRef.current = target
+    }
+    if (tooltipInteractionAnchorRef.current !== target) {
+      return target
+    }
+    if (event.type === 'focus' || event.type === 'focusin' || event.type === 'blur') {
+      tooltipInteractionFocusRef.current = isActive
+    } else {
+      tooltipInteractionPointerRef.current = isActive
+    }
+    return target
+  }
+
+  const handleShow = (value: boolean) => {
+    if (!mounted.current) {
+      return
+    }
+    const showRequest = tooltipShowRequestRef.current + 1
+    tooltipShowRequestRef.current = showRequest
+    if (!value) {
+      clearTooltipShowDelay()
+    }
+    if (value) {
+      setRendered(true)
+    }
+    /**
+     * wait for the component to render and calculate position
+     * before actually showing
+     */
+    setTimeout(() => {
+      if (!mounted.current || tooltipShowRequestRef.current !== showRequest) {
+        return
+      }
+      setIsOpen?.(value)
+      if (isOpen === undefined) {
+        setShow(value)
+      }
+    }, 10)
+  }
+
+  /**
+   * this replicates the effect from `handleShow()`
+   * when `isOpen` is changed from outside
+   */
+  useEffect(() => {
+    if (isOpen === undefined) {
+      return () => null
+    }
+    clearTooltipShowDelay()
+    const showRequest = tooltipShowRequestRef.current + 1
+    tooltipShowRequestRef.current = showRequest
+    if (isOpen) {
+      setRendered(true)
+    }
+    const timeout = setTimeout(() => {
+      if (mounted.current && tooltipShowRequestRef.current === showRequest) {
+        setShow(isOpen)
+      }
+    }, 10)
+    return () => {
+      clearTimeout(timeout)
+    }
+  }, [isOpen])
+
+  useEffect(() => {
+    if (show === wasShowing.current) {
+      return
+    }
+    if (missedTransitionTimerRef.current) {
+      clearTimeout(missedTransitionTimerRef.current)
+    }
+    wasShowing.current = show
+    if (show) {
+      afterShow?.()
+    } else {
+      /**
+       * see `onTransitionEnd` on tooltip wrapper
+       */
+      const style = getComputedStyle(document.body)
+      const transitionShowDelay = cssTimeToMs(style.getPropertyValue('--rt-transition-show-delay'))
+      missedTransitionTimerRef.current = setTimeout(() => {
+        /**
+         * if the tooltip switches from `show === true` to `show === false` too fast
+         * the transition never runs, so `onTransitionEnd` callback never gets fired
+         */
+        setRendered(false)
+        setImperativeOptions(null)
+        afterHide?.()
+        // +25ms just to make sure `onTransitionEnd` (if it gets fired) has time to run
+      }, transitionShowDelay + 25)
+    }
+  }, [show])
+
+  const handleComputedPosition = (newComputedPosition: IComputedPosition) => {
+    setComputedPosition((oldComputedPosition) =>
+      deepEqual(oldComputedPosition, newComputedPosition)
+        ? oldComputedPosition
+        : newComputedPosition,
+    )
+  }
+
+  const handleShowTooltipDelayed = (
+    delay = delayShow,
+    anchor: HTMLElement | null = null,
+    preserveElapsed = false,
+    tracksDelayShow = true,
+  ) => {
+    if (tooltipShowDelayTimerRef.current) {
+      clearTimeout(tooltipShowDelayTimerRef.current)
+    }
+
+    const canPreserveElapsed = preserveElapsed && tooltipShowDelayStartRef.current !== null
+    const interactionStart = canPreserveElapsed
+      ? tooltipShowDelayStartRef.current
+      : Date.now()
+    const elapsed = Date.now() - interactionStart
+    const remainingDelay = Math.max(delay - elapsed, 0)
+
+    tooltipShowDelayStartRef.current = interactionStart
+    tooltipShowDelayAnchorRef.current = anchor
+    tooltipShowDelayTracksPropRef.current = tracksDelayShow
+
+    if (rendered) {
+      clearTooltipShowDelay(false)
+      handleShow(true)
+      return
+    }
+
+    tooltipShowDelayTimerRef.current = setTimeout(() => {
+      tooltipShowDelayTimerRef.current = null
+      tooltipShowDelayStartRef.current = null
+      tooltipShowDelayAnchorRef.current = null
+      tooltipShowDelayTracksPropRef.current = false
+      handleShow(true)
+    }, remainingDelay)
+  }
+
+  const handleHideTooltipDelayed = (delay = delayHide) => {
+    if (tooltipHideDelayTimerRef.current) {
+      clearTimeout(tooltipHideDelayTimerRef.current)
+    }
+
+    tooltipHideDelayTimerRef.current = setTimeout(() => {
+      if (hoveringTooltip.current) {
+        return
+      }
+      handleShow(false)
+    }, delay)
+  }
+
+  const handleShowTooltip = (event?: Event) => {
+    if (!event) {
+      return
+    }
+    const isImperativeShowPending = Boolean(
+      tooltipShowDelayTimerRef.current &&
+        !tooltipShowDelayTracksPropRef.current &&
+        tooltipShowDelayAnchorRef.current === null,
+    )
+    if (isImperativeShowPending) {
+      return
+    }
+    const target = updateTooltipInteraction(event, true)
+    if (!target?.isConnected) {
+      clearTooltipShowDelay()
+      setActiveAnchor(null)
+      setProviderActiveAnchor({ current: null })
+      return
+    }
+    if (delayShow) {
+      const isCurrentInteractionPending =
+        tooltipShowDelayTimerRef.current &&
+        tooltipShowDelayAnchorRef.current === target &&
+        tooltipShowDelayStartRef.current !== null
+      if (!isCurrentInteractionPending) {
+        handleShowTooltipDelayed(delayShow, target)
+      }
+    } else {
+      clearTooltipShowDelay(false)
+      handleShow(true)
+    }
+    setActiveAnchor(target)
+    setProviderActiveAnchor({ current: target })
+
+    if (tooltipHideDelayTimerRef.current) {
+      clearTimeout(tooltipHideDelayTimerRef.current)
+      tooltipHideDelayTimerRef.current = null
+    }
+  }
+
+  const handleHideTooltip = (event?: Event) => {
+    const isImperativeShowPending = Boolean(
+      tooltipShowDelayTimerRef.current &&
+        !tooltipShowDelayTracksPropRef.current &&
+        tooltipShowDelayAnchorRef.current === null,
+    )
+    if (event) {
+      const target = (event.currentTarget ?? event.target) as HTMLElement | null
+      if (tooltipInteractionAnchorRef.current && tooltipInteractionAnchorRef.current !== target) {
+        return
+      }
+      updateTooltipInteraction(event, false)
+      if (tooltipInteractionPointerRef.current || tooltipInteractionFocusRef.current) {
+        return
+      }
+      if (isImperativeShowPending) {
+        clearTooltipInteraction()
+        return
+      }
+    }
+    clearTooltipShowDelay()
+    if (clickable) {
+      // allow time for the mouse to reach the tooltip, in case there's a gap
+      handleHideTooltipDelayed(delayHide || 100)
+    } else if (delayHide) {
+      handleHideTooltipDelayed()
+    } else {
+      handleShow(false)
+    }
+  }
+
+  const handleTooltipPosition = ({ x, y }: IPosition) => {
+    const virtualElement = {
+      getBoundingClientRect() {
+        return {
+          x,
+          y,
+          width: 0,
+          height: 0,
+          top: y,
+          left: x,
+          right: x,
+          bottom: y,
+        }
+      },
+    } as Element
+    computeTooltipPosition({
+      place: imperativeOptions?.place ?? place,
+      offset,
+      elementReference: virtualElement,
+      tooltipReference: tooltipRef.current,
+      tooltipArrowReference: tooltipArrowRef.current,
+      strategy: positionStrategy,
+      middlewares,
+      border,
+    }).then((computedStylesData) => {
+      handleComputedPosition(computedStylesData)
+    })
+  }
+
+  const handlePointerMove = (event?: Event) => {
+    if (!event) {
+      return
+    }
+    const mouseEvent = event as MouseEvent
+    const mousePosition = {
+      x: mouseEvent.clientX,
+      y: mouseEvent.clientY,
+    }
+    handleTooltipPosition(mousePosition)
+    lastFloatPosition.current = mousePosition
+  }
+
+  const handleClickOutsideAnchors = (event: MouseEvent) => {
+    if (!show && !tooltipShowDelayTimerRef.current) {
+      return
+    }
+    const target = event.target as HTMLElement
+    if (!target.isConnected) {
+      return
+    }
+    if (tooltipRef.current?.contains(target)) {
+      return
+    }
+    const anchorById = document.querySelector<HTMLElement>(`[id='${anchorId}']`)
+    const anchors = [anchorById, ...anchorsBySelect]
+    if (anchors.some((anchor) => anchor?.contains(target))) {
+      return
+    }
+    handleShow(false)
+    if (tooltipShowDelayTimerRef.current) {
+      clearTimeout(tooltipShowDelayTimerRef.current)
+    }
+  }
+
+  // debounce handler to prevent call twice when
+  // mouse enter and focus events being triggered toggether
+  const internalDebouncedHandleShowTooltip = debounce(handleShowTooltip, 50, true)
+  const internalDebouncedHandleHideTooltip = debounce(handleHideTooltip, 50, true)
+  // If either of the functions is called while the other is still debounced,
+  // reset the timeout. Otherwise if there is a sub-50ms (leave A, enter B, leave B)
+  // sequence of events, the tooltip will stay open because the hide debounce
+  // from leave A prevented the leave B event from calling it, leaving the
+  // tooltip visible.
+  const debouncedHandleShowTooltip = (e?: Event) => {
+    internalDebouncedHandleHideTooltip.cancel()
+    internalDebouncedHandleShowTooltip(e)
+  }
+  const debouncedHandleHideTooltip = (event?: Event) => {
+    internalDebouncedHandleShowTooltip.cancel()
+    internalDebouncedHandleHideTooltip(event)
+  }
+
+  const updateTooltipPosition = useCallback(() => {
+    const actualPosition = imperativeOptions?.position ?? position
+    if (actualPosition) {
+      // if `position` is set, override regular and `float` positioning
+      handleTooltipPosition(actualPosition)
+      return
+    }
+
+    if (float) {
+      if (lastFloatPosition.current) {
+        /*
+          Without this, changes to `content`, `place`, `offset`, ..., will only
+          trigger a position calculation after a `mousemove` event.
+
+          To see why this matters, comment this line, run `yarn dev` and click the
+          "Hover me!" anchor.
+        */
+        handleTooltipPosition(lastFloatPosition.current)
+      }
+      // if `float` is set, override regular positioning
+      return
+    }
+
+    if (!activeAnchor?.isConnected) {
+      return
+    }
+
+    computeTooltipPosition({
+      place: imperativeOptions?.place ?? place,
+      offset,
+      elementReference: activeAnchor,
+      tooltipReference: tooltipRef.current,
+      tooltipArrowReference: tooltipArrowRef.current,
+      strategy: positionStrategy,
+      middlewares,
+      border,
+    }).then((computedStylesData) => {
+      if (!mounted.current) {
+        // invalidate computed positions after remount
+        return
+      }
+      handleComputedPosition(computedStylesData)
+    })
+  }, [
+    show,
+    activeAnchor,
+    content,
+    externalStyles,
+    place,
+    imperativeOptions?.place,
+    offset,
+    positionStrategy,
+    position,
+    imperativeOptions?.position,
+    float,
+  ])
+
+  useEffect(() => {
+    const elementRefs = new Set(anchorRefs)
+
+    anchorsBySelect.forEach((anchor) => {
+      elementRefs.add({ current: anchor })
+    })
+
+    const anchorById = document.querySelector<HTMLElement>(`[id='${anchorId}']`)
+    if (anchorById) {
+      elementRefs.add({ current: anchorById })
+    }
+
+    const handleScrollResize = () => {
+      handleShow(false)
+    }
+
+    const anchorScrollParent = getScrollParent(activeAnchor)
+    const tooltipScrollParent = getScrollParent(tooltipRef.current)
+
+    if (actualGlobalCloseEvents.scroll) {
+      window.addEventListener('scroll', handleScrollResize)
+      anchorScrollParent?.addEventListener('scroll', handleScrollResize)
+      tooltipScrollParent?.addEventListener('scroll', handleScrollResize)
+    }
+    let updateTooltipCleanup: null | (() => void) = null
+    if (actualGlobalCloseEvents.resize) {
+      window.addEventListener('resize', handleScrollResize)
+    } else if (activeAnchor && tooltipRef.current) {
+      updateTooltipCleanup = autoUpdate(
+        activeAnchor as HTMLElement,
+        tooltipRef.current as HTMLElement,
+        updateTooltipPosition,
+        {
+          ancestorResize: true,
+          elementResize: true,
+          layoutShift: true,
+        },
+      )
+    }
+
+    const handleEsc = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') {
+        return
+      }
+      handleShow(false)
+    }
+    if (actualGlobalCloseEvents.escape) {
+      window.addEventListener('keydown', handleEsc)
+    }
+
+    if (actualGlobalCloseEvents.clickOutsideAnchor) {
+      window.addEventListener('click', handleClickOutsideAnchors)
+    }
+
+    const enabledEvents: { event: string; listener: (event?: Event) => void }[] = []
+
+    let lastOpenEvent: Event | undefined
+    const handleClickOpenTooltipAnchor = (event?: Event) => {
+      const target = (event?.currentTarget ?? event?.target) as HTMLElement | null
+      if (wasShowing.current && target === activeAnchor) {
+        /**
+         * ignore clicking the anchor that was used to open the tooltip.
+         * this avoids conflict with the click close event.
+         */
+        return
+      }
+      lastOpenEvent = event
+      handleShowTooltip(event)
+    }
+    const handleClickCloseTooltipAnchor = (event?: Event) => {
+      if (event === lastOpenEvent) {
+        return
+      }
+      const target = (event?.currentTarget ?? event?.target) as HTMLElement | null
+      if (!wasShowing.current || target !== activeAnchor) {
+        /**
+         * ignore clicking the anchor that was NOT used to open the tooltip.
+         * this avoids closing the tooltip when clicking on a
+         * new anchor with the tooltip already open.
+         */
+        return
+      }
+      handleHideTooltip(event)
+    }
+
+    const regularEvents = ['mouseover', 'mouseout', 'mouseenter', 'mouseleave', 'focus', 'blur']
+    const clickEvents = ['click', 'dblclick', 'mousedown', 'mouseup']
+
+    Object.entries(actualOpenEvents).forEach(([event, enabled]) => {
+      if (!enabled) {
+        return
+      }
+      if (regularEvents.includes(event)) {
+        enabledEvents.push({ event, listener: debouncedHandleShowTooltip })
+      } else if (clickEvents.includes(event)) {
+        enabledEvents.push({ event, listener: handleClickOpenTooltipAnchor })
+      } else {
+        // never happens
+      }
+    })
+
+    Object.entries(actualCloseEvents).forEach(([event, enabled]) => {
+      if (!enabled) {
+        return
+      }
+      if (regularEvents.includes(event)) {
+        enabledEvents.push({ event, listener: debouncedHandleHideTooltip })
+      } else if (clickEvents.includes(event)) {
+        enabledEvents.push({ event, listener: handleClickCloseTooltipAnchor })
+      } else {
+        // never happens
+      }
+    })
+
+    if (float) {
+      enabledEvents.push({
+        event: 'pointermove',
+        listener: handlePointerMove,
+      })
+    }
+
+    const handleMouseEnterTooltip = () => {
+      hoveringTooltip.current = true
+    }
+    const handleMouseLeaveTooltip = () => {
+      hoveringTooltip.current = false
+      handleHideTooltip()
+    }
+
+    if (clickable && !hasClickEvent) {
+      // used to keep the tooltip open when hovering content.
+      // not needed if using click events.
+      tooltipRef.current?.addEventListener('mouseenter', handleMouseEnterTooltip)
+      tooltipRef.current?.addEventListener('mouseleave', handleMouseLeaveTooltip)
+    }
+
+    enabledEvents.forEach(({ event, listener }) => {
+      elementRefs.forEach((ref) => {
+        ref.current?.addEventListener(event, listener)
+      })
+    })
+
+    return () => {
+      if (actualGlobalCloseEvents.scroll) {
+        window.removeEventListener('scroll', handleScrollResize)
+        anchorScrollParent?.removeEventListener('scroll', handleScrollResize)
+        tooltipScrollParent?.removeEventListener('scroll', handleScrollResize)
+      }
+      if (actualGlobalCloseEvents.resize) {
+        window.removeEventListener('resize', handleScrollResize)
+      } else {
+        updateTooltipCleanup?.()
+      }
+      if (actualGlobalCloseEvents.clickOutsideAnchor) {
+        window.removeEventListener('click', handleClickOutsideAnchors)
+      }
+      if (actualGlobalCloseEvents.escape) {
+        window.removeEventListener('keydown', handleEsc)
+      }
+      if (clickable && !hasClickEvent) {
+        tooltipRef.current?.removeEventListener('mouseenter', handleMouseEnterTooltip)
+        tooltipRef.current?.removeEventListener('mouseleave', handleMouseLeaveTooltip)
+      }
+      enabledEvents.forEach(({ event, listener }) => {
+        elementRefs.forEach((ref) => {
+          ref.current?.removeEventListener(event, listener)
+        })
+      })
+    }
+    /**
+     * rendered is also a dependency to ensure anchor observers are re-registered
+     * since `tooltipRef` becomes stale after removing/adding the tooltip to the DOM
+     */
+  }, [
+    activeAnchor,
+    updateTooltipPosition,
+    rendered,
+    anchorRefs,
+    anchorsBySelect,
+    // the effect uses the `actual*Events` objects, but this should work
+    openEvents,
+    closeEvents,
+    globalCloseEvents,
+    shouldOpenOnClick,
+    delayShow,
+    delayHide,
+  ])
+
+  useEffect(() => {
+    let selector = imperativeOptions?.anchorSelect ?? anchorSelect ?? ''
+    if (!selector && id) {
+      selector = `[data-tooltip-id='${id.replace(/'/g, "\\'")}']`
+    }
+    const documentObserverCallback: MutationCallback = (mutationList) => {
+      const newAnchors: HTMLElement[] = []
+      const removedAnchors: HTMLElement[] = []
+      mutationList.forEach((mutation) => {
+        if (mutation.type === 'attributes' && mutation.attributeName === 'data-tooltip-id') {
+          const newId = (mutation.target as HTMLElement).getAttribute('data-tooltip-id')
+          if (newId === id) {
+            newAnchors.push(mutation.target as HTMLElement)
+          } else if (mutation.oldValue === id) {
+            // data-tooltip-id has now been changed, so we need to remove this anchor
+            removedAnchors.push(mutation.target as HTMLElement)
+          }
+        }
+        if (mutation.type !== 'childList') {
+          return
+        }
+        if (activeAnchor) {
+          const elements = [...mutation.removedNodes].filter((node) => node.nodeType === 1)
+          if (selector) {
+            try {
+              removedAnchors.push(
+                // the element itself is an anchor
+                ...(elements.filter((element) =>
+                  (element as HTMLElement).matches(selector),
+                ) as HTMLElement[]),
+              )
+              removedAnchors.push(
+                // the element has children which are anchors
+                ...elements.flatMap(
+                  (element) =>
+                    [...(element as HTMLElement).querySelectorAll(selector)] as HTMLElement[],
+                ),
+              )
+            } catch {
+              /**
+               * invalid CSS selector.
+               * already warned on tooltip controller
+               */
+            }
+          }
+          elements.some((node) => {
+            if (node?.contains?.(activeAnchor)) {
+              setRendered(false)
+              handleShow(false)
+              setActiveAnchor(null)
+              if (tooltipShowDelayTimerRef.current) {
+                clearTimeout(tooltipShowDelayTimerRef.current)
+              }
+              if (tooltipHideDelayTimerRef.current) {
+                clearTimeout(tooltipHideDelayTimerRef.current)
+              }
+              return true
+            }
+            return false
+          })
+        }
+        if (!selector) {
+          return
+        }
+        try {
+          const elements = [...mutation.addedNodes].filter((node) => node.nodeType === 1)
+          newAnchors.push(
+            // the element itself is an anchor
+            ...(elements.filter((element) =>
+              (element as HTMLElement).matches(selector),
+            ) as HTMLElement[]),
+          )
+          newAnchors.push(
+            // the element has children which are anchors
+            ...elements.flatMap(
+              (element) =>
+                [...(element as HTMLElement).querySelectorAll(selector)] as HTMLElement[],
+            ),
+          )
+        } catch {
+          /**
+           * invalid CSS selector.
+           * already warned on tooltip controller
+           */
+        }
+      })
+      if (newAnchors.length || removedAnchors.length) {
+        setAnchorsBySelect((anchors) => [
+          ...anchors.filter((anchor) => !removedAnchors.includes(anchor)),
+          ...newAnchors,
+        ])
+      }
+    }
+    const documentObserver = new MutationObserver(documentObserverCallback)
+    // watch for anchor being removed from the DOM
+    documentObserver.observe(document.body, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['data-tooltip-id'],
+      // to track the prev value if we need to remove anchor when data-tooltip-id gets changed
+      attributeOldValue: true,
+    })
+    return () => {
+      documentObserver.disconnect()
+    }
+  }, [id, anchorSelect, imperativeOptions?.anchorSelect, activeAnchor])
+
+  useEffect(() => {
+    updateTooltipPosition()
+  }, [updateTooltipPosition])
+
+  useEffect(() => {
+    if (!contentWrapperRef?.current) {
+      return () => null
+    }
+    const contentObserver = new ResizeObserver(() => {
+      setTimeout(() => updateTooltipPosition())
+    })
+    contentObserver.observe(contentWrapperRef.current)
+    return () => {
+      contentObserver.disconnect()
+    }
+  }, [content, contentWrapperRef?.current])
+
+  useEffect(() => {
+    const anchorById = document.querySelector<HTMLElement>(`[id='${anchorId}']`)
+    const anchors = [...anchorsBySelect, anchorById]
+    if (!activeAnchor || !anchors.includes(activeAnchor)) {
+      /**
+       * if there is no active anchor,
+       * or if the current active anchor is not amongst the allowed ones,
+       * reset it
+       */
+      setActiveAnchor(anchorsBySelect[0] ?? anchorById)
+    }
+  }, [anchorId, anchorsBySelect, activeAnchor])
+
+  useEffect(() => {
+    if (defaultIsOpen) {
+      handleShow(true)
+    }
+    return () => {
+      clearTooltipShowDelay()
+      if (tooltipHideDelayTimerRef.current) {
+        clearTimeout(tooltipHideDelayTimerRef.current)
+        tooltipHideDelayTimerRef.current = null
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    let selector = imperativeOptions?.anchorSelect ?? anchorSelect
+    if (!selector && id) {
+      selector = `[data-tooltip-id='${id.replace(/'/g, "\\'")}']`
+    }
+    if (!selector) {
+      return
+    }
+    try {
+      const anchors = Array.from(document.querySelectorAll<HTMLElement>(selector))
+      setAnchorsBySelect(anchors)
+    } catch {
+      // warning was already issued in the controller
+      setAnchorsBySelect([])
+    }
+  }, [id, anchorSelect, imperativeOptions?.anchorSelect])
+
+  useEffect(() => {
+    if (
+      tooltipShowDelayTimerRef.current &&
+      tooltipShowDelayTracksPropRef.current
+    ) {
+      handleShowTooltipDelayed(
+        delayShow,
+        tooltipShowDelayAnchorRef.current,
+        true,
+      )
+    }
+  }, [delayShow])
+
+  const actualContent = imperativeOptions?.content ?? content
+  const canShow = show && Object.keys(computedPosition.tooltipStyles).length > 0
+
+  useImperativeHandle(forwardRef, () => ({
+    open: (options) => {
+      if (options?.anchorSelect) {
+        try {
+          document.querySelector(options.anchorSelect)
+        } catch {
+          if (!process.env.NODE_ENV || process.env.NODE_ENV !== 'production') {
+            // eslint-disable-next-line no-console
+            console.warn(`[react-tooltip] "${options.anchorSelect}" is not a valid CSS selector`)
+          }
+          return
+        }
+      }
+      clearTooltipShowDelay()
+      if (tooltipHideDelayTimerRef.current) {
+        clearTimeout(tooltipHideDelayTimerRef.current)
+        tooltipHideDelayTimerRef.current = null
+      }
+      if (options?.delay) {
+        tooltipShowDelayStartRef.current = Date.now()
+        tooltipShowDelayAnchorRef.current = null
+        tooltipShowDelayTracksPropRef.current = false
+        tooltipShowDelayTimerRef.current = setTimeout(() => {
+          tooltipShowDelayTimerRef.current = null
+          tooltipShowDelayStartRef.current = null
+          tooltipShowDelayAnchorRef.current = null
+          tooltipShowDelayTracksPropRef.current = false
+          setImperativeOptions(options)
+          handleShow(true)
+        }, options.delay)
+      } else {
+        setImperativeOptions(options ?? null)
+        handleShow(true)
+      }
+    },
+    close: (options) => {
+      clearTooltipShowDelay()
+      if (options?.delay) {
+        handleHideTooltipDelayed(options.delay)
+      } else {
+        setImperativeOptions(null)
+        handleShow(false)
+      }
+    },
+    activeAnchor,
+    place: computedPosition.place,
+    isOpen: Boolean(rendered && !hidden && actualContent && canShow),
+  }))
+
+  return rendered && !hidden && actualContent ? (
+    <WrapperElement
+      id={id}
+      role={role}
+      className={classNames(
+        'react-tooltip',
+        coreStyles['tooltip'],
+        styles['tooltip'],
+        styles[variant],
+        className,
+        `react-tooltip__place-${computedPosition.place}`,
+        coreStyles[canShow ? 'show' : 'closing'],
+        canShow ? 'react-tooltip__show' : 'react-tooltip__closing',
+        positionStrategy === 'fixed' && coreStyles['fixed'],
+        clickable && coreStyles['clickable'],
+      )}
+      onTransitionEnd={(event: TransitionEvent) => {
+        if (missedTransitionTimerRef.current) {
+          clearTimeout(missedTransitionTimerRef.current)
+        }
+        if (show || event.propertyName !== 'opacity') {
+          return
+        }
+        setRendered(false)
+        setImperativeOptions(null)
+        afterHide?.()
+      }}
+      style={{
+        ...externalStyles,
+        ...computedPosition.tooltipStyles,
+        opacity: opacity !== undefined && canShow ? opacity : undefined,
+      }}
+      ref={tooltipRef}
+    >
+      {actualContent}
+      <WrapperElement
+        className={classNames(
+          'react-tooltip-arrow',
+          coreStyles['arrow'],
+          styles['arrow'],
+          classNameArrow,
+          noArrow && coreStyles['noArrow'],
+        )}
+        style={{
+          ...computedPosition.tooltipArrowStyles,
+          background: arrowColor
+            ? `linear-gradient(to right bottom, transparent 50%, ${arrowColor} 50%)`
+            : undefined,
+        }}
+        ref={tooltipArrowRef}
+      />
+    </WrapperElement>
+  ) : null
+}
+
+export default Tooltip

--- a/packages/fuzz/scripts/import-react-bench-audit-corpus.mjs
+++ b/packages/fuzz/scripts/import-react-bench-audit-corpus.mjs
@@ -5,6 +5,7 @@ import * as path from "node:path";
 const HASH_PREFIX_LENGTH = 12;
 const COMPLETE_SOURCE_START_LINE = 1;
 const CORPUS_DIRECTORY_NAME = "react-bench-0.9.7-audit";
+const DEFAULT_AUDIT_VERSION = "0.9.7";
 const TRUE_POSITIVE_SUFFIXES = new Set(["SQSmbFe", "eGYGezE"]);
 
 const sha256 = (value) => crypto.createHash("sha256").update(value).digest("hex");
@@ -115,10 +116,12 @@ const main = () => {
       source,
       verdict,
       rules: new Set(),
+      auditVersions: new Set(),
       callsitePaths: [],
       callsites: [],
     };
     group.rules.add(callsite.rule);
+    group.auditVersions.add(callsite.auditVersion ?? DEFAULT_AUDIT_VERSION);
     group.callsitePaths.push(callsite.reconstructedFilePath || callsite.reportedFilePath);
     group.callsites.push(callsite);
     fixtureGroups.set(fixtureSourceSha256, group);
@@ -145,7 +148,7 @@ const main = () => {
       `// rule: ${rules.join(", ")}`,
       group.verdict === "fail" ? "// verdict: fail" : "// audit-verdict: pass",
       "// weakness: react-bench-exact-callsite",
-      `// source: React Bench 0.9.7 exhaustive audit ${fixtureSourceSha256}`,
+      `// source: React Bench ${[...group.auditVersions].sort().join("+")} exhaustive audit ${fixtureSourceSha256}`,
     ].join("\n");
     fs.mkdirSync(path.dirname(outputPath), { recursive: true });
     fs.writeFileSync(outputPath, `${header}\n${group.source}`);
@@ -177,6 +180,7 @@ const main = () => {
     ].join(":");
     return {
       suffix: callsite.suffix,
+      auditVersion: callsite.auditVersion ?? DEFAULT_AUDIT_VERSION,
       task: callsite.task,
       patchSha256: callsite.patchSha256,
       rule: callsite.rule,
@@ -189,7 +193,9 @@ const main = () => {
     };
   });
   const manifest = {
-    source: "React Bench 0.9.7 exhaustive all-diffs audit",
+    source: `React Bench ${[...new Set(manifestCallsites.map((callsite) => callsite.auditVersion))]
+      .sort()
+      .join("+")} exhaustive all-diffs audit`,
     expected: {
       totalCallsites: manifestCallsites.length,
       passCallsites: manifestCallsites.filter((callsite) => callsite.verdict === "pass").length,

--- a/packages/fuzz/tests/react-bench-0.9.7-audit-corpus.test.ts
+++ b/packages/fuzz/tests/react-bench-0.9.7-audit-corpus.test.ts
@@ -22,6 +22,7 @@ interface ReactBenchAuditFixture {
 
 interface ReactBenchAuditCallsite {
   suffix: string;
+  auditVersion: string;
   rule: string;
   filePath: string;
   reportedLine: number;
@@ -43,7 +44,7 @@ const manifest: ReactBenchAuditManifest = JSON.parse(fs.readFileSync(manifestPat
 const fixtureHeaderPattern = /^(?:\/\/[^\n]*\n){4}/;
 const sha256 = (value: string): string => crypto.createHash("sha256").update(value).digest("hex");
 
-describe("React Bench 0.9.7 exact audit corpus", () => {
+describe("React Bench exact audit corpus", () => {
   it("accounts for every audited callsite instance", () => {
     const passCallsites = manifest.callsites.filter((callsite) => callsite.verdict === "pass");
     const failCallsites = manifest.callsites.filter((callsite) => callsite.verdict === "fail");
@@ -54,6 +55,7 @@ describe("React Bench 0.9.7 exact audit corpus", () => {
     expect(failCallsites).toHaveLength(manifest.expected.failCallsites);
     expect(uniqueTrials.size).toBe(manifest.expected.uniqueTrials);
     expect(manifest.fixtures).toHaveLength(manifest.expected.uniqueFixtures);
+    expect(manifest.callsites.every((callsite) => callsite.auditVersion.length > 0)).toBe(true);
   });
 
   it("contains no duplicate callsite or source fixture", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup-reactbench-regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup-reactbench-regressions.test.ts
@@ -1177,6 +1177,54 @@ const Delayed = ({ delay, task }) => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("accepts a one-shot timer with a leading compound unmount guard", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect, useRef } from "react";
+      const C = ({ setIsOpen }) => {
+        const mounted = useRef(true);
+        const requestRef = useRef(0);
+        useEffect(() => () => { mounted.current = false; }, []);
+        const show = () => {
+          const request = requestRef.current + 1;
+          requestRef.current = request;
+          setTimeout(() => {
+            if (!mounted.current || requestRef.current !== request) return;
+            setIsOpen(true);
+          }, 10);
+        };
+        useEffect(() => { show(); }, [setIsOpen]);
+        return null;
+      };`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("keeps a compound guard that does not exit whenever unmounted", () => {
+    const result = runRule(
+      effectNeedsCleanup,
+      `import { useEffect, useRef } from "react";
+      const C = ({ setIsOpen }) => {
+        const mounted = useRef(true);
+        const requestRef = useRef(0);
+        useEffect(() => () => { mounted.current = false; }, []);
+        const show = () => {
+          const request = requestRef.current + 1;
+          requestRef.current = request;
+          setTimeout(() => {
+            if (!mounted.current && requestRef.current !== request) return;
+            setIsOpen(true);
+          }, 10);
+        };
+        useEffect(() => { show(); }, [setIsOpen]);
+        return null;
+      };`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
   it("keeps a mounted guard whose cleanup invalidation is conditional", () => {
     const result = runRule(
       effectNeedsCleanup,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -4935,7 +4935,10 @@ const oneShotTimerHasUnmountGuard = (usage: SubscribeLikeUsage, context: RuleCon
   const leadingStatement = timerCallback.body.body[0];
   if (!leadingStatement || !isNodeOfType(leadingStatement, "IfStatement")) return false;
   if (!isEarlyExitStatement(leadingStatement.consequent)) return false;
-  const test = stripParenExpression(leadingStatement.test);
+  let test = stripParenExpression(leadingStatement.test);
+  while (isNodeOfType(test, "LogicalExpression") && test.operator === "||") {
+    test = stripParenExpression(test.left);
+  }
   if (!isNodeOfType(test, "UnaryExpression") || test.operator !== "!") return false;
   const guardRefSymbol = resolveReactRefSymbol(
     stripParenExpression(test.argument),


### PR DESCRIPTION
## Summary

- recognize one-shot effect timer callbacks that exit through a leading compound `||` unmount guard
- retain diagnostics for `&&` guards that do not guarantee an exit when unmounted
- add the exact ReactTooltip React Bench callsite to the deduplicated exhaustive audit corpus
- make the corpus importer retain the audit version for each callsite

## Validation

- full `oxlint-plugin-react-doctor` suite: 26,291 passed, 205 skipped
- fuzz suite: 788 passed
- fuzz package suite: 210 passed, 788 skipped
- plugin and fuzz typechecks
- full workspace build
- formatting and lint (existing corpus warnings only)
- corpus integrity: 109 callsites, 99 trials, 96 unique exact source fixtures, zero duplicate callsite keys or source hashes

## React Bench evidence

React Bench PR #498's 0.9.8 remote oracle sweep produced a new `effect-needs-cleanup` diagnostic for `react-tooltip` at the `setTimeout` guarded by:

```ts
if (!mounted.current || tooltipShowRequestRef.current !== showRequest) {
  return
}
```

The unmount cleanup sets `mounted.current = false`, so the first disjunct guarantees an early exit after unmount. With this patch, the exact post-agent source retains only its unrelated pre-existing legitimate diagnostic and no longer reports the new guarded timer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The change narrows `effect-needs-cleanup` heuristics; incorrect `||` peeling could suppress real missing-cleanup findings, though bounded tests and the new bench fixture mitigate that.
> 
> **Overview**
> **`effect-needs-cleanup`** no longer flags one-shot `setTimeout` callbacks whose first statement is an early return guarded by a compound expression like `!mounted.current || …`. The rule now peels leading `||` operands until it finds a negated ref (e.g. `!mounted.current`) tied to effect cleanup, while **`&&`-style guards** that do not always exit when unmounted still report.
> 
> Regression coverage adds unit tests for both cases, a **React Bench 0.9.8** `react-tooltip` fixture (guarded `setTimeout` in `handleShow`), and corpus importer/manifest updates so each callsite records **`auditVersion`** (manifest now spans 0.9.7+0.9.8, 109 callsites).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5f884c317c1347f7288b73fe7a01500442ebace. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->