### PR TITLE
test(fuzz): complete React Bench audit corpus

### DIFF
--- a/packages/fuzz/corpus/react-bench-0.9.7-audit.json
+++ b/packages/fuzz/corpus/react-bench-0.9.7-audit.json
@@ -1,11 +1,11 @@
 {
-  "source": "React Bench 0.9.7+0.9.8+0.9.9 exhaustive all-diffs audit",
+  "source": "React Bench 0.9.7+0.9.8+0.9.9+0.9.11 exhaustive all-diffs audit",
   "expected": {
-    "totalCallsites": 337,
-    "passCallsites": 332,
+    "totalCallsites": 345,
+    "passCallsites": 340,
     "failCallsites": 5,
-    "uniqueTrials": 326,
-    "uniqueFixtures": 321
+    "uniqueTrials": 334,
+    "uniqueFixtures": 329
   },
   "fixtures": [
     {
@@ -133,6 +133,15 @@
       ],
       "fixtureSourceSha256": "0b01d2a7af6022d01971e58df27dcf8883d1d0dcba494853f58841078198e42e",
       "filePath": "src/components/Tooltip/Tooltip.tsx"
+    },
+    {
+      "fixture": "react-bench-0.9.7-audit/regressions/0b687e3ab1b3--victory-animation.tsx.txt",
+      "verdict": "pass",
+      "rules": [
+        "effect-needs-cleanup"
+      ],
+      "fixtureSourceSha256": "0b687e3ab1b3bf0368fe33c3f31c9c952e228203a7898b066e09033d6adcb719",
+      "filePath": "src/victory-animation/victory-animation.tsx"
     },
     {
       "fixture": "react-bench-0.9.7-audit/regressions/0c68a8171284--victory-animation.tsx.txt",
@@ -522,6 +531,15 @@
       "filePath": "src/victory-animation/victory-animation.tsx"
     },
     {
+      "fixture": "react-bench-0.9.7-audit/true-positives/2bc6fc6d20a5--message-markdown.tsx.txt",
+      "verdict": "fail",
+      "rules": [
+        "dangerous-html-sink"
+      ],
+      "fixtureSourceSha256": "2bc6fc6d20a5cd769a0806ef42bab0baf0595e5dc24e70972dfa0081234f7190",
+      "filePath": "src/components/chat/message/message-markdown.tsx"
+    },
+    {
       "fixture": "react-bench-0.9.7-audit/regressions/2c59f8fba961--victory-animation.tsx.txt",
       "verdict": "pass",
       "rules": [
@@ -592,6 +610,15 @@
       ],
       "fixtureSourceSha256": "320d3caddb53aa62715cf8235cb7009fcabf45082238a48c86e76c3ef0b70c31",
       "filePath": "src/components/document/history/DocumentHistoryModal.tsx"
+    },
+    {
+      "fixture": "react-bench-0.9.7-audit/regressions/3269b60ea7d5--victory-animation.tsx.txt",
+      "verdict": "pass",
+      "rules": [
+        "effect-needs-cleanup"
+      ],
+      "fixtureSourceSha256": "3269b60ea7d5d28fa1517e25c42834d5fb7d6f5d743d8706d1d885a2d1206f33",
+      "filePath": "src/victory-animation/victory-animation.tsx"
     },
     {
       "fixture": "react-bench-0.9.7-audit/regressions/32e13847aeea--tooltip.tsx.txt",
@@ -954,6 +981,15 @@
       "filePath": "src/victory-animation/victory-animation.tsx"
     },
     {
+      "fixture": "react-bench-0.9.7-audit/regressions/5432afbc7b3d--victory-animation.tsx.txt",
+      "verdict": "pass",
+      "rules": [
+        "effect-needs-cleanup"
+      ],
+      "fixtureSourceSha256": "5432afbc7b3d608a25c32978184b9edb4016a74b4b92acf60bd9123286be0da2",
+      "filePath": "src/victory-animation/victory-animation.tsx"
+    },
+    {
       "fixture": "react-bench-0.9.7-audit/regressions/5489e66536e2--victory-animation.tsx.txt",
       "verdict": "pass",
       "rules": [
@@ -1062,6 +1098,24 @@
       "filePath": "src/victory-animation/victory-animation.tsx"
     },
     {
+      "fixture": "react-bench-0.9.7-audit/regressions/5fe3e8c35aa8--victory-animation.tsx.txt",
+      "verdict": "pass",
+      "rules": [
+        "effect-needs-cleanup"
+      ],
+      "fixtureSourceSha256": "5fe3e8c35aa8d2469086612e14d90e27cfb14dfffc9ad8d95c56d4a89fb79ccb",
+      "filePath": "src/victory-animation/victory-animation.tsx"
+    },
+    {
+      "fixture": "react-bench-0.9.7-audit/regressions/60151913eb09--victory-animation.tsx.txt",
+      "verdict": "pass",
+      "rules": [
+        "effect-needs-cleanup"
+      ],
+      "fixtureSourceSha256": "60151913eb092a935273f16053b6235d52a27f7d0c557475dfc1641be5e641fb",
+      "filePath": "src/victory-animation/victory-animation.tsx"
+    },
+    {
       "fixture": "react-bench-0.9.7-audit/regressions/611ff01af283--tooltip.tsx.txt",
       "verdict": "pass",
       "rules": [
@@ -1131,7 +1185,7 @@
         "effect-needs-cleanup"
       ],
       "fixtureSourceSha256": "64609f5c7a70a23c306ffadc0d360814e1f743006fbb5575445facef30abd358",
-      "filePath": "src/victory-animation/victory-animation.tsx"
+      "filePath": "packages/victory-core/src/victory-animation/victory-animation.tsx"
     },
     {
       "fixture": "react-bench-0.9.7-audit/regressions/65b78f44bac5--victory-animation.tsx.txt",
@@ -1413,6 +1467,15 @@
       "filePath": "packages/cli/src/pages/settings.tsx"
     },
     {
+      "fixture": "react-bench-0.9.7-audit/true-positives/74931c270c70--editorial-health-panel.jsx.txt",
+      "verdict": "fail",
+      "rules": [
+        "no-side-effect-in-state-updater-function"
+      ],
+      "fixtureSourceSha256": "74931c270c7093eec0c0f1a5b01c8aaf52035141e7723fac04089836143bffa5",
+      "filePath": "client/src/components/pipeline/editorial/EditorialHealthPanel.jsx"
+    },
+    {
       "fixture": "react-bench-0.9.7-audit/regressions/7499ba110010--settings.tsx.txt",
       "verdict": "pass",
       "rules": [
@@ -1501,6 +1564,15 @@
       ],
       "fixtureSourceSha256": "7ec8d7342a3e8fc4dd349f2a4493d2bff7bc679deb73269b9b4e7b4a757b6cf4",
       "filePath": "src/victory-animation/victory-animation.tsx"
+    },
+    {
+      "fixture": "react-bench-0.9.7-audit/regressions/7f0af04f254c--tooltip.tsx.txt",
+      "verdict": "pass",
+      "rules": [
+        "effect-needs-cleanup"
+      ],
+      "fixtureSourceSha256": "7f0af04f254ce28a63d0f8ae884e9d8ee4773ab5de0117f06184fac928da2311",
+      "filePath": "src/components/Tooltip/Tooltip.tsx"
     },
     {
       "fixture": "react-bench-0.9.7-audit/regressions/81e6d1272b73--victory-animation.tsx.txt",
@@ -1698,6 +1770,15 @@
         "effect-needs-cleanup"
       ],
       "fixtureSourceSha256": "927c1a89aecd48393051b576b4e9c2c503583bdbc6fa0e45eab0ffcc0ede234c",
+      "filePath": "src/victory-animation/victory-animation.tsx"
+    },
+    {
+      "fixture": "react-bench-0.9.7-audit/regressions/9421df7d6d70--victory-animation.tsx.txt",
+      "verdict": "pass",
+      "rules": [
+        "effect-needs-cleanup"
+      ],
+      "fixtureSourceSha256": "9421df7d6d706e34f416e6576229e00ccb7442d99166744f5f7facd5117b0a81",
       "filePath": "src/victory-animation/victory-animation.tsx"
     },
     {
@@ -1978,6 +2059,15 @@
       ],
       "fixtureSourceSha256": "b1c60af0015d7b1cbd7432b7e7ea100183b9b4066d62b8222600a4e271b6a244",
       "filePath": "src/components/document/history/DocumentHistoryModal.tsx"
+    },
+    {
+      "fixture": "react-bench-0.9.7-audit/regressions/b2b78b886500--victory-animation.tsx.txt",
+      "verdict": "pass",
+      "rules": [
+        "effect-needs-cleanup"
+      ],
+      "fixtureSourceSha256": "b2b78b886500ff5ccc6c8eafebdf8796fc2b2f4206b6948842b312a2a119279d",
+      "filePath": "src/victory-animation/victory-animation.tsx"
     },
     {
       "fixture": "react-bench-0.9.7-audit/regressions/b3046c95a339--photo.tsx.txt",
@@ -2566,6 +2656,15 @@
       "filePath": "packages/shared/src/components/conversation/blocks/shared/PermissionCard.tsx"
     },
     {
+      "fixture": "react-bench-0.9.7-audit/true-positives/e31ae15e51f0--use-zoom-pan.ts.txt",
+      "verdict": "fail",
+      "rules": [
+        "effect-needs-cleanup"
+      ],
+      "fixtureSourceSha256": "e31ae15e51f07a2e0748f68765d8e14c96dbcb6c5149d39582ebede4bc1737d2",
+      "filePath": "src/hooks/use-zoom-pan.ts"
+    },
+    {
       "fixture": "react-bench-0.9.7-audit/regressions/e5619c73acf0--session-interaction-card.tsx.txt",
       "verdict": "pass",
       "rules": [
@@ -2851,7 +2950,7 @@
         "effect-needs-cleanup"
       ],
       "fixtureSourceSha256": "fc9cd4b5ce6776cb8b900e3b2213fb323d4d8f0448867e66c6f988490bff2a13",
-      "filePath": "tooltip_copy.tsx"
+      "filePath": "tooltip_backup.tsx"
     },
     {
       "fixture": "react-bench-0.9.7-audit/regressions/fd8217ccc23e--victory-animation.tsx.txt",
@@ -2870,33 +2969,6 @@
       ],
       "fixtureSourceSha256": "fe17519a02eec3af5861da5b711a49694c185aaa7f1b5dd4756194d018594648",
       "filePath": "src/victory-animation/victory-animation.tsx"
-    },
-    {
-      "fixture": "react-bench-0.9.7-audit/true-positives/2bc6fc6d20a5--message-markdown.tsx.txt",
-      "verdict": "fail",
-      "rules": [
-        "dangerous-html-sink"
-      ],
-      "fixtureSourceSha256": "2bc6fc6d20a5cd769a0806ef42bab0baf0595e5dc24e70972dfa0081234f7190",
-      "filePath": "src/components/chat/message/message-markdown.tsx"
-    },
-    {
-      "fixture": "react-bench-0.9.7-audit/true-positives/74931c270c70--editorial-health-panel.jsx.txt",
-      "verdict": "fail",
-      "rules": [
-        "no-side-effect-in-state-updater-function"
-      ],
-      "fixtureSourceSha256": "74931c270c7093eec0c0f1a5b01c8aaf52035141e7723fac04089836143bffa5",
-      "filePath": "client/src/components/pipeline/editorial/EditorialHealthPanel.jsx"
-    },
-    {
-      "fixture": "react-bench-0.9.7-audit/true-positives/e31ae15e51f0--use-zoom-pan.ts.txt",
-      "verdict": "fail",
-      "rules": [
-        "effect-needs-cleanup"
-      ],
-      "fixtureSourceSha256": "e31ae15e51f07a2e0748f68765d8e14c96dbcb6c5149d39582ebede4bc1737d2",
-      "filePath": "src/hooks/use-zoom-pan.ts"
     }
   ],
   "callsites": [
@@ -3771,6 +3843,21 @@
       "verdict": "pass"
     },
     {
+      "suffix": "aZiUW5R",
+      "sourceTrialId": "ec3a31ee-2dc8-4a54-8a5b-8a841bb602fb",
+      "auditVersion": "0.9.11",
+      "task": "fix-react-formidablelabs-victory-victory-animation",
+      "patchSha256": "7e4b73e5f592dcb6f7bbd05ec43703d631632afc5262bc499a1fb97d5b6be095",
+      "rule": "effect-needs-cleanup",
+      "filePath": "src/victory-animation/victory-animation.tsx",
+      "reportedLine": 224,
+      "reportedColumn": 31,
+      "sourceSha256": "9421df7d6d706e34f416e6576229e00ccb7442d99166744f5f7facd5117b0a81",
+      "snippetSha256": "2a14d5a9886266d3a7e35f4d4cf2e8d20aa4e5e5f1f650055f3d46e72ca29983",
+      "fixture": "react-bench-0.9.7-audit/regressions/9421df7d6d70--victory-animation.tsx.txt",
+      "verdict": "pass"
+    },
+    {
       "suffix": "bBnR7XV",
       "sourceTrialId": "4df723c6-8828-4410-9962-f84d449c6129",
       "auditVersion": "0.9.9",
@@ -3796,6 +3883,21 @@
       "sourceSha256": "404dd58ecef08ade8f25d2a22770fd204a34ea889a6375f67e9c990502329d12",
       "snippetSha256": "404dd58ecef08ade8f25d2a22770fd204a34ea889a6375f67e9c990502329d12",
       "fixture": "react-bench-0.9.7-audit/regressions/404dd58ecef0--gallery.tsx.txt",
+      "verdict": "pass"
+    },
+    {
+      "suffix": "beiMt8M",
+      "sourceTrialId": "e9cc2c10-2e25-4796-b78d-b87495e00198",
+      "auditVersion": "0.9.11",
+      "task": "fix-react-formidablelabs-victory-victory-animation",
+      "patchSha256": "dafe7c5aea9a93eccef834dfaf976f332feff9bfdfb04b531f40d5fa7e7c16bd",
+      "rule": "effect-needs-cleanup",
+      "filePath": "src/victory-animation/victory-animation.tsx",
+      "reportedLine": 196,
+      "reportedColumn": 9,
+      "sourceSha256": "60151913eb092a935273f16053b6235d52a27f7d0c557475dfc1641be5e641fb",
+      "snippetSha256": "cabdbfa7bce975efe0da0ec3987579e237f8a62f0c6fc045115128a5a06dbeeb",
+      "fixture": "react-bench-0.9.7-audit/regressions/60151913eb09--victory-animation.tsx.txt",
       "verdict": "pass"
     },
     {
@@ -4166,6 +4268,21 @@
       "sourceSha256": "fe17519a02eec3af5861da5b711a49694c185aaa7f1b5dd4756194d018594648",
       "snippetSha256": "b02aa160783949a1599b601f0873e1f42f41752c9f0e0576dd071109e3e3b50a",
       "fixture": "react-bench-0.9.7-audit/regressions/fe17519a02ee--victory-animation.tsx.txt",
+      "verdict": "pass"
+    },
+    {
+      "suffix": "dQGUfbS",
+      "sourceTrialId": "b332f2c8-095e-4201-8847-5ff237c20832",
+      "auditVersion": "0.9.11",
+      "task": "fix-react-formidablelabs-victory-victory-animation",
+      "patchSha256": "b0119bb16b60f3a275330c2a6dd2be94a2c3c23904d5c3b68e2766436f871e28",
+      "rule": "effect-needs-cleanup",
+      "filePath": "src/victory-animation/victory-animation.tsx",
+      "reportedLine": 243,
+      "reportedColumn": 25,
+      "sourceSha256": "b2b78b886500ff5ccc6c8eafebdf8796fc2b2f4206b6948842b312a2a119279d",
+      "snippetSha256": "da1668d4843831d1da85073aef20f19fae79720796b1c1299b6be09f77482447",
+      "fixture": "react-bench-0.9.7-audit/regressions/b2b78b886500--victory-animation.tsx.txt",
       "verdict": "pass"
     },
     {
@@ -4693,6 +4810,21 @@
       "verdict": "pass"
     },
     {
+      "suffix": "gxyWiEv",
+      "sourceTrialId": "1947471b-348d-491d-8950-94c930edac1e",
+      "auditVersion": "0.9.11",
+      "task": "fix-react-formidablelabs-victory-victory-animation",
+      "patchSha256": "ffd2ef48cd1836e45b6e624ea4b807a141f177f10dac10f70a725b4eae7d17ef",
+      "rule": "effect-needs-cleanup",
+      "filePath": "src/victory-animation/victory-animation.tsx",
+      "reportedLine": 231,
+      "reportedColumn": 23,
+      "sourceSha256": "5432afbc7b3d608a25c32978184b9edb4016a74b4b92acf60bd9123286be0da2",
+      "snippetSha256": "20f7b332a1d67378182f84de911e90f93a654f65c01a301a11f159833000d3e8",
+      "fixture": "react-bench-0.9.7-audit/regressions/5432afbc7b3d--victory-animation.tsx.txt",
+      "verdict": "pass"
+    },
+    {
       "suffix": "GYKqNsZ",
       "sourceTrialId": "b0b5ec4a-f8a2-4608-a313-b9363751b4ad",
       "auditVersion": "0.9.9",
@@ -4761,6 +4893,21 @@
       "sourceSha256": "15acf80df50292173c2c267e54e6e2a1d30dac1d8cec66b6a8786d81cb4e22f9",
       "snippetSha256": "7fa01849c71dbbc65fa10022db7abaa2b8bbcfec74f5ff6a142730ebae2744e6",
       "fixture": "react-bench-0.9.7-audit/regressions/15acf80df502--victory-animation.tsx.txt",
+      "verdict": "pass"
+    },
+    {
+      "suffix": "HBUMdWN",
+      "sourceTrialId": "bf3672b0-f95a-4764-815f-b759b3e8f8c1",
+      "auditVersion": "0.9.11",
+      "task": "fix-react-formidablelabs-victory-victory-animation",
+      "patchSha256": "5c6cd30858b261d4ead2b9aed33a1ab852161a9cc3f4e49f20f9b5864ab68dc6",
+      "rule": "effect-needs-cleanup",
+      "filePath": "src/victory-animation/victory-animation.tsx",
+      "reportedLine": 209,
+      "reportedColumn": 9,
+      "sourceSha256": "3269b60ea7d5d28fa1517e25c42834d5fb7d6f5d743d8706d1d885a2d1206f33",
+      "snippetSha256": "cabdbfa7bce975efe0da0ec3987579e237f8a62f0c6fc045115128a5a06dbeeb",
+      "fixture": "react-bench-0.9.7-audit/regressions/3269b60ea7d5--victory-animation.tsx.txt",
       "verdict": "pass"
     },
     {
@@ -4995,6 +5142,21 @@
       "sourceSha256": "56bc7335a8d1e328210dbacd4bead368d9913ded612766770f5fd329f9c718c6",
       "snippetSha256": "0961c3130a2b55d206decc888701f163e86b810db0bdb7ef92941d44d9936ede",
       "fixture": "react-bench-0.9.7-audit/regressions/56bc7335a8d1--victory-animation.tsx.txt",
+      "verdict": "pass"
+    },
+    {
+      "suffix": "jrL6BAP",
+      "sourceTrialId": "37d8d328-9b30-41e7-bb9d-146977ca3236",
+      "auditVersion": "0.9.11",
+      "task": "fix-react-reacttooltip-react-tooltip-1205",
+      "patchSha256": "04178d3d964ba5cb39a7d26b37bdfab7bbe5180dcecdd6c25ad540d10b98aa22",
+      "rule": "effect-needs-cleanup",
+      "filePath": "src/components/Tooltip/Tooltip.tsx",
+      "reportedLine": 942,
+      "reportedColumn": 3,
+      "sourceSha256": "7f0af04f254ce28a63d0f8ae884e9d8ee4773ab5de0117f06184fac928da2311",
+      "snippetSha256": "5966fbfa88998da74656c50194956c25f0849457660c009fe63d1e9fa9dc931c",
+      "fixture": "react-bench-0.9.7-audit/regressions/7f0af04f254c--tooltip.tsx.txt",
       "verdict": "pass"
     },
     {
@@ -6700,6 +6862,21 @@
       "verdict": "pass"
     },
     {
+      "suffix": "v6NYckM",
+      "sourceTrialId": "600001bb-768a-40b6-8d45-2a7c58b452cb",
+      "auditVersion": "0.9.11",
+      "task": "fix-react-formidablelabs-victory-victory-animation",
+      "patchSha256": "c7a5f800c710fc0be6de79b23283e5f5d1aae8df744746ebf409bc289810febd",
+      "rule": "effect-needs-cleanup",
+      "filePath": "src/victory-animation/victory-animation.tsx",
+      "reportedLine": 229,
+      "reportedColumn": 30,
+      "sourceSha256": "5fe3e8c35aa8d2469086612e14d90e27cfb14dfffc9ad8d95c56d4a89fb79ccb",
+      "snippetSha256": "0065edb7bc1c7499dae6ebc0b6b34d0675e844b5be098e832a42074f469e599b",
+      "fixture": "react-bench-0.9.7-audit/regressions/5fe3e8c35aa8--victory-animation.tsx.txt",
+      "verdict": "pass"
+    },
+    {
       "suffix": "vaDcpDf",
       "sourceTrialId": "e3e00853-e05e-405d-ba4e-ccc32b627dbe",
       "auditVersion": "0.9.9",
@@ -7520,6 +7697,21 @@
       "sourceSha256": "7499ba110010198fb7bb24f8d0265481830797602c0dca7dc05664a345873370",
       "snippetSha256": "7499ba110010198fb7bb24f8d0265481830797602c0dca7dc05664a345873370",
       "fixture": "react-bench-0.9.7-audit/regressions/7499ba110010--settings.tsx.txt",
+      "verdict": "pass"
+    },
+    {
+      "suffix": "yt7HnzD",
+      "sourceTrialId": "4e6d991f-8c65-48bf-87b2-189ed43c559d",
+      "auditVersion": "0.9.11",
+      "task": "fix-react-formidablelabs-victory-victory-animation",
+      "patchSha256": "bb01e90629977c04f12fc9bd1e8642fb71a842f723dc7d6b22620661e2fdc9b6",
+      "rule": "effect-needs-cleanup",
+      "filePath": "src/victory-animation/victory-animation.tsx",
+      "reportedLine": 175,
+      "reportedColumn": 9,
+      "sourceSha256": "0b687e3ab1b3bf0368fe33c3f31c9c952e228203a7898b066e09033d6adcb719",
+      "snippetSha256": "e249fd0fbe6e4954974eb3fcae6832e68d507f0d9409db81cccefefd23136522",
+      "fixture": "react-bench-0.9.7-audit/regressions/0b687e3ab1b3--victory-animation.tsx.txt",
       "verdict": "pass"
     },
     {

--- a/packages/fuzz/corpus/react-bench-0.9.7-audit/regressions/0b687e3ab1b3--victory-animation.tsx.txt
+++ b/packages/fuzz/corpus/react-bench-0.9.7-audit/regressions/0b687e3ab1b3--victory-animation.tsx.txt
@@ -1,0 +1,232 @@
+// rule: effect-needs-cleanup
+// file-path: src/victory-animation/victory-animation.tsx
+// audit-verdict: pass
+// weakness: react-bench-exact-callsite
+// source: React Bench 0.9.11 exhaustive audit 0b687e3ab1b3bf0368fe33c3f31c9c952e228203a7898b066e09033d6adcb719
+import React from "react";
+import * as d3Ease from "victory-vendor/d3-ease";
+import { victoryInterpolator } from "./util";
+import TimerContext from "../victory-util/timer-context";
+
+/**
+ * Single animation object to interpolate
+ */
+export type AnimationStyle = { [key: string]: string | number };
+/**
+ * Animation styles to interpolate
+ */
+
+export type AnimationData = AnimationStyle | AnimationStyle[];
+
+export type AnimationEasing =
+  | "back"
+  | "backIn"
+  | "backOut"
+  | "backInOut"
+  | "bounce"
+  | "bounceIn"
+  | "bounceOut"
+  | "bounceInOut"
+  | "circle"
+  | "circleIn"
+  | "circleOut"
+  | "circleInOut"
+  | "linear"
+  | "linearIn"
+  | "linearOut"
+  | "linearInOut"
+  | "cubic"
+  | "cubicIn"
+  | "cubicOut"
+  | "cubicInOut"
+  | "elastic"
+  | "elasticIn"
+  | "elasticOut"
+  | "elasticInOut"
+  | "exp"
+  | "expIn"
+  | "expOut"
+  | "expInOut"
+  | "poly"
+  | "polyIn"
+  | "polyOut"
+  | "polyInOut"
+  | "quad"
+  | "quadIn"
+  | "quadOut"
+  | "quadInOut"
+  | "sin"
+  | "sinIn"
+  | "sinOut"
+  | "sinInOut";
+
+export interface VictoryAnimationProps {
+  children: (style: AnimationStyle, info: AnimationInfo) => React.ReactElement;
+  duration?: number;
+  easing?: AnimationEasing;
+  delay?: number;
+  onEnd?: () => void;
+  data: AnimationData;
+}
+
+export interface VictoryAnimationState {
+  data: AnimationStyle;
+  animationInfo: AnimationInfo;
+}
+
+export interface AnimationInfo {
+  progress: number;
+  animating: boolean;
+  terminating?: boolean;
+}
+
+export interface VictoryAnimation {
+  context: React.ContextType<typeof TimerContext>;
+}
+
+/** d3-ease changed the naming scheme for ease from "linear" -> "easeLinear" etc. */
+const formatAnimationName = (name: AnimationEasing) => {
+  const capitalizedName = name.charAt(0).toUpperCase() + name.slice(1);
+  return `ease${capitalizedName}`;
+};
+
+const DEFAULT_DURATION = 1000;
+
+export const VictoryAnimation = ({
+  duration = DEFAULT_DURATION,
+  easing = "quadInOut",
+  delay = 0,
+  data,
+  children,
+  onEnd,
+}: VictoryAnimationProps) => {
+  const [state, setState] = React.useState<VictoryAnimationState>({
+    data: Array.isArray(data) ? data[0] : data,
+    animationInfo: {
+      progress: 0,
+      animating: false,
+    },
+  });
+
+  const timer = React.useContext(TimerContext).animationTimer;
+  const queue = React.useRef<AnimationStyle[]>(
+    Array.isArray(data) ? data.slice(1) : [],
+  );
+  const loopID = React.useRef<number | undefined>(undefined);
+  const ease = d3Ease[formatAnimationName(easing)];
+
+  // Long-running animations are driven by a callback subscribed once to the
+  // timer; refs let that callback pick up the latest duration/easing/onEnd
+  // on every frame instead of being frozen to the values at subscribe time.
+  const durationRef = React.useRef(duration);
+  durationRef.current = duration;
+  const easeRef = React.useRef(ease);
+  easeRef.current = ease;
+  const onEndRef = React.useRef(onEnd);
+  onEndRef.current = onEnd;
+
+  // Bumped whenever a fresh tween should take over. Callbacks scheduled by a
+  // superseded tween (a pending delayed start, or a frame in flight) compare
+  // their captured generation against this ref and no-op if they lost.
+  const generation = React.useRef(0);
+
+  React.useEffect(() => {
+    // Length check prevents us from triggering `onEnd` in `traverseQueue`.
+    if (queue.current.length) {
+      traverseQueue(state.data, generation.current);
+    }
+
+    // Clean up the animation loop
+    return () => {
+      generation.current++;
+      if (loopID.current) {
+        timer.unsubscribe(loopID.current);
+      } else {
+        timer.stop();
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  React.useEffect(() => {
+    // Supersede whatever tween is currently running (or scheduled to start)
+    // and continue from the currently visible style toward the new data, so
+    // the superseded target is never rendered.
+    const gen = ++generation.current;
+    timer.unsubscribe(loopID.current);
+    loopID.current = undefined;
+    queue.current = Array.isArray(data) ? data : [data];
+    traverseQueue(state.data, gen);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data]);
+
+  const traverseQueue = (fromStyle: AnimationStyle, gen: number) => {
+    if (gen !== generation.current) return;
+
+    if (queue.current.length) {
+      const nextData = queue.current[0];
+      const currentInterpolator = victoryInterpolator(fromStyle, nextData);
+
+      const subscribe = () => {
+        if (gen !== generation.current) return;
+        loopID.current = timer.subscribe(
+          (elapsed) =>
+            functionToBeRunEachFrame(elapsed, gen, currentInterpolator),
+          durationRef.current,
+        );
+      };
+
+      if (delay) {
+        setTimeout(subscribe, delay);
+      } else {
+        subscribe();
+      }
+    } else if (onEndRef.current) {
+      onEndRef.current();
+    }
+  };
+
+  const functionToBeRunEachFrame = (
+    elapsed: number,
+    gen: number,
+    currentInterpolator: (value: number) => AnimationStyle,
+  ) => {
+    if (gen !== generation.current) return;
+
+    // Step can generate imprecise values, sometimes greater than 1
+    // if this happens set the state to 1 and return, cancelling the timer
+    const currentDuration = durationRef.current;
+    const step = currentDuration ? elapsed / currentDuration : 1;
+
+    if (step >= 1) {
+      const finalStyle = currentInterpolator(1);
+      setState({
+        data: finalStyle,
+        animationInfo: {
+          progress: 1,
+          animating: false,
+          terminating: true,
+        },
+      });
+      if (loopID.current) {
+        timer.unsubscribe(loopID.current);
+      }
+      queue.current.shift();
+      traverseQueue(finalStyle, gen);
+      return;
+    }
+
+    // If we're not at the end of the timer, set the state by passing
+    // current step value that's transformed by the ease function to the
+    // interpolator, which is cached for performance whenever props are received
+    setState({
+      data: currentInterpolator(easeRef.current(step)),
+      animationInfo: {
+        progress: step,
+        animating: step < 1,
+      },
+    });
+  };
+
+  return children(state.data, state.animationInfo);
+};

--- a/packages/fuzz/corpus/react-bench-0.9.7-audit/regressions/3269b60ea7d5--victory-animation.tsx.txt
+++ b/packages/fuzz/corpus/react-bench-0.9.7-audit/regressions/3269b60ea7d5--victory-animation.tsx.txt
@@ -1,0 +1,258 @@
+// rule: effect-needs-cleanup
+// file-path: src/victory-animation/victory-animation.tsx
+// audit-verdict: pass
+// weakness: react-bench-exact-callsite
+// source: React Bench 0.9.11 exhaustive audit 3269b60ea7d5d28fa1517e25c42834d5fb7d6f5d743d8706d1d885a2d1206f33
+import React from "react";
+import * as d3Ease from "victory-vendor/d3-ease";
+import { victoryInterpolator } from "./util";
+import TimerContext from "../victory-util/timer-context";
+
+/**
+ * Single animation object to interpolate
+ */
+export type AnimationStyle = { [key: string]: string | number };
+/**
+ * Animation styles to interpolate
+ */
+
+export type AnimationData = AnimationStyle | AnimationStyle[];
+
+export type AnimationEasing =
+  | "back"
+  | "backIn"
+  | "backOut"
+  | "backInOut"
+  | "bounce"
+  | "bounceIn"
+  | "bounceOut"
+  | "bounceInOut"
+  | "circle"
+  | "circleIn"
+  | "circleOut"
+  | "circleInOut"
+  | "linear"
+  | "linearIn"
+  | "linearOut"
+  | "linearInOut"
+  | "cubic"
+  | "cubicIn"
+  | "cubicOut"
+  | "cubicInOut"
+  | "elastic"
+  | "elasticIn"
+  | "elasticOut"
+  | "elasticInOut"
+  | "exp"
+  | "expIn"
+  | "expOut"
+  | "expInOut"
+  | "poly"
+  | "polyIn"
+  | "polyOut"
+  | "polyInOut"
+  | "quad"
+  | "quadIn"
+  | "quadOut"
+  | "quadInOut"
+  | "sin"
+  | "sinIn"
+  | "sinOut"
+  | "sinInOut";
+
+export interface VictoryAnimationProps {
+  children: (style: AnimationStyle, info: AnimationInfo) => React.ReactElement;
+  duration?: number;
+  easing?: AnimationEasing;
+  delay?: number;
+  onEnd?: () => void;
+  data: AnimationData;
+}
+
+export interface VictoryAnimationState {
+  data: AnimationStyle;
+  animationInfo: AnimationInfo;
+}
+
+export interface AnimationInfo {
+  progress: number;
+  animating: boolean;
+  terminating?: boolean;
+}
+
+export interface VictoryAnimation {
+  context: React.ContextType<typeof TimerContext>;
+}
+
+/** d3-ease changed the naming scheme for ease from "linear" -> "easeLinear" etc. */
+const formatAnimationName = (name: AnimationEasing) => {
+  const capitalizedName = name.charAt(0).toUpperCase() + name.slice(1);
+  return `ease${capitalizedName}`;
+};
+
+const DEFAULT_DURATION = 1000;
+
+export const VictoryAnimation = ({
+  duration = DEFAULT_DURATION,
+  easing = "quadInOut",
+  delay = 0,
+  data,
+  children,
+  onEnd,
+}: VictoryAnimationProps) => {
+  const [state, setState] = React.useState<VictoryAnimationState>({
+    data: Array.isArray(data) ? data[0] : data,
+    animationInfo: {
+      progress: 0,
+      animating: false,
+    },
+  });
+
+  const timer = React.useContext(TimerContext).animationTimer;
+  const queue = React.useRef<AnimationStyle[]>(
+    Array.isArray(data) ? data.slice(1) : [],
+  );
+  const interpolator = React.useRef<null | ((value: number) => AnimationStyle)>(
+    null,
+  );
+  const loopID = React.useRef<number | undefined>(undefined);
+
+  // Keep the currently visible style so that a run started later (e.g. after a
+  // mid-flight `data` change, or the next step in an array queue) always
+  // continues from what's on screen rather than a stale closure value.
+  const currentData = React.useRef<AnimationStyle>(
+    Array.isArray(data) ? data[0] : data,
+  );
+
+  // Latest props, so that an already-subscribed timer callback adopts the most
+  // recent `duration`, `easing`, and `onEnd` instead of the values captured
+  // when the run started.
+  const durationRef = React.useRef(duration);
+  const easeRef = React.useRef(d3Ease[formatAnimationName(easing)]);
+  const delayRef = React.useRef(delay);
+  const onEndRef = React.useRef(onEnd);
+  durationRef.current = duration;
+  easeRef.current = d3Ease[formatAnimationName(easing)];
+  delayRef.current = delay;
+  onEndRef.current = onEnd;
+
+  // Identifies the active run. Any run whose generation no longer matches has
+  // been superseded and must not render or complete.
+  const generation = React.useRef(0);
+  const isFirstRender = React.useRef(true);
+
+  const commit = (
+    nextData: AnimationStyle,
+    animationInfo: AnimationInfo,
+  ): void => {
+    currentData.current = nextData;
+    setState({ data: nextData, animationInfo });
+  };
+
+  React.useEffect(() => {
+    // Length check prevents us from triggering `onEnd` in `traverseQueue`.
+    if (queue.current.length) {
+      traverseQueue(generation.current);
+    }
+
+    // Clean up the animation loop
+    return () => {
+      // Invalidate any in-flight or delayed run so it can't fire after unmount.
+      generation.current += 1;
+      if (loopID.current) {
+        timer.unsubscribe(loopID.current);
+      } else {
+        timer.stop();
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  React.useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+
+    // Supersede any run in progress (including a delayed start or a queued
+    // step) so it stops rendering and never completes.
+    generation.current += 1;
+    if (loopID.current) {
+      timer.unsubscribe(loopID.current);
+      loopID.current = undefined;
+    }
+
+    // Continue from the currently visible style toward the new data. Copy the
+    // array so the queue's `shift` never mutates the caller's prop.
+    queue.current = Array.isArray(data) ? data.slice() : [data];
+    traverseQueue(generation.current);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data]);
+
+  const traverseQueue = (runID: number) => {
+    if (runID !== generation.current) {
+      return;
+    }
+    if (queue.current.length) {
+      const nextData = queue.current[0];
+
+      // Interpolate from what's currently on screen to the next target.
+      interpolator.current = victoryInterpolator(currentData.current, nextData);
+
+      const start = () => {
+        // A `data` change or unmount during the delay may have superseded us.
+        if (runID !== generation.current) {
+          return;
+        }
+        loopID.current = timer.subscribe(
+          (elapsed: number) => functionToBeRunEachFrame(elapsed, runID),
+          durationRef.current,
+        );
+      };
+
+      if (delayRef.current) {
+        setTimeout(start, delayRef.current);
+      } else {
+        start();
+      }
+    } else if (onEndRef.current) {
+      onEndRef.current();
+    }
+  };
+
+  const functionToBeRunEachFrame = (elapsed: number, runID: number) => {
+    // A superseded run must not render or complete.
+    if (runID !== generation.current || !interpolator.current) {
+      return;
+    }
+
+    // Step can generate imprecise values, sometimes greater than 1
+    // if this happens set the state to 1 and return, cancelling the timer
+    const duration = durationRef.current;
+    const step = duration ? elapsed / duration : 1;
+
+    if (step >= 1) {
+      commit(interpolator.current(1), {
+        progress: 1,
+        animating: false,
+        terminating: true,
+      });
+      if (loopID.current) {
+        timer.unsubscribe(loopID.current);
+      }
+      queue.current.shift();
+      traverseQueue(runID);
+      return;
+    }
+
+    // If we're not at the end of the timer, set the state by passing
+    // current step value that's transformed by the ease function to the
+    // interpolator, which is cached for performance whenever props are received
+    commit(interpolator.current(easeRef.current(step)), {
+      progress: step,
+      animating: step < 1,
+    });
+  };
+
+  return children(state.data, state.animationInfo);
+};

--- a/packages/fuzz/corpus/react-bench-0.9.7-audit/regressions/5432afbc7b3d--victory-animation.tsx.txt
+++ b/packages/fuzz/corpus/react-bench-0.9.7-audit/regressions/5432afbc7b3d--victory-animation.tsx.txt
@@ -1,0 +1,289 @@
+// rule: effect-needs-cleanup
+// file-path: src/victory-animation/victory-animation.tsx
+// audit-verdict: pass
+// weakness: react-bench-exact-callsite
+// source: React Bench 0.9.11 exhaustive audit 5432afbc7b3d608a25c32978184b9edb4016a74b4b92acf60bd9123286be0da2
+import React from "react";
+import * as d3Ease from "victory-vendor/d3-ease";
+import { victoryInterpolator } from "./util";
+import TimerContext from "../victory-util/timer-context";
+
+/**
+ * Single animation object to interpolate
+ */
+export type AnimationStyle = { [key: string]: string | number };
+/**
+ * Animation styles to interpolate
+ */
+
+export type AnimationData = AnimationStyle | AnimationStyle[];
+
+export type AnimationEasing =
+  | "back"
+  | "backIn"
+  | "backOut"
+  | "backInOut"
+  | "bounce"
+  | "bounceIn"
+  | "bounceOut"
+  | "bounceInOut"
+  | "circle"
+  | "circleIn"
+  | "circleOut"
+  | "circleInOut"
+  | "linear"
+  | "linearIn"
+  | "linearOut"
+  | "linearInOut"
+  | "cubic"
+  | "cubicIn"
+  | "cubicOut"
+  | "cubicInOut"
+  | "elastic"
+  | "elasticIn"
+  | "elasticOut"
+  | "elasticInOut"
+  | "exp"
+  | "expIn"
+  | "expOut"
+  | "expInOut"
+  | "poly"
+  | "polyIn"
+  | "polyOut"
+  | "polyInOut"
+  | "quad"
+  | "quadIn"
+  | "quadOut"
+  | "quadInOut"
+  | "sin"
+  | "sinIn"
+  | "sinOut"
+  | "sinInOut";
+
+export interface VictoryAnimationProps {
+  children: (style: AnimationStyle, info: AnimationInfo) => React.ReactElement;
+  duration?: number;
+  easing?: AnimationEasing;
+  delay?: number;
+  onEnd?: () => void;
+  data: AnimationData;
+}
+
+export interface VictoryAnimationState {
+  data: AnimationStyle;
+  animationInfo: AnimationInfo;
+}
+
+export interface AnimationInfo {
+  progress: number;
+  animating: boolean;
+  terminating?: boolean;
+}
+
+export interface VictoryAnimation {
+  context: React.ContextType<typeof TimerContext>;
+}
+
+/** d3-ease changed the naming scheme for ease from "linear" -> "easeLinear" etc. */
+const formatAnimationName = (name: AnimationEasing) => {
+  const capitalizedName = name.charAt(0).toUpperCase() + name.slice(1);
+  return `ease${capitalizedName}`;
+};
+
+const DEFAULT_DURATION = 1000;
+
+export const VictoryAnimation = ({
+  duration = DEFAULT_DURATION,
+  easing = "quadInOut",
+  delay = 0,
+  data,
+  children,
+  onEnd,
+}: VictoryAnimationProps) => {
+  const [state, setState] = React.useState<VictoryAnimationState>({
+    data: Array.isArray(data) ? data[0] : data,
+    animationInfo: {
+      progress: 0,
+      animating: false,
+    },
+  });
+
+  const timer = React.useContext(TimerContext).animationTimer;
+  const timerRef = React.useRef(timer);
+  timerRef.current = timer;
+
+  // These refs let an already subscribed timer use the newest props. In
+  // particular, the callback must not retain the props from the render that
+  // created the subscription.
+  const durationRef = React.useRef(duration);
+  const easeRef = React.useRef(d3Ease[formatAnimationName(easing)]);
+  const delayRef = React.useRef(delay);
+  const onEndRef = React.useRef(onEnd);
+  durationRef.current = duration;
+  easeRef.current = d3Ease[formatAnimationName(easing)];
+  delayRef.current = delay;
+  onEndRef.current = onEnd;
+
+  const queue = React.useRef<AnimationStyle[]>([]);
+  const visibleData = React.useRef<AnimationStyle>(state.data);
+  const animationID = React.useRef(0);
+  const hasStarted = React.useRef(false);
+  const mounted = React.useRef(true);
+
+  type AnimationRun = {
+    id: number;
+    interpolator: (value: number) => AnimationStyle;
+    loopID?: number;
+    delayID?: ReturnType<typeof setTimeout>;
+  };
+  const currentRun = React.useRef<AnimationRun | null>(null);
+
+  const cancelAnimation = React.useCallback(() => {
+    animationID.current += 1;
+    const run = currentRun.current;
+    if (run) {
+      if (run.loopID !== undefined) {
+        timerRef.current.unsubscribe(run.loopID);
+      }
+      if (run.delayID !== undefined) {
+        clearTimeout(run.delayID);
+      }
+    }
+    currentRun.current = null;
+  }, []);
+
+  const functionToBeRunEachFrame = React.useCallback((elapsed: number) => {
+    const run = currentRun.current;
+    if (!run || run.id !== animationID.current || !mounted.current) return;
+
+    // Step can generate imprecise values, sometimes greater than 1. Duration
+    // is read for every frame so a running animation adopts a new duration.
+    const currentDuration = durationRef.current;
+    const step = currentDuration ? elapsed / currentDuration : 1;
+
+    if (step >= 1) {
+      const finalData = run.interpolator(1);
+      visibleData.current = finalData;
+      setState({
+        data: finalData,
+        animationInfo: {
+          progress: 1,
+          animating: false,
+          terminating: true,
+        },
+      });
+      if (run.loopID !== undefined) {
+        timerRef.current.unsubscribe(run.loopID);
+      }
+      currentRun.current = null;
+      queue.current.shift();
+
+      if (queue.current.length) {
+        traverseQueue(run.id);
+      } else {
+        // Read the callback at completion time so a changed onEnd replaces the
+        // callback belonging to the superseded run.
+        onEndRef.current?.();
+      }
+      return;
+    }
+
+    // If we're not at the end of the timer, set the state by passing the
+    // current step through the latest easing function.
+    const nextData = run.interpolator(easeRef.current(step));
+    visibleData.current = nextData;
+    setState({
+      data: nextData,
+      animationInfo: {
+        progress: step,
+        animating: step < 1,
+      },
+    });
+  }, []);
+
+  const traverseQueue = React.useCallback(
+    (id: number) => {
+      if (id !== animationID.current || !mounted.current) return;
+
+      const nextData = queue.current[0];
+      if (!nextData) {
+        onEndRef.current?.();
+        return;
+      }
+
+      const run: AnimationRun = {
+        id,
+        interpolator: victoryInterpolator(visibleData.current, nextData),
+      };
+      currentRun.current = run;
+
+      const subscribe = () => {
+        if (
+          currentRun.current !== run ||
+          id !== animationID.current ||
+          !mounted.current
+        ) {
+          return;
+        }
+        run.delayID = undefined;
+        run.loopID = timerRef.current.subscribe(
+          functionToBeRunEachFrame,
+          durationRef.current,
+        );
+      };
+
+      if (delayRef.current) {
+        run.delayID = setTimeout(subscribe, delayRef.current);
+      } else {
+        subscribe();
+      }
+    },
+    [functionToBeRunEachFrame],
+  );
+
+  React.useEffect(() => {
+    const isInitialData = !hasStarted.current;
+    hasStarted.current = true;
+
+    // The first item in an array is the initial style. Once props replace an
+    // existing run, every item is a target in the replacement queue.
+    queue.current = Array.isArray(data)
+      ? isInitialData
+        ? data.slice(1)
+        : data.slice()
+      : [data];
+
+    cancelAnimation();
+    const id = animationID.current;
+
+    if (queue.current.length) {
+      if (isInitialData) {
+        traverseQueue(id);
+      } else {
+        // Keep the style that was actually visible at handoff. The old target
+        // is never committed as a transitional state.
+        setState({
+          data: visibleData.current,
+          animationInfo: {
+            progress: 0,
+            animating: true,
+          },
+        });
+        traverseQueue(id);
+      }
+    } else {
+      onEndRef.current?.();
+    }
+
+    return cancelAnimation;
+  }, [cancelAnimation, data, traverseQueue]);
+
+  React.useEffect(() => {
+    return () => {
+      mounted.current = false;
+      cancelAnimation();
+    };
+  }, [cancelAnimation]);
+
+  return children(state.data, state.animationInfo);
+};

--- a/packages/fuzz/corpus/react-bench-0.9.7-audit/regressions/5fe3e8c35aa8--victory-animation.tsx.txt
+++ b/packages/fuzz/corpus/react-bench-0.9.7-audit/regressions/5fe3e8c35aa8--victory-animation.tsx.txt
@@ -1,0 +1,289 @@
+// rule: effect-needs-cleanup
+// file-path: src/victory-animation/victory-animation.tsx
+// audit-verdict: pass
+// weakness: react-bench-exact-callsite
+// source: React Bench 0.9.11 exhaustive audit 5fe3e8c35aa8d2469086612e14d90e27cfb14dfffc9ad8d95c56d4a89fb79ccb
+import React from "react";
+import * as d3Ease from "victory-vendor/d3-ease";
+import { victoryInterpolator } from "./util";
+import type Timer from "../victory-util/timer";
+import TimerContext from "../victory-util/timer-context";
+
+/**
+ * Single animation object to interpolate
+ */
+export type AnimationStyle = { [key: string]: string | number };
+/**
+ * Animation styles to interpolate
+ */
+
+export type AnimationData = AnimationStyle | AnimationStyle[];
+
+export type AnimationEasing =
+  | "back"
+  | "backIn"
+  | "backOut"
+  | "backInOut"
+  | "bounce"
+  | "bounceIn"
+  | "bounceOut"
+  | "bounceInOut"
+  | "circle"
+  | "circleIn"
+  | "circleOut"
+  | "circleInOut"
+  | "linear"
+  | "linearIn"
+  | "linearOut"
+  | "linearInOut"
+  | "cubic"
+  | "cubicIn"
+  | "cubicOut"
+  | "cubicInOut"
+  | "elastic"
+  | "elasticIn"
+  | "elasticOut"
+  | "elasticInOut"
+  | "exp"
+  | "expIn"
+  | "expOut"
+  | "expInOut"
+  | "poly"
+  | "polyIn"
+  | "polyOut"
+  | "polyInOut"
+  | "quad"
+  | "quadIn"
+  | "quadOut"
+  | "quadInOut"
+  | "sin"
+  | "sinIn"
+  | "sinOut"
+  | "sinInOut";
+
+export interface VictoryAnimationProps {
+  children: (style: AnimationStyle, info: AnimationInfo) => React.ReactElement;
+  duration?: number;
+  easing?: AnimationEasing;
+  delay?: number;
+  onEnd?: () => void;
+  data: AnimationData;
+}
+
+export interface VictoryAnimationState {
+  data: AnimationStyle;
+  animationInfo: AnimationInfo;
+}
+
+export interface AnimationInfo {
+  progress: number;
+  animating: boolean;
+  terminating?: boolean;
+}
+
+export interface VictoryAnimation {
+  context: React.ContextType<typeof TimerContext>;
+}
+
+interface AnimationRun {
+  duration: number;
+  ease: (value: number) => number;
+  interpolator: (value: number) => AnimationStyle;
+  timer: Timer;
+  loopID?: number;
+  timeoutID?: ReturnType<typeof setTimeout>;
+}
+
+/** d3-ease changed the naming scheme for ease from "linear" -> "easeLinear" etc. */
+const formatAnimationName = (name: AnimationEasing) => {
+  const capitalizedName = name.charAt(0).toUpperCase() + name.slice(1);
+  return `ease${capitalizedName}`;
+};
+
+const DEFAULT_DURATION = 1000;
+
+export const VictoryAnimation = ({
+  duration = DEFAULT_DURATION,
+  easing = "quadInOut",
+  delay = 0,
+  data,
+  children,
+  onEnd,
+}: VictoryAnimationProps) => {
+  const initialData = Array.isArray(data) ? data[0] : data;
+  const [state, setState] = React.useState<VictoryAnimationState>({
+    data: initialData,
+    animationInfo: {
+      progress: 0,
+      animating: false,
+    },
+  });
+
+  const timer = React.useContext(TimerContext).animationTimer;
+  const stateRef = React.useRef(state);
+  const queue = React.useRef<AnimationStyle[]>(
+    Array.isArray(data) ? data.slice(1) : [],
+  );
+  const run = React.useRef<AnimationRun | null>(null);
+  const isMounted = React.useRef(false);
+  const hasInitialized = React.useRef(false);
+  const hasHandledInitialProps = React.useRef(false);
+  const previousProps = React.useRef({ data, duration, easing, delay, onEnd });
+  const latestProps = React.useRef({ data, duration, easing, delay, onEnd });
+
+  latestProps.current = { data, duration, easing, delay, onEnd };
+
+  const setAnimationState = React.useCallback(
+    (nextState: VictoryAnimationState) => {
+      stateRef.current = nextState;
+      if (isMounted.current) {
+        setState(nextState);
+      }
+    },
+    [],
+  );
+
+  const cancelRun = React.useCallback(() => {
+    const currentRun = run.current;
+    if (!currentRun) {
+      return;
+    }
+
+    if (currentRun.timeoutID !== undefined) {
+      clearTimeout(currentRun.timeoutID);
+    }
+    if (currentRun.loopID !== undefined) {
+      currentRun.timer.unsubscribe(currentRun.loopID);
+    }
+    run.current = null;
+  }, []);
+
+  const startNext = React.useCallback(() => {
+    const target = queue.current[0];
+    if (!target || !isMounted.current) {
+      return false;
+    }
+
+    const {
+      duration: nextDuration,
+      easing: nextEasing,
+      delay: nextDelay,
+    } = latestProps.current;
+    const currentRun: AnimationRun = {
+      duration: nextDuration,
+      ease: d3Ease[formatAnimationName(nextEasing)],
+      interpolator: victoryInterpolator(stateRef.current.data, target),
+      timer,
+    };
+    run.current = currentRun;
+
+    const runFrame = (elapsed: number) => {
+      // A new prop change may have replaced this run before a queued timer
+      // callback has a chance to fire.
+      if (run.current !== currentRun || !isMounted.current) {
+        return;
+      }
+
+      const step = currentRun.duration ? elapsed / currentRun.duration : 1;
+      if (step >= 1) {
+        if (currentRun.loopID !== undefined) {
+          currentRun.timer.unsubscribe(currentRun.loopID);
+        }
+        run.current = null;
+        queue.current.shift();
+        setAnimationState({
+          data: currentRun.interpolator(1),
+          animationInfo: {
+            progress: 1,
+            animating: false,
+            terminating: true,
+          },
+        });
+
+        if (!startNext()) {
+          latestProps.current.onEnd?.();
+        }
+        return;
+      }
+
+      setAnimationState({
+        data: currentRun.interpolator(currentRun.ease(step)),
+        animationInfo: {
+          progress: step,
+          animating: true,
+        },
+      });
+    };
+
+    const subscribe = () => {
+      if (run.current !== currentRun || !isMounted.current) {
+        return;
+      }
+      currentRun.timeoutID = undefined;
+      currentRun.loopID = timer.subscribe(runFrame, currentRun.duration);
+      setAnimationState({
+        data: stateRef.current.data,
+        animationInfo: {
+          progress: 0,
+          animating: true,
+        },
+      });
+    };
+
+    if (nextDelay) {
+      currentRun.timeoutID = setTimeout(subscribe, nextDelay);
+    } else {
+      subscribe();
+    }
+    return true;
+  }, [setAnimationState, timer]);
+
+  React.useEffect(() => {
+    isMounted.current = true;
+    if (!hasInitialized.current) {
+      hasInitialized.current = true;
+      queue.current = Array.isArray(data) ? data.slice(1) : [];
+    }
+    if (!run.current && queue.current.length) {
+      startNext();
+    }
+
+    return () => {
+      isMounted.current = false;
+      cancelRun();
+    };
+    // The initial queue is intentionally captured once. Later data changes are
+    // handled below so they can begin from the currently rendered style.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  React.useEffect(() => {
+    const previous = previousProps.current;
+    previousProps.current = { data, duration, easing, delay, onEnd };
+
+    if (!hasHandledInitialProps.current) {
+      hasHandledInitialProps.current = true;
+      return;
+    }
+
+    if (previous.data !== data) {
+      cancelRun();
+      queue.current = Array.isArray(data) ? data.slice() : [data];
+      startNext();
+      return;
+    }
+
+    // onEnd is read from latestProps at completion, so changing it never
+    // needs to restart a run. A changed duration or easing does: restart the
+    // current step from its visible style, leaving the rest of the queue intact.
+    if (
+      run.current &&
+      (previous.duration !== duration || previous.easing !== easing)
+    ) {
+      cancelRun();
+      startNext();
+    }
+  }, [cancelRun, data, delay, duration, easing, onEnd, startNext]);
+
+  return children(state.data, state.animationInfo);
+};

--- a/packages/fuzz/corpus/react-bench-0.9.7-audit/regressions/60151913eb09--victory-animation.tsx.txt
+++ b/packages/fuzz/corpus/react-bench-0.9.7-audit/regressions/60151913eb09--victory-animation.tsx.txt
@@ -1,0 +1,254 @@
+// rule: effect-needs-cleanup
+// file-path: src/victory-animation/victory-animation.tsx
+// audit-verdict: pass
+// weakness: react-bench-exact-callsite
+// source: React Bench 0.9.11 exhaustive audit 60151913eb092a935273f16053b6235d52a27f7d0c557475dfc1641be5e641fb
+import React from "react";
+import * as d3Ease from "victory-vendor/d3-ease";
+import { victoryInterpolator } from "./util";
+import TimerContext from "../victory-util/timer-context";
+
+/**
+ * Single animation object to interpolate
+ */
+export type AnimationStyle = { [key: string]: string | number };
+/**
+ * Animation styles to interpolate
+ */
+
+export type AnimationData = AnimationStyle | AnimationStyle[];
+
+export type AnimationEasing =
+  | "back"
+  | "backIn"
+  | "backOut"
+  | "backInOut"
+  | "bounce"
+  | "bounceIn"
+  | "bounceOut"
+  | "bounceInOut"
+  | "circle"
+  | "circleIn"
+  | "circleOut"
+  | "circleInOut"
+  | "linear"
+  | "linearIn"
+  | "linearOut"
+  | "linearInOut"
+  | "cubic"
+  | "cubicIn"
+  | "cubicOut"
+  | "cubicInOut"
+  | "elastic"
+  | "elasticIn"
+  | "elasticOut"
+  | "elasticInOut"
+  | "exp"
+  | "expIn"
+  | "expOut"
+  | "expInOut"
+  | "poly"
+  | "polyIn"
+  | "polyOut"
+  | "polyInOut"
+  | "quad"
+  | "quadIn"
+  | "quadOut"
+  | "quadInOut"
+  | "sin"
+  | "sinIn"
+  | "sinOut"
+  | "sinInOut";
+
+export interface VictoryAnimationProps {
+  children: (style: AnimationStyle, info: AnimationInfo) => React.ReactElement;
+  duration?: number;
+  easing?: AnimationEasing;
+  delay?: number;
+  onEnd?: () => void;
+  data: AnimationData;
+}
+
+export interface VictoryAnimationState {
+  data: AnimationStyle;
+  animationInfo: AnimationInfo;
+}
+
+export interface AnimationInfo {
+  progress: number;
+  animating: boolean;
+  terminating?: boolean;
+}
+
+export interface VictoryAnimation {
+  context: React.ContextType<typeof TimerContext>;
+}
+
+/** d3-ease changed the naming scheme for ease from "linear" -> "easeLinear" etc. */
+const formatAnimationName = (name: AnimationEasing) => {
+  const capitalizedName = name.charAt(0).toUpperCase() + name.slice(1);
+  return `ease${capitalizedName}`;
+};
+
+const DEFAULT_DURATION = 1000;
+
+export const VictoryAnimation = ({
+  duration = DEFAULT_DURATION,
+  easing = "quadInOut",
+  delay = 0,
+  data,
+  children,
+  onEnd,
+}: VictoryAnimationProps) => {
+  const [state, setState] = React.useState<VictoryAnimationState>({
+    data: Array.isArray(data) ? data[0] : data,
+    animationInfo: {
+      progress: 0,
+      animating: false,
+    },
+  });
+
+  const timer = React.useContext(TimerContext).animationTimer;
+  const queue = React.useRef<AnimationStyle[]>(
+    Array.isArray(data) ? data.slice(1) : [],
+  );
+  const interpolator = React.useRef<null | ((value: number) => AnimationStyle)>(
+    null,
+  );
+  const loopID = React.useRef<number | undefined>(undefined);
+
+  // Latest-value refs so an in-progress animation always adopts the most
+  // recent settings instead of the values captured when it was subscribed.
+  const durationRef = React.useRef(duration);
+  const easeRef = React.useRef(d3Ease[formatAnimationName(easing)]);
+  const delayRef = React.useRef(delay);
+  const onEndRef = React.useRef(onEnd);
+  durationRef.current = duration;
+  easeRef.current = d3Ease[formatAnimationName(easing)];
+  delayRef.current = delay;
+  onEndRef.current = onEnd;
+
+  // Tracks the currently visible style so a hand-off can continue from it
+  // rather than the superseded target.
+  const styleRef = React.useRef<AnimationStyle>(state.data);
+  // Identifies the active run. Bumping it invalidates any in-flight frame or
+  // pending delayed start so a superseded run can neither render nor complete.
+  const runIDRef = React.useRef(0);
+
+  const isFirstRun = React.useRef(true);
+
+  // Mount / unmount lifecycle.
+  React.useEffect(() => {
+    // Length check prevents us from triggering `onEnd` in `traverseQueue`.
+    if (queue.current.length) {
+      traverseQueue();
+    }
+
+    // Clean up the animation loop. Invalidate the active run first so a queued
+    // completion cannot fire after the component has unmounted.
+    return () => {
+      runIDRef.current++;
+      if (loopID.current) {
+        timer.unsubscribe(loopID.current);
+      } else {
+        timer.stop();
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Respond to `data` changes. Other prop changes (duration/easing/delay/onEnd)
+  // are picked up live through the refs above and must not restart the run.
+  React.useEffect(() => {
+    if (isFirstRun.current) {
+      isFirstRun.current = false;
+      return;
+    }
+
+    // Cancel the existing loop so the superseded run can't render or complete.
+    if (loopID.current) {
+      timer.unsubscribe(loopID.current);
+      loopID.current = undefined;
+    }
+    // Continue from the currently visible style toward the new data.
+    queue.current = Array.isArray(data) ? data : [data];
+    // Start traversing the tween queue (this also invalidates prior runs).
+    traverseQueue();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data]);
+
+  const traverseQueue = () => {
+    // Every traversal is a fresh run; bumping invalidates anything still in
+    // flight from a previous run (including a pending delayed start).
+    const runID = ++runIDRef.current;
+
+    if (queue.current.length) {
+      const nextData = queue.current[0];
+
+      // Interpolate from the currently visible style to the next target.
+      interpolator.current = victoryInterpolator(styleRef.current, nextData);
+
+      const start = () => {
+        // Bail if a newer run superseded this one during the delay.
+        if (runID !== runIDRef.current) return;
+        loopID.current = timer.subscribe(
+          functionToBeRunEachFrame(runID),
+          durationRef.current,
+        );
+      };
+
+      if (delayRef.current) {
+        setTimeout(start, delayRef.current);
+      } else {
+        start();
+      }
+    } else if (onEndRef.current) {
+      onEndRef.current();
+    }
+  };
+
+  const functionToBeRunEachFrame = (runID: number) => (elapsed: number) => {
+    // Ignore frames belonging to a superseded run.
+    if (runID !== runIDRef.current) return;
+    if (!interpolator.current) return;
+
+    // Step can generate imprecise values, sometimes greater than 1
+    // if this happens set the state to 1 and return, cancelling the timer
+    const duration = durationRef.current;
+    const step = duration ? elapsed / duration : 1;
+
+    if (step >= 1) {
+      const finalData = interpolator.current(1);
+      styleRef.current = finalData;
+      setState({
+        data: finalData,
+        animationInfo: {
+          progress: 1,
+          animating: false,
+          terminating: true,
+        },
+      });
+      if (loopID.current) {
+        timer.unsubscribe(loopID.current);
+      }
+      queue.current.shift();
+      traverseQueue();
+      return;
+    }
+
+    // If we're not at the end of the timer, set the state by passing
+    // current step value that's transformed by the ease function to the
+    // interpolator, which is cached for performance whenever props are received
+    const nextData = interpolator.current(easeRef.current(step));
+    styleRef.current = nextData;
+    setState({
+      data: nextData,
+      animationInfo: {
+        progress: step,
+        animating: step < 1,
+      },
+    });
+  };
+
+  return children(state.data, state.animationInfo);
+};

--- a/packages/fuzz/corpus/react-bench-0.9.7-audit/regressions/64609f5c7a70--victory-animation.tsx.txt
+++ b/packages/fuzz/corpus/react-bench-0.9.7-audit/regressions/64609f5c7a70--victory-animation.tsx.txt
@@ -1,8 +1,8 @@
 // rule: effect-needs-cleanup
-// file-path: src/victory-animation/victory-animation.tsx
+// file-path: packages/victory-core/src/victory-animation/victory-animation.tsx
 // audit-verdict: pass
 // weakness: react-bench-exact-callsite
-// source: React Bench 0.9.7 exhaustive audit 64609f5c7a70a23c306ffadc0d360814e1f743006fbb5575445facef30abd358
+// source: React Bench 0.9.7+0.9.9 exhaustive audit 64609f5c7a70a23c306ffadc0d360814e1f743006fbb5575445facef30abd358
 import React from "react";
 import * as d3Ease from "victory-vendor/d3-ease";
 import isEqual from "react-fast-compare";

--- a/packages/fuzz/corpus/react-bench-0.9.7-audit/regressions/7f0af04f254c--tooltip.tsx.txt
+++ b/packages/fuzz/corpus/react-bench-0.9.7-audit/regressions/7f0af04f254c--tooltip.tsx.txt
@@ -1,13 +1,12 @@
 // rule: effect-needs-cleanup
-// file-path: tooltip_backup.tsx
+// file-path: src/components/Tooltip/Tooltip.tsx
 // audit-verdict: pass
 // weakness: react-bench-exact-callsite
-// source: React Bench 0.9.7 exhaustive audit fc9cd4b5ce6776cb8b900e3b2213fb323d4d8f0448867e66c6f988490bff2a13
+// source: React Bench 0.9.11 exhaustive audit 7f0af04f254ce28a63d0f8ae884e9d8ee4773ab5de0117f06184fac928da2311
 import React, { useEffect, useState, useRef, useCallback, useImperativeHandle } from 'react'
 import { autoUpdate } from '@floating-ui/dom'
 import classNames from 'classnames'
 import {
-  debounce,
   deepEqual,
   useIsomorphicLayoutEffect,
   getScrollParent,
@@ -77,6 +76,24 @@ const Tooltip = ({
   const tooltipArrowRef = useRef<HTMLElement>(null)
   const tooltipShowDelayTimerRef = useRef<NodeJS.Timeout | null>(null)
   const tooltipHideDelayTimerRef = useRef<NodeJS.Timeout | null>(null)
+  const visibilityTimerRef = useRef<NodeJS.Timeout | null>(null)
+  const pendingOpenRef = useRef<{
+    id: number
+    type: 'interaction' | 'imperative'
+    startedAt: number
+    delay: number
+    anchor: HTMLElement | null
+    options?: TooltipImperativeOpenOptions
+  } | null>(null)
+  const pendingOpenIdRef = useRef(0)
+  const pendingImperativeOptionsRef = useRef<TooltipImperativeOpenOptions | null>(null)
+  const interactionRef = useRef<{
+    anchor: HTMLElement | null
+    hover: boolean
+    focus: boolean
+  }>({ anchor: null, hover: false, focus: false })
+  const isControlledRef = useRef(isOpen !== undefined)
+  const wasControlledRef = useRef(isOpen !== undefined)
   const missedTransitionTimerRef = useRef<NodeJS.Timeout | null>(null)
   const [computedPosition, setComputedPosition] = useState<IComputedPosition>({
     tooltipStyles: {},
@@ -183,6 +200,32 @@ const Tooltip = ({
     }
   }, [])
 
+  const clearShowDelay = () => {
+    if (tooltipShowDelayTimerRef.current) {
+      clearTimeout(tooltipShowDelayTimerRef.current)
+      tooltipShowDelayTimerRef.current = null
+    }
+  }
+
+  const clearHideDelay = () => {
+    if (tooltipHideDelayTimerRef.current) {
+      clearTimeout(tooltipHideDelayTimerRef.current)
+      tooltipHideDelayTimerRef.current = null
+    }
+  }
+
+  const cancelPendingOpen = (type?: 'interaction' | 'imperative') => {
+    if (type && pendingOpenRef.current?.type !== type) {
+      return
+    }
+    pendingOpenIdRef.current += 1
+    pendingOpenRef.current = null
+    clearShowDelay()
+    if (!type || type === 'imperative') {
+      pendingImperativeOptionsRef.current = null
+    }
+  }
+
   const handleShow = (value: boolean) => {
     if (!mounted.current) {
       return
@@ -190,16 +233,16 @@ const Tooltip = ({
     if (value) {
       setRendered(true)
     }
-    /**
-     * wait for the component to render and calculate position
-     * before actually showing
-     */
-    setTimeout(() => {
-      if (!mounted.current) {
-        return
-      }
-      setIsOpen?.(value)
-      if (isOpen === undefined) {
+    setIsOpen?.(value)
+    if (isControlledRef.current) {
+      return
+    }
+    if (visibilityTimerRef.current) {
+      clearTimeout(visibilityTimerRef.current)
+    }
+    /** Wait for the component to render and calculate its position first. */
+    visibilityTimerRef.current = setTimeout(() => {
+      if (mounted.current) {
         setShow(value)
       }
     }, 10)
@@ -210,7 +253,16 @@ const Tooltip = ({
    * when `isOpen` is changed from outside
    */
   useEffect(() => {
-    if (isOpen === undefined) {
+    const controlled = isOpen !== undefined
+    isControlledRef.current = controlled
+    if (wasControlledRef.current && !controlled) {
+      // A controlled tooltip must not inherit an interaction that happened while
+      // the parent owned its visibility.
+      cancelPendingOpen()
+      setShow(false)
+    }
+    wasControlledRef.current = controlled
+    if (!controlled) {
       return () => null
     }
     if (isOpen) {
@@ -261,26 +313,56 @@ const Tooltip = ({
     )
   }
 
-  const handleShowTooltipDelayed = (delay = delayShow) => {
-    if (tooltipShowDelayTimerRef.current) {
-      clearTimeout(tooltipShowDelayTimerRef.current)
+  const startPendingOpen = (
+    type: 'interaction' | 'imperative',
+    delay: number,
+    anchor: HTMLElement | null,
+    options?: TooltipImperativeOpenOptions,
+  ) => {
+    cancelPendingOpen()
+    if (type === 'imperative') {
+      pendingImperativeOptionsRef.current = options ?? null
     }
-
-    if (rendered) {
-      // if the tooltip is already rendered, ignore delay
-      handleShow(true)
-      return
+    const pending = {
+      id: pendingOpenIdRef.current + 1,
+      type,
+      startedAt: Date.now(),
+      delay,
+      anchor,
+      options,
     }
-
-    tooltipShowDelayTimerRef.current = setTimeout(() => {
+    pendingOpenIdRef.current = pending.id
+    pendingOpenRef.current = pending
+    const open = () => {
+      if (pendingOpenRef.current?.id !== pending.id) {
+        return
+      }
+      pendingOpenRef.current = null
+      tooltipShowDelayTimerRef.current = null
+      if (pending.type === 'interaction') {
+        const interaction = interactionRef.current
+        if (interaction.anchor !== pending.anchor || (!interaction.hover && !interaction.focus)) {
+          return
+        }
+      } else {
+        pendingImperativeOptionsRef.current = null
+        setImperativeOptions(pending.options ?? null)
+        if (pending.anchor) {
+          setActiveAnchor(pending.anchor)
+          setProviderActiveAnchor({ current: pending.anchor })
+        }
+      }
       handleShow(true)
-    }, delay)
+    }
+    if (delay <= 0) {
+      open()
+    } else {
+      tooltipShowDelayTimerRef.current = setTimeout(open, delay)
+    }
   }
 
   const handleHideTooltipDelayed = (delay = delayHide) => {
-    if (tooltipHideDelayTimerRef.current) {
-      clearTimeout(tooltipHideDelayTimerRef.current)
-    }
+    clearHideDelay()
 
     tooltipHideDelayTimerRef.current = setTimeout(() => {
       if (hoveringTooltip.current) {
@@ -294,8 +376,8 @@ const Tooltip = ({
     if (!event) {
       return
     }
-    const target = (event.currentTarget ?? event.target) as HTMLElement | null
-    if (!target?.isConnected) {
+    const anchor = event.currentTarget as HTMLElement | null
+    if (!anchor?.isConnected) {
       /**
        * this happens when the target is removed from the DOM
        * at the same time the tooltip gets triggered
@@ -304,20 +386,79 @@ const Tooltip = ({
       setProviderActiveAnchor({ current: null })
       return
     }
-    if (delayShow) {
-      handleShowTooltipDelayed()
-    } else {
-      handleShow(true)
+    // An imperative open owns its pending request. Anchor events, including
+    // late leaves, must not replace or cancel it.
+    if (pendingOpenRef.current?.type === 'imperative') {
+      return
     }
-    setActiveAnchor(target)
-    setProviderActiveAnchor({ current: target })
-
-    if (tooltipHideDelayTimerRef.current) {
-      clearTimeout(tooltipHideDelayTimerRef.current)
+    clearHideDelay()
+    const interaction = interactionRef.current
+    const eventType = event.type
+    const relatedTarget = (event as MouseEvent).relatedTarget as Node | null
+    if (
+      (eventType === 'mouseover' || eventType === 'mouseenter') &&
+      relatedTarget &&
+      anchor.contains(relatedTarget)
+    ) {
+      return
+    }
+    if (interaction.anchor !== anchor) {
+      interaction.anchor = anchor
+      interaction.hover = false
+      interaction.focus = false
+    }
+    if (eventType === 'mouseover' || eventType === 'mouseenter') interaction.hover = true
+    if (eventType === 'focus' || eventType === 'focusin') interaction.focus = true
+    if (show) {
+      // Moving between anchors must never wait for the old delay.
+      cancelPendingOpen('interaction')
+      handleShow(true)
+      setActiveAnchor(anchor)
+      setProviderActiveAnchor({ current: anchor })
+      return
+    }
+    if (pendingOpenRef.current?.type === 'interaction') {
+      return
+    }
+    // Preserve the established zero-delay update order: rendering begins before
+    // the controller observes the new anchor's data attributes.
+    if (delayShow <= 0) {
+      handleShow(true)
+      setActiveAnchor(anchor)
+      setProviderActiveAnchor({ current: anchor })
+    } else {
+      setActiveAnchor(anchor)
+      setProviderActiveAnchor({ current: anchor })
+      startPendingOpen('interaction', delayShow, anchor)
     }
   }
 
-  const handleHideTooltip = () => {
+  const handleHideTooltip = (event?: Event) => {
+    const anchor = event?.currentTarget as HTMLElement | null
+    if (pendingOpenRef.current?.type === 'imperative') {
+      return
+    }
+    if (anchor) {
+      const interaction = interactionRef.current
+      if (interaction.anchor !== anchor) {
+        return
+      }
+      const eventType = event?.type
+      const relatedTarget = (event as MouseEvent).relatedTarget as Node | null
+      if (
+        (eventType === 'mouseout' || eventType === 'mouseleave' || eventType === 'focusout') &&
+        relatedTarget &&
+        anchor.contains(relatedTarget)
+      ) {
+        return
+      }
+      if (eventType === 'mouseout' || eventType === 'mouseleave') interaction.hover = false
+      if (eventType === 'blur' || eventType === 'focusout') interaction.focus = false
+      if (interaction.hover || interaction.focus) {
+        return
+      }
+    }
+    cancelPendingOpen('interaction')
     if (clickable) {
       // allow time for the mouse to reach the tooltip, in case there's a gap
       handleHideTooltipDelayed(delayHide || 100)
@@ -325,9 +466,6 @@ const Tooltip = ({
       handleHideTooltipDelayed()
     } else {
       handleShow(false)
-      if (tooltipShowDelayTimerRef.current) {
-        clearTimeout(tooltipShowDelayTimerRef.current)
-      }
     }
   }
 
@@ -374,7 +512,7 @@ const Tooltip = ({
   }
 
   const handleClickOutsideAnchors = (event: MouseEvent) => {
-    if (!show) {
+    if (!show && !pendingOpenRef.current) {
       return
     }
     const target = event.target as HTMLElement
@@ -389,28 +527,9 @@ const Tooltip = ({
     if (anchors.some((anchor) => anchor?.contains(target))) {
       return
     }
+    cancelPendingOpen()
+    setImperativeOptions(null)
     handleShow(false)
-    if (tooltipShowDelayTimerRef.current) {
-      clearTimeout(tooltipShowDelayTimerRef.current)
-    }
-  }
-
-  // debounce handler to prevent call twice when
-  // mouse enter and focus events being triggered toggether
-  const internalDebouncedHandleShowTooltip = debounce(handleShowTooltip, 50, true)
-  const internalDebouncedHandleHideTooltip = debounce(handleHideTooltip, 50, true)
-  // If either of the functions is called while the other is still debounced,
-  // reset the timeout. Otherwise if there is a sub-50ms (leave A, enter B, leave B)
-  // sequence of events, the tooltip will stay open because the hide debounce
-  // from leave A prevented the leave B event from calling it, leaving the
-  // tooltip visible.
-  const debouncedHandleShowTooltip = (e?: Event) => {
-    internalDebouncedHandleHideTooltip.cancel()
-    internalDebouncedHandleShowTooltip(e)
-  }
-  const debouncedHandleHideTooltip = () => {
-    internalDebouncedHandleShowTooltip.cancel()
-    internalDebouncedHandleHideTooltip()
   }
 
   const updateTooltipPosition = useCallback(() => {
@@ -471,10 +590,6 @@ const Tooltip = ({
   ])
 
   useEffect(() => {
-    if (activeAnchor && tooltipShowDelayTimerRef.current) {
-      handleShowTooltipDelayed()
-    }
-
     const elementRefs = new Set(anchorRefs)
 
     anchorsBySelect.forEach((anchor) => {
@@ -487,6 +602,8 @@ const Tooltip = ({
     }
 
     const handleScrollResize = () => {
+      cancelPendingOpen()
+      setImperativeOptions(null)
       handleShow(false)
     }
 
@@ -518,6 +635,8 @@ const Tooltip = ({
       if (event.key !== 'Escape') {
         return
       }
+      cancelPendingOpen()
+      setImperativeOptions(null)
       handleShow(false)
     }
     if (actualGlobalCloseEvents.escape) {
@@ -531,7 +650,8 @@ const Tooltip = ({
     const enabledEvents: { event: string; listener: (event?: Event) => void }[] = []
 
     const handleClickOpenTooltipAnchor = (event?: Event) => {
-      if (show && event?.target === activeAnchor) {
+      const anchor = event?.currentTarget as HTMLElement | null
+      if (show && anchor === activeAnchor) {
         /**
          * ignore clicking the anchor that was used to open the tooltip.
          * this avoids conflict with the click close event.
@@ -541,7 +661,8 @@ const Tooltip = ({
       handleShowTooltip(event)
     }
     const handleClickCloseTooltipAnchor = (event?: Event) => {
-      if (!show || event?.target !== activeAnchor) {
+      const anchor = event?.currentTarget as HTMLElement | null
+      if (!show || anchor !== activeAnchor) {
         /**
          * ignore clicking the anchor that was NOT used to open the tooltip.
          * this avoids closing the tooltip when clicking on a
@@ -549,7 +670,7 @@ const Tooltip = ({
          */
         return
       }
-      handleHideTooltip()
+      handleHideTooltip(event)
     }
 
     const regularEvents = ['mouseover', 'mouseout', 'mouseenter', 'mouseleave', 'focus', 'blur']
@@ -560,7 +681,10 @@ const Tooltip = ({
         return
       }
       if (regularEvents.includes(event)) {
-        enabledEvents.push({ event, listener: debouncedHandleShowTooltip })
+        enabledEvents.push({
+          event: event === 'focus' ? 'focusin' : event,
+          listener: handleShowTooltip,
+        })
       } else if (clickEvents.includes(event)) {
         enabledEvents.push({ event, listener: handleClickOpenTooltipAnchor })
       } else {
@@ -573,7 +697,10 @@ const Tooltip = ({
         return
       }
       if (regularEvents.includes(event)) {
-        enabledEvents.push({ event, listener: debouncedHandleHideTooltip })
+        enabledEvents.push({
+          event: event === 'blur' ? 'focusout' : event,
+          listener: handleHideTooltip,
+        })
       } else if (clickEvents.includes(event)) {
         enabledEvents.push({ event, listener: handleClickCloseTooltipAnchor })
       } else {
@@ -703,14 +830,10 @@ const Tooltip = ({
           elements.some((node) => {
             if (node?.contains?.(activeAnchor)) {
               setRendered(false)
+              cancelPendingOpen()
               handleShow(false)
               setActiveAnchor(null)
-              if (tooltipShowDelayTimerRef.current) {
-                clearTimeout(tooltipShowDelayTimerRef.current)
-              }
-              if (tooltipHideDelayTimerRef.current) {
-                clearTimeout(tooltipHideDelayTimerRef.current)
-              }
+              clearHideDelay()
               return true
             }
             return false
@@ -798,12 +921,9 @@ const Tooltip = ({
       handleShow(true)
     }
     return () => {
-      if (tooltipShowDelayTimerRef.current) {
-        clearTimeout(tooltipShowDelayTimerRef.current)
-      }
-      if (tooltipHideDelayTimerRef.current) {
-        clearTimeout(tooltipHideDelayTimerRef.current)
-      }
+      cancelPendingOpen()
+      clearHideDelay()
+      if (visibilityTimerRef.current) clearTimeout(visibilityTimerRef.current)
     }
   }, [])
 
@@ -825,12 +945,31 @@ const Tooltip = ({
   }, [id, anchorSelect, imperativeOptions?.anchorSelect])
 
   useEffect(() => {
-    if (activeAnchor) {
-      if (tooltipShowDelayTimerRef.current) {
-        clearTimeout(tooltipShowDelayTimerRef.current)
-      }
-      handleShowTooltipDelayed(delayShow)
+    const pending = pendingOpenRef.current
+    if (pending?.type !== 'interaction') {
+      return
     }
+    // Keep the original interaction start time: changing the delay changes the
+    // deadline, rather than beginning a new wait after every prop update.
+    const remaining = Math.max(0, delayShow - (Date.now() - pending.startedAt))
+    pending.delay = delayShow
+    clearShowDelay()
+    if (remaining === 0) {
+      const interaction = interactionRef.current
+      if (interaction.anchor === pending.anchor && (interaction.hover || interaction.focus)) {
+        pendingOpenRef.current = null
+        handleShow(true)
+      }
+      return
+    }
+    tooltipShowDelayTimerRef.current = setTimeout(() => {
+      if (pendingOpenRef.current?.id !== pending.id) return
+      pendingOpenRef.current = null
+      const interaction = interactionRef.current
+      if (interaction.anchor === pending.anchor && (interaction.hover || interaction.focus)) {
+        handleShow(true)
+      }
+    }, remaining)
   }, [delayShow])
 
   const actualContent = imperativeOptions?.content ?? content
@@ -849,17 +988,20 @@ const Tooltip = ({
           return
         }
       }
-      setImperativeOptions(options ?? null)
-      if (options?.delay) {
-        handleShowTooltipDelayed(options.delay)
-      } else {
-        handleShow(true)
-      }
+      clearHideDelay()
+      const anchor = options?.anchorSelect
+        ? document.querySelector<HTMLElement>(options.anchorSelect)
+        : activeAnchor
+      startPendingOpen('imperative', options?.delay ?? 0, anchor, options)
     },
     close: (options) => {
+      // Closing invalidates an opening immediately, even when the visual close
+      // itself is delayed.
+      cancelPendingOpen()
       if (options?.delay) {
         handleHideTooltipDelayed(options.delay)
       } else {
+        setImperativeOptions(null)
         handleShow(false)
       }
     },

--- a/packages/fuzz/corpus/react-bench-0.9.7-audit/regressions/9421df7d6d70--victory-animation.tsx.txt
+++ b/packages/fuzz/corpus/react-bench-0.9.7-audit/regressions/9421df7d6d70--victory-animation.tsx.txt
@@ -1,0 +1,280 @@
+// rule: effect-needs-cleanup
+// file-path: src/victory-animation/victory-animation.tsx
+// audit-verdict: pass
+// weakness: react-bench-exact-callsite
+// source: React Bench 0.9.11 exhaustive audit 9421df7d6d706e34f416e6576229e00ccb7442d99166744f5f7facd5117b0a81
+import React from "react";
+import * as d3Ease from "victory-vendor/d3-ease";
+import { victoryInterpolator } from "./util";
+import TimerContext from "../victory-util/timer-context";
+
+/**
+ * Single animation object to interpolate
+ */
+export type AnimationStyle = { [key: string]: string | number };
+/**
+ * Animation styles to interpolate
+ */
+
+export type AnimationData = AnimationStyle | AnimationStyle[];
+
+export type AnimationEasing =
+  | "back"
+  | "backIn"
+  | "backOut"
+  | "backInOut"
+  | "bounce"
+  | "bounceIn"
+  | "bounceOut"
+  | "bounceInOut"
+  | "circle"
+  | "circleIn"
+  | "circleOut"
+  | "circleInOut"
+  | "linear"
+  | "linearIn"
+  | "linearOut"
+  | "linearInOut"
+  | "cubic"
+  | "cubicIn"
+  | "cubicOut"
+  | "cubicInOut"
+  | "elastic"
+  | "elasticIn"
+  | "elasticOut"
+  | "elasticInOut"
+  | "exp"
+  | "expIn"
+  | "expOut"
+  | "expInOut"
+  | "poly"
+  | "polyIn"
+  | "polyOut"
+  | "polyInOut"
+  | "quad"
+  | "quadIn"
+  | "quadOut"
+  | "quadInOut"
+  | "sin"
+  | "sinIn"
+  | "sinOut"
+  | "sinInOut";
+
+export interface VictoryAnimationProps {
+  children: (style: AnimationStyle, info: AnimationInfo) => React.ReactElement;
+  duration?: number;
+  easing?: AnimationEasing;
+  delay?: number;
+  onEnd?: () => void;
+  data: AnimationData;
+}
+
+export interface VictoryAnimationState {
+  data: AnimationStyle;
+  animationInfo: AnimationInfo;
+}
+
+export interface AnimationInfo {
+  progress: number;
+  animating: boolean;
+  terminating?: boolean;
+}
+
+export interface VictoryAnimation {
+  context: React.ContextType<typeof TimerContext>;
+}
+
+/** d3-ease changed the naming scheme for ease from "linear" -> "easeLinear" etc. */
+const formatAnimationName = (name: AnimationEasing) => {
+  const capitalizedName = name.charAt(0).toUpperCase() + name.slice(1);
+  return `ease${capitalizedName}`;
+};
+
+const DEFAULT_DURATION = 1000;
+
+/**
+ * The internal state of a single animation run. A new run object is created
+ * every time the animation target changes, so stale closures can detect that
+ * they have been superseded and bail out without rendering or completing.
+ */
+interface AnimationRun {
+  interpolator: (value: number) => AnimationStyle;
+  loopID?: number;
+  timeoutID?: ReturnType<typeof setTimeout>;
+  /** The eased progress of this run, as of the latest frame */
+  progress: number;
+  /** Whether this run has been replaced by a newer one */
+  superseded: boolean;
+}
+
+export const VictoryAnimation = ({
+  duration = DEFAULT_DURATION,
+  easing = "quadInOut",
+  delay = 0,
+  data,
+  children,
+  onEnd,
+}: VictoryAnimationProps) => {
+  const [state, setState] = React.useState<VictoryAnimationState>({
+    data: Array.isArray(data) ? data[0] : data,
+    animationInfo: {
+      progress: 0,
+      animating: false,
+    },
+  });
+
+  const timer = React.useContext(TimerContext).animationTimer;
+
+  // Always read the latest props from within timer callbacks, so that an
+  // in-progress animation adopts new `duration`, `easing`, and `onEnd` values.
+  const latestProps = React.useRef({ duration, easing, delay, onEnd });
+  latestProps.current = { duration, easing, delay, onEnd };
+
+  // The latest rendered (visible) data, used as the starting point when an
+  // animation is interrupted by new data.
+  const currentData = React.useRef<AnimationStyle>(state.data);
+  currentData.current = state.data;
+
+  const queue = React.useRef<AnimationStyle[]>(
+    Array.isArray(data) ? data.slice(1) : [],
+  );
+  const run = React.useRef<AnimationRun | null>(null);
+
+  const stopRun = (runToStop: AnimationRun) => {
+    runToStop.superseded = true;
+    if (runToStop.timeoutID !== undefined) {
+      clearTimeout(runToStop.timeoutID);
+      runToStop.timeoutID = undefined;
+    }
+    if (runToStop.loopID !== undefined) {
+      timer.unsubscribe(runToStop.loopID);
+      runToStop.loopID = undefined;
+    }
+  };
+
+  const functionToBeRunEachFrame = (
+    activeRun: AnimationRun,
+    elapsed: number,
+  ) => {
+    // A superseded run must not render or complete.
+    if (activeRun.superseded || run.current !== activeRun) return;
+
+    const { duration: latestDuration, easing: latestEasing } =
+      latestProps.current;
+    const ease = d3Ease[formatAnimationName(latestEasing)];
+
+    // Step can generate imprecise values, sometimes greater than 1
+    // if this happens set the state to 1 and return, cancelling the timer
+    const step = latestDuration ? elapsed / latestDuration : 1;
+
+    if (step >= 1) {
+      const finalData = activeRun.interpolator(1);
+      activeRun.progress = 1;
+      setState({
+        data: finalData,
+        animationInfo: {
+          progress: 1,
+          animating: false,
+          terminating: true,
+        },
+      });
+      if (activeRun.loopID !== undefined) {
+        timer.unsubscribe(activeRun.loopID);
+        activeRun.loopID = undefined;
+      }
+      queue.current.shift();
+      traverseQueue();
+      return;
+    }
+
+    // If we're not at the end of the timer, set the state by passing
+    // current step value that's transformed by the ease function to the
+    // interpolator, which is cached for performance whenever props are received
+    activeRun.progress = step;
+    setState({
+      data: activeRun.interpolator(ease(step)),
+      animationInfo: {
+        progress: step,
+        animating: step < 1,
+      },
+    });
+  };
+
+  const traverseQueue = () => {
+    if (queue.current.length) {
+      const nextData = queue.current[0];
+
+      const activeRun: AnimationRun = {
+        // Start from the currently visible data so that interrupting an
+        // in-progress animation does not flash the superseded target.
+        interpolator: victoryInterpolator(currentData.current, nextData),
+        progress: 0,
+        superseded: false,
+      };
+      run.current = activeRun;
+
+      const { duration: latestDuration, delay: latestDelay } =
+        latestProps.current;
+      const subscribe = () => {
+        // A superseded run must not start after its delay has elapsed.
+        if (activeRun.superseded || run.current !== activeRun) return;
+        activeRun.loopID = timer.subscribe(
+          (elapsed) => functionToBeRunEachFrame(activeRun, elapsed),
+          latestDuration,
+        );
+      };
+
+      // Reset step to zero
+      if (latestDelay) {
+        activeRun.timeoutID = setTimeout(subscribe, latestDelay);
+      } else {
+        subscribe();
+      }
+    } else if (latestProps.current.onEnd) {
+      // Only the latest `onEnd` callback is invoked when the queue completes.
+      latestProps.current.onEnd();
+    }
+  };
+
+  React.useEffect(() => {
+    // Length check prevents us from triggering `onEnd` in `traverseQueue`.
+    if (queue.current.length) {
+      traverseQueue();
+    }
+
+    // Clean up the animation loop on unmount so that completion cannot fire
+    // afterward.
+    return () => {
+      if (run.current) {
+        stopRun(run.current);
+        run.current = null;
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const isFirstRender = React.useRef(true);
+
+  React.useEffect(() => {
+    // Skip the initial render; the mount effect above already started the
+    // initial queue.
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+    // Cancel the existing run, if any. The superseded run must not render or
+    // complete later.
+    if (run.current) {
+      stopRun(run.current);
+      run.current = null;
+    }
+    // Set the tween queue to the new data. The replacement run continues from
+    // the currently visible style toward the new data.
+    queue.current = Array.isArray(data) ? data.slice() : [data];
+    // Start traversing the tween queue
+    traverseQueue();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data]);
+
+  return children(state.data, state.animationInfo);
+};

--- a/packages/fuzz/corpus/react-bench-0.9.7-audit/regressions/b2b78b886500--victory-animation.tsx.txt
+++ b/packages/fuzz/corpus/react-bench-0.9.7-audit/regressions/b2b78b886500--victory-animation.tsx.txt
@@ -1,0 +1,299 @@
+// rule: effect-needs-cleanup
+// file-path: src/victory-animation/victory-animation.tsx
+// audit-verdict: pass
+// weakness: react-bench-exact-callsite
+// source: React Bench 0.9.11 exhaustive audit b2b78b886500ff5ccc6c8eafebdf8796fc2b2f4206b6948842b312a2a119279d
+import React from "react";
+import * as d3Ease from "victory-vendor/d3-ease";
+import { victoryInterpolator } from "./util";
+import TimerContext from "../victory-util/timer-context";
+
+/**
+ * Single animation object to interpolate
+ */
+export type AnimationStyle = { [key: string]: string | number };
+/**
+ * Animation styles to interpolate
+ */
+
+export type AnimationData = AnimationStyle | AnimationStyle[];
+
+export type AnimationEasing =
+  | "back"
+  | "backIn"
+  | "backOut"
+  | "backInOut"
+  | "bounce"
+  | "bounceIn"
+  | "bounceOut"
+  | "bounceInOut"
+  | "circle"
+  | "circleIn"
+  | "circleOut"
+  | "circleInOut"
+  | "linear"
+  | "linearIn"
+  | "linearOut"
+  | "linearInOut"
+  | "cubic"
+  | "cubicIn"
+  | "cubicOut"
+  | "cubicInOut"
+  | "elastic"
+  | "elasticIn"
+  | "elasticOut"
+  | "elasticInOut"
+  | "exp"
+  | "expIn"
+  | "expOut"
+  | "expInOut"
+  | "poly"
+  | "polyIn"
+  | "polyOut"
+  | "polyInOut"
+  | "quad"
+  | "quadIn"
+  | "quadOut"
+  | "quadInOut"
+  | "sin"
+  | "sinIn"
+  | "sinOut"
+  | "sinInOut";
+
+export interface VictoryAnimationProps {
+  children: (style: AnimationStyle, info: AnimationInfo) => React.ReactElement;
+  duration?: number;
+  easing?: AnimationEasing;
+  delay?: number;
+  onEnd?: () => void;
+  data: AnimationData;
+}
+
+export interface VictoryAnimationState {
+  data: AnimationStyle;
+  animationInfo: AnimationInfo;
+}
+
+export interface AnimationInfo {
+  progress: number;
+  animating: boolean;
+  terminating?: boolean;
+}
+
+export interface VictoryAnimation {
+  context: React.ContextType<typeof TimerContext>;
+}
+
+/** d3-ease changed the naming scheme for ease from "linear" -> "easeLinear" etc. */
+const formatAnimationName = (name: AnimationEasing) => {
+  const capitalizedName = name.charAt(0).toUpperCase() + name.slice(1);
+  return `ease${capitalizedName}`;
+};
+
+const DEFAULT_DURATION = 1000;
+
+/**
+ * A run is one pass through a queue of animation steps. A new run is started
+ * whenever the `data` prop changes, and any previously active run is
+ * superseded: it stops rendering, never completes, and never calls `onEnd`.
+ */
+interface AnimationRun {
+  steps: AnimationStyle[];
+  stepIndex: number;
+  interpolator: null | ((value: number) => AnimationStyle);
+  loopID: number | undefined;
+  timeoutID: ReturnType<typeof setTimeout> | undefined;
+}
+
+export const VictoryAnimation = ({
+  duration = DEFAULT_DURATION,
+  easing = "quadInOut",
+  delay = 0,
+  data,
+  children,
+  onEnd,
+}: VictoryAnimationProps) => {
+  const [state, setState] = React.useState<VictoryAnimationState>({
+    data: Array.isArray(data) ? data[0] : data,
+    animationInfo: {
+      progress: 0,
+      animating: false,
+    },
+  });
+
+  const timer = React.useContext(TimerContext).animationTimer;
+
+  // The latest prop values are kept in refs so that an in-progress animation
+  // always uses the current `duration`, `easing`, and `onEnd`, even if they
+  // changed after the animation started.
+  const latestProps = React.useRef({ duration, easing, delay, onEnd });
+  latestProps.current = { duration, easing, delay, onEnd };
+
+  // The currently active run, or null when no animation is in progress.
+  const activeRun = React.useRef<AnimationRun | null>(null);
+  // Whether the initial run (triggered by mount) has started. The initial
+  // run's rendered style already equals the first step, so it is skipped.
+  const hasStarted = React.useRef(false);
+  // Monotonically increasing id used to detect superseded runs. Any tick or
+  // timeout that holds a token other than the current epoch is stale.
+  const epoch = React.useRef(0);
+  // The latest rendered state, kept in sync so a replacement run can
+  // seamlessly continue from the currently visible style.
+  const renderedState = React.useRef(state);
+
+  const updateState = (newState: VictoryAnimationState) => {
+    renderedState.current = newState;
+    setState(newState);
+  };
+
+  const stopRun = (run: AnimationRun) => {
+    if (run.timeoutID !== undefined) {
+      clearTimeout(run.timeoutID);
+      run.timeoutID = undefined;
+    }
+    if (run.loopID !== undefined) {
+      timer.unsubscribe(run.loopID);
+      run.loopID = undefined;
+    }
+  };
+
+  // Supersede the active run: it must not render or complete afterwards.
+  const cancelActiveRun = () => {
+    epoch.current += 1;
+    if (activeRun.current) {
+      stopRun(activeRun.current);
+      activeRun.current = null;
+    }
+  };
+
+  const getDuration = () => {
+    const currentDuration = latestProps.current.duration;
+    return typeof currentDuration === "number" ? currentDuration : 0;
+  };
+
+  const getEase = () => {
+    return d3Ease[formatAnimationName(latestProps.current.easing)];
+  };
+
+  const functionToBeRunEachFrame = (
+    run: AnimationRun,
+    token: number,
+    elapsed: number,
+  ) => {
+    // A superseded run must not render or complete.
+    if (token !== epoch.current || activeRun.current !== run) return;
+    if (!run.interpolator) return;
+
+    const currentDuration = getDuration();
+    // Step can generate imprecise values, sometimes greater than 1
+    // if this happens set the state to 1 and return, cancelling the timer
+    const step = currentDuration ? elapsed / currentDuration : 1;
+
+    if (step >= 1) {
+      updateState({
+        data: run.interpolator(1),
+        animationInfo: {
+          progress: 1,
+          animating: false,
+          terminating: true,
+        },
+      });
+      if (run.loopID !== undefined) {
+        timer.unsubscribe(run.loopID);
+        run.loopID = undefined;
+      }
+      run.stepIndex += 1;
+      run.interpolator = null;
+      traverseQueue(run, token);
+      return;
+    }
+
+    // If we're not at the end of the timer, set the state by passing
+    // current step value that's transformed by the ease function to the
+    // interpolator, which is cached for performance whenever props are received
+    updateState({
+      data: run.interpolator(getEase()(step)),
+      animationInfo: {
+        progress: step,
+        animating: step < 1,
+      },
+    });
+  };
+
+  const traverseQueue = (run: AnimationRun, token: number) => {
+    if (token !== epoch.current || activeRun.current !== run) return;
+
+    if (run.stepIndex < run.steps.length) {
+      const nextData = run.steps[run.stepIndex];
+
+      // Compare the currently visible style to the next step so the
+      // animation continues smoothly from wherever the previous step (or
+      // a superseded run) left off.
+      run.interpolator = victoryInterpolator(
+        renderedState.current.data,
+        nextData,
+      );
+
+      // Reset step to zero
+      const startLoop = () => {
+        if (token !== epoch.current || activeRun.current !== run) return;
+        run.timeoutID = undefined;
+        run.loopID = timer.subscribe(
+          (elapsed) => functionToBeRunEachFrame(run, token, elapsed),
+          getDuration(),
+        );
+      };
+      const currentDelay = latestProps.current.delay;
+      if (currentDelay) {
+        run.timeoutID = setTimeout(startLoop, currentDelay);
+      } else {
+        startLoop();
+      }
+    } else {
+      // The queue is complete. Only the latest run reaches this point, so
+      // only the latest `onEnd` callback is invoked.
+      activeRun.current = null;
+      const currentOnEnd = latestProps.current.onEnd;
+      if (currentOnEnd) {
+        currentOnEnd();
+      }
+    }
+  };
+
+  React.useEffect(() => {
+    const steps = Array.isArray(data) ? data : [data];
+    if (!steps.length) return;
+
+    // Start a replacement run toward the new data. It continues from the
+    // currently visible style, so the superseded target is never flashed,
+    // and only this replacement run can render or complete.
+    cancelActiveRun();
+    const token = epoch.current;
+    // On the initial run the rendered style already equals the first step,
+    // so begin from the next one (the original mount behavior).
+    const stepIndex = !hasStarted.current && steps.length > 1 ? 1 : 0;
+    hasStarted.current = true;
+    const run: AnimationRun = {
+      steps,
+      stepIndex,
+      interpolator: null,
+      loopID: undefined,
+      timeoutID: undefined,
+    };
+    activeRun.current = run;
+    traverseQueue(run, token);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data]);
+
+  React.useEffect(() => {
+    // Clean up the animation loop when unmounting so completion (and
+    // `onEnd`) cannot fire afterwards.
+    return () => {
+      cancelActiveRun();
+      timer.stop();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return children(state.data, state.animationInfo);
+};

--- a/packages/fuzz/corpus/react-bench-0.9.7-audit/true-positives/74931c270c70--editorial-health-panel.jsx.txt
+++ b/packages/fuzz/corpus/react-bench-0.9.7-audit/true-positives/74931c270c70--editorial-health-panel.jsx.txt
@@ -2,7 +2,7 @@
 // file-path: client/src/components/pipeline/editorial/EditorialHealthPanel.jsx
 // verdict: fail
 // weakness: react-bench-exact-callsite
-// source: React Bench 0.9.7 exhaustive audit 74931c270c7093eec0c0f1a5b01c8aaf52035141e7723fac04089836143bffa5
+// source: React Bench 0.9.7+0.9.9 exhaustive audit 74931c270c7093eec0c0f1a5b01c8aaf52035141e7723fac04089836143bffa5
 /**
  * Editorial health panel (#1316) for the Editorial Checks page — turns the
  * point-in-time findings into something the author can MANAGE the draft with:

--- a/packages/fuzz/scripts/import-react-bench-audit-corpus.mjs
+++ b/packages/fuzz/scripts/import-react-bench-audit-corpus.mjs
@@ -9,6 +9,8 @@ const DEFAULT_AUDIT_VERSION = "0.9.7";
 const TRUE_POSITIVE_SUFFIXES = new Set(["2JPrD6x", "SQSmbFe", "eGYGezE", "p9AQ8ui"]);
 
 const sha256 = (value) => crypto.createHash("sha256").update(value).digest("hex");
+const compareAuditVersions = (left, right) =>
+  left.localeCompare(right, undefined, { numeric: true });
 
 const collectFiles = (directory) => {
   const filePaths = [];
@@ -141,7 +143,7 @@ const main = () => {
       path.basename(group.callsitePaths[0], path.extname(group.callsitePaths[0])),
     );
     const directoryName = group.verdict === "pass" ? "regressions" : "true-positives";
-    const fileName = `${fixtureSourceSha256.slice(0, HASH_PREFIX_LENGTH)}--${sourceBaseName}${extension}`;
+    const fileName = `${fixtureSourceSha256.slice(0, HASH_PREFIX_LENGTH)}--${sourceBaseName}${extension}.txt`;
     const relativePath = path.posix.join(CORPUS_DIRECTORY_NAME, directoryName, fileName);
     const outputPath = path.join(resolvedCorpusDirectory, directoryName, fileName);
     const rules = [...group.rules].sort();
@@ -150,16 +152,16 @@ const main = () => {
       `// file-path: ${group.callsitePaths[0]}`,
       group.verdict === "fail" ? "// verdict: fail" : "// audit-verdict: pass",
       "// weakness: react-bench-exact-callsite",
-      `// source: React Bench ${[...group.auditVersions].sort().join("+")} exhaustive audit ${fixtureSourceSha256}`,
+      `// source: React Bench ${[...group.auditVersions].sort(compareAuditVersions).join("+")} exhaustive audit ${fixtureSourceSha256}`,
     ].join("\n");
     fs.mkdirSync(path.dirname(outputPath), { recursive: true });
     fs.writeFileSync(outputPath, `${header}\n${group.source}`);
     fixtures.push({
       fixture: relativePath,
-      filePath: group.callsitePaths[0],
       verdict: group.verdict,
       rules,
       fixtureSourceSha256,
+      filePath: group.callsitePaths[0],
     });
     for (const callsite of group.callsites) {
       const callsiteKey = [
@@ -180,8 +182,13 @@ const main = () => {
       callsite.rule,
       callsite.reconstructedFilePath,
       callsite.reportedLine,
+      callsite.reportedColumn ?? "",
       callsite.snippetSha256,
     ].join(":");
+    const fixture = fixtureByCallsiteKey.get(callsiteKey);
+    if (!fixture) {
+      throw new Error(`Missing fixture mapping for ${callsiteKey}`);
+    }
     return {
       suffix: callsite.suffix,
       ...(callsite.sourceTrialId ? { sourceTrialId: callsite.sourceTrialId } : {}),
@@ -194,13 +201,13 @@ const main = () => {
       ...(callsite.reportedColumn ? { reportedColumn: callsite.reportedColumn } : {}),
       sourceSha256: callsite.sourceSha256,
       snippetSha256: callsite.snippetSha256,
-      fixture: fixtureByCallsiteKey.get(callsiteKey),
+      fixture,
       verdict: TRUE_POSITIVE_SUFFIXES.has(callsite.suffix) ? "fail" : "pass",
     };
   });
   const manifest = {
     source: `React Bench ${[...new Set(manifestCallsites.map((callsite) => callsite.auditVersion))]
-      .sort()
+      .sort(compareAuditVersions)
       .join("+")} exhaustive all-diffs audit`,
     expected: {
       totalCallsites: manifestCallsites.length,

--- a/packages/fuzz/tests/import-react-bench-audit-corpus.test.ts
+++ b/packages/fuzz/tests/import-react-bench-audit-corpus.test.ts
@@ -1,0 +1,66 @@
+import * as crypto from "node:crypto";
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vite-plus/test";
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const importerPath = path.join(packageRoot, "scripts/import-react-bench-audit-corpus.mjs");
+const sha256 = (value: string): string => crypto.createHash("sha256").update(value).digest("hex");
+
+describe("React Bench audit corpus importer", () => {
+  it("keeps fixture mappings when callsites include reported columns", () => {
+    const temporaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-fuzz-import-"));
+    try {
+      const source = "setTimeout(runLater, delay);\n";
+      const suffix = "column-key";
+      const relativeSourcePath = "src/example.tsx";
+      const currentSourcesDirectory = path.join(temporaryRoot, "sources");
+      const sourcePath = path.join(currentSourcesDirectory, suffix, relativeSourcePath);
+      const contextsPath = path.join(temporaryRoot, "contexts.json");
+      const corpusDirectory = path.join(temporaryRoot, "react-bench-0.9.7-audit");
+      const manifestPath = path.join(temporaryRoot, "manifest.json");
+      fs.mkdirSync(path.dirname(sourcePath), { recursive: true });
+      fs.writeFileSync(sourcePath, source);
+      fs.writeFileSync(
+        contextsPath,
+        JSON.stringify([
+          {
+            suffix,
+            sourceTrialId: "00000000-0000-4000-8000-000000000000",
+            auditVersion: "0.9.11",
+            task: "example",
+            patchSha256: sha256("patch"),
+            rule: "effect-needs-cleanup",
+            reconstructedFilePath: relativeSourcePath,
+            reportedFilePath: relativeSourcePath,
+            reportedLine: 1,
+            reportedColumn: 1,
+            sourceSha256: sha256(source),
+            snippet: source,
+            snippetSha256: sha256(source),
+            snippetStartLine: 1,
+            snippetEndLine: 1,
+          },
+        ]),
+      );
+
+      execFileSync(process.execPath, [
+        importerPath,
+        contextsPath,
+        currentSourcesDirectory,
+        corpusDirectory,
+        manifestPath,
+      ]);
+
+      const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+      expect(manifest.callsites[0].fixture).toBe(manifest.fixtures[0].fixture);
+      expect(manifest.callsites[0].reportedColumn).toBe(1);
+      expect(manifest.callsites[0].fixture).toMatch(/\.tsx\.txt$/);
+    } finally {
+      fs.rmSync(temporaryRoot, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add the eight exact full-source callsites exposed by the RD 0.9.11 exhaustive 15,810-trial delta audit
- raise the deduplicated audit corpus to 345 callsite instances / 329 byte-unique fixtures
- fix `reportedColumn` fixture-map lookup drift and fail closed on missing mappings
- keep generated audit fixtures as `.tsx.txt` source data and naturally sort audit versions

## Audit result
- 15,810/15,810 reports complete
- 233 removed `effect-needs-cleanup` diagnostics: 225 previously confirmed FPs + 8 newly reviewed safe ownership/invalidation cases
- 0 newly introduced diagnostics
- 0 RD gate regressions; 6 gates corrected from fail to pass

## Validation
- full `nr test`: 15/15 tasks successful
- fuzz package: 215 passed, 788 skipped
- `nr typecheck`
- `nr lint`
- `nr format:check`
- `git diff --check`

No changeset: this only hardens internal audit corpus/import tooling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to fuzz corpus data and the audit import script; no product runtime or rule logic is modified.
> 
> **Overview**
> Extends the React Bench exhaustive audit fuzz corpus to include **0.9.11** delta results, bringing the manifest to **345 callsites** and **329** byte-unique fixtures (still **5** expected failures). Adds **eight** new regression fixtures—mostly `effect-needs-cleanup` on `victory-animation` plus one **Tooltip** case—and folds the existing true-positive entries into the sorted fixture list with small metadata fixes (e.g. monorepo `file-path`, `tooltip_backup.tsx`).
> 
> The **import script** now builds fixture lookup keys with **`reportedColumn`**, names generated sources as `*.tsx.txt`, sorts audit versions numerically (`0.9.9` before `0.9.11`), and **throws** if a callsite has no fixture mapping. A **unit test** covers column-aware import end-to-end.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c23dac3682b3d078022f7fe293a7a7dbf640489. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->