### PR TITLE
fix(core): resolve typed Expo config plugins

### DIFF
--- a/.changeset/fix-expo-config-plugins.md
+++ b/.changeset/fix-expo-config-plugins.md
@@ -1,0 +1,5 @@
+---
+"@react-doctor/core": patch
+---
+
+Recognize Expo config plugin packages and local plugin paths behind TypeScript `satisfies` expressions.

--- a/packages/core/src/project-analysis/collect/expo-config-plugin-entries.ts
+++ b/packages/core/src/project-analysis/collect/expo-config-plugin-entries.ts
@@ -2,6 +2,7 @@ import { readFileSync, statSync } from "node:fs";
 import { basename, dirname, extname, isAbsolute, join, relative, resolve } from "node:path";
 import fg from "fast-glob";
 import ts from "typescript";
+import { unwrapTypescriptExpression } from "../../utils/unwrap-typescript-expression.js";
 import { EXPO_CONFIG_SCAN_MAX_DEPTH, SOURCE_EXTENSIONS } from "../constants.js";
 
 const EXPO_CONFIG_FILE_GLOBS = ["app.config.{ts,mts,cts,js,mjs,cjs}", "app.json"];
@@ -85,14 +86,6 @@ const getPropertyName = (name: ts.PropertyName): string | undefined => {
   return undefined;
 };
 
-const unwrapExpression = (expression: ts.Expression): ts.Expression => {
-  let currentExpression = expression;
-  while (ts.isParenthesizedExpression(currentExpression)) {
-    currentExpression = currentExpression.expression;
-  }
-  return currentExpression;
-};
-
 const collectExpoPluginPathsFromArray = (
   array: ts.ArrayLiteralExpression,
   entries: Set<string>,
@@ -165,7 +158,7 @@ const collectReturnedExpoConfigPluginPaths = (
   configDirectory: string,
 ): void => {
   if (!ts.isBlock(body)) {
-    const expression = unwrapExpression(body);
+    const expression = unwrapTypescriptExpression(body);
     if (ts.isObjectLiteralExpression(expression)) {
       collectExpoPluginPathsFromConfigObject(
         expression,
@@ -183,7 +176,7 @@ const collectReturnedExpoConfigPluginPaths = (
       return;
 
     if (ts.isReturnStatement(node) && node.expression) {
-      const expression = unwrapExpression(node.expression);
+      const expression = unwrapTypescriptExpression(node.expression);
       if (ts.isObjectLiteralExpression(expression)) {
         collectExpoPluginPathsFromConfigObject(
           expression,
@@ -211,7 +204,7 @@ const collectExpoPluginPathsFromConfigExpression = (
   bindings: StaticConfigBindings,
   seenIdentifiers = new Set<string>(),
 ): void => {
-  const configExpression = unwrapExpression(expression);
+  const configExpression = unwrapTypescriptExpression(expression);
   if (ts.isObjectLiteralExpression(configExpression)) {
     collectExpoPluginPathsFromConfigObject(
       configExpression,

--- a/packages/core/tests/project-analysis.test.ts
+++ b/packages/core/tests/project-analysis.test.ts
@@ -141,6 +141,47 @@ describe("analyzeProject", () => {
     ).toEqual(expect.arrayContaining(["src/cycle-a.ts", "src/cycle-b.ts"]));
   });
 
+  it("treats Expo plugins behind a satisfies expression as used", async () => {
+    const rootDirectory = createProject(
+      {
+        "src/App.tsx": "export const App = () => <>hello</>;",
+        "plugins/with-example.ts": "export default (config: unknown) => config;",
+        "app.config.ts": `
+          import type { ExpoConfig } from "expo/config";
+          const config = {
+            name: "repro",
+            slug: "repro",
+            plugins: [
+              "@config-plugins/react-native-webrtc",
+              "./plugins/with-example",
+            ],
+          } satisfies ExpoConfig;
+          export default config;
+        `,
+      },
+      {
+        dependencies: {
+          expo: "56.0.0",
+          "@config-plugins/react-native-webrtc": "14.0.0",
+          "unused-package": "1.0.0",
+          react: "19.2.3",
+          "react-native": "0.85.3",
+        },
+      },
+    );
+
+    const result = await analyzeProject({ rootDirectory, entryPatterns: ["src/App.tsx"] });
+    const unusedDependencyNames = result.unusedDependencies.map(
+      (unusedDependency) => unusedDependency.name,
+    );
+
+    expect(relativePaths(rootDirectory, result.unusedFiles)).not.toContain(
+      "plugins/with-example.ts",
+    );
+    expect(unusedDependencyNames).not.toContain("@config-plugins/react-native-webrtc");
+    expect(unusedDependencyNames).toContain("unused-package");
+  });
+
   it("keeps exported types referenced by other exported type declarations", async () => {
     const rootDirectory = createProject(
       {

--- a/packages/core/tests/run-inspect.test.ts
+++ b/packages/core/tests/run-inspect.test.ts
@@ -1313,6 +1313,19 @@ describe("runInspect — runDeadCode=false short-circuits dead-code", () => {
 });
 
 describe("runInspect — Reporter sees post-filter diagnostics", () => {
+  const projectAnalysisDiagnostics: ReadonlyArray<Diagnostic> = [
+    {
+      ...deadCodeDiagnostic,
+      filePath: "plugins/with-example.ts",
+      rule: "unused-file",
+    },
+    {
+      ...deadCodeDiagnostic,
+      filePath: "package.json",
+      rule: "unused-dependency",
+    },
+  ];
+
   it("filters out a diagnostic on a file ignored by config, then emits remaining", async () => {
     const ignoredDiagnostic: Diagnostic = {
       ...lintDiagnostic,
@@ -1346,6 +1359,47 @@ describe("runInspect — Reporter sees post-filter diagnostics", () => {
     );
     expect(result.output.diagnostics.map((d) => d.filePath)).toEqual(["/repo/src/App.tsx"]);
     expect(result.captured.map((d) => d.filePath)).toEqual(["/repo/src/App.tsx"]);
+  });
+
+  it("applies rule ignores to project-analysis diagnostics", async () => {
+    const output = await Effect.runPromise(
+      runInspect(baseInput).pipe(
+        Effect.provide(
+          layersOf({
+            deadCode: projectAnalysisDiagnostics,
+            reactDoctorConfig: {
+              ignore: {
+                rules: ["react-doctor/unused-file", "react-doctor/unused-dependency"],
+              },
+            },
+          }),
+        ),
+      ),
+    );
+
+    expect(output.diagnostics).toEqual([]);
+  });
+
+  it("applies path overrides to project-analysis diagnostics", async () => {
+    const output = await Effect.runPromise(
+      runInspect(baseInput).pipe(
+        Effect.provide(
+          layersOf({
+            deadCode: projectAnalysisDiagnostics,
+            reactDoctorConfig: {
+              ignore: {
+                overrides: [
+                  { files: ["plugins/**"], rules: ["react-doctor/unused-file"] },
+                  { files: ["package.json"], rules: ["react-doctor/unused-dependency"] },
+                ],
+              },
+            },
+          }),
+        ),
+      ),
+    );
+
+    expect(output.diagnostics).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Summary

- recognize Expo plugin entries when an exported config uses TypeScript `satisfies`
- reuse the shared TypeScript expression unwrapping helper
- pin `ignore.rules` and `ignore.overrides` for project-analysis diagnostics

## Validation

- `nr test`
- `nr lint`
- `nr typecheck`
- `nr format:check`
- `nr build`
- `nr smoke:json-report`
- `REACT_DOCTOR_NO_TELEMETRY=1 nlx react-doctor@latest --verbose --scope changed` (100/100, no findings)

Fixes #1709.
Closes #1710.