### PR TITLE
feat(rules): add Octane correctness diagnostics

### DIFF
--- a/.changeset/deep-octane-rules.md
+++ b/.changeset/deep-octane-rules.md
@@ -1,0 +1,7 @@
+---
+"oxlint-plugin-react-doctor": patch
+"eslint-plugin-react-doctor": patch
+"react-doctor": patch
+---
+
+Add Octane-specific diagnostics for slot-keyed hooks called from plain JavaScript loops and React-style native text `onChange` handlers.

--- a/packages/oxlint-plugin-react-doctor/scripts/generate-rule-registry.mjs
+++ b/packages/oxlint-plugin-react-doctor/scripts/generate-rule-registry.mjs
@@ -102,6 +102,7 @@ const getRequiredCapabilities = (bucketName, ruleId) => {
 const BUCKET_TO_AUTO_TAGS = {
   design: ["design"],
   ink: ["ink"],
+  octane: ["octane"],
   project: ["project-analysis"],
   "react-native": ["react-native"],
   r3f: ["r3f", "webgl"],
@@ -223,6 +224,7 @@ const BUCKET_TO_DEFAULT_CATEGORY = {
   jotai: "State & Effects",
   mobx: "State & Effects",
   nextjs: "Next.js",
+  octane: "Correctness",
   performance: "Performance",
   preact: "Preact",
   project: "Architecture",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/core-rule-registry-data.json
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/core-rule-registry-data.json
@@ -8081,6 +8081,39 @@
     }
   },
   {
+    "key": "react-doctor/octane-no-hook-in-loop",
+    "id": "octane-no-hook-in-loop",
+    "source": "react-doctor",
+    "originallyExternal": false,
+    "rule": {
+      "id": "octane-no-hook-in-loop",
+      "title": "Octane hook called inside a plain loop",
+      "severity": "error",
+      "recommendation": "Render repeated hook state with Octane's keyed `@for` directive or extract the loop body into a child component.",
+      "category": "Bugs",
+      "framework": "global",
+      "tags": ["octane"],
+      "isScanRule": false
+    }
+  },
+  {
+    "key": "react-doctor/octane-no-native-text-onchange",
+    "id": "octane-no-native-text-onchange",
+    "source": "react-doctor",
+    "originallyExternal": false,
+    "rule": {
+      "id": "octane-no-native-text-onchange",
+      "title": "React-style text onChange used in Octane",
+      "severity": "warn",
+      "recommendation": "Use `onInput` for per-edit text updates, or add `suppressNativeChangeWarning` when native commit-on-blur behavior is intentional.",
+      "category": "Bugs",
+      "framework": "global",
+      "tags": ["octane"],
+      "matchByOccurrence": true,
+      "isScanRule": false
+    }
+  },
+  {
     "key": "react-doctor/only-export-components",
     "id": "only-export-components",
     "source": "react-doctor",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness-fixtures.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/liveness/liveness-fixtures.ts
@@ -1352,6 +1352,12 @@ export const livenessFixtures: Readonly<Record<string, LivenessFixture>> = {
     code: "export const findUsers = (req, collection) => collection.find(JSON.parse(req.query.filter));",
     filePath: "src/server/db/users.ts",
   },
+  "octane-no-hook-in-loop": {
+    code: 'import {useState} from "octane";for(const value of values)useState(value);',
+  },
+  "octane-no-native-text-onchange": {
+    code: 'import {Fragment} from "octane";const Field=()=> <input onChange={()=>{}}/>;',
+  },
   "only-export-components": {
     code: "export const foo = () => 'label'; export const Bar = () => <div />;",
     forceJsx: true,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rule-registry.ts
@@ -497,6 +497,8 @@ import { noWideLetterSpacing } from "./rules/design/no-wide-letter-spacing.js";
 import { noWillUpdateSetState } from "./rules/react-builtins/no-will-update-set-state.js";
 import { noZIndex9999 } from "./rules/design/no-z-index9999.js";
 import { nosqlInjectionRisk } from "./rules/security-scan/nosql-injection-risk.js";
+import { octaneNoHookInLoop } from "./rules/octane/octane-no-hook-in-loop.js";
+import { octaneNoNativeTextOnchange } from "./rules/octane/octane-no-native-text-onchange.js";
 import { onlyExportComponents } from "./rules/react-builtins/only-export-components.js";
 import { packageMetadataSecret } from "./rules/security-scan/package-metadata-secret.js";
 import { pathTraversalRisk } from "./rules/security-scan/path-traversal-risk.js";
@@ -6815,6 +6817,30 @@ export const reactDoctorRules = [
       framework: "global",
       category: "Security",
       tags: [...new Set(["security-scan", ...(nosqlInjectionRisk.tags ?? [])])],
+    },
+  },
+  {
+    key: "react-doctor/octane-no-hook-in-loop",
+    id: "octane-no-hook-in-loop",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...octaneNoHookInLoop,
+      framework: "global",
+      category: "Bugs",
+      tags: [...new Set(["octane", ...(octaneNoHookInLoop.tags ?? [])])],
+    },
+  },
+  {
+    key: "react-doctor/octane-no-native-text-onchange",
+    id: "octane-no-native-text-onchange",
+    source: "react-doctor",
+    originallyExternal: false,
+    rule: {
+      ...octaneNoNativeTextOnchange,
+      framework: "global",
+      category: "Bugs",
+      tags: [...new Set(["octane", ...(octaneNoNativeTextOnchange.tags ?? [])])],
     },
   },
   {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/octane/octane-no-hook-in-loop.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/octane/octane-no-hook-in-loop.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { octaneNoHookInLoop } from "./octane-no-hook-in-loop.js";
+
+const runOctaneRule = (source: string) =>
+  runRule(octaneNoHookInLoop, source, { filename: "app.tsx" });
+
+describe("octane-no-hook-in-loop", () => {
+  it("reports built-in hooks in every plain JavaScript loop form", () => {
+    const result = runOctaneRule(`
+      import { useId, useMemo, useRef, useState } from "octane";
+      export const Example = ({ count, records }) => {
+        for (let index = 0; index < count; index++) useMemo(() => index);
+        for (const key in records) useId();
+        for (const value of records) useState(value);
+        while (records.length > 0) useRef(null);
+        do useState(0); while (false);
+        return null;
+      };
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(5);
+    expect(result.diagnostics.map((diagnostic) => diagnostic.message)).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("`for` iteration"),
+        expect.stringContaining("`for…in` iteration"),
+        expect.stringContaining("`for…of` iteration"),
+        expect.stringContaining("`while` iteration"),
+        expect.stringContaining("`do…while` iteration"),
+      ]),
+    );
+  });
+
+  it("resolves Octane hook aliases and namespace members", () => {
+    const result = runOctaneRule(`
+      import * as Octane from "octane";
+      import { useState as state } from "octane";
+      export const Example = ({ values }) => {
+        for (const value of values) {
+          state(value);
+          Octane.useReducer((current) => current, value);
+        }
+        return null;
+      };
+    `);
+
+    expect(result.diagnostics).toHaveLength(2);
+    expect(result.diagnostics[0]?.message).toContain("`useState`");
+    expect(result.diagnostics[1]?.message).toContain("`useReducer`");
+  });
+
+  it("reports custom identifier and method hooks in an Octane module", () => {
+    const result = runOctaneRule(`
+      import { Fragment } from "octane";
+      export const Example = ({ routes }) => {
+        for (const route of routes) {
+          useRoute(route);
+          route.useMatch();
+        }
+        return null;
+      };
+    `);
+
+    expect(result.diagnostics).toHaveLength(2);
+    expect(result.diagnostics[0]?.message).toContain("`useRoute`");
+    expect(result.diagnostics[1]?.message).toContain("`useMatch`");
+  });
+
+  it("follows IIFEs and synchronous callbacks executing inside a loop", () => {
+    const result = runOctaneRule(`
+      import { useMemo, useRef } from "octane";
+      export const Example = ({ groups }) => {
+        for (const group of groups) {
+          (() => useMemo(() => group))();
+          (function () { useRef(null); }).call(null);
+          group.items.map(() => useRow());
+        }
+        return null;
+      };
+    `);
+
+    expect(result.diagnostics).toHaveLength(3);
+  });
+
+  it("allows deferred nested functions and loop-free iterator callbacks", () => {
+    const result = runOctaneRule(`
+      import { useState } from "octane";
+      export const Example = ({ values }) => {
+        const rows = values.map((value) => useRow(value));
+        for (const value of values) {
+          rows.push(() => useState(value));
+        }
+        return rows;
+      };
+    `);
+
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("allows use and useContext inside loops", () => {
+    const result = runOctaneRule(`
+      import { use, useContext } from "octane";
+      export const Example = ({ Context, promises }) => {
+        for (const promise of promises) {
+          use(promise);
+          useContext(Context);
+        }
+        return null;
+      };
+    `);
+
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("allows Octane hooks behind conditions and early returns", () => {
+    const result = runOctaneRule(`
+      import { useState } from "octane";
+      export const Example = ({ enabled }) => {
+        if (!enabled) return null;
+        if (enabled) useState(0);
+        return null;
+      };
+    `);
+
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not apply Octane semantics to foreign or type-only modules", () => {
+    const reactResult = runOctaneRule(`
+      import { useState } from "react";
+      export const Example = ({ values }) => {
+        for (const value of values) useState(value);
+        return null;
+      };
+    `);
+    const typeOnlyResult = runOctaneRule(`
+      import type { Component } from "octane";
+      export const Example = ({ values }) => {
+        for (const value of values) useLocalState(value);
+        return null;
+      };
+    `);
+
+    expect(reactResult.diagnostics).toHaveLength(0);
+    expect(typeOnlyResult.diagnostics).toHaveLength(0);
+  });
+
+  it("recognizes the Octane JSX import-source pragma", () => {
+    const result = runOctaneRule(`
+      /** @jsxImportSource octane */
+      export const Example = ({ values }) => {
+        for (const value of values) useRow(value);
+        return null;
+      };
+    `);
+
+    expect(result.diagnostics).toHaveLength(1);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/octane/octane-no-hook-in-loop.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/octane/octane-no-hook-in-loop.ts
@@ -1,4 +1,5 @@
 import { LOOP_TYPES } from "../../constants/js.js";
+import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
 import { defineRule } from "../../utils/define-rule.js";
 import { executesDuringRender } from "../../utils/executes-during-render.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
@@ -11,7 +12,6 @@ import { isOctaneModule } from "../../utils/is-octane-module.js";
 import { isOctanePackageSource } from "../../utils/is-octane-package-source.js";
 import { resolveImportedApiReference } from "../../utils/resolve-imported-api-reference.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
-import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
 
 const SLOT_KEYED_HOOK_NAME_PATTERN = /^use[A-Z]/;
 const LOOP_DISPLAY_NAMES: Readonly<Record<string, string>> = {
@@ -76,9 +76,7 @@ const getSlotKeyedHookName = (
   else if (isNodeOfType(callee, "MemberExpression") && !callee.optional) {
     hookName = getStaticPropertyName(callee);
   }
-  return hookName &&
-    SLOT_KEYED_HOOK_NAME_PATTERN.test(hookName) &&
-    hookName !== "useContext"
+  return hookName && SLOT_KEYED_HOOK_NAME_PATTERN.test(hookName) && hookName !== "useContext"
     ? hookName
     : null;
 };
@@ -93,7 +91,7 @@ export const octaneNoHookInLoop = defineRule({
     let fileIsOctaneModule = false;
     return {
       Program(node: EsTreeNodeOfType<"Program">) {
-        fileIsOctaneModule = isOctaneModule(node, context.sourceCode.getText());
+        fileIsOctaneModule = isOctaneModule(node, context.sourceCode?.getText?.() ?? "");
       },
       CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
         if (!fileIsOctaneModule) return;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/octane/octane-no-hook-in-loop.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/octane/octane-no-hook-in-loop.ts
@@ -1,0 +1,112 @@
+import { LOOP_TYPES } from "../../constants/js.js";
+import { defineRule } from "../../utils/define-rule.js";
+import { executesDuringRender } from "../../utils/executes-during-render.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { findTransparentExpressionRoot } from "../../utils/find-transparent-expression-root.js";
+import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
+import { isFunctionLike } from "../../utils/is-function-like.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { isOctaneModule } from "../../utils/is-octane-module.js";
+import { isOctanePackageSource } from "../../utils/is-octane-package-source.js";
+import { resolveImportedApiReference } from "../../utils/resolve-imported-api-reference.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
+
+const SLOT_KEYED_HOOK_NAME_PATTERN = /^use[A-Z]/;
+const LOOP_DISPLAY_NAMES: Readonly<Record<string, string>> = {
+  DoWhileStatement: "do…while",
+  ForInStatement: "for…in",
+  ForOfStatement: "for…of",
+  ForStatement: "for",
+  WhileStatement: "while",
+};
+
+const isImmediatelyCalledFunction = (functionNode: EsTreeNode): boolean => {
+  const functionRoot = findTransparentExpressionRoot(functionNode);
+  const parent = functionRoot.parent;
+  if (isNodeOfType(parent, "CallExpression") && parent.callee === functionRoot) return true;
+  if (!isNodeOfType(parent, "MemberExpression") || parent.object !== functionRoot) return false;
+  const methodName = getStaticPropertyName(parent);
+  const call = parent.parent;
+  return Boolean(
+    (methodName === "call" || methodName === "apply") &&
+    isNodeOfType(call, "CallExpression") &&
+    call.callee === parent,
+  );
+};
+
+const findEnclosingPlainLoopExecution = (
+  node: EsTreeNode,
+  scopes: ScopeAnalysis,
+): EsTreeNode | null => {
+  let current = node.parent ?? null;
+  while (current) {
+    if (LOOP_TYPES.includes(current.type)) return current;
+    if (
+      isFunctionLike(current) &&
+      !isImmediatelyCalledFunction(current) &&
+      !executesDuringRender(current, scopes)
+    ) {
+      return null;
+    }
+    current = current.parent ?? null;
+  }
+  return null;
+};
+
+const getSlotKeyedHookName = (
+  call: EsTreeNodeOfType<"CallExpression">,
+  scopes: ScopeAnalysis,
+): string | null => {
+  const importedReference = resolveImportedApiReference(call.callee, scopes);
+  if (
+    importedReference &&
+    isOctanePackageSource(importedReference.source) &&
+    importedReference.importedName &&
+    SLOT_KEYED_HOOK_NAME_PATTERN.test(importedReference.importedName) &&
+    importedReference.importedName !== "useContext"
+  ) {
+    return importedReference.importedName;
+  }
+
+  const callee = stripParenExpression(call.callee);
+  let hookName: string | null = null;
+  if (isNodeOfType(callee, "Identifier")) hookName = callee.name;
+  else if (isNodeOfType(callee, "MemberExpression") && !callee.optional) {
+    hookName = getStaticPropertyName(callee);
+  }
+  return hookName &&
+    SLOT_KEYED_HOOK_NAME_PATTERN.test(hookName) &&
+    hookName !== "useContext"
+    ? hookName
+    : null;
+};
+
+export const octaneNoHookInLoop = defineRule({
+  id: "octane-no-hook-in-loop",
+  title: "Octane hook called inside a plain loop",
+  severity: "error",
+  recommendation:
+    "Render repeated hook state with Octane's keyed `@for` directive or extract the loop body into a child component.",
+  create: (context) => {
+    let fileIsOctaneModule = false;
+    return {
+      Program(node: EsTreeNodeOfType<"Program">) {
+        fileIsOctaneModule = isOctaneModule(node, context.sourceCode.getText());
+      },
+      CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
+        if (!fileIsOctaneModule) return;
+        const hookName = getSlotKeyedHookName(node, context.scopes);
+        if (!hookName) return;
+        const loop = findEnclosingPlainLoopExecution(node, context.scopes);
+        if (!loop) return;
+        const loopDisplayName = LOOP_DISPLAY_NAMES[loop.type] ?? "plain JavaScript";
+        context.report({
+          node,
+          message: `\`${hookName}\` shares one compiler-assigned hook slot across every \`${loopDisplayName}\` iteration. Use a keyed \`@for\` directive or a child component so each item owns its hook state.`,
+        });
+      },
+    };
+  },
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/octane/octane-no-native-text-onchange.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/octane/octane-no-native-text-onchange.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { octaneNoNativeTextOnchange } from "./octane-no-native-text-onchange.js";
+
+const runOctaneRule = (source: string) =>
+  runRule(
+    octaneNoNativeTextOnchange,
+    `
+      import { Fragment } from "octane";
+      ${source}
+    `,
+    { filename: "field.tsx" },
+  );
+
+describe("octane-no-native-text-onchange", () => {
+  it("reports React-style change handlers on text inputs and textareas", () => {
+    const result = runOctaneRule(`
+      export const Field = ({ value }) => (
+        <>
+          <input value={value} onChange={() => {}} />
+          <textarea onChangeCapture={() => {}} />
+        </>
+      );
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(2);
+    expect(result.diagnostics[0]?.message).toContain("`onInput`");
+    expect(result.diagnostics[0]?.message).toContain("`defaultValue`");
+    expect(result.diagnostics[1]?.message).toContain("`onInputCapture`");
+  });
+
+  it("covers missing, text-entry, and invalid input types", () => {
+    const textEntryTypes = [
+      "",
+      "text",
+      "SEARCH",
+      "url",
+      "tel",
+      "password",
+      "email",
+      "number",
+      "not-a-real-input-state",
+    ];
+    const fields = textEntryTypes
+      .map((inputType) => `<input type="${inputType}" onChange={() => {}} />`)
+      .join("\n");
+    const result = runOctaneRule(`
+      export const Field = () => (
+        <>
+          <input onChange={() => {}} />
+          <input type onChange={() => {}} />
+          <input type={42} onChange={() => {}} />
+          ${fields}
+        </>
+      );
+    `);
+
+    expect(result.diagnostics).toHaveLength(textEntryTypes.length + 3);
+  });
+
+  it("allows known non-text controls and component callbacks", () => {
+    const nonTextTypes = [
+      "button",
+      "checkbox",
+      "color",
+      "date",
+      "datetime-local",
+      "file",
+      "hidden",
+      "image",
+      "month",
+      "radio",
+      "range",
+      "reset",
+      "submit",
+      "time",
+      "week",
+    ];
+    const fields = nonTextTypes
+      .map((inputType) => `<input type="${inputType}" onChange={() => {}} />`)
+      .join("\n");
+    const result = runOctaneRule(`
+      const Field = () => null;
+      export const Form = () => (
+        <>
+          ${fields}
+          <select onChange={() => {}} />
+          <custom-input onChange={() => {}} />
+          <Field onChange={() => {}} />
+        </>
+      );
+    `);
+
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("allows usable input handlers and explicit native commit intent", () => {
+    const result = runOctaneRule(`
+      const handleInput = () => {};
+      export const Field = () => (
+        <>
+          <input onChange={() => {}} onInput={() => {}} />
+          <input onChange={() => {}} onInputCapture={handleInput} />
+          <input onChange={() => {}} readOnly />
+          <textarea onChange={() => {}} disabled="disabled" />
+          <input onChange={() => {}} suppressNativeChangeWarning />
+        </>
+      );
+    `);
+
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("reports false host booleans and false suppression", () => {
+    const result = runOctaneRule(`
+      export const Field = () => (
+        <>
+          <input onChange={() => {}} readOnly={false} />
+          <input onChange={() => {}} readonly="" />
+          <input onChange={() => {}} disabled={0} />
+          <input onChange={() => {}} suppressNativeChangeWarning={false} />
+        </>
+      );
+    `);
+
+    expect(result.diagnostics).toHaveLength(4);
+  });
+
+  it("defers dynamic and spread-owned decisions to Octane runtime checks", () => {
+    const result = runOctaneRule(`
+      import { importedInput } from "./handlers";
+      export const Field = (props) => (
+        <>
+          <input type={props.type} onChange={() => {}} />
+          <input {...props.inputProps} onChange={() => {}} />
+          <textarea onChange={() => {}} onInput={importedInput} />
+          <input onChange={() => {}} readOnly={props.readOnly} />
+          <input
+            onChange={() => {}}
+            suppressNativeChangeWarning={props.commitOnly}
+          />
+        </>
+      );
+    `);
+
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("ignores absent change handlers and honors final readonly spelling", () => {
+    const result = runOctaneRule(`
+      export const Field = () => (
+        <>
+          <input onChange={null} />
+          <input onChange={false} />
+          <input onChange={undefined} />
+          <input readOnly={false} readonly onChange={() => {}} />
+          <input readonly readOnly={false} onChange={() => {}} />
+        </>
+      );
+    `);
+
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not apply Octane event semantics to React modules", () => {
+    const result = runRule(
+      octaneNoNativeTextOnchange,
+      `
+        import { Fragment } from "react";
+        export const Field = () => <input onChange={() => {}} />;
+      `,
+      { filename: "field.tsx" },
+    );
+
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("recognizes Octane's DOM pragma and skips non-DOM renderer pragmas", () => {
+    const domResult = runRule(
+      octaneNoNativeTextOnchange,
+      `
+        /** @jsxImportSource octane */
+        export const Field = () => <textarea onChange={() => {}} />;
+      `,
+      { filename: "field.tsx" },
+    );
+    const rendererResult = runRule(
+      octaneNoNativeTextOnchange,
+      `
+        /** @jsxImportSource @octanejs/three/intrinsics */
+        export const Field = () => <textarea onChange={() => {}} />;
+      `,
+      { filename: "field.tsx" },
+    );
+
+    expect(domResult.diagnostics).toHaveLength(1);
+    expect(rendererResult.diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/octane/octane-no-native-text-onchange.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/octane/octane-no-native-text-onchange.ts
@@ -1,0 +1,202 @@
+import { defineRule } from "../../utils/define-rule.js";
+import type { EsTreeNode } from "../../utils/es-tree-node.js";
+import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { getStaticTemplateLiteralValue } from "../../utils/get-static-template-literal-value.js";
+import { isFunctionLike } from "../../utils/is-function-like.js";
+import { isNodeOfType } from "../../utils/is-node-of-type.js";
+import { isOctaneModule } from "../../utils/is-octane-module.js";
+import { resolveJsxElementType } from "../../utils/resolve-jsx-element-type.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
+import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
+
+const NON_TEXT_INPUT_TYPES = new Set([
+  "button",
+  "checkbox",
+  "color",
+  "date",
+  "datetime-local",
+  "file",
+  "hidden",
+  "image",
+  "month",
+  "radio",
+  "range",
+  "reset",
+  "submit",
+  "time",
+  "week",
+]);
+const NON_DOM_OCTANE_RENDERER_PATTERN =
+  /@jsxImportSource\s+@octanejs\/[^\s*]+\/intrinsics\b/;
+const UNKNOWN_STATIC_VALUE = Symbol("unknown-static-value");
+
+const findLastAttribute = (
+  attributes: ReadonlyArray<EsTreeNode>,
+  attributeNames: ReadonlySet<string>,
+): EsTreeNodeOfType<"JSXAttribute"> | null => {
+  for (let attributeIndex = attributes.length - 1; attributeIndex >= 0; attributeIndex -= 1) {
+    const attribute = attributes[attributeIndex];
+    if (
+      attribute &&
+      isNodeOfType(attribute, "JSXAttribute") &&
+      isNodeOfType(attribute.name, "JSXIdentifier") &&
+      attributeNames.has(attribute.name.name)
+    ) {
+      return attribute;
+    }
+  }
+  return null;
+};
+
+const getAttributeStaticValue = (
+  attribute: EsTreeNodeOfType<"JSXAttribute">,
+): unknown => {
+  if (!attribute.value) return true;
+  if (isNodeOfType(attribute.value, "Literal")) return attribute.value.value;
+  if (!isNodeOfType(attribute.value, "JSXExpressionContainer")) return UNKNOWN_STATIC_VALUE;
+  const expression = stripParenExpression(attribute.value.expression);
+  if (isNodeOfType(expression, "Literal")) return expression.value;
+  if (isNodeOfType(expression, "TemplateLiteral")) {
+    return getStaticTemplateLiteralValue(expression) ?? UNKNOWN_STATIC_VALUE;
+  }
+  if (isNodeOfType(expression, "Identifier") && expression.name === "undefined") return undefined;
+  if (isNodeOfType(expression, "UnaryExpression") && expression.operator === "void") {
+    return undefined;
+  }
+  return UNKNOWN_STATIC_VALUE;
+};
+
+const getAttributeExpression = (
+  attribute: EsTreeNodeOfType<"JSXAttribute">,
+): EsTreeNode | null => {
+  if (!attribute.value || !isNodeOfType(attribute.value, "JSXExpressionContainer")) return null;
+  return stripParenExpression(attribute.value.expression);
+};
+
+const isProvenCallableAttribute = (
+  attribute: EsTreeNodeOfType<"JSXAttribute">,
+  scopes: ScopeAnalysis,
+): boolean => {
+  const expression = getAttributeExpression(attribute);
+  if (!expression) return false;
+  if (isFunctionLike(expression)) return true;
+  if (!isNodeOfType(expression, "Identifier")) return false;
+  const symbol = scopes.symbolFor(expression);
+  return Boolean(
+    symbol?.kind === "const" && symbol.initializer && isFunctionLike(stripParenExpression(symbol.initializer)),
+  );
+};
+
+const isPresentChangeHandler = (
+  attribute: EsTreeNodeOfType<"JSXAttribute"> | null,
+): attribute is EsTreeNodeOfType<"JSXAttribute"> =>
+  Boolean(attribute && getAttributeStaticValue(attribute) === UNKNOWN_STATIC_VALUE);
+
+const isKnownTruthyHostBoolean = (
+  attribute: EsTreeNodeOfType<"JSXAttribute"> | null,
+): boolean | null => {
+  if (!attribute) return false;
+  const staticValue = getAttributeStaticValue(attribute);
+  return staticValue === UNKNOWN_STATIC_VALUE ? null : Boolean(staticValue);
+};
+
+const hasUnresolvedInputHandler = (
+  attribute: EsTreeNodeOfType<"JSXAttribute"> | null,
+  scopes: ScopeAnalysis,
+): boolean =>
+  Boolean(
+    attribute &&
+    getAttributeStaticValue(attribute) === UNKNOWN_STATIC_VALUE &&
+    !isProvenCallableAttribute(attribute, scopes),
+  );
+
+const isStaticallyTextEntryInput = (
+  typeAttribute: EsTreeNodeOfType<"JSXAttribute"> | null,
+): boolean | null => {
+  if (!typeAttribute || !typeAttribute.value) return true;
+  const staticValue = getAttributeStaticValue(typeAttribute);
+  if (staticValue === UNKNOWN_STATIC_VALUE) return null;
+  return typeof staticValue !== "string" || !NON_TEXT_INPUT_TYPES.has(staticValue.toLowerCase());
+};
+
+export const octaneNoNativeTextOnchange = defineRule({
+  id: "octane-no-native-text-onchange",
+  title: "React-style text onChange used in Octane",
+  severity: "warn",
+  recommendation:
+    "Use `onInput` for per-edit text updates, or add `suppressNativeChangeWarning` when native commit-on-blur behavior is intentional.",
+  matchByOccurrence: true,
+  create: (context) => {
+    let fileIsOctaneModule = false;
+    return {
+      Program(node: EsTreeNodeOfType<"Program">) {
+        const sourceText = context.sourceCode.getText();
+        fileIsOctaneModule =
+          isOctaneModule(node, sourceText) && !NON_DOM_OCTANE_RENDERER_PATTERN.test(sourceText);
+      },
+      JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
+        if (!fileIsOctaneModule) return;
+        const elementType = resolveJsxElementType(node);
+        if (elementType !== "input" && elementType !== "textarea") return;
+        if (node.attributes.some((attribute) => isNodeOfType(attribute, "JSXSpreadAttribute"))) {
+          return;
+        }
+
+        const changeAttributes = [
+          findLastAttribute(node.attributes, new Set(["onChange"])),
+          findLastAttribute(node.attributes, new Set(["onChangeCapture"])),
+        ].filter(isPresentChangeHandler);
+        if (changeAttributes.length === 0) return;
+
+        const typeAttribute = findLastAttribute(node.attributes, new Set(["type"]));
+        if (elementType === "input" && isStaticallyTextEntryInput(typeAttribute) !== true) return;
+
+        const readOnlyAttribute = findLastAttribute(
+          node.attributes,
+          new Set(["readOnly", "readonly"]),
+        );
+        const disabledAttribute = findLastAttribute(node.attributes, new Set(["disabled"]));
+        const suppressionAttribute = findLastAttribute(
+          node.attributes,
+          new Set(["suppressNativeChangeWarning"]),
+        );
+        const readOnlyState = isKnownTruthyHostBoolean(readOnlyAttribute);
+        const disabledState = isKnownTruthyHostBoolean(disabledAttribute);
+        const suppressionState = isKnownTruthyHostBoolean(suppressionAttribute);
+        if (readOnlyState === true || disabledState === true || suppressionState === true) return;
+        if (readOnlyState === null || disabledState === null || suppressionState === null) return;
+
+        const inputAttributes = [
+          findLastAttribute(node.attributes, new Set(["onInput"])),
+          findLastAttribute(node.attributes, new Set(["onInputCapture"])),
+        ];
+        if (
+          inputAttributes.some(
+            (attribute) => attribute && isProvenCallableAttribute(attribute, context.scopes),
+          ) ||
+          inputAttributes.some((attribute) =>
+            hasUnresolvedInputHandler(attribute, context.scopes),
+          )
+        ) {
+          return;
+        }
+
+        const firstChangeAttribute = changeAttributes.toSorted(
+          (left, right) => node.attributes.indexOf(left) - node.attributes.indexOf(right),
+        )[0];
+        if (!firstChangeAttribute) return;
+        const changeAttributeName = isNodeOfType(firstChangeAttribute.name, "JSXIdentifier")
+          ? firstChangeAttribute.name.name
+          : "onChange";
+        const replacement = changeAttributeName === "onChangeCapture" ? "onInputCapture" : "onInput";
+        const hasControlledValue = Boolean(
+          findLastAttribute(node.attributes, new Set(["value"])),
+        );
+        context.report({
+          node: firstChangeAttribute,
+          message: `\`${changeAttributeName}\` is a native commit event in Octane, so it does not run for each text edit. Use \`${replacement}\` for per-edit updates or add \`suppressNativeChangeWarning\` for intentional commit-on-blur behavior.${hasControlledValue ? " This control also has `value`, so use `defaultValue` if commit-only editing should remain uncontrolled." : ""}`,
+        });
+      },
+    };
+  },
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/octane/octane-no-native-text-onchange.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/octane/octane-no-native-text-onchange.ts
@@ -1,13 +1,14 @@
+import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
 import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import type { EsTreeNodeOfType } from "../../utils/es-tree-node-of-type.js";
+import { getNodeStartIndex } from "../../utils/get-node-start-index.js";
 import { getStaticTemplateLiteralValue } from "../../utils/get-static-template-literal-value.js";
 import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isOctaneModule } from "../../utils/is-octane-module.js";
 import { resolveJsxElementType } from "../../utils/resolve-jsx-element-type.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
-import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
 
 const NON_TEXT_INPUT_TYPES = new Set([
   "button",
@@ -26,13 +27,13 @@ const NON_TEXT_INPUT_TYPES = new Set([
   "time",
   "week",
 ]);
-const NON_DOM_OCTANE_RENDERER_PATTERN =
-  /@jsxImportSource\s+@octanejs\/[^\s*]+\/intrinsics\b/;
+const NON_DOM_OCTANE_RENDERER_PATTERN = /@jsxImportSource\s+@octanejs\/[^\s*]+\/intrinsics\b/;
 const UNKNOWN_STATIC_VALUE = Symbol("unknown-static-value");
 
 const findLastAttribute = (
   attributes: ReadonlyArray<EsTreeNode>,
-  attributeNames: ReadonlySet<string>,
+  attributeName: string,
+  alias?: string,
 ): EsTreeNodeOfType<"JSXAttribute"> | null => {
   for (let attributeIndex = attributes.length - 1; attributeIndex >= 0; attributeIndex -= 1) {
     const attribute = attributes[attributeIndex];
@@ -40,7 +41,7 @@ const findLastAttribute = (
       attribute &&
       isNodeOfType(attribute, "JSXAttribute") &&
       isNodeOfType(attribute.name, "JSXIdentifier") &&
-      attributeNames.has(attribute.name.name)
+      (attribute.name.name === attributeName || attribute.name.name === alias)
     ) {
       return attribute;
     }
@@ -48,9 +49,7 @@ const findLastAttribute = (
   return null;
 };
 
-const getAttributeStaticValue = (
-  attribute: EsTreeNodeOfType<"JSXAttribute">,
-): unknown => {
+const getAttributeStaticValue = (attribute: EsTreeNodeOfType<"JSXAttribute">): unknown => {
   if (!attribute.value) return true;
   if (isNodeOfType(attribute.value, "Literal")) return attribute.value.value;
   if (!isNodeOfType(attribute.value, "JSXExpressionContainer")) return UNKNOWN_STATIC_VALUE;
@@ -66,9 +65,7 @@ const getAttributeStaticValue = (
   return UNKNOWN_STATIC_VALUE;
 };
 
-const getAttributeExpression = (
-  attribute: EsTreeNodeOfType<"JSXAttribute">,
-): EsTreeNode | null => {
+const getAttributeExpression = (attribute: EsTreeNodeOfType<"JSXAttribute">): EsTreeNode | null => {
   if (!attribute.value || !isNodeOfType(attribute.value, "JSXExpressionContainer")) return null;
   return stripParenExpression(attribute.value.expression);
 };
@@ -83,7 +80,9 @@ const isProvenCallableAttribute = (
   if (!isNodeOfType(expression, "Identifier")) return false;
   const symbol = scopes.symbolFor(expression);
   return Boolean(
-    symbol?.kind === "const" && symbol.initializer && isFunctionLike(stripParenExpression(symbol.initializer)),
+    symbol?.kind === "const" &&
+    symbol.initializer &&
+    isFunctionLike(stripParenExpression(symbol.initializer)),
   );
 };
 
@@ -130,7 +129,7 @@ export const octaneNoNativeTextOnchange = defineRule({
     let fileIsOctaneModule = false;
     return {
       Program(node: EsTreeNodeOfType<"Program">) {
-        const sourceText = context.sourceCode.getText();
+        const sourceText = context.sourceCode?.getText?.() ?? "";
         fileIsOctaneModule =
           isOctaneModule(node, sourceText) && !NON_DOM_OCTANE_RENDERER_PATTERN.test(sourceText);
       },
@@ -143,22 +142,19 @@ export const octaneNoNativeTextOnchange = defineRule({
         }
 
         const changeAttributes = [
-          findLastAttribute(node.attributes, new Set(["onChange"])),
-          findLastAttribute(node.attributes, new Set(["onChangeCapture"])),
+          findLastAttribute(node.attributes, "onChange"),
+          findLastAttribute(node.attributes, "onChangeCapture"),
         ].filter(isPresentChangeHandler);
         if (changeAttributes.length === 0) return;
 
-        const typeAttribute = findLastAttribute(node.attributes, new Set(["type"]));
+        const typeAttribute = findLastAttribute(node.attributes, "type");
         if (elementType === "input" && isStaticallyTextEntryInput(typeAttribute) !== true) return;
 
-        const readOnlyAttribute = findLastAttribute(
-          node.attributes,
-          new Set(["readOnly", "readonly"]),
-        );
-        const disabledAttribute = findLastAttribute(node.attributes, new Set(["disabled"]));
+        const readOnlyAttribute = findLastAttribute(node.attributes, "readOnly", "readonly");
+        const disabledAttribute = findLastAttribute(node.attributes, "disabled");
         const suppressionAttribute = findLastAttribute(
           node.attributes,
-          new Set(["suppressNativeChangeWarning"]),
+          "suppressNativeChangeWarning",
         );
         const readOnlyState = isKnownTruthyHostBoolean(readOnlyAttribute);
         const disabledState = isKnownTruthyHostBoolean(disabledAttribute);
@@ -167,31 +163,28 @@ export const octaneNoNativeTextOnchange = defineRule({
         if (readOnlyState === null || disabledState === null || suppressionState === null) return;
 
         const inputAttributes = [
-          findLastAttribute(node.attributes, new Set(["onInput"])),
-          findLastAttribute(node.attributes, new Set(["onInputCapture"])),
+          findLastAttribute(node.attributes, "onInput"),
+          findLastAttribute(node.attributes, "onInputCapture"),
         ];
         if (
           inputAttributes.some(
             (attribute) => attribute && isProvenCallableAttribute(attribute, context.scopes),
           ) ||
-          inputAttributes.some((attribute) =>
-            hasUnresolvedInputHandler(attribute, context.scopes),
-          )
+          inputAttributes.some((attribute) => hasUnresolvedInputHandler(attribute, context.scopes))
         ) {
           return;
         }
 
         const firstChangeAttribute = changeAttributes.toSorted(
-          (left, right) => node.attributes.indexOf(left) - node.attributes.indexOf(right),
+          (left, right) => getNodeStartIndex(left) - getNodeStartIndex(right),
         )[0];
         if (!firstChangeAttribute) return;
         const changeAttributeName = isNodeOfType(firstChangeAttribute.name, "JSXIdentifier")
           ? firstChangeAttribute.name.name
           : "onChange";
-        const replacement = changeAttributeName === "onChangeCapture" ? "onInputCapture" : "onInput";
-        const hasControlledValue = Boolean(
-          findLastAttribute(node.attributes, new Set(["value"])),
-        );
+        const replacement =
+          changeAttributeName === "onChangeCapture" ? "onInputCapture" : "onInput";
+        const hasControlledValue = Boolean(findLastAttribute(node.attributes, "value"));
         context.report({
           node: firstChangeAttribute,
           message: `\`${changeAttributeName}\` is a native commit event in Octane, so it does not run for each text edit. Use \`${replacement}\` for per-edit updates or add \`suppressNativeChangeWarning\` for intentional commit-on-blur behavior.${hasControlledValue ? " This control also has `value`, so use `defaultValue` if commit-only editing should remain uncontrolled." : ""}`,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-octane-module.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-octane-module.ts
@@ -1,0 +1,29 @@
+import type { EsTreeNodeOfType } from "./es-tree-node-of-type.js";
+import { isOctanePackageSource } from "./is-octane-package-source.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+
+const OCTANE_JSX_IMPORT_SOURCE_PATTERN =
+  /@jsxImportSource\s+(?:octane(?:\/[^\s*]+)?|@octanejs\/[^\s*]+\/intrinsics)\b/;
+
+const hasRuntimeImportSpecifier = (
+  declaration: EsTreeNodeOfType<"ImportDeclaration">,
+): boolean =>
+  declaration.importKind !== "type" &&
+  (declaration.specifiers.length === 0 ||
+    declaration.specifiers.some(
+      (specifier) =>
+        !isNodeOfType(specifier, "ImportSpecifier") || specifier.importKind !== "type",
+    ));
+
+export const isOctaneModule = (
+  program: EsTreeNodeOfType<"Program">,
+  sourceText: string,
+): boolean =>
+  OCTANE_JSX_IMPORT_SOURCE_PATTERN.test(sourceText) ||
+  program.body.some(
+    (statement) =>
+      isNodeOfType(statement, "ImportDeclaration") &&
+      typeof statement.source.value === "string" &&
+      isOctanePackageSource(statement.source.value) &&
+      hasRuntimeImportSpecifier(statement),
+  );

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-octane-module.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-octane-module.ts
@@ -5,20 +5,14 @@ import { isNodeOfType } from "./is-node-of-type.js";
 const OCTANE_JSX_IMPORT_SOURCE_PATTERN =
   /@jsxImportSource\s+(?:octane(?:\/[^\s*]+)?|@octanejs\/[^\s*]+\/intrinsics)\b/;
 
-const hasRuntimeImportSpecifier = (
-  declaration: EsTreeNodeOfType<"ImportDeclaration">,
-): boolean =>
+const hasRuntimeImportSpecifier = (declaration: EsTreeNodeOfType<"ImportDeclaration">): boolean =>
   declaration.importKind !== "type" &&
   (declaration.specifiers.length === 0 ||
     declaration.specifiers.some(
-      (specifier) =>
-        !isNodeOfType(specifier, "ImportSpecifier") || specifier.importKind !== "type",
+      (specifier) => !isNodeOfType(specifier, "ImportSpecifier") || specifier.importKind !== "type",
     ));
 
-export const isOctaneModule = (
-  program: EsTreeNodeOfType<"Program">,
-  sourceText: string,
-): boolean =>
+export const isOctaneModule = (program: EsTreeNodeOfType<"Program">, sourceText: string): boolean =>
   OCTANE_JSX_IMPORT_SOURCE_PATTERN.test(sourceText) ||
   program.body.some(
     (statement) =>

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-octane-package-source.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-octane-package-source.ts
@@ -1,0 +1,2 @@
+export const isOctanePackageSource = (source: string): boolean =>
+  source === "octane" || source.startsWith("octane/") || source.startsWith("@octanejs/");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Catches Octane hook-slot collisions in plain JavaScript loops and React-style text `onChange` handlers that only fire on native commit.

## Why

Octane tracks slot-keyed hooks by compiler-assigned call site. Repeating one call site in a plain JavaScript loop makes iterations share state, memo, or effect storage, so Octane rejects the pattern. Octane also uses native DOM events: text `onChange` runs on commit or blur, while `onInput` runs for each edit.

```tsx
import { useState } from "octane";

for (const item of items) {
  useState(item);
}

<input value={query} onChange={(event) => setQuery(event.currentTarget.value)} />
```

Use keyed TSRX iteration or a child component for repeated hooks, and use `onInput` for per-edit text updates:

```tsx
@for (const item of items; key item.id) {
  const [value] = useState(item);
  <Row value={value} />
}

<input value={query} onInput={(event) => setQuery(event.currentTarget.value)} />
```

Intentional native commit behavior remains supported with `suppressNativeChangeWarning`.

## What changed

- Added `octane-no-hook-in-loop`, including aliases, namespace calls, custom hooks, IIFEs, `.call()`/`.apply()` IIFEs, and synchronous iterator callbacks.
- Exempted `use()`, `useContext`, deferred nested functions, conditions, early returns, and loop-free callbacks.
- Added `octane-no-native-text-onchange` using Octane's compiler decision boundaries for text input types, callable input handlers, readonly/disabled controls, dynamic props, spreads, capture handlers, explicit suppression, and non-DOM renderers.
- Gated both rules to modules proven to use Octane and tagged them `octane`.
- Added generated registry entries, liveness fixtures, adversarial tests, and a patch changeset.

## Evidence

The contracts follow Octane's current `compile-errors.test.ts`, `native-change-compiler.test.ts`, `compile.js`, `native-change-diagnostics.js`, and public differences-from-React documentation. The implementation intentionally stays within those compiler-proven boundaries.

## Validation

- Plugin tests: 1,114 files passed; 27,521 tests passed and 187 skipped.
- Plugin typecheck: passed.
- Strict fuzzing: 500 iterations per new rule, both passed and both reached their liveness fixture.
- Full repository `test`, `lint`, `typecheck`, `format:check`, and `smoke:json-report`: passed.
- Local RDE inspection was unavailable because no React Doctor Evals checkout exists in this environment.
- PR parity was blocked because `DAYTONA_API_KEY` is not available in this environment.

## Test plan

- `nr --filter oxlint-plugin-react-doctor test`
- `nr --filter oxlint-plugin-react-doctor typecheck`
- `FUZZ_RULE=octane-no-hook-in-loop FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz`
- `FUZZ_RULE=octane-no-native-text-onchange FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz`
- `nr test`
- `nr lint`
- `nr typecheck`
- `nr format:check`
- `nr smoke:json-report`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f4441fd8-a923-4e0f-808d-8b724ae3993d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f4441fd8-a923-4e0f-808d-8b724ae3993d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

