### PR TITLE
fix(action): strip leading non-JSON content in ensure-json-report

### DIFF
--- a/.changeset/slick-meteors-grin.md
+++ b/.changeset/slick-meteors-grin.md
@@ -1,0 +1,7 @@
+---
+"react-doctor": patch
+---
+
+Fix GitHub Action false failures when npm exec pollutes JSON report with install messages.
+
+When running on a cold cache, `npm exec` can print informational messages to stdout that corrupt the JSON report file. The action's `ensure-json-report.mjs` script now strips any leading non-JSON content before parsing, preventing false failures on clean scans.

--- a/scripts/ensure-json-report.mjs
+++ b/scripts/ensure-json-report.mjs
@@ -37,7 +37,11 @@ const fallbackReport = {
 const KNOWN_SCHEMA_VERSIONS = new Set([1, 2, 3]);
 
 try {
-  const raw = fs.readFileSync(reportPath, "utf8").trim();
+  let raw = fs.readFileSync(reportPath, "utf8").trim();
+  const firstBrace = raw.indexOf("{");
+  if (firstBrace > 0) {
+    raw = raw.slice(firstBrace);
+  }
   const parsed = JSON.parse(raw);
   if (parsed && KNOWN_SCHEMA_VERSIONS.has(parsed.schemaVersion) && typeof parsed.ok === "boolean") {
     process.exit(0);

--- a/scripts/ensure-json-report.test.mjs
+++ b/scripts/ensure-json-report.test.mjs
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const scriptPath = path.join(__dirname, "ensure-json-report.mjs");
+
+const validReport = {
+  schemaVersion: 3,
+  version: "0.9.12",
+  ok: true,
+  directory: "/test",
+  mode: "full",
+  diff: null,
+  projects: [],
+  diagnostics: [],
+  summary: {
+    errorCount: 0,
+    warningCount: 0,
+    affectedFileCount: 0,
+    totalDiagnosticCount: 0,
+    score: 100,
+    scoreLabel: "excellent",
+  },
+  elapsedMilliseconds: 1234,
+};
+
+const runScript = (reportPath, exitCode) => {
+  return new Promise((resolve) => {
+    const proc = spawn(process.execPath, [scriptPath, reportPath, String(exitCode)], {
+      stdio: "pipe",
+    });
+    proc.on("close", (code) => {
+      resolve(code);
+    });
+  });
+};
+
+describe("ensure-json-report.mjs", () => {
+  let tempDir;
+  let reportPath;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "ensure-json-report-test-"));
+    reportPath = path.join(tempDir, "report.json");
+  });
+
+  afterEach(() => {
+    if (tempDir && fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts valid JSON report and exits 0", async () => {
+    fs.writeFileSync(reportPath, JSON.stringify(validReport));
+    const exitCode = await runScript(reportPath, 0);
+    expect(exitCode).toBe(0);
+    const content = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+    expect(content.ok).toBe(true);
+  });
+
+  it("strips leading npm warning and accepts report", async () => {
+    const corruptedContent = `npm warn exec The following package was not found and will be installed: react-doctor@0.9.12
+${JSON.stringify(validReport)}`;
+    fs.writeFileSync(reportPath, corruptedContent);
+    const exitCode = await runScript(reportPath, 0);
+    expect(exitCode).toBe(0);
+  });
+
+  it("strips multiple leading lines before JSON", async () => {
+    const corruptedContent = `npm warn exec The following package was not found and will be installed: react-doctor@0.9.12
+npm warn exec Some other warning
+${JSON.stringify(validReport)}`;
+    fs.writeFileSync(reportPath, corruptedContent);
+    const exitCode = await runScript(reportPath, 0);
+    expect(exitCode).toBe(0);
+  });
+
+  it("writes fallback report for completely invalid content", async () => {
+    fs.writeFileSync(reportPath, "completely invalid content with no JSON");
+    const exitCode = await runScript(reportPath, 1);
+    expect(exitCode).toBe(1);
+    const content = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+    expect(content.ok).toBe(false);
+    expect(content.schemaVersion).toBe(3);
+    expect(content.error).toBeDefined();
+  });
+
+  it("writes fallback report when report has invalid schema version", async () => {
+    const invalidReport = { ...validReport, schemaVersion: 999 };
+    fs.writeFileSync(reportPath, JSON.stringify(invalidReport));
+    const exitCode = await runScript(reportPath, 1);
+    expect(exitCode).toBe(1);
+    const content = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+    expect(content.ok).toBe(false);
+  });
+
+  it("writes fallback report when report is missing ok field", async () => {
+    const invalidReport = { ...validReport };
+    delete invalidReport.ok;
+    fs.writeFileSync(reportPath, JSON.stringify(invalidReport));
+    const exitCode = await runScript(reportPath, 1);
+    expect(exitCode).toBe(1);
+    const content = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+    expect(content.ok).toBe(false);
+  });
+
+  it("preserves scan failure exit code in fallback message", async () => {
+    fs.writeFileSync(reportPath, "invalid");
+    const exitCode = await runScript(reportPath, 42);
+    expect(exitCode).toBe(1);
+    const content = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+    expect(content.error.message).toContain("status 42");
+  });
+
+  it("accepts report with schemaVersion 1", async () => {
+    const v1Report = { ...validReport, schemaVersion: 1 };
+    fs.writeFileSync(reportPath, JSON.stringify(v1Report));
+    const exitCode = await runScript(reportPath, 0);
+    expect(exitCode).toBe(0);
+  });
+
+  it("accepts report with schemaVersion 2", async () => {
+    const v2Report = { ...validReport, schemaVersion: 2 };
+    fs.writeFileSync(reportPath, JSON.stringify(v2Report));
+    const exitCode = await runScript(reportPath, 0);
+    expect(exitCode).toBe(0);
+  });
+});

--- a/scripts/test-ensure-json-report-integration.sh
+++ b/scripts/test-ensure-json-report-integration.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Integration test for ensure-json-report.mjs fix
+# Simulates the npm exec stdout pollution scenario
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEMP_DIR="$(mktemp -d)"
+REPORT_FILE="$TEMP_DIR/report.json"
+
+cleanup() {
+  rm -rf "$TEMP_DIR"
+}
+trap cleanup EXIT
+
+echo "Testing ensure-json-report.mjs with npm exec pollution..."
+
+# Valid JSON report
+VALID_REPORT='{
+  "schemaVersion": 3,
+  "version": "0.9.12",
+  "ok": true,
+  "directory": "/test",
+  "mode": "full",
+  "diff": null,
+  "projects": [],
+  "diagnostics": [],
+  "summary": {
+    "errorCount": 0,
+    "warningCount": 0,
+    "affectedFileCount": 0,
+    "totalDiagnosticCount": 0,
+    "score": 100,
+    "scoreLabel": "excellent"
+  },
+  "elapsedMilliseconds": 1234
+}'
+
+# Test 1: Corrupted with npm warning
+echo "Test 1: Report corrupted with npm warning prefix..."
+echo "npm warn exec The following package was not found and will be installed: react-doctor@0.9.12" > "$REPORT_FILE"
+echo "$VALID_REPORT" >> "$REPORT_FILE"
+
+if node "$SCRIPT_DIR/ensure-json-report.mjs" "$REPORT_FILE" 0; then
+  echo "✓ Test 1 passed: Script accepted corrupted report and stripped npm warning"
+else
+  echo "✗ Test 1 failed: Script rejected valid report with npm warning prefix"
+  exit 1
+fi
+
+# Verify the report wasn't overwritten with fallback
+if grep -q '"ok": true' "$REPORT_FILE"; then
+  echo "✓ Original report preserved"
+else
+  echo "✗ Report was incorrectly overwritten"
+  exit 1
+fi
+
+# Test 2: Clean report (no corruption)
+echo ""
+echo "Test 2: Clean report (control)..."
+echo "$VALID_REPORT" > "$REPORT_FILE"
+
+if node "$SCRIPT_DIR/ensure-json-report.mjs" "$REPORT_FILE" 0; then
+  echo "✓ Test 2 passed: Script accepted clean report"
+else
+  echo "✗ Test 2 failed: Script rejected valid clean report"
+  exit 1
+fi
+
+# Test 3: Completely invalid content
+echo ""
+echo "Test 3: Invalid content (should write fallback)..."
+echo "completely invalid content with no JSON" > "$REPORT_FILE"
+
+if ! node "$SCRIPT_DIR/ensure-json-report.mjs" "$REPORT_FILE" 1; then
+  echo "✓ Test 3 passed: Script wrote fallback for invalid content"
+else
+  echo "✗ Test 3 failed: Script incorrectly accepted invalid content"
+  exit 1
+fi
+
+# Verify fallback was written
+if grep -q '"ok":false' "$REPORT_FILE" && grep -q '"schemaVersion":3' "$REPORT_FILE"; then
+  echo "✓ Fallback report written correctly"
+else
+  echo "✗ Fallback report incorrect"
+  cat "$REPORT_FILE"
+  exit 1
+fi
+
+echo ""
+echo "All integration tests passed! ✓"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Root Cause

When `npm exec --yes --package` runs on a cold cache, npm can print informational messages to stdout (e.g., `npm warn exec The following package was not found and will be installed: react-doctor@X.Y.Z`). Since the action redirects stdout to the report file (`> $REPORT_FILE`), these messages corrupt the JSON, causing `ensure-json-report.mjs` to fail parsing and force exit code 1.

This only affects the **non-cacheable path** at line 336 in `action.yml`. The cacheable path (lines 307-330) installs to a prefix and runs the binary directly, avoiding this issue.

## Fix

Made `ensure-json-report.mjs` defensive by finding the first `{` and parsing from there. This handles:
- npm exec stdout pollution (the reported issue)
- Any other future stdout contamination

## Scope

The fix is minimal and surgical:
- Only changes the parsing logic in `ensure-json-report.mjs`
- Doesn't change any react-doctor diagnostic rules or CLI behavior
- Doesn't change what gets reported, only how corrupted reports are handled
- Backwards compatible - still accepts clean reports

## Testing

- Added comprehensive unit tests covering:
  - Clean reports (control)
  - Reports with npm warning prefixes (the bug)
  - Multiple leading non-JSON lines
  - Completely invalid content (fallback behavior)
  - Various schema versions
- Added integration test simulating real npm exec pollution
- All tests passing

Closes #1707
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d15f5f21-b581-402f-a115-00d2bb824598?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d15f5f21-b581-402f-a115-00d2bb824598&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

