### PR TITLE
fix: unwrap TypeScript type annotations in Expo config plugin collector

### DIFF
--- a/.changeset/fix-expo-satisfies-1709.md
+++ b/.changeset/fix-expo-satisfies-1709.md
@@ -1,0 +1,5 @@
+---
+"@react-doctor/core": patch
+---
+
+Fix Expo config plugin discovery through TypeScript type annotations. The config plugin collector now properly unwraps `satisfies`, `as`, and other TypeScript type annotations when reading `app.config.ts` files, fixing false positives for scoped package names and local plugin paths when the config object uses `satisfies ExpoConfig`.

--- a/packages/core/src/project-analysis/collect/expo-config-plugin-entries.ts
+++ b/packages/core/src/project-analysis/collect/expo-config-plugin-entries.ts
@@ -87,7 +87,13 @@ const getPropertyName = (name: ts.PropertyName): string | undefined => {
 
 const unwrapExpression = (expression: ts.Expression): ts.Expression => {
   let currentExpression = expression;
-  while (ts.isParenthesizedExpression(currentExpression)) {
+  while (
+    ts.isParenthesizedExpression(currentExpression) ||
+    ts.isSatisfiesExpression(currentExpression) ||
+    ts.isAsExpression(currentExpression) ||
+    ts.isNonNullExpression(currentExpression) ||
+    ts.isTypeAssertionExpression(currentExpression)
+  ) {
     currentExpression = currentExpression.expression;
   }
   return currentExpression;

--- a/packages/core/tests/project-analysis.test.ts
+++ b/packages/core/tests/project-analysis.test.ts
@@ -3204,4 +3204,78 @@ describe("analyzeProject", () => {
       "packages/application/src/value.weapp.ts",
     );
   });
+
+  it("discovers Expo config plugins through TypeScript type annotations", async () => {
+    const rootDirectory = createProject(
+      {
+        "app.config.ts": `
+          import type { ExpoConfig } from "expo/config";
+
+          const config = {
+            name: "repro",
+            slug: "repro",
+            plugins: [
+              "expo-build-properties",
+              "@config-plugins/react-native-webrtc",
+              "./plugins/with-example",
+            ],
+          } satisfies ExpoConfig;
+
+          export default config;
+        `,
+        "plugins/with-example.ts": "export default (config: unknown) => config;",
+        "src/index.tsx": "export const App = () => null;",
+      },
+      {
+        dependencies: {
+          expo: "^56.0.0",
+          "expo-build-properties": "^56.0.0",
+          "@config-plugins/react-native-webrtc": "^14.0.0",
+          react: "19.0.0",
+          "react-native": "0.85.0",
+        },
+      },
+    );
+
+    const result = await analyzeProject({ rootDirectory });
+    const unusedFilePaths = relativePaths(rootDirectory, result.unusedFiles);
+    const unusedPackageNames = result.unusedDependencies.map((dependency) => dependency.name);
+
+    expect(unusedFilePaths).not.toContain("plugins/with-example.ts");
+    expect(unusedPackageNames).not.toContain("expo-build-properties");
+    expect(unusedPackageNames).not.toContain("@config-plugins/react-native-webrtc");
+  });
+
+  it("discovers Expo config plugins through as expressions", async () => {
+    const rootDirectory = createProject(
+      {
+        "app.config.ts": `
+          import type { ExpoConfig } from "expo/config";
+
+          export default {
+            name: "repro",
+            slug: "repro",
+            plugins: ["expo-build-properties", "./plugins/with-example"],
+          } as ExpoConfig;
+        `,
+        "plugins/with-example.ts": "export default (config: unknown) => config;",
+        "src/index.tsx": "export const App = () => null;",
+      },
+      {
+        dependencies: {
+          expo: "^56.0.0",
+          "expo-build-properties": "^56.0.0",
+          react: "19.0.0",
+          "react-native": "0.85.0",
+        },
+      },
+    );
+
+    const result = await analyzeProject({ rootDirectory });
+    const unusedFilePaths = relativePaths(rootDirectory, result.unusedFiles);
+    const unusedPackageNames = result.unusedDependencies.map((dependency) => dependency.name);
+
+    expect(unusedFilePaths).not.toContain("plugins/with-example.ts");
+    expect(unusedPackageNames).not.toContain("expo-build-properties");
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Root Cause

The Expo config plugin collector (`expo-config-plugin-entries.ts`) failed to unwrap TypeScript type annotation nodes when reading `app.config.ts` files. When a config object was annotated with `satisfies ExpoConfig`, the collector stopped at the `TSSatisfiesExpression` AST node and never reached the underlying object literal containing the plugins array.

This caused scoped package names (`@config-plugins/react-native-webrtc`) and local plugin paths (`./plugins/with-example`) to be reported as unused, while unscoped package names (`expo-build-properties`) were still resolved.

## Fix

Updated `unwrapExpression` to handle all TypeScript transparent expression wrappers:
- `TSSatisfiesExpression` (`satisfies` keyword)
- `TSAsExpression` (`as` keyword)  
- `TSNonNullExpression` (`!` postfix)
- `TSTypeAssertionExpression` (`<Type>` prefix syntax)

This aligns the Expo config collector with the pattern used elsewhere in the codebase (`evaluate-static-config.ts`, `graphql-codegen-entries.ts`).

## Scope

The fix is narrowly scoped to the `unwrapExpression` helper in `expo-config-plugin-entries.ts`. The same TypeScript annotation support already exists in other collectors throughout the codebase. This change brings the Expo collector to parity.

## Tests

Added two unit tests in `project-analysis.test.ts`:
1. Covers `satisfies` with all three plugin entry forms (scoped, unscoped, local)
2. Covers `as` expressions

These tests verify that plugins are correctly recognized as used and don't trigger `unused-dependency` or `unused-file` diagnostics.

## Validation

- ✅ Unit tests pass
- ✅ Typecheck passes
- ✅ Lint passes
- ✅ Changeset added (patch)

Closes #1709
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a04d934e-56af-45d7-934b-4606d2c3eafd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a04d934e-56af-45d7-934b-4606d2c3eafd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

