### PR TITLE
fix(rule): correct flatMap performance advice

### DIFF
--- a/.changeset/honest-flatmap-advice.md
+++ b/.changeset/honest-flatmap-advice.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Stop recommending `flatMap` as a guaranteed performance improvement for `.map().filter(Boolean)`. The rule now suggests a single-pass `reduce` or `for...of` rewrite only for measured hot paths.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/core-rule-registry-data.json
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/core-rule-registry-data.json
@@ -1996,7 +1996,7 @@
       "id": "js-flatmap-filter",
       "title": ".map().filter(Boolean) loops twice",
       "severity": "warn",
-      "recommendation": "Use `.flatMap(item => condition ? [value] : [])` to change and drop items in one pass, instead of building a throwaway array in between",
+      "recommendation": "If this is a measured hot path, combine the transform and truthy check with `.reduce()` or a `for...of` loop to avoid the intermediate array and second pass",
       "category": "Performance",
       "framework": "global",
       "tags": ["test-noise"],

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-flatmap-filter.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-flatmap-filter.regressions.test.ts
@@ -11,4 +11,18 @@ describe("js-performance/js-flatmap-filter — regressions", () => {
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toHaveLength(1);
   });
+
+  it("recommends a direct single-pass rewrite instead of flatMap", () => {
+    const result = runRule(jsFlatmapFilter, `items.map((item) => item.value).filter(Boolean);`);
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("measured hot path");
+    expect(result.diagnostics[0].message).toContain(".reduce()");
+    expect(result.diagnostics[0].message).toContain("for...of");
+    expect(result.diagnostics[0].message).not.toContain("flatMap");
+    expect(jsFlatmapFilter.recommendation).toContain("measured hot path");
+    expect(jsFlatmapFilter.recommendation).toContain("`.reduce()`");
+    expect(jsFlatmapFilter.recommendation).toContain("`for...of`");
+    expect(jsFlatmapFilter.recommendation).not.toContain("flatMap");
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-flatmap-filter.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-flatmap-filter.ts
@@ -24,7 +24,7 @@ export const jsFlatmapFilter = defineRule({
   tags: ["test-noise"],
   severity: "warn",
   recommendation:
-    "Use `.flatMap(item => condition ? [value] : [])` to change and drop items in one pass, instead of building a throwaway array in between",
+    "If this is a measured hot path, combine the transform and truthy check with `.reduce()` or a `for...of` loop to avoid the intermediate array and second pass",
   create: (context: RuleContext) => ({
     CallExpression(node: EsTreeNodeOfType<"CallExpression">) {
       if (
@@ -82,7 +82,7 @@ export const jsFlatmapFilter = defineRule({
       context.report({
         node,
         message:
-          "This loops over your list twice because .map().filter(Boolean) makes two passes, so use .flatMap() to change & drop items in one pass",
+          "This .map().filter(Boolean) chain creates an intermediate array and traverses it again; if this is a measured hot path, combine the transform and truthy check with .reduce() or for...of",
       });
     },
   }),


### PR DESCRIPTION
## Why

Closes #1466.

The `js-flatmap-filter` rule correctly identifies an intermediate array and second eager traversal, but it recommends `flatMap` as a performance fix. `flatMap` adds flattening work and short-lived arrays of its own, so it is not a reliable performance improvement over `.map().filter(Boolean)`.

Before:

```ts
items.map(transform).filter(Boolean);
// Recommended: flatMap
```

After:

```ts
// Keep the readable chain unless profiling identifies a hot path.
// For a measured hot path, combine the work with reduce or for...of.
```

## What changed

- replace the `flatMap` recommendation with measured-hot-path guidance
- recommend `reduce` or `for...of` for a direct single-pass rewrite
- preserve the existing detector and all bounded-pipeline exclusions
- add a regression test that prevents `flatMap` from returning to the diagnostic or generated rule metadata
- add a patch changeset for `oxlint-plugin-react-doctor`

## Eval results

RDE and PR parity were skipped because the detector and hit set are unchanged; this PR only corrects the emitted message and recommendation metadata.

## Test plan

- `nr test` — 12/12 tasks passed
- oxlint plugin — 1,116 files; 27,518 tests passed, 187 skipped
- React Doctor — 247 files; 2,492 tests passed, 24 skipped
- `nr lint`
- `nr typecheck` — 10/10 tasks passed
- `nr format:check`
- `nr smoke:json-report`
- `REACT_DOCTOR_NO_TELEMETRY=1 nlx react-doctor@latest --verbose --scope changed` — 100/100, no issues

