### PR TITLE
fix(core): resolve local Expo Metro config wrappers

### DIFF
--- a/.changeset/expo-metro-wrapper-fix.md
+++ b/.changeset/expo-metro-wrapper-fix.md
@@ -1,0 +1,9 @@
+---
+"@react-doctor/core": patch
+---
+
+Fix `expo-metro-config` false positive when using local config wrappers
+
+The `expo-metro-config` rule now correctly handles metro configs that delegate to local wrappers (e.g. `./metro-helper.js`) that extend `expo/metro-config`. Previously, the rule only detected direct references to `expo/metro-config` or known third-party wrappers, causing false positives on user-defined helpers and monorepo shared configs - the common pattern for config presets like PostHog, custom Sentry setups, Storybook, and workspace-level metro utilities.
+
+The fix adds a heuristic: if the metro config contains a relative `require()` or ES module `import from` statement, the rule assumes it might be delegating to a wrapper and stays quiet. This trades a small false-negative risk (custom configs with relative imports that don't extend Expo's) for eliminating false positives on every local wrapper.

--- a/.changeset/expo-metro-wrapper-fix.md
+++ b/.changeset/expo-metro-wrapper-fix.md
@@ -1,9 +1,0 @@
----
-"@react-doctor/core": patch
----
-
-Fix `expo-metro-config` false positive when using local config wrappers
-
-The `expo-metro-config` rule now correctly handles metro configs that delegate to local wrappers (e.g. `./metro-helper.js`) that extend `expo/metro-config`. Previously, the rule only detected direct references to `expo/metro-config` or known third-party wrappers, causing false positives on user-defined helpers and monorepo shared configs - the common pattern for config presets like PostHog, custom Sentry setups, Storybook, and workspace-level metro utilities.
-
-The fix adds a heuristic: if the metro config contains a relative `require()` or ES module `import from` statement, the rule assumes it might be delegating to a wrapper and stays quiet. This trades a small false-negative risk (custom configs with relative imports that don't extend Expo's) for eliminating false positives on every local wrapper.

--- a/.changeset/fix-expo-metro-config-wrappers.md
+++ b/.changeset/fix-expo-metro-config-wrappers.md
@@ -1,0 +1,5 @@
+---
+"@react-doctor/core": patch
+---
+
+Fix Expo Metro config false positives for local helpers and the PostHog Expo wrapper.

--- a/packages/core/src/checks/expo/check-metro-config.ts
+++ b/packages/core/src/checks/expo/check-metro-config.ts
@@ -33,6 +33,15 @@ const EXPO_METRO_CONFIG_EXTEND_SIGNALS: ReadonlyArray<string> = [
   "getSentryExpoConfig",
 ];
 
+// Patterns that indicate the config might delegate to a local wrapper that
+// extends Expo's config. User-defined helpers (e.g. `./metro-helper.js`)
+// and monorepo shared configs (e.g. `../shared/metro`) are common patterns
+// where `expo/metro-config` is required by the wrapper, not the config
+// itself. A relative require or import is a signal that indirection is
+// happening. Matches both CJS `require("./...")` and ESM `import ... from "./..."`.
+const hasRelativeImport = (contents: string): boolean =>
+  /(?:require\s*\(\s*|from\s+)["']\.\.?\//u.test(contents);
+
 export const checkExpoMetroConfig = (context: ExpoCheckContext): Diagnostic[] => {
   const metroConfigPath = METRO_CONFIG_FILE_NAMES.map((fileName) =>
     path.join(context.rootDirectory, fileName),
@@ -46,6 +55,7 @@ export const checkExpoMetroConfig = (context: ExpoCheckContext): Diagnostic[] =>
     return [];
   }
   if (EXPO_METRO_CONFIG_EXTEND_SIGNALS.some((signal) => contents.includes(signal))) return [];
+  if (hasRelativeImport(contents)) return [];
 
   return [
     buildExpoDiagnostic({

--- a/packages/core/src/checks/expo/check-metro-config.ts
+++ b/packages/core/src/checks/expo/check-metro-config.ts
@@ -1,7 +1,11 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { isFile } from "../../project-info/index.js";
+import { collectStaticModuleSpecifiers } from "../../project-analysis/utils/collect-static-module-specifiers.js";
+import { isPathInsideDirectoryOrEqual } from "../../project-analysis/utils/is-path-inside-directory-or-equal.js";
+import { resolveEntryWithExtensions } from "../../project-analysis/utils/resolve-entry-with-extensions.js";
 import type { Diagnostic } from "../../types/index.js";
+import { EXPO_METRO_CONFIG_MAX_MODULE_COUNT } from "./constants.js";
 import type { ExpoCheckContext } from "./expo-check-context.js";
 import { buildExpoDiagnostic } from "./utils/build-expo-diagnostic.js";
 
@@ -31,16 +35,74 @@ const EXPO_METRO_CONFIG_EXTEND_SIGNALS: ReadonlyArray<string> = [
   "expo/metro-config",
   "@sentry/react-native/metro",
   "getSentryExpoConfig",
+  "posthog-react-native/metro",
+  "getPostHogExpoConfig",
 ];
 
-// Patterns that indicate the config might delegate to a local wrapper that
-// extends Expo's config. User-defined helpers (e.g. `./metro-helper.js`)
-// and monorepo shared configs (e.g. `../shared/metro`) are common patterns
-// where `expo/metro-config` is required by the wrapper, not the config
-// itself. A relative require or import is a signal that indirection is
-// happening. Matches both CJS `require("./...")` and ESM `import ... from "./..."`.
-const hasRelativeImport = (contents: string): boolean =>
-  /(?:require\s*\(\s*|from\s+)["']\.\.?\//u.test(contents);
+const resolveLocalMetroConfigModule = (
+  moduleSpecifier: string,
+  importingFilePath: string,
+  rootDirectory: string,
+): string | undefined => {
+  if (!moduleSpecifier.startsWith(".")) return undefined;
+
+  const importedPath = path.resolve(path.dirname(importingFilePath), moduleSpecifier);
+  const sourceImportedPath = importedPath.replace(/\.[cm]?js$/, "");
+  const candidateBasePaths = [importedPath, sourceImportedPath, path.join(importedPath, "index")];
+  for (const candidateBasePath of candidateBasePaths) {
+    const resolvedPath = resolveEntryWithExtensions(candidateBasePath);
+    if (
+      resolvedPath !== undefined &&
+      isFile(resolvedPath) &&
+      isPathInsideDirectoryOrEqual(resolvedPath, rootDirectory)
+    ) {
+      return resolvedPath;
+    }
+  }
+  return undefined;
+};
+
+const hasExpoMetroConfigSignal = (metroConfigPath: string, rootDirectory: string): boolean => {
+  const pendingFilePaths = [metroConfigPath];
+  const visitedFilePaths = new Set<string>();
+
+  while (pendingFilePaths.length > 0) {
+    const currentFilePath = pendingFilePaths.pop();
+    if (currentFilePath === undefined || visitedFilePaths.has(currentFilePath)) continue;
+    if (visitedFilePaths.size >= EXPO_METRO_CONFIG_MAX_MODULE_COUNT) return true;
+    visitedFilePaths.add(currentFilePath);
+
+    let contents: string;
+    try {
+      contents = fs.readFileSync(currentFilePath, "utf-8");
+    } catch {
+      return true;
+    }
+    if (EXPO_METRO_CONFIG_EXTEND_SIGNALS.some((signal) => contents.includes(signal))) return true;
+
+    let moduleSpecifiers: Set<string>;
+    try {
+      moduleSpecifiers = collectStaticModuleSpecifiers(contents, {
+        filePath: currentFilePath,
+        includeTypeOnly: false,
+      });
+    } catch {
+      continue;
+    }
+    for (const moduleSpecifier of moduleSpecifiers) {
+      const localModulePath = resolveLocalMetroConfigModule(
+        moduleSpecifier,
+        currentFilePath,
+        rootDirectory,
+      );
+      if (localModulePath !== undefined && !visitedFilePaths.has(localModulePath)) {
+        pendingFilePaths.push(localModulePath);
+      }
+    }
+  }
+
+  return false;
+};
 
 export const checkExpoMetroConfig = (context: ExpoCheckContext): Diagnostic[] => {
   const metroConfigPath = METRO_CONFIG_FILE_NAMES.map((fileName) =>
@@ -48,14 +110,7 @@ export const checkExpoMetroConfig = (context: ExpoCheckContext): Diagnostic[] =>
   ).find((candidatePath) => isFile(candidatePath));
   if (metroConfigPath === undefined) return [];
 
-  let contents: string;
-  try {
-    contents = fs.readFileSync(metroConfigPath, "utf-8");
-  } catch {
-    return [];
-  }
-  if (EXPO_METRO_CONFIG_EXTEND_SIGNALS.some((signal) => contents.includes(signal))) return [];
-  if (hasRelativeImport(contents)) return [];
+  if (hasExpoMetroConfigSignal(metroConfigPath, context.rootDirectory)) return [];
 
   return [
     buildExpoDiagnostic({

--- a/packages/core/src/checks/expo/constants.ts
+++ b/packages/core/src/checks/expo/constants.ts
@@ -1,0 +1,1 @@
+export const EXPO_METRO_CONFIG_MAX_MODULE_COUNT = 100;

--- a/packages/core/src/project-analysis/utils/collect-static-module-package-names.ts
+++ b/packages/core/src/project-analysis/utils/collect-static-module-package-names.ts
@@ -1,82 +1,13 @@
-import { parseSync } from "oxc-parser";
-import { isOxcAstNode } from "./oxc-ast-node.js";
+import { collectStaticModuleSpecifiers } from "./collect-static-module-specifiers.js";
 import { extractPackageName } from "./package-name.js";
 
 export const collectStaticModulePackageNames = (sourceText: string): Set<string> => {
-  const parsedModule = parseSync("package-reference.tsx", sourceText, { sourceType: "module" });
-
   const packageNames = new Set<string>();
-  const addSpecifier = (specifier: string): void => {
+  for (const specifier of collectStaticModuleSpecifiers(sourceText, {
+    filePath: "package-reference.tsx",
+  })) {
     const packageName = extractPackageName(specifier);
     if (packageName) packageNames.add(packageName);
-  };
-  const getStaticSpecifier = (value: unknown): string | undefined => {
-    if (!isOxcAstNode(value)) return undefined;
-    if (typeof value.value === "string") return value.value;
-    if (
-      value.type === "TemplateLiteral" &&
-      Array.isArray(value.expressions) &&
-      value.expressions.length === 0 &&
-      Array.isArray(value.quasis) &&
-      isOxcAstNode(value.quasis[0]) &&
-      value.quasis[0].value &&
-      typeof value.quasis[0].value === "object" &&
-      "cooked" in value.quasis[0].value &&
-      typeof value.quasis[0].value.cooked === "string"
-    ) {
-      return value.quasis[0].value.cooked;
-    }
-    return undefined;
-  };
-  for (const staticImport of parsedModule.module.staticImports) {
-    addSpecifier(staticImport.moduleRequest.value);
   }
-  for (const staticExport of parsedModule.module.staticExports) {
-    for (const entry of staticExport.entries) {
-      if (entry.moduleRequest) addSpecifier(entry.moduleRequest.value);
-    }
-  }
-
-  const visitNode = (value: unknown, isInTypeScriptModuleBlock = false): void => {
-    if (Array.isArray(value)) {
-      for (const child of value) visitNode(child, isInTypeScriptModuleBlock);
-      return;
-    }
-    if (!isOxcAstNode(value)) return;
-    if (
-      isInTypeScriptModuleBlock &&
-      (value.type === "ImportDeclaration" ||
-        value.type === "ExportNamedDeclaration" ||
-        value.type === "ExportAllDeclaration")
-    ) {
-      const sourceValue = getStaticSpecifier(value.source);
-      if (sourceValue) addSpecifier(sourceValue);
-    }
-    if (value.type === "ImportExpression" || value.type === "TSImportType") {
-      const sourceValue = getStaticSpecifier(value.source);
-      if (sourceValue) addSpecifier(sourceValue);
-    }
-    if (value.type === "TSExternalModuleReference") {
-      const expressionValue = getStaticSpecifier(value.expression);
-      if (expressionValue) addSpecifier(expressionValue);
-    }
-    if (
-      value.type === "CallExpression" &&
-      isOxcAstNode(value.callee) &&
-      value.callee.type === "Identifier" &&
-      value.callee.name === "require" &&
-      Array.isArray(value.arguments) &&
-      value.arguments.length > 0
-    ) {
-      const argumentValue = getStaticSpecifier(value.arguments[0]);
-      if (argumentValue) addSpecifier(argumentValue);
-    }
-    const childIsInTypeScriptModuleBlock =
-      isInTypeScriptModuleBlock || value.type === "TSModuleBlock";
-    for (const child of Object.values(value)) {
-      visitNode(child, childIsInTypeScriptModuleBlock);
-    }
-  };
-  visitNode(parsedModule.program);
   return packageNames;
 };

--- a/packages/core/src/project-analysis/utils/collect-static-module-specifiers.ts
+++ b/packages/core/src/project-analysis/utils/collect-static-module-specifiers.ts
@@ -1,0 +1,92 @@
+import { parseSync } from "oxc-parser";
+import { isOxcAstNode } from "./oxc-ast-node.js";
+
+interface CollectStaticModuleSpecifiersOptions {
+  filePath?: string;
+  includeTypeOnly?: boolean;
+}
+
+const getStaticModuleSpecifier = (value: unknown): string | undefined => {
+  if (!isOxcAstNode(value)) return undefined;
+  if (typeof value.value === "string") return value.value;
+  if (
+    value.type === "TemplateLiteral" &&
+    Array.isArray(value.expressions) &&
+    value.expressions.length === 0 &&
+    Array.isArray(value.quasis) &&
+    isOxcAstNode(value.quasis[0]) &&
+    value.quasis[0].value &&
+    typeof value.quasis[0].value === "object" &&
+    "cooked" in value.quasis[0].value &&
+    typeof value.quasis[0].value.cooked === "string"
+  ) {
+    return value.quasis[0].value.cooked;
+  }
+  return undefined;
+};
+
+export const collectStaticModuleSpecifiers = (
+  sourceText: string,
+  options: CollectStaticModuleSpecifiersOptions = {},
+): Set<string> => {
+  const { filePath = "module.tsx", includeTypeOnly = true } = options;
+  const parsedModule = parseSync(filePath, sourceText, { sourceType: "unambiguous" });
+  const moduleSpecifiers = new Set<string>();
+
+  const addSpecifier = (value: unknown): void => {
+    const moduleSpecifier = getStaticModuleSpecifier(value);
+    if (moduleSpecifier) moduleSpecifiers.add(moduleSpecifier);
+  };
+
+  const visitNode = (value: unknown): void => {
+    if (Array.isArray(value)) {
+      for (const child of value) visitNode(child);
+      return;
+    }
+    if (!isOxcAstNode(value)) return;
+
+    if (value.type === "ImportDeclaration") {
+      const specifiers = Array.isArray(value.specifiers) ? value.specifiers : [];
+      const hasRuntimeSpecifier = specifiers.some(
+        (specifier) => !isOxcAstNode(specifier) || specifier.importKind !== "type",
+      );
+      if (
+        includeTypeOnly ||
+        (value.importKind !== "type" && (specifiers.length === 0 || hasRuntimeSpecifier))
+      ) {
+        addSpecifier(value.source);
+      }
+    } else if (value.type === "ExportNamedDeclaration") {
+      const specifiers = Array.isArray(value.specifiers) ? value.specifiers : [];
+      const hasRuntimeSpecifier = specifiers.some(
+        (specifier) => !isOxcAstNode(specifier) || specifier.exportKind !== "type",
+      );
+      if (
+        includeTypeOnly ||
+        (value.exportKind !== "type" && (specifiers.length === 0 || hasRuntimeSpecifier))
+      ) {
+        addSpecifier(value.source);
+      }
+    } else if (value.type === "ExportAllDeclaration" || value.type === "ImportExpression") {
+      if (includeTypeOnly || value.exportKind !== "type") addSpecifier(value.source);
+    } else if (value.type === "TSImportType") {
+      if (includeTypeOnly) addSpecifier(value.source);
+    } else if (value.type === "TSExternalModuleReference") {
+      addSpecifier(value.expression);
+    } else if (
+      value.type === "CallExpression" &&
+      isOxcAstNode(value.callee) &&
+      value.callee.type === "Identifier" &&
+      value.callee.name === "require" &&
+      Array.isArray(value.arguments) &&
+      value.arguments.length > 0
+    ) {
+      addSpecifier(value.arguments[0]);
+    }
+
+    for (const child of Object.values(value)) visitNode(child);
+  };
+
+  visitNode(parsedModule.program);
+  return moduleSpecifiers;
+};

--- a/packages/core/tests/check-expo-project.test.ts
+++ b/packages/core/tests/check-expo-project.test.ts
@@ -381,13 +381,12 @@ describe("checkExpoProject — metro config", () => {
     ).not.toContain("expo-metro-config");
   });
 
-  it("stays quiet when metro.config.js requires a local wrapper with a relative path", () => {
+  it("stays quiet when a local Metro helper extends expo/metro-config", () => {
     const projectDirectory = makeProjectDirectory();
     writePackageJson(projectDirectory, { name: "expo-app", dependencies: { expo: "~56.0.0" } });
-    writeFile(
-      projectDirectory,
-      "metro-helper.js",
-      'const { getDefaultConfig } = require("expo/metro-config");\nmodule.exports = { getWrappedConfig: (root) => getDefaultConfig(root) };\n',
+    fs.writeFileSync(
+      path.join(projectDirectory, "metro-helper.js"),
+      'const { getDefaultConfig } = require("expo/metro-config");\nmodule.exports = { getWrappedConfig: getDefaultConfig };\n',
     );
     fs.writeFileSync(
       path.join(projectDirectory, "metro.config.js"),
@@ -398,36 +397,60 @@ describe("checkExpoProject — metro config", () => {
     ).not.toContain("expo-metro-config");
   });
 
-  it("stays quiet when metro.config.js requires a parent directory wrapper", () => {
+  it("stays quiet when metro.config.js uses PostHog's Expo wrapper", () => {
     const projectDirectory = makeProjectDirectory();
     writePackageJson(projectDirectory, { name: "expo-app", dependencies: { expo: "~56.0.0" } });
     fs.writeFileSync(
       path.join(projectDirectory, "metro.config.js"),
-      'const getConfig = require("../shared/metro-config");\nmodule.exports = getConfig(__dirname);\n',
+      'const { getPostHogExpoConfig } = require("posthog-react-native/metro");\nmodule.exports = getPostHogExpoConfig(__dirname);\n',
     );
     expect(
       rulesOf(checkExpoProject(projectDirectory, buildExpoProject(projectDirectory))),
     ).not.toContain("expo-metro-config");
   });
 
-  it("stays quiet when metro.config.mjs uses ESM import from a relative path", () => {
+  it("flags a local Metro helper that does not extend expo/metro-config", () => {
     const projectDirectory = makeProjectDirectory();
     writePackageJson(projectDirectory, { name: "expo-app", dependencies: { expo: "~56.0.0" } });
     fs.writeFileSync(
-      path.join(projectDirectory, "metro.config.mjs"),
-      'import getConfig from "./metro-helper.mjs";\nexport default getConfig();\n',
+      path.join(projectDirectory, "metro-helper.js"),
+      "module.exports = { getWrappedConfig: () => ({ resolver: {} }) };\n",
+    );
+    fs.writeFileSync(
+      path.join(projectDirectory, "metro.config.js"),
+      'const { getWrappedConfig } = require("./metro-helper");\nmodule.exports = getWrappedConfig(__dirname);\n',
     );
     expect(
       rulesOf(checkExpoProject(projectDirectory, buildExpoProject(projectDirectory))),
-    ).not.toContain("expo-metro-config");
+    ).toContain("expo-metro-config");
   });
 
-  it("flags a config with only unrelated imports, no expo/metro-config or relative requires", () => {
+  it("does not follow type-only imports to Metro helpers", () => {
     const projectDirectory = makeProjectDirectory();
     writePackageJson(projectDirectory, { name: "expo-app", dependencies: { expo: "~56.0.0" } });
     fs.writeFileSync(
+      path.join(projectDirectory, "metro-helper.ts"),
+      'export type Config = typeof import("expo/metro-config");\n',
+    );
+    fs.writeFileSync(
+      path.join(projectDirectory, "metro.config.ts"),
+      'import type { Config } from "./metro-helper";\nconst config: Config = { resolver: {} };\nexport default config;\n',
+    );
+    expect(
+      rulesOf(checkExpoProject(projectDirectory, buildExpoProject(projectDirectory))),
+    ).toContain("expo-metro-config");
+  });
+
+  it("handles cyclic local Metro helpers", () => {
+    const projectDirectory = makeProjectDirectory();
+    writePackageJson(projectDirectory, { name: "expo-app", dependencies: { expo: "~56.0.0" } });
+    fs.writeFileSync(
+      path.join(projectDirectory, "metro-helper.js"),
+      'require("./metro.config");\nmodule.exports = { resolver: {} };\n',
+    );
+    fs.writeFileSync(
       path.join(projectDirectory, "metro.config.js"),
-      'const path = require("path");\nmodule.exports = { resolver: { sourceExts: ["js"] } };\n',
+      'module.exports = require("./metro-helper");\n',
     );
     expect(
       rulesOf(checkExpoProject(projectDirectory, buildExpoProject(projectDirectory))),

--- a/packages/core/tests/check-expo-project.test.ts
+++ b/packages/core/tests/check-expo-project.test.ts
@@ -380,6 +380,59 @@ describe("checkExpoProject — metro config", () => {
       rulesOf(checkExpoProject(projectDirectory, buildExpoProject(projectDirectory))),
     ).not.toContain("expo-metro-config");
   });
+
+  it("stays quiet when metro.config.js requires a local wrapper with a relative path", () => {
+    const projectDirectory = makeProjectDirectory();
+    writePackageJson(projectDirectory, { name: "expo-app", dependencies: { expo: "~56.0.0" } });
+    writeFile(
+      projectDirectory,
+      "metro-helper.js",
+      'const { getDefaultConfig } = require("expo/metro-config");\nmodule.exports = { getWrappedConfig: (root) => getDefaultConfig(root) };\n',
+    );
+    fs.writeFileSync(
+      path.join(projectDirectory, "metro.config.js"),
+      'const { getWrappedConfig } = require("./metro-helper");\nmodule.exports = getWrappedConfig(__dirname);\n',
+    );
+    expect(
+      rulesOf(checkExpoProject(projectDirectory, buildExpoProject(projectDirectory))),
+    ).not.toContain("expo-metro-config");
+  });
+
+  it("stays quiet when metro.config.js requires a parent directory wrapper", () => {
+    const projectDirectory = makeProjectDirectory();
+    writePackageJson(projectDirectory, { name: "expo-app", dependencies: { expo: "~56.0.0" } });
+    fs.writeFileSync(
+      path.join(projectDirectory, "metro.config.js"),
+      'const getConfig = require("../shared/metro-config");\nmodule.exports = getConfig(__dirname);\n',
+    );
+    expect(
+      rulesOf(checkExpoProject(projectDirectory, buildExpoProject(projectDirectory))),
+    ).not.toContain("expo-metro-config");
+  });
+
+  it("stays quiet when metro.config.mjs uses ESM import from a relative path", () => {
+    const projectDirectory = makeProjectDirectory();
+    writePackageJson(projectDirectory, { name: "expo-app", dependencies: { expo: "~56.0.0" } });
+    fs.writeFileSync(
+      path.join(projectDirectory, "metro.config.mjs"),
+      'import getConfig from "./metro-helper.mjs";\nexport default getConfig();\n',
+    );
+    expect(
+      rulesOf(checkExpoProject(projectDirectory, buildExpoProject(projectDirectory))),
+    ).not.toContain("expo-metro-config");
+  });
+
+  it("flags a config with only unrelated imports, no expo/metro-config or relative requires", () => {
+    const projectDirectory = makeProjectDirectory();
+    writePackageJson(projectDirectory, { name: "expo-app", dependencies: { expo: "~56.0.0" } });
+    fs.writeFileSync(
+      path.join(projectDirectory, "metro.config.js"),
+      'const path = require("path");\nmodule.exports = { resolver: { sourceExts: ["js"] } };\n',
+    );
+    expect(
+      rulesOf(checkExpoProject(projectDirectory, buildExpoProject(projectDirectory))),
+    ).toContain("expo-metro-config");
+  });
 });
 
 describe("checkExpoProject — env local files (git)", () => {


### PR DESCRIPTION
## Why

`expo-metro-config` only read the root Metro config. It reported a false positive when that file delegated to a local helper that imported `expo/metro-config`, including the reproduction in #1715.

Before: any local helper hid the valid Expo signal from the check.

After: the check follows statically resolvable runtime imports inside the project and reports only when the reachable config graph has no Expo signal.

## What changed

- Extract static module-specifier collection for reuse.
- Follow relative Metro config imports with cycle protection and a bounded, fail-open scan.
- Ignore type-only imports when building the runtime config graph.
- Recognize the verified `posthog-react-native/metro` Expo wrapper.
- Add positive and negative regressions for local helpers, PostHog, type-only imports, and cycles.
- Add a patch changeset for `@react-doctor/core`.

## Test plan

- `nr test`
- `nr lint`
- `nr typecheck`
- `nr format:check`
- `nr build`
- `nr smoke:json-report`
- `REACT_DOCTOR_NO_TELEMETRY=1 nlx react-doctor@latest --verbose --scope changed` — 100/100

RDE was not run because this is a core Expo project check, not an Oxlint rule.

Closes #1715
