### PR TITLE
fix(rule): narrow live cancellation guards

### DIFF
--- a/.changeset/curly-hounds-invite.md
+++ b/.changeset/curly-hounds-invite.md
@@ -2,4 +2,4 @@
 "oxlint-plugin-react-doctor": patch
 ---
 
-Fix `async-defer-await` false positive on `run.live` liveness guards. The rule now recognizes "live" as a cancellation/liveness flag name, silencing false positives on the standard React effect pattern `if (!run.live) return` after an await.
+Fix an `async-defer-await` false positive on exact `live` and `isLive` liveness guards without exempting unrelated names that only contain the same text.

--- a/.changeset/curly-hounds-invite.md
+++ b/.changeset/curly-hounds-invite.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Fix `async-defer-await` false positive on `run.live` liveness guards. The rule now recognizes "live" as a cancellation/liveness flag name, silencing false positives on the standard React effect pattern `if (!run.live) return` after an await.

--- a/packages/fuzz/corpus/regressions/async-defer-await--run-live-guard.ts
+++ b/packages/fuzz/corpus/regressions/async-defer-await--run-live-guard.ts
@@ -1,0 +1,15 @@
+// rule: async-defer-await
+// verdict: pass
+// weakness: name-heuristic
+// source: issue #1758
+
+declare const refreshSession: () => Promise<boolean>;
+declare const setOk: (value: boolean) => void;
+
+const run = { live: true };
+
+export const effect = async () => {
+  const refreshed = await refreshSession();
+  if (!run.live) return;
+  setOk(refreshed);
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/async-defer-await.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/async-defer-await.regressions.test.ts
@@ -498,4 +498,22 @@ describe("performance/async-defer-await — regressions", () => {
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toHaveLength(1);
   });
+
+  it("stays silent on a run.live liveness guard in a React effect", () => {
+    const result = runRule(
+      asyncDeferAwait,
+      `
+      declare const refreshSession: () => Promise<boolean>;
+      declare const setOk: (value: boolean) => void;
+      const run = { live: true };
+      export const effect = async () => {
+        const refreshed = await refreshSession();
+        if (!run.live) return;
+        setOk(refreshed);
+      };
+    `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/async-defer-await.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/async-defer-await.regressions.test.ts
@@ -516,4 +516,21 @@ describe("performance/async-defer-await — regressions", () => {
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toHaveLength(0);
   });
+
+  it("still reports guards with unrelated names that contain live", () => {
+    const result = runRule(
+      asyncDeferAwait,
+      `
+      declare const loadDelivery: () => Promise<string>;
+      declare const deliverNow: boolean;
+      export const deliver = async () => {
+        const payload = await loadDelivery();
+        if (!deliverNow) return;
+        console.log(payload);
+      };
+    `,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/async-defer-await.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/async-defer-await.ts
@@ -155,6 +155,7 @@ const CANCELLATION_NAME_FRAGMENTS: ReadonlyArray<string> = [
   "destroy",
   "stale",
   "alive",
+  "live",
   "mounted",
   "stopped",
   "settled",

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/async-defer-await.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/performance/async-defer-await.ts
@@ -119,6 +119,8 @@ const CANCELLATION_GUARD_NAMES: ReadonlySet<string> = new Set([
   "isActive",
   "stale",
   "isStale",
+  "live",
+  "isLive",
   "ignore",
   "signal",
   "abortSignal",
@@ -155,7 +157,6 @@ const CANCELLATION_NAME_FRAGMENTS: ReadonlyArray<string> = [
   "destroy",
   "stale",
   "alive",
-  "live",
   "mounted",
   "stopped",
   "settled",
@@ -203,7 +204,7 @@ const isCancellationGuardTest = (test: EsTreeNode | null): boolean => {
   // `controller.signal.aborted`, `this._destroyed`, `batch.aborted`,
   // `seq !== getSeq.current`, `token !== runToken`.
   for (const name of collectAllTestNames(test)) {
-    if (isCancellationLikeName(name)) return true;
+    if (CANCELLATION_GUARD_NAMES.has(name) || isCancellationLikeName(name)) return true;
   }
   return testReadsRefCurrent(test);
 };

--- a/packages/react-doctor/tests/regressions/js-performance-rules.test.ts
+++ b/packages/react-doctor/tests/regressions/js-performance-rules.test.ts
@@ -1504,3 +1504,37 @@ describe("issue #543: js-tosorted-immutable is gated off for React Native / Expo
     expect(hits).toHaveLength(1);
   });
 });
+
+describe("performance/async-defer-await", () => {
+  it("stays silent on a run.live liveness guard in a React effect (issue #1758)", async () => {
+    const projectDir = setupReactProject(tempRoot, "async-defer-run-live", {
+      files: {
+        "src/liveness-guard.tsx": `
+          "use client";
+          import { useEffect, useState } from "react";
+
+          declare function refreshSession(): Promise<boolean>;
+
+          export function LivenessGuard() {
+            const [ok, setOk] = useState<boolean | null>(null);
+            useEffect(() => {
+              const run = { live: true };
+              void (async () => {
+                const refreshed = await refreshSession();
+                if (!run.live) return;
+                setOk(refreshed);
+              })();
+              return () => {
+                run.live = false;
+              };
+            }, []);
+            return <span>{String(ok)}</span>;
+          }
+        `,
+      },
+    });
+
+    const hits = await collectRuleHits(projectDir, "async-defer-await");
+    expect(hits).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Why

`async-defer-await` did not recognize the exact `run.live` lifecycle guard. A broad substring exemption would also hide unrelated names such as `deliverNow`.

## What changed

- recognize exact `live` and `isLive` guard names on identifiers and member properties
- remove the broad `live` substring match
- keep unrelated names that only contain those letters reportable
- retain focused, end-to-end, and strict fuzz regression coverage

## Test plan

- `nr -C packages/oxlint-plugin-react-doctor test src/plugin/rules/performance/async-defer-await.regressions.test.ts`
- `nr -C packages/oxlint-plugin-react-doctor typecheck`
- `FUZZ_RULE=async-defer-await FUZZ_STRICT=1 FUZZ_ITERATIONS=500 nr fuzz`
- `nr lint`
- `nr format`

Closes #1758