### PR TITLE
fix: exclude nested workspace projects regardless of selection

### DIFF
--- a/.changeset/nested-workspace-config-fix.md
+++ b/.changeset/nested-workspace-config-fix.md
@@ -1,0 +1,9 @@
+---
+"react-doctor": patch
+---
+
+Fix nested workspace project config resolution (#1772)
+
+Nested workspace projects with their own configs (framework, React Compiler, etc.) are now correctly excluded from parent scans, regardless of whether they're selected. Previously, when scanning only the root project, files from nested workspace projects were incorrectly scanned with the parent's config, causing false positives when configs differed.
+
+For example, a React Native app with React Compiler enabled inside a Vite monorepo would trigger `prefer-module-scope-pure-function` warnings when scanning only the root, even though the rule should be suppressed by the nested project's React Compiler setting.

--- a/packages/react-doctor/src/cli/commands/inspect.ts
+++ b/packages/react-doctor/src/cli/commands/inspect.ts
@@ -13,6 +13,7 @@ import {
   remainingDeadlineBudgetMs,
   resolveScanTarget,
   toRelativePath,
+  discoverSupportedSubprojects,
 } from "@react-doctor/core";
 import { createInvocationInspect } from "../../inspect.js";
 import type { ReactDoctorInspectOptions } from "../../inspect-options.js";
@@ -139,6 +140,23 @@ const isProjectSupplyChainEnabled = ({
 }: IsProjectSupplyChainEnabledInput): boolean =>
   flags.supplyChain ?? projectConfig?.supplyChain?.enabled !== false;
 
+const computeExcludedProjectDirectories = (
+  scanDirectory: string,
+): string[] => {
+  const allSupportedSubprojects = discoverSupportedSubprojects(scanDirectory);
+  const resolvedScanDirectory = path.resolve(scanDirectory);
+  
+  return allSupportedSubprojects
+    .filter((subproject) => {
+      const subprojectDirectory = path.resolve(subproject.directory);
+      return (
+        isPathInsideDirectory(subprojectDirectory, scanDirectory) &&
+        subprojectDirectory !== resolvedScanDirectory
+      );
+    })
+    .map((subproject) => subproject.directory);
+};
+
 const buildProjectInspectOptions = ({
   context,
   projectScan,
@@ -146,6 +164,8 @@ const buildProjectInspectOptions = ({
   ownsWorkspaceDeadCode,
 }: BuildProjectInspectOptionsInput): ReactDoctorInspectOptions => {
   const scanDirectory = projectScan.directory;
+  const excludedProjectDirectories = computeExcludedProjectDirectories(scanDirectory);
+  
   return {
     ...context.scanOptions,
     deadCode:
@@ -159,11 +179,7 @@ const buildProjectInspectOptions = ({
     configSourceDirectory: projectScan.configSourceDirectory ?? undefined,
     suppressRendering: context.isMultiProject,
     concurrentScan: context.isMultiProject,
-    excludedProjectDirectories: context.projectScans
-      .filter((candidateProjectScan) =>
-        isPathInsideDirectory(candidateProjectScan.directory, scanDirectory),
-      )
-      .map((candidateProjectScan) => candidateProjectScan.directory),
+    excludedProjectDirectories,
     retainExcludedProjectDeadCodeDiagnostics: ownsWorkspaceDeadCode,
     baseline:
       context.baselineRef !== null &&

--- a/packages/react-doctor/tests/regressions/issue-1772-nested-workspace-config.test.ts
+++ b/packages/react-doctor/tests/regressions/issue-1772-nested-workspace-config.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Regression test for issue #1772: nested workspace project's config is
+ * ignored when only the root project is selected.
+ *
+ * In a monorepo, nested workspace projects with their own configs (framework,
+ * React Compiler, etc.) were only excluded from the root scan when they were
+ * also selected for scanning. This caused files from non-selected nested
+ * projects to be scanned with the parent's config, producing false positives
+ * when configs differed.
+ *
+ * The fix discovers all supported subprojects and excludes them from the
+ * parent scan, regardless of selection.
+ */
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterAll, describe, expect, it } from "vite-plus/test";
+import {
+  discoverProject,
+  runOxlint,
+  discoverSupportedSubprojects,
+  isPathInsideDirectory,
+} from "@react-doctor/core";
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "rd-issue-1772-"));
+
+const setupMonorepo = (): { root: string; web: string; native: string } => {
+  const root = path.join(tempRoot, "monorepo");
+  const web = path.join(root, "apps", "web");
+  const native = path.join(root, "apps", "native");
+
+  fs.mkdirSync(path.join(web, "src"), { recursive: true });
+  fs.mkdirSync(path.join(native, "src"), { recursive: true });
+
+  fs.writeFileSync(
+    path.join(root, "package.json"),
+    JSON.stringify({
+      name: "repro-root",
+      private: true,
+      version: "1.0.0",
+      workspaces: ["apps/*"],
+      dependencies: { react: "19.2.0", "react-dom": "19.2.0" },
+      devDependencies: { vite: "7.1.0" },
+    }),
+  );
+
+  fs.writeFileSync(
+    path.join(web, "package.json"),
+    JSON.stringify({
+      name: "web",
+      version: "1.0.0",
+      dependencies: { react: "19.2.0", "react-dom": "19.2.0" },
+      devDependencies: { vite: "7.1.0" },
+    }),
+  );
+
+  fs.writeFileSync(
+    path.join(native, "package.json"),
+    JSON.stringify({
+      name: "native",
+      version: "1.0.0",
+      main: "index.js",
+      dependencies: { expo: "54.0.0", react: "19.2.0", "react-native": "0.81.0" },
+      devDependencies: { "babel-plugin-react-compiler": "19.1.0" },
+    }),
+  );
+
+  fs.writeFileSync(
+    path.join(native, "app.config.ts"),
+    `export default {
+  expo: {
+    name: 'native',
+    slug: 'native',
+    experiments: {
+      reactCompiler: true,
+    },
+  },
+};
+`,
+  );
+
+  const panelSource = `import { FlatList } from 'react-native';
+
+type Item = { id: string };
+
+export const Panel = ({ items }: { items: Item[] }) => {
+  const renderItem = ({ item }: { item: Item }) => <Row id={item.id} />;
+
+  return <FlatList data={items} renderItem={renderItem} keyExtractor={(i) => i.id} />;
+};
+
+const Row = ({ id }: { id: string }) => <>{id}</>;
+`;
+
+  const thingSource = `export const Thing = ({ items }: { items: string[] }) => {
+  const renderItem = (item: string) => <span key={item}>{item}</span>;
+
+  return <div>{items.map(renderItem)}</div>;
+};
+`;
+
+  fs.writeFileSync(path.join(native, "src", "panel.tsx"), panelSource);
+  fs.writeFileSync(path.join(web, "src", "thing.tsx"), thingSource);
+
+  fs.writeFileSync(
+    path.join(root, "tsconfig.json"),
+    JSON.stringify({
+      compilerOptions: {
+        jsx: "react-jsx",
+        target: "ES2022",
+        module: "ESNext",
+        moduleResolution: "bundler",
+        strict: true,
+      },
+    }),
+  );
+
+  return { root, web, native };
+};
+
+afterAll(() => {
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+});
+
+describe("Nested workspace config resolution (#1772)", () => {
+  it("excludes nested workspace projects when scanning root only", async () => {
+    const { root } = setupMonorepo();
+
+    const project = discoverProject(root);
+
+    const allSupportedSubprojects = discoverSupportedSubprojects(root);
+    const resolvedRoot = path.resolve(root);
+    const excludedDirectories = allSupportedSubprojects
+      .filter((subproject) => {
+        const subprojectDirectory = path.resolve(subproject.directory);
+        return (
+          isPathInsideDirectory(subprojectDirectory, root) && subprojectDirectory !== resolvedRoot
+        );
+      })
+      .map((subproject) => subproject.directory);
+
+    const diagnostics = await runOxlint({
+      rootDirectory: root,
+      project,
+    });
+
+    const panelDiagnosticsBeforeFilter = diagnostics.filter(
+      (diagnostic) =>
+        diagnostic.filePath.includes("panel.tsx") &&
+        diagnostic.rule === "prefer-module-scope-pure-function",
+    );
+
+    expect(
+      panelDiagnosticsBeforeFilter.length,
+      "without exclusion, root scan incorrectly flags nested project files",
+    ).toBeGreaterThan(0);
+
+    const filteredDiagnostics = diagnostics.filter((diagnostic) => {
+      const diagnosticPath = path.resolve(root, diagnostic.filePath);
+      return !excludedDirectories.some((excludedDir) =>
+        isPathInsideDirectory(diagnosticPath, excludedDir),
+      );
+    });
+
+    const panelDiagnosticsAfterFilter = filteredDiagnostics.filter(
+      (diagnostic) =>
+        diagnostic.filePath.includes("panel.tsx") &&
+        diagnostic.rule === "prefer-module-scope-pure-function",
+    );
+
+    expect(
+      panelDiagnosticsAfterFilter,
+      "after excluding nested projects, no false positive from panel.tsx",
+    ).toHaveLength(0);
+
+    expect(
+      excludedDirectories.length,
+      "should discover and exclude nested workspace projects",
+    ).toBeGreaterThan(0);
+  });
+
+  it("suppresses React Compiler-gated rule when scanning the native project directly", async () => {
+    const { native } = setupMonorepo();
+
+    const project = discoverProject(native);
+    expect(project.hasReactCompiler, "native project should have React Compiler enabled").toBe(
+      true,
+    );
+
+    const diagnostics = await runOxlint({
+      rootDirectory: native,
+      project,
+    });
+
+    const panelDiagnostics = diagnostics.filter(
+      (diagnostic) =>
+        diagnostic.filePath.includes("panel.tsx") &&
+        diagnostic.rule === "prefer-module-scope-pure-function",
+    );
+
+    expect(
+      panelDiagnostics,
+      "React Compiler-gated rule should be suppressed",
+    ).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #1772

## Problem

When scanning a monorepo root without selecting nested workspace projects, React Doctor was scanning files from those nested projects using the ROOT's config instead of excluding them. This caused false positives when nested projects had different configurations.

**Example:** A React Native app with React Compiler enabled inside a Vite monorepo would trigger `prefer-module-scope-pure-function` warnings when scanning only the root, even though the rule should be suppressed by the nested project's React Compiler setting.

## Solution

Added `computeExcludedProjectDirectories` helper that discovers all supported subprojects and excludes them from the parent scan, regardless of selection. This prevents nested project files from being scanned with the wrong config.

**Before:**
- `--project .` (root only): Scanned 3 files, flagged both apps/native and apps/web  
- False positive from apps/native/src/panel.tsx:6 (should be suppressed by React Compiler)

**After:**
- `--project .` (root only): Scans only root's own files, excludes nested projects
- No false positives
- To scan nested projects, explicitly select them: `--project web` or `--project .,native`

## Testing

- Added regression test `issue-1772-nested-workspace-config.test.ts`
- Manually verified with the reproduction from the issue  
- Confirmed React Compiler gating works correctly
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-451abad9-547b-4526-98f0-ab1087ebc837?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-451abad9-547b-4526-98f0-ab1087ebc837&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

