### PR TITLE
fix: recognize global String substring lookups

### DIFF
--- a/.changeset/fix-string-includes-false-positive.md
+++ b/.changeset/fix-string-includes-false-positive.md
@@ -1,0 +1,10 @@
+---
+"oxlint-plugin-react-doctor": patch
+"react-doctor": patch
+---
+
+fix: prevent false positive in js-set-map-lookups for String().includes()
+
+The rule now correctly recognizes `String(entry).includes(code)` as a substring search on the string returned by the global `String()` constructor, rather than flagging it as an inefficient array lookup. The fix adds a check to ensure that `String` refers to the global constructor and not a shadowed local variable.
+
+Closes #1733

--- a/.changeset/fix-string-includes-false-positive.md
+++ b/.changeset/fix-string-includes-false-positive.md
@@ -3,8 +3,4 @@
 "react-doctor": patch
 ---
 
-fix: prevent false positive in js-set-map-lookups for String().includes()
-
-The rule now correctly recognizes `String(entry).includes(code)` as a substring search on the string returned by the global `String()` constructor, rather than flagging it as an inefficient array lookup. The fix adds a check to ensure that `String` refers to the global constructor and not a shadowed local variable.
-
-Closes #1733
+Fix `js-set-map-lookups` false positives for substring checks on values returned by the global `String` constructor.

--- a/packages/fuzz/corpus/regressions/js-set-map-lookups--string-constructor.ts
+++ b/packages/fuzz/corpus/regressions/js-set-map-lookups--string-constructor.ts
@@ -4,4 +4,4 @@
 // verdict: pass
 
 const hasCode = (messages: unknown[], code: string) =>
-  messages.some((entry) => String(entry).includes(code))
+  messages.some((entry) => String(entry).includes(code));

--- a/packages/fuzz/corpus/regressions/js-set-map-lookups--string-constructor.ts
+++ b/packages/fuzz/corpus/regressions/js-set-map-lookups--string-constructor.ts
@@ -1,0 +1,7 @@
+// rule: js-set-map-lookups
+// weakness: name-heuristic
+// source: GitHub issue #1733
+// verdict: pass
+
+const hasCode = (messages: unknown[], code: string) =>
+  messages.some((entry) => String(entry).includes(code))

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-set-map-lookups.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-set-map-lookups.regressions.test.ts
@@ -816,4 +816,38 @@ describe("js-performance/js-set-map-lookups — regressions", () => {
       }`,
     );
   });
+
+  it("does not flag String(x).includes() inside a loop (issue #1733)", () => {
+    expectPass(
+      `const hasCode = (messages: unknown[], code: string) => messages.some((entry) => String(entry).includes(code))`,
+    );
+  });
+
+  it("does not flag String(x).includes() in a for-of loop", () => {
+    expectPass(
+      `function hasCode(messages: unknown[], code: string) {
+        for (const entry of messages) {
+          if (String(entry).includes(code)) return true;
+        }
+        return false;
+      }`,
+    );
+  });
+
+  it("does not flag String(x).includes() in a filter callback", () => {
+    expectPass(
+      `const withCode = (messages: unknown[], code: string) => messages.filter((entry) => String(entry).includes(code))`,
+    );
+  });
+
+  it("flags String(x).includes() when String is a shadowed local variable returning non-string", () => {
+    expectFail(
+      `function test() {
+        const String = (x: unknown) => JSON.stringify(x);
+        const hasCode = (messages: unknown[], code: string) =>
+          messages.some((entry) => String(entry).includes(code));
+        return hasCode;
+      }`,
+    );
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-set-map-lookups.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-set-map-lookups.regressions.test.ts
@@ -840,14 +840,27 @@ describe("js-performance/js-set-map-lookups — regressions", () => {
     );
   });
 
-  it("flags String(x).includes() when String is a shadowed local variable returning non-string", () => {
+  it("does not flag String(x).indexOf() as a substring search", () => {
+    expectPass(
+      `const hasCode = (messages: unknown[], code: string) => messages.some((entry) => String(entry).indexOf(code) !== -1)`,
+    );
+  });
+
+  it("flags String(x).includes() when String is a shadowed local collection factory", () => {
     expectFail(
       `function test() {
-        const String = (x: unknown) => JSON.stringify(x);
+        const String = (value: unknown) => [value];
         const hasCode = (messages: unknown[], code: string) =>
           messages.some((entry) => String(entry).includes(code));
         return hasCode;
       }`,
+    );
+  });
+
+  it("flags String(x).includes() when String is a function parameter", () => {
+    expectFail(
+      `const hasCode = (String, messages: unknown[], code: string) =>
+        messages.some((entry) => String(entry).includes(code))`,
     );
   });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-set-map-lookups.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-set-map-lookups.ts
@@ -262,7 +262,8 @@ const isLikelyStringReceiver = (receiver: EsTreeNode | null | undefined): boolea
   if (
     isNodeOfType(receiver, "CallExpression") &&
     isNodeOfType(receiver.callee, "Identifier") &&
-    receiver.callee.name === "String"
+    receiver.callee.name === "String" &&
+    findVariableInitializer(receiver.callee, receiver.callee.name) === null
   ) {
     return true;
   }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-set-map-lookups.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/js-performance/js-set-map-lookups.ts
@@ -253,17 +253,20 @@ const FRESH_ARRAY_METHOD_NAMES: ReadonlySet<string> = new Set([
 
 // HACK: returns true when the receiver of `.includes()` / `.indexOf()`
 // is obviously a string, so the Set rewrite suggestion doesn't apply.
-const isLikelyStringReceiver = (receiver: EsTreeNode | null | undefined): boolean => {
+const isLikelyStringReceiver = (
+  receiver: EsTreeNode | null | undefined,
+  scopes: ScopeAnalysis,
+): boolean => {
   if (!receiver) return false;
   const unwrappedReceiver = stripParenExpression(receiver);
-  if (unwrappedReceiver !== receiver) return isLikelyStringReceiver(unwrappedReceiver);
+  if (unwrappedReceiver !== receiver) return isLikelyStringReceiver(unwrappedReceiver, scopes);
   if (isNodeOfType(receiver, "Literal") && typeof receiver.value === "string") return true;
   if (isNodeOfType(receiver, "TemplateLiteral")) return true;
   if (
     isNodeOfType(receiver, "CallExpression") &&
     isNodeOfType(receiver.callee, "Identifier") &&
     receiver.callee.name === "String" &&
-    findVariableInitializer(receiver.callee, receiver.callee.name) === null
+    scopes.isGlobalReference(receiver.callee)
   ) {
     return true;
   }
@@ -289,7 +292,7 @@ const isLikelyStringReceiver = (receiver: EsTreeNode | null | undefined): boolea
     isNodeOfType(receiver.callee, "MemberExpression") &&
     isNodeOfType(receiver.callee.property, "Identifier") &&
     (receiver.callee.property.name === "concat" || receiver.callee.property.name === "slice") &&
-    isLikelyStringReceiver(receiver.callee.object)
+    isLikelyStringReceiver(receiver.callee.object, scopes)
   ) {
     return true;
   }
@@ -299,7 +302,7 @@ const isLikelyStringReceiver = (receiver: EsTreeNode | null | undefined): boolea
   if (
     isNodeOfType(receiver, "ChainExpression") &&
     receiver.expression &&
-    isLikelyStringReceiver(receiver.expression)
+    isLikelyStringReceiver(receiver.expression, scopes)
   ) {
     return true;
   }
@@ -323,22 +326,29 @@ const isLikelyStringReceiver = (receiver: EsTreeNode | null | undefined): boolea
   }
   // `a + ':' + b` — string concatenation yields a string.
   if (isNodeOfType(receiver, "BinaryExpression") && receiver.operator === "+") {
-    return isLikelyStringReceiver(receiver.left) || isLikelyStringReceiver(receiver.right);
+    return (
+      isLikelyStringReceiver(receiver.left, scopes) ||
+      isLikelyStringReceiver(receiver.right, scopes)
+    );
   }
   if (isNodeOfType(receiver, "ConditionalExpression")) {
     return (
-      isLikelyStringReceiver(receiver.consequent) && isLikelyStringReceiver(receiver.alternate)
+      isLikelyStringReceiver(receiver.consequent, scopes) &&
+      isLikelyStringReceiver(receiver.alternate, scopes)
     );
   }
   if (isNodeOfType(receiver, "LogicalExpression")) {
-    return isLikelyStringReceiver(receiver.left) && isLikelyStringReceiver(receiver.right);
+    return (
+      isLikelyStringReceiver(receiver.left, scopes) &&
+      isLikelyStringReceiver(receiver.right, scopes)
+    );
   }
   return false;
 };
 
-const isFreshArrayReceiver = (receiver: EsTreeNode): boolean => {
+const isFreshArrayReceiver = (receiver: EsTreeNode, scopes: ScopeAnalysis): boolean => {
   const unwrappedReceiver = stripParenExpression(receiver);
-  if (unwrappedReceiver !== receiver) return isFreshArrayReceiver(unwrappedReceiver);
+  if (unwrappedReceiver !== receiver) return isFreshArrayReceiver(unwrappedReceiver, scopes);
   if (
     !isNodeOfType(receiver, "CallExpression") ||
     !isNodeOfType(receiver.callee, "MemberExpression") ||
@@ -348,11 +358,11 @@ const isFreshArrayReceiver = (receiver: EsTreeNode): boolean => {
   }
   if (!FRESH_ARRAY_METHOD_NAMES.has(receiver.callee.property.name)) return false;
   if (receiver.callee.property.name === "split") {
-    return isLikelyStringReceiver(receiver.callee.object);
+    return isLikelyStringReceiver(receiver.callee.object, scopes);
   }
   if (receiver.callee.property.name === "slice") return true;
   const sourceReceiver = stripParenExpression(receiver.callee.object);
-  return isKnownNativeArrayReceiver(sourceReceiver) || isFreshArrayReceiver(sourceReceiver);
+  return isKnownNativeArrayReceiver(sourceReceiver) || isFreshArrayReceiver(sourceReceiver, scopes);
 };
 
 const isSmallRestHelperOmissionList = (node: EsTreeNode | undefined): boolean => {
@@ -1740,9 +1750,9 @@ export const jsSetMapLookups = defineRule({
       ) {
         return;
       }
-      if (isLikelyStringReceiver(receiver)) return;
+      if (isLikelyStringReceiver(receiver, context.scopes)) return;
       if (isDeclaredStringReceiver(receiver)) return;
-      if (isFreshArrayReceiver(receiver)) return;
+      if (isFreshArrayReceiver(receiver, context.scopes)) return;
       if (isTypeScriptRestHelperLookup(node, receiver, context.scopes)) return;
       if (isSmallInlineLiteralArray(receiver)) return;
       if (isScreamingSnakeCaseConstantReceiver(receiver)) return;
@@ -1751,7 +1761,7 @@ export const jsSetMapLookups = defineRule({
       if (isIndexedArrayElementWithStringArgument(receiver, query)) return;
       const resolvedInitializer = getResolvedInitializer(receiver);
       if (resolvedInitializer) {
-        if (isLikelyStringReceiver(resolvedInitializer.initializer)) return;
+        if (isLikelyStringReceiver(resolvedInitializer.initializer, context.scopes)) return;
         if (
           !resolvedInitializer.isDefault &&
           isSmallInlineLiteralArray(resolvedInitializer.initializer)


### PR DESCRIPTION
## Why

`String(entry).includes(code)` is a substring search, but `js-set-map-lookups` treated it as a repeated collection lookup and suggested a `Set`.

Before, the rule used missing initializer data as proof that `String` was global. After this change, it uses scope analysis to prove the global constructor while keeping shadowed collection factories reportable.

Closes #1733

## What changed

- recognize `includes` and membership-style `indexOf` calls on values returned by the global `String` constructor
- preserve diagnostics when a local variable or function parameter shadows `String`
- add focused rule tests, a strict fuzz regression, and a patch changeset

## Local evaluation

A bounded RDE run scanned 100 project roots. The target rule produced 472 existing diagnostics across 29 project roots in 10 repositories. One hit from each repository was inspected; all 10 were repeated collection lookups.

PR parity was not run because `DAYTONA_API_KEY` is not available in the current environment.

Artifact: `/Users/aidenybai/.codex/worktrees/pr1734/rde-artifacts/js-set-map-lookups-hits.json`

## Test plan

- `nr test`
- `nr lint`
- `nr typecheck`
- `nr format:check`
- `REACT_DOCTOR_NO_TELEMETRY=1 nr smoke:json-report`
- `FUZZ_RULE=js-set-map-lookups FUZZ_STRICT=1 FUZZ_ITERATIONS=500 FUZZ_PRINT_STATS=1 nr fuzz --disableConsoleIntercept`
- focused regression suite: 144 tests passed
