### PR TITLE
fix(core): preserve settings from adopted lint configs

### DIFF
--- a/.changeset/adopt-tailwind-settings.md
+++ b/.changeset/adopt-tailwind-settings.md
@@ -3,4 +3,4 @@
 "react-doctor": patch
 ---
 
-Adopt settings from existing `.oxlintrc.json` and `.eslintrc.json` configs. React Doctor now reads and merges plugin settings like `tailwindcss.entryPoint` from adopted lint configs alongside its own `react-doctor` settings, preserving third-party plugin configurations when `adoptExistingLintConfig: true`.
+Preserve plugin settings when React Doctor adopts an existing lint config.

--- a/.changeset/adopt-tailwind-settings.md
+++ b/.changeset/adopt-tailwind-settings.md
@@ -1,0 +1,6 @@
+---
+"@react-doctor/core": patch
+"react-doctor": patch
+---
+
+Adopt settings from existing `.oxlintrc.json` and `.eslintrc.json` configs. React Doctor now reads and merges plugin settings like `tailwindcss.entryPoint` from adopted lint configs alongside its own `react-doctor` settings, preserving third-party plugin configurations when `adoptExistingLintConfig: true`.

--- a/packages/core/src/can-oxlint-extend-config.ts
+++ b/packages/core/src/can-oxlint-extend-config.ts
@@ -1,4 +1,5 @@
 import * as fs from "node:fs";
+import { parseJSONC } from "confbox";
 import { isPlainObject } from "./project-info/index.js";
 
 const EXTENDS_LOCAL_PATH_PREFIXES = ["./", "../", "/"];
@@ -8,61 +9,6 @@ const isLocalPathExtend = (entry: string): boolean => {
     if (entry.startsWith(prefix)) return true;
   }
   return false;
-};
-
-// HACK: ESLint's JSON config files in the wild are routinely JSONC —
-// `//` line comments and `/* */` block comments. Strict `JSON.parse`
-// throws on them. Strip both forms (avoiding matches inside string
-// literals) so the extends pre-screen still works on real Next.js /
-// CRA / TypeScript scaffolds.
-const stripJsoncComments = (raw: string): string => {
-  let result = "";
-  let cursor = 0;
-  let inString = false;
-  let stringQuote = "";
-  while (cursor < raw.length) {
-    const character = raw[cursor];
-    const nextCharacter = raw[cursor + 1];
-    if (inString) {
-      result += character;
-      if (character === "\\" && cursor + 1 < raw.length) {
-        result += nextCharacter;
-        cursor += 2;
-        continue;
-      }
-      if (character === stringQuote) inString = false;
-      cursor += 1;
-      continue;
-    }
-    if (character === '"' || character === "'") {
-      inString = true;
-      stringQuote = character;
-      result += character;
-      cursor += 1;
-      continue;
-    }
-    if (character === "/" && nextCharacter === "/") {
-      const lineEndIndex = raw.indexOf("\n", cursor);
-      cursor = lineEndIndex === -1 ? raw.length : lineEndIndex;
-      continue;
-    }
-    if (character === "/" && nextCharacter === "*") {
-      const blockEndIndex = raw.indexOf("*/", cursor + 2);
-      cursor = blockEndIndex === -1 ? raw.length : blockEndIndex + 2;
-      continue;
-    }
-    result += character;
-    cursor += 1;
-  }
-  return result;
-};
-
-const parseJsonOrJsonc = (raw: string): unknown => {
-  try {
-    return JSON.parse(raw);
-  } catch {
-    return JSON.parse(stripJsoncComments(raw));
-  }
 };
 
 // HACK: oxlint's `extends` resolver only handles local file paths and
@@ -83,7 +29,7 @@ export const canOxlintExtendConfig = (configPath: string): boolean => {
   let parsed: unknown;
   try {
     const raw = fs.readFileSync(configPath, "utf-8");
-    parsed = parseJsonOrJsonc(raw);
+    parsed = parseJSONC<unknown>(raw, { allowTrailingComma: true });
   } catch {
     return true;
   }

--- a/packages/core/src/read-adopted-lint-config-settings.ts
+++ b/packages/core/src/read-adopted-lint-config-settings.ts
@@ -1,0 +1,84 @@
+import * as fs from "node:fs";
+import { isPlainObject } from "./project-info/index.js";
+
+const stripJsoncComments = (raw: string): string => {
+  let result = "";
+  let cursor = 0;
+  let inString = false;
+  let stringQuote = "";
+  while (cursor < raw.length) {
+    const character = raw[cursor];
+    const nextCharacter = raw[cursor + 1];
+    if (inString) {
+      result += character;
+      if (character === "\\" && cursor + 1 < raw.length) {
+        result += nextCharacter;
+        cursor += 2;
+        continue;
+      }
+      if (character === stringQuote) inString = false;
+      cursor += 1;
+      continue;
+    }
+    if (character === '"' || character === "'") {
+      inString = true;
+      stringQuote = character;
+      result += character;
+      cursor += 1;
+      continue;
+    }
+    if (character === "/" && nextCharacter === "/") {
+      const lineEndIndex = raw.indexOf("\n", cursor);
+      cursor = lineEndIndex === -1 ? raw.length : lineEndIndex;
+      continue;
+    }
+    if (character === "/" && nextCharacter === "*") {
+      const blockEndIndex = raw.indexOf("*/", cursor + 2);
+      cursor = blockEndIndex === -1 ? raw.length : blockEndIndex + 2;
+      continue;
+    }
+    result += character;
+    cursor += 1;
+  }
+  return result;
+};
+
+const parseJsonOrJsonc = (raw: string): unknown => {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return JSON.parse(stripJsoncComments(raw));
+  }
+};
+
+export interface AdoptedLintConfigSettings {
+  readonly [pluginName: string]: unknown;
+}
+
+export const readAdoptedLintConfigSettings = (
+  configPaths: ReadonlyArray<string>,
+): AdoptedLintConfigSettings => {
+  const mergedSettings: Record<string, unknown> = {};
+
+  for (const configPath of configPaths) {
+    let parsed: unknown;
+    try {
+      const raw = fs.readFileSync(configPath, "utf-8");
+      parsed = parseJsonOrJsonc(raw);
+    } catch {
+      continue;
+    }
+
+    if (!isPlainObject(parsed)) continue;
+
+    const settings = parsed.settings;
+    if (!isPlainObject(settings)) continue;
+
+    for (const [pluginName, pluginSettings] of Object.entries(settings)) {
+      if (pluginName === "react-doctor") continue;
+      mergedSettings[pluginName] = pluginSettings;
+    }
+  }
+
+  return mergedSettings;
+};

--- a/packages/core/src/read-adopted-lint-config-settings.ts
+++ b/packages/core/src/read-adopted-lint-config-settings.ts
@@ -1,55 +1,6 @@
 import * as fs from "node:fs";
+import { parseJSONC } from "confbox";
 import { isPlainObject } from "./project-info/index.js";
-
-const stripJsoncComments = (raw: string): string => {
-  let result = "";
-  let cursor = 0;
-  let inString = false;
-  let stringQuote = "";
-  while (cursor < raw.length) {
-    const character = raw[cursor];
-    const nextCharacter = raw[cursor + 1];
-    if (inString) {
-      result += character;
-      if (character === "\\" && cursor + 1 < raw.length) {
-        result += nextCharacter;
-        cursor += 2;
-        continue;
-      }
-      if (character === stringQuote) inString = false;
-      cursor += 1;
-      continue;
-    }
-    if (character === '"' || character === "'") {
-      inString = true;
-      stringQuote = character;
-      result += character;
-      cursor += 1;
-      continue;
-    }
-    if (character === "/" && nextCharacter === "/") {
-      const lineEndIndex = raw.indexOf("\n", cursor);
-      cursor = lineEndIndex === -1 ? raw.length : lineEndIndex;
-      continue;
-    }
-    if (character === "/" && nextCharacter === "*") {
-      const blockEndIndex = raw.indexOf("*/", cursor + 2);
-      cursor = blockEndIndex === -1 ? raw.length : blockEndIndex + 2;
-      continue;
-    }
-    result += character;
-    cursor += 1;
-  }
-  return result;
-};
-
-const parseJsonOrJsonc = (raw: string): unknown => {
-  try {
-    return JSON.parse(raw);
-  } catch {
-    return JSON.parse(stripJsoncComments(raw));
-  }
-};
 
 export interface AdoptedLintConfigSettings {
   readonly [pluginName: string]: unknown;
@@ -58,13 +9,13 @@ export interface AdoptedLintConfigSettings {
 export const readAdoptedLintConfigSettings = (
   configPaths: ReadonlyArray<string>,
 ): AdoptedLintConfigSettings => {
-  const mergedSettings: Record<string, unknown> = {};
+  const mergedSettings = new Map<string, unknown>();
 
   for (const configPath of configPaths) {
     let parsed: unknown;
     try {
       const raw = fs.readFileSync(configPath, "utf-8");
-      parsed = parseJsonOrJsonc(raw);
+      parsed = parseJSONC<unknown>(raw, { allowTrailingComma: true });
     } catch {
       continue;
     }
@@ -76,9 +27,9 @@ export const readAdoptedLintConfigSettings = (
 
     for (const [pluginName, pluginSettings] of Object.entries(settings)) {
       if (pluginName === "react-doctor") continue;
-      mergedSettings[pluginName] = pluginSettings;
+      mergedSettings.set(pluginName, pluginSettings);
     }
   }
 
-  return mergedSettings;
+  return Object.fromEntries(mergedSettings);
 };

--- a/packages/core/src/run-oxlint.ts
+++ b/packages/core/src/run-oxlint.ts
@@ -14,6 +14,7 @@ import { buildRuleSeverityControls } from "./build-rule-severity-controls.js";
 import { canOxlintExtendConfig } from "./can-oxlint-extend-config.js";
 import { collectIgnorePatterns } from "./collect-ignore-patterns.js";
 import { detectUserLintConfigPaths } from "./detect-user-lint-config.js";
+import { readAdoptedLintConfigSettings } from "./read-adopted-lint-config-settings.js";
 import { ReactDoctorError } from "./errors.js";
 import { neutralizeDisableDirectives } from "./neutralize-disable-directives.js";
 import { computeRulesetHash } from "./runners/oxlint/compute-ruleset-hash.js";
@@ -328,6 +329,8 @@ export const runOxlint = async (options: RunOxlintOptions): Promise<Diagnostic[]
   // the parser crash + misleading warning. Drop them up front so the
   // scan starts in the same state the fallback would land in.
   const extendsPaths = detectedConfigPaths.filter(canOxlintExtendConfig);
+  const adoptedSettings =
+    extendsPaths.length > 0 ? readAdoptedLintConfigSettings(extendsPaths) : {};
   const userPlugins =
     includedTags.size > 0 ? [] : resolveUserPlugins(userConfig?.plugins, configSourceDirectory);
 
@@ -452,6 +455,7 @@ export const runOxlint = async (options: RunOxlintOptions): Promise<Diagnostic[]
         serverAuthFunctionNames,
         projectIndexModuleSources,
         severityControls,
+        adoptedSettings,
         userPlugins,
         disableReactHooksJsPlugin: overrides.disableReactHooksJsPlugin,
         ruleSelection: overrides.ruleSelection,

--- a/packages/core/src/run-oxlint.ts
+++ b/packages/core/src/run-oxlint.ts
@@ -330,7 +330,7 @@ export const runOxlint = async (options: RunOxlintOptions): Promise<Diagnostic[]
   // scan starts in the same state the fallback would land in.
   const extendsPaths = detectedConfigPaths.filter(canOxlintExtendConfig);
   const adoptedSettings =
-    extendsPaths.length > 0 ? readAdoptedLintConfigSettings(extendsPaths) : {};
+    detectedConfigPaths.length > 0 ? readAdoptedLintConfigSettings(detectedConfigPaths) : {};
   const userPlugins =
     includedTags.size > 0 ? [] : resolveUserPlugins(userConfig?.plugins, configSourceDirectory);
 

--- a/packages/core/src/runners/oxlint/config.ts
+++ b/packages/core/src/runners/oxlint/config.ts
@@ -7,6 +7,7 @@ import {
 } from "oxlint-plugin-react-doctor/core";
 import type { OxlintRuleSeverity } from "oxlint-plugin-react-doctor/core";
 import type { ProjectInfo, RuleSeverityControls } from "../../types/index.js";
+import type { AdoptedLintConfigSettings } from "../../read-adopted-lint-config-settings.js";
 import { resolveRuleSeverityOverride } from "../../resolve-rule-severity-override.js";
 import { COMPILER_CLEANUP_BUCKET, COMPILER_CLEANUP_RULE_KEYS } from "../../constants.js";
 import { getCapabilities, shouldEnableRule } from "../../project-info/capabilities.js";
@@ -28,13 +29,7 @@ export interface OxlintConfigOptions {
   serverAuthFunctionNames?: ReadonlyArray<string>;
   projectIndexModuleSources?: ReadonlyArray<string>;
   severityControls?: RuleSeverityControls;
-  /**
-   * Settings from adopted lint configs (`.oxlintrc.json`, `.eslintrc.json`),
-   * already read + extracted via `readAdoptedLintConfigSettings`. These
-   * settings are merged with react-doctor's own settings to preserve
-   * plugin configurations like `tailwindcss.entryPoint`.
-   */
-  adoptedSettings?: Record<string, unknown>;
+  adoptedSettings?: AdoptedLintConfigSettings;
   /**
    * User-declared plugins from `react-doctor.config.json`'s
    * `plugins: [...]`, already resolved + introspected via

--- a/packages/core/src/runners/oxlint/config.ts
+++ b/packages/core/src/runners/oxlint/config.ts
@@ -29,6 +29,13 @@ export interface OxlintConfigOptions {
   projectIndexModuleSources?: ReadonlyArray<string>;
   severityControls?: RuleSeverityControls;
   /**
+   * Settings from adopted lint configs (`.oxlintrc.json`, `.eslintrc.json`),
+   * already read + extracted via `readAdoptedLintConfigSettings`. These
+   * settings are merged with react-doctor's own settings to preserve
+   * plugin configurations like `tailwindcss.entryPoint`.
+   */
+  adoptedSettings?: Record<string, unknown>;
+  /**
    * User-declared plugins from `react-doctor.config.json`'s
    * `plugins: [...]`, already resolved + introspected via
    * `resolveUserPlugins`. Each plugin's rules are opt-in: they don't
@@ -134,6 +141,7 @@ export const createOxlintConfig = ({
   serverAuthFunctionNames,
   projectIndexModuleSources,
   severityControls,
+  adoptedSettings = {},
   userPlugins = [],
   disableReactHooksJsPlugin = false,
   ruleSelection,
@@ -281,6 +289,7 @@ export const createOxlintConfig = ({
     plugins: [],
     jsPlugins: [...jsPlugins, pluginPath],
     settings: {
+      ...adoptedSettings,
       "react-doctor": {
         portedRuleMode: "curated",
         framework: project.framework,

--- a/packages/core/tests/can-oxlint-extend-config.test.ts
+++ b/packages/core/tests/can-oxlint-extend-config.test.ts
@@ -94,7 +94,7 @@ describe("canOxlintExtendConfig", () => {
   "extends": ["next", "plugin:@typescript-eslint/recommended"],
   "rules": {
     // "off-for-now": "off"
-  }
+  },
 }
 `,
     );

--- a/packages/core/tests/fixtures/user-tailwind-config/.oxlintrc.json
+++ b/packages/core/tests/fixtures/user-tailwind-config/.oxlintrc.json
@@ -1,0 +1,14 @@
+{
+  "plugins": ["oxlint-plugin-tailwindcss"],
+  "rules": {
+    "tailwindcss/enforce-canonical": "error",
+    "tailwindcss/enforce-sort-order": "error",
+    "tailwindcss/no-conflicting-classes": "error",
+    "tailwindcss/no-unknown-classes": "error"
+  },
+  "settings": {
+    "tailwindcss": {
+      "entryPoint": "src/styles.css"
+    }
+  }
+}

--- a/packages/core/tests/fixtures/user-tailwind-config/package.json
+++ b/packages/core/tests/fixtures/user-tailwind-config/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "user-tailwind-config",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "tailwindcss": "^4.0.0"
+  },
+  "devDependencies": {
+    "oxlint-plugin-tailwindcss": "^1.0.0"
+  }
+}

--- a/packages/core/tests/fixtures/user-tailwind-config/src/button.tsx
+++ b/packages/core/tests/fixtures/user-tailwind-config/src/button.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export const Button = () => {
+  return (
+    <button className="bg-blue-500 hover:bg-blue-700 text-white">
+      Click me
+    </button>
+  );
+};

--- a/packages/core/tests/fixtures/user-tailwind-config/src/button.tsx
+++ b/packages/core/tests/fixtures/user-tailwind-config/src/button.tsx
@@ -1,9 +1,5 @@
-import React from 'react';
+import React from "react";
 
 export const Button = () => {
-  return (
-    <button className="bg-blue-500 hover:bg-blue-700 text-white">
-      Click me
-    </button>
-  );
+  return <button className="bg-blue-500 hover:bg-blue-700 text-white">Click me</button>;
 };

--- a/packages/core/tests/fixtures/user-tailwind-config/src/styles.css
+++ b/packages/core/tests/fixtures/user-tailwind-config/src/styles.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/packages/core/tests/oxlint-config-settings.test.ts
+++ b/packages/core/tests/oxlint-config-settings.test.ts
@@ -269,10 +269,11 @@ describe("createOxlintConfig settings", () => {
     });
   });
 
-  it("merges adopted settings with react-doctor settings", () => {
+  it("merges adopted settings without replacing react-doctor settings", () => {
     const config = createOxlintConfig({
       pluginPath: "/tmp/plugin.js",
       project: tailwindViteWebProject,
+      runtimeGlobals: ["DatePicker"],
       adoptedSettings: {
         tailwindcss: {
           entryPoint: "src/styles.css",
@@ -289,26 +290,8 @@ describe("createOxlintConfig settings", () => {
     expect(config.settings["other-plugin"]).toEqual({
       option: "value",
     });
-    expect(config.settings["react-doctor"]).toBeDefined();
     expect(config.settings["react-doctor"].framework).toBe("vite");
-  });
-
-  it("preserves react-doctor settings when merging adopted settings", () => {
-    const config = createOxlintConfig({
-      pluginPath: "/tmp/plugin.js",
-      project: viteWebProject,
-      runtimeGlobals: ["DatePicker"],
-      adoptedSettings: {
-        tailwindcss: {
-          entryPoint: "src/styles.css",
-        },
-      },
-    });
-
     expect(config.settings["react-doctor"].runtimeGlobals).toEqual(["DatePicker"]);
-    expect(config.settings.tailwindcss).toEqual({
-      entryPoint: "src/styles.css",
-    });
   });
 
   it("never registers security scan rules (they run as a core environment check)", () => {

--- a/packages/core/tests/oxlint-config-settings.test.ts
+++ b/packages/core/tests/oxlint-config-settings.test.ts
@@ -269,6 +269,48 @@ describe("createOxlintConfig settings", () => {
     });
   });
 
+  it("merges adopted settings with react-doctor settings", () => {
+    const config = createOxlintConfig({
+      pluginPath: "/tmp/plugin.js",
+      project: tailwindViteWebProject,
+      adoptedSettings: {
+        tailwindcss: {
+          entryPoint: "src/styles.css",
+        },
+        "other-plugin": {
+          option: "value",
+        },
+      },
+    });
+
+    expect(config.settings.tailwindcss).toEqual({
+      entryPoint: "src/styles.css",
+    });
+    expect(config.settings["other-plugin"]).toEqual({
+      option: "value",
+    });
+    expect(config.settings["react-doctor"]).toBeDefined();
+    expect(config.settings["react-doctor"].framework).toBe("vite");
+  });
+
+  it("preserves react-doctor settings when merging adopted settings", () => {
+    const config = createOxlintConfig({
+      pluginPath: "/tmp/plugin.js",
+      project: viteWebProject,
+      runtimeGlobals: ["DatePicker"],
+      adoptedSettings: {
+        tailwindcss: {
+          entryPoint: "src/styles.css",
+        },
+      },
+    });
+
+    expect(config.settings["react-doctor"].runtimeGlobals).toEqual(["DatePicker"]);
+    expect(config.settings.tailwindcss).toEqual({
+      entryPoint: "src/styles.css",
+    });
+  });
+
   it("never registers security scan rules (they run as a core environment check)", () => {
     const config = createOxlintConfig({
       pluginPath: "/tmp/plugin.js",

--- a/packages/core/tests/read-adopted-lint-config-settings.test.ts
+++ b/packages/core/tests/read-adopted-lint-config-settings.test.ts
@@ -2,196 +2,105 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+import { canOxlintExtendConfig } from "../src/can-oxlint-extend-config.js";
 import { readAdoptedLintConfigSettings } from "../src/read-adopted-lint-config-settings.js";
 
 describe("readAdoptedLintConfigSettings", () => {
   let temporaryDirectory: string;
 
   beforeEach(() => {
-    temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-test-"));
+    temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-settings-"));
   });
 
   afterEach(() => {
     fs.rmSync(temporaryDirectory, { recursive: true, force: true });
   });
 
-  const writeJson = (filePath: string, content: unknown): void => {
-    fs.writeFileSync(filePath, JSON.stringify(content));
+  const writeConfig = (filename: string, content: string): string => {
+    const configPath = path.join(temporaryDirectory, filename);
+    fs.writeFileSync(configPath, content);
+    return configPath;
   };
 
-  it("returns empty object when no config paths provided", () => {
-    const settings = readAdoptedLintConfigSettings([]);
-    expect(settings).toEqual({});
-  });
-
-  it("extracts tailwindcss settings from .oxlintrc.json", () => {
-    const configPath = path.join(temporaryDirectory, ".oxlintrc.json");
-    writeJson(configPath, {
-      settings: {
-        tailwindcss: {
-          entryPoint: "src/styles.css",
-        },
-      },
-    });
-
-    const settings = readAdoptedLintConfigSettings([configPath]);
-    expect(settings).toEqual({
-      tailwindcss: {
-        entryPoint: "src/styles.css",
-      },
-    });
-  });
-
-  it("skips react-doctor settings to avoid circular override", () => {
-    const configPath = path.join(temporaryDirectory, ".oxlintrc.json");
-    writeJson(configPath, {
-      settings: {
-        "react-doctor": {
-          framework: "next",
-        },
-        tailwindcss: {
-          entryPoint: "src/styles.css",
-        },
-      },
-    });
-
-    const settings = readAdoptedLintConfigSettings([configPath]);
-    expect(settings).toEqual({
-      tailwindcss: {
-        entryPoint: "src/styles.css",
-      },
-    });
-  });
-
-  it("merges settings from multiple config files", () => {
-    const config1Path = path.join(temporaryDirectory, ".oxlintrc.json");
-    const config2Path = path.join(temporaryDirectory, ".eslintrc.json");
-
-    writeJson(config1Path, {
-      settings: {
-        tailwindcss: {
-          entryPoint: "src/styles.css",
-        },
-      },
-    });
-
-    writeJson(config2Path, {
-      settings: {
-        "some-plugin": {
-          option: "value",
-        },
-      },
-    });
-
-    const settings = readAdoptedLintConfigSettings([config1Path, config2Path]);
-    expect(settings).toEqual({
-      tailwindcss: {
-        entryPoint: "src/styles.css",
-      },
-      "some-plugin": {
-        option: "value",
-      },
-    });
-  });
-
-  it("handles JSONC comments in config files", () => {
-    const configPath = path.join(temporaryDirectory, ".oxlintrc.json");
-    fs.writeFileSync(
-      configPath,
+  it("reads JSONC settings and skips react-doctor settings", () => {
+    const configPath = writeConfig(
+      ".oxlintrc.json",
       `{
-        // Line comment
+        // Keep the Tailwind source path.
         "settings": {
-          /* Block comment */
-          "tailwindcss": {
-            "entryPoint": "src/styles.css"
-          }
-        }
+          "react-doctor": { "framework": "next" },
+          "tailwindcss": { "entryPoint": "src/styles.css" },
+        },
       }`,
     );
 
-    const settings = readAdoptedLintConfigSettings([configPath]);
-    expect(settings).toEqual({
-      tailwindcss: {
-        entryPoint: "src/styles.css",
-      },
+    expect(readAdoptedLintConfigSettings([configPath])).toEqual({
+      tailwindcss: { entryPoint: "src/styles.css" },
     });
   });
 
-  it("handles tailwindcss monorepo array format", () => {
-    const configPath = path.join(temporaryDirectory, ".oxlintrc.json");
-    writeJson(configPath, {
-      settings: {
-        tailwindcss: {
-          entryPoint: [
-            { files: "apps/web/**/*.tsx", use: "apps/web/styles.css" },
-            { files: "apps/docs/**/*.tsx", use: "apps/docs/styles.css" },
-          ],
+  it("reads settings from an ESLint config that Oxlint cannot extend", () => {
+    const configPath = writeConfig(
+      ".eslintrc.json",
+      JSON.stringify({
+        extends: ["next/core-web-vitals"],
+        settings: { tailwindcss: { entryPoint: "src/styles.css" } },
+      }),
+    );
+
+    expect(canOxlintExtendConfig(configPath)).toBe(false);
+    expect(readAdoptedLintConfigSettings([configPath])).toEqual({
+      tailwindcss: { entryPoint: "src/styles.css" },
+    });
+  });
+
+  it("uses the last value when configs contain the same setting", () => {
+    const firstConfigPath = writeConfig(
+      "first.json",
+      JSON.stringify({ settings: { tailwindcss: { entryPoint: "first.css" } } }),
+    );
+    const secondConfigPath = writeConfig(
+      "second.json",
+      JSON.stringify({
+        settings: {
+          tailwindcss: { entryPoint: "second.css" },
+          "other-plugin": { option: true },
         },
-      },
-    });
+      }),
+    );
 
-    const settings = readAdoptedLintConfigSettings([configPath]);
-    expect(settings).toEqual({
-      tailwindcss: {
-        entryPoint: [
-          { files: "apps/web/**/*.tsx", use: "apps/web/styles.css" },
-          { files: "apps/docs/**/*.tsx", use: "apps/docs/styles.css" },
-        ],
-      },
+    expect(readAdoptedLintConfigSettings([firstConfigPath, secondConfigPath])).toEqual({
+      tailwindcss: { entryPoint: "second.css" },
+      "other-plugin": { option: true },
     });
   });
 
-  it("gracefully skips files that cannot be read", () => {
-    const validConfigPath = path.join(temporaryDirectory, ".oxlintrc.json");
-    const invalidConfigPath = path.join(temporaryDirectory, "nonexistent.json");
+  it("skips missing, invalid, and non-settings configs", () => {
+    const invalidConfigPath = writeConfig("invalid.json", "{ invalid json");
+    const rulesOnlyConfigPath = writeConfig(
+      "rules-only.json",
+      JSON.stringify({ rules: { "no-debugger": "error" } }),
+    );
 
-    writeJson(validConfigPath, {
-      settings: {
-        tailwindcss: {
-          entryPoint: "src/styles.css",
-        },
-      },
-    });
-
-    const settings = readAdoptedLintConfigSettings([invalidConfigPath, validConfigPath]);
-    expect(settings).toEqual({
-      tailwindcss: {
-        entryPoint: "src/styles.css",
-      },
-    });
+    expect(
+      readAdoptedLintConfigSettings([
+        path.join(temporaryDirectory, "missing.json"),
+        invalidConfigPath,
+        rulesOnlyConfigPath,
+      ]),
+    ).toEqual({});
   });
 
-  it("gracefully skips files with invalid JSON", () => {
-    const validConfigPath = path.join(temporaryDirectory, "valid.json");
-    const invalidConfigPath = path.join(temporaryDirectory, "invalid.json");
-
-    writeJson(validConfigPath, {
-      settings: {
-        tailwindcss: {
-          entryPoint: "src/styles.css",
-        },
-      },
-    });
-
-    fs.writeFileSync(invalidConfigPath, "{ invalid json");
-
-    const settings = readAdoptedLintConfigSettings([invalidConfigPath, validConfigPath]);
-    expect(settings).toEqual({
-      tailwindcss: {
-        entryPoint: "src/styles.css",
-      },
-    });
-  });
-
-  it("skips configs without settings field", () => {
-    const configPath = path.join(temporaryDirectory, ".oxlintrc.json");
-    writeJson(configPath, {
-      rules: {
-        "no-debugger": "error",
-      },
-    });
+  it("does not allow special keys to change the result prototype", () => {
+    const configPath = writeConfig(
+      ".oxlintrc.json",
+      `{"settings":{"__proto__":{"polluted":true}}}`,
+    );
 
     const settings = readAdoptedLintConfigSettings([configPath]);
-    expect(settings).toEqual({});
+
+    expect(Object.getPrototypeOf(settings)).toBe(Object.prototype);
+    expect(Object.hasOwn(settings, "__proto__")).toBe(false);
+    expect(Object.prototype).not.toHaveProperty("polluted");
   });
 });

--- a/packages/core/tests/read-adopted-lint-config-settings.test.ts
+++ b/packages/core/tests/read-adopted-lint-config-settings.test.ts
@@ -1,0 +1,197 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+import { readAdoptedLintConfigSettings } from "../src/read-adopted-lint-config-settings.js";
+
+describe("readAdoptedLintConfigSettings", () => {
+  let temporaryDirectory: string;
+
+  beforeEach(() => {
+    temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+  });
+
+  const writeJson = (filePath: string, content: unknown): void => {
+    fs.writeFileSync(filePath, JSON.stringify(content));
+  };
+
+  it("returns empty object when no config paths provided", () => {
+    const settings = readAdoptedLintConfigSettings([]);
+    expect(settings).toEqual({});
+  });
+
+  it("extracts tailwindcss settings from .oxlintrc.json", () => {
+    const configPath = path.join(temporaryDirectory, ".oxlintrc.json");
+    writeJson(configPath, {
+      settings: {
+        tailwindcss: {
+          entryPoint: "src/styles.css",
+        },
+      },
+    });
+
+    const settings = readAdoptedLintConfigSettings([configPath]);
+    expect(settings).toEqual({
+      tailwindcss: {
+        entryPoint: "src/styles.css",
+      },
+    });
+  });
+
+  it("skips react-doctor settings to avoid circular override", () => {
+    const configPath = path.join(temporaryDirectory, ".oxlintrc.json");
+    writeJson(configPath, {
+      settings: {
+        "react-doctor": {
+          framework: "next",
+        },
+        tailwindcss: {
+          entryPoint: "src/styles.css",
+        },
+      },
+    });
+
+    const settings = readAdoptedLintConfigSettings([configPath]);
+    expect(settings).toEqual({
+      tailwindcss: {
+        entryPoint: "src/styles.css",
+      },
+    });
+  });
+
+  it("merges settings from multiple config files", () => {
+    const config1Path = path.join(temporaryDirectory, ".oxlintrc.json");
+    const config2Path = path.join(temporaryDirectory, ".eslintrc.json");
+
+    writeJson(config1Path, {
+      settings: {
+        tailwindcss: {
+          entryPoint: "src/styles.css",
+        },
+      },
+    });
+
+    writeJson(config2Path, {
+      settings: {
+        "some-plugin": {
+          option: "value",
+        },
+      },
+    });
+
+    const settings = readAdoptedLintConfigSettings([config1Path, config2Path]);
+    expect(settings).toEqual({
+      tailwindcss: {
+        entryPoint: "src/styles.css",
+      },
+      "some-plugin": {
+        option: "value",
+      },
+    });
+  });
+
+  it("handles JSONC comments in config files", () => {
+    const configPath = path.join(temporaryDirectory, ".oxlintrc.json");
+    fs.writeFileSync(
+      configPath,
+      `{
+        // Line comment
+        "settings": {
+          /* Block comment */
+          "tailwindcss": {
+            "entryPoint": "src/styles.css"
+          }
+        }
+      }`,
+    );
+
+    const settings = readAdoptedLintConfigSettings([configPath]);
+    expect(settings).toEqual({
+      tailwindcss: {
+        entryPoint: "src/styles.css",
+      },
+    });
+  });
+
+  it("handles tailwindcss monorepo array format", () => {
+    const configPath = path.join(temporaryDirectory, ".oxlintrc.json");
+    writeJson(configPath, {
+      settings: {
+        tailwindcss: {
+          entryPoint: [
+            { files: "apps/web/**/*.tsx", use: "apps/web/styles.css" },
+            { files: "apps/docs/**/*.tsx", use: "apps/docs/styles.css" },
+          ],
+        },
+      },
+    });
+
+    const settings = readAdoptedLintConfigSettings([configPath]);
+    expect(settings).toEqual({
+      tailwindcss: {
+        entryPoint: [
+          { files: "apps/web/**/*.tsx", use: "apps/web/styles.css" },
+          { files: "apps/docs/**/*.tsx", use: "apps/docs/styles.css" },
+        ],
+      },
+    });
+  });
+
+  it("gracefully skips files that cannot be read", () => {
+    const validConfigPath = path.join(temporaryDirectory, ".oxlintrc.json");
+    const invalidConfigPath = path.join(temporaryDirectory, "nonexistent.json");
+
+    writeJson(validConfigPath, {
+      settings: {
+        tailwindcss: {
+          entryPoint: "src/styles.css",
+        },
+      },
+    });
+
+    const settings = readAdoptedLintConfigSettings([invalidConfigPath, validConfigPath]);
+    expect(settings).toEqual({
+      tailwindcss: {
+        entryPoint: "src/styles.css",
+      },
+    });
+  });
+
+  it("gracefully skips files with invalid JSON", () => {
+    const validConfigPath = path.join(temporaryDirectory, "valid.json");
+    const invalidConfigPath = path.join(temporaryDirectory, "invalid.json");
+
+    writeJson(validConfigPath, {
+      settings: {
+        tailwindcss: {
+          entryPoint: "src/styles.css",
+        },
+      },
+    });
+
+    fs.writeFileSync(invalidConfigPath, "{ invalid json");
+
+    const settings = readAdoptedLintConfigSettings([invalidConfigPath, validConfigPath]);
+    expect(settings).toEqual({
+      tailwindcss: {
+        entryPoint: "src/styles.css",
+      },
+    });
+  });
+
+  it("skips configs without settings field", () => {
+    const configPath = path.join(temporaryDirectory, ".oxlintrc.json");
+    writeJson(configPath, {
+      rules: {
+        "no-debugger": "error",
+      },
+    });
+
+    const settings = readAdoptedLintConfigSettings([configPath]);
+    expect(settings).toEqual({});
+  });
+});

--- a/packages/react-doctor/tests/run-oxlint/_helpers.ts
+++ b/packages/react-doctor/tests/run-oxlint/_helpers.ts
@@ -22,10 +22,7 @@ export const USER_OXLINT_CONFIG_BROKEN_DIRECTORY = path.join(
   FIXTURES_DIRECTORY,
   "user-oxlint-config-broken",
 );
-export const USER_TAILWIND_CONFIG_DIRECTORY = path.join(
-  FIXTURES_DIRECTORY,
-  "user-tailwind-config",
-);
+export const USER_TAILWIND_CONFIG_DIRECTORY = path.join(FIXTURES_DIRECTORY, "user-tailwind-config");
 
 const findDiagnosticsByRule = (diagnostics: Diagnostic[], rule: string): Diagnostic[] =>
   diagnostics.filter((diagnostic) => diagnostic.rule === rule);

--- a/packages/react-doctor/tests/run-oxlint/_helpers.ts
+++ b/packages/react-doctor/tests/run-oxlint/_helpers.ts
@@ -22,6 +22,10 @@ export const USER_OXLINT_CONFIG_BROKEN_DIRECTORY = path.join(
   FIXTURES_DIRECTORY,
   "user-oxlint-config-broken",
 );
+export const USER_TAILWIND_CONFIG_DIRECTORY = path.join(
+  FIXTURES_DIRECTORY,
+  "user-tailwind-config",
+);
 
 const findDiagnosticsByRule = (diagnostics: Diagnostic[], rule: string): Diagnostic[] =>
   diagnostics.filter((diagnostic) => diagnostic.rule === rule);

--- a/packages/react-doctor/tests/run-oxlint/adopt-existing-lint-config.test.ts
+++ b/packages/react-doctor/tests/run-oxlint/adopt-existing-lint-config.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vite-plus/test";
 import { runOxlint } from "@react-doctor/core";
 import { buildTestProject } from "../regressions/_helpers.js";
-import { USER_OXLINT_CONFIG_BROKEN_DIRECTORY, USER_OXLINT_CONFIG_DIRECTORY } from "./_helpers.js";
+import {
+  USER_OXLINT_CONFIG_BROKEN_DIRECTORY,
+  USER_OXLINT_CONFIG_DIRECTORY,
+  USER_TAILWIND_CONFIG_DIRECTORY,
+} from "./_helpers.js";
 
 describe("runOxlint", () => {
   describe("adoptExistingLintConfig", () => {
@@ -86,6 +90,22 @@ describe("runOxlint", () => {
       const stderrOutput = stderrChunks.join("");
       expect(stderrOutput).not.toContain("could not adopt existing lint config");
       expect(stderrOutput).not.toContain("retrying without extends");
+    });
+
+    it("adopts tailwindcss settings from .oxlintrc.json", async () => {
+      const diagnostics = await runOxlint({
+        rootDirectory: USER_TAILWIND_CONFIG_DIRECTORY,
+        project: buildTestProject({
+          rootDirectory: USER_TAILWIND_CONFIG_DIRECTORY,
+          tailwindVersion: "^4.0.0",
+        }),
+      });
+
+      const tailwindErrors = diagnostics.filter((diagnostic) =>
+        diagnostic.message.includes("`settings.tailwindcss.entryPoint` is required"),
+      );
+
+      expect(tailwindErrors).toHaveLength(0);
     });
   });
 });


### PR DESCRIPTION
## Summary

- preserve third-party plugin settings when React Doctor adopts `.oxlintrc.json` or `.eslintrc.json`
- read settings even when Oxlint cannot use an ESLint config through `extends`
- use the existing JSONC parser and protect generated settings from prototype keys
- add focused unit and end-to-end Tailwind regressions

## Product check

- User job: keep existing lint plugin configuration active during a React Doctor scan.
- Reuse: extend the existing lint-config detection and generated Oxlint config.
- Telemetry: existing `rule.fired` and `lint.failed` signals cover adopted plugin behavior. No new metric is needed.
- Kill metric: revert settings adoption if adopted-config scans increase `lint.failed` by more than 1% across two releases.

## Validation

- `nr test`
- `nr lint`
- `nr typecheck`
- `nr format:check`
- `nr build`
- `nr smoke:json-report`
- focused core and CLI regressions
- one separate performance threshold failed once during the concurrent suite, then passed three direct reruns and the full-suite rerun

Closes #1694
