### PR TITLE
fix: handle missing index.html in TanStack Start projects

### DIFF
--- a/.changeset/fix-missing-index-html.md
+++ b/.changeset/fix-missing-index-html.md
@@ -1,0 +1,5 @@
+---
+"@react-doctor/core": patch
+---
+
+Fix lint failure on TanStack Start projects without index.html. Added existence check before reading HTML/Astro files to prevent ENOENT errors when index.html is referenced but doesn't exist.

--- a/packages/core/src/utils/prepare-lint-sources.ts
+++ b/packages/core/src/utils/prepare-lint-sources.ts
@@ -46,6 +46,9 @@ export const prepareLintSources = (
     const absoluteSourcePath = path.isAbsolute(candidateFile)
       ? candidateFile
       : path.resolve(rootDirectory, candidateFile);
+    if (!fs.existsSync(absoluteSourcePath)) {
+      continue;
+    }
     const sourceBuffer = fs.readFileSync(absoluteSourcePath);
     if (ASTRO_FILE_PATTERN.test(candidateFile)) {
       const compilerSourcePath = absoluteSourcePath.replaceAll("\\", "/");

--- a/packages/core/tests/tanstack-start-no-index-html.test.ts
+++ b/packages/core/tests/tanstack-start-no-index-html.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vite-plus/test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { prepareLintSources } from "../src/utils/prepare-lint-sources.js";
+
+describe("prepareLintSources - missing HTML files", () => {
+  it("should skip non-existent HTML files without throwing", () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-test-"));
+    const htmlDir = path.join(tempDir, "html-prep");
+    fs.mkdirSync(htmlDir, { recursive: true });
+
+    try {
+      // Create a real JS file
+      const realFile = path.join(tempDir, "app.js");
+      fs.writeFileSync(realFile, "console.log('test');");
+
+      // Reference a non-existent index.html
+      const nonExistentHtml = path.join(tempDir, "index.html");
+
+      // Should not throw even though index.html doesn't exist
+      const result = prepareLintSources(tempDir, htmlDir, [
+        "app.js",
+        "index.html", // This file doesn't exist
+      ]);
+
+      // Should only include the real JS file
+      expect(result.lintFiles).toContain("app.js");
+      expect(result.lintFiles).not.toContain("index.html");
+      expect(result.lintFiles.some((file) => file.includes("index.html"))).toBe(false);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #1770 

TanStack Start projects use Vite but don't require a root `index.html` file (it's generated during build). This was causing lint failures with ENOENT errors when react-doctor tried to read the non-existent file.

## Changes

- Added existence check in `prepare-lint-sources.ts` before attempting to read HTML/Astro files
- Added regression test to verify the fix

## Root Cause

The `prepareLintSources` function was attempting to read HTML files without checking if they exist first. While most code paths that add HTML files to the candidate list do check existence, there could be edge cases (like framework detection patterns) where a non-existent file makes it through.

## Testing

- Added regression test: `tanstack-start-no-index-html.test.ts`
- All existing tests pass
- The fix is defensive and safe - it simply skips files that don't exist rather than throwing
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2e7141fd-f285-4f9c-882b-32963a1b9aea?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e7141fd-f285-4f9c-882b-32963a1b9aea&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

