### PR TITLE
fix(action): clean npm output from JSON reports

### DIFF
--- a/.changeset/fix-action-json-report.md
+++ b/.changeset/fix-action-json-report.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Clean leading npm messages from GitHub Action JSON reports before later steps read them.

--- a/packages/react-doctor/tests/ensure-json-report.test.ts
+++ b/packages/react-doctor/tests/ensure-json-report.test.ts
@@ -1,0 +1,70 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { spawnSync } from "node:child_process";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+
+const repositoryRoot = path.resolve(import.meta.dirname, "../../..");
+const scriptPath = path.join(repositoryRoot, "scripts", "ensure-json-report.mjs");
+const temporaryDirectories: string[] = [];
+
+const runEnsureJsonReport = (reportPath: string, scanStatus: number) =>
+  spawnSync(process.execPath, [scriptPath, reportPath, String(scanStatus)], {
+    encoding: "utf8",
+  });
+
+const createReportPath = (): string => {
+  const temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-report-"));
+  temporaryDirectories.push(temporaryDirectory);
+  return path.join(temporaryDirectory, "report.json");
+};
+
+afterEach(() => {
+  for (const temporaryDirectory of temporaryDirectories.splice(0)) {
+    fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+  }
+});
+
+describe("ensure-json-report", () => {
+  it("removes leading npm output from a valid report", () => {
+    const reportPath = createReportPath();
+    const report = { schemaVersion: 3, ok: true, diagnostics: [] };
+    fs.writeFileSync(
+      reportPath,
+      `npm warn exec {cache miss}\nnpm warn exec Installing react-doctor\n${JSON.stringify(report)}\n`,
+    );
+
+    const result = runEnsureJsonReport(reportPath, 0);
+
+    expect(result.status).toBe(0);
+    expect(JSON.parse(fs.readFileSync(reportPath, "utf8"))).toEqual(report);
+  });
+
+  it("keeps a clean valid report", () => {
+    const reportPath = createReportPath();
+    const report = { schemaVersion: 3, ok: false, diagnostics: [] };
+    fs.writeFileSync(reportPath, `${JSON.stringify(report)}\n`);
+
+    const result = runEnsureJsonReport(reportPath, 1);
+
+    expect(result.status).toBe(0);
+    expect(JSON.parse(fs.readFileSync(reportPath, "utf8"))).toEqual(report);
+  });
+
+  it("replaces invalid output with a fallback report", () => {
+    const reportPath = createReportPath();
+    fs.writeFileSync(reportPath, "npm output without a report\n");
+
+    const result = runEnsureJsonReport(reportPath, 42);
+    const fallbackReport = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+
+    expect(result.status).toBe(1);
+    expect(fallbackReport).toMatchObject({
+      schemaVersion: 3,
+      ok: false,
+      error: {
+        message: "react-doctor exited with status 42 before producing a JSON report.",
+      },
+    });
+  });
+});

--- a/scripts/ensure-json-report.mjs
+++ b/scripts/ensure-json-report.mjs
@@ -36,10 +36,34 @@ const fallbackReport = {
 // unparseable or unrecognized payload is treated as a failed scan.
 const KNOWN_SCHEMA_VERSIONS = new Set([1, 2, 3]);
 
+const findValidReport = (raw) => {
+  const candidateStarts = [0];
+  for (const match of raw.matchAll(/\r?\n(?=\s*\{)/g)) {
+    candidateStarts.push(match.index + match[0].length);
+  }
+
+  for (const candidateStart of candidateStarts) {
+    const candidate = raw.slice(candidateStart).trim();
+    try {
+      const parsed = JSON.parse(candidate);
+      if (
+        parsed &&
+        KNOWN_SCHEMA_VERSIONS.has(parsed.schemaVersion) &&
+        typeof parsed.ok === "boolean"
+      ) {
+        return candidate;
+      }
+    } catch {}
+  }
+
+  return null;
+};
+
 try {
   const raw = fs.readFileSync(reportPath, "utf8").trim();
-  const parsed = JSON.parse(raw);
-  if (parsed && KNOWN_SCHEMA_VERSIONS.has(parsed.schemaVersion) && typeof parsed.ok === "boolean") {
+  const validReport = findValidReport(raw);
+  if (validReport !== null) {
+    if (validReport !== raw) fs.writeFileSync(reportPath, `${validReport}\n`);
     process.exit(0);
   }
 } catch {


### PR DESCRIPTION
## Summary

- find a valid React Doctor report after leading npm output
- rewrite the report file with clean JSON for later Action steps
- test polluted, clean, and invalid report paths in the package test suite

This supersedes #1708. That change validates a clean suffix but does not rewrite the report file, so later Action steps still receive invalid JSON.

## Validation

- `nr test`
- `nr lint`
- `nr typecheck`
- `nr format:check`
- `nr build`
- `nr smoke:json-report`
- `nr test ensure-json-report.test.ts` from `packages/react-doctor`
- `REACT_DOCTOR_NO_TELEMETRY=1 nlx react-doctor@latest --verbose --scope changed` (100/100, no findings)

## Release

This changes an Action release file. Merge requires explicit approval for Action `v2.2.9` and the `v2` floating tag move.

Fixes #1707.