### PR TITLE
fix: honor React Compiler in ESLint presets

### DIFF
--- a/.changeset/calm-compilers-rest.md
+++ b/.changeset/calm-compilers-rest.md
@@ -1,0 +1,6 @@
+---
+"eslint-plugin-react-doctor": patch
+"oxlint-plugin-react-doctor": patch
+---
+
+Keep ESLint presets on React Doctor's curated low-noise rule behavior and honor configured capabilities when a rule declares `disabledWhen`, including suppressing manual-memoization diagnostics for React Compiler projects.

--- a/packages/eslint-plugin-react-doctor/README.md
+++ b/packages/eslint-plugin-react-doctor/README.md
@@ -44,6 +44,24 @@ export default [
 
 Pick only the configs that match your stack. `recommended` is framework-agnostic; the others layer on framework-specific rules.
 
+If React Compiler is enabled, declare that capability once so React Doctor can disable compiler-redundant manual-memoization rules:
+
+```js
+export default [
+  reactDoctor.configs.recommended,
+  reactDoctor.configs["react-native"],
+  {
+    settings: {
+      "react-doctor": {
+        capabilities: ["react-compiler"],
+      },
+    },
+  },
+];
+```
+
+React Doctor's CLI discovers this automatically. ESLint flat configs are static, so standalone ESLint users declare the capability explicitly.
+
 ## Available configs
 
 | Config           | What it adds                                                  |

--- a/packages/eslint-plugin-react-doctor/src/index.ts
+++ b/packages/eslint-plugin-react-doctor/src/index.ts
@@ -42,6 +42,11 @@ interface EslintFlatConfig {
   name: string;
   plugins: Record<string, EslintPlugin>;
   rules: Record<string, OxlintRuleSeverity>;
+  settings: {
+    "react-doctor": {
+      portedRuleMode: "curated";
+    };
+  };
 }
 
 interface EslintPlugin {
@@ -94,6 +99,7 @@ const buildFlatConfig = (
   name: `react-doctor/${configName}`,
   plugins: {},
   rules: { ...ruleSet },
+  settings: { "react-doctor": { portedRuleMode: "curated" } },
 });
 
 const eslintPlugin: EslintPlugin = {

--- a/packages/eslint-plugin-react-doctor/tests/plugin-shape.test.ts
+++ b/packages/eslint-plugin-react-doctor/tests/plugin-shape.test.ts
@@ -30,6 +30,14 @@ describe("eslint-plugin-react-doctor", () => {
     }
   });
 
+  it("keeps every preset on React Doctor's curated rule behavior", () => {
+    for (const flatConfig of Object.values(eslintPlugin.configs)) {
+      expect(flatConfig.settings).toEqual({
+        "react-doctor": { portedRuleMode: "curated" },
+      });
+    }
+  });
+
   it("mirrors oxlint preset rule maps", () => {
     expect(eslintPlugin.configs.recommended.rules).toEqual(RECOMMENDED_RULES);
     expect(eslintPlugin.configs.next.rules).toEqual(NEXTJS_RULES);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-no-new-array-as-prop.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/jsx-no-new-array-as-prop.regressions.test.ts
@@ -66,4 +66,15 @@ describe("react-builtins/jsx-no-new-array-as-prop — regressions", () => {
       const Item = memo((props) => props.children, (prev, next) => prev.payload.every((v, i) => v === next.payload[i]));
       const Foo = () => <Item payload={[a, b].concat(c)} />;`,
     ));
+
+  it("does not flag fresh arrays when React Compiler is configured", () => {
+    const result = runRule(
+      jsxNoNewArrayAsProp,
+      `${memoisedConsumer}const Foo = () => <Item payload={[a, b]} />;`,
+      { settings: { "react-doctor": { capabilities: ["react-compiler"] } } },
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/define-rule.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/define-rule.test.ts
@@ -58,4 +58,49 @@ describe("defineRule", () => {
     expect(visitors.Program).toBeTypeOf("function");
     expect(visitors.JSXOpeningElement).toBeTypeOf("function");
   });
+
+  it("keeps capability-gated rules compatible when capabilities are unspecified", () => {
+    const rule = defineRule({
+      id: "compiler-disabled-rule",
+      title: "test",
+      severity: "warn",
+      disabledWhen: ["react-compiler"],
+      create: () => ({ Program: () => {} }),
+    });
+
+    const visitors = rule.create({
+      report: () => {},
+      get scopes(): never {
+        throw new Error("scopes should stay lazy");
+      },
+      get cfg(): never {
+        throw new Error("cfg should stay lazy");
+      },
+    });
+
+    expect(visitors.Program).toBeTypeOf("function");
+  });
+
+  it("skips rules disabled by an explicitly configured capability", () => {
+    const rule = defineRule({
+      id: "compiler-disabled-rule",
+      title: "test",
+      severity: "warn",
+      disabledWhen: ["react-compiler"],
+      create: () => ({ Program: () => {} }),
+    });
+
+    const visitors = rule.create({
+      report: () => {},
+      settings: { "react-doctor": { capabilities: ["react-compiler"] } },
+      get scopes(): never {
+        throw new Error("scopes should stay lazy");
+      },
+      get cfg(): never {
+        throw new Error("cfg should stay lazy");
+      },
+    });
+
+    expect(visitors).toEqual({});
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/define-rule.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/define-rule.ts
@@ -5,6 +5,7 @@ import {
   jsxAttributeIsNonReactDialectMarker,
 } from "./non-react-jsx-dialect.js";
 import { skipNonProductionFiles } from "./skip-non-production-files.js";
+import { shouldCreateRuleVisitors } from "./should-create-rule-visitors.js";
 import type { Rule } from "./rule.js";
 import type { EsTreeNodeOfType } from "./es-tree-node-of-type.js";
 
@@ -27,6 +28,13 @@ export type RuleDefinition =
 // Solid/Qwik. The JSXOpeningElement guard preserves the same behavior for
 // hosts that invoke visitors without a Program pass.
 type GenericVisitors = Record<string, unknown>;
+
+const wrapCreateForCapabilities =
+  (create: Rule["create"], disabledWhen: Rule["disabledWhen"]): Rule["create"] =>
+  (context) =>
+    shouldCreateRuleVisitors(context.settings, disabledWhen)
+      ? create(context)
+      : EMPTY_RULE_VISITORS;
 
 const wrapCreateForReactJsxOnly = <
   CreateFn extends (context: { filename?: string }) => GenericVisitors,
@@ -114,6 +122,9 @@ export const defineRule = (rule: RuleDefinition): Rule => {
   }
   if (honorsTestNoise) {
     wrappedCreate = skipNonProductionFiles(wrappedCreate);
+  }
+  if (rule.disabledWhen) {
+    wrappedCreate = wrapCreateForCapabilities(wrappedCreate, rule.disabledWhen);
   }
   if (wrappedCreate === rule.create) return rule;
   return {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/should-create-rule-visitors.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/should-create-rule-visitors.ts
@@ -1,0 +1,8 @@
+import type { Capability } from "./capability.js";
+import { hasCapability } from "./get-react-doctor-setting.js";
+import type { RuleContext } from "./rule-context.js";
+
+export const shouldCreateRuleVisitors = (
+  settings: RuleContext["settings"],
+  disabledWhen: ReadonlyArray<Capability> | undefined,
+): boolean => !disabledWhen?.some((capability) => hasCapability(settings, capability));


### PR DESCRIPTION
## Why

Standalone ESLint users can enable React Doctor's presets in a React Compiler project, but the adapter previously ignored the rules' `disabledWhen: ["react-compiler"]` metadata. A recent faithful-port change also left ESLint presets in upstream mode, producing hundreds of memoization warnings such as `jsx-no-new-array-as-prop` even though React Compiler handles those allocations.

Before, declaring the React Compiler capability had no effect and ESLint presets used the noisier upstream behavior. After this change, presets retain React Doctor's curated defaults and explicitly configured compiler capability suppresses compiler-redundant rules.

## What changed

- keep every ESLint preset on React Doctor's curated port behavior
- honor `disabledWhen` metadata when standalone lint settings declare a matching capability
- document the `react-compiler` capability for ESLint flat configs
- add adapter, capability-gate, and fresh-array regression coverage
- add patch changesets for `eslint-plugin-react-doctor` and `oxlint-plugin-react-doctor`

RDE was not run because this is an ESLint-adapter configuration regression; the React Doctor CLI already discovers React Compiler and applies the existing capability gate.

## Test plan

- `nr test`
- `nr lint`
- `nr typecheck`
- `nr format:check`
- `FUZZ_RULE=jsx-no-new-array-as-prop FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz`
- built-adapter ESLint smoke check: target rule reports once without compiler capability and zero times with it

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration and lint-behavior alignment for ESLint/Oxlint adapters; no auth, data, or runtime app changes.
> 
> **Overview**
> ESLint flat presets now ship **`settings["react-doctor"].portedRuleMode: "curated"`** on every preset so standalone ESLint matches the CLI’s lower-noise ported-rule behavior instead of noisier upstream defaults.
> 
> **`defineRule`** now wraps rule `create` with capability gating: rules that declare **`disabledWhen`** (e.g. manual-memoization rules with **`react-compiler`**) return empty visitors when **`settings["react-doctor"].capabilities`** includes a matching capability. The README documents declaring **`capabilities: ["react-compiler"]`** for flat-config users.
> 
> Tests cover preset settings, capability on/off for gated rules, and **`jsx-no-new-array-as-prop`** staying silent under React Compiler.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9158c5ae6f9353e5a0a6d31e4b2711f392814eec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->