### PR TITLE
fix: `--scope changed` should detect commits relative to remote base

### DIFF
--- a/.changeset/fix-scope-changed-remote-base.md
+++ b/.changeset/fix-scope-changed-remote-base.md
@@ -1,0 +1,9 @@
+---
+"@react-doctor/core": patch
+---
+
+fix(git): prefer remote tracking branch for --scope changed auto-detection
+
+When running `--scope changed` without an explicit `--base` flag, React Doctor now auto-detects `origin/<branch>` instead of just `<branch>` when the remote tracking branch exists. This fixes the issue where committed changes on a feature branch (or on main ahead of origin/main) were not detected unless `--base origin/main` was explicitly specified.
+
+Fixes #1674

--- a/packages/core/src/services/git.ts
+++ b/packages/core/src/services/git.ts
@@ -473,7 +473,12 @@ export class Git extends Context.Service<
           const symref = yield* runGit(directory, ["symbolic-ref", "refs/remotes/origin/HEAD"]);
           if (symref.status === 0) {
             const trimmed = trimOrNull(symref.stdout);
-            if (trimmed !== null) return trimmed.replace("refs/remotes/origin/", "");
+            if (trimmed !== null) {
+              const branchName = trimmed.replace("refs/remotes/origin/", "");
+              const remoteBranch = `origin/${branchName}`;
+              const remoteExists = yield* branchExists(directory, remoteBranch);
+              return remoteExists ? remoteBranch : branchName;
+            }
           }
           const candidateRefs = DEFAULT_BRANCH_CANDIDATES.map(
             (candidate) => `refs/heads/${candidate}`,
@@ -484,7 +489,11 @@ export class Git extends Context.Service<
             ...candidateRefs,
           ]);
           if (candidates.status !== 0) return null;
-          return trimOrNull(candidates.stdout.split("\n")[0] ?? "");
+          const localBranch = trimOrNull(candidates.stdout.split("\n")[0] ?? "");
+          if (localBranch === null) return null;
+          const remoteBranch = `origin/${localBranch}`;
+          const remoteExists = yield* branchExists(directory, remoteBranch);
+          return remoteExists ? remoteBranch : localBranch;
         }).pipe(Effect.withSpan("Git.defaultBranch"));
 
       const branchExists = (

--- a/packages/core/tests/regressions/issue-1674-scope-changed-remote-base.test.ts
+++ b/packages/core/tests/regressions/issue-1674-scope-changed-remote-base.test.ts
@@ -1,0 +1,84 @@
+import { exec as execCallback } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+import { getDiffInfo } from "../../src/get-diff-files.js";
+
+const exec = promisify(execCallback);
+
+describe("issue #1674: --scope changed should detect commits relative to remote base", () => {
+  let testDirectory: string;
+
+  beforeEach(async () => {
+    testDirectory = await fs.promises.mkdtemp(path.join(os.tmpdir(), "react-doctor-test-"));
+  });
+
+  afterEach(async () => {
+    if (testDirectory) {
+      await fs.promises.rm(testDirectory, { recursive: true, force: true });
+    }
+  });
+
+  it("detects committed changes on feature branch when local main doesn't exist", async () => {
+    await exec("git init", { cwd: testDirectory });
+    await exec('git config user.email "test@example.com"', { cwd: testDirectory });
+    await exec('git config user.name "Test User"', { cwd: testDirectory });
+
+    await fs.promises.writeFile(path.join(testDirectory, "initial.txt"), "initial content");
+    await exec("git add .", { cwd: testDirectory });
+    await exec('git commit -m "initial commit"', { cwd: testDirectory });
+    await exec("git branch -m main", { cwd: testDirectory });
+
+    await exec("git remote add origin https://github.com/test/repo.git", { cwd: testDirectory });
+    await exec("git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main", {
+      cwd: testDirectory,
+    });
+    await exec("git update-ref refs/remotes/origin/main HEAD", { cwd: testDirectory });
+
+    await exec("git checkout -b feature-branch", { cwd: testDirectory });
+    await exec("git branch -D main", { cwd: testDirectory });
+
+    await fs.promises.writeFile(path.join(testDirectory, "feature.txt"), "feature content");
+    await exec("git add .", { cwd: testDirectory });
+    await exec('git commit -m "add feature"', { cwd: testDirectory });
+
+    const diffInfo = await getDiffInfo(testDirectory);
+
+    expect(diffInfo).not.toBeNull();
+    expect(diffInfo?.changedFiles).toContain("feature.txt");
+    expect(diffInfo?.isCurrentChanges).toBeFalsy();
+    expect(diffInfo?.currentBranch).toBe("feature-branch");
+    expect(diffInfo?.baseBranch).toBe("origin/main");
+  });
+
+  it("detects committed changes on main when ahead of origin/main", async () => {
+    await exec("git init", { cwd: testDirectory });
+    await exec('git config user.email "test@example.com"', { cwd: testDirectory });
+    await exec('git config user.name "Test User"', { cwd: testDirectory });
+
+    await fs.promises.writeFile(path.join(testDirectory, "initial.txt"), "initial content");
+    await exec("git add .", { cwd: testDirectory });
+    await exec('git commit -m "initial commit"', { cwd: testDirectory });
+    await exec("git branch -m main", { cwd: testDirectory });
+
+    await exec("git remote add origin https://github.com/test/repo.git", { cwd: testDirectory });
+    await exec("git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main", {
+      cwd: testDirectory,
+    });
+    await exec("git update-ref refs/remotes/origin/main HEAD", { cwd: testDirectory });
+
+    await fs.promises.writeFile(path.join(testDirectory, "local-commit.txt"), "local change");
+    await exec("git add .", { cwd: testDirectory });
+    await exec('git commit -m "local commit ahead of origin"', { cwd: testDirectory });
+
+    const diffInfo = await getDiffInfo(testDirectory);
+
+    expect(diffInfo).not.toBeNull();
+    expect(diffInfo?.changedFiles).toContain("local-commit.txt");
+    expect(diffInfo?.isCurrentChanges).toBeFalsy();
+    expect(diffInfo?.currentBranch).toBe("main");
+    expect(diffInfo?.baseBranch).toBe("origin/main");
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #1674 by improving the auto-detection of the base branch for `--scope changed` when no explicit `--base` flag is provided.

## Root Cause

When running `npx react-doctor --scope changed` without an explicit `--base` flag, the `defaultBranch()` function would return the local branch name (e.g., `"main"`). When comparing `currentBranch === baseBranch` by name, the code would fall into the "uncommitted changes only" path, missing any committed changes.

This affected two scenarios:
1. **Feature branches without a local main**: Users on a feature branch with no local `main` branch (only `origin/main`) would get `null` from `diffSelection` because `git merge-base main HEAD` failed
2. **Local main ahead of origin**: Users on local `main` with committed changes ahead of `origin/main` would only see uncommitted working-tree changes

## Fix

The `defaultBranch()` function now:
1. Checks if the remote tracking branch (`origin/<branch>`) exists
2. Returns `origin/<branch>` instead of `<branch>` when it does
3. Falls back to the old behavior when no remote exists

This ensures:
- `--scope changed` on a feature branch auto-compares against `origin/main` 
- `--scope changed` on local `main` ahead of `origin/main` auto-compares against the remote
- The name comparison `currentBranch === baseBranch` correctly fails, triggering the merge-base path

## Testing

Added two regression tests:
1. Feature branch with no local `main` - detects committed changes
2. Local `main` ahead of `origin/main` - detects committed changes

All core tests pass (2368/2368).

## Scope

This change only affects local development when using `--scope changed` WITHOUT `--base`. It does NOT affect:
- CI workflows (GitHub Action provides explicit base via `REACT_DOCTOR_BASE_SHA` or `--changed-files-from`)
- Explicit `--base` usage (already worked correctly)
- Parity testing (uses explicit refs)

Closes #1674
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c0e023b5-3e8a-4bf4-8598-c09e750535e3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c0e023b5-3e8a-4bf4-8598-c09e750535e3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

