### PR TITLE
revert: restore publish workflow action tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,13 +26,11 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
-        with:
-          persist-credentials: false
+      - uses: actions/checkout@v5
 
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+      - uses: pnpm/action-setup@v5
 
-      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 22.18.0
           cache: pnpm
@@ -58,7 +56,7 @@ jobs:
       - name: Create release PR or publish
         if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.force_publish) }}
         id: changesets
-        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1
+        uses: changesets/action@v1
         with:
           publish: pnpm release
           version: pnpm run version
@@ -84,13 +82,11 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
-        with:
-          persist-credentials: false
+      - uses: actions/checkout@v5
 
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+      - uses: pnpm/action-setup@v5
 
-      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 22.18.0
           cache: pnpm


### PR DESCRIPTION
Reverts #1720 at the maintainer's request.

This restores the previous action references and credential behavior in `.github/workflows/publish.yml`.

Validation: `actionlint .github/workflows/publish.yml`.