### PR TITLE
feat(cli): accept positional file paths

### DIFF
--- a/.changeset/quiet-taxis-smile.md
+++ b/.changeset/quiet-taxis-smile.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Accept source file paths as positional CLI arguments.

--- a/packages/react-doctor/README.md
+++ b/packages/react-doctor/README.md
@@ -25,6 +25,12 @@ Run this at your project root to get an audit.
 npx react-doctor@latest
 ```
 
+Pass file paths to scan only the files that another CI step selected.
+
+```bash
+npx react-doctor@latest src/a.tsx src/b.tsx
+```
+
 https://github.com/user-attachments/assets/07cc88d9-9589-44c3-aa73-5d603cb1c570
 
 ### 2. Install for agents

--- a/packages/react-doctor/src/cli/commands/inspect.ts
+++ b/packages/react-doctor/src/cli/commands/inspect.ts
@@ -78,14 +78,14 @@ import {
 } from "../utils/finalize-cli-scans.js";
 import { runStagedInspect } from "../utils/run-staged-inspect.js";
 
-const buildChangedFilesDiffInfo = (changedFiles: string[]): DiffInfo => ({
+const buildFileSelectionDiffInfo = (filePaths: ReadonlyArray<string>): DiffInfo => ({
   currentBranch: process.env.GITHUB_HEAD_REF?.trim() || null,
   baseBranch: process.env.GITHUB_BASE_REF?.trim() || "pull request target",
   // The GitHub Action forwards the PR base commit so baseline mode can read
   // base content against a SHA that's actually fetched (branch names rarely
   // resolve in a shallow PR checkout). Empty in non-Action runs.
   baseSha: process.env.REACT_DOCTOR_BASE_SHA?.trim() || undefined,
-  changedFiles,
+  changedFiles: [...filePaths],
   isCurrentChanges: false,
 });
 
@@ -261,6 +261,7 @@ export const inspectAction = async (
   directory: string,
   flags: InspectFlags,
   invocationCommand = "inspect",
+  selectedFilePaths?: ReadonlyArray<string>,
 ): Promise<void> => {
   const isScoreOnly = Boolean(flags.score);
   const isJsonMode = Boolean(flags.json);
@@ -375,19 +376,22 @@ export const inspectAction = async (
       userConfig?.projects,
     );
     const projectSelectionCompletedTime = performance.now();
-    let changedFilesDiffInfo = flags.changedFilesFrom
-      ? buildChangedFilesDiffInfo(readChangedFilesFrom(path.resolve(flags.changedFilesFrom)))
-      : null;
-    if (changedFilesDiffInfo !== null && scanTarget.didRedirectViaRootDir) {
+    const hasPositionalFileSelection = selectedFilePaths !== undefined;
+    let providedFilesDiffInfo = hasPositionalFileSelection
+      ? buildFileSelectionDiffInfo(selectedFilePaths)
+      : flags.changedFilesFrom
+        ? buildFileSelectionDiffInfo(readChangedFilesFrom(path.resolve(flags.changedFilesFrom)))
+        : null;
+    if (providedFilesDiffInfo !== null && requestedDirectory !== resolvedDirectory) {
       const relativeProjectDirectory = resolveProjectRelativeDirectory(
         requestedDirectory,
         resolvedDirectory,
       );
       if (relativeProjectDirectory) {
         const projectPrefix = `${relativeProjectDirectory}/`;
-        changedFilesDiffInfo = {
-          ...changedFilesDiffInfo,
-          changedFiles: changedFilesDiffInfo.changedFiles.flatMap((filePath) => {
+        providedFilesDiffInfo = {
+          ...providedFilesDiffInfo,
+          changedFiles: providedFilesDiffInfo.changedFiles.flatMap((filePath) => {
             return filePath.startsWith(projectPrefix) ? [filePath.slice(projectPrefix.length)] : [];
           }),
         };
@@ -397,11 +401,11 @@ export const inspectAction = async (
     // Untracked files only exist in a local working tree, so this is a
     // CLI-only modifier (like `--staged`) — off unless the user opts in.
     const includeUntracked = flags.includeUntracked ?? false;
-    // The internal `--changed-files-from` path (the GitHub Action) implies the
-    // `changed` scope when the user didn't pick one explicitly — it always ran
-    // in diff mode historically.
-    const scopeRequest: RequestedScope =
-      requestedScope.scope === undefined && changedFilesDiffInfo !== null
+    // Positional files are an exact selection. The internal
+    // `--changed-files-from` path implies the historical `changed` scope.
+    const scopeRequest: RequestedScope = hasPositionalFileSelection
+      ? { scope: "files", base: undefined, usedDeprecatedDiff: false }
+      : requestedScope.scope === undefined && providedFilesDiffInfo !== null
         ? { ...requestedScope, scope: "changed" }
         : requestedScope;
     // Validate against the EFFECTIVE scope (post `--changed-files-from`
@@ -423,10 +427,10 @@ export const inspectAction = async (
     // "full vs changed" prompt never appears for users on a feature branch who
     // didn't explicitly pass a scope.
     const shouldDetectDiff =
-      changedFilesDiffInfo === null &&
+      providedFilesDiffInfo === null &&
       (wantsDiffMode || (scopeRequest.scope === undefined && !skipPrompts && !isQuiet));
     const diffInfo =
-      changedFilesDiffInfo ??
+      providedFilesDiffInfo ??
       (shouldDetectDiff
         ? await getDiffInfo(resolvedDirectory, scopeRequest.base, includeUntracked)
         : null);
@@ -449,7 +453,7 @@ export const inspectAction = async (
     // exact base (`diffBaseRef`). `null` when uncommitted, detached, or git is
     // unavailable. Shared by `changed` (baseline) and `lines` (hunk ranges).
     const comparisonBaseRef =
-      isDiffMode && diffInfo && !diffInfo.isCurrentChanges
+      isDiffMode && diffInfo && !diffInfo.isCurrentChanges && !hasPositionalFileSelection
         ? diffInfo.baseSha
           ? await resolveMergeBaseRef(resolvedDirectory, diffInfo.baseSha)
           : (diffInfo.diffBaseRef ??
@@ -497,7 +501,10 @@ export const inspectAction = async (
     setJsonReportMode(baselineRef ? "baseline" : isDiffMode ? "diff" : "full");
 
     if (isDiffMode && diffInfo && !isQuiet) {
-      if (diffInfo.isCurrentChanges) {
+      if (hasPositionalFileSelection) {
+        const fileLabel = diffInfo.changedFiles.length === 1 ? "file" : "files";
+        logger.log(`Scanning ${diffInfo.changedFiles.length} selected ${fileLabel}`);
+      } else if (diffInfo.isCurrentChanges) {
         logger.log("Scanning uncommitted changes");
       } else {
         const currentBranchLabel = diffInfo.currentBranch ?? "(detached HEAD)";

--- a/packages/react-doctor/src/cli/commands/scan.ts
+++ b/packages/react-doctor/src/cli/commands/scan.ts
@@ -9,21 +9,28 @@ import { resolveCliInspectOptions } from "../utils/resolve-cli-inspect-options.j
 import { resolveTuiEnvironment } from "../utils/resolve-tui-environment.js";
 import { warnDeprecatedDiff } from "../utils/resolve-scope.js";
 import { shouldUseTui } from "../utils/should-use-tui.js";
-import { validateModeFlags } from "../utils/validate-mode-flags.js";
+import { validateFilePathSelectionFlags, validateModeFlags } from "../utils/validate-mode-flags.js";
 import { warnDeprecatedFailOn } from "../utils/warn-deprecated-fail-on.js";
 
 export interface RunScanCommandInput {
   readonly directory: string;
+  readonly filePaths?: ReadonlyArray<string>;
   readonly flags: InspectFlags;
   readonly invocationCommand: string;
 }
 
 export const runScanCommand = async (input: RunScanCommandInput): Promise<void> => {
   if (input.flags.cache === false) process.env.REACT_DOCTOR_NO_CACHE = "1";
+  if (input.filePaths !== undefined) validateFilePathSelectionFlags(input.flags);
   const tuiEnvironment = {
     flags: input.flags,
     ...resolveTuiEnvironment(),
   };
+
+  if (input.filePaths !== undefined) {
+    await inspectAction(input.directory, input.flags, input.invocationCommand, input.filePaths);
+    return;
+  }
 
   if (!shouldUseTui(tuiEnvironment)) {
     await inspectAction(input.directory, input.flags, input.invocationCommand);

--- a/packages/react-doctor/src/cli/index.ts
+++ b/packages/react-doctor/src/cli/index.ts
@@ -15,6 +15,7 @@ import { normalizeHelpInvocation } from "./utils/normalize-help-command.js";
 import { printDebugTrace } from "./utils/print-debug-trace.js";
 import { assertNoRemovedFlags } from "./utils/removed-cli-flags.js";
 import { reportErrorToSentry } from "./utils/report-error.js";
+import { resolvePositionalScanInput } from "./utils/resolve-positional-scan-input.js";
 import { stripUnknownCliFlags } from "./utils/strip-unknown-cli-flags.js";
 import { unrefStdin } from "./utils/unref-stdin.js";
 import { VERSION } from "./utils/version.js";
@@ -58,6 +59,7 @@ ${highlighter.dim("Examples:")}
 ${formatExampleLines([
   ["react-doctor", "scan the current project"],
   ["react-doctor ./apps/web", "scan a specific directory"],
+  ["react-doctor src/a.tsx src/b.tsx", "scan only selected files"],
   ["react-doctor scan http://localhost:3000", "profile one interaction in a running React app"],
   ["react-doctor --scope changed --base main", "scan only new issues vs. main"],
   ["react-doctor --project modules/a,modules/b", "score each module separately (names or paths)"],
@@ -180,7 +182,7 @@ const program = new Command()
   .name("react-doctor")
   .description("Diagnose React codebase health")
   .version(VERSION, "-v, --version", "display the version number")
-  .argument("[directory]", "project directory to scan", ".")
+  .argument("[paths...]", "one project directory or source file paths to scan")
   .option("--lint", "enable linting")
   .option("--no-lint", "skip linting")
   .addOption(new Option("--dead-code").hideHelp())
@@ -273,10 +275,11 @@ const program = new Command()
   .option("--no-color", "disable colored output (also honors NO_COLOR)")
   .addHelpText("after", renderRootHelpEpilog);
 
-program.action(async (directory = ".", flags: InspectFlags) => {
+program.action(async (positionalPaths: string[] = [], flags: InspectFlags) => {
   const { runScanCommand } = await import("./commands/scan.js");
+  const scanInput = resolvePositionalScanInput(positionalPaths);
   return runScanCommand({
-    directory,
+    ...scanInput,
     flags,
     invocationCommand: "inspect",
   });

--- a/packages/react-doctor/src/cli/utils/resolve-positional-scan-input.ts
+++ b/packages/react-doctor/src/cli/utils/resolve-positional-scan-input.ts
@@ -1,0 +1,46 @@
+import * as path from "node:path";
+import { filterSourceFiles, isDirectory, isFile, isPathInsideDirectory } from "@react-doctor/core";
+import { CliInputError } from "./cli-input-error.js";
+import { toForwardSlashes } from "./path-format.js";
+
+export interface PositionalScanInput {
+  readonly directory: string;
+  readonly filePaths: string[] | undefined;
+}
+
+export const resolvePositionalScanInput = (
+  positionalPaths: ReadonlyArray<string>,
+  currentDirectory = process.cwd(),
+): PositionalScanInput => {
+  const absoluteCurrentDirectory = path.resolve(currentDirectory);
+  if (positionalPaths.length === 0) {
+    return { directory: absoluteCurrentDirectory, filePaths: undefined };
+  }
+
+  const onlyAbsolutePath = path.resolve(absoluteCurrentDirectory, positionalPaths[0]);
+  const shouldUseDirectoryMode =
+    positionalPaths.length === 1 &&
+    (isDirectory(onlyAbsolutePath) ||
+      (!isFile(onlyAbsolutePath) && filterSourceFiles([positionalPaths[0]]).length === 0));
+  if (shouldUseDirectoryMode) {
+    return { directory: positionalPaths[0], filePaths: undefined };
+  }
+
+  const uniqueFilePaths = new Set<string>();
+  for (const positionalPath of positionalPaths) {
+    const absolutePath = path.resolve(absoluteCurrentDirectory, positionalPath);
+    if (isDirectory(absolutePath)) {
+      throw new CliInputError(
+        `Cannot combine the directory "${positionalPath}" with file path arguments. Pass one directory or only file paths.`,
+      );
+    }
+    if (!isPathInsideDirectory(absolutePath, absoluteCurrentDirectory)) {
+      throw new CliInputError(
+        `The file path "${positionalPath}" is outside the current directory. Run React Doctor from a common project root.`,
+      );
+    }
+    uniqueFilePaths.add(toForwardSlashes(path.relative(absoluteCurrentDirectory, absolutePath)));
+  }
+
+  return { directory: absoluteCurrentDirectory, filePaths: [...uniqueFilePaths] };
+};

--- a/packages/react-doctor/src/cli/utils/validate-mode-flags.ts
+++ b/packages/react-doctor/src/cli/utils/validate-mode-flags.ts
@@ -25,6 +25,29 @@ export const validateIncludeUntrackedScope = (
   );
 };
 
+export const validateFilePathSelectionFlags = (flags: InspectFlags): void => {
+  if (flags.staged || flags.changedFilesFrom !== undefined) {
+    throw new CliInputError(
+      "Cannot combine file path arguments with --staged or --changed-files-from. Use one file source.",
+    );
+  }
+  if (usedDiffAlias(flags)) {
+    throw new CliInputError(
+      "Cannot combine file path arguments with --diff. File path arguments use the files scope.",
+    );
+  }
+  if (usedScope(flags) && flags.scope !== "files") {
+    throw new CliInputError(
+      `Cannot combine file path arguments with --scope ${flags.scope}. File path arguments use --scope files.`,
+    );
+  }
+  if (flags.base !== undefined) {
+    throw new CliInputError(
+      "Cannot combine file path arguments with --base. The selected files do not need a Git base.",
+    );
+  }
+};
+
 export const validateModeFlags = (flags: InspectFlags): void => {
   if (usedScope(flags) && usedDiffAlias(flags)) {
     throw new CliInputError("Cannot combine --scope and --diff; --diff is the deprecated alias.");

--- a/packages/react-doctor/tests/inspect-action-setup-prompt.test.ts
+++ b/packages/react-doctor/tests/inspect-action-setup-prompt.test.ts
@@ -241,6 +241,39 @@ describe("inspectAction setup prompt", () => {
     );
   });
 
+  it("scans positional file paths without resolving a Git diff", async () => {
+    const rootDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-file-paths-"));
+    tempDirectories.push(rootDirectory);
+    const webDirectory = path.join(rootDirectory, "apps", "web");
+    const adminDirectory = path.join(rootDirectory, "apps", "admin");
+    writePackageJson(rootDirectory, {
+      name: "monorepo",
+      workspaces: ["apps/*"],
+      scripts: {},
+    });
+    writePackageJson(webDirectory, { name: "web", scripts: {} });
+    writePackageJson(adminDirectory, { name: "admin", scripts: {} });
+    mockState.projectDirectories = [webDirectory, adminDirectory];
+
+    await inspectAction(rootDirectory, { lint: false }, "inspect", [
+      "apps/web/src/App.tsx",
+      "apps/admin/src/Dashboard.tsx",
+    ]);
+
+    expect(mockState.lifecycleEvents).not.toContain("diff");
+    expect(inspect).toHaveBeenCalledTimes(2);
+    expect(inspect).toHaveBeenNthCalledWith(
+      1,
+      webDirectory,
+      expect.objectContaining({ includePaths: ["src/App.tsx"] }),
+    );
+    expect(inspect).toHaveBeenNthCalledWith(
+      2,
+      adminDirectory,
+      expect.objectContaining({ includePaths: ["src/Dashboard.tsx"] }),
+    );
+  });
+
   it("rebases explicit changed-file paths after a rootDir redirect", async () => {
     const rootDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-rootdir-"));
     tempDirectories.push(rootDirectory);

--- a/packages/react-doctor/tests/resolve-positional-scan-input.test.ts
+++ b/packages/react-doctor/tests/resolve-positional-scan-input.test.ts
@@ -1,0 +1,74 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+import { resolvePositionalScanInput } from "../src/cli/utils/resolve-positional-scan-input.js";
+
+describe("resolvePositionalScanInput", () => {
+  let currentDirectory: string;
+
+  beforeEach(() => {
+    currentDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-positional-input-"));
+    fs.mkdirSync(path.join(currentDirectory, "src"));
+    fs.writeFileSync(path.join(currentDirectory, "src", "a.tsx"), "export const A = () => null;\n");
+  });
+
+  afterEach(() => {
+    fs.rmSync(currentDirectory, { recursive: true, force: true });
+  });
+
+  it("uses the current directory when no path is passed", () => {
+    expect(resolvePositionalScanInput([], currentDirectory)).toEqual({
+      directory: currentDirectory,
+      filePaths: undefined,
+    });
+  });
+
+  it("keeps one directory as the scan directory", () => {
+    expect(resolvePositionalScanInput(["src"], currentDirectory)).toEqual({
+      directory: "src",
+      filePaths: undefined,
+    });
+  });
+
+  it("treats one source file as an explicit file selection", () => {
+    expect(resolvePositionalScanInput(["src/a.tsx"], currentDirectory)).toEqual({
+      directory: currentDirectory,
+      filePaths: ["src/a.tsx"],
+    });
+  });
+
+  it("normalizes and deduplicates several file paths", () => {
+    expect(
+      resolvePositionalScanInput(
+        ["./src/a.tsx", path.join(currentDirectory, "src", "a.tsx"), "src/missing.tsx"],
+        currentDirectory,
+      ),
+    ).toEqual({
+      directory: currentDirectory,
+      filePaths: ["src/a.tsx", "src/missing.tsx"],
+    });
+  });
+
+  it("keeps a missing non-source path compatible with directory scans", () => {
+    expect(resolvePositionalScanInput(["missing-project"], currentDirectory)).toEqual({
+      directory: "missing-project",
+      filePaths: undefined,
+    });
+  });
+
+  it("rejects a directory mixed with file paths", () => {
+    expect(() => resolvePositionalScanInput(["src", "src/a.tsx"], currentDirectory)).toThrow(
+      "Cannot combine the directory",
+    );
+  });
+
+  it("rejects files outside the current directory", () => {
+    expect(() =>
+      resolvePositionalScanInput(
+        [path.join(currentDirectory, "..", "outside.tsx")],
+        currentDirectory,
+      ),
+    ).toThrow("outside the current directory");
+  });
+});

--- a/packages/react-doctor/tests/run-scan-command.test.ts
+++ b/packages/react-doctor/tests/run-scan-command.test.ts
@@ -34,6 +34,7 @@ vi.mock("../src/cli/utils/resolve-scope.js", () => ({
 }));
 
 vi.mock("../src/cli/utils/validate-mode-flags.js", () => ({
+  validateFilePathSelectionFlags: vi.fn(),
   validateModeFlags: vi.fn(),
 }));
 
@@ -129,6 +130,21 @@ describe("runScanCommand", () => {
     expect(runScanApp).not.toHaveBeenCalled();
     expect(runProjectMigrations).not.toHaveBeenCalled();
     expect(recordCount).not.toHaveBeenCalled();
+  });
+
+  it("uses headless output for an explicit file selection", async () => {
+    const flags = { scope: "files" };
+    const filePaths = ["src/a.tsx", "src/b.tsx"];
+
+    await runScanCommand({
+      directory: "/tmp/project",
+      filePaths,
+      flags,
+      invocationCommand: "inspect",
+    });
+
+    expect(inspectAction).toHaveBeenCalledWith("/tmp/project", flags, "inspect", filePaths);
+    expect(runScanApp).not.toHaveBeenCalled();
   });
 
   it("preserves the TUI scan exit code", async () => {

--- a/packages/react-doctor/tests/validate-mode-flags.test.ts
+++ b/packages/react-doctor/tests/validate-mode-flags.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
 import {
+  validateFilePathSelectionFlags,
   validateIncludeUntrackedScope,
   validateModeFlags,
 } from "../src/cli/utils/validate-mode-flags.js";
@@ -61,6 +62,31 @@ describe("validateModeFlags", () => {
     expect(() =>
       validateModeFlags({ includeUntracked: true, staged: true, scope: "files" }),
     ).toThrow("Cannot combine --include-untracked with --staged");
+  });
+});
+
+describe("validateFilePathSelectionFlags", () => {
+  it("allows file selection flags that do not change the file source", () => {
+    expect(() => validateFilePathSelectionFlags({ scope: "files", project: "app" })).not.toThrow();
+  });
+
+  it("rejects another file source", () => {
+    expect(() => validateFilePathSelectionFlags({ staged: true })).toThrow("Use one file source");
+    expect(() => validateFilePathSelectionFlags({ changedFilesFrom: "files.txt" })).toThrow(
+      "Use one file source",
+    );
+  });
+
+  it("rejects Git-derived scopes", () => {
+    expect(() => validateFilePathSelectionFlags({ scope: "changed" })).toThrow(
+      "File path arguments use --scope files",
+    );
+    expect(() => validateFilePathSelectionFlags({ diff: "main" })).toThrow(
+      "File path arguments use the files scope",
+    );
+    expect(() => validateFilePathSelectionFlags({ base: "main" })).toThrow(
+      "selected files do not need a Git base",
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

- accept one or more source file paths as positional CLI arguments
- keep the existing single-directory command compatible
- route selected files through the existing `files` scope and split them per workspace project
- reject conflicting Git-derived file sources and document the new command

Closes #1744.

## Product check

- Job: let CI pass its existing file selection directly to React Doctor.
- Reuse: uses the current `files` scope, include-path pipeline, and workspace path mapping.
- Telemetry: existing `scan.mode=files` and `scan.fileCount` fields measure adoption and scan size.
- Compatibility: one directory and no-argument scans are unchanged; JSON schemaVersion remains 3; no Action files changed.
- Kill check: revert or narrow the input if a confirmed run scans a file outside the passed selection in the next two releases.

## Validation

- built CLI reproduced `react-doctor src/a.tsx src/b.tsx` and analyzed exactly both files
- CLI: 2528 tests passed
- core: 2395 tests passed
- Oxlint plugin: 27596 tests passed
- API, eval, fuzz, and ESLint package suites passed
- `nr lint`
- `nr typecheck`
- `nr format:check`
- `nr smoke:json-report`
- `git diff --check`
- post-change Truffler searches found no duplicate utility or validator