### PR TITLE
fix(rn-scrollview-dynamic-padding): treat conditionals between static values as static

### DIFF
--- a/.changeset/fix-1785-static-conditional-padding.md
+++ b/.changeset/fix-1785-static-conditional-padding.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Fix an `rn-scrollview-dynamic-padding` false positive on `contentContainerStyle` padding that picks between two static values (`hasHeader ? 0 : 16`), and scope the recommendation to iOS `contentInset`.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/core-rule-registry-data.json
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/core-rule-registry-data.json
@@ -12063,7 +12063,7 @@
       "id": "rn-scrollview-dynamic-padding",
       "title": "Dynamic padding on contentContainerStyle",
       "severity": "warn",
-      "recommendation": "Use `contentInset={{ bottom: dynamicValue }}` so the OS shifts the content instead of relaying it out, which avoids the jump.",
+      "recommendation": "Move the changing value to the matching `contentInset` edge (`contentInset={{ bottom: keyboardHeight }}`, iOS-only) so the OS shifts the content instead of relaying it out, and keep static spacing in `contentContainerStyle`.",
       "category": "Bugs",
       "framework": "react-native",
       "requires": ["react-native"],

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-scrollview-dynamic-padding.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-scrollview-dynamic-padding.regressions.test.ts
@@ -201,4 +201,72 @@ const C = () => <ScrollView contentContainerStyle={{ paddingTop: -OVERLAP }} />;
     expect(result.parseErrors).toEqual([]);
     expect(result.diagnostics).toEqual([]);
   });
+
+  it("stays silent on a conditional between two static literals keyed off a prop", () => {
+    const result = runRule(
+      rnScrollviewDynamicPadding,
+      `const List = ({ ListHeaderComponent, ...props }) => (
+  <FlashList
+    ListHeaderComponent={ListHeaderComponent}
+    contentContainerStyle={{ paddingTop: ListHeaderComponent ? 0 : 16 }}
+    {...props}
+  />
+);`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent on a conditional between two static consts", () => {
+    const result = runRule(
+      rnScrollviewDynamicPadding,
+      `const COMPACT_PADDING = 8;
+const REGULAR_PADDING = 16;
+const C = ({ compact }) => <ScrollView contentContainerStyle={{ paddingBottom: compact ? COMPACT_PADDING : REGULAR_PADDING }} />;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("stays silent on nested conditionals whose leaves are all static", () => {
+    const result = runRule(
+      rnScrollviewDynamicPadding,
+      `const C = ({ hasHeader, dense }) => <ScrollView contentContainerStyle={{ paddingTop: hasHeader ? 0 : dense ? 8 : 16 }} />;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("still flags a conditional whose consequent is dynamic", () => {
+    const result = runRule(
+      rnScrollviewDynamicPadding,
+      `const C = ({ keyboardHeight, isKeyboardOpen }) => <ScrollView contentContainerStyle={{ paddingBottom: isKeyboardOpen ? keyboardHeight : 0 }} />;`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("still flags a conditional whose alternate is dynamic", () => {
+    const result = runRule(
+      rnScrollviewDynamicPadding,
+      `const C = ({ hasTabBar }) => {
+  const insets = useSafeAreaInsets();
+  return <ScrollView contentContainerStyle={{ paddingBottom: hasTabBar ? 0 : insets.bottom }} />;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
+
+  it("still flags a conditional whose branches are both dynamic", () => {
+    const result = runRule(
+      rnScrollviewDynamicPadding,
+      `const C = ({ keyboardHeight, isKeyboardOpen }) => {
+  const insets = useSafeAreaInsets();
+  return <ScrollView contentContainerStyle={{ paddingBottom: isKeyboardOpen ? keyboardHeight : insets.bottom }} />;
+};`,
+    );
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-scrollview-dynamic-padding.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-native/rn-scrollview-dynamic-padding.ts
@@ -54,10 +54,12 @@ const isSpacingTokenExpression = (
 
 // A value is "static" when it can't change between renders: any literal
 // (`16`, `"10%"`), an expression-free template literal, unary minus /
-// arithmetic over static values (`BASE + 8`), or an identifier bound by a
-// `const` declaration whose initializer is itself static
-// (`const EXTRA = TAB_BAR_HEIGHT + 8`). `let` / `var` bindings can be
-// reassigned after declaration, and state / hook / prop values
+// arithmetic over static values (`BASE + 8`), a conditional whose two
+// branches are both static (`hasHeader ? 0 : 16` picks between two
+// design-time values rather than tracking a runtime measurement), or an
+// identifier bound by a `const` declaration whose initializer is itself
+// static (`const EXTRA = TAB_BAR_HEIGHT + 8`). `let` / `var` bindings can
+// be reassigned after declaration, and state / hook / prop values
 // (keyboardHeight, insets.bottom) never resolve to a static initializer,
 // so all of those still fire.
 const isStaticStyleValue = (value: EsTreeNode, resolutionDepth = 0): boolean => {
@@ -80,6 +82,12 @@ const isStaticStyleValue = (value: EsTreeNode, resolutionDepth = 0): boolean => 
       isStaticStyleValue(value.right, resolutionDepth + 1)
     );
   }
+  if (isNodeOfType(value, "ConditionalExpression")) {
+    return (
+      isStaticStyleValue(value.consequent, resolutionDepth + 1) &&
+      isStaticStyleValue(value.alternate, resolutionDepth + 1)
+    );
+  }
   if (!isNodeOfType(value, "Identifier")) return false;
   const binding = findVariableInitializer(value, value.name);
   if (!binding?.initializer || !isConstDeclaredBinding(binding)) return false;
@@ -99,7 +107,7 @@ export const rnScrollviewDynamicPadding = defineRule({
   requires: ["react-native"],
   severity: "warn",
   recommendation:
-    "Use `contentInset={{ bottom: dynamicValue }}` so the OS shifts the content instead of relaying it out, which avoids the jump.",
+    "Move the changing value to the matching `contentInset` edge (`contentInset={{ bottom: keyboardHeight }}`, iOS-only) so the OS shifts the content instead of relaying it out, and keep static spacing in `contentContainerStyle`.",
   create: (context: RuleContext) => ({
     JSXOpeningElement(node: EsTreeNodeOfType<"JSXOpeningElement">) {
       const elementName = resolveJsxElementName(node);


### PR DESCRIPTION
## Summary

Closes #1785. `contentContainerStyle={{ paddingTop: ListHeaderComponent ? 0 : 16 }}` was reported as "changing padding" even though both outcomes are design-time constants; the rule exists for values that track a runtime measurement (`keyboardHeight`, `insets.bottom`) and reflow the list every time they move.

`isStaticStyleValue` now accepts a `ConditionalExpression` when **both** branches are themselves static (recursing with the existing depth budget, so nested ternaries and const-bound branches work):

```ts
if (isNodeOfType(value, "ConditionalExpression")) {
  return isStaticStyleValue(value.consequent, depth + 1) && isStaticStyleValue(value.alternate, depth + 1);
}
```

This is not a prop-based blanket exemption: `isKeyboardOpen ? keyboardHeight : 0`, `hasTabBar ? 0 : insets.bottom`, and two-dynamic-branch ternaries all still report (covered by new tests, alongside the exact `FlashList` repro, static-const branches, and a nested static ternary).

Also reworded the recommendation: the old text (`contentInset={{ bottom: dynamicValue }}`) implied a cross-platform drop-in that also covered the top edge. It now says to move the changing value to the matching `contentInset` edge, notes that `contentInset` is iOS-only, and to keep static spacing in `contentContainerStyle`. `core-rule-registry-data.json` is regenerated for that string. Changeset added for `oxlint-plugin-react-doctor`.

Supersedes the auto-triage draft #1789.

Link to Devin session: https://app.devin.ai/sessions/3401e96268dc4245bf9a058d631ccc36
Open in Devin Desktop: https://app.devin.ai/desktop/session/3401e96268dc4245bf9a058d631ccc36?variant=devin
Requested by: @aidenybai