### PR TITLE
fix(rules): recognize member hook state consumption

### DIFF
--- a/.changeset/fix-member-hook-state-consumption.md
+++ b/.changeset/fix-member-hook-state-consumption.md
@@ -2,4 +2,4 @@
 "oxlint-plugin-react-doctor": patch
 ---
 
-Fix `rerender-state-only-in-handlers` false positive when state is consumed via member expression hook calls like `styles.useVariants({ state })`. The rule now recognizes both direct identifier calls (`useX`) and member expression calls (`obj.useX`) when tracking custom hook arguments that consume state.
+Fix a `rerender-state-only-in-handlers` false positive when a member hook consumes state.

--- a/.changeset/fix-member-hook-state-consumption.md
+++ b/.changeset/fix-member-hook-state-consumption.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Fix `rerender-state-only-in-handlers` false positive when state is consumed via member expression hook calls like `styles.useVariants({ state })`. The rule now recognizes both direct identifier calls (`useX`) and member expression calls (`obj.useX`) when tracking custom hook arguments that consume state.

--- a/packages/fuzz/corpus/regressions/rerender-state-only-in-handlers--unistyles-use-variants.tsx
+++ b/packages/fuzz/corpus/regressions/rerender-state-only-in-handlers--unistyles-use-variants.tsx
@@ -1,0 +1,33 @@
+// rule: rerender-state-only-in-handlers
+// weakness: library-idiom
+// source: GitHub issue #1716
+// verdict: pass
+
+import { useState } from "react";
+import { TextInput } from "react-native";
+import { StyleSheet } from "react-native-unistyles";
+
+const styles = StyleSheet.create(() => ({
+  input: {
+    variants: {
+      state: {
+        focused: { borderColor: "blue", borderWidth: 2 },
+      },
+    },
+  },
+}));
+
+export const Input = () => {
+  const [focused, setFocused] = useState(false);
+  const state = focused ? "focused" : undefined;
+
+  styles.useVariants({ state });
+
+  return (
+    <TextInput
+      onBlur={() => setFocused(false)}
+      onFocus={() => setFocused(true)}
+      style={styles.input}
+    />
+  );
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/rerender-state-only-in-handlers.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/rerender-state-only-in-handlers.regressions.test.ts
@@ -3809,4 +3809,41 @@ describe("rerender-state-only-in-handlers — external location invalidation", (
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].message).toContain("revision");
   });
+
+  it("does not flag state consumed by react-native-unistyles useVariants (issue #1716)", () => {
+    const result = runRule(
+      rerenderStateOnlyInHandlers,
+      `import { useState } from "react";
+      import { TextInput } from "react-native";
+      import { StyleSheet } from "react-native-unistyles";
+
+      const styles = StyleSheet.create(() => ({
+        input: {
+          borderWidth: 1,
+          variants: {
+            state: {
+              focused: { borderColor: "blue", borderWidth: 2 },
+            },
+          },
+        },
+      }));
+
+      export const Input = () => {
+        const [focused, setFocused] = useState(false);
+        const state = focused ? ("focused" as const) : undefined;
+
+        styles.useVariants({ state });
+
+        return (
+          <TextInput
+            onBlur={() => setFocused(false)}
+            onFocus={() => setFocused(true)}
+            style={styles.input}
+          />
+        );
+      };`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/rerender-state-only-in-handlers.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/rerender-state-only-in-handlers.test.ts
@@ -149,4 +149,47 @@ describe("rerender-state-only-in-handlers", () => {
 
     expect(result.diagnostics).toEqual([]);
   });
+
+  it("does not flag state consumed by a member expression hook call", () => {
+    const result = runRule(
+      rerenderStateOnlyInHandlers,
+      `
+      function Input() {
+        const styles = { useVariants: (v) => v };
+        const [focused, setFocused] = useState(false);
+        const state = focused ? "focused" : undefined;
+        styles.useVariants({ state });
+        return (
+          <input
+            onFocus={() => setFocused(true)}
+            onBlur={() => setFocused(false)}
+          />
+        );
+      }
+    `,
+    );
+
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("does not flag state consumed directly by a member expression hook call", () => {
+    const result = runRule(
+      rerenderStateOnlyInHandlers,
+      `
+      function Input() {
+        const styles = { useVariants: (v) => v };
+        const [focused, setFocused] = useState(false);
+        styles.useVariants({ focused });
+        return (
+          <input
+            onFocus={() => setFocused(true)}
+            onBlur={() => setFocused(false)}
+          />
+        );
+      }
+    `,
+    );
+
+    expect(result.diagnostics).toEqual([]);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/rerender-state-only-in-handlers.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/rerender-state-only-in-handlers.test.ts
@@ -192,4 +192,23 @@ describe("rerender-state-only-in-handlers", () => {
 
     expect(result.diagnostics).toEqual([]);
   });
+
+  it("still flags state not consumed even with member expression non-hook calls", () => {
+    const result = runRule(
+      rerenderStateOnlyInHandlers,
+      `
+      function Widget() {
+        const [logged, setLogged] = useState(false);
+        const onClick = () => {
+          Math.random();
+          setLogged(true);
+        };
+        return <button onClick={onClick}>go</button>;
+      }
+    `,
+    );
+
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].message).toContain("logged");
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/rerender-state-only-in-handlers.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/rerender-state-only-in-handlers.test.ts
@@ -211,4 +211,19 @@ describe("rerender-state-only-in-handlers", () => {
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0].message).toContain("logged");
   });
+
+  it("does not treat an unrelated member call as the state setter", () => {
+    const result = runRule(
+      rerenderStateOnlyInHandlers,
+      `
+      function Widget() {
+        const [logged, setLogged] = useState(false);
+        const store = { setLogged: (value) => console.log(value) };
+        return <button onClick={() => store.setLogged(true)}>go</button>;
+      }
+    `,
+    );
+
+    expect(result.diagnostics).toEqual([]);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/rerender-state-only-in-handlers.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/rerender-state-only-in-handlers.ts
@@ -74,22 +74,23 @@ const collectComponentStateUsageInfo = (
   const effectInfos: EffectDependencyInfo[] = [];
   walkAst(componentBody, (child: EsTreeNode) => {
     if (!isNodeOfType(child, "CallExpression")) return;
-    let calleeName: string | null = null;
-    if (isNodeOfType(child.callee, "Identifier")) {
-      calleeName = child.callee.name;
-    } else if (
-      isNodeOfType(child.callee, "MemberExpression") &&
-      isNodeOfType(child.callee.property, "Identifier")
-    ) {
-      calleeName = child.callee.property.name;
+    const directCalleeName = isNodeOfType(child.callee, "Identifier") ? child.callee.name : null;
+    if (directCalleeName !== null && setterNames.has(directCalleeName)) {
+      calledSetterNames.add(directCalleeName);
     }
-    if (calleeName !== null) {
-      if (setterNames.has(calleeName)) calledSetterNames.add(calleeName);
+    const customHookCalleeName =
+      directCalleeName ??
+      (isNodeOfType(child.callee, "MemberExpression") &&
+      !child.callee.computed &&
+      isNodeOfType(child.callee.property, "Identifier")
+        ? child.callee.property.name
+        : null);
+    if (customHookCalleeName !== null) {
       if (
-        isReactHookName(calleeName) &&
+        isReactHookName(customHookCalleeName) &&
         !isReactHookCall(child, BUILTIN_HOOK_NAMES, scopes) &&
-        !BUILTIN_HOOK_NAMES.has(calleeName) &&
-        !EFFECT_HOOK_NAMES.has(calleeName)
+        !BUILTIN_HOOK_NAMES.has(customHookCalleeName) &&
+        !EFFECT_HOOK_NAMES.has(customHookCalleeName)
       ) {
         for (const argument of child.arguments ?? []) {
           walkAst(argument as EsTreeNode, (argumentNode: EsTreeNode) => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/rerender-state-only-in-handlers.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/rerender-state-only-in-handlers.ts
@@ -74,8 +74,16 @@ const collectComponentStateUsageInfo = (
   const effectInfos: EffectDependencyInfo[] = [];
   walkAst(componentBody, (child: EsTreeNode) => {
     if (!isNodeOfType(child, "CallExpression")) return;
+    let calleeName: string | null = null;
     if (isNodeOfType(child.callee, "Identifier")) {
-      const calleeName = child.callee.name;
+      calleeName = child.callee.name;
+    } else if (
+      isNodeOfType(child.callee, "MemberExpression") &&
+      isNodeOfType(child.callee.property, "Identifier")
+    ) {
+      calleeName = child.callee.property.name;
+    }
+    if (calleeName !== null) {
       if (setterNames.has(calleeName)) calledSetterNames.add(calleeName);
       if (
         isReactHookName(calleeName) &&


### PR DESCRIPTION
## Summary

Fixes #1716.

`rerender-state-only-in-handlers` now treats state passed to a member hook such as `styles.useVariants({ state })` as render consumption.

## Safety

- State setter tracking stays limited to direct identifier calls.
- An unrelated call such as `store.setLogged()` cannot match the React setter binding.
- A strict fuzz regression covers the reported Unistyles pattern.
- A patch changeset is included.

## Validation

- Full repository test suite: 12 tasks passed.
- Lint, typecheck, and format: passed.
- Build and JSON report smoke test: passed.
- Strict fuzz: 500 iterations passed.
- Local RDE: 100 projects, 54 base and 54 candidate diagnostics, exact match.
- Daytona parity: blocked because `DAYTONA_API_KEY` is unavailable in this environment.
