### PR TITLE
fix: exclude git-ignored files from staged snapshot divergence check

### DIFF
--- a/.changeset/fix-staged-ignore-divergence.md
+++ b/.changeset/fix-staged-ignore-divergence.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Fix `--staged` false positive on git-ignored config files. Git-ignored config files (e.g. `.opencode/package.json`) can never be staged, so they should not block staged scans with divergence errors.

--- a/packages/react-doctor/src/cli/utils/parse-staged-snapshot-divergences.ts
+++ b/packages/react-doctor/src/cli/utils/parse-staged-snapshot-divergences.ts
@@ -22,7 +22,7 @@ export const parseStagedSnapshotDivergences = (statusOutput: string): ReadonlyAr
     const sourcePath = hasRenameOrCopySource ? statusEntries[entryIndex + 1] : undefined;
     const worktreePaths =
       worktreeStatus === "R" || worktreeStatus === "C" ? [filePath, sourcePath] : [filePath];
-    if (worktreeStatus !== " ") {
+    if (worktreeStatus !== " " && worktreeStatus !== "!") {
       for (const worktreePath of worktreePaths) {
         if (worktreePath && SNAPSHOT_CONFIG_FILENAMES.has(path.basename(worktreePath))) {
           divergentConfigFiles.add(worktreePath);

--- a/packages/react-doctor/tests/find-staged-snapshot-divergences.test.ts
+++ b/packages/react-doctor/tests/find-staged-snapshot-divergences.test.ts
@@ -74,18 +74,24 @@ describe("findStagedSnapshotDivergences", () => {
     ]);
   });
 
-  it("reports ordinary and ignored untracked configuration", () => {
+  it("reports ordinary untracked configuration", () => {
     const directory = createRepository();
-    fs.writeFileSync(path.join(directory, ".gitignore"), "next.config.mjs\n");
+    fs.writeFileSync(path.join(directory, "eslint.config.mjs"), "export default [];\n");
+
+    expect(findStagedSnapshotDivergences(directory)).toEqual(["eslint.config.mjs"]);
+  });
+
+  it("accepts git-ignored configuration that can never be staged", () => {
+    const directory = createRepository();
+    fs.writeFileSync(path.join(directory, ".gitignore"), "next.config.mjs\n.opencode/\n");
     execFileSync("git", ["add", ".gitignore"], { cwd: directory });
     execFileSync("git", ["commit", "-q", "-m", "ignore config"], { cwd: directory });
-    fs.writeFileSync(path.join(directory, "eslint.config.mjs"), "export default [];\n");
     fs.writeFileSync(path.join(directory, "next.config.mjs"), "export default {};\n");
+    fs.mkdirSync(path.join(directory, ".opencode"), { recursive: true });
+    fs.writeFileSync(path.join(directory, ".opencode/package.json"), '{"name":"local-plugin"}\n');
+    execFileSync("git", ["add", "src/app.tsx"], { cwd: directory });
 
-    expect(findStagedSnapshotDivergences(directory)).toEqual([
-      "eslint.config.mjs",
-      "next.config.mjs",
-    ]);
+    expect(findStagedSnapshotDivergences(directory)).toEqual([]);
   });
 
   it("returns null outside a Git worktree", () => {
@@ -113,6 +119,10 @@ describe("findStagedSnapshotDivergences", () => {
 
   it("accepts an index-only rename with a directory-prefixed configuration source", () => {
     expect(parseStagedSnapshotDivergences("R  archive.txt\0a/b/doctor.config.json\0")).toEqual([]);
+  });
+
+  it("accepts git-ignored configuration with worktree status !", () => {
+    expect(parseStagedSnapshotDivergences("!! package.json\0")).toEqual([]);
   });
 
   it("ignores unstaged lockfile and .gitignore edits that cannot shape a staged scan", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Root Cause

The `parseStagedSnapshotDivergences` function was treating ALL non-space worktree statuses as divergences, including `"!"` (git-ignored files). Since git-ignored files can never be staged, they should not block `--staged` scans with divergence errors.

Git status with `--ignored=matching` includes ignored files with worktree status `"!"`. The existing condition `if (worktreeStatus !== " ")` caught these ignored files along with genuinely modified files, causing false positives on every commit in projects with git-ignored config files (e.g., `.opencode/package.json`).

## Scope

The fix is narrowly scoped to exclude only worktree status `"!"` from the divergence check:

```typescript
if (worktreeStatus !== " " && worktreeStatus !== "!") {
```

This preserves the correct behavior for:
- Genuinely modified tracked config files (still blocked, as intended)
- Untracked-but-not-ignored config files (still reported, as intended)
- Staged source files with later worktree edits (still isolated, as intended)

Only git-ignored config files are now correctly excluded, since they structurally cannot cause the "staged snapshot doesn't match worktree" problem this gate exists to prevent.

## Changes

- Updated `parse-staged-snapshot-divergences.ts` to exclude worktree status `"!"`
- Split the existing test into two cases: ordinary untracked (still reported) and ignored (now accepted)
- Added unit test for the `"!"` status parser behavior
- Added integration test for the reported `.opencode/package.json` case

## Testing

All existing tests pass, including:
- The new regression tests for git-ignored config files
- The existing divergence detection tests (unchanged behavior for tracked files)
- Full test suite (278 files passed)
- Lint and typecheck clean

## Parity Analysis

This fix doesn't affect diagnostic rules or scan output - it only fixes a pre-scan gate check that was incorrectly blocking `--staged` mode. Parity is not applicable since:

1. This is a gate check fix, not a rule change
2. The change only affects `--staged` mode, which isn't used in corpus scans
3. No diagnostic output changes - only the ability to proceed with the scan

Closes #1620
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9af215ad-0ed4-4369-b314-a3ecea56fc63?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9af215ad-0ed4-4369-b314-a3ecea56fc63&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

