### PR TITLE
fix(cli): ignore gitignored configs in staged scans

### DIFF
--- a/.changeset/calm-config-snapshots.md
+++ b/.changeset/calm-config-snapshots.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Ignore Git-ignored configuration files when checking staged scan snapshot divergence.

--- a/packages/react-doctor/src/cli/utils/parse-staged-snapshot-divergences.ts
+++ b/packages/react-doctor/src/cli/utils/parse-staged-snapshot-divergences.ts
@@ -22,7 +22,7 @@ export const parseStagedSnapshotDivergences = (statusOutput: string): ReadonlyAr
     const sourcePath = hasRenameOrCopySource ? statusEntries[entryIndex + 1] : undefined;
     const worktreePaths =
       worktreeStatus === "R" || worktreeStatus === "C" ? [filePath, sourcePath] : [filePath];
-    if (worktreeStatus !== " ") {
+    if (worktreeStatus !== " " && worktreeStatus !== "!") {
       for (const worktreePath of worktreePaths) {
         if (worktreePath && SNAPSHOT_CONFIG_FILENAMES.has(path.basename(worktreePath))) {
           divergentConfigFiles.add(worktreePath);

--- a/packages/react-doctor/tests/find-staged-snapshot-divergences.test.ts
+++ b/packages/react-doctor/tests/find-staged-snapshot-divergences.test.ts
@@ -74,7 +74,7 @@ describe("findStagedSnapshotDivergences", () => {
     ]);
   });
 
-  it("reports ordinary and ignored untracked configuration", () => {
+  it("reports ordinary untracked configuration but ignores ignored configuration", () => {
     const directory = createRepository();
     fs.writeFileSync(path.join(directory, ".gitignore"), "next.config.mjs\n");
     execFileSync("git", ["add", ".gitignore"], { cwd: directory });
@@ -82,10 +82,18 @@ describe("findStagedSnapshotDivergences", () => {
     fs.writeFileSync(path.join(directory, "eslint.config.mjs"), "export default [];\n");
     fs.writeFileSync(path.join(directory, "next.config.mjs"), "export default {};\n");
 
-    expect(findStagedSnapshotDivergences(directory)).toEqual([
-      "eslint.config.mjs",
-      "next.config.mjs",
-    ]);
+    expect(findStagedSnapshotDivergences(directory)).toEqual(["eslint.config.mjs"]);
+  });
+
+  it("ignores a nested package manifest excluded by a local gitignore", () => {
+    const directory = createRepository();
+    fs.mkdirSync(path.join(directory, ".opencode"), { recursive: true });
+    fs.writeFileSync(path.join(directory, ".opencode/.gitignore"), "package.json\nnode_modules\n");
+    execFileSync("git", ["add", ".opencode/.gitignore"], { cwd: directory });
+    execFileSync("git", ["commit", "-q", "-m", "ignore local plugin files"], { cwd: directory });
+    fs.writeFileSync(path.join(directory, ".opencode/package.json"), '{"private":true}\n');
+
+    expect(findStagedSnapshotDivergences(directory)).toEqual([]);
   });
 
   it("returns null outside a Git worktree", () => {
@@ -133,5 +141,9 @@ describe("findStagedSnapshotDivergences", () => {
     expect(parseStagedSnapshotDivergences(" M react-doctor.config.json\0")).toEqual([
       "react-doctor.config.json",
     ]);
+  });
+
+  it("ignores an ignored configuration status entry", () => {
+    expect(parseStagedSnapshotDivergences("!! .opencode/package.json\0")).toEqual([]);
   });
 });


### PR DESCRIPTION
## Why

`react-doctor --staged` asks Git to include ignored entries, but the staged snapshot divergence parser treated every non-blank worktree status as actionable. A Git-ignored configuration file therefore blocked every staged scan even though it cannot be added to the index normally.

Before, an ignored file such as `.opencode/package.json` produced a permanent mixed-snapshot error. After, ignored (`!!`) entries are excluded while modified tracked configuration and ordinary untracked configuration continue to guard the scan.

Closes #1620.

## What changed

- exclude Git's ignored worktree status from staged snapshot divergences
- preserve divergence detection for tracked edits and ordinary untracked configuration
- cover raw porcelain parsing and the nested local `.gitignore` reproduction
- add a patch changeset for `react-doctor`

## Eval results

RDE and parity were not run because this changes CLI Git-status parsing, not a diagnostic rule or detector.

## Test plan

- `nr test` — 15 tasks passed; React Doctor: 2,449 passed, 24 skipped
- `nr lint` — passed
- `nr typecheck` — 16 tasks passed
- `nr format:check` — passed
- `nr smoke:json-report` — passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow CLI Git status parsing change with focused tests; no auth, data, or scan rule behavior changes.
> 
> **Overview**
> **Staged snapshot divergence** no longer treats Git-ignored config files as blocking `react-doctor --staged`. Porcelain worktree status `!` is skipped in `parseStagedSnapshotDivergences`, so ignored paths like `.opencode/package.json` or gitignored `next.config.mjs` no longer trigger a permanent mixed-snapshot error.
> 
> Tracked config edits and ordinary untracked config files still count as divergences. Tests cover root `.gitignore`, nested local ignores, and raw `!!` porcelain lines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6103e7241b2b220cc49c970fbad5d8e32ed3183. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->