### PR TITLE
fix(cli): explain incomplete npx installs

### DIFF
--- a/.changeset/fix-npm-cache-corruption-error.md
+++ b/.changeset/fix-npm-cache-corruption-error.md
@@ -2,4 +2,4 @@
 "react-doctor": patch
 ---
 
-Detect and provide helpful guidance for npm cache corruption errors (MODULE_NOT_FOUND for ajv/conf in npx cache), a known issue with npm 12 + Node 26 where packages are incompletely installed. The CLI now recognizes this failure pattern and suggests clearing the npx cache or using an alternative package manager (bunx/pnpm dlx) instead of treating it as an internal bug.
+Show an npm-native recovery command when an incomplete npx installation is missing Ajv meta-schema files.

--- a/.changeset/fix-npm-cache-corruption-error.md
+++ b/.changeset/fix-npm-cache-corruption-error.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Detect and provide helpful guidance for npm cache corruption errors (MODULE_NOT_FOUND for ajv/conf in npx cache), a known issue with npm 12 + Node 26 where packages are incompletely installed. The CLI now recognizes this failure pattern and suggests clearing the npx cache or using an alternative package manager (bunx/pnpm dlx) instead of treating it as an internal bug.

--- a/packages/react-doctor/src/cli/index.ts
+++ b/packages/react-doctor/src/cli/index.ts
@@ -590,7 +590,8 @@ Promise.resolve()
       process.exit(1);
     }
     if (isUserError) {
-      handleUserError(error);
+      handleUserError(error, { shouldExit: false });
+      await Promise.all([flushSentry(), shutdownTelemetry()]);
       return;
     }
     handleError(error, { sentryEventId });

--- a/packages/react-doctor/src/cli/utils/handle-error.ts
+++ b/packages/react-doctor/src/cli/utils/handle-error.ts
@@ -13,6 +13,10 @@ import type { HandleErrorOptions } from "@react-doctor/core";
 import { VERSION } from "./version.js";
 import { METRIC } from "./constants.js";
 import { formatEnvironmentError, isEnvironmentError } from "./is-environment-error.js";
+import {
+  formatNpmCacheCorruptionError,
+  isNpmCacheCorruptionError,
+} from "./is-npm-cache-corruption-error.js";
 import { recordCount } from "./record-metric.js";
 
 // `shouldExit` is optional here (defaults to exiting) and the CLI adds a Sentry
@@ -151,23 +155,24 @@ export const handleError = (error: unknown, options: CliHandleErrorOptions = {})
 
 /**
  * Renderer for expected, user-actionable failures — a bad `--diff` value,
- * a base branch that isn't fetched, or environment errors like disk-full or
- * permission-denied. Prints just the (already human-readable) message — no
- * "Something went wrong", prefilled issue, Discord link, or Sentry reference
- * — because there is no bug to report.
+ * a base branch that isn't fetched, environment errors like disk-full or
+ * permission-denied, or npm cache corruption. Prints just the (already
+ * human-readable) message — no "Something went wrong", prefilled issue,
+ * Discord link, or Sentry reference — because there is no bug to report.
  */
 export const handleUserError = (error: unknown, options: { shouldExit?: boolean } = {}): void => {
   const isEnvError = isEnvironmentError(error);
   if (isEnvError) {
-    // Environment errors are dropped from Sentry (the user's machine, not our
-    // bug), so a low-cardinality counter keyed by code keeps the failure rate
-    // visible. `recordCount` no-ops unless Sentry is initialized, and its
-    // `withRunAttributes` already tags the command — only the code is passed.
     recordCount(METRIC.cliEnvironmentError, 1, {
       code: (isErrnoException(error) ? error.code : undefined) ?? "unknown",
     });
   }
-  const message = isEnvError ? formatEnvironmentError(error) : formatErrorForReport(error);
+
+  const message = isNpmCacheCorruptionError(error)
+    ? formatNpmCacheCorruptionError(error)
+    : isEnvError
+      ? formatEnvironmentError(error)
+      : formatErrorForReport(error);
 
   Effect.runSync(
     Effect.gen(function* () {

--- a/packages/react-doctor/src/cli/utils/handle-error.ts
+++ b/packages/react-doctor/src/cli/utils/handle-error.ts
@@ -161,18 +161,17 @@ export const handleError = (error: unknown, options: CliHandleErrorOptions = {})
  * Discord link, or Sentry reference — because there is no bug to report.
  */
 export const handleUserError = (error: unknown, options: { shouldExit?: boolean } = {}): void => {
-  const isEnvError = isEnvironmentError(error);
-  if (isEnvError) {
+  let message = formatErrorForReport(error);
+
+  if (isNpmCacheCorruptionError(error)) {
+    recordCount(METRIC.cliEnvironmentError, 1, { code: "NPX_CACHE_CORRUPTION" });
+    message = formatNpmCacheCorruptionError(error);
+  } else if (isEnvironmentError(error)) {
     recordCount(METRIC.cliEnvironmentError, 1, {
       code: (isErrnoException(error) ? error.code : undefined) ?? "unknown",
     });
+    message = formatEnvironmentError(error);
   }
-
-  const message = isNpmCacheCorruptionError(error)
-    ? formatNpmCacheCorruptionError(error)
-    : isEnvError
-      ? formatEnvironmentError(error)
-      : formatErrorForReport(error);
 
   Effect.runSync(
     Effect.gen(function* () {

--- a/packages/react-doctor/src/cli/utils/is-expected-user-error.ts
+++ b/packages/react-doctor/src/cli/utils/is-expected-user-error.ts
@@ -30,10 +30,9 @@ import { isNpmCacheCorruptionError } from "./is-npm-cache-corruption-error.js";
  *   actionable message instead of crashing. See `is-environment-error.ts` for
  *   why the set stays narrow (codes that usually mean our bug keep reaching
  *   Sentry).
- * - **npm cache corruption** (`MODULE_NOT_FOUND` for ajv/conf in the npx
- *   cache) — incomplete package installations in the npx cache, a known issue
- *   with npm 12 + Node 26. The user can clear the cache to recover; not a
- *   react-doctor bug.
+ * - **npm cache corruption** (missing Ajv meta-schema files inside `_npx`) —
+ *   an incomplete npx package installation that the user can remove and
+ *   reinstall.
  *
  * This composes the existing core narrowers rather than introducing a new
  * error-shape helper (AGENTS.md): it encodes CLI-layer reporting policy, not

--- a/packages/react-doctor/src/cli/utils/is-expected-user-error.ts
+++ b/packages/react-doctor/src/cli/utils/is-expected-user-error.ts
@@ -1,6 +1,7 @@
 import { isProjectDiscoveryError, isReactDoctorError } from "@react-doctor/core";
 import { CliInputError } from "./cli-input-error.js";
 import { isEnvironmentError } from "./is-environment-error.js";
+import { isNpmCacheCorruptionError } from "./is-npm-cache-corruption-error.js";
 
 /**
  * Whether `error` is an expected, user-actionable failure — the user's project
@@ -9,7 +10,7 @@ import { isEnvironmentError } from "./is-environment-error.js";
  * `handleUserError` (a plain message — no "Something went wrong", prefilled
  * issue, Discord link, or Sentry reference), since there is no bug to report.
  *
- * Four distinct shapes reach the CLI's catch blocks:
+ * Five distinct shapes reach the CLI's catch blocks:
  *
  * - **Project-discovery failures** (`NoReactDependencyError`,
  *   `ProjectNotFoundError`, `PackageJsonNotFoundError`, `NotADirectoryError`,
@@ -29,6 +30,10 @@ import { isEnvironmentError } from "./is-environment-error.js";
  *   actionable message instead of crashing. See `is-environment-error.ts` for
  *   why the set stays narrow (codes that usually mean our bug keep reaching
  *   Sentry).
+ * - **npm cache corruption** (`MODULE_NOT_FOUND` for ajv/conf in the npx
+ *   cache) — incomplete package installations in the npx cache, a known issue
+ *   with npm 12 + Node 26. The user can clear the cache to recover; not a
+ *   react-doctor bug.
  *
  * This composes the existing core narrowers rather than introducing a new
  * error-shape helper (AGENTS.md): it encodes CLI-layer reporting policy, not
@@ -38,5 +43,6 @@ export const isExpectedUserError = (error: unknown): boolean =>
   error instanceof CliInputError ||
   isProjectDiscoveryError(error) ||
   isEnvironmentError(error) ||
+  isNpmCacheCorruptionError(error) ||
   (isReactDoctorError(error) &&
     (error.reason._tag === "GitBaseBranchInvalid" || error.reason._tag === "GitBaseBranchMissing"));

--- a/packages/react-doctor/src/cli/utils/is-npm-cache-corruption-error.ts
+++ b/packages/react-doctor/src/cli/utils/is-npm-cache-corruption-error.ts
@@ -1,0 +1,71 @@
+import { messageFromUnknown } from "@react-doctor/core";
+
+interface ModuleNotFoundError extends Error {
+  code: string;
+  requireStack?: string[];
+}
+
+const isModuleNotFoundError = (error: unknown): error is ModuleNotFoundError =>
+  error instanceof Error &&
+  "code" in error &&
+  error.code === "MODULE_NOT_FOUND";
+
+const findNpmCacheCorruptionError = (error: unknown): ModuleNotFoundError | null => {
+  const pendingErrors: unknown[] = [error];
+  const visitedErrors = new Set<object>();
+
+  while (pendingErrors.length > 0) {
+    const currentError = pendingErrors.pop();
+    if (typeof currentError !== "object" || currentError === null) continue;
+    if (visitedErrors.has(currentError)) continue;
+    visitedErrors.add(currentError);
+
+    if (isModuleNotFoundError(currentError)) {
+      const message = currentError.message;
+      const requireStack = currentError.requireStack ?? [];
+      const allPaths = [message, ...requireStack].join(" ");
+
+      const isNpxCache = allPaths.includes("_npx") || allPaths.includes("npx");
+      const normalizedPaths = allPaths.replaceAll("\\", "/");
+      const isConfOrAjv = normalizedPaths.includes("/ajv/") || normalizedPaths.includes("/conf/");
+
+      if (isNpxCache && isConfOrAjv) {
+        return currentError;
+      }
+    }
+
+    if (currentError instanceof Error && currentError.cause !== undefined) {
+      pendingErrors.push(currentError.cause);
+    }
+  }
+
+  return null;
+};
+
+export const isNpmCacheCorruptionError = (error: unknown): boolean =>
+  findNpmCacheCorruptionError(error) !== null;
+
+export const formatNpmCacheCorruptionError = (error: unknown): string => {
+  const moduleError = findNpmCacheCorruptionError(error);
+  if (!moduleError) return messageFromUnknown(error);
+
+  const platform = process.platform;
+  const clearCacheCommand =
+    platform === "win32"
+      ? 'rd /s /q "%LOCALAPPDATA%\\npm-cache\\_npx"'
+      : "rm -rf ~/.npm/_npx";
+
+  return [
+    "The npx cache has an incomplete installation. This is a known issue with npm 12 + Node 26.",
+    "",
+    "To fix, clear the npx cache and try again:",
+    `  ${clearCacheCommand}`,
+    "  npm cache clean --force",
+    "",
+    "Or use an alternative package manager:",
+    "  bunx react-doctor@latest",
+    "  pnpm dlx react-doctor@latest",
+    "",
+    `Original error: ${moduleError.message}`,
+  ].join("\n");
+};

--- a/packages/react-doctor/src/cli/utils/is-npm-cache-corruption-error.ts
+++ b/packages/react-doctor/src/cli/utils/is-npm-cache-corruption-error.ts
@@ -2,15 +2,25 @@ import { messageFromUnknown } from "@react-doctor/core";
 
 interface ModuleNotFoundError extends Error {
   code: string;
-  requireStack?: string[];
+  requireStack?: unknown;
 }
 
-const isModuleNotFoundError = (error: unknown): error is ModuleNotFoundError =>
-  error instanceof Error &&
-  "code" in error &&
-  error.code === "MODULE_NOT_FOUND";
+interface NpmCacheCorruptionMatch {
+  cacheKey: string;
+  moduleNotFoundError: ModuleNotFoundError;
+}
 
-const findNpmCacheCorruptionError = (error: unknown): ModuleNotFoundError | null => {
+const MISSING_AJV_META_SCHEMA_MESSAGES = new Set([
+  "Cannot find module './meta/unevaluated.json'",
+  "Cannot find module './meta/validation.json'",
+]);
+const NPX_AJV_META_SCHEMA_REQUIRE_PATH_PATTERN =
+  /(?:^|\/)_npx\/(?<cacheKey>[a-f0-9]{16})\/node_modules\/ajv\/dist\/refs\/json-schema-2020-12\/index\.js$/;
+
+const isModuleNotFoundError = (error: unknown): error is ModuleNotFoundError =>
+  error instanceof Error && "code" in error && error.code === "MODULE_NOT_FOUND";
+
+const findNpmCacheCorruptionError = (error: unknown): NpmCacheCorruptionMatch | null => {
   const pendingErrors: unknown[] = [error];
   const visitedErrors = new Set<object>();
 
@@ -21,16 +31,21 @@ const findNpmCacheCorruptionError = (error: unknown): ModuleNotFoundError | null
     visitedErrors.add(currentError);
 
     if (isModuleNotFoundError(currentError)) {
-      const message = currentError.message;
-      const requireStack = currentError.requireStack ?? [];
-      const allPaths = [message, ...requireStack].join(" ");
-
-      const isNpxCache = allPaths.includes("_npx") || allPaths.includes("npx");
-      const normalizedPaths = allPaths.replaceAll("\\", "/");
-      const isConfOrAjv = normalizedPaths.includes("/ajv/") || normalizedPaths.includes("/conf/");
-
-      if (isNpxCache && isConfOrAjv) {
-        return currentError;
+      const [message] = currentError.message.split("\n");
+      if (message && MISSING_AJV_META_SCHEMA_MESSAGES.has(message)) {
+        const requireStack = Array.isArray(currentError.requireStack)
+          ? currentError.requireStack
+          : [];
+        for (const requirePath of requireStack) {
+          if (typeof requirePath !== "string") continue;
+          const match = requirePath
+            .replaceAll("\\", "/")
+            .match(NPX_AJV_META_SCHEMA_REQUIRE_PATH_PATTERN);
+          const cacheKey = match?.groups?.cacheKey;
+          if (cacheKey !== undefined) {
+            return { cacheKey, moduleNotFoundError: currentError };
+          }
+        }
       }
     }
 
@@ -46,26 +61,16 @@ export const isNpmCacheCorruptionError = (error: unknown): boolean =>
   findNpmCacheCorruptionError(error) !== null;
 
 export const formatNpmCacheCorruptionError = (error: unknown): string => {
-  const moduleError = findNpmCacheCorruptionError(error);
-  if (!moduleError) return messageFromUnknown(error);
-
-  const platform = process.platform;
-  const clearCacheCommand =
-    platform === "win32"
-      ? 'rd /s /q "%LOCALAPPDATA%\\npm-cache\\_npx"'
-      : "rm -rf ~/.npm/_npx";
+  const corruptionMatch = findNpmCacheCorruptionError(error);
+  if (!corruptionMatch) return messageFromUnknown(error);
 
   return [
-    "The npx cache has an incomplete installation. This is a known issue with npm 12 + Node 26.",
+    "The npx cache has an incomplete Ajv installation.",
     "",
-    "To fix, clear the npx cache and try again:",
-    `  ${clearCacheCommand}`,
-    "  npm cache clean --force",
+    "Remove this cache entry, then run React Doctor again:",
+    `  npm cache npx rm ${corruptionMatch.cacheKey}`,
+    "  npx react-doctor@latest",
     "",
-    "Or use an alternative package manager:",
-    "  bunx react-doctor@latest",
-    "  pnpm dlx react-doctor@latest",
-    "",
-    `Original error: ${moduleError.message}`,
+    `Original error: ${corruptionMatch.moduleNotFoundError.message}`,
   ].join("\n");
 };

--- a/packages/react-doctor/tests/handle-error.test.ts
+++ b/packages/react-doctor/tests/handle-error.test.ts
@@ -1,6 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+vi.mock("../src/cli/utils/record-metric.js", () => ({
+  recordCount: vi.fn(),
+}));
+
 import { GitBaseBranchInvalid, ReactDoctorError } from "@react-doctor/core";
+import { METRIC } from "../src/cli/utils/constants.js";
 import { buildErrorIssueUrl, handleError, handleUserError } from "../src/cli/utils/handle-error.js";
+import { recordCount } from "../src/cli/utils/record-metric.js";
 
 const OTLP_ENDPOINT_ENVIRONMENT_VARIABLE = "REACT_DOCTOR_OTLP_ENDPOINT";
 const OTLP_AUTH_HEADER_ENVIRONMENT_VARIABLE = "REACT_DOCTOR_OTLP_AUTH_HEADER";
@@ -102,6 +109,7 @@ describe("handleUserError", () => {
   let savedExitCode: number | string | undefined;
 
   beforeEach(() => {
+    vi.clearAllMocks();
     savedExitCode = process.exitCode;
   });
 
@@ -133,5 +141,25 @@ describe("handleUserError", () => {
     expect(output).not.toContain("Discord");
     expect(output).not.toContain("Reference (mention this when reporting)");
     expect(process.exitCode).toBe(1);
+  });
+
+  it("records incomplete npx installs as environment errors", () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const cacheError = Object.assign(new Error("Cannot find module './meta/unevaluated.json'"), {
+      code: "MODULE_NOT_FOUND",
+      requireStack: [
+        "/home/user/.npm/_npx/81e833f6d16d6127/node_modules/ajv/dist/refs/json-schema-2020-12/index.js",
+      ],
+    });
+
+    try {
+      handleUserError(cacheError, { shouldExit: false });
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+
+    expect(recordCount).toHaveBeenCalledWith(METRIC.cliEnvironmentError, 1, {
+      code: "NPX_CACHE_CORRUPTION",
+    });
   });
 });

--- a/packages/react-doctor/tests/is-expected-user-error.test.ts
+++ b/packages/react-doctor/tests/is-expected-user-error.test.ts
@@ -108,6 +108,17 @@ describe("isExpectedUserError", () => {
     ).toBe(true);
   });
 
+  it("classifies incomplete npx installs as expected user errors", () => {
+    const cacheError = Object.assign(new Error("Cannot find module './meta/unevaluated.json'"), {
+      code: "MODULE_NOT_FOUND",
+      requireStack: [
+        "/home/user/.npm/_npx/81e833f6d16d6127/node_modules/ajv/dist/refs/json-schema-2020-12/index.js",
+      ],
+    });
+
+    expect(isExpectedUserError(cacheError)).toBe(true);
+  });
+
   it("does not mask genuine bugs (those stay reportable)", () => {
     expect(isExpectedUserError(new Error("boom"))).toBe(false);
     expect(isExpectedUserError(undefined)).toBe(false);

--- a/packages/react-doctor/tests/is-npm-cache-corruption-error.test.ts
+++ b/packages/react-doctor/tests/is-npm-cache-corruption-error.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  formatNpmCacheCorruptionError,
+  isNpmCacheCorruptionError,
+} from "../src/cli/utils/is-npm-cache-corruption-error.js";
+
+interface ModuleNotFoundError extends Error {
+  code: string;
+  requireStack?: string[];
+}
+
+const moduleNotFoundError = (
+  message: string,
+  requireStack: string[] = [],
+): ModuleNotFoundError =>
+  Object.assign(new Error(message), {
+    code: "MODULE_NOT_FOUND",
+    requireStack,
+  });
+
+describe("isNpmCacheCorruptionError", () => {
+  it("recognizes ajv missing module errors in npx cache", () => {
+    const error = moduleNotFoundError(
+      "Cannot find module './meta/unevaluated.json'",
+      [
+        "/home/user/.npm/_npx/81e833f6d16d6127/node_modules/ajv/dist/refs/json-schema-2020-12/index.js",
+        "/home/user/.npm/_npx/81e833f6d16d6127/node_modules/ajv/dist/2020.js",
+      ],
+    );
+    expect(isNpmCacheCorruptionError(error)).toBe(true);
+  });
+
+  it("recognizes conf-related module errors in npx cache", () => {
+    const error = moduleNotFoundError(
+      "Cannot find module 'ajv-formats'",
+      [
+        "/home/user/.npm/_npx/abc123/node_modules/conf/dist/index.js",
+      ],
+    );
+    expect(isNpmCacheCorruptionError(error)).toBe(true);
+  });
+
+  it("recognizes npx cache errors on Windows", () => {
+    const error = moduleNotFoundError(
+      "Cannot find module './meta/validation.json'",
+      [
+        "C:\\Users\\user\\AppData\\Local\\npm-cache\\_npx\\abc123\\node_modules\\ajv\\dist\\2020.js",
+      ],
+    );
+    expect(isNpmCacheCorruptionError(error)).toBe(true);
+  });
+
+  it("recognizes errors with _npx path in the message", () => {
+    const error = moduleNotFoundError(
+      "Cannot find module '/home/user/.npm/_npx/abc/node_modules/ajv/dist/meta/unevaluated.json'",
+    );
+    expect(isNpmCacheCorruptionError(error)).toBe(true);
+  });
+
+  it("does NOT recognize regular MODULE_NOT_FOUND errors", () => {
+    const error = moduleNotFoundError(
+      "Cannot find module './missing-file.js'",
+      ["/home/user/project/src/index.js"],
+    );
+    expect(isNpmCacheCorruptionError(error)).toBe(false);
+  });
+
+  it("does NOT recognize non-npx cache ajv errors", () => {
+    const error = moduleNotFoundError(
+      "Cannot find module 'ajv'",
+      ["/home/user/project/node_modules/some-package/index.js"],
+    );
+    expect(isNpmCacheCorruptionError(error)).toBe(false);
+  });
+
+  it("does NOT recognize npx cache errors for unrelated packages", () => {
+    const error = moduleNotFoundError(
+      "Cannot find module 'some-other-package'",
+      ["/home/user/.npm/_npx/abc123/node_modules/some-other-package/index.js"],
+    );
+    expect(isNpmCacheCorruptionError(error)).toBe(false);
+  });
+
+  it("returns false for non-Error and non-MODULE_NOT_FOUND values", () => {
+    expect(isNpmCacheCorruptionError(new Error("Something went wrong"))).toBe(false);
+    expect(isNpmCacheCorruptionError("string error")).toBe(false);
+    expect(isNpmCacheCorruptionError(null)).toBe(false);
+    expect(isNpmCacheCorruptionError(undefined)).toBe(false);
+  });
+
+  it("handles errors wrapped in cause chains", () => {
+    const innerError = moduleNotFoundError(
+      "Cannot find module './meta/unevaluated.json'",
+      ["/home/user/.npm/_npx/abc/node_modules/ajv/dist/2020.js"],
+    );
+    const outerError = new Error("Failed to initialize", { cause: innerError });
+    expect(isNpmCacheCorruptionError(outerError)).toBe(true);
+  });
+});
+
+describe("formatNpmCacheCorruptionError", () => {
+  it("formats npm cache corruption errors with clear instructions", () => {
+    const error = moduleNotFoundError(
+      "Cannot find module './meta/unevaluated.json'",
+      ["/home/user/.npm/_npx/abc/node_modules/ajv/dist/2020.js"],
+    );
+
+    const formatted = formatNpmCacheCorruptionError(error);
+
+    expect(formatted).toContain("npx cache has an incomplete installation");
+    expect(formatted).toContain("npm 12 + Node 26");
+    expect(formatted).toContain("npm cache clean --force");
+    expect(formatted).toContain("bunx react-doctor@latest");
+    expect(formatted).toContain("pnpm dlx react-doctor@latest");
+    expect(formatted).toContain("Cannot find module './meta/unevaluated.json'");
+  });
+
+  it("includes platform-specific cache clear command", () => {
+    const error = moduleNotFoundError(
+      "Cannot find module './meta/unevaluated.json'",
+      ["/home/user/.npm/_npx/abc/node_modules/ajv/dist/2020.js"],
+    );
+
+    const formatted = formatNpmCacheCorruptionError(error);
+
+    if (process.platform === "win32") {
+      expect(formatted).toContain('rd /s /q "%LOCALAPPDATA%\\npm-cache\\_npx"');
+    } else {
+      expect(formatted).toContain("rm -rf ~/.npm/_npx");
+    }
+  });
+
+  it("falls back to the raw message for non-npm-cache errors", () => {
+    const error = new Error("Some other error");
+    expect(formatNpmCacheCorruptionError(error)).toBe("Some other error");
+  });
+});

--- a/packages/react-doctor/tests/is-npm-cache-corruption-error.test.ts
+++ b/packages/react-doctor/tests/is-npm-cache-corruption-error.test.ts
@@ -9,10 +9,7 @@ interface ModuleNotFoundError extends Error {
   requireStack?: string[];
 }
 
-const moduleNotFoundError = (
-  message: string,
-  requireStack: string[] = [],
-): ModuleNotFoundError =>
+const moduleNotFoundError = (message: string, requireStack: string[] = []): ModuleNotFoundError =>
   Object.assign(new Error(message), {
     code: "MODULE_NOT_FOUND",
     requireStack,
@@ -20,64 +17,59 @@ const moduleNotFoundError = (
 
 describe("isNpmCacheCorruptionError", () => {
   it("recognizes ajv missing module errors in npx cache", () => {
-    const error = moduleNotFoundError(
-      "Cannot find module './meta/unevaluated.json'",
-      [
-        "/home/user/.npm/_npx/81e833f6d16d6127/node_modules/ajv/dist/refs/json-schema-2020-12/index.js",
-        "/home/user/.npm/_npx/81e833f6d16d6127/node_modules/ajv/dist/2020.js",
-      ],
-    );
+    const error = moduleNotFoundError("Cannot find module './meta/unevaluated.json'", [
+      "/home/user/.npm/_npx/81e833f6d16d6127/node_modules/ajv/dist/refs/json-schema-2020-12/index.js",
+      "/home/user/.npm/_npx/81e833f6d16d6127/node_modules/ajv/dist/2020.js",
+    ]);
     expect(isNpmCacheCorruptionError(error)).toBe(true);
   });
 
-  it("recognizes conf-related module errors in npx cache", () => {
-    const error = moduleNotFoundError(
-      "Cannot find module 'ajv-formats'",
-      [
-        "/home/user/.npm/_npx/abc123/node_modules/conf/dist/index.js",
-      ],
-    );
-    expect(isNpmCacheCorruptionError(error)).toBe(true);
+  it("does not classify missing conf dependencies as cache corruption", () => {
+    const error = moduleNotFoundError("Cannot find module 'ajv-formats'", [
+      "/home/user/.npm/_npx/81e833f6d16d6127/node_modules/conf/dist/index.js",
+    ]);
+    expect(isNpmCacheCorruptionError(error)).toBe(false);
   });
 
   it("recognizes npx cache errors on Windows", () => {
-    const error = moduleNotFoundError(
-      "Cannot find module './meta/validation.json'",
-      [
-        "C:\\Users\\user\\AppData\\Local\\npm-cache\\_npx\\abc123\\node_modules\\ajv\\dist\\2020.js",
-      ],
-    );
+    const error = moduleNotFoundError("Cannot find module './meta/validation.json'", [
+      "C:\\Users\\user\\AppData\\Local\\npm-cache\\_npx\\81e833f6d16d6127\\node_modules\\ajv\\dist\\refs\\json-schema-2020-12\\index.js",
+    ]);
     expect(isNpmCacheCorruptionError(error)).toBe(true);
   });
 
-  it("recognizes errors with _npx path in the message", () => {
+  it("does not trust an npx path in the message alone", () => {
     const error = moduleNotFoundError(
-      "Cannot find module '/home/user/.npm/_npx/abc/node_modules/ajv/dist/meta/unevaluated.json'",
+      "Cannot find module './meta/unevaluated.json'\nRequire stack:\n- /home/user/.npm/_npx/81e833f6d16d6127/node_modules/ajv/dist/refs/json-schema-2020-12/index.js",
     );
-    expect(isNpmCacheCorruptionError(error)).toBe(true);
+    expect(isNpmCacheCorruptionError(error)).toBe(false);
   });
 
   it("does NOT recognize regular MODULE_NOT_FOUND errors", () => {
-    const error = moduleNotFoundError(
-      "Cannot find module './missing-file.js'",
-      ["/home/user/project/src/index.js"],
-    );
+    const error = moduleNotFoundError("Cannot find module './missing-file.js'", [
+      "/home/user/project/src/index.js",
+    ]);
     expect(isNpmCacheCorruptionError(error)).toBe(false);
   });
 
   it("does NOT recognize non-npx cache ajv errors", () => {
-    const error = moduleNotFoundError(
-      "Cannot find module 'ajv'",
-      ["/home/user/project/node_modules/some-package/index.js"],
-    );
+    const error = moduleNotFoundError("Cannot find module './meta/unevaluated.json'", [
+      "/home/user/project/node_modules/ajv/dist/refs/json-schema-2020-12/index.js",
+    ]);
+    expect(isNpmCacheCorruptionError(error)).toBe(false);
+  });
+
+  it("does not classify other Ajv entry points as the reported corruption", () => {
+    const error = moduleNotFoundError("Cannot find module './meta/unevaluated.json'", [
+      "/home/user/.npm/_npx/81e833f6d16d6127/node_modules/ajv/dist/2020.js",
+    ]);
     expect(isNpmCacheCorruptionError(error)).toBe(false);
   });
 
   it("does NOT recognize npx cache errors for unrelated packages", () => {
-    const error = moduleNotFoundError(
-      "Cannot find module 'some-other-package'",
-      ["/home/user/.npm/_npx/abc123/node_modules/some-other-package/index.js"],
-    );
+    const error = moduleNotFoundError("Cannot find module 'some-other-package'", [
+      "/home/user/.npm/_npx/81e833f6d16d6127/node_modules/some-other-package/index.js",
+    ]);
     expect(isNpmCacheCorruptionError(error)).toBe(false);
   });
 
@@ -89,10 +81,9 @@ describe("isNpmCacheCorruptionError", () => {
   });
 
   it("handles errors wrapped in cause chains", () => {
-    const innerError = moduleNotFoundError(
-      "Cannot find module './meta/unevaluated.json'",
-      ["/home/user/.npm/_npx/abc/node_modules/ajv/dist/2020.js"],
-    );
+    const innerError = moduleNotFoundError("Cannot find module './meta/unevaluated.json'", [
+      "/home/user/.npm/_npx/81e833f6d16d6127/node_modules/ajv/dist/refs/json-schema-2020-12/index.js",
+    ]);
     const outerError = new Error("Failed to initialize", { cause: innerError });
     expect(isNpmCacheCorruptionError(outerError)).toBe(true);
   });
@@ -100,34 +91,28 @@ describe("isNpmCacheCorruptionError", () => {
 
 describe("formatNpmCacheCorruptionError", () => {
   it("formats npm cache corruption errors with clear instructions", () => {
-    const error = moduleNotFoundError(
-      "Cannot find module './meta/unevaluated.json'",
-      ["/home/user/.npm/_npx/abc/node_modules/ajv/dist/2020.js"],
-    );
+    const error = moduleNotFoundError("Cannot find module './meta/unevaluated.json'", [
+      "/home/user/.npm/_npx/81e833f6d16d6127/node_modules/ajv/dist/refs/json-schema-2020-12/index.js",
+    ]);
 
     const formatted = formatNpmCacheCorruptionError(error);
 
-    expect(formatted).toContain("npx cache has an incomplete installation");
-    expect(formatted).toContain("npm 12 + Node 26");
-    expect(formatted).toContain("npm cache clean --force");
-    expect(formatted).toContain("bunx react-doctor@latest");
-    expect(formatted).toContain("pnpm dlx react-doctor@latest");
+    expect(formatted).toContain("npx cache has an incomplete Ajv installation");
+    expect(formatted).toContain("npm cache npx rm 81e833f6d16d6127");
+    expect(formatted).toContain("npx react-doctor@latest");
+    expect(formatted).not.toContain("npm cache clean --force");
+    expect(formatted).not.toContain("npm 12 + Node 26");
     expect(formatted).toContain("Cannot find module './meta/unevaluated.json'");
   });
 
-  it("includes platform-specific cache clear command", () => {
-    const error = moduleNotFoundError(
-      "Cannot find module './meta/unevaluated.json'",
-      ["/home/user/.npm/_npx/abc/node_modules/ajv/dist/2020.js"],
-    );
+  it("uses the same npm command on every platform", () => {
+    const error = moduleNotFoundError("Cannot find module './meta/validation.json'", [
+      "C:\\Users\\user\\AppData\\Local\\npm-cache\\_npx\\81e833f6d16d6127\\node_modules\\ajv\\dist\\refs\\json-schema-2020-12\\index.js",
+    ]);
 
     const formatted = formatNpmCacheCorruptionError(error);
 
-    if (process.platform === "win32") {
-      expect(formatted).toContain('rd /s /q "%LOCALAPPDATA%\\npm-cache\\_npx"');
-    } else {
-      expect(formatted).toContain("rm -rf ~/.npm/_npx");
-    }
+    expect(formatted).toContain("npm cache npx rm 81e833f6d16d6127");
   });
 
   it("falls back to the raw message for non-npm-cache errors", () => {


### PR DESCRIPTION
## Why

An interrupted or incomplete `_npx` install can omit Ajv meta-schema files and stop React Doctor before a scan starts.

Before, the CLI treated this package-manager state as a React Doctor crash and asked the user to open an issue. After, the CLI recognizes only the exact missing Ajv files from an `_npx` cache entry and gives one cross-platform npm recovery command.

A fresh isolated install with Node 26.7.0 and npm 12.0.2 succeeded. Removing the Ajv files reproduced the reported scan failure, and `npm cache npx rm <key>` restored the scan. This does not support a general Node 26 or npm 12 defect claim.

### Product brief

- Job: A developer who runs React Doctor with `npx` needs to recover from an incomplete cached install without diagnosing React Doctor internals.
- Change: Classify the exact Ajv meta-schema failure and print the affected npm cache key.
- Reuse: Extend `isExpectedUserError`, `handleUserError`, and the existing `cli.env_error` metric instead of adding a flag or a second error renderer.
- Metric: `cli.env_error` with `code=NPX_CACHE_CORRUPTION`; success means confirmed events recover without new duplicate issues.
- Compat: Default command behavior and exit status stay unchanged. This includes a patch changeset. No JSON schema or GitHub Action change is required.
- Kill: Remove the special case if the metric records zero events across two releases.

## What changed

- Match only `MODULE_NOT_FOUND` for Ajv's missing `unevaluated.json` or `validation.json` from a 16-character `_npx` cache entry.
- Keep other missing dependencies and Ajv packaging errors reportable.
- Print `npm cache npx rm <key>` and the retry command without deleting the complete npm cache.
- Record the recovery path as an environment error and flush telemetry before the top-level user-error exit.
- Cover Linux paths, Windows paths, wrapped errors, false-positive boundaries, output, metric emission, and Sentry classification.

Rule parity was not run because this changes CLI error handling and no diagnostic detector.

## Test plan

- `nr build`
- `nr test` — 12 tasks passed; React Doctor: 2,509 passed, 24 skipped
- `nr lint`
- `nr typecheck` — 10 tasks passed
- `nr format:check`
- `nr smoke:json-report` — schema version 3, zero diagnostics
- `nr test tests/is-npm-cache-corruption-error.test.ts tests/handle-error.test.ts tests/is-expected-user-error.test.ts` — 26 passed
- `npx react-doctor@latest --verbose --scope changed --no-color` — 100/100, no issues

Closes #1692
