### PR TITLE
fix(js-set-map-lookups): recognize *Message naming pattern as string-typed

### DIFF
--- a/.changeset/fix-message-pattern.md
+++ b/.changeset/fix-message-pattern.md
@@ -1,0 +1,9 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+fix(js-set-map-lookups): recognize *Message naming pattern as string-typed
+
+The `js-set-map-lookups` rule was incorrectly flagging `String.prototype.includes()` calls on identifiers with the `*Message` naming pattern (e.g., `rawMessage`, `errorMessage`, `logMessage`) as array membership tests that should use Set/Map lookups. These are actually substring searches.
+
+Added "Message" to `STRING_TYPED_IDENTIFIER_SUFFIXES` so the rule now recognizes this common string convention even without explicit type annotations.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-set-map-lookups.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-set-map-lookups.regressions.test.ts
@@ -794,4 +794,29 @@ describe("js-performance/js-set-map-lookups — regressions", () => {
       }
     `);
   });
+
+  it("does not flag *Message identifier pattern as substring search (#1701)", () => {
+    expectPass(
+      `function translateError(rawMessage, locale) {
+        const POSTGRES_CODE_MESSAGES = { '23505': { en: 'Duplicate', es: 'Duplicado' } };
+        for (const [code, friendly] of Object.entries(POSTGRES_CODE_MESSAGES)) {
+          if (rawMessage.includes(code)) return friendly[locale];
+        }
+      }`,
+    );
+  });
+
+  it.each(["errorMessage", "logMessage", "debugMessage", "responseMessage"])(
+    "does not flag %s identifier pattern as substring search",
+    (identifier) => {
+      expectPass(
+        `function f(codes) {
+          const ${identifier} = "some error text";
+          for (const code of codes) {
+            if (${identifier}.includes(code)) return code;
+          }
+        }`,
+      );
+    },
+  );
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-set-map-lookups.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-set-map-lookups.ts
@@ -133,6 +133,7 @@ const STRING_TYPED_IDENTIFIER_SUFFIXES: ReadonlyArray<string> = [
   "Line",
   "Filename",
   "Filepath",
+  "Message",
 ];
 
 const hasStringTypedSuffix = (name: string): boolean => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #1701

## Root Cause

The `js-set-map-lookups` rule was incorrectly flagging `String.prototype.includes()` substring searches on identifiers with the `*Message` naming pattern (e.g., `rawMessage`, `errorMessage`, `logMessage`) as if they were array membership tests that should use Set/Map lookups.

The rule's heuristics checked for exact identifier names like "message" but didn't recognize the common `*Message` suffix pattern. When code lacked explicit type annotations, the rule would fire incorrectly.

## Scope Decision

**What was gated:** Added "Message" to `STRING_TYPED_IDENTIFIER_SUFFIXES` so identifiers ending in "Message" are recognized as string-typed.

**What was deliberately left:** The existing heuristics remain unchanged. Only added the one missing pattern.

## Fix Verification

- ✅ Added regression test for the reported `rawMessage.includes(code)` case
- ✅ Added parametric tests for common `*Message` patterns (errorMessage, logMessage, etc.)
- ✅ All existing tests pass (27,524 tests across 1,116 test files)
- ✅ Lint and typecheck clean
- ✅ Manual verification with reproduction case

## Parity

Parity should be run as part of review to confirm:
- The reported false positive is resolved
- No new false negatives introduced across the corpus
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-39024c4b-046c-4bdf-a13a-f7b5c92161b5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-39024c4b-046c-4bdf-a13a-f7b5c92161b5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

