### PR TITLE
fix: allow conditional padding with static branches in rn-scrollview-dynamic-padding

### DIFF
--- a/.changeset/fix-1785-static-conditional-padding.md
+++ b/.changeset/fix-1785-static-conditional-padding.md
@@ -1,0 +1,9 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Fix false positive in `rn-scrollview-dynamic-padding` for conditionals with static branches.
+
+The rule now recognizes ConditionalExpressions (ternaries) where both branches are static values (e.g., `hasHeader ? 0 : 16`). These are fundamentally different from truly dynamic values like `keyboardHeight` which can take unpredictable runtime values. A toggle between two fixed values is more predictable and less likely to cause the jarring "rows jump" behavior the rule is concerned about.
+
+Fixes #1785

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-scrollview-dynamic-padding.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-scrollview-dynamic-padding.regressions.test.ts
@@ -201,4 +201,79 @@ const C = () => <ScrollView contentContainerStyle={{ paddingTop: -OVERLAP }} />;
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toEqual([]);
   });
+
+  it("stays silent on a conditional with both static branches", () => {
+    const result = runRule(
+      rnScrollviewDynamicPadding,
+      `const C = ({ hasHeader }) => <ScrollView contentContainerStyle={{ paddingTop: hasHeader ? 0 : 16 }} />;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent on a conditional with both static const branches", () => {
+    const result = runRule(
+      rnScrollviewDynamicPadding,
+      `const HEADER_SPACING = 0;
+const DEFAULT_SPACING = 16;
+const C = ({ hasHeader }) => <ScrollView contentContainerStyle={{ paddingTop: hasHeader ? HEADER_SPACING : DEFAULT_SPACING }} />;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent on a nested conditional with all static branches", () => {
+    const result = runRule(
+      rnScrollviewDynamicPadding,
+      `const C = ({ mode, hasHeader }) => <ScrollView contentContainerStyle={{ paddingTop: mode === 'compact' ? 0 : (hasHeader ? 8 : 16) }} />;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still flags a conditional where consequent is dynamic", () => {
+    const result = runRule(
+      rnScrollviewDynamicPadding,
+      `const C = ({ keyboardHeight, hasHeader }) => <ScrollView contentContainerStyle={{ paddingBottom: hasHeader ? keyboardHeight : 16 }} />;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("still flags a conditional where alternate is dynamic", () => {
+    const result = runRule(
+      rnScrollviewDynamicPadding,
+      `const C = ({ keyboardHeight, hasHeader }) => <ScrollView contentContainerStyle={{ paddingBottom: hasHeader ? 0 : keyboardHeight }} />;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("still flags a conditional where both branches are dynamic", () => {
+    const result = runRule(
+      rnScrollviewDynamicPadding,
+      `const C = ({ keyboardHeight, insets }) => <ScrollView contentContainerStyle={{ paddingBottom: keyboardHeight > 0 ? keyboardHeight : insets.bottom }} />;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("stays silent on FlashList with conditional static padding based on header presence (#1785)", () => {
+    const result = runRule(
+      rnScrollviewDynamicPadding,
+      `import { FlashList } from '@shopify/flash-list';
+import { Text } from 'react-native';
+
+const Grid = ({ ListHeaderComponent }) => (
+  <FlashList
+    data={[]}
+    renderItem={() => <Text>Item</Text>}
+    ListHeaderComponent={ListHeaderComponent}
+    contentContainerStyle={{ paddingTop: ListHeaderComponent ? 0 : 16 }}
+  />
+);`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-scrollview-dynamic-padding.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-scrollview-dynamic-padding.ts
@@ -80,6 +80,12 @@ const isStaticStyleValue = (value: EsTreeNode, resolutionDepth = 0): boolean => 
       isStaticStyleValue(value.right, resolutionDepth + 1)
     );
   }
+  if (isNodeOfType(value, "ConditionalExpression")) {
+    return (
+      isStaticStyleValue(value.consequent, resolutionDepth + 1) &&
+      isStaticStyleValue(value.alternate, resolutionDepth + 1)
+    );
+  }
   if (!isNodeOfType(value, "Identifier")) return false;
   const binding = findVariableInitializer(value, value.name);
   if (!binding?.initializer || !isConstDeclaredBinding(binding)) return false;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Root Cause

The `rn-scrollview-dynamic-padding` rule's `isStaticStyleValue` function didn't handle `ConditionalExpression` (ternary operators). When it encountered code like `hasHeader ? 0 : 16`, it returned `false` and flagged it as dynamic padding, even though both branches are static literals.

The rule's concern is unpredictable runtime values like `keyboardHeight` that cause jarring visual jumps when they change. However, a ternary that toggles between two static values (e.g., `0` and `16`) is fundamentally different from truly dynamic values. Even if the condition changes, the padding only switches between two fixed, predictable values.

## Scope Decision

**What was gated:** ConditionalExpressions where **both** the consequent and alternate branches are static values (literals, constants, design tokens, arithmetic over static values, etc.).

**What was deliberately left:** ConditionalExpressions where **either** branch contains dynamic values like `keyboardHeight`, `insets.bottom`, or other runtime-dependent expressions. These are still correctly flagged as they can cause the visual jump behavior the rule is designed to catch.

## Examples

### Now passes (static branches):
```tsx
// Both branches are literals
<ScrollView contentContainerStyle={{ paddingTop: hasHeader ? 0 : 16 }} />

// Both branches are constants
const HEADER_SPACING = 0;
const DEFAULT_SPACING = 16;
<ScrollView contentContainerStyle={{ paddingTop: hasHeader ? HEADER_SPACING : DEFAULT_SPACING }} />

// Nested conditionals, all static
<ScrollView contentContainerStyle={{ paddingTop: mode === 'compact' ? 0 : (hasHeader ? 8 : 16) }} />
```

### Still correctly flagged (dynamic values):
```tsx
// Dynamic consequent
<ScrollView contentContainerStyle={{ paddingBottom: hasKeyboard ? keyboardHeight : 16 }} />

// Dynamic alternate
<ScrollView contentContainerStyle={{ paddingBottom: hasHeader ? 0 : insets.bottom }} />

// Both branches dynamic
<ScrollView contentContainerStyle={{ paddingBottom: condition ? keyboardHeight : insets.bottom }} />
```

## Testing

### Unit Tests
Added comprehensive regression tests covering:
- Conditionals with both static literal branches
- Conditionals with both static constant branches
- Nested conditionals with all static branches
- Conditionals with one dynamic branch (still flags correctly)
- Conditionals with both dynamic branches (still flags correctly)
- The exact reported FlashList + ListHeaderComponent pattern

All 26 rule tests pass.

### Full Test Suite
All 30,000+ tests pass across all packages (core, api, react-doctor, oxlint-plugin-react-doctor, eslint-plugin-react-doctor, fuzz, evals).

### Reproduction
The reported case in #1785 now passes cleanly with zero diagnostics.

## Validation Note

Full `rde parity` validation against the 8000+ repo corpus was initiated but not completed due to time constraints (would take several hours). The fix is conservatively scoped and comprehensively unit tested. Recommend running parity before merge to validate no unexpected cross-repo changes.

## Changes
- Extended `isStaticStyleValue` to handle `ConditionalExpression` by checking if both branches are static
- Added 7 new regression tests including the exact reported pattern
- Added changeset

Closes #1785
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a9ed7152-5cb4-4d53-ba0b-9bfd1cdf3b66?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a9ed7152-5cb4-4d53-ba0b-9bfd1cdf3b66&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

