### PR TITLE
fix(rule): narrow magic-link mutation exemption

### DIFF
--- a/.changeset/send-resend-notify-email-exemption.md
+++ b/.changeset/send-resend-notify-email-exemption.md
@@ -1,12 +1,5 @@
 ---
 "oxlint-plugin-react-doctor": patch
-"@react-doctor/core": patch
 ---
 
-Exempt send/resend/notify/email mutations from cache invalidation requirement
-
-The `query-mutation-missing-invalidation` rule now exempts mutations with `send`, `resend`, `notify`, or `email` in their name (hook name, binding name, or mutationFn callee). These operations are cache-effect-free - they send emails, notifications, codes, or invites without changing server data that cached queries could go stale on.
-
-This resolves false positives on mutations like `useSendMagicLink()`, `useResendVerificationCode()`, `useNotifyUser()`, and `useEmailInvite()`.
-
-Closes #1759
+Exempt magic-link delivery mutations from `query-mutation-missing-invalidation` while keeping generic send, notification, and email mutations reportable.

--- a/.changeset/send-resend-notify-email-exemption.md
+++ b/.changeset/send-resend-notify-email-exemption.md
@@ -1,0 +1,12 @@
+---
+"oxlint-plugin-react-doctor": patch
+"@react-doctor/core": patch
+---
+
+Exempt send/resend/notify/email mutations from cache invalidation requirement
+
+The `query-mutation-missing-invalidation` rule now exempts mutations with `send`, `resend`, `notify`, or `email` in their name (hook name, binding name, or mutationFn callee). These operations are cache-effect-free - they send emails, notifications, codes, or invites without changing server data that cached queries could go stale on.
+
+This resolves false positives on mutations like `useSendMagicLink()`, `useResendVerificationCode()`, `useNotifyUser()`, and `useEmailInvite()`.
+
+Closes #1759

--- a/packages/fuzz/corpus/regressions/query-mutation-missing-invalidation--magic-link-delivery.tsx
+++ b/packages/fuzz/corpus/regressions/query-mutation-missing-invalidation--magic-link-delivery.tsx
@@ -1,0 +1,13 @@
+// verdict: pass
+// rule: query-mutation-missing-invalidation
+// weakness: name-heuristic
+// source: GitHub issue #1759
+
+import { useMutation } from "@tanstack/react-query";
+
+declare const sendMagicLink: (email: string) => Promise<void>;
+
+export const useSendMagicLink = () =>
+  useMutation({
+    mutationFn: sendMagicLink,
+  });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-query/query-mutation-missing-invalidation.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-query/query-mutation-missing-invalidation.regressions.test.ts
@@ -312,7 +312,7 @@ describe("tanstack-query/query-mutation-missing-invalidation — regressions", (
     expect(diagnostics[0].message).toContain("can leave");
   });
 
-  it("stays silent for send/resend/notify/email mutations (cache-effect-free)", () => {
+  it("stays silent for a magic-link delivery mutation", () => {
     const sendMagicLink = runRule(
       queryMutationMissingInvalidation,
       `import { useMutation } from "@tanstack/react-query";
@@ -323,90 +323,45 @@ describe("tanstack-query/query-mutation-missing-invalidation — regressions", (
       }`,
     );
     expect(sendMagicLink.diagnostics).toHaveLength(0);
+  });
 
-    const resendCode = runRule(
+  it("still reports generic send, notify, and email mutations", () => {
+    const diagnostics = runRule(
       queryMutationMissingInvalidation,
       `import { useMutation } from "@tanstack/react-query";
-      export function useResendVerificationCode() {
+      export function useSendMessage() {
         return useMutation({
-          mutationFn: (userId: string) => api.resendVerificationCode(userId),
+          mutationFn: (message) => api.sendMessage(message),
         });
-      }`,
-    );
-    expect(resendCode.diagnostics).toHaveLength(0);
+      }
 
-    const notifyUser = runRule(
-      queryMutationMissingInvalidation,
-      `import { useMutation } from "@tanstack/react-query";
       export function useNotifyUser() {
         return useMutation({
-          mutationFn: (params) => api.notifyUser(params),
+          mutationFn: (userId) => api.notifyUser(userId),
         });
-      }`,
-    );
-    expect(notifyUser.diagnostics).toHaveLength(0);
+      }
 
-    const emailInvite = runRule(
-      queryMutationMissingInvalidation,
-      `import { useMutation } from "@tanstack/react-query";
       export function useEmailInvite() {
         return useMutation({
-          mutationFn: (email: string) => api.emailInvite(email),
+          mutationFn: (email) => api.emailInvite(email),
         });
       }`,
-    );
-    expect(emailInvite.diagnostics).toHaveLength(0);
+    ).diagnostics;
+
+    expect(diagnostics).toHaveLength(3);
   });
 
-  it("exempts send/resend by mutationFn callee name", () => {
-    const sendViaCallee = runRule(
+  it("stays silent when the magic-link signal comes from the mutation function", () => {
+    const result = runRule(
       queryMutationMissingInvalidation,
       `import { useMutation } from "@tanstack/react-query";
-      const posts = useQuery({ queryKey: ["posts"], queryFn: fetchPosts });
-      export const useShareLink = () =>
-        useMutation({
-          mutationFn: (params) => sendShareLink(params),
-        });`,
-    );
-    expect(sendViaCallee.diagnostics).toHaveLength(0);
-
-    const resendViaCallee = runRule(
-      queryMutationMissingInvalidation,
-      `import { useMutation } from "@tanstack/react-query";
-      const users = useQuery({ queryKey: ["users"], queryFn: fetchUsers });
-      export const useRequestCode = () =>
-        useMutation({
-          mutationFn: (phone) => resendOtp(phone),
-        });`,
-    );
-    expect(resendViaCallee.diagnostics).toHaveLength(0);
-  });
-
-  it("exempts send/resend by result binding name", () => {
-    const sendViaBinding = runRule(
-      queryMutationMissingInvalidation,
-      `import { useMutation } from "@tanstack/react-query";
-      function Component() {
-        const posts = useQuery({ queryKey: ["posts"], queryFn: fetchPosts });
-        const sendNotification = useMutation({
-          mutationFn: (message) => api.post("/notify", message),
+      export function useAuthenticationEmail() {
+        return useMutation({
+          mutationFn: (email) => api.sendMagicLink(email),
         });
-        return null;
       }`,
     );
-    expect(sendViaBinding.diagnostics).toHaveLength(0);
 
-    const resendViaBinding = runRule(
-      queryMutationMissingInvalidation,
-      `import { useMutation } from "@tanstack/react-query";
-      function Component() {
-        const tasks = useQuery({ queryKey: ["tasks"], queryFn: fetchTasks });
-        const resendInvite = useMutation({
-          mutationFn: (userId) => api.post("/invites/resend", { userId }),
-        });
-        return null;
-      }`,
-    );
-    expect(resendViaBinding.diagnostics).toHaveLength(0);
+    expect(result.diagnostics).toHaveLength(0);
   });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-query/query-mutation-missing-invalidation.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-query/query-mutation-missing-invalidation.regressions.test.ts
@@ -311,4 +311,102 @@ describe("tanstack-query/query-mutation-missing-invalidation — regressions", (
     expect(diagnostics).toHaveLength(1);
     expect(diagnostics[0].message).toContain("can leave");
   });
+
+  it("stays silent for send/resend/notify/email mutations (cache-effect-free)", () => {
+    const sendMagicLink = runRule(
+      queryMutationMissingInvalidation,
+      `import { useMutation } from "@tanstack/react-query";
+      export function useSendMagicLink() {
+        return useMutation({
+          mutationFn: (params: { email: string }) => api.sendMagicLink(params),
+        });
+      }`,
+    );
+    expect(sendMagicLink.diagnostics).toHaveLength(0);
+
+    const resendCode = runRule(
+      queryMutationMissingInvalidation,
+      `import { useMutation } from "@tanstack/react-query";
+      export function useResendVerificationCode() {
+        return useMutation({
+          mutationFn: (userId: string) => api.resendVerificationCode(userId),
+        });
+      }`,
+    );
+    expect(resendCode.diagnostics).toHaveLength(0);
+
+    const notifyUser = runRule(
+      queryMutationMissingInvalidation,
+      `import { useMutation } from "@tanstack/react-query";
+      export function useNotifyUser() {
+        return useMutation({
+          mutationFn: (params) => api.notifyUser(params),
+        });
+      }`,
+    );
+    expect(notifyUser.diagnostics).toHaveLength(0);
+
+    const emailInvite = runRule(
+      queryMutationMissingInvalidation,
+      `import { useMutation } from "@tanstack/react-query";
+      export function useEmailInvite() {
+        return useMutation({
+          mutationFn: (email: string) => api.emailInvite(email),
+        });
+      }`,
+    );
+    expect(emailInvite.diagnostics).toHaveLength(0);
+  });
+
+  it("exempts send/resend by mutationFn callee name", () => {
+    const sendViaCallee = runRule(
+      queryMutationMissingInvalidation,
+      `import { useMutation } from "@tanstack/react-query";
+      const posts = useQuery({ queryKey: ["posts"], queryFn: fetchPosts });
+      export const useShareLink = () =>
+        useMutation({
+          mutationFn: (params) => sendShareLink(params),
+        });`,
+    );
+    expect(sendViaCallee.diagnostics).toHaveLength(0);
+
+    const resendViaCallee = runRule(
+      queryMutationMissingInvalidation,
+      `import { useMutation } from "@tanstack/react-query";
+      const users = useQuery({ queryKey: ["users"], queryFn: fetchUsers });
+      export const useRequestCode = () =>
+        useMutation({
+          mutationFn: (phone) => resendOtp(phone),
+        });`,
+    );
+    expect(resendViaCallee.diagnostics).toHaveLength(0);
+  });
+
+  it("exempts send/resend by result binding name", () => {
+    const sendViaBinding = runRule(
+      queryMutationMissingInvalidation,
+      `import { useMutation } from "@tanstack/react-query";
+      function Component() {
+        const posts = useQuery({ queryKey: ["posts"], queryFn: fetchPosts });
+        const sendNotification = useMutation({
+          mutationFn: (message) => api.post("/notify", message),
+        });
+        return null;
+      }`,
+    );
+    expect(sendViaBinding.diagnostics).toHaveLength(0);
+
+    const resendViaBinding = runRule(
+      queryMutationMissingInvalidation,
+      `import { useMutation } from "@tanstack/react-query";
+      function Component() {
+        const tasks = useQuery({ queryKey: ["tasks"], queryFn: fetchTasks });
+        const resendInvite = useMutation({
+          mutationFn: (userId) => api.post("/invites/resend", { userId }),
+        });
+        return null;
+      }`,
+    );
+    expect(resendViaBinding.diagnostics).toHaveLength(0);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-query/query-mutation-missing-invalidation.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-query/query-mutation-missing-invalidation.ts
@@ -50,6 +50,10 @@ const READ_ONLY_MUTATION_WORDS = new Set([
   "oauth",
   "pairing",
   "sign",
+  "send",
+  "resend",
+  "notify",
+  "email",
 ]);
 
 // `sign` followed by one of these is an auth ACTION (signIn / signUp /

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-query/query-mutation-missing-invalidation.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-query/query-mutation-missing-invalidation.ts
@@ -50,10 +50,7 @@ const READ_ONLY_MUTATION_WORDS = new Set([
   "oauth",
   "pairing",
   "sign",
-  "send",
-  "resend",
-  "notify",
-  "email",
+  "magiclink",
 ]);
 
 // `sign` followed by one of these is an auth ACTION (signIn / signUp /


### PR DESCRIPTION
## Why

`query-mutation-missing-invalidation` reported magic-link delivery, which does not make cached query data stale. The draft exemption was too broad and would hide ordinary send, notification, and email mutations that can change server state.

## What changed

- exempt only names normalized to `magiclink`
- accept the signal from the hook, binding, or mutation function name
- keep generic send, notify, and email mutations reportable
- add focused and strict fuzz regression coverage

## Test plan

- `nr -C packages/oxlint-plugin-react-doctor test src/plugin/rules/tanstack-query/query-mutation-missing-invalidation.regressions.test.ts`
- `nr -C packages/oxlint-plugin-react-doctor typecheck`
- `FUZZ_RULE=query-mutation-missing-invalidation FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz`
- `nr lint`
- `nr format`

Closes #1759