### PR TITLE
fix: recognize indirect effect cleanup

### DIFF
--- a/.changeset/upset-facts-hide.md
+++ b/.changeset/upset-facts-hide.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Avoid cleanup false positives for callback refs, observer iteration, and effect-local stored disposers.

--- a/packages/fuzz/corpus/regressions/effect-needs-cleanup--callback-ref-observer.tsx
+++ b/packages/fuzz/corpus/regressions/effect-needs-cleanup--callback-ref-observer.tsx
@@ -1,0 +1,19 @@
+// rule: effect-needs-cleanup
+// weakness: framework-gating
+// source: issue #1736 callback ref false positive
+// verdict: pass
+
+import { useCallback, useRef } from "react";
+
+export const CallbackRefObserver = () => {
+  const observerRef = useRef<ResizeObserver | null>(null);
+  const setRef = useCallback((element: HTMLDivElement | null) => {
+    observerRef.current?.disconnect();
+    observerRef.current = null;
+    if (!element) return;
+    const observer = new ResizeObserver(() => {});
+    observer.observe(element);
+    observerRef.current = observer;
+  }, []);
+  return <div ref={setRef} />;
+};

--- a/packages/fuzz/corpus/regressions/effect-needs-cleanup--observer-for-each.tsx
+++ b/packages/fuzz/corpus/regressions/effect-needs-cleanup--observer-for-each.tsx
@@ -1,0 +1,15 @@
+// rule: effect-needs-cleanup
+// weakness: control-flow
+// source: issue #1736 observer forEach false positive
+// verdict: pass
+
+import { useEffect } from "react";
+
+export const ObserverForEach = ({ elements }: { elements: HTMLElement[] }) => {
+  useEffect(() => {
+    const observer = new IntersectionObserver(() => {});
+    elements.forEach((element) => observer.observe(element));
+    return () => observer.disconnect();
+  }, [elements]);
+  return null;
+};

--- a/packages/fuzz/corpus/regressions/effect-needs-cleanup--stored-disposer.tsx
+++ b/packages/fuzz/corpus/regressions/effect-needs-cleanup--stored-disposer.tsx
@@ -1,0 +1,20 @@
+// rule: effect-needs-cleanup
+// weakness: cleanup-provenance
+// source: issue #1736 stored disposer false positive
+// verdict: pass
+
+import { useEffect } from "react";
+
+export const StoredDisposer = ({ element }: { element: HTMLElement }) => {
+  useEffect(() => {
+    let cleanupObserver = () => {};
+    const observe = () => {
+      const observer = new IntersectionObserver(() => {});
+      observer.observe(element);
+      return () => observer.disconnect();
+    };
+    cleanupObserver = observe();
+    return () => cleanupObserver();
+  }, [element]);
+  return null;
+};

--- a/packages/fuzz/corpus/regressions/effect-observer-needs-disconnect--stored-disposer.tsx
+++ b/packages/fuzz/corpus/regressions/effect-observer-needs-disconnect--stored-disposer.tsx
@@ -1,0 +1,20 @@
+// rule: effect-observer-needs-disconnect
+// weakness: cleanup-provenance
+// source: issue #1736 stored disposer false positive
+// verdict: pass
+
+import { useEffect } from "react";
+
+export const StoredObserverDisposer = ({ element }: { element: HTMLElement }) => {
+  useEffect(() => {
+    let cleanupObserver = () => {};
+    const observe = () => {
+      const observer = new IntersectionObserver(() => {});
+      observer.observe(element);
+      return () => observer.disconnect();
+    };
+    cleanupObserver = observe();
+    return () => cleanupObserver();
+  }, [element]);
+  return null;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup-issue-1736.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup-issue-1736.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { effectNeedsCleanup } from "./effect-needs-cleanup.js";
+import { effectObserverNeedsDisconnect } from "./effect-observer-needs-disconnect.js";
+
+const closureHeldCleanup = `
+import { useEffect, useRef } from "react";
+
+export const ClosureHeldCleanup = ({ selector }: { selector: string }) => {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    let cleanupObserver = () => {};
+
+    const observeHero = () => {
+      const hero = document.querySelector<HTMLElement>(selector);
+      if (!hero) return () => {};
+      const observer = new IntersectionObserver(() => {});
+      observer.observe(hero);
+      return () => observer.disconnect();
+    };
+
+    cleanupObserver = observeHero();
+    return () => cleanupObserver();
+  }, [selector]);
+
+  return <div ref={ref} />;
+};
+`;
+
+const callbackRefObserver = `
+import { useCallback, useRef, useState } from "react";
+
+export const CallbackRefObserver = () => {
+  const observerRef = useRef<ResizeObserver | null>(null);
+  const [width, setWidth] = useState(0);
+
+  const setRef = useCallback((element: HTMLDivElement | null) => {
+    observerRef.current?.disconnect();
+    observerRef.current = null;
+    if (!element) return;
+    const observer = new ResizeObserver((entries) =>
+      setWidth(entries[0].contentRect.width)
+    );
+    observer.observe(element);
+    observerRef.current = observer;
+  }, []);
+
+  return <div ref={setRef}>{width}</div>;
+};
+`;
+
+const observeInForEach = `
+import { useEffect, useRef } from "react";
+
+export const ObserveInForEach = () => {
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+    const cards = root.querySelectorAll<HTMLElement>("[data-card]");
+    const observer = new IntersectionObserver(() => {});
+    cards.forEach((card) => observer.observe(card));
+    return () => observer.disconnect();
+  }, []);
+
+  return <div ref={rootRef} />;
+};
+`;
+
+const teardownViaHelper = `
+import { useEffect } from "react";
+
+export const TeardownViaHelper = () => {
+  useEffect(() => {
+    let animationFrameId: number | null = null;
+    let resumeTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const stopAutoScroll = () => {
+      if (animationFrameId !== null) {
+        cancelAnimationFrame(animationFrameId);
+        animationFrameId = null;
+      }
+    };
+
+    const onEvent = () => {
+      if (resumeTimer) clearTimeout(resumeTimer);
+      resumeTimer = setTimeout(() => {
+        animationFrameId = requestAnimationFrame(() => {});
+      }, 1500);
+    };
+
+    const events = ["scroll", "pointerdown", "keydown"] as const;
+    for (const eventName of events) {
+      window.addEventListener(eventName, onEvent, { passive: true });
+    }
+
+    return () => {
+      for (const eventName of events) {
+        window.removeEventListener(eventName, onEvent);
+      }
+      stopAutoScroll();
+      if (resumeTimer) clearTimeout(resumeTimer);
+    };
+  }, []);
+
+  return null;
+};
+`;
+
+const unsafeClosureHeldCleanup = `
+import { useEffect } from "react";
+
+export const UnsafeClosureHeldCleanup = ({ selector }: { selector: string }) => {
+  useEffect(() => {
+    let frame = 0;
+    let cleanupObserver = () => {};
+    const observeHero = () => {
+      const hero = document.querySelector<HTMLElement>(selector);
+      if (!hero) return () => {};
+      const observer = new IntersectionObserver(() => {});
+      observer.observe(hero);
+      return () => observer.disconnect();
+    };
+    const scheduleReobserve = () => {
+      frame = window.requestAnimationFrame(() => {
+        cleanupObserver();
+        cleanupObserver = observeHero();
+      });
+    };
+    cleanupObserver = observeHero();
+    window.addEventListener("resize", scheduleReobserve);
+    return () => {
+      window.cancelAnimationFrame(frame);
+      cleanupObserver();
+      window.removeEventListener("resize", scheduleReobserve);
+    };
+  }, [selector]);
+  return null;
+};
+`;
+
+const unsafeTeardownViaHelper = teardownViaHelper.replace(
+  "    const onEvent = () => {\n      if (resumeTimer) clearTimeout(resumeTimer);",
+  "    const onEvent = () => {",
+);
+
+const callbackRefWithoutUnmountRelease = callbackRefObserver.replace(
+  "    observerRef.current?.disconnect();",
+  "    if (element) observerRef.current?.disconnect();",
+);
+
+const callbackRefWithoutOwnershipStorage = callbackRefObserver.replace(
+  "    observerRef.current = observer;",
+  "",
+);
+
+const forEachWithoutUniversalDisconnect = observeInForEach.replace(
+  "    return () => observer.disconnect();",
+  "    return () => observer.unobserve(cards[0]);",
+);
+
+const storedDisposerWithoutCleanup = closureHeldCleanup.replace(
+  "    return () => cleanupObserver();",
+  "    return () => {};",
+);
+
+const storedDisposerWithCleanupBeforeAssignment = `
+import { useEffect } from "react";
+
+export const StoredDisposerWithEarlyCleanup = ({ element, skip }) => {
+  useEffect(() => {
+    let cleanupObserver = () => {};
+    const observe = () => {
+      const observer = new IntersectionObserver(() => {});
+      observer.observe(element);
+      return () => observer.disconnect();
+    };
+    if (skip) return () => cleanupObserver();
+    cleanupObserver = observe();
+    return () => {};
+  }, [element, skip]);
+  return null;
+};
+`;
+
+const partialUnsubscribe = `
+import { useEffect } from "react";
+
+export const PartialUnsubscribe = ({ api }) => {
+  useEffect(() => {
+    const onSelect = () => {};
+    api.on("reInit", onSelect);
+    api.on("select", onSelect);
+    return () => {
+      api?.off("select", onSelect);
+    };
+  }, [api]);
+  return null;
+};
+`;
+
+describe("issue 1736", () => {
+  it.each([
+    ["closure-held cleanup", closureHeldCleanup],
+    ["callback ref observer", callbackRefObserver],
+    ["observe in forEach", observeInForEach],
+    ["teardown through helper", teardownViaHelper],
+  ])("accepts %s", (_name, code) => {
+    expect(runRule(effectNeedsCleanup, code).diagnostics).toEqual([]);
+  });
+
+  it("accepts a closure-held observer cleanup", () => {
+    expect(runRule(effectObserverNeedsDisconnect, closureHeldCleanup).diagnostics).toEqual([]);
+  });
+
+  it("reports a partial unsubscribe", () => {
+    expect(runRule(effectNeedsCleanup, partialUnsubscribe).diagnostics).toHaveLength(1);
+  });
+
+  it.each([
+    ["overwritten animation frames", unsafeClosureHeldCleanup],
+    ["overwritten timeouts", unsafeTeardownViaHelper],
+    ["a callback ref without unmount release", callbackRefWithoutUnmountRelease],
+    ["a callback ref without ownership storage", callbackRefWithoutOwnershipStorage],
+    ["a partial forEach observer release", forEachWithoutUniversalDisconnect],
+    ["a stored disposer without cleanup", storedDisposerWithoutCleanup],
+    ["a stored disposer with only an earlier cleanup", storedDisposerWithCleanupBeforeAssignment],
+  ])("reports %s", (_name, code) => {
+    expect(runRule(effectNeedsCleanup, code).diagnostics).toHaveLength(1);
+  });
+
+  it.each([
+    ["a deferred stored disposer", unsafeClosureHeldCleanup],
+    ["a stored disposer without cleanup", storedDisposerWithoutCleanup],
+    ["a stored disposer with only an earlier cleanup", storedDisposerWithCleanupBeforeAssignment],
+  ])("reports %s for the observer rule", (_name, code) => {
+    expect(runRule(effectObserverNeedsDisconnect, code).diagnostics).toHaveLength(1);
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -15,6 +15,7 @@ import {
 } from "../../constants/react.js";
 import { INERT_REF_ONE_SHOT_TIMER_MAX_DELAY_MS } from "../../constants/thresholds.js";
 import { defineRule } from "../../utils/define-rule.js";
+import { doesEffectInvokeStoredDisposer } from "../../utils/does-effect-invoke-stored-disposer.js";
 import { canNodeReachLaterNodeWithinFunction } from "../../utils/can-node-reach-later-node-within-function.js";
 import { componentOrHookDisplayNameForFunction } from "../../utils/component-or-hook-display-name.js";
 import { resolveImportedExportName } from "../../utils/find-exported-function-body.js";
@@ -5944,6 +5945,68 @@ const oneShotTimerHasUnmountGuard = (usage: SubscribeLikeUsage, context: RuleCon
   return hasUnmountInvalidation;
 };
 
+const hasReturnedObserverDisconnectAfterSynchronousIteration = (
+  callback: EsTreeNode,
+  usage: SubscribeLikeUsage,
+  context: RuleContext,
+): boolean => {
+  const usageFunction = findEnclosingFunction(usage.node);
+  if (
+    usage.kind !== "subscribe" ||
+    usage.registrationVerbName !== "observe" ||
+    usage.receiverKey === null ||
+    !usageFunction ||
+    !isSynchronousIteratorCallback(usageFunction) ||
+    !isFunctionLike(callback) ||
+    !isNodeOfType(callback.body, "BlockStatement")
+  ) {
+    return false;
+  }
+  const matchingCleanupReturns: EsTreeNode[] = [];
+  walkInsideStatementBlocks(callback.body, (child: EsTreeNode) => {
+    if (!isNodeOfType(child, "ReturnStatement") || !child.argument) return;
+    const cleanupFunction = resolveRefOwnedCleanupFunction(child.argument, context);
+    if (!cleanupFunction || !isFunctionLike(cleanupFunction)) return;
+    const disconnectCalls: EsTreeNode[] = [];
+    walkAst(cleanupFunction.body, (cleanupChild: EsTreeNode) => {
+      if (cleanupChild !== cleanupFunction.body && isFunctionLike(cleanupChild)) return false;
+      const cleanupCall = isNodeOfType(cleanupChild, "ChainExpression")
+        ? cleanupChild.expression
+        : cleanupChild;
+      const cleanupCallee = isNodeOfType(cleanupCall, "CallExpression")
+        ? stripParenExpression(cleanupCall.callee)
+        : null;
+      if (
+        isNodeOfType(cleanupCall, "CallExpression") &&
+        isNodeOfType(cleanupCallee, "MemberExpression") &&
+        !cleanupCallee.computed &&
+        isNodeOfType(cleanupCallee.property, "Identifier") &&
+        cleanupCallee.property.name === "disconnect" &&
+        resolveExpressionKey(cleanupCallee.object, context) === usage.receiverKey
+      ) {
+        disconnectCalls.push(cleanupChild);
+      }
+    });
+    if (doNodesCoverEveryPathFromFunctionEntry(cleanupFunction, disconnectCalls, context)) {
+      matchingCleanupReturns.push(child);
+    }
+  });
+  return doMatchingNodesCoverEveryPathAfterUsage(usage.node, matchingCleanupReturns, context);
+};
+
+const hasEffectLocalStoredDisposerCleanup = (
+  callback: EsTreeNode,
+  usage: SubscribeLikeUsage,
+  context: RuleContext,
+): boolean =>
+  doesEffectInvokeStoredDisposer({
+    context,
+    effectCallback: callback,
+    resourceNode: usage.node,
+    doesFunctionReleaseResource: (functionNode) =>
+      isFunctionLike(functionNode) && doesCleanupFunctionReleaseUsage(functionNode, usage, context),
+  });
+
 const effectHasCleanupForUsage = (
   callback: EsTreeNode,
   usage: SubscribeLikeUsage,
@@ -5960,6 +6023,8 @@ const effectHasCleanupForUsage = (
   if (
     cleanupRegistryReleasesUsage(callback, usage, context) ||
     symmetricForEachListenerCleanupReleasesUsage(callback, usage, context) ||
+    hasReturnedObserverDisconnectAfterSynchronousIteration(callback, usage, context) ||
+    hasEffectLocalStoredDisposerCleanup(callback, usage, context) ||
     oneShotTimerHasUnmountGuard(usage, context) ||
     hasGuaranteedRefOwnedUnmountCleanup(callback, usage, context)
   ) {
@@ -6758,6 +6823,55 @@ const isReactRefListenerReplacementRelease = (
   );
 };
 
+const isReactRefObserverReplacementRelease = (
+  releaseCall: EsTreeNodeOfType<"CallExpression">,
+  usage: SubscribeLikeUsage,
+  context: RuleContext,
+): boolean => {
+  if (
+    usage.kind !== "subscribe" ||
+    usage.registrationVerbName !== "observe" ||
+    usage.receiverKey === null ||
+    !isNodeOfType(usage.node, "CallExpression")
+  ) {
+    return false;
+  }
+  const ownerFunction = findEnclosingFunction(usage.node);
+  const releaseCallee = stripParenExpression(releaseCall.callee);
+  if (
+    !ownerFunction ||
+    !isFunctionLike(ownerFunction) ||
+    ownerFunction !== findEnclosingFunction(releaseCall) ||
+    !isFunctionUsedAsReactRef(ownerFunction, context) ||
+    !isNodeOfType(releaseCallee, "MemberExpression") ||
+    releaseCallee.computed ||
+    !isNodeOfType(releaseCallee.property, "Identifier") ||
+    releaseCallee.property.name !== "disconnect"
+  ) {
+    return false;
+  }
+  const nodeParameterKey = resolveExpressionKey(ownerFunction.params[0], context);
+  const releaseRefSymbol = resolveReactRefCurrentReceiverSymbol(releaseCallee.object, context);
+  if (!nodeParameterKey || usage.eventKey !== nodeParameterKey || !releaseRefSymbol) return false;
+  const ownershipAssignments: EsTreeNode[] = [];
+  walkAst(ownerFunction.body, (child: EsTreeNode) => {
+    if (child !== ownerFunction.body && isFunctionLike(child)) return false;
+    if (
+      isNodeOfType(child, "AssignmentExpression") &&
+      child.operator === "=" &&
+      resolveReactRefSymbol(stripParenExpression(child.left), context.scopes)?.id ===
+        releaseRefSymbol.id &&
+      resolveExpressionKey(child.right, context) === usage.receiverKey
+    ) {
+      ownershipAssignments.push(child);
+    }
+  });
+  return (
+    doNodesCoverEveryPathFromFunctionEntry(ownerFunction, [releaseCall], context) &&
+    doMatchingNodesCoverEveryPathAfterUsage(usage.node, ownershipAssignments, context)
+  );
+};
+
 const findDirectExhaustiveForEachCleanupFunction = (
   releaseNode: EsTreeNode,
   requiredCollectionKeys: ReadonlySet<string>,
@@ -7153,7 +7267,12 @@ const doesReleaseCallMatchUsage = (
     return true;
   }
 
-  if (isReactRefListenerReplacementRelease(callNode, usage, context)) return true;
+  if (
+    isReactRefListenerReplacementRelease(callNode, usage, context) ||
+    isReactRefObserverReplacementRelease(callNode, usage, context)
+  ) {
+    return true;
+  }
 
   if (doesSocketOwnerReleaseListenerUsage(releaseReceiverKey, releaseVerbName, usage, context)) {
     return true;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-observer-needs-disconnect.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-observer-needs-disconnect.ts
@@ -6,6 +6,7 @@ import {
 } from "../../utils/collect-returned-cleanup-functions.js";
 import { collectFunctionReturnStatements } from "../../utils/collect-function-return-statements.js";
 import { defineRule } from "../../utils/define-rule.js";
+import { doesEffectInvokeStoredDisposer } from "../../utils/does-effect-invoke-stored-disposer.js";
 import { doNodesCoverEveryPathAfterNode } from "../../utils/do-nodes-cover-every-path-after-node.js";
 import { doNodesCoverEveryPathFromFunctionEntry } from "../../utils/do-nodes-cover-every-path-from-function-entry.js";
 import { getEffectCallback } from "../../utils/get-effect-callback.js";
@@ -676,6 +677,39 @@ const doesReturnedCleanupDisconnectCollection = (
   );
 };
 
+const doesEffectInvokeStoredObserverDisposer = (
+  callback: EsTreeNode,
+  tracked: TrackedObserver,
+  context: RuleContext,
+): boolean => {
+  const doesFunctionDisconnectObserver = (functionNode: EsTreeNode): boolean => {
+    if (!isFunctionLike(functionNode)) return false;
+    const disconnectCalls: EsTreeNode[] = [];
+    walkAst(functionNode.body, (child: EsTreeNode) => {
+      if (child !== functionNode.body && isFunctionLike(child)) return false;
+      const callNode = isNodeOfType(child, "ChainExpression") ? child.expression : child;
+      const callee = isNodeOfType(callNode, "CallExpression")
+        ? stripParenExpression(callNode.callee)
+        : null;
+      if (
+        isNodeOfType(callNode, "CallExpression") &&
+        isNodeOfType(callee, "MemberExpression") &&
+        getStaticPropertyName(callee) === "disconnect" &&
+        isTrackedObserverReference(callee.object, tracked.bindingIdentifiers)
+      ) {
+        disconnectCalls.push(child);
+      }
+    });
+    return doNodesCoverEveryPathFromFunctionEntry(functionNode, disconnectCalls, context);
+  };
+  return doesEffectInvokeStoredDisposer({
+    context,
+    effectCallback: callback,
+    resourceNode: tracked.construction,
+    doesFunctionReleaseResource: doesFunctionDisconnectObserver,
+  });
+};
+
 export const effectObserverNeedsDisconnect = defineRule({
   id: "effect-observer-needs-disconnect",
   title: "Observer created in an effect never disconnected",
@@ -812,7 +846,8 @@ export const effectObserverNeedsDisconnect = defineRule({
           !tracked.didObserve ||
           tracked.didReleaseAll ||
           tracked.didReleaseAllViaCallbackParameter ||
-          didReleaseEveryActiveTarget
+          didReleaseEveryActiveTarget ||
+          doesEffectInvokeStoredObserverDisposer(callback, tracked, context)
         ) {
           continue;
         }

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/does-effect-invoke-stored-disposer.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/does-effect-invoke-stored-disposer.ts
@@ -1,0 +1,129 @@
+import { collectFunctionReturnStatements } from "./collect-function-return-statements.js";
+import { doNodesCoverEveryPathAfterNode } from "./do-nodes-cover-every-path-after-node.js";
+import { doNodesCoverEveryPathFromFunctionEntry } from "./do-nodes-cover-every-path-from-function-entry.js";
+import { findEnclosingFunction } from "./find-enclosing-function.js";
+import { findTransparentExpressionRoot } from "./find-transparent-expression-root.js";
+import { getFunctionBindingIdentifier } from "./get-function-binding-name.js";
+import { isFunctionLike } from "./is-function-like.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+import { resolveExactLocalFunction } from "./resolve-exact-local-function.js";
+import { stripParenExpression } from "./strip-paren-expression.js";
+import type { EsTreeNode } from "./es-tree-node.js";
+import type { RuleContext } from "./rule-context.js";
+
+interface StoredEffectDisposerOptions {
+  context: RuleContext;
+  effectCallback: EsTreeNode;
+  resourceNode: EsTreeNode;
+  doesFunctionReleaseResource: (functionNode: EsTreeNode) => boolean;
+}
+
+export const doesEffectInvokeStoredDisposer = ({
+  context,
+  effectCallback,
+  resourceNode,
+  doesFunctionReleaseResource,
+}: StoredEffectDisposerOptions): boolean => {
+  const resourceOwner = findEnclosingFunction(resourceNode);
+  if (
+    !resourceOwner ||
+    !isFunctionLike(resourceOwner) ||
+    resourceOwner === effectCallback ||
+    !isNodeOfType(resourceOwner.body, "BlockStatement")
+  ) {
+    return false;
+  }
+  const disposerReturns = collectFunctionReturnStatements(resourceOwner).filter(
+    (returnStatement) => {
+      const returnedValue = returnStatement.argument
+        ? stripParenExpression(returnStatement.argument)
+        : null;
+      return Boolean(returnedValue && doesFunctionReleaseResource(returnedValue));
+    },
+  );
+  if (!doNodesCoverEveryPathAfterNode(resourceNode, disposerReturns, context, resourceNode)) {
+    return false;
+  }
+  const resourceOwnerBinding = getFunctionBindingIdentifier(resourceOwner);
+  const resourceOwnerSymbol = resourceOwnerBinding
+    ? context.scopes.symbolFor(resourceOwnerBinding)
+    : null;
+  if (!resourceOwnerSymbol || resourceOwnerSymbol.references.length !== 1) return false;
+  const resourceOwnerReference = resourceOwnerSymbol.references[0];
+  if (!resourceOwnerReference) return false;
+  const resourceOwnerReferenceRoot = findTransparentExpressionRoot(
+    resourceOwnerReference.identifier,
+  );
+  const resourceOwnerCall = resourceOwnerReferenceRoot.parent;
+  const resourceOwnerCallRoot = isNodeOfType(resourceOwnerCall, "CallExpression")
+    ? findTransparentExpressionRoot(resourceOwnerCall)
+    : null;
+  const storageAssignment = resourceOwnerCallRoot?.parent;
+  if (
+    !isNodeOfType(resourceOwnerCall, "CallExpression") ||
+    resourceOwnerCall.callee !== resourceOwnerReferenceRoot ||
+    !isNodeOfType(storageAssignment, "AssignmentExpression") ||
+    storageAssignment.operator !== "=" ||
+    storageAssignment.right !== resourceOwnerCallRoot ||
+    !isNodeOfType(storageAssignment.left, "Identifier") ||
+    findEnclosingFunction(storageAssignment) !== effectCallback
+  ) {
+    return false;
+  }
+  const storageSymbol = context.scopes.symbolFor(storageAssignment.left);
+  const initializer = storageSymbol?.initializer
+    ? stripParenExpression(storageSymbol.initializer)
+    : null;
+  if (
+    !storageSymbol ||
+    (storageSymbol.kind !== "let" && storageSymbol.kind !== "var") ||
+    !isNodeOfType(storageSymbol.declarationNode, "VariableDeclarator") ||
+    findEnclosingFunction(storageSymbol.declarationNode) !== effectCallback ||
+    !initializer ||
+    !isFunctionLike(initializer) ||
+    !isNodeOfType(initializer.body, "BlockStatement") ||
+    initializer.body.body.length !== 0
+  ) {
+    return false;
+  }
+  const cleanupCallsByFunction = new Map<EsTreeNode, EsTreeNode[]>();
+  for (const reference of storageSymbol.references) {
+    const referenceRoot = findTransparentExpressionRoot(reference.identifier);
+    const referenceParent = referenceRoot.parent;
+    if (referenceParent === storageAssignment && storageAssignment.left === referenceRoot) {
+      continue;
+    }
+    if (
+      !isNodeOfType(referenceParent, "CallExpression") ||
+      referenceParent.callee !== referenceRoot
+    ) {
+      return false;
+    }
+    const callOwner = findEnclosingFunction(referenceParent);
+    if (!callOwner) return false;
+    const cleanupCalls = cleanupCallsByFunction.get(callOwner) ?? [];
+    cleanupCalls.push(referenceParent);
+    cleanupCallsByFunction.set(callOwner, cleanupCalls);
+  }
+  const matchingCleanupReturns = collectFunctionReturnStatements(effectCallback).filter(
+    (returnStatement) => {
+      const cleanupFunction = returnStatement.argument
+        ? resolveExactLocalFunction(returnStatement.argument, context.scopes)
+        : null;
+      return Boolean(
+        cleanupFunction &&
+        doNodesCoverEveryPathFromFunctionEntry(
+          cleanupFunction,
+          cleanupCallsByFunction.get(cleanupFunction) ?? [],
+          context,
+        ),
+      );
+    },
+  );
+  return doNodesCoverEveryPathAfterNode(
+    storageAssignment,
+    matchingCleanupReturns,
+    context,
+    storageAssignment,
+  );
+};


### PR DESCRIPTION
Catches valid cleanup paths that pass through callback refs, synchronous observer iteration, and effect-local stored disposers.

## Why

`effect-needs-cleanup` and `effect-observer-needs-disconnect` reported valid teardown when cleanup ownership was indirect. This affected callback refs that release the prior observer, `forEach` observer registration followed by one `disconnect`, and helpers that return a disposer stored by the effect.

The exact overwritten animation-frame and timeout examples remain reportable. An earlier callback can run after unmount because the stored handle is replaced before cleanup.

## What changed

- Prove callback-ref observer replacement only when the ref owns the observer and every invocation releases the previous owner.
- Prove one returned `disconnect` covers synchronous observer iteration.
- Reuse one strict stored-disposer proof for both cleanup rules.
- Add adversarial rule tests, fuzz regression seeds, and a patch changeset.

## Eval results

A local RDE scan covered 100 project roots across 12 repositories. It found 50 existing `effect-needs-cleanup` diagnostics in 8 repositories and no `effect-observer-needs-disconnect` diagnostics. None matched the new suppression gates, and manual review found no new false positives.

## Test plan

- `nr lint`
- `nr typecheck`
- `nr format:check`
- `nr smoke:json-report`
- `nr -C packages/oxlint-plugin-react-doctor test` (1,117 files; 27,596 passed)
- `nr -C packages/react-doctor test` (251 files; 2,516 passed)
- `FUZZ_RULE=effect-needs-cleanup FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz`
- `FUZZ_RULE=effect-observer-needs-disconnect FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz`
- fuzz regression hunt: no regression in the four new seeds

Closes #1736