### PR TITLE
fix: handle undefined code field in oxlint diagnostics

### DIFF
--- a/.changeset/fix-missing-code-field.md
+++ b/.changeset/fix-missing-code-field.md
@@ -1,0 +1,5 @@
+---
+"@react-doctor/core": patch
+---
+
+Fix crash when oxlint diagnostic has no code field. Some diagnostics (like parse errors) omit the code field, causing parseRuleCode to throw "Cannot read properties of undefined (reading 'match')". parseRuleCode now returns { plugin: "unknown", rule: "unknown" } when code is missing.

--- a/packages/core/src/runners/oxlint/parse-output.ts
+++ b/packages/core/src/runners/oxlint/parse-output.ts
@@ -237,7 +237,8 @@ const resolveCleanedDiagnostic = (
   };
 };
 
-const parseRuleCode = (code: string): { plugin: string; rule: string } => {
+const parseRuleCode = (code: string | undefined): { plugin: string; rule: string } => {
+  if (!code) return { plugin: "unknown", rule: "unknown" };
   const match = code.match(/^(.+)\((.+)\)$/);
   if (!match) return { plugin: "unknown", rule: code };
   return { plugin: match[1].replace(/^eslint-plugin-/, ""), rule: match[2] };

--- a/packages/core/tests/oxlint-missing-code.test.ts
+++ b/packages/core/tests/oxlint-missing-code.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vite-plus/test";
+import { parseOxlintOutput } from "../src/runners/oxlint/parse-output.js";
+import { buildProject } from "./helpers/oxlint-parse-harness.js";
+
+describe("parseOxlintOutput with missing code field", () => {
+  it("handles diagnostics with no code field without crashing", () => {
+    const stdout = JSON.stringify({
+      diagnostics: [
+        {
+          message: "Parse error: unexpected token",
+          severity: "error",
+          causes: [],
+          url: "",
+          help: "",
+          filename: "src/components/widget.tsx",
+          labels: [{ label: "", span: { offset: 0, length: 1, line: 12, column: 3 } }],
+          related: [],
+        },
+      ],
+      number_of_files: 1,
+      number_of_rules: 1,
+    });
+
+    expect(() => {
+      parseOxlintOutput(stdout, buildProject(), "/home/user/app");
+    }).not.toThrow();
+  });
+
+  it("handles diagnostics with undefined code field", () => {
+    const stdout = JSON.stringify({
+      diagnostics: [
+        {
+          message: "Parse error",
+          code: undefined,
+          severity: "error",
+          causes: [],
+          url: "",
+          help: "",
+          filename: "src/components/widget.tsx",
+          labels: [{ label: "", span: { offset: 0, length: 1, line: 12, column: 3 } }],
+          related: [],
+        },
+      ],
+      number_of_files: 1,
+      number_of_rules: 1,
+    });
+
+    expect(() => {
+      parseOxlintOutput(stdout, buildProject(), "/home/user/app");
+    }).not.toThrow();
+  });
+
+  it("handles diagnostics with null code field", () => {
+    const stdout = JSON.stringify({
+      diagnostics: [
+        {
+          message: "Parse error",
+          code: null,
+          severity: "error",
+          causes: [],
+          url: "",
+          help: "",
+          filename: "src/components/widget.tsx",
+          labels: [{ label: "", span: { offset: 0, length: 1, line: 12, column: 3 } }],
+          related: [],
+        },
+      ],
+      number_of_files: 1,
+      number_of_rules: 1,
+    });
+
+    expect(() => {
+      parseOxlintOutput(stdout, buildProject(), "/home/user/app");
+    }).not.toThrow();
+  });
+
+  it("handles diagnostics with empty string code field", () => {
+    const stdout = JSON.stringify({
+      diagnostics: [
+        {
+          message: "Parse error",
+          code: "",
+          severity: "error",
+          causes: [],
+          url: "",
+          help: "",
+          filename: "src/components/widget.tsx",
+          labels: [{ label: "", span: { offset: 0, length: 1, line: 12, column: 3 } }],
+          related: [],
+        },
+      ],
+      number_of_files: 1,
+      number_of_rules: 1,
+    });
+
+    expect(() => {
+      parseOxlintOutput(stdout, buildProject(), "/home/user/app");
+    }).not.toThrow();
+  });
+});

--- a/packages/react-doctor/tests/regressions/scan-resilience.test.ts
+++ b/packages/react-doctor/tests/regressions/scan-resilience.test.ts
@@ -19,6 +19,9 @@
  *          exports — older plugin versions can lack newer compiler rules,
  *          so React Compiler users would otherwise hit
  *          "Rule 'void-use-memo' not found in plugin 'react-hooks-js'".
+ *   #1635 — parseRuleCode must handle diagnostics with no code field —
+ *          some oxlint diagnostics (like parse errors) omit the code field,
+ *          causing "Cannot read properties of undefined (reading 'match')".
  */
 
 import { spawnSync } from "node:child_process";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Root Cause

The error occurs in `parseRuleCode` when processing oxlint diagnostics that don't include a `code` field. Some oxlint diagnostics (like parse errors) omit this field, causing `code.match()` to throw `TypeError: Cannot read properties of undefined (reading 'match')`.

The bug can trigger in two code paths:
1. Line 441: When processing diagnostics with prepared source maps (e.g. Astro files)
2. Line 469: When mapping filtered diagnostics (though this is protected by `isMappableOxlintDiagnostic` which requires a string code)

## Fix

Added a defensive null check at the start of `parseRuleCode`:
```typescript
if (!code) return { plugin: "unknown", rule: "unknown" };
```

This returns a safe fallback when `code` is undefined, null, or empty string.

## Scope

The fix is narrowly scoped to handle the missing code field gracefully without changing any other behavior. Updated the type signature from `code: string` to `code: string | undefined` to reflect reality.

## Testing

- Added unit tests in `packages/core/tests/oxlint-missing-code.test.ts` covering all edge cases (undefined, null, empty, missing)
- Added regression test documentation in `packages/react-doctor/tests/regressions/scan-resilience.test.ts`
- All existing tests pass
- Parity check in progress

Closes #1635
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9a45-8b93-4bcd-a6f5-3f09ea4d2b09?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9a45-8b93-4bcd-a6f5-3f09ea4d2b09&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

