### PR TITLE
fix(core): detect React Compiler via @vitejs/plugin-react `compiler` option

### DIFF
--- a/.changeset/detect-vite-plugin-react-compiler-option.md
+++ b/.changeset/detect-vite-plugin-react-compiler-option.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Detect React Compiler when `@vitejs/plugin-react` is called with an enabled `compiler` option (`react({ compiler: true })` or `react({ compiler: { ... } })`), including aliased, namespace, and CommonJS forms of the default export. `compiler: false` and unrelated objects with a `compiler` property stay undetected, so rules disabled under React Compiler now switch off for these Vite projects.

--- a/packages/core/src/project-info/react-compiler-config-evaluator.ts
+++ b/packages/core/src/project-info/react-compiler-config-evaluator.ts
@@ -1502,6 +1502,42 @@ const hasReactCompilerConfigInSentryWrapperArgument = (
   return Boolean(configArgument && analyzeConfigNode(configArgument, analysis, false));
 };
 
+const hasEnabledCompilerOptionInVitePluginArgument = (
+  callExpression: ts.CallExpression,
+  analysis: ConfigExpressionAnalysis,
+  moduleSpecifier: string,
+  exportName: string,
+): boolean => {
+  if (moduleSpecifier !== "@vitejs/plugin-react" || exportName !== "default") return false;
+  const [optionsArgument] = callExpression.arguments;
+  if (!optionsArgument) return false;
+  const compilerProperty = getSelectedObjectProperty(optionsArgument, "compiler", analysis);
+  if (compilerProperty === null) return false;
+  return (
+    !ts.isExpression(compilerProperty.node) ||
+    !isStaticallyDisabledConfigExpression(compilerProperty.node, compilerProperty.analysis)
+  );
+};
+
+const hasReactCompilerConfigInCallArguments = (
+  callExpression: ts.CallExpression,
+  analysis: ConfigExpressionAnalysis,
+  moduleSpecifier: string,
+  exportName: string,
+): boolean =>
+  hasReactCompilerConfigInSentryWrapperArgument(
+    callExpression,
+    analysis,
+    moduleSpecifier,
+    exportName,
+  ) ||
+  hasEnabledCompilerOptionInVitePluginArgument(
+    callExpression,
+    analysis,
+    moduleSpecifier,
+    exportName,
+  );
+
 const analyzeConfigCallTarget = (
   callExpression: ts.CallExpression,
   analysis: ConfigExpressionAnalysis,
@@ -1520,6 +1556,16 @@ const analyzeConfigCallTarget = (
     if (
       allowCompilerTransform &&
       isCompilerTransformModule(callableRequiredModuleSpecifier, "default")
+    ) {
+      return true;
+    }
+    if (
+      hasReactCompilerConfigInCallArguments(
+        callExpression,
+        analysis,
+        callableRequiredModuleSpecifier,
+        "default",
+      )
     ) {
       return true;
     }
@@ -1555,7 +1601,7 @@ const analyzeConfigCallTarget = (
       return true;
     }
     if (
-      hasReactCompilerConfigInSentryWrapperArgument(
+      hasReactCompilerConfigInCallArguments(
         callExpression,
         analysis,
         requiredModuleSpecifier,
@@ -1592,7 +1638,7 @@ const analyzeConfigCallTarget = (
       return true;
     }
     if (
-      hasReactCompilerConfigInSentryWrapperArgument(
+      hasReactCompilerConfigInCallArguments(
         callExpression,
         analysis,
         importBinding.moduleSpecifier,
@@ -1896,7 +1942,7 @@ const analyzeConfigNode = (
             return true;
           }
           if (
-            hasReactCompilerConfigInSentryWrapperArgument(
+            hasReactCompilerConfigInCallArguments(
               node,
               analysis,
               importBinding.moduleSpecifier,

--- a/packages/core/tests/discover-project.test.ts
+++ b/packages/core/tests/discover-project.test.ts
@@ -2773,6 +2773,177 @@ describe("discoverProject", () => {
     },
   );
 
+  it.each([
+    {
+      name: "default-import-boolean",
+      config:
+        "import react from '@vitejs/plugin-react'; export default { plugins: [react({ compiler: true })] };",
+      helper: null,
+      expected: true,
+    },
+    {
+      name: "default-import-options-object",
+      config:
+        "import react from '@vitejs/plugin-react'; export default { plugins: [react({ compiler: { compilationMode: 'annotation' } })] };",
+      helper: null,
+      expected: true,
+    },
+    {
+      name: "aliased-default-import",
+      config:
+        "import viteReact from '@vitejs/plugin-react'; export default { plugins: [viteReact({ compiler: true })] };",
+      helper: null,
+      expected: true,
+    },
+    {
+      name: "namespace-import",
+      config:
+        "import * as viteReact from '@vitejs/plugin-react'; export default { plugins: [viteReact.default({ compiler: true })] };",
+      helper: null,
+      expected: true,
+    },
+    {
+      name: "commonjs-require",
+      config:
+        "const react = require('@vitejs/plugin-react'); module.exports = { plugins: [react({ compiler: true })] };",
+      helper: null,
+      expected: true,
+    },
+    {
+      name: "inline-require",
+      config:
+        "module.exports = { plugins: [require('@vitejs/plugin-react')({ compiler: true })] };",
+      helper: null,
+      expected: true,
+    },
+    {
+      name: "inline-require-default",
+      config:
+        "module.exports = { plugins: [require('@vitejs/plugin-react').default({ compiler: true })] };",
+      helper: null,
+      expected: true,
+    },
+    {
+      name: "options-variable",
+      config:
+        "import react from '@vitejs/plugin-react'; const reactOptions = { compiler: true }; export default { plugins: [react(reactOptions)] };",
+      helper: null,
+      expected: true,
+    },
+    {
+      name: "spread-options",
+      config:
+        "import react from '@vitejs/plugin-react'; const shared = { compiler: {} }; export default { plugins: [react({ jsxRuntime: 'automatic', ...shared })] };",
+      helper: null,
+      expected: true,
+    },
+    {
+      name: "define-config-lazy-plugins",
+      config:
+        "import { defineConfig, lazyPlugins } from 'vite-plus'; import react from '@vitejs/plugin-react'; export default defineConfig({ plugins: lazyPlugins(() => [react({ compiler: true })]) });",
+      helper: null,
+      expected: true,
+    },
+    {
+      name: "local-plugin-factory",
+      config:
+        "import { createPlugins } from './plugins'; export default { plugins: createPlugins() };",
+      helper:
+        "import react from '@vitejs/plugin-react'; export const createPlugins = () => [react({ compiler: true })];",
+      expected: true,
+    },
+    {
+      name: "disabled-option",
+      config:
+        "import react from '@vitejs/plugin-react'; export default { plugins: [react({ compiler: false })] };",
+      helper: null,
+      expected: false,
+    },
+    {
+      name: "later-disabled-option",
+      config:
+        "import react from '@vitejs/plugin-react'; const shared = { compiler: true }; export default { plugins: [react({ ...shared, compiler: false })] };",
+      helper: null,
+      expected: false,
+    },
+    {
+      name: "statically-disabled-binding",
+      config:
+        "import react from '@vitejs/plugin-react'; const useCompiler = false; export default { plugins: [react({ compiler: useCompiler })] };",
+      helper: null,
+      expected: false,
+    },
+    {
+      name: "missing-option",
+      config:
+        "import react from '@vitejs/plugin-react'; export default { plugins: [react({ jsxRuntime: 'automatic' })] };",
+      helper: null,
+      expected: false,
+    },
+    {
+      name: "no-arguments",
+      config: "import react from '@vitejs/plugin-react'; export default { plugins: [react()] };",
+      helper: null,
+      expected: false,
+    },
+    {
+      name: "unrelated-plugin-option",
+      config:
+        "import react from '@vitejs/plugin-react'; import other from 'other-plugin'; export default { plugins: [react(), other({ compiler: true })] };",
+      helper: null,
+      expected: false,
+    },
+    {
+      name: "unrelated-config-property",
+      config:
+        "import react from '@vitejs/plugin-react'; export default { compiler: true, plugins: [react()] };",
+      helper: null,
+      expected: false,
+    },
+    {
+      name: "shadowed-import",
+      config:
+        "import react from '@vitejs/plugin-react'; const make = (react) => ({ plugins: [react({ compiler: true })] }); export default make(other);",
+      helper: null,
+      expected: false,
+    },
+  ])(
+    "detects React Compiler through the @vitejs/plugin-react compiler option: $name",
+    ({ name, config, helper, expected }) => {
+      const projectDirectory = path.join(
+        tempDirectory,
+        `vite-plugin-react-compiler-option-${name}`,
+      );
+      const pluginDirectory = path.join(
+        projectDirectory,
+        "node_modules",
+        "@vitejs",
+        "plugin-react",
+      );
+      fs.mkdirSync(pluginDirectory, { recursive: true });
+      fs.writeFileSync(
+        path.join(projectDirectory, "package.json"),
+        JSON.stringify({
+          name: `vite-plugin-react-compiler-option-${name}`,
+          dependencies: { react: "^19.0.0" },
+          devDependencies: { "@vitejs/plugin-react": "^6.1.0", "oxc-transform-react": "^0.145.0" },
+        }),
+      );
+      fs.writeFileSync(
+        path.join(pluginDirectory, "package.json"),
+        JSON.stringify({ name: "@vitejs/plugin-react", type: "module", exports: "./index.js" }),
+      );
+      fs.writeFileSync(
+        path.join(pluginDirectory, "index.js"),
+        "export default (_options) => [{ name: 'vite:react' }];\nexport const reactCompilerPreset = () => ({});\n",
+      );
+      fs.writeFileSync(path.join(projectDirectory, "vite.config.ts"), config);
+      if (helper) fs.writeFileSync(path.join(projectDirectory, "plugins.ts"), helper);
+
+      expect(discoverProject(projectDirectory).hasReactCompiler).toBe(expected);
+    },
+  );
+
   it("detects the Rsbuild React Compiler transform", () => {
     const projectDirectory = path.join(tempDirectory, "rsbuild-react-compiler");
     fs.mkdirSync(projectDirectory, { recursive: true });


### PR DESCRIPTION
## Why

Fixes #1774.

`@vitejs/plugin-react` 6.1 enables React Compiler through its own `compiler?: boolean | ReactCompilerPluginOptions` option. `react-compiler-config-evaluator.ts` only recognized `babel-plugin-react-compiler`, `reactCompilerPreset`, and the generic `reactCompiler` flag.

**Before:** `react({ compiler: true })` in `vite.config.ts` reported `hasReactCompiler: false`, so rules with `disabledWhen: ["react-compiler"]` stayed active on compiler-enabled Vite apps.

**After:** the plugin's `compiler` option is honored (unless statically falsy), and `hasReactCompiler` flips to `true` for those projects.

## What changed

- The evaluator already had a hook for "a call to a specific export of a specific module, inspect its arguments" (`hasReactCompilerConfigInSentryWrapperArgument`). Added a sibling for the Vite plugin and folded both into one dispatcher used at every call-target site:
  ```ts
  const hasEnabledCompilerOptionInVitePluginArgument = (callExpression, analysis, moduleSpecifier, exportName) => {
    if (moduleSpecifier !== "@vitejs/plugin-react" || exportName !== "default") return false;
    const [optionsArgument] = callExpression.arguments;
    const compilerProperty = getSelectedObjectProperty(optionsArgument, "compiler", analysis);
    return compilerProperty !== null && !isStaticallyDisabledConfigExpression(compilerProperty.node, ...);
  };
  const hasReactCompilerConfigInCallArguments = (...) =>
    hasReactCompilerConfigInSentryWrapperArgument(...) || hasEnabledCompilerOptionInVitePluginArgument(...);
  ```
- `hasReactCompilerConfigInCallArguments` replaces the three Sentry call sites (`require(m).x(...)`, namespace `ns.x(...)`, direct binding `x(...)`) and is additionally wired into the callable-require branch (`require('@vitejs/plugin-react')({ compiler: true })`), which previously inspected no arguments. `exportName === "default"` covers the ESM default export and the CJS `module.exports` / `.default` shapes the package ships.
- Reusing `getSelectedObjectProperty` means options variables, spreads, later-property overrides, and aliased/shadowed bindings behave exactly like the existing `reactCompiler` flag. The option is only honored on the plugin's default export, so `other({ compiler: true })` or a top-level `{ compiler: true }` config property do not trigger detection.
- Tests: 19 table-driven `discover-project` cases — default/aliased/namespace/CJS/inline-require imports, options variable, spread, `defineConfig` + lazy plugins, local plugin factory; negatives for `compiler: false`, later-disabled override, statically-false binding, missing option, unrelated `compiler` properties, shadowed import. All 11 positive cases fail on `main`.
- Changeset: `react-doctor` patch.

## Eval results

RDE parity not run — project-info detection change, not a rule change.

## Test plan

- `nr test tests/discover-project.test.ts` in `packages/core` — all cases pass.
- Full `@react-doctor/core` suite — passes.
- `nr typecheck`, `nr lint`, `nr format:check` — clean (lint warnings only in pre-existing `packages/fuzz/corpus`).


Link to Devin session: https://app.devin.ai/sessions/a7ca592f952d4cabb23e274335226e42
Open in Devin Desktop: https://app.devin.ai/desktop/session/a7ca592f952d4cabb23e274335226e42?variant=devin
Requested by: @aidenybai