### PR TITLE
fix(query-mutation-missing-invalidation): accept a Zustand store re-synced from an awaited fetch

### DIFF
--- a/.changeset/fix-1786-zustand-reconciliation.md
+++ b/.changeset/fix-1786-zustand-reconciliation.md
@@ -1,0 +1,5 @@
+---
+"oxlint-plugin-react-doctor": patch
+---
+
+Fix a `query-mutation-missing-invalidation` false positive when a mutation re-syncs a Zustand store from an awaited server fetch, without exempting unrelated Zustand writes.

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-query/query-mutation-missing-invalidation.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-query/query-mutation-missing-invalidation.regressions.test.ts
@@ -364,4 +364,119 @@ describe("tanstack-query/query-mutation-missing-invalidation — regressions", (
 
     expect(result.diagnostics).toHaveLength(0);
   });
+
+  it("stays silent when a helper re-syncs a Zustand store from an awaited fetch", () => {
+    const result = runRule(
+      queryMutationMissingInvalidation,
+      `import { useMutation } from "@tanstack/react-query";
+      import { create } from "zustand";
+
+      export const useMembership = create(() => ({ tier: "free" }));
+
+      async function reconcileMembership() {
+        const membership = await getMembership();
+        useMembership.setState(membership);
+      }
+
+      export function usePurchase() {
+        return useMutation({
+          mutationFn: async () => {
+            await purchase();
+            await reconcileMembership();
+          },
+        });
+      }`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("stays silent when onSuccess writes an awaited refetch into a Zustand store", () => {
+    const result = runRule(
+      queryMutationMissingInvalidation,
+      `import { useMutation } from "@tanstack/react-query";
+      import { createStore } from "zustand/vanilla";
+
+      const membershipStore = createStore(() => ({ tier: "free" }));
+
+      export function usePurchase() {
+        return useMutation({
+          mutationFn: purchase,
+          onSuccess: async () => {
+            membershipStore.setState({ membership: await getMembership() });
+          },
+        });
+      }`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("still flags a Zustand write that is not fed by an awaited fetch", () => {
+    const result = runRule(
+      queryMutationMissingInvalidation,
+      `import { useMutation } from "@tanstack/react-query";
+      import { create } from "zustand";
+
+      export const useCheckoutUi = create(() => ({ isOpen: false }));
+
+      export function usePurchase() {
+        return useMutation({
+          mutationFn: async () => {
+            await purchase();
+            useCheckoutUi.setState({ isOpen: false });
+          },
+        });
+      }`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a Zustand write of a value computed without awaiting", () => {
+    const result = runRule(
+      queryMutationMissingInvalidation,
+      `import { useMutation } from "@tanstack/react-query";
+      import { create } from "zustand";
+
+      export const useMembership = create(() => ({ tier: "free" }));
+
+      export function usePurchase() {
+        return useMutation({
+          mutationFn: async (tier) => {
+            await purchase(tier);
+            const optimistic = { tier };
+            useMembership.setState(optimistic);
+          },
+        });
+      }`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it("still flags a setState on something that is not a Zustand store", () => {
+    const result = runRule(
+      queryMutationMissingInvalidation,
+      `import { useMutation } from "@tanstack/react-query";
+
+      const membershipCache = createCache();
+
+      export function usePurchase() {
+        return useMutation({
+          mutationFn: async () => {
+            await purchase();
+            membershipCache.setState(await getMembership());
+          },
+        });
+      }`,
+    );
+
+    expect(result.parseErrors).toEqual([]);
+    expect(result.diagnostics).toHaveLength(1);
+  });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-query/query-mutation-missing-invalidation.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/tanstack-query/query-mutation-missing-invalidation.ts
@@ -10,6 +10,10 @@ import { defineRule } from "../../utils/define-rule.js";
 import { enclosingComponentOrHookName } from "../../utils/enclosing-component-or-hook-name.js";
 import { flattenCalleeName } from "../../utils/flatten-callee-name.js";
 import { getCalleeName } from "../../utils/get-callee-name.js";
+import { getStaticPropertyName } from "../../utils/get-static-property-name.js";
+import { resolveConstIdentifierAlias } from "../../utils/resolve-const-identifier-alias.js";
+import { resolveZustandStoreFactoryCall } from "../../utils/resolve-zustand-api.js";
+import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import { tokenizeIdentifierWords } from "../../utils/tokenize-identifier-words.js";
 import { walkAst } from "../../utils/walk-ast.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
@@ -32,6 +36,7 @@ const MUTATION_LIFECYCLE_CALLBACK_NAMES = new Set([
 ]);
 const FULL_PAGE_NAVIGATION_METHODS = new Set(["assign", "reload", "replace"]);
 const MAX_HELPER_RESOLUTION_DEPTH = 3;
+const ZUSTAND_SET_STATE_METHOD = "setState";
 
 // Words that mark a mutation as read-style: it fetches, checks, or produces
 // something ephemeral (a download URL, a validation verdict, a pairing code,
@@ -201,6 +206,47 @@ const isFullPageNavigation = (node: EsTreeNode): boolean => {
   return false;
 };
 
+const isZustandStoreIdentifier = (node: EsTreeNode, scopes: ScopeAnalysis): boolean => {
+  const symbol = resolveConstIdentifierAlias(stripParenExpression(node), scopes);
+  if (symbol?.kind !== "const" || !symbol.initializer) return false;
+  const initializer = stripParenExpression(symbol.initializer);
+  return (
+    isNodeOfType(initializer, "CallExpression") &&
+    resolveZustandStoreFactoryCall(initializer, scopes) !== null
+  );
+};
+
+const isAwaitedValue = (node: EsTreeNode, scopes: ScopeAnalysis): boolean => {
+  const value = stripParenExpression(node);
+  if (isNodeOfType(value, "AwaitExpression")) return true;
+  if (isNodeOfType(value, "ObjectExpression")) {
+    return value.properties.some(
+      (property) => isNodeOfType(property, "Property") && isAwaitedValue(property.value, scopes),
+    );
+  }
+  if (!isNodeOfType(value, "Identifier")) return false;
+  const symbol = resolveConstIdentifierAlias(value, scopes, true);
+  return Boolean(
+    symbol?.initializer &&
+    isNodeOfType(stripParenExpression(symbol.initializer), "AwaitExpression"),
+  );
+};
+
+// `useMembership.setState(await getMembership())` re-syncs the Zustand store
+// the UI reads from, so no cached data is left stale. A store write not fed
+// by an awaited fetch (`useUi.setState({ open: false })`) still flags.
+const isZustandServerStateSync = (
+  node: EsTreeNodeOfType<"CallExpression">,
+  scopes: ScopeAnalysis,
+): boolean => {
+  const callee = stripParenExpression(node.callee);
+  if (!isNodeOfType(callee, "MemberExpression")) return false;
+  if (getStaticPropertyName(callee) !== ZUSTAND_SET_STATE_METHOD) return false;
+  if (!isZustandStoreIdentifier(callee.object, scopes)) return false;
+  const nextState = node.arguments[0];
+  return Boolean(nextState && isAwaitedValue(nextState, scopes));
+};
+
 const mutationResultBindingName = (
   mutationCall: EsTreeNodeOfType<"CallExpression">,
 ): string | null => {
@@ -311,6 +357,7 @@ const createCacheUpdateDetector = (scopes: ScopeAnalysis): CacheUpdateDetector =
 
     if (isNodeOfType(node, "CallExpression")) {
       if (doesCallableSyncCache(node.callee, remainingDepth)) return true;
+      if (isZustandServerStateSync(node, scopes)) return true;
       // Handing the query client to a helper (`fetchDetails(queryClient)`)
       // delegates the cache update to it.
       return (node.arguments ?? []).some((argument) => isQueryClientValue(argument, scopes));


### PR DESCRIPTION
## Summary

Closes #1786. A mutation whose follow-up is `await purchase(); await reconcileMembership()` — where the helper does `const membership = await getMembership(); useMembership.setState(membership)` — was reported as leaving stale data, even though the UI reads from that Zustand store and the fresh server state was just written into it.

The cache-update detector gains one more accepted shape, checked per `CallExpression` inside `mutationFn` / lifecycle callbacks / same-file helpers (the existing helper-resolution path already walks into `reconcileMembership`):

```ts
isZustandServerStateSync(call):
  callee is `<store>.setState`
  && <store> resolves (through const aliases) to a `create` / `createStore` / `createWithEqualityFn` call from zustand   // resolveZustandStoreFactoryCall
  && arguments[0] is an awaited value:
       `await getMembership()`
     | identifier whose (possibly destructured) const initializer is an AwaitExpression
     | object literal with at least one such property (`{ membership: await getMembership() }`, `{ membership }`)
```

What still reports (all covered by new tests):
- `useCheckoutUi.setState({ isOpen: false })` after `await purchase()` — a UI write, not fed by a fetch.
- `const optimistic = { tier }; useMembership.setState(optimistic)` — no awaited data behind the value.
- `membershipCache.setState(await getMembership())` where `membershipCache` is not a zustand store.

Not included on purpose: `onSuccess: (data) => store.setState(data)` (a callback parameter, not an awaited value) — happy to widen in a follow-up if desired. Changeset added for `oxlint-plugin-react-doctor`.

Supersedes the auto-triage draft #1788.

Link to Devin session: https://app.devin.ai/sessions/3401e96268dc4245bf9a058d631ccc36
Open in Devin Desktop: https://app.devin.ai/desktop/session/3401e96268dc4245bf9a058d631ccc36?variant=devin
Requested by: @aidenybai