### PR TITLE
fix: run test-noise rules in application directories

### DIFF
--- a/.changeset/fix-test-noise-application-paths.md
+++ b/.changeset/fix-test-noise-application-paths.md
@@ -1,0 +1,7 @@
+---
+"oxlint-plugin-react-doctor": patch
+"eslint-plugin-react-doctor": patch
+"react-doctor": patch
+---
+
+Run `test-noise` rules in ambiguous product-named directories such as `tools`, `demo`, and `migrations` when they are below a recognized application source root. Explicit test surfaces and root-level tooling or example directories remain excluded.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/no-placeholder-only-field.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/a11y/no-placeholder-only-field.test.ts
@@ -320,12 +320,12 @@ describe("no-placeholder-only-field", () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
-  it("does not report placeholder-only fields in non-production files", () => {
+  it("reports placeholder-only fields in application demo directories", () => {
     const result = runRule(
       noPlaceholderOnlyField,
       `const Example = () => <input placeholder="Demo value" />;`,
       { filename: "src/demo/example.tsx" },
     );
-    expect(result.diagnostics).toHaveLength(0);
+    expect(result.diagnostics).toHaveLength(1);
   });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-create-object-url-without-revoke.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/no-create-object-url-without-revoke.test.ts
@@ -246,13 +246,13 @@ describe("no-create-object-url-without-revoke", () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
-  it("stays quiet in a demo file", () => {
+  it("reports in application demo directories", () => {
     const result = runRule(
       noCreateObjectUrlWithoutRevoke,
       `export default () => <a href={URL.createObjectURL(blob)}>download</a>;`,
       { filename: "/src/demos/index.tsx" },
     );
-    expect(result.diagnostics).toHaveLength(0);
+    expect(result.diagnostics).toHaveLength(1);
   });
 
   it("stays quiet when URL is a local binding, not the DOM global", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-no-a-element.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-no-a-element.regressions.test.ts
@@ -23,6 +23,30 @@ describe("nextjs/nextjs-no-a-element — regressions", () => {
     expect(result.diagnostics.length).toBeGreaterThan(0);
   });
 
+  it.each([
+    "src/components/tools/widget.tsx",
+    "src/components/demo/widget.tsx",
+    "src/migrations/widget.tsx",
+  ])("still flags an internal route in application code at %s", (filename) => {
+    const result = runRule(
+      nextjsNoAElement,
+      `export default function C() { return <a href="/about">About</a>; }`,
+      { filename },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("stays silent for an internal route in a root-level tooling directory", () => {
+    const result = runRule(
+      nextjsNoAElement,
+      `export default function C() { return <a href="/about">About</a>; }`,
+      { filename: "tools/widget.tsx" },
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("stays silent on a download anchor", () => {
     const result = runRule(
       nextjsNoAElement,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/define-rule.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/define-rule.test.ts
@@ -59,6 +59,62 @@ describe("defineRule", () => {
     expect(visitors.JSXOpeningElement).toBeTypeOf("function");
   });
 
+  it("keeps test-noise visitors in product directories below a source root", () => {
+    let didCreateVisitors = false;
+    const rule = defineRule({
+      id: "test-noise-rule",
+      title: "test",
+      severity: "warn",
+      tags: ["test-noise"],
+      create: () => {
+        didCreateVisitors = true;
+        return { Program: () => {} };
+      },
+    });
+
+    const visitors = rule.create({
+      filename: "src/components/tools/widget.tsx",
+      report: () => {},
+      get scopes(): never {
+        throw new Error("scopes should stay lazy");
+      },
+      get cfg(): never {
+        throw new Error("cfg should stay lazy");
+      },
+    });
+
+    expect(didCreateVisitors).toBe(true);
+    expect(visitors.Program).toBeTypeOf("function");
+  });
+
+  it("skips test-noise visitors in root-level tooling directories", () => {
+    let didCreateVisitors = false;
+    const rule = defineRule({
+      id: "test-noise-rule",
+      title: "test",
+      severity: "warn",
+      tags: ["test-noise"],
+      create: () => {
+        didCreateVisitors = true;
+        return { Program: () => {} };
+      },
+    });
+
+    const visitors = rule.create({
+      filename: "tools/widget.tsx",
+      report: () => {},
+      get scopes(): never {
+        throw new Error("scopes should stay lazy");
+      },
+      get cfg(): never {
+        throw new Error("cfg should stay lazy");
+      },
+    });
+
+    expect(didCreateVisitors).toBe(false);
+    expect(visitors).toEqual({});
+  });
+
   it("keeps capability-gated rules compatible when capabilities are unspecified", () => {
     const rule = defineRule({
       id: "compiler-disabled-rule",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/define-rule.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/define-rule.ts
@@ -4,6 +4,7 @@ import {
   collectJsxRuntimeImports,
   jsxAttributeIsNonReactDialectMarker,
 } from "./non-react-jsx-dialect.js";
+import { isTestNoiseFilename } from "./is-testlike-filename.js";
 import { skipNonProductionFiles } from "./skip-non-production-files.js";
 import { shouldCreateRuleVisitors } from "./should-create-rule-visitors.js";
 import type { Rule } from "./rule.js";
@@ -121,7 +122,7 @@ export const defineRule = (rule: RuleDefinition): Rule => {
     wrappedCreate = wrapCreateForReactJsxOnly(wrappedCreate as never) as never;
   }
   if (honorsTestNoise) {
-    wrappedCreate = skipNonProductionFiles(wrappedCreate);
+    wrappedCreate = skipNonProductionFiles(wrappedCreate, isTestNoiseFilename);
   }
   if (rule.disabledWhen) {
     wrappedCreate = wrapCreateForCapabilities(wrappedCreate, rule.disabledWhen);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-testlike-filename.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-testlike-filename.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vite-plus/test";
-import { isTestlikeFilename } from "./is-testlike-filename.js";
+import { isTestlikeFilename, isTestNoiseFilename } from "./is-testlike-filename.js";
 
 describe("isTestlikeFilename", () => {
   it.each(["/workspace/test-stubs/trycompai-ui.tsx", "/workspace/src/test-stubs/trycompai-ui.tsx"])(
@@ -11,5 +11,35 @@ describe("isTestlikeFilename", () => {
 
   it("does not classify a production stub component as test-only", () => {
     expect(isTestlikeFilename("/workspace/src/components/dialog-stub.tsx")).toBe(false);
+  });
+});
+
+describe("isTestNoiseFilename", () => {
+  it.each([
+    "/workspace/src/components/tools/widget.tsx",
+    "src/demo/widget.tsx",
+    "app/migrations/page.tsx",
+    "components/spec/widget.tsx",
+    "src/perf/metrics.tsx",
+    "C:\\workspace\\src\\components\\tools\\widget.tsx",
+  ])("treats an ambiguous directory below a source root as production at %s", (filename) => {
+    expect(isTestNoiseFilename(filename)).toBe(false);
+  });
+
+  it.each([
+    "/workspace/tools/widget.tsx",
+    "/workspace/examples/widget.tsx",
+    "/workspace/migrations/widget.tsx",
+  ])("keeps a root-level non-application directory testlike at %s", (filename) => {
+    expect(isTestNoiseFilename(filename)).toBe(true);
+  });
+
+  it.each([
+    "/workspace/src/__tests__/tools/widget.tsx",
+    "/workspace/src/fixtures/demo/widget.tsx",
+    "/workspace/src/components/tools/widget.test.tsx",
+    "/workspace/src/.storybook/components/widget.tsx",
+  ])("keeps an explicit test surface testlike at %s", (filename) => {
+    expect(isTestNoiseFilename(filename)).toBe(true);
   });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-testlike-filename.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/is-testlike-filename.ts
@@ -1,3 +1,39 @@
+// These names describe non-application code at the repository root, but they
+// also name common product areas below an application source root.
+const AMBIGUOUS_NON_PRODUCTION_PATH_SEGMENTS: ReadonlySet<string> = new Set([
+  "/playground/",
+  "/playgrounds/",
+  "/examples/",
+  "/example/",
+  "/demo/",
+  "/demos/",
+  "/sandbox/",
+  "/sandboxes/",
+  "/specs/",
+  "/spec/",
+  "/integration/",
+  "/it/",
+  "/perf/",
+  "/scripts/",
+  "/cli/",
+  "/bin/",
+  "/tooling/",
+  "/tools/",
+  "/codemods/",
+  "/codemod/",
+  "/migrations/",
+  "/migration/",
+  "/generators/",
+  "/generator/",
+  "/runbooks/",
+  "/devtools/",
+  "/internal-tools/",
+  "/seeds/",
+  "/seed/",
+  "/dev-seeder/",
+]);
+const EMPTY_IGNORED_PATH_SEGMENTS: ReadonlySet<string> = new Set();
+
 // Directory names that mark a file as part of a test / fixture /
 // Storybook / Cypress / docs-site (`.dumi`) / example surface, regardless
 // of the file's own suffix.
@@ -21,48 +57,14 @@ const NON_PRODUCTION_PATH_SEGMENTS: ReadonlyArray<string> = [
   "/.dumi/",
   "/stories/",
   "/__stories__/",
-  "/playground/",
-  "/playgrounds/",
-  "/examples/",
-  "/example/",
-  "/demo/",
-  "/demos/",
-  "/sandbox/",
-  "/sandboxes/",
+  ...AMBIGUOUS_NON_PRODUCTION_PATH_SEGMENTS,
   "/e2e/",
   "/e2e-tests/",
-  "/specs/",
-  "/spec/",
   "/integration-tests/",
-  "/integration/",
-  "/it/",
   "/benchmarks/",
   "/benchmark/",
   "/__benchmarks__/",
-  "/perf/",
   "/perf-tests/",
-  // CLI / one-shot / build-time tooling — never shipped in the
-  // user-facing bundle, no render-perf or React-rule concerns. Captures
-  // top-level `scripts/`, `cli/`, `bin/`, `tooling/`, `tools/`,
-  // `codemods/`, `migrations/`, `generators/`, `runbooks/`, etc. as well
-  // as `src/scripts/...` shaped layouts.
-  "/scripts/",
-  "/cli/",
-  "/bin/",
-  "/tooling/",
-  "/tools/",
-  "/codemods/",
-  "/codemod/",
-  "/migrations/",
-  "/migration/",
-  "/generators/",
-  "/generator/",
-  "/runbooks/",
-  "/devtools/",
-  "/internal-tools/",
-  "/seeds/",
-  "/seed/",
-  "/dev-seeder/",
 ];
 
 // True iff `filename` looks like test / spec / Storybook / Cypress /
@@ -217,6 +219,8 @@ const sliceBelowSourceRoot = (filename: string): string => {
 // call per file.
 let lastFilename: string | undefined;
 let lastResult = false;
+let lastTestNoiseFilename: string | undefined;
+let lastTestNoiseResult = false;
 
 export const isTestlikeFilename = (rawFilename: string | undefined): boolean => {
   if (!rawFilename) return false;
@@ -226,6 +230,22 @@ export const isTestlikeFilename = (rawFilename: string | undefined): boolean => 
   return lastResult;
 };
 
+export const isTestNoiseFilename = (rawFilename: string | undefined): boolean => {
+  if (!rawFilename) return false;
+  if (rawFilename === lastTestNoiseFilename) return lastTestNoiseResult;
+  lastTestNoiseFilename = rawFilename;
+  const filename = rawFilename.replaceAll("\\", "/");
+  const rootedFilename = filename.startsWith("/") ? filename : `/${filename}`;
+  const isBelowSourceRoot = SOURCE_ROOT_SEGMENTS.some((segment) =>
+    rootedFilename.includes(segment),
+  );
+  lastTestNoiseResult = computeIsTestlikeFilename(
+    rootedFilename,
+    isBelowSourceRoot ? AMBIGUOUS_NON_PRODUCTION_PATH_SEGMENTS : EMPTY_IGNORED_PATH_SEGMENTS,
+  );
+  return lastTestNoiseResult;
+};
+
 export const isTestlikeFilenameIgnoringPathSegments = (
   rawFilename: string | undefined,
   ignoredPathSegments: ReadonlySet<string>,
@@ -233,7 +253,7 @@ export const isTestlikeFilenameIgnoringPathSegments = (
 
 const computeIsTestlikeFilename = (
   rawFilename: string,
-  ignoredPathSegments: ReadonlySet<string> = new Set(),
+  ignoredPathSegments: ReadonlySet<string> = EMPTY_IGNORED_PATH_SEGMENTS,
 ): boolean => {
   const filename = rawFilename.replaceAll("\\", "/");
   const lastSlash = filename.lastIndexOf("/");

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/skip-non-production-files.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/skip-non-production-files.ts
@@ -10,6 +10,6 @@ import type { RuleVisitors } from "./rule-visitors.js";
 // `new Function` / a token in web storage is not a real vulnerability in test
 // scaffolding that never reaches a browser.
 export const skipNonProductionFiles =
-  (create: (context: RuleContext) => RuleVisitors) =>
+  (create: (context: RuleContext) => RuleVisitors, isNonProductionFilename = isTestlikeFilename) =>
   (context: RuleContext): RuleVisitors =>
-    isTestlikeFilename(context.filename) ? EMPTY_RULE_VISITORS : create(context);
+    isNonProductionFilename(context.filename) ? EMPTY_RULE_VISITORS : create(context);


### PR DESCRIPTION
## Why

Rules tagged `test-noise` returned no visitors for files under common product directory names such as `tools`, `demo`, and `migrations`. This silently disabled 332 rules in valid application code.

Closes #1724.

## What changed

- Add a test-noise-specific filename classifier that treats ambiguous directory names as application code below a recognized source root.
- Keep explicit tests, fixtures, mocks, Storybook, Cypress, and root-level tooling or example directories excluded.
- Keep direct security and other non-production rule guards on the existing strict classifier.
- Add path, wrapper, rule-level, Windows-path, and package regression coverage.
- Add patch changesets for the affected packages.

## Validation

- `nr test`
- `nr lint`
- `nr typecheck`
- `nr format:check`
- `nr build`
- `nr smoke:json-report`
- `FUZZ_RULE=nextjs-no-a-element FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz`
- Local RDE scan of 100 project roots: 2 `nextjs-no-a-element` hits in Excalidraw, both confirmed true positives.

Daytona parity was not available because `DAYTONA_API_KEY` is not set in this environment.