### PR TITLE
fix: normalize diagnostic file URLs

### DIFF
--- a/.changeset/tough-rules-juggle.md
+++ b/.changeset/tough-rules-juggle.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Normalize Oxlint file URLs before applying ignore patterns and writing report-relative diagnostic paths.

--- a/packages/core/src/apply-ignore-overrides.ts
+++ b/packages/core/src/apply-ignore-overrides.ts
@@ -2,7 +2,7 @@ import type { Diagnostic, ReactDoctorConfig, ReactDoctorIgnoreOverride } from ".
 import { isPlainObject } from "./project-info/index.js";
 import { isSameRuleKey } from "./rule-key-aliases.js";
 import { compileGlobPatternsLenient } from "./utils/match-glob-pattern.js";
-import { toRelativePath } from "./utils/to-relative-path.js";
+import { toNormalizedRelativePath } from "./utils/to-normalized-relative-path.js";
 import { warnConfigIssue } from "./utils/warn-config-issue.js";
 
 interface CompiledIgnoreOverride {
@@ -76,7 +76,7 @@ export const isDiagnosticIgnoredByOverrides = (
   overrides: CompiledIgnoreOverride[],
 ): boolean => {
   if (overrides.length === 0) return false;
-  const relativeFilePath = toRelativePath(diagnostic.filePath, rootDirectory);
+  const relativeFilePath = toNormalizedRelativePath(diagnostic.filePath, rootDirectory);
   const ruleIdentifier = `${diagnostic.plugin}/${diagnostic.rule}`;
 
   return overrides.some(

--- a/packages/core/src/build-json-report.ts
+++ b/packages/core/src/build-json-report.ts
@@ -1,4 +1,3 @@
-import * as path from "node:path";
 import type {
   Diagnostic,
   DiffInfo,
@@ -16,6 +15,7 @@ import { summarizeDiagnostics } from "./summarize-diagnostics.js";
 import { hasReactRuntime } from "./utils/has-react-runtime.js";
 import { isScanComplete } from "./utils/is-scan-complete.js";
 import { toNormalizedRelativePath } from "./utils/to-normalized-relative-path.js";
+import { resolveCandidateReadPath } from "./utils/resolve-candidate-read-path.js";
 
 interface BuildJsonReportInput {
   version: string;
@@ -72,11 +72,9 @@ const toJsonReportDiagnostic = (
   projectRoot: string,
   reportRoot: string,
 ): JsonReportDiagnosticV3 => {
-  const normalizedFilePath = toNormalizedRelativePath(diagnostic.filePath, projectRoot);
-  const reportRelativeFilePath = toNormalizedRelativePath(
-    path.resolve(projectRoot, diagnostic.filePath),
-    reportRoot,
-  );
+  const resolvedFilePath = resolveCandidateReadPath(projectRoot, diagnostic.filePath);
+  const normalizedFilePath = toNormalizedRelativePath(resolvedFilePath, projectRoot);
+  const reportRelativeFilePath = toNormalizedRelativePath(resolvedFilePath, reportRoot);
   const ruleIdentity = getDiagnosticRuleIdentity(diagnostic);
   return {
     ...diagnostic,

--- a/packages/core/src/is-ignored-file.ts
+++ b/packages/core/src/is-ignored-file.ts
@@ -1,6 +1,6 @@
 import type { ReactDoctorConfig } from "./types/index.js";
 import { compileGlobPatternsLenient } from "./utils/match-glob-pattern.js";
-import { toRelativePath } from "./utils/to-relative-path.js";
+import { toNormalizedRelativePath } from "./utils/to-normalized-relative-path.js";
 import { warnConfigIssue } from "./utils/warn-config-issue.js";
 
 export const compileIgnoredFilePatterns = (userConfig: ReactDoctorConfig | null): RegExp[] => {
@@ -18,6 +18,6 @@ export const isFileIgnoredByPatterns = (
   patterns: RegExp[],
 ): boolean => {
   if (patterns.length === 0) return false;
-  const relativePath = toRelativePath(filePath, rootDirectory);
+  const relativePath = toNormalizedRelativePath(filePath, rootDirectory);
   return patterns.some((pattern) => pattern.test(relativePath));
 };

--- a/packages/core/src/utils/to-normalized-relative-path.ts
+++ b/packages/core/src/utils/to-normalized-relative-path.ts
@@ -1,6 +1,10 @@
 import * as path from "node:path";
+import { resolveCandidateReadPath } from "./resolve-candidate-read-path.js";
 
 export const toNormalizedRelativePath = (filePath: string, rootDirectory: string): string =>
   path
-    .relative(path.resolve(rootDirectory), path.resolve(rootDirectory, filePath))
+    .relative(
+      path.resolve(rootDirectory),
+      path.resolve(resolveCandidateReadPath(rootDirectory, filePath)),
+    )
     .replaceAll("\\", "/") || ".";

--- a/packages/core/tests/build-json-report.test.ts
+++ b/packages/core/tests/build-json-report.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
+import * as path from "node:path";
+import { pathToFileURL } from "node:url";
 import { buildJsonReport } from "@react-doctor/core";
 import type { Diagnostic, InspectResult, ProjectInfo } from "@react-doctor/core";
 
@@ -114,6 +116,32 @@ describe("buildJsonReport", () => {
     expect(report.diagnostics[0].tags).toEqual([...report.diagnostics[0].tags].sort());
     expect(report.diagnostics[0]).not.toHaveProperty("ruleId");
     expect(report.diagnostics[0]).not.toHaveProperty("location");
+  });
+
+  it("normalizes a diagnostic file URL without changing the report schema", () => {
+    const fileUrl = pathToFileURL(path.join(projectInfo.rootDirectory, "src", "App.tsx")).href;
+    const report = buildJsonReport({
+      version: "1.2.3",
+      directory: projectInfo.rootDirectory,
+      mode: "full",
+      diff: null,
+      scans: [
+        {
+          directory: projectInfo.rootDirectory,
+          result: result({ diagnostics: [{ ...errorDiagnostic, filePath: fileUrl }] }),
+        },
+      ],
+      totalElapsedMilliseconds: 1200,
+    });
+
+    expect(report.schemaVersion).toBe(3);
+    expect(report.diagnostics[0]).toMatchObject({
+      filePath: fileUrl,
+      normalizedFilePath: "src/App.tsx",
+      id: expect.stringMatching(
+        /^src\/App\.tsx::12:1::react-doctor\/no-array-index-as-key::[a-f0-9]{64}$/,
+      ),
+    });
   });
 
   it("assigns distinct occurrence identities to same-site findings from one rule", () => {

--- a/packages/core/tests/merge-and-filter-diagnostics.test.ts
+++ b/packages/core/tests/merge-and-filter-diagnostics.test.ts
@@ -416,6 +416,24 @@ describe("buildDiagnosticPipeline — summarizeSuppressions", () => {
     ]);
   });
 
+  it("matches `ignore.overrides` when oxlint reports a file URL", () => {
+    const projectDirectory = setupCase("file-url-override", `const value = 1;\n`);
+    const pipeline = buildPipeline(
+      {
+        ignore: {
+          overrides: [{ files: ["src/app.tsx"], rules: ["react-doctor/no-derived-state-effect"] }],
+        },
+      },
+      projectDirectory,
+    );
+    const fileUrl = pathToFileURL(path.join(projectDirectory, "src", "app.tsx")).href;
+
+    expect(pipeline.apply(baseDiagnostic({ filePath: fileUrl }))).toBeNull();
+    expect(pipeline.summarizeSuppressions()).toEqual([
+      { rule: "react-doctor/no-derived-state-effect", source: "override", count: 1 },
+    ]);
+  });
+
   it("tallies inline disable comments as `inline`", () => {
     const projectDir = setupCase(
       "suppression-summary-inline",


### PR DESCRIPTION
Fixes relative ignore patterns when Oxlint reports a diagnostic path as a `file:` URL.

## Why

Job: a developer uses `ignore.overrides` to silence one rule in one file. With a file-URL diagnostic, the documented relative pattern did not match, so the developer had to use an inline disable.

Change: decode diagnostic URLs through the existing candidate-path resolver before matching ignore patterns and before writing report-relative paths.

Reuse: this keeps the existing config and JSON schema. It also uses the existing `rule.suppressed` metric with `source=override` and the existing `diag.suppressedOverride` run-event attribute.

Compat: defaults and schema version 3 are unchanged. This PR adds a patch changeset. It does not change Action files.

Kill check: revert if one confirmed out-of-root file is suppressed by this normalization in the next two releases.

## What changed

- Normalize file URLs before `ignore.files` and `ignore.overrides` matching.
- Normalize the same paths before JSON diagnostic identity and `normalizedFilePath` generation.
- Add regressions for override suppression, suppression telemetry, report identity, and schema stability.

## Test plan

- `nr -C packages/core test` (169 files; 2,395 passed)
- `nr -C packages/react-doctor test` (251 files; 2,516 passed)
- `nr lint`
- `nr typecheck`
- `nr format:check`
- `nr smoke:json-report`

Closes #1741