### PR TITLE
fix(core): skip tracked source files missing from the working tree

### DIFF
--- a/.changeset/drop-missing-tracked-sources.md
+++ b/.changeset/drop-missing-tracked-sources.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Skip source files that Git still tracks but that no longer exist in the working tree (for example a deleted root `index.html` in a TanStack Start app) instead of failing the scan with `ENOENT` while preparing lint sources.

--- a/packages/core/src/utils/is-missing-path.ts
+++ b/packages/core/src/utils/is-missing-path.ts
@@ -1,0 +1,13 @@
+import * as fs from "node:fs";
+import { isErrnoException } from "./is-errno-exception.js";
+
+// True only when nothing exists at the path (a dangling symlink included);
+// permission or I/O failures are not "missing" and return false.
+export const isMissingPath = (absolutePath: string): boolean => {
+  try {
+    fs.statSync(absolutePath);
+    return false;
+  } catch (error) {
+    return isErrnoException(error) && error.code === "ENOENT";
+  }
+};

--- a/packages/core/src/utils/is-missing-path.ts
+++ b/packages/core/src/utils/is-missing-path.ts
@@ -1,8 +1,6 @@
 import * as fs from "node:fs";
 import { isErrnoException } from "./is-errno-exception.js";
 
-// True only when nothing exists at the path (a dangling symlink included);
-// permission or I/O failures are not "missing" and return false.
 export const isMissingPath = (absolutePath: string): boolean => {
   try {
     fs.statSync(absolutePath);

--- a/packages/core/src/utils/list-source-files.ts
+++ b/packages/core/src/utils/list-source-files.ts
@@ -21,11 +21,8 @@ import { yieldToEventLoop } from "./yield-to-event-loop.js";
 // `listSourceFilesWithSize`, so the scanned set and the reported source-file
 // count can never diverge. A file that can't be stat'd but still exists is
 // KEPT (parity with `isLargeMinifiedFile`'s keep-on-error) with size `0`, so
-// it sorts to the cheap tail. A path with no file behind it is dropped:
-// `git ls-files --stage` lists index entries whose working-tree copy was
-// deleted or skipped (sparse checkout), and a dangling symlink survives the
-// filesystem walk, but neither can be read by the lint or maintainability
-// passes.
+// it sorts to the cheap tail. A missing path is dropped: `git ls-files --stage`
+// still lists index entries whose working-tree copy was deleted.
 const toSizedSourceFileEntry = (
   rootDirectory: string,
   relativePath: string,

--- a/packages/core/src/utils/list-source-files.ts
+++ b/packages/core/src/utils/list-source-files.ts
@@ -11,6 +11,7 @@ import { collectTypeScriptEmitDuplicateJsPaths } from "./collect-typescript-emit
 import { hasIgnoredPathSegment } from "./has-ignored-path-segment.js";
 import { isLintableSourceFile } from "./is-lintable-source-file.js";
 import { isLargeMinifiedFile, statSourceFileSize } from "./is-large-minified-file.js";
+import { isMissingPath } from "./is-missing-path.js";
 import { walkSourceTreeFiles } from "./walk-source-tree-files.js";
 import { yieldToEventLoop } from "./yield-to-event-loop.js";
 
@@ -18,19 +19,32 @@ import { yieldToEventLoop } from "./yield-to-event-loop.js";
 // drops files that sniff as large minified bundles, and keeps the size so the
 // lint pass can order batches largest-first. `countSourceFiles` delegates to
 // `listSourceFilesWithSize`, so the scanned set and the reported source-file
-// count can never diverge. A file that can't be stat'd is KEPT (parity with
-// `isLargeMinifiedFile`'s keep-on-error) with size `0`, so it sorts to the
-// cheap tail.
+// count can never diverge. A file that can't be stat'd but still exists is
+// KEPT (parity with `isLargeMinifiedFile`'s keep-on-error) with size `0`, so
+// it sorts to the cheap tail. A path with no file behind it is dropped:
+// `git ls-files --stage` lists index entries whose working-tree copy was
+// deleted or skipped (sparse checkout), and a dangling symlink survives the
+// filesystem walk, but neither can be read by the lint or maintainability
+// passes.
+const toSizedSourceFileEntry = (
+  rootDirectory: string,
+  relativePath: string,
+): SourceFileEntry | null => {
+  const absolutePath = path.resolve(rootDirectory, relativePath);
+  const sizeBytes = statSourceFileSize(absolutePath);
+  if (sizeBytes === null && isMissingPath(absolutePath)) return null;
+  if (isLargeMinifiedFile(absolutePath, sizeBytes)) return null;
+  return { path: relativePath, sizeBytes: sizeBytes ?? 0 };
+};
+
 const collectSizedSourceFiles = (
   rootDirectory: string,
   relativePaths: ReadonlyArray<string>,
 ): SourceFileEntry[] => {
   const entries: SourceFileEntry[] = [];
   for (const relativePath of relativePaths) {
-    const absolutePath = path.resolve(rootDirectory, relativePath);
-    const sizeBytes = statSourceFileSize(absolutePath);
-    if (isLargeMinifiedFile(absolutePath, sizeBytes)) continue;
-    entries.push({ path: relativePath, sizeBytes: sizeBytes ?? 0 });
+    const entry = toSizedSourceFileEntry(rootDirectory, relativePath);
+    if (entry !== null) entries.push(entry);
   }
   return entries;
 };
@@ -44,11 +58,8 @@ const collectSizedSourceFilesCooperative = async (
   let sliceStartedAt = performance.now();
   for (const relativePath of relativePaths) {
     signal?.throwIfAborted();
-    const absolutePath = path.resolve(rootDirectory, relativePath);
-    const sizeBytes = statSourceFileSize(absolutePath);
-    if (!isLargeMinifiedFile(absolutePath, sizeBytes)) {
-      entries.push({ path: relativePath, sizeBytes: sizeBytes ?? 0 });
-    }
+    const entry = toSizedSourceFileEntry(rootDirectory, relativePath);
+    if (entry !== null) entries.push(entry);
     if (performance.now() - sliceStartedAt >= COOPERATIVE_YIELD_BUDGET_MS) {
       await yieldToEventLoop();
       sliceStartedAt = performance.now();

--- a/packages/core/src/utils/prepare-lint-sources.ts
+++ b/packages/core/src/utils/prepare-lint-sources.ts
@@ -47,8 +47,6 @@ export const prepareLintSources = (
     const absoluteSourcePath = path.isAbsolute(candidateFile)
       ? candidateFile
       : path.resolve(rootDirectory, candidateFile);
-    // Oxlint silently skips a listed JS/TS file that no longer exists; keep
-    // the same tolerance for the HTML/Astro sources we transpile ourselves.
     if (isMissingPath(absoluteSourcePath)) continue;
     const sourceBuffer = fs.readFileSync(absoluteSourcePath);
     if (ASTRO_FILE_PATTERN.test(candidateFile)) {

--- a/packages/core/src/utils/prepare-lint-sources.ts
+++ b/packages/core/src/utils/prepare-lint-sources.ts
@@ -4,6 +4,7 @@ import { convertToTSX } from "@astrojs/compiler/sync";
 import { TraceMap } from "@jridgewell/trace-mapping";
 import { HTML_FILE_PATTERN } from "../constants.js";
 import { containsThreeModuleImport } from "./contains-three-module-import.js";
+import { isMissingPath } from "./is-missing-path.js";
 import { prepareHtmlScriptSource } from "./prepare-html-script-source.js";
 
 const ASTRO_FILE_PATTERN = /\.astro$/;
@@ -46,6 +47,9 @@ export const prepareLintSources = (
     const absoluteSourcePath = path.isAbsolute(candidateFile)
       ? candidateFile
       : path.resolve(rootDirectory, candidateFile);
+    // Oxlint silently skips a listed JS/TS file that no longer exists; keep
+    // the same tolerance for the HTML/Astro sources we transpile ourselves.
+    if (isMissingPath(absoluteSourcePath)) continue;
     const sourceBuffer = fs.readFileSync(absoluteSourcePath);
     if (ASTRO_FILE_PATTERN.test(candidateFile)) {
       const compilerSourcePath = absoluteSourcePath.replaceAll("\\", "/");

--- a/packages/core/tests/html-diagnostic-mapping.test.ts
+++ b/packages/core/tests/html-diagnostic-mapping.test.ts
@@ -49,6 +49,25 @@ describe("HTML diagnostic mapping", () => {
     ).toEqual([]);
   });
 
+  it("skips HTML and Astro candidates with no file behind them", () => {
+    const rootDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-missing-html-"));
+    temporaryDirectories.push(rootDirectory);
+    fs.mkdirSync(path.join(rootDirectory, "src"));
+    fs.writeFileSync(
+      path.join(rootDirectory, "src", "app.tsx"),
+      "export const App = () => null;\n",
+    );
+
+    const preparedSources = prepareLintSources(rootDirectory, path.join(rootDirectory, "tmp"), [
+      "index.html",
+      "src/page.astro",
+      "src/app.tsx",
+    ]);
+
+    expect(preparedSources.lintFiles).toEqual(["src/app.tsx"]);
+    expect(preparedSources.sourcePathByLintPath.size).toBe(0);
+  });
+
   it("maps a virtual script diagnostic back to the HTML path and source position", () => {
     const rootDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "react-doctor-html-map-"));
     temporaryDirectories.push(rootDirectory);

--- a/packages/core/tests/list-source-files-with-size.test.ts
+++ b/packages/core/tests/list-source-files-with-size.test.ts
@@ -251,6 +251,34 @@ describe("listSourceFilesWithSize", () => {
     ).toHaveLength(1);
   });
 
+  // Issue #1770: a TanStack Start app committed `index.html`, then deleted
+  // it from the working tree. `git ls-files --stage` still listed the index
+  // entry, so `prepareLintSources` hit ENOENT reading it and the scan died.
+  it("git discovery drops tracked files deleted from the working tree", async () => {
+    writeNestedFile("index.html", '<script type="module" src="/src/app.tsx"></script>\n');
+    writeNestedFile("src/app.tsx", "export const App = () => null;\n");
+    writeNestedFile("src/removed.tsx", "export const Removed = () => null;\n");
+    runGit("init", "--quiet");
+    commitAll();
+    fs.rmSync(path.join(temporaryDirectory, "index.html"));
+    fs.rmSync(path.join(temporaryDirectory, "src/removed.tsx"));
+    fs.symlinkSync(
+      path.join(temporaryDirectory, "src/removed.tsx"),
+      path.join(temporaryDirectory, "src/dangling.tsx"),
+    );
+
+    const filePaths = listSourceFiles(temporaryDirectory);
+
+    expect(filePaths).toEqual(["src/app.tsx"]);
+    expect(listSourceFilesWithSize(temporaryDirectory)).toEqual([
+      {
+        path: "src/app.tsx",
+        sizeBytes: fs.statSync(path.join(temporaryDirectory, "src/app.tsx")).size,
+      },
+    ]);
+    await expect(listSourceFilesCooperative(temporaryDirectory)).resolves.toEqual(filePaths);
+  });
+
   const writeEmitQuartet = (): void => {
     writeNestedFile("src/store.js", "export const store = 1;\n//# sourceMappingURL=store.js.map\n");
     writeNestedFile(


### PR DESCRIPTION
## Why

Fixes #1770.

**Before:** a TanStack Start app that committed `index.html` and later deleted it crashed the scan with `ENOENT: no such file or directory, open '.../index.html'` from `prepareLintSources`.

Root cause is in source discovery, not the HTML transpiler: `listSourceFiles*` prefers `git ls-files --stage --others --exclude-standard`, which still lists index entries whose working-tree copy was deleted (or skipped by sparse checkout). `collectSizedSourceFiles` deliberately kept stat failures with `sizeBytes: 0` (parity with `isLargeMinifiedFile`'s keep-on-error), so the phantom path flowed into `run-oxlint.ts` → `prepareLintSources`, which does a bare `fs.readFileSync`.

**After:** paths with nothing behind them are dropped at discovery, so the scanned set, reported file count, and maintainability/baseline inputs all agree, and the HTML/Astro transpile step tolerates a missing explicit candidate the way oxlint already tolerates a missing JS/TS path.

## What changed

- `utils/is-missing-path.ts` (new): `isMissingPath(absolutePath)` — `true` only on `ENOENT` (dangling symlinks included). `EACCES`/`EIO` etc. return `false`, so the keep-on-error contract for existing-but-unstatable files is unchanged.
- `utils/list-source-files.ts`: sync and cooperative collectors share `toSizedSourceFileEntry`:
  ```ts
  const sizeBytes = statSourceFileSize(absolutePath);
  if (sizeBytes === null && isMissingPath(absolutePath)) return null;
  if (isLargeMinifiedFile(absolutePath, sizeBytes)) return null;
  return { path: relativePath, sizeBytes: sizeBytes ?? 0 };
  ```
- `utils/prepare-lint-sources.ts`: HTML/Astro candidates that resolve to a missing path are skipped instead of read — defense in depth for explicit `includePaths` (positional files, `--changed-files-from`).
- Tests: `list-source-files-with-size.test.ts` (tracked `index.html` + `src/removed.tsx` deleted after commit, plus a dangling symlink — git, sized, and cooperative listings all return only `src/app.tsx`; fails on `main`); `html-diagnostic-mapping.test.ts` (`prepareLintSources` with missing `index.html`/`src/page.astro` yields only the real `.tsx` lint file).
- Changeset: `react-doctor` patch.

## Eval results

RDE parity not run — source discovery change, not a rule change.

## Test plan

- `nr test tests/list-source-files-with-size.test.ts tests/html-diagnostic-mapping.test.ts` in `packages/core` — 18 passed.
- Full `@react-doctor/core` suite — passes.
- `nr typecheck` (10/10), `nr lint` (pre-existing `packages/fuzz/corpus` warnings only), `nr format:check` — clean.


Link to Devin session: https://app.devin.ai/sessions/a7ca592f952d4cabb23e274335226e42
Open in Devin Desktop: https://app.devin.ai/desktop/session/a7ca592f952d4cabb23e274335226e42?variant=devin
Requested by: @aidenybai