### PR TITLE
fix: ignore TypeScript type-only positions in no-unguarded-browser-global-at-module-scope

### DIFF
--- a/.changeset/fix-type-only-window.md
+++ b/.changeset/fix-type-only-window.md
@@ -1,0 +1,9 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+fix(no-unguarded-browser-global-at-module-scope): Ignore TypeScript type-only positions
+
+The rule was incorrectly flagging browser-global names (`window`, `navigator`, etc.) when they appeared as property keys in TypeScript interfaces and type aliases. These are type-only positions that TypeScript erases during compilation, so no runtime reference error occurs.
+
+Fixes #1667

--- a/.changeset/fix-type-only-window.md
+++ b/.changeset/fix-type-only-window.md
@@ -2,8 +2,4 @@
 "oxlint-plugin-react-doctor": patch
 ---
 
-fix(no-unguarded-browser-global-at-module-scope): Ignore TypeScript type-only positions
-
-The rule was incorrectly flagging browser-global names (`window`, `navigator`, etc.) when they appeared as property keys in TypeScript interfaces and type aliases. These are type-only positions that TypeScript erases during compilation, so no runtime reference error occurs.
-
-Fixes #1667
+Ignore browser-global names in TypeScript-only positions so interface and type property keys are not reported as unsafe module-scope runtime access.

--- a/packages/fuzz/corpus/regressions/no-unguarded-browser-global-at-module-scope--type-property-key.ts
+++ b/packages/fuzz/corpus/regressions/no-unguarded-browser-global-at-module-scope--type-property-key.ts
@@ -1,0 +1,17 @@
+// rule: no-unguarded-browser-global-at-module-scope
+// weakness: type-position
+// source: GitHub issue #1667
+// verdict: pass
+
+interface TweetSearchCoverageStrategyMetadata {
+  readonly window:
+    | {
+        readonly sinceTime: string;
+        readonly untilTime: string;
+      }
+    | undefined;
+}
+
+export const metadata: TweetSearchCoverageStrategyMetadata = {
+  window: undefined,
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-unguarded-browser-global-at-module-scope.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-unguarded-browser-global-at-module-scope.test.ts
@@ -809,4 +809,37 @@ describe("no-unguarded-browser-global-at-module-scope", () => {
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toHaveLength(1);
   });
+
+  it("does not flag type parameters that happen to be named window", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalAtModuleScope,
+      `type MapState<window> = (state: window) => window;`,
+      prod,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag type-only intersection/union member keys", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalAtModuleScope,
+      `type Config = { window: number } | { navigator: string } & { localStorage: boolean };`,
+      prod,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag method signature return types", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalAtModuleScope,
+      `interface API {
+         getWindow(): window;
+       }
+       type window = { width: number };`,
+      prod,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-unguarded-browser-global-at-module-scope.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-unguarded-browser-global-at-module-scope.test.ts
@@ -771,4 +771,42 @@ describe("no-unguarded-browser-global-at-module-scope", () => {
     );
     expect(result.diagnostics).toHaveLength(0);
   });
+
+  it("does not flag type-only property names in interfaces", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalAtModuleScope,
+      `interface TweetSearchCoverageStrategyMetadata {
+         readonly window: { readonly sinceTime: string; readonly untilTime: string } | undefined;
+       }`,
+      prod,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does not flag type-only property names in type aliases", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalAtModuleScope,
+      `type Config = {
+         window: number;
+         navigator: string;
+       };`,
+      prod,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still flags runtime window property access", () => {
+    const result = runRule(
+      noUnguardedBrowserGlobalAtModuleScope,
+      `interface Config {
+         window: number;
+       }
+       const w = window.innerWidth;`,
+      prod,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-unguarded-browser-global-at-module-scope.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/correctness/no-unguarded-browser-global-at-module-scope.ts
@@ -10,6 +10,7 @@ import { isFunctionLike } from "../../utils/is-function-like.js";
 import { isNonSourceFilename } from "../../utils/is-non-source-filename.js";
 import { isNodeOfType } from "../../utils/is-node-of-type.js";
 import { isTestlikeFilename } from "../../utils/is-testlike-filename.js";
+import { isTypeScriptTypePosition } from "../../utils/is-typescript-type-position.js";
 import { readBrowserGlobalAvailability } from "../../utils/read-browser-global-availability.js";
 import { resolveCrossFileExport } from "../../utils/resolve-cross-file-export.js";
 import { findTransparentExpressionRoot } from "../../utils/find-transparent-expression-root.js";
@@ -628,6 +629,7 @@ export const noUnguardedBrowserGlobalAtModuleScope = defineRule({
       Identifier(node: EsTreeNodeOfType<"Identifier">) {
         if (!BROWSER_GLOBAL_NAMES.has(node.name)) return;
         if (!context.scopes.isGlobalReference(node)) return;
+        if (isTypeScriptTypePosition(node)) return;
         const expressionRoot = findTransparentExpressionRoot(node);
         if (
           expressionRoot.parent &&


### PR DESCRIPTION
## Why

TypeScript property keys such as `window` are erased at compile time, but `no-unguarded-browser-global-at-module-scope` treated them as runtime global reads and warned that they would crash during SSR.

Fixes #1667.

## What changed

- skip browser-global identifiers when the existing `isTypeScriptTypePosition` utility proves they are type-only
- preserve diagnostics for actual module-scope runtime reads
- cover interface keys, type aliases, type parameters, union/intersection members, and runtime reads
- preserve the reported false positive in the canonical fuzz regression corpus

## Eval results

| Check | Result |
| --- | --- |
| Repositories | 12 |
| Project roots | 100 |
| Scan errors | 0 |
| Total diagnostics | 12,181 |
| Target-rule diagnostics | 1 |
| Inspected target hits | 1 |
| New false positives | 0 |

The remaining target-rule hit is an existing runtime `window` read guarded by an imported path-alias constant. This change does not affect runtime expressions; no type-position hits remained in the sample. Local artifacts are in `tmp/rde-1668-local/hits.json`.

Daytona PR parity could not run because `DAYTONA_API_KEY` / `DAYTONA_API_TOKEN` is unavailable in this environment.

## Test plan

- `nr test src/plugin/rules/correctness/no-unguarded-browser-global-at-module-scope.test.ts` — 75 passed
- `nr typecheck` in `packages/oxlint-plugin-react-doctor` — passed
- `nr test` in `packages/fuzz` — 220 passed, 907 skipped
- `FUZZ_RULE=no-unguarded-browser-global-at-module-scope FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz` — passed with no findings
- `nr build` — passed
- focused format check — passed
