### PR TITLE
fix: allow fbt content in verified text wrappers

### DIFF
--- a/.changeset/fix-fbt-in-text-wrappers.md
+++ b/.changeset/fix-fbt-in-text-wrappers.md
@@ -4,4 +4,4 @@
 "react-doctor": patch
 ---
 
-Fix `rn-no-raw-text` false positive on `<fbt>` children of text-wrapping custom components. The transparent wrapper check now sees through auto-detected and imported text wrappers, not just built-in text components, so `<Card><fbt>...</fbt></Card>` (where `Card` renders `<Text>{children}</Text>`) is correctly exempt. Fixes #1722.
+Prevent `rn-no-raw-text` reports for `<fbt>` content passed through verified React Native text wrappers.

--- a/.changeset/fix-fbt-in-text-wrappers.md
+++ b/.changeset/fix-fbt-in-text-wrappers.md
@@ -1,0 +1,7 @@
+---
+"oxlint-plugin-react-doctor": patch
+"eslint-plugin-react-doctor": patch
+"react-doctor": patch
+---
+
+Fix `rn-no-raw-text` false positive on `<fbt>` children of text-wrapping custom components. The transparent wrapper check now sees through auto-detected and imported text wrappers, not just built-in text components, so `<Card><fbt>...</fbt></Card>` (where `Card` renders `<Text>{children}</Text>`) is correctly exempt. Fixes #1722.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-raw-text.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-raw-text.test.ts
@@ -584,30 +584,6 @@ describe("react-native/rn-no-raw-text", () => {
       `);
     });
 
-    it("does not fire on fbs inside an auto-detected text wrapper", () => {
-      expectPass(`
-        const Banner = ({ children }) => <Text>{children}</Text>;
-        const App = () => (
-          <Banner>
-            <fbs desc="banner text">Important announcement</fbs>
-          </Banner>
-        );
-      `);
-    });
-
-    it("does not fire on namespaced fbt tags inside a text wrapper (issue #1722)", () => {
-      expectPass(`
-        const Label = ({ children }) => <Text>{children}</Text>;
-        const App = () => (
-          <Label>
-            <fbt desc="parameterized">
-              <fbt:param name="count">5</fbt:param> items
-            </fbt>
-          </Label>
-        );
-      `);
-    });
-
     it("still fires on fbt inside an auto-detected non-text wrapper", () => {
       expectFail(`
         const Box = ({ children }) => <View>{children}</View>;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-raw-text.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-raw-text.test.ts
@@ -554,6 +554,70 @@ describe("react-native/rn-no-raw-text", () => {
         );
       `);
     });
+
+    it("does not fire on fbt inside an auto-detected text wrapper (issue #1722)", () => {
+      expectPass(`
+        const Card = ({ children }) => <Text>{children}</Text>;
+        const App = () => (
+          <Card>
+            <fbt desc="greeting">Fbt in Card</fbt>
+          </Card>
+        );
+      `);
+    });
+
+    it("does not fire on fbt inside a text-named wrapper (issue #1722)", () => {
+      expectPass(`
+        const Button = ({ children }) => <Text>{children}</Text>;
+        const App = () => (
+          <Button>
+            <fbt desc="cta">Click me</fbt>
+          </Button>
+        );
+      `);
+    });
+
+    it("does not fire on fbt passed as a prop to a text wrapper (issue #1722)", () => {
+      expectPass(`
+        const Card = ({ title }) => <Text>{title}</Text>;
+        const App = () => <Card title={<fbt desc="title">Scrollable content</fbt>} />;
+      `);
+    });
+
+    it("does not fire on fbs inside an auto-detected text wrapper", () => {
+      expectPass(`
+        const Banner = ({ children }) => <Text>{children}</Text>;
+        const App = () => (
+          <Banner>
+            <fbs desc="banner text">Important announcement</fbs>
+          </Banner>
+        );
+      `);
+    });
+
+    it("does not fire on namespaced fbt tags inside a text wrapper (issue #1722)", () => {
+      expectPass(`
+        const Label = ({ children }) => <Text>{children}</Text>;
+        const App = () => (
+          <Label>
+            <fbt desc="parameterized">
+              <fbt:param name="count">5</fbt:param> items
+            </fbt>
+          </Label>
+        );
+      `);
+    });
+
+    it("still fires on fbt inside an auto-detected non-text wrapper", () => {
+      expectFail(`
+        const Box = ({ children }) => <View>{children}</View>;
+        const App = () => (
+          <Box>
+            <fbt desc="greeting">Hello</fbt>
+          </Box>
+        );
+      `);
+    });
   });
 
   describe("test-noise suppression", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-raw-text.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-raw-text.ts
@@ -80,25 +80,6 @@ const isTextHandlingComponent = (elementName: string): boolean => {
 const isTransparentTextWrapper = (elementName: string | null): boolean =>
   elementName !== null && REACT_NATIVE_TEXT_TRANSPARENT_COMPONENTS.has(elementName);
 
-// Walks ancestors to a real text component, stepping through transparent
-// wrappers. Returns false as soon as a non-transparent, non-text element
-// breaks the chain — so the text boundary is only honored when every link
-// up to the <Text> is itself transparent.
-const isInsideTextHandlingComponent = (node: EsTreeNodeOfType<"JSXElement">): boolean => {
-  let parentNode = node.parent;
-  while (parentNode) {
-    if (!isNodeOfType(parentNode, "JSXElement")) {
-      parentNode = parentNode.parent;
-      continue;
-    }
-    const parentName = resolveTextBoundaryName(parentNode.openingElement);
-    if (parentName && isTextHandlingComponent(parentName)) return true;
-    if (!isTransparentTextWrapper(parentName)) return false;
-    parentNode = parentNode.parent;
-  }
-  return false;
-};
-
 export const rnNoRawText = defineRule({
   id: "rn-no-raw-text",
   title: "Raw text outside a Text component",
@@ -167,6 +148,56 @@ export const rnNoRawText = defineRule({
         isNonTextHostName,
       );
       return forwardingKind === "nonText";
+    };
+
+    // Resolve an imported component as a text wrapper: true when the cross-file
+    // analysis confirms it renders children into `<Text>`, making it safe for
+    // transparent wrappers like `<fbt>` to nest inside.
+    const isImportedTextWrapper = (
+      elementName: string | null,
+      contextNode: EsTreeNode,
+    ): boolean => {
+      if (elementName === null || !isReactComponentName(elementName)) return false;
+      const { filename } = context;
+      if (filename === undefined) return false;
+      const forwardingKind = resolveImportedComponentForwarding(
+        contextNode,
+        context.scopes,
+        filename,
+        elementName,
+        isTextHandlingComponent,
+        isNonTextHostName,
+      );
+      return forwardingKind === "text";
+    };
+
+    // Walks ancestors to a real text component, stepping through transparent
+    // wrappers. Returns false as soon as a non-transparent, non-text element
+    // breaks the chain — so the text boundary is only honored when every link
+    // up to the <Text> is itself transparent. Now checks auto-detected same-file
+    // wrappers and cross-file imported wrappers in addition to built-in text
+    // components, so `<fbt>` inside a custom text-wrapping component is correctly
+    // exempted (fixes #1722).
+    const isInsideTextHandlingComponent = (node: EsTreeNodeOfType<"JSXElement">): boolean => {
+      let parentNode = node.parent;
+      while (parentNode) {
+        if (!isNodeOfType(parentNode, "JSXElement")) {
+          parentNode = parentNode.parent;
+          continue;
+        }
+        const parentName = resolveTextBoundaryName(parentNode.openingElement);
+        if (
+          parentName &&
+          (isTextHandlingComponent(parentName) ||
+            autoDetectedTextWrappers.has(parentName) ||
+            isImportedTextWrapper(parentName, parentNode))
+        ) {
+          return true;
+        }
+        if (!isTransparentTextWrapper(parentName)) return false;
+        parentNode = parentNode.parent;
+      }
+      return false;
     };
 
     return {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-raw-text.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-raw-text.ts
@@ -129,55 +129,25 @@ export const rnNoRawText = defineRule({
       elementName !== null &&
       (isNonTextHostName(elementName) || autoDetectedNonTextWrappers.has(elementName));
 
-    // Resolve an imported component cross-file: "nonText" (renders children into
-    // a host) → reported; "text" or unresolvable (`node_modules`, namespace
-    // imports, shadowed bindings, unanalyzable exports) → left alone.
+    const resolveImportedWrapper = (elementName: string | null, contextNode: EsTreeNode) => {
+      if (elementName === null || !isReactComponentName(elementName)) return null;
+      const { filename } = context;
+      if (filename === undefined) return null;
+      return resolveImportedComponentForwarding(
+        contextNode,
+        context.scopes,
+        filename,
+        elementName,
+        isTextHandlingComponent,
+        isNonTextHostName,
+      );
+    };
+
     const isImportedNonTextWrapper = (
       elementName: string | null,
       contextNode: EsTreeNode,
-    ): boolean => {
-      if (elementName === null || !isReactComponentName(elementName)) return false;
-      const { filename } = context;
-      if (filename === undefined) return false;
-      const forwardingKind = resolveImportedComponentForwarding(
-        contextNode,
-        context.scopes,
-        filename,
-        elementName,
-        isTextHandlingComponent,
-        isNonTextHostName,
-      );
-      return forwardingKind === "nonText";
-    };
+    ): boolean => resolveImportedWrapper(elementName, contextNode) === "nonText";
 
-    // Resolve an imported component as a text wrapper: true when the cross-file
-    // analysis confirms it renders children into `<Text>`, making it safe for
-    // transparent wrappers like `<fbt>` to nest inside.
-    const isImportedTextWrapper = (
-      elementName: string | null,
-      contextNode: EsTreeNode,
-    ): boolean => {
-      if (elementName === null || !isReactComponentName(elementName)) return false;
-      const { filename } = context;
-      if (filename === undefined) return false;
-      const forwardingKind = resolveImportedComponentForwarding(
-        contextNode,
-        context.scopes,
-        filename,
-        elementName,
-        isTextHandlingComponent,
-        isNonTextHostName,
-      );
-      return forwardingKind === "text";
-    };
-
-    // Walks ancestors to a real text component, stepping through transparent
-    // wrappers. Returns false as soon as a non-transparent, non-text element
-    // breaks the chain — so the text boundary is only honored when every link
-    // up to the <Text> is itself transparent. Now checks auto-detected same-file
-    // wrappers and cross-file imported wrappers in addition to built-in text
-    // components, so `<fbt>` inside a custom text-wrapping component is correctly
-    // exempted (fixes #1722).
     const isInsideTextHandlingComponent = (node: EsTreeNodeOfType<"JSXElement">): boolean => {
       let parentNode = node.parent;
       while (parentNode) {
@@ -190,7 +160,7 @@ export const rnNoRawText = defineRule({
           parentName &&
           (isTextHandlingComponent(parentName) ||
             autoDetectedTextWrappers.has(parentName) ||
-            isImportedTextWrapper(parentName, parentNode))
+            resolveImportedWrapper(parentName, parentNode) === "text")
         ) {
           return true;
         }

--- a/packages/react-doctor/tests/regressions/rn-and-motion.test.ts
+++ b/packages/react-doctor/tests/regressions/rn-and-motion.test.ts
@@ -10,6 +10,9 @@
  *              children
  *   #581     — fbtee `<fbt>` / `<fbs>` translation tags stay transparent to
  *              the `<Text>` boundary (so raw text inside them isn't flagged)
+ *   #1722    — `<fbt>` children of text-wrapping custom components are safe
+ *              (the transparent wrapper check now sees through auto-detected
+ *              and imported text wrappers, not just built-in text components)
  *   #76      — maintained Expo packages are not treated as legacy packages
  *   #94      — `MotionConfig reducedMotion="user"` must satisfy the
  *              reduced-motion accessibility check (so the rule doesn't
@@ -408,6 +411,107 @@ export const App = () => (
 
     const diagnostics = await getRnNoRawTextDiagnostics(projectDirectory);
     expect(diagnostics).toHaveLength(1);
+  });
+});
+
+describe("issue #1722: fbt inside text-wrapping custom components is not flagged", () => {
+  const buildFbtInWrapperProject = (projectName: string, appSource: string) =>
+    setupReactProject(tempRoot, projectName, {
+      packageJsonExtras: { dependencies: { react: "^19.0.0", "react-native": "^0.79.0" } },
+      files: { "src/App.tsx": appSource },
+    });
+
+  const getRnNoRawTextDiagnostics = async (projectDirectory: string) => {
+    const diagnostics = await runOxlint({
+      rootDirectory: projectDirectory,
+      project: buildTestProject({
+        rootDirectory: projectDirectory,
+        framework: "react-native",
+      }),
+    });
+    return diagnostics.filter((diagnostic) => diagnostic.rule === "rn-no-raw-text");
+  };
+
+  it("does not report fbt inside an auto-detected text wrapper", async () => {
+    const projectDirectory = buildFbtInWrapperProject(
+      "issue-1722-fbt-in-card",
+      `import { Text } from "react-native";
+
+const Card = ({ children }) => <Text>{children}</Text>;
+
+export const App = () => (
+  <Card>
+    <fbt desc="card content">Fbt in Card</fbt>
+  </Card>
+);
+`,
+    );
+
+    const diagnostics = await getRnNoRawTextDiagnostics(projectDirectory);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it("does not report fbt passed as a prop to a text wrapper", async () => {
+    const projectDirectory = buildFbtInWrapperProject(
+      "issue-1722-fbt-as-prop",
+      `import { Text } from "react-native";
+
+const Card = ({ title }) => <Text>{title}</Text>;
+
+export const App = () => (
+  <Card title={<fbt desc="title">Scrollable content</fbt>} />
+);
+`,
+    );
+
+    const diagnostics = await getRnNoRawTextDiagnostics(projectDirectory);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it("still reports fbt inside a non-text wrapper", async () => {
+    const projectDirectory = buildFbtInWrapperProject(
+      "issue-1722-fbt-in-view-wrapper",
+      `import { View } from "react-native";
+
+const Box = ({ children }) => <View>{children}</View>;
+
+export const App = () => (
+  <Box>
+    <fbt desc="box content">This will crash</fbt>
+  </Box>
+);
+`,
+    );
+
+    const diagnostics = await getRnNoRawTextDiagnostics(projectDirectory);
+    expect(diagnostics).toHaveLength(1);
+  });
+
+  it("handles the matrix case from the issue report", async () => {
+    const projectDirectory = buildFbtInWrapperProject(
+      "issue-1722-matrix",
+      `import { Text } from "react-native";
+
+const Card = ({ children }) => <Text>{children}</Text>;
+const Button = ({ children }) => <Text>{children}</Text>;
+
+export const CardString = () => <Card>Plain string in Card</Card>;
+export const CardFbt = () => (
+  <Card>
+    <fbt desc="d">Fbt in Card</fbt>
+  </Card>
+);
+export const ButtonString = () => <Button>Plain string in Button</Button>;
+export const ButtonFbt = () => (
+  <Button>
+    <fbt desc="d">Fbt in Button</fbt>
+  </Button>
+);
+`,
+    );
+
+    const diagnostics = await getRnNoRawTextDiagnostics(projectDirectory);
+    expect(diagnostics).toHaveLength(0);
   });
 });
 

--- a/packages/react-doctor/tests/regressions/rn-and-motion.test.ts
+++ b/packages/react-doctor/tests/regressions/rn-and-motion.test.ts
@@ -10,9 +10,7 @@
  *              children
  *   #581     — fbtee `<fbt>` / `<fbs>` translation tags stay transparent to
  *              the `<Text>` boundary (so raw text inside them isn't flagged)
- *   #1722    — `<fbt>` children of text-wrapping custom components are safe
- *              (the transparent wrapper check now sees through auto-detected
- *              and imported text wrappers, not just built-in text components)
+ *   #1722    — `<fbt>` content is safe inside verified text wrappers
  *   #76      — maintained Expo packages are not treated as legacy packages
  *   #94      — `MotionConfig reducedMotion="user"` must satisfy the
  *              reduced-motion accessibility check (so the rule doesn't
@@ -279,7 +277,9 @@ describe("rn-no-raw-text resolves imported components across files", () => {
           `export const App = () => (\n` +
           `  <>\n` +
           `    <SafeButton>Safe label</SafeButton>\n` +
+          `    <SafeButton><fbt desc="safe">Safe translated label</fbt></SafeButton>\n` +
           `    <CrashingCard>Crashing text</CrashingCard>\n` +
+          `    <CrashingCard><fbt desc="crash">Crashing translated text</fbt></CrashingCard>\n` +
           `  </>\n` +
           `);\n`,
       },
@@ -296,9 +296,15 @@ describe("rn-no-raw-text resolves imported components across files", () => {
       .filter((diagnostic) => diagnostic.rule === "rn-no-raw-text")
       .map((diagnostic) => diagnostic.message);
 
-    expect(rnRawTextMessages).toHaveLength(1);
-    expect(rnRawTextMessages[0]).toContain("Crashing text");
+    expect(rnRawTextMessages).toHaveLength(2);
+    expect(rnRawTextMessages.some((message) => message.includes("Crashing text"))).toBe(true);
+    expect(rnRawTextMessages.some((message) => message.includes("Crashing translated text"))).toBe(
+      true,
+    );
     expect(rnRawTextMessages.some((message) => message.includes("Safe label"))).toBe(false);
+    expect(rnRawTextMessages.some((message) => message.includes("Safe translated label"))).toBe(
+      false,
+    );
   });
 
   it("follows a wrapper that forwards children through another component in the same module", async () => {
@@ -411,107 +417,6 @@ export const App = () => (
 
     const diagnostics = await getRnNoRawTextDiagnostics(projectDirectory);
     expect(diagnostics).toHaveLength(1);
-  });
-});
-
-describe("issue #1722: fbt inside text-wrapping custom components is not flagged", () => {
-  const buildFbtInWrapperProject = (projectName: string, appSource: string) =>
-    setupReactProject(tempRoot, projectName, {
-      packageJsonExtras: { dependencies: { react: "^19.0.0", "react-native": "^0.79.0" } },
-      files: { "src/App.tsx": appSource },
-    });
-
-  const getRnNoRawTextDiagnostics = async (projectDirectory: string) => {
-    const diagnostics = await runOxlint({
-      rootDirectory: projectDirectory,
-      project: buildTestProject({
-        rootDirectory: projectDirectory,
-        framework: "react-native",
-      }),
-    });
-    return diagnostics.filter((diagnostic) => diagnostic.rule === "rn-no-raw-text");
-  };
-
-  it("does not report fbt inside an auto-detected text wrapper", async () => {
-    const projectDirectory = buildFbtInWrapperProject(
-      "issue-1722-fbt-in-card",
-      `import { Text } from "react-native";
-
-const Card = ({ children }) => <Text>{children}</Text>;
-
-export const App = () => (
-  <Card>
-    <fbt desc="card content">Fbt in Card</fbt>
-  </Card>
-);
-`,
-    );
-
-    const diagnostics = await getRnNoRawTextDiagnostics(projectDirectory);
-    expect(diagnostics).toHaveLength(0);
-  });
-
-  it("does not report fbt passed as a prop to a text wrapper", async () => {
-    const projectDirectory = buildFbtInWrapperProject(
-      "issue-1722-fbt-as-prop",
-      `import { Text } from "react-native";
-
-const Card = ({ title }) => <Text>{title}</Text>;
-
-export const App = () => (
-  <Card title={<fbt desc="title">Scrollable content</fbt>} />
-);
-`,
-    );
-
-    const diagnostics = await getRnNoRawTextDiagnostics(projectDirectory);
-    expect(diagnostics).toHaveLength(0);
-  });
-
-  it("still reports fbt inside a non-text wrapper", async () => {
-    const projectDirectory = buildFbtInWrapperProject(
-      "issue-1722-fbt-in-view-wrapper",
-      `import { View } from "react-native";
-
-const Box = ({ children }) => <View>{children}</View>;
-
-export const App = () => (
-  <Box>
-    <fbt desc="box content">This will crash</fbt>
-  </Box>
-);
-`,
-    );
-
-    const diagnostics = await getRnNoRawTextDiagnostics(projectDirectory);
-    expect(diagnostics).toHaveLength(1);
-  });
-
-  it("handles the matrix case from the issue report", async () => {
-    const projectDirectory = buildFbtInWrapperProject(
-      "issue-1722-matrix",
-      `import { Text } from "react-native";
-
-const Card = ({ children }) => <Text>{children}</Text>;
-const Button = ({ children }) => <Text>{children}</Text>;
-
-export const CardString = () => <Card>Plain string in Card</Card>;
-export const CardFbt = () => (
-  <Card>
-    <fbt desc="d">Fbt in Card</fbt>
-  </Card>
-);
-export const ButtonString = () => <Button>Plain string in Button</Button>;
-export const ButtonFbt = () => (
-  <Button>
-    <fbt desc="d">Fbt in Button</fbt>
-  </Button>
-);
-`,
-    );
-
-    const diagnostics = await getRnNoRawTextDiagnostics(projectDirectory);
-    expect(diagnostics).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
## Why

`rn-no-raw-text` reported `<fbt>` content inside custom components that static analysis had already verified as React Native text wrappers. The false report affected both children and JSX props.

## What changed

- Accept built-in, same-file, and imported wrappers only when analysis proves that they render content through `<Text>`.
- Keep reports for wrappers that render through non-text hosts such as `<View>`.
- Add focused unit and cross-file regression coverage.
- Add a patch changeset.

## Validation

- `nr test`
- `nr lint`
- `nr typecheck`
- `nr format:check`
- `nr build`
- `nr smoke:json-report`
- Focused rule tests: 65 passed
- Focused CLI regression tests: 25 passed
- Strict fuzz: 500 iterations passed
- Local RDE: 100 project roots, 0 target-rule hits
- Daytona parity was unavailable because `DAYTONA_API_KEY` is not set.

Closes #1722
