### PR TITLE
fix(cli): check root workflow before recommending CI

### DIFF
--- a/.changeset/fix-ci-recommendation-monorepo.md
+++ b/.changeset/fix-ci-recommendation-monorepo.md
@@ -2,4 +2,4 @@
 "react-doctor": patch
 ---
 
-Fix multi-project scans incorrectly recommending GitHub Actions when already configured at root. The CLI now checks for `.github/workflows/react-doctor.yml` at the repository root instead of unconditionally showing the recommendation for all multi-project scans or checking individual project directories.
+Stop multi-project scans from recommending GitHub Actions when the root workflow is already configured.

--- a/.changeset/fix-ci-recommendation-monorepo.md
+++ b/.changeset/fix-ci-recommendation-monorepo.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Fix multi-project scans incorrectly recommending GitHub Actions when already configured at root. The CLI now checks for `.github/workflows/react-doctor.yml` at the repository root instead of unconditionally showing the recommendation for all multi-project scans or checking individual project directories.

--- a/packages/react-doctor/src/cli/ink/run-scan-app.tsx
+++ b/packages/react-doctor/src/cli/ink/run-scan-app.tsx
@@ -518,7 +518,11 @@ const runSingleProjectScan = async (
     process.stdout.write("No changed source files in the selected project.\n");
     return { shouldFail: false };
   }
-  const presentation = resolveScanPresentation(input, [projectScan], rootScanTarget.resolvedDirectory);
+  const presentation = resolveScanPresentation(
+    input,
+    [projectScan],
+    rootScanTarget.resolvedDirectory,
+  );
   return runMountedScan(projectScan.directory, presentation, blockingLevel, async (context) => {
     const result = await inspectProject(projectScan.directory, {
       ...resolveTuiInspectOptions(input, projectScan.config),

--- a/packages/react-doctor/src/cli/ink/run-scan-app.tsx
+++ b/packages/react-doctor/src/cli/ink/run-scan-app.tsx
@@ -459,6 +459,7 @@ const runMountedScan = async (
     const completedScan = await executeScan(context);
     mountedRenderer.dispose();
     mountedRenderer = mountRenderer("report");
+    if (presentation.shouldRecommendCi) recordCount(METRIC.tuiCiRecommendationShown);
     await mountedRenderer.instance.waitUntilExit();
     mountedRenderer.dispose();
     if (presentation.outputDirectory !== undefined || presentation.verbose) {

--- a/packages/react-doctor/src/cli/ink/run-scan-app.tsx
+++ b/packages/react-doctor/src/cli/ink/run-scan-app.tsx
@@ -128,6 +128,7 @@ const qualifyDiagnosticPaths = (
 const resolveScanPresentation = (
   input: RunScanAppInput,
   projectScans: ReadonlyArray<ResolvedProjectScan>,
+  rootDirectory: string,
 ): ScanPresentation => {
   const isScoreDisabled =
     input.options?.noScore === true ||
@@ -140,9 +141,7 @@ const resolveScanPresentation = (
     initialProgress: projectScans.length > 1 ? "Indexing workspace files…" : "Scanning project…",
     noScoreMessage: buildNoScoreMessage({ isScoreDisabled }),
     outputDirectory: input.options?.outputDirectory,
-    shouldRecommendCi:
-      projectScans.length > 1 ||
-      projectScans.some((projectScan) => isCiUnconfigured(projectScan.directory)),
+    shouldRecommendCi: isCiUnconfigured(rootDirectory),
     verbose: input.options?.verbose === true,
   };
 };
@@ -519,7 +518,7 @@ const runSingleProjectScan = async (
     process.stdout.write("No changed source files in the selected project.\n");
     return { shouldFail: false };
   }
-  const presentation = resolveScanPresentation(input, [projectScan]);
+  const presentation = resolveScanPresentation(input, [projectScan], rootScanTarget.resolvedDirectory);
   return runMountedScan(projectScan.directory, presentation, blockingLevel, async (context) => {
     const result = await inspectProject(projectScan.directory, {
       ...resolveTuiInspectOptions(input, projectScan.config),
@@ -624,6 +623,7 @@ const runMultiProjectScan = async (
   const presentation = resolveScanPresentation(
     input,
     projectScans.map(({ projectScan }) => projectScan),
+    rootDirectory,
   );
   return runMountedScan(rootDirectory, presentation, blockingLevel, async (context) => {
     const startTime = performance.now();

--- a/packages/react-doctor/src/cli/utils/constants.ts
+++ b/packages/react-doctor/src/cli/utils/constants.ts
@@ -321,6 +321,7 @@ export const METRIC = {
   tuiIssueStreamShown: "tui.issue_stream_shown",
   tuiProjectPathContextShown: "tui.project_path_context_shown",
   tuiProjectSelectShown: "tui.project_select_shown",
+  tuiCiRecommendationShown: "tui.ci_recommendation_shown",
   tuiReportActionSelected: "tui.report_action_selected",
   tuiCancelled: "tui.cancelled",
   tuiScanInlineShown: "tui.scan_inline_shown",

--- a/packages/react-doctor/tests/ink/run-scan-app.test.ts
+++ b/packages/react-doctor/tests/ink/run-scan-app.test.ts
@@ -141,8 +141,10 @@ vi.mock("../../src/cli/utils/detect-launchable-agents.js", () => ({
   detectLaunchableAgents: vi.fn(async () => []),
 }));
 
+const mockIsReactDoctorWorkflowInstalled = vi.hoisted(() => vi.fn(() => true));
+
 vi.mock("../../src/cli/utils/install-github-workflow.js", () => ({
-  isReactDoctorWorkflowInstalled: vi.fn(() => true),
+  isReactDoctorWorkflowInstalled: mockIsReactDoctorWorkflowInstalled,
 }));
 
 vi.mock("../../src/cli/utils/set-up-github-actions.js", () => ({
@@ -915,8 +917,9 @@ describe("runScanApp", () => {
     );
   });
 
-  it("recommends GitHub Actions after scanning multiple projects", async () => {
+  it("recommends GitHub Actions when CI is not configured at root", async () => {
     vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    mockIsReactDoctorWorkflowInstalled.mockReturnValue(false);
     const rootDirectory = "/repo";
     const webDirectory = "/repo/apps/web";
     const adminDirectory = "/repo/apps/admin";
@@ -936,6 +939,51 @@ describe("runScanApp", () => {
     );
     mockState.inspectResults.set(webDirectory, buildInspectResult(webDirectory));
     mockState.inspectResults.set(adminDirectory, buildInspectResult(adminDirectory));
+
+    await runScanApp({ directory: rootDirectory, skipPrompts: true });
+
+    expect(mockState.ciRecommendationStates).toEqual([true]);
+  });
+
+  it("does not recommend CI when root workflow already exists (issue #1696)", async () => {
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    mockIsReactDoctorWorkflowInstalled.mockReturnValue(true);
+    const rootDirectory = "/repo";
+    const webDirectory = "/repo/apps/web";
+    const adminDirectory = "/repo/apps/admin";
+
+    mockState.projectDirectories.push(webDirectory, adminDirectory);
+    mockState.scanTargets.set(
+      rootDirectory,
+      buildScanTarget(rootDirectory, rootDirectory, null, rootDirectory),
+    );
+    mockState.scanTargets.set(
+      webDirectory,
+      buildScanTarget(webDirectory, webDirectory, null, webDirectory),
+    );
+    mockState.scanTargets.set(
+      adminDirectory,
+      buildScanTarget(adminDirectory, adminDirectory, null, adminDirectory),
+    );
+    mockState.inspectResults.set(webDirectory, buildInspectResult(webDirectory));
+    mockState.inspectResults.set(adminDirectory, buildInspectResult(adminDirectory));
+
+    await runScanApp({ directory: rootDirectory, skipPrompts: true });
+
+    expect(mockState.ciRecommendationStates).toEqual([false]);
+  });
+
+  it("checks root directory for CI config in single-project scans", async () => {
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    mockIsReactDoctorWorkflowInstalled.mockReturnValue(false);
+    const rootDirectory = "/repo";
+
+    mockState.projectDirectories.push(rootDirectory);
+    mockState.scanTargets.set(
+      rootDirectory,
+      buildScanTarget(rootDirectory, rootDirectory, null, rootDirectory),
+    );
+    mockState.inspectResults.set(rootDirectory, buildInspectResult(rootDirectory));
 
     await runScanApp({ directory: rootDirectory, skipPrompts: true });
 

--- a/packages/react-doctor/tests/ink/run-scan-app.test.ts
+++ b/packages/react-doctor/tests/ink/run-scan-app.test.ts
@@ -14,6 +14,7 @@ import { runScanApp } from "../../src/cli/ink/run-scan-app.js";
 import type { ScanStore, TuiHandoffRequest } from "../../src/cli/ink/scan-store.js";
 import { preserveActiveTuiRendererOutput } from "../../src/cli/utils/active-tui-renderer.js";
 import { computeProjectedScore } from "../../src/cli/utils/compute-score-projection.js";
+import { METRIC } from "../../src/cli/utils/constants.js";
 import { inspect } from "../../src/inspect.js";
 import { buildDiagnostic, buildTestProject } from "../regressions/_helpers.js";
 
@@ -48,6 +49,13 @@ const mockState = vi.hoisted(() => ({
   initialProgressStates: new Array<string | null>(),
   ciRecommendationStates: new Array<boolean>(),
 }));
+
+const mockRecordCount = vi.hoisted(() => vi.fn());
+
+vi.mock("../../src/cli/utils/record-metric.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/cli/utils/record-metric.js")>();
+  return { ...actual, recordCount: mockRecordCount };
+});
 
 vi.mock("ink", async (importOriginal) => {
   const actual = await importOriginal<typeof import("ink")>();
@@ -943,6 +951,8 @@ describe("runScanApp", () => {
     await runScanApp({ directory: rootDirectory, skipPrompts: true });
 
     expect(mockState.ciRecommendationStates).toEqual([true]);
+    expect(mockIsReactDoctorWorkflowInstalled).toHaveBeenCalledWith(rootDirectory);
+    expect(mockRecordCount).toHaveBeenCalledWith(METRIC.tuiCiRecommendationShown);
   });
 
   it("does not recommend CI when root workflow already exists (issue #1696)", async () => {
@@ -971,6 +981,8 @@ describe("runScanApp", () => {
     await runScanApp({ directory: rootDirectory, skipPrompts: true });
 
     expect(mockState.ciRecommendationStates).toEqual([false]);
+    expect(mockIsReactDoctorWorkflowInstalled).toHaveBeenCalledWith(rootDirectory);
+    expect(mockRecordCount).not.toHaveBeenCalledWith(METRIC.tuiCiRecommendationShown);
   });
 
   it("checks root directory for CI config in single-project scans", async () => {


### PR DESCRIPTION
## Summary

- Check the scan root for the React Doctor workflow in single-project and multi-project scans.
- Do not show the GitHub Actions recommendation when the root workflow is already installed.
- Record `tui.ci_recommendation_shown` only when the report displays the recommendation.

## Product brief

- User job: run a monorepo scan without receiving a setup prompt for CI that is already configured.
- Reuse: use the existing root workflow detector and the existing report surface.
- Compatibility: this removes one incorrect recommendation. It does not change scan results, configuration, or report schemas.
- Success metric: `tui.ci_recommendation_shown` measures actual recommendation displays.
- Kill metric: remove the metric if it stays unused or cannot measure this surface after two releases.

## Validation

- Full test suite
- Lint
- Typecheck
- Format check
- Build
- JSON report smoke test
- React Doctor focused regression: configured and unconfigured monorepo roots

Closes #1696
