### PR TITLE
fix(cli): exclude unselected nested workspace projects from ancestor scans

### DIFF
--- a/.changeset/exclude-unselected-nested-projects.md
+++ b/.changeset/exclude-unselected-nested-projects.md
@@ -1,0 +1,5 @@
+---
+"react-doctor": patch
+---
+
+Exclude every discovered nested workspace project from an ancestor scan, whether or not it was selected. Scanning only the root of a monorepo previously pulled a nested app's files into the root scan and judged them against the root's framework and React Compiler settings, so a compiler-enabled Expo app inside a Vite workspace reported compiler-gated rules like `prefer-module-scope-pure-function` that its own config suppresses. A nested project's files are now only checked by that project's scan, matching what selecting both projects already did.

--- a/packages/react-doctor/src/cli/commands/inspect.ts
+++ b/packages/react-doctor/src/cli/commands/inspect.ts
@@ -8,7 +8,6 @@ import {
   getChangedLineRanges,
   getDiffInfo,
   highlighter,
-  isPathInsideDirectory,
   type JsonReportSkippedProject,
   remainingDeadlineBudgetMs,
   resolveScanTarget,
@@ -62,7 +61,8 @@ import { runExplain } from "../utils/run-explain.js";
 import { type ProjectScanOutcome, runProjectScanBatch } from "../utils/run-project-scan-batch.js";
 import { buildProjectScanPlan, type ProjectScanPlan } from "../utils/build-project-scan-plan.js";
 import { filterScansForSurface } from "../utils/filter-scans-for-surface.js";
-import { selectProjects } from "../utils/select-projects.js";
+import { resolveExcludedProjectDirectories } from "../utils/resolve-excluded-project-directories.js";
+import { discoverWorkspacePackages, selectProjects } from "../utils/select-projects.js";
 import { resolveProjectRelativeDirectory } from "../utils/resolve-project-relative-directory.js";
 import { spinner } from "../utils/spinner.js";
 import { shouldSkipPrompts } from "../utils/should-skip-prompts.js";
@@ -108,6 +108,7 @@ interface ProjectScanExecutionContext {
   readonly workspaceDeadCodeOwner: string | null;
   readonly precomputedSourceFileCounts: ReadonlyMap<string, number> | null;
   readonly projectScans: ReadonlyArray<ResolvedProjectScan>;
+  readonly workspaceProjectDirectories: ReadonlyArray<string>;
   readonly baselineRef: string | null;
   readonly scope: RequestedScope["scope"];
   readonly changedLineRanges: ReadonlyArray<ChangedFileLineRanges> | null;
@@ -159,11 +160,11 @@ const buildProjectInspectOptions = ({
     configSourceDirectory: projectScan.configSourceDirectory ?? undefined,
     suppressRendering: context.isMultiProject,
     concurrentScan: context.isMultiProject,
-    excludedProjectDirectories: context.projectScans
-      .filter((candidateProjectScan) =>
-        isPathInsideDirectory(candidateProjectScan.directory, scanDirectory),
-      )
-      .map((candidateProjectScan) => candidateProjectScan.directory),
+    excludedProjectDirectories: resolveExcludedProjectDirectories({
+      scanDirectory,
+      selectedProjectDirectories: context.projectScans.map((projectScan) => projectScan.directory),
+      workspaceProjectDirectories: context.workspaceProjectDirectories,
+    }),
     retainExcludedProjectDeadCodeDiagnostics: ownsWorkspaceDeadCode,
     baseline:
       context.baselineRef !== null &&
@@ -369,6 +370,9 @@ export const inspectAction = async (
       });
       return;
     }
+    const workspaceProjectDirectories = discoverWorkspacePackages(resolvedDirectory).map(
+      (workspacePackage) => workspacePackage.directory,
+    );
     const projectDirectories = await selectProjects(
       resolvedDirectory,
       flags.project,
@@ -557,6 +561,7 @@ export const inspectAction = async (
       workspaceDeadCodeOwner,
       precomputedSourceFileCounts,
       projectScans,
+      workspaceProjectDirectories,
       baselineRef,
       scope,
       changedLineRanges,

--- a/packages/react-doctor/src/cli/commands/inspect.ts
+++ b/packages/react-doctor/src/cli/commands/inspect.ts
@@ -160,11 +160,10 @@ const buildProjectInspectOptions = ({
     configSourceDirectory: projectScan.configSourceDirectory ?? undefined,
     suppressRendering: context.isMultiProject,
     concurrentScan: context.isMultiProject,
-    excludedProjectDirectories: resolveExcludedProjectDirectories({
-      scanDirectory,
-      selectedProjectDirectories: context.projectScans.map((projectScan) => projectScan.directory),
-      workspaceProjectDirectories: context.workspaceProjectDirectories,
-    }),
+    excludedProjectDirectories: resolveExcludedProjectDirectories(scanDirectory, [
+      ...context.projectScans.map((candidateProjectScan) => candidateProjectScan.directory),
+      ...context.workspaceProjectDirectories,
+    ]),
     retainExcludedProjectDeadCodeDiagnostics: ownsWorkspaceDeadCode,
     baseline:
       context.baselineRef !== null &&

--- a/packages/react-doctor/src/cli/ink/run-scan-app.tsx
+++ b/packages/react-doctor/src/cli/ink/run-scan-app.tsx
@@ -5,7 +5,6 @@ import * as Effect from "effect/Effect";
 import {
   DEFAULT_PROJECT_SCAN_CONCURRENCY,
   highlighter,
-  isPathInsideDirectory,
   mapWithConcurrency,
   remainingDeadlineBudgetMs,
   Reporter,
@@ -32,6 +31,7 @@ import { computeProjectedScore } from "../utils/compute-score-projection.js";
 import { countUniqueScannedFiles } from "../utils/count-unique-scanned-files.js";
 import { deduplicateProjectScans } from "../utils/deduplicate-project-scans.js";
 import { collectProjectSourceFileCounts } from "../utils/collect-project-source-file-counts.js";
+import { resolveExcludedProjectDirectories } from "../utils/resolve-excluded-project-directories.js";
 import { discoverWorkspacePackages, selectProjects } from "../utils/select-projects.js";
 import { isCiEnvironment } from "../utils/is-ci-environment.js";
 import { formatElapsedTime } from "../utils/format-elapsed-time.js";
@@ -108,6 +108,11 @@ interface TuiProjectScan {
   readonly config: ReactDoctorConfig | null;
 }
 
+interface TuiProjectSelection {
+  readonly selectedDirectories: ReadonlyArray<string>;
+  readonly workspaceProjectDirectories: ReadonlyArray<string>;
+}
+
 const qualifyDiagnosticPaths = (
   diagnostics: ReadonlyArray<Diagnostic>,
   rootDirectory: string,
@@ -157,11 +162,14 @@ const resolveTuiInspectOptions = (
   return warnings === undefined ? { ...input.options } : { ...input.options, warnings };
 };
 
-const resolveSelectedDirectories = async (
+const resolveProjectSelection = async (
   rootDirectory: string,
   input: RunScanAppInput,
-): Promise<string[]> => {
+): Promise<TuiProjectSelection> => {
   const packages = discoverWorkspacePackages(rootDirectory);
+  const workspaceProjectDirectories = packages.map(
+    (workspacePackage) => workspacePackage.directory,
+  );
   const needsPrompt =
     packages.length > 1 &&
     !input.projectFlag &&
@@ -169,16 +177,15 @@ const resolveSelectedDirectories = async (
     (input.configProjects ?? []).length === 0 &&
     process.stdin.isTTY === true;
 
-  if (!needsPrompt) {
-    return selectProjects(
-      rootDirectory,
-      input.projectFlag,
-      input.skipPrompts ?? false,
-      input.configProjects,
-    );
-  }
-
-  return promptProjectSelection(packages, rootDirectory);
+  const selectedDirectories = needsPrompt
+    ? await promptProjectSelection(packages, rootDirectory)
+    : await selectProjects(
+        rootDirectory,
+        input.projectFlag,
+        input.skipPrompts ?? false,
+        input.configProjects,
+      );
+  return { selectedDirectories, workspaceProjectDirectories };
 };
 
 const promptProjectSelection = (
@@ -501,12 +508,15 @@ const runMountedScan = async (
 const runSingleProjectScan = async (
   rootScanTarget: ResolvedScanTarget,
   projectDirectory: string,
+  workspaceProjectDirectories: ReadonlyArray<string>,
   input: RunScanAppInput,
   scopePlan: TuiScanScopePlan,
   blockingLevel: BlockingLevel,
   inspectProject: ReturnType<typeof createInvocationInspect>,
 ): Promise<RunScanAppResult> => {
   const projectScan = await resolveProjectScan(rootScanTarget, projectDirectory);
+  const isRootProject =
+    path.resolve(projectScan.directory) === path.resolve(rootScanTarget.resolvedDirectory);
   const isSupplyChainEnabled =
     input.options?.supplyChain ?? projectScan.config?.supplyChain?.enabled ?? true;
   const scopeOptions = resolveProjectTuiScanScope({
@@ -535,6 +545,12 @@ const runSingleProjectScan = async (
         reporter: reporterLayerForStore(context.store),
         progress: progressLayerForStore(context.store),
       },
+      excludedProjectDirectories: resolveExcludedProjectDirectories({
+        scanDirectory: projectScan.directory,
+        selectedProjectDirectories: [],
+        workspaceProjectDirectories,
+      }),
+      retainExcludedProjectDeadCodeDiagnostics: isRootProject,
     });
     const reportSelection = selectReportDiagnostics({
       scan: { result, config: projectScan.config },
@@ -582,6 +598,7 @@ const runSingleProjectScan = async (
 const runMultiProjectScan = async (
   rootScanTarget: ResolvedScanTarget,
   directories: ReadonlyArray<string>,
+  workspaceProjectDirectories: ReadonlyArray<string>,
   input: RunScanAppInput,
   scopePlan: TuiScanScopePlan,
   blockingLevel: BlockingLevel,
@@ -689,11 +706,13 @@ const runMultiProjectScan = async (
             }),
           },
           concurrentScan: true,
-          excludedProjectDirectories: discoveredProjectScans
-            .filter((candidateProjectScan) =>
-              isPathInsideDirectory(candidateProjectScan.directory, projectScan.directory),
-            )
-            .map((candidateProjectScan) => candidateProjectScan.directory),
+          excludedProjectDirectories: resolveExcludedProjectDirectories({
+            scanDirectory: projectScan.directory,
+            selectedProjectDirectories: discoveredProjectScans.map(
+              (candidateProjectScan) => candidateProjectScan.directory,
+            ),
+            workspaceProjectDirectories,
+          }),
           retainExcludedProjectDeadCodeDiagnostics: ownsWorkspaceDeadCode,
         });
         finishedCount += 1;
@@ -837,7 +856,10 @@ export const runScanApp = async (input: RunScanAppInput): Promise<RunScanAppResu
     configProjects: input.configProjects ?? scanTarget.userConfig?.projects,
     share: input.share ?? scanTarget.userConfig?.share ?? true,
   };
-  const selectedDirectories = await resolveSelectedDirectories(rootDirectory, resolvedInput);
+  const { selectedDirectories, workspaceProjectDirectories } = await resolveProjectSelection(
+    rootDirectory,
+    resolvedInput,
+  );
   const inspectProject = createInvocationInspect(input.options?.concurrency);
   const blockingLevel = resolveBlockingLevel(
     { blocking: resolvedInput.blocking },
@@ -851,6 +873,7 @@ export const runScanApp = async (input: RunScanAppInput): Promise<RunScanAppResu
     return runSingleProjectScan(
       scanTarget,
       selectedDirectories[0],
+      workspaceProjectDirectories,
       resolvedInput,
       scopePlan,
       blockingLevel,
@@ -860,6 +883,7 @@ export const runScanApp = async (input: RunScanAppInput): Promise<RunScanAppResu
   return runMultiProjectScan(
     scanTarget,
     selectedDirectories,
+    workspaceProjectDirectories,
     resolvedInput,
     scopePlan,
     blockingLevel,

--- a/packages/react-doctor/src/cli/ink/run-scan-app.tsx
+++ b/packages/react-doctor/src/cli/ink/run-scan-app.tsx
@@ -545,11 +545,10 @@ const runSingleProjectScan = async (
         reporter: reporterLayerForStore(context.store),
         progress: progressLayerForStore(context.store),
       },
-      excludedProjectDirectories: resolveExcludedProjectDirectories({
-        scanDirectory: projectScan.directory,
-        selectedProjectDirectories: [],
+      excludedProjectDirectories: resolveExcludedProjectDirectories(
+        projectScan.directory,
         workspaceProjectDirectories,
-      }),
+      ),
       retainExcludedProjectDeadCodeDiagnostics: isRootProject,
     });
     const reportSelection = selectReportDiagnostics({
@@ -706,13 +705,10 @@ const runMultiProjectScan = async (
             }),
           },
           concurrentScan: true,
-          excludedProjectDirectories: resolveExcludedProjectDirectories({
-            scanDirectory: projectScan.directory,
-            selectedProjectDirectories: discoveredProjectScans.map(
-              (candidateProjectScan) => candidateProjectScan.directory,
-            ),
-            workspaceProjectDirectories,
-          }),
+          excludedProjectDirectories: resolveExcludedProjectDirectories(projectScan.directory, [
+            ...discoveredProjectScans.map((candidateProjectScan) => candidateProjectScan.directory),
+            ...workspaceProjectDirectories,
+          ]),
           retainExcludedProjectDeadCodeDiagnostics: ownsWorkspaceDeadCode,
         });
         finishedCount += 1;

--- a/packages/react-doctor/src/cli/utils/resolve-excluded-project-directories.ts
+++ b/packages/react-doctor/src/cli/utils/resolve-excluded-project-directories.ts
@@ -1,21 +1,13 @@
 import * as path from "node:path";
 import { isPathInsideDirectory } from "@react-doctor/core";
 
-export interface ResolveExcludedProjectDirectoriesInput {
-  readonly scanDirectory: string;
-  readonly selectedProjectDirectories: ReadonlyArray<string>;
-  readonly workspaceProjectDirectories: ReadonlyArray<string>;
-}
-
 export const resolveExcludedProjectDirectories = (
-  input: ResolveExcludedProjectDirectoriesInput,
+  scanDirectory: string,
+  projectDirectories: ReadonlyArray<string>,
 ): string[] => {
   const excludedDirectories = new Map<string, string>();
-  for (const projectDirectory of [
-    ...input.selectedProjectDirectories,
-    ...input.workspaceProjectDirectories,
-  ]) {
-    if (!isPathInsideDirectory(projectDirectory, input.scanDirectory)) continue;
+  for (const projectDirectory of projectDirectories) {
+    if (!isPathInsideDirectory(projectDirectory, scanDirectory)) continue;
     const resolvedDirectory = path.resolve(projectDirectory);
     if (!excludedDirectories.has(resolvedDirectory)) {
       excludedDirectories.set(resolvedDirectory, projectDirectory);

--- a/packages/react-doctor/src/cli/utils/resolve-excluded-project-directories.ts
+++ b/packages/react-doctor/src/cli/utils/resolve-excluded-project-directories.ts
@@ -1,0 +1,25 @@
+import * as path from "node:path";
+import { isPathInsideDirectory } from "@react-doctor/core";
+
+export interface ResolveExcludedProjectDirectoriesInput {
+  readonly scanDirectory: string;
+  readonly selectedProjectDirectories: ReadonlyArray<string>;
+  readonly workspaceProjectDirectories: ReadonlyArray<string>;
+}
+
+export const resolveExcludedProjectDirectories = (
+  input: ResolveExcludedProjectDirectoriesInput,
+): string[] => {
+  const excludedDirectories = new Map<string, string>();
+  for (const projectDirectory of [
+    ...input.selectedProjectDirectories,
+    ...input.workspaceProjectDirectories,
+  ]) {
+    if (!isPathInsideDirectory(projectDirectory, input.scanDirectory)) continue;
+    const resolvedDirectory = path.resolve(projectDirectory);
+    if (!excludedDirectories.has(resolvedDirectory)) {
+      excludedDirectories.set(resolvedDirectory, projectDirectory);
+    }
+  }
+  return [...excludedDirectories.values()];
+};

--- a/packages/react-doctor/tests/e2e/root-only-workspace-scan.test.ts
+++ b/packages/react-doctor/tests/e2e/root-only-workspace-scan.test.ts
@@ -18,7 +18,9 @@ interface CliWorkspaceReport {
 const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
 const builtCliPath = path.resolve(currentDirectory, "../../dist/cli.js");
 const hasBuiltCli = fs.existsSync(builtCliPath);
-const temporaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), "rd-root-only-workspace-scan-"));
+const temporaryRoot = fs.realpathSync(
+  fs.mkdtempSync(path.join(os.tmpdir(), "rd-root-only-workspace-scan-")),
+);
 
 afterAll(() => {
   fs.rmSync(temporaryRoot, { recursive: true, force: true });
@@ -95,7 +97,7 @@ const runScan = (directory: string, projects: string): CliWorkspaceReport => {
   return JSON.parse(result.stdout);
 };
 
-const collectRuleHits = (report: CliWorkspaceReport): string[] =>
+const collectRuleHitPaths = (report: CliWorkspaceReport): string[] =>
   report.projects.flatMap((projectReport) =>
     projectReport.diagnostics
       .filter((diagnostic) => diagnostic.rule === RULE_UNDER_TEST)
@@ -113,13 +115,13 @@ describe.skipIf(!hasBuiltCli)("root-only scan of a workspace with a nested proje
       rootDirectory,
       path.join(rootDirectory, "apps/native"),
     ]);
-    expect(collectRuleHits(bothReport)).toEqual([rootListPath]);
+    expect(collectRuleHitPaths(bothReport)).toEqual([rootListPath]);
 
     const rootOnlyReport = runScan(rootDirectory, "workspace-root");
     expect(rootOnlyReport.projects.map((projectReport) => projectReport.directory)).toEqual([
       rootDirectory,
     ]);
-    expect(collectRuleHits(rootOnlyReport)).toEqual([rootListPath]);
-    expect(collectRuleHits(rootOnlyReport)).not.toContain(nativePanelPath);
+    expect(collectRuleHitPaths(rootOnlyReport)).toEqual([rootListPath]);
+    expect(collectRuleHitPaths(rootOnlyReport)).not.toContain(nativePanelPath);
   }, 120_000);
 });

--- a/packages/react-doctor/tests/e2e/root-only-workspace-scan.test.ts
+++ b/packages/react-doctor/tests/e2e/root-only-workspace-scan.test.ts
@@ -1,0 +1,125 @@
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, describe, expect, it } from "vite-plus/test";
+import { writeFile, writeJson } from "../regressions/_helpers.js";
+
+interface CliProjectReport {
+  readonly directory: string;
+  readonly diagnostics: ReadonlyArray<{ readonly filePath: string; readonly rule: string }>;
+}
+
+interface CliWorkspaceReport {
+  readonly projects: ReadonlyArray<CliProjectReport>;
+}
+
+const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
+const builtCliPath = path.resolve(currentDirectory, "../../dist/cli.js");
+const hasBuiltCli = fs.existsSync(builtCliPath);
+const temporaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), "rd-root-only-workspace-scan-"));
+
+afterAll(() => {
+  fs.rmSync(temporaryRoot, { recursive: true, force: true });
+});
+
+const RULE_UNDER_TEST = "prefer-module-scope-pure-function";
+
+const NATIVE_PANEL = `import { FlatList } from "react-native";
+
+interface Item {
+  id: string;
+}
+
+const Row = ({ id }: { id: string }) => <>{id}</>;
+
+export const Panel = ({ items }: { items: Item[] }) => {
+  const renderItem = ({ item }: { item: Item }) => <Row id={item.id} />;
+  return <FlatList data={items} renderItem={renderItem} keyExtractor={(entry) => entry.id} />;
+};
+`;
+
+const WEB_LIST = `export const List = ({ items }: { items: string[] }) => {
+  const renderItem = (item: string) => <span key={item}>{item}</span>;
+  return <div>{items.map(renderItem)}</div>;
+};
+`;
+
+const TSCONFIG = {
+  compilerOptions: { jsx: "react-jsx", strict: true, target: "es2022", module: "esnext" },
+};
+
+const setupWorkspace = (): string => {
+  const rootDirectory = path.join(temporaryRoot, "issue-1772");
+  writeJson(path.join(rootDirectory, "package.json"), {
+    name: "workspace-root",
+    private: true,
+    workspaces: ["apps/*"],
+    dependencies: { react: "^19.0.0", "react-dom": "^19.0.0" },
+    devDependencies: { vite: "^7.0.0" },
+  });
+  writeJson(path.join(rootDirectory, "tsconfig.json"), TSCONFIG);
+  writeFile(path.join(rootDirectory, "src/list.tsx"), WEB_LIST);
+  writeJson(path.join(rootDirectory, "apps/native/package.json"), {
+    name: "native",
+    main: "index.js",
+    dependencies: { expo: "^54.0.0", react: "^19.0.0", "react-native": "^0.81.0" },
+    devDependencies: { "babel-plugin-react-compiler": "^19.0.0" },
+  });
+  writeJson(path.join(rootDirectory, "apps/native/tsconfig.json"), TSCONFIG);
+  writeFile(
+    path.join(rootDirectory, "apps/native/app.config.ts"),
+    'export default { expo: { name: "native", slug: "native", experiments: { reactCompiler: true } } };\n',
+  );
+  writeFile(path.join(rootDirectory, "apps/native/src/panel.tsx"), NATIVE_PANEL);
+  return rootDirectory;
+};
+
+const runScan = (directory: string, projects: string): CliWorkspaceReport => {
+  const result = spawnSync(
+    process.execPath,
+    [
+      builtCliPath,
+      ".",
+      "--project",
+      projects,
+      "--json",
+      "--no-score",
+      "--no-supply-chain",
+      "--no-telemetry",
+      "--no-cache",
+    ],
+    { cwd: directory, encoding: "utf8", env: { ...process.env, CI: "1", FORCE_COLOR: "0" } },
+  );
+  return JSON.parse(result.stdout);
+};
+
+const collectRuleHits = (report: CliWorkspaceReport): string[] =>
+  report.projects.flatMap((projectReport) =>
+    projectReport.diagnostics
+      .filter((diagnostic) => diagnostic.rule === RULE_UNDER_TEST)
+      .map((diagnostic) => path.resolve(projectReport.directory, diagnostic.filePath)),
+  );
+
+describe.skipIf(!hasBuiltCli)("root-only scan of a workspace with a nested project", () => {
+  it("leaves nested project files to that project's own config", () => {
+    const rootDirectory = setupWorkspace();
+    const rootListPath = path.join(rootDirectory, "src/list.tsx");
+    const nativePanelPath = path.join(rootDirectory, "apps/native/src/panel.tsx");
+
+    const bothReport = runScan(rootDirectory, "workspace-root,native");
+    expect(bothReport.projects.map((projectReport) => projectReport.directory)).toEqual([
+      rootDirectory,
+      path.join(rootDirectory, "apps/native"),
+    ]);
+    expect(collectRuleHits(bothReport)).toEqual([rootListPath]);
+
+    const rootOnlyReport = runScan(rootDirectory, "workspace-root");
+    expect(rootOnlyReport.projects.map((projectReport) => projectReport.directory)).toEqual([
+      rootDirectory,
+    ]);
+    expect(collectRuleHits(rootOnlyReport)).toEqual([rootListPath]);
+    expect(collectRuleHits(rootOnlyReport)).not.toContain(nativePanelPath);
+  }, 120_000);
+});

--- a/packages/react-doctor/tests/ink/run-scan-app.test.ts
+++ b/packages/react-doctor/tests/ink/run-scan-app.test.ts
@@ -422,6 +422,64 @@ describe("runScanApp", () => {
     );
   });
 
+  it("excludes unselected nested workspace projects from a root-only scan", async () => {
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const rootDirectory = "/repo";
+    const nativeDirectory = "/repo/apps/native";
+    mockState.workspacePackages.push(
+      { name: "root", directory: rootDirectory },
+      { name: "native", directory: nativeDirectory },
+    );
+    mockState.projectDirectories.push(rootDirectory);
+    mockState.scanTargets.set(
+      rootDirectory,
+      buildScanTarget(rootDirectory, rootDirectory, null, rootDirectory),
+    );
+    mockState.inspectResults.set(rootDirectory, buildInspectResult(rootDirectory));
+
+    await runScanApp({ directory: rootDirectory, skipPrompts: true });
+
+    expect(inspect).toHaveBeenCalledTimes(1);
+    expect(inspect).toHaveBeenCalledWith(
+      rootDirectory,
+      expect.objectContaining({
+        excludedProjectDirectories: [nativeDirectory],
+        retainExcludedProjectDeadCodeDiagnostics: true,
+      }),
+    );
+  });
+
+  it("scans a selected nested project without excluding its own directory", async () => {
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const rootDirectory = "/repo";
+    const nativeDirectory = "/repo/apps/native";
+    mockState.workspacePackages.push(
+      { name: "root", directory: rootDirectory },
+      { name: "native", directory: nativeDirectory },
+    );
+    mockState.projectDirectories.push(nativeDirectory);
+    mockState.scanTargets.set(
+      rootDirectory,
+      buildScanTarget(rootDirectory, rootDirectory, null, rootDirectory),
+    );
+    mockState.scanTargets.set(
+      nativeDirectory,
+      buildScanTarget(nativeDirectory, nativeDirectory, null, nativeDirectory),
+    );
+    mockState.inspectResults.set(nativeDirectory, buildInspectResult(nativeDirectory));
+
+    await runScanApp({ directory: rootDirectory, skipPrompts: true });
+
+    expect(inspect).toHaveBeenCalledTimes(1);
+    expect(inspect).toHaveBeenCalledWith(
+      nativeDirectory,
+      expect.objectContaining({
+        excludedProjectDirectories: [],
+        retainExcludedProjectDeadCodeDiagnostics: false,
+      }),
+    );
+  });
+
   it("preserves workspace dead-code ownership when a scoped scan skips the root", async () => {
     vi.spyOn(process.stdout, "write").mockImplementation(() => true);
     const rootDirectory = "/repo";

--- a/packages/react-doctor/tests/inspect-action-exit-code.test.ts
+++ b/packages/react-doctor/tests/inspect-action-exit-code.test.ts
@@ -2,7 +2,12 @@ import * as fs from "node:fs";
 import os from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
-import type { InspectResult, JsonReport, ReactDoctorConfig } from "@react-doctor/core";
+import type {
+  InspectResult,
+  JsonReport,
+  ReactDoctorConfig,
+  WorkspacePackage,
+} from "@react-doctor/core";
 import { inspectAction } from "../src/cli/commands/inspect.js";
 import type { InspectFlags } from "../src/cli/utils/inspect-flags.js";
 import { buildDiagnostic, buildTestProject } from "./regressions/_helpers.js";
@@ -16,6 +21,7 @@ interface InspectInvocation {
 
 const mockState = vi.hoisted(() => ({
   projectDirectories: [] as string[],
+  workspacePackages: [] as WorkspacePackage[],
   inspectInvocations: [] as InspectInvocation[],
   resolvedDirectories: new Map<string, string>(),
   result: undefined as InspectResult | undefined,
@@ -92,6 +98,7 @@ vi.mock("../src/inspect.js", () => {
 });
 
 vi.mock("../src/cli/utils/select-projects.js", () => ({
+  discoverWorkspacePackages: vi.fn(() => mockState.workspacePackages),
   selectProjects: vi.fn(async () => mockState.projectDirectories),
 }));
 
@@ -142,6 +149,7 @@ describe("inspectAction exit-code gate", () => {
     process.exitCode = savedExitCode;
     mockState.result = undefined;
     mockState.projectDirectories = [];
+    mockState.workspacePackages = [];
     mockState.inspectInvocations = [];
     mockState.resolvedDirectories.clear();
     mockState.userConfig = undefined;
@@ -235,6 +243,27 @@ describe("inspectAction exit-code gate", () => {
       excludedProjectDirectories: [],
       retainExcludedProjectDeadCodeDiagnostics: false,
     });
+  });
+
+  it("excludes unselected nested workspace projects from a root-only scan", async () => {
+    const nestedProjectDirectory = path.join(projectDirectory, "apps", "native");
+    fs.mkdirSync(nestedProjectDirectory, { recursive: true });
+    mockState.workspacePackages = [
+      { name: "root", directory: projectDirectory },
+      { name: "native", directory: nestedProjectDirectory },
+    ];
+    mockState.projectDirectories = [projectDirectory];
+
+    await runInspectAction({});
+
+    expect(mockState.inspectInvocations).toEqual([
+      {
+        directory: projectDirectory,
+        deadCode: true,
+        excludedProjectDirectories: [nestedProjectDirectory],
+        retainExcludedProjectDeadCodeDiagnostics: true,
+      },
+    ]);
   });
 
   it("computes workspace exclusions from unique resolved project roots", async () => {

--- a/packages/react-doctor/tests/inspect-action-setup-prompt.test.ts
+++ b/packages/react-doctor/tests/inspect-action-setup-prompt.test.ts
@@ -97,6 +97,7 @@ vi.mock("../src/inspect.js", () => {
 });
 
 vi.mock("../src/cli/utils/select-projects.js", () => ({
+  discoverWorkspacePackages: vi.fn(() => []),
   selectProjects: vi.fn(async () => mockState.projectDirectories),
 }));
 

--- a/packages/react-doctor/tests/resolve-excluded-project-directories.test.ts
+++ b/packages/react-doctor/tests/resolve-excluded-project-directories.test.ts
@@ -7,47 +7,33 @@ const webDirectory = path.join(rootDirectory, "apps", "web");
 const nativeDirectory = path.join(rootDirectory, "apps", "native");
 
 describe("resolveExcludedProjectDirectories", () => {
-  it("excludes discovered nested projects even when only the root is selected", () => {
+  it("excludes every project nested inside the scan directory", () => {
     expect(
-      resolveExcludedProjectDirectories({
-        scanDirectory: rootDirectory,
-        selectedProjectDirectories: [rootDirectory],
-        workspaceProjectDirectories: [rootDirectory, webDirectory, nativeDirectory],
-      }),
+      resolveExcludedProjectDirectories(rootDirectory, [
+        rootDirectory,
+        webDirectory,
+        nativeDirectory,
+      ]),
     ).toEqual([webDirectory, nativeDirectory]);
   });
 
   it("never excludes the scan directory itself or its ancestors", () => {
     expect(
-      resolveExcludedProjectDirectories({
-        scanDirectory: nativeDirectory,
-        selectedProjectDirectories: [rootDirectory, nativeDirectory],
-        workspaceProjectDirectories: [rootDirectory, webDirectory, nativeDirectory],
-      }),
+      resolveExcludedProjectDirectories(nativeDirectory, [
+        rootDirectory,
+        webDirectory,
+        nativeDirectory,
+      ]),
     ).toEqual([]);
   });
 
-  it("merges selected and discovered projects by resolved path", () => {
+  it("deduplicates directories by resolved path, keeping the first spelling", () => {
     expect(
-      resolveExcludedProjectDirectories({
-        scanDirectory: rootDirectory,
-        selectedProjectDirectories: [rootDirectory, webDirectory],
-        workspaceProjectDirectories: [
-          path.join(rootDirectory, "apps", ".", "web"),
-          nativeDirectory,
-        ],
-      }),
+      resolveExcludedProjectDirectories(rootDirectory, [
+        webDirectory,
+        path.join(rootDirectory, "apps", ".", "web"),
+        nativeDirectory,
+      ]),
     ).toEqual([webDirectory, nativeDirectory]);
-  });
-
-  it("keeps selected directories that workspace discovery did not list", () => {
-    const extraDirectory = path.join(rootDirectory, "tools", "storybook");
-    expect(
-      resolveExcludedProjectDirectories({
-        scanDirectory: rootDirectory,
-        selectedProjectDirectories: [rootDirectory, extraDirectory],
-        workspaceProjectDirectories: [],
-      }),
-    ).toEqual([extraDirectory]);
   });
 });

--- a/packages/react-doctor/tests/resolve-excluded-project-directories.test.ts
+++ b/packages/react-doctor/tests/resolve-excluded-project-directories.test.ts
@@ -1,0 +1,53 @@
+import * as path from "node:path";
+import { describe, expect, it } from "vite-plus/test";
+import { resolveExcludedProjectDirectories } from "../src/cli/utils/resolve-excluded-project-directories.js";
+
+const rootDirectory = path.resolve("/repo");
+const webDirectory = path.join(rootDirectory, "apps", "web");
+const nativeDirectory = path.join(rootDirectory, "apps", "native");
+
+describe("resolveExcludedProjectDirectories", () => {
+  it("excludes discovered nested projects even when only the root is selected", () => {
+    expect(
+      resolveExcludedProjectDirectories({
+        scanDirectory: rootDirectory,
+        selectedProjectDirectories: [rootDirectory],
+        workspaceProjectDirectories: [rootDirectory, webDirectory, nativeDirectory],
+      }),
+    ).toEqual([webDirectory, nativeDirectory]);
+  });
+
+  it("never excludes the scan directory itself or its ancestors", () => {
+    expect(
+      resolveExcludedProjectDirectories({
+        scanDirectory: nativeDirectory,
+        selectedProjectDirectories: [rootDirectory, nativeDirectory],
+        workspaceProjectDirectories: [rootDirectory, webDirectory, nativeDirectory],
+      }),
+    ).toEqual([]);
+  });
+
+  it("merges selected and discovered projects by resolved path", () => {
+    expect(
+      resolveExcludedProjectDirectories({
+        scanDirectory: rootDirectory,
+        selectedProjectDirectories: [rootDirectory, webDirectory],
+        workspaceProjectDirectories: [
+          path.join(rootDirectory, "apps", ".", "web"),
+          nativeDirectory,
+        ],
+      }),
+    ).toEqual([webDirectory, nativeDirectory]);
+  });
+
+  it("keeps selected directories that workspace discovery did not list", () => {
+    const extraDirectory = path.join(rootDirectory, "tools", "storybook");
+    expect(
+      resolveExcludedProjectDirectories({
+        scanDirectory: rootDirectory,
+        selectedProjectDirectories: [rootDirectory, extraDirectory],
+        workspaceProjectDirectories: [],
+      }),
+    ).toEqual([extraDirectory]);
+  });
+});


### PR DESCRIPTION
## Why

Closes #1772.

Both scan orchestrators (classic `inspectAction` and the Ink `runScanApp` path) derived an ancestor project's `excludedProjectDirectories` from the *selected* scans only:

```ts
excludedProjectDirectories: context.projectScans
  .filter((scan) => isPathInsideDirectory(scan.directory, scanDirectory))
  .map((scan) => scan.directory)
```

**Before:** with `--project root` (or picking only the root in the prompt) a nested Expo app was absent from `projectScans`, so its files fell into the root scan and were linted with the root's `ProjectInfo`. A Vite root without React Compiler re-enabled `disabledWhen: ["react-compiler"]` rules like `prefer-module-scope-pure-function` on files whose own project disables them. Selecting both projects only worked because the nested scan happened to be in the list.

**After:** exclusion is computed from every *discovered* workspace project, independent of selection. Root-only and root+native report the same set of root findings, and the nested app's files are only judged by the nested app's scan.

## What changed

- New `utils/resolve-excluded-project-directories.ts`:
  ```ts
  resolveExcludedProjectDirectories(scanDirectory, projectDirectories): string[]
  // -> unique (by path.resolve) directories strictly inside scanDirectory
  ```
  Callers pass `[...selectedScanDirectories, ...workspaceProjectDirectories]` so an explicit `--project` dir that discovery didn't list is still excluded.
- `inspectAction` calls `discoverWorkspacePackages(root)` once before `selectProjects` and threads `workspaceProjectDirectories` through `ProjectScanExecutionContext`.
- `runScanApp`: `resolveSelectedDirectories` → `resolveProjectSelection`, returning `{ selectedDirectories, workspaceProjectDirectories }`, passed to both `runSingleProjectScan` and `runMultiProjectScan`. The single-project path previously passed no `excludedProjectDirectories` at all; it now also sets `retainExcludedProjectDeadCodeDiagnostics` when the scanned project is the workspace root, matching the classic path.
- Which projects get scanned is unchanged — only what the ancestor leaves out.
- Tests: `resolve-excluded-project-directories.test.ts` (unit), root-only regressions in `inspect-action-exit-code.test.ts` and `ink/run-scan-app.test.ts`, and `tests/e2e/root-only-workspace-scan.test.ts` against the built CLI with a Vite root + nested Expo (`experiments.reactCompiler: true`) fixture.
- Changeset: `react-doctor` patch.

## Eval results

RDE parity not run — CLI orchestration change, not a rule change.

## Test plan

- `nr test` in `packages/react-doctor` for the five touched test files — 51 passed.
- Full `packages/react-doctor` suite — 253 files pass; the one failure (`install-agent-hooks.test.ts > exits quietly when no react-doctor runner is available`) is pre-existing and unrelated.
- `nr typecheck` — 10/10 tasks OK.
- `nr lint` — only pre-existing warnings in `packages/fuzz/corpus`.
- `nr format:check` — clean.
- Manual: `--project workspace-root` on the fixture no longer reports `apps/native/src/panel.tsx prefer-module-scope-pure-function`.


Link to Devin session: https://app.devin.ai/sessions/a7ca592f952d4cabb23e274335226e42
Open in Devin Desktop: https://app.devin.ai/desktop/session/a7ca592f952d4cabb23e274335226e42?variant=devin
Requested by: @aidenybai