### PR TITLE
fix(cli): run agent hooks at turn completion

### DIFF
--- a/.changeset/quiet-agent-stop-hooks.md
+++ b/.changeset/quiet-agent-stop-hooks.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Run installed Claude Code and Cursor hooks once at the end of an agent turn, include untracked files in the changed-file scan, and migrate existing per-tool React Doctor hooks automatically.

--- a/packages/react-doctor/src/cli/index.ts
+++ b/packages/react-doctor/src/cli/index.ts
@@ -275,7 +275,7 @@ program
   .description("Install the react-doctor skill into your coding agents and optional git hook")
   .option("-y, --yes", "skip prompts, install for all detected agents")
   .option("--dry-run", "show what would be installed without writing files")
-  .option("--agent-hooks", "install native non-blocking agent hooks for Claude Code and Cursor")
+  .option("--agent-hooks", "install end-of-turn agent hooks for Claude Code and Cursor")
   .option("-c, --cwd <cwd>", "working directory", process.cwd())
   .option("--color", "force colored output")
   .option("--no-color", "disable colored output (also honors NO_COLOR)")

--- a/packages/react-doctor/src/cli/utils/cli-migrations.ts
+++ b/packages/react-doctor/src/cli/utils/cli-migrations.ts
@@ -3,7 +3,7 @@ import { cliLogger as logger } from "./cli-logger.js";
 import { type CliStateOptions } from "./cli-state-store.js";
 import { type Migration, type MigrationResult, runMigrations } from "./cli-lifecycle.js";
 import {
-  findAgentsWithLegacyShellHooks,
+  findAgentsWithOutdatedReactDoctorHooks,
   installReactDoctorAgentHooks,
 } from "./install-agent-hooks.js";
 import { migrateActionPin } from "./migrate-action-pin.js";
@@ -66,28 +66,22 @@ const actionPinMainToMajor: Migration = {
   },
 };
 
-// Replaces the ≤0.5.8 `react-doctor.sh` shell agent hooks with the current
-// Node hook by re-running the installer for exactly the agents that still
-// carry a legacy entry (the installer strips the legacy entry, writes the
-// `.mjs` hook, and deletes the orphaned script). A re-install migrates in
-// place already; this covers everyone who never re-runs
-// `install --agent-hooks`. With no legacy hooks it's a no-op that returns
-// `false` (stays pending, so a legacy hook restored from an old branch later
-// is still migrated).
-const agentHooksShellToNode: Migration = {
+// Re-runs the installer for managed hooks that predate end-of-turn scanning.
+// Version 2 also moves previously installed Node hooks from per-tool events to
+// Stop events; version 1 only replaced the ≤0.5.8 shell scripts.
+const agentHooksToStop: Migration = {
   id: "agent-hooks-sh-to-mjs",
+  version: 2,
   scope: "project",
   run: ({ projectRoot }) => {
     if (projectRoot === undefined) return false;
-    const agents = findAgentsWithLegacyShellHooks(projectRoot);
+    const agents = findAgentsWithOutdatedReactDoctorHooks(projectRoot);
     if (agents.length === 0) return false;
 
     installReactDoctorAgentHooks({ projectRoot, agents });
-    logger.success(
-      `Upgraded the legacy react-doctor.sh agent hook to the Node hook (${agents.join(", ")})`,
-    );
+    logger.success(`Moved React Doctor agent hooks to end-of-turn checks (${agents.join(", ")})`);
     logger.dim(
-      "  The shell hook can't run on Windows and would double-scan next to the current hook. Review and commit the change.",
+      "  Hooks now scan changed and untracked files once when the agent stops. Review and commit the change.",
     );
     logger.break();
     return true;
@@ -97,7 +91,7 @@ const agentHooksShellToNode: Migration = {
 const PROJECT_MIGRATIONS: ReadonlyArray<Migration> = [
   legacyConfigToTypescript,
   actionPinMainToMajor,
-  agentHooksShellToNode,
+  agentHooksToStop,
 ];
 
 // Runs every pending per-repo migration for `projectRoot` once, recording the

--- a/packages/react-doctor/src/cli/utils/constants.ts
+++ b/packages/react-doctor/src/cli/utils/constants.ts
@@ -93,6 +93,7 @@ export const RUN_GIT_MAX_BUFFER_BYTES = 64 * 1024 * 1024;
 export const GIT_HOOK_EXECUTABLE_MODE = 0o755;
 
 export const AGENT_HOOK_TIMEOUT_SECONDS = 120;
+export const AGENT_HOOK_MAX_CONTINUATIONS = 1;
 
 // Hard cap on the `gh repo view` default-branch probe. A healthy gh answers
 // well under a second; a cold gh.exe on Windows CI has taken 30s+, and the

--- a/packages/react-doctor/src/cli/utils/install-agent-hooks.ts
+++ b/packages/react-doctor/src/cli/utils/install-agent-hooks.ts
@@ -1,7 +1,7 @@
 import * as path from "node:path";
 import type { SkillAgentType } from "agent-install";
 import { isErrnoException } from "@react-doctor/core";
-import { AGENT_HOOK_TIMEOUT_SECONDS } from "./constants.js";
+import { AGENT_HOOK_MAX_CONTINUATIONS, AGENT_HOOK_TIMEOUT_SECONDS } from "./constants.js";
 import * as fs from "node:fs";
 import { CliInputError } from "./cli-input-error.js";
 import { writeJsonFile } from "./git-hook-shared.js";
@@ -51,7 +51,6 @@ const CLAUDE_HOOK_COMMAND = 'node "$CLAUDE_PROJECT_DIR/.claude/hooks/react-docto
 const CURSOR_HOOKS_RELATIVE_PATH = ".cursor/hooks.json";
 const CURSOR_HOOK_RELATIVE_PATH = ".cursor/hooks/react-doctor.mjs";
 const CURSOR_HOOK_COMMAND = "node .cursor/hooks/react-doctor.mjs";
-const CURSOR_HOOK_MATCHER = "Write|Edit|MultiEdit|ApplyPatch";
 const CURSOR_HOOKS_SCHEMA_VERSION = 1;
 // Releases up to 0.5.8 installed a `react-doctor.sh` shell hook; re-installs
 // must replace those entries (and the orphaned script) instead of stacking a
@@ -68,6 +67,9 @@ const LEGACY_HOOK_SCRIPT_PATHS = [
 const isLegacyHookCommand = (command: string | undefined): boolean =>
   typeof command === "string" &&
   LEGACY_HOOK_SCRIPT_PATHS.some((legacyPath) => command.includes(legacyPath));
+
+const isManagedHookCommand = (command: string | undefined, installedCommand: string): boolean =>
+  command === installedCommand || isLegacyHookCommand(command);
 
 const isSupportedAgent = (agent: SkillAgentType): boolean =>
   agent === CLAUDE_AGENT || agent === CURSOR_AGENT;
@@ -98,29 +100,34 @@ const readJsonFileSafely = <Value>(filePath: string, fallback: Value): Value => 
   }
 };
 
-// Detection half of the `agent-hooks-sh-to-mjs` migration (cli-migrations.ts):
-// which supported agents still have a ≤0.5.8 shell hook registered. Checks
-// exactly the event keys the installers strip (Claude `PostToolBatch`, Cursor
-// `postToolUse`) so one install pass always clears the detection.
-export const findAgentsWithLegacyShellHooks = (projectRoot: string): SkillAgentType[] => {
+// Detection half of the agent-hook migration (cli-migrations.ts). It finds
+// managed hooks that still run after tools, plus ≤0.5.8 shell hooks registered
+// on either the old or current events, so one install pass clears the probe.
+export const findAgentsWithOutdatedReactDoctorHooks = (projectRoot: string): SkillAgentType[] => {
   const agents: SkillAgentType[] = [];
   const settings = readJsonFileSafely<ClaudeSettings>(
     path.join(projectRoot, CLAUDE_SETTINGS_RELATIVE_PATH),
     {},
   );
-  const hasLegacyClaudeHook = (settings.hooks?.PostToolBatch ?? []).some((group) =>
-    (group.hooks ?? []).some((hook) => isLegacyHookCommand(hook.command)),
-  );
-  if (hasLegacyClaudeHook) agents.push(CLAUDE_AGENT);
+  const hasOutdatedClaudeHook =
+    [...(settings.hooks?.PostToolBatch ?? []), ...(settings.hooks?.Stop ?? [])].some((group) =>
+      (group.hooks ?? []).some((hook) => isLegacyHookCommand(hook.command)),
+    ) ||
+    (settings.hooks?.PostToolBatch ?? []).some((group) =>
+      (group.hooks ?? []).some((hook) => hook.command === CLAUDE_HOOK_COMMAND),
+    );
+  if (hasOutdatedClaudeHook) agents.push(CLAUDE_AGENT);
 
   const config = readJsonFileSafely<CursorHooksConfig>(
     path.join(projectRoot, CURSOR_HOOKS_RELATIVE_PATH),
     {},
   );
-  const hasLegacyCursorHook = (config.hooks?.postToolUse ?? []).some((handler) =>
-    isLegacyHookCommand(handler.command),
-  );
-  if (hasLegacyCursorHook) agents.push(CURSOR_AGENT);
+  const hasOutdatedCursorHook =
+    [...(config.hooks?.postToolUse ?? []), ...(config.hooks?.stop ?? [])].some((handler) =>
+      isLegacyHookCommand(handler.command),
+    ) ||
+    (config.hooks?.postToolUse ?? []).some((handler) => handler.command === CURSOR_HOOK_COMMAND);
+  if (hasOutdatedCursorHook) agents.push(CURSOR_AGENT);
   return agents;
 };
 
@@ -153,9 +160,9 @@ const writeJsonFileWithDirectoryCheck = (filePath: string, value: unknown): void
   writeJsonFile(filePath, value);
 };
 
-const writeHookScript = (filePath: string): void => {
+const writeHookScript = (filePath: string, hookEventName: "Stop" | "stop"): void => {
   ensureDirectoryExists(path.dirname(filePath));
-  fs.writeFileSync(filePath, buildAgentHookScript());
+  fs.writeFileSync(filePath, buildAgentHookScript(hookEventName));
   // Remove the orphaned ≤0.5.8 `.sh` sibling so a re-install doesn't leave it
   // behind. Best-effort: a stale script that can't be deleted only wastes disk.
   try {
@@ -163,74 +170,70 @@ const writeHookScript = (filePath: string): void => {
   } catch {}
 };
 
-const hasClaudeHookCommand = (groups: readonly ClaudeHookGroup[]): boolean =>
-  groups.some((group) => (group.hooks ?? []).some((hook) => hook.command === CLAUDE_HOOK_COMMAND));
-
 const installClaudeHook = (projectRoot: string): readonly string[] => {
   const settingsPath = path.join(projectRoot, CLAUDE_SETTINGS_RELATIVE_PATH);
   const hookPath = path.join(projectRoot, CLAUDE_HOOK_RELATIVE_PATH);
   const settings = readJsonFile<ClaudeSettings>(settingsPath, {});
   const hooks = { ...(settings.hooks ?? {}) };
-  // Strip legacy entries, dropping a group only when that strip emptied it.
+  // Strip managed entries, dropping a group only when that strip emptied it.
   // Groups react-doctor never touched (including empty or hook-less ones) pass
   // through verbatim — the installer must not rewrite settings it doesn't own.
-  const postToolBatchHooks = (hooks.PostToolBatch ?? []).flatMap((group) => {
-    const groupHooks = group.hooks ?? [];
-    const keptHooks = groupHooks.filter((hook) => !isLegacyHookCommand(hook.command));
-    if (keptHooks.length === groupHooks.length) return [group];
-    return keptHooks.length > 0 ? [{ ...group, hooks: keptHooks }] : [];
+  const stripManagedHooks = (groups: readonly ClaudeHookGroup[]): ClaudeHookGroup[] =>
+    groups.flatMap((group) => {
+      const groupHooks = group.hooks ?? [];
+      const keptHooks = groupHooks.filter(
+        (hook) => !isManagedHookCommand(hook.command, CLAUDE_HOOK_COMMAND),
+      );
+      if (keptHooks.length === groupHooks.length) return [group];
+      return keptHooks.length > 0 ? [{ ...group, hooks: keptHooks }] : [];
+    });
+
+  const stopHooks = stripManagedHooks(hooks.Stop ?? []);
+  stopHooks.push({
+    hooks: [
+      {
+        type: "command",
+        command: CLAUDE_HOOK_COMMAND,
+      },
+    ],
   });
 
-  if (!hasClaudeHookCommand(postToolBatchHooks)) {
-    postToolBatchHooks.push({
-      hooks: [
-        {
-          type: "command",
-          command: CLAUDE_HOOK_COMMAND,
-        },
-      ],
-    });
-  }
-
-  hooks.PostToolBatch = postToolBatchHooks;
+  hooks.PostToolBatch = stripManagedHooks(hooks.PostToolBatch ?? []);
+  hooks.Stop = stopHooks;
   writeJsonFileWithDirectoryCheck(settingsPath, { ...settings, hooks });
-  writeHookScript(hookPath);
+  writeHookScript(hookPath, "Stop");
 
   return [settingsPath, hookPath];
 };
-
-const hasCursorHookCommand = (handlers: readonly CursorHookHandler[]): boolean =>
-  handlers.some((handler) => handler.command === CURSOR_HOOK_COMMAND);
 
 const installCursorHook = (projectRoot: string): readonly string[] => {
   const configPath = path.join(projectRoot, CURSOR_HOOKS_RELATIVE_PATH);
   const hookPath = path.join(projectRoot, CURSOR_HOOK_RELATIVE_PATH);
   const config = readJsonFile<CursorHooksConfig>(configPath, {});
   const hooks = { ...(config.hooks ?? {}) };
-  const postToolUseHooks = (hooks.postToolUse ?? []).filter(
-    (handler) => !isLegacyHookCommand(handler.command),
+  const stopHooks = (hooks.stop ?? []).filter(
+    (handler) => !isManagedHookCommand(handler.command, CURSOR_HOOK_COMMAND),
   );
+  stopHooks.push({
+    command: CURSOR_HOOK_COMMAND,
+    timeout: AGENT_HOOK_TIMEOUT_SECONDS,
+  });
 
-  if (!hasCursorHookCommand(postToolUseHooks)) {
-    postToolUseHooks.push({
-      command: CURSOR_HOOK_COMMAND,
-      matcher: CURSOR_HOOK_MATCHER,
-      timeout: AGENT_HOOK_TIMEOUT_SECONDS,
-    });
-  }
-
-  hooks.postToolUse = postToolUseHooks;
+  hooks.postToolUse = (hooks.postToolUse ?? []).filter(
+    (handler) => !isManagedHookCommand(handler.command, CURSOR_HOOK_COMMAND),
+  );
+  hooks.stop = stopHooks;
   writeJsonFileWithDirectoryCheck(configPath, {
     ...config,
     version: config.version ?? CURSOR_HOOKS_SCHEMA_VERSION,
     hooks,
   });
-  writeHookScript(hookPath);
+  writeHookScript(hookPath, "stop");
 
   return [configPath, hookPath];
 };
 
-const buildAgentHookScript = (): string =>
+const buildAgentHookScript = (hookEventName: "Stop" | "stop"): string =>
   [
     "import { existsSync, readFileSync, writeFileSync, unlinkSync } from 'node:fs';",
     "import { tmpdir } from 'node:os';",
@@ -240,11 +243,11 @@ const buildAgentHookScript = (): string =>
     "",
     "const __filename = fileURLToPath(import.meta.url);",
     "const __dirname = dirname(__filename);",
+    `const HOOK_EVENT_NAME = ${JSON.stringify(hookEventName)};`,
+    `const MAX_CONTINUATIONS = ${AGENT_HOOK_MAX_CONTINUATIONS};`,
     "",
     "// --verbose scans on large diffs can exceed spawnSync's 1 MiB default.",
     "const SPAWN_MAX_BUFFER_BYTES = 16 * 1024 * 1024;",
-    "",
-    "const EDIT_TOOL_NAMES = new Set(['Edit', 'Write', 'MultiEdit', 'NotebookEdit', 'ApplyPatch']);",
     "",
     "const readFileOrEmpty = (source) => {",
     "  try {",
@@ -255,13 +258,10 @@ const buildAgentHookScript = (): string =>
     "};",
     "",
     "const shouldScan = (input) => {",
-    "  const eventName = input.hook_event_name || input.eventName || input.event_name;",
-    "  if (eventName === 'PostToolBatch') {",
-    "    const toolCalls = Array.isArray(input.tool_calls) ? input.tool_calls : [];",
-    "    return toolCalls.some((toolCall) => EDIT_TOOL_NAMES.has(toolCall.tool_name));",
-    "  }",
-    "  const toolName = input.tool_name || input.toolName || input.tool;",
-    "  return !toolName || EDIT_TOOL_NAMES.has(toolName);",
+    "  if (HOOK_EVENT_NAME === 'Stop') return !input.stop_hook_active;",
+    "  if (input.status && input.status !== 'completed') return false;",
+    "  const loopCount = Number(input.loop_count);",
+    "  return !Number.isFinite(loopCount) || loopCount < MAX_CONTINUATIONS;",
     "};",
     "",
     "const runReactDoctor = (outputPath) => {",
@@ -277,11 +277,11 @@ const buildAgentHookScript = (): string =>
     "    : './node_modules/.bin/react-doctor';",
     "  const commands = [",
     "    ...(existsSync(localBin)",
-    "      ? [localBin + ' --verbose --scope changed --blocking warning --no-score']",
+    "      ? [localBin + ' --verbose --scope changed --include-untracked --blocking warning --no-score']",
     "      : []),",
-    "    'react-doctor --verbose --scope changed --blocking warning --no-score',",
-    "    'pnpm dlx react-doctor@latest --verbose --scope changed --blocking warning --no-score',",
-    "    'npx --yes react-doctor@latest --verbose --scope changed --blocking warning --no-score',",
+    "    'react-doctor --verbose --scope changed --include-untracked --blocking warning --no-score',",
+    "    'pnpm dlx react-doctor@latest --verbose --scope changed --include-untracked --blocking warning --no-score',",
+    "    'npx --yes react-doctor@latest --verbose --scope changed --include-untracked --blocking warning --no-score',",
     "  ];",
     "",
     "  for (const command of commands) {",
@@ -340,10 +340,10 @@ const buildAgentHookScript = (): string =>
     "",
     "  const message = `React Doctor found issues in the changed files. Review this output and fix the regressions before finishing. For confirmed issues that cannot be fixed now, create GitHub issues with the rule, file/line, confidence, impact, and proposed fix.\\n\\n${scanOutput}`;",
     "",
-    "  if (input.hook_event_name === 'PostToolBatch') {",
-    "    console.log(JSON.stringify({ hookSpecificOutput: { hookEventName: 'PostToolBatch', additionalContext: message } }));",
+    "  if (HOOK_EVENT_NAME === 'Stop') {",
+    "    console.log(JSON.stringify({ decision: 'block', reason: message }));",
     "  } else {",
-    "    console.log(JSON.stringify({ additional_context: message }));",
+    "    console.log(JSON.stringify({ followup_message: message }));",
     "  }",
     "};",
     "",

--- a/packages/react-doctor/src/cli/utils/install-react-doctor.ts
+++ b/packages/react-doctor/src/cli/utils/install-react-doctor.ts
@@ -431,6 +431,7 @@ const installReactDoctorAgentHooksStep = (
       );
       recordCount(METRIC.installAgentHooks, 1, {
         agentsCount: hookResult.installedAgents.length,
+        hookEvent: "stop",
       });
     }
   } catch (error) {

--- a/packages/react-doctor/tests/cli-migrations.test.ts
+++ b/packages/react-doctor/tests/cli-migrations.test.ts
@@ -106,16 +106,16 @@ describe("runProjectMigrations", () => {
       const report = await runProjectMigrations(projectRoot);
 
       expect(report).toContainEqual({ id: "agent-hooks-sh-to-mjs", ran: true, applied: true });
-      const settings: { hooks: { PostToolBatch: Array<{ hooks: Array<{ command: string }> }> } } =
+      const settings: { hooks: { Stop: Array<{ hooks: Array<{ command: string }> }> } } =
         JSON.parse(fs.readFileSync(path.join(projectRoot, ".claude/settings.json"), "utf8"));
-      const hookCommands = settings.hooks.PostToolBatch.flatMap((group) =>
+      const hookCommands = settings.hooks.Stop.flatMap((group) =>
         group.hooks.map((hook) => hook.command),
       );
       expect(hookCommands).toHaveLength(1);
       expect(hookCommands[0]).toContain("react-doctor.mjs");
       expect(fs.existsSync(path.join(projectRoot, ".claude/hooks/react-doctor.sh"))).toBe(false);
       expect(fs.existsSync(path.join(projectRoot, ".claude/hooks/react-doctor.mjs"))).toBe(true);
-      expect(capturedOutput()).toContain("Upgraded the legacy react-doctor.sh agent hook");
+      expect(capturedOutput()).toContain("Moved React Doctor agent hooks to end-of-turn checks");
     });
 
     it("stays pending with no legacy hooks and doesn't touch agent settings", async () => {
@@ -135,6 +135,59 @@ describe("runProjectMigrations", () => {
 
       expect(second).toContainEqual({ id: "agent-hooks-sh-to-mjs", ran: false, applied: true });
       expect(logSpy.mock.calls.length).toBe(0);
+    });
+
+    it("moves installed Node hooks from per-tool events to Stop events", async () => {
+      const settingsPath = path.join(projectRoot, ".claude/settings.json");
+      const configPath = path.join(projectRoot, ".cursor/hooks.json");
+      fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+      fs.mkdirSync(path.dirname(configPath), { recursive: true });
+      fs.writeFileSync(
+        settingsPath,
+        JSON.stringify({
+          hooks: {
+            PostToolBatch: [
+              {
+                hooks: [
+                  {
+                    type: "command",
+                    command: 'node "$CLAUDE_PROJECT_DIR/.claude/hooks/react-doctor.mjs"',
+                  },
+                ],
+              },
+            ],
+          },
+        }),
+      );
+      fs.writeFileSync(
+        configPath,
+        JSON.stringify({
+          version: 1,
+          hooks: {
+            postToolUse: [
+              {
+                command: "node .cursor/hooks/react-doctor.mjs",
+                matcher: "Write|Edit|MultiEdit|ApplyPatch",
+                timeout: 120,
+              },
+            ],
+          },
+        }),
+      );
+
+      const report = await runProjectMigrations(projectRoot);
+      const settings: { hooks: { PostToolBatch: unknown[]; Stop: unknown[] } } = JSON.parse(
+        fs.readFileSync(settingsPath, "utf8"),
+      );
+      const config: { hooks: { postToolUse: unknown[]; stop: unknown[] } } = JSON.parse(
+        fs.readFileSync(configPath, "utf8"),
+      );
+
+      expect(report).toContainEqual({ id: "agent-hooks-sh-to-mjs", ran: true, applied: true });
+      expect(settings.hooks.PostToolBatch).toEqual([]);
+      expect(settings.hooks.Stop).toHaveLength(1);
+      expect(config.hooks.postToolUse).toEqual([]);
+      expect(config.hooks.stop).toHaveLength(1);
     });
 
     it("ignores a user's own wrapper outside our install paths (anchored detection)", async () => {

--- a/packages/react-doctor/tests/install-agent-hooks.test.ts
+++ b/packages/react-doctor/tests/install-agent-hooks.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
 import {
-  findAgentsWithLegacyShellHooks,
+  findAgentsWithOutdatedReactDoctorHooks,
   installReactDoctorAgentHooks,
 } from "../src/cli/utils/install-agent-hooks.js";
 import * as fs from "node:fs";
@@ -14,14 +14,12 @@ interface AgentHooksFixture {
 }
 
 interface AgentHookJsonOutput {
-  readonly additional_context: string;
+  readonly followup_message: string;
 }
 
 interface ClaudeAgentHookJsonOutput {
-  readonly hookSpecificOutput: {
-    readonly hookEventName: string;
-    readonly additionalContext: string;
-  };
+  readonly decision: "block";
+  readonly reason: string;
 }
 
 interface FakeBinaryOptions {
@@ -115,7 +113,7 @@ describe.skipIf(process.platform === "win32")("installReactDoctorAgentHooks", ()
     fixture.cleanup();
   });
 
-  it("installs a Claude Code PostToolBatch hook without duplicating existing hooks", () => {
+  it("installs a Claude Code Stop hook without duplicating existing hooks", () => {
     const settingsPath = path.join(fixture.projectRoot, ".claude/settings.json");
     const hookPath = path.join(fixture.projectRoot, ".claude/hooks/react-doctor.mjs");
     fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
@@ -144,9 +142,12 @@ describe.skipIf(process.platform === "win32")("installReactDoctorAgentHooks", ()
 
     const settings = readJson<{
       permissions: { allow: string[] };
-      hooks: { PostToolBatch: Array<{ hooks: Array<{ command: string }> }> };
+      hooks: {
+        PostToolBatch: Array<{ hooks: Array<{ command: string }> }>;
+        Stop: Array<{ hooks: Array<{ command: string }> }>;
+      };
     }>(settingsPath);
-    const hookCommands = settings.hooks.PostToolBatch.flatMap((group) =>
+    const hookCommands = settings.hooks.Stop.flatMap((group) =>
       group.hooks.map((hook) => hook.command),
     );
     const hookContent = fs.readFileSync(hookPath, "utf8");
@@ -154,11 +155,16 @@ describe.skipIf(process.platform === "win32")("installReactDoctorAgentHooks", ()
     expect(result.installedAgents).toEqual(["claude-code"]);
     expect(result.files).toContain(settingsPath);
     expect(settings.permissions.allow).toEqual(["Bash(git status)"]);
+    expect(settings.hooks.PostToolBatch).toEqual([
+      { hooks: [{ type: "command", command: "echo existing" }] },
+    ]);
     expect(hookCommands.filter((command) => command.includes("react-doctor.mjs"))).toHaveLength(1);
     expect(hookContent).toContain("CLAUDE_PROJECT_DIR");
-    expect(hookContent).toContain("react-doctor --verbose --scope changed --blocking warning");
+    expect(hookContent).toContain(
+      "react-doctor --verbose --scope changed --include-untracked --blocking warning",
+    );
     // cmd.exe signals a missing command with exit 9009 (not the POSIX 127) —
-    // the generated runner loop must fall through on it or every Windows edit
+    // the generated runner loop must fall through on it or every Windows check
     // reports shell noise as scan findings.
     expect(hookContent).toContain("9009");
     expect(hookContent).toContain("maxBuffer");
@@ -193,12 +199,16 @@ describe.skipIf(process.platform === "win32")("installReactDoctorAgentHooks", ()
     });
 
     const settings = readJson<{
-      hooks: { PostToolBatch: Array<{ hooks: Array<{ command: string }> }> };
+      hooks: {
+        PostToolBatch: Array<{ hooks: Array<{ command: string }> }>;
+        Stop: Array<{ hooks: Array<{ command: string }> }>;
+      };
     }>(settingsPath);
-    const hookCommands = settings.hooks.PostToolBatch.flatMap((group) =>
+    const hookCommands = settings.hooks.Stop.flatMap((group) =>
       group.hooks.map((hook) => hook.command),
     );
 
+    expect(settings.hooks.PostToolBatch).toEqual([]);
     expect(hookCommands).toHaveLength(1);
     expect(hookCommands[0]).toContain("react-doctor.mjs");
     expect(fs.existsSync(legacyScriptPath)).toBe(false);
@@ -222,10 +232,10 @@ describe.skipIf(process.platform === "win32")("installReactDoctorAgentHooks", ()
       });
     }).not.toThrow();
 
-    const config = readJson<{ hooks: { postToolUse: Array<{ command?: string }> } }>(configPath);
-    expect(
-      config.hooks.postToolUse.some((handler) => handler.command?.includes("react-doctor.mjs")),
-    ).toBe(true);
+    const config = readJson<{ hooks: { stop: Array<{ command?: string }> } }>(configPath);
+    expect(config.hooks.stop.some((handler) => handler.command?.includes("react-doctor.mjs"))).toBe(
+      true,
+    );
   });
 
   it("replaces a legacy .sh Cursor hook instead of stacking a second entry", () => {
@@ -249,11 +259,15 @@ describe.skipIf(process.platform === "win32")("installReactDoctorAgentHooks", ()
     });
 
     const config = readJson<{
-      hooks: { postToolUse: Array<{ command: string }> };
+      hooks: {
+        postToolUse: Array<{ command: string }>;
+        stop: Array<{ command: string }>;
+      };
     }>(configPath);
 
-    expect(config.hooks.postToolUse).toHaveLength(1);
-    expect(config.hooks.postToolUse[0].command).toContain("react-doctor.mjs");
+    expect(config.hooks.postToolUse).toEqual([]);
+    expect(config.hooks.stop).toHaveLength(1);
+    expect(config.hooks.stop[0].command).toContain("react-doctor.mjs");
     expect(fs.existsSync(legacyScriptPath)).toBe(false);
   });
 
@@ -275,21 +289,22 @@ describe.skipIf(process.platform === "win32")("installReactDoctorAgentHooks", ()
     });
 
     const settings = readJson<{
-      hooks: { PostToolBatch: Array<{ matcher?: string; hooks?: Array<{ command: string }> }> };
+      hooks: {
+        PostToolBatch: Array<{ matcher?: string; hooks?: Array<{ command: string }> }>;
+        Stop: Array<{ hooks: Array<{ command: string }> }>;
+      };
     }>(settingsPath);
 
-    expect(settings.hooks.PostToolBatch).toHaveLength(3);
+    expect(settings.hooks.PostToolBatch).toHaveLength(2);
     expect(settings.hooks.PostToolBatch[0]).toEqual({ matcher: "Bash" });
     expect(settings.hooks.PostToolBatch[1]).toEqual({ matcher: "Write", hooks: [] });
     expect(
-      settings.hooks.PostToolBatch[2].hooks?.some((hook) =>
-        hook.command.includes("react-doctor.mjs"),
-      ),
+      settings.hooks.Stop[0].hooks.some((hook) => hook.command.includes("react-doctor.mjs")),
     ).toBe(true);
   });
 
-  it("detects legacy shell hooks per agent and tolerates invalid settings JSON", () => {
-    expect(findAgentsWithLegacyShellHooks(fixture.projectRoot)).toEqual([]);
+  it("detects outdated hooks per agent and tolerates invalid settings JSON", () => {
+    expect(findAgentsWithOutdatedReactDoctorHooks(fixture.projectRoot)).toEqual([]);
 
     const settingsPath = path.join(fixture.projectRoot, ".claude/settings.json");
     fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
@@ -319,11 +334,14 @@ describe.skipIf(process.platform === "win32")("installReactDoctorAgentHooks", ()
         hooks: { postToolUse: [{ command: ".cursor/hooks/react-doctor.sh", matcher: "Write" }] },
       }),
     );
-    expect(findAgentsWithLegacyShellHooks(fixture.projectRoot)).toEqual(["claude-code", "cursor"]);
+    expect(findAgentsWithOutdatedReactDoctorHooks(fixture.projectRoot)).toEqual([
+      "claude-code",
+      "cursor",
+    ]);
 
     // A probe must never crash a scan on a user-mangled file.
     fs.writeFileSync(settingsPath, "{ not json");
-    expect(findAgentsWithLegacyShellHooks(fixture.projectRoot)).toEqual(["cursor"]);
+    expect(findAgentsWithOutdatedReactDoctorHooks(fixture.projectRoot)).toEqual(["cursor"]);
   });
 
   it("leaves a user's own wrapper referencing a react-doctor.sh outside our install paths", () => {
@@ -343,13 +361,21 @@ describe.skipIf(process.platform === "win32")("installReactDoctorAgentHooks", ()
       agents: ["cursor"],
     });
 
-    const config = readJson<{ hooks: { postToolUse: Array<{ command: string }> } }>(configPath);
-    const commands = config.hooks.postToolUse.map((handler) => handler.command);
-    expect(commands).toContain(userWrapperCommand);
-    expect(commands.some((command) => command.includes("react-doctor.mjs"))).toBe(true);
+    const config = readJson<{
+      hooks: {
+        postToolUse: Array<{ command: string }>;
+        stop: Array<{ command: string }>;
+      };
+    }>(configPath);
+    expect(config.hooks.postToolUse.map((handler) => handler.command)).toContain(
+      userWrapperCommand,
+    );
+    expect(config.hooks.stop.some((handler) => handler.command.includes("react-doctor.mjs"))).toBe(
+      true,
+    );
   });
 
-  it("installs a Cursor postToolUse hook and preserves existing hook config", () => {
+  it("installs a Cursor stop hook and preserves existing hook config", () => {
     const configPath = path.join(fixture.projectRoot, ".cursor/hooks.json");
     const hookPath = path.join(fixture.projectRoot, ".cursor/hooks/react-doctor.mjs");
     fs.mkdirSync(path.dirname(configPath), { recursive: true });
@@ -376,7 +402,7 @@ describe.skipIf(process.platform === "win32")("installReactDoctorAgentHooks", ()
       version: number;
       hooks: {
         sessionStart: Array<{ command: string }>;
-        postToolUse: Array<{ command: string; matcher: string; timeout: number }>;
+        stop: Array<{ command: string; timeout: number }>;
       };
     }>(configPath);
 
@@ -384,15 +410,14 @@ describe.skipIf(process.platform === "win32")("installReactDoctorAgentHooks", ()
     const hookContent = fs.readFileSync(hookPath, "utf8");
     expect(config.version).toBe(1);
     expect(config.hooks.sessionStart).toEqual([{ command: ".cursor/hooks/bootstrap.sh" }]);
-    expect(config.hooks.postToolUse).toHaveLength(1);
-    expect(config.hooks.postToolUse[0]).toEqual({
+    expect(config.hooks.stop).toHaveLength(1);
+    expect(config.hooks.stop[0]).toEqual({
       command: "node .cursor/hooks/react-doctor.mjs",
-      matcher: "Write|Edit|MultiEdit|ApplyPatch",
       timeout: 120,
     });
     expect(fs.existsSync(hookPath)).toBe(true);
     expect(hookContent).toContain("__dirname");
-    expect(hookContent).toContain("additional_context");
+    expect(hookContent).toContain("followup_message");
   });
 
   it("runs generated agent hooks from the project root and returns scan context", () => {
@@ -409,7 +434,9 @@ describe.skipIf(process.platform === "win32")("installReactDoctorAgentHooks", ()
     const output = execFileSync(process.execPath, [hookPath], {
       cwd: nestedDirectory,
       input: JSON.stringify({
-        tool_name: "Write",
+        hook_event_name: "stop",
+        status: "completed",
+        loop_count: 0,
       }),
       encoding: "utf8",
     });
@@ -425,8 +452,8 @@ describe.skipIf(process.platform === "win32")("installReactDoctorAgentHooks", ()
     expect(
       fs.readFileSync(path.join(fixture.projectRoot, ".react-doctor/agent-hook-args.txt"), "utf8"),
     ).toContain("--verbose");
-    expect(parsedOutput.additional_context).toContain("fake scan output");
-    expect(parsedOutput.additional_context).toContain("create GitHub issues");
+    expect(parsedOutput.followup_message).toContain("fake scan output");
+    expect(parsedOutput.followup_message).toContain("create GitHub issues");
   });
 
   it("uses CLAUDE_PROJECT_DIR when a generated Claude hook runs outside the repo", () => {
@@ -447,8 +474,8 @@ describe.skipIf(process.platform === "win32")("installReactDoctorAgentHooks", ()
         CLAUDE_PROJECT_DIR: fixture.projectRoot,
       },
       input: JSON.stringify({
-        hook_event_name: "PostToolBatch",
-        tool_calls: [{ tool_name: "Write" }],
+        hook_event_name: "Stop",
+        stop_hook_active: false,
       }),
       encoding: "utf8",
     });
@@ -461,11 +488,9 @@ describe.skipIf(process.platform === "win32")("installReactDoctorAgentHooks", ()
           .trim(),
       ),
     ).toBe(fs.realpathSync(fixture.projectRoot));
-    expect(parsedOutput.hookSpecificOutput).toEqual({
-      hookEventName: "PostToolBatch",
-      additionalContext: expect.stringContaining("fake scan output"),
-    });
-    expect(parsedOutput.hookSpecificOutput.additionalContext).toContain("create GitHub issues");
+    expect(parsedOutput.decision).toBe("block");
+    expect(parsedOutput.reason).toContain("fake scan output");
+    expect(parsedOutput.reason).toContain("create GitHub issues");
   });
 
   it("uses a PATH react-doctor binary when the local binary is missing", () => {
@@ -494,7 +519,9 @@ describe.skipIf(process.platform === "win32")("installReactDoctorAgentHooks", ()
         ].join(path.delimiter),
       },
       input: JSON.stringify({
-        tool_name: "Write",
+        hook_event_name: "stop",
+        status: "completed",
+        loop_count: 0,
       }),
       encoding: "utf8",
     });
@@ -506,7 +533,7 @@ describe.skipIf(process.platform === "win32")("installReactDoctorAgentHooks", ()
         "utf8",
       ),
     ).toContain("--verbose");
-    expect(parsedOutput.additional_context).toContain("path scan output");
+    expect(parsedOutput.followup_message).toContain("path scan output");
   });
 
   it("exits quietly when no react-doctor runner is available", () => {
@@ -525,7 +552,9 @@ describe.skipIf(process.platform === "win32")("installReactDoctorAgentHooks", ()
         PATH: "/usr/bin:/bin",
       },
       input: JSON.stringify({
-        tool_name: "Write",
+        hook_event_name: "stop",
+        status: "completed",
+        loop_count: 0,
       }),
       encoding: "utf8",
     });
@@ -534,7 +563,7 @@ describe.skipIf(process.platform === "win32")("installReactDoctorAgentHooks", ()
     expect(fs.existsSync(invocationPath)).toBe(false);
   });
 
-  it("skips generated agent hooks for non-edit tool batches", () => {
+  it("does not re-run a Claude hook continuation", () => {
     const hookPath = path.join(fixture.projectRoot, ".claude/hooks/react-doctor.mjs");
     const invocationPath = path.join(fixture.projectRoot, ".react-doctor/agent-hook-args.txt");
     fs.mkdirSync(path.join(fixture.projectRoot, ".react-doctor"), { recursive: true });
@@ -547,8 +576,8 @@ describe.skipIf(process.platform === "win32")("installReactDoctorAgentHooks", ()
     const output = execFileSync(process.execPath, [hookPath], {
       cwd: path.join(fixture.projectRoot, ".claude/hooks"),
       input: JSON.stringify({
-        hook_event_name: "PostToolBatch",
-        tool_calls: [{ tool_name: "Read" }],
+        hook_event_name: "Stop",
+        stop_hook_active: true,
       }),
       encoding: "utf8",
     });
@@ -569,7 +598,9 @@ describe.skipIf(process.platform === "win32")("installReactDoctorAgentHooks", ()
     const output = execFileSync(process.execPath, [hookPath], {
       cwd: fixture.projectRoot,
       input: JSON.stringify({
-        tool_name: "Write",
+        hook_event_name: "stop",
+        status: "completed",
+        loop_count: 0,
       }),
       encoding: "utf8",
     });
@@ -580,7 +611,7 @@ describe.skipIf(process.platform === "win32")("installReactDoctorAgentHooks", ()
     ).toContain("--verbose");
   });
 
-  it("skips generated agent hooks for non-edit single tool events", () => {
+  it("does not re-run a Cursor hook continuation", () => {
     const hookPath = path.join(fixture.projectRoot, ".cursor/hooks/react-doctor.mjs");
     const invocationPath = path.join(fixture.projectRoot, ".react-doctor/agent-hook-args.txt");
     fs.mkdirSync(path.join(fixture.projectRoot, ".react-doctor"), { recursive: true });
@@ -593,7 +624,9 @@ describe.skipIf(process.platform === "win32")("installReactDoctorAgentHooks", ()
     const output = execFileSync(process.execPath, [hookPath], {
       cwd: fixture.projectRoot,
       input: JSON.stringify({
-        tool_name: "Read",
+        hook_event_name: "stop",
+        status: "completed",
+        loop_count: 1,
       }),
       encoding: "utf8",
     });
@@ -618,7 +651,7 @@ describe.skipIf(process.platform === "win32")("installReactDoctorAgentHooks", ()
     });
     const parsedOutput: AgentHookJsonOutput = JSON.parse(output);
 
-    expect(parsedOutput.additional_context).toContain("fake scan output");
+    expect(parsedOutput.followup_message).toContain("fake scan output");
   });
 
   it("ignores agents without native hook support", () => {

--- a/packages/react-doctor/tests/install-react-doctor.test.ts
+++ b/packages/react-doctor/tests/install-react-doctor.test.ts
@@ -667,9 +667,9 @@ describe("runInstallReactDoctor", () => {
     ).toBe(true);
     expect(
       fs.readFileSync(path.join(fixture.projectRoot, ".claude/settings.json"), "utf8"),
-    ).toContain("PostToolBatch");
+    ).toContain('"Stop"');
     expect(fs.readFileSync(path.join(fixture.projectRoot, ".cursor/hooks.json"), "utf8")).toContain(
-      "postToolUse",
+      '"stop"',
     );
     expect(fs.existsSync(path.join(fixture.projectRoot, ".codex/hooks.json"))).toBe(false);
   });
@@ -888,11 +888,11 @@ describe("runInstallReactDoctor", () => {
       false,
     );
     expect(fs.readFileSync(path.join(fixture.projectRoot, ".cursor/hooks.json"), "utf8")).toContain(
-      "postToolUse",
+      '"stop"',
     );
     expect(
       fs.readFileSync(path.join(fixture.projectRoot, ".claude/settings.json"), "utf8"),
-    ).toContain("PostToolBatch");
+    ).toContain('"Stop"');
   });
 
   it("--yes upgrades an existing @v1 workflow to @v2 in place", async () => {
@@ -1112,7 +1112,7 @@ describe("runInstallReactDoctor", () => {
       fs.existsSync(path.join(fixture.projectRoot, ".agents/skills/react-doctor/SKILL.md")),
     ).toBe(true);
     expect(fs.readFileSync(path.join(fixture.projectRoot, ".cursor/hooks.json"), "utf8")).toContain(
-      "postToolUse",
+      '"stop"',
     );
     expect(fs.existsSync(path.join(fixture.projectRoot, ".git/hooks/pre-commit"))).toBe(false);
     expect(fs.existsSync(path.join(fixture.projectRoot, ".react-doctor/hooks/pre-commit"))).toBe(


### PR DESCRIPTION
## Why

Before this change, installed Claude Code and Cursor hooks ran after editing tools, so long agent turns repeatedly launched React Doctor and accumulated several seconds of avoidable scan time.

After this change, each supported agent runs one changed-file scan when the turn completes. A failed scan resumes the agent once with the diagnostics, while each agent's native loop guard prevents an infinite continuation cycle.

Fixes #1647.

## What changed

- move managed Claude Code hooks from `PostToolBatch` to `Stop` and Cursor hooks from `postToolUse` to `stop`
- return the native Claude `decision: "block"` and Cursor `followup_message` continuation payloads
- scan changed and untracked files and cap hook-driven continuations at one
- migrate existing Node and legacy shell hook registrations while preserving unrelated user hooks
- record the installed hook event in existing telemetry and add a patch changeset
- add regression coverage for installation, migration, output protocols, and loop guards

## Eval results

Not run; this changes CLI hook lifecycle behavior rather than a diagnostic rule or detector.

## Test plan

- `nr test` — passed (12 workspace tasks; React Doctor: 2,457 passed, 24 skipped)
- `nr lint` — passed with existing fuzz-corpus warnings
- `nr typecheck` — passed (10 workspace tasks)
- `nr format:check` — passed
- `nr smoke:json-report` — passed (`schemaVersion=3`, zero diagnostics)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Rewrites optional agent hook config and changes when/how agents are blocked or prompted to continue, though behavior is gated by loop limits and covered by migration plus regression tests.
> 
> **Overview**
> React Doctor’s Claude Code and Cursor integrations now run **once at the end of an agent turn** instead of after every edit-related tool call, so long sessions aren’t hammered with repeated scans.
> 
> Managed hooks are registered on Claude **`Stop`** and Cursor **`stop`** (no per-tool matcher). The generated hook runs `react-doctor` with **`--scope changed --include-untracked`**, and on findings it uses each agent’s native continuation shape: Claude **`decision: "block"`** with a reason, Cursor **`followup_message`**. **Loop guards** skip re-scanning when Claude reports `stop_hook_active` or when Cursor’s `loop_count` reaches the cap (**one** continuation).
> 
> A **bumped project migration** (v2) re-installs hooks for repos that still have legacy shell scripts or Node hooks on the old events, without touching unrelated user hook entries. Install help/telemetry now describe **end-of-turn** hooks and record `hookEvent: "stop"`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3310a68925bf4ab820dcc6319d05bfa816aa38dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->