### PR TITLE
fix(eslint-plugin): honor disabledWhen capabilities in ESLint plugin

### DIFF
--- a/.changeset/eslint-plugin-disabledwhen.md
+++ b/.changeset/eslint-plugin-disabledwhen.md
@@ -9,11 +9,11 @@ Users can enable this by adding to their ESLint config:
 ```js
 export default {
   settings: {
-    'react-doctor': {
-      capabilities: ['react-compiler']
-    }
-  }
-}
+    "react-doctor": {
+      capabilities: ["react-compiler"],
+    },
+  },
+};
 ```
 
 This matches the CLI behavior where these rules are automatically disabled when React Compiler is detected in `next.config.ts`/`vite.config.ts`.

--- a/.changeset/eslint-plugin-disabledwhen.md
+++ b/.changeset/eslint-plugin-disabledwhen.md
@@ -1,0 +1,19 @@
+---
+"eslint-plugin-react-doctor": patch
+---
+
+ESLint plugin now respects `disabledWhen` capabilities. Rules like `jsx-no-new-function-as-prop` that have `disabledWhen: ['react-compiler']` will no longer fire when React Compiler is configured in ESLint settings.
+
+Users can enable this by adding to their ESLint config:
+
+```js
+export default {
+  settings: {
+    'react-doctor': {
+      capabilities: ['react-compiler']
+    }
+  }
+}
+```
+
+This matches the CLI behavior where these rules are automatically disabled when React Compiler is detected in `next.config.ts`/`vite.config.ts`.

--- a/packages/eslint-plugin-react-doctor/src/index.ts
+++ b/packages/eslint-plugin-react-doctor/src/index.ts
@@ -7,7 +7,13 @@ import oxlintPlugin, {
   TANSTACK_QUERY_RULES,
   TANSTACK_START_RULES,
 } from "oxlint-plugin-react-doctor";
-import type { EsTreeNode, OxlintRuleSeverity, RuleVisitors } from "oxlint-plugin-react-doctor";
+import type {
+  Capability,
+  EsTreeNode,
+  OxlintRuleSeverity,
+  Rule,
+  RuleVisitors,
+} from "oxlint-plugin-react-doctor";
 
 interface EslintRuleContext {
   report: (descriptor: { node: EsTreeNode; message: string }) => void;
@@ -15,6 +21,11 @@ interface EslintRuleContext {
   readonly filename?: string;
   /** @deprecated Use `filename`. Kept only for host compatibility. */
   getFilename?: () => string | undefined;
+  settings?: {
+    "react-doctor"?: {
+      capabilities?: ReadonlyArray<string>;
+    };
+  };
 }
 
 interface EslintAdapterRule {
@@ -68,7 +79,26 @@ const RULE_DOCS_BASE_URL = "https://react.doctor/docs/rules";
 
 const recommendedRuleKeys = new Set(Object.keys(RECOMMENDED_RULES));
 
-const wrapAsEslintRule = (ruleName: string, ruleImpl: EslintAdapterRule): EslintRule => ({
+const EMPTY_VISITORS: RuleVisitors = {};
+
+const hasCapability = (
+  settings: EslintRuleContext["settings"],
+  capability: Capability,
+): boolean => {
+  const capabilities = settings?.["react-doctor"]?.capabilities;
+  if (!Array.isArray(capabilities)) return false;
+  return capabilities.includes(capability);
+};
+
+const shouldCreateRuleVisitors = (
+  settings: EslintRuleContext["settings"],
+  disabledWhen: ReadonlyArray<Capability> | undefined,
+): boolean => !disabledWhen?.some((capability) => hasCapability(settings, capability));
+
+const wrapAsEslintRule = (
+  ruleName: string,
+  ruleImpl: EslintAdapterRule & Pick<Rule, "disabledWhen">,
+): EslintRule => ({
   meta: {
     type: ruleImpl.severity === "warn" ? "suggestion" : "problem",
     docs: {
@@ -82,7 +112,10 @@ const wrapAsEslintRule = (ruleName: string, ruleImpl: EslintAdapterRule): Eslint
     },
     schema: [],
   },
-  create: ruleImpl.create,
+  create: (context: EslintRuleContext) =>
+    shouldCreateRuleVisitors(context.settings, ruleImpl.disabledWhen)
+      ? ruleImpl.create(context)
+      : EMPTY_VISITORS,
 });
 
 const eslintShapedRules: Record<string, EslintRule> = Object.fromEntries(

--- a/packages/eslint-plugin-react-doctor/tests/plugin-shape.test.ts
+++ b/packages/eslint-plugin-react-doctor/tests/plugin-shape.test.ts
@@ -71,4 +71,55 @@ describe("eslint-plugin-react-doctor", () => {
     );
     expect(eslintRule.meta.type).toBe(oxlintRule.severity === "warn" ? "suggestion" : "problem");
   });
+
+  it("respects disabledWhen: ['react-compiler'] when capability is present", () => {
+    const ruleName = "jsx-no-new-function-as-prop";
+    const oxlintRule = oxlintPlugin.rules[ruleName];
+    const eslintRule = eslintPlugin.rules[ruleName];
+    expect(oxlintRule).toBeDefined();
+    expect(eslintRule).toBeDefined();
+    if (!oxlintRule || !eslintRule) return;
+
+    expect(oxlintRule.disabledWhen).toContain("react-compiler");
+
+    const mockContext = {
+      report: () => {},
+      filename: "test.tsx",
+      settings: { "react-doctor": { capabilities: ["react-compiler"] } },
+    };
+
+    const visitors = eslintRule.create(mockContext);
+    expect(Object.keys(visitors)).toHaveLength(0);
+  });
+
+  it("enables rules when disabledWhen capability is not present", () => {
+    const ruleName = "jsx-no-new-function-as-prop";
+    const eslintRule = eslintPlugin.rules[ruleName];
+    expect(eslintRule).toBeDefined();
+    if (!eslintRule) return;
+
+    const mockContext = {
+      report: () => {},
+      filename: "test.tsx",
+      settings: { "react-doctor": { capabilities: [] } },
+    };
+
+    const visitors = eslintRule.create(mockContext);
+    expect(Object.keys(visitors).length).toBeGreaterThan(0);
+  });
+
+  it("enables rules when settings are missing", () => {
+    const ruleName = "jsx-no-new-function-as-prop";
+    const eslintRule = eslintPlugin.rules[ruleName];
+    expect(eslintRule).toBeDefined();
+    if (!eslintRule) return;
+
+    const mockContext = {
+      report: () => {},
+      filename: "test.tsx",
+    };
+
+    const visitors = eslintRule.create(mockContext);
+    expect(Object.keys(visitors).length).toBeGreaterThan(0);
+  });
 });

--- a/packages/eslint-plugin-react-doctor/tests/react-compiler-disabledWhen.test.ts
+++ b/packages/eslint-plugin-react-doctor/tests/react-compiler-disabledWhen.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vite-plus/test";
+import oxlintPlugin from "oxlint-plugin-react-doctor";
+import eslintPlugin from "../src/index.js";
+
+describe("ESLint plugin respects disabledWhen for react-compiler", () => {
+  const REACT_COMPILER_DISABLED_RULES = [
+    "jsx-no-new-function-as-prop",
+    "jsx-no-new-object-as-prop",
+    "jsx-no-new-array-as-prop",
+    "jsx-no-jsx-as-prop",
+    "jsx-no-constructed-context-values",
+    "context-provider-value-from-unmemoized-local-literal",
+    "no-inline-prop-on-memo-component",
+    "prefer-module-scope-static-value",
+    "prefer-module-scope-pure-function",
+    "prefer-stable-empty-fallback",
+    "rendering-hoist-jsx",
+    "rerender-memo-with-default-value",
+    "rerender-dependencies",
+    "no-effect-with-fresh-deps",
+    "rn-no-inline-object-in-list-item",
+    "rn-no-inline-flatlist-renderitem",
+    "rn-list-data-mapped",
+    "rn-list-callback-per-row",
+  ];
+
+  it("verifies test rules have disabledWhen: ['react-compiler'] in oxlint plugin", () => {
+    for (const ruleName of REACT_COMPILER_DISABLED_RULES) {
+      const rule = oxlintPlugin.rules[ruleName];
+      expect(rule).toBeDefined();
+      expect(rule?.disabledWhen).toContain("react-compiler");
+    }
+  });
+
+  it("disables all react-compiler-gated rules when capability is present", () => {
+    const mockContext = {
+      report: () => {},
+      filename: "test.tsx",
+      settings: { "react-doctor": { capabilities: ["react-compiler"] } },
+    };
+
+    for (const ruleName of REACT_COMPILER_DISABLED_RULES) {
+      const eslintRule = eslintPlugin.rules[ruleName];
+      expect(eslintRule).toBeDefined();
+      if (!eslintRule) continue;
+
+      const visitors = eslintRule.create(mockContext);
+      expect(Object.keys(visitors)).toHaveLength(0);
+    }
+  });
+
+  it("enables all react-compiler-gated rules when capability is absent", () => {
+    const mockContext = {
+      report: () => {},
+      filename: "test.tsx",
+      settings: { "react-doctor": { capabilities: [] } },
+    };
+
+    for (const ruleName of REACT_COMPILER_DISABLED_RULES) {
+      const eslintRule = eslintPlugin.rules[ruleName];
+      expect(eslintRule).toBeDefined();
+      if (!eslintRule) continue;
+
+      const visitors = eslintRule.create(mockContext);
+      expect(Object.keys(visitors).length).toBeGreaterThan(0);
+    }
+  });
+
+  it("enables rules when settings object is missing entirely", () => {
+    const mockContext = {
+      report: () => {},
+      filename: "test.tsx",
+    };
+
+    for (const ruleName of REACT_COMPILER_DISABLED_RULES) {
+      const eslintRule = eslintPlugin.rules[ruleName];
+      expect(eslintRule).toBeDefined();
+      if (!eslintRule) continue;
+
+      const visitors = eslintRule.create(mockContext);
+      expect(Object.keys(visitors).length).toBeGreaterThan(0);
+    }
+  });
+
+  it("requires: ['react-compiler'] rule stays active when capability is present", () => {
+    const ruleName = "react-compiler-no-manual-memoization";
+    const oxlintRule = oxlintPlugin.rules[ruleName];
+    const eslintRule = eslintPlugin.rules[ruleName];
+
+    expect(oxlintRule).toBeDefined();
+    expect(eslintRule).toBeDefined();
+    if (!oxlintRule || !eslintRule) return;
+
+    expect(oxlintRule.requires).toContain("react-compiler");
+    expect(oxlintRule.disabledWhen).toBeUndefined();
+
+    const mockContext = {
+      report: () => {},
+      filename: "test.tsx",
+      settings: { "react-doctor": { capabilities: ["react-compiler"] } },
+    };
+
+    const visitors = eslintRule.create(mockContext);
+    expect(Object.keys(visitors).length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #1661

## Root Cause

The ESLint plugin wrapper was not checking rule.disabledWhen metadata. Rules like jsx-no-new-function-as-prop that have disabledWhen: ['react-compiler'] kept firing in ESLint even when React Compiler was configured.

The CLI correctly disabled these rules via the oxlint plugin's shouldCreateRuleVisitors check, but the ESLint wrapper just unconditionally called ruleImpl.create.

## Scope

The fix is narrowly scoped to the ESLint plugin wrapper only:

- Import capability checking helpers from oxlint-plugin-react-doctor
- Check context.settings['react-doctor'].capabilities against rule.disabledWhen
- Return empty visitors when any disabledWhen capability is present
- This matches the oxlint plugin's behavior

Affects 18 rules with disabledWhen: ['react-compiler']:
- jsx-no-new-{function,array,object,jsx}-as-prop
- jsx-no-constructed-context-values
- context-provider-value-from-unmemoized-local-literal
- no-inline-prop-on-memo-component
- prefer-module-scope-{static-value,pure-function}
- prefer-stable-empty-fallback
- rendering-hoist-jsx
- rerender-{memo-with-default-value,dependencies}
- no-effect-with-fresh-deps
- rn-no-inline-{object-in-list-item,flatlist-renderitem}
- rn-list-{data-mapped,callback-per-row}

## Usage

Users enable this by adding to their ESLint config:

```js
export default {
  settings: {
    'react-doctor': {
      capabilities: ['react-compiler']
    }
  }
}
```

## Testing

- Added comprehensive test coverage for all 18 affected rules
- Verified rules return empty visitors when capability is present
- Verified rules return populated visitors when capability is absent
- Verified behavior when settings are missing
- All existing tests pass

## Parity

Not applicable - this change only affects the ESLint plugin wrapper. The CLI uses oxlint-plugin-react-doctor directly and is unchanged, so there are no CLI diagnostic changes to verify.

## Changeset

Included patch-level changeset with user-facing documentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-605345a7-5783-4625-ad57-41971197aa45?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-605345a7-5783-4625-ad57-41971197aa45&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

