### PR TITLE
fix(cli): restore copy prompt option

### DIFF
--- a/.changeset/bright-prompts-return.md
+++ b/.changeset/bright-prompts-return.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Restore the option to copy the full fix prompt from the interactive report.

--- a/packages/react-doctor/src/cli/ink/components/agent-handoff.tsx
+++ b/packages/react-doctor/src/cli/ink/components/agent-handoff.tsx
@@ -11,21 +11,36 @@ import type { ActionMenuAction } from "./action-menu.js";
 export interface AgentHandoffProps {
   readonly agents: ReadonlyArray<CliAgentId>;
   readonly onSelect: (agentId: CliAgentId) => void;
+  readonly onCopyPrompt: () => void;
   readonly onBack: () => void;
   readonly onQuit: () => void;
 }
 
-export const AgentHandoff = ({ agents, onSelect, onBack, onQuit }: AgentHandoffProps) => {
-  const actions: ReadonlyArray<ActionMenuAction> = agents.map((agentId) => ({
-    id: agentId,
-    label: getSkillAgentConfig(agentId).displayName,
-    onSelect: () => onSelect(agentId),
-  }));
+export const AgentHandoff = ({
+  agents,
+  onSelect,
+  onCopyPrompt,
+  onBack,
+  onQuit,
+}: AgentHandoffProps) => {
+  const actions: ReadonlyArray<ActionMenuAction> = [
+    ...agents.map((agentId) => ({
+      id: agentId,
+      label: getSkillAgentConfig(agentId).displayName,
+      onSelect: () => onSelect(agentId),
+    })),
+    {
+      id: "copy-prompt",
+      label: "Copy prompt",
+      description: <Text dimColor>Paste into any agent or edit it first</Text>,
+      onSelect: onCopyPrompt,
+    },
+  ];
 
   return (
     <Box flexDirection="column">
       <Box paddingLeft={TUI_HORIZONTAL_PADDING_COLUMNS}>
-        <Text bold>Choose an agent</Text>
+        <Text bold>Choose how to continue</Text>
       </Box>
       <ActionMenu actions={actions} onEscape={onBack} onQuit={onQuit} />
       <Box marginTop={TUI_REPORT_ACTION_MENU_MARGIN_ROWS}>

--- a/packages/react-doctor/src/cli/ink/components/report.tsx
+++ b/packages/react-doctor/src/cli/ink/components/report.tsx
@@ -133,8 +133,20 @@ export const Report = ({
   };
 
   const isCiSetupAvailable = Boolean(canAddToCi && onAddToCi && !isCiSetupQueued);
-  const isHandoffAvailable =
-    diagnosticRows.length > 0 && launchableAgents.length > 0 && Boolean(onHandoff);
+  const isHandoffAvailable = diagnosticRows.length > 0 && Boolean(onHandoff);
+  const handoffPrompt = useMemo(
+    () =>
+      buildHandoffPayload({
+        diagnostics: report.diagnostics,
+        projectName: report.projectName,
+      }),
+    [report.diagnostics, report.projectName],
+  );
+  const completeHandoff = (destination: TuiHandoffRequest["destination"]): void => {
+    if (!onHandoff) return;
+    onHandoff({ destination, prompt: handoffPrompt });
+    onExit();
+  };
   const firstDiagnosticEntry = diagnosticListEntries.find((entry) => entry.kind === "item");
   const resolvedViewerSelectedRowIndex =
     viewerSelectedRowIndex ??
@@ -239,17 +251,8 @@ export const Report = ({
     activeScreenContent = (
       <AgentHandoff
         agents={launchableAgents}
-        onSelect={(agentId) => {
-          if (!onHandoff) return;
-          onHandoff({
-            agentId,
-            prompt: buildHandoffPayload({
-              diagnostics: report.diagnostics,
-              projectName: report.projectName,
-            }),
-          });
-          onExit();
-        }}
+        onSelect={completeHandoff}
+        onCopyPrompt={() => completeHandoff("clipboard")}
         onBack={() => setActiveReportScreen("landing")}
         onQuit={onQuit}
       />

--- a/packages/react-doctor/src/cli/ink/components/report.tsx
+++ b/packages/react-doctor/src/cli/ink/components/report.tsx
@@ -134,17 +134,15 @@ export const Report = ({
 
   const isCiSetupAvailable = Boolean(canAddToCi && onAddToCi && !isCiSetupQueued);
   const isHandoffAvailable = diagnosticRows.length > 0 && Boolean(onHandoff);
-  const handoffPrompt = useMemo(
-    () =>
-      buildHandoffPayload({
+  const completeHandoff = (destination: TuiHandoffRequest["destination"]): void => {
+    if (!onHandoff) return;
+    onHandoff({
+      destination,
+      prompt: buildHandoffPayload({
         diagnostics: report.diagnostics,
         projectName: report.projectName,
       }),
-    [report.diagnostics, report.projectName],
-  );
-  const completeHandoff = (destination: TuiHandoffRequest["destination"]): void => {
-    if (!onHandoff) return;
-    onHandoff({ destination, prompt: handoffPrompt });
+    });
     onExit();
   };
   const firstDiagnosticEntry = diagnosticListEntries.find((entry) => entry.kind === "item");

--- a/packages/react-doctor/src/cli/ink/run-scan-app.tsx
+++ b/packages/react-doctor/src/cli/ink/run-scan-app.tsx
@@ -41,7 +41,7 @@ import { printDiagnosticsDump } from "../utils/print-diagnostics-dump.js";
 import { printFooter } from "../utils/print-footer.js";
 import { toForwardSlashes } from "../utils/path-format.js";
 import { detectLaunchableAgents } from "../utils/detect-launchable-agents.js";
-import { CLI_AGENT_BINARIES, launchCliAgent } from "../utils/launch-agent.js";
+import { CLI_AGENT_BINARIES, copyToClipboard, launchCliAgent } from "../utils/launch-agent.js";
 import { isReactDoctorWorkflowInstalled } from "../utils/install-github-workflow.js";
 import { findNearestPackageDirectory } from "../utils/install-doctor-script.js";
 import { hasLintHardFailure } from "../utils/has-lint-hard-failure.js";
@@ -325,16 +325,32 @@ const performTuiHandoff = async (
   request: TuiHandoffRequest,
   rootDirectory: string,
 ): Promise<void> => {
-  try {
-    await launchCliAgent(request.agentId, request.prompt, rootDirectory);
-  } catch {
-    process.stdout.write(
-      `${highlighter.warn("⚠")} Couldn't launch ${CLI_AGENT_BINARIES[request.agentId]}. Here's the prompt instead:\n`,
-    );
-    process.stdout.write(`${highlighter.dim("──── Agent prompt ────")}\n`);
-    process.stdout.write(`${request.prompt}\n`);
-    process.stdout.write(`${highlighter.dim("──────────────────────")}\n`);
+  let failureMessage: string | null = null;
+  if (request.destination === "clipboard") {
+    const didCopy = await copyToClipboard(request.prompt);
+    recordCount(METRIC.agentHandoff, 1, {
+      outcome: "clipboard",
+      source: "tui",
+      copied: didCopy,
+    });
+    if (didCopy) {
+      process.stdout.write(`${highlighter.success("✔")} Copied the prompt to your clipboard.\n`);
+      return;
+    }
+    failureMessage = "Couldn't access the clipboard. Here's the prompt instead:";
+  } else {
+    try {
+      await launchCliAgent(request.destination, request.prompt, rootDirectory);
+      return;
+    } catch {
+      failureMessage = `Couldn't launch ${CLI_AGENT_BINARIES[request.destination]}. Here's the prompt instead:`;
+    }
   }
+
+  process.stdout.write(`${highlighter.warn("⚠")} ${failureMessage}\n`);
+  process.stdout.write(`${highlighter.dim("──── Agent prompt ────")}\n`);
+  process.stdout.write(`${request.prompt}\n`);
+  process.stdout.write(`${highlighter.dim("──────────────────────")}\n`);
 };
 
 const isCiUnconfigured = (directory: string): boolean =>

--- a/packages/react-doctor/src/cli/ink/scan-store.ts
+++ b/packages/react-doctor/src/cli/ink/scan-store.ts
@@ -8,7 +8,7 @@ import { TUI_LIVE_FEED_MAX_ENTRIES, TUI_PROGRESS_UPDATE_INTERVAL_MS } from "../u
 import type { CliAgentId } from "../utils/launch-agent.js";
 
 export interface TuiHandoffRequest {
-  readonly agentId: CliAgentId;
+  readonly destination: CliAgentId | "clipboard";
   readonly prompt: string;
 }
 

--- a/packages/react-doctor/tests/ink/run-scan-app.test.ts
+++ b/packages/react-doctor/tests/ink/run-scan-app.test.ts
@@ -630,11 +630,11 @@ describe("runScanApp", () => {
 
     await runScanApp({ directory: rootDirectory, skipPrompts: true });
 
+    const writtenOutput = write.mock.calls.flat().join("");
     expect(mockState.lifecycleEvents).toEqual(["footer", "copy"]);
-    expect(write.mock.calls.flat().join("")).toContain(
-      "Couldn't access the clipboard. Here's the prompt instead:\n",
-    );
-    expect(write.mock.calls.flat().join("")).toContain("──── Agent prompt ────\nfix\n");
+    expect(writtenOutput).toContain("Couldn't access the clipboard. Here's the prompt instead:\n");
+    expect(writtenOutput).toContain("──── Agent prompt ────");
+    expect(writtenOutput).toContain("\nfix\n");
   });
 
   it("does not start queued project scans after the shared deadline", async () => {

--- a/packages/react-doctor/tests/ink/run-scan-app.test.ts
+++ b/packages/react-doctor/tests/ink/run-scan-app.test.ts
@@ -37,6 +37,7 @@ const mockState = vi.hoisted(() => ({
   scanTargets: new Map<string, ResolvedScanTarget>(),
   inspectResults: new Map<string, InspectResult>(),
   shouldRequestHandoff: false,
+  shouldRequestPromptCopy: false,
   shouldSetUpCi: false,
   shouldQuit: false,
   shouldAutoSubmitProjectSelection: true,
@@ -69,7 +70,10 @@ vi.mock("ink", async (importOriginal) => {
           mockState.ciRecommendationStates.push(Boolean(node.props.canAddToCi));
         }
         if (mockState.shouldRequestHandoff && node.props.displayMode === "report") {
-          node.props.onHandoff?.({ agentId: "codex", prompt: "fix" });
+          node.props.onHandoff?.({ destination: "codex", prompt: "fix" });
+        }
+        if (mockState.shouldRequestPromptCopy && node.props.displayMode === "report") {
+          node.props.onHandoff?.({ destination: "clipboard", prompt: "fix" });
         }
         if (mockState.shouldSetUpCi && node.props.displayMode === "report") {
           node.props.onAddToCi?.();
@@ -158,6 +162,10 @@ vi.mock("../../src/cli/utils/launch-agent.js", async (importOriginal) => {
     launchCliAgent: vi.fn(async () => {
       mockState.lifecycleEvents.push("handoff");
     }),
+    copyToClipboard: vi.fn(async () => {
+      mockState.lifecycleEvents.push("copy");
+      return true;
+    }),
   };
 });
 
@@ -200,6 +208,7 @@ describe("runScanApp", () => {
     mockState.scanTargets.clear();
     mockState.inspectResults.clear();
     mockState.shouldRequestHandoff = false;
+    mockState.shouldRequestPromptCopy = false;
     mockState.shouldSetUpCi = false;
     mockState.shouldQuit = false;
     mockState.shouldAutoSubmitProjectSelection = true;
@@ -586,6 +595,23 @@ describe("runScanApp", () => {
     expect(firstOptions?.deadlineEpochMs).toBeTypeOf("number");
     expect(mockState.lifecycleEvents).toEqual(["footer", "handoff"]);
     expect(result.shouldFail).toBe(true);
+  });
+
+  it("copies the full handoff prompt after exiting the report", async () => {
+    const write = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    mockState.shouldRequestPromptCopy = true;
+    const rootDirectory = "/repo";
+    mockState.projectDirectories.push(rootDirectory);
+    mockState.scanTargets.set(
+      rootDirectory,
+      buildScanTarget(rootDirectory, rootDirectory, null, rootDirectory),
+    );
+    mockState.inspectResults.set(rootDirectory, buildInspectResult(rootDirectory));
+
+    await runScanApp({ directory: rootDirectory, skipPrompts: true });
+
+    expect(mockState.lifecycleEvents).toEqual(["footer", "copy"]);
+    expect(write.mock.calls.flat().join("")).toContain("Copied the prompt to your clipboard.");
   });
 
   it("does not start queued project scans after the shared deadline", async () => {

--- a/packages/react-doctor/tests/ink/run-scan-app.test.ts
+++ b/packages/react-doctor/tests/ink/run-scan-app.test.ts
@@ -38,6 +38,7 @@ const mockState = vi.hoisted(() => ({
   inspectResults: new Map<string, InspectResult>(),
   shouldRequestHandoff: false,
   shouldRequestPromptCopy: false,
+  shouldCopyPromptSucceed: true,
   shouldSetUpCi: false,
   shouldQuit: false,
   shouldAutoSubmitProjectSelection: true,
@@ -164,7 +165,7 @@ vi.mock("../../src/cli/utils/launch-agent.js", async (importOriginal) => {
     }),
     copyToClipboard: vi.fn(async () => {
       mockState.lifecycleEvents.push("copy");
-      return true;
+      return mockState.shouldCopyPromptSucceed;
     }),
   };
 });
@@ -209,6 +210,7 @@ describe("runScanApp", () => {
     mockState.inspectResults.clear();
     mockState.shouldRequestHandoff = false;
     mockState.shouldRequestPromptCopy = false;
+    mockState.shouldCopyPromptSucceed = true;
     mockState.shouldSetUpCi = false;
     mockState.shouldQuit = false;
     mockState.shouldAutoSubmitProjectSelection = true;
@@ -612,6 +614,27 @@ describe("runScanApp", () => {
 
     expect(mockState.lifecycleEvents).toEqual(["footer", "copy"]);
     expect(write.mock.calls.flat().join("")).toContain("Copied the prompt to your clipboard.");
+  });
+
+  it("prints the full handoff prompt when clipboard access fails", async () => {
+    const write = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    mockState.shouldRequestPromptCopy = true;
+    mockState.shouldCopyPromptSucceed = false;
+    const rootDirectory = "/repo";
+    mockState.projectDirectories.push(rootDirectory);
+    mockState.scanTargets.set(
+      rootDirectory,
+      buildScanTarget(rootDirectory, rootDirectory, null, rootDirectory),
+    );
+    mockState.inspectResults.set(rootDirectory, buildInspectResult(rootDirectory));
+
+    await runScanApp({ directory: rootDirectory, skipPrompts: true });
+
+    expect(mockState.lifecycleEvents).toEqual(["footer", "copy"]);
+    expect(write.mock.calls.flat().join("")).toContain(
+      "Couldn't access the clipboard. Here's the prompt instead:\n",
+    );
+    expect(write.mock.calls.flat().join("")).toContain("──── Agent prompt ────\nfix\n");
   });
 
   it("does not start queued project scans after the shared deadline", async () => {

--- a/packages/react-doctor/tests/ink/scan-app.test.tsx
+++ b/packages/react-doctor/tests/ink/scan-app.test.tsx
@@ -13,6 +13,7 @@ import {
 import * as exitGracefullyModule from "../../src/cli/utils/exit-gracefully.js";
 import * as launchAgent from "../../src/cli/utils/launch-agent.js";
 import * as openUrlModule from "../../src/cli/utils/open-url.js";
+import * as writeDiagnosticsDirectoryModule from "../../src/cli/utils/write-diagnostics-directory.js";
 import { ScanApp } from "../../src/cli/ink/scan-app.js";
 import { createScanStore } from "../../src/cli/ink/scan-store.js";
 import { severityVariant } from "../../src/cli/ink/lib/severity-variants.js";
@@ -1237,6 +1238,9 @@ describe("ScanApp", () => {
 
   it("offers the full prompt for copying without a launchable agent", async () => {
     const onHandoff = vi.fn();
+    const writeDiagnosticsDirectory = vi
+      .spyOn(writeDiagnosticsDirectoryModule, "writeDiagnosticsDirectory")
+      .mockReturnValue("/tmp/react-doctor-diagnostics");
     const store = createScanStore();
     store.setReport({
       diagnostics: [makeDiagnostic({ rule: "rules-of-hooks", severity: "error" })],
@@ -1254,6 +1258,7 @@ describe("ScanApp", () => {
       <ScanApp store={store} launchableAgents={[]} onHandoff={onHandoff} />,
     );
     await flush();
+    expect(writeDiagnosticsDirectory).not.toHaveBeenCalled();
 
     stdin.write("j");
     await flush();
@@ -1261,6 +1266,7 @@ describe("ScanApp", () => {
     stdin.write("\r");
     await flush();
 
+    expect(writeDiagnosticsDirectory).not.toHaveBeenCalled();
     expect(lastFrame()).toContain("Choose how to continue");
     expect(lastFrame()).toContain(`${figures.pointer} Copy prompt`);
     expect(lastFrame()).toContain("Paste into any agent or edit it first");
@@ -1268,6 +1274,7 @@ describe("ScanApp", () => {
     await flush();
 
     expect(onHandoff).toHaveBeenCalledOnce();
+    expect(writeDiagnosticsDirectory).toHaveBeenCalledOnce();
     expect(onHandoff.mock.calls[0]?.[0].destination).toBe("clipboard");
     expect(onHandoff.mock.calls[0]?.[0].prompt).toContain("react-doctor/rules-of-hooks");
     unmount();

--- a/packages/react-doctor/tests/ink/scan-app.test.tsx
+++ b/packages/react-doctor/tests/ink/scan-app.test.tsx
@@ -1163,15 +1163,16 @@ describe("ScanApp", () => {
     stdin.write("\u001B");
     await flush();
     expect(onAddToCi).not.toHaveBeenCalled();
-    expect(lastFrame()).toContain("  Choose an agent");
+    expect(lastFrame()).toContain("  Choose how to continue");
     expect(lastFrame()).toContain(`${figures.pointer} Codex`);
     expect(lastFrame()).toContain("Cursor");
+    expect(lastFrame()).toContain("Copy prompt");
 
     stdin.write("\r");
     await flush();
     expect(onHandoff).toHaveBeenCalledOnce();
     const request = onHandoff.mock.calls[0]?.[0];
-    expect(request?.agentId).toBe("codex");
+    expect(request?.destination).toBe("codex");
     expect(request?.prompt).not.toContain("First, configure React Doctor in GitHub Actions");
     unmount();
   });
@@ -1231,6 +1232,44 @@ describe("ScanApp", () => {
       "First, configure React Doctor in GitHub Actions",
     );
     expect(onAddToCi).toHaveBeenCalledOnce();
+    unmount();
+  });
+
+  it("offers the full prompt for copying without a launchable agent", async () => {
+    const onHandoff = vi.fn();
+    const store = createScanStore();
+    store.setReport({
+      diagnostics: [makeDiagnostic({ rule: "rules-of-hooks", severity: "error" })],
+      score: SCORE,
+      projectedScore: null,
+      projectName: "demo-app",
+      rootDirectory: "/tmp/demo-app",
+      scannedFileCount: 1,
+      elapsedMilliseconds: 10,
+      isOffline: true,
+      noScoreMessage: "Score unavailable.",
+    });
+
+    const { lastFrame, stdin, unmount } = render(
+      <ScanApp store={store} launchableAgents={[]} onHandoff={onHandoff} />,
+    );
+    await flush();
+
+    stdin.write("j");
+    await flush();
+    expect(lastFrame()).toContain(`${figures.pointer} Hand off to an agent`);
+    stdin.write("\r");
+    await flush();
+
+    expect(lastFrame()).toContain("Choose how to continue");
+    expect(lastFrame()).toContain(`${figures.pointer} Copy prompt`);
+    expect(lastFrame()).toContain("Paste into any agent or edit it first");
+    stdin.write("\r");
+    await flush();
+
+    expect(onHandoff).toHaveBeenCalledOnce();
+    expect(onHandoff.mock.calls[0]?.[0].destination).toBe("clipboard");
+    expect(onHandoff.mock.calls[0]?.[0].prompt).toContain("react-doctor/rules-of-hooks");
     unmount();
   });
 });


### PR DESCRIPTION
## What changed

- restore **Copy prompt** in the interactive post-scan handoff menu
- make the copy path available even when no supported CLI agent is detected
- copy the complete multi-finding handoff payload for editing or pasting into any chat
- print the prompt when clipboard access is unavailable
- preserve the existing anonymized `agent.handoff` telemetry signal

## Why

The new default Ink report built its handoff menu only from launchable CLI agents. The legacy prompt flow still supported copying, but that choice was never carried into the new report, removing the manual workflow and hiding handoff entirely when no supported agent binary was installed.

Fixes #1612.

## Product brief

**Job:** Developers want to inspect, edit, or paste React Doctor's fix prompt into any agent or an existing long-running chat.

**Change:** Restore the existing copy behavior inside the current handoff menu rather than adding a new flag or command.

**Compatibility:** Existing agent-launch defaults are unchanged. This includes a patch changeset and does not alter config, score, JSON output, or GitHub Action behavior.

**Metric:** `agent.handoff{outcome=clipboard,source=tui}` records adoption and whether clipboard access succeeded.

**Kill metric:** Revisit the menu entry if clipboard selections remain below 1% of TUI handoff actions after two releases.

## Validation

- `nr build`
- focused Ink tests: 56 passed
- full workspace tests: 15 tasks passed; 2,449 tests passed
- `nr typecheck`
- `nr lint`
- `nr format:check`
- React Doctor changed-files regression scan: 100/100

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only UX and clipboard handling with existing fallbacks; no changes to scoring, config, or CI workflows.
> 
> **Overview**
> Restores **Copy prompt** in the post-scan handoff menu so users can copy the full multi-finding fix payload for any agent or chat, not only launch a detected CLI agent.
> 
> **Hand off to an agent** now appears whenever there are diagnostics and a handoff handler, even with no launchable agent binaries. The handoff screen is titled **Choose how to continue** and lists agents plus **Copy prompt** (with helper text). `TuiHandoffRequest` uses a `destination` of `clipboard` or a CLI agent id instead of `agentId` only.
> 
> After the TUI exits, clipboard copies go through `copyToClipboard`, record `agent.handoff` with `outcome=clipboard`, and print success or fall back to dumping the prompt on stdout (same pattern as failed agent launch). Agent launch behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d50b9ef33692cf1f5856070e97e9e327bf7cdbf5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->