### PR TITLE
fix: remove react/no-multi-comp alias to enable strict oxlint version

### DIFF
--- a/.changeset/remove-no-multi-comp-alias.md
+++ b/.changeset/remove-no-multi-comp-alias.md
@@ -1,0 +1,24 @@
+---
+"@react-doctor/core": patch
+"oxlint-plugin-react-doctor": patch
+---
+
+fix: remove react/no-multi-comp alias to enable strict oxlint version
+
+Removes the alias from `react/no-multi-comp` to `react-doctor/no-multi-comp`. This change allows users who want strict "one component per file" enforcement to access oxlint's `react/no-multi-comp` rule via `.oxlintrc.json`, while preserving the lenient `react-doctor/no-multi-comp` behavior for users who explicitly configure it.
+
+The react-doctor version is intentionally more permissive, with corpus-informed exemptions for:
+- Files with ≤2 components (main + helper)  
+- Feature modules (1-2 exports + private helpers)
+- Barrel files (mostly-exported components)
+
+Users who previously configured `react/no-multi-comp` and want to continue using the lenient version should update their config to use `react-doctor/no-multi-comp` explicitly. Users who want the strict oxlint behavior can create an `.oxlintrc.json` file:
+
+```json
+{
+  "plugins": ["react"],
+  "rules": {"react/no-multi-comp": "error"}
+}
+```
+
+Closes #1639

--- a/packages/core/src/rule-key-aliases.ts
+++ b/packages/core/src/rule-key-aliases.ts
@@ -111,7 +111,6 @@ const LEGACY_RULE_KEY_TO_NATIVE_RULE_KEY: Readonly<Record<string, string>> = {
   "react/no-direct-mutation-state": "react-doctor/no-direct-mutation-state",
   "react/no-find-dom-node": "react-doctor/no-find-dom-node",
   "react/no-is-mounted": "react-doctor/no-is-mounted",
-  "react/no-multi-comp": "react-doctor/no-multi-comp",
   "react/no-namespace": "react-doctor/no-namespace",
   "react/no-react-children": "react-doctor/no-react-children",
   "react/no-redundant-should-component-update": "react-doctor/no-redundant-should-component-update",

--- a/packages/core/tests/rule-key-aliases.test.ts
+++ b/packages/core/tests/rule-key-aliases.test.ts
@@ -113,4 +113,22 @@ describe("rule-key-aliases", () => {
       expect(getEquivalentRuleKeys("toString")).toEqual(["toString"]);
     });
   });
+
+  describe("removed aliases (issue #1639)", () => {
+    it("does not alias react/no-multi-comp to react-doctor/no-multi-comp", () => {
+      expect(isSameRuleKey("react/no-multi-comp", "react-doctor/no-multi-comp")).toBe(false);
+    });
+
+    it("treats react/no-multi-comp as a distinct rule from react-doctor/no-multi-comp", () => {
+      const reactKeys = getEquivalentRuleKeys("react/no-multi-comp");
+      expect(reactKeys).toEqual(["react/no-multi-comp"]);
+      expect(reactKeys).not.toContain("react-doctor/no-multi-comp");
+    });
+
+    it("treats react-doctor/no-multi-comp as its own rule", () => {
+      const rdKeys = getEquivalentRuleKeys("react-doctor/no-multi-comp");
+      expect(rdKeys).toEqual(["react-doctor/no-multi-comp"]);
+      expect(rdKeys).not.toContain("react/no-multi-comp");
+    });
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-multi-comp.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-multi-comp.regressions.test.ts
@@ -202,6 +202,21 @@ describe("react-builtins/no-multi-comp — regressions", () => {
     );
   });
 
+  // Regression test for issue #1639: A file with 3 components where 1 is
+  // exported falls under the "feature module" exemption (1-2 exports + private
+  // helpers). This is intentional — users who want strict "one component per
+  // file" enforcement should use oxlint's `react/no-multi-comp` via
+  // `.oxlintrc.json` instead of the lenient react-doctor version.
+  it("exempts a file with 1 exported component + 2 private helpers (feature module)", () => {
+    expectPass(
+      `function Row() { return <li>row</li>; }
+       function Header() { return <h1>header</h1>; }
+       export function List() {
+         return <div><Header /><Row /></div>;
+       }`,
+    );
+  });
+
   it("does not trace an overwritten mutable React HoC alias", () => {
     expectFail(
       `import { memo } from "react";

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-multi-comp.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/no-multi-comp.ts
@@ -23,6 +23,20 @@ import { REACT_HOC_NAMES, REACT_RUNTIME_MODULE_SOURCES } from "../../constants/r
 const MESSAGE =
   "This file declares several components, so each component is harder to find, test, and change.";
 
+// React Doctor's `no-multi-comp` is intentionally more lenient than oxlint's
+// `react/no-multi-comp` to accommodate common real-world React patterns:
+//
+// - Files with ≤2 components (1 main + 1 helper) are exempt
+// - Feature modules (1-2 public exports + private helpers) are exempt
+// - Barrel files (mostly-exported components) are exempt
+//
+// For stricter "one component per file" enforcement matching oxlint's behavior,
+// create an `.oxlintrc.json` with:
+//   {"plugins": ["react"], "rules": {"react/no-multi-comp": "error"}}
+//
+// This rule was corpus-tuned to avoid false positives in design systems,
+// feature modules, and icon barrels. See regression tests for examples.
+
 interface NoMultiCompSettings {
   ignoreStateless?: boolean;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the alias from `react/no-multi-comp` to `react-doctor/no-multi-comp` to resolve issue #1639.

## Problem

The alias `react/no-multi-comp` → `react-doctor/no-multi-comp` created an expectation mismatch:

- **oxlint's `react/no-multi-comp`**: Strict "one component per file" rule (fires on 2+ components)
- **react-doctor's `react-doctor/no-multi-comp`**: Lenient with corpus-informed exemptions (fires on 3+ components with specific exceptions)

Users writing `react/no-multi-comp` in their config expected oxlint's strict behavior but got react-doctor's lenient version instead. There was no way to access oxlint's strict version through react-doctor config.

## Solution

**Remove the alias** so users can explicitly choose:

1. **Lenient (react-doctor version)**: Explicitly use `react-doctor/no-multi-comp` in config
2. **Strict (oxlint version)**: Create `.oxlintrc.json` with:
   ```json
   {
     "plugins": ["react"],
     "rules": {"react/no-multi-comp": "error"}
   }
   ```

## Why the lenient version exists

React Doctor's `no-multi-comp` was intentionally designed with exemptions based on corpus analysis to avoid false positives in real-world patterns:

- **Files with ≤2 components**: Common "1 main + 1 helper" co-location
- **Feature modules**: 1-2 public exports + N private helpers  
- **Barrel files**: Mostly-exported components (design systems, icon libraries)
- **All-exported files**: Component primitive files (Alert + AlertTitle + AlertDescription)

These exemptions are well-tested (see regression tests) and reflect production React code patterns.

## Migration

Users who previously configured `react/no-multi-comp` and relied on the lenient behavior should update their config to explicitly use `react-doctor/no-multi-comp`. The rule continues to run by default with unchanged behavior.

## Testing

- ✅ Unit tests for alias removal
- ✅ Regression test for reported case  
- ✅ Documentation explaining exemptions and how to use oxlint's strict version
- ✅ All existing no-multi-comp tests pass

## Closes

Closes #1639
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6ab4925b-3994-4214-a546-99ef63c4e382?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6ab4925b-3994-4214-a546-99ef63c4e382&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

