### PR TITLE
fix: make cache partition portable via git-relative paths

### DIFF
--- a/.changeset/1789170719-portable-cache-partition.md
+++ b/.changeset/1789170719-portable-cache-partition.md
@@ -1,0 +1,14 @@
+---
+"@react-doctor/core": patch
+---
+
+Make cache partition portable via git-relative paths
+
+Cache partition keys are now derived from git-relative project paths instead of absolute paths, enabling CI runners and local developer machines to share the same cache state when scanning the same logical project within a repository.
+
+The partition key resolution order is:
+1. `REACT_DOCTOR_CACHE_PARTITION` env var (explicit override)
+2. Git-relative path from repository root (when in a git repo)
+3. Absolute path (fallback for non-git projects)
+
+Fixes #1799

--- a/packages/core/src/utils/resolve-react-doctor-cache-dir.ts
+++ b/packages/core/src/utils/resolve-react-doctor-cache-dir.ts
@@ -3,15 +3,29 @@ import * as fs from "node:fs";
 import os from "node:os";
 import * as path from "node:path";
 import { CACHE_FILENAME_HASH_LENGTH_CHARS } from "../constants.js";
+import { findGitRepositoryRoot } from "./find-git-repository-root.js";
 
-// SHA-256 (not SHA-1) purely to name a per-project cache subdirectory — it's a
-// filesystem-safe digest of the path, never a security/identity hash.
-const projectCacheSubdir = (projectDirectory: string): string =>
-  crypto
+const resolveRelativeProjectPath = (projectDirectory: string): string | null => {
+  const explicitPartition = process.env["REACT_DOCTOR_CACHE_PARTITION"]?.trim();
+  if (explicitPartition) return explicitPartition;
+
+  const gitRoot = findGitRepositoryRoot(projectDirectory);
+  if (!gitRoot) return null;
+
+  const relativePath = path.relative(gitRoot, projectDirectory);
+  return relativePath || ".";
+};
+
+const projectCacheSubdir = (projectDirectory: string): string => {
+  const relativePath = resolveRelativeProjectPath(projectDirectory);
+  const pathToHash = relativePath ?? projectDirectory;
+
+  return crypto
     .createHash("sha256")
-    .update(projectDirectory)
+    .update(pathToHash)
     .digest("hex")
     .slice(0, CACHE_FILENAME_HASH_LENGTH_CHARS);
+};
 
 // Resolves the directory react-doctor's on-disk caches live in. Order:
 //   1. `REACT_DOCTOR_CACHE_DIR` — an operator/CI-pinned cache root. The GitHub
@@ -19,6 +33,10 @@ const projectCacheSubdir = (projectDirectory: string): string =>
 //      `actions/cache` across runs (the project-local `node_modules/.cache` is
 //      a fresh, SHA-scoped checkout in CI, so it never survives between commits).
 //      A per-project subdirectory keeps a batch scan's projects from colliding.
+//      The subdirectory name is a hash of the git-relative project path (when in
+//      a git repo) or `REACT_DOCTOR_CACHE_PARTITION` (when set), making the cache
+//      portable between CI and local checkouts of the same repository. Falls back
+//      to hashing the absolute path when neither is available.
 //   2. the project's `node_modules/.cache/react-doctor` (npm convention,
 //      project-local, cleaned by `node_modules` removal).
 //   3. a per-user, per-project subdirectory of the OS temp dir, when the

--- a/packages/core/tests/resolve-react-doctor-cache-dir.test.ts
+++ b/packages/core/tests/resolve-react-doctor-cache-dir.test.ts
@@ -6,16 +6,20 @@ import { resolveReactDoctorCacheDir } from "../src/utils/resolve-react-doctor-ca
 
 const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "rd-cache-dir-"));
 const originalCacheDirEnv = process.env["REACT_DOCTOR_CACHE_DIR"];
+const originalCachePartitionEnv = process.env["REACT_DOCTOR_CACHE_PARTITION"];
 
 afterEach(() => {
   if (originalCacheDirEnv === undefined) delete process.env["REACT_DOCTOR_CACHE_DIR"];
   else process.env["REACT_DOCTOR_CACHE_DIR"] = originalCacheDirEnv;
+  if (originalCachePartitionEnv === undefined) delete process.env["REACT_DOCTOR_CACHE_PARTITION"];
+  else process.env["REACT_DOCTOR_CACHE_PARTITION"] = originalCachePartitionEnv;
 });
 
 describe("resolveReactDoctorCacheDir", () => {
   it("honors REACT_DOCTOR_CACHE_DIR (the CI override) with a per-project subdir", () => {
     const overrideRoot = path.join(tempRoot, "ci-cache-root");
     process.env["REACT_DOCTOR_CACHE_DIR"] = overrideRoot;
+    delete process.env["REACT_DOCTOR_CACHE_PARTITION"];
     const projectA = path.join(tempRoot, "project-a");
     const projectB = path.join(tempRoot, "project-b");
     const dirA = resolveReactDoctorCacheDir(projectA);
@@ -29,8 +33,68 @@ describe("resolveReactDoctorCacheDir", () => {
     expect(resolveReactDoctorCacheDir(projectA)).toBe(dirA);
   });
 
+  it("uses git-relative path for cache partition when in a git repo", () => {
+    const overrideRoot = path.join(tempRoot, "git-aware-cache");
+    process.env["REACT_DOCTOR_CACHE_DIR"] = overrideRoot;
+    delete process.env["REACT_DOCTOR_CACHE_PARTITION"];
+
+    const gitRoot = path.join(tempRoot, "git-repo");
+    const gitDir = path.join(gitRoot, ".git");
+    fs.mkdirSync(gitDir, { recursive: true });
+
+    const projectInGit = path.join(gitRoot, "packages", "app");
+    fs.mkdirSync(projectInGit, { recursive: true });
+
+    const cacheDir = resolveReactDoctorCacheDir(projectInGit);
+    expect(cacheDir.startsWith(overrideRoot + path.sep)).toBe(true);
+
+    const anotherCloneRoot = path.join(tempRoot, "another-clone");
+    const anotherGitDir = path.join(anotherCloneRoot, ".git");
+    fs.mkdirSync(anotherGitDir, { recursive: true });
+    const sameRelativeProject = path.join(anotherCloneRoot, "packages", "app");
+    fs.mkdirSync(sameRelativeProject, { recursive: true });
+
+    const anotherCacheDir = resolveReactDoctorCacheDir(sameRelativeProject);
+    expect(path.basename(cacheDir)).toBe(path.basename(anotherCacheDir));
+  });
+
+  it("honors REACT_DOCTOR_CACHE_PARTITION for explicit partition key", () => {
+    const overrideRoot = path.join(tempRoot, "explicit-partition-cache");
+    process.env["REACT_DOCTOR_CACHE_DIR"] = overrideRoot;
+    process.env["REACT_DOCTOR_CACHE_PARTITION"] = "my-custom-partition";
+
+    const projectA = path.join(tempRoot, "arbitrary-path-a");
+    const projectB = path.join(tempRoot, "arbitrary-path-b");
+
+    const dirA = resolveReactDoctorCacheDir(projectA);
+    const dirB = resolveReactDoctorCacheDir(projectB);
+
+    expect(path.basename(dirA)).toBe(path.basename(dirB));
+  });
+
+  it("project at git root uses '.' as relative path", () => {
+    const overrideRoot = path.join(tempRoot, "git-root-cache");
+    process.env["REACT_DOCTOR_CACHE_DIR"] = overrideRoot;
+    delete process.env["REACT_DOCTOR_CACHE_PARTITION"];
+
+    const gitRoot = path.join(tempRoot, "standalone-project");
+    const gitDir = path.join(gitRoot, ".git");
+    fs.mkdirSync(gitDir, { recursive: true });
+
+    const cacheDir = resolveReactDoctorCacheDir(gitRoot);
+    expect(cacheDir.startsWith(overrideRoot + path.sep)).toBe(true);
+
+    const anotherClone = path.join(tempRoot, "another-standalone");
+    const anotherGitDir = path.join(anotherClone, ".git");
+    fs.mkdirSync(anotherGitDir, { recursive: true });
+
+    const anotherCacheDir = resolveReactDoctorCacheDir(anotherClone);
+    expect(path.basename(cacheDir)).toBe(path.basename(anotherCacheDir));
+  });
+
   it("falls back to node_modules/.cache/react-doctor when no override is set", () => {
     delete process.env["REACT_DOCTOR_CACHE_DIR"];
+    delete process.env["REACT_DOCTOR_CACHE_PARTITION"];
     const projectDir = path.join(tempRoot, "with-node-modules");
     fs.mkdirSync(path.join(projectDir, "node_modules"), { recursive: true });
     expect(resolveReactDoctorCacheDir(projectDir)).toBe(
@@ -40,6 +104,7 @@ describe("resolveReactDoctorCacheDir", () => {
 
   it("falls back to a user-scoped OS-temp per-project dir when there is no node_modules or override", () => {
     delete process.env["REACT_DOCTOR_CACHE_DIR"];
+    delete process.env["REACT_DOCTOR_CACHE_PARTITION"];
     const projectDir = path.join(tempRoot, "no-node-modules");
     fs.mkdirSync(projectDir, { recursive: true });
     const resolved = resolveReactDoctorCacheDir(projectDir);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Root Cause

The cache partition subdirectory was keyed by a hash of the **absolute** project path (`/home/runner/work/my-repo/packages/app` on CI vs `/Users/me/dev/my-repo/packages/app` locally), preventing cache sharing between environments even though the cached content itself (file-lint-cache.json, sidecar-lint-cache.json, supply-chain/*.json) is already fully relocatable and uses relative paths.

## Solution

Derive the cache partition from the **git-relative** project path when in a git repository. This makes the partition key identical across CI and local checkouts of the same logical project location.

Resolution order:
1. `REACT_DOCTOR_CACHE_PARTITION` env var (explicit override for edge cases)
2. Git-relative path from repository root (when `.git` is found)
3. Absolute path (fallback for non-git projects)

## Scope

- ✅ Changes only cache **directory naming**, not cache **contents or validation**
- ✅ Existing cache validation (content SHA, ruleset hash) remains unchanged
- ✅ No diagnostic behavior changes - this is pure infrastructure
- ✅ Backward compatible - falls back to absolute path when git root unavailable

## Testing

**Unit tests (comprehensive):**
- Git-relative path derivation for nested project directories
- Project at git root (uses `.` as relative path)
- Explicit `REACT_DOCTOR_CACHE_PARTITION` override
- Fallback to absolute path outside git repos
- Cache portability between different absolute paths with same git-relative location

**Integration:** All existing tests pass (typecheck, lint, full test suite)

**Parity testing:** Skipped - this is a cache infrastructure change that only affects where cache is stored, not what diagnostics are produced. The cache contents remain identical and all cache validation logic is unchanged. Parity would confirm zero diagnostic changes.

## Edge Cases Handled

- Project at repository root → uses `.` as relative path (consistent hash)
- Nested monorepo packages → each gets unique git-relative partition
- Non-git projects → graceful fallback to absolute path (existing behavior)
- Explicit partition override → highest priority for special environments

Closes #1799
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b94d4cf6-0166-4569-9c19-8fcb720f4db8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b94d4cf6-0166-4569-9c19-8fcb720f4db8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

