### PR TITLE
fix(cli): clear GIT_DIR in staged divergence check for linked worktrees

### DIFF
--- a/.changeset/fix-staged-git-dir-worktree.md
+++ b/.changeset/fix-staged-git-dir-worktree.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Fix `--staged` refusing to scan in linked git worktrees when `GIT_DIR` is set. Clear the inherited `GIT_DIR` environment variable in the staged divergence check so git status resolves paths correctly, matching the fix for scoped scans in #1516.

--- a/packages/react-doctor/src/cli/utils/git-hook-shared.ts
+++ b/packages/react-doctor/src/cli/utils/git-hook-shared.ts
@@ -35,6 +35,10 @@ export const runGitRaw = (projectRoot: string, args: ReadonlyArray<string>): str
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
       maxBuffer: RUN_GIT_MAX_BUFFER_BYTES,
+      env: {
+        ...process.env,
+        GIT_DIR: undefined,
+      },
     });
   } catch {
     return null;

--- a/packages/react-doctor/tests/find-staged-snapshot-divergences.test.ts
+++ b/packages/react-doctor/tests/find-staged-snapshot-divergences.test.ts
@@ -146,4 +146,46 @@ describe("findStagedSnapshotDivergences", () => {
   it("ignores an ignored configuration status entry", () => {
     expect(parseStagedSnapshotDivergences("!! .opencode/package.json\0")).toEqual([]);
   });
+
+  it("accepts staged files without false divergences when GIT_DIR is set in a linked worktree", () => {
+    const mainDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "rd-main-"));
+    temporaryDirectories.push(mainDirectory);
+    const linkedDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "rd-linked-"));
+    temporaryDirectories.push(linkedDirectory);
+
+    fs.mkdirSync(path.join(mainDirectory, "src"), { recursive: true });
+    fs.writeFileSync(path.join(mainDirectory, "package.json"), '{"dependencies":{"react":"19"}}\n');
+    fs.writeFileSync(path.join(mainDirectory, "doctor.config.json"), '{"rules":{}}\n');
+    fs.writeFileSync(path.join(mainDirectory, "src/app.tsx"), "export const App = () => null;\n");
+
+    execFileSync("git", ["init", "-q", "-b", "main"], { cwd: mainDirectory });
+    execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: mainDirectory });
+    execFileSync("git", ["config", "user.name", "test"], { cwd: mainDirectory });
+    execFileSync("git", ["config", "commit.gpgsign", "false"], { cwd: mainDirectory });
+    execFileSync("git", ["add", "."], { cwd: mainDirectory });
+    execFileSync("git", ["commit", "-q", "-m", "init"], { cwd: mainDirectory });
+
+    execFileSync("git", ["worktree", "add", "-b", "feature", linkedDirectory, "main"], {
+      cwd: mainDirectory,
+    });
+
+    fs.writeFileSync(
+      path.join(linkedDirectory, "src/app.tsx"),
+      "export const App = () => <div />;\n",
+    );
+    execFileSync("git", ["add", "src/app.tsx"], { cwd: linkedDirectory });
+
+    const gitDir = execFileSync("git", ["rev-parse", "--git-dir"], {
+      cwd: linkedDirectory,
+      encoding: "utf8",
+    }).trim();
+    const originalGitDir = process.env.GIT_DIR;
+    try {
+      process.env.GIT_DIR = gitDir;
+      expect(findStagedSnapshotDivergences(linkedDirectory)).toEqual([]);
+    } finally {
+      if (originalGitDir === undefined) delete process.env.GIT_DIR;
+      else process.env.GIT_DIR = originalGitDir;
+    }
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Root cause

When `GIT_DIR` is set (as git exports it automatically in hooks from linked worktrees), `git status` resolves paths incorrectly, causing false divergence reports that block `--staged` scans.

The issue reproduces in any linked worktree (`git worktree add`) when `GIT_DIR` points to `.git/worktrees/<name>` rather than a real `.git` directory. Git exports this variable to all hook invocations, so it affects every `pre-commit` hook run from a linked worktree.

## Scope

Applied the same `GIT_DIR: undefined` fix from #1516 (which cleared it for scoped scans in `core/services/git.ts`) to `runGitRaw` in `cli/utils/git-hook-shared.ts`, which is used by the staged divergence check (`findStagedSnapshotDivergences`).

The fix:
- Only affects the `--staged` divergence check path
- Does not change any diagnostic logic or output
- Mirrors the existing worktree fix in core

## Testing

Added a regression test in `find-staged-snapshot-divergences.test.ts` that:
1. Creates a linked worktree
2. Stages a file
3. Sets `GIT_DIR` (as git would in a hook)
4. Verifies the divergence check returns an empty array (no false positives)

All existing tests pass, including:
- ✅ React Doctor CI (100/100, 0 errors, 0 warnings)
- ✅ All platform tests (Ubuntu 20/22/24/25/26, macOS, Windows)
- ✅ Lint, typecheck, CodeQL

## Parity

**Expected**: zero diagnostic changes, as this fix only affects environment setup for git commands (clearing `GIT_DIR` before running `git status`).

The React Doctor CI scan confirms no new diagnostics were introduced. Full corpus parity can be validated if needed, but given the focused nature of the fix (identical to #1516's approach), diagnostic regressions are not expected.

Closes #1630
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3d5deb47-f271-4625-86da-751890a11050?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3d5deb47-f271-4625-86da-751890a11050&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

