### PR TITLE
fix(rule): avoid false positives in common patterns

### DIFF
--- a/.changeset/fix-recent-rule-false-positives.md
+++ b/.changeset/fix-recent-rule-false-positives.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Avoid false positives for loading resets in `finally`, animation duration utilities, and string message substring searches.

--- a/packages/fuzz/corpus/regressions/js-set-map-lookups--message-substring.ts
+++ b/packages/fuzz/corpus/regressions/js-set-map-lookups--message-substring.ts
@@ -1,0 +1,16 @@
+// rule: js-set-map-lookups
+// weakness: name-heuristic
+// source: GitHub issue #1701
+// verdict: pass
+
+const POSTGRES_CODE_MESSAGES = {
+  "23505": "Duplicate record",
+  "23503": "Missing related record",
+};
+
+export const translateError = (rawMessage, locale) => {
+  for (const [code, friendlyMessage] of Object.entries(POSTGRES_CODE_MESSAGES)) {
+    if (rawMessage.includes(code)) return `${friendlyMessage}:${locale}`;
+  }
+  return rawMessage;
+};

--- a/packages/fuzz/corpus/regressions/no-loading-flag-reset-outside-finally--preceding-finalizer-call.tsx
+++ b/packages/fuzz/corpus/regressions/no-loading-flag-reset-outside-finally--preceding-finalizer-call.tsx
@@ -1,0 +1,16 @@
+// rule: no-loading-flag-reset-outside-finally
+// weakness: control-flow
+// source: GitHub issue #1698
+// verdict: pass
+
+export const submitPayment = async () => {
+  setIsProcessing(true);
+  try {
+    await doPayment();
+  } catch (error) {
+    showSnackbar(String(error), "error");
+  } finally {
+    guard.unlock();
+    setIsProcessing(false);
+  }
+};

--- a/packages/fuzz/corpus/regressions/no-transition-all--tw-animate-duration.tsx
+++ b/packages/fuzz/corpus/regressions/no-transition-all--tw-animate-duration.tsx
@@ -1,0 +1,8 @@
+// rule: no-transition-all
+// weakness: library-idiom
+// source: GitHub issue #1700
+// verdict: pass
+
+export const EntrancePanel = () => (
+  <div className="animate-in fade-in slide-in-from-bottom-2 duration-300">Ready</div>
+);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-set-map-lookups.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-set-map-lookups.regressions.test.ts
@@ -794,4 +794,26 @@ describe("js-performance/js-set-map-lookups — regressions", () => {
       }
     `);
   });
+
+  it("does not treat a message substring search as array membership", () => {
+    expectPass(
+      `function translateError(rawMessage: string, locale: string) {
+        const POSTGRES_CODE_MESSAGES = { "23505": { en: "Duplicate", es: "Duplicado" } };
+        for (const [code, friendly] of Object.entries(POSTGRES_CODE_MESSAGES)) {
+          if (rawMessage.includes(code)) return friendly[locale];
+        }
+      }`,
+    );
+  });
+
+  it("infers an untyped message receiver as a substring source", () => {
+    expectPass(
+      `function translateError(rawMessage, locale) {
+        const POSTGRES_CODE_MESSAGES = { "23505": { en: "Duplicate", es: "Duplicado" } };
+        for (const [code, friendly] of Object.entries(POSTGRES_CODE_MESSAGES)) {
+          if (rawMessage.includes(code)) return friendly[locale];
+        }
+      }`,
+    );
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-set-map-lookups.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-set-map-lookups.ts
@@ -133,6 +133,7 @@ const STRING_TYPED_IDENTIFIER_SUFFIXES: ReadonlyArray<string> = [
   "Line",
   "Filename",
   "Filepath",
+  "Message",
 ];
 
 const hasStringTypedSuffix = (name: string): boolean => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-transition-all.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-transition-all.test.ts
@@ -317,4 +317,28 @@ describe("no-transition-all", () => {
     const result = runRule(noTransitionAll, code);
     expect(result.diagnostics).toHaveLength(3);
   });
+
+  it("does NOT treat animation durations as transitions", () => {
+    const code = `const A = () => <><div className="animate-in fade-in slide-in-from-bottom-2 duration-300" /><div className="animate-out fade-out duration-200" /><div className="[animation:spin_1s_linear] duration-1000" /></>;`;
+    const result = runRule(noTransitionAll, code);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still flags explicit transition-all with animation utilities", () => {
+    const code = `const A = () => <><div className="animate-in transition-all duration-300" /><div className="animate-in" style={{ transition: "all 200ms" }} /></>;`;
+    const result = runRule(noTransitionAll, code);
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
+  it("keeps animation and transition variant scopes separate", () => {
+    const code = `const A = () => <><div className="hover:animate-in duration-300" /><div className="animate-in hover:duration-300" /></>;`;
+    const result = runRule(noTransitionAll, code);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("does not treat disabled animation utilities as animation context", () => {
+    const code = `const A = () => <><div className="animate-none duration-300" /><div className="[animation:none] duration-300" /></>;`;
+    const result = runRule(noTransitionAll, code);
+    expect(result.diagnostics).toHaveLength(2);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-transition-all.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/no-transition-all.ts
@@ -52,6 +52,19 @@ const hasMergedTransitionAll = (
   if (styleAttribute && !styleExpression) return false;
   const variantScopes = [[], ...parsedTokens.map((parsedToken) => parsedToken.variants)];
   return variantScopes.some((variantScope) => {
+    const hasApplicableAnimationUtility = parsedTokens.some((parsedToken) => {
+      const animationUtility = parsedToken.utility;
+      const hasActiveAnimation =
+        animationUtility !== "animate-none" &&
+        animationUtility !== "[animation:none]" &&
+        animationUtility !== "[animation-name:none]" &&
+        (animationUtility.startsWith("animate-") ||
+          animationUtility.startsWith("[animation:") ||
+          animationUtility.startsWith("[animation-name:"));
+      return (
+        hasActiveAnimation && doesTailwindVariantScopeCover(parsedToken.variants, variantScope)
+      );
+    });
     const hasApplicablePropertySetter = parsedTokens.some(
       (parsedToken) =>
         getTailwindTransitionAllState(parsedToken.utility) !== null &&
@@ -83,7 +96,10 @@ const hasMergedTransitionAll = (
         {
           hasPositiveDuration: durationState === true,
           propertyName:
-            !hasApplicablePropertySetter || transitionAllState === true ? "all" : "opacity",
+            (!hasApplicablePropertySetter && !hasApplicableAnimationUtility) ||
+            transitionAllState === true
+              ? "all"
+              : "opacity",
           sourceNode: reportNode,
         },
       ],

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-loading-flag-reset-outside-finally.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-loading-flag-reset-outside-finally.test.ts
@@ -3453,8 +3453,30 @@ describe("no-loading-flag-reset-outside-finally audit regressions", () => {
     );
     expect(catchBefore.diagnostics).toHaveLength(1);
     expect(catchAfter.diagnostics).toHaveLength(0);
-    expect(finallyBefore.diagnostics).toHaveLength(1);
+    expect(finallyBefore.diagnostics).toHaveLength(0);
     expect(finallyAfter.diagnostics).toHaveLength(0);
+  });
+
+  it("stays quiet for a latest-request guard in finally", () => {
+    const result = runRule(
+      noLoadingFlagResetOutsideFinally,
+      `import { useEffect, useRef, useState } from "react";
+       const Preview = () => {
+         const [, setIsLoading] = useState(false);
+         const mounted = useRef(true);
+         const requestId = useRef(0);
+         useEffect(() => () => { mounted.current = false; }, []);
+         const load = async () => {
+           const id = ++requestId.current;
+           setIsLoading(true);
+           try { await fetchFeed(); }
+           finally {
+             if (mounted.current && id === requestId.current) setIsLoading(false);
+           }
+         };
+       };`,
+    );
+    expect(result.diagnostics).toHaveLength(0);
   });
 
   it("does not flag the reported formatting calls from issue #1421", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-loading-flag-reset-outside-finally.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-loading-flag-reset-outside-finally.ts
@@ -1828,6 +1828,7 @@ const hasAbruptCompletionBefore = (
   boundary: EsTreeNode,
   node: EsTreeNode,
   context: RuleContext,
+  shouldTreatPotentiallyThrowingCallsAsAbrupt = true,
 ): boolean => {
   const nodeStart = getNodeStart(node);
   if (nodeStart === null) return true;
@@ -1846,6 +1847,7 @@ const hasAbruptCompletionBefore = (
       return false;
     }
     if (
+      shouldTreatPotentiallyThrowingCallsAsAbrupt &&
       isNodeOfType(child, "CallExpression") &&
       !isProvenNonThrowingSynchronousCall(child, context)
     ) {
@@ -1917,7 +1919,7 @@ const getExceptionalResetProtection = (
         isUnconditional:
           isUnconditional &&
           Boolean(cursor.finalizer) &&
-          !hasAbruptCompletionBefore(cursor.finalizer, callNode, context),
+          !hasAbruptCompletionBefore(cursor.finalizer, callNode, context, false),
       };
     }
     child = cursor;


### PR DESCRIPTION
## Why

Three rules report valid code as a performance or correctness problem:

- `js-set-map-lookups` treats `rawMessage.includes(code)` as array membership.
- `no-transition-all` treats animation-only `duration-*` utilities as an implicit transition.
- `no-loading-flag-reset-outside-finally` rejects valid resets after cleanup calls inside `finally`.

After this change, these valid patterns stay quiet. Explicit array membership, active `transition-all`, and explicit abrupt completion before a reset still report.

Fixes #1698.
Fixes #1700.
Fixes #1701.

## What changed

- Recognize `*Message` identifiers as string receivers for `.includes()`.
- Treat active Tailwind and arbitrary animation utilities as animation context within the applicable variant scope.
- Keep explicit `transition-all` detection active when animation utilities are present.
- Ignore potentially throwing calls when a reset is already protected by `finally`, while retaining explicit abrupt-completion checks.
- Add focused rule tests, three fuzz regression fixtures, and a patch changeset.

## Eval results

Local RDE did not run because the RDE checkout has existing user changes and `AXIOM_DATASET` is not set. Pull request parity requires `DAYTONA_API_KEY`, which is also not set in this environment.

## Test plan

- `nr test` — 12 tasks passed; 27,526 plugin tests and 2,509 CLI tests passed.
- `nr lint` — passed with existing warnings.
- `nr typecheck` — passed.
- `nr format:check` — passed.
- `nr build` — passed.
- `nr smoke:json-report` — passed.
- `FUZZ_RULE=no-transition-all FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz` — passed.
- `FUZZ_RULE=js-set-map-lookups FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz` — passed.
- `FUZZ_RULE=no-loading-flag-reset-outside-finally FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz` — passed.
