### PR TITLE
fix(rule): recognize owned effect cleanup paths

### DIFF
--- a/.changeset/calm-timers-listen.md
+++ b/.changeset/calm-timers-listen.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Avoid `effect-needs-cleanup` diagnostics for owned chained timers, guarded post-await timers, and listeners released through an abort handler.

--- a/packages/fuzz/corpus/regressions/effect-needs-cleanup--issue-1756-abort-handler.tsx
+++ b/packages/fuzz/corpus/regressions/effect-needs-cleanup--issue-1756-abort-handler.tsx
@@ -1,0 +1,18 @@
+// rule: effect-needs-cleanup
+// weakness: cleanup-provenance
+// source: issue #1756
+// verdict: pass
+import { useEffect } from "react";
+
+export const AbortHandlerCleanup = () => {
+  useEffect(() => {
+    const controller = new AbortController();
+    const onChange = () => {};
+    document.addEventListener("visibilitychange", onChange);
+    controller.signal.addEventListener("abort", () => {
+      document.removeEventListener("visibilitychange", onChange);
+    });
+    return () => controller.abort();
+  }, []);
+  return null;
+};

--- a/packages/fuzz/corpus/regressions/effect-needs-cleanup--issue-1756-chained-timer.tsx
+++ b/packages/fuzz/corpus/regressions/effect-needs-cleanup--issue-1756-chained-timer.tsx
@@ -1,0 +1,27 @@
+// rule: effect-needs-cleanup
+// weakness: cleanup-provenance
+// source: issue #1756
+// verdict: pass
+import { useEffect } from "react";
+
+export const ChainedTimer = () => {
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const clearTimer = () => {
+      if (timer !== null) {
+        clearTimeout(timer);
+        timer = null;
+      }
+    };
+    const schedule = (callback: () => void) => {
+      timer = setTimeout(callback, 1000);
+    };
+    const advance = () => {
+      timer = null;
+      schedule(advance);
+    };
+    schedule(advance);
+    return () => clearTimer();
+  }, []);
+  return null;
+};

--- a/packages/fuzz/corpus/regressions/effect-needs-cleanup--issue-1756-guarded-async-timer.tsx
+++ b/packages/fuzz/corpus/regressions/effect-needs-cleanup--issue-1756-guarded-async-timer.tsx
@@ -1,0 +1,27 @@
+// rule: effect-needs-cleanup
+// weakness: async-lifecycle-provenance
+// source: issue #1756
+// verdict: pass
+import { useEffect } from "react";
+
+declare const refresh: () => Promise<void>;
+
+export const GuardedAsyncTimer = () => {
+  useEffect(() => {
+    const run = { live: true };
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const schedule = () => {
+      timer = setTimeout(() => {}, 1000);
+    };
+    void (async () => {
+      await refresh();
+      if (!run.live) return;
+      schedule();
+    })();
+    return () => {
+      run.live = false;
+      if (timer !== null) clearTimeout(timer);
+    };
+  }, []);
+  return null;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup-issue-1756.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup-issue-1756.test.ts
@@ -6,6 +6,12 @@ const runEffectNeedsCleanup = (code: string) => runRule(effectNeedsCleanup, code
 
 describe("effect-needs-cleanup issue #1756", () => {
   describe("chained timer cleared by helper", () => {
+    // TODO: The rule currently doesn't recognize that when a timer handle is
+    // reassigned inside its own callback (chained timers), the cleanup helper
+    // still correctly clears whatever value is currently in the handle variable.
+    // At any point there's only one active timer. Need to extend the rule to
+    // understand mutable handle semantics where `clearTimeout(timer)` clears
+    // the current value regardless of reassignments.
     it("accepts a timer that is reassigned multiple times and cleared by a helper", () => {
       const result = runEffectNeedsCleanup(`
         import { useEffect, useState } from "react";
@@ -47,6 +53,11 @@ describe("effect-needs-cleanup issue #1756", () => {
   });
 
   describe("timer scheduled after await with guard", () => {
+    // TODO: The rule recognizes guards INSIDE promise callbacks (issue #1241),
+    // but doesn't track guards in the async caller that protect calls to sync
+    // functions containing allocations. Need to extend guard tracking to
+    // understand that `if (!run.live) return; refreshAndBound()` prevents
+    // allocation in refreshAndBound() after teardown.
     it("accepts a timer allocated in a nested function called after an await, with a guard before the call", () => {
       const result = runEffectNeedsCleanup(`
         import { useEffect, useState } from "react";
@@ -91,6 +102,11 @@ describe("effect-needs-cleanup issue #1756", () => {
   });
 
   describe("AbortController-based listener cleanup", () => {
+    // TODO: The rule recognizes direct `{signal}` usage, but doesn't recognize
+    // the delegated pattern where signal.addEventListener("abort", ...) removes
+    // the listener and cleanup calls controller.abort(). Need to add logic to
+    // detect this event-based delegation: verify the abort handler removes the
+    // correct listener, and cleanup calls abort() on the controller.
     it("accepts a listener removed by an abort event handler when the cleanup calls abort()", () => {
       const result = runEffectNeedsCleanup(`
         import { useEffect, useState } from "react";

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup-issue-1756.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup-issue-1756.test.ts
@@ -5,139 +5,269 @@ import { effectNeedsCleanup } from "./effect-needs-cleanup.js";
 const runEffectNeedsCleanup = (code: string) => runRule(effectNeedsCleanup, code);
 
 describe("effect-needs-cleanup issue #1756", () => {
-  describe("chained timer cleared by helper", () => {
-    // TODO: The rule currently doesn't recognize that when a timer handle is
-    // reassigned inside its own callback (chained timers), the cleanup helper
-    // still correctly clears whatever value is currently in the handle variable.
-    // At any point there's only one active timer. Need to extend the rule to
-    // understand mutable handle semantics where `clearTimeout(timer)` clears
-    // the current value regardless of reassignments.
-    it("accepts a timer that is reassigned multiple times and cleared by a helper", () => {
-      const result = runEffectNeedsCleanup(`
-        import { useEffect, useState } from "react";
+  it("accepts chained timers cleared by the returned cleanup helper", () => {
+    const result = runEffectNeedsCleanup(`
+      import { useEffect, useState } from "react";
 
-        const ChainedTimer = () => {
-          const [frame, setFrame] = useState(0);
-          useEffect(() => {
-            let timer: ReturnType<typeof setTimeout> | null = null;
-            
-            const clearTimer = () => {
-              if (timer !== null) {
-                clearTimeout(timer);
-                timer = null;
-              }
-            };
-            
-            const scheduleNext = (delay: number) => {
-              timer = setTimeout(() => {
-                timer = null;
-                setFrame(f => f + 1);
-                // Chain to next timer
-                timer = setTimeout(() => setFrame(10), 1000);
-              }, delay);
-            };
-            
-            scheduleNext(500);
-            
-            return () => {
-              clearTimer();
-            };
-          }, []);
-          return <div>{frame}</div>;
-        };
-      `);
+      const STEPS = [0, 400, 800];
 
-      expect(result.parseErrors).toEqual([]);
-      expect(result.diagnostics).toHaveLength(0);
-    });
+      const ChainedTimer = () => {
+        const [frame, setFrame] = useState(0);
+        const [loop, setLoop] = useState(0);
+        useEffect(() => {
+          let cancelled = false;
+          let timer: ReturnType<typeof setTimeout> | null = null;
+          let index = 0;
+          const startedAt = Date.now();
+          const clearTimer = () => {
+            if (timer !== null) {
+              clearTimeout(timer);
+              timer = null;
+            }
+          };
+          const scheduleAt = (at: number, callback: () => void) => {
+            timer = setTimeout(callback, Math.max(0, at - (Date.now() - startedAt)));
+          };
+          const advance = () => {
+            timer = null;
+            if (cancelled) return;
+            setFrame(index);
+            index += 1;
+            if (index < STEPS.length) {
+              scheduleAt(STEPS[index], advance);
+            } else {
+              scheduleAt(2000, () => {
+                if (!cancelled) setLoop((count) => count + 1);
+              });
+            }
+          };
+          const onVisibilityChange = () => {
+            if (cancelled) return;
+            if (document.hidden) clearTimer();
+            else setLoop((count) => count + 1);
+          };
+          document.addEventListener("visibilitychange", onVisibilityChange);
+          if (!document.hidden) scheduleAt(STEPS[0], advance);
+          return () => {
+            cancelled = true;
+            clearTimer();
+            document.removeEventListener("visibilitychange", onVisibilityChange);
+          };
+        }, [loop]);
+        return <span>{frame}</span>;
+      };
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
   });
 
-  describe("timer scheduled after await with guard", () => {
-    // TODO: The rule recognizes guards INSIDE promise callbacks (issue #1241),
-    // but doesn't track guards in the async caller that protect calls to sync
-    // functions containing allocations. Need to extend guard tracking to
-    // understand that `if (!run.live) return; refreshAndBound()` prevents
-    // allocation in refreshAndBound() after teardown.
-    it("accepts a timer allocated in a nested function called after an await, with a guard before the call", () => {
-      const result = runEffectNeedsCleanup(`
-        import { useEffect, useState } from "react";
-        
-        declare function refresh(): Promise<"refreshed" | "invalid">;
+  it("reports timer handle overwrites before the previous timer fires", () => {
+    const result = runEffectNeedsCleanup(`
+      import { useEffect } from "react";
 
-        const AsyncBoundedTimer = () => {
-          const [unproven, setUnproven] = useState(false);
-          useEffect(() => {
-            const run = { live: true };
-            let settleTimer: ReturnType<typeof setTimeout> | null = null;
-            
-            const refreshAndBound = () => {
-              settleTimer = setTimeout(() => {
-                settleTimer = null;
-                if (run.live) setUnproven(true);
-              }, 4000);
-            };
-            
+      const UnsafeTimers = () => {
+        useEffect(() => {
+          let timer: ReturnType<typeof setTimeout> | null = null;
+          const schedule = () => {
+            timer = setTimeout(() => {}, 1000);
+          };
+          schedule();
+          schedule();
+          return () => {
+            if (timer !== null) clearTimeout(timer);
+          };
+        }, []);
+        return null;
+      };
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("accepts a guarded timer scheduled through a helper after an await", () => {
+    const result = runEffectNeedsCleanup(`
+      import { useEffect, useState } from "react";
+
+      declare function refresh(): Promise<"refreshed" | "invalid">;
+
+      const AsyncBoundedTimer = () => {
+        const [unproven, setUnproven] = useState(false);
+        useEffect(() => {
+          const run = { live: true };
+          let settleTimer: ReturnType<typeof setTimeout> | null = null;
+          const refreshAndBound = () => {
+            settleTimer = setTimeout(() => {
+              settleTimer = null;
+              if (run.live) setUnproven(true);
+            }, 4000);
+          };
+          void (async () => {
+            const outcome = await refresh();
+            if (!run.live) return;
+            if (outcome === "refreshed") {
+              refreshAndBound();
+              return;
+            }
+            setUnproven(true);
+          })();
+          return () => {
+            run.live = false;
+            if (settleTimer !== null) clearTimeout(settleTimer);
+          };
+        }, []);
+        return <span>{String(unproven)}</span>;
+      };
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("reports a helper timer scheduled after an await without a lifecycle guard", () => {
+    const result = runEffectNeedsCleanup(`
+      import { useEffect } from "react";
+
+      declare function refresh(): Promise<void>;
+
+      const UnsafeAsyncTimer = () => {
+        useEffect(() => {
+          let timer: ReturnType<typeof setTimeout> | null = null;
+          const schedule = () => {
+            timer = setTimeout(() => {}, 1000);
+          };
+          void (async () => {
+            await refresh();
+            schedule();
+          })();
+          return () => {
+            if (timer !== null) clearTimeout(timer);
+          };
+        }, []);
+        return null;
+      };
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("reports an interruption between the lifecycle guard and timer helper", () => {
+    const result = runEffectNeedsCleanup(`
+      import { useEffect } from "react";
+
+      declare function refresh(): Promise<void>;
+
+      const UnsafeInterruptedTimer = () => {
+        useEffect(() => {
+          const run = { live: true };
+          let timer: ReturnType<typeof setTimeout> | null = null;
+          const schedule = () => {
+            timer = setTimeout(() => {}, 1000);
+          };
+          void (async () => {
+            await refresh();
+            if (!run.live) return;
+            await refresh();
+            schedule();
+          })();
+          return () => {
+            run.live = false;
+            if (timer !== null) clearTimeout(timer);
+          };
+        }, []);
+        return null;
+      };
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("reports guarded async timer work started repeatedly by the effect", () => {
+    const result = runEffectNeedsCleanup(`
+      import { useEffect } from "react";
+
+      declare function refresh(): Promise<void>;
+
+      const UnsafeRepeatedAsyncTimer = () => {
+        useEffect(() => {
+          const run = { live: true };
+          let timer: ReturnType<typeof setTimeout> | null = null;
+          const schedule = () => {
+            timer = setTimeout(() => {}, 1000);
+          };
+          for (let index = 0; index < 2; index += 1) {
             void (async () => {
-              const outcome = await refresh();
-              if (!run.live) return;  // Guard prevents allocation after teardown
-              if (outcome === "refreshed") {
-                refreshAndBound();
-                return;
-              }
-              setUnproven(true);
+              await refresh();
+              if (!run.live) return;
+              schedule();
             })();
-            
-            return () => {
-              run.live = false;
-              if (settleTimer !== null) clearTimeout(settleTimer);
-            };
-          }, []);
-          return <span>{String(unproven)}</span>;
-        };
-      `);
+          }
+          return () => {
+            run.live = false;
+            if (timer !== null) clearTimeout(timer);
+          };
+        }, []);
+        return null;
+      };
+    `);
 
-      expect(result.parseErrors).toEqual([]);
-      expect(result.diagnostics).toHaveLength(0);
-    });
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
   });
 
-  describe("AbortController-based listener cleanup", () => {
-    // TODO: The rule recognizes direct `{signal}` usage, but doesn't recognize
-    // the delegated pattern where signal.addEventListener("abort", ...) removes
-    // the listener and cleanup calls controller.abort(). Need to add logic to
-    // detect this event-based delegation: verify the abort handler removes the
-    // correct listener, and cleanup calls abort() on the controller.
-    it("accepts a listener removed by an abort event handler when the cleanup calls abort()", () => {
-      const result = runEffectNeedsCleanup(`
-        import { useEffect, useState } from "react";
+  it("accepts a listener released by an abort handler when cleanup aborts the controller", () => {
+    const result = runEffectNeedsCleanup(`
+      import { useEffect, useState } from "react";
 
-        const AbortTeardown = () => {
-          const [visible, setVisible] = useState(true);
-          useEffect(() => {
-            const controller = new AbortController();
-            const { signal } = controller;
-            const onChange = () => setVisible(!document.hidden);
-            
-            document.addEventListener("visibilitychange", onChange);
-            
-            signal.addEventListener(
-              "abort",
-              () => {
-                document.removeEventListener("visibilitychange", onChange);
-              },
-              { once: true },
-            );
-            
-            return () => {
-              controller.abort();
-            };
-          }, []);
-          return <span>{visible ? "visible" : "hidden"}</span>;
-        };
-      `);
+      const AbortTeardown = () => {
+        const [visible, setVisible] = useState(true);
+        useEffect(() => {
+          const controller = new AbortController();
+          const { signal } = controller;
+          const onChange = () => setVisible(!document.hidden);
+          document.addEventListener("visibilitychange", onChange);
+          signal.addEventListener(
+            "abort",
+            () => {
+              document.removeEventListener("visibilitychange", onChange);
+            },
+            { once: true },
+          );
+          return () => {
+            controller.abort();
+          };
+        }, []);
+        return <span>{visible ? "visible" : "hidden"}</span>;
+      };
+    `);
 
-      expect(result.parseErrors).toEqual([]);
-      expect(result.diagnostics).toHaveLength(0);
-    });
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("reports an abort handler that removes a different listener", () => {
+    const result = runEffectNeedsCleanup(`
+      import { useEffect } from "react";
+
+      const UnsafeAbortTeardown = () => {
+        useEffect(() => {
+          const controller = new AbortController();
+          const onChange = () => {};
+          const otherHandler = () => {};
+          document.addEventListener("visibilitychange", onChange);
+          controller.signal.addEventListener("abort", () => {
+            document.removeEventListener("visibilitychange", otherHandler);
+          });
+          return () => controller.abort();
+        }, []);
+        return null;
+      };
+    `);
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
   });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup-issue-1756.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup-issue-1756.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { effectNeedsCleanup } from "./effect-needs-cleanup.js";
+
+const runEffectNeedsCleanup = (code: string) => runRule(effectNeedsCleanup, code);
+
+describe("effect-needs-cleanup issue #1756", () => {
+  describe("chained timer cleared by helper", () => {
+    it("accepts a timer that is reassigned multiple times and cleared by a helper", () => {
+      const result = runEffectNeedsCleanup(`
+        import { useEffect, useState } from "react";
+
+        const ChainedTimer = () => {
+          const [frame, setFrame] = useState(0);
+          useEffect(() => {
+            let timer: ReturnType<typeof setTimeout> | null = null;
+            
+            const clearTimer = () => {
+              if (timer !== null) {
+                clearTimeout(timer);
+                timer = null;
+              }
+            };
+            
+            const scheduleNext = (delay: number) => {
+              timer = setTimeout(() => {
+                timer = null;
+                setFrame(f => f + 1);
+                // Chain to next timer
+                timer = setTimeout(() => setFrame(10), 1000);
+              }, delay);
+            };
+            
+            scheduleNext(500);
+            
+            return () => {
+              clearTimer();
+            };
+          }, []);
+          return <div>{frame}</div>;
+        };
+      `);
+
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(0);
+    });
+  });
+
+  describe("timer scheduled after await with guard", () => {
+    it("accepts a timer allocated in a nested function called after an await, with a guard before the call", () => {
+      const result = runEffectNeedsCleanup(`
+        import { useEffect, useState } from "react";
+        
+        declare function refresh(): Promise<"refreshed" | "invalid">;
+
+        const AsyncBoundedTimer = () => {
+          const [unproven, setUnproven] = useState(false);
+          useEffect(() => {
+            const run = { live: true };
+            let settleTimer: ReturnType<typeof setTimeout> | null = null;
+            
+            const refreshAndBound = () => {
+              settleTimer = setTimeout(() => {
+                settleTimer = null;
+                if (run.live) setUnproven(true);
+              }, 4000);
+            };
+            
+            void (async () => {
+              const outcome = await refresh();
+              if (!run.live) return;  // Guard prevents allocation after teardown
+              if (outcome === "refreshed") {
+                refreshAndBound();
+                return;
+              }
+              setUnproven(true);
+            })();
+            
+            return () => {
+              run.live = false;
+              if (settleTimer !== null) clearTimeout(settleTimer);
+            };
+          }, []);
+          return <span>{String(unproven)}</span>;
+        };
+      `);
+
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(0);
+    });
+  });
+
+  describe("AbortController-based listener cleanup", () => {
+    it("accepts a listener removed by an abort event handler when the cleanup calls abort()", () => {
+      const result = runEffectNeedsCleanup(`
+        import { useEffect, useState } from "react";
+
+        const AbortTeardown = () => {
+          const [visible, setVisible] = useState(true);
+          useEffect(() => {
+            const controller = new AbortController();
+            const { signal } = controller;
+            const onChange = () => setVisible(!document.hidden);
+            
+            document.addEventListener("visibilitychange", onChange);
+            
+            signal.addEventListener(
+              "abort",
+              () => {
+                document.removeEventListener("visibilitychange", onChange);
+              },
+              { once: true },
+            );
+            
+            return () => {
+              controller.abort();
+            };
+          }, []);
+          return <span>{visible ? "visible" : "hidden"}</span>;
+        };
+      `);
+
+      expect(result.parseErrors).toEqual([]);
+      expect(result.diagnostics).toHaveLength(0);
+    });
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -5074,7 +5074,11 @@ const isTimerCallbackForSameHandle = (
   if (!isFunctionLike(functionNode) || usage.handleKey === null) return false;
   const functionIdentityKeys = getFunctionIdentityKeys(functionNode, context);
   return allUsages.some((candidateUsage) => {
-    if (candidateUsage.kind !== "timer" || candidateUsage.handleKey !== usage.handleKey) {
+    if (
+      candidateUsage.kind !== "timer" ||
+      candidateUsage.handleKey !== usage.handleKey ||
+      findEnclosingFunction(candidateUsage.node) === functionNode
+    ) {
       return false;
     }
     const candidateCallbackIdentityKeys = getTimerCallbackIdentityKeys(candidateUsage, context);
@@ -5275,6 +5279,10 @@ const hasEffectOwnedNestedTimerCleanup = (
     ? context.scopes.symbolFor(functionBindingIdentifier)
     : null;
   if (!functionSymbol || functionSymbol.references.length === 0) return false;
+  const singleInvocationCall =
+    functionSymbol.references.length === 1
+      ? findDirectCallForReference(functionSymbol.references[0].identifier)
+      : null;
   const isSelfRescheduling = isSelfReschedulingOneShotTimer(
     usage,
     usageFunction,
@@ -5285,7 +5293,7 @@ const hasEffectOwnedNestedTimerCleanup = (
     handleStorageSymbol &&
     !isSelfRescheduling &&
     !hasLiveHandleOverwriteProtection(usageFunction, usage, context) &&
-    functionSymbol.references.length !== 1 &&
+    !singleInvocationCall &&
     !hasOnlyOwnedTimerHelperInvocations(callback, usage, usageFunction, functionSymbol, context)
   ) {
     return false;

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -6007,6 +6007,144 @@ const hasEffectLocalStoredDisposerCleanup = (
       isFunctionLike(functionNode) && doesCleanupFunctionReleaseUsage(functionNode, usage, context),
   });
 
+const hasAbortSignalDelegatedCleanup = (
+  callback: EsTreeNode,
+  usage: SubscribeLikeUsage,
+  context: RuleContext,
+): boolean => {
+  if (
+    usage.kind !== "subscribe" ||
+    usage.registrationVerbName !== "addEventListener" ||
+    !isNodeOfType(usage.node, "CallExpression") ||
+    !isNodeOfType(callback.body, "BlockStatement")
+  ) {
+    return false;
+  }
+
+  const usageCallee = stripParenExpression(usage.node.callee);
+  const usageReceiver = isNodeOfType(usageCallee, "MemberExpression")
+    ? resolveExpressionKey(usageCallee.object, context)
+    : null;
+  const usageEvent = resolveExpressionKey(usage.node.arguments?.[0], context);
+  const usageHandler = resolveExpressionKey(usage.node.arguments?.[1], context);
+
+  if (!usageReceiver || !usageEvent || !usageHandler) return false;
+
+  let controllerKey: string | null = null;
+  let hasMatchingAbortHandler = false;
+
+  walkAst(callback.body, (child: EsTreeNode) => {
+    if (child !== callback.body && isFunctionLike(child)) {
+      const isAbortListener =
+        isNodeOfType(child.parent, "CallExpression") &&
+        child.parent.arguments?.some((arg) => arg === child);
+      if (!isAbortListener) return false;
+
+      const abortCall = child.parent;
+      const abortCallee = stripParenExpression(abortCall.callee);
+      if (
+        !isNodeOfType(abortCallee, "MemberExpression") ||
+        abortCallee.computed ||
+        !isNodeOfType(abortCallee.property, "Identifier") ||
+        abortCallee.property.name !== "addEventListener"
+      ) {
+        return false;
+      }
+
+      const abortEvent = resolveExpressionKey(abortCall.arguments?.[0], context);
+      if (abortEvent !== `"abort"`) return;
+
+      const signalExpression = stripParenExpression(abortCallee.object);
+      if (!isNodeOfType(signalExpression, "Identifier")) return;
+
+      const signalSymbol = context.scopes.symbolFor(signalExpression);
+      if (!signalSymbol) return;
+
+      const signalInitializer = signalSymbol.initializer
+        ? stripParenExpression(signalSymbol.initializer)
+        : null;
+      if (
+        isNodeOfType(signalInitializer, "MemberExpression") &&
+        !signalInitializer.computed &&
+        isNodeOfType(signalInitializer.property, "Identifier") &&
+        signalInitializer.property.name === "signal"
+      ) {
+        controllerKey = resolveExpressionKey(signalInitializer.object, context);
+      } else if (signalSymbol.bindingIdentifier.parent) {
+        const bindingParent = signalSymbol.bindingIdentifier.parent;
+        if (
+          isNodeOfType(bindingParent, "Property") &&
+          isNodeOfType(bindingParent.parent, "ObjectPattern") &&
+          isNodeOfType(bindingParent.parent.parent, "VariableDeclarator") &&
+          bindingParent.parent.parent.init
+        ) {
+          controllerKey = resolveExpressionKey(bindingParent.parent.parent.init, context);
+        }
+      }
+
+      walkAst(child.body, (handlerChild: EsTreeNode) => {
+        if (handlerChild !== child.body && isFunctionLike(handlerChild)) return false;
+        if (!isNodeOfType(handlerChild, "CallExpression")) return;
+
+        const handlerCallee = stripParenExpression(handlerChild.callee);
+        if (
+          !isNodeOfType(handlerCallee, "MemberExpression") ||
+          handlerCallee.computed ||
+          !isNodeOfType(handlerCallee.property, "Identifier") ||
+          handlerCallee.property.name !== "removeEventListener"
+        ) {
+          return;
+        }
+
+        const removeReceiver = resolveExpressionKey(handlerCallee.object, context);
+        const removeEvent = resolveExpressionKey(handlerChild.arguments?.[0], context);
+        const removeHandler = resolveExpressionKey(handlerChild.arguments?.[1], context);
+
+        if (
+          removeReceiver === usageReceiver &&
+          removeEvent === usageEvent &&
+          removeHandler === usageHandler
+        ) {
+          hasMatchingAbortHandler = true;
+        }
+      });
+      return false;
+    }
+  });
+
+  if (!controllerKey || !hasMatchingAbortHandler) return false;
+
+  const matchingCleanupReturns: EsTreeNode[] = [];
+  walkInsideStatementBlocks(callback.body, (child: EsTreeNode) => {
+    if (!isNodeOfType(child, "ReturnStatement") || !child.argument) return;
+    const cleanupFunction = resolveStableValue(child.argument, context);
+    if (!cleanupFunction || !isFunctionLike(cleanupFunction)) return;
+
+    let hasAbortCall = false;
+    walkAst(cleanupFunction.body, (cleanupChild: EsTreeNode) => {
+      if (cleanupChild !== cleanupFunction.body && isFunctionLike(cleanupChild)) return false;
+      if (!isNodeOfType(cleanupChild, "CallExpression")) return;
+
+      const cleanupCallee = stripParenExpression(cleanupChild.callee);
+      if (
+        isNodeOfType(cleanupCallee, "MemberExpression") &&
+        !cleanupCallee.computed &&
+        isNodeOfType(cleanupCallee.property, "Identifier") &&
+        cleanupCallee.property.name === "abort" &&
+        resolveExpressionKey(cleanupCallee.object, context) === controllerKey
+      ) {
+        hasAbortCall = true;
+      }
+    });
+
+    if (hasAbortCall) {
+      matchingCleanupReturns.push(child);
+    }
+  });
+
+  return doMatchingNodesCoverEveryPathAfterUsage(usage.node, matchingCleanupReturns, context);
+};
+
 const effectHasCleanupForUsage = (
   callback: EsTreeNode,
   usage: SubscribeLikeUsage,
@@ -6025,6 +6163,7 @@ const effectHasCleanupForUsage = (
     symmetricForEachListenerCleanupReleasesUsage(callback, usage, context) ||
     hasReturnedObserverDisconnectAfterSynchronousIteration(callback, usage, context) ||
     hasEffectLocalStoredDisposerCleanup(callback, usage, context) ||
+    hasAbortSignalDelegatedCleanup(callback, usage, context) ||
     oneShotTimerHasUnmountGuard(usage, context) ||
     hasGuaranteedRefOwnedUnmountCleanup(callback, usage, context)
   ) {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/effect-needs-cleanup.ts
@@ -2641,6 +2641,123 @@ const getListenerAbortControllerKey = (
   return null;
 };
 
+const resolveAbortSignalControllerKey = (
+  signalExpression: EsTreeNode,
+  context: RuleContext,
+): string | null => {
+  const unwrappedSignal = stripParenExpression(signalExpression);
+  if (
+    isNodeOfType(unwrappedSignal, "MemberExpression") &&
+    !unwrappedSignal.computed &&
+    isNodeOfType(unwrappedSignal.property, "Identifier") &&
+    unwrappedSignal.property.name === "signal"
+  ) {
+    return resolveExpressionKey(unwrappedSignal.object, context);
+  }
+  if (!isNodeOfType(unwrappedSignal, "Identifier")) return null;
+  const signalSymbol = context.scopes.symbolFor(unwrappedSignal);
+  if (!signalSymbol) return null;
+  const signalInitializer = signalSymbol.initializer
+    ? stripParenExpression(signalSymbol.initializer)
+    : null;
+  if (
+    isNodeOfType(signalInitializer, "MemberExpression") &&
+    !signalInitializer.computed &&
+    isNodeOfType(signalInitializer.property, "Identifier") &&
+    signalInitializer.property.name === "signal"
+  ) {
+    return resolveExpressionKey(signalInitializer.object, context);
+  }
+  const bindingProperty = signalSymbol.bindingIdentifier.parent;
+  if (
+    !isNodeOfType(bindingProperty, "Property") ||
+    getStaticPropertyKeyName(bindingProperty) !== "signal" ||
+    !isNodeOfType(bindingProperty.parent, "ObjectPattern") ||
+    !isNodeOfType(bindingProperty.parent.parent, "VariableDeclarator") ||
+    !bindingProperty.parent.parent.init
+  ) {
+    return null;
+  }
+  return resolveExpressionKey(bindingProperty.parent.parent.init, context);
+};
+
+const getDelegatedListenerAbortControllerKey = (
+  usage: SubscribeLikeUsage,
+  context: RuleContext,
+): string | null => {
+  if (
+    usage.registrationVerbName !== "addEventListener" ||
+    !isNodeOfType(usage.node, "CallExpression")
+  ) {
+    return null;
+  }
+  const registrationCall = usage.node;
+  const registrationOwner = findEnclosingFunction(usage.node);
+  if (!registrationOwner || !isFunctionLike(registrationOwner)) return null;
+  let matchingControllerKey: string | null = null;
+  walkAst(registrationOwner.body, (child: EsTreeNode) => {
+    if (matchingControllerKey) return false;
+    if (child !== registrationOwner.body && isFunctionLike(child)) return false;
+    if (!isNodeOfType(child, "CallExpression") || getCalleeName(child) !== "addEventListener") {
+      return;
+    }
+    const callee = stripParenExpression(child.callee);
+    if (!isNodeOfType(callee, "MemberExpression")) return;
+    const eventName = child.arguments[0] ? stripParenExpression(child.arguments[0]) : null;
+    if (!isNodeOfType(eventName, "Literal") || eventName.value !== "abort") return;
+    const controllerKey = resolveAbortSignalControllerKey(callee.object, context);
+    if (!controllerKey) return;
+    const handler = resolveStableValue(child.arguments[1], context);
+    if (!handler || !isFunctionLike(handler) || handler.async || handler.generator) return;
+    const matchingRemovalCalls: EsTreeNode[] = [];
+    walkAst(handler.body, (handlerChild: EsTreeNode) => {
+      if (handlerChild !== handler.body && isFunctionLike(handlerChild)) return false;
+      if (!isNodeOfType(handlerChild, "CallExpression")) return;
+      const removalCallee = stripParenExpression(handlerChild.callee);
+      if (
+        !isNodeOfType(removalCallee, "MemberExpression") ||
+        getCalleeName(handlerChild) !== "removeEventListener" ||
+        resolveResourceIdentityKey(removalCallee.object, context) !== usage.receiverKey ||
+        resolveResourceIdentityKey(handlerChild.arguments[0], context) !== usage.eventKey ||
+        resolveResourceIdentityKey(handlerChild.arguments[1], context) !== usage.handlerKey ||
+        !doEventListenerCapturesMatch(
+          registrationCall.arguments[2],
+          handlerChild.arguments[2],
+          context,
+          true,
+        )
+      ) {
+        return;
+      }
+      matchingRemovalCalls.push(handlerChild);
+    });
+    if (doNodesCoverEveryPathFromFunctionEntry(handler, matchingRemovalCalls, context)) {
+      matchingControllerKey = controllerKey;
+      return false;
+    }
+  });
+  return matchingControllerKey;
+};
+
+const getAbortSignalListenerControllerKey = (
+  usage: SubscribeLikeUsage,
+  context: RuleContext,
+): string | null => {
+  if (
+    usage.registrationVerbName !== "addEventListener" ||
+    !isNodeOfType(usage.node, "CallExpression")
+  ) {
+    return null;
+  }
+  const eventName = usage.node.arguments[0] ? stripParenExpression(usage.node.arguments[0]) : null;
+  const callee = stripParenExpression(usage.node.callee);
+  return isNodeOfType(eventName, "Literal") &&
+    eventName.value === "abort" &&
+    isNodeOfType(callee, "MemberExpression")
+    ? resolveAbortSignalControllerKey(callee.object, context)
+    : null;
+};
+
 const findEnclosingForEachCall = (node: EsTreeNode): EsTreeNodeOfType<"CallExpression"> | null => {
   const callbackNode = isFunctionLike(node) ? node : findEnclosingFunction(node);
   if (
@@ -3990,8 +4107,9 @@ const collectDeferredUsageGuardStates = (
   callback: EsTreeNode,
   usageNode: EsTreeNode,
   context: RuleContext,
+  allowAsyncCallback = false,
 ): BooleanGuardState[] => {
-  if (!isFunctionLike(callback) || callback.async) return [];
+  if (!isFunctionLike(callback) || (callback.async && !allowAsyncCallback)) return [];
   const guardStates: BooleanGuardState[] = [];
   walkAst(callback.body, (child: EsTreeNode) => {
     if (child !== callback.body && isFunctionLike(child)) return false;
@@ -4129,6 +4247,70 @@ const isEffectLocalLifecycleGuard = (
   });
 };
 
+const isEffectLocalObjectLifecycleGuard = (
+  callback: EsTreeNode,
+  guardState: BooleanGuardState,
+  cleanupFunctions: ReadonlyArray<EsTreeNode>,
+  context: RuleContext,
+): boolean => {
+  const guardMemberExpressions: EsTreeNodeOfType<"MemberExpression">[] = [];
+  walkAst(guardState.guardNode, (child: EsTreeNode) => {
+    if (
+      guardMemberExpressions.length === 0 &&
+      isNodeOfType(child, "MemberExpression") &&
+      !child.computed &&
+      isNodeOfType(child.object, "Identifier") &&
+      isNodeOfType(child.property, "Identifier") &&
+      resolveExpressionKey(child, context) === guardState.key
+    ) {
+      guardMemberExpressions.push(child);
+      return false;
+    }
+  });
+  const guardMemberExpression = guardMemberExpressions[0];
+  if (!guardMemberExpression) return false;
+  const objectSymbol = context.scopes.symbolFor(guardMemberExpression.object);
+  const initializer = objectSymbol?.initializer
+    ? stripParenExpression(objectSymbol.initializer)
+    : null;
+  if (
+    !objectSymbol ||
+    objectSymbol.kind !== "const" ||
+    !isNodeOfType(objectSymbol.declarationNode, "VariableDeclarator") ||
+    findEnclosingFunction(objectSymbol.declarationNode) !== callback ||
+    !isNodeOfType(initializer, "ObjectExpression") ||
+    initializer.properties.length !== 1
+  ) {
+    return false;
+  }
+  const initialProperty = initializer.properties[0];
+  if (
+    !isNodeOfType(initialProperty, "Property") ||
+    getStaticPropertyKeyName(initialProperty) !== getStaticPropertyKeyName(guardMemberExpression) ||
+    readStaticBoolean(initialProperty.value) !== !guardState.value
+  ) {
+    return false;
+  }
+  return objectSymbol.references.every((reference) => {
+    const memberExpression = getOutermostMemberReference(reference.identifier);
+    if (
+      !isNodeOfType(memberExpression, "MemberExpression") ||
+      resolveExpressionKey(memberExpression, context) !== guardState.key
+    ) {
+      return false;
+    }
+    if (!isWithinAssignmentTarget(reference.identifier)) return true;
+    const assignment = memberExpression.parent;
+    return (
+      isNodeOfType(assignment, "AssignmentExpression") &&
+      assignment.operator === "=" &&
+      assignment.left === memberExpression &&
+      readStaticBoolean(assignment.right) === guardState.value &&
+      cleanupFunctions.includes(findEnclosingFunction(assignment) ?? assignment)
+    );
+  });
+};
+
 const hasPotentialInterruptionAfterGuard = (
   callback: EsTreeNode,
   guardState: BooleanGuardState,
@@ -4161,6 +4343,60 @@ const hasPotentialInterruptionAfterGuard = (
     }
   });
   return hasPotentialInterruption;
+};
+
+const isDeferredHelperInvocationProtectedByEffectLifecycleGuard = (
+  callback: EsTreeNode,
+  invocationOwner: EsTreeNode,
+  invocationCall: EsTreeNode,
+  cleanupReturns: ReadonlyArray<EsTreeNode>,
+  context: RuleContext,
+): boolean => {
+  const invocationOwnerRoot = findTransparentExpressionRoot(invocationOwner);
+  const directInvocation =
+    isNodeOfType(invocationOwnerRoot.parent, "CallExpression") &&
+    invocationOwnerRoot.parent.callee === invocationOwnerRoot
+      ? invocationOwnerRoot.parent
+      : findSingleDirectInvocation(invocationOwner, callback, context);
+  if (
+    !isFunctionLike(invocationOwner) ||
+    !invocationOwner.async ||
+    invocationOwner.generator ||
+    !directInvocation ||
+    findEnclosingFunction(directInvocation) !== callback ||
+    !collectEffectInvokedFunctions(callback, context.scopes).has(invocationOwner)
+  ) {
+    return false;
+  }
+  let invocationAncestor = directInvocation.parent;
+  while (invocationAncestor && invocationAncestor !== callback) {
+    if (
+      isNodeOfType(invocationAncestor, "ForStatement") ||
+      isNodeOfType(invocationAncestor, "ForInStatement") ||
+      isNodeOfType(invocationAncestor, "ForOfStatement") ||
+      isNodeOfType(invocationAncestor, "WhileStatement") ||
+      isNodeOfType(invocationAncestor, "DoWhileStatement")
+    ) {
+      return false;
+    }
+    invocationAncestor = invocationAncestor.parent;
+  }
+  const cleanupFunctions = cleanupReturns.flatMap((cleanupReturn) => {
+    if (!isNodeOfType(cleanupReturn, "ReturnStatement") || !cleanupReturn.argument) return [];
+    const cleanupFunction = resolveStableValue(cleanupReturn.argument, context);
+    return cleanupFunction && isFunctionLike(cleanupFunction) ? [cleanupFunction] : [];
+  });
+  if (cleanupFunctions.length !== cleanupReturns.length) return false;
+  return collectDeferredUsageGuardStates(invocationOwner, invocationCall, context, true).some(
+    (guardState) =>
+      (isEffectLocalLifecycleGuard(callback, guardState, cleanupFunctions, context) ||
+        isEffectLocalObjectLifecycleGuard(callback, guardState, cleanupFunctions, context)) &&
+      !hasPotentialInterruptionAfterGuard(invocationOwner, guardState, invocationCall, context) &&
+      !deferredUsageWritesGuardBeforeUsage(invocationOwner, invocationCall, guardState, context) &&
+      cleanupReturns.every((cleanupReturn) =>
+        cleanupReturnInvalidatesGuard(cleanupReturn, guardState, context),
+      ),
+  );
 };
 
 const getNumericReactRefCurrentKey = (
@@ -4781,10 +5017,124 @@ const getOutermostMemberReference = (identifier: EsTreeNode): EsTreeNode => {
   return findTransparentExpressionRoot(expression);
 };
 
+const getTimerCallbackIdentityKeys = (
+  usage: SubscribeLikeUsage,
+  context: RuleContext,
+): ReadonlySet<string> => {
+  const callbackIdentityKeys = new Set<string>();
+  const invocationCallbackIdentityKeys = new Set<string>();
+  const callbackKey = getUsageCallbackKey(usage, context);
+  if (callbackKey) callbackIdentityKeys.add(callbackKey);
+  if (usage.kind !== "timer" || !isNodeOfType(usage.node, "CallExpression")) {
+    return callbackIdentityKeys;
+  }
+  const callbackArgument = usage.node.arguments[0];
+  if (!callbackArgument || !isNodeOfType(callbackArgument, "Identifier")) {
+    return callbackIdentityKeys;
+  }
+  const callbackSymbol = context.scopes.symbolFor(callbackArgument);
+  const usageFunction = callbackSymbol
+    ? findEnclosingFunction(callbackSymbol.bindingIdentifier)
+    : null;
+  if (!callbackSymbol || !usageFunction || !isFunctionLike(usageFunction)) {
+    return callbackIdentityKeys;
+  }
+  const callbackParameterIndex = usageFunction.params.findIndex(
+    (parameter) => parameter === callbackSymbol.bindingIdentifier,
+  );
+  const functionBindingIdentifier = getFunctionBindingIdentifier(usageFunction);
+  const functionSymbol = functionBindingIdentifier
+    ? context.scopes.symbolFor(functionBindingIdentifier)
+    : null;
+  if (callbackParameterIndex < 0 || !functionSymbol) return callbackIdentityKeys;
+  for (const reference of functionSymbol.references) {
+    const invocationCall = findDirectCallForReference(reference.identifier);
+    if (!isNodeOfType(invocationCall, "CallExpression")) {
+      return callbackIdentityKeys;
+    }
+    const invocationArgument = invocationCall.arguments[callbackParameterIndex];
+    if (!invocationArgument || !isAstNode(invocationArgument)) {
+      return callbackIdentityKeys;
+    }
+    const invocationCallbackKey = resolveExpressionKey(invocationArgument, context);
+    if (invocationCallbackKey) invocationCallbackIdentityKeys.add(invocationCallbackKey);
+  }
+  for (const identityKey of invocationCallbackIdentityKeys) {
+    callbackIdentityKeys.add(identityKey);
+  }
+  return callbackIdentityKeys;
+};
+
+const isTimerCallbackForSameHandle = (
+  functionNode: EsTreeNode,
+  usage: SubscribeLikeUsage,
+  allUsages: ReadonlyArray<SubscribeLikeUsage>,
+  context: RuleContext,
+): boolean => {
+  if (!isFunctionLike(functionNode) || usage.handleKey === null) return false;
+  const functionIdentityKeys = getFunctionIdentityKeys(functionNode, context);
+  return allUsages.some((candidateUsage) => {
+    if (candidateUsage.kind !== "timer" || candidateUsage.handleKey !== usage.handleKey) {
+      return false;
+    }
+    const candidateCallbackIdentityKeys = getTimerCallbackIdentityKeys(candidateUsage, context);
+    return [...functionIdentityKeys].some((identityKey) =>
+      candidateCallbackIdentityKeys.has(identityKey),
+    );
+  });
+};
+
+const hasOnlyOwnedTimerHelperInvocations = (
+  callback: EsTreeNode,
+  usage: SubscribeLikeUsage,
+  usageFunction: EsTreeNode,
+  functionSymbol: SymbolDescriptor,
+  context: RuleContext,
+): boolean => {
+  const invocationsByOwner = new Map<EsTreeNode, EsTreeNode[]>();
+  let directEffectInvocationCount = 0;
+  for (const reference of functionSymbol.references) {
+    const invocationCall = findDirectCallForReference(reference.identifier);
+    const invocationOwner = invocationCall ? findEnclosingFunction(invocationCall) : null;
+    if (!invocationCall || !invocationOwner || !isFunctionLike(invocationOwner)) return false;
+    if (invocationOwner === callback) {
+      directEffectInvocationCount += 1;
+    } else if (!isTimerCallbackForSameHandle(invocationOwner, usage, [usage], context)) {
+      return false;
+    }
+    const ownerInvocations = invocationsByOwner.get(invocationOwner) ?? [];
+    ownerInvocations.push(invocationCall);
+    invocationsByOwner.set(invocationOwner, ownerInvocations);
+  }
+  if (directEffectInvocationCount > 1) return false;
+  return [...invocationsByOwner.entries()].every(([invocationOwner, invocations]) =>
+    invocations.every((invocation, invocationIndex) =>
+      invocations
+        .slice(invocationIndex + 1)
+        .every(
+          (laterInvocation) =>
+            !canNodeReachLaterNodeWithinFunction(
+              invocation,
+              laterInvocation,
+              invocationOwner,
+              context,
+            ) &&
+            !canNodeReachLaterNodeWithinFunction(
+              laterInvocation,
+              invocation,
+              invocationOwner,
+              context,
+            ),
+        ),
+    ),
+  );
+};
+
 const hasOnlySafeHandleStorageAssignments = (
   usage: SubscribeLikeUsage,
   handleStorageSymbol: SymbolDescriptor,
   usageAssignment: EsTreeNodeOfType<"AssignmentExpression">,
+  allUsages: ReadonlyArray<SubscribeLikeUsage>,
   context: RuleContext,
 ): boolean =>
   handleStorageSymbol.references.every((reference) => {
@@ -4803,13 +5153,32 @@ const hasOnlySafeHandleStorageAssignments = (
       return false;
     }
     const assignedValue = stripParenExpression(assignment.right);
+    const assignmentOwner = findEnclosingFunction(assignment);
+    const assignedTimerUsage = allUsages.find(
+      (candidateUsage) =>
+        candidateUsage.kind === "timer" &&
+        candidateUsage.node === assignedValue &&
+        candidateUsage.handleKey === usage.handleKey,
+    );
+    const currentUsageOwner = findEnclosingFunction(usage.node);
+    const currentUsageOwnerKeys = currentUsageOwner
+      ? getFunctionIdentityKeys(currentUsageOwner, context)
+      : new Set<string>();
+    if (
+      assignedTimerUsage &&
+      ((assignmentOwner &&
+        isTimerCallbackForSameHandle(assignmentOwner, usage, allUsages, context)) ||
+        currentUsageOwnerKeys.has(getUsageCallbackKey(assignedTimerUsage, context) ?? ""))
+    ) {
+      return true;
+    }
     const isNullishReset =
       (isNodeOfType(assignedValue, "Literal") && assignedValue.value === null) ||
       (isNodeOfType(assignedValue, "Identifier") &&
         assignedValue.name === "undefined" &&
         context.scopes.isGlobalReference(assignedValue));
-    const assignmentOwner = findEnclosingFunction(assignment);
     if (!isNullishReset || !assignmentOwner || !isFunctionLike(assignmentOwner)) return false;
+    if (isTimerCallbackForSameHandle(assignmentOwner, usage, allUsages, context)) return true;
     const matchingReleaseCalls: EsTreeNode[] = [];
     walkAst(assignmentOwner.body, (child: EsTreeNode) => {
       if (child !== assignmentOwner.body && isFunctionLike(child)) return false;
@@ -4888,10 +5257,24 @@ const hasEffectOwnedNestedTimerCleanup = (
   if (
     handleStorageSymbol &&
     isNodeOfType(usageAssignment, "AssignmentExpression") &&
-    !hasOnlySafeHandleStorageAssignments(usage, handleStorageSymbol, usageAssignment, context)
+    !hasOnlySafeHandleStorageAssignments(
+      usage,
+      handleStorageSymbol,
+      usageAssignment,
+      allUsages,
+      context,
+    )
   ) {
     return false;
   }
+  if (isTimerCallbackForSameHandle(usageFunction, usage, allUsages, context)) {
+    return true;
+  }
+  const functionBindingIdentifier = getFunctionBindingIdentifier(usageFunction);
+  const functionSymbol = functionBindingIdentifier
+    ? context.scopes.symbolFor(functionBindingIdentifier)
+    : null;
+  if (!functionSymbol || functionSymbol.references.length === 0) return false;
   const isSelfRescheduling = isSelfReschedulingOneShotTimer(
     usage,
     usageFunction,
@@ -4901,7 +5284,9 @@ const hasEffectOwnedNestedTimerCleanup = (
   if (
     handleStorageSymbol &&
     !isSelfRescheduling &&
-    !hasLiveHandleOverwriteProtection(usageFunction, usage, context)
+    !hasLiveHandleOverwriteProtection(usageFunction, usage, context) &&
+    functionSymbol.references.length !== 1 &&
+    !hasOnlyOwnedTimerHelperInvocations(callback, usage, usageFunction, functionSymbol, context)
   ) {
     return false;
   }
@@ -4919,11 +5304,6 @@ const hasEffectOwnedNestedTimerCleanup = (
     }
     usageAncestor = usageAncestor.parent;
   }
-  const functionBindingIdentifier = getFunctionBindingIdentifier(usageFunction);
-  const functionSymbol = functionBindingIdentifier
-    ? context.scopes.symbolFor(functionBindingIdentifier)
-    : null;
-  if (!functionSymbol || functionSymbol.references.length === 0) return false;
   const selfSchedulingReferences = functionSymbol.references.filter(
     (reference) =>
       isSelfRescheduling &&
@@ -4969,7 +5349,19 @@ const hasEffectOwnedNestedTimerCleanup = (
     if (!invocationOwner || !isFunctionLike(invocationOwner) || invocationOwner === usageFunction) {
       return false;
     }
-    if (invocationOwner.async || invocationOwner.generator) return false;
+    if (invocationOwner.generator) return false;
+    if (invocationOwner.async) {
+      return isDeferredHelperInvocationProtectedByEffectLifecycleGuard(
+        callback,
+        invocationOwner,
+        invocationCall,
+        cleanupReturns,
+        context,
+      );
+    }
+    if (isTimerCallbackForSameHandle(invocationOwner, usage, allUsages, context)) {
+      return true;
+    }
     if (invocationOwner === callback) {
       return doMatchingNodesCoverEveryPathAfterUsage(
         resolveCleanupPathAnchor(invocationCall, callback, context),
@@ -6007,144 +6399,6 @@ const hasEffectLocalStoredDisposerCleanup = (
       isFunctionLike(functionNode) && doesCleanupFunctionReleaseUsage(functionNode, usage, context),
   });
 
-const hasAbortSignalDelegatedCleanup = (
-  callback: EsTreeNode,
-  usage: SubscribeLikeUsage,
-  context: RuleContext,
-): boolean => {
-  if (
-    usage.kind !== "subscribe" ||
-    usage.registrationVerbName !== "addEventListener" ||
-    !isNodeOfType(usage.node, "CallExpression") ||
-    !isNodeOfType(callback.body, "BlockStatement")
-  ) {
-    return false;
-  }
-
-  const usageCallee = stripParenExpression(usage.node.callee);
-  const usageReceiver = isNodeOfType(usageCallee, "MemberExpression")
-    ? resolveExpressionKey(usageCallee.object, context)
-    : null;
-  const usageEvent = resolveExpressionKey(usage.node.arguments?.[0], context);
-  const usageHandler = resolveExpressionKey(usage.node.arguments?.[1], context);
-
-  if (!usageReceiver || !usageEvent || !usageHandler) return false;
-
-  let controllerKey: string | null = null;
-  let hasMatchingAbortHandler = false;
-
-  walkAst(callback.body, (child: EsTreeNode) => {
-    if (child !== callback.body && isFunctionLike(child)) {
-      const isAbortListener =
-        isNodeOfType(child.parent, "CallExpression") &&
-        child.parent.arguments?.some((arg) => arg === child);
-      if (!isAbortListener) return false;
-
-      const abortCall = child.parent;
-      const abortCallee = stripParenExpression(abortCall.callee);
-      if (
-        !isNodeOfType(abortCallee, "MemberExpression") ||
-        abortCallee.computed ||
-        !isNodeOfType(abortCallee.property, "Identifier") ||
-        abortCallee.property.name !== "addEventListener"
-      ) {
-        return false;
-      }
-
-      const abortEvent = resolveExpressionKey(abortCall.arguments?.[0], context);
-      if (abortEvent !== `"abort"`) return;
-
-      const signalExpression = stripParenExpression(abortCallee.object);
-      if (!isNodeOfType(signalExpression, "Identifier")) return;
-
-      const signalSymbol = context.scopes.symbolFor(signalExpression);
-      if (!signalSymbol) return;
-
-      const signalInitializer = signalSymbol.initializer
-        ? stripParenExpression(signalSymbol.initializer)
-        : null;
-      if (
-        isNodeOfType(signalInitializer, "MemberExpression") &&
-        !signalInitializer.computed &&
-        isNodeOfType(signalInitializer.property, "Identifier") &&
-        signalInitializer.property.name === "signal"
-      ) {
-        controllerKey = resolveExpressionKey(signalInitializer.object, context);
-      } else if (signalSymbol.bindingIdentifier.parent) {
-        const bindingParent = signalSymbol.bindingIdentifier.parent;
-        if (
-          isNodeOfType(bindingParent, "Property") &&
-          isNodeOfType(bindingParent.parent, "ObjectPattern") &&
-          isNodeOfType(bindingParent.parent.parent, "VariableDeclarator") &&
-          bindingParent.parent.parent.init
-        ) {
-          controllerKey = resolveExpressionKey(bindingParent.parent.parent.init, context);
-        }
-      }
-
-      walkAst(child.body, (handlerChild: EsTreeNode) => {
-        if (handlerChild !== child.body && isFunctionLike(handlerChild)) return false;
-        if (!isNodeOfType(handlerChild, "CallExpression")) return;
-
-        const handlerCallee = stripParenExpression(handlerChild.callee);
-        if (
-          !isNodeOfType(handlerCallee, "MemberExpression") ||
-          handlerCallee.computed ||
-          !isNodeOfType(handlerCallee.property, "Identifier") ||
-          handlerCallee.property.name !== "removeEventListener"
-        ) {
-          return;
-        }
-
-        const removeReceiver = resolveExpressionKey(handlerCallee.object, context);
-        const removeEvent = resolveExpressionKey(handlerChild.arguments?.[0], context);
-        const removeHandler = resolveExpressionKey(handlerChild.arguments?.[1], context);
-
-        if (
-          removeReceiver === usageReceiver &&
-          removeEvent === usageEvent &&
-          removeHandler === usageHandler
-        ) {
-          hasMatchingAbortHandler = true;
-        }
-      });
-      return false;
-    }
-  });
-
-  if (!controllerKey || !hasMatchingAbortHandler) return false;
-
-  const matchingCleanupReturns: EsTreeNode[] = [];
-  walkInsideStatementBlocks(callback.body, (child: EsTreeNode) => {
-    if (!isNodeOfType(child, "ReturnStatement") || !child.argument) return;
-    const cleanupFunction = resolveStableValue(child.argument, context);
-    if (!cleanupFunction || !isFunctionLike(cleanupFunction)) return;
-
-    let hasAbortCall = false;
-    walkAst(cleanupFunction.body, (cleanupChild: EsTreeNode) => {
-      if (cleanupChild !== cleanupFunction.body && isFunctionLike(cleanupChild)) return false;
-      if (!isNodeOfType(cleanupChild, "CallExpression")) return;
-
-      const cleanupCallee = stripParenExpression(cleanupChild.callee);
-      if (
-        isNodeOfType(cleanupCallee, "MemberExpression") &&
-        !cleanupCallee.computed &&
-        isNodeOfType(cleanupCallee.property, "Identifier") &&
-        cleanupCallee.property.name === "abort" &&
-        resolveExpressionKey(cleanupCallee.object, context) === controllerKey
-      ) {
-        hasAbortCall = true;
-      }
-    });
-
-    if (hasAbortCall) {
-      matchingCleanupReturns.push(child);
-    }
-  });
-
-  return doMatchingNodesCoverEveryPathAfterUsage(usage.node, matchingCleanupReturns, context);
-};
-
 const effectHasCleanupForUsage = (
   callback: EsTreeNode,
   usage: SubscribeLikeUsage,
@@ -6163,7 +6417,6 @@ const effectHasCleanupForUsage = (
     symmetricForEachListenerCleanupReleasesUsage(callback, usage, context) ||
     hasReturnedObserverDisconnectAfterSynchronousIteration(callback, usage, context) ||
     hasEffectLocalStoredDisposerCleanup(callback, usage, context) ||
-    hasAbortSignalDelegatedCleanup(callback, usage, context) ||
     oneShotTimerHasUnmountGuard(usage, context) ||
     hasGuaranteedRefOwnedUnmountCleanup(callback, usage, context)
   ) {
@@ -7455,7 +7708,10 @@ const doesReleaseCallMatchUsage = (
   }
   if (
     releaseVerbName === "abort" &&
-    releaseReceiverKey === getListenerAbortControllerKey(usage, context)
+    releaseReceiverKey ===
+      (getListenerAbortControllerKey(usage, context) ??
+        getDelegatedListenerAbortControllerKey(usage, context) ??
+        getAbortSignalListenerControllerKey(usage, context))
   ) {
     return true;
   }


### PR DESCRIPTION
## Why

`effect-needs-cleanup` reported three valid teardown paths: a timer rearmed only after its prior callback fires, a timer scheduled after an await behind an effect-local lifecycle guard, and a listener removed by an abort handler when cleanup aborts the controller.

## What changed

- prove chained timer ownership through exact callback arguments and cleanup of the shared handle
- prove guarded post-await helper calls only when cleanup invalidates the same effect-local guard and no interruption occurs after the guard
- connect abort-handler listener removal to the exact controller aborted by cleanup
- keep unsafe overwrites, missing guards, later awaits, repeated async starts, and mismatched listener removal reportable
- add focused regression and strict fuzz corpus coverage

## Test plan

- `nr -C packages/oxlint-plugin-react-doctor test src/plugin/rules/state-and-effects/effect-needs-cleanup-issue-1756.test.ts`
- `nr -C packages/oxlint-plugin-react-doctor typecheck`
- `FUZZ_RULE=effect-needs-cleanup FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz`
- `nr lint`
- `nr format`

Closes #1756