### PR TITLE
fix: treat Sanity blueprint files as convention entries

### DIFF
--- a/.changeset/sanity-blueprint-convention.md
+++ b/.changeset/sanity-blueprint-convention.md
@@ -1,0 +1,9 @@
+---
+"@react-doctor/core": patch
+---
+
+Treat Sanity blueprint files as convention entries
+
+`sanity.blueprint.ts` is a Sanity Studio convention file loaded by filename by the Sanity CLI (`sanity blueprints deploy`), similar to `sanity.config.ts` and `sanity.cli.ts`. It was incorrectly reported as unused by `react-doctor/unused-file`.
+
+Fixes #1747

--- a/packages/core/src/project-analysis/collect/entries.ts
+++ b/packages/core/src/project-analysis/collect/entries.ts
@@ -2726,7 +2726,7 @@ const FRAMEWORK_PATTERNS: ToolingPluginDefinition[] = [
     enablers: ["sanity", "@sanity/cli"],
     enablerPrefixes: ["@sanity/"],
     entryPatterns: [],
-    alwaysUsed: ["sanity.config.{ts,js}", "sanity.cli.{ts,js}"],
+    alwaysUsed: ["sanity.config.{ts,js}", "sanity.cli.{ts,js}", "sanity.blueprint.{ts,js}"],
   },
   {
     enablers: ["astro"],

--- a/packages/core/tests/project-analysis.test.ts
+++ b/packages/core/tests/project-analysis.test.ts
@@ -638,6 +638,28 @@ describe("analyzeProject", () => {
     expect(relativePaths(rootDirectory, result.unusedFiles)).toEqual(["src/orphan.jsx"]);
   });
 
+  it("treats Sanity blueprint configuration as a convention entry", async () => {
+    const rootDirectory = createProject(
+      {
+        "sanity.config.ts": `export default { name: "studio", title: "Studio" };`,
+        "sanity.blueprint.ts": `
+          import { defineBlueprint } from "@sanity/blueprints";
+          import { blueprintHelper } from "./lib/blueprint-helper";
+          export default defineBlueprint({
+            resources: blueprintHelper,
+          });
+        `,
+        "lib/blueprint-helper.ts": "export const blueprintHelper = [];",
+        "src/orphan.ts": "export const orphan = true;",
+      },
+      { dependencies: { sanity: "1.0.0", "@sanity/blueprints": "1.0.0" } },
+    );
+
+    const result = await analyzeProject({ rootDirectory });
+
+    expect(relativePaths(rootDirectory, result.unusedFiles)).toEqual(["src/orphan.ts"]);
+  });
+
   it("discovers static entries from CoffeeScript interpolated require factories", async () => {
     const rootDirectory = createProject(
       {


### PR DESCRIPTION
## Why

React Doctor reported Sanity blueprint configuration as unused even though the Sanity CLI loads it by filename.

Before: `sanity.blueprint.ts` could be reported as unused.
After: Sanity blueprint files and their imported helpers remain reachable.

## What changed

- Add `sanity.blueprint.{ts,js}` to the Sanity convention entries.
- Add a regression test that keeps the blueprint and its imported helper while still reporting an orphan.
- Add a patch changeset for `@react-doctor/core`.

Daytona parity did not run because `DAYTONA_API_KEY` is not available in this environment.

## Test plan

- Project-analysis regression test passed.
- Hosted test matrix passed on macOS, Ubuntu, Windows, and supported Node versions.
- Hosted lint, typecheck, build, formatting, and smoke checks passed.

Fixes #1747