### PR TITLE
fix(cli): recognize supported library projects

### DIFF
--- a/.changeset/quiet-three-runtime.md
+++ b/.changeset/quiet-three-runtime.md
@@ -1,0 +1,8 @@
+---
+"oxlint-plugin-react-doctor": patch
+"react-doctor": patch
+"@react-doctor/api": patch
+"@react-doctor/core": patch
+---
+
+Recognize every detected framework and library capability as a supported scan target, including plain Three.js projects and React-backed frameworks without direct React declarations, and anchor remote-installer diagnostics on the executable download command.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -103,6 +103,7 @@ export * from "./utils/group-by.js";
 export * from "./utils/hash-file-contents.js";
 export * from "./utils/has-published-fix-recipe.js";
 export * from "./utils/has-react-runtime.js";
+export * from "./utils/has-supported-framework-or-library.js";
 export * from "./utils/filter-paths-outside-directories.js";
 export * from "./utils/is-errno-exception.js";
 export * from "./utils/is-large-minified-file.js";

--- a/packages/core/src/project-info/capabilities.ts
+++ b/packages/core/src/project-info/capabilities.ts
@@ -29,6 +29,7 @@ import {
   REACT_ROUTER_CAPABILITY_THRESHOLDS,
   REANIMATED_WORKLETS_MINIMUM_MAJOR_VERSION,
 } from "../constants.js";
+import { hasReactRuntime } from "../utils/has-react-runtime.js";
 import {
   getLowestDependencyMajor,
   isMajorMinorAtLeast,
@@ -88,9 +89,10 @@ export const buildCapabilities = (project: ProjectInfo): ReadonlySet<Capability>
 
   capabilities.add(project.framework);
   // `react` gates every React-runtime rule family (hooks, JSX, a11y, render
-  // performance) so they stay off on a plain TS/JS project. Preact satisfies
-  // it too (same hooks + JSX model).
-  if (project.reactVersion !== null || project.preactVersion !== null) {
+  // performance) so they stay off on a plain TS/JS project. Preact and
+  // React-backed frameworks satisfy it even when the leaf manifest omits a
+  // direct runtime dependency.
+  if (hasReactRuntime(project)) {
     capabilities.add("react");
   }
   // `hasReactNativeWorkspace` / `expoVersion` cover the inverted case the

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -178,11 +178,11 @@ export class JsonReportV1 extends Schema.Class<JsonReportV1>("JsonReportV1")({
    */
   baselineDegraded: Schema.optional(Schema.Boolean),
   /**
-   * Whether any scanned project resolved a React-compatible runtime (React
-   * or Preact). `false` means every React-runtime rule family was gated off,
-   * so an empty `diagnostics` array is vacuous — NOT the same as a clean
-   * React scan. Consumers gating on the report (CI, verifiers, hooks) should
-   * treat `reactDetected === false` as "wrong scan target", not "all clear".
+   * Whether any scanned project resolved a React-compatible runtime directly
+   * or through a React-backed framework. `false` means every React-runtime
+   * rule family was gated off, not that the scan target was unsupported:
+   * other detected framework and library rule families still run, as do
+   * framework-neutral rules on any analyzable project.
    * Absent when nothing was scanned (`projects` is empty), on error reports,
    * and on reports from older CLI versions.
    */

--- a/packages/core/src/types/diagnose.ts
+++ b/packages/core/src/types/diagnose.ts
@@ -40,11 +40,11 @@ export interface DiagnoseResult {
   scannedFileCount?: number;
   project: ProjectInfo;
   /**
-   * Whether the scanned project resolved a React-compatible runtime (React
-   * or Preact). `false` means every React-runtime rule family was gated
-   * off, so an empty `diagnostics` array is vacuous — NOT the same as a
-   * clean React scan. Consumers gating on the result should treat
-   * `reactDetected === false` as "wrong scan target", not "all clear".
+   * Whether the scanned project resolved a React-compatible runtime directly
+   * or through a React-backed framework. `false` means every React-runtime
+   * rule family was gated off, not that the scan target was unsupported:
+   * other detected framework and library rule families still run, as do
+   * framework-neutral rules on any analyzable project.
    * Mirrors `JsonReport.reactDetected`; same predicate as
    * `hasReactRuntime(result.project)`. Always set by `diagnose()`;
    * optional so hand-constructed results keep compiling.
@@ -107,7 +107,8 @@ export interface DiagnoseProjectsResult {
   score: ScoreResult | null;
   /**
    * Whether any successfully scanned project resolved a React-compatible
-   * runtime (React or Preact). Absent when no project scanned successfully.
+   * runtime directly or through a React-backed framework. Absent when no
+   * project scanned successfully.
    * See `DiagnoseResult.reactDetected` for gating guidance; per-project
    * detail is on each `ProjectResultOk.reactDetected`.
    */

--- a/packages/core/src/types/inspect.ts
+++ b/packages/core/src/types/inspect.ts
@@ -389,14 +389,13 @@ export interface JsonReportV1 {
   mode: JsonReportMode;
   baselineDegraded?: boolean;
   /**
-   * Whether any scanned project resolved a React-compatible runtime (React
-   * or Preact). `false` means every React-runtime rule family was gated off,
-   * so an empty `diagnostics` array is vacuous — NOT the same as a clean
-   * React scan. Consumers gating on the report (CI, verifiers, hooks) should
-   * treat `reactDetected === false` as "wrong scan target", not "all clear"
-   * (per project, `projects[].project.reactVersion` / `preactVersion` say
-   * which roots were non-React). Absent when nothing was scanned (`projects`
-   * is empty), on error reports, and on reports from older CLI versions.
+   * Whether any scanned project resolved a React-compatible runtime directly
+   * or through a React-backed framework. `false` means every React-runtime
+   * rule family was gated off, not that the scan target was unsupported:
+   * other detected framework and library rule families still run, as do
+   * framework-neutral rules on any analyzable project. Absent when
+   * nothing was scanned (`projects` is empty), on error reports, and on
+   * reports from older CLI versions.
    */
   reactDetected?: boolean;
   diff: JsonReportDiffInfo | null;

--- a/packages/core/src/utils/has-react-runtime.ts
+++ b/packages/core/src/utils/has-react-runtime.ts
@@ -1,10 +1,21 @@
 import type { ProjectInfo } from "../types/index.js";
 
+const REACT_COMPATIBLE_FRAMEWORKS: ReadonlySet<ProjectInfo["framework"]> = new Set([
+  "nextjs",
+  "tanstack-start",
+  "cra",
+  "remix",
+  "gatsby",
+  "expo",
+  "react-native",
+  "preact",
+]);
+
 /**
- * Whether project discovery resolved a React-compatible runtime (React or
- * Preact, which ships the same hooks + JSX model). This is the same
- * predicate that grants the `react` capability, so `false` means every
- * React-runtime rule family was gated off for the project.
+ * Whether project discovery resolved a React-compatible runtime directly or
+ * through a framework whose runtime is necessarily React-compatible.
  */
 export const hasReactRuntime = (project: ProjectInfo): boolean =>
-  project.reactVersion !== null || project.preactVersion !== null;
+  project.reactVersion !== null ||
+  project.preactVersion !== null ||
+  REACT_COMPATIBLE_FRAMEWORKS.has(project.framework);

--- a/packages/core/src/utils/has-supported-framework-or-library.ts
+++ b/packages/core/src/utils/has-supported-framework-or-library.ts
@@ -1,0 +1,16 @@
+import type { Capability } from "oxlint-plugin-react-doctor/core";
+import { buildCapabilities } from "../project-info/capabilities.js";
+import type { ProjectInfo } from "../types/index.js";
+
+const AMBIENT_PROJECT_CAPABILITIES: ReadonlySet<Capability> = new Set([
+  "unknown",
+  "typescript",
+  "pre-es2023",
+]);
+
+export const hasSupportedFrameworkOrLibrary = (project: ProjectInfo): boolean => {
+  for (const capability of buildCapabilities(project)) {
+    if (!AMBIENT_PROJECT_CAPABILITIES.has(capability)) return true;
+  }
+  return false;
+};

--- a/packages/core/tests/build-capabilities.test.ts
+++ b/packages/core/tests/build-capabilities.test.ts
@@ -5,6 +5,8 @@ import {
   getCapabilities,
   shouldEnableRule,
 } from "../src/project-info/capabilities.js";
+import { hasReactRuntime } from "../src/utils/has-react-runtime.js";
+import { hasSupportedFrameworkOrLibrary } from "../src/utils/has-supported-framework-or-library.js";
 
 const baseProject: ProjectInfo = {
   rootDirectory: "/tmp/project",
@@ -55,6 +57,91 @@ const baseProject: ProjectInfo = {
 };
 
 describe("buildCapabilities", () => {
+  it("recognizes every framework and library capability as a supported scan target", () => {
+    const plainProject: ProjectInfo = {
+      ...baseProject,
+      framework: "unknown",
+      reactVersion: null,
+      reactMajorVersion: null,
+      isPreES2023Target: true,
+    };
+    expect(hasSupportedFrameworkOrLibrary(plainProject)).toBe(false);
+
+    const supportedFrameworks: ReadonlyArray<ProjectInfo["framework"]> = [
+      "nextjs",
+      "astro",
+      "vite",
+      "cra",
+      "remix",
+      "gatsby",
+      "expo",
+      "react-native",
+      "tanstack-start",
+      "preact",
+    ];
+    for (const framework of supportedFrameworks) {
+      expect(hasSupportedFrameworkOrLibrary({ ...plainProject, framework })).toBe(true);
+    }
+
+    const supportedLibraryProjects: ReadonlyArray<ProjectInfo> = [
+      { ...plainProject, reactVersion: "19.0.0", reactMajorVersion: 19 },
+      { ...plainProject, tailwindVersion: "4.0.0" },
+      { ...plainProject, zodVersion: "4.0.0", zodMajorVersion: 4 },
+      { ...plainProject, mobxVersion: "6.0.0", mobxMajorVersion: 6 },
+      { ...plainProject, zustandVersion: "5.0.0", zustandMajorVersion: 5 },
+      { ...plainProject, hasReactCompiler: true },
+      { ...plainProject, reanimatedVersion: "4.0.0" },
+      { ...plainProject, hasTanStackQuery: true },
+      { ...plainProject, styledComponentsVersion: "6.0.0" },
+      { ...plainProject, hasI18nLibrary: true },
+      { ...plainProject, valtioVersion: "2.0.0", valtioMajorVersion: 2 },
+      { ...plainProject, hasRemotion: true },
+      { ...plainProject, hasThree: true },
+      { ...plainProject, hasReactThreeFiber: true },
+      { ...plainProject, preactVersion: "10.0.0", preactMajorVersion: 10 },
+      { ...plainProject, reactRouterVersion: "7.0.0" },
+      { ...plainProject, expoVersion: "54.0.0" },
+      { ...plainProject, hasReactNativeWorkspace: true },
+      { ...plainProject, hasSsrDependency: true },
+    ];
+    for (const project of supportedLibraryProjects) {
+      expect(hasSupportedFrameworkOrLibrary(project)).toBe(true);
+    }
+  });
+
+  it("treats React-backed frameworks as runtime evidence without a direct React version", () => {
+    for (const framework of [
+      "nextjs",
+      "tanstack-start",
+      "cra",
+      "remix",
+      "gatsby",
+      "expo",
+      "react-native",
+      "preact",
+    ] as const) {
+      const frameworkProject = {
+        ...baseProject,
+        framework,
+        reactVersion: null,
+        reactMajorVersion: null,
+      };
+      expect(hasReactRuntime(frameworkProject)).toBe(true);
+      expect(buildCapabilities(frameworkProject).has("react")).toBe(true);
+    }
+
+    for (const framework of ["vite", "astro"] as const) {
+      const frameworkProject = {
+        ...baseProject,
+        framework,
+        reactVersion: null,
+        reactMajorVersion: null,
+      };
+      expect(hasReactRuntime(frameworkProject)).toBe(false);
+      expect(buildCapabilities(frameworkProject).has("react")).toBe(false);
+    }
+  });
+
   it("emits Expo 54 only when tree shaking is enabled by default", () => {
     const expoFiftyThreeCapabilities = buildCapabilities({
       ...baseProject,

--- a/packages/core/tests/build-json-report.test.ts
+++ b/packages/core/tests/build-json-report.test.ts
@@ -349,6 +349,24 @@ describe("buildJsonReport", () => {
     expect(report.reactDetected).toBe(true);
   });
 
+  it("marks reactDetected true for Next.js without a direct React declaration", () => {
+    const nextProject: ProjectInfo = {
+      ...projectInfo,
+      reactVersion: null,
+      reactMajorVersion: null,
+      framework: "nextjs",
+    };
+    const report = buildJsonReport({
+      version: "1.2.3",
+      directory: "/repo",
+      mode: "full",
+      diff: null,
+      scans: [{ directory: "/repo", result: result({ project: nextProject }) }],
+      totalElapsedMilliseconds: 1200,
+    });
+    expect(report.reactDetected).toBe(true);
+  });
+
   it("omits reactDetected when nothing was scanned", () => {
     const report = buildJsonReport({
       version: "1.2.3",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/plugin-update-trust-risk.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/plugin-update-trust-risk.regressions.test.ts
@@ -86,7 +86,7 @@ describe("security-scan/plugin-update-trust-risk — regressions", () => {
   it("anchors a Docker installer finding on the download command instead of a package-list curl", () => {
     const findings = runScanRule(pluginUpdateTrustRisk, {
       relativePath: "Dockerfile",
-      content: `FROM oven/bun:1.3.14-debian\n\n# tmux is required by the agent harness.\nRUN apt-get update && apt-get install -y --no-install-recommends \\\n+    ca-certificates bash curl git \\\n+    && rm -rf /var/lib/apt/lists/*\n\n# Native installer.\nRUN curl -fsSL https://claude.ai/install.sh | bash\n`,
+      content: `FROM oven/bun:1.3.14-debian\n\n# tmux is required by the agent harness.\nRUN apt-get update && apt-get install -y --no-install-recommends \\\n    ca-certificates bash curl git \\\n    && rm -rf /var/lib/apt/lists/*\n\n# Native installer.\nRUN curl -fsSL https://claude.ai/install.sh | bash\n`,
     });
     expect(findings).toHaveLength(1);
     expect(findings[0]?.line).toBe(9);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/plugin-update-trust-risk.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/plugin-update-trust-risk.regressions.test.ts
@@ -83,6 +83,16 @@ describe("security-scan/plugin-update-trust-risk — regressions", () => {
     expect(findings).toHaveLength(1);
   });
 
+  it("anchors a Docker installer finding on the download command instead of a package-list curl", () => {
+    const findings = runScanRule(pluginUpdateTrustRisk, {
+      relativePath: "Dockerfile",
+      content: `FROM oven/bun:1.3.14-debian\n\n# tmux is required by the agent harness.\nRUN apt-get update && apt-get install -y --no-install-recommends \\\n+    ca-certificates bash curl git \\\n+    && rm -rf /var/lib/apt/lists/*\n\n# Native installer.\nRUN curl -fsSL https://claude.ai/install.sh | bash\n`,
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.line).toBe(9);
+    expect(findings[0]?.column).toBe(5);
+  });
+
   it("stays silent on healthcheck wget near unrelated chmod (outline Dockerfile shape)", () => {
     const findings = runScanRule(pluginUpdateTrustRisk, {
       relativePath: "Dockerfile",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/plugin-update-trust-risk.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/security-scan/plugin-update-trust-risk.ts
@@ -14,6 +14,9 @@ import { getScannableContent } from "./utils/scan-by-pattern.js";
 const UPDATER_TRUST_PATTERN =
   /\b(?:repoUrl|updateUrl|UpdateApp|InstallApp|auto.?updater?|installer|curl(?!\s+(?:-T\b|--upload-file\b))|wget)\b[\s\S]{0,250}(?:\.(?:zip|exe|dmg|appimage|msi|deb|rpm)\b|\.tar\.gz\b|\|\s*(?:bash|sh)\b)/i;
 
+const REMOTE_SCRIPT_EXECUTION_PATTERN =
+  /\b(?:curl|wget)\b(?=(?:[^\r\n]|\\\r?\n)*https?:\/\/)(?:[^\r\n]|\\\r?\n)*?\|\s*(?:bash|sh)\b/i;
+
 // A download whose hash is checked before use is exactly what the rule's
 // recommendation asks for.
 const CHECKSUM_VERIFICATION_PATTERN =
@@ -55,12 +58,16 @@ export const pluginUpdateTrustRisk = defineRule({
       return [];
     }
     const content = getScannableContent(file);
-    if (!UPDATER_TRUST_PATTERN.test(content)) return [];
+    const hasRemoteScriptExecution = REMOTE_SCRIPT_EXECUTION_PATTERN.test(content);
+    if (!hasRemoteScriptExecution && !UPDATER_TRUST_PATTERN.test(content)) return [];
+    const locationPattern = hasRemoteScriptExecution
+      ? REMOTE_SCRIPT_EXECUTION_PATTERN
+      : UPDATER_TRUST_PATTERN;
     if (CHECKSUM_VERIFICATION_PATTERN.test(content)) return [];
     if (SOURCE_FILE_PATTERN.test(file.relativePath) && !EXECUTION_CONTEXT_PATTERN.test(content)) {
       return [];
     }
-    const location = getMatchLocation(content, UPDATER_TRUST_PATTERN);
+    const location = getMatchLocation(content, locationPattern);
     return [
       {
         message:

--- a/packages/react-doctor/src/cli/utils/build-final-cli-scan-outcome.ts
+++ b/packages/react-doctor/src/cli/utils/build-final-cli-scan-outcome.ts
@@ -1,5 +1,5 @@
 import {
-  hasReactRuntime,
+  hasSupportedFrameworkOrLibrary,
   type InspectResult,
   type JsonReportMode,
   type JsonReportSkippedProject,
@@ -32,7 +32,7 @@ export interface FinalCliScanOutcome {
   readonly baselineDegraded: boolean;
   readonly mode: JsonReportMode;
   readonly scansForJsonReport: ReadonlyArray<CompletedScan>;
-  readonly shouldWarnNoReactDetected: boolean;
+  readonly shouldWarnNoSupportedLibraryDetected: boolean;
 }
 
 const filterCompletedScansByCategories = (
@@ -77,8 +77,8 @@ export const buildFinalCliScanOutcome = (
       input.completedScans,
       input.categoryFilters,
     ),
-    shouldWarnNoReactDetected:
+    shouldWarnNoSupportedLibraryDetected:
       input.completedScans.length > 0 &&
-      !input.completedScans.some((scan) => hasReactRuntime(scan.result.project)),
+      !input.completedScans.some((scan) => hasSupportedFrameworkOrLibrary(scan.result.project)),
   };
 };

--- a/packages/react-doctor/src/cli/utils/constants.ts
+++ b/packages/react-doctor/src/cli/utils/constants.ts
@@ -283,10 +283,9 @@ export const METRIC = {
   // Kill metric for workspace-owned dead-code analysis. If this never fires,
   // multi-project scans do not include their root and cannot share the pass.
   scanWorkspaceDeadCodeShared: "scan.workspace_deadcode_shared",
-  // One count per completed scan where no project resolved a React /
-  // Preact runtime — the JSON report's `reactDetected: false` case. The
-  // kill metric for the vacuous-clean-scan signal: if it never fires,
-  // nobody points react-doctor at non-React targets and the surface can go.
+  // One count per completed scan where no project resolved a supported
+  // framework or library capability. The kill metric for the
+  // vacuous-clean-scan signal: if it never fires, the warning surface can go.
   scanNoReactDetected: "scan.no_react_detected",
   baselineDegraded: "baseline.degraded",
   ruleFired: "rule.fired",

--- a/packages/react-doctor/src/cli/utils/finalize-cli-scans.ts
+++ b/packages/react-doctor/src/cli/utils/finalize-cli-scans.ts
@@ -61,10 +61,10 @@ export const finalizeCliScans = (input: FinalizeCliScansInput): void => {
     categoryFilters: input.categoryFilters,
   });
 
-  if (outcome.shouldWarnNoReactDetected) {
+  if (outcome.shouldWarnNoSupportedLibraryDetected) {
     recordCount(METRIC.scanNoReactDetected, 1);
     logger.warn(
-      `No React project detected at ${input.resolvedDirectory} — React rules were gated off; this is not the same as a clean scan.`,
+      `No supported framework or library detected at ${input.resolvedDirectory} — library-specific rules were gated off; framework-neutral rules still ran.`,
     );
   }
 

--- a/packages/react-doctor/tests/build-final-cli-scan-outcome.test.ts
+++ b/packages/react-doctor/tests/build-final-cli-scan-outcome.test.ts
@@ -9,7 +9,9 @@ import { buildDiagnostic, buildTestProject } from "./regressions/_helpers.js";
 interface BuildCompletedScanOptions {
   readonly directory: string;
   readonly diagnostics?: Diagnostic[];
+  readonly framework?: InspectResult["project"]["framework"];
   readonly hasReact?: boolean;
+  readonly hasThree?: boolean;
   readonly baselineDelta?: InspectResult["baselineDelta"];
 }
 
@@ -20,11 +22,15 @@ const buildCompletedScan = (options: BuildCompletedScanOptions): CompletedScan =
     diagnostics: options.diagnostics ?? [],
     score: null,
     skippedChecks: [],
-    project: buildTestProject({
-      rootDirectory: options.directory,
-      reactMajorVersion: options.hasReact === false ? null : 19,
-      reactVersion: options.hasReact === false ? null : "^19.0.0",
-    }),
+    project: {
+      ...buildTestProject({
+        rootDirectory: options.directory,
+        framework: options.framework,
+        reactMajorVersion: options.hasReact === false ? null : 19,
+        reactVersion: options.hasReact === false ? null : "^19.0.0",
+      }),
+      hasThree: options.hasThree === true,
+    },
     elapsedMilliseconds: 1,
     baselineDelta: options.baselineDelta,
   },
@@ -85,18 +91,37 @@ describe("buildFinalCliScanOutcome", () => {
     expect(outcome.baseline).toBeUndefined();
   });
 
-  it("detects completed scans where React rules were gated off", () => {
+  it("warns only when no supported framework or library was detected", () => {
     expect(
       buildOutcome([buildCompletedScan({ directory: "/repo", hasReact: false })])
-        .shouldWarnNoReactDetected,
+        .shouldWarnNoSupportedLibraryDetected,
     ).toBe(true);
     expect(
       buildOutcome([
         buildCompletedScan({ directory: "/repo/plain", hasReact: false }),
         buildCompletedScan({ directory: "/repo/react" }),
-      ]).shouldWarnNoReactDetected,
+      ]).shouldWarnNoSupportedLibraryDetected,
     ).toBe(false);
-    expect(buildOutcome([]).shouldWarnNoReactDetected).toBe(false);
+    expect(
+      buildOutcome([
+        buildCompletedScan({ directory: "/repo/three", hasReact: false, hasThree: true }),
+      ]).shouldWarnNoSupportedLibraryDetected,
+    ).toBe(false);
+    expect(
+      buildOutcome([
+        buildCompletedScan({
+          directory: "/repo/next",
+          framework: "nextjs",
+          hasReact: false,
+        }),
+      ]).shouldWarnNoSupportedLibraryDetected,
+    ).toBe(false);
+    expect(
+      buildOutcome([
+        buildCompletedScan({ directory: "/repo/vite", framework: "vite", hasReact: false }),
+      ]).shouldWarnNoSupportedLibraryDetected,
+    ).toBe(false);
+    expect(buildOutcome([]).shouldWarnNoSupportedLibraryDetected).toBe(false);
   });
 
   it("filters only the JSON report diagnostics by category", () => {

--- a/packages/react-doctor/tests/regressions/_helpers.ts
+++ b/packages/react-doctor/tests/regressions/_helpers.ts
@@ -205,6 +205,8 @@ export const buildTestProject = (options: BuildTestProjectOptions): ProjectInfo 
     tanstackQueryVersion: options.tanstackQueryVersion ?? null,
     mobxVersion: null,
     styledComponentsVersion: null,
+    valtioVersion: null,
+    valtioMajorVersion: null,
     hasSsrDependency: options.hasSsrDependency ?? false,
     nextjsVersion,
     nextjsMajorVersion,


### PR DESCRIPTION
## Why

React Doctor already detects Three.js and many other framework/library capabilities, but its terminal target check only accepted React or Preact. A valid Three.js scan therefore ended with `No React project detected`, and React-backed framework roots without a direct `react` declaration could lose the general React capability. The same evaluator report also showed the updater trust diagnostic anchored on an earlier package-list mention of `curl` instead of the actual `curl ... | bash` command.

After this change, any detected framework or library capability identifies a supported scan target, React-backed frameworks activate general React rules without requiring a direct declaration, and remote-installer findings point to the executable download command.

## What changed

- derive supported-target classification from the canonical project capability set instead of a React-only predicate
- treat Next.js, TanStack Start, CRA, Remix, Gatsby, Expo, React Native, and Preact framework detection as React-runtime evidence when a leaf manifest omits React
- keep `reactDetected` backward-compatible while clarifying that non-React framework/library rule families can still run
- anchor `plugin-update-trust-risk` on the concrete remote script execution command
- add framework, library, JSON report, CLI outcome, and Docker location regressions
- add a patch changeset for the affected packages

## Eval results

A bounded local RDE run inspected 100 projects. `plugin-update-trust-risk` produced 0 hits across that sample, so the location refinement introduced no observed false positives. PR parity was not available before the PR head existed and will be checked on this PR.

## Test plan

- `nr test` — 15/15 tasks successful
- `nr typecheck` — 16/16 tasks successful
- `nr lint` — passed (existing fuzz-corpus warnings only)
- `nr format:check` — passed
- `nr smoke:json-report` — passed (`schemaVersion=3`)
- `FUZZ_RULE=plugin-update-trust-risk FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz` — passed
- targeted capability tests — 75 passed
- targeted CLI outcome tests — 4 passed
- oxlint plugin suite — 26,987 passed, 185 skipped

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes scan-target warnings and React capability gating used by CLI and consumers of `reactDetected`; security rule location logic is adjusted but behavior is regression-tested.
> 
> **Overview**
> The CLI **no longer treats “no React in package.json” as an unsupported target**. Post-scan warnings now use `hasSupportedFrameworkOrLibrary`, which treats any non-ambient capability (frameworks like Vite/Astro, libraries like Three.js, Tailwind, etc.) as a valid scan target—so plain Three.js projects stop getting a misleading “No React project detected” message while framework-neutral rules still run.
> 
> **React rule gating** is widened: `hasReactRuntime` and the `react` capability now count React-backed frameworks (Next.js, Remix, Expo, etc.) even when the leaf manifest omits a direct `react` dependency. `reactDetected` in JSON/diagnose types keeps the same field but docs clarify it only reflects React-runtime rules, not overall support.
> 
> **Security scan** `plugin-update-trust-risk` adds a dedicated `curl|wget … | bash|sh` pattern and uses it for match location when present, so Dockerfiles that install `curl` via `apt-get` no longer anchor findings on the package list instead of the actual remote installer `RUN` line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11ad48f817cc6bf7bfd5a4978b22a139b5018469. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->