### PR TITLE
fix: no-transition-all false positive on tw-animate-css entrance animations

### DIFF
--- a/.changeset/fix-no-transition-all-animation-false-positive.md
+++ b/.changeset/fix-no-transition-all-animation-false-positive.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Fix `no-transition-all` false positive on tw-animate-css entrance/exit animations. The rule was incorrectly flagging `animate-in`/`animate-out` with `duration-*` utilities as transition-all violations. Animation utilities use `duration-*` for animation timing, not transition timing, so they should not be flagged.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-transition-all.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-transition-all.test.ts
@@ -335,4 +335,10 @@ describe("no-transition-all", () => {
     const result = runRule(noTransitionAll, code);
     expect(result.diagnostics).toHaveLength(0);
   });
+
+  it("flags inline transition: all even when animate-in is present", () => {
+    const code = `const A = () => <div className="animate-in fade-in" style={{ transition: "all 200ms" }} />;`;
+    const result = runRule(noTransitionAll, code);
+    expect(result.diagnostics).toHaveLength(1);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-transition-all.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-transition-all.test.ts
@@ -317,4 +317,22 @@ describe("no-transition-all", () => {
     const result = runRule(noTransitionAll, code);
     expect(result.diagnostics).toHaveLength(3);
   });
+
+  it("does NOT flag tw-animate-css entrance animations (animate-in + duration-*)", () => {
+    const code = `const A = () => <div className="animate-in fade-in slide-in-from-bottom-2 duration-300" />;`;
+    const result = runRule(noTransitionAll, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag tw-animate-css exit animations (animate-out + duration-*)", () => {
+    const code = `const A = () => <div className="animate-out fade-out zoom-out duration-200" />;`;
+    const result = runRule(noTransitionAll, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("does NOT flag keyframe animations with duration-* utilities", () => {
+    const code = `const A = () => <div className="animate-bounce duration-1000" />;`;
+    const result = runRule(noTransitionAll, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-transition-all.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-transition-all.ts
@@ -17,6 +17,11 @@ import type { ScopeAnalysis } from "../../semantic/scope-analysis.js";
 
 const ALL_TRANSITION_PROPERTY_NAMES = new Set(["all"]);
 
+const isAnimationUtility = (utility: string): boolean =>
+  utility.startsWith("animate-") ||
+  utility.startsWith("[animation:") ||
+  utility.startsWith("[animation-name:");
+
 const isTransitionDurationSetter = (utility: string): boolean =>
   !utility.startsWith("[transition-property:") &&
   (utility.startsWith("duration-") ||
@@ -57,6 +62,12 @@ const hasMergedTransitionAll = (
         getTailwindTransitionAllState(parsedToken.utility) !== null &&
         doesTailwindVariantScopeCover(parsedToken.variants, variantScope),
     );
+    const hasAnimationUtility = parsedTokens.some(
+      (parsedToken) =>
+        isAnimationUtility(parsedToken.utility) &&
+        doesTailwindVariantScopeCover(parsedToken.variants, variantScope),
+    );
+    if (hasAnimationUtility) return false;
     const transitionAllState = resolveTailwindBooleanPropertyState(
       parsedTokens,
       variantScope,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-transition-all.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-transition-all.ts
@@ -67,17 +67,19 @@ const hasMergedTransitionAll = (
         isAnimationUtility(parsedToken.utility) &&
         doesTailwindVariantScopeCover(parsedToken.variants, variantScope),
     );
-    if (hasAnimationUtility) return false;
     const transitionAllState = resolveTailwindBooleanPropertyState(
       parsedTokens,
       variantScope,
       getTailwindTransitionAllState,
     );
-    const durationState = resolveTailwindTransitionDurationState(
-      parsedTokens,
-      variantScope,
-      ALL_TRANSITION_PROPERTY_NAMES,
-    );
+    const durationState =
+      hasAnimationUtility
+        ? null
+        : resolveTailwindTransitionDurationState(
+            parsedTokens,
+            variantScope,
+            ALL_TRANSITION_PROPERTY_NAMES,
+          );
     const hasImportantTransitionProperty = hasImportantTailwindClassNameToken(
       parsedTokens,
       variantScope,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Root cause:** The `no-transition-all` rule was detecting `duration-*` utilities without distinguishing between transition durations and animation durations. When `animate-in`, `animate-out`, or other animation utilities were present alongside `duration-*`, the rule incorrectly flagged them as `transition: all` violations.

**Scope:** Animation utilities (`animate-in`, `animate-out`, `animate-bounce`, etc.) use `duration-*` for animation timing, not transition timing. The fix adds animation context detection—when animation utilities are present in a variant scope, `duration-*` utilities are not treated as transition duration setters. This preserves correct detection of actual `transition-all` issues (explicit transitions in Tailwind classes or inline styles) while eliminating false positives on animations.

**Testing:**
- ✅ Added unit tests for `animate-in`, `animate-out`, and keyframe animations with `duration-*`
- ✅ Added test for mixed case (animation + inline transition: all)
- ✅ Ran parity check against small dataset - no unexpected diagnostic changes
- ✅ All existing tests pass

Closes #1700
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-905a2a25-5cd6-4424-9310-d799515aca81?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-905a2a25-5cd6-4424-9310-d799515aca81&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

