### PR TITLE
fix(core): compare changed scope against remote default

### DIFF
--- a/.changeset/fix-scope-changed-remote-base.md
+++ b/.changeset/fix-scope-changed-remote-base.md
@@ -1,0 +1,5 @@
+---
+"@react-doctor/core": patch
+---
+
+Compare automatic changed scopes against the remote default branch, so committed branch changes are not mistaken for working-tree changes or skipped when no local default branch exists.

--- a/packages/core/src/services/git.ts
+++ b/packages/core/src/services/git.ts
@@ -473,7 +473,12 @@ export class Git extends Context.Service<
           const symref = yield* runGit(directory, ["symbolic-ref", "refs/remotes/origin/HEAD"]);
           if (symref.status === 0) {
             const trimmed = trimOrNull(symref.stdout);
-            if (trimmed !== null) return trimmed.replace("refs/remotes/origin/", "");
+            if (trimmed !== null) {
+              const branchName = trimmed.replace("refs/remotes/origin/", "");
+              const remoteBranch = `origin/${branchName}`;
+              const doesRemoteBranchExist = yield* branchExists(directory, remoteBranch);
+              return doesRemoteBranchExist ? remoteBranch : branchName;
+            }
           }
           const candidateRefs = DEFAULT_BRANCH_CANDIDATES.map(
             (candidate) => `refs/heads/${candidate}`,
@@ -484,7 +489,11 @@ export class Git extends Context.Service<
             ...candidateRefs,
           ]);
           if (candidates.status !== 0) return null;
-          return trimOrNull(candidates.stdout.split("\n")[0] ?? "");
+          const localBranch = trimOrNull(candidates.stdout.split("\n")[0] ?? "");
+          if (localBranch === null) return null;
+          const remoteBranch = `origin/${localBranch}`;
+          const doesRemoteBranchExist = yield* branchExists(directory, remoteBranch);
+          return doesRemoteBranchExist ? remoteBranch : localBranch;
         }).pipe(Effect.withSpan("Git.defaultBranch"));
 
       const branchExists = (

--- a/packages/react-doctor/tests/regressions/issue-1674-scope-changed-remote-base.test.ts
+++ b/packages/react-doctor/tests/regressions/issue-1674-scope-changed-remote-base.test.ts
@@ -1,0 +1,71 @@
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import os from "node:os";
+import * as path from "node:path";
+import { afterAll, describe, expect, it } from "vite-plus/test";
+
+import { getDiffInfo } from "@react-doctor/core";
+import { commitAll, initGitRepo, writeFile } from "./_helpers.js";
+
+const temporaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), "rd-issue-1674-"));
+
+afterAll(() => {
+  fs.rmSync(temporaryRoot, { recursive: true, force: true });
+});
+
+const buildRepositoryWithRemoteDefaultBranch = (caseId: string): string => {
+  const repositoryDirectory = path.join(temporaryRoot, caseId);
+  writeFile(path.join(repositoryDirectory, "src", "app.tsx"), "export const App = () => null;\n");
+  initGitRepo(repositoryDirectory);
+  commitAll(repositoryDirectory, "initial commit");
+  spawnSync("git", ["remote", "add", "origin", "https://github.com/test/repository.git"], {
+    cwd: repositoryDirectory,
+  });
+  spawnSync("git", ["update-ref", "refs/remotes/origin/main", "HEAD"], {
+    cwd: repositoryDirectory,
+  });
+  spawnSync("git", ["symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main"], {
+    cwd: repositoryDirectory,
+  });
+  return repositoryDirectory;
+};
+
+describe("issue #1674: changed scope uses the remote default branch", () => {
+  it("detects committed feature changes without a local default branch", async () => {
+    const repositoryDirectory = buildRepositoryWithRemoteDefaultBranch("feature-without-main");
+    spawnSync("git", ["checkout", "-q", "-b", "feature"], { cwd: repositoryDirectory });
+    spawnSync("git", ["branch", "-q", "-D", "main"], { cwd: repositoryDirectory });
+    writeFile(
+      path.join(repositoryDirectory, "src", "feature.tsx"),
+      "export const Feature = () => null;\n",
+    );
+    commitAll(repositoryDirectory, "add feature");
+
+    const diffInfo = await getDiffInfo(repositoryDirectory);
+
+    expect(diffInfo).toMatchObject({
+      baseBranch: "origin/main",
+      changedFiles: ["src/feature.tsx"],
+      currentBranch: "feature",
+    });
+    expect(diffInfo?.isCurrentChanges).toBeUndefined();
+  });
+
+  it("detects committed changes when local main is ahead of origin/main", async () => {
+    const repositoryDirectory = buildRepositoryWithRemoteDefaultBranch("main-ahead");
+    writeFile(
+      path.join(repositoryDirectory, "src", "local-change.tsx"),
+      "export const LocalChange = () => null;\n",
+    );
+    commitAll(repositoryDirectory, "add local change");
+
+    const diffInfo = await getDiffInfo(repositoryDirectory);
+
+    expect(diffInfo).toMatchObject({
+      baseBranch: "origin/main",
+      changedFiles: ["src/local-change.tsx"],
+      currentBranch: "main",
+    });
+    expect(diffInfo?.isCurrentChanges).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Why

`--scope changed` auto-detected the default branch as the local name, such as `main`. A feature checkout with only `origin/main` could not compute a merge base, while local commits ahead of `origin/main` were treated as working-tree-only changes.

After this change, automatic changed scopes compare with the reachable remote default branch. The existing `--base` option remains the explicit override, and repositories without a remote tracking ref keep the current local behavior.

This reuses the existing scope surface and its `scan.scope` / `baseline.degraded` telemetry. Watch the degraded-baseline rate for automatic changed scans over the next two releases; revert if it increases.

Closes #1674.

## What changed

- Prefer `origin/<default>` when the remote tracking ref exists.
- Fall back to the local default branch when it does not exist.
- Cover feature branches without local `main` and local `main` commits ahead of `origin/main`.
- Add a patch changeset.

Rule parity was not run because this change does not modify a rule or diagnostic.

## Test plan

- `nr test`
- `nr lint`
- `nr typecheck`
- `nr format:check`
- `nr smoke:json-report`
- `nr test tests/regressions/issue-1674-scope-changed-remote-base.test.ts tests/regressions/diff-detached-head.test.ts tests/regressions/untracked-working-tree-scope.test.ts` in `packages/react-doctor`
