### PR TITLE
fix: rn-prefer-reanimated false positive for native-driver animations

### DIFF
--- a/.changeset/rn-prefer-reanimated-message-fix.md
+++ b/.changeset/rn-prefer-reanimated-message-fix.md
@@ -1,0 +1,7 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+fix(rn-prefer-reanimated): soften message to conditional, mention useNativeDriver option
+
+The rule was claiming definite JS-thread execution even when code uses `useNativeDriver: true` for native-thread animations. Changed to conditional framing and updated recommendation to mention both Reanimated and useNativeDriver options.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/core-rule-registry-data.json
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/core-rule-registry-data.json
@@ -11978,7 +11978,7 @@
       "id": "rn-prefer-reanimated",
       "title": "JS-thread animation instead of Reanimated",
       "severity": "warn",
-      "recommendation": "Use `import Animated from 'react-native-reanimated'` so animations run on the UI thread instead of the JS thread, which keeps them smooth.",
+      "recommendation": "Use Reanimated for always-native animations (`import Animated from 'react-native-reanimated'`), or ensure every Animated.timing/spring/decay has `useNativeDriver: true` for native-thread execution.",
       "category": "Bugs",
       "framework": "react-native",
       "requires": ["react-native"],

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-prefer-reanimated.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-prefer-reanimated.regressions.test.ts
@@ -20,4 +20,33 @@ describe("react-native/rn-prefer-reanimated — regressions", () => {
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics.length).toBeGreaterThan(0);
   });
+
+  it("still flags Animated even with useNativeDriver (import-level heuristic)", () => {
+    const result = runRule(
+      rnPreferReanimated,
+      `import { useEffect, useState } from 'react';
+      import { Animated } from 'react-native';
+
+      export function NativePulse() {
+        const [opacity] = useState(() => new Animated.Value(1));
+        useEffect(() => {
+          const animation = Animated.loop(
+            Animated.timing(opacity, {
+              toValue: 0.7,
+              duration: 2000,
+              useNativeDriver: true,
+              isInteraction: false,
+            }),
+          );
+          animation.start();
+          return () => animation.stop();
+        }, [opacity]);
+        return <Animated.View style={{ opacity }} />;
+      }`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+    expect(result.diagnostics[0].message).toContain("may cause stutter");
+    expect(result.diagnostics[0].message).toContain("useNativeDriver: true");
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-prefer-reanimated.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-prefer-reanimated.ts
@@ -14,7 +14,7 @@ export const rnPreferReanimated = defineRule({
   requires: ["react-native"],
   severity: "warn",
   recommendation:
-    "Use `import Animated from 'react-native-reanimated'` so animations run on the UI thread instead of the JS thread, which keeps them smooth.",
+    "Use Reanimated for always-native animations (`import Animated from 'react-native-reanimated'`), or ensure every Animated.timing/spring/decay has `useNativeDriver: true` for native-thread execution.",
   create: (context: RuleContext) => ({
     ImportDeclaration(node: EsTreeNodeOfType<"ImportDeclaration">) {
       if (node.source?.value !== "react-native") return;
@@ -26,14 +26,14 @@ export const rnPreferReanimated = defineRule({
         const importedName = getImportedName(specifier);
         if (!importedName || !JS_THREAD_ANIMATION_IMPORTS.has(importedName)) continue;
 
-        const suggestion =
+        const message =
           importedName === "LayoutAnimation"
-            ? "Your users see stutter when LayoutAnimation runs on the JS thread."
-            : "Your users see stutter when Animated from react-native runs on the JS thread.";
+            ? "LayoutAnimation from react-native may cause stutter when it runs on the JS thread."
+            : "Animated from react-native may cause stutter when animations run on the JS thread without `useNativeDriver: true`.";
 
         context.report({
           node: specifier,
-          message: suggestion,
+          message,
         });
       }
     },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #1784

The `rn-prefer-reanimated` rule was claiming definite JS-thread execution even when code explicitly uses `useNativeDriver: true` for native-thread animations.

## Changes

- **Message:** Changed from definite claim to conditional framing  
- **Recommendation:** Updated to mention both Reanimated and useNativeDriver options
- **Detection:** Remains import-level (no behavioral change)
- **Tests:** Added regression test with native-driver example

## Scope

The rule remains import-level by design. This fix addresses the misleading message, not the detection granularity.

The message now acknowledges that Animated CAN run on the JS thread (conditional), mentions the `useNativeDriver: true` option, and doesn't claim definite JS-thread execution when it's not provable.

## Testing

- Unit tests pass  
- Manual repro confirms message change
- Parity validation running
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5c098359-ca2c-42d8-9a67-26966c21585f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5c098359-ca2c-42d8-9a67-26966c21585f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

