### PR TITLE
test: stabilize CI timing guards

### DIFF
--- a/packages/api/tests/diagnose.test.ts
+++ b/packages/api/tests/diagnose.test.ts
@@ -17,6 +17,7 @@ const FIXTURES_DIRECTORY = path.resolve(
   "tests",
   "fixtures",
 );
+const LINT_OPT_OUT_TEST_TIMEOUT_MS = 60_000;
 
 const noReactTempDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "rdc-api-test-"));
 fs.writeFileSync(
@@ -124,20 +125,24 @@ describe("diagnose", () => {
     expect(result.elapsedMilliseconds).toBeGreaterThanOrEqual(0);
   });
 
-  it("respects lint: false by providing a no-op linter layer", async () => {
-    const directory = path.join(FIXTURES_DIRECTORY, "basic-react");
-    const lintEnabledResult = await diagnose(directory, { deadCode: false, lint: true });
-    const lintDisabledResult = await diagnose(directory, { deadCode: false, lint: false });
-    const lintEnabledSourceDiagnostics = lintEnabledResult.diagnostics.filter(
-      (diagnostic) => diagnostic.filePath !== "package.json",
-    );
-    const lintDisabledSourceDiagnostics = lintDisabledResult.diagnostics.filter(
-      (diagnostic) => diagnostic.filePath !== "package.json",
-    );
+  it(
+    "respects lint: false by providing a no-op linter layer",
+    { timeout: LINT_OPT_OUT_TEST_TIMEOUT_MS },
+    async () => {
+      const directory = path.join(FIXTURES_DIRECTORY, "basic-react");
+      const lintEnabledResult = await diagnose(directory, { deadCode: false, lint: true });
+      const lintDisabledResult = await diagnose(directory, { deadCode: false, lint: false });
+      const lintEnabledSourceDiagnostics = lintEnabledResult.diagnostics.filter(
+        (diagnostic) => diagnostic.filePath !== "package.json",
+      );
+      const lintDisabledSourceDiagnostics = lintDisabledResult.diagnostics.filter(
+        (diagnostic) => diagnostic.filePath !== "package.json",
+      );
 
-    expect(lintEnabledSourceDiagnostics.length).toBeGreaterThan(0);
-    expect(lintDisabledSourceDiagnostics).toHaveLength(0);
-  });
+      expect(lintEnabledSourceDiagnostics.length).toBeGreaterThan(0);
+      expect(lintDisabledSourceDiagnostics).toHaveLength(0);
+    },
+  );
 });
 
 describe("diagnose({ projects })", () => {

--- a/packages/core/tests/spawn-batches.test.ts
+++ b/packages/core/tests/spawn-batches.test.ts
@@ -102,6 +102,8 @@ describe("issue #599: spawnLintBatches never leaks its progress interval", () =>
  * the run succeeds — the assertion is purely about how many ran at once.
  */
 const SLEEP_MS = 200;
+const SHARED_SLOT_POLL_INTERVAL_MS = 10;
+const SHARED_SLOT_WAIT_TIMEOUT_MS = 5_000;
 
 const computePeakConcurrency = (marks: string): number => {
   let depth = 0;
@@ -166,7 +168,12 @@ describe("spawnLintBatches concurrency", () => {
       `const markFile = ${JSON.stringify(markFile)};`,
       'fs.appendFileSync(markFile, "+");',
       "const files = process.argv.slice(1);",
-      "setTimeout(() => {",
+      `const deadline = Date.now() + ${SHARED_SLOT_WAIT_TIMEOUT_MS};`,
+      "const interval = setInterval(() => {",
+      '  const marks = fs.readFileSync(markFile, "utf8");',
+      '  const activeCount = Array.from(marks).reduce((count, mark) => count + (mark === "+" ? 1 : -1), 0);',
+      "  if (activeCount < 2 && Date.now() < deadline) return;",
+      "  clearInterval(interval);",
       '  fs.appendFileSync(markFile, "-");',
       "  const diagnostics = files.map((filename) => ({",
       '    message: "Array index used as a key",',
@@ -178,7 +185,7 @@ describe("spawnLintBatches concurrency", () => {
       "    related: [],",
       "  }));",
       "  process.stdout.write(JSON.stringify({ diagnostics, number_of_files: files.length, number_of_rules: 1 }));",
-      `}, ${SLEEP_MS});`,
+      `}, ${SHARED_SLOT_POLL_INTERVAL_MS});`,
     ].join("\n");
     const spawnSlots = createOxlintSpawnSlots(2);
     const runProjectBatches = (projectName: string) =>

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.performance.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.performance.test.ts
@@ -4,7 +4,7 @@ import { effectNeedsCleanup } from "./effect-needs-cleanup.js";
 
 const SMALL_HANDLER_COUNT = 100;
 const LARGE_HANDLER_COUNT = 500;
-const MEASUREMENT_REPETITION_COUNT = 3;
+const MEASUREMENT_SAMPLE_COUNT = 3;
 const MAXIMUM_SCALING_MULTIPLIER = 15;
 
 const buildRetainedHandlersSource = (
@@ -28,13 +28,15 @@ const measureDuration = (
   buildRegistration: (handlerIndex: number) => string,
 ): number => {
   const source = buildRetainedHandlersSource(handlerCount, buildRegistration);
-  const startedAt = process.hrtime.bigint();
-  for (let repetition = 0; repetition < MEASUREMENT_REPETITION_COUNT; repetition += 1) {
+  const sampleDurations = Array.from({ length: MEASUREMENT_SAMPLE_COUNT }, () => {
+    const startedAt = process.hrtime.bigint();
     const result = runRule(effectNeedsCleanup, source);
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toHaveLength(handlerCount);
-  }
-  return Number(process.hrtime.bigint() - startedAt);
+    return Number(process.hrtime.bigint() - startedAt);
+  });
+  sampleDurations.sort((firstDuration, secondDuration) => firstDuration - secondDuration);
+  return sampleDurations[Math.floor(sampleDurations.length / 2)] ?? Number.POSITIVE_INFINITY;
 };
 
 describe("effect-needs-cleanup performance", () => {

--- a/packages/react-doctor/tests/ink/use-report-reveal.test.tsx
+++ b/packages/react-doctor/tests/ink/use-report-reveal.test.tsx
@@ -1,5 +1,6 @@
 import { Text } from "ink";
 import { render } from "ink-testing-library";
+import { act } from "react";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import {
   TUI_DEFAULT_TERMINAL_COLUMNS,
@@ -26,6 +27,7 @@ const RevealProbe = ({ issueCount, onRevealComplete }: RevealProbeProps) => {
 };
 
 afterEach(() => {
+  vi.useRealTimers();
   if (previousForceOnboarding === undefined) delete process.env[FORCE_ONBOARDING_ENV_VAR];
   else process.env[FORCE_ONBOARDING_ENV_VAR] = previousForceOnboarding;
   if (previousTerminalName === undefined) delete process.env.TERM;
@@ -35,6 +37,7 @@ afterEach(() => {
 
 describe("useReportReveal", () => {
   it("completes onboarding only after the animated report reveal", async () => {
+    vi.useFakeTimers();
     process.env[FORCE_ONBOARDING_ENV_VAR] = "1";
     process.env.TERM = "xterm-256color";
     const onRevealComplete = vi.fn();
@@ -47,13 +50,17 @@ describe("useReportReveal", () => {
 
     renderedView.rerender(<RevealProbe issueCount={2} onRevealComplete={onRevealComplete} />);
 
-    await vi.waitFor(() => expect(renderedView.lastFrame()).toContain("streaming"));
+    expect(renderedView.lastFrame()).toContain("streaming");
     expect(onRevealComplete).not.toHaveBeenCalled();
-    await vi.waitFor(() => expect(onRevealComplete).toHaveBeenCalledOnce(), {
-      timeout:
-        TUI_REPORT_ISSUE_STREAM_FRAME_DELAY_MS * TUI_REPORT_ISSUE_STREAM_MAX_STEPS +
-        ONBOARDING_SECTION_DELAY_MS * 2,
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(
+        TUI_REPORT_ISSUE_STREAM_FRAME_DELAY_MS * TUI_REPORT_ISSUE_STREAM_MAX_STEPS,
+      );
     });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(ONBOARDING_SECTION_DELAY_MS);
+    });
+    expect(onRevealComplete).toHaveBeenCalledOnce();
     expect(renderedView.lastFrame()).toContain("actions");
     renderedView.unmount();
   });


### PR DESCRIPTION
## What changed

- gives the real-linter API integration test a 60-second timeout under saturated CI runners
- measures the effect-cleanup scaling guard with the median of three independent samples
- synchronizes the shared subprocess-cap test on concurrent child startup instead of a fixed 200ms scheduler window
- keeps the existing scaling threshold unchanged

## Why

The `0.9.12` release commit exposed timing-only flakes on `main`: one API test exceeded Vitest's default 30-second timeout on Ubuntu Node 22, one macOS performance sample missed its scaling ceiling by 2.3%, and a subprocess test's 200ms overlap window closed before a second child started under a saturated Ubuntu runner. The release commit itself only changed versions and changelogs.

## Validation

- `nr build`
- `nr test`
- `nr lint` (existing corpus warnings only)
- `nr typecheck`
- `nr format`
- `nr smoke:json-report`
- API diagnose test: 21/21
- performance test: five consecutive focused passes
- shared subprocess-cap test: ten consecutive focused passes
- full core suite: 1,900/1,900
- full plugin suite: three consecutive passes (27,337 passed, 187 skipped each)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production code paths; risk is limited to test signal if guards become too loose.
> 
> **Overview**
> Hardens several tests that were flaking on slow or saturated CI runners without changing production behavior or performance thresholds.
> 
> The API **lint opt-out** integration test now gets a **60s** Vitest timeout so a full lint-on vs lint-off comparison can finish on Ubuntu Node 22. The **shared subprocess cap** test stops relying on a fixed **200ms** sleep and instead polls a shared mark file until two children are active (or a **5s** deadline), so overlap is asserted on real concurrency. The **effect-needs-cleanup** performance guard now uses the **median of three** independent runs instead of one bundled timing loop. The **useReportReveal** onboarding animation test drives completion with **fake timers** and `act`/`advanceTimersByTimeAsync` instead of a long `vi.waitFor` timeout, and restores real timers in `afterEach`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8834d66398f0f9fc47ebeab16521d13141a98387. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->