### PR TITLE
fix: handle code-less oxlint diagnostics

### DIFF
--- a/.changeset/safe-astro-diagnostics.md
+++ b/.changeset/safe-astro-diagnostics.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Avoid crashing when oxlint emits a code-less diagnostic while scanning Astro files.

--- a/packages/core/src/runners/oxlint/parse-output.ts
+++ b/packages/core/src/runners/oxlint/parse-output.ts
@@ -237,7 +237,10 @@ const resolveCleanedDiagnostic = (
   };
 };
 
-const parseRuleCode = (code: string): { plugin: string; rule: string } => {
+const parseRuleCode = (code: unknown): { plugin: string; rule: string } => {
+  if (typeof code !== "string" || code.length === 0) {
+    return { plugin: "unknown", rule: "unknown" };
+  }
   const match = code.match(/^(.+)\((.+)\)$/);
   if (!match) return { plugin: "unknown", rule: code };
   return { plugin: match[1].replace(/^eslint-plugin-/, ""), rule: match[2] };

--- a/packages/core/tests/html-diagnostic-mapping.test.ts
+++ b/packages/core/tests/html-diagnostic-mapping.test.ts
@@ -15,6 +15,40 @@ afterEach(() => {
 });
 
 describe("HTML diagnostic mapping", () => {
+  it("drops a code-less Astro diagnostic without crashing", () => {
+    const rootDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-astro-map-"));
+    temporaryDirectories.push(rootDirectory);
+    fs.mkdirSync(path.join(rootDirectory, "src"));
+    fs.writeFileSync(path.join(rootDirectory, "src", "page.astro"), "<main>Hello</main>");
+    const preparedSources = prepareLintSources(rootDirectory, path.join(rootDirectory, "tmp"), [
+      "src/page.astro",
+    ]);
+    const lintPath = preparedSources.lintFiles.find((filePath) => filePath.endsWith(".tsx"));
+    if (lintPath === undefined) throw new Error("Expected a virtual Astro lint source");
+    const stdout = JSON.stringify({
+      diagnostics: [
+        {
+          message: "Unexpected token",
+          severity: "error",
+          filename: lintPath,
+          labels: [],
+        },
+      ],
+      number_of_files: 1,
+      number_of_rules: 1,
+    });
+
+    expect(
+      parseOxlintOutput(
+        stdout,
+        buildProject({ rootDirectory }),
+        rootDirectory,
+        preparedSources.sourcePathByLintPath,
+        preparedSources.sourceMapByLintPath,
+      ),
+    ).toEqual([]);
+  });
+
   it("maps a virtual script diagnostic back to the HTML path and source position", () => {
     const rootDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-html-map-"));
     temporaryDirectories.push(rootDirectory);


### PR DESCRIPTION
## Why

Oxlint can emit per-file diagnostics without a `code` field. Astro scans preprocess generated TSX diagnostics before the normal shape filter, so React Doctor called `.match()` on `undefined` and aborted the lint run instead of dropping the unmappable diagnostic.

After this change, code-less diagnostics use an unknown rule identity during preprocessing and are discarded by the existing validation path without crashing the scan.

Fixes #1635.

## What changed

- make oxlint rule-code parsing tolerate missing and empty values
- add a regression test using a prepared Astro source map
- add a patch changeset for `react-doctor`

## Test plan

- `nr test`
- `nr lint`
- `nr typecheck`
- `nr format:check`
- `nr smoke:json-report`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive fix in oxlint diagnostic parsing with a regression test; no auth, data, or architectural changes.
> 
> **Overview**
> Prevents Astro lint scans from aborting when oxlint emits a diagnostic with no `code` field.
> 
> `parseRuleCode` now treats missing or empty codes as `unknown/unknown`, so Astro source-map preprocessing no longer calls `.match()` on `undefined`. Those diagnostics are then dropped by the existing validation path. Adds a regression test covering a prepared Astro virtual TSX source.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df2558d8b57b9f2e516dd0d6ad50a3dd2c74f30f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->