### PR TITLE
fix(core): detect React Compiler through Sentry config wrappers

### DIFF
--- a/.changeset/detect-sentry-wrapped-compiler-config.md
+++ b/.changeset/detect-sentry-wrapped-compiler-config.md
@@ -1,0 +1,5 @@
+---
+"@react-doctor/core": patch
+---
+
+Detect React Compiler configuration passed through `withSentryConfig`.

--- a/packages/core/src/project-info/react-compiler-config-evaluator.ts
+++ b/packages/core/src/project-info/react-compiler-config-evaluator.ts
@@ -1491,6 +1491,17 @@ const analyzeConfigIdentifier = (
   );
 };
 
+const hasReactCompilerConfigInSentryWrapperArgument = (
+  callExpression: ts.CallExpression,
+  analysis: ConfigExpressionAnalysis,
+  moduleSpecifier: string,
+  exportName: string,
+): boolean => {
+  if (moduleSpecifier !== "@sentry/nextjs" || exportName !== "withSentryConfig") return false;
+  const [configArgument] = callExpression.arguments;
+  return Boolean(configArgument && analyzeConfigNode(configArgument, analysis, false));
+};
+
 const analyzeConfigCallTarget = (
   callExpression: ts.CallExpression,
   analysis: ConfigExpressionAnalysis,
@@ -1543,6 +1554,16 @@ const analyzeConfigCallTarget = (
     ) {
       return true;
     }
+    if (
+      hasReactCompilerConfigInSentryWrapperArgument(
+        callExpression,
+        analysis,
+        requiredModuleSpecifier,
+        propertyName,
+      )
+    ) {
+      return true;
+    }
     const hasCompilerTransform = analyzeImportedConfig({
       analysis,
       moduleSpecifier: requiredModuleSpecifier,
@@ -1567,6 +1588,16 @@ const analyzeConfigCallTarget = (
     if (
       allowCompilerTransform &&
       isCompilerTransformModule(importBinding.moduleSpecifier, propertyName)
+    ) {
+      return true;
+    }
+    if (
+      hasReactCompilerConfigInSentryWrapperArgument(
+        callExpression,
+        analysis,
+        importBinding.moduleSpecifier,
+        propertyName,
+      )
     ) {
       return true;
     }
@@ -1861,6 +1892,16 @@ const analyzeConfigNode = (
           if (
             allowCompilerTransform &&
             isCompilerTransformModule(importBinding.moduleSpecifier, importBinding.exportName)
+          ) {
+            return true;
+          }
+          if (
+            hasReactCompilerConfigInSentryWrapperArgument(
+              node,
+              analysis,
+              importBinding.moduleSpecifier,
+              importBinding.exportName,
+            )
           ) {
             return true;
           }

--- a/packages/core/tests/discover-project.test.ts
+++ b/packages/core/tests/discover-project.test.ts
@@ -2704,6 +2704,75 @@ describe("discoverProject", () => {
     },
   );
 
+  it.each([
+    {
+      name: "named-import",
+      config:
+        "import { withSentryConfig } from '@sentry/nextjs'; const nextConfig = { reactCompiler: true }; export default withSentryConfig(nextConfig, { org: 'x' });",
+      helper: null,
+      expected: true,
+    },
+    {
+      name: "namespace-import",
+      config:
+        "import * as Sentry from '@sentry/nextjs'; const nextConfig = { reactCompiler: true }; export default Sentry.withSentryConfig(nextConfig, { org: 'x' });",
+      helper: null,
+      expected: true,
+    },
+    {
+      name: "commonjs-require",
+      config:
+        "const Sentry = require('@sentry/nextjs'); const nextConfig = { reactCompiler: true }; module.exports = Sentry.withSentryConfig(nextConfig, { org: 'x' });",
+      helper: null,
+      expected: true,
+    },
+    {
+      name: "local-wrapper",
+      config:
+        "import { wrap } from './wrapper'; const nextConfig = { reactCompiler: true }; export default wrap(nextConfig);",
+      helper:
+        "import { withSentryConfig } from '@sentry/nextjs'; export const wrap = (config) => withSentryConfig(config, { org: 'x' });",
+      expected: true,
+    },
+    {
+      name: "compiler-only-in-options",
+      config:
+        "import { withSentryConfig } from '@sentry/nextjs'; export default withSentryConfig({ reactCompiler: false }, { reactCompiler: true });",
+      helper: null,
+      expected: false,
+    },
+  ])(
+    "detects React Compiler through Sentry config wrappers: $name",
+    ({ name, config, helper, expected }) => {
+      const projectDirectory = path.join(tempDirectory, `nextjs-sentry-wrapper-${name}`);
+      const wrapperDirectory = path.join(projectDirectory, "node_modules", "@sentry", "nextjs");
+      fs.mkdirSync(wrapperDirectory, { recursive: true });
+      fs.writeFileSync(
+        path.join(projectDirectory, "package.json"),
+        JSON.stringify({
+          name: `nextjs-sentry-wrapper-${name}`,
+          dependencies: { next: "^16.0.0", react: "^19.0.0", "@sentry/nextjs": "^10.0.0" },
+        }),
+      );
+      fs.writeFileSync(
+        path.join(wrapperDirectory, "package.json"),
+        JSON.stringify({
+          name: "@sentry/nextjs",
+          type: "module",
+          exports: "./index.js",
+        }),
+      );
+      fs.writeFileSync(
+        path.join(wrapperDirectory, "index.js"),
+        "export const withSentryConfig = (_config, _options) => ({ sentry: true });\n",
+      );
+      fs.writeFileSync(path.join(projectDirectory, "next.config.ts"), config);
+      if (helper) fs.writeFileSync(path.join(projectDirectory, "wrapper.ts"), helper);
+
+      expect(discoverProject(projectDirectory).hasReactCompiler).toBe(expected);
+    },
+  );
+
   it("detects the Rsbuild React Compiler transform", () => {
     const projectDirectory = path.join(tempDirectory, "rsbuild-react-compiler");
     fs.mkdirSync(projectDirectory, { recursive: true });


### PR DESCRIPTION
## Why

React Doctor evaluated the imported `withSentryConfig` implementation before it checked the Next.js configuration passed to that wrapper. An opaque wrapper could therefore hide `reactCompiler: true`.

Before: React Compiler could be missed when `next.config` used `withSentryConfig`.
After: the first Sentry wrapper argument is checked before imported implementation analysis.

## What changed

- Detect the first configuration argument passed to `@sentry/nextjs` `withSentryConfig`.
- Support named imports, namespace imports, CommonJS require calls, and local wrapper functions.
- Ignore the separate Sentry options argument.
- Keep arbitrary third-party wrappers conservative.
- Add five regression cases and a patch changeset for `@react-doctor/core`.

Daytona parity did not run because `DAYTONA_API_KEY` is not available in this environment.

## Test plan

- 334 focused core tests passed.
- Full test suite passed.
- Lint, typecheck, format, build, and JSON smoke checks passed.
- Hosted CI passed after retrying unrelated macOS performance-test timing noise.

Fixes #1751