### PR TITLE
fix: no-loading-flag-reset-outside-finally false positives with cleanup statements in finally

### DIFF
--- a/.changeset/fix-no-loading-flag-reset-outside-finally-1698.md
+++ b/.changeset/fix-no-loading-flag-reset-outside-finally-1698.md
@@ -1,0 +1,7 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+fix(no-loading-flag-reset-outside-finally): allow unconditional resets in finally after cleanup statements
+
+Fixes #1698. The rule was incorrectly flagging loading-flag resets in finally blocks when preceded by other statements (e.g., `guard.unlock()`). Now only explicit control flow (return/throw) before a reset makes it conditional, not potentially-throwing calls.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-loading-flag-reset-outside-finally.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-loading-flag-reset-outside-finally.test.ts
@@ -156,6 +156,47 @@ describe("no-loading-flag-reset-outside-finally", () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("stays quiet when the reset is in finally after other statements (issue #1698 case A)", () => {
+    const result = runRule(
+      noLoadingFlagResetOutsideFinally,
+      `const submit = async () => {
+        setIsProcessing(true)
+        try {
+          await doPayment()
+        } catch (err) {
+          showSnackbar(messageOf(err), "error")
+        } finally {
+          guard.unlock()
+          setIsProcessing(false)
+        }
+      };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet when the reset in finally is guarded for stale responses (issue #1698 case B)", () => {
+    const result = runRule(
+      noLoadingFlagResetOutsideFinally,
+      `import { useRef, useState } from "react";
+       const Component = () => {
+         const [, setIsLoading] = useState(false);
+         const reqIdRef = useRef(0);
+         const currentReqRef = useRef(0);
+         const load = async () => {
+           const id = ++reqIdRef.current;
+           currentReqRef.current = id;
+           setIsLoading(true);
+           try {
+             await fetchData();
+           } finally {
+             if (currentReqRef.current === id) setIsLoading(false);
+           }
+         };
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
   it("stays quiet when an effect cleanup lifecycle guard wraps a reset in finally", () => {
     const result = runRule(
       noLoadingFlagResetOutsideFinally,
@@ -3434,22 +3475,22 @@ describe("no-loading-flag-reset-outside-finally audit regressions", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
-  it("distinguishes opaque calls before and after catch and finally resets", () => {
+  it("distinguishes explicit abrupt completions before and after catch and finally resets", () => {
     const catchBefore = runRule(
       noLoadingFlagResetOutsideFinally,
-      `const run = async () => { setLoading(true); try { await load(); } catch { risky(); setLoading(false); } };`,
+      `const run = async () => { setLoading(true); try { await load(); } catch { throw new Error(); setLoading(false); } };`,
     );
     const catchAfter = runRule(
       noLoadingFlagResetOutsideFinally,
-      `const run = async () => { setLoading(true); try { await load(); } catch { setLoading(false); risky(); } };`,
+      `const run = async () => { setLoading(true); try { await load(); } catch { setLoading(false); throw new Error(); } };`,
     );
     const finallyBefore = runRule(
       noLoadingFlagResetOutsideFinally,
-      `const run = async () => { setLoading(true); try { await load(); } finally { risky(); setLoading(false); } };`,
+      `const run = async () => { setLoading(true); try { await load(); } finally { return; setLoading(false); } };`,
     );
     const finallyAfter = runRule(
       noLoadingFlagResetOutsideFinally,
-      `const run = async () => { setLoading(true); try { await load(); } finally { setLoading(false); risky(); } };`,
+      `const run = async () => { setLoading(true); try { await load(); } finally { setLoading(false); return; } };`,
     );
     expect(catchBefore.diagnostics).toHaveLength(1);
     expect(catchAfter.diagnostics).toHaveLength(0);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-loading-flag-reset-outside-finally.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-loading-flag-reset-outside-finally.ts
@@ -1824,6 +1824,26 @@ const subtreeCallsDefinitelyThrowingLocalFunction = (
   return doesDefinitelyThrow;
 };
 
+const hasExplicitAbruptCompletionBefore = (
+  boundary: EsTreeNode,
+  node: EsTreeNode,
+): boolean => {
+  const nodeStart = getNodeStart(node);
+  if (nodeStart === null) return true;
+  let hasAbruptCompletion = false;
+  walkAst(boundary, (child: EsTreeNode) => {
+    if (hasAbruptCompletion) return false;
+    if (child !== boundary && isFunctionLike(child)) return false;
+    const childStart = getNodeStart(child);
+    if (childStart === null || childStart >= nodeStart) return;
+    if (isNodeOfType(child, "ReturnStatement") || isNodeOfType(child, "ThrowStatement")) {
+      hasAbruptCompletion = true;
+      return false;
+    }
+  });
+  return hasAbruptCompletion;
+};
+
 const hasAbruptCompletionBefore = (
   boundary: EsTreeNode,
   node: EsTreeNode,
@@ -1917,7 +1937,7 @@ const getExceptionalResetProtection = (
         isUnconditional:
           isUnconditional &&
           Boolean(cursor.finalizer) &&
-          !hasAbruptCompletionBefore(cursor.finalizer, callNode, context),
+          !hasExplicitAbruptCompletionBefore(cursor.finalizer, callNode),
       };
     }
     child = cursor;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #1698

The `no-loading-flag-reset-outside-finally` rule was incorrectly flagging loading-flag resets in `finally` blocks when preceded by other statements (e.g., cleanup calls like `guard.unlock()`).

## Root Cause

The rule used `hasAbruptCompletionBefore()` to check if a reset in `finally` was unconditional. This function treated ANY potentially-throwing call as an "abrupt completion", making the reset "conditional" even when it wasn't inside an explicit control flow statement (if/loop/etc.).

For example:
```typescript
finally {
  guard.unlock()            // Treated as potentially throwing
  setIsProcessing(false)    // Incorrectly flagged as conditional
}
```

## Solution

Added `hasExplicitAbruptCompletionBefore()` that only checks for EXPLICIT control flow (return/throw statements), not potentially-throwing calls. Updated `finally` block handling to use this more lenient check.

Philosophy: If a reset is in a `finally` block (the recommended pattern), trust the developer unless there's an explicit control flow issue.

## Changes

- Added `hasExplicitAbruptCompletionBefore()` function
- Updated `getExceptionalResetProtection()` to use the new check for `finally` blocks
- Added regression tests for both reported cases
- Updated existing test to use explicit control flow examples

## Testing

- All existing tests pass (27,521 tests)
- Added 2 new regression tests for issue #1698
- Updated 1 existing test to reflect new philosophy
- rde parity scan in progress (will update with results)

## Example Fixes

**Before (false positive):**
```typescript
finally {
  guard.unlock()
  setIsProcessing(false)  // ❌ Flagged
}
```

**After (correctly quiet):**
```typescript
finally {
  guard.unlock()
  setIsProcessing(false)  // ✅ No warning
}
```

**Still correctly flags explicit control flow:**
```typescript
finally {
  return                 // Explicit abrupt completion
  setIsProcessing(false) // ✅ Still flagged (unreachable)
}
```

Closes #1698
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8397f51a-4e5e-4efd-afb6-4b02097dbd60?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8397f51a-4e5e-4efd-afb6-4b02097dbd60&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

