### PR TITLE
fix: classify fragment returns of translation text as text-producing

### DIFF
--- a/.changeset/fix-fbt-fragment-returns.md
+++ b/.changeset/fix-fbt-fragment-returns.md
@@ -1,0 +1,9 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+fix: classify fragment returns of translation text as text-producing
+
+Fragment returns mixing translation text elements (fbt/fbs) with literal text now classify correctly as text-producing components. The fragment is render-transparent, so both halves land in the caller's `<Text>`.
+
+Fixes #1731

--- a/.changeset/fix-fbt-fragment-returns.md
+++ b/.changeset/fix-fbt-fragment-returns.md
@@ -2,8 +2,4 @@
 "oxlint-plugin-react-doctor": patch
 ---
 
-fix: classify fragment returns of translation text as text-producing
-
-Fragment returns mixing translation text elements (fbt/fbs) with literal text now classify correctly as text-producing components. The fragment is render-transparent, so both halves land in the caller's `<Text>`.
-
-Fixes #1731
+Classify fragment returns that contain only translation elements and static text as text-producing components.

--- a/packages/fuzz/corpus/regressions/rn-no-raw-text--translation-fragment.tsx
+++ b/packages/fuzz/corpus/regressions/rn-no-raw-text--translation-fragment.tsx
@@ -1,0 +1,29 @@
+// rule: rn-no-raw-text
+// verdict: pass
+// weakness: wrapper-transparency
+// source: issue #1731
+
+import { Text } from "react-native";
+
+interface ReminderLabelProps {
+  reminder: "none" | "morning";
+}
+
+export const ReminderLabel = ({ reminder }: ReminderLabelProps) => {
+  switch (reminder) {
+    case "none":
+      return <fbt desc="no reminder">No reminder</fbt>;
+    case "morning":
+      return (
+        <>
+          <fbt desc="morning reminder">Morning</fbt>, 7:00 AM
+        </>
+      );
+  }
+};
+
+export const Screen = () => (
+  <Text>
+    <ReminderLabel reminder="morning" />
+  </Text>
+);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-raw-text.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-raw-text.test.ts
@@ -655,14 +655,54 @@ describe("react-native/rn-no-raw-text", () => {
       `);
     });
 
-    it("still fires when fbt is nested under a fragment return", () => {
-      expectFail(`
+    it("does not fire when fbt is nested under a fragment return", () => {
+      expectPass(`
         const FbtMarker = () => (
           <Fragment>
             <fbt desc="d">Travel with confidence</fbt>
           </Fragment>
         );
         const Screen = () => <Text><FbtMarker /></Text>;
+      `);
+    });
+
+    it("still fires when a fragment return mixes fbt with a non-text element", () => {
+      expectFail(`
+        const MixedComponent = () => (
+          <>
+            <fbt desc="label">Morning</fbt>
+            <View>icon</View>
+          </>
+        );
+        const Screen = () => (
+          <Text>
+            <MixedComponent />
+          </Text>
+        );
+      `);
+    });
+
+    it("does not fire on fragment returns mixing fbt with literal text (issue #1731)", () => {
+      expectPass(`
+        const ReminderLabel = ({ reminder }) => {
+          switch (reminder) {
+            case "none": {
+              return <fbt desc="no reminder">No reminder</fbt>;
+            }
+            case "morning": {
+              return (
+                <>
+                  <fbt desc="morning reminder">Morning</fbt>, 7:00 AM
+                </>
+              );
+            }
+          }
+        };
+        const Screen = () => (
+          <Text>
+            <ReminderLabel reminder="morning" />
+          </Text>
+        );
       `);
     });
 

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-raw-text.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-no-raw-text.test.ts
@@ -706,6 +706,63 @@ describe("react-native/rn-no-raw-text", () => {
       `);
     });
 
+    it("does not fire on static expression text beside translation elements", () => {
+      expectPass(`
+        const FbtMarker = () => (
+          <>
+            <fbt desc="label">Morning</fbt>
+            {", 7:00 AM"}
+          </>
+        );
+        const Screen = () => <Text><FbtMarker /></Text>;
+      `);
+    });
+
+    it("does not fire on translation elements inside nested fragment expressions", () => {
+      expectPass(`
+        const FbtMarker = ({ useShortLabel }) => (
+          <>
+            <Fragment>
+              {useShortLabel ? <fbt desc="short">AM</fbt> : <fbs>Morning</fbs>}
+            </Fragment>
+          </>
+        );
+        const Screen = () => <Text><FbtMarker useShortLabel /></Text>;
+      `);
+    });
+
+    it("still fires when a fragment contains an opaque expression", () => {
+      expectFail(`
+        const MixedComponent = ({ content }) => (
+          <>
+            <fbt desc="label">Morning</fbt>
+            {content}
+          </>
+        );
+        const Screen = () => (
+          <Text>
+            <MixedComponent content={<View>icon</View>} />
+          </Text>
+        );
+      `);
+    });
+
+    it("still fires when an expression can render a non-text element", () => {
+      expectFail(`
+        const MixedComponent = ({ showIcon }) => (
+          <>
+            <fbt desc="label">Morning</fbt>
+            {showIcon && <View>icon</View>}
+          </>
+        );
+        const Screen = () => (
+          <Text>
+            <MixedComponent showIcon />
+          </Text>
+        );
+      `);
+    });
+
     it("does not classify a direct fbt return as a Text wrapper", () => {
       expectFail(`
         const FbtMarker = ({ children }) => <fbt desc="d">Label</fbt>;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/collect-text-wrapper-components.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/collect-text-wrapper-components.ts
@@ -408,18 +408,24 @@ const resolveClassRenderFunction = (classNode: EsTreeNode): FunctionNode | null 
   return null;
 };
 
+const isTranslationTextJsxRoot = (jsxRoot: EsTreeNode): boolean => {
+  const fragmentChildren = fragmentChildrenOrNull(jsxRoot);
+  if (fragmentChildren !== null) {
+    const elementChildren = fragmentChildren.filter(
+      (child) => isNodeOfType(child, "JSXElement") || isNodeOfType(child, "JSXFragment"),
+    );
+    return elementChildren.length > 0 && elementChildren.every(isTranslationTextJsxRoot);
+  }
+  if (!isNodeOfType(jsxRoot, "JSXElement")) return false;
+  const rootName = resolveJsxElementName(jsxRoot.openingElement);
+  return rootName !== null && REACT_NATIVE_TRANSLATION_TEXT_COMPONENTS.has(rootName);
+};
+
 const returnsOnlyTranslationTextElements = (definitionNode: EsTreeNode): boolean => {
   const unwrapped = unwrapComponentDefinition(definitionNode);
   if (!isFunctionNode(unwrapped)) return false;
   const jsxRoots = collectReturnedJsxRoots(unwrapped);
-  return (
-    jsxRoots.length > 0 &&
-    jsxRoots.every((jsxRoot) => {
-      if (!isNodeOfType(jsxRoot, "JSXElement")) return false;
-      const rootName = resolveJsxElementName(jsxRoot.openingElement);
-      return rootName !== null && REACT_NATIVE_TRANSLATION_TEXT_COMPONENTS.has(rootName);
-    })
-  );
+  return jsxRoots.length > 0 && jsxRoots.every(isTranslationTextJsxRoot);
 };
 
 export interface ChildrenForwardingComponents {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/collect-text-wrapper-components.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/collect-text-wrapper-components.ts
@@ -5,6 +5,7 @@ import { isJsxFragmentElement } from "./is-jsx-fragment-element.js";
 import { isNodeOfType } from "./is-node-of-type.js";
 import { isReactComponentName } from "./is-react-component-name.js";
 import { stripParenExpression } from "./strip-paren-expression.js";
+import { visitStaticJsxChildren } from "./visit-static-jsx-children.js";
 import { walkAst } from "./walk-ast.js";
 import { resolveJsxElementName } from "./resolve-jsx-element-name.js";
 
@@ -411,10 +412,24 @@ const resolveClassRenderFunction = (classNode: EsTreeNode): FunctionNode | null 
 const isTranslationTextJsxRoot = (jsxRoot: EsTreeNode): boolean => {
   const fragmentChildren = fragmentChildrenOrNull(jsxRoot);
   if (fragmentChildren !== null) {
-    const elementChildren = fragmentChildren.filter(
-      (child) => isNodeOfType(child, "JSXElement") || isNodeOfType(child, "JSXFragment"),
-    );
-    return elementChildren.length > 0 && elementChildren.every(isTranslationTextJsxRoot);
+    let didContainTranslationTextElement = false;
+    let didContainUnsupportedChild = false;
+    visitStaticJsxChildren(fragmentChildren, {
+      onElement: (element) => {
+        if (isJsxFragmentElement(element.openingElement)) return true;
+        const elementName = resolveJsxElementName(element.openingElement);
+        if (elementName && REACT_NATIVE_TRANSLATION_TEXT_COMPONENTS.has(elementName)) {
+          didContainTranslationTextElement = true;
+        } else {
+          didContainUnsupportedChild = true;
+        }
+        return false;
+      },
+      onOpaqueExpression: () => {
+        didContainUnsupportedChild = true;
+      },
+    });
+    return didContainTranslationTextElement && !didContainUnsupportedChild;
   }
   if (!isNodeOfType(jsxRoot, "JSXElement")) return false;
   const rootName = resolveJsxElementName(jsxRoot.openingElement);


### PR DESCRIPTION
## Why

Issue #1731 reports a false positive when a component returns translation text through a fragment.

Before this change, `rn-no-raw-text` did not classify fragment returns as text-producing. After this change, fragments that contain only `fbt` or `fbs` elements and static text are render-transparent text producers.

## What changed

- Reuse `visitStaticJsxChildren` to inspect fragment children.
- Support shorthand, named, and nested fragments.
- Support static JSX text and literal expression text.
- Reject fragments with opaque expressions or non-translation elements.
- Add adversarial tests and a fuzz regression corpus entry.
- Add a patch changeset for `oxlint-plugin-react-doctor`.

## Local eval

- 100 project roots across 12 repositories
- 0 evaluator error rows
- 0 `rn-no-raw-text` hits in this sample
- Daytona parity was not run because `DAYTONA_API_KEY` is not available in the current environment

The issue reporter also verified the PR package against the Expo 57 reproduction: diagnostics decreased from 4 to 0, with a score of 100.

## Test plan

- `nr build`
- `nr test`
- `nr lint`
- `nr typecheck`
- `nr format:check`
- `REACT_DOCTOR_NO_TELEMETRY=1 nr smoke:json-report`
- `nr -C packages/fuzz test`
- `FUZZ_RULE=rn-no-raw-text FUZZ_STRICT=1 FUZZ_ITERATIONS=500 FUZZ_PRINT_STATS=1 nr fuzz --disableConsoleIntercept`

Fixes #1731
