### PR TITLE
fix: avoid false positives for local use methods and 2D canvas loops

### DIFF
--- a/.changeset/quiet-local-methods-and-canvas.md
+++ b/.changeset/quiet-local-methods-and-canvas.md
@@ -1,0 +1,9 @@
+---
+"react-doctor": patch
+"oxlint-plugin-react-doctor": patch
+"eslint-plugin-react-doctor": patch
+---
+
+Stop reporting local service `.use()` methods as React hooks. Preserve diagnostics for React namespace calls, including aliases and CommonJS imports.
+
+Only recommend `setAnimationLoop` when a recursive animation frame callback renders through a known Three.js renderer. Leave independent 2D canvas and DOM loops alone, including files that also import Three.js.

--- a/packages/fuzz/corpus/regressions/rules-of-hooks--local-member-use.tsx
+++ b/packages/fuzz/corpus/regressions/rules-of-hooks--local-member-use.tsx
@@ -1,0 +1,10 @@
+// rule: rules-of-hooks
+// weakness: name-heuristic
+// source: https://github.com/millionco/react-doctor/issues/1797
+// verdict: pass
+declare const Service: {
+  use: (callback: (value: string) => unknown) => unknown;
+};
+export const fixture = async () => {
+  Service.use((value) => value);
+};

--- a/packages/fuzz/corpus/regressions/three-prefer-set-animation-loop--canvas-2d.tsx
+++ b/packages/fuzz/corpus/regressions/three-prefer-set-animation-loop--canvas-2d.tsx
@@ -1,0 +1,13 @@
+// rule: three-prefer-set-animation-loop
+// weakness: framework-gating
+// source: https://github.com/millionco/react-doctor/issues/1795
+// verdict: pass
+import { WebGLRenderer } from "three";
+const renderer = new WebGLRenderer();
+renderer.setSize(1, 1);
+const context = canvas.getContext("2d");
+const frame = () => {
+  context.fillRect(0, 0, 1, 1);
+  requestAnimationFrame(frame);
+};
+requestAnimationFrame(frame);

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/r3f/three-prefer-set-animation-loop.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/r3f/three-prefer-set-animation-loop.test.ts
@@ -29,7 +29,7 @@ describe("three-prefer-set-animation-loop", () => {
     expect(runRule(threePreferSetAnimationLoop, code).diagnostics).toHaveLength(1);
   });
 
-  it("reports a recursive loop that delegates rendering to an imported viewer", () => {
+  it("allows an imported viewer whose renderer cannot be resolved", () => {
     const code = `
       import { Viewer } from "./scene/viewer";
       const viewer = new Viewer(canvas);
@@ -40,7 +40,7 @@ describe("three-prefer-set-animation-loop", () => {
       }
       requestAnimationFrame(frame);
     `;
-    expect(runRule(threePreferSetAnimationLoop, code).diagnostics).toHaveLength(1);
+    expect(runRule(threePreferSetAnimationLoop, code).diagnostics).toHaveLength(0);
   });
 
   it("allows renderer-managed frames and unrelated or shadowed callbacks", () => {
@@ -67,5 +67,110 @@ describe("three-prefer-set-animation-loop", () => {
       requestAnimationFrame(runBuildChunk);
     `;
     expect(runRule(threePreferSetAnimationLoop, code).diagnostics).toHaveLength(0);
+  });
+});
+
+describe("three-prefer-set-animation-loop renderer provenance", () => {
+  it.each([
+    "",
+    'import { Vector3 } from "three";',
+    'import { Canvas } from "@react-three/fiber";',
+    'import { WebGLRenderer } from "three"; const renderer = new WebGLRenderer();',
+  ])("allows a 2D canvas loop with unrelated imports: %s", (declaration) => {
+    expect(
+      runRule(
+        threePreferSetAnimationLoop,
+        `
+      ${declaration}
+      const context = canvas.getContext("2d");
+      const frame = () => { context.fillRect(0, 0, 1, 1); requestAnimationFrame(frame); };
+      requestAnimationFrame(frame);
+    `,
+      ).diagnostics,
+    ).toHaveLength(0);
+  });
+
+  it.each([
+    'import { WebGLRenderer as Renderer } from "three";',
+    'import { WebGPURenderer as Renderer } from "three/webgpu";',
+    'const { WebGLRenderer: Renderer } = require("three");',
+  ])("reports a loop that calls a local rendering helper: %s", (declaration) => {
+    expect(
+      runRule(
+        threePreferSetAnimationLoop,
+        `
+      ${declaration}
+      const renderer = new Renderer();
+      const draw = () => renderer.render(scene, camera);
+      const frame = () => { draw(); window.requestAnimationFrame(frame); };
+      window.requestAnimationFrame(frame);
+    `,
+      ).diagnostics,
+    ).toHaveLength(1);
+  });
+
+  it("does not use an uncalled nested function as renderer evidence", () => {
+    expect(
+      runRule(
+        threePreferSetAnimationLoop,
+        `
+      import { WebGLRenderer } from "three";
+      const renderer = new WebGLRenderer();
+      const frame = () => {
+        const draw = () => renderer.render(scene, camera);
+        updateDom();
+        requestAnimationFrame(frame);
+      };
+      requestAnimationFrame(frame);
+    `,
+      ).diagnostics,
+    ).toHaveLength(0);
+  });
+
+  it("does not treat a local render method as a Three.js renderer", () => {
+    expect(
+      runRule(
+        threePreferSetAnimationLoop,
+        `
+      import { Vector3 } from "three";
+      const renderer = { render: () => updateDom() };
+      const frame = () => { renderer.render(); requestAnimationFrame(frame); };
+      requestAnimationFrame(frame);
+    `,
+      ).diagnostics,
+    ).toHaveLength(0);
+  });
+
+  it("reports only the Three.js loop when a file also animates a 2D canvas", () => {
+    const diagnostics = runRule(
+      threePreferSetAnimationLoop,
+      `
+      import { WebGLRenderer } from "three";
+      const renderer = new WebGLRenderer();
+      const context = canvas.getContext("2d");
+      const draw2d = () => { context.fillRect(0, 0, 1, 1); requestAnimationFrame(draw2d); };
+      const draw3d = () => { renderer.render(scene, camera); requestAnimationFrame(draw3d); };
+      requestAnimationFrame(draw2d);
+      requestAnimationFrame(draw3d);
+    `,
+    ).diagnostics;
+    expect(diagnostics).toHaveLength(1);
+  });
+
+  it("allows conditional scheduling even when the callback renders with Three.js", () => {
+    expect(
+      runRule(
+        threePreferSetAnimationLoop,
+        `
+      import { WebGLRenderer } from "three";
+      const renderer = new WebGLRenderer();
+      const frame = () => {
+        renderer.render(scene, camera);
+        if (needsUpdate) requestAnimationFrame(frame);
+      };
+      requestAnimationFrame(frame);
+    `,
+      ).diagnostics,
+    ).toHaveLength(0);
   });
 });

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/r3f/three-prefer-set-animation-loop.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/r3f/three-prefer-set-animation-loop.ts
@@ -2,6 +2,7 @@ import { defineRule } from "../../utils/define-rule.js";
 import type { EsTreeNode } from "../../utils/es-tree-node.js";
 import { isGlobalAnimationFrameCallee } from "../../utils/is-global-animation-frame-callee.js";
 import { resolveRecursiveAnimationFrameCallback } from "../../utils/resolve-recursive-animation-frame-callback.js";
+import { callbackRendersWithThree } from "./utils/callback-renders-with-three.js";
 
 export const threePreferSetAnimationLoop = defineRule({
   id: "three-prefer-set-animation-loop",
@@ -11,15 +12,16 @@ export const threePreferSetAnimationLoop = defineRule({
   recommendation:
     "Use renderer.setAnimationLoop for Three.js animation-loop compatibility, including WebXR",
   create: (context) => {
-    const reportedCallbacks = new Set<EsTreeNode>();
+    const checkedCallbacks = new Set<EsTreeNode>();
     return {
       CallExpression(node) {
         if (!isGlobalAnimationFrameCallee(node.callee, context.scopes)) return;
         const callback = resolveRecursiveAnimationFrameCallback(node, context.scopes, {
           requireUnconditionalSchedule: true,
         });
-        if (!callback || reportedCallbacks.has(callback)) return;
-        reportedCallbacks.add(callback);
+        if (!callback || checkedCallbacks.has(callback)) return;
+        checkedCallbacks.add(callback);
+        if (!callbackRendersWithThree(callback, context.scopes)) return;
         context.report({
           node,
           message:

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/r3f/utils/callback-renders-with-three.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/r3f/utils/callback-renders-with-three.ts
@@ -1,0 +1,24 @@
+import type { ScopeAnalysis } from "../../../semantic/scope-analysis.js";
+import type { EsTreeNode } from "../../../utils/es-tree-node.js";
+import { getStaticPropertyName } from "../../../utils/get-static-property-name.js";
+import { isNodeOfType } from "../../../utils/is-node-of-type.js";
+import { stripParenExpression } from "../../../utils/strip-paren-expression.js";
+import { isThreeRendererReference } from "./is-three-renderer-reference.js";
+import { THREE_RENDER_METHOD_NAMES } from "./three-render-method-names.js";
+import { walkFunctionExecution } from "./walk-function-execution.js";
+
+export const callbackRendersWithThree = (callback: EsTreeNode, scopes: ScopeAnalysis): boolean => {
+  let doesRenderWithThree = false;
+  walkFunctionExecution(callback, scopes, (candidate) => {
+    if (doesRenderWithThree || !isNodeOfType(candidate, "CallExpression")) return;
+    const callee = stripParenExpression(candidate.callee);
+    if (
+      isNodeOfType(callee, "MemberExpression") &&
+      THREE_RENDER_METHOD_NAMES.has(getStaticPropertyName(callee) ?? "") &&
+      isThreeRendererReference(callee.object, scopes)
+    ) {
+      doesRenderWithThree = true;
+    }
+  });
+  return doesRenderWithThree;
+};

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/r3f/utils/resolve-three-animation-loop-callback.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/r3f/utils/resolve-three-animation-loop-callback.ts
@@ -7,24 +7,7 @@ import { resolveRecursiveAnimationFrameCallback } from "../../../utils/resolve-r
 import { stripParenExpression } from "../../../utils/strip-paren-expression.js";
 import { isThreeRendererReference } from "./is-three-renderer-reference.js";
 import { resolveLocalReactCallback } from "./resolve-local-react-callback.js";
-import { THREE_RENDER_METHOD_NAMES } from "./three-render-method-names.js";
-import { walkFunctionExecution } from "./walk-function-execution.js";
-
-const callbackRendersWithThree = (callback: EsTreeNode, scopes: ScopeAnalysis): boolean => {
-  let doesRenderWithThree = false;
-  walkFunctionExecution(callback, scopes, (candidate) => {
-    if (doesRenderWithThree || !isNodeOfType(candidate, "CallExpression")) return;
-    const callee = stripParenExpression(candidate.callee);
-    if (
-      isNodeOfType(callee, "MemberExpression") &&
-      THREE_RENDER_METHOD_NAMES.has(getStaticPropertyName(callee) ?? "") &&
-      isThreeRendererReference(callee.object, scopes)
-    ) {
-      doesRenderWithThree = true;
-    }
-  });
-  return doesRenderWithThree;
-};
+import { callbackRendersWithThree } from "./callback-renders-with-three.js";
 
 export const resolveThreeAnimationLoopCallback = (
   call: EsTreeNodeOfType<"CallExpression">,

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/rules-of-hooks.regressions.test.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/rules-of-hooks.regressions.test.ts
@@ -1341,3 +1341,59 @@ describe("react-builtins/rules-of-hooks — regressions: upstream disable-commen
     });
   });
 });
+
+describe("react-builtins/rules-of-hooks — local member use bindings", () => {
+  it.each([
+    "declare const Service: { use: (callback: (value: string) => unknown) => unknown };",
+    'const Service = { use: (callback) => callback("value") };',
+    'class Service { static use(callback) { return callback("value"); } }',
+    'import { useState as Service } from "react";',
+    'import { use as Service } from "react";',
+    "const Service = React.useState;",
+  ])("allows non-namespace .use calls: %s", (declaration) => {
+    expect(
+      runTsx(`
+      import * as React from "react";
+      ${declaration}
+      export const fixture = async () => { Service.use((value) => value); };
+    `).diagnostics,
+    ).toHaveLength(0);
+  });
+
+  it("allows a parameter that shadows the React namespace", () => {
+    expect(
+      runTsx(`
+      import * as React from "react";
+      export const fixture = async (React) => { React.use((value) => value); };
+    `).diagnostics,
+    ).toHaveLength(0);
+  });
+
+  it("allows a shadowed require that returns a local service", () => {
+    expect(
+      runTsx(`
+      export const fixture = async (require) => {
+        const Service = require("react");
+        Service.use((value) => value);
+      };
+    `).diagnostics,
+    ).toHaveLength(0);
+  });
+
+  it.each([
+    'import * as ReactApi from "react";',
+    'import ReactApi from "react";',
+    'import { default as ReactApi } from "react";',
+    'import * as React from "react"; const ReactApi = React;',
+    'const ReactApi = require("react");',
+    'const React = require("react"); const ReactApi = React;',
+    'import ReactApi = require("react");',
+  ])("keeps async React.use diagnostics: %s", (declaration) => {
+    const diagnostics = runTsx(`
+      ${declaration}
+      export const App = async () => { ReactApi.use(promise); return null; };
+    `).diagnostics;
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.message).toContain("async function");
+  });
+});

--- a/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/rules-of-hooks.ts
+++ b/packages/oxlint-plugin-react-doctor/src/plugin/rules/react-builtins/rules-of-hooks.ts
@@ -32,6 +32,7 @@ import { resolveImportedApiReference } from "../../utils/resolve-imported-api-re
 import { statementAlwaysExits } from "../../utils/statement-always-exits.js";
 import { stripParenExpression } from "../../utils/strip-paren-expression.js";
 import { walkAst } from "../../utils/walk-ast.js";
+import { getModuleNamespaceSource } from "../r3f/utils/get-module-namespace-source.js";
 import { isRulesOfHooksSuppressedAt } from "./rules-of-hooks-suppression.js";
 
 // Port of `oxc_linter::rules::react::rules_of_hooks`. Enforces React's
@@ -234,6 +235,14 @@ const isHookCall = (
         propertyName === "use" &&
         callObject.name !== "React" &&
         isNodeOfType(call.arguments[0], "ArrayExpression")
+      ) {
+        return null;
+      }
+      if (
+        propertyName === "use" &&
+        scopes.symbolFor(callObject) &&
+        !isReactNamespaceImport(callObject, scopes) &&
+        !REACT_RUNTIME_MODULE_SOURCES.has(getModuleNamespaceSource(callObject, scopes) ?? "")
       ) {
         return null;
       }

--- a/packages/react-doctor/tests/regressions/rules-of-hooks-local-use.test.ts
+++ b/packages/react-doctor/tests/regressions/rules-of-hooks-local-use.test.ts
@@ -36,6 +36,28 @@ describe("rules-of-hooks local use false positives", () => {
     ).toHaveLength(0);
   });
 
+  it("reports only React.use when an async service also has a use method", async () => {
+    const projectDirectory = setupReactProject(tempRoot, "local-member-use", {
+      files: {
+        "src/fixture.tsx": `
+          import * as React from "react";
+          declare const Service: { use: (callback: (value: string) => unknown) => unknown };
+          export const fixture = async () => { Service.use((value) => value); };
+          export const App = async () => { React.use(Promise.resolve("value")); return null; };
+        `,
+      },
+    });
+    const diagnostics = await runOxlint({
+      rootDirectory: projectDirectory,
+      project: buildTestProject({ rootDirectory: projectDirectory }),
+    });
+    const hookDiagnostics = diagnostics.filter(
+      (diagnostic) => diagnostic.plugin === "react-doctor" && diagnostic.rule === "rules-of-hooks",
+    );
+    expect(hookDiagnostics).toHaveLength(1);
+    expect(hookDiagnostics[0]?.line).toBe(5);
+  });
+
   it("still reports React use inside async components", async () => {
     const projectDir = setupReactProject(tempRoot, "react-use-async", {
       files: {


### PR DESCRIPTION
## Why

Fixes #1797 and fixes #1795.

A local `Service.use(callback)` call currently receives a React hook error. A recursive 2D canvas loop also receives a Three.js warning when the project depends on Three.js. After this change, the service method and 2D loop stay quiet, while misused `React.use()` and recursive callbacks that render through Three.js still report.

## What changed

- Check resolved `.use()` receivers against React namespace bindings. Preserve default imports, constant aliases, CommonJS imports, TypeScript import-equals bindings, and existing handling of unresolved names.
- Require a known Three.js render call in the animation callback or a local helper. Reuse the existing renderer analysis; a file-level import alone is insufficient for files with both 2D and 3D loops.
- Add regression tests, fuzz corpus cases, a CLI integration test, and a patch Changeset for the CLI and both lint plugins.

## Eval results

The local candidate completed 10 project roots across five repositories with no failed scans. A pinned Bippy source comparison removed three local `Dispatcher.use()` false positives and added no diagnostics. The other 22 hook diagnostics in Bippy's debug dispatcher are unchanged. The candidate sample contained no target Three.js diagnostics, so Three.js positive coverage comes from regression and fuzz tests.

Hosted base/head parity has not run: `DAYTONA_API_KEY` is unavailable in the local environment. This local sample does not replace hosted parity.

## Test plan

- Added regressions failed in 16 cases against the base implementation.
- Full repository tests: 33,131 passed, 1,118 skipped. Two unchanged terminal UI tests needed a retry; all six tests in that file pass in isolation.
- Build, lint, typecheck, format check, and JSON report smoke passed.
- Both target rules passed 500 strict fuzz iterations with firing required.
- Built-CLI reproduction reports only the async React call and the Three.js loop in a file that also contains the local service and 2D loop.
