### PR TITLE
test: stabilize no-boolean-toggle scaling guard on slow runners

### DIFF
--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-boolean-toggle-without-functional-update.performance.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-boolean-toggle-without-functional-update.performance.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vite-plus/test";
+import { runRule } from "../../../test-utils/run-rule.js";
+import { noBooleanToggleWithoutFunctionalUpdate } from "./no-boolean-toggle-without-functional-update.js";
+
+const SMALL_SETTER_COUNT = 2_000;
+const LARGE_SETTER_COUNT = 10_000;
+const MEASUREMENT_SAMPLE_COUNT = 5;
+const MAXIMUM_SCALING_MULTIPLIER = 18;
+
+const buildAwaitedTogglesSource = (setterCount: number): string =>
+  `const C=()=>{const[open,setOpen]=useState(false);const run=async()=>{await load();${"setOpen(!open);".repeat(setterCount)}}}`;
+
+const measureDuration = (source: string, setterCount: number): number => {
+  const startedAt = process.hrtime.bigint();
+  const result = runRule(noBooleanToggleWithoutFunctionalUpdate, source);
+  const duration = Number(process.hrtime.bigint() - startedAt);
+  expect(result.parseErrors).toEqual([]);
+  expect(result.diagnostics).toHaveLength(setterCount);
+  return duration;
+};
+
+const medianDuration = (durations: readonly number[]): number => {
+  const sortedDurations = [...durations].sort(
+    (firstDuration, secondDuration) => firstDuration - secondDuration,
+  );
+  return sortedDurations[Math.floor(sortedDurations.length / 2)] ?? Number.POSITIVE_INFINITY;
+};
+
+describe("no-boolean-toggle-without-functional-update performance", () => {
+  it("caches await reachability across many setters", () => {
+    const smallSource = buildAwaitedTogglesSource(SMALL_SETTER_COUNT);
+    const largeSource = buildAwaitedTogglesSource(LARGE_SETTER_COUNT);
+    measureDuration(smallSource, SMALL_SETTER_COUNT);
+    measureDuration(largeSource, LARGE_SETTER_COUNT);
+    const smallDurations: number[] = [];
+    const largeDurations: number[] = [];
+    // Interleaving keeps both sizes under the same runner load, and the median
+    // (unlike the minimum) cannot be won by a single quiet window that only a
+    // short run is brief enough to fit inside.
+    for (let sampleIndex = 0; sampleIndex < MEASUREMENT_SAMPLE_COUNT; sampleIndex += 1) {
+      smallDurations.push(measureDuration(smallSource, SMALL_SETTER_COUNT));
+      largeDurations.push(measureDuration(largeSource, LARGE_SETTER_COUNT));
+    }
+    expect(medianDuration(largeDurations)).toBeLessThan(
+      medianDuration(smallDurations) * MAXIMUM_SCALING_MULTIPLIER,
+    );
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-boolean-toggle-without-functional-update.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-boolean-toggle-without-functional-update.test.ts
@@ -2,6 +2,11 @@ import { describe, expect, it } from "vite-plus/test";
 import { runRule } from "../../../test-utils/run-rule.js";
 import { noBooleanToggleWithoutFunctionalUpdate } from "./no-boolean-toggle-without-functional-update.js";
 
+const SMALL_SETTER_COUNT = 2_000;
+const LARGE_SETTER_COUNT = 10_000;
+const MEASUREMENT_SAMPLE_COUNT = 5;
+const MAXIMUM_SCALING_MULTIPLIER = 18;
+
 describe("no-boolean-toggle-without-functional-update", () => {
   it("flags setIsOpen(!isOpen) inside a setTimeout", () => {
     const result = runRule(
@@ -545,20 +550,24 @@ describe("no-boolean-toggle-without-functional-update", () => {
   it("caches await reachability across many setters", () => {
     const buildSource = (setterCount: number): string =>
       `const C=()=>{const[open,setOpen]=useState(false);const run=async()=>{await load();${"setOpen(!open);".repeat(setterCount)}}}`;
-    runRule(noBooleanToggleWithoutFunctionalUpdate, buildSource(100));
-    const measureFastestDuration = (setterCount: number): number => {
-      let fastestDuration = Number.POSITIVE_INFINITY;
-      for (let repetition = 0; repetition < 3; repetition += 1) {
-        const start = performance.now();
-        const result = runRule(noBooleanToggleWithoutFunctionalUpdate, buildSource(setterCount));
-        fastestDuration = Math.min(fastestDuration, performance.now() - start);
-        expect(result.diagnostics).toHaveLength(setterCount);
-      }
-      return fastestDuration;
+    const smallSource = buildSource(SMALL_SETTER_COUNT);
+    const largeSource = buildSource(LARGE_SETTER_COUNT);
+    const measureDuration = (source: string, setterCount: number): number => {
+      const startedAt = performance.now();
+      const result = runRule(noBooleanToggleWithoutFunctionalUpdate, source);
+      const duration = performance.now() - startedAt;
+      expect(result.diagnostics).toHaveLength(setterCount);
+      return duration;
     };
-    const smallDuration = measureFastestDuration(2_000);
-    const largeDuration = measureFastestDuration(10_000);
-    expect(largeDuration).toBeLessThan(smallDuration * 18);
+    measureDuration(smallSource, SMALL_SETTER_COUNT);
+    measureDuration(largeSource, LARGE_SETTER_COUNT);
+    let smallDuration = Number.POSITIVE_INFINITY;
+    let largeDuration = Number.POSITIVE_INFINITY;
+    for (let sampleIndex = 0; sampleIndex < MEASUREMENT_SAMPLE_COUNT; sampleIndex += 1) {
+      smallDuration = Math.min(smallDuration, measureDuration(smallSource, SMALL_SETTER_COUNT));
+      largeDuration = Math.min(largeDuration, measureDuration(largeSource, LARGE_SETTER_COUNT));
+    }
+    expect(largeDuration).toBeLessThan(smallDuration * MAXIMUM_SCALING_MULTIPLIER);
   });
 
   it("proves cleanup identity, correlated paths, and render-time ref freshness", () => {

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-boolean-toggle-without-functional-update.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/state-and-effects/no-boolean-toggle-without-functional-update.test.ts
@@ -2,11 +2,6 @@ import { describe, expect, it } from "vite-plus/test";
 import { runRule } from "../../../test-utils/run-rule.js";
 import { noBooleanToggleWithoutFunctionalUpdate } from "./no-boolean-toggle-without-functional-update.js";
 
-const SMALL_SETTER_COUNT = 2_000;
-const LARGE_SETTER_COUNT = 10_000;
-const MEASUREMENT_SAMPLE_COUNT = 5;
-const MAXIMUM_SCALING_MULTIPLIER = 18;
-
 describe("no-boolean-toggle-without-functional-update", () => {
   it("flags setIsOpen(!isOpen) inside a setTimeout", () => {
     const result = runRule(
@@ -545,29 +540,6 @@ describe("no-boolean-toggle-without-functional-update", () => {
       "const C=({flag})=>{const[open,setOpen]=useState(false);const run=async()=>{if(flag)await load();if(flag)return;setOpen(!open)};return run}",
     );
     expect(result.diagnostics).toHaveLength(0);
-  });
-
-  it("caches await reachability across many setters", () => {
-    const buildSource = (setterCount: number): string =>
-      `const C=()=>{const[open,setOpen]=useState(false);const run=async()=>{await load();${"setOpen(!open);".repeat(setterCount)}}}`;
-    const smallSource = buildSource(SMALL_SETTER_COUNT);
-    const largeSource = buildSource(LARGE_SETTER_COUNT);
-    const measureDuration = (source: string, setterCount: number): number => {
-      const startedAt = performance.now();
-      const result = runRule(noBooleanToggleWithoutFunctionalUpdate, source);
-      const duration = performance.now() - startedAt;
-      expect(result.diagnostics).toHaveLength(setterCount);
-      return duration;
-    };
-    measureDuration(smallSource, SMALL_SETTER_COUNT);
-    measureDuration(largeSource, LARGE_SETTER_COUNT);
-    let smallDuration = Number.POSITIVE_INFINITY;
-    let largeDuration = Number.POSITIVE_INFINITY;
-    for (let sampleIndex = 0; sampleIndex < MEASUREMENT_SAMPLE_COUNT; sampleIndex += 1) {
-      smallDuration = Math.min(smallDuration, measureDuration(smallSource, SMALL_SETTER_COUNT));
-      largeDuration = Math.min(largeDuration, measureDuration(largeSource, LARGE_SETTER_COUNT));
-    }
-    expect(largeDuration).toBeLessThan(smallDuration * MAXIMUM_SCALING_MULTIPLIER);
   });
 
   it("proves cleanup identity, correlated paths, and render-time ref freshness", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The `caches await reachability across many setters` scaling guard for `no-boolean-toggle-without-functional-update` flaked on the macOS CI leg ([run 34367296704](https://github.com/millionco/react-doctor/actions/runs/34367296704)): `expected 512.68 to be less than 465.20` — the 10k-setter run came out ~20× the 2k-setter run against an 18× bound.

The rule itself is linear (~12µs per setter, flat from 1k to 20k setters, under default and constrained V8 heap settings). The failure is the estimator: `min` over N wall-clock samples is biased toward the *shorter* input under intermittent runner contention. A ~25ms sample can land in a quiet scheduling window that a ~125ms sample never fits inside, so `min(large) / min(small)` inflates even though per-setter cost is unchanged. That is exactly the CI shape — the 2k run at idle speed (12.9µs/setter, same as a quiet machine) while all three 10k samples were 4× slower per setter. Reproduced locally by oversubscribing CPUs: the min-based ratio drifted from ~4.3× to 8.7× while the median ratio stayed at 4.4–5.7×.

Across the last 40 failed CI runs, every min-based scaling test in the plugin package flaked at least once (`no-derived-state` ×2, `no-tiny-text`, `no-mutate-then-set-or-return-same-reference`, this one); the median-based `effect-needs-cleanup.performance.test.ts` with comparable durations did not.

## Changes

- Keep the interleaved sampling from the first commit (each small sample is adjacent in time to a large one, so both see the same load) and take the **median** of each size instead of the minimum.
- Move the guard into `no-boolean-toggle-without-functional-update.performance.test.ts`, matching the other five scaling tests, so it runs in a fresh worker instead of after 36 unrelated tests in the same process.
- Sizes (2k / 10k) and the 18× bound are unchanged. With the await-proof cache disabled the ratio is ~25× (1.8s vs 45s), so the guard still trips on the regression it exists for.

## Verification

- New perf test: 3/3 idle, 5/5 with 8 busy loops on 4 cores.
- Rule test file: 36/36.
- Cache removed from the rule → `AssertionError: expected 45001018788 to be less than 32183702928` (then restored).
- `pnpm lint`, `pnpm format:check`, plugin `typecheck` all clean.

Test-only change; no changeset.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e3dffcb8-e4f6-4806-8b6d-3cac56a2eb2c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e3dffcb8-e4f6-4806-8b6d-3cac56a2eb2c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

