### PR TITLE
fix(cli): keep baseline mode when the change set deletes a source file

### DIFF
--- a/.changeset/keep-baseline-with-deleted-files.md
+++ b/.changeset/keep-baseline-with-deleted-files.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Keep `--scope changed` in baseline mode when the change set deletes a source file. A deleted file that cannot be read or linted at the base commit no longer degrades the whole comparison to a plain diff; only an unreadable or unlinted base file that still exists at head does, since that is the only gap that could surface a pre-existing finding as new.

--- a/packages/react-doctor/src/cli/utils/has-unlinted-surviving-base-file.ts
+++ b/packages/react-doctor/src/cli/utils/has-unlinted-surviving-base-file.ts
@@ -1,17 +1,15 @@
 import { filterSourceFiles } from "@react-doctor/core";
 import { toForwardSlashes } from "./path-format.js";
 
-/**
- * Whether the base lint pass left a file unanalyzed that still exists at head.
- * Those are the only gaps that can hide a pre-existing finding: a base file
- * deleted at head has no head counterpart, so skipping it can only undercount
- * fixed findings, never surface a stale one as new.
- */
-export const hasUnlintedSurvivingBaseFile = (input: {
+export interface HasUnlintedSurvivingBaseFileInput {
   readonly baseLintPaths: ReadonlyArray<string>;
   readonly headFiles: ReadonlySet<string>;
   readonly analyzedBaseFiles: ReadonlyArray<string>;
-}): boolean => {
+}
+
+// A base file deleted at head has no counterpart to compare against, so only an
+// unanalyzed base file that survives at head can hide a pre-existing finding.
+export const hasUnlintedSurvivingBaseFile = (input: HasUnlintedSurvivingBaseFileInput): boolean => {
   const analyzedBaseFiles = new Set(input.analyzedBaseFiles.map(toForwardSlashes));
   return filterSourceFiles(input.baseLintPaths.map(toForwardSlashes)).some(
     (filePath) => input.headFiles.has(filePath) && !analyzedBaseFiles.has(filePath),

--- a/packages/react-doctor/src/cli/utils/has-unlinted-surviving-base-file.ts
+++ b/packages/react-doctor/src/cli/utils/has-unlinted-surviving-base-file.ts
@@ -1,0 +1,19 @@
+import { filterSourceFiles } from "@react-doctor/core";
+import { toForwardSlashes } from "./path-format.js";
+
+/**
+ * Whether the base lint pass left a file unanalyzed that still exists at head.
+ * Those are the only gaps that can hide a pre-existing finding: a base file
+ * deleted at head has no head counterpart, so skipping it can only undercount
+ * fixed findings, never surface a stale one as new.
+ */
+export const hasUnlintedSurvivingBaseFile = (input: {
+  readonly baseLintPaths: ReadonlyArray<string>;
+  readonly headFiles: ReadonlySet<string>;
+  readonly analyzedBaseFiles: ReadonlyArray<string>;
+}): boolean => {
+  const analyzedBaseFiles = new Set(input.analyzedBaseFiles.map(toForwardSlashes));
+  return filterSourceFiles(input.baseLintPaths.map(toForwardSlashes)).some(
+    (filePath) => input.headFiles.has(filePath) && !analyzedBaseFiles.has(filePath),
+  );
+};

--- a/packages/react-doctor/src/cli/utils/materialize-baseline-files.ts
+++ b/packages/react-doctor/src/cli/utils/materialize-baseline-files.ts
@@ -19,8 +19,10 @@ export interface BaselineMaterializedTree extends MaterializedTree {
  * `tempDirectory`, mirroring the project layout plus head's config files so
  * both sides lint under the same rules. Git rename heuristics are disabled by
  * the diff planner, so an old path is retained as a base deletion while its
- * new path is a head addition. Missing head-only additions are expected;
- * missing paths that the plan says must exist at base make `isComplete` false.
+ * new path is a head addition. Missing head-only additions are expected, and a
+ * base-only deletion that cannot be read has nothing at head to compare
+ * against; only a missing path that the plan says exists on both sides makes
+ * `isComplete` false.
  */
 export const materializeBaselineFiles = (input: {
   directory: string;
@@ -61,11 +63,14 @@ export const materializeBaselineFiles = (input: {
             ),
       });
       const materializedFiles = new Set(tree.materializedFiles);
+      const headFileSet = new Set(headFiles);
       return {
         ...tree,
         baseFiles,
         headFiles,
-        isComplete: baseFiles.every((filePath) => materializedFiles.has(filePath)),
+        isComplete: baseFiles.every(
+          (filePath) => materializedFiles.has(filePath) || !headFileSet.has(filePath),
+        ),
         untrackedFiles,
       } satisfies BaselineMaterializedTree;
     }).pipe(Effect.provide(Git.layerNode)),

--- a/packages/react-doctor/src/cli/utils/run-baseline-comparison.ts
+++ b/packages/react-doctor/src/cli/utils/run-baseline-comparison.ts
@@ -32,6 +32,7 @@ import { createDiagnosticEvidenceReader } from "./read-diagnostic-evidence.js";
 import { createSourceLineReader } from "./read-source-line.js";
 import { materializeBaselineFiles } from "./materialize-baseline-files.js";
 import { makeNoopConsole } from "./noop-console.js";
+import { hasUnlintedSurvivingBaseFile } from "./has-unlinted-surviving-base-file.js";
 import { toForwardSlashes } from "./path-format.js";
 import { getRunId } from "./run-id.js";
 import { VERSION } from "./version.js";
@@ -243,10 +244,14 @@ export const runBaselineComparison = async (
       ),
       { signal: input.oxlintRuntime.abortSignal },
     );
+    if (baseOutput.didLintFail || baseOutput.didDeadCodeFail) return null;
     if (
-      baseOutput.didLintFail ||
-      baseOutput.didDeadCodeFail ||
-      countIncompleteLintFiles(baseOutput.lintPartialFailures) > 0
+      countIncompleteLintFiles(baseOutput.lintPartialFailures) > 0 &&
+      hasUnlintedSurvivingBaseFile({
+        baseLintPaths: materializedLintPaths,
+        headFiles: expectedHeadFiles,
+        analyzedBaseFiles: baseOutput.analyzedFiles,
+      })
     ) {
       return null;
     }

--- a/packages/react-doctor/tests/e2e/baseline-deleted-file.test.ts
+++ b/packages/react-doctor/tests/e2e/baseline-deleted-file.test.ts
@@ -1,0 +1,92 @@
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, describe, expect, it } from "vite-plus/test";
+import { commitAll, initGitRepo, setupReactProject, writeFile } from "../regressions/_helpers.js";
+
+interface CliBaselineReport {
+  readonly mode: string;
+  readonly baselineDegraded?: boolean;
+  readonly baseline?: {
+    readonly newCount: number;
+    readonly fixedCount: number;
+    readonly baseTotalCount: number;
+  };
+}
+
+const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
+const builtCliPath = path.resolve(currentDirectory, "../../dist/cli.js");
+const hasBuiltCli = fs.existsSync(builtCliPath);
+const temporaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), "rd-baseline-deleted-file-"));
+
+afterAll(() => {
+  fs.rmSync(temporaryRoot, { recursive: true, force: true });
+});
+
+const FOOTER_WITH_FINDINGS = `import { useEffect, useState } from "react";
+
+export const Footer = ({ year }: { year: number }) => {
+  const [label, setLabel] = useState("");
+  useEffect(() => {
+    setLabel(String(year));
+  }, [year]);
+  return <footer>{label}</footer>;
+};
+`;
+
+const runChangedScan = (directory: string, baseRef: string): CliBaselineReport => {
+  const result = spawnSync(
+    process.execPath,
+    [
+      builtCliPath,
+      ".",
+      "--scope",
+      "changed",
+      "--base",
+      baseRef,
+      "--json",
+      "--no-score",
+      "--no-supply-chain",
+      "--no-telemetry",
+      "--no-cache",
+    ],
+    { cwd: directory, encoding: "utf8", env: { ...process.env, CI: "1", FORCE_COLOR: "0" } },
+  );
+  return JSON.parse(result.stdout);
+};
+
+describe.skipIf(!hasBuiltCli)("baseline comparison with a deleted source file", () => {
+  it("keeps baseline mode and counts the deleted file's findings as fixed", () => {
+    const projectDirectory = setupReactProject(temporaryRoot, "issue-1768", {
+      files: {
+        "doctor.config.json": `${JSON.stringify({ noScore: true })}\n`,
+        "src/components/footer.tsx": FOOTER_WITH_FINDINGS,
+        "src/components/header.tsx": "export const Header = () => <header />;\n",
+        "src/locales/en.json": `${JSON.stringify({ title: "Hello" })}\n`,
+      },
+    });
+    initGitRepo(projectDirectory);
+    const baseRef = commitAll(projectDirectory, "base");
+
+    fs.rmSync(path.join(projectDirectory, "src/components/footer.tsx"));
+    writeFile(
+      path.join(projectDirectory, "src/components/header.tsx"),
+      "export const Header = () => <header>Hello</header>;\n",
+    );
+    writeFile(
+      path.join(projectDirectory, "src/locales/en.json"),
+      `${JSON.stringify({ title: "Hello there" })}\n`,
+    );
+    commitAll(projectDirectory, "delete footer");
+
+    const report = runChangedScan(projectDirectory, baseRef);
+
+    expect(report.baselineDegraded).not.toBe(true);
+    expect(report.mode).toBe("baseline");
+    expect(report.baseline?.newCount).toBe(0);
+    expect(report.baseline?.baseTotalCount).toBeGreaterThan(0);
+    expect(report.baseline?.fixedCount).toBe(report.baseline?.baseTotalCount);
+  }, 60_000);
+});

--- a/packages/react-doctor/tests/has-unlinted-surviving-base-file.test.ts
+++ b/packages/react-doctor/tests/has-unlinted-surviving-base-file.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vite-plus/test";
+import { hasUnlintedSurvivingBaseFile } from "../src/cli/utils/has-unlinted-surviving-base-file.js";
+
+describe("hasUnlintedSurvivingBaseFile", () => {
+  const baseLintPaths = ["src/deleted.tsx", "src/modified.tsx"];
+  const headFiles = new Set(["src/modified.tsx", "src/added.tsx"]);
+
+  it("ignores a skipped base file that was deleted at head", () => {
+    expect(
+      hasUnlintedSurvivingBaseFile({
+        baseLintPaths,
+        headFiles,
+        analyzedBaseFiles: ["src/modified.tsx"],
+      }),
+    ).toBe(false);
+  });
+
+  it("flags a skipped base file that still exists at head", () => {
+    expect(
+      hasUnlintedSurvivingBaseFile({
+        baseLintPaths,
+        headFiles,
+        analyzedBaseFiles: ["src/deleted.tsx"],
+      }),
+    ).toBe(true);
+  });
+
+  it("normalizes Windows separators before matching", () => {
+    expect(
+      hasUnlintedSurvivingBaseFile({
+        baseLintPaths: ["src\\modified.tsx"],
+        headFiles,
+        analyzedBaseFiles: ["src\\modified.tsx"],
+      }),
+    ).toBe(false);
+  });
+
+  it("ignores non-source base paths", () => {
+    expect(
+      hasUnlintedSurvivingBaseFile({
+        baseLintPaths: ["src/locale.json"],
+        headFiles: new Set(["src/locale.json"]),
+        analyzedBaseFiles: [],
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/react-doctor/tests/materialize-baseline-files.test.ts
+++ b/packages/react-doctor/tests/materialize-baseline-files.test.ts
@@ -104,4 +104,62 @@ describe("materializeBaselineFiles", () => {
     expect(snapshot?.unmaterializedFiles).toEqual([filePath]);
     snapshot?.cleanup();
   });
+
+  it("materializes a deleted base source alongside the modified files", async () => {
+    const deletedPath = path.join(directory, "src/components/footer.tsx");
+    const modifiedPath = path.join(directory, "src/components/header.tsx");
+    fs.mkdirSync(path.dirname(deletedPath), { recursive: true });
+    fs.writeFileSync(deletedPath, "export const Footer = () => <footer />;\n");
+    fs.writeFileSync(modifiedPath, "export const Header = () => <header />;\n");
+    const baseRef = commitAll(directory, "base");
+    fs.rmSync(deletedPath);
+    fs.writeFileSync(modifiedPath, "export const Header = () => <header>hi</header>;\n");
+    commitAll(directory, "delete footer");
+
+    const snapshot = await materializeBaselineFiles({
+      directory,
+      ref: baseRef,
+      files: ["src/components/header.tsx"],
+      tempDirectory,
+    });
+
+    expect(snapshot?.isComplete).toBe(true);
+    expect(snapshot?.baseFiles).toEqual(["src/components/footer.tsx", "src/components/header.tsx"]);
+    expect(snapshot?.headFiles).toEqual(["src/components/header.tsx"]);
+    expect(snapshot?.materializedFiles).toEqual([
+      "src/components/header.tsx",
+      "src/components/footer.tsx",
+    ]);
+    expect(fs.readFileSync(path.join(tempDirectory, "src/components/footer.tsx"), "utf-8")).toBe(
+      "export const Footer = () => <footer />;\n",
+    );
+    snapshot?.cleanup();
+  });
+
+  it("stays complete when an unreadable base source no longer exists at head", async () => {
+    const deletedPath = "src/pointer.tsx";
+    const modifiedPath = "src/tracked.tsx";
+    fs.mkdirSync(path.join(directory, "src"), { recursive: true });
+    fs.writeFileSync(
+      path.join(directory, deletedPath),
+      "version https://git-lfs.github.com/spec/v1\noid sha256:0123456789\nsize 10\n",
+    );
+    fs.writeFileSync(path.join(directory, modifiedPath), "export const value = 1;\n");
+    const baseRef = commitAll(directory, "base");
+    fs.rmSync(path.join(directory, deletedPath));
+    fs.writeFileSync(path.join(directory, modifiedPath), "export const value = 2;\n");
+
+    const snapshot = await materializeBaselineFiles({
+      directory,
+      ref: baseRef,
+      files: [modifiedPath],
+      tempDirectory,
+    });
+
+    expect(snapshot?.isComplete).toBe(true);
+    expect(snapshot?.baseFiles).toEqual([deletedPath, modifiedPath]);
+    expect(snapshot?.headFiles).toEqual([modifiedPath]);
+    expect(snapshot?.unmaterializedFiles).toEqual([deletedPath]);
+    snapshot?.cleanup();
+  });
 });


### PR DESCRIPTION
## Why

Fixes #1768.

**Before:** `--scope changed` flipped to `"mode":"diff"` / `"baselineDegraded":true` as soon as the change set deleted a `.tsx` file, with a misleading shallow-clone hint even though the merge base resolved fine.

`runBaselineComparison` treated every base file identically when deciding whether the base scan is trustworthy. Two of its `return null` guards can trip on a *deleted* file even though a deleted file has nothing at head to compare against — skipping it can only undercount `fixedCount`, never surface a stale finding as new.

**After:** a base-only deleted file that can't be materialized or linted no longer degrades the comparison. Unreadable or unlinted base files that *survive* at head still degrade exactly as before.

## What changed

- `materializeBaselineFiles` → `isComplete` required every `baseFiles` entry to be materialized. A base-only (`D`) path that `git show` / `isMaterializableGitSource` rejects (e.g. an LFS pointer at base) degraded the whole comparison. Now only a path the diff plan says exists on **both** sides can make the snapshot incomplete:
  ```ts
  isComplete: baseFiles.every(
    (filePath) => materializedFiles.has(filePath) || !headFileSet.has(filePath),
  )
  ```
- The base lint pass returned `null` on any `countIncompleteLintFiles(...) > 0`. It now only degrades when a dropped/deadline-skipped base file still exists at head:
  ```ts
  if (baseOutput.didLintFail || baseOutput.didDeadCodeFail) return null;
  if (
    countIncompleteLintFiles(baseOutput.lintPartialFailures) > 0 &&
    hasUnlintedSurvivingBaseFile({ baseLintPaths, headFiles, analyzedBaseFiles })
  ) return null;
  ```
  `hasUnlintedSurvivingBaseFile` (new `utils/` file) = some lintable `baseLintPaths` entry that is in `headFiles` but missing from `analyzedBaseFiles`.
- `M`/`T` behavior unchanged: the existing LFS-pointer test still asserts `isComplete === false`.
- Tests: `materialize-baseline-files.test.ts` (deleted file materialized alongside modified ones; unreadable deleted file keeps `isComplete`), unit tests for the new util, and `tests/e2e/baseline-deleted-file.test.ts` against the built CLI (deletes a `.tsx` with findings, edits a `.tsx` and a locale `.json`; asserts `mode === "baseline"`, `newCount === 0`, `fixedCount === baseTotalCount`).
- Changeset: `react-doctor` patch.
- Not in scope: surfacing *which* guard degraded (#1769) is a public-surface change.

## Eval results

RDE parity not run — baseline orchestration change, not a rule change.

## Test plan

- `nr test tests/has-unlinted-surviving-base-file.test.ts tests/materialize-baseline-files.test.ts tests/e2e/baseline-deleted-file.test.ts` in `packages/react-doctor` — 10 passed.
- Full `packages/react-doctor` suite — passes apart from the pre-existing `install-agent-hooks.test.ts` failure.
- `nr typecheck` (10/10), `nr lint` (pre-existing `packages/fuzz/corpus` warnings only), `nr format:check` — clean.
- Note: the exact degradation could not be reproduced with a TanStack Start + pnpm-workspace fixture on Git 2.52 (a straightforward deleted file already returned baseline mode on 0.9.13), so this hardens the two deletion-sensitive guards rather than pinning a single trigger.


Link to Devin session: https://app.devin.ai/sessions/a7ca592f952d4cabb23e274335226e42
Open in Devin Desktop: https://app.devin.ai/desktop/session/a7ca592f952d4cabb23e274335226e42?variant=devin
Requested by: @aidenybai