### PR TITLE
fix(rule): scope GET helper safety to exact calls

### DIFF
--- a/.changeset/fix-1757-headers-helper.md
+++ b/.changeset/fix-1757-headers-helper.md
@@ -1,10 +1,9 @@
 ---
-"react-doctor": patch
 "oxlint-plugin-react-doctor": patch
 ---
 
 Fix false positive in `nextjs-no-side-effect-in-get-handler` when locally-built `Headers` object is passed to a same-file helper that mutates it.
 
-The rule now tracks when safe objects (like `new Headers()`) are passed as arguments to helpers, treating the corresponding parameters as safe when scanning the helper body.
+The rule now transfers locally-created response object safety through the exact same-file helper call. Calls that pass external state to the same helper remain reportable.
 
 Fixes #1757

--- a/.changeset/fix-1757-headers-helper.md
+++ b/.changeset/fix-1757-headers-helper.md
@@ -1,0 +1,10 @@
+---
+"react-doctor": patch
+"oxlint-plugin-react-doctor": patch
+---
+
+Fix false positive in `nextjs-no-side-effect-in-get-handler` when locally-built `Headers` object is passed to a same-file helper that mutates it.
+
+The rule now tracks when safe objects (like `new Headers()`) are passed as arguments to helpers, treating the corresponding parameters as safe when scanning the helper body.
+
+Fixes #1757

--- a/packages/fuzz/corpus/regressions/nextjs-no-side-effect-in-get-handler--local-headers-helper.ts
+++ b/packages/fuzz/corpus/regressions/nextjs-no-side-effect-in-get-handler--local-headers-helper.ts
@@ -1,0 +1,15 @@
+// verdict: pass
+// rule: nextjs-no-side-effect-in-get-handler
+// weakness: copy-tracking
+// source: GitHub issue #1757
+// file-path: src/app/api/proxy/route.ts
+
+const applyCachePolicy = (responseHeaders: Headers) => {
+  responseHeaders.set("Cache-Control", "max-age=60");
+};
+
+export const GET = () => {
+  const responseHeaders = new Headers();
+  applyCachePolicy(responseHeaders);
+  return new Response(null, { headers: responseHeaders });
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-no-side-effect-in-get-handler.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-no-side-effect-in-get-handler.ts
@@ -207,6 +207,7 @@ const resolveGetHandlerBodies = (
 interface HelperBodyInfo {
   body: EsTreeNode;
   helperFunction: EsTreeNode;
+  callExpression: EsTreeNodeOfType<"CallExpression">;
 }
 
 const collectCalledSameFileHelpers = (
@@ -214,17 +215,18 @@ const collectCalledSameFileHelpers = (
   resolveBinding: (identifierName: string) => EsTreeNode | null,
 ): HelperBodyInfo[] => {
   const helpers: HelperBodyInfo[] = [];
-  const visitedHelperNames = new Set<string>();
   walkAst(handlerBody, (child: EsTreeNode) => {
     if (!isNodeOfType(child, "CallExpression")) return;
     if (!isNodeOfType(child.callee, "Identifier")) return;
     const helperName = child.callee.name;
-    if (visitedHelperNames.has(helperName)) return;
-    visitedHelperNames.add(helperName);
     const helperBinding = resolveBinding(helperName);
     if (!isFunctionLike(helperBinding) || !helperBinding.body) return;
     if (helperBinding.body === handlerBody) return;
-    helpers.push({ body: helperBinding.body, helperFunction: helperBinding });
+    helpers.push({
+      body: helperBinding.body,
+      helperFunction: helperBinding,
+      callExpression: child,
+    });
   });
   return helpers;
 };
@@ -279,9 +281,9 @@ export const nextjsNoSideEffectInGetHandler = defineRule({
           }
 
           const helpers = collectCalledSameFileHelpers(handlerBody, resolveBinding);
-          for (const { body: helperBody, helperFunction } of helpers) {
+          for (const { body: helperBody, helperFunction, callExpression } of helpers) {
             const helperParameterSafeBindings = collectHelperParameterSafeBindings(
-              handlerBody,
+              callExpression,
               helperFunction,
               locallyScopedSafeBindings,
             );

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-no-side-effect-in-get-handler.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/nextjs/nextjs-no-side-effect-in-get-handler.ts
@@ -4,6 +4,7 @@ import {
   ROUTE_HANDLER_FILE_PATTERN,
 } from "../../constants/nextjs.js";
 import { GET_HANDLER_BINDING_RESOLUTION_DEPTH } from "../../constants/thresholds.js";
+import { collectHelperParameterSafeBindings } from "../../utils/collect-helper-parameter-safe-bindings.js";
 import { collectLocallyScopedCookieBindings } from "../../utils/collect-locally-scoped-cookie-bindings.js";
 import { collectLocallyScopedSafeBindings } from "../../utils/collect-locally-scoped-safe-bindings.js";
 import { defineRule } from "../../utils/define-rule.js";
@@ -203,11 +204,16 @@ const resolveGetHandlerBodies = (
 // `destroySession()` whose body does `cookies().delete(...)`). Collect those
 // helper bodies so they're scanned alongside the handler body; helpers called
 // from within helpers are NOT followed.
-const collectCalledSameFileHelperBodies = (
+interface HelperBodyInfo {
+  body: EsTreeNode;
+  helperFunction: EsTreeNode;
+}
+
+const collectCalledSameFileHelpers = (
   handlerBody: EsTreeNode,
   resolveBinding: (identifierName: string) => EsTreeNode | null,
-): EsTreeNode[] => {
-  const helperBodies: EsTreeNode[] = [];
+): HelperBodyInfo[] => {
+  const helpers: HelperBodyInfo[] = [];
   const visitedHelperNames = new Set<string>();
   walkAst(handlerBody, (child: EsTreeNode) => {
     if (!isNodeOfType(child, "CallExpression")) return;
@@ -218,9 +224,9 @@ const collectCalledSameFileHelperBodies = (
     const helperBinding = resolveBinding(helperName);
     if (!isFunctionLike(helperBinding) || !helperBinding.body) return;
     if (helperBinding.body === handlerBody) return;
-    helperBodies.push(helperBinding.body);
+    helpers.push({ body: helperBinding.body, helperFunction: helperBinding });
   });
-  return helperBodies;
+  return helpers;
 };
 
 export const nextjsNoSideEffectInGetHandler = defineRule({
@@ -257,21 +263,44 @@ export const nextjsNoSideEffectInGetHandler = defineRule({
 
         const handlerBodies = resolveGetHandlerBodies(node, resolveBinding);
         for (const handlerBody of handlerBodies) {
-          const bodiesToScan = [
-            handlerBody,
-            ...collectCalledSameFileHelperBodies(handlerBody, resolveBinding),
-          ];
-          for (const scanBody of bodiesToScan) {
-            const sideEffect = findSideEffect(scanBody, {
-              locallyScopedSafeBindings: collectLocallyScopedSafeBindings(scanBody),
-              locallyScopedCookieBindings: collectLocallyScopedCookieBindings(scanBody),
-            });
-            if (!sideEffect) continue;
+          const locallyScopedSafeBindings = collectLocallyScopedSafeBindings(handlerBody);
+          const locallyScopedCookieBindings = collectLocallyScopedCookieBindings(handlerBody);
+
+          const sideEffectInHandler = findSideEffect(handlerBody, {
+            locallyScopedSafeBindings,
+            locallyScopedCookieBindings,
+          });
+          if (sideEffectInHandler) {
             const message = mutatingSegment
-              ? `This GET handler on the "/${mutatingSegment}" route performs a side effect (${sideEffect}) and is prone to CSRF vulnerabilities, since prefetching or a forged request can trigger it.`
-              : `This GET handler's side effect (${sideEffect}) is prone to CSRF vulnerabilities, since prefetching or a forged request can trigger it.`;
+              ? `This GET handler on the "/${mutatingSegment}" route performs a side effect (${sideEffectInHandler}) and is prone to CSRF vulnerabilities, since prefetching or a forged request can trigger it.`
+              : `This GET handler's side effect (${sideEffectInHandler}) is prone to CSRF vulnerabilities, since prefetching or a forged request can trigger it.`;
             context.report({ node, message });
             return;
+          }
+
+          const helpers = collectCalledSameFileHelpers(handlerBody, resolveBinding);
+          for (const { body: helperBody, helperFunction } of helpers) {
+            const helperParameterSafeBindings = collectHelperParameterSafeBindings(
+              handlerBody,
+              helperFunction,
+              locallyScopedSafeBindings,
+            );
+            const effectiveSafeBindings = new Set([
+              ...locallyScopedSafeBindings,
+              ...helperParameterSafeBindings,
+            ]);
+
+            const sideEffectInHelper = findSideEffect(helperBody, {
+              locallyScopedSafeBindings: effectiveSafeBindings,
+              locallyScopedCookieBindings,
+            });
+            if (sideEffectInHelper) {
+              const message = mutatingSegment
+                ? `This GET handler on the "/${mutatingSegment}" route performs a side effect (${sideEffectInHelper}) and is prone to CSRF vulnerabilities, since prefetching or a forged request can trigger it.`
+                : `This GET handler's side effect (${sideEffectInHelper}) is prone to CSRF vulnerabilities, since prefetching or a forged request can trigger it.`;
+              context.report({ node, message });
+              return;
+            }
           }
         }
       },

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/collect-helper-parameter-safe-bindings.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/collect-helper-parameter-safe-bindings.ts
@@ -1,0 +1,39 @@
+import { collectPatternNames } from "./collect-pattern-names.js";
+import type { EsTreeNode } from "./es-tree-node.js";
+import { isFunctionLike } from "./is-function-like.js";
+import { isNodeOfType } from "./is-node-of-type.js";
+import { walkAst } from "./walk-ast.js";
+
+export const collectHelperParameterSafeBindings = (
+  handlerBody: EsTreeNode,
+  helperFunction: EsTreeNode,
+  locallyScopedSafeBindings: Set<string>,
+): Set<string> => {
+  const parameterSafeBindings = new Set<string>();
+
+  if (!isFunctionLike(helperFunction)) return parameterSafeBindings;
+
+  const helperParameters = helperFunction.params ?? [];
+  if (helperParameters.length === 0) return parameterSafeBindings;
+
+  walkAst(handlerBody, (node: EsTreeNode) => {
+    if (!isNodeOfType(node, "CallExpression")) return;
+    if (!isNodeOfType(node.callee, "Identifier")) return;
+
+    const callArguments = node.arguments ?? [];
+    if (callArguments.length === 0) return;
+
+    for (let argumentIndex = 0; argumentIndex < callArguments.length; argumentIndex++) {
+      const argument = callArguments[argumentIndex];
+      if (!isNodeOfType(argument, "Identifier")) continue;
+      if (!locallyScopedSafeBindings.has(argument.name)) continue;
+
+      const correspondingParameter = helperParameters[argumentIndex];
+      if (!correspondingParameter) continue;
+
+      collectPatternNames(correspondingParameter, parameterSafeBindings);
+    }
+  });
+
+  return parameterSafeBindings;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/utils/collect-helper-parameter-safe-bindings.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/utils/collect-helper-parameter-safe-bindings.ts
@@ -1,39 +1,31 @@
-import { collectPatternNames } from "./collect-pattern-names.js";
 import type { EsTreeNode } from "./es-tree-node.js";
 import { isFunctionLike } from "./is-function-like.js";
 import { isNodeOfType } from "./is-node-of-type.js";
-import { walkAst } from "./walk-ast.js";
 
 export const collectHelperParameterSafeBindings = (
-  handlerBody: EsTreeNode,
+  callExpression: EsTreeNode,
   helperFunction: EsTreeNode,
   locallyScopedSafeBindings: Set<string>,
 ): Set<string> => {
   const parameterSafeBindings = new Set<string>();
 
-  if (!isFunctionLike(helperFunction)) return parameterSafeBindings;
+  if (!isNodeOfType(callExpression, "CallExpression") || !isFunctionLike(helperFunction)) {
+    return parameterSafeBindings;
+  }
 
   const helperParameters = helperFunction.params ?? [];
   if (helperParameters.length === 0) return parameterSafeBindings;
 
-  walkAst(handlerBody, (node: EsTreeNode) => {
-    if (!isNodeOfType(node, "CallExpression")) return;
-    if (!isNodeOfType(node.callee, "Identifier")) return;
+  for (let argumentIndex = 0; argumentIndex < callExpression.arguments.length; argumentIndex++) {
+    const argument = callExpression.arguments[argumentIndex];
+    if (!isNodeOfType(argument, "Identifier")) continue;
+    if (!locallyScopedSafeBindings.has(argument.name)) continue;
 
-    const callArguments = node.arguments ?? [];
-    if (callArguments.length === 0) return;
+    const correspondingParameter = helperParameters[argumentIndex];
+    if (!isNodeOfType(correspondingParameter, "Identifier")) continue;
 
-    for (let argumentIndex = 0; argumentIndex < callArguments.length; argumentIndex++) {
-      const argument = callArguments[argumentIndex];
-      if (!isNodeOfType(argument, "Identifier")) continue;
-      if (!locallyScopedSafeBindings.has(argument.name)) continue;
-
-      const correspondingParameter = helperParameters[argumentIndex];
-      if (!correspondingParameter) continue;
-
-      collectPatternNames(correspondingParameter, parameterSafeBindings);
-    }
-  });
+    parameterSafeBindings.add(correspondingParameter.name);
+  }
 
   return parameterSafeBindings;
 };

--- a/packages/react-doctor/tests/regressions/nextjs-get-side-effects.test.ts
+++ b/packages/react-doctor/tests/regressions/nextjs-get-side-effects.test.ts
@@ -294,24 +294,56 @@ export async function GET() {
       expect(filterRule(diagnostics)).toHaveLength(0);
     });
 
-    it("locally-built Headers with destructured parameter", async () => {
+    it("does not transfer a safe argument to a different helper", async () => {
       const diagnostics = await writeRouteAndLint(
-        "issue-1757-destructured",
+        "issue-1757-helper-identity",
         "src/app/api/config/route.ts",
         `import { NextResponse } from "next/server";
 
-function applyConfig({ headers }: { headers: Headers }) {
-  headers.set("X-Config", "applied");
+const cache = new Map<string, number>();
+
+function applyHeaders(headers: Headers) {
+  headers.set("Cache-Control", "max-age=60");
+}
+
+function updateCache(cacheMap: Map<string, number>) {
+  cacheMap.set("requests", Date.now());
 }
 
 export async function GET() {
   const headers = new Headers();
-  applyConfig({ headers });
+  applyHeaders(headers);
+  updateCache(cache);
   return new NextResponse(null, { headers });
 }
 `,
       );
-      expect(filterRule(diagnostics)).toHaveLength(0);
+      const hits = filterRule(diagnostics);
+      expect(hits).toHaveLength(1);
+      expect(hits[0].message).toContain("cacheMap.set()");
+    });
+
+    it("reports when one helper receives both safe and external receivers", async () => {
+      const diagnostics = await writeRouteAndLint(
+        "issue-1757-mixed-helper-calls",
+        "src/app/api/config/route.ts",
+        `import { NextResponse } from "next/server";
+
+const cache = new Map<string, string>();
+
+function applyValue(target: Headers | Map<string, string>) {
+  target.set("Cache-Control", "max-age=60");
+}
+
+export async function GET() {
+  const headers = new Headers();
+  applyValue(headers);
+  applyValue(cache);
+  return new NextResponse(null, { headers });
+}
+`,
+      );
+      expect(filterRule(diagnostics)).toHaveLength(1);
     });
 
     it("aliased read-only `headers()` — `const h = headers(); h.get('user-agent')`", async () => {

--- a/packages/react-doctor/tests/regressions/nextjs-get-side-effects.test.ts
+++ b/packages/react-doctor/tests/regressions/nextjs-get-side-effects.test.ts
@@ -246,6 +246,74 @@ export async function GET() {
       expect(filterRule(diagnostics)).toHaveLength(0);
     });
 
+    it("locally-built Headers passed to a helper that calls `.set()` (issue #1757)", async () => {
+      const diagnostics = await writeRouteAndLint(
+        "issue-1757-headers-helper",
+        "src/app/api/proxy/route.ts",
+        `import type { NextRequest } from "next/server";
+
+function applyCachePolicy(responseHeaders: Headers) {
+  responseHeaders.set("Cache-Control", "public, max-age=3, stale-while-revalidate=10");
+}
+
+async function handler(request: NextRequest) {
+  const upstream = await fetch(\`https://api.example.com\${request.nextUrl.pathname}\`, {
+    method: request.method,
+  });
+  const headers = new Headers(upstream.headers);
+  if (request.method === "GET" && upstream.ok) {
+    applyCachePolicy(headers);
+  }
+  return new Response(upstream.body, { status: upstream.status, headers });
+}
+
+export const GET = handler;
+export const POST = handler;
+`,
+      );
+      expect(filterRule(diagnostics)).toHaveLength(0);
+    });
+
+    it("locally-built Headers in second parameter position", async () => {
+      const diagnostics = await writeRouteAndLint(
+        "issue-1757-second-param",
+        "src/app/api/cache/route.ts",
+        `import { NextResponse } from "next/server";
+
+function setCacheHeaders(status: number, headers: Headers) {
+  headers.set("Cache-Control", "max-age=60");
+}
+
+export async function GET() {
+  const headers = new Headers();
+  setCacheHeaders(200, headers);
+  return new NextResponse(null, { headers });
+}
+`,
+      );
+      expect(filterRule(diagnostics)).toHaveLength(0);
+    });
+
+    it("locally-built Headers with destructured parameter", async () => {
+      const diagnostics = await writeRouteAndLint(
+        "issue-1757-destructured",
+        "src/app/api/config/route.ts",
+        `import { NextResponse } from "next/server";
+
+function applyConfig({ headers }: { headers: Headers }) {
+  headers.set("X-Config", "applied");
+}
+
+export async function GET() {
+  const headers = new Headers();
+  applyConfig({ headers });
+  return new NextResponse(null, { headers });
+}
+`,
+      );
+      expect(filterRule(diagnostics)).toHaveLength(0);
+    });
+
     it("aliased read-only `headers()` — `const h = headers(); h.get('user-agent')`", async () => {
       const diagnostics = await writeRouteAndLint(
         "issue-206-headers-alias-read",
@@ -432,6 +500,29 @@ export async function GET() {
       const hits = filterRule(diagnostics);
       expect(hits).toHaveLength(1);
       expect(hits[0].message).toContain("cookies().delete()");
+    });
+
+    it("module-level Map passed to helper still fires (not locally scoped)", async () => {
+      const diagnostics = await writeRouteAndLint(
+        "issue-1757-module-map-helper",
+        "src/app/api/cache/route.ts",
+        `import { NextResponse } from "next/server";
+
+const cache = new Map<string, number>();
+
+function updateCache(cacheMap: Map<string, number>, key: string) {
+  cacheMap.set(key, Date.now());
+}
+
+export async function GET(req: Request) {
+  updateCache(cache, req.url);
+  return NextResponse.json({ ok: true });
+}
+`,
+      );
+      const hits = filterRule(diagnostics);
+      expect(hits).toHaveLength(1);
+      expect(hits[0].message).toContain("cacheMap.set()");
     });
 
     it("read-only GET on a mutating route segment `/logout` does NOT fire", async () => {


### PR DESCRIPTION
## Why

`nextjs-no-side-effect-in-get-handler` treated safe state passed to one helper as proof for unrelated helper calls. This could hide a real GET side effect while fixing the reported `Headers` false positive.

## What changed

- transfer safe receiver bindings through the exact same-file helper call
- retain one helper-body analysis per call so mixed safe and external arguments stay distinct
- accept local `Headers` mutation while reporting unrelated or mixed external mutation
- add end-to-end and strict fuzz regression coverage

## Test plan

- `nr -C packages/react-doctor test tests/regressions/nextjs-get-side-effects.test.ts`
- `nr typecheck`
- `FUZZ_RULE=nextjs-no-side-effect-in-get-handler FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz`
- `nr lint`
- `nr format`

Closes #1757