### PR TITLE
fix(rule): preserve Fast Refresh coverage in nested checkouts

### DIFF
--- a/.changeset/fruity-wombats-teach.md
+++ b/.changeset/fruity-wombats-teach.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Use the nearest workspace root when detecting Fast Refresh ownership so nested checkouts keep the correct rule coverage.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-fast-refresh-file-status.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-fast-refresh-file-status.test.ts
@@ -668,6 +668,32 @@ describe("probeFastRefreshFileStatus", () => {
     ).toBe(false);
   });
 
+  it("uses the nearest workspace root for a checkout nested inside another workspace", () => {
+    const outerWorkspaceDirectory = createWorkspaceFixture({
+      "package.json": JSON.stringify({ workspaces: ["unrelated/*"] }),
+      "checkouts/inner/package.json": JSON.stringify({
+        workspaces: ["apps/*", "packages/*"],
+      }),
+      "checkouts/inner/apps/web/package.json": JSON.stringify({
+        ...viteManifest({ dev: "vite" }),
+        dependencies: { react: "19.0.0", ui: "workspace:*" },
+      }),
+      "checkouts/inner/apps/web/vite.config.ts":
+        'import react from "@vitejs/plugin-react"; export default { plugins: [react()] };',
+      "checkouts/inner/packages/ui/package.json": JSON.stringify({
+        name: "ui",
+        main: "./src/index.ts",
+      }),
+      "checkouts/inner/packages/ui/src/Card.tsx": "export const Card = () => <div />;",
+    });
+
+    expect(
+      probeFastRefreshFileStatus(
+        path.join(outerWorkspaceDirectory, "checkouts/inner/packages/ui/src/Card.tsx"),
+      ).isActive,
+    ).toBe(true);
+  });
+
   it("ignores Fast Refresh consumers outside declared pnpm workspace packages", () => {
     const workspaceDirectory = createWorkspaceFixture({
       "package.json": JSON.stringify({ name: "workspace" }),

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-fast-refresh-file-status.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/get-fast-refresh-file-status.ts
@@ -712,12 +712,11 @@ const isWorkspaceRoot = (directory: string, manifest: PackageManifest | null): b
 
 const findWorkspaceRoot = (packageDirectory: string): string | null => {
   let currentDirectory = packageDirectory;
-  let workspaceRoot: string | null = null;
   while (true) {
     const manifest = readPackageManifest(currentDirectory);
-    if (isWorkspaceRoot(currentDirectory, manifest)) workspaceRoot = currentDirectory;
+    if (isWorkspaceRoot(currentDirectory, manifest)) return currentDirectory;
     const parentDirectory = path.dirname(currentDirectory);
-    if (parentDirectory === currentDirectory) return workspaceRoot;
+    if (parentDirectory === currentDirectory) return null;
     currentDirectory = parentDirectory;
   }
 };


### PR DESCRIPTION
## Why

Before this change, Fast Refresh ownership kept replacing the discovered workspace root while walking upward. A checkout nested below another workspace used the outermost marker, so `only-export-components` could silently disable itself when the outer workspace did not own the inner packages.

After this change, the walk stops at the nearest workspace marker, so nested checkouts use their own package graph and keep the expected rule coverage.

## What changed

- return the first workspace root found during the upward walk
- preserve the existing no-workspace fallback
- add a regression fixture with an inner workspace nested below an unrelated outer workspace
- add a patch changeset for `oxlint-plugin-react-doctor`

Parity could not run because `DAYTONA_API_KEY` is not available in the task environment. The impact manifest resolves the change to `react-doctor/only-export-components` in incremental mode.

## Test plan

- `nr test src/plugin/utils/get-fast-refresh-file-status.test.ts`
- `nr test src/plugin/rules/ink/ink-no-dom-host-elements.performance.test.ts src/plugin/rules/state-and-effects/no-mutate-then-set-or-return-same-reference.test.ts`
- `nr test`
- `nr lint`
- `nr typecheck`
- `nr format:check`
- `nr smoke:json-report`
